### PR TITLE
docs: add common service domain lists to egress-filtering docs

### DIFF
--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -129,14 +129,342 @@ logs. This is deliberate: a misconfigured deploy degrades to the
 unrestricted baseline rather than making workspaces unusable, but the
 warning makes the gap visible.
 
+## Common service domain lists
+
+When building an `allowed_domains` list, you need to know which hosts and
+ports a service requires. The tables below cover the most-requested
+services; the same research pattern (check the provider's firewall /
+proxy docs, then test) works for any service.
+
+> **Note:** Hostnames are resolved to IPs at container-create time. If a
+> service's IPs change (common with CDN-fronted domains), the container
+> must be **restarted** to pick up the new addresses. See the
+> [Caveats](#caveats) section.
+
+### GitHub (SSH git operations)
+
+For `git clone git@github.com:…` / `git push` over SSH:
+
+| Entry           | Purpose                |
+| --------------- | ---------------------- |
+| `github.com:22` | Standard SSH transport |
+
+If upstream firewalls block port 22, GitHub offers an SSH-over-HTTPS
+fallback on `ssh.github.com:443` (requires `~/.ssh/config` stanza —
+see [Using SSH over the HTTPS port][gh-ssh-443]).
+
+### GitHub (HTTPS git + API)
+
+For `git clone https://github.com/…` and the `gh` CLI:
+
+| Entry                | Purpose                                           |
+| -------------------- | ------------------------------------------------- |
+| `github.com:443`     | HTTPS clone / push / pull, web UI                 |
+| `api.github.com:443` | REST & GraphQL API (`gh` CLI, credential helpers) |
+
+If you also need raw file views, release-asset downloads, or Git LFS:
+
+| Entry                                       | Purpose                     |
+| ------------------------------------------- | --------------------------- |
+| `raw.githubusercontent.com:443`             | Raw file content            |
+| `objects.githubusercontent.com:443`         | Git LFS objects             |
+| `github-releases.githubusercontent.com:443` | Release-asset downloads     |
+| `codeload.github.com:443`                   | Archive / tarball downloads |
+
+### GitHub (full development)
+
+A workspace that uses the web UI, GitHub Packages, or Copilot in
+addition to git typically needs a broader set. Because klangk's
+netfilter resolves at container-create time and doesn't support
+wildcards, list the specific subdomains you use:
+
+| Entry                                       | Purpose                 |
+| ------------------------------------------- | ----------------------- |
+| `github.com:22`                             | SSH git                 |
+| `github.com:443`                            | HTTPS git, web UI       |
+| `api.github.com:443`                        | API                     |
+| `ssh.github.com:443`                        | SSH-over-HTTPS fallback |
+| `raw.githubusercontent.com:443`             | Raw file views          |
+| `objects.githubusercontent.com:443`         | LFS objects             |
+| `github-releases.githubusercontent.com:443` | Release assets          |
+| `codeload.github.com:443`                   | Archives                |
+| `ghcr.io:443`                               | Container registry      |
+| `npm.pkg.github.com:443`                    | npm packages            |
+| `pypi.pkg.github.com:443`                   | PyPI packages           |
+
+GitHub warns that their domain list is not comprehensive and IP ranges
+change over time — see [Allowing access to GitHub's services from a
+restricted network][gh-firewall] and the live
+[`/meta` API endpoint][gh-meta].
+
+### Debian / Ubuntu (apt)
+
+The default klangk workspace image is Debian Trixie. For `apt update`
+and `apt install`:
+
+| Entry                           | Purpose                           |
+| ------------------------------- | --------------------------------- |
+| `deb.debian.org:80`             | Main Debian archive (Fastly CDN)  |
+| `deb.debian.org:443`            | Main archive over HTTPS           |
+| `security.debian.org:80`        | Security updates                  |
+| `security.debian.org:443`       | Security updates over HTTPS       |
+| `cdn-fastly.deb.debian.org:80`  | Fastly CDN backend (CNAME target) |
+| `cdn-fastly.deb.debian.org:443` | Fastly CDN backend over HTTPS     |
+| `cdn-aws.deb.debian.org:443`    | CloudFront CDN backend            |
+
+For GPG key operations (`apt-key`, `gpg --recv-keys`):
+
+| Entry                        | Purpose                       |
+| ---------------------------- | ----------------------------- |
+| `keyserver.ubuntu.com:80`    | Primary keyserver (HTTP)      |
+| `keyserver.ubuntu.com:443`   | Primary keyserver (HTTPS)     |
+| `keyserver.ubuntu.com:11371` | HKP (HTTP Keyserver Protocol) |
+
+**Ubuntu** workspaces replace the Debian entries with:
+
+| Entry                          | Purpose                       |
+| ------------------------------ | ----------------------------- |
+| `archive.ubuntu.com:80`        | Main Ubuntu archive           |
+| `archive.ubuntu.com:443`       | Main archive over HTTPS       |
+| `security.ubuntu.com:80`       | Security updates              |
+| `security.ubuntu.com:443`      | Security updates over HTTPS   |
+| `ppa.launchpadcontent.net:443` | PPA downloads (if using PPAs) |
+
+Port 80 is important — apt's default Debian/Ubuntu configuration
+uses HTTP. The packages themselves are GPG-verified regardless of
+transport.
+
+### PyPI
+
+| Entry                        | Purpose           |
+| ---------------------------- | ----------------- |
+| `pypi.org:443`               | Package index     |
+| `files.pythonhosted.org:443` | Package downloads |
+
+### npm
+
+| Entry                    | Purpose                  |
+| ------------------------ | ------------------------ |
+| `registry.npmjs.org:443` | Package index + tarballs |
+
+### Nix
+
+For `nix build`, `nix develop`, `nix-shell`, and `nix-env -i` (the
+binary cache, channels, and source tarballs):
+
+| Entry                    | Purpose                                 |
+| ------------------------ | --------------------------------------- |
+| `cache.nixos.org:443`    | Default binary cache (Fastly CDN → S3)  |
+| `channels.nixos.org:443` | Channel metadata, flake registry        |
+| `releases.nixos.org:443` | Nix release tarballs, installer scripts |
+| `tarballs.nixos.org:443` | Source tarballs for packages (fetchurl) |
+
+Nix flakes typically pull inputs from GitHub, so the GitHub HTTPS
+entries above are needed too (`github.com:443`, `api.github.com:443`,
+`codeload.github.com:443`, `raw.githubusercontent.com:443`).
+
+The CDN backends behind `*.nixos.org` are Fastly and S3. If your
+firewall resolves CNAMEs or inspects SNI you may also need:
+
+| Entry                            | Purpose                       |
+| -------------------------------- | ----------------------------- |
+| `nix-cache.s3.amazonaws.com:443` | S3 origin for cache.nixos.org |
+
+If using [Cachix](https://cachix.org) binary caches, add each cache
+you use (klangk's netfilter doesn't support wildcards):
+
+| Entry                          | Purpose                       |
+| ------------------------------ | ----------------------------- |
+| `cachix.org:443`               | Main service                  |
+| `devenv.cachix.org:443`        | devenv cache (example)        |
+| `nix-community.cachix.org:443` | nix-community cache (example) |
+
+All Nix traffic is HTTPS (port 443). No HTTP or non-standard ports
+are required.
+
+### GitLab
+
+| Entry                     | Purpose            |
+| ------------------------- | ------------------ |
+| `gitlab.com:22`           | SSH git            |
+| `gitlab.com:443`          | HTTPS git, web UI  |
+| `registry.gitlab.com:443` | Container registry |
+
+Self-managed GitLab instances use their own hostname instead of
+`gitlab.com`.
+
+### Bitbucket
+
+| Entry                   | Purpose           |
+| ----------------------- | ----------------- |
+| `bitbucket.org:22`      | SSH git           |
+| `bitbucket.org:443`     | HTTPS git, web UI |
+| `api.bitbucket.org:443` | REST API          |
+
+### Codeberg
+
+| Entry              | Purpose           |
+| ------------------ | ----------------- |
+| `codeberg.org:22`  | SSH git           |
+| `codeberg.org:443` | HTTPS git, web UI |
+
+### Canonical Launchpad
+
+| Entry                          | Purpose               |
+| ------------------------------ | --------------------- |
+| `launchpad.net:443`            | Web UI, API           |
+| `git.launchpad.net:22`         | Git over SSH          |
+| `git.launchpad.net:443`        | Git over HTTPS        |
+| `ppa.launchpadcontent.net:443` | PPA package downloads |
+
+### Anthropic API (Claude Code)
+
+| Entry                       | Purpose                        |
+| --------------------------- | ------------------------------ |
+| `api.anthropic.com:443`     | Claude API (chat, completions) |
+| `statsig.anthropic.com:443` | Feature flags / telemetry      |
+| `sentry.io:443`             | Error reporting                |
+
+### OpenAI API (Codex, ChatGPT)
+
+| Entry                              | Purpose                      |
+| ---------------------------------- | ---------------------------- |
+| `api.openai.com:443`               | Chat, completions, Codex API |
+| `cdn.openai.com:443`               | Static assets                |
+| `openaiapi-site.azureedge.net:443` | CDN edge (Azure)             |
+
+### Zencoder (z.ai)
+
+| Entry                  | Purpose                                   |
+| ---------------------- | ----------------------------------------- |
+| `api.z.ai:443`         | LLM API (`/api/coding/paas/v4` base path) |
+| `auth.zencoder.ai:443` | Authentication                            |
+
+### OpenRouter
+
+| Entry               | Purpose                               |
+| ------------------- | ------------------------------------- |
+| `openrouter.ai:443` | LLM API (`/api/v1` base path), web UI |
+
+### Ollama
+
+| Entry                  | Purpose                                  |
+| ---------------------- | ---------------------------------------- |
+| `cloud.ollama.com:443` | Ollama cloud API (direct from container) |
+
+A self-hosted Ollama configured as `KLANGKD_LLM_BASE_URL` is proxied
+through the backend's `/llm-proxy/` endpoint and needs no netfilter
+entry. `cloud.ollama.com` is for workspaces that contact the Ollama
+cloud service directly (e.g. from user code or an agent).
+
+### Bare-domain shortcut
+
+A domain without a port (e.g. `github.com`) allows **all** ports to
+that host. This is convenient for quick iteration but less restrictive
+than pinning individual ports.
+
+[gh-ssh-443]: https://docs.github.com/en/authentication/troubleshooting-ssh/using-ssh-over-the-https-port
+[gh-firewall]: https://docs.github.com/en/get-started/using-github/allowing-access-to-githubs-services-from-a-restricted-network
+[gh-meta]: https://api.github.com/meta
+
+### Deploy-wide default: all common services
+
+The following `klangkd.yaml` snippet applies the union of every service
+listed above as the deploy-wide default. Paste it into your
+`klangkd.yaml` and every workspace that doesn't declare its own
+`allowed_domains` inherits this list. A workspace that sets its own
+list **overrides** (replaces) the default entirely.
+
+Remove services you don't need — the tighter the list, the smaller the
+attack surface.
+
+```yaml
+# Deploy-wide egress allow-list (union of all common services).
+# Each workspace that does NOT set its own allowed_domains inherits this.
+# A workspace with its own list overrides it completely.
+netfilter_default_domains:
+  # --- GitHub (SSH + HTTPS + API + assets) ---
+  - github.com:22
+  - github.com:443
+  - api.github.com:443
+  - ssh.github.com:443
+  - codeload.github.com:443
+  - raw.githubusercontent.com:443
+  - objects.githubusercontent.com:443
+  - github-releases.githubusercontent.com:443
+  - ghcr.io:443
+  - npm.pkg.github.com:443
+  - pypi.pkg.github.com:443
+  # --- GitLab ---
+  - gitlab.com:22
+  - gitlab.com:443
+  - registry.gitlab.com:443
+  # --- Bitbucket ---
+  - bitbucket.org:22
+  - bitbucket.org:443
+  - api.bitbucket.org:443
+  # --- Codeberg ---
+  - codeberg.org:22
+  - codeberg.org:443
+  # --- Canonical Launchpad ---
+  - launchpad.net:443
+  - git.launchpad.net:22
+  - git.launchpad.net:443
+  - ppa.launchpadcontent.net:443
+  # --- Debian apt ---
+  - deb.debian.org:80
+  - deb.debian.org:443
+  - security.debian.org:80
+  - security.debian.org:443
+  - cdn-fastly.deb.debian.org:80
+  - cdn-fastly.deb.debian.org:443
+  - cdn-aws.deb.debian.org:443
+  # --- Ubuntu apt ---
+  - archive.ubuntu.com:80
+  - archive.ubuntu.com:443
+  - security.ubuntu.com:80
+  - security.ubuntu.com:443
+  # --- GPG keyservers ---
+  - keyserver.ubuntu.com:80
+  - keyserver.ubuntu.com:443
+  - keyserver.ubuntu.com:11371
+  # --- PyPI ---
+  - pypi.org:443
+  - files.pythonhosted.org:443
+  # --- npm ---
+  - registry.npmjs.org:443
+  # --- Nix ---
+  - cache.nixos.org:443
+  - channels.nixos.org:443
+  - releases.nixos.org:443
+  - tarballs.nixos.org:443
+  - nix-cache.s3.amazonaws.com:443
+  - cachix.org:443
+  - devenv.cachix.org:443
+  - nix-community.cachix.org:443
+  # --- LLM providers ---
+  - api.anthropic.com:443
+  - statsig.anthropic.com:443
+  - sentry.io:443
+  - api.openai.com:443
+  - cdn.openai.com:443
+  - openaiapi-site.azureedge.net:443
+  - api.z.ai:443
+  - auth.zencoder.ai:443
+  - openrouter.ai:443
+  - cloud.ollama.com:443
+```
+
 ## Caveats
 
-- **DNS resolution at creation time.** iptables matches IPs, so hostnames
-  are resolved when the container is created. If a service rotates IPs
-  (common with CDNs), access may break until the workspace is restarted.
-  Mitigation: allow a port without pinning a host, or allow a CIDR
-  range (a possible future enhancement; the initial implementation is
-  `host`/`host:port` only).
+- **DNS resolution at creation time — restart on IP change.** iptables
+  matches IPs, so hostnames are resolved once when the container is
+  created. If a service rotates IPs (common with CDNs like Fastly,
+  CloudFront, and Cloudflare), access may break without warning.
+  **Restart the workspace container** to re-resolve hostnames and
+  update the iptables rules. Mitigation: allow a port without pinning a
+  host, or allow a CIDR range (a possible future enhancement; the
+  initial implementation is `host`/`host:port` only).
 - **DNS is pinned to resolvers, not blocked entirely.** Outbound `:53` is
   accepted only to the nameservers in the container's `/etc/resolv.conf`,
   so a workspace cannot talk to an arbitrary host on port 53. This does

--- a/scripts/test-netfilter.sh
+++ b/scripts/test-netfilter.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Manual integration test for the workspace netfilter (allowed_domains).
+#
+# Prerequisites:
+#   - klangkd running locally (default: http://localhost:8997)
+#   - admin/admin credentials seeded (devenv default)
+#   - SSH key loaded in the local agent (ssh-add -l shows a key)
+#   - forward-agent: true in klangkd.yaml (devenv default)
+#   - expect(1) available (NixOS: in system packages; Debian: apt install expect)
+#
+# Usage:
+#   scripts/test-netfilter.sh                    # default server
+#   scripts/test-netfilter.sh http://localhost:9000   # custom server
+#
+# The script creates ephemeral workspaces, runs tests, and cleans up.
+# It is NOT run in CI — it requires a live klangkd + container runtime.
+
+set -uo pipefail
+# Not using set -e — we handle errors per-test and report them in the summary.
+
+SERVER="${1:-http://localhost:8997}"
+USER="admin"
+PASS="admin"
+CLONE_REPO="git@github.com:mcdonc/klangk.git"
+CLONE_OPTS="--depth 1" # shallow clone for speed
+SHELL_SETTLE=8         # seconds to wait for klangk shell to be ready
+CLONE_TIMEOUT=90       # seconds before declaring a git-clone hung
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+RESET=$'\033[0m'
+
+pass=0
+fail=0
+skip=0
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+log() { echo "${GREEN}[+]${RESET} $*"; }
+warn() { echo "${YELLOW}[!]${RESET} $*"; }
+err() { echo "${RED}[-]${RESET} $*"; }
+
+cleanup_ws() {
+  local ws_id="$1"
+  # Stop then delete — stop is idempotent, delete fails if running.
+  curl -s -X POST "$SERVER/api/v1/workspaces/$ws_id/stop" \
+    -H "Authorization: Bearer $TOKEN" >/dev/null 2>&1 || true
+  sleep 1
+  curl -s -X DELETE "$SERVER/api/v1/workspaces/$ws_id" \
+    -H "Authorization: Bearer $TOKEN" >/dev/null 2>&1 || true
+}
+
+api_login() {
+  local resp
+  resp=$(curl -s -X POST "$SERVER/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"identifier\":\"$USER\",\"password\":\"$PASS\"}")
+  TOKEN=$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+  if [[ -z $TOKEN || $TOKEN == "None" ]]; then
+    err "Login failed: $resp"
+    exit 1
+  fi
+}
+
+create_ws() {
+  # $1 = name, $2 = JSON allowed_domains (e.g. '["github.com:22"]' or 'null')
+  local name="$1" domains="$2"
+  local resp
+  resp=$(curl -s -X POST "$SERVER/api/v1/workspaces" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"$name\",\"allowed_domains\":$domains}")
+  local ws_id
+  ws_id=$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+  if [[ -z $ws_id ]]; then
+    err "Failed to create workspace '$name': $resp"
+    return 1
+  fi
+  echo "$ws_id"
+}
+
+start_ws() {
+  curl -s -X POST "$SERVER/api/v1/workspaces/$1/start" \
+    -H "Authorization: Bearer $TOKEN" >/dev/null
+  # Wait for the container to be running.
+  local _i
+  for _i in $(seq 1 15); do
+    local running
+    running=$(curl -s "$SERVER/api/v1/workspaces/$1/status" \
+      -H "Authorization: Bearer $TOKEN" |
+      python3 -c "import sys,json; print(json.load(sys.stdin).get('running',False))")
+    [[ $running == "True" ]] && return 0
+    sleep 1
+  done
+  err "workspace $1 did not start within 15s"
+  return 1
+}
+
+# Run a command inside a klangk shell via expect.
+# $1 = workspace name, $2 = command string
+# Prints the raw expect output; caller greps for result markers.
+shell_exec() {
+  local ws_name="$1" cmd="$2"
+  expect -f - <<EXPECT_SCRIPT 2>&1
+set timeout $CLONE_TIMEOUT
+spawn bash -c "devenv shell -- python -m klangk.cli.main --server $SERVER shell $ws_name 0"
+sleep $SHELL_SETTLE
+send "\r"
+sleep 1
+send "$cmd; echo __MARKER_RC=\\\$?\r"
+expect {
+    -re {__MARKER_RC=(\d+)} {
+        set code \$expect_out(1,string)
+        puts "\n__RESULT=\$code"
+    }
+    timeout {
+        puts "\n__RESULT=EXPECT_TIMEOUT"
+    }
+}
+send "exit\r"
+sleep 1
+send "q"
+expect eof
+EXPECT_SCRIPT
+}
+
+# Extract the __RESULT= value from shell_exec output.
+extract_result() {
+  grep -oP '__RESULT=\K\S+' <<<"$1" | tail -1
+}
+
+record() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ $actual == "$expected" ]]; then
+    log "PASS: $label (got $actual)"
+    ((pass++))
+  else
+    err "FAIL: $label — expected $expected, got $actual"
+    ((fail++))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# preflight
+# ---------------------------------------------------------------------------
+
+log "Server: $SERVER"
+
+if ! command -v expect &>/dev/null; then
+  err "expect(1) not found — install it first"
+  exit 1
+fi
+
+if ! ssh-add -l &>/dev/null; then
+  err "No SSH keys in agent — load one first (ssh-add)"
+  exit 1
+fi
+
+if ! curl -sf "$SERVER/api/v1/config" >/dev/null 2>&1; then
+  err "Cannot reach $SERVER — is klangkd running?"
+  exit 1
+fi
+
+api_login
+log "Logged in as $USER (token ${TOKEN:0:20}…)"
+
+# Clean up any leftover test workspaces from previous runs.
+cleanup_stale() {
+  local ws_list
+  ws_list=$(curl -s "$SERVER/api/v1/workspaces?limit=100" \
+    -H "Authorization: Bearer $TOKEN" |
+    python3 -c "
+import sys, json
+for ws in json.load(sys.stdin).get('items', []):
+    if ws['name'].startswith('nf-test-'):
+        print(ws['id'], ws['name'])
+" 2>/dev/null)
+  while IFS=' ' read -r ws_id ws_name; do
+    [[ -z $ws_id ]] && continue
+    warn "Cleaning up stale workspace $ws_name ($ws_id)"
+    cleanup_ws "$ws_id"
+  done <<<"$ws_list"
+}
+cleanup_stale
+
+# ---------------------------------------------------------------------------
+# Test 1: git clone over SSH works WITHOUT a netfilter
+# ---------------------------------------------------------------------------
+
+log "--- Test 1: git clone SSH without netfilter ---"
+
+WS1_ID=$(create_ws "nf-test-open" "null")
+log "Created workspace nf-test-open ($WS1_ID)"
+start_ws "$WS1_ID"
+log "Workspace started"
+
+out=$(shell_exec "nf-test-open" "rm -rf /tmp/nf-clone && git clone $CLONE_OPTS $CLONE_REPO /tmp/nf-clone 2>&1")
+rc=$(extract_result "$out")
+record "git clone SSH (no netfilter)" "0" "$rc"
+
+cleanup_ws "$WS1_ID"
+log "Cleaned up nf-test-open"
+
+# ---------------------------------------------------------------------------
+# Test 2: git clone over SSH works WITH github.com:22 netfilter
+# ---------------------------------------------------------------------------
+
+log "--- Test 2: git clone SSH with github.com:22 netfilter ---"
+
+WS2_ID=$(create_ws "nf-test-ssh" '["github.com:22"]')
+log "Created workspace nf-test-ssh ($WS2_ID) — allowed_domains=[github.com:22]"
+start_ws "$WS2_ID"
+log "Workspace started"
+
+out=$(shell_exec "nf-test-ssh" "rm -rf /tmp/nf-clone && git clone $CLONE_OPTS $CLONE_REPO /tmp/nf-clone 2>&1")
+rc=$(extract_result "$out")
+record "git clone SSH (github.com:22)" "0" "$rc"
+
+cleanup_ws "$WS2_ID"
+log "Cleaned up nf-test-ssh"
+
+# ---------------------------------------------------------------------------
+# Test 3: git clone over SSH BLOCKED with wrong netfilter (example.com:22)
+# ---------------------------------------------------------------------------
+
+log "--- Test 3: git clone SSH blocked by wrong netfilter ---"
+
+WS3_ID=$(create_ws "nf-test-blocked" '["example.com:22"]')
+log "Created workspace nf-test-blocked ($WS3_ID) — allowed_domains=[example.com:22]"
+start_ws "$WS3_ID"
+log "Workspace started"
+
+out=$(shell_exec "nf-test-blocked" "rm -rf /tmp/nf-clone && git clone $CLONE_OPTS $CLONE_REPO /tmp/nf-clone 2>&1")
+rc=$(extract_result "$out")
+# Should NOT be 0 — clone should fail (timeout or connection refused).
+if [[ $rc != "0" ]]; then
+  log "PASS: git clone blocked by wrong netfilter (got $rc)"
+  ((pass++))
+else
+  err "FAIL: git clone should have been blocked but succeeded"
+  ((fail++))
+fi
+
+cleanup_ws "$WS3_ID"
+log "Cleaned up nf-test-blocked"
+
+# ---------------------------------------------------------------------------
+# Test 4: HTTPS blocked when only SSH allowed
+# ---------------------------------------------------------------------------
+
+log "--- Test 4: HTTPS blocked when only github.com:22 allowed ---"
+
+WS4_ID=$(create_ws "nf-test-no-https" '["github.com:22"]')
+log "Created workspace nf-test-no-https ($WS4_ID) — allowed_domains=[github.com:22]"
+start_ws "$WS4_ID"
+log "Workspace started"
+
+out=$(shell_exec "nf-test-no-https" "timeout 10 curl -sf https://github.com >/dev/null 2>&1")
+rc=$(extract_result "$out")
+if [[ $rc != "0" ]]; then
+  log "PASS: HTTPS to github.com blocked when only :22 allowed (got $rc)"
+  ((pass++))
+else
+  err "FAIL: HTTPS should have been blocked but succeeded"
+  ((fail++))
+fi
+
+cleanup_ws "$WS4_ID"
+log "Cleaned up nf-test-no-https"
+
+# ---------------------------------------------------------------------------
+# Test 5: bare domain (no port) allows all traffic to that host
+# ---------------------------------------------------------------------------
+
+log "--- Test 5: bare domain allows all ports ---"
+
+WS5_ID=$(create_ws "nf-test-bare" '["github.com"]')
+log "Created workspace nf-test-bare ($WS5_ID) — allowed_domains=[github.com]"
+start_ws "$WS5_ID"
+log "Workspace started"
+
+out=$(shell_exec "nf-test-bare" "rm -rf /tmp/nf-clone && git clone $CLONE_OPTS $CLONE_REPO /tmp/nf-clone 2>&1")
+rc=$(extract_result "$out")
+record "git clone SSH (bare github.com — all ports)" "0" "$rc"
+
+cleanup_ws "$WS5_ID"
+log "Cleaned up nf-test-bare"
+
+# ---------------------------------------------------------------------------
+# Test 6: apt install works with Debian netfilter domains
+# ---------------------------------------------------------------------------
+
+log "--- Test 6: apt install with Debian netfilter ---"
+
+DEBIAN_DOMAINS='["deb.debian.org:80","deb.debian.org:443","security.debian.org:80","security.debian.org:443","cdn-fastly.deb.debian.org:80","cdn-fastly.deb.debian.org:443","cdn-aws.deb.debian.org:443"]'
+WS6_ID=$(create_ws "nf-test-apt" "$DEBIAN_DOMAINS")
+log "Created workspace nf-test-apt ($WS6_ID) — Debian netfilter"
+start_ws "$WS6_ID"
+log "Workspace started"
+
+out=$(shell_exec "nf-test-apt" "sudo apt-get update -qq 2>&1 && sudo apt-get install -y -qq sl 2>&1 && sl --version 2>&1 || which sl")
+rc=$(extract_result "$out")
+record "apt install with Debian netfilter" "0" "$rc"
+
+cleanup_ws "$WS6_ID"
+log "Cleaned up nf-test-apt"
+
+# ---------------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=============================="
+echo "  Results: ${GREEN}${pass} passed${RESET}, ${RED}${fail} failed${RESET}, ${YELLOW}${skip} skipped${RESET}"
+echo "=============================="
+
+[[ $fail -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Add "Common service domain lists" section to `docs/features/egress-filtering.md` with tables for:
  - **GitHub** — SSH (`github.com:22`), HTTPS + API, full development (LFS, packages, registry)
  - **Debian/Ubuntu** — apt archives, security repos, CDN backends, GPG keyservers
  - **PyPI** — index + download hosts
  - **npm** — registry
- Add `scripts/test-netfilter.sh` — a manual integration test that creates ephemeral workspaces with various netfilter configs and verifies git clone behavior using expect-driven klangk shell sessions

## Test plan

- [x] Manual: `scripts/test-netfilter.sh` passes all 5 tests against live klangkd
- [ ] CI (docs-only change, no code tests affected)

Closes #1927