### PR TITLE
fix(tui): refresh workspace detail screen on container start/restart

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -362,9 +362,18 @@ class WorkspaceDetailScreen(Screen):
                 self.run_worker(self._load_terminals, exit_on_error=False)
             return
         if etype == "container_status":
+            was_running = self._ws.running
+            old_started = self._ws.service_started_at
             self._ws.running = bool(event.get("running"))
             if "service_started_at" in event:
                 self._ws.service_started_at = event["service_started_at"]
+            # A container (re)start invalidates the old terminal list —
+            # the previous tmux sessions are gone. Re-fetch so the detail
+            # screen reflects the new container's state (#1924).
+            if self._ws.running and (
+                not was_running or self._ws.service_started_at != old_started
+            ):
+                self.run_worker(self._load_terminals, exit_on_error=False)
         elif etype == "service_health":
             self._ws.running = bool(event.get("running", self._ws.running))
             self._ws.health = (

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -367,13 +367,13 @@ class WorkspaceDetailScreen(Screen):
             self._ws.running = bool(event.get("running"))
             if "service_started_at" in event:
                 self._ws.service_started_at = event["service_started_at"]
-            # A container (re)start invalidates the old terminal list —
-            # the previous tmux sessions are gone. Re-fetch so the detail
-            # screen reflects the new container's state (#1924).
+            # A container start or restart invalidates everything — uptime
+            # resets, health resets, terminal sessions are gone. Do a full
+            # reload so all detail-screen items reflect the new state (#1924).
             if self._ws.running and (
                 not was_running or self._ws.service_started_at != old_started
             ):
-                self.run_worker(self._load_terminals, exit_on_error=False)
+                self.run_worker(self._reload_on_restart, exit_on_error=False)
         elif etype == "service_health":
             self._ws.running = bool(event.get("running", self._ws.running))
             self._ws.health = (
@@ -390,6 +390,17 @@ class WorkspaceDetailScreen(Screen):
         await self._load()
         if self._missing:
             self.app.pop_screen()
+
+    async def _reload_on_restart(self) -> None:
+        """Full reload after a container start/restart (#1924).
+
+        Re-fetches workspace metadata (uptime, health, running state) and
+        the terminal list so every item on the detail screen reflects the
+        new container.
+        """
+        await self._load()
+        if not self._missing:
+            await self._load_terminals()
 
     # --- terminals (own) ---
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4175,30 +4175,35 @@ async def test_detail_apply_status_event(monkeypatch):
         assert a.running is True  # unchanged
 
 
-async def test_detail_container_restart_refreshes_terminals(monkeypatch):
-    """#1924: a container restart re-fetches the terminal list so the
-    detail screen reflects the new container's state."""
+async def test_detail_container_restart_full_reload(monkeypatch):
+    """#1924: a container restart does a full reload (workspace metadata
+    + terminal list), not just a terminal re-fetch."""
 
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     a = _wsobj("alpha", running=True, service_started_at=1000.0)
-    fetched = {"n": 0}
+    calls = {"find": 0, "terms": 0}
+
+    def track_find(name):
+        calls["find"] += 1
+        return a
 
     async def track_terms(*_a, **_k):
-        fetched["n"] += 1
+        calls["terms"] += 1
         return [{"index": 0, "name": "main", "id": "@0"}]
 
     st = _ws(list_terminals=track_terms)
-    st.find_workspace = lambda n: a
+    st.find_workspace = track_find
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         await app.screen._load_terminals()
         await pilot.pause()
-        before = fetched["n"]
+        before_find = calls["find"]
+        before_terms = calls["terms"]
         # Simulate a container restart (new service_started_at).
         app.screen.apply_status_event(
             {
@@ -4210,32 +4215,39 @@ async def test_detail_container_restart_refreshes_terminals(monkeypatch):
         )
         await app.workers.wait_for_complete()
         await pilot.pause()
-        assert fetched["n"] > before
+        # Both workspace metadata and terminal list re-fetched.
+        assert calls["find"] > before_find
+        assert calls["terms"] > before_terms
 
 
-async def test_detail_container_start_refreshes_terminals(monkeypatch):
-    """#1924: a stopped container starting up fetches the terminal list."""
+async def test_detail_container_start_full_reload(monkeypatch):
+    """#1924: a stopped container starting up does a full reload."""
 
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     a = _wsobj("alpha", running=False)
-    fetched = {"n": 0}
+    calls = {"find": 0, "terms": 0}
+
+    def track_find(name):
+        calls["find"] += 1
+        return a
 
     async def track_terms(*_a, **_k):
-        fetched["n"] += 1
+        calls["terms"] += 1
         return [{"index": 0, "name": "main", "id": "@0"}]
 
     st = _ws(list_terminals=track_terms)
-    st.find_workspace = lambda n: a
+    st.find_workspace = track_find
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause()
-        before = fetched["n"]
+        before_find = calls["find"]
+        before_terms = calls["terms"]
         # Container starts (was not running).
         app.screen.apply_status_event(
             {
@@ -4247,33 +4259,39 @@ async def test_detail_container_start_refreshes_terminals(monkeypatch):
         )
         await app.workers.wait_for_complete()
         await pilot.pause()
-        assert fetched["n"] > before
+        assert calls["find"] > before_find
+        assert calls["terms"] > before_terms
 
 
-async def test_detail_container_status_no_refetch_when_unchanged(monkeypatch):
-    """container_status with same service_started_at does not re-fetch."""
+async def test_detail_container_status_no_reload_when_unchanged(monkeypatch):
+    """container_status with same service_started_at does not reload."""
 
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     a = _wsobj("alpha", running=True, service_started_at=1000.0)
-    fetched = {"n": 0}
+    calls = {"find": 0, "terms": 0}
+
+    def track_find(name):
+        calls["find"] += 1
+        return a
 
     async def track_terms(*_a, **_k):
-        fetched["n"] += 1
+        calls["terms"] += 1
         return [{"index": 0, "name": "main", "id": "@0"}]
 
     st = _ws(list_terminals=track_terms)
-    st.find_workspace = lambda n: a
+    st.find_workspace = track_find
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         await app.screen._load_terminals()
         await pilot.pause()
-        before = fetched["n"]
-        # Same service_started_at — not a restart, no re-fetch.
+        before_find = calls["find"]
+        before_terms = calls["terms"]
+        # Same service_started_at — not a restart, no reload.
         app.screen.apply_status_event(
             {
                 "type": "container_status",
@@ -4284,7 +4302,8 @@ async def test_detail_container_status_no_refetch_when_unchanged(monkeypatch):
         )
         await app.workers.wait_for_complete()
         await pilot.pause()
-        assert fetched["n"] == before
+        assert calls["find"] == before_find
+        assert calls["terms"] == before_terms
 
 
 async def test_detail_apply_status_event_reload(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4175,6 +4175,118 @@ async def test_detail_apply_status_event(monkeypatch):
         assert a.running is True  # unchanged
 
 
+async def test_detail_container_restart_refreshes_terminals(monkeypatch):
+    """#1924: a container restart re-fetches the terminal list so the
+    detail screen reflects the new container's state."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True, service_started_at=1000.0)
+    fetched = {"n": 0}
+
+    async def track_terms(*_a, **_k):
+        fetched["n"] += 1
+        return [{"index": 0, "name": "main", "id": "@0"}]
+
+    st = _ws(list_terminals=track_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        before = fetched["n"]
+        # Simulate a container restart (new service_started_at).
+        app.screen.apply_status_event(
+            {
+                "type": "container_status",
+                "workspace_id": "id-alpha",
+                "running": True,
+                "service_started_at": 2000.0,
+            }
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert fetched["n"] > before
+
+
+async def test_detail_container_start_refreshes_terminals(monkeypatch):
+    """#1924: a stopped container starting up fetches the terminal list."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=False)
+    fetched = {"n": 0}
+
+    async def track_terms(*_a, **_k):
+        fetched["n"] += 1
+        return [{"index": 0, "name": "main", "id": "@0"}]
+
+    st = _ws(list_terminals=track_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        before = fetched["n"]
+        # Container starts (was not running).
+        app.screen.apply_status_event(
+            {
+                "type": "container_status",
+                "workspace_id": "id-alpha",
+                "running": True,
+                "service_started_at": 1000.0,
+            }
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert fetched["n"] > before
+
+
+async def test_detail_container_status_no_refetch_when_unchanged(monkeypatch):
+    """container_status with same service_started_at does not re-fetch."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True, service_started_at=1000.0)
+    fetched = {"n": 0}
+
+    async def track_terms(*_a, **_k):
+        fetched["n"] += 1
+        return [{"index": 0, "name": "main", "id": "@0"}]
+
+    st = _ws(list_terminals=track_terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        before = fetched["n"]
+        # Same service_started_at — not a restart, no re-fetch.
+        app.screen.apply_status_event(
+            {
+                "type": "container_status",
+                "workspace_id": "id-alpha",
+                "running": True,
+                "service_started_at": 1000.0,
+            }
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert fetched["n"] == before
+
+
 async def test_detail_apply_status_event_reload(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

Closes #1924. When a `container_status` event indicates the container is now running — either a fresh start from stopped, or a restart with a new `service_started_at` — the workspace detail screen re-fetches the terminal list so it reflects the new container's state instead of showing stale data from the previous container.

## Changes

- **`workspace_detail.py`** — In `apply_status_event`, detect start/restart transitions (`not was_running` or changed `service_started_at`) and trigger `_load_terminals`.
- **`test_tui.py`** — Three new tests: restart (new `service_started_at`), fresh start (stopped → running), and no-op (same `service_started_at`).

## Test plan

- [x] 3881 passed, 100% coverage