### PR TITLE
TUI: add running status to workspace list sort cycle

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -172,7 +172,7 @@ class MainScreen(Screen):
             yield Button("sort: created ▼", id="sort_btn", variant="default")
 
     # Sort keys matching Flutter defaults: created desc.
-    SORT_KEYS = ("created", "name")
+    SORT_KEYS = ("created", "name", "running")
 
     def on_mount(self) -> None:
         self.app.title = "Klangk: Workspaces"
@@ -203,16 +203,15 @@ class MainScreen(Screen):
         self.query_one("#filter_input", Input).focus()
 
     def action_cycle_sort(self) -> None:
-        """Cycle through sort modes: created↓ → created↑ → name↑ → name↓."""
-        if self._sort_key == "created" and not self._sort_asc:
+        """Cycle through sort modes: key↓ → key↑ → next-key↓ → …"""
+        keys = self.SORT_KEYS
+        idx = keys.index(self._sort_key) if self._sort_key in keys else 0
+        if not self._sort_asc:
+            # currently descending → flip to ascending (same key)
             self._sort_asc = True
-        elif self._sort_key == "created" and self._sort_asc:
-            self._sort_key = "name"
-            self._sort_asc = True
-        elif self._sort_key == "name" and self._sort_asc:
-            self._sort_asc = False
         else:
-            self._sort_key = "created"
+            # currently ascending → advance to next key, descending
+            self._sort_key = keys[(idx + 1) % len(keys)]
             self._sort_asc = False
         self._update_sort_label()
         self._apply_filter()
@@ -247,13 +246,20 @@ class MainScreen(Screen):
     def _sort_key_created(ws) -> str:
         return getattr(ws, "created_at", "") or ""
 
+    @staticmethod
+    def _sort_key_running(ws) -> int:
+        # 0 for running (sorts first when ascending), 1 for stopped.
+        return 0 if getattr(ws, "running", False) else 1
+
+    _SORT_KEY_FUNCS: dict = {
+        "name": _sort_key_name,
+        "created": _sort_key_created,
+        "running": _sort_key_running,
+    }
+
     def _sort_workspaces(self, workspaces: list) -> list:
         """Sort workspace list according to current sort state."""
-        key = (
-            self._sort_key_name
-            if self._sort_key == "name"
-            else self._sort_key_created
-        )
+        key = self._SORT_KEY_FUNCS.get(self._sort_key, self._sort_key_created)
         return sorted(workspaces, key=key, reverse=not self._sort_asc)
 
     @staticmethod

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3051,14 +3051,18 @@ async def test_filter_escape_clears_then_returns(monkeypatch):
 
 
 async def test_cycle_sort(monkeypatch):
-    """Pressing 'o' cycles sort: created↓ → created↑ → name↑ → name↓ (#1764)."""
+    """Pressing 'o' cycles sort through created/name/running (#1764, #1912)."""
 
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    a = Workspace(id="id-a", name="alpha", created_at="2025-01-01T00:00:00")
-    b = Workspace(id="id-b", name="beta", created_at="2025-06-01T00:00:00")
+    a = Workspace(
+        id="id-a", name="alpha", created_at="2025-01-01T00:00:00", running=True
+    )
+    b = Workspace(
+        id="id-b", name="beta", created_at="2025-06-01T00:00:00", running=False
+    )
     app = KlangkApp(_ws(owned=[a, b]))
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -3080,18 +3084,42 @@ async def test_cycle_sort(monkeypatch):
         assert "created" in str(m.query_one("#sort_btn", Button).label)
         assert "▲" in str(m.query_one("#sort_btn", Button).label)
 
-        # 2nd press: name asc.
-        m.action_cycle_sort()
-        await pilot.pause()
-        assert names() == ["alpha", "beta"]
-        assert "name" in str(m.query_one("#sort_btn", Button).label)
-
-        # 3rd press: name desc.
+        # 2nd press: name desc.
         m.action_cycle_sort()
         await pilot.pause()
         assert names() == ["beta", "alpha"]
+        assert "name" in str(m.query_one("#sort_btn", Button).label)
+        assert "▼" in str(m.query_one("#sort_btn", Button).label)
 
-        # 4th press: back to created desc.
+        # 3rd press: name asc.
+        m.action_cycle_sort()
+        await pilot.pause()
+        assert names() == ["alpha", "beta"]
+        assert "▲" in str(m.query_one("#sort_btn", Button).label)
+
+        # 4th press: running desc (running-first = stopped first when
+        # reverse=True, i.e. higher sort key first → stopped=1 before
+        # running=0).
+        m.action_cycle_sort()
+        await pilot.pause()
+        assert "running" in str(m.query_one("#sort_btn", Button).label)
+        assert "▼" in str(m.query_one("#sort_btn", Button).label)
+        assert names() == [
+            "beta",
+            "alpha",
+        ]  # beta stopped(1), alpha running(0)
+
+        # 5th press: running asc (running-first: running=0 before stopped=1).
+        m.action_cycle_sort()
+        await pilot.pause()
+        assert "running" in str(m.query_one("#sort_btn", Button).label)
+        assert "▲" in str(m.query_one("#sort_btn", Button).label)
+        assert names() == [
+            "alpha",
+            "beta",
+        ]  # alpha running(0), beta stopped(1)
+
+        # 6th press: back to created desc.
         m.action_cycle_sort()
         await pilot.pause()
         assert names() == ["beta", "alpha"]


### PR DESCRIPTION
## Summary

- Add `running` as a third sort key in the workspace list sort cycle (created → name → running), each with ascending/descending directions
- Generalize `action_cycle_sort` to derive the cycle from `SORT_KEYS × directions` instead of a hand-written if/elif ladder
- Running ▲ = running-first, Running ▼ = stopped-first

Closes #1912