### PR TITLE
fix(tui): poll terminal list on workspace detail screen

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -92,6 +92,7 @@ class WorkspaceDetailScreen(Screen):
     def on_mount(self) -> None:
         self.run_worker(self._mount_async, exit_on_error=False)
         self._uptime_timer = self.set_interval(5, self._tick_uptime)
+        self._terminal_poll_timer = self.set_interval(10, self._poll_terminals)
 
     async def _mount_async(self) -> None:
         await self._load()
@@ -302,6 +303,29 @@ class WorkspaceDetailScreen(Screen):
             self.app.pop_screen()
 
     # --- terminals (own) ---
+
+    def _poll_terminals(self) -> None:
+        """Periodically re-fetch the terminal list so changes made in
+        other clients (Flutter, CLI) appear without manual refresh."""
+        if self._ws is None or not self._ws.running:
+            return
+        self.run_worker(
+            self._refresh_terminals, exit_on_error=False, exclusive=True
+        )
+
+    async def _refresh_terminals(self) -> None:
+        """Re-fetch terminals and update only if the list changed."""
+        try:
+            windows = await self.app.tui_state.list_terminals(self._name)
+        except Exception:
+            return  # transient failure — keep the current list
+        windows = windows or []
+        old_keys = [(w.get("index"), w.get("name")) for w in self._terminals]
+        new_keys = [(w.get("index"), w.get("name")) for w in windows]
+        if old_keys == new_keys:
+            return
+        self._terminals = windows
+        self._render_terminals()
 
     async def _load_terminals(self) -> None:
         try:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -7090,3 +7090,127 @@ async def test_main_screen_action_account_opens_screen(monkeypatch):
         app.screen.action_account()
         await pilot.pause()
         assert isinstance(app.screen, AccountScreen)
+
+
+# ---------------------------------------------------------------------------
+# Terminal list polling (#1884)
+# ---------------------------------------------------------------------------
+
+
+async def test_detail_terminal_poll_updates_on_change(monkeypatch):
+    """_poll_terminals refreshes the list when terminals are added
+    externally (e.g. via the Flutter UI)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    added = {"extra": False}
+
+    async def growing_terms(*a, **k):
+        terms = [{"index": 0, "name": "main", "id": "@0"}]
+        if added["extra"]:
+            terms.append({"index": 1, "name": "build", "id": "@1"})
+        return terms
+
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=growing_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        # Initially one terminal.
+        lv = app.screen.query_one("#term_list", ListView)
+        assert len(lv.query(ListItem)) == 1
+        # Simulate a terminal being added externally.
+        added["extra"] = True
+        app.screen._poll_terminals()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # Now two terminals.
+        assert len(lv.query(ListItem)) == 2
+
+
+async def test_detail_terminal_poll_noop_when_unchanged(monkeypatch):
+    """_poll_terminals does not re-render if the list hasn't changed."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        lv = app.screen.query_one("#term_list", ListView)
+        initial_count = len(lv.query(ListItem))
+        # Poll with same data — should not re-render.
+        app.screen._poll_terminals()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(lv.query(ListItem)) == initial_count
+
+
+async def test_detail_terminal_poll_skips_when_not_running(monkeypatch):
+    """_poll_terminals is a no-op when the workspace is not running."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=False)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # _poll_terminals should return early without launching a worker.
+        app.screen._poll_terminals()
+        await pilot.pause()
+
+
+async def test_detail_terminal_refresh_survives_error(monkeypatch):
+    """_refresh_terminals swallows exceptions and keeps the current list."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    calls = {"n": 0}
+
+    async def flaky_terms(*a, **k):
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("connection reset")
+        return [{"index": 0, "name": "main", "id": "@0"}]
+
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=flaky_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        lv = app.screen.query_one("#term_list", ListView)
+        assert len(lv.query(ListItem)) == 1
+        # Second call raises — list should be unchanged.
+        app.screen._poll_terminals()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(lv.query(ListItem)) == 1


### PR DESCRIPTION
## Summary

- Adds a 10-second polling timer on `WorkspaceDetailScreen` that re-fetches the terminal list
- Only re-renders the list when terminals have actually changed (compares index/name tuples)
- Terminals added or removed via Flutter or CLI now appear automatically without navigating away

## Test plan

- [x] 3806 tests pass
- [x] New tests: poll updates list on change, poll is no-op when unchanged
- [ ] CI green
- [ ] Manual: open workspace in TUI, add terminal in Flutter, observe it appears within ~10s

Closes #1884