### PR TITLE
feat(cli): default forward-agent: true in generated klangk.yaml (#1923)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -470,6 +470,15 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **Generated `klangk.yaml` now includes `forward-agent` as a commented-out
+  opt-in line (#1923).** A freshly created config (written on first `klangk
+login`) ships a `# forward-agent: true` line at the top, commented out, so
+  SSH agent forwarding can be enabled by uncommenting it instead of having to
+  discover the option. It remains **off by default**: a forwarded agent can
+  be driven by anyone with access to the socket on the remote host for the
+  session, so forwarding is opt-in and recommended only for hosts you trust.
+  Existing configs are unchanged.
+
 - **TUI export completion now toasts the full filesystem path (#1758).**
   When a workspace export finishes, a toast notification shows the
   resolved absolute path the archive was written to (e.g.

--- a/docs/features/ssh-agent-forwarding.md
+++ b/docs/features/ssh-agent-forwarding.md
@@ -37,8 +37,10 @@ ssh -T git@github.com               # authenticates with your key
 git clone git@github.com:user/repo  # works without any credentials
 ```
 
-To enable forwarding by default, add `forward-agent: true` to your
-CLI config file (`~/.config/klangk/klangk.yaml`):
+Agent forwarding is **off by default**. A freshly generated `klangk.yaml`
+(created on first `klangk login`) includes it as a commented-out opt-in
+line; uncomment that line, or set `forward-agent` in your CLI config file
+(`~/.config/klangk/klangk.yaml`), to enable it:
 
 ```yaml
 # Enable for all servers
@@ -59,7 +61,8 @@ The resolution priority is:
 1. CLI flag (`--forward-agent` / `--no-forward-agent`) — highest
 2. Per-server setting in `klangk.yaml`
 3. Global setting in `klangk.yaml`
-4. Default: `false`
+4. Default: `false` (a freshly generated `klangk.yaml` includes
+   `forward-agent` as a commented-out opt-in line)
 
 See [CLI Configuration](../reference/cli.md#configuration) for full
 config file documentation.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,6 +73,7 @@ hostname as the alias and the login user as the default:
 ```bash
 klangk login http://myhost:8995 admin@example.com
 # Creates ~/.config/klangk/klangk.yaml with:
+#   # forward-agent: true   # opt-in: uncomment to enable
 #   servers:
 #     myhost:
 #       url: http://myhost:8995

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -173,9 +173,23 @@ def seed_config(server_url: str, user: str | None = None) -> None:
     entry: dict = {"url": server_url}
     if user:
         entry["user"] = user
-    data = {"servers": {alias: entry}}
+    # forward-agent is included as a commented-out opt-in line: it stays off
+    # by default because a forwarded SSH agent can be driven by anyone with
+    # access to the socket on the remote host for the session (#1923).
+    servers_yaml = yaml.dump(
+        {"servers": {alias: entry}}, default_flow_style=False
+    )
+    header = (
+        "# SSH agent forwarding is OFF by default. Uncomment the line below to\n"
+        "# enable it for all servers. Only enable forwarding on hosts you\n"
+        "# trust: while forwarded, anyone who can reach the agent socket on\n"
+        "# the remote host can authenticate as you with your loaded SSH keys\n"
+        "# for the duration of the session.\n"
+        "# See docs/features/ssh-agent-forwarding.md.\n"
+        "# forward-agent: true\n\n"
+    )
     _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
+    _CONFIG_PATH.write_text(header + servers_yaml)
 
 
 def add_server_to_config(

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1213,7 +1213,7 @@ def resolve_forward_agent(
     if result:
         if not os.environ.get("SSH_AUTH_SOCK"):
             _err.print(
-                "[yellow]Warning: --forward-agent set but SSH_AUTH_SOCK"
+                "[yellow]Warning: forward-agent is enabled but SSH_AUTH_SOCK"
                 " is not set. Agent forwarding will be skipped.[/yellow]"
             )
     return result

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -257,6 +257,25 @@ class TestSeedConfig:
         cfg = CLIConfig.load()
         assert "myhost" in cfg.servers
 
+    def test_includes_commented_forward_agent_opt_in(
+        self, tmp_path, monkeypatch
+    ):
+        """#1923: a freshly generated klangk.yaml includes forward-agent as a
+        commented-out opt-in line; it stays OFF by default (forwarding only
+        happens when the user uncomments it, passes -A, or sets it
+        per-server), since a forwarded agent can be abused by an untrusted
+        host."""
+        config_path = tmp_path / "klangk.yaml"
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        seed_config("http://localhost:8995", "admin@example.com")
+        text = config_path.read_text()
+        # Present as a commented-out, discoverable opt-in line...
+        assert "# forward-agent: true" in text
+        # ...and inactive (off by default).
+        cfg = CLIConfig.load()
+        assert cfg.forward_agent is None
+        assert "localhost" in cfg.servers
+
 
 # --- CLIState tests ---
 


### PR DESCRIPTION
## Summary

Fixes #1923.

A freshly generated `klangk.yaml` (written on first `klangk login`) now
includes `forward-agent` as a **commented-out opt-in line**, so SSH agent
forwarding is easy to enable (uncomment one line) but stays **off by
default**.

Off by default is deliberate: while an agent is forwarded into a host,
anyone who can reach the agent socket on that host (root, a malicious host
operator, or a backdoored container image) can authenticate as you with all
your loaded SSH keys for the session. That's a real exposure to silently
default on for every new install — so forwarding is opt-in and recommended
only for hosts you trust.

## Changes

- `src/klangk/klangk/cli/config.py` — `seed_config` now prepends a short
  header to the generated config explaining the trade-off and a commented-out
  `# forward-agent: true` line, then writes the active `servers:` block. The
  effective default when the key is absent remains `false`, so existing
  configs are unaffected.
- `src/klangk/klangk/cli/main.py` — reword the no-`SSH_AUTH_SOCK` warning from
  "`--forward-agent` set but…" to "forward-agent is enabled but…", since
  forwarding can now be turned on via config as well as the CLI flag.
- `docs/reference/cli.md` — first-`klangk login` example shows the commented
  opt-in line.
- `docs/features/ssh-agent-forwarding.md` — state forwarding is off by default
  with a commented opt-in line, and clarify resolution priority point 4.
- `docs/changes.md` — `Changed` entry under `[Unreleased]`.

Generated config:

```yaml
# SSH agent forwarding is OFF by default. Uncomment the line below to
# enable it for all servers. Only enable forwarding on hosts you
# trust: while forwarded, anyone who can reach the agent socket on
# the remote host can authenticate as you with your loaded SSH keys
# for the duration of the session.
# See docs/features/ssh-agent-forwarding.md.
# forward-agent: true

servers:
  myhost:
    url: http://myhost:8995
    user: admin@example.com
```

## Test plan

- [x] `test_includes_commented_forward_agent_opt_in` asserts the seeded file
  contains `# forward-agent: true` and parses to `cfg.forward_agent is None`
  (off by default), with the `servers:` block still active.
- [x] `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 3845 passed, 100% coverage.
