### PR TITLE
fix(tui): separate workspace id and date into fixed-width columns (#1907)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1028,6 +1028,14 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **TUI: workspace id and date are now separate, fixed-width columns with
+  clear spacing between them in the workspaces list (#1907).** Both were
+  `width: auto` and the date had no left padding, so a row's short id and
+  created date rendered flush against each other (`a1b2c3d42025-06-15`) and
+  didn't line up across rows of varying name length. The id is now a fixed
+  10-cell column and the date a fixed 12-cell column with `padding-left: 2`,
+  so ids/dates align vertically regardless of name length.
+
 - **TUI workspace form: Add/Remove buttons in the mounts / environment /
   netfilter editors are now clickable (#1891).** The editor `Input`'s greedy
   default width consumed the whole row, pushing the Add/Remove buttons past

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -89,12 +89,13 @@ class MainScreen(Screen):
         width: 1fr;
     }
     .ws-id {
-        width: auto;
+        width: 10;
         padding-left: 1;
         color: $text-muted;
     }
     .ws-date {
-        width: auto;
+        width: 12;
+        padding-left: 2;
         text-align: right;
         color: $text-muted;
     }

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2385,6 +2385,37 @@ async def test_main_screen_shared_list_shows_short_id(monkeypatch):
         assert "abcdef12" in str(id_label.render())
 
 
+async def test_main_screen_row_id_and_date_are_separate_columns(monkeypatch):
+    """#1907: the workspace id and date render as separate, fixed-width
+    columns (not two auto-width labels stuck together), with clear left
+    spacing on the date column so the date never runs flush against the id."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = Workspace(
+        id="3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        name="alpha",
+        created_at="2025-06-15T10:30:00",
+        running=True,
+    )
+    app = KlangkApp(_ws(owned=[ws], shared=[]))
+    async with app.run_test():
+        m = app.screen
+        items = m.query_one("#owned_list", ListView).query(ListItem)
+        id_label = items[0].query_one(".ws-id")
+        date_label = items[0].query_one(".ws-date")
+        # Fixed (cell) widths, not auto: ids/dates line up across rows of
+        # varying name length (.ws-name absorbs the slack at width: 1fr).
+        assert id_label.styles.width.is_cells
+        assert date_label.styles.width.is_cells
+        assert not id_label.styles.width.is_auto
+        assert not date_label.styles.width.is_auto
+        # Clear space between the id and date columns.
+        assert date_label.styles.padding.left >= 2
+
+
 async def test_update_running_unknown_workspace(monkeypatch):
     """_update_running returns early for unknown workspace_id (line 692)."""
 


### PR DESCRIPTION
## Summary

Fixes #1907.

In the TUI workspaces list, each row's short workspace **id** and created
**date** were both `width: auto` with no left spacing on the date, so they
collapsed to their content and rendered flush against each other
(`a1b2c3d42025-06-15`) and didn't line up across rows of varying name length.

## Changes

- `src/klangk/klangk/cli/tui/screens/main.py` — give the columns fixed widths
  and clear spacing:
  - `.ws-id { width: 10; padding-left: 1; }`
  - `.ws-date { width: 12; padding-left: 2; text-align: right; }`
- `src/klangk/klangkc-tests/tests/test_tui.py` —
  `test_main_screen_row_id_and_date_are_separate_columns` asserts both labels
  have fixed (cell) widths (not auto) and the date has `padding-left >= 2`.
- `docs/changes.md` — Fixed entry under `[Unreleased]`.

`.ws-name` stays `width: 1fr` and absorbs the slack, so ids/dates align
vertically regardless of name length.

## Test plan

- [x] `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 3852 passed, 100% coverage.
