### PR TITLE
fix: exit on Caddy bind failure or uvicorn UDS error instead of restart loop

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -110,7 +110,9 @@ def _is_bind_error(line: str) -> bool:
     except (json.JSONDecodeError, ValueError):
         return False
     msg = (obj.get("msg") or "").lower()
-    return "bind:" in msg or "address already in use" in msg
+    # Go's net package formats socket bind errors as
+    # "bind: address already in use" or "bind: permission denied".
+    return "address already in use" in msg or "bind: permission denied" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -96,6 +96,23 @@ def _classify_caddy_line(line: str) -> tuple[int, str]:
     return logging.DEBUG, msg
 
 
+def _is_bind_error(line: str) -> bool:
+    """Return True if *line* is a Caddy bind failure (admin, ingress, or egress).
+
+    Caddy emits structured JSON to stderr when it can't bind a listener.
+    Admin socket failures come from ``"logger":"admin"``; HTTP listener
+    failures (ingress/egress ports) come from other loggers but contain
+    the same bind-related keywords in the message. Detecting any of these
+    lets the watchdog abort instead of respawning in a tight loop (#1917).
+    """
+    try:
+        obj = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    msg = (obj.get("msg") or "").lower()
+    return "bind:" in msg or "address already in use" in msg
+
+
 # ---------------------------------------------------------------------------
 # Upstream constructors (pure — no settings)
 # ---------------------------------------------------------------------------
@@ -775,6 +792,10 @@ class CaddyWatchdog:
         # sync reconfigure loop). #1559 Phase 1: a settings change is a
         # fresh POST /load, not stale-until-restart.
         self._pending_reload = False
+        # Set by _relay_stderr when Caddy emits a bind error (admin socket,
+        # ingress, or egress port). The _watch loop checks this after the
+        # process exits and aborts instead of respawning (#1917).
+        self._bind_fatal = False
 
     def reconfigure(self, app) -> None:
         self.app = app
@@ -900,8 +921,8 @@ class CaddyWatchdog:
                 await asyncio.sleep(0.2)
         return False
 
-    @staticmethod
     async def _relay_stderr(
+        self,
         stream: asyncio.StreamReader,
     ) -> None:  # pragma: no cover  – covered by the e2e suite
         """Read Caddy's stderr line-by-line and relay through Python logging.
@@ -909,6 +930,10 @@ class CaddyWatchdog:
         Errors are logged at ERROR; routine info/warn messages are logged at
         DEBUG so they're hidden by default but accessible via
         ``KLANGKD_LOG_LEVEL=DEBUG``.
+
+        When a bind failure is detected (admin socket, ingress, or egress
+        listener), sets ``_bind_fatal`` so the supervision loop exits
+        instead of respawning (#1917).
         """
         while True:
             raw = await stream.readline()
@@ -919,6 +944,8 @@ class CaddyWatchdog:
                 continue
             level, msg = _classify_caddy_line(line)
             logger.log(level, "caddy: %s", msg)
+            if level >= logging.ERROR and _is_bind_error(line):
+                self._bind_fatal = True
 
     def _log_listeners(self) -> None:
         """Log which addresses Caddy is serving after a successful config load."""
@@ -960,6 +987,7 @@ class CaddyWatchdog:
             self._renderer._bootstrap_block(self.admin_socket)
         )
         while not self._stopping:
+            self._bind_fatal = False
             # A stale socket from a prior run blocks the bind.
             try:
                 os.unlink(self.admin_socket)
@@ -1015,6 +1043,15 @@ class CaddyWatchdog:
                 await stderr_task
             self._proc = None
             if self._stopping:
+                return
+            if self._bind_fatal:
+                logger.error(
+                    "caddy failed to bind a listener (rc=%d) — not "
+                    "restarting. Check the admin socket (%s), ingress "
+                    "port, and egress port, then restart klangkd.",
+                    rc,
+                    self.admin_socket,
+                )
                 return
             logger.warning(
                 "caddy exited (rc=%d); restarting in %.1fs", rc, backoff

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -210,17 +210,25 @@ def main(  # pragma: no cover
     # proxy (same-uid socket access). Set here, from the bind decision —
     # not via a config field (#1422 retired KLANGKD_UDS_MODE).
     asgi_app.state.util.set_uds_mode(True)
-    uvicorn.run(
-        asgi_app,
-        uds=uds_path,
-        # proxy_headers=False: over a UDS request.client is None; our
-        # trust helpers handle header trust via _UDS_MODE. Letting uvicorn
-        # also rewrite client would double-resolve.
-        proxy_headers=False,
-        ws_max_size=ws_max_size,
-        ws_ping_interval=20,
-        ws_ping_timeout=20,
-    )
+    try:
+        uvicorn.run(
+            asgi_app,
+            uds=uds_path,
+            # proxy_headers=False: over a UDS request.client is None; our
+            # trust helpers handle header trust via _UDS_MODE. Letting uvicorn
+            # also rewrite client would double-resolve.
+            proxy_headers=False,
+            ws_max_size=ws_max_size,
+            ws_ping_interval=20,
+            ws_ping_timeout=20,
+        )
+    except OSError as exc:
+        from klangk.logger import logger  # noqa: allow-deferred-import
+
+        logger.error(
+            "uvicorn failed to bind UDS at %s: %s — exiting", uds_path, exc
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -22,6 +22,7 @@ from klangk.caddy import (
     CaddyRenderer,
     CaddyWatchdog,
     _classify_caddy_line,
+    _is_bind_error,
 )
 from klangk.caddy import (
     CADDYFILE_CONTENT_TYPE,
@@ -1594,3 +1595,66 @@ class TestLogListeners:
             wd._log_listeners()
         assert "browser" not in caplog.text
         assert "caddy egress listening on 0.0.0.0:8995" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _is_bind_error (#1917)
+# ---------------------------------------------------------------------------
+
+
+class TestIsBindError:
+    """Detect Caddy bind failures from structured JSON stderr lines."""
+
+    def test_admin_bind_address_in_use(self):
+        line = (
+            '{"level":"error","logger":"admin",'
+            '"msg":"listen unix //tmp/caddy.sock: bind: address already in use"}'
+        )
+        assert _is_bind_error(line) is True
+
+    def test_http_bind_address_in_use(self):
+        line = (
+            '{"level":"error","logger":"http",'
+            '"msg":"listen tcp :8443: bind: address already in use"}'
+        )
+        assert _is_bind_error(line) is True
+
+    def test_bind_permission_denied(self):
+        line = (
+            '{"level":"error","logger":"admin",'
+            '"msg":"listen unix //run/caddy.sock: bind: permission denied"}'
+        )
+        assert _is_bind_error(line) is True
+
+    def test_non_bind_error_is_false(self):
+        line = '{"level":"error","logger":"admin","msg":"listener closed"}'
+        assert _is_bind_error(line) is False
+
+    def test_info_level_is_false(self):
+        line = (
+            '{"level":"info","logger":"admin",'
+            '"msg":"admin endpoint started, bind to unix socket"}'
+        )
+        assert _is_bind_error(line) is False
+
+    def test_non_json_is_false(self):
+        assert _is_bind_error("panic: something broke") is False
+
+    def test_no_msg_field_is_false(self):
+        line = '{"level":"error","logger":"admin"}'
+        assert _is_bind_error(line) is False
+
+
+# ---------------------------------------------------------------------------
+# CaddyWatchdog._bind_fatal flag (#1917)
+# ---------------------------------------------------------------------------
+
+
+class TestWatchdogBindFatal:
+    """The watchdog aborts instead of respawning on bind errors."""
+
+    def test_init_flag_is_false(self):
+        app = Mock()
+        app.state.settings.state_dir = "/tmp"
+        wd = CaddyWatchdog(app)
+        assert wd._bind_fatal is False


### PR DESCRIPTION
## Summary

Closes #1917.

- Detect bind errors (admin socket, ingress port, egress port) from Caddy's structured JSON stderr via `_is_bind_error()` and abort the watchdog instead of respawning in a backoff loop.
- Wrap `uvicorn.run()` to catch `OSError` on UDS bind failure and exit with code 1 instead of silently failing.

## Changes

- **`caddy.py`** — `_is_bind_error()` parses Caddy stderr for `"bind:"` or `"address already in use"` keywords. `_relay_stderr` (now an instance method) sets `_bind_fatal` on detection. `_watch` checks the flag after process exit and returns instead of respawning.
- **`launcher.py`** — `uvicorn.run()` wrapped in `try/except OSError` with error log and `sys.exit(1)`.
- **`test_caddy.py`** — `TestIsBindError` (7 tests) and `TestWatchdogBindFatal` (1 test).

## Test plan

- [x] 3871 passed, 100% coverage