### PR TITLE
TUI: push terminal windows to the detail screen (no per-poll podman exec)

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -95,7 +95,6 @@ class WorkspaceDetailScreen(Screen):
     def on_mount(self) -> None:
         self.run_worker(self._mount_async, exit_on_error=False)
         self._uptime_timer = self.set_interval(5, self._tick_uptime)
-        self._terminal_poll_timer = self.set_interval(10, self._poll_terminals)
 
     async def _mount_async(self) -> None:
         await self._load()
@@ -286,10 +285,17 @@ class WorkspaceDetailScreen(Screen):
             self.run_worker(self._reload_on_status, exit_on_error=False)
             return
         if etype == "terminals_changed":
-            # A terminal was added / removed / renamed from another surface
-            # (e.g. the Flutter UI); re-enumerate this workspace's windows
-            # so the list reflects it without a navigate-away (#1885).
-            self.run_worker(self._load_terminals, exit_on_error=False)
+            # A terminal was added / removed / renamed from another surface.
+            # The event carries the window list (like the Flutter UI's
+            # terminal_windows push), so update directly instead of
+            # re-enumerating via a terminal_start round-trip (#1894).
+            windows = event.get("windows")
+            if windows is not None:
+                self._terminals = windows
+                self._render_terminals()
+            else:
+                # Older server without the payload -- fall back to a fetch.
+                self.run_worker(self._load_terminals, exit_on_error=False)
             return
         if etype == "container_status":
             self._ws.running = bool(event.get("running"))
@@ -313,29 +319,6 @@ class WorkspaceDetailScreen(Screen):
             self.app.pop_screen()
 
     # --- terminals (own) ---
-
-    def _poll_terminals(self) -> None:
-        """Periodically re-fetch the terminal list so changes made in
-        other clients (Flutter, CLI) appear without manual refresh."""
-        if self._ws is None or not self._ws.running:
-            return
-        self.run_worker(
-            self._refresh_terminals, exit_on_error=False, exclusive=True
-        )
-
-    async def _refresh_terminals(self) -> None:
-        """Re-fetch terminals and update only if the list changed."""
-        try:
-            windows = await self.app.tui_state.list_terminals(self._name)
-        except Exception:
-            return  # transient failure — keep the current list
-        windows = windows or []
-        old_keys = [(w.get("index"), w.get("name")) for w in self._terminals]
-        new_keys = [(w.get("index"), w.get("name")) for w in windows]
-        if old_keys == new_keys:
-            return
-        self._terminals = windows
-        self._render_terminals()
 
     async def _load_terminals(self) -> None:
         try:

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -290,11 +290,17 @@ class WorkspaceDetailScreen(Screen):
             # terminal_windows push), so update directly instead of
             # re-enumerating via a terminal_start round-trip (#1894).
             windows = event.get("windows")
-            if windows is not None:
+            if isinstance(windows, list):
+                # Adopt the pushed list verbatim. Events are serialized
+                # per status-WS connection, so out-of-order arrival (a
+                # close broadcast beating its create) is not expected;
+                # the payload type check above also makes the push path
+                # resilient to a malformed payload (fall back to fetch).
                 self._terminals = windows
                 self._render_terminals()
             else:
-                # Older server without the payload -- fall back to a fetch.
+                # No payload (older server) or malformed -- fall back to a
+                # fetch, preserving the resilience of the old poll path.
                 self.run_worker(self._load_terminals, exit_on_error=False)
             return
         if etype == "container_status":

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -826,19 +826,21 @@ class TerminalController:
             if conn and conn.user.get("id") == user_id:
                 sock.send_json(msg)
 
-    def _notify_terminals_changed(self) -> None:
+    def _notify_terminals_changed(
+        self, windows: list[dict] | None = None
+    ) -> None:
         """Nudge all of this user's status connections to refresh terminals.
 
-        Complements ``notify_user_terminal_windows`` (which pushes the full
-        window list to workspace-WS subscribers for the Flutter UI) by
-        pinging pure status-feed consumers like the TUI detail screen,
-        which re-enumerates on receipt (#1885).
+        Carries ``windows`` so push-fed consumers (e.g. the TUI detail screen)
+        can update without re-enumerating -- complementing
+        ``notify_user_terminal_windows`` (which pushes the full list to
+        workspace-WS subscribers for the Flutter UI) (#1894).
         """
         ws_id = self._conn.workspace_id
         if not ws_id:
             return
         self._conn.app.state.sockets.notify_user_terminals_changed(
-            self._conn.user["id"], ws_id
+            self._conn.user["id"], ws_id, windows
         )
 
     async def new_window(self, msg: dict) -> None:
@@ -860,7 +862,7 @@ class TerminalController:
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
-            self._notify_terminals_changed()
+            self._notify_terminals_changed(windows)
         except Exception as e:
             send_error(self._conn.sock, f"Failed to create window: {e}")
 
@@ -917,7 +919,7 @@ class TerminalController:
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
-            self._notify_terminals_changed()
+            self._notify_terminals_changed(windows)
         except Exception as e:
             send_error(self._conn.sock, f"Failed to close window: {e}")
 
@@ -944,7 +946,7 @@ class TerminalController:
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
-            self._notify_terminals_changed()
+            self._notify_terminals_changed(windows)
         except Exception as e:
             send_error(self._conn.sock, f"Failed to rename window: {e}")
 

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -776,18 +776,24 @@ class WebSocketState:
             self.connections.pop(sock, None)
 
     def notify_user_terminals_changed(
-        self, user_id: str, workspace_id: str
+        self,
+        user_id: str,
+        workspace_id: str,
+        windows: list[dict] | None = None,
     ) -> None:
         """Send ``terminals_changed`` to all of a user's connections.
 
-        A payload-free nudge the TUI workspace-detail screen listens for
-        over its ``/ws`` status feed, so it re-fetches the terminal list
-        when terminals are added / removed / renamed from another surface
-        (e.g. the Flutter UI) — mirroring ``notify_user_workspaces_changed``.
-        The TUI re-enumerates rather than trusting a payload, the same way
-        it handles ``workspaces_changed`` (#1885).
+        Carries the current ``windows`` list so push-fed consumers (e.g. the
+        TUI workspace-detail screen) can update directly, the way the Flutter
+        UI receives ``terminal_windows`` over its workspace WS -- avoiding a
+        ``terminal_start`` re-enumeration round-trip per change (#1894).
+        ``windows`` is optional for backward compatibility with older callers.
         """
-        message = {"type": "terminals_changed", "workspace_id": workspace_id}
+        message = {
+            "type": "terminals_changed",
+            "workspace_id": workspace_id,
+            "windows": windows,
+        }
         dead = []
         for sock, conn in self.connections.items():
             if conn.user.get("id") != user_id:

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -787,13 +787,13 @@ class WebSocketState:
         TUI workspace-detail screen) can update directly, the way the Flutter
         UI receives ``terminal_windows`` over its workspace WS -- avoiding a
         ``terminal_start`` re-enumeration round-trip per change (#1894).
-        ``windows`` is optional for backward compatibility with older callers.
+        ``windows`` is optional for backward compatibility with older callers;
+        the key is omitted entirely when it is ``None`` so legacy consumers
+        that test ``"windows" in event`` are not misled.
         """
-        message = {
-            "type": "terminals_changed",
-            "workspace_id": workspace_id,
-            "windows": windows,
-        }
+        message = {"type": "terminals_changed", "workspace_id": workspace_id}
+        if windows is not None:
+            message["windows"] = windows
         dead = []
         for sock, conn in self.connections.items():
             if conn.user.get("id") != user_id:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -7275,19 +7275,55 @@ async def test_main_screen_action_account_opens_screen(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Terminal list polling (#1884)
+# Terminal list push (#1894)
 # ---------------------------------------------------------------------------
 
 
-async def test_detail_terminal_poll_updates_on_change(monkeypatch):
-    """_poll_terminals refreshes the list when terminals are added
-    externally (e.g. via the Flutter UI)."""
+async def test_detail_terminal_push_updates_list(monkeypatch):
+    """terminals_changed carrying the window list updates the detail
+    screen directly, with no terminal_start re-enumeration (#1894)."""
 
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
 
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        # Server pushes a new window list (e.g. a terminal was added in
+        # the Flutter UI). The detail screen adopts it verbatim, no fetch.
+        app.screen.apply_status_event(
+            {
+                "type": "terminals_changed",
+                "windows": [
+                    {"index": 0, "name": "main", "id": "@0"},
+                    {"index": 1, "name": "build", "id": "@1"},
+                    {"index": 2, "name": "logs", "id": "@2"},
+                ],
+            }
+        )
+        await pilot.pause()
+        lv = app.screen.query_one("#term_list", ListView)
+        assert len(lv.query(ListItem)) == 3
+
+
+async def test_detail_terminal_push_falls_back_when_no_windows(monkeypatch):
+    """terminals_changed without a payload falls back to a fetch
+    (backward compat with older servers) (#1894)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    a = _wsobj("alpha", running=True)
     added = {"extra": False}
 
     async def growing_terms(*a, **k):
@@ -7296,7 +7332,6 @@ async def test_detail_terminal_poll_updates_on_change(monkeypatch):
             terms.append({"index": 1, "name": "build", "id": "@1"})
         return terms
 
-    a = _wsobj("alpha", running=True)
     st = _ws(list_terminals=growing_terms)
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
@@ -7305,97 +7340,14 @@ async def test_detail_terminal_poll_updates_on_change(monkeypatch):
         await pilot.pause()
         await app.screen._load_terminals()
         await pilot.pause()
-        # Initially one terminal.
         lv = app.screen.query_one("#term_list", ListView)
         assert len(lv.query(ListItem)) == 1
-        # Simulate a terminal being added externally.
+        # Older server: no windows payload -> re-fetch.
         added["extra"] = True
-        app.screen._poll_terminals()
+        app.screen.apply_status_event({"type": "terminals_changed"})
         await app.workers.wait_for_complete()
         await pilot.pause()
-        # Now two terminals.
         assert len(lv.query(ListItem)) == 2
-
-
-async def test_detail_terminal_poll_noop_when_unchanged(monkeypatch):
-    """_poll_terminals does not re-render if the list hasn't changed."""
-
-    async def noop(*a, **k):
-        return None
-
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-
-    a = _wsobj("alpha", running=True)
-    st = _ws(list_terminals=_async_terms)
-    st.find_workspace = lambda n: a
-    app = KlangkApp(st)
-    async with app.run_test() as pilot:
-        app.push_screen(WorkspaceDetailScreen("alpha"))
-        await pilot.pause()
-        await app.screen._load_terminals()
-        await pilot.pause()
-        lv = app.screen.query_one("#term_list", ListView)
-        initial_count = len(lv.query(ListItem))
-        # Poll with same data — should not re-render.
-        app.screen._poll_terminals()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-        assert len(lv.query(ListItem)) == initial_count
-
-
-async def test_detail_terminal_poll_skips_when_not_running(monkeypatch):
-    """_poll_terminals is a no-op when the workspace is not running."""
-
-    async def noop(*a, **k):
-        return None
-
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    a = _wsobj("alpha", running=False)
-    st = _ws(list_terminals=_async_terms)
-    st.find_workspace = lambda n: a
-    app = KlangkApp(st)
-    async with app.run_test() as pilot:
-        app.push_screen(WorkspaceDetailScreen("alpha"))
-        await pilot.pause()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-        # _poll_terminals should return early without launching a worker.
-        app.screen._poll_terminals()
-        await pilot.pause()
-
-
-async def test_detail_terminal_refresh_survives_error(monkeypatch):
-    """_refresh_terminals swallows exceptions and keeps the current list."""
-
-    async def noop(*a, **k):
-        return None
-
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-
-    calls = {"n": 0}
-
-    async def flaky_terms(*a, **k):
-        calls["n"] += 1
-        if calls["n"] > 1:
-            raise RuntimeError("connection reset")
-        return [{"index": 0, "name": "main", "id": "@0"}]
-
-    a = _wsobj("alpha", running=True)
-    st = _ws(list_terminals=flaky_terms)
-    st.find_workspace = lambda n: a
-    app = KlangkApp(st)
-    async with app.run_test() as pilot:
-        app.push_screen(WorkspaceDetailScreen("alpha"))
-        await pilot.pause()
-        await app.screen._load_terminals()
-        await pilot.pause()
-        lv = app.screen.query_one("#term_list", ListView)
-        assert len(lv.query(ListItem)) == 1
-        # Second call raises — list should be unchanged.
-        app.screen._poll_terminals()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-        assert len(lv.query(ListItem)) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3581,7 +3581,9 @@ async def test_detail_apply_status_event_reload(monkeypatch):
 
 
 async def test_detail_apply_status_event_terminals_changed(monkeypatch):
-    """#1885: a terminals_changed nudge re-fetches the terminal list."""
+    """terminals_changed without a windows payload (older server) falls
+    back to a fetch — #1885's re-fetch behavior, now the backward-compat
+    path under #1894's push."""
 
     async def noop(*a, **k):
         return None
@@ -3649,6 +3651,97 @@ async def test_detail_apply_status_event_terminals_changed_other_ws(
         await pilot.pause()
         # Not for this workspace -> no re-fetch.
         assert len(calls) == after_mount
+
+
+async def test_detail_apply_status_event_terminals_changed_other_ws_with_windows(
+    monkeypatch,
+):
+    """A terminals_changed push for a different workspace is ignored even
+    when it carries a windows payload — the ws filter gates the push path
+    too, not just the fallback (#1896)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws()
+    st.find_workspace = lambda n: a
+
+    calls = []
+
+    async def terms(name):
+        calls.append(name)
+        return [{"index": 0, "name": "main", "id": "@0"}]
+
+    st.list_terminals = terms
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        after_mount = len(calls)  # _load_terminals ran once on mount
+        # Push carries a windows payload but for a different workspace.
+        d.apply_status_event(
+            {
+                "type": "terminals_changed",
+                "workspace_id": "other-ws",
+                "windows": [{"index": 9, "name": "impostor", "id": "@9"}],
+            }
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # Rejected at the ws filter -> no extra fetch, no impostor row.
+        assert len(calls) == after_mount
+        lv = d.query_one("#term_list", ListView)
+        assert not any(
+            "impostor" in str(it.render()) for it in lv.query(Label)
+        )
+
+
+async def test_detail_terminal_push_falls_back_on_malformed_windows(
+    monkeypatch,
+):
+    """A non-list windows payload falls back to a fetch instead of crashing
+    — the push path validates the payload (#1896, restoring the resilience
+    the old poll path had)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+
+    calls = []
+
+    async def fetch_terms(name):
+        calls.append(name)
+        return [{"index": 0, "name": "fetched", "id": "@0"}]
+
+    st = _ws(list_terminals=fetch_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        after_mount = len(calls)
+        # Malformed payload (not a list) -> isinstance check fails -> fetch.
+        app.screen.apply_status_event(
+            {
+                "type": "terminals_changed",
+                "workspace_id": "id-alpha",
+                "windows": "not-a-list",
+            }
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(calls) == after_mount + 1  # fell back to a fetch
+        lv = app.screen.query_one("#term_list", ListView)
+        assert any("fetched" in str(it.render()) for it in lv.query(Label))
 
 
 async def test_detail_apply_status_event_ws_none(monkeypatch):

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -4042,13 +4042,30 @@ class TestNotifyUserTerminalsChanged:
             sockets.connections.pop(sock_a, None)
             sockets.connections.pop(sock_other, None)
         sock_a.send_json.assert_called_once_with(
+            {"type": "terminals_changed", "workspace_id": "ws-9"}
+        )
+        sock_other.send_json.assert_not_called()
+
+    def test_includes_windows_when_provided(self, app_state):
+        # A windows payload is included verbatim (push path); the key is
+        # omitted entirely when None (above) so legacy consumers that test
+        # `"windows" in event` aren't misled (#1896).
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock = _mock_sock()
+        payload = [{"id": "@0", "index": 0, "name": "bash"}]
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_user_terminals_changed("uid-1", "ws-9", payload)
+        finally:
+            sockets.connections.pop(sock, None)
+        sock.send_json.assert_called_once_with(
             {
                 "type": "terminals_changed",
                 "workspace_id": "ws-9",
-                "windows": None,
+                "windows": payload,
             }
         )
-        sock_other.send_json.assert_not_called()
 
     def test_no_connections_is_noop(self, app_state):
         app_state = _make_app_state()

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -4042,7 +4042,11 @@ class TestNotifyUserTerminalsChanged:
             sockets.connections.pop(sock_a, None)
             sockets.connections.pop(sock_other, None)
         sock_a.send_json.assert_called_once_with(
-            {"type": "terminals_changed", "workspace_id": "ws-9"}
+            {
+                "type": "terminals_changed",
+                "workspace_id": "ws-9",
+                "windows": None,
+            }
         )
         sock_other.send_json.assert_not_called()
 
@@ -5159,8 +5163,8 @@ class TestTerminalWindowHandlers:
         assert len(sent["windows"]) == 2
 
     async def test_new_window_nudges_status_connections(self):
-        # #1885: creating a window pings the user's /ws status connections
-        # (e.g. the TUI) so they re-fetch terminals. Guarded on workspace_id.
+        # #1885/#1894: creating a window pushes the window list to the
+        # user's /ws status connections (e.g. the TUI). Guarded on workspace_id.
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
@@ -5180,7 +5184,11 @@ class TestTerminalWindowHandlers:
             ) as mock_nudge,
         ):
             await conn.handle_terminal_new_window({})
-        mock_nudge.assert_called_once_with(conn.user["id"], "ws-1")
+        mock_nudge.assert_called_once_with(
+            conn.user["id"],
+            "ws-1",
+            [{"id": "@0", "index": 0, "name": "bash", "active": True}],
+        )
 
     async def test_new_window_with_name(self):
         sock = _mock_sock()


### PR DESCRIPTION
## Summary

Closes #1894. The TUI workspace-detail screen refreshed its terminal-windows list every 10s by driving a **full workspace-WS lifecycle** — connect, `terminal_start` (spawn a tmux session via `podman exec`), recv windows, `terminal_stop` (kill the tmux session), close — just to enumerate. That ran a container exec + tmux create/kill per poll per viewer and produced a constant stream of server-log noise.

Switch to **push-based** updates, the way the Flutter UI already receives `terminal_windows` — no per-poll `podman exec`.

## Changes

- **`wshandler/session.py`** — `notify_user_terminals_changed` now carries the window list in the `terminals_changed` broadcast (`windows` kwarg, optional for backward compat with older callers).
- **`wshandler/controllers.py`** — `_notify_terminals_changed(windows)` passes the windows it just computed at each `new_window` / `close_window` / `rename_window`.
- **`cli/tui/screens/workspace_detail.py`** — on `terminals_changed`, adopt the pushed `windows` list directly instead of re-enumerating via a `terminal_start` round-trip; fall back to a fetch if an older server sends no payload. The 10s `_terminal_poll_timer` is removed (along with `_poll_terminals` / `_refresh_terminals`).

## Result

Enumeration of changes is now **exec-free** — the list arrives via the existing status-WS push. One fetch remains on mount for the initial list. Tests updated: the four poll tests are replaced by two push tests; the two server-side `notify_user_terminals_changed` assertions updated for the new `windows` arg.

```
3833 passed, 100% coverage
```
