### PR TITLE
fix: qualify select-window target with session name

### DIFF
--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -690,13 +690,13 @@ class Terminal:
 
         *target* can be a window index (int), window name (str), or
         window id (``@N`` string — preferred, globally unique).
+
+        Always qualifies the target with ``session_name`` so that in a
+        session group the command affects only the caller's grouped
+        session, not whichever session tmux considers "most recent"
+        (#1883).
         """
-        # Window IDs (@N) can be used directly as targets without
-        # a session prefix.
-        if isinstance(target, str) and target.startswith("@"):
-            t = target
-        else:
-            t = f"{session_name}:{target}"
+        t = f"{session_name}:{target}"
         await self.tmux_command(
             container_id,
             session_name,

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -917,13 +917,15 @@ class TestSelectWindow:
         )
 
     async def test_selects_by_window_id(self):
+        """Window IDs are qualified with session name so grouped sessions
+        are addressed independently (#1883)."""
         with patch.object(
             _terminal,
             "tmux_command",
         ) as mock_cmd:
             await _terminal.select_window("cid", "sess", "@5")
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["select-window", "-t", "@5"]
+            "cid", "sess", ["select-window", "-t", "sess:@5"]
         )
 
 


### PR DESCRIPTION
## Summary

Closes #1883. Always qualify the tmux `select-window` target with the grouped session name, even for `@N` window IDs.

## Problem

When both a CLI shell and Flutter are connected to the same workspace, clicking a terminal tab in Flutter changes the CLI's active window instead of Flutter's. This is because `select-window -t @0` (without a session qualifier) lets tmux pick whichever grouped session was most recently active — typically the CLI's.

## Fix

The original code (before `5749ccd3`) always used `{session_name}:{target}`. When `@N` window IDs were introduced, a bypass was added under the assumption that globally-unique IDs don't need qualification. That's true for single sessions, but wrong for session groups where the same `@N` exists in multiple grouped sessions. This restores the original behavior: `select-window -t user123-a1b2c3d4:@0`.

## Test plan

- [x] Updated `test_selects_by_window_id` to assert session-qualified target
- [x] Full suite: 3804 passed, 100% coverage