### PR TITLE
Instrument token/session events to diagnose spurious logouts (#1877)

### DIFF
--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -376,6 +376,12 @@ async def refresh_token(request: Request):
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Not authenticated")
     token = authorization[7:]
+    logger.info(
+        "REFRESH CALL ua=%s origin=%s referer=%s",
+        request.headers.get("user-agent", "?"),
+        request.headers.get("origin", "?"),
+        request.headers.get("referer", "?"),
+    )
     return await request.app.state.auth.refresh_token(token)
 
 
@@ -523,8 +529,26 @@ async def logout(
     # the ``terminal`` permission). Stopping on logout was a holdover from
     # the per-user-container era and destroyed service sessions that should
     # outlive any single user's login.
-    # Blocklist the token so it can't be reused after logout
+    # --- instrumentation: identify who is calling logout (#1877 follow-up) ---
     authorization = request.headers.get("authorization", "")
+    _h = request.headers
+    _ip = (
+        _h.get("x-forwarded-for")
+        or _h.get("x-real-ip")
+        or getattr(request.client, "host", "?")
+    )
+    logger.info(
+        "LOGOUT CALL x_forwarded_for=%r ip=%s ua=%s origin=%s referer=%s "
+        "scope_client=%s scope_server=%s",
+        _h.get("x-forwarded-for"),
+        _ip,
+        _h.get("user-agent", "?"),
+        _h.get("origin", "?"),
+        _h.get("referer", "?"),
+        request.scope.get("client"),
+        request.scope.get("server"),
+    )
+    # Blocklist the token so it can't be reused after logout
     if authorization.startswith("Bearer "):
         await request.app.state.auth.logout(authorization[7:])
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -532,6 +532,10 @@ class Auth:
             expires_at = datetime.fromtimestamp(
                 exp, tz=timezone.utc
             ).isoformat()
+            logger.info(
+                "REFRESH: blocklisting old access token; any WS still using "
+                "it will be rejected as 4001 on its next connect"
+            )
             await self.app.state.model.tokens.blocklist_token(
                 jti, expires_at, new_token=new_token
             )
@@ -566,9 +570,16 @@ class Auth:
             if user_id is None or jti is None:
                 return None
             if await self.app.state.model.tokens.is_token_blocklisted(jti):
+                logger.info(
+                    "token reject: BLOCKLISTED (revoked by a refresh or "
+                    "logout -> WS will close 4001 -> client logout)"
+                )
                 return None
             return await self.app.state.model.users.get_user_by_id(user_id)
         except ExpiredSignatureError:
+            logger.info(
+                "token reject: EXPIRED -> WS will close 4002 -> client logout"
+            )
             return self.TOKEN_EXPIRED
         except JWTError:
             return None

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -6,6 +6,8 @@ import base64
 import html
 import http.server
 import json
+import logging
+import os
 import socket
 import threading
 import webbrowser
@@ -341,8 +343,44 @@ def refresh_token(server_url: str, token: str) -> str | None:
         return None
 
 
+def _log_logout_caller() -> None:  # pragma: no cover
+    """Diagnostic: log the parent-process chain that invoked logout.
+
+    Walks /proc upward so the next spurious logout reveals its spawner
+    (shell, script, cron, the TUI, ...). Best-effort; never raises.
+    """
+    chain: list[str] = []
+    cur = os.getppid()
+    for _ in range(8):
+        try:
+            cmd = (
+                open(f"/proc/{cur}/cmdline", "rb")
+                .read()
+                .replace(b"\0", b" ")
+                .decode("utf-8", "replace")
+                .strip()
+            )
+        except OSError:
+            break
+        chain.append(f"{cur}=[{cmd}]")
+        try:
+            ppid = int(
+                open(f"/proc/{cur}/stat", "rb").read().decode().split()[3]
+            )
+        except (OSError, ValueError):
+            break
+        if ppid <= 1 or ppid == cur:
+            break
+        cur = ppid
+    msg = "auth.logout() invoked; process chain: " + (
+        " <- ".join(chain) or "(unknown)"
+    )
+    logging.getLogger(__name__).warning(msg)
+
+
 def logout(server_url: str) -> None:
     """Clear stored credentials for a server."""
+    _log_logout_caller()
     state = CLIState.load()
     token = state.get_token(server_url)
 

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -998,6 +998,17 @@ class TerminalSession:
                 data = await self._shell.read()
                 if not data:
                     logger.info("Terminal read loop: EOF from PTY")
+                    _p = getattr(self._shell, "_proc", None)
+                    if _p is not None:  # pragma: no cover
+                        try:
+                            _rc = await asyncio.wait_for(_p.wait(), timeout=2)
+                            logger.info(
+                                "Terminal exec exited rc=%s "
+                                "(nonzero = tmux/podman error; 0 = clean detach)",
+                                _rc,
+                            )
+                        except Exception:
+                            pass
                     break
                 text = decoder.decode(data)
                 if text:

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -587,6 +587,11 @@ class TerminalController:
         await self.stop()
         cols = msg.get("cols", self.cols)
         rows = msg.get("rows", self.rows)
+        logger.info(
+            "terminal_start: cols=%s rows=%s (0 may make tmux/podman attach fail)",
+            cols,
+            rows,
+        )
         self.cols = cols
         self.rows = rows
 


### PR DESCRIPTION
## Summary

Adds operational logging across the server and CLI to diagnose spurious session expiry / premature logouts (context: #1877 investigation — logouts and refreshes were happening with no server-side visibility into *who* called them or *how* the request arrived). **No JWT token values or decoded claims (jti, email, exp) are logged** — only request metadata and process context.

## What it logs

- **`/auth/refresh` and `/auth/logout`** (`api/auth.py`) — caller `User-Agent`, IP (`X-Forwarded-For` → `X-Real-IP` → `request.client`), `Origin`, `Referer`, and the ASGI `scope` (`client`/`server`). The scope distinguishes ingress: the backend is UDS-only, so a request with `X-Forwarded-For` came via Caddy:8997; without it, direct on the UDS.
- **`auth.refresh_token`** — when an access token is blocklisted (any WS still using it will be rejected `4001` on its next connect).
- **`auth.get_user_from_token`** — WS-connect rejection reason: `BLOCKLISTED` vs `EXPIRED`.
- **`terminal_start`** — requested `cols`/`rows`; **`_read_loop`** — the podman exec returncode on PTY EOF (nonzero = tmux/podman error, 0 = clean detach).
- **`cli/auth.logout`** — a best-effort parent-process-chain log (`/proc` walk) so a spurious `klangk logout` reveals its spawner (shell / script / cron / the TUI / …).

## Notes

- Diagnostic instrumentation; safe to trim once the root cause is found.
- The raw JWT is never logged, and decoded token claims (jti, email, exp) are intentionally omitted per request — the diagnostic value is in the event + caller + ingress path, not the token contents.
