### PR TITLE
TUI: toast the full filesystem path on export completion

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -466,6 +466,13 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI export completion now toasts the full filesystem path (#1758).**
+  When a workspace export finishes, a toast notification shows the
+  resolved absolute path the archive was written to (e.g.
+  `/home/user/alpha.tar.gz`), so a relative input like `alpha.tar.gz` —
+  written under the TUI's CWD — is no longer ambiguous. Export failures
+  still report the error inline on the detail screen.
+
 - **TUI now defaults to Textual's built-in `ansi-light` theme (#1904).**
   The app default switched from the custom hard-coded `klangk` palette
   (fixed RGB background `#0D1117`, `dark=True`) to Textual's built-in

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -580,19 +580,30 @@ class WorkspaceDetailScreen(Screen):
         if not path:
             return
         state = self.app.tui_state
+        # Resolve to an absolute path so the completion toast reports
+        # exactly where the archive landed on disk — a relative input
+        # like "x.tar.gz" is written under the TUI's CWD, which isn't
+        # obvious without the resolved path (#1758).
+        full_path = str(Path(path).expanduser().resolve())
 
         def make_call(on_progress):
-            state.export_workspace(self._name, Path(path), on_progress)
+            state.export_workspace(self._name, Path(full_path), on_progress)
 
         self.app.push_screen(
             TransferScreen(
                 f"Exporting '{self._name}'…",
                 make_call,
-                f"Exported → {path}",
+                full_path,
             ),
             self._on_export_done,
         )
 
     def _on_export_done(self, result: tuple[bool, str]) -> None:
-        ok, msg = result
-        self._msg(msg, error=not ok)
+        ok, payload = result
+        if ok:
+            # payload is the resolved absolute filesystem path — toast it
+            # so the user can find / copy the archive location.
+            self.app.notify(f"Exported to {payload}", timeout=10)
+        else:
+            # payload is the error text; show it inline on the detail screen.
+            self._msg(payload, error=True)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2060,6 +2060,16 @@ async def test_detail_export_flow_with_progress(monkeypatch):
     st.find_workspace = lambda n: a
     st.export_workspace = fake_export
     app = KlangkApp(st)
+    # Spy on app.notify so we can assert the completion toast (#1758):
+    # a resolved absolute filesystem path is toasted on success.
+    notified = []
+    orig_notify = app.notify
+
+    def spy_notify(message="", *a, **k):
+        notified.append(message)
+        return orig_notify(message, *a, **k)
+
+    app.notify = spy_notify
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -2074,9 +2084,47 @@ async def test_detail_export_flow_with_progress(monkeypatch):
         await app.workers.wait_for_complete()
         await pilot.pause()
         await pilot.pause()
-        # Transfer ran (mock completes instantly) -> back on detail, msg set.
-        assert exported["args"] == ("alpha", str(Path("alpha.tar.gz")))
-        assert "Exported" in str(d.query_one("#detail_msg", Static).render())
+        # Transfer ran (mock completes instantly) -> back on detail. The
+        # export is written to the *resolved absolute* path (the relative
+        # default is resolved against the TUI's CWD).
+        resolved = str(Path("alpha.tar.gz").resolve())
+        assert exported["args"] == ("alpha", resolved)
+        # A completion toast fired carrying the full filesystem path.
+        assert any(resolved in m for m in notified), notified
+
+
+async def test_detail_export_failure_shows_inline_error(monkeypatch):
+    """#1758: on export failure the error text is shown inline on the
+    detail screen (not toasted) — the error path of _on_export_done."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha", running=True)
+
+    def fake_export(name, out, on_progress=None):
+        raise RuntimeError("disk full")
+
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.export_workspace = fake_export
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        d.action_export()
+        await pilot.pause()
+        app.screen.on_button_pressed(FakeBtnPress("ok"))  # accept default
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        await pilot.pause()
+        # Failure -> error text rendered inline on the detail screen.
+        assert "disk full" in str(d.query_one("#detail_msg", Static).render())
 
 
 async def test_detail_export_cancel_aborts(monkeypatch):


### PR DESCRIPTION
## Summary

When a workspace export finishes, toast the **resolved absolute
filesystem path** the archive was written to, instead of the previous
inline `Exported → <path>` message that used whatever the user typed
(often a relative name like `alpha.tar.gz`, written under the TUI's CWD
and ambiguous without the resolved location).

Redo of the export-toast change lost when #1905 was merged mid-edit
(the worktree was deleted with the uncommitted edits). Branch is off
current `main` (which includes #1905).

## Changes

- `src/klangk/klangk/cli/tui/screens/workspace_detail.py`:
  - `_on_export` resolves the input via
    `Path(path).expanduser().resolve()` and both **writes to** and
    **reports** that absolute location, so the displayed path is exactly
    where the archive landed.
  - `_on_export_done` toasts `Exported to <abs path>` on success via
    `app.notify`; on failure it keeps showing the error inline on the
    detail screen (`#detail_msg`), consistent with other failure paths.
- `docs/changes.md`: `## [Unreleased]` → `### Changed` entry.
- `src/klangk/klangkc-tests/tests/test_tui.py`:
  - `test_detail_export_flow_with_progress` now spies on `app.notify` and
    asserts the toast fires with the resolved absolute path (and that the
    export wrote to that path).
  - New `test_detail_export_failure_shows_inline_error` covers the error
    branch (error text rendered inline, not toasted) — keeps coverage at
    100%.

## Verification

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto`
  → **3862 passed**, **100% coverage** (matches CI).
- Pre-commit hooks green (ruff, ruff-format, markdownlint, deferred-imports,
  binary-integrity, trufflehog).
- Branch based on `origin/main` (`e6fe4d6c`); no divergence.
