### PR TITLE
feat(tui): tabbed workspace create/edit forms

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1011,6 +1011,15 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **TUI workspace form: Add/Remove buttons in the mounts / environment /
+  netfilter editors are now clickable (#1891).** The editor `Input`'s greedy
+  default width consumed the whole row, pushing the Add/Remove buttons past
+  the editor row's clip region (and, under the new tabbed layout, past the
+  tab pane's narrower clip) — so a mouse click on Add silently missed and
+  the entry was never added; typing a mount/env/domain and clicking Add then
+  Create/Save persisted nothing (Enter still worked). The Input is now
+  fractional width, leaving room for the buttons on every tab.
+
 - **TUI workspace detail now reflects terminal add/remove from other
   surfaces in realtime (#1885).** The detail screen's terminal list now
   updates when terminals are added, closed, or renamed from the Flutter web

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -448,6 +448,15 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI: tabbed workspace edit form (#1891).** The workspace edit screen
+  now groups its fields under five tabs — General (name / image /
+  auto-start), Mounts, Environment, Netfilter (allowed domains), and
+  Advanced (service command / health check) — instead of one long scroll.
+  Save / Cancel, the status line, and the restart-needed prompt stay
+  pinned outside the tab content so they remain visible on every tab.
+  Left/Right switch tabs, Up/Down move between the tab strip and a pane's
+  fields, and Delete / `e` act on whichever list is under the active tab.
+
 - **TUI login: the server-list delete key is hinted inline (#1890).**
   The `d` (delete server) key no longer appears in the bottom Footer — its
   hint now renders on the server picker header (`[d] delete`), next to the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -448,14 +448,15 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
-- **TUI: tabbed workspace edit form (#1891).** The workspace edit screen
-  now groups its fields under five tabs — General (name / image /
-  auto-start), Mounts, Environment, Netfilter (allowed domains), and
-  Advanced (service command / health check) — instead of one long scroll.
-  Save / Cancel, the status line, and the restart-needed prompt stay
-  pinned outside the tab content so they remain visible on every tab.
-  Left/Right switch tabs, Up/Down move between the tab strip and a pane's
-  fields, and Delete / `e` act on whichever list is under the active tab.
+- **TUI: tabbed workspace create/edit forms (#1891).** The workspace
+  create and edit screens now group their fields under five tabs — General
+  (name / image / auto-start), Mounts, Environment, Netfilter (allowed
+  domains), and Advanced (service command / health check) — instead of one
+  long scroll. Save / Create / Cancel, the status line, and the
+  restart-needed prompt stay pinned outside the tab content so they remain
+  visible on every tab. Left/Right switch tabs, Up/Down move between the
+  tab strip and a pane's fields, and (edit only) Delete / `e` act on
+  whichever list is under the active tab.
 
 - **TUI login: the server-list delete key is hinted inline (#1890).**
   The `d` (delete server) key no longer appears in the bottom Footer — its

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -144,6 +144,13 @@ class KlangkApp(App):
     .field-row > Input, .field-row > Select {
         width: 1fr;
     }
+    /* Editor rows (Input + Add/Remove buttons): keep the Input fractional so
+    the buttons always fit inside the pane (#1891) — a greedy default-width
+    Input otherwise pushes Add/Remove past the tab pane's clip region, where
+    they render but can't be clicked. */
+    #mount_input, #env_input, #allow_input {
+        width: 1fr;
+    }
     /* Bounded list editors (#1783). */
     .editor-list {
         height: 4;

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -21,6 +21,9 @@ from textual.widgets import (
     OptionList,
     Select,
     Static,
+    TabbedContent,
+    TabPane,
+    Tabs,
 )
 from textual.widgets.option_list import Option
 
@@ -420,12 +423,19 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
     """Full-screen workspace edit form (parity with Flutter
     ``WorkspaceSettingsPanel``).
 
-    Like :class:`CreateWorkspaceScreen` but pre-populated from an existing
-    workspace, saving via a partial ``PUT``. Saving a change to a
-    container-create-time field (image / mounts / env / service_command /
-    allowed_domains) on a *running* workspace prompts a "restart needed to
-    apply" offer (#1778, #1749); ``setup_state`` / ``health_check`` propagate
-    live and never trigger it.
+    Fields are grouped under a ``TabbedContent`` with five panes — General
+    (name / image / auto-start), Mounts, Environment, Netfilter (allowed
+    domains), and Advanced (service command / health check) — so each
+    logical category has its own tab instead of one long scroll (#1891).
+    Save / Cancel, the status line (``#edit_msg``), and the restart-needed
+    prompt live *outside* the tab content so they stay visible regardless
+    of which tab is active.
+
+    Pre-populated from an existing workspace, saving via a partial ``PUT``.
+    Saving a change to a container-create-time field (image / mounts / env /
+    service_command / allowed_domains) on a *running* workspace prompts a
+    "restart needed to apply" offer (#1778, #1749); ``setup_state`` /
+    ``health_check`` propagate live and never trigger it.
     """
 
     BINDINGS = [
@@ -437,10 +447,12 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
     _TAB_ORDER = [
         "name",
         "image",
+        "auto_start",
         "mount_input",
         "env_input",
         "allow_input",
-        "auto_start",
+        "command",
+        "health_check",
         "cancel",
         "save",
     ]
@@ -448,6 +460,24 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         "mount_list": "mount_input",
         "env_list": "env_input",
         "allow_list": "allow_input",
+    }
+    # Spatial nav around the form tab strip (#1891): the first focusable
+    # field of each pane — Down from the strip lands here, Up returns.
+    _PANE_FIRST_FIELD = {
+        "general_pane": "name",
+        "mounts_pane": "mount_input",
+        "env_pane": "env_input",
+        "netfilter_pane": "allow_input",
+        "advanced_pane": "command",
+    }
+    # Delete/'e' act on the list under the active tab (#1891).
+    _PANE_LIST_HANDLER = {
+        "mounts_pane": ("_remove_mount", "_edit_mount"),
+        "env_pane": ("_remove_env", "_edit_env"),
+        "netfilter_pane": (
+            "_remove_allowed_domain",
+            "_edit_allowed_domain",
+        ),
     }
 
     def __init__(
@@ -496,68 +526,83 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         else:  # pragma: no cover
             image_select = Select(self._select_options, id="image")
         yield Header(show_clock=False)
-        yield NonFocusableVerticalScroll(
-            Static(Text(f"Edit workspace: {self._ws.name}"), classes="title"),
-            Static("", id="edit_msg"),
-            Horizontal(
-                Static("Name"),
-                Input(value=self._ws.name or "", id="name"),
-                classes="field-row",
-            ),
-            Horizontal(Static("Image"), image_select, classes="field-row"),
-            Static(
-                "Mounts  (source:/container/path[:opts])",
-                classes="editor-label",
-            ),
-            Horizontal(
-                Input(
-                    id="mount_input",
-                    placeholder="/host/path:/container/path",
-                ),
-                Button("Add", id="add_mount"),
-                Button("Remove", id="rm_mount"),
-            ),
-            OptionList(id="mount_list", classes="editor-list"),
-            Static("Environment  (KEY=VALUE)", classes="editor-label"),
-            Horizontal(
-                Input(id="env_input", placeholder="KEY=VALUE"),
-                Button("Add", id="add_env"),
-                Button("Remove", id="rm_env"),
-            ),
-            OptionList(id="env_list", classes="editor-list"),
-            Static(
-                "Allowed Domains  (host or host:port; empty = unrestricted)",
-                classes="editor-label",
-            ),
-            Horizontal(
-                Input(id="allow_input", placeholder="github.com:443"),
-                Button("Add", id="add_allow"),
-                Button("Remove", id="rm_allow"),
-            ),
-            OptionList(id="allow_list", classes="editor-list"),
-            Collapsible(
-                Horizontal(
-                    Static("Command"),
-                    Input(value=self._ws.service_command or "", id="command"),
-                    classes="field-row",
-                ),
-                Horizontal(
-                    Static("Health"),
-                    Input(
-                        value=self._ws.health_check or "", id="health_check"
-                    ),
-                    classes="field-row",
-                ),
-                title="Advanced",
-            ),
-            Checkbox("Auto start", value=self._ws.auto_start, id="auto_start"),
-            Horizontal(
+        with NonFocusableVerticalScroll(id="edit_box"):
+            yield Static(
+                Text(f"Edit workspace: {self._ws.name}"), classes="title"
+            )
+            yield Static("", id="edit_msg")
+            with TabbedContent(id="form_tabs"):
+                with TabPane("General", id="general_pane"):
+                    yield Horizontal(
+                        Static("Name"),
+                        Input(value=self._ws.name or "", id="name"),
+                        classes="field-row",
+                    )
+                    yield Horizontal(
+                        Static("Image"), image_select, classes="field-row"
+                    )
+                    yield Checkbox(
+                        "Auto start",
+                        value=self._ws.auto_start,
+                        id="auto_start",
+                    )
+                with TabPane("Mounts", id="mounts_pane"):
+                    yield Static(
+                        "Mounts  (source:/container/path[:opts])",
+                        classes="editor-label",
+                    )
+                    yield Horizontal(
+                        Input(
+                            id="mount_input",
+                            placeholder="/host/path:/container/path",
+                        ),
+                        Button("Add", id="add_mount"),
+                        Button("Remove", id="rm_mount"),
+                    )
+                    yield OptionList(id="mount_list", classes="editor-list")
+                with TabPane("Environment", id="env_pane"):
+                    yield Static(
+                        "Environment  (KEY=VALUE)", classes="editor-label"
+                    )
+                    yield Horizontal(
+                        Input(id="env_input", placeholder="KEY=VALUE"),
+                        Button("Add", id="add_env"),
+                        Button("Remove", id="rm_env"),
+                    )
+                    yield OptionList(id="env_list", classes="editor-list")
+                with TabPane("Netfilter", id="netfilter_pane"):
+                    yield Static(
+                        "Allowed Domains  "
+                        "(host or host:port; empty = unrestricted)",
+                        classes="editor-label",
+                    )
+                    yield Horizontal(
+                        Input(id="allow_input", placeholder="github.com:443"),
+                        Button("Add", id="add_allow"),
+                        Button("Remove", id="rm_allow"),
+                    )
+                    yield OptionList(id="allow_list", classes="editor-list")
+                with TabPane("Advanced", id="advanced_pane"):
+                    yield Horizontal(
+                        Static("Command"),
+                        Input(
+                            value=self._ws.service_command or "", id="command"
+                        ),
+                        classes="field-row",
+                    )
+                    yield Horizontal(
+                        Static("Health"),
+                        Input(
+                            value=self._ws.health_check or "",
+                            id="health_check",
+                        ),
+                        classes="field-row",
+                    )
+            yield Horizontal(
                 Button("Cancel", id="cancel"),
                 Button("Save", id="save", variant="primary"),
                 classes="actions",
-            ),
-            id="edit_box",
-        )
+            )
         yield Footer()
 
     def on_mount(self) -> None:
@@ -569,6 +614,9 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()
+        # General tab is active on entry — focus Name so the user can start
+        # typing immediately (the tab strip is one Up away, #1891).
+        self.query_one("#name", Input).focus()
 
     def _skip_editors_on_tab(self) -> None:
         """Editor buttons stay out of the Tab cycle (#1783).
@@ -743,25 +791,48 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         inp.focus()
         self._msg("Editing allowed-domain — press Add to update.")
 
-    # --- keyboard remove/edit of the focused OptionList (#1778) ---
+    # --- tab + keyboard navigation (#1891) ---
+
+    def _active_tab(self) -> str:
+        """The id of the currently active form tab pane."""
+        return self.query_one("#form_tabs", TabbedContent).active
+
+    def _focus_first_in_active_pane(self) -> None:
+        """Focus the first field of the active tab pane (Down from strip)."""
+        first = self._PANE_FIRST_FIELD.get(self._active_tab(), "name")
+        self.query_one(f"#{first}").focus()
+
+    def on_key(self, event) -> None:
+        # Spatial nav around the form tab strip (AGENTS.md "TUI spatial
+        # navigation"): Down from the strip drops into the active pane's
+        # first field; Up from that field returns to the strip. Left/Right
+        # on the strip switch tabs (Textual built-in). Tab/Shift-Tab still
+        # cycles fields via TabSkipMixin (#1783).
+        focused = self.focused
+        if isinstance(focused, Tabs) and event.key == "down":
+            event.stop()
+            self._focus_first_in_active_pane()
+            return
+        if event.key == "up":
+            fid = getattr(focused, "id", None)
+            first = self._PANE_FIRST_FIELD.get(self._active_tab(), "name")
+            if fid == first:
+                event.stop()
+                self.query_one(Tabs).focus()
+                return
+        super().on_key(event)
+
+    # --- keyboard remove/edit of the active tab's list (#1778, #1891) ---
 
     def action_remove_item(self) -> None:
-        fid = getattr(self.focused, "id", None) if self.focused else None
-        if fid == "mount_list":
-            self._remove_mount()
-        elif fid == "env_list":
-            self._remove_env()
-        elif fid == "allow_list":
-            self._remove_allowed_domain()
+        handler = self._PANE_LIST_HANDLER.get(self._active_tab())
+        if handler:
+            getattr(self, handler[0])()
 
     def action_edit_item(self) -> None:
-        fid = getattr(self.focused, "id", None) if self.focused else None
-        if fid == "mount_list":
-            self._edit_mount()
-        elif fid == "env_list":
-            self._edit_env()
-        elif fid == "allow_list":
-            self._edit_allowed_domain()
+        handler = self._PANE_LIST_HANDLER.get(self._active_tab())
+        if handler:
+            getattr(self, handler[1])()
 
     # --- save ---
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -14,7 +14,6 @@ from textual.screen import Screen
 from textual.widgets import (
     Button,
     Checkbox,
-    Collapsible,
     Footer,
     Header,
     Input,
@@ -40,13 +39,17 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
     """Full-screen workspace create form (parity with Flutter
     ``CreateWorkspaceDialog``).
 
-    Fields, top to bottom: name, container image (``Select`` populated
-    from ``/api/v1/images``), a mounts list editor, an env list editor,
-    an optional service shell command, an optional health-check command,
-    and — only when the server permits it — an auto-start checkbox.
-    Mounts/env are validated client-side (``validate_mount_spec`` /
-    ``validate_env_entry``) exactly as the Flutter dialog and the CLI
-    ``create`` command do.
+    Fields are grouped under a ``TabbedContent`` with five panes — General
+    (name / image / auto-start), Mounts, Environment, Netfilter (allowed
+    domains), and Advanced (service command / health check) — so each
+    logical category has its own tab instead of one long scroll (#1891).
+    Cancel / Create and the ``#create_msg`` status line live *outside* the
+    tab content so they stay visible regardless of which tab is active.
+
+    The container image comes from a ``Select`` populated from
+    ``/api/v1/images``; mounts/env are validated client-side
+    (``validate_mount_spec`` / ``validate_env_entry``) exactly as the
+    Flutter dialog and the CLI ``create`` command do.
 
     Images and the ``allow_autostart`` flag are fetched by the caller
     (``MainScreen.action_create``) and passed in, because ``self.app`` is
@@ -58,10 +61,12 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
     _TAB_ORDER = [
         "name",
         "image",
+        "auto_start",
         "mount_input",
         "env_input",
         "allow_input",
-        "auto_start",
+        "command",
+        "health_check",
         "cancel",
         "create",
     ]
@@ -69,6 +74,15 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         "mount_list": "mount_input",
         "env_list": "env_input",
         "allow_list": "allow_input",
+    }
+    # Spatial nav around the form tab strip (#1891): the first focusable
+    # field of each pane — Down from the strip lands here, Up returns.
+    _PANE_FIRST_FIELD = {
+        "general_pane": "name",
+        "mounts_pane": "mount_input",
+        "env_pane": "env_input",
+        "netfilter_pane": "allow_input",
+        "advanced_pane": "command",
     }
 
     def __init__(
@@ -110,62 +124,70 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
             # (the server applies its default image if none is chosen).
             image_select = Select(self._select_options, id="image")
         yield Header(show_clock=False)
-        yield NonFocusableVerticalScroll(
-            Static("New workspace", classes="title"),
-            Static("", id="create_msg"),
-            Horizontal(Static("Name"), Input(id="name"), classes="field-row"),
-            Horizontal(Static("Image"), image_select, classes="field-row"),
-            Static(
-                "Mounts  (source:/container/path[:opts])",
-                classes="editor-label",
-            ),
-            Horizontal(
-                Input(
-                    id="mount_input",
-                    placeholder="/host/path:/container/path",
-                ),
-                Button("Add", id="add_mount"),
-                Button("Remove", id="rm_mount"),
-            ),
-            OptionList(id="mount_list", classes="editor-list"),
-            Static("Environment  (KEY=VALUE)", classes="editor-label"),
-            Horizontal(
-                Input(id="env_input", placeholder="KEY=VALUE"),
-                Button("Add", id="add_env"),
-                Button("Remove", id="rm_env"),
-            ),
-            OptionList(id="env_list", classes="editor-list"),
-            Static(
-                "Allowed Domains  (host or host:port; empty = unrestricted)",
-                classes="editor-label",
-            ),
-            Horizontal(
-                Input(id="allow_input", placeholder="github.com:443"),
-                Button("Add", id="add_allow"),
-                Button("Remove", id="rm_allow"),
-            ),
-            OptionList(id="allow_list", classes="editor-list"),
-            Collapsible(
-                Horizontal(
-                    Static("Command"),
-                    Input(id="command"),
-                    classes="field-row",
-                ),
-                Horizontal(
-                    Static("Health"),
-                    Input(id="health_check"),
-                    classes="field-row",
-                ),
-                title="Advanced",
-            ),
-            Checkbox("Auto start", id="auto_start"),
-            Horizontal(
+        with NonFocusableVerticalScroll(id="create_box"):
+            yield Static("New workspace", classes="title")
+            yield Static("", id="create_msg")
+            with TabbedContent(id="form_tabs"):
+                with TabPane("General", id="general_pane"):
+                    yield Horizontal(
+                        Static("Name"), Input(id="name"), classes="field-row"
+                    )
+                    yield Horizontal(
+                        Static("Image"), image_select, classes="field-row"
+                    )
+                    yield Checkbox("Auto start", id="auto_start")
+                with TabPane("Mounts", id="mounts_pane"):
+                    yield Static(
+                        "Mounts  (source:/container/path[:opts])",
+                        classes="editor-label",
+                    )
+                    yield Horizontal(
+                        Input(
+                            id="mount_input",
+                            placeholder="/host/path:/container/path",
+                        ),
+                        Button("Add", id="add_mount"),
+                        Button("Remove", id="rm_mount"),
+                    )
+                    yield OptionList(id="mount_list", classes="editor-list")
+                with TabPane("Environment", id="env_pane"):
+                    yield Static(
+                        "Environment  (KEY=VALUE)", classes="editor-label"
+                    )
+                    yield Horizontal(
+                        Input(id="env_input", placeholder="KEY=VALUE"),
+                        Button("Add", id="add_env"),
+                        Button("Remove", id="rm_env"),
+                    )
+                    yield OptionList(id="env_list", classes="editor-list")
+                with TabPane("Netfilter", id="netfilter_pane"):
+                    yield Static(
+                        "Allowed Domains  "
+                        "(host or host:port; empty = unrestricted)",
+                        classes="editor-label",
+                    )
+                    yield Horizontal(
+                        Input(id="allow_input", placeholder="github.com:443"),
+                        Button("Add", id="add_allow"),
+                        Button("Remove", id="rm_allow"),
+                    )
+                    yield OptionList(id="allow_list", classes="editor-list")
+                with TabPane("Advanced", id="advanced_pane"):
+                    yield Horizontal(
+                        Static("Command"),
+                        Input(id="command"),
+                        classes="field-row",
+                    )
+                    yield Horizontal(
+                        Static("Health"),
+                        Input(id="health_check"),
+                        classes="field-row",
+                    )
+            yield Horizontal(
                 Button("Cancel", id="cancel"),
                 Button("Create", id="create", variant="primary"),
                 classes="actions",
-            ),
-            id="create_box",
-        )
+            )
         yield Footer()
 
     def on_mount(self) -> None:
@@ -177,6 +199,9 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()
+        # General tab is active on entry — focus Name so the user can start
+        # typing immediately (the tab strip is one Up away, #1891).
+        self.query_one("#name", Input).focus()
 
     def _skip_editors_on_tab(self) -> None:
         """Editor buttons stay out of the Tab cycle (#1783).
@@ -301,6 +326,37 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
             return
         del self._allowed_domains[idx]
         self._render_allowed_domains()
+
+    # --- tab + keyboard navigation (#1891) ---
+
+    def _active_tab(self) -> str:
+        """The id of the currently active form tab pane."""
+        return self.query_one("#form_tabs", TabbedContent).active
+
+    def _focus_first_in_active_pane(self) -> None:
+        """Focus the first field of the active tab pane (Down from strip)."""
+        first = self._PANE_FIRST_FIELD.get(self._active_tab(), "name")
+        self.query_one(f"#{first}").focus()
+
+    def on_key(self, event) -> None:
+        # Spatial nav around the form tab strip (AGENTS.md "TUI spatial
+        # navigation"): Down from the strip drops into the active pane's
+        # first field; Up from that field returns to the strip. Left/Right
+        # on the strip switch tabs (Textual built-in). Tab/Shift-Tab still
+        # cycles fields via TabSkipMixin (#1783).
+        focused = self.focused
+        if isinstance(focused, Tabs) and event.key == "down":
+            event.stop()
+            self._focus_first_in_active_pane()
+            return
+        if event.key == "up":
+            fid = getattr(focused, "id", None)
+            first = self._PANE_FIRST_FIELD.get(self._active_tab(), "name")
+            if fid == first:
+                event.stop()
+                self.query_one(Tabs).focus()
+                return
+        super().on_key(event)
 
     # --- create ---
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -19,6 +19,8 @@ from textual.widgets import (
     ListView,
     Select,
     Static,
+    TabbedContent,
+    TabPane,
     Tabs,
 )
 
@@ -5394,22 +5396,34 @@ async def test_edit_screen_keyboard_remove(monkeypatch):
         _edit_screen(app, ws)
         await pilot.pause()
         es = app.screen
-        # Delete/remove dispatches to the focused OptionList.
-        for lid, attr in (
-            ("#mount_list", "_mounts"),
-            ("#env_list", "_env"),
-            ("#allow_list", "_allowed_domains"),
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        # Delete/remove acts on the list under the active tab (#1891). Switch
+        # to each pane by focusing its input (TabbedContent syncs `active` to
+        # the focused pane, so this is also the realistic path).
+        for inp_id, lid, attr in (
+            ("#mount_input", "#mount_list", "_mounts"),
+            ("#env_input", "#env_list", "_env"),
+            ("#allow_input", "#allow_list", "_allowed_domains"),
         ):
-            ol = es.query_one(lid)
-            ol.focus()
+            es.query_one(inp_id).focus()
             await pilot.pause()
-            ol.highlighted = 0
+            assert (
+                tabs.active
+                == {
+                    "#mount_input": "mounts_pane",
+                    "#env_input": "env_pane",
+                    "#allow_input": "netfilter_pane",
+                }[inp_id]
+            )
+            es.query_one(lid).highlighted = 0
             es.action_remove_item()
             assert not getattr(es, attr)  # [] or {}
-        # Not focused on a list -> no-op.
+        # Active tab has no list (General) -> remove/edit are no-ops.
         es.query_one("#name").focus()
         await pilot.pause()
+        assert tabs.active == "general_pane"
         es.action_remove_item()
+        es.action_edit_item()
 
 
 async def test_edit_screen_edit_in_place(monkeypatch):
@@ -5428,11 +5442,13 @@ async def test_edit_screen_edit_in_place(monkeypatch):
         _edit_screen(app, ws)
         await pilot.pause()
         es = app.screen
-        # 'e' on the focused mount loads it into the input (edit mode).
-        ol = es.query_one("#mount_list")
-        ol.focus()
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        # Switch panes by focusing each editor's input (TabbedContent syncs
+        # `active` to the focused pane). 'e' loads the highlighted row.
+        es.query_one("#mount_input").focus()
         await pilot.pause()
-        ol.highlighted = 0
+        assert tabs.active == "mounts_pane"
+        es.query_one("#mount_list").highlighted = 0
         es.action_edit_item()
         assert es.query_one("#mount_input").value == "/h:/c"
         assert es._editing_mount == 0
@@ -5441,20 +5457,20 @@ async def test_edit_screen_edit_in_place(monkeypatch):
         assert es._mounts == ["/h:/c2"]
         assert es._editing_mount is None
         # env edit (key tracked)
-        ol = es.query_one("#env_list")
-        ol.focus()
+        es.query_one("#env_input").focus()
         await pilot.pause()
-        ol.highlighted = 0
+        assert tabs.active == "env_pane"
+        es.query_one("#env_list").highlighted = 0
         es.action_edit_item()
         assert es.query_one("#env_input").value == "K=v"
         es.query_one("#env_input").value = "K=changed"
         es._add_env()
         assert es._env == {"K": "changed"}
         # allowed-domain edit
-        ol = es.query_one("#allow_list")
-        ol.focus()
+        es.query_one("#allow_input").focus()
         await pilot.pause()
-        ol.highlighted = 0
+        assert tabs.active == "netfilter_pane"
+        es.query_one("#allow_list").highlighted = 0
         es.action_edit_item()
         assert es.query_one("#allow_input").value == "github.com:443"
         es.query_one("#allow_input").value = "pypi.org"
@@ -5467,6 +5483,115 @@ async def test_edit_screen_edit_in_place(monkeypatch):
         es._edit_env()
         es.query_one("#allow_list").highlighted = None
         es.action_edit_item()
+
+
+async def test_edit_screen_tabbed_layout(monkeypatch):
+    """Edit form groups fields under five tabs; Save/Cancel + #edit_msg stay
+    pinned outside the tab content, always visible (#1891)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = _wsobj("alpha", image="py:3", service_command="sh", health_check="hc")
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        # Five panes in the proposed order; General active on entry.
+        assert tabs.active == "general_pane"
+        for pane in (
+            "general_pane",
+            "mounts_pane",
+            "env_pane",
+            "netfilter_pane",
+            "advanced_pane",
+        ):
+            es.query_one(f"#{pane}", TabPane)
+        # No field dropped — a representative field per group is present.
+        es.query_one("#name", Input)
+        es.query_one("#image", Select)
+        es.query_one("#auto_start", Checkbox)
+        es.query_one("#mount_input", Input)
+        es.query_one("#mount_list")
+        es.query_one("#env_input", Input)
+        es.query_one("#allow_input", Input)
+        es.query_one("#command", Input)
+        es.query_one("#health_check", Input)
+        # Pinned outside the tab content: #edit_msg, #cancel, #save are
+        # siblings of the TabbedContent (never inside a TabPane).
+        for wid in ("#edit_msg", "#cancel", "#save"):
+            assert not isinstance(es.query_one(wid).parent, TabPane)
+        # Name is auto-focused on entry (General tab active).
+        assert app.focused is es.query_one("#name")
+
+
+async def test_edit_screen_tab_spatial_nav(monkeypatch):
+    """Down from the strip enters the active pane; Up from the first field
+    returns to the strip; Tab still cycles fields (#1891, #1781, #1783)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        # Up from Name (General's first field) -> focus the tab strip.
+        es.query_one("#name").focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert isinstance(app.focused, Tabs)
+        # Down from the strip -> back into the active pane's first field.
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is es.query_one("#name")
+        # Tab from Name advances to the next General field (Image).
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.focused is es.query_one("#image")
+        # Up from a non-first Input (Health, on the Advanced tab) is a no-op:
+        # it doesn't match the pane's first field (Command), so focus stays.
+        tabs.active = "advanced_pane"
+        es.query_one("#command").focus()  # switch to Advanced via focus-sync
+        await pilot.pause()
+        es.query_one("#health_check").focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused is es.query_one("#health_check")
+
+
+async def test_edit_screen_tab_left_right_switches(monkeypatch):
+    """Left/Right on the tab strip switches the active pane (#1891)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        assert tabs.active == "general_pane"
+        es.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        assert tabs.active == "mounts_pane"
+        await pilot.press("left")
+        await pilot.pause()
+        assert tabs.active == "general_pane"
 
 
 async def test_edit_rename_propagates_to_detail_and_list(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -8030,3 +8030,43 @@ async def test_edit_screen_editor_add_buttons_clickable(monkeypatch):
         assert captured["k"]["mounts"] == ["/host:/c"]
         assert captured["k"]["env"] == {"A": "1"}
         assert captured["k"]["allowed_domains"] == ["github.com:443"]
+
+
+async def test_edit_running_env_saved_before_restart_prompt(monkeypatch):
+    """Editing a RUNNING workspace's env persists the change *before* the
+    restart-needed prompt appears; dismissing the prompt (Skip) must not
+    drop it (#1891). The update PUT fires unconditionally in _do_save,
+    ahead of the ConfirmScreen."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = _wsobj("alpha", running=True, env={"OLD": "x"})
+    captured = {}
+
+    def fake_update(*a, **k):
+        captured["k"] = k
+
+    app = KlangkApp(_edit_state(ws, update=fake_update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        tabs.active = "env_pane"
+        await pilot.pause()
+        es.query_one("#env_input", Input).value = "a=1"
+        await pilot.pause()
+        assert await pilot.click("#add_env")  # Add button reachable
+        await pilot.pause()
+        assert es._env == {"OLD": "x", "a": "1"}
+        assert await pilot.click("#save")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # The PUT fired with the merged env before any prompt.
+        assert captured["k"]["env"] == {"OLD": "x", "a": "1"}
+        # Restart-needed prompt is on top — Skip it.
+        assert await pilot.click("#no")
+        await pilot.pause()
+        assert captured["k"]["env"] == {"OLD": "x", "a": "1"}  # unchanged

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -5594,6 +5594,115 @@ async def test_edit_screen_tab_left_right_switches(monkeypatch):
         assert tabs.active == "general_pane"
 
 
+async def test_create_screen_tabbed_layout(monkeypatch):
+    """Create form groups fields under five tabs; Cancel/Create +
+    #create_msg stay pinned outside the tab content, always visible (#1891)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        tabs = cs.query_one("#form_tabs", TabbedContent)
+        # Five panes in the proposed order; General active on entry.
+        assert tabs.active == "general_pane"
+        for pane in (
+            "general_pane",
+            "mounts_pane",
+            "env_pane",
+            "netfilter_pane",
+            "advanced_pane",
+        ):
+            cs.query_one(f"#{pane}", TabPane)
+        # No field dropped — a representative field per group is present.
+        cs.query_one("#name", Input)
+        cs.query_one("#image", Select)
+        cs.query_one("#auto_start", Checkbox)
+        cs.query_one("#mount_input", Input)
+        cs.query_one("#mount_list")
+        cs.query_one("#env_input", Input)
+        cs.query_one("#allow_input", Input)
+        cs.query_one("#command", Input)
+        cs.query_one("#health_check", Input)
+        # Pinned outside the tab content: #create_msg, #cancel, #create are
+        # siblings of the TabbedContent (never inside a TabPane).
+        for wid in ("#create_msg", "#cancel", "#create"):
+            assert not isinstance(cs.query_one(wid).parent, TabPane)
+        # Name is auto-focused on entry (General tab active).
+        assert app.focused is cs.query_one("#name")
+
+
+async def test_create_screen_tab_spatial_nav(monkeypatch):
+    """Down from the strip enters the active pane; Up from the first field
+    returns to the strip; Tab still cycles fields (#1891, #1781, #1783)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        tabs = cs.query_one("#form_tabs", TabbedContent)
+        # Up from Name (General's first field) -> focus the tab strip.
+        cs.query_one("#name").focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert isinstance(app.focused, Tabs)
+        # Down from the strip -> back into the active pane's first field.
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is cs.query_one("#name")
+        # Tab from Name advances to the next General field (Image).
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.focused is cs.query_one("#image")
+        # Up from a non-first Input (Health, on the Advanced tab) is a no-op:
+        # it doesn't match the pane's first field (Command), so focus stays.
+        tabs.active = "advanced_pane"
+        cs.query_one("#command").focus()  # switch to Advanced via focus-sync
+        await pilot.pause()
+        cs.query_one("#health_check").focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused is cs.query_one("#health_check")
+
+
+async def test_create_screen_tab_left_right_switches(monkeypatch):
+    """Left/Right on the tab strip switches the active pane (#1891)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        tabs = cs.query_one("#form_tabs", TabbedContent)
+        assert tabs.active == "general_pane"
+        cs.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        assert tabs.active == "mounts_pane"
+        await pilot.press("left")
+        await pilot.pause()
+        assert tabs.active == "general_pane"
+
+
 async def test_edit_rename_propagates_to_detail_and_list(monkeypatch):
     # #1778/#1768: renaming via the edit form must update the detail screen's
     # name (so it doesn't 404) and refresh the list (so the new name shows).

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4274,7 +4274,7 @@ async def test_create_screen_renders_defaults(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4292,7 +4292,7 @@ async def test_create_screen_autostart_hidden_when_not_allowed(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state(allow_autostart=lambda: False))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4307,7 +4307,7 @@ async def test_create_screen_mount_editor(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4336,7 +4336,7 @@ async def test_create_screen_env_editor(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4368,7 +4368,7 @@ async def test_create_screen_name_required(monkeypatch):
     app = KlangkApp(
         _create_state(create=lambda *a, **k: called.append(k) or _wsobj("z"))
     )
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4395,7 +4395,7 @@ async def test_create_screen_submit_omits_default_image(monkeypatch):
     app = KlangkApp(
         _create_state(create=create, allow_autostart=lambda: False)
     )
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4423,7 +4423,7 @@ async def test_create_screen_submit_custom_fields(monkeypatch):
         return _wsobj(name)
 
     app = KlangkApp(_create_state(create=create))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4464,7 +4464,7 @@ async def test_create_screen_http_error_shows_detail(monkeypatch):
         )
 
     app = KlangkApp(_create_state(create=create))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4486,7 +4486,7 @@ async def test_create_screen_auth_error(monkeypatch):
         raise AuthError("expired")
 
     app = KlangkApp(_create_state(create=create))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4514,7 +4514,7 @@ async def test_create_screen_images_unavailable(monkeypatch):
     app = KlangkApp(
         _create_state(create=create, list_images=boom, allow_autostart=boom)
     )
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4533,7 +4533,7 @@ async def test_create_screen_cancel_button(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4548,7 +4548,7 @@ async def test_create_screen_input_submit_routing(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4580,7 +4580,7 @@ async def test_create_flow_offer_opens_detail(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("new")))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4602,7 +4602,7 @@ async def test_create_flow_offer_declined(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("new")))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4624,7 +4624,7 @@ async def test_create_editor_guards(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4653,7 +4653,7 @@ async def test_create_screen_generic_error(monkeypatch):
         raise RuntimeError("boom")
 
     app = KlangkApp(_create_state(create=create))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4674,7 +4674,7 @@ async def test_create_button_routing(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("ws")))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4729,7 +4729,7 @@ async def test_create_screen_image_names_markup_safe(monkeypatch):
             create_workspace=lambda *a, **k: _wsobj("z"),
         )
     )
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4764,7 +4764,7 @@ async def test_create_screen_http_error_non_json(monkeypatch):
         )
 
     app = KlangkApp(_create_state(create=create))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4801,7 +4801,7 @@ async def test_create_screen_default_not_in_allowed(monkeypatch):
             create_workspace=create,
         )
     )
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -4848,7 +4848,7 @@ async def test_create_screen_allowed_domains_editor(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -5603,7 +5603,7 @@ async def test_create_screen_tabbed_layout(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -5646,7 +5646,7 @@ async def test_create_screen_tab_spatial_nav(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -5686,7 +5686,7 @@ async def test_create_screen_tab_left_right_switches(monkeypatch):
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     app = KlangkApp(_create_state())
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -5750,7 +5750,7 @@ async def test_create_screen_no_server_does_not_crash(monkeypatch):
         raise ValueError("no server configured")
 
     app = KlangkApp(_create_state(list_images=boom, allow_autostart=boom))
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()  # must not raise
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -7917,3 +7917,116 @@ async def test_run_token_refresh_loop_concurrent_rotation(monkeypatch):
     monkeypatch.setattr(scr_main, "_refresh_token", lambda url, tok: None)
     result = await _real_run_token_refresh_loop(FakeState())
     assert result == "no_token"
+
+
+async def test_create_screen_editor_add_buttons_clickable(monkeypatch):
+    """Regression (#1891): the Add buttons inside each editor tab must be
+    reachable by mouse. A greedy default-width Input used to push Add/Remove
+    past the tab pane's clip region, so clicks silently missed — typing a
+    mount/env/domain and clicking Add then Create saved nothing. Also covers
+    the Advanced-tab text inputs (command/health)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    captured = {}
+
+    def fake_create(*a, **k):
+        captured["k"] = k
+        return _wsobj("zzz")
+
+    app = KlangkApp(_create_state(create=fake_create))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        tabs = cs.query_one("#form_tabs", TabbedContent)
+        # General tab is active on entry — set the required name first.
+        cs.query_one("#name", Input).value = "myws"
+        await pilot.pause()
+        # Mounts tab: input + Add button must both be inside the pane.
+        tabs.active = "mounts_pane"
+        await pilot.pause()
+        cs.query_one("#mount_input", Input).value = "/host:/c"
+        await pilot.pause()
+        assert await pilot.click("#add_mount")  # True == landed on the button
+        await pilot.pause()
+        # Environment tab
+        tabs.active = "env_pane"
+        await pilot.pause()
+        cs.query_one("#env_input", Input).value = "A=1"
+        await pilot.pause()
+        assert await pilot.click("#add_env")
+        await pilot.pause()
+        # Netfilter tab
+        tabs.active = "netfilter_pane"
+        await pilot.pause()
+        cs.query_one("#allow_input", Input).value = "github.com:443"
+        await pilot.pause()
+        assert await pilot.click("#add_allow")
+        await pilot.pause()
+        # Advanced tab text inputs (field-row; never had the overflow, but
+        # confirm they're reachable and flow through to Create).
+        tabs.active = "advanced_pane"
+        await pilot.pause()
+        cs.query_one("#command", Input).value = "./run"
+        cs.query_one("#health_check", Input).value = "curl localhost"
+        await pilot.pause()
+        # Create — every field must be persisted.
+        assert await pilot.click("#create")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert captured["k"]["mounts"] == ["/host:/c"]
+        assert captured["k"]["env"] == {"A": "1"}
+        assert captured["k"]["allowed_domains"] == ["github.com:443"]
+        assert captured["k"]["service_command"] == "./run"
+        assert captured["k"]["health_check"] == "curl localhost"
+
+
+async def test_edit_screen_editor_add_buttons_clickable(monkeypatch):
+    """Regression (#1891): same as the create-screen case but for the edit
+    form — Add buttons inside each editor tab must be clickable and the
+    entries must reach the PUT on Save."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = _wsobj("alpha", running=False)  # not running -> no restart prompt
+    captured = {}
+
+    def fake_update(*a, **k):
+        captured["k"] = k
+
+    app = KlangkApp(_edit_state(ws, update=fake_update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        tabs.active = "mounts_pane"
+        await pilot.pause()
+        es.query_one("#mount_input", Input).value = "/host:/c"
+        await pilot.pause()
+        assert await pilot.click("#add_mount")
+        await pilot.pause()
+        tabs.active = "env_pane"
+        await pilot.pause()
+        es.query_one("#env_input", Input).value = "A=1"
+        await pilot.pause()
+        assert await pilot.click("#add_env")
+        await pilot.pause()
+        tabs.active = "netfilter_pane"
+        await pilot.pause()
+        es.query_one("#allow_input", Input).value = "github.com:443"
+        await pilot.pause()
+        assert await pilot.click("#add_allow")
+        await pilot.pause()
+        assert await pilot.click("#save")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert captured["k"]["mounts"] == ["/host:/c"]
+        assert captured["k"]["env"] == {"A": "1"}
+        assert captured["k"]["allowed_domains"] == ["github.com:443"]

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2303,6 +2303,27 @@ class TestWorkspaceRoutes:
         match = [w for w in resp.json() if w["id"] == ws_id]
         assert match[0]["allowed_domains"] == ["github.com:443"]
 
+    async def test_update_workspace_env(self, client, user):
+        # Regression: a partial PUT of env (e.g. adding a new var from the
+        # TUI/Flutter edit form) must persist and round-trip through GET.
+        # This was the only creatable field with no PUT coverage (#1891).
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "env-ws"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"env": {"a": "1"}},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["env"] == {"a": "1"}
+
     async def test_update_workspace_propagates_to_live_state(
         self, client, app, user, registry
     ):


### PR DESCRIPTION
## Summary

Closes #1891. The TUI workspace **create and edit** forms are reorganized into a tabbed interface — five tabs (General / Mounts / Environment / Netfilter / Advanced) instead of one long scroll. Cancel/Create/Save and the status line stay pinned outside the tab content so they're always visible.

> The issue scoped this to the edit form and listed create as a follow-up; per request both are done in this PR since they share an identical layout.

## What changed

Both `CreateWorkspaceScreen.compose()` and `EditWorkspaceScreen.compose()` now yield a `TabbedContent` (`#form_tabs`) with five `TabPane`s:

- **General** — Name, Image, Auto start
- **Mounts** — the mounts editor
- **Environment** — the env-vars editor
- **Netfilter** — the allowed-domains editor
- **Advanced** — Service command + Health check (was previously grouped via `Collapsible`; Advanced is now its own tab, so the `Collapsible` import is dropped)

Cancel/Create/Save and the `#create_msg` / `#edit_msg` status line live *outside* the `ContentSwitcher` (still inside the scroll box) so they remain visible on every tab. The edit screen's restart-needed prompt is likewise unaffected.

## Keyboard navigation (acceptance: no focus traps)

- **Left / Right** switch tabs (Textual `Tabs` built-in).
- **Down** from the tab strip drops into the active pane's first field; **Up** from that first field returns to the strip (`on_key` + `_PANE_FIRST_FIELD` map).
- **Tab / Shift-Tab** still cycles fields via `TabSkipMixin` — `_TAB_ORDER` / `_LIST_TO_INPUT` updated for the new DOM (#1783). Fields in hidden panes are skipped because `ContentSwitcher` hides inactive panes.
- **Delete / `e`** (edit screen only — create has no list-scoped keybindings) act on whichever list is under the active tab via a `_PANE_LIST_HANDLER` pane→handler map.

`_create()` / `_save()` validation reads every field across tabs (widgets in hidden panes are still in the DOM/queryable), so an invalid entry on a non-active tab still blocks submit. Name is auto-focused on entry.

## Bug found and fixed while expanding to the create form

While testing the tabbed create form I found that the editor **Add/Remove buttons were unreachable by mouse**: the editor `Horizontal(Input, Add, Remove)` gave the `Input` no width rule (only `.field-row > Input` had one), so the Input consumed the whole row and pushed the buttons past the editor row's clip region — and under the tabbed layout, past the tab pane's narrower clip. `get_widget_at` at the button's center returned the *Screen*, i.e. the button wasn't actually painted there, so a click on Add silently missed and the entry was never added. **Typing a mount/env/domain and clicking Add then Create/Save saved nothing** (pressing Enter still worked, which is why the existing method-level tests never caught it). This affected both screens and all three editors.

Fix: `#mount_input, #env_input, #allow_input { width: 1fr }` so the Input leaves room for the buttons on every tab. Regression tests (`test_*_editor_add_buttons_clickable`) click each editor's Add button through the real mouse path (`pilot.click` must return True — i.e. land on the button) on both forms and assert the entries reach the create/update call.

## Test plan

- [x] `test_edit_screen_tabbed_layout` / `test_create_screen_tabbed_layout` — five panes present, default active = General, status/buttons pinned outside, Name auto-focused.
- [x] `test_edit_screen_tab_left_right_switches` / `test_create_screen_tab_left_right_switches` — Right → Mounts, Left → back to General.
- [x] `test_edit_screen_tab_spatial_nav` / `test_create_screen_tab_spatial_nav` — Down from strip enters the pane's first field; Up from it returns; Tab advances within General; Up from a non-first field (Health on Advanced) is a no-op.
- [x] Edit `action_edit_item` / `action_remove_item` keyed off the active tab (Mounts / Environment / Netfilter).
- [x] All existing create/edit save / restart-notice / list-editor / autostart-hidden coverage preserved (create tests query by id, so they survive the DOM change unchanged).
- [x] Full Python suite (CI invocation): `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — **3844 passed, 100% coverage**.
- [x] Rebased onto latest `main`; pre-commit (incl. markdownlint MD024) passes.

Closes #1891
