### PR TITLE
feat(tui): tabbed account screen (Password / Handle / Email) (#1898)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -33,6 +33,18 @@ operators or integrators to act when upgrading.
   on its row (#1899). Name matching is unchanged; the empty filter still
   shows all workspaces.
 
+- **TUI account screen is now tabbed (Password / Handle / Email)
+  (#1898).** The three self-service forms — change password, change
+  handle, change email — now live in a `TabbedContent` with one tab per
+  credential concern, mirroring the workspace editor's tabbed layout
+  (#1891) so the two editor screens share one interaction model. The
+  current `@handle` / email profile header is pinned above the tabs and
+  stays visible on every tab. Keyboard nav: Left/Right switch tabs on the
+  strip, Down enters the active tab, Up returns to the strip, and Up/Down
+  walks the active tab's fields — no focus traps. Per-field validation
+  (handle charset, email format, password minimum) and the handle-change
+  confirm dialog are unchanged.
+
 - **TUI workspace import/export with progress (#1758).** The workspace
   detail screen gains `x` → Export (downloads a `.tar.gz` via
   `GET /api/v1/workspaces/{id}/export`, admin-only) and the workspaces
@@ -480,6 +492,14 @@ invitations send` stay email-only (a deliverable address is required);
   imposing fixed RGB values, and renders correctly on a light-background
   terminal. The `klangk` theme is still registered and remains selectable
   for users who want the original GitHub-dark-inspired palette.
+
+- **TUI: tabbed account screen (#1898).** The account screen now groups
+  its three self-service forms under tabs — Password / Handle / Email —
+  instead of one long scroll, mirroring the tabbed workspace forms (#1891).
+  The `@handle` / email profile header stays pinned above the tabs so it is
+  visible on every tab. Left/Right switch tabs, Up/Down move between the
+  tab strip and a pane's fields, and Up from the first field returns to the
+  strip — no focus traps.
 
 - **TUI: tabbed workspace create/edit forms (#1891).** The workspace
   create and edit screens now group their fields under five tabs — General

--- a/src/klangk/klangk/cli/tui/screens/account.py
+++ b/src/klangk/klangk/cli/tui/screens/account.py
@@ -15,13 +15,15 @@ from textual.widgets import (
     Header,
     Input,
     Static,
+    TabbedContent,
+    TabPane,
+    Tabs,
 )
 
 from ... import account as _account_mod
 from ..state import LoginError
 from ._base import (
     ConfirmScreen,
-    NonFocusableVerticalScroll,
     SpatialNavScreen,
 )
 
@@ -29,11 +31,19 @@ from ._base import (
 class AccountScreen(SpatialNavScreen):
     """Account self-service: change password / handle / email (#1753).
 
-    Mirrors the Flutter ``SettingsPage`` — current @handle + email from
-    ``GET /auth/me``, the same client-side validation (handle charset, email
-    format, password minimum from ``/api/v1/config``), and a confirm dialog
-    for the handle change (it affects the terminal home directory and how
-    others see you in chat).
+    The three credential forms live in a :class:`TabbedContent` — one tab
+    per concern (Password / Handle / Email) — with the ``#profile`` header
+    pinned above the tabs so the current ``@handle`` / email stays visible
+    regardless of which tab is active (#1898). Mirrors the Flutter
+    ``SettingsPage`` semantics: same client-side validation (handle charset,
+    email format, password minimum from ``/api/v1/config``) and a confirm
+    dialog for the handle change (it affects the terminal home directory and
+    how others see you in chat).
+
+    Spatial navigation (#1781): Up/Down walks the active tab's field chain;
+    Up from the first field returns focus to the tab strip, Left/Right on
+    the strip switches tabs (native :class:`Tabs` binding), and Down from
+    the strip enters the active tab — no focus traps.
     """
 
     BINDINGS = [
@@ -42,19 +52,14 @@ class AccountScreen(SpatialNavScreen):
         Binding("escape", "app.pop_screen", "Back", show=True),
     ]
 
-    # Focus chain for spatial Up/Down (reading order).
-    SPATIAL_CHAIN = [
-        "pw_current",
-        "pw_new",
-        "pw_confirm",
-        "pw_submit",
-        "handle_new",
-        "handle_pw",
-        "handle_submit",
-        "email_new",
-        "email_pw",
-        "email_submit",
-    ]
+    # Per-tab focus chains (reading order), keyed by TabPane id. The active
+    # tab's chain is exposed via the :attr:`SPATIAL_CHAIN` property so the
+    # inherited spatial Up/Down handler walks only the visible tab (#1898).
+    _TAB_CHAINS: dict[str, list[str]] = {
+        "pw_pane": ["pw_current", "pw_new", "pw_confirm", "pw_submit"],
+        "handle_pane": ["handle_new", "handle_pw", "handle_submit"],
+        "email_pane": ["email_new", "email_pw", "email_submit"],
+    }
 
     DEFAULT_CSS = """
     AccountScreen { align: center top; }
@@ -64,13 +69,10 @@ class AccountScreen(SpatialNavScreen):
         height: auto;
         padding: 0 2;
     }
-    #account_scroll { padding: 0 0 1 0; }
     #profile { padding: 1 0; text-style: bold; color: $text-secondary; }
-    .acct-section {
-        height: auto;
-        padding: 1 0;
-        border-top: solid $border-blurred;
-    }
+    #acct_tabs { height: auto; }
+    AccountScreen TabPane { padding: 1 0; height: auto; }
+    .acct-section { height: auto; }
     .acct-title {
         text-style: bold;
         color: $primary;
@@ -84,71 +86,123 @@ class AccountScreen(SpatialNavScreen):
     .acct-actions { align-horizontal: right; height: auto; }
     """
 
+    @property
+    def SPATIAL_CHAIN(self) -> list[str]:
+        """Fields of the active tab, in reading order (#1898)."""
+        return self._TAB_CHAINS.get(self._active_tab_id(), [])
+
+    def _active_tab_id(self) -> str:
+        return self.query_one("#acct_tabs", TabbedContent).active or ""
+
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
-        with NonFocusableVerticalScroll(id="account_scroll"):
-            yield Vertical(
-                Static("", id="profile"),
-                # --- Change password ---
-                Vertical(
-                    Static("Change password", classes="acct-title"),
-                    Input(
-                        placeholder="Current password",
-                        id="pw_current",
-                        password=True,
-                    ),
-                    Input(
-                        placeholder="New password",
-                        id="pw_new",
-                        password=True,
-                    ),
-                    Input(
-                        placeholder="Confirm new password",
-                        id="pw_confirm",
-                        password=True,
-                    ),
-                    Static("", id="pw_msg", classes="acct-msg"),
-                    Horizontal(
-                        Button("Update password", id="pw_submit"),
-                        classes="acct-actions",
-                    ),
-                    classes="acct-section",
-                ),
-                # --- Change handle ---
-                Vertical(
-                    Static("Change handle", classes="acct-title"),
-                    Input(placeholder="New handle", id="handle_new"),
-                    Input(
-                        placeholder="Password (to confirm)",
-                        id="handle_pw",
-                        password=True,
-                    ),
-                    Static("", id="handle_msg", classes="acct-msg"),
-                    Horizontal(
-                        Button("Update handle", id="handle_submit"),
-                        classes="acct-actions",
-                    ),
-                    classes="acct-section",
-                ),
-                # --- Change email ---
-                Vertical(
-                    Static("Change email", classes="acct-title"),
-                    Input(placeholder="New email", id="email_new"),
-                    Input(
-                        placeholder="Password (to confirm)",
-                        id="email_pw",
-                        password=True,
-                    ),
-                    Static("", id="email_msg", classes="acct-msg"),
-                    Horizontal(
-                        Button("Update email", id="email_submit"),
-                        classes="acct-actions",
-                    ),
-                    classes="acct-section",
-                ),
-                id="account_box",
-            )
+        # #account_box is a direct child of the screen (no
+        # VerticalScroll wrapper): a VerticalScroll's own up/down scroll
+        # bindings would sit between the focused Input and the screen's
+        # spatial_up/spatial_down and silently swallow arrow keys
+        # (#1898). The tabbed layout is short enough to need no scroll.
+        with Vertical(id="account_box"):
+            # Profile header is pinned ABOVE the tabs so the current
+            # @handle / email stays visible regardless of the active
+            # tab (#1898).
+            yield Static("", id="profile")
+            with TabbedContent(id="acct_tabs"):
+                with TabPane("Password", id="pw_pane"):
+                    yield Vertical(
+                        Static("Change password", classes="acct-title"),
+                        Input(
+                            placeholder="Current password",
+                            id="pw_current",
+                            password=True,
+                        ),
+                        Input(
+                            placeholder="New password",
+                            id="pw_new",
+                            password=True,
+                        ),
+                        Input(
+                            placeholder="Confirm new password",
+                            id="pw_confirm",
+                            password=True,
+                        ),
+                        Static("", id="pw_msg", classes="acct-msg"),
+                        Horizontal(
+                            Button("Update password", id="pw_submit"),
+                            classes="acct-actions",
+                        ),
+                        classes="acct-section",
+                    )
+                with TabPane("Handle", id="handle_pane"):
+                    yield Vertical(
+                        Static("Change handle", classes="acct-title"),
+                        Input(placeholder="New handle", id="handle_new"),
+                        Input(
+                            placeholder="Password (to confirm)",
+                            id="handle_pw",
+                            password=True,
+                        ),
+                        Static("", id="handle_msg", classes="acct-msg"),
+                        Horizontal(
+                            Button("Update handle", id="handle_submit"),
+                            classes="acct-actions",
+                        ),
+                        classes="acct-section",
+                    )
+                with TabPane("Email", id="email_pane"):
+                    yield Vertical(
+                        Static("Change email", classes="acct-title"),
+                        Input(placeholder="New email", id="email_new"),
+                        Input(
+                            placeholder="Password (to confirm)",
+                            id="email_pw",
+                            password=True,
+                        ),
+                        Static("", id="email_msg", classes="acct-msg"),
+                        Horizontal(
+                            Button("Update email", id="email_submit"),
+                            classes="acct-actions",
+                        ),
+                        classes="acct-section",
+                    )
         yield Footer()
+
+    # --- spatial navigation across tabs (#1898) ---
+
+    def action_spatial_up(self) -> None:
+        """Up within a tab walks its chain; from the first field, Up
+        returns focus to the tab strip so Left/Right can switch tabs
+        (#1781, #1898).
+        """
+        chain = self.SPATIAL_CHAIN
+        fid = getattr(self.focused, "id", None) if self.focused else None
+        if not fid or fid not in chain:
+            return
+        pos = chain.index(fid)
+        if pos > 0:
+            self.query_one(f"#{chain[pos - 1]}").focus()
+        else:
+            # Top of a tab → return focus to the tab strip.
+            self.query_one(Tabs).focus()
+
+    def on_key(self, event) -> None:
+        """Down from the tab strip enters the first field of the active
+        tab. Left/Right on the strip switch tabs natively (handled by
+        :class:`Tabs`' own bindings)."""
+        if event.key == "down" and isinstance(self.focused, Tabs):
+            chain = self.SPATIAL_CHAIN
+            if chain:
+                event.stop()
+                self.query_one(f"#{chain[0]}").focus()
+
+    def on_tabbed_content_tab_activated(self, event) -> None:
+        """Focus the first field of the newly-active tab (#1792, #1898).
+
+        Mirrors the workspace-list screen: switching tabs drops you into
+        the pane's content rather than stranding focus on the strip.
+        """
+        chain = self.SPATIAL_CHAIN
+        if chain:
+            self.query_one(f"#{chain[0]}").focus()
 
     def on_mount(self) -> None:
         self.app.title = "Klangk: Account"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -8100,6 +8100,286 @@ async def test_main_screen_action_account_opens_screen(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Account screen tabbed DOM (#1898): three tabs (Password / Handle /
+# Email), profile pinned above the tabs, spatial nav across tabs.
+# ---------------------------------------------------------------------------
+
+
+def _acct_pane_ids(screen):
+    """Ids of the TabPanes inside the account TabbedContent, in order."""
+    tc = screen.query_one("#acct_tabs", TabbedContent)
+    return [p.id for p in tc.query(TabPane)]
+
+
+async def test_account_screen_has_three_tabs_with_all_fields(monkeypatch):
+    """Three tabs (Password / Handle / Email); no field dropped (#1898)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(
+        scr_account._account_mod, "password_min_length", lambda url: 4
+    )
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        tc = s.query_one("#acct_tabs", TabbedContent)
+        # Exactly three panes, in the documented order.
+        assert _acct_pane_ids(s) == ["pw_pane", "handle_pane", "email_pane"]
+        # Every per-section field/button is mounted (under its own pane).
+        for fid, pane_id in [
+            ("pw_current", "pw_pane"),
+            ("pw_new", "pw_pane"),
+            ("pw_confirm", "pw_pane"),
+            ("pw_msg", "pw_pane"),
+            ("pw_submit", "pw_pane"),
+            ("handle_new", "handle_pane"),
+            ("handle_pw", "handle_pane"),
+            ("handle_msg", "handle_pane"),
+            ("handle_submit", "handle_pane"),
+            ("email_new", "email_pane"),
+            ("email_pw", "email_pane"),
+            ("email_msg", "email_pane"),
+            ("email_submit", "email_pane"),
+        ]:
+            field = s.query_one(f"#{fid}")
+            pane = s.query_one(f"#{pane_id}", TabPane)
+            assert pane in field.ancestors, f"{fid} not under {pane_id}"
+        # The submit flows still resolve (handlers unchanged).
+        assert tc.active == "pw_pane"  # Password is the initial tab
+
+
+async def test_account_screen_profile_pinned_above_tabs(monkeypatch):
+    """#profile sits above the TabbedContent, not inside any tab pane, so
+    the current @handle / email stays visible on every tab (#1898)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        profile = s.query_one("#profile")
+        tc = s.query_one("#acct_tabs", TabbedContent)
+        # Profile is a sibling of the TabbedContent, both inside #account_box.
+        assert profile.parent.id == "account_box"
+        assert tc.parent.id == "account_box"
+        # And profile is NOT a descendant of the TabbedContent.
+        with pytest.raises(Exception):
+            tc.query_one("#profile")
+
+
+async def test_account_screen_left_right_switch_tabs(monkeypatch):
+    """Left/Right on the tab strip switches the active tab; switching
+    drops focus into the new tab's first field (#1898)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        tc = s.query_one("#acct_tabs", TabbedContent)
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+
+        await pilot.press("right")
+        await pilot.pause()
+        assert tc.active == "handle_pane"
+        assert app.focused is s.query_one("#handle_new", Input)
+
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        assert tc.active == "email_pane"
+        assert app.focused is s.query_one("#email_new", Input)
+
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("left")
+        await pilot.pause()
+        assert tc.active == "handle_pane"
+        assert app.focused is s.query_one("#handle_new", Input)
+
+
+async def test_account_screen_spatial_chain_follows_active_tab(monkeypatch):
+    """SPATIAL_CHAIN returns the active tab's fields, so the inherited
+    Up/Down handler walks only the visible tab (#1898).
+
+    Tab switches are driven via the keyboard (Left/Right on the strip)
+    rather than assigning ``tc.active`` directly: the programmatic set
+    races the TabActivated message under load, while the keyboard path
+    settles reliably (it's the real user interaction)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+
+        # Password tab is active on mount.
+        assert s.SPATIAL_CHAIN == [
+            "pw_current",
+            "pw_new",
+            "pw_confirm",
+            "pw_submit",
+        ]
+
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("right")  # -> handle_pane
+        await pilot.pause()
+        assert s._active_tab_id() == "handle_pane"
+        assert s.SPATIAL_CHAIN == ["handle_new", "handle_pw", "handle_submit"]
+
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("right")  # -> email_pane
+        await pilot.pause()
+        assert s._active_tab_id() == "email_pane"
+        assert s.SPATIAL_CHAIN == ["email_new", "email_pw", "email_submit"]
+
+
+async def test_account_screen_down_from_strip_enters_tab(monkeypatch):
+    """Down from the tab strip focuses the first field of the active tab
+    (#1781, #1898)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+
+        # Password tab (default).
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is s.query_one("#pw_current", Input)
+
+        # Handle tab — switch via the keyboard (reliable settling).
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("right")  # -> handle_pane
+        await pilot.pause()
+        s.query_one(Tabs).focus()  # back to the strip
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is s.query_one("#handle_new", Input)
+
+
+async def test_account_screen_up_from_first_field_returns_to_strip(
+    monkeypatch,
+):
+    """Up from the first field of a tab returns focus to the tab strip so
+    Left/Right can switch tabs — no focus trap (#1781, #1898)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+
+        s.query_one("#pw_current", Input).focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert isinstance(app.focused, Tabs)
+
+        # Non-first field: Up stays inside the chain (no jump to strip).
+        s.query_one("#pw_new", Input).focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused is s.query_one("#pw_current", Input)
+
+
+async def test_account_screen_spatial_up_down_within_tab(monkeypatch):
+    """Up/Down walks the active tab's chain top-to-bottom and stops at the
+    last field (no trap downward) (#1898)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+
+        s.query_one("#pw_current", Input).focus()
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is s.query_one("#pw_new", Input)
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is s.query_one("#pw_confirm", Input)
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is s.query_one("#pw_submit", Button)
+        # Past the last field: focus stays put (no trap, no wrap).
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is s.query_one("#pw_submit", Button)
+
+
+async def test_account_screen_spatial_up_noop_off_chain(monkeypatch):
+    """action_spatial_up is a no-op when focus isn't on a chain widget
+    (e.g. on the tab strip itself) — the early-return branch (#1898)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+
+        # The tab strip is not in any tab's SPATIAL_CHAIN, so Up from it
+        # returns early without crashing or moving focus.
+        s.query_one(Tabs).focus()
+        await pilot.pause()
+        s.action_spatial_up()
+        await pilot.pause()
+        assert isinstance(app.focused, Tabs)
+
+
+# ---------------------------------------------------------------------------
 # Terminal list push (#1894)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Converts the TUI account screen from three stacked `.acct-section` blocks (in a single scroll) into a `TabbedContent` with one tab per credential concern — **Password / Handle / Email** — mirroring the workspace editor's tabbed layout (#1891) so the two editor screens share one interaction model. Closes #1898.

The `#profile` header (current `@handle` + email) is pinned **above** the tabs and stays visible on every tab.

## Spatial navigation (#1781, no focus traps)

- `SPATIAL_CHAIN` is now a property returning the **active tab's** fields, so the inherited Up/Down handler walks only the visible tab.
- **Up/Down** — walks the active tab's field chain; stops at the last field (no wrap, no trap).
- **Up** from the first field — returns focus to the tab strip.
- **Left/Right** on the strip — switches tabs (Textual `Tabs` built-in).
- **Down** from the strip — enters the active tab's first field (`on_key`).
- **Tab/Shift-Tab** still cycles fields as a fallback.

## Notable fix

Removed the `NonFocusableVerticalScroll` wrapper. Its `up`/`down` scroll bindings sat between the focused `Input` and the screen's `spatial_up`/`spatial_down` bindings and silently swallowed arrow keys — so spatial nav on the account screen had **never actually worked** (it was untested). The login screen works precisely because it has no such wrapper. The tabbed layout is short enough to need no scroll.

## Unchanged

Per-field validation (handle charset, email format, password minimum from `/api/v1/config`), the handle-change confirm dialog, and all submit flows. All 19 existing account-screen tests pass unchanged.

## Tests

- 7 new tests cover the tabbed DOM: three tabs / no field dropped, `#profile` pinned outside the `TabbedContent`, Left/Right switching + focus-into-pane, `SPATIAL_CHAIN` follows the active tab, Down-from-strip, Up-to-strip, within-tab Up/Down, and the off-chain early-return.
- Two of those originally flaked under load from programmatic `tc.active =` assignment; rewritten to drive tab switches via the keyboard path (the real user interaction), which settles reliably.
- Full Python suite: **3859 passed, 100% coverage** (`-n auto`, both dirs) — matches CI.

## Changelog

Added an entry under `[Unreleased]` → `Added`.
