### PR TITLE
fix(tui): reflect terminal add/remove from other surfaces in realtime

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -994,6 +994,14 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **TUI workspace detail now reflects terminal add/remove from other
+  surfaces in realtime (#1885).** The detail screen's terminal list now
+  updates when terminals are added, closed, or renamed from the Flutter web
+  UI (or any other client), without a navigate-away. The server broadcasts a
+  payload-free `terminals_changed` nudge to the user's `/ws` status
+  connections on those operations; the TUI re-fetches the list on receipt,
+  mirroring the existing `workspaces_changed` pattern.
+
 - **TUI login: no blank row between the server status line and the server
   list (#1865).** Dropped a 1-row bottom margin on the "Server: …"
   status line so the server picker renders directly beneath it.

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -281,6 +281,12 @@ class WorkspaceDetailScreen(Screen):
         if etype == "workspaces_changed":
             self.run_worker(self._reload_on_status, exit_on_error=False)
             return
+        if etype == "terminals_changed":
+            # A terminal was added / removed / renamed from another surface
+            # (e.g. the Flutter UI); re-enumerate this workspace's windows
+            # so the list reflects it without a navigate-away (#1885).
+            self.run_worker(self._load_terminals, exit_on_error=False)
+            return
         if etype == "container_status":
             self._ws.running = bool(event.get("running"))
             if "service_started_at" in event:

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -826,6 +826,21 @@ class TerminalController:
             if conn and conn.user.get("id") == user_id:
                 sock.send_json(msg)
 
+    def _notify_terminals_changed(self) -> None:
+        """Nudge all of this user's status connections to refresh terminals.
+
+        Complements ``notify_user_terminal_windows`` (which pushes the full
+        window list to workspace-WS subscribers for the Flutter UI) by
+        pinging pure status-feed consumers like the TUI detail screen,
+        which re-enumerates on receipt (#1885).
+        """
+        ws_id = self._conn.workspace_id
+        if not ws_id:
+            return
+        self._conn.app.state.sockets.notify_user_terminals_changed(
+            self._conn.user["id"], ws_id
+        )
+
     async def new_window(self, msg: dict) -> None:
         t0 = time.monotonic()
         if not self._conn.container_id or not self._conn._user_home:
@@ -845,6 +860,7 @@ class TerminalController:
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
+            self._notify_terminals_changed()
         except Exception as e:
             send_error(self._conn.sock, f"Failed to create window: {e}")
 
@@ -901,6 +917,7 @@ class TerminalController:
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
+            self._notify_terminals_changed()
         except Exception as e:
             send_error(self._conn.sock, f"Failed to close window: {e}")
 
@@ -927,6 +944,7 @@ class TerminalController:
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
+            self._notify_terminals_changed()
         except Exception as e:
             send_error(self._conn.sock, f"Failed to rename window: {e}")
 

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -775,6 +775,30 @@ class WebSocketState:
         for sock, _ in dead:
             self.connections.pop(sock, None)
 
+    def notify_user_terminals_changed(
+        self, user_id: str, workspace_id: str
+    ) -> None:
+        """Send ``terminals_changed`` to all of a user's connections.
+
+        A payload-free nudge the TUI workspace-detail screen listens for
+        over its ``/ws`` status feed, so it re-fetches the terminal list
+        when terminals are added / removed / renamed from another surface
+        (e.g. the Flutter UI) — mirroring ``notify_user_workspaces_changed``.
+        The TUI re-enumerates rather than trusting a payload, the same way
+        it handles ``workspaces_changed`` (#1885).
+        """
+        message = {"type": "terminals_changed", "workspace_id": workspace_id}
+        dead = []
+        for sock, conn in self.connections.items():
+            if conn.user.get("id") != user_id:
+                continue
+            try:
+                sock.send_json(message)
+            except WS_ERRORS:
+                dead.append((sock, conn))
+        for sock, _ in dead:
+            self.connections.pop(sock, None)
+
     def handle_browser_response(
         self, msg: dict, sender: SafeWebSocket | None = None
     ) -> None:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3537,6 +3537,77 @@ async def test_detail_apply_status_event_reload(monkeypatch):
         assert "running: yes" in str(d.query_one("#detail_body").render())
 
 
+async def test_detail_apply_status_event_terminals_changed(monkeypatch):
+    """#1885: a terminals_changed nudge re-fetches the terminal list."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws()
+    st.find_workspace = lambda n: a
+    st.list_terminals = _async_empty  # initially no terminals
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        lv = d.query_one("#term_list", ListView)
+        assert any(
+            "(no terminals)" in str(it.render()) for it in lv.query(Label)
+        )
+        # Another surface adds a terminal; the nudge arrives over /ws.
+        from unittest.mock import AsyncMock
+
+        st.list_terminals = AsyncMock(
+            return_value=[{"index": 0, "name": "build"}]
+        )
+        d.apply_status_event(
+            {"type": "terminals_changed", "workspace_id": "id-alpha"}
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        lv = d.query_one("#term_list", ListView)
+        assert any("build" in str(it.render()) for it in lv.query(Label))
+
+
+async def test_detail_apply_status_event_terminals_changed_other_ws(
+    monkeypatch,
+):
+    """A terminals_changed nudge for a different workspace is ignored."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws()
+    st.find_workspace = lambda n: a
+    from unittest.mock import AsyncMock
+
+    calls = []
+    st.list_terminals = AsyncMock(
+        side_effect=lambda name: calls.append(name) or []
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        after_mount = len(calls)  # _load_terminals ran once on mount
+        d.apply_status_event(
+            {"type": "terminals_changed", "workspace_id": "other-ws"}
+        )
+        await pilot.pause()
+        # Not for this workspace -> no re-fetch.
+        assert len(calls) == after_mount
+
+
 async def test_detail_apply_status_event_ws_none(monkeypatch):
     async def noop(*a, **k):
         return None

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -4018,6 +4018,54 @@ class TestNotifyUserWorkspacesChanged:
             sockets.connections.pop(sock, None)
 
 
+class TestNotifyUserTerminalsChanged:
+    """notify_user_terminals_changed nudges a user's status connections
+    (e.g. the TUI's /ws feed) to re-fetch terminals (#1885)."""
+
+    def _register(self, sock, user, app_state):
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        app_state.state.sockets.connections[sock] = conn
+        return conn
+
+    def test_sends_to_matching_user_with_workspace_id(self, app_state):
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock_a = _mock_sock()
+        sock_other = _mock_sock()
+        try:
+            self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
+            self._register(
+                sock_other, {"id": "uid-2", "email": "c@x"}, app_state
+            )
+            sockets.notify_user_terminals_changed("uid-1", "ws-9")
+        finally:
+            sockets.connections.pop(sock_a, None)
+            sockets.connections.pop(sock_other, None)
+        sock_a.send_json.assert_called_once_with(
+            {"type": "terminals_changed", "workspace_id": "ws-9"}
+        )
+        sock_other.send_json.assert_not_called()
+
+    def test_no_connections_is_noop(self, app_state):
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sockets.notify_user_terminals_changed("nobody", "ws-9")  # no raise
+
+    def test_dead_socket_is_pruned(self, app_state):
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        from klangk.wshandler import WS_ERRORS
+
+        sock = _mock_sock()
+        sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_user_terminals_changed("uid-1", "ws-9")
+            assert sock not in sockets.connections
+        finally:
+            sockets.connections.pop(sock, None)
+
+
 class TestNotifyContainerStatus:
     """notify_container_status broadcasts to all authenticated connections."""
 
@@ -5109,6 +5157,30 @@ class TestTerminalWindowHandlers:
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "terminal_windows"
         assert len(sent["windows"]) == 2
+
+    async def test_new_window_nudges_status_connections(self):
+        # #1885: creating a window pings the user's /ws status connections
+        # (e.g. the TUI) so they re-fetch terminals. Guarded on workspace_id.
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        conn.workspace_id = "ws-1"
+        sockets = conn.app.state.sockets
+        with (
+            patch.object(
+                _mock_term,
+                "new_window",
+                return_value=[
+                    {"id": "@0", "index": 0, "name": "bash", "active": True}
+                ],
+            ),
+            patch.object(
+                sockets, "notify_user_terminals_changed"
+            ) as mock_nudge,
+        ):
+            await conn.handle_terminal_new_window({})
+        mock_nudge.assert_called_once_with(conn.user["id"], "ws-1")
 
     async def test_new_window_with_name(self):
         sock = _mock_sock()


### PR DESCRIPTION
## Summary

Closes #1885. The TUI workspace detail screen's terminal list now updates live when terminals are added/closed/renamed from the Flutter UI (or any other client) — no navigate-away needed.

## Root cause

The server already broadcasts `{"type": "terminal_windows", …}` to the workspace's **WS subscribers** (that's how Flutter's tabs update), via `TerminalController.notify_user_terminal_windows`. But the TUI's status feed is a generic `/ws` connection in `sockets.connections` that never subscribes to a workspace session — so it never heard about terminal changes. That disjoint audience is the bug.

## Fix

Mirror the existing `notify_user_workspaces_changed` nudge pattern:

- **Server** — `WebSocketState.notify_user_terminals_changed(user_id, workspace_id)` sends a payload-free `{"type": "terminals_changed", "workspace_id": …}` to all of the user's `/ws` status connections. Wired into `new_window` / `close_window` / `rename_window` (guarded on `workspace_id` being set), alongside the existing `notify_user_terminal_windows` (which still pushes the full window list to workspace-WS subscribers for Flutter).
- **TUI** — `WorkspaceDetailScreen.apply_status_event` handles `terminals_changed` by re-running `_load_terminals`; the existing per-workspace guard (`event workspace_id != this screen's ws → skip`) scopes it.

### Why a separate nudge instead of reusing `terminal_windows`

`notify_user_terminal_windows` targets `ws_session.subscribers` — the TUI's `/ws` connection isn't one, so reusing it can't reach the TUI. Routing it at the TUI would also require adding `workspace_id` to the `terminal_windows` payload (otherwise a detail screen open on workspace A couldn't distinguish a change in B). The payload-free `terminals_changed` nudge carries `workspace_id` for scoping and keeps workspace-scoped window lists off the shared `/ws` channel that `klangk monitor` also reads — consistent with `workspaces_changed`.

## Test plan

- [x] `TestNotifyUserTerminalsChanged` (3 tests): matching-user-only, no-connections noop, dead-socket pruning — mirrors `TestNotifyUserWorkspacesChanged`.
- [x] `test_new_window_nudges_status_connections` — handler wiring (spy on `notify_user_terminals_changed`); the `new_window`/`close_window`/`rename_window` success paths exercise the call sites, and the no-`workspace_id` guard is covered by the existing tests (which don't set it).
- [x] TUI: `apply_status_event` with `terminals_changed` re-fetches the list; an event for a different workspace is ignored.
- [x] Full Python suite (CI invocation): `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — **3822 passed, 100% coverage**.
- [x] Rebased onto latest `main`; pre-commit passes.

Closes #1885
