### PR TITLE
Flutter: restart-now offer on workspace settings notice (#1780)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -40,6 +40,13 @@ operators or integrators to act when upgrading.
   after a change — the JWT subject is your user id, so the token stays valid;
   only the key it's filed under changes.
 
+- **Flutter workspace settings: the restart-needed notice offers a
+  "Restart now" button (#1780).** Editing a create-time field (image,
+  service command, mounts, env, or allowed domains) on a _running_ workspace
+  shows a "restart to apply" notice; it now includes a Restart now action
+  that triggers the restart immediately (routed through the workspace page,
+  which owns the in-flight indicator), rather than being informational only.
+
 - **`klangk stop` and `klangk start` commands** stop and (re)start a
   workspace container (#1750), closing the CLI parity gap with the TUI and
   Flutter app (which already reach shutdown via `POST /api/v1/workspaces/{id}/stop`).

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -507,7 +507,10 @@ class _WorkspacePageState extends State<WorkspacePage> {
       chatUnread: _chatUnread,
       chatMentioned: _chatMentioned,
       settings: _hasPerm('edit')
-          ? WorkspaceSettingsPanel(workspaceId: widget.workspaceId)
+          ? WorkspaceSettingsPanel(
+              workspaceId: widget.workspaceId,
+              onRestart: _restartContainer,
+            )
           : null,
       sharing: _hasPerm('share')
           ? WorkspaceSharingPanel(workspaceId: widget.workspaceId)

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -14,7 +14,16 @@ import 'workspace_list_page.dart' show validateAllowedDomainSpec;
 class WorkspaceSettingsPanel extends StatefulWidget {
   final String workspaceId;
 
-  const WorkspaceSettingsPanel({super.key, required this.workspaceId});
+  /// Invoked when the user accepts the "restart needed" notice from inside
+  /// the panel. Routed through the workspace page so it owns the restart
+  /// lifecycle (in-flight indicator + container_ready handling) (#1780).
+  final VoidCallback onRestart;
+
+  const WorkspaceSettingsPanel({
+    super.key,
+    required this.workspaceId,
+    required this.onRestart,
+  });
 
   @override
   State<WorkspaceSettingsPanel> createState() => WorkspaceSettingsPanelState();
@@ -144,6 +153,14 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     }
   }
 
+  /// The user accepted the restart-needed notice: delegate to the workspace
+  /// page's restart (it owns the in-flight indicator + container_ready
+  /// handling) and clear the notice (#1780).
+  void _restartNow() {
+    widget.onRestart();
+    setState(() => _pendingRestart = false);
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) return const Center(child: CircularProgressIndicator());
@@ -162,6 +179,7 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
       netfilterEnabled:
           context.select<AuthService, bool>((a) => a.netfilterEnabled),
       onSave: _saveSettings,
+      onRestart: _restartNow,
     );
   }
 }
@@ -233,6 +251,7 @@ class _SettingsForm extends StatefulWidget {
   final bool pendingRestart;
   final bool netfilterEnabled;
   final Future<void> Function(Map<String, dynamic>) onSave;
+  final VoidCallback onRestart;
 
   const _SettingsForm({
     required this.workspaceId,
@@ -244,6 +263,7 @@ class _SettingsForm extends StatefulWidget {
     required this.pendingRestart,
     required this.netfilterEnabled,
     required this.onSave,
+    required this.onRestart,
   });
 
   @override
@@ -496,6 +516,10 @@ class _SettingsFormState extends State<_SettingsForm> {
               'Restart the workspace to apply these changes — '
               'they take effect at container create time.',
             ),
+          ),
+          TextButton(
+            onPressed: widget.onRestart,
+            child: const Text('Restart now'),
           ),
         ],
       ),

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -123,7 +123,7 @@ http.Client _client({
   });
 }
 
-Widget _buildPanel() => MultiProvider(
+Widget _buildPanel({VoidCallback? onRestart}) => MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthService()),
         ChangeNotifierProvider.value(value: WsClient()),
@@ -132,7 +132,12 @@ Widget _buildPanel() => MultiProvider(
       // the constructor call at runtime.  Const constructors are evaluated
       // at compile time and invisible to coverage (dart-lang/sdk#38934).
       child: MaterialApp(
-        home: Scaffold(body: WorkspaceSettingsPanel(workspaceId: _wsId)),
+        home: Scaffold(
+          body: WorkspaceSettingsPanel(
+            workspaceId: _wsId,
+            onRestart: onRestart ?? () {},
+          ),
+        ),
       ),
     );
 
@@ -639,6 +644,159 @@ void main() {
       expect(
           find.textContaining('Restart the workspace to apply'), findsNothing);
       await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('image change on a running container shows restart notice',
+        (tester) async {
+      // #1780: the restart notice is generalized to ALL create-time fields,
+      // not just allowed_domains. Changing the image on a running workspace
+      // must prompt a restart.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'running': true,
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Change the image via the dropdown (klangk-pi -> other:latest).
+      await _scrollToAndTap(tester, find.text('klangk-pi'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('other:latest').last);
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(find.textContaining('Restart the workspace to apply'),
+          findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+        'service_command change on a running container shows restart notice',
+        (tester) async {
+      // #1780: changing the shell command on a running workspace prompts a
+      // restart.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'running': true,
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Replace the loaded service_command ('pi') so the save differs.
+      await tester.enterText(
+        find.byWidgetPredicate(
+          (w) =>
+              w is TextField &&
+              w.decoration?.hintText == 'Optional — runs on terminal open',
+        ),
+        'pi --updated',
+      );
+      await tester.pump();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(find.textContaining('Restart the workspace to apply'),
+          findsOneWidget);
+      // The offer-to-restart action is present (#1780).
+      expect(find.text('Restart now'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('mounts change on a running container shows restart notice',
+        (tester) async {
+      // #1780: removing a mount on a running workspace prompts a restart.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'running': true,
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Remove the existing mount (/host:/cont) — the first close icon.
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pump();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(find.textContaining('Restart the workspace to apply'),
+          findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('env change on a running container shows restart notice',
+        (tester) async {
+      // #1780: removing an env var on a running workspace prompts a restart.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'running': true,
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Remove the existing env var (FOO=bar) — the last close icon.
+      await tester.tap(find.byIcon(Icons.close).last);
+      await tester.pump();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(find.textContaining('Restart the workspace to apply'),
+          findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('"Restart now" invokes onRestart and dismisses the notice',
+        (tester) async {
+      // #1780: the notice offers to restart now. Tapping it routes through
+      // the workspace page's restart callback and clears the notice.
+      var restartRequested = 0;
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'mounts': <String>[],
+        'env': <String, String>{},
+        'allowed_domains': <String>['old.example:443'],
+        'running': true,
+      });
+      await tester.pumpWidget(_buildPanel(onRestart: () => restartRequested++));
+      await tester.pumpAndSettle();
+
+      // Trigger the notice by removing the existing domain.
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pump();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('Restart the workspace to apply'),
+          findsOneWidget);
+      expect(find.text('Restart now'), findsOneWidget);
+
+      await _scrollToAndTap(tester, find.text('Restart now'));
+      await tester.pump();
+
+      expect(restartRequested, 1);
+      // The notice (and its button) are dismissed once restart is requested.
+      expect(
+          find.textContaining('Restart the workspace to apply'), findsNothing);
+      expect(find.text('Restart now'), findsNothing);
       await tester.pumpAndSettle();
     });
   });


### PR DESCRIPTION
Closes #1780.

## What

- **"Restart now" offer on the restart-needed notice** (`workspace_settings_panel.dart`). The notice (shown when a create-time field — image, service command, mounts, env, allowed_domains — is changed on a *running* workspace) was informational only. It now includes a **Restart now** action that triggers the restart immediately. The action is routed through the workspace page's existing `_restartContainer` (which owns the in-flight indicator + `container_ready` handling); the panel clears the notice once restart is requested. Styled via the existing notice banner.
- **Widget tests for the generalized notice** (`workspace_settings_panel_test.dart`). The detection was already generalized to all create-time fields, but only the `allowed_domains` path was tested. Added tests that changing **image**, **service command**, **mounts**, or **env** on a running workspace shows the notice — plus a test that "Restart now" invokes the restart callback and dismisses the notice.
- `allowed_domains` was already surfaced in the workspace settings/detail panel (the "Allowed Domains" editor), so no change was needed there.

## Verification

- `flutter test test/workspace_settings_panel_test.dart` → 56 passed (5 new).
- `flutter analyze` on the touched files → clean.
- Rebased onto latest `main` (resolves cleanly alongside #1868's shutdown-to-REST migration).

## Heads-up

- The full `flutter test --coverage` run has **one pre-existing failure** unrelated to this change: `chat_message_list_test.dart › formatTime shows day abbreviation for this week` — a date/timezone-sensitive test that also fails on `main` today. This PR doesn't touch chat code.
- The changelog commit also normalizes some pre-existing `_underscore_` emphasis in older `docs/changes.md` entries to keep markdownlint (MD049) happy, since landing the new entry triggered a full-file lint of previously-unflagged lines.
