### PR TITLE
TUI login: rename "Use server" button to "Add server" (#1871)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -420,6 +420,10 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI login: the server-input button is relabeled "Use server" →
+  "Add server" (#1871)** — clearer that typing a new server URL/alias and
+  pressing it adds the server (rather than just selecting an existing one).
+
 - **Workspace shutdown is now uniformly REST-backed across Flutter, TUI,
   and CLI (#1858).** The redundant WebSocket `shutdown_container` handler
   is retired; the Flutter settings panel's "Shut Down" button now calls

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -257,7 +257,7 @@ class LoginScreen(SpatialNavScreen):
                 id="server_input",
             ),
             Horizontal(
-                Button("Use server", id="use_server"),
+                Button("Add server", id="use_server"),
                 classes="actions",
             ),
             Static("", id="notice"),

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4939,7 +4939,7 @@ async def test_login_server_picker(monkeypatch):
         await app.workers.wait_for_complete()
         assert calls.get("add") == ("other.sock", "/var/run/other.sock")
 
-        # "Use server" button also dispatches
+        # "Add server" button also dispatches
         srv_input.value = "prod"
         login.on_button_pressed(FakeBtnPress("use_server"))
         await app.workers.wait_for_complete()


### PR DESCRIPTION
## Summary

Renames the TUI login screen's server-input button from **"Use server"** to **"Add server"**. Closes #1871.

The button sits next to the server URL/alias input; when the input holds a new URL it saves it as a new alias and switches to it — i.e. it *adds* a server. "Add server" conveys that better than "Use server", and pairs with the existing "Delete server" action (`d`).

## Changes

- `cli/tui/screens.py:260` — `Button("Use server", id="use_server")` → `Button("Add server", id="use_server")`. The `use_server` id is unchanged (the handler/dispatch and tests key off the id, not the label).
- `klangkc-tests/tests/test_tui.py:4942` — comment updated to match (the test presses the button by id, so no assertion logic changed).

(Note: the separate `AddServerScreen` at `screens.py:2798` already uses "Add server" as its title — unrelated, predates this change; the two now read consistently.)

## Verification

- `pytest src/klangk/klangkc-tests/tests/test_tui.py -k "server or login or populate"` → **77 passed**.
- No other "Use server" copy remains in the TUI (`grep -rn "Use server" src/` is empty).
- Label-only change; no code paths added/removed, so coverage is unaffected.
- Rebased onto latest `origin/main` (account-self-service #1869 had landed).

Closes #1871.
