### PR TITLE
TUI: workspace-list filter matches the id too

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,12 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **TUI workspaces-list filter now also matches the workspace id (#1911).**
+  Typing into the filter (`/`) narrows by name **or** id — so a workspace
+  matches whether you type part of its name or the short id prefix shown
+  on its row (#1899). Name matching is unchanged; the empty filter still
+  shows all workspaces.
+
 - **TUI workspace import/export with progress (#1758).** The workspace
   detail screen gains `x` → Export (downloads a `.tar.gz` via
   `GET /api/v1/workspaces/{id}/export`, admin-only) and the workspaces

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -257,22 +257,26 @@ class MainScreen(Screen):
         )
         return sorted(workspaces, key=key, reverse=not self._sort_asc)
 
+    @staticmethod
+    def _matches(ws, q: str) -> bool:
+        """Whether a workspace matches the filter query — by name or id.
+
+        Matching the full id also covers the 8-char prefix shown on the row
+        (the prefix is a substring of the id) (#1911).
+        """
+        return (
+            q in (getattr(ws, "name", "") or "").lower()
+            or q in (str(getattr(ws, "id", "") or "")).lower()
+        )
+
     def _apply_filter(self) -> None:
         """Re-populate both lists from cached data with filter + sort."""
         q = self._filter_text
         owned = self._owned_all
         shared = self._shared_all
         if q:
-            owned = [
-                ws
-                for ws in owned
-                if q in (getattr(ws, "name", "") or "").lower()
-            ]
-            shared = [
-                ws
-                for ws in shared
-                if q in (getattr(ws, "name", "") or "").lower()
-            ]
+            owned = [ws for ws in owned if self._matches(ws, q)]
+            shared = [ws for ws in shared if self._matches(ws, q)]
         owned = self._sort_workspaces(owned)
         shared = self._sort_workspaces(shared)
         empty = "(no matches)" if q else "(no workspaces)"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2853,6 +2853,77 @@ async def test_filter_narrows_workspace_list(monkeypatch):
         assert names == {"alpha", "alphabet"}
 
 
+def test_main_screen_matches_name_or_id():
+    """_matches narrows by name or id (and the 8-char id prefix) (#1911)."""
+    ws = Workspace(
+        id="3fa85f64-1b2c-4d5e-8f9a-0123456789ab",
+        name="alpha",
+        created_at="x",
+    )
+    # name substring
+    assert MainScreen._matches(ws, "alph")
+    # full id
+    assert MainScreen._matches(ws, "3fa85f64-1b2c-4d5e-8f9a-0123456789ab")
+    # 8-char row prefix (a substring of the id)
+    assert MainScreen._matches(ws, "3fa85f64")
+    # case-insensitive: queries are lowercased before _matches is called
+    assert MainScreen._matches(ws, "alpha")
+    # neither name nor id
+    assert not MainScreen._matches(ws, "zzz")
+    # missing attrs don't crash; empty id never matches on its own
+    bare = type("W", (), {"name": "x", "id": ""})()
+    assert MainScreen._matches(bare, "x")
+    assert not MainScreen._matches(bare, "y")
+
+
+async def test_filter_matches_workspace_id(monkeypatch):
+    """Typing a workspace's id (or prefix) into the filter matches it (#1911)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = Workspace(
+        id="3fa85f64-1b2c-4d5e-8f9a-0123456789ab", name="alpha", created_at="x"
+    )
+    b = Workspace(
+        id="11111111-2222-3333-4444-555555555555", name="beta", created_at="x"
+    )
+    app = KlangkApp(_ws(owned=[a, b]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        lv = m.query_one("#owned_list", ListView)
+        assert len(lv.query(ListItem)) == 2
+
+        # Type the 8-char prefix of alpha's id -> only alpha matches.
+        inp = m.query_one("#filter_input", Input)
+        inp.value = "3fa85f64"
+        await pilot.pause()
+        items = lv.query(ListItem)
+        assert len(items) == 1
+        assert items[0].name == "alpha"
+
+        # Full id also narrows to alpha.
+        inp.value = "3fa85f64-1b2c-4d5e-8f9a-0123456789ab"
+        await pilot.pause()
+        assert len(lv.query(ListItem)) == 1
+
+        # Clearing the filter shows both again (empty filter = all).
+        inp.value = ""
+        await pilot.pause()
+        assert len(lv.query(ListItem)) == 2
+
+        # Name matching still works unchanged.
+        inp.value = "bet"
+        await pilot.pause()
+        items = lv.query(ListItem)
+        assert len(items) == 1
+        assert items[0].name == "beta"
+
+
 async def test_filter_no_matches_shows_placeholder(monkeypatch):
     """A filter with no matches shows '(no matches)' placeholder (#1764)."""
 


### PR DESCRIPTION
## Summary

The TUI workspaces-list filter (`/`) now matches by **id** in addition to **name**, so typing the short id prefix shown on a row narrows to that workspace. Closes #1911.

## Current behavior

`_apply_filter` in `src/klangk/klangk/cli/tui/screens/main.py` narrowed by name only, so typing a visible id prefix (e.g. `3fa85f64`, shown on the row per #1899) returned `(no matches)`.

## Change

- Added a `MainScreen._matches(ws, q)` static helper that returns `True` when `q` is a substring of the workspace's **name** (lowercased) **or** its full **id** (lowercased).
- `_apply_filter` now uses it for both the Owned and Shared lists.
- Matching against the full id covers the 8-char row prefix (the prefix is a substring of the id), so no special-casing is needed.

Name matching and the empty-filter (show all) path are unchanged.

## Test plan

- [x] `test_main_screen_matches_name_or_id` — direct unit test of `_matches`: name substring, full id, 8-char prefix, case-insensitivity, no-match, and missing-attr safety.
- [x] `test_filter_matches_workspace_id` — end-to-end through the filter input: 8-char prefix → 1 match, full id → 1 match, cleared → both, and name matching still works.
- [x] Full Python suite: **3863 passed, 100% coverage**; `main.py` at 100%.
