### PR TITLE
fix(tui): detect session expiry, redirect to login, proactive token refresh

### DIFF
--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -252,6 +252,25 @@ class KlangkApp(App):
             self.pop_screen()
         self.push_screen(LoginScreen())
 
+    def session_expired(self) -> None:
+        """Redirect to login when the access token is irrecoverably dead."""
+        if isinstance(self.screen, LoginScreen):
+            return
+
+        async def _expire() -> None:
+            await asyncio.to_thread(self.tui_state.logout)
+            while len(self.screen_stack) > 1:
+                self.pop_screen()
+            self.live_extra = ""
+            self.push_screen(LoginScreen())
+            self.notify(
+                "Session expired — please log in again.",
+                severity="warning",
+                timeout=8,
+            )
+
+        self.run_worker(_expire, exit_on_error=False)
+
     def refresh_workspaces(self) -> None:
         """Refresh the workspace list on the MainScreen (if present)."""
         for screen in reversed(self.screen_stack):

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -180,6 +180,7 @@ class KlangkApp(App):
         super().__init__()
         self.tui_state = state
         self.live_extra = ""
+        self._expiring = False
         self.register_theme(KLANGK_THEME)
         self.theme = "klangk"
 
@@ -253,21 +254,31 @@ class KlangkApp(App):
         self.push_screen(LoginScreen())
 
     def session_expired(self) -> None:
-        """Redirect to login when the access token is irrecoverably dead."""
-        if isinstance(self.screen, LoginScreen):
+        """Redirect to login when the access token is irrecoverably dead.
+
+        Re-entrancy-safe: the status loop, token-refresh loop, and
+        workspace loads can all detect auth failure near-simultaneously.
+        ``_expiring`` is set synchronously before the worker spawns, so
+        only the first call runs the redirect; the rest bail out.
+        """
+        if self._expiring or isinstance(self.screen, LoginScreen):
             return
+        self._expiring = True
 
         async def _expire() -> None:
-            await asyncio.to_thread(self.tui_state.logout)
-            while len(self.screen_stack) > 1:
-                self.pop_screen()
-            self.live_extra = ""
-            self.push_screen(LoginScreen())
-            self.notify(
-                "Session expired — please log in again.",
-                severity="warning",
-                timeout=8,
-            )
+            try:
+                await asyncio.to_thread(self.tui_state.logout)
+                while len(self.screen_stack) > 1:
+                    self.pop_screen()
+                self.live_extra = ""
+                self.push_screen(LoginScreen())
+                self.notify(
+                    "Session expired — please log in again.",
+                    severity="warning",
+                    timeout=8,
+                )
+            finally:
+                self._expiring = False
 
         self.run_worker(_expire, exit_on_error=False)
 

--- a/src/klangk/klangk/cli/tui/screens/__init__.py
+++ b/src/klangk/klangk/cli/tui/screens/__init__.py
@@ -16,7 +16,7 @@ from ._base import (
     WorkspaceListView,
 )
 from .login import LoginScreen
-from .main import MainScreen
+from .main import MainScreen, run_token_refresh_loop
 from .server import AddServerScreen, EditServerScreen, ServerSwitchScreen
 from .workspace_detail import WorkspaceDetailScreen
 from .workspace_form import CreateWorkspaceScreen, EditWorkspaceScreen
@@ -31,6 +31,7 @@ __all__ = [
     "EditWorkspaceScreen",
     "LoginScreen",
     "MainScreen",
+    "run_token_refresh_loop",
     "NonFocusableVerticalScroll",
     "ServerListView",
     "ServerSwitchScreen",

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -624,7 +624,6 @@ class MainScreen(Screen):
                     sel, [], empty_label="(session expired — re-login)"
                 )
             self._refresh_status()
-            self.app.session_expired()
             return
         self._owned_all = owned
         self._shared_all = shared

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+import time
 
 import httpx
 
@@ -29,12 +30,44 @@ from textual.widgets import (
     Tabs,
 )
 
-from ...client import AuthError, WorkspaceNotFoundError
+from ...client import AuthError, WorkspaceNotFoundError, decode_token_claims
+from ...auth import refresh_token as _refresh_token
 from ..widgets import StatusBar
 from ..ws import listen_for_status
 from ._base import ConfirmScreen, WorkspaceListView
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_REFRESH_MARGIN = 600  # refresh 10 minutes before expiry
+_TOKEN_REFRESH_POLL = 60  # check every 60 seconds
+
+
+async def run_token_refresh_loop(state) -> str:
+    """Proactively refresh the access token before it expires.
+
+    Returns ``"expired"`` if the refresh failed (caller should redirect
+    to login), or ``"no_token"`` if credentials disappeared.
+    Runs indefinitely until the token can't be refreshed.
+    """
+    while True:
+        await asyncio.sleep(_TOKEN_REFRESH_POLL)
+        url = state.current_url()
+        token = state.token()
+        if not url or not token:
+            return "no_token"
+        exp = decode_token_claims(token).get("exp")
+        if exp is None:
+            continue
+        remaining = exp - time.time()
+        if remaining > _TOKEN_REFRESH_MARGIN:
+            continue
+        logger.debug("Token expires in %.0fs, refreshing", remaining)
+        new = await asyncio.to_thread(_refresh_token, url, token)
+        if new:
+            logger.debug("Token refreshed proactively")
+        else:
+            logger.warning("Proactive token refresh failed")
+            return "expired"
 
 
 class MainScreen(Screen):
@@ -135,6 +168,7 @@ class MainScreen(Screen):
         self.refresh_lists()
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
+            self.app.run_worker(self._token_refresh_loop, name="token-refresh")
 
     def on_tabbed_content_tab_activated(self, event) -> None:
         """Focus the first workspace row when switching tabs (#1792)."""
@@ -583,6 +617,7 @@ class MainScreen(Screen):
                     sel, [], empty_label="(session expired — re-login)"
                 )
             self._refresh_status()
+            self.app.session_expired()
             return
         self._owned_all = owned
         self._shared_all = shared
@@ -681,14 +716,47 @@ class MainScreen(Screen):
         token = state.token()
         if not url or not token:
             return
-        try:
-            await listen_for_status(url, token, on_event=self._on_status_event)
-        except Exception:
-            # Best-effort: the TUI stays usable if the status stream dies.
-            self.app.live_extra = (
-                "status: disconnected (switch server to reconnect)"
-            )
-            self._refresh_status()
+        retries = 0
+        max_retries = 3
+        while retries <= max_retries:
+            token = state.token()
+            if not token:
+                self.app.session_expired()
+                return
+            try:
+                await listen_for_status(
+                    url, token, on_event=self._on_status_event
+                )
+                retries += 1
+                self.app.live_extra = "status: reconnecting…"
+                self._refresh_status()
+                await asyncio.sleep(2)
+                continue
+            except AuthError:
+                self.app.session_expired()
+                return
+            except Exception as exc:
+                retries += 1
+                if retries > max_retries:
+                    logger.debug(
+                        "Status WS gave up after %d retries: %s",
+                        max_retries,
+                        exc,
+                    )
+                    break
+                self.app.live_extra = "status: reconnecting…"
+                self._refresh_status()
+                await asyncio.sleep(2)
+        self.app.live_extra = (
+            "status: disconnected (switch server to reconnect)"
+        )
+        self._refresh_status()
+
+    async def _token_refresh_loop(self) -> None:
+        """Proactively refresh the access token before it expires."""
+        result = await run_token_refresh_loop(self.app.tui_state)
+        if result == "expired":
+            self.app.session_expired()
 
     def _on_status_event(self, event: dict) -> None:
         etype = event.get("type", "event")

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -66,6 +66,13 @@ async def run_token_refresh_loop(state) -> str:
         if new:
             logger.debug("Token refreshed proactively")
         else:
+            # Refresh failed — but a concurrent refresher (e.g. the CLI's
+            # background thread) may already have rotated the token and got
+            # this one blocklisted. Re-read state: if the token changed,
+            # keep running instead of forcing a logout (#1882 review).
+            if state.token() != token:
+                logger.debug("Token rotated concurrently; not expiring")
+                continue
             logger.warning("Proactive token refresh failed")
             return "expired"
 
@@ -727,6 +734,7 @@ class MainScreen(Screen):
                 await listen_for_status(
                     url, token, on_event=self._on_status_event
                 )
+                # Clean close (server restart, idle timeout) — reconnect.
                 retries += 1
                 self.app.live_extra = "status: reconnecting…"
                 self._refresh_status()
@@ -736,6 +744,7 @@ class MainScreen(Screen):
                 self.app.session_expired()
                 return
             except Exception as exc:
+                # Transient error — back off (exponential) and retry.
                 retries += 1
                 if retries > max_retries:
                     logger.debug(
@@ -746,7 +755,8 @@ class MainScreen(Screen):
                     break
                 self.app.live_extra = "status: reconnecting…"
                 self._refresh_status()
-                await asyncio.sleep(2)
+                await asyncio.sleep(min(2 * (2 ** (retries - 1)), 30))
+                continue
         self.app.live_extra = (
             "status: disconnected (switch server to reconnect)"
         )
@@ -755,7 +765,7 @@ class MainScreen(Screen):
     async def _token_refresh_loop(self) -> None:
         """Proactively refresh the access token before it expires."""
         result = await run_token_refresh_loop(self.app.tui_state)
-        if result == "expired":
+        if result in ("expired", "no_token"):
             self.app.session_expired()
 
     def _on_status_event(self, event: dict) -> None:

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -118,7 +118,6 @@ class WorkspaceDetailScreen(Screen):
             self._ws = None
             self._missing = False
             self._load_error = "Session expired — please log in again."
-            self.app.session_expired()
         except Exception as exc:
             self._ws = None
             self._missing = False

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import subprocess
 import sys
 import time
@@ -25,6 +26,8 @@ from textual.widgets import (
 
 from ...client import AuthError, WorkspaceNotFoundError
 from ._base import ConfirmScreen, DuplicateScreen, SpatialListView
+
+logger = logging.getLogger(__name__)
 
 
 class WorkspaceDetailScreen(Screen):
@@ -115,10 +118,12 @@ class WorkspaceDetailScreen(Screen):
             self._ws = None
             self._missing = False
             self._load_error = "Session expired — please log in again."
-        except Exception:
+            self.app.session_expired()
+        except Exception as exc:
             self._ws = None
             self._missing = False
-            self._load_error = None
+            self._load_error = f"Could not load workspace: {exc}"
+            logger.warning("Workspace load failed: %s", exc)
         self._display()
 
     async def _start_if_stopped(self) -> None:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1728,6 +1728,7 @@ async def test_main_screen_action_hints_toggle_stop_start(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(
         _ws(
             owned=[
@@ -1755,6 +1756,7 @@ async def test_main_screen_action_requires_highlight(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -1783,6 +1785,7 @@ async def test_main_screen_action_stop_cancel(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     stopped = {}
     st = _ws(owned=[_wsobj("alpha", running=True)])
     st.stop_workspace = lambda n: stopped.__setitem__("s", n)
@@ -1802,6 +1805,7 @@ async def test_main_screen_action_delete_cancel(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     deleted = {}
     st = _ws(owned=[_wsobj("alpha")])
     st.delete_workspace = lambda n: deleted.__setitem__("d", n)
@@ -1821,6 +1825,7 @@ async def test_main_screen_action_duplicate_cancel(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     duped = {}
     st = _ws(owned=[_wsobj("alpha")])
     st.duplicate_workspace = lambda n, nn: duped.__setitem__("d", (n, nn))
@@ -1842,6 +1847,7 @@ async def test_main_screen_action_edit_load_fallbacks(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     a = _wsobj("alpha")
     # Generic load error -> flashed, no screen pushed.
     st = _ws(owned=[a])
@@ -1874,6 +1880,7 @@ async def test_main_screen_on_edited_refreshes(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -1895,6 +1902,7 @@ async def test_main_screen_update_running_refreshes_hints(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     a = _wsobj("alpha", running=True)
     app = KlangkApp(_ws(owned=[a]))
     async with app.run_test() as pilot:
@@ -1912,6 +1920,7 @@ async def test_main_screen_highlighted_ws_falls_back_to_name(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     # A workspace with an empty id is never entered into _ws_by_id, so the
     # name fallback path is exercised.
     no_id = Workspace(id="", name="gamma", created_at="x")
@@ -1926,6 +1935,7 @@ async def test_main_screen_action_restart_success_cancel_error(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     a = _wsobj("alpha", running=True)
     restarted = {}
     st = _ws(owned=[a])
@@ -1969,6 +1979,7 @@ async def test_main_screen_action_stop_running_success_error(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     a = _wsobj("alpha", running=True)
     stopped = {}
     st = _ws(owned=[a])
@@ -2002,6 +2013,7 @@ async def test_main_screen_action_start_stopped(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     a = _wsobj("alpha", running=False)
     started = []
     st = _ws(owned=[a])
@@ -2020,6 +2032,7 @@ async def test_main_screen_action_start_error(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     a = _wsobj("alpha", running=False)
     st = _ws(owned=[a])
     st.start_workspace = lambda n: (_ for _ in ()).throw(RuntimeError("boom"))
@@ -2036,6 +2049,7 @@ async def test_main_screen_action_delete_success_error(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     deleted = {}
     st = _ws(owned=[_wsobj("alpha")])
     st.delete_workspace = lambda n: deleted.__setitem__("d", n)
@@ -2068,6 +2082,7 @@ async def test_main_screen_action_duplicate_success_error(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     duped = {}
     st = _ws(owned=[_wsobj("alpha")])
     st.duplicate_workspace = lambda n, nn: duped.__setitem__("d", (n, nn))
@@ -2100,6 +2115,7 @@ async def test_main_screen_action_edit_pushes_screen(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     a = _wsobj("alpha")
     st = _ws(owned=[a])
     st.find_workspace = lambda n: a
@@ -2119,6 +2135,7 @@ async def test_main_screen_action_edit_not_found(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     from klangk.cli.client import WorkspaceNotFoundError
 
     st = _ws(owned=[_wsobj("alpha")])
@@ -2141,6 +2158,7 @@ async def test_main_screen_c_key_switches_server(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -2189,6 +2207,7 @@ async def test_main_screen_action_targets_active_tab(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     restarted = {}
     app = KlangkApp(
         _ws(
@@ -2227,6 +2246,7 @@ async def test_main_screen_hints_refresh_on_tab_switch(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(_ws(owned=[_wsobj("alpha", running=True)], shared=[]))
     async with app.run_test() as pilot:
         await _settle(app)
@@ -7388,3 +7408,143 @@ async def test_run_token_refresh_loop_returns_no_token():
         assert result == "no_token"
     finally:
         scr_main._TOKEN_REFRESH_POLL = original_poll
+
+
+def _fake_jwt(exp=None):
+    """Build a fake JWT with the given ``exp`` claim (or none)."""
+    import base64
+    import json
+
+    payload = {} if exp is None else {"exp": exp}
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+    return f"{header.decode()}.{body.decode()}.sig"
+
+
+async def test_run_token_refresh_loop_skips_when_exp_missing():
+    """A token with no ``exp`` claim is skipped (continue); exits on no-token."""
+    original_poll = scr_main._TOKEN_REFRESH_POLL
+    scr_main._TOKEN_REFRESH_POLL = 0
+    try:
+        tokens = iter([_fake_jwt(exp=None), None])
+
+        class FakeState:
+            def current_url(self):
+                return "https://x.example"
+
+            def token(self):
+                return next(tokens)
+
+        result = await scr_main.run_token_refresh_loop(FakeState())
+        assert result == "no_token"
+    finally:
+        scr_main._TOKEN_REFRESH_POLL = original_poll
+
+
+async def test_run_token_refresh_loop_skips_when_far_from_expiry():
+    """A token not near expiry is skipped (continue); exits on no-token."""
+    import time as _time
+
+    original_poll = scr_main._TOKEN_REFRESH_POLL
+    scr_main._TOKEN_REFRESH_POLL = 0
+    try:
+        tokens = iter([_fake_jwt(exp=int(_time.time()) + 3600), None])
+
+        class FakeState:
+            def current_url(self):
+                return "https://x.example"
+
+            def token(self):
+                return next(tokens)
+
+        result = await scr_main.run_token_refresh_loop(FakeState())
+        assert result == "no_token"
+    finally:
+        scr_main._TOKEN_REFRESH_POLL = original_poll
+
+
+async def test_run_token_refresh_loop_refreshes_near_expiry(monkeypatch):
+    """A near-expiry token is refreshed (success branch); exits on no-token."""
+    import time as _time
+
+    original_poll = scr_main._TOKEN_REFRESH_POLL
+    scr_main._TOKEN_REFRESH_POLL = 0
+    try:
+        tokens = iter([_fake_jwt(exp=int(_time.time()) + 60), None])
+
+        class FakeState:
+            def current_url(self):
+                return "https://x.example"
+
+            def token(self):
+                return next(tokens)
+
+        monkeypatch.setattr(
+            scr_main, "_refresh_token", lambda url, tok: "newtok"
+        )
+        result = await scr_main.run_token_refresh_loop(FakeState())
+        assert result == "no_token"
+    finally:
+        scr_main._TOKEN_REFRESH_POLL = original_poll
+
+
+async def test_status_loop_token_disappears_mid_retry(monkeypatch):
+    """Token vanishing between retries redirects to login (inner no-token)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    calls = {"n": 0}
+
+    def token():
+        calls["n"] += 1
+        return "tok" if calls["n"] == 1 else None
+
+    app = KlangkApp(_authed_state(token=token))
+    expired = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
+    async with app.run_test() as pilot:
+        await app.screen._status_loop()
+        await pilot.pause()
+    assert expired
+
+
+async def test_status_loop_auth_error_expires_session(monkeypatch):
+    """An AuthError from the status WS redirects to login."""
+
+    async def auth_err(*a, **k):
+        raise AuthError("401")
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", auth_err)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_authed_state())
+    expired = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
+    async with app.run_test() as pilot:
+        await app.screen._status_loop()
+        await pilot.pause()
+    assert expired
+
+
+async def test_token_refresh_loop_expires_session(monkeypatch):
+    """_token_refresh_loop redirects to login when refresh fails ('expired')."""
+
+    async def expired(*a, **k):
+        return "expired"
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", expired)
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_authed_state())
+    fired = []
+    monkeypatch.setattr(app, "session_expired", lambda: fired.append(1))
+    async with app.run_test():
+        await app.screen._token_refresh_loop()
+    assert fired

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -166,6 +166,29 @@ async def _async_empty(*a, **k):
     return []
 
 
+# Capture the real refresh loop before any test stubs it, so direct-call
+# coverage tests can still exercise it despite the autouse stub below.
+_real_run_token_refresh_loop = scr_main.run_token_refresh_loop
+
+
+@pytest.fixture(autouse=True)
+def _stub_tui_bg_workers(monkeypatch):
+    """Stub MainScreen's on-mount bg workers for every TUI test.
+
+    #1882's on_mount spawns a status-WS worker and a proactive token-refresh
+    worker (a 60s-sleep loop). The refresh loop never completes during a
+    test, wedging ``wait_for_complete()`` for any test that mounts a
+    MainScreen without stubbing it. Tests that need the real refresh loop
+    call ``_real_run_token_refresh_loop`` directly.
+    """
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", _noop)
+    monkeypatch.setattr(scr_main, "listen_for_status", _noop)
+
+
 # ---------------------------------------------------------------------------
 # config.add_server_to_config
 # ---------------------------------------------------------------------------
@@ -7311,30 +7334,6 @@ async def test_session_expired_noop_on_login_screen(monkeypatch):
         assert isinstance(app.screen, LoginScreen)
 
 
-async def test_workspace_load_auth_error_triggers_session_expired(monkeypatch):
-    """WorkspaceDetailScreen._load() calls session_expired on AuthError."""
-
-    async def noop(*a, **k):
-        return None
-
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
-    st = _ws()
-
-    def _raise_auth(*a, **k):
-        raise AuthError("expired")
-
-    st.find_workspace = _raise_auth
-    expired_calls = []
-    app = KlangkApp(st)
-    async with app.run_test() as pilot:
-        app.session_expired = lambda: expired_calls.append(True)
-        app.push_screen(WorkspaceDetailScreen("ws"))
-        await pilot.pause()
-        await app.workers.wait_for_complete()
-        assert expired_calls == [True]
-
-
 async def test_workspace_load_generic_error_surfaces_message(monkeypatch):
     """WorkspaceDetailScreen._load() shows the error for non-auth failures."""
 
@@ -7387,7 +7386,7 @@ async def test_run_token_refresh_loop_returns_expired_on_failure(monkeypatch):
             return fake_jwt
 
     monkeypatch.setattr(scr_main, "_refresh_token", lambda url, tok: None)
-    result = await scr_main.run_token_refresh_loop(FakeState())
+    result = await _real_run_token_refresh_loop(FakeState())
     assert result == "expired"
 
 
@@ -7402,7 +7401,7 @@ async def test_run_token_refresh_loop_returns_no_token(monkeypatch):
         def token(self):
             return None
 
-    result = await scr_main.run_token_refresh_loop(FakeState())
+    result = await _real_run_token_refresh_loop(FakeState())
     assert result == "no_token"
 
 
@@ -7429,7 +7428,7 @@ async def test_run_token_refresh_loop_skips_when_exp_missing(monkeypatch):
         def token(self):
             return next(tokens)
 
-    result = await scr_main.run_token_refresh_loop(FakeState())
+    result = await _real_run_token_refresh_loop(FakeState())
     assert result == "no_token"
 
 
@@ -7447,7 +7446,7 @@ async def test_run_token_refresh_loop_skips_when_far_from_expiry(monkeypatch):
         def token(self):
             return next(tokens)
 
-    result = await scr_main.run_token_refresh_loop(FakeState())
+    result = await _real_run_token_refresh_loop(FakeState())
     assert result == "no_token"
 
 
@@ -7466,7 +7465,7 @@ async def test_run_token_refresh_loop_refreshes_near_expiry(monkeypatch):
             return next(tokens)
 
     monkeypatch.setattr(scr_main, "_refresh_token", lambda url, tok: "newtok")
-    result = await scr_main.run_token_refresh_loop(FakeState())
+    result = await _real_run_token_refresh_loop(FakeState())
     assert result == "no_token"
 
 
@@ -7571,5 +7570,5 @@ async def test_run_token_refresh_loop_concurrent_rotation(monkeypatch):
             return next(tokens)
 
     monkeypatch.setattr(scr_main, "_refresh_token", lambda url, tok: None)
-    result = await scr_main.run_token_refresh_loop(FakeState())
+    result = await _real_run_token_refresh_loop(FakeState())
     assert result == "no_token"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -7242,3 +7242,149 @@ async def test_detail_terminal_refresh_survives_error(monkeypatch):
         await app.workers.wait_for_complete()
         await pilot.pause()
         assert len(lv.query(ListItem)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Session expiry / token refresh (#1877)
+# ---------------------------------------------------------------------------
+
+
+async def test_session_expired_redirects_to_login(monkeypatch):
+    """KlangkApp.session_expired() pops to login with a notification."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    st = _authed_state()
+    logged_out = []
+    st.logout = lambda: logged_out.append(True)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        assert isinstance(app.screen, MainScreen)
+        app.session_expired()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+        assert logged_out == [True]
+
+
+async def test_session_expired_noop_on_login_screen(monkeypatch):
+    """session_expired() is a no-op when already on the login screen."""
+    st = TuiState()
+    st.current_url = lambda: None
+    st.cfg = lambda: type("C", (), {"servers": {}})()
+    st.state = lambda: type(
+        "S",
+        (),
+        {
+            "active_server": None,
+            "get_token": lambda self, u: None,
+        },
+    )()
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        assert isinstance(app.screen, LoginScreen)
+        app.session_expired()
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+
+
+async def test_workspace_load_auth_error_triggers_session_expired(monkeypatch):
+    """WorkspaceDetailScreen._load() calls session_expired on AuthError."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    st = _ws()
+
+    def _raise_auth(*a, **k):
+        raise AuthError("expired")
+
+    st.find_workspace = _raise_auth
+    expired_calls = []
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.session_expired = lambda: expired_calls.append(True)
+        app.push_screen(WorkspaceDetailScreen("ws"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        assert expired_calls == [True]
+
+
+async def test_workspace_load_generic_error_surfaces_message(monkeypatch):
+    """WorkspaceDetailScreen._load() shows the error for non-auth failures."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    st = _ws()
+
+    def _raise_rt(*a, **k):
+        raise RuntimeError("db connection lost")
+
+    st.find_workspace = _raise_rt
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("ws"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        body = str(app.screen.query_one("#detail_body").render())
+        assert "db connection lost" in body
+
+
+async def test_run_token_refresh_loop_returns_expired_on_failure(monkeypatch):
+    """run_token_refresh_loop returns 'expired' when refresh fails."""
+    import time as _time
+
+    monkeypatch.setattr(scr_main, "_TOKEN_REFRESH_POLL", 0)
+    monkeypatch.setattr(scr_main, "_TOKEN_REFRESH_MARGIN", 99999)
+
+    fake_token_payload = {
+        "sub": "uid",
+        "exp": int(_time.time()) + 60,
+    }
+    import base64
+    import json
+
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(fake_token_payload).encode()
+    ).rstrip(b"=")
+    fake_jwt = f"{header.decode()}.{payload.decode()}.sig"
+
+    class FakeState:
+        def current_url(self):
+            return "https://x.example"
+
+        def token(self):
+            return fake_jwt
+
+    monkeypatch.setattr(scr_main, "_refresh_token", lambda url, tok: None)
+    result = await scr_main.run_token_refresh_loop(FakeState())
+    assert result == "expired"
+
+
+async def test_run_token_refresh_loop_returns_no_token():
+    """run_token_refresh_loop returns 'no_token' when token disappears."""
+    original_poll = scr_main._TOKEN_REFRESH_POLL
+    scr_main._TOKEN_REFRESH_POLL = 0
+    try:
+
+        class FakeState:
+            def current_url(self):
+                return "https://x.example"
+
+            def token(self):
+                return None
+
+        result = await scr_main.run_token_refresh_loop(FakeState())
+        assert result == "no_token"
+    finally:
+        scr_main._TOKEN_REFRESH_POLL = original_poll

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -7391,23 +7391,19 @@ async def test_run_token_refresh_loop_returns_expired_on_failure(monkeypatch):
     assert result == "expired"
 
 
-async def test_run_token_refresh_loop_returns_no_token():
+async def test_run_token_refresh_loop_returns_no_token(monkeypatch):
     """run_token_refresh_loop returns 'no_token' when token disappears."""
-    original_poll = scr_main._TOKEN_REFRESH_POLL
-    scr_main._TOKEN_REFRESH_POLL = 0
-    try:
+    monkeypatch.setattr(scr_main, "_TOKEN_REFRESH_POLL", 0)
 
-        class FakeState:
-            def current_url(self):
-                return "https://x.example"
+    class FakeState:
+        def current_url(self):
+            return "https://x.example"
 
-            def token(self):
-                return None
+        def token(self):
+            return None
 
-        result = await scr_main.run_token_refresh_loop(FakeState())
-        assert result == "no_token"
-    finally:
-        scr_main._TOKEN_REFRESH_POLL = original_poll
+    result = await scr_main.run_token_refresh_loop(FakeState())
+    assert result == "no_token"
 
 
 def _fake_jwt(exp=None):
@@ -7421,71 +7417,57 @@ def _fake_jwt(exp=None):
     return f"{header.decode()}.{body.decode()}.sig"
 
 
-async def test_run_token_refresh_loop_skips_when_exp_missing():
+async def test_run_token_refresh_loop_skips_when_exp_missing(monkeypatch):
     """A token with no ``exp`` claim is skipped (continue); exits on no-token."""
-    original_poll = scr_main._TOKEN_REFRESH_POLL
-    scr_main._TOKEN_REFRESH_POLL = 0
-    try:
-        tokens = iter([_fake_jwt(exp=None), None])
+    monkeypatch.setattr(scr_main, "_TOKEN_REFRESH_POLL", 0)
+    tokens = iter([_fake_jwt(exp=None), None])
 
-        class FakeState:
-            def current_url(self):
-                return "https://x.example"
+    class FakeState:
+        def current_url(self):
+            return "https://x.example"
 
-            def token(self):
-                return next(tokens)
+        def token(self):
+            return next(tokens)
 
-        result = await scr_main.run_token_refresh_loop(FakeState())
-        assert result == "no_token"
-    finally:
-        scr_main._TOKEN_REFRESH_POLL = original_poll
+    result = await scr_main.run_token_refresh_loop(FakeState())
+    assert result == "no_token"
 
 
-async def test_run_token_refresh_loop_skips_when_far_from_expiry():
+async def test_run_token_refresh_loop_skips_when_far_from_expiry(monkeypatch):
     """A token not near expiry is skipped (continue); exits on no-token."""
     import time as _time
 
-    original_poll = scr_main._TOKEN_REFRESH_POLL
-    scr_main._TOKEN_REFRESH_POLL = 0
-    try:
-        tokens = iter([_fake_jwt(exp=int(_time.time()) + 3600), None])
+    monkeypatch.setattr(scr_main, "_TOKEN_REFRESH_POLL", 0)
+    tokens = iter([_fake_jwt(exp=int(_time.time()) + 3600), None])
 
-        class FakeState:
-            def current_url(self):
-                return "https://x.example"
+    class FakeState:
+        def current_url(self):
+            return "https://x.example"
 
-            def token(self):
-                return next(tokens)
+        def token(self):
+            return next(tokens)
 
-        result = await scr_main.run_token_refresh_loop(FakeState())
-        assert result == "no_token"
-    finally:
-        scr_main._TOKEN_REFRESH_POLL = original_poll
+    result = await scr_main.run_token_refresh_loop(FakeState())
+    assert result == "no_token"
 
 
 async def test_run_token_refresh_loop_refreshes_near_expiry(monkeypatch):
     """A near-expiry token is refreshed (success branch); exits on no-token."""
     import time as _time
 
-    original_poll = scr_main._TOKEN_REFRESH_POLL
-    scr_main._TOKEN_REFRESH_POLL = 0
-    try:
-        tokens = iter([_fake_jwt(exp=int(_time.time()) + 60), None])
+    monkeypatch.setattr(scr_main, "_TOKEN_REFRESH_POLL", 0)
+    tokens = iter([_fake_jwt(exp=int(_time.time()) + 60), None])
 
-        class FakeState:
-            def current_url(self):
-                return "https://x.example"
+    class FakeState:
+        def current_url(self):
+            return "https://x.example"
 
-            def token(self):
-                return next(tokens)
+        def token(self):
+            return next(tokens)
 
-        monkeypatch.setattr(
-            scr_main, "_refresh_token", lambda url, tok: "newtok"
-        )
-        result = await scr_main.run_token_refresh_loop(FakeState())
-        assert result == "no_token"
-    finally:
-        scr_main._TOKEN_REFRESH_POLL = original_poll
+    monkeypatch.setattr(scr_main, "_refresh_token", lambda url, tok: "newtok")
+    result = await scr_main.run_token_refresh_loop(FakeState())
+    assert result == "no_token"
 
 
 async def test_status_loop_token_disappears_mid_retry(monkeypatch):
@@ -7548,3 +7530,46 @@ async def test_token_refresh_loop_expires_session(monkeypatch):
     async with app.run_test():
         await app.screen._token_refresh_loop()
     assert fired
+
+
+async def test_session_expired_is_re_entrant_safe(monkeypatch):
+    """Concurrent session_expired() calls fire the redirect exactly once."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    st = _authed_state()
+    st.logout = lambda: None  # avoid real credential I/O
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.session_expired()  # first call: sets _expiring, spawns worker
+        app.session_expired()  # second call: bails on _expiring
+        await pilot.pause()
+        logins = [
+            s for s in app.screen_stack if isinstance(s, scr.LoginScreen)
+        ]
+        assert len(logins) == 1
+
+
+async def test_run_token_refresh_loop_concurrent_rotation(monkeypatch):
+    """If the token was rotated concurrently, don't expire — keep running."""
+    import time as _time
+
+    monkeypatch.setattr(scr_main, "_TOKEN_REFRESH_POLL", 0)
+    near = _fake_jwt(exp=int(_time.time()) + 60)
+    # token() returns: the near-expiry token, then a *different* one (the
+    # mitigation re-reads state and sees the rotation), then None (exit).
+    tokens = iter([near, "rotated-by-other-refresher", None])
+
+    class FakeState:
+        def current_url(self):
+            return "https://x.example"
+
+        def token(self):
+            return next(tokens)
+
+    monkeypatch.setattr(scr_main, "_refresh_token", lambda url, tok: None)
+    result = await scr_main.run_token_refresh_loop(FakeState())
+    assert result == "no_token"


### PR DESCRIPTION
## Summary

- **Better error surfacing:** `WorkspaceDetailScreen._load()` now shows the actual error message instead of generic "Could not load workspace" when non-auth exceptions occur
- **Auto-redirect to login on auth failure:** `AuthError` in workspace load, list refresh, or WS status loop triggers `session_expired()`, which clears credentials, pops all screens back to login, and shows a warning notification
- **WS status loop reconnection:** The status WebSocket reconnects up to 3 times on transient failures, re-reading the (possibly refreshed) token each attempt, and shows "reconnecting…" / "disconnected" in the status bar
- **Proactive token refresh:** A background `run_token_refresh_loop` checks every 60s whether the access token expires within 10 minutes and refreshes it before expiry, preventing silent auth death during idle sessions

## Test plan

- [x] 3790 tests pass
- [x] New tests for `session_expired` redirect, auth error detection, generic error surfacing, and `run_token_refresh_loop` (expired + no_token paths)
- [ ] CI green
- [ ] Manual: login, wait, verify status bar shows "live:", verify token refresh happens before expiry

Closes #1877