### PR TITLE
Stop klangkc-tests from bouncing the live TUI (real logout via shared global state)

### DIFF
--- a/src/klangk/klangkc-tests/tests/conftest.py
+++ b/src/klangk/klangkc-tests/tests/conftest.py
@@ -2,7 +2,34 @@
 
 import os
 
+import pytest
+
 # Use sysmon coverage engine for pytest-xdist compatibility — mirrors the
 # server suite's conftest (src/klangk/klangkd-tests/tests/conftest.py) so
 # coverage is tracked correctly across xdist workers (#1526).
 os.environ.setdefault("COVERAGE_CORE", "sysmon")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cli_state(tmp_path, monkeypatch):
+    """Redirect CLI config/state to a per-test tmp dir for every klangkc-test.
+
+    ``klangk.cli.config`` resolves ``_CONFIG_PATH`` / ``_STATE_PATH`` at
+    *import* time from ``XDG_CONFIG_HOME`` / ``XDG_STATE_HOME`` (with
+    ~/.config / ~/.local/state fallbacks), so setting the env vars later
+    has no effect — the module globals are patched directly, and the
+    ``_cfg()`` / ``_state()`` caches in ``klangk.cli.main`` are reset so
+    the next call re-loads from the isolated path.
+
+    Without this, a unit test that invokes the real CLI in-process (e.g.
+    ``CliRunner().invoke(app, ["logout"])``) reads the developer's live
+    ``klangk-state.yaml`` and POSTs a real logout to their running server,
+    revoking the live TUI's token (#1900).
+    """
+    import klangk.cli.config as _cfg
+    import klangk.cli.main as _main
+
+    monkeypatch.setattr(_cfg, "_CONFIG_PATH", tmp_path / "klangk.yaml")
+    monkeypatch.setattr(_cfg, "_STATE_PATH", tmp_path / "klangk-state.yaml")
+    monkeypatch.setattr(_main, "_cfg_cache", None)
+    monkeypatch.setattr(_main, "_state_cache", None)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -6522,6 +6522,10 @@ def test_subcommand_does_not_launch_tui(monkeypatch):
         "run_tui",
         lambda server_url=None: launched.__setitem__("v", True),
     )
+    # Never let this in-process invoke POST a real logout at a live server.
+    # The klangkc-tests conftest isolates CLI state to a tmp dir, but this
+    # guard keeps the test safe even if a fixture pre-seeds credentials (#1900).
+    monkeypatch.setattr("klangk.cli.main.do_logout", lambda *a, **k: None)
     CliRunner().invoke(app, ["logout"])
     assert launched["v"] is False
 


### PR DESCRIPTION
## Summary

Closes #1900. The spurious TUI logouts were a **unit test** firing a real `klangk logout` at the live server via the developer's shared global CLI state.

## Root cause

`test_subcommand_does_not_launch_tui` ran `CliRunner().invoke(app, ["logout"])` in-process with **no** CLI-state isolation. No `klangkc-tests` conftest isolates `HOME`/`XDG_STATE_HOME`, and `klangk.cli.config._STATE_PATH` resolves at import time to the global `~/.local/state/klangk/klangk-state.yaml`. So the in-process logout read `active-server: http://localhost:8997` + the admin token and **POSTed `/api/v1/auth/logout` to the live server**, blocklisting the TUI's token → bounce to login. Run from any worktree whose `cli/auth.py` predates `_log_logout_caller` (nearly all of them), the POST left no trace — which is why the investigation kept hitting a wall.

## Fix (two layers)

- **Targeted** — `test_subcommand_does_not_launch_tui` now stubs `klangk.cli.main.do_logout`, so the in-process `["logout"]` can never POST.
- **Systemic** — new autouse `_isolate_cli_state` fixture in `klangkc-tests/tests/conftest.py` redirects `_CONFIG_PATH`/`_STATE_PATH` to a per-test `tmp_path` and resets the `_cfg()`/`_state()` caches, so **no** `klangkc-test` can ever read or mutate the developer's real state again.

## Verification

- Full suite: **3836 passed, 100% coverage** (post-rebase onto #1895).
- End-to-end: ran the fixed `test_subcommand_does_not_launch_tui` against the live server — no `LOGOUT CALL` in the server log, global state untouched.
- The two `WARNING`s sometimes seen in the combined klangkd+klangkc run are **pre-existing** (15 appear on `main`'s full run) — not introduced here.

This was the root cause the #1895 instrumentation was chasing; #1895's logging now in-tree remains useful for future diagnostics.

Test-only change — no changelog entry.
