### PR TITLE
feat(tui): inline server-scoped keybindings on switch-server screen (#1872)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -420,6 +420,12 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI switch-server: server-scoped keybindings moved inline (#1872).**
+  The `e` (edit) and `d` (delete) keys no longer appear in the bottom Footer —
+  their hints now render on the servers list header (`[e] edit  [d] delete`),
+  next to the list they act on. The Footer is now screen-level only (`Back`).
+  Mirrors the term-header pattern shipped for workspace detail in #1863.
+
 - **TUI login: the server-input button is relabeled "Use server" →
   "Add server" (#1871)** — clearer that typing a new server URL/alias and
   pressing it adds the server (rather than just selecting an existing one).

--- a/src/klangk/klangk/cli/tui/screens/server.py
+++ b/src/klangk/klangk/cli/tui/screens/server.py
@@ -7,6 +7,7 @@ import asyncio
 from rich.text import Text
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen, Screen
 from textual.widgets import (
@@ -29,15 +30,40 @@ class ServerSwitchScreen(Screen):
     """Pick a known server alias to switch to."""
 
     BINDINGS = [
-        ("escape", "app.pop_screen", "Back"),
-        ("e", "edit_server", "Edit"),
-        ("d", "delete_server", "Delete"),
+        Binding("escape", "app.pop_screen", "Back"),
+        # Server-scoped keys are hidden from the Footer — their hints render
+        # inline on the servers list header instead (#1872).
+        Binding("e", "edit_server", "Edit", show=False),
+        Binding("d", "delete_server", "Delete", show=False),
     ]
+
+    DEFAULT_CSS = """
+    ServerSwitchScreen #server_header {
+        height: auto;
+        padding: 1 0;
+    }
+    ServerSwitchScreen #server_title {
+        text-style: bold;
+        color: $primary;
+        width: auto;
+    }
+    ServerSwitchScreen #server_hints {
+        width: 1fr;
+        text-align: right;
+        color: $text-muted;
+    }
+    """
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Vertical(
-            Static("Switch server", classes="title"),
+            Horizontal(
+                Static("Switch server", id="server_title"),
+                Static(
+                    "[e] edit  [d] delete", id="server_hints", markup=False
+                ),
+                id="server_header",
+            ),
             Static("", id="switch_msg"),
             SpatialListView(id="server_options"),
             id="switch_box",

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1307,6 +1307,43 @@ async def test_edit_server_saves(monkeypatch):
         assert isinstance(app.screen, ServerSwitchScreen)
 
 
+async def test_server_switch_hints_inline_not_in_footer(monkeypatch):
+    """#1872: server-scoped keys (e/d) are hinted inline on the servers list
+    header and hidden from the Footer."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example"),
+        ],
+        current_url=lambda: "https://prod.example",
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+
+        # (a) Server action hints render on the list header, with the literal
+        # [e] / [d] keycaps intact (not eaten as Rich markup).
+        hints = str(app.screen.query_one("#server_hints").render())
+        assert "[e]" in hints
+        assert "[d]" in hints
+        assert "edit" in hints
+        assert "delete" in hints
+
+        bindings = {b.key: b for b in app.screen.BINDINGS}
+
+        # (b) Server keys still exist (so the keys work) but are hidden.
+        assert bindings["e"].show is False
+        assert bindings["d"].show is False
+
+        # (c) The screen-level Back key remains visible.
+        assert bindings["escape"].show is True
+
+
 async def test_edit_server_empty_fields(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
Closes #1872.

## What & why

`ServerSwitchScreen` listed `e Edit` / `d Delete` in the bottom Footer, even
though both act on the selected row of the servers list — the same
scope-mixing problem the workspace detail page had for terminals before #1863.
The binding's target wasn't obvious from where it was displayed.

## Change

Apply the pattern shipped in #1863 for the Terminals list: show the
server-scoped shortcuts as **inline hints next to the servers list**, and
reserve the Footer for screen-level actions.

- `ServerSwitchScreen`: the list header is now a `Horizontal` carrying inline
  hints `[e] edit  [d] delete` (right-aligned; `markup=False` so the literal
  `[e]` / `[d]` keycaps aren't parsed as Rich markup — the gotcha hit in #1863).
- `e` / `d` bindings retained with `show=False` — the keys still work, they
  just no longer appear in the Footer. Footer is now `Back` only.
- The bold/primary `.title` look and its vertical spacing are preserved.

Resulting header: `Switch server                         [e] edit  [d] delete`.

### Scope decision: LoginScreen left as-is

The issue's acceptance criteria allowed leaving `LoginScreen`'s server picker
as a conscious choice. Its Footer is sparse (only the single `d Delete server`
binding), so there's nothing for `d` to be confused with — the scope-mixing
problem this pattern addresses doesn't apply there. Left unchanged.

## Verification

- Full Python suite (klangkd + klangkc), `-n auto`: **3784 passed, 100% coverage.**
- Added `test_server_switch_hints_inline_not_in_footer` guarding the inline
  hints (incl. literal `[e]`/`[d]` keycaps) and the hidden bindings.
- Render check: title left, hints right-aligned on the same row, Footer = `Back`.
