### PR TITLE
TUI: default to ansi-light theme, keep klangk theme

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -448,6 +448,15 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI now defaults to Textual's built-in `ansi-light` theme (#1904).**
+  The app default switched from the custom hard-coded `klangk` palette
+  (fixed RGB background `#0D1117`, `dark=True`) to Textual's built-in
+  `ansi-light`, which uses only the terminal's 16 ANSI colors — so it
+  respects the user's actual terminal palette / shell theme instead of
+  imposing fixed RGB values, and renders correctly on a light-background
+  terminal. The `klangk` theme is still registered and remains selectable
+  for users who want the original GitHub-dark-inspired palette.
+
 - **TUI: tabbed workspace create/edit forms (#1891).** The workspace
   create and edit screens now group their fields under five tabs — General
   (name / image / auto-start), Mounts, Environment, Netfilter (allowed

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -19,10 +19,18 @@ from .screens import (
 from .state import TuiState
 
 # ---------------------------------------------------------------------------
-# Klangk theme — echoes the Flutter web UI's GitHub-dark-inspired palette
-# (src/frontend/lib/theme/colors.dart).
+# Theme.
 #
-# Tokens:
+# The custom `klangk` theme echoes the Flutter web UI's GitHub-dark-inspired
+# palette (src/frontend/lib/theme/colors.dart) and stays registered so a user
+# (or a future theme toggle) can switch to it. The app DEFAULT, however, is
+# Textual's built-in `ansi-light`: unlike the hard-coded klangk palette, the
+# `ansi-*` themes restrict themselves to the terminal's 16 ANSI colors, so the
+# TUI respects the user's actual terminal palette / shell theme instead of
+# imposing fixed RGB values, and renders correctly on a light-background
+# terminal (#1904).
+#
+# klangk theme tokens:
 #   primary   — green (#238636): primary actions (login, create, start)
 #   secondary — blue (#58A6FF): links, focus, informational
 #   accent    — yellow (#F5C518): brand highlight
@@ -189,7 +197,7 @@ class KlangkApp(App):
         self.live_extra = ""
         self._expiring = False
         self.register_theme(KLANGK_THEME)
-        self.theme = "klangk"
+        self.theme = "ansi-light"
 
     def on_mount(self) -> None:
         self.title = "Klangk"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -764,6 +764,34 @@ async def test_app_opens_login_when_unauthenticated():
         assert isinstance(app.screen, LoginScreen)
 
 
+async def test_app_uses_ansi_light_theme():
+    """#1904: the TUI defaults to Textual's built-in ansi-light theme
+    (terminal-palette-aware) instead of the hard-coded klangk palette. The
+    klangk theme stays registered so it remains selectable."""
+    from klangk.cli.tui.app import KLANGK_THEME
+
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "password",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+    )
+    app = KlangkApp(st)
+    # The default is set in __init__, before run_test mounts the app.
+    assert app.theme == "ansi-light"
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Still ansi-light after mount (no on_mount override flips it).
+        assert app.theme == "ansi-light"
+        # The klangk theme stays registered — switching to it must not raise
+        # (Textual raises ThemeError for an unknown theme name).
+        app.theme = "klangk"
+        await pilot.pause()
+        assert app.theme == "klangk"
+        assert KLANGK_THEME.name == "klangk"
+
+
 async def test_app_none_mode_auto_logs_in():
     flag = {"ok": False}
 


### PR DESCRIPTION
## Summary

Switch the TUI's default theme from the custom hard-coded `klangk`
palette to Textual's built-in **`ansi-light`**, while keeping the `klangk`
theme registered and selectable.

Closes #1904.

## Why

The `klangk` palette (background `#0D1117`, `dark=True`) ignores the
user's actual terminal palette and only looks right on a dark terminal
configured with those exact RGB values. The `ansi-*` themes restrict
themselves to the terminal's 16 ANSI colors, so the TUI respects the
user's real palette / shell theme and renders correctly on a
light-background terminal.

## Changes

- `src/klangk/klangk/cli/tui/app.py`:
  - `KLANGK_THEME`, the `Theme` import, and `register_theme(KLANGK_THEME)`
    are **kept** — the `klangk` theme remains available for anyone who
    wants the original GitHub-dark-inspired palette.
  - `self.theme` changes from `"klangk"` → `"ansi-light"` (the only
    behavioral change). Comment updated to explain both halves.
- `docs/changes.md`: `## [Unreleased]` → `### Changed` entry.
- `src/klangk/klangkc-tests/tests/test_tui.py`:
  `test_app_uses_ansi_light_theme` asserts the default is `ansi-light`
  after mount **and** that the `klangk` theme is still registered and
  switchable (setting it does not raise).

## Verification

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto`
  → **3848 passed**, **100% coverage** (matches CI).
- Pre-commit hooks green (ruff, ruff-format, markdownlint, deferred-imports,
  binary-integrity, trufflehog).
- Branch based on `origin/main` (`fd49a045`); no divergence.
