### PR TITLE
feat(tui): per-workspace actions on the workspaces list

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Per-workspace quick actions on the TUI workspaces list (#1878).** The
+  workspaces page now acts on the highlighted row: `r` restart, `s` stop /
+  start, `d` duplicate, `x` delete, `e` edit (Enter still opens the detail
+  screen). The keys mirror the detail screen, with an inline hint bar above
+  the list whose Stop/Start label tracks the highlighted workspace's state.
+  **`s` is now Stop/Start** (it was Switch server) — Switch server moved to
+  `c`.
+
 - **Account self-service from the CLI and TUI (#1753).** A new
   `klangk account` group (`show`, `passwd`, `handle`, `email`) changes your
   password, handle, or email from the command line, and a new TUI **Account**

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -11,6 +11,7 @@ import httpx
 from rich.text import Text
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.dom import NoMatches
 from textual.screen import Screen
@@ -22,12 +23,13 @@ from textual.widgets import (
     Label,
     ListItem,
     ListView,
+    Static,
     TabbedContent,
     TabPane,
     Tabs,
 )
 
-from ...client import AuthError
+from ...client import AuthError, WorkspaceNotFoundError
 from ..widgets import StatusBar
 from ..ws import listen_for_status
 from ._base import ConfirmScreen, WorkspaceListView
@@ -50,6 +52,11 @@ class MainScreen(Screen):
         width: auto;
         text-align: right;
         color: $text-muted;
+    }
+    .ws_hints {
+        height: 1;
+        color: $text-muted;
+        padding: 0 1;
     }
     #filter_bar {
         dock: bottom;
@@ -74,19 +81,32 @@ class MainScreen(Screen):
     """
 
     BINDINGS = [
-        ("s", "switch_server", "Switch server"),
+        ("c", "switch_server", "Switch server"),
         ("n", "create", "New"),
         ("a", "account", "Account"),
         ("l", "logout", "Logout"),
         ("slash", "focus_filter", "Filter"),
         ("o", "cycle_sort", "Sort"),
+        # Per-workspace actions act on the highlighted row of the active
+        # list. Hidden from the Footer; their hints render inline above the
+        # list (#1878), mirroring the terminal-action pattern on the detail
+        # screen (#1860). `s` matches the detail screen's Stop/Start.
+        Binding("r", "restart", "Restart", show=False),
+        Binding("s", "stop", "Stop/Start", show=False),
+        Binding("d", "duplicate", "Duplicate", show=False),
+        Binding("x", "delete", "Delete", show=False),
+        Binding("e", "edit", "Edit", show=False),
     ]
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         with TabbedContent(id="ws_tabs"):
-            yield TabPane("Owned by me", WorkspaceListView(id="owned_list"))
-            yield TabPane("Shared to me", WorkspaceListView(id="shared_list"))
+            with TabPane("Owned by me", id="owned_pane"):
+                yield Static("", classes="ws_hints")
+                yield WorkspaceListView(id="owned_list")
+            with TabPane("Shared to me", id="shared_pane"):
+                yield Static("", classes="ws_hints")
+                yield WorkspaceListView(id="shared_list")
         yield StatusBar(id="status")
         yield Footer()
         # Filter bar is yielded LAST so that — since docked-bottom widgets
@@ -111,6 +131,7 @@ class MainScreen(Screen):
         self._shared_all: list = []
         self._filter_text = ""
         self.query_one("#filter_bar").display = False
+        self._refresh_action_hints()
         self.refresh_lists()
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
@@ -118,6 +139,9 @@ class MainScreen(Screen):
     def on_tabbed_content_tab_activated(self, event) -> None:
         """Focus the first workspace row when switching tabs (#1792)."""
         self._focus_visible_list()
+        # The highlighted row (and thus the Stop/Start label) changes with
+        # the tab — re-render even if the new pane has no rows to highlight.
+        self._refresh_action_hints()
 
     # --- filter / sort ---
 
@@ -200,15 +224,15 @@ class MainScreen(Screen):
         empty = "(no matches)" if q else "(no workspaces)"
         self._populate("#owned_list", owned, empty_label=empty)
         self._populate("#shared_list", shared, empty_label=empty)
+        self._refresh_action_hints()
 
     def _focus_visible_list(self) -> None:
         """Focus the first item in the visible workspace list (#1792)."""
-        for lv in self.query(WorkspaceListView):
-            if lv.display and lv.query(ListItem):
-                lv.focus()
-                if lv.index is None:
-                    lv.index = 0
-                return
+        lv = self._active_list()
+        if lv is not None and lv.query(ListItem):
+            lv.focus()
+            if lv.index is None:
+                lv.index = 0
 
     def on_key(self, event) -> None:
         # Escape in the filter input: clear text or hide bar and return.
@@ -223,13 +247,12 @@ class MainScreen(Screen):
             return
         # Down from the tab strip drops into the active workspace list (#1781).
         if event.key == "down" and isinstance(self.focused, Tabs):
-            for lv in self.query(WorkspaceListView):
-                if lv.display:
-                    event.stop()
-                    lv.focus()
-                    if lv.index is None:
-                        lv.index = 0
-                    break
+            lv = self._active_list()
+            if lv is not None:
+                event.stop()
+                lv.focus()
+                if lv.index is None:
+                    lv.index = 0
 
     def action_switch_server(self) -> None:
         from .server import ServerSwitchScreen  # noqa: allow-deferred-import
@@ -240,6 +263,246 @@ class MainScreen(Screen):
         from .account import AccountScreen  # noqa: allow-deferred-import
 
         self.app.push_screen(AccountScreen())
+
+    # --- per-workspace actions (act on the highlighted row, #1878) ---
+
+    def _active_list(self):
+        """The WorkspaceListView in the currently active tab pane, or None.
+
+        ``TabbedContent`` toggles ``display`` on the ``TabPane`` (the list's
+        *parent*), not on the list itself — ``lv.display`` is True for every
+        list regardless of tab — so the active list is the one whose parent
+        pane is displayed. Keying off ``lv.display`` silently targets the
+        Owned list even on the Shared tab (#1879 review).
+        """
+        for lv in self.query(WorkspaceListView):
+            if lv.parent is not None and lv.parent.display:
+                return lv
+        return None
+
+    def _highlighted_item(self):
+        lv = self._active_list()
+        return lv.highlighted_child if lv is not None else None
+
+    def _highlighted_ws(self):
+        """The workspace object for the highlighted row, or None."""
+        item = self._highlighted_item()
+        if item is None:
+            return None
+        wid = str(getattr(item, "workspace_id", "") or "")
+        by_id = getattr(self, "_ws_by_id", {}) or {}
+        if wid and wid in by_id:
+            return by_id[wid]
+        name = getattr(item, "name", "") or ""
+        for ws in list(self._owned_all) + list(self._shared_all):
+            if getattr(ws, "name", "") == name:
+                return ws
+        return None
+
+    def _require_highlighted(self) -> str | None:
+        """Return the highlighted workspace name, or flash a hint + None."""
+        item = self._highlighted_item()
+        name = getattr(item, "name", "") or "" if item is not None else ""
+        if not name:
+            self._flash("Select a workspace first.")
+            return None
+        return name
+
+    def _refresh_action_hints(self) -> None:
+        """Re-render the inline per-workspace hint bar.
+
+        The Stop/Start label tracks the highlighted workspace's running
+        state so it never offers the wrong action (#1878).
+        """
+        ws = self._highlighted_ws()
+        toggle = "stop" if (ws is not None and ws.running) else "start"
+        text = (
+            f"[\u21b5 open]  [r restart]  [s {toggle}]"
+            "  [d duplicate]  [x delete]  [e edit]"
+        )
+        for hints in self.query(".ws_hints"):
+            hints.update(Text(text))
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        self._refresh_action_hints()
+
+    def _flash(self, message: str) -> None:
+        """Show a transient message in the status bar's 'extra' slot.
+
+        The next status event overwrites it. There's no dedicated message
+        line on this screen (unlike the detail screen's #detail_msg), so we
+        borrow the status 'extra' channel that already shows transient flags.
+        """
+        self.app.live_extra = message
+        self._refresh_status()
+
+    def action_restart(self) -> None:
+        name = self._require_highlighted()
+        if not name:
+            return
+
+        def _on_confirm(confirmed: bool) -> None:
+            if not confirmed:
+                return
+            self.run_worker(self._do_restart(name), exit_on_error=False)
+
+        self.app.push_screen(
+            ConfirmScreen(
+                f"Restart '{name}'? This ends active terminal sessions"
+                " and recreates the container.",
+                yes_label="Restart",
+                yes_variant="warning",
+            ),
+            _on_confirm,
+        )
+
+    async def _do_restart(self, name: str) -> None:
+        try:
+            await asyncio.to_thread(self.app.tui_state.restart_workspace, name)
+        except Exception as exc:
+            self._flash(f"Restart failed: {exc}")
+            return
+        self._flash(f"Restart requested for '{name}'.")
+        self.app.refresh_workspaces()
+
+    def action_stop(self) -> None:
+        name = self._require_highlighted()
+        if not name:
+            return
+        ws = self._highlighted_ws()
+        if ws is not None and ws.running:
+
+            def _on_confirm(confirmed: bool) -> None:
+                if not confirmed:
+                    return
+                self.run_worker(self._do_stop(name), exit_on_error=False)
+
+            self.app.push_screen(
+                ConfirmScreen(
+                    f"Stop '{name}'? This ends active terminal sessions.",
+                    yes_label="Stop",
+                    yes_variant="warning",
+                ),
+                _on_confirm,
+            )
+        else:
+            self.run_worker(self._do_start(name), exit_on_error=False)
+
+    async def _do_stop(self, name: str) -> None:
+        try:
+            await asyncio.to_thread(self.app.tui_state.stop_workspace, name)
+        except Exception as exc:
+            self._flash(f"Stop failed: {exc}")
+            return
+        self._flash(f"Stop requested for '{name}'.")
+        self.app.refresh_workspaces()
+        self._refresh_action_hints()
+
+    async def _do_start(self, name: str) -> None:
+        try:
+            await asyncio.to_thread(self.app.tui_state.start_workspace, name)
+        except Exception as exc:
+            self._flash(f"Start failed: {exc}")
+            return
+        self._flash(f"Start requested for '{name}'.")
+        self.app.refresh_workspaces()
+        self._refresh_action_hints()
+
+    def action_duplicate(self) -> None:
+        from ._base import DuplicateScreen  # noqa: allow-deferred-import
+
+        name = self._require_highlighted()
+        if not name:
+            return
+
+        def _on_dup(new_name: str | None) -> None:
+            if not new_name:
+                return
+            self.run_worker(
+                self._do_duplicate(name, new_name), exit_on_error=False
+            )
+
+        self.app.push_screen(DuplicateScreen(name), _on_dup)
+
+    async def _do_duplicate(self, src: str, new_name: str) -> None:
+        try:
+            await asyncio.to_thread(
+                self.app.tui_state.duplicate_workspace, src, new_name
+            )
+        except Exception as exc:
+            self._flash(f"Duplicate failed: {exc}")
+            return
+        self._flash(f"Duplicated '{src}' -> '{new_name}'.")
+        self.app.refresh_workspaces()
+
+    def action_delete(self) -> None:
+        name = self._require_highlighted()
+        if not name:
+            return
+
+        def _on_confirm(confirmed: bool) -> None:
+            if not confirmed:
+                return
+            self.run_worker(self._do_delete(name), exit_on_error=False)
+
+        self.app.push_screen(
+            ConfirmScreen(
+                f"Delete '{name}'? This permanently deletes the workspace"
+                " and its container.",
+            ),
+            _on_confirm,
+        )
+
+    async def _do_delete(self, name: str) -> None:
+        try:
+            await asyncio.to_thread(self.app.tui_state.delete_workspace, name)
+        except Exception as exc:
+            self._flash(f"Delete failed: {exc}")
+            return
+        self._flash(f"Deleted '{name}'.")
+        self.app.refresh_workspaces()
+
+    def action_edit(self) -> None:
+        name = self._require_highlighted()
+        if not name:
+            return
+        self.run_worker(self._do_edit(name), exit_on_error=False)
+
+    async def _do_edit(self, name: str) -> None:
+        from .workspace_form import EditWorkspaceScreen  # noqa: allow-deferred-import
+
+        state = self.app.tui_state
+        try:
+            ws = await asyncio.to_thread(state.find_workspace, name)
+        except WorkspaceNotFoundError:
+            self._flash(f"Workspace '{name}' not found.")
+            return
+        except Exception as exc:
+            self._flash(f"Could not load workspace: {exc}")
+            return
+        try:
+            data = await asyncio.to_thread(state.list_images)
+            default = data.get("default", "") or ""
+            allowed = list(data.get("allowed") or [])
+        except Exception:
+            default, allowed = "", []
+        try:
+            allow_autostart = await asyncio.to_thread(state.allow_autostart)
+        except Exception:
+            allow_autostart = False
+        self.app.push_screen(
+            EditWorkspaceScreen(
+                workspace=ws,
+                allowed=allowed,
+                default=default,
+                allow_autostart=allow_autostart,
+            ),
+            self._on_edited,
+        )
+
+    def _on_edited(self, result) -> None:
+        if result:
+            self.refresh_lists()
 
     def action_logout(self) -> None:
         self.app.do_logout()
@@ -459,7 +722,10 @@ class MainScreen(Screen):
                         item.query_one(".ws-name").update(self._fmt_name(ws))
                     except NoMatches:
                         pass
-                    return
+                    break
+        # The highlighted row's running state may have changed — refresh
+        # the Stop/Start hint label so it never offers the wrong action.
+        self._refresh_action_hints()
 
     def _forward_status_to_detail(self, event: dict) -> None:
         """Mirror a live status broadcast onto an open detail screen."""

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1686,6 +1686,537 @@ async def test_main_screen_lists_and_status(monkeypatch):
         assert "me@x.example" in status
 
 
+# ---------------------------------------------------------------------------
+# MainScreen per-workspace actions (act on the highlighted row, #1878)
+# ---------------------------------------------------------------------------
+
+
+async def _settle(app):
+    """Deterministically drain pending workers.
+
+    ``pilot.pause()`` is a one-tick, nondeterministic wait. The proper
+    primitive is ``app.workers.wait_for_complete()`` — but
+    ``MainScreen.refresh_lists`` registers its worker ``exclusive=True``, so
+    a refresh spawned mid-test (e.g. after an action) cancels a still-pending
+    one, and ``wait_for_complete()`` raises ``WorkerCancelled`` on the
+    cancelled worker. That cancellation is *expected* (it's how exclusive
+    workers avoid overlapping fetches), so retry until the pool drains.
+    """
+    from textual.worker import WorkerCancelled, WorkerFailed
+
+    while app.workers:
+        try:
+            await app.workers.wait_for_complete()
+        except (WorkerCancelled, WorkerFailed):
+            continue
+        break
+
+
+async def _highlight_first(pilot, app, *, pane="#owned_list"):
+    """Populate the MainScreen, highlight row 0, return the screen."""
+    await _settle(app)
+    m = app.screen
+    lv = m.query_one(pane, ListView)
+    lv.focus()
+    lv.index = 0
+    await pilot.pause()  # let the Highlighted event propagate
+    return m
+
+
+async def test_main_screen_action_hints_toggle_stop_start(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(
+        _ws(
+            owned=[
+                _wsobj("alpha", running=True),
+                _wsobj("beta", running=False),
+            ]
+        )
+    )
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        hints = str(m.query_one(".ws_hints", Static).render())
+        assert "restart" in hints and "s stop" in hints
+        assert "open" in hints and "duplicate" in hints
+        assert "delete" in hints and "edit" in hints
+        # Highlight the stopped row -> label flips to 'start'.
+        lv = m.query_one("#owned_list", ListView)
+        lv.index = 1
+        await pilot.pause()
+        m._refresh_action_hints()
+        assert "s start" in str(m.query_one(".ws_hints", Static).render())
+
+
+async def test_main_screen_action_requires_highlight(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        lv = m.query_one("#owned_list", ListView)
+        lv.index = None  # nothing highlighted
+        await pilot.pause()
+        # Every per-workspace action guards on a highlighted row.
+        for action in (
+            "action_restart",
+            "action_stop",
+            "action_duplicate",
+            "action_delete",
+            "action_edit",
+        ):
+            getattr(m, action)()
+            await pilot.pause()
+            assert not isinstance(app.screen, ConfirmScreen)
+        assert "Select a workspace" in (app.live_extra or "")
+
+
+async def test_main_screen_action_stop_cancel(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    stopped = {}
+    st = _ws(owned=[_wsobj("alpha", running=True)])
+    st.stop_workspace = lambda n: stopped.__setitem__("s", n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_stop()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(False)  # cancel
+        await pilot.pause()
+        assert "s" not in stopped
+
+
+async def test_main_screen_action_delete_cancel(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    deleted = {}
+    st = _ws(owned=[_wsobj("alpha")])
+    st.delete_workspace = lambda n: deleted.__setitem__("d", n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_delete()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(False)  # cancel
+        await pilot.pause()
+        assert "d" not in deleted
+
+
+async def test_main_screen_action_duplicate_cancel(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    duped = {}
+    st = _ws(owned=[_wsobj("alpha")])
+    st.duplicate_workspace = lambda n, nn: duped.__setitem__("d", (n, nn))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_duplicate()
+        await pilot.pause()
+        assert isinstance(app.screen, DuplicateScreen)
+        app.screen.on_button_pressed(FakeBtnPress("cancel"))  # cancel
+        await pilot.pause()
+        assert "d" not in duped
+
+
+async def test_main_screen_action_edit_load_fallbacks(monkeypatch):
+    """_do_edit tolerates find_workspace/list_images/allow_autostart errors."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    # Generic load error -> flashed, no screen pushed.
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: (_ for _ in ()).throw(RuntimeError("boom"))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_edit()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "Could not load workspace" in (app.live_extra or "")
+
+    # find_workspace ok but list_images / allow_autostart raise -> the edit
+    # screen still opens with empty/default fallbacks.
+    st2 = _ws(owned=[a])
+    st2.find_workspace = lambda n: a
+    st2.list_images = lambda: (_ for _ in ()).throw(RuntimeError("img"))
+    st2.allow_autostart = lambda: (_ for _ in ()).throw(RuntimeError("auto"))
+    app2 = KlangkApp(st2)
+    async with app2.run_test() as pilot:
+        m = await _highlight_first(pilot, app2)
+        m.action_edit()
+        await app2.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app2.screen, EditWorkspaceScreen)
+
+
+async def test_main_screen_on_edited_refreshes(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        called = {}
+        m.refresh_lists = lambda: called.__setitem__("r", True)
+        m._on_edited(True)  # truthy result -> refresh
+        assert called.get("r") is True
+        m._on_edited(None)  # falsy -> no refresh
+        assert called.get("r") is True  # unchanged
+
+
+async def test_main_screen_update_running_refreshes_hints(monkeypatch):
+    """_update_running reaches the hint-refresh tail for a known workspace."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    app = KlangkApp(_ws(owned=[a]))
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        # Highlight alpha, then flip its running state via a status event.
+        m._update_running("id-alpha", False)
+        await pilot.pause()
+        assert "s start" in str(m.query_one(".ws_hints", Static).render())
+
+
+async def test_main_screen_highlighted_ws_falls_back_to_name(monkeypatch):
+    """_highlighted_ws resolves by name when the row has no workspace_id."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    # A workspace with an empty id is never entered into _ws_by_id, so the
+    # name fallback path is exercised.
+    no_id = Workspace(id="", name="gamma", created_at="x")
+    app = KlangkApp(_ws(owned=[no_id]))
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        assert m._highlighted_ws() is no_id
+
+
+async def test_main_screen_action_restart_success_cancel_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    restarted = {}
+    st = _ws(owned=[a])
+    st.restart_workspace = lambda n: restarted.__setitem__("r", n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        # cancel -> not restarted
+        m.action_restart()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(False)
+        await pilot.pause()
+        assert "r" not in restarted
+        # confirm -> restarted
+        m.action_restart()
+        await pilot.pause()
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert restarted.get("r") == "alpha"
+        assert "Restart requested" in (app.live_extra or "")
+        # The success path refreshed the list and cleared the highlight;
+        # re-select the row before re-triggering.
+        m.query_one("#owned_list", ListView).index = 0
+        await pilot.pause()
+        # error
+        st.restart_workspace = lambda n: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        )
+        m.action_restart()
+        await pilot.pause()
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "Restart failed" in (app.live_extra or "")
+
+
+async def test_main_screen_action_stop_running_success_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    stopped = {}
+    st = _ws(owned=[a])
+    st.stop_workspace = lambda n: stopped.__setitem__("s", n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_stop()  # running -> confirm
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert stopped.get("s") == "alpha"
+        m.query_one("#owned_list", ListView).index = 0
+        await pilot.pause()
+        # error
+        st.stop_workspace = lambda n: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        )
+        m.action_stop()
+        await pilot.pause()
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "Stop failed" in (app.live_extra or "")
+
+
+async def test_main_screen_action_start_stopped(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=False)
+    started = []
+    st = _ws(owned=[a])
+    st.start_workspace = lambda n: started.append(n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_stop()  # stopped -> start, no confirm
+        await _settle(app)
+        assert started == ["alpha"]
+        assert not isinstance(app.screen, ConfirmScreen)
+
+
+async def test_main_screen_action_start_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=False)
+    st = _ws(owned=[a])
+    st.start_workspace = lambda n: (_ for _ in ()).throw(RuntimeError("boom"))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_stop()
+        await _settle(app)
+        assert "Start failed" in (app.live_extra or "")
+
+
+async def test_main_screen_action_delete_success_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    deleted = {}
+    st = _ws(owned=[_wsobj("alpha")])
+    st.delete_workspace = lambda n: deleted.__setitem__("d", n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_delete()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert deleted.get("d") == "alpha"
+        m.query_one("#owned_list", ListView).index = 0
+        await pilot.pause()
+        # error
+        st.delete_workspace = lambda n: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        )
+        m.action_delete()
+        await pilot.pause()
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "Delete failed" in (app.live_extra or "")
+
+
+async def test_main_screen_action_duplicate_success_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    duped = {}
+    st = _ws(owned=[_wsobj("alpha")])
+    st.duplicate_workspace = lambda n, nn: duped.__setitem__("d", (n, nn))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_duplicate()
+        await pilot.pause()
+        assert isinstance(app.screen, DuplicateScreen)
+        app.screen.on_button_pressed(FakeBtnPress("ok"))  # prefilled copy
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert duped.get("d") == ("alpha", "alpha-copy")
+        m.query_one("#owned_list", ListView).index = 0
+        await pilot.pause()
+        # error
+        st.duplicate_workspace = lambda n, nn: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        )
+        m.action_duplicate()
+        await pilot.pause()
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "Duplicate failed" in (app.live_extra or "")
+
+
+async def test_main_screen_action_edit_pushes_screen(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.list_images = lambda: {"default": "base", "allowed": ["base"]}
+    st.allow_autostart = lambda: True
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_edit()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, EditWorkspaceScreen)
+
+
+async def test_main_screen_action_edit_not_found(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    from klangk.cli.client import WorkspaceNotFoundError
+
+    st = _ws(owned=[_wsobj("alpha")])
+    st.find_workspace = lambda n: (_ for _ in ()).throw(
+        WorkspaceNotFoundError("nope")
+    )
+    st.list_images = lambda: {}
+    st.allow_autostart = lambda: False
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_edit()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "not found" in (app.live_extra or "")
+
+
+async def test_main_screen_c_key_switches_server(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        await pilot.press("c")
+        await pilot.pause()
+        assert isinstance(app.screen, ServerSwitchScreen)
+
+
+async def test_main_screen_action_targets_active_tab(monkeypatch):
+    """#1879 review: per-workspace actions act on the highlighted row of the
+    ACTIVE tab. TabbedContent toggles display on the TabPane (the list's
+    parent), not on the list, so naively checking lv.display silently targets
+    the Owned list even on the Shared tab — destructive actions included."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    restarted = {}
+    app = KlangkApp(
+        _ws(
+            owned=[_wsobj("alpha", running=True)],
+            shared=[_wsobj("beta", running=True)],
+            restart_workspace=lambda n: restarted.__setitem__("r", n),
+        )
+    )
+    async with app.run_test() as pilot:
+        await _settle(app)
+        m = app.screen
+        # Switch to the Shared tab and highlight beta.
+        m.query_one("#ws_tabs").active = "shared_pane"
+        await pilot.pause()
+        shared = m.query_one("#shared_list", ListView)
+        shared.focus()
+        shared.index = 0
+        await pilot.pause()
+        assert m._active_list().id == "shared_list"
+        assert m._highlighted_item().name == "beta"
+        # The confirm dialog must name beta, and the request must target beta.
+        m.action_restart()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(True)
+        await pilot.pause()  # let the dismiss callback spawn the worker
+        await _settle(app)
+        assert restarted.get("r") == "beta"
+
+
+async def test_main_screen_hints_refresh_on_tab_switch(monkeypatch):
+    """#1879 review: the hint bar re-renders on tab switch even when the new
+    pane has no highlight yet (no Highlighted event would fire)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha", running=True)], shared=[]))
+    async with app.run_test() as pilot:
+        await _settle(app)
+        m = app.screen
+        # Highlight alpha on the Owned tab -> hint says 'stop'.
+        owned = m.query_one("#owned_list", ListView)
+        owned.focus()
+        owned.index = 0
+        await pilot.pause()
+        m._refresh_action_hints()
+        assert "s stop" in str(m.query_one(".ws_hints", Static).render())
+        # Switch to the empty Shared tab -> no highlight, label defaults to
+        # 'start', not the stale 'stop' from the hidden Owned row.
+        m.query_one("#ws_tabs").active = "shared_pane"
+        await pilot.pause()
+        assert "s start" in str(m.query_one(".ws_hints", Static).render())
+
+
 async def test_main_screen_shows_created_date(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

Closes #1878. The workspaces page (`MainScreen`) now acts on the **highlighted row** instead of only offering global actions — `r` restart, `s` stop/start, `d` duplicate, `x` delete, `e` edit (Enter still opens the detail screen).

## Design

Mirrors the detail-screen terminal-action pattern (#1860): the per-workspace bindings are `show=False`, so the footer stays the global set and the row-scoped keys are surfaced as an **inline hint bar** above each workspace list:

```
[↵ open]  [r restart]  [s stop]  [d duplicate]  [x delete]  [e edit]
```

The **Stop/Start hint label is dynamic** — it re-renders on `ListView.Highlighted` and on `container_status` events so it never offers the wrong action for the highlighted workspace's state.

Destructive actions (restart/stop/delete) confirm via `ConfirmScreen`; duplicate uses `DuplicateScreen`; edit pushes `EditWorkspaceScreen`. With no row highlighted, an action flashes "Select a workspace first." in the status bar.

## Key change: `s` is now Stop/Start

`s` was **Switch server**. It's now **Stop/Start** to match the detail screen (so workspace-scoped keys are identical across both screens). **Switch server moved to `c`.** Documented in the changelog.

## Bug fix

`_update_running` placed its hint-refresh call after an early `return`, so the Stop/Start hint never updated on a live `container_status` event. Fixed (the early `return` is now a `break`, and the refresh runs after the loop).

## Notes

- Rebased onto latest `main`, which split `screens.py` into a `screens/` subpackage (#1875) mid-flight; resolved the delete/modify conflict by re-applying the `MainScreen` changes to the new `screens/main.py` (using its deferred-import style for the pushed screens).
- Tests use a deterministic `_settle(app)` helper that drains `app.workers` while tolerating the `exclusive=True` `refresh_lists` cancellation (which otherwise makes `wait_for_complete()` raise `WorkerCancelled`) — see the conversation on the issue for the determinism rationale.

## Test plan

- [x] New `MainScreen` tests: hint toggle (stop/start), all 5 no-highlight guards, restart/stop/delete cancel + success + backend-error, start success + error, duplicate cancel + success + error, edit success + not-found + load fallbacks, `_on_edited`, `_update_running` hint refresh, `c`→switch-server, and the `_highlighted_ws` name fallback.
- [x] Full Python suite (CI invocation): `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — **3802 passed, 100% coverage**.
- [x] Rebased onto latest `main`; pre-commit (markdownlint, prettier, ruff, trufflehog) passes.

Closes #1878
