### PR TITLE
feat(tui): render workspace detail info as a two-column table (#1910)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -479,6 +479,16 @@ invitations send` stay email-only (a deliverable address is required);
   written under the TUI's CWD — is no longer ambiguous. Export failures
   still report the error inline on the detail screen.
 
+- **TUI: workspace detail info now renders as a two-column table (#1910).**
+  Fields were previously a single left-aligned `"key: value"` text block, so
+  values started in different columns depending on label length (`id:` vs
+  `service command:`) and the multi-valued sections (mounts / environment /
+  allowed domains) were hand-indented. The detail body is now a Rich table
+  with an auto-sized label column and a value column, so every value lines
+  up vertically regardless of label length; long values fold to fit the pane
+  instead of running off the right edge. The live uptime counter keeps
+  refreshing in place.
+
 - **TUI now defaults to Textual's built-in `ansi-light` theme (#1904).**
   The app default switched from the custom hard-coded `klangk` palette
   (fixed RGB background `#0D1117`, `dark=True`) to Textual's built-in

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -7,8 +7,11 @@ import logging
 import subprocess
 import sys
 import time
+from io import StringIO
 from pathlib import Path
 
+from rich.console import Console
+from rich.table import Table
 from rich.text import Text
 
 from textual.app import ComposeResult
@@ -178,10 +181,20 @@ class WorkspaceDetailScreen(Screen):
         # Toggle the 's' binding label between Stop / Start.
         self.BINDINGS = self._bindings_list("Stop" if ws.running else "Start")
         self.refresh_bindings()
-        lines = [
-            f"id: {ws.id}",
-            f"running: {'yes' if ws.running else 'no'}",
-            f"health: {ws.health or '-'}",
+        # Render the detail as a two-column table so every value lines up in
+        # the same column regardless of label length (#1910). Wrapped in Text()
+        # so values that look like markup (e.g. an image named "[img]") render
+        # literally instead of being parsed as Textual markup.
+        width = self.size.width or 80
+        body.update(Text(self._render_detail(self._detail_rows(ws), width)))
+
+    @staticmethod
+    def _detail_rows(ws) -> list[tuple[str, str]]:
+        """Build the (label, value) rows shown in the workspace detail table."""
+        rows: list[tuple[str, str]] = [
+            ("id", str(ws.id)),
+            ("running", "yes" if ws.running else "no"),
+            ("health", ws.health or "-"),
         ]
         if ws.running and ws.service_started_at:
             elapsed = int(time.time() - ws.service_started_at)
@@ -195,28 +208,64 @@ class WorkspaceDetailScreen(Screen):
                 if hours:
                     parts.append(f"{hours}h")
                 parts.append(f"{minutes}m")
-                lines.append(f"uptime: {' '.join(parts)}")
+                rows.append(("uptime", " ".join(parts)))
         if ws.health_message:
-            lines.append(f"health note: {ws.health_message}")
+            rows.append(("health note", ws.health_message))
         if ws.image:
-            lines.append(f"image: {ws.image}")
+            rows.append(("image", ws.image))
         if ws.service_command:
-            lines.append(f"service command: {ws.service_command}")
+            rows.append(("service command", ws.service_command))
         if ws.health_check:
-            lines.append(f"health check: {ws.health_check}")
-        lines.append(f"auto-start: {'on' if ws.auto_start else 'off'}")
+            rows.append(("health check", ws.health_check))
+        rows.append(("auto-start", "on" if ws.auto_start else "off"))
         if ws.mounts:
-            lines.append("mounts:")
-            lines.extend(f"  {m}" for m in ws.mounts)
+            rows.append(("mounts", "\n".join(str(m) for m in ws.mounts)))
         if ws.env:
-            lines.append("environment:")
-            lines.extend(f"  {k}={v}" for k, v in ws.env.items())
+            rows.append(
+                (
+                    "environment",
+                    "\n".join(f"{k}={v}" for k, v in ws.env.items()),
+                )
+            )
         if ws.allowed_domains:
-            lines.append("allowed domains:")
-            lines.extend(f"  {d}" for d in ws.allowed_domains)
+            rows.append(
+                (
+                    "allowed domains",
+                    "\n".join(str(d) for d in ws.allowed_domains),
+                )
+            )
         if ws.owner_email:
-            lines.append(f"owner: {ws.owner_email}")
-        body.update(Text("\n".join(lines)))
+            rows.append(("owner", ws.owner_email))
+        return rows
+
+    @staticmethod
+    def _render_detail(rows: list[tuple[str, str]], width: int) -> str:
+        """Render (label, value) rows as an aligned two-column table string.
+
+        The label column auto-sizes to the longest label, so every value
+        starts at the same column; the value column folds long values to fit
+        ``width`` instead of running off the right edge."""
+        table = Table(
+            show_header=False,
+            box=None,
+            pad_edge=False,
+            padding=(0, 1),
+            expand=True,
+        )
+        table.add_column("label", no_wrap=True)
+        table.add_column("value", overflow="fold", ratio=1)
+        for label, value in rows:
+            table.add_row(label, value)
+        buf = StringIO()
+        Console(
+            file=buf,
+            width=width,
+            force_terminal=False,
+            no_color=True,
+            highlight=False,
+            markup=False,
+        ).print(table, end="")
+        return buf.getvalue()
 
     def _tick_uptime(self) -> None:
         """Refresh the display periodically to update the uptime counter."""

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -347,7 +347,7 @@ class TestTuiE2E:
                 body = str(
                     app.screen.query_one("#detail_body", Static).render()
                 )
-                assert "running:" in body.lower()
+                assert "running" in body.lower()
         finally:
             _api_delete_workspace(base_url, token, ws_id)
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -168,6 +168,35 @@ def _wsobj(name, **k):
     return Workspace(id="id-" + name, name=name, created_at="x", **k)
 
 
+def _detail_value(body: str, label: str) -> str | None:
+    """Return the value-column text for ``label``'s row in the workspace
+    detail table, or None if no such row.
+
+    The detail body renders as a two-column table (#1910): a label at the
+    start of a line, then a column of padding (>=2 spaces), then the value.
+    A label is matched only when it's followed by that padding gap, so
+    ``health`` doesn't match the ``health note`` / ``health check`` rows.
+    Multi-line value cells (mounts / environment / allowed domains) are
+    rejoined with newlines."""
+    lines = body.splitlines()
+    for i, line in enumerate(lines):
+        if not line.startswith(label):
+            continue
+        rest = line[len(label) :]
+        # "health" must not match "health note" (rest starts with a word,
+        # not the column gap). The gap is always >=2 spaces.
+        if rest.strip() and not rest[:2].isspace():
+            continue
+        parts = [rest.strip()] if rest.strip() else []
+        for cont in lines[i + 1 :]:
+            if not cont[:1].isspace():
+                break
+            if cont.strip():
+                parts.append(cont.strip())
+        return "\n".join(parts)
+    return None
+
+
 async def _async_empty(*a, **k):
     """Async stub for TuiState terminal methods (returns no terminals)."""
     return []
@@ -3340,21 +3369,19 @@ async def test_detail_loads_and_renders(monkeypatch):
         await pilot.pause()
         d = app.screen
         body = str(d.query_one("#detail_body").render())
-        for s in [
-            "running: yes",
-            "health: healthy",
-            "health note: ok",
-            "image: img",
-            "service command: cmd",
-            "health check: hc",
-            "auto-start: off",
-            "mounts:",
-            "/h:/c",
-            "environment:",
-            "K=v",
-            "owner: o@x",
-        ]:
-            assert s in body, s
+        # #1910: detail renders as a two-column table — labels and values
+        # are separate columns, so assert each row's label + value.
+        assert _detail_value(body, "id") == "id-alpha"
+        assert _detail_value(body, "running") == "yes"
+        assert _detail_value(body, "health") == "healthy"
+        assert _detail_value(body, "health note") == "ok"
+        assert _detail_value(body, "image") == "img"
+        assert _detail_value(body, "service command") == "cmd"
+        assert _detail_value(body, "health check") == "hc"
+        assert _detail_value(body, "auto-start") == "off"
+        assert _detail_value(body, "mounts") == "/h:/c"
+        assert _detail_value(body, "environment") == "K=v"
+        assert _detail_value(body, "owner") == "o@x"
 
 
 async def test_detail_shows_full_id(monkeypatch):
@@ -3379,9 +3406,9 @@ async def test_detail_shows_full_id(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         body = str(app.screen.query_one("#detail_body").render())
-        assert f"id: {full_id}" in body
-        # The id line appears before the running/health lines (near the top).
-        assert body.index(f"id: {full_id}") < body.index("running:")
+        assert _detail_value(body, "id") == full_id
+        # The id row appears before the running row (near the top).
+        assert body.index(full_id) < body.index("running")
 
 
 async def test_detail_renders_allowed_domains(monkeypatch):
@@ -3398,9 +3425,50 @@ async def test_detail_renders_allowed_domains(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         body = str(app.screen.query_one("#detail_body").render())
-        assert "allowed domains:" in body
+        assert _detail_value(body, "allowed domains") is not None
         assert "github.com:443" in body
         assert "pypi.org" in body
+
+
+async def test_detail_renders_aligned_two_column_table(monkeypatch):
+    """#1910: the detail body renders as a two-column table — every value
+    starts at the same column regardless of label length, so labels and
+    values line up vertically."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj(
+        "alpha",
+        running=True,
+        health="healthy",
+        image="img",
+        service_command="cmd",
+        owner_email="o@x",
+    )
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        body = str(app.screen.query_one("#detail_body").render())
+        # Every value starts at the same column: the label column is a fixed
+        # width, so the longest label ("service command") and the shortest
+        # ("id") align their values.
+        starts = set()
+        for label in ("id", "running", "image", "service command", "owner"):
+            assert _detail_value(body, label) is not None, label
+            line = next(
+                ln
+                for ln in body.splitlines()
+                if ln.startswith(label)
+                and ln[len(label) : len(label) + 2].isspace()
+            )
+            rest = line[len(label) :]
+            starts.add(len(label) + len(rest) - len(rest.lstrip()))
+        assert len(starts) == 1, f"detail values don't align: {starts}"
 
 
 async def test_detail_shows_uptime(monkeypatch):
@@ -3421,7 +3489,7 @@ async def test_detail_shows_uptime(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         body = str(app.screen.query_one("#detail_body").render())
-        assert "uptime: 1d 2h 30m" in body
+        assert _detail_value(body, "uptime") == "1d 2h 30m"
 
 
 async def test_detail_no_uptime_when_stopped(monkeypatch):
@@ -3685,7 +3753,7 @@ async def test_detail_start_when_stopped(monkeypatch):
         assert labels == ["Stop"]
         # service_started_at reset on start (#1814).
         assert a.service_started_at is not None
-        assert "uptime:" in str(app.screen.query_one("#detail_body").render())
+        assert "uptime" in str(app.screen.query_one("#detail_body").render())
 
 
 async def test_detail_terminal_actions_inline_not_in_footer(monkeypatch):
@@ -3745,12 +3813,12 @@ async def test_detail_uptime_ticks(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         body1 = str(app.screen.query_one("#detail_body").render())
-        assert "uptime:" in body1
+        assert "uptime" in body1
         # Simulate time passing and trigger the tick.
         a.service_started_at = _time.time() - 180
         app.screen._tick_uptime()
         body2 = str(app.screen.query_one("#detail_body").render())
-        assert "uptime: 3m" in body2
+        assert _detail_value(body2, "uptime") == "3m"
 
 
 async def test_detail_uptime_tick_noop_when_stopped(monkeypatch):
@@ -4075,7 +4143,10 @@ async def test_detail_apply_status_event(monkeypatch):
         )
         assert a.running is True
         assert a.service_started_at == started
-        assert "running: yes" in str(d.query_one("#detail_body").render())
+        assert (
+            _detail_value(str(d.query_one("#detail_body").render()), "running")
+            == "yes"
+        )
         # service_health updates health + message
         d.apply_status_event(
             {
@@ -4087,8 +4158,8 @@ async def test_detail_apply_status_event(monkeypatch):
             }
         )
         body = str(d.query_one("#detail_body").render())
-        assert "health: unhealthy" in body
-        assert "health note: curl fail" in body
+        assert _detail_value(body, "health") == "unhealthy"
+        assert _detail_value(body, "health note") == "curl fail"
         # non-matching workspace id is ignored
         d.apply_status_event(
             {
@@ -4121,7 +4192,10 @@ async def test_detail_apply_status_event_reload(monkeypatch):
         a.running = True  # mutated after load
         d.apply_status_event({"type": "workspaces_changed"})
         await pilot.pause()
-        assert "running: yes" in str(d.query_one("#detail_body").render())
+        assert (
+            _detail_value(str(d.query_one("#detail_body").render()), "running")
+            == "yes"
+        )
 
 
 async def test_detail_apply_status_event_terminals_changed(monkeypatch):
@@ -4331,8 +4405,11 @@ async def test_status_event_routed_to_detail(monkeypatch):
         )
         await pilot.pause()
         assert a.running is True
-        assert "running: yes" in str(
-            app.screen.query_one("#detail_body").render()
+        assert (
+            _detail_value(
+                str(app.screen.query_one("#detail_body").render()), "running"
+            )
+            == "yes"
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #1910.

The TUI workspace **detail** screen rendered its fields as a single
left-aligned `"key: value"` text block, so values started in different
columns depending on label length (`id:` vs `service command:`) and the
multi-valued sections (mounts / environment / allowed domains) were
hand-indented continuation lines.

## Changes

- `src/klangk/klangk/cli/tui/screens/workspace_detail.py` — `_display` now
  renders the detail as a **two-column Rich table**: an auto-sized label
  column and a value column (`_render_detail`), built from a new
  `_detail_rows(ws)` helper that splits the old line-building logic into
  `(label, value)` pairs. Multi-value sections become a single value cell
  with newlines. The table is rendered to text at the screen width (so long
  values fold to fit instead of running off the edge) and wrapped in `Text()`
  with `markup=False` so values that look like markup (e.g. an image named
  `[img]`) render literally.
- `src/klangk/klangkc-tests/tests/test_tui.py` — add a `_detail_value(body, label)`
  helper to read a row's value out of the rendered table (handles the column
  padding and multi-line value cells, and disambiguates `health` from
  `health note` / `health check`). Rewrote the `"key: value"` substring
  assertions (which alignment inherently breaks) to use it. New test
  `test_detail_renders_aligned_two_column_table` asserts every value starts
  at the same column regardless of label length.
- `src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py` — update the one
  `running:` substring check.
- `docs/changes.md` — Changed entry under `[Unreleased]`.

Rendered (width 80):

```
id               3fa85f64-5717-4562-b3fc-2c963f66afa6
running          yes
health           healthy
uptime           1d 1h 0m
image            python:3.13
service command  python -m myapp
health check     curl -f http://localhost:8080/health
auto-start       on
mounts           /home/chris:/home/chris
                 /data:/data
environment      DEBUG=1
                 LOG_LEVEL=info
allowed domains  github.com:443
                 pypi.org
owner            chris@example.com
```

The periodic `_tick_uptime` refresh is unchanged — it re-runs `_display`, so
the table (including the uptime counter) updates in place without a screen
rebuild.

## Test plan

- [x] `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 3862 passed, 100% coverage.
