### PR TITLE
TUI: workspace import/export with progress

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,16 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **TUI workspace import/export with progress (#1758).** The workspace
+  detail screen gains `x` → Export (downloads a `.tar.gz` via
+  `GET /api/v1/workspaces/{id}/export`, admin-only) and the workspaces
+  list gains `i` → Import (uploads a `.tar.gz` via
+  `POST /api/v1/workspaces/import`). Both show a live progress bar with a
+  byte counter during the transfer, reusing the existing CLI transport
+  (`KlangkClient.export_workspace` / `import_workspace`). Import prompts
+  for the archive path; export prompts for an output path (default
+  `<name>.tar.gz`).
+
 - **TUI shows workspace id on the detail screen and a short id on each
   workspaces-list row (#1899).** The full server-assigned `id` is now
   shown on the workspace detail screen (top line, `id: <id>`), and the

--- a/src/klangk/klangk/cli/tui/screens/__init__.py
+++ b/src/klangk/klangk/cli/tui/screens/__init__.py
@@ -8,11 +8,13 @@ from .account import AccountScreen
 from ._base import (
     ConfirmScreen,
     DuplicateScreen,
+    InputScreen,
     NonFocusableVerticalScroll,
     ServerListView,
     SpatialListView,
     SpatialNavScreen,
     TabSkipMixin,
+    TransferScreen,
     WorkspaceListView,
 )
 from .login import LoginScreen
@@ -29,6 +31,7 @@ __all__ = [
     "DuplicateScreen",
     "EditServerScreen",
     "EditWorkspaceScreen",
+    "InputScreen",
     "LoginScreen",
     "MainScreen",
     "run_token_refresh_loop",
@@ -38,6 +41,7 @@ __all__ = [
     "SpatialListView",
     "SpatialNavScreen",
     "TabSkipMixin",
+    "TransferScreen",
     "WorkspaceDetailScreen",
     "WorkspaceListView",
 ]

--- a/src/klangk/klangk/cli/tui/screens/_base.py
+++ b/src/klangk/klangk/cli/tui/screens/_base.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from rich.text import Text
 
 from textual.app import ComposeResult
@@ -13,6 +15,7 @@ from textual.widgets import (
     Input,
     ListItem,
     ListView,
+    ProgressBar,
     Static,
     Tabs,
 )
@@ -227,3 +230,140 @@ class DuplicateScreen(ModalScreen):
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id == "dup_name":
             self._commit()
+
+
+def _human_bytes(n: float) -> str:
+    """Format a byte count as e.g. ``"12.3 MB"``."""
+    value = float(n)
+    for unit in ("B", "KB", "MB"):
+        if value < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GB"
+
+
+def _fmt_transfer(done: float, total: float | None) -> str:
+    """Render a progress counter, tolerating an unknown total."""
+    d = _human_bytes(done)
+    return f"{d} / {_human_bytes(total)}" if total else f"{d} (size unknown)"
+
+
+class InputScreen(ModalScreen):
+    """Generic single-line input prompt (title + default + OK/Cancel).
+
+    Dismisses with the trimmed value on OK, or ``None`` on cancel (#1758).
+    """
+
+    DEFAULT_CSS = """
+    InputScreen { align: center middle; }
+    InputScreen > Vertical {
+        width: 64; max-width: 90%; padding: 0 2;
+        border: round $primary; background: $panel;
+    }
+    InputScreen Horizontal {
+        align-horizontal: right; height: auto; padding-top: 1;
+    }
+    """
+
+    def __init__(
+        self, title: str, default: str = "", ok_label: str = "OK"
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._default = default
+        self._ok_label = ok_label
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static(Text(self._title)),
+            Input(value=self._default, id="inp_value"),
+            Horizontal(
+                Button("Cancel", id="cancel"),
+                Button(self._ok_label, id="ok", variant="primary"),
+            ),
+            id="inp_box",
+        )
+
+    def on_mount(self) -> None:
+        self.query_one("#inp_value", Input).focus()
+
+    def _commit(self) -> None:
+        val = self.query_one("#inp_value", Input).value.strip()
+        self.dismiss(val or None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "ok":
+            self._commit()
+        elif event.button.id == "cancel":
+            self.dismiss(None)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "inp_value":
+            self._commit()
+
+
+class TransferScreen(ModalScreen):
+    """Runs a blocking transfer (export/import) in a worker thread while
+    showing a live progress bar (#1758).
+
+    ``make_call`` is invoked once as ``make_call(on_progress)`` inside
+    ``asyncio.to_thread``; ``on_progress`` is ``on_progress(done_bytes,
+    total_bytes_or_None)``. The screen dismisses with ``(True, success_msg)``
+    on completion or ``(False, error_text)`` on failure.
+    """
+
+    DEFAULT_CSS = """
+    TransferScreen { align: center middle; }
+    TransferScreen > Vertical {
+        width: 64; max-width: 90%; padding: 1 2;
+        border: round $primary; background: $panel;
+    }
+    TransferScreen #xfer_title { text-style: bold; margin-bottom: 1; }
+    TransferScreen #xfer_status { color: $text-muted; margin-top: 1; }
+    """
+
+    def __init__(
+        self,
+        title: str,
+        make_call,
+        success_msg: str,
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._make_call = make_call
+        self._success_msg = success_msg
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static(Text(self._title), id="xfer_title"),
+            ProgressBar(id="xfer_bar"),
+            Static(Text("Starting…"), id="xfer_status"),
+            id="xfer_box",
+        )
+
+    def on_mount(self) -> None:
+        self.run_worker(self._run, exit_on_error=False)
+
+    async def _run(self) -> None:
+        def on_progress(done, total):
+            # Fires inside the worker thread — hop back to the UI thread.
+            self.app.call_from_thread(self._update, done, total)
+
+        try:
+            await asyncio.to_thread(self._make_call, on_progress)
+        except Exception as exc:  # noqa: BLE001 — surface any failure
+            self.dismiss((False, str(exc)))
+            return
+        self.dismiss((True, self._success_msg))
+
+    def _update(self, done: float, total: float | None) -> None:
+        bar = self.query_one("#xfer_bar", ProgressBar)
+        if total:
+            bar.update(total=total, progress=done)
+        else:
+            # Unknown length — keep the bar full and let the byte counter
+            # carry the real progress, mirroring the CLI's estimate trick.
+            bar.update(total=max(done, 1), progress=done)
+        self.query_one("#xfer_status", Static).update(
+            Text(_fmt_transfer(done, total))
+        )

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -6,6 +6,7 @@ import asyncio
 import datetime
 import logging
 import time
+from pathlib import Path
 
 import httpx
 
@@ -34,7 +35,12 @@ from ...client import AuthError, WorkspaceNotFoundError, decode_token_claims
 from ...auth import refresh_token as _refresh_token
 from ..widgets import StatusBar
 from ..ws import listen_for_status
-from ._base import ConfirmScreen, WorkspaceListView
+from ._base import (
+    ConfirmScreen,
+    InputScreen,
+    TransferScreen,
+    WorkspaceListView,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +134,7 @@ class MainScreen(Screen):
     BINDINGS = [
         ("c", "switch_server", "Switch server"),
         ("n", "create", "New"),
+        ("i", "import", "Import"),
         ("a", "account", "Account"),
         ("l", "logout", "Logout"),
         ("slash", "focus_filter", "Filter"),
@@ -555,6 +562,43 @@ class MainScreen(Screen):
 
     def action_create(self) -> None:
         self.run_worker(self._do_create, exit_on_error=False)
+
+    def action_import(self) -> None:
+        """Import a workspace from a .tar.gz archive with upload progress (#1758)."""
+        self.app.push_screen(
+            InputScreen(
+                "Import workspace from (.tar.gz):",
+                ok_label="Import",
+            ),
+            self._on_import_path,
+        )
+
+    def _on_import_path(self, path: str | None) -> None:
+        if not path:
+            return
+        archive = Path(path)
+        if not archive.exists():
+            self._flash(f"Import failed: file not found: {path}")
+            return
+        state = self.app.tui_state
+
+        def make_call(on_progress):
+            return state.import_workspace(archive, on_progress=on_progress)
+
+        self.app.push_screen(
+            TransferScreen(
+                f"Importing '{archive.name}'…",
+                make_call,
+                f"Imported '{archive.name}'",
+            ),
+            self._on_import_done,
+        )
+
+    def _on_import_done(self, result: tuple[bool, str]) -> None:
+        ok, msg = result
+        self._flash(msg)
+        if ok:
+            self.refresh_lists()
 
     async def _do_create(self) -> None:
         from .workspace_form import CreateWorkspaceScreen  # noqa: allow-deferred-import

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -7,6 +7,7 @@ import logging
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 from rich.text import Text
 
@@ -25,7 +26,13 @@ from textual.widgets import (
 )
 
 from ...client import AuthError, WorkspaceNotFoundError
-from ._base import ConfirmScreen, DuplicateScreen, SpatialListView
+from ._base import (
+    ConfirmScreen,
+    DuplicateScreen,
+    InputScreen,
+    SpatialListView,
+    TransferScreen,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +47,7 @@ class WorkspaceDetailScreen(Screen):
         Binding("s", "stop", "Stop"),
         Binding("u", "duplicate", "Dup"),
         Binding("d", "delete", "Del ws"),
+        Binding("x", "export", "Export"),
         # Terminal-scoped keys are hidden from the Footer — their hints
         # are shown inline on the Terminals list header instead (#1860).
         Binding("n", "new_terminal", "New term", show=False),
@@ -556,3 +564,35 @@ class WorkspaceDetailScreen(Screen):
             return
         self._msg(f"Duplicated as '{new_name}'.")
         self.app.refresh_workspaces()
+
+    def action_export(self) -> None:
+        """Export this workspace to a .tar.gz (admin only) with progress (#1758)."""
+        self.app.push_screen(
+            InputScreen(
+                f"Export '{self._name}' to:",
+                default=f"{self._name}.tar.gz",
+                ok_label="Export",
+            ),
+            self._on_export,
+        )
+
+    def _on_export(self, path: str | None) -> None:
+        if not path:
+            return
+        state = self.app.tui_state
+
+        def make_call(on_progress):
+            state.export_workspace(self._name, Path(path), on_progress)
+
+        self.app.push_screen(
+            TransferScreen(
+                f"Exporting '{self._name}'…",
+                make_call,
+                f"Exported → {path}",
+            ),
+            self._on_export_done,
+        )
+
+    def _on_export_done(self, result: tuple[bool, str]) -> None:
+        ok, msg = result
+        self._msg(msg, error=not ok)

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -145,6 +145,34 @@ class TuiState:
     def duplicate_workspace(self, name: str, new_name: str) -> dict:
         return self.client().duplicate_workspace(name, new_name)
 
+    def export_workspace(
+        self,
+        name: str,
+        output: Path,
+        on_progress=None,
+    ) -> None:
+        """Export a workspace to ``output`` (a .tar.gz path).
+
+        ``on_progress(bytes_so_far, total_bytes_or_None)`` fires per chunk;
+        ``total_bytes`` is ``None`` when the server omits ``Content-Length``.
+        """
+        ws = self.client().resolve_workspace(name)
+        self.client().export_workspace(ws.id, output, on_progress=on_progress)
+
+    def import_workspace(
+        self,
+        archive: Path,
+        name: str | None = None,
+        on_progress=None,
+    ) -> Workspace:
+        """Upload ``archive`` (a .tar.gz) and return the created workspace.
+
+        ``on_progress(bytes_so_far, total_bytes)`` fires as bytes are read.
+        """
+        return self.client().import_workspace(
+            archive, name=name, on_progress=on_progress
+        )
+
     def create_workspace(
         self,
         name: str,

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -7,6 +7,8 @@ and the ``add_server_to_config`` helper — under the 100% coverage gate.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 import pytest
 from rich.text import Text
@@ -34,6 +36,7 @@ from klangk.cli.tui.screens import account as scr_account
 from klangk.cli.tui import state as tui_state_mod
 from klangk.cli.tui import ws as ws_mod
 from klangk.cli.tui.app import KlangkApp, run_tui
+from klangk.cli.tui.widgets import StatusBar
 from klangk.cli.config import (
     AliasConflictError,
     CLIConfig,
@@ -51,9 +54,11 @@ from klangk.cli.tui.screens import (
     DuplicateScreen,
     EditServerScreen,
     EditWorkspaceScreen,
+    InputScreen,
     LoginScreen,
     MainScreen,
     ServerSwitchScreen,
+    TransferScreen,
     WorkspaceDetailScreen,
 )
 from klangk.cli.tui.state import LoginError, TuiState
@@ -1891,6 +1896,290 @@ async def test_main_screen_action_duplicate_cancel(monkeypatch):
         app.screen.on_button_pressed(FakeBtnPress("cancel"))  # cancel
         await pilot.pause()
         assert "d" not in duped
+
+
+# --- import / export with progress (#1758) ---
+
+
+def test_tui_state_export_import(monkeypatch, redirect_xdg):
+    """TuiState.export/import forward to the client, resolving name->id."""
+    from unittest.mock import MagicMock
+
+    fake = MagicMock()
+    fake.resolve_workspace.return_value = _wsobj("a")
+    fake.import_workspace.return_value = _wsobj("imp")
+    st = TuiState("https://x.example")
+    monkeypatch.setattr(st, "client", lambda: fake)
+
+    # export resolves the name to an id, then downloads to the path.
+    st.export_workspace("a", Path("a.tar.gz"))
+    fake.resolve_workspace.assert_called_once_with("a")
+    fake.export_workspace.assert_called_once_with(
+        "id-a", Path("a.tar.gz"), on_progress=None
+    )
+
+    # import forwards the archive + optional name + progress callback.
+    assert st.import_workspace(Path("imp.tar.gz")).name == "imp"
+    fake.import_workspace.assert_called_once_with(
+        Path("imp.tar.gz"), name=None, on_progress=None
+    )
+
+    # on_progress is threaded straight through to the client.
+    def cb(d, t):
+        return None
+
+    st.export_workspace("a", Path("a.tar.gz"), on_progress=cb)
+    fake.export_workspace.assert_called_with(
+        "id-a", Path("a.tar.gz"), on_progress=cb
+    )
+
+
+def test_fmt_transfer_known_unknown_and_units():
+    """Byte formatter covers B/KB/MB/GB and the unknown-total branch."""
+    from klangk.cli.tui.screens._base import _fmt_transfer, _human_bytes
+
+    assert _human_bytes(0) == "0.0 B"
+    assert _human_bytes(512).endswith("B")
+    assert _human_bytes(1536) == "1.5 KB"
+    assert _human_bytes(2 * 1024 * 1024) == "2.0 MB"
+    assert _human_bytes(3 * 1024**3) == "3.0 GB"
+    assert _fmt_transfer(1536, 4096) == "1.5 KB / 4.0 KB"
+    assert _fmt_transfer(9999, None) == "9.8 KB (size unknown)"
+
+
+async def test_input_screen_ok_cancel_and_enter(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        cap = {}
+        app.push_screen(
+            InputScreen("Path:", default="x.tar.gz", ok_label="Go"),
+            lambda r: cap.__setitem__("r", r),
+        )
+        await pilot.pause()
+        assert isinstance(app.screen, InputScreen)
+        # OK with the default value commits it.
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        await pilot.pause()
+        assert cap["r"] == "x.tar.gz"
+
+        # Cancel dismisses with None.
+        app.push_screen(
+            InputScreen("Path:"), lambda r: cap.__setitem__("c", r)
+        )
+        await pilot.pause()
+        app.screen.on_button_pressed(FakeBtnPress("cancel"))
+        await pilot.pause()
+        assert cap["c"] is None
+
+        # Empty value on OK -> None.
+        app.push_screen(
+            InputScreen("Path:"), lambda r: cap.__setitem__("e", r)
+        )
+        await pilot.pause()
+        app.screen.query_one("#inp_value", Input).value = "   "
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        await pilot.pause()
+        assert cap["e"] is None
+
+        # Enter submits the focused input.
+        app.push_screen(
+            InputScreen("Path:", default="z"),
+            lambda r: cap.__setitem__("s", r),
+        )
+        await pilot.pause()
+        inp = app.screen.query_one("#inp_value", Input)
+        app.screen.on_input_submitted(Input.Submitted(input=inp, value="z"))
+        await pilot.pause()
+        assert cap["s"] == "z"
+
+
+async def test_transfer_screen_success_error_and_progress(monkeypatch):
+    """TransferScreen drives the bar from the worker thread and reports
+    success/failure via its dismiss value (#1758)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+
+    async with app.run_test() as pilot:
+        cap = {}
+
+        # Success: on_progress fires from the thread with both a known and
+        # an unknown total (covers both _update branches), then dismisses.
+        def ok_call(on_progress):
+            on_progress(50, 200)
+            on_progress(80, None)
+            return None
+
+        app.push_screen(
+            TransferScreen("Working", ok_call, "done!"),
+            lambda r: cap.__setitem__("ok", r),
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert cap["ok"] == (True, "done!")
+
+        # Failure: make_call raises -> dismisses with (False, str(exc)).
+        def bad_call(on_progress):
+            raise RuntimeError("boom")
+
+        app.push_screen(
+            TransferScreen("Working", bad_call, "done!"),
+            lambda r: cap.__setitem__("bad", r),
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert cap["bad"] == (False, "boom")
+
+
+async def test_detail_export_flow_with_progress(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha", running=True)
+    exported = {}
+
+    def fake_export(name, out, on_progress=None):
+        if on_progress:
+            on_progress(10, 100)
+            on_progress(100, 100)
+        exported["args"] = (name, str(out))
+        return None
+
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.export_workspace = fake_export
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        # 'x' opens the export prompt prefilled with <name>.tar.gz.
+        d.action_export()
+        await pilot.pause()
+        assert isinstance(app.screen, InputScreen)
+        app.screen.on_button_pressed(FakeBtnPress("ok"))  # accept default
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        await pilot.pause()
+        # Transfer ran (mock completes instantly) -> back on detail, msg set.
+        assert exported["args"] == ("alpha", str(Path("alpha.tar.gz")))
+        assert "Exported" in str(d.query_one("#detail_msg", Static).render())
+
+
+async def test_detail_export_cancel_aborts(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        d.action_export()
+        await pilot.pause()
+        app.screen.on_button_pressed(FakeBtnPress("cancel"))
+        await pilot.pause()
+        # No transfer pushed; still on the detail screen.
+        assert not isinstance(app.screen, TransferScreen)
+
+
+async def test_main_import_missing_file_flashes(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    st = _ws(owned=[_wsobj("alpha")])
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_import()
+        await pilot.pause()
+        assert isinstance(app.screen, InputScreen)
+        app.screen.query_one(
+            "#inp_value", Input
+        ).value = "/no/such/nope.tar.gz"
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        await pilot.pause()
+        # Missing file -> no transfer, error flashed on the status bar.
+        assert not isinstance(app.screen, TransferScreen)
+        status = m.query_one("#status", StatusBar)
+        assert "not found" in str(status.render())
+
+
+async def test_main_import_flow_with_progress(monkeypatch, tmp_path):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    archive = tmp_path / "imp.tar.gz"
+    archive.write_bytes(b"PK\x03\x04payload")
+    imported = {}
+
+    def fake_import(path, name=None, on_progress=None):
+        if on_progress:
+            on_progress(8, 16)
+            on_progress(16, 16)
+        imported["path"] = str(path)
+        return _wsobj("imp")
+
+    st = _ws(owned=[_wsobj("alpha")])
+    st.import_workspace = fake_import
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        refreshed = {}
+        m.refresh_lists = lambda: refreshed.__setitem__("r", True)
+        m.action_import()
+        await pilot.pause()
+        assert isinstance(app.screen, InputScreen)
+        app.screen.query_one("#inp_value", Input).value = str(archive)
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        await pilot.pause()
+        assert imported["path"] == str(archive)
+        assert refreshed.get("r") is True  # list refreshed on success
+        status = m.query_one("#status", StatusBar)
+        assert "Imported" in str(status.render())
+
+
+async def test_main_import_cancel_aborts(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    st = _ws(owned=[_wsobj("alpha")])
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_import()
+        await pilot.pause()
+        app.screen.on_button_pressed(FakeBtnPress("cancel"))
+        await pilot.pause()
+        assert not isinstance(app.screen, TransferScreen)
 
 
 async def test_main_screen_action_edit_load_fallbacks(monkeypatch):


### PR DESCRIPTION
## Summary

Adds workspace import/export to the TUI with a live progress UI, mirroring the `klangk export` / `import` CLI and reusing the existing `KlangkClient` transport (`export_workspace` / `import_workspace`, both with an `on_progress` callback). Closes #1758 (part of the TUI epic #1743).

## Changes

- **Workspace detail screen — `x` → Export.** Prompts for an output path (default `<name>.tar.gz`), then streams the download from `GET /api/v1/workspaces/{id}/export` (admin-only) with a live progress bar + byte counter.
- **Workspaces list — `i` → Import.** Prompts for a `.tar.gz` archive (must exist on disk), uploads it via `POST /api/v1/workspaces/import` with an upload progress bar, then refreshes the list so the new workspace appears.
- **Two new reusable modals** in `cli/tui/screens/_base.py`:
  - `InputScreen` — a generic labeled single-line input prompt (title + default + OK/Cancel), dismisses with the value or `None`.
  - `TransferScreen` — runs a blocking transfer in a worker thread, bridges the per-chunk `on_progress(done, total)` callback (which fires in the thread) back to the UI thread via `app.call_from_thread`, renders a `ProgressBar` + byte counter, and dismisses with `(ok, message)`. Handles both known-length (`Content-Length` present) and unknown-length transfers.
- **`TuiState`** gains `export_workspace` / `import_workspace` wrappers; export resolves name → id before downloading.

## Notes

- There was no pre-existing progress widget in the TUI, so the issue's "reuse the existing rich progress" is satisfied by a new lightweight `ProgressBar`-based modal built on the `rich`/textual primitives already in the stack. The byte-counter mirrors the CLI's estimate behavior for unknown-length downloads.
- `InputScreen` is a generic primitive; `DuplicateScreen` is a near-duplicate that could be refactored onto it, but that's deliberately out of scope here.
- Export overwrites an existing output path if one is given (the CLI auto-picks a unique name); acceptable for v1, can add a confirm later.

## Test plan

- [x] New unit tests: `TuiState` export/import forwarding (incl. `on_progress` passthrough); `_fmt_transfer`/`_human_bytes` (B/KB/MB/GB + unknown-total branch); `InputScreen` (OK/Cancel/Enter/empty); `TransferScreen` (success + error + both progress branches).
- [x] New flow tests: detail export (prompt → transfer → success message), export cancel, main import (valid file → transfer → list refresh + status), import missing-file flash, import cancel.
- [x] Full Python suite: **3856 passed, 100% coverage**; the four changed modules (`_base.py`, `main.py`, `workspace_detail.py`, `state.py`) at 100%.
