### PR TITLE
TUI: show workspace id on detail screen, short id on list rows

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **TUI shows workspace id on the detail screen and a short id on each
+  workspaces-list row (#1899).** The full server-assigned `id` is now
+  shown on the workspace detail screen (top line, `id: <id>`), and the
+  first 8 chars of it are appended (muted) to each row on the Owned and
+  Shared workspaces lists. The short id is a prefix of the full id, so a
+  row can be matched to its detail screen and copied for `klangk` CLI /
+  server-log / support correlation without leaving the TUI.
+
 - **TUI keybinding + label change: Duplicate is now `u` / "Dup", Delete is
   now `d` / "Del" (#1888).** On both the workspaces list and the workspace
   detail screen, Duplicate moved from `d` to `u` and Delete moved from `x`

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -88,6 +88,11 @@ class MainScreen(Screen):
     .ws-name {
         width: 1fr;
     }
+    .ws-id {
+        width: auto;
+        padding-left: 1;
+        color: $text-muted;
+    }
     .ws-date {
         width: auto;
         text-align: right;
@@ -674,6 +679,14 @@ class MainScreen(Screen):
                 return Text(date, style="dim")
         return Text("")
 
+    @staticmethod
+    def _fmt_id(ws) -> Text:
+        """Short id (first 8 chars) for list rows — a prefix of the full
+        id shown on the detail screen, so a row can be matched to its
+        detail without consuming much horizontal space (#1899)."""
+        wid = str(getattr(ws, "id", "") or "")
+        return Text(wid[:8], style="dim") if wid else Text("")
+
     def _populate(
         self,
         selector: str,
@@ -688,9 +701,10 @@ class MainScreen(Screen):
             return
         for ws in workspaces:
             name_label = Label(self._fmt_name(ws), classes="ws-name")
+            id_label = Label(self._fmt_id(ws), classes="ws-id")
             date_label = Label(self._fmt_date(ws), classes="ws-date")
             item = ListItem(
-                Horizontal(name_label, date_label, classes="ws-row"),
+                Horizontal(name_label, id_label, date_label, classes="ws-row"),
                 name=ws.name,
             )
             wid = str(getattr(ws, "id", "") or "")

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -171,6 +171,7 @@ class WorkspaceDetailScreen(Screen):
         self.BINDINGS = self._bindings_list("Stop" if ws.running else "Start")
         self.refresh_bindings()
         lines = [
+            f"id: {ws.id}",
             f"running: {'yes' if ws.running else 'no'}",
             f"health: {ws.health or '-'}",
         ]

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2309,6 +2309,54 @@ async def test_main_screen_shows_created_date(monkeypatch):
         assert "2025-06-15" in str(date_label.render())
 
 
+async def test_main_screen_shows_short_id_on_row(monkeypatch):
+    """#1899: each list row shows the first 8 chars of the workspace id,
+    a prefix of the full id on the detail screen, so a row can be matched
+    to its workspace."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = Workspace(
+        id="3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        name="alpha",
+        created_at="2025-06-15T10:30:00",
+        running=True,
+    )
+    app = KlangkApp(_ws(owned=[ws], shared=[]))
+    async with app.run_test():
+        m = app.screen
+        items = m.query_one("#owned_list", ListView).query(ListItem)
+        id_label = items[0].query_one(".ws-id")
+        rendered = str(id_label.render())
+        assert "3fa85f64" in rendered  # first 8 chars of the full id
+        assert "3fa85f64-5717-4562-b3fc-2c963f66afa6" not in rendered
+        # The full id is NOT on the row (only its 8-char prefix is).
+
+
+async def test_main_screen_shared_list_shows_short_id(monkeypatch):
+    """#1899: the shared-workspaces list also shows the short id — no
+    regression from the row-population path that the Owned list uses."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = Workspace(
+        id="abcdef12-3456-7890-abcd-ef1234567890",
+        name="shared-ws",
+        created_at="2025-06-15T10:30:00",
+        running=False,
+    )
+    app = KlangkApp(_ws(owned=[], shared=[ws]))
+    async with app.run_test():
+        m = app.screen
+        items = m.query_one("#shared_list", ListView).query(ListItem)
+        id_label = items[0].query_one(".ws-id")
+        assert "abcdef12" in str(id_label.render())
+
+
 async def test_update_running_unknown_workspace(monkeypatch):
     """_update_running returns early for unknown workspace_id (line 692)."""
 
@@ -2840,6 +2888,33 @@ async def test_detail_loads_and_renders(monkeypatch):
             "owner: o@x",
         ]:
             assert s in body, s
+
+
+async def test_detail_shows_full_id(monkeypatch):
+    """#1899: the detail screen shows the full server-assigned workspace id,
+    so it can be copied for CLI / log / support correlation."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    full_id = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    a = Workspace(
+        id=full_id,
+        name="alpha",
+        created_at="x",
+        running=True,
+    )
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        body = str(app.screen.query_one("#detail_body").render())
+        assert f"id: {full_id}" in body
+        # The id line appears before the running/health lines (near the top).
+        assert body.index(f"id: {full_id}") < body.index("running:")
 
 
 async def test_detail_renders_allowed_domains(monkeypatch):


### PR DESCRIPTION
## Summary

The workspace server-assigned `id` was already in hand in both the
workspaces-list row population and the detail-screen `_display` path, but
was never rendered. Surface it so a TUI user can correlate a workspace
with CLI output, server logs, and support tickets.

Closes #1899.

## Changes

- **Detail screen** (`workspace_detail.py` `_display()`): add `id: <full
  id>` as the first line, ahead of running/health — easy to copy/reference.
- **Workspaces list** (`main.py`):
  - New `_fmt_id(ws)` helper → first 8 chars of `ws.id` (the conventional
    container/hash prefix), rendered `style="dim"`.
  - New `.ws-id` CSS class (`width: auto; padding-left: 1; color:
    $text-muted`), placed between `.ws-name` and `.ws-date`.
  - `_populate()` adds an `id_label` to each row. The same path populates
    the Owned and Shared tabs, so both lists show the id.
- **Changelog**: `## [Unreleased]` → Added entry.
- **Tests** (`test_tui.py`):
  - `test_detail_shows_full_id` — full id appears on the detail screen,
    above the running/health lines.
  - `test_main_screen_shows_short_id_on_row` — Owned list row shows the
    8-char prefix (and not the full id).
  - `test_main_screen_shared_list_shows_short_id` — Shared list also
    shows the short id (no regression from the shared populate path).

The short id on a row is a prefix of the full id on that workspace's
detail screen, so the two are visually correlatable.

## Verification

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto`
  → **3850 passed**, **100% coverage** (matches CI).
- Pre-commit hooks green (ruff, ruff-format, markdownlint, deferred-imports,
  binary-integrity, trufflehog).
- Branch based on `origin/main` (`fd49a045`); no divergence.
