### PR TITLE
feat(tui): inline hint on login server-list header (#1890)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -448,6 +448,13 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI login: the server-list delete key is hinted inline (#1890).**
+  The `d` (delete server) key no longer appears in the bottom Footer — its
+  hint now renders on the server picker header (`[d] delete`), next to the
+  list it acts on. Mirrors the switch-server (#1872) and workspace-detail
+  (#1863) screens, so all three server/workspace lists now group their
+  per-row actions the same way.
+
 - **TUI switch-server: server-scoped keybindings moved inline (#1872).**
   The `e` (edit) and `d` (delete) keys no longer appear in the bottom Footer —
   their hints now render on the servers list header (`[e] edit  [d] delete`),

--- a/src/klangk/klangk/cli/tui/screens/login.py
+++ b/src/klangk/klangk/cli/tui/screens/login.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from rich.text import Text
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.widgets import (
     Button,
@@ -37,8 +38,11 @@ class LoginScreen(SpatialNavScreen):
     password form; ``unreachable`` → diagnostic.
     """
 
+    # Server-scoped keys are hidden from the Footer — their hints render
+    # inline on the server list header instead (#1890), matching the
+    # workspace-detail / switch-server screens.
     BINDINGS = [
-        ("d", "delete_server", "Delete server")
+        Binding("d", "delete_server", "Delete server", show=False),
     ]  # spatial nav via SpatialNavScreen mixin
     SPATIAL_CHAIN = [
         "server_input",
@@ -49,10 +53,30 @@ class LoginScreen(SpatialNavScreen):
     ]
     SPATIAL_UP_EXIT = "server_options"
 
+    DEFAULT_CSS = """
+    LoginScreen #server_header {
+        height: auto;
+        padding: 0;
+        margin: 0;
+    }
+    LoginScreen #server_line {
+        width: 1fr;
+    }
+    LoginScreen #server_hints {
+        width: auto;
+        text-align: right;
+        color: $text-muted;
+    }
+    """
+
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Vertical(
-            Static("", id="server_line"),
+            Horizontal(
+                Static("", id="server_line"),
+                Static("[d] delete", id="server_hints", markup=False),
+                id="server_header",
+            ),
             ServerListView(id="server_options"),
             Input(
                 placeholder=("Server URL or alias (e.g. https://host, prod)"),

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -5639,6 +5639,46 @@ async def test_login_server_line_hugs_list_and_headers_styled(monkeypatch):
         assert notice.styles.color != message.styles.color
 
 
+async def test_login_server_hints_inline_not_in_footer(monkeypatch):
+    """#1890: the server-list delete key is hinted inline on the server
+    header and hidden from the Footer (matching the workspace-detail and
+    switch-server screens)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    st = _st(
+        current_url=lambda: "http://localhost:8997",
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "http://localhost:8997"),
+        ],
+        default_uds=lambda: None,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        login = app.screen
+
+        # (a) The delete hint renders on the server header, with the [d]
+        # keycap intact (not eaten as Rich markup).
+        hints = str(login.query_one("#server_hints").render())
+        assert "[d]" in hints
+        assert "delete" in hints
+
+        bindings = {b.key: b for b in login.BINDINGS}
+
+        # (b) The server key still exists (so it works) but is hidden
+        # from the Footer.
+        assert bindings["d"].show is False
+
+
 async def test_login_server_list_empty_no_crash(monkeypatch):
     """#1826: no servers → no crash, focus degrades gracefully."""
 


### PR DESCRIPTION
## Summary

Closes #1890. Moves the login screen's server-list `Delete server` (`d`) action out of the screen-wide Footer and into an inline hint on the server picker header, so the action's hint sits next to the row it acts on. This matches the inline-hint pattern already shipped for the switch-server screen (#1872) and the workspace-detail terminal list (#1863) — all three server/workspace lists now group their per-row actions the same way.

## Changes

- **`src/klangk/klangk/cli/tui/screens/login.py`**
  - `BINDINGS`: `("d", "delete_server", "Delete server")` → `Binding("d", "delete_server", "Delete server", show=False)` (hidden from Footer).
  - `compose()`: the existing `#server_line` status Static is wrapped in a `#server_header` `Horizontal` alongside a new `#server_hints` `Static` rendering `[d] delete`.
  - `DEFAULT_CSS`: `#server_header` has zero padding/margin so the #1865 "list hugs the status line" geometry is preserved; `#server_line` flexes (`width: 1fr`), `#server_hints` is right-aligned and muted.
  - All `query_one("#server_line", Static).update(...)` call sites are unchanged — the id is preserved, just nested inside the header.
- **`src/klangk/klangkc-tests/tests/test_tui.py`** — new `test_login_server_hints_inline_not_in_footer` mirrors the switch-server / workspace-detail coverage: asserts the `[d]` keycap renders inline (not eaten as Rich markup) and that the binding is hidden from the Footer.
- **`docs/changes.md`** — `### Changed` entry under `[Unreleased]`.

## What's intentionally preserved

- The `#server_line` status text ("Server: <url>" / "No server selected…") still drives the header's left side — no redundant "Servers" label was added.
- Spatial nav (`SPATIAL_CHAIN`, `SPATIAL_UP_EXIT="server_options"`, `ServerListView.SPATIAL_DOWN_TARGET="#server_input"`) is untouched; the header is non-focusable so it doesn't enter the focus cycle.
- The `d` key still deletes the highlighted server via the existing `action_delete_server`.

## Test plan

- [x] New test `test_login_server_hints_inline_not_in_footer`.
- [x] Existing `test_login_server_line_hugs_list_and_headers_styled` (#1865 geometry) still passes — the header's zero padding/margin keeps `opts.region.y == line.region.y + line.region.height`.
- [x] Full Python suite: **3817 passed, 100% coverage** on `klangk` (`-n auto`).
- [x] pre-commit clean (ruff, markdownlint, prettier, trufflehog, …).
