### PR TITLE
feat(tui): pre-fill create Netfilter list with deploy default (#1931)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,15 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **TUI create form pre-fills the Netfilter list with the deploy default
+  (#1931).** When `KLANGKD_NETFILTER_DEFAULT_DOMAINS` is set, opening the
+  TUI create-workspace dialog now seeds its Netfilter (allowed-domains)
+  tab with those domains — matching the Flutter web UI, which already
+  pre-fills them. The seeded entries are a starting set the user can edit
+  or remove before creating; with no deploy default the list still starts
+  empty. The edit form is unaffected (it shows the workspace's persisted
+  allow-list).
+
 - **TUI workspaces-list filter now also matches the workspace id (#1911).**
   Typing into the filter (`/`) narrows by name **or** id — so a workspace
   matches whether you type part of its name or the short id prefix shown

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -553,6 +553,20 @@ class KlangkClient:
         self._raise_for_status(resp)
         return resp.json()
 
+    def config(self) -> dict:
+        """Authed ``GET /api/v1/config``.
+
+        Sends the persisted token, so the response includes the auth-gated
+        fields (``netfilter_default_domains``, ``netfilter_enabled``) that
+        the pre-auth :func:`fetch_config` helper can't see — the
+        create-workspace form seeds its Netfilter tab from
+        ``netfilter_default_domains`` (#1931).
+        """
+        resp = self.get("/api/v1/config")
+        self.check_auth(resp)
+        self._raise_for_status(resp)
+        return resp.json()
+
     def resolve_workspace(self, name: str) -> Workspace:
         """Find a workspace by name (owned or shared).
 

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -621,11 +621,19 @@ class MainScreen(Screen):
         except (httpx.HTTPError, OSError, ValueError) as exc:
             logger.debug("Could not fetch autostart config: %s", exc)
             allow_autostart = False
+        try:
+            default_domains = await asyncio.to_thread(
+                state.default_allowed_domains
+            )
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            logger.debug("Could not fetch default allowed domains: %s", exc)
+            default_domains = []
         self.app.push_screen(
             CreateWorkspaceScreen(
                 allowed=allowed,
                 default=default,
                 allow_autostart=allow_autostart,
+                default_allowed_domains=default_domains,
             ),
             self._on_created,
         )

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -91,6 +91,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         allowed: list[str],
         default: str,
         allow_autostart: bool,
+        default_allowed_domains: list[str] | None = None,
     ) -> None:
         super().__init__()
         self._allowed = list(allowed)
@@ -98,7 +99,10 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         self._allow_autostart = bool(allow_autostart)
         self._mounts: list[str] = []
         self._env: dict[str, str] = {}
-        self._allowed_domains: list[str] = []
+        # Seed the Netfilter list with the deploy default
+        # (KLANGKD_NETFILTER_DEFAULT_DOMAINS) so the TUI create form matches
+        # the Flutter dialog — a starting set the user can edit/remove (#1931).
+        self._allowed_domains: list[str] = list(default_allowed_domains or [])
         if self._allowed:
             # Select tuples are (prompt, value). Prompts are rich Text so an
             # image name containing brackets can't trigger markup parsing.

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -202,6 +202,20 @@ class TuiState:
     def list_images(self) -> dict:
         return self.client().list_images()
 
+    def default_allowed_domains(self) -> list[str]:
+        """Deploy-wide netfilter allow-list (``KLANGKD_NETFILTER_DEFAULT_DOMAINS``)
+        used to seed the create form's Netfilter tab (#1931).
+
+        Auth-gated on ``/api/v1/config`` (absent from the pre-auth payload),
+        so this uses the authed client — ``fetch_config`` would not see it.
+        Mirrors the Flutter dialog's ``defaultAllowedDomains``. Raises on a
+        transport/server error; ``_do_create`` catches that and falls back
+        to an empty list so the form still opens.
+        """
+        cfg = self.client().config()
+        doms = cfg.get("netfilter_default_domains")
+        return list(doms) if isinstance(doms, list) else []
+
     async def list_terminals(self, name: str) -> list[dict]:
         return await self.client().list_terminals(name)
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1077,6 +1077,23 @@ class TestKlangkClient:
                 json={"name": "src-copy"},
             )
 
+    def test_config_returns_authed_payload(self):
+        # #1931: config() GETs /api/v1/config through the authed client
+        # (self.get -> _request attaches the Bearer token), so the response
+        # carries the auth-gated netfilter_default_domains that the pre-auth
+        # fetch_config helper can't see.
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "auth_modes": "password",
+            "netfilter_default_domains": ["github.com:443"],
+            "netfilter_enabled": True,
+        }
+        with patch.object(client, "get", return_value=mock_resp):
+            cfg = client.config()
+            assert cfg["netfilter_default_domains"] == ["github.com:443"]
+            client.get.assert_called_once_with("/api/v1/config")
+
     def test_create_workspace_includes_allowed_domains(self):
         client = KlangkClient("http://test:8995", "token")
         mock_resp = MagicMock(status_code=200)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -19,6 +19,7 @@ from textual.widgets import (
     Label,
     ListItem,
     ListView,
+    OptionList,
     Select,
     Static,
     TabbedContent,
@@ -540,6 +541,28 @@ def test_allow_autostart(monkeypatch, redirect_xdg):
     monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
     assert TuiState("https://x.example").allow_autostart() is False
     assert TuiState().allow_autostart() is False
+
+
+def test_default_allowed_domains(monkeypatch, redirect_xdg):
+    # netfilter_default_domains is auth-gated on /api/v1/config (absent from
+    # the pre-auth payload), so default_allowed_domains() reads it via the
+    # authed client, not fetch_config. Seed list verbatim; non-list / absent
+    # -> [] (no regression) (#1931).
+    from unittest.mock import MagicMock
+
+    t = TuiState("https://x.example")
+    fake = MagicMock()
+    monkeypatch.setattr(t, "client", lambda: fake)
+    fake.config.return_value = {
+        "netfilter_default_domains": ["github.com:443", "pypi.org:443"]
+    }
+    assert t.default_allowed_domains() == ["github.com:443", "pypi.org:443"]
+    # absent key -> None -> not a list -> []
+    fake.config.return_value = {}
+    assert t.default_allowed_domains() == []
+    # wrong shape -> []
+    fake.config.return_value = {"netfilter_default_domains": "github.com"}
+    assert t.default_allowed_domains() == []
 
 
 async def test_create_terminal_delegates(monkeypatch, redirect_xdg):
@@ -5130,6 +5153,7 @@ def _create_state(create=None, **extra):
             "allowed": ["base", "py:3"],
         },
         allow_autostart=lambda: True,
+        default_allowed_domains=lambda: [],
         create_workspace=create or (lambda *a, **k: _wsobj("zzz")),
     )
     base.update(extra)
@@ -5196,6 +5220,68 @@ async def test_create_screen_mount_editor(monkeypatch):
         cs.query_one("#mount_list").highlighted = 0
         cs._remove_mount()
         assert cs._mounts == []
+
+
+async def test_create_screen_seeds_default_allowed_domains(monkeypatch):
+    """#1931: the Netfilter tab is pre-filled with the deploy default
+    (KLANGKD_NETFILTER_DEFAULT_DOMAINS) as a starting set the user can
+    edit/remove — parity with the Flutter create dialog."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(
+        _create_state(
+            default_allowed_domains=lambda: [
+                "github.com:443",
+                "pypi.org:443",
+            ]
+        )
+    )
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        # Seeded verbatim from the deploy default, and rendered into the
+        # Netfilter tab's list (option ids a0 / a1, not the placeholder).
+        assert cs._allowed_domains == ["github.com:443", "pypi.org:443"]
+        ol = cs.query_one("#allow_list", OptionList)
+        assert ol.get_option_at_index(0).id == "a0"
+        assert ol.get_option_at_index(1).id == "a1"
+        # Editable: remove the first seeded entry (a starting set, not a floor).
+        ol.highlighted = 0
+        cs._remove_allowed_domain()
+        assert cs._allowed_domains == ["pypi.org:443"]
+        # Editable: add a new entry on top of the seed.
+        cs.query_one("#allow_input").value = "registry.npmjs.org:443"
+        cs._add_allowed_domain()
+        assert cs._allowed_domains == [
+            "pypi.org:443",
+            "registry.npmjs.org:443",
+        ]
+
+
+async def test_create_screen_allowed_domains_empty_when_no_default(
+    monkeypatch,
+):
+    """#1931: with no deploy default the Netfilter tab still starts empty
+    (no regression) — the list shows the inert (unrestricted) placeholder."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_create_state())  # default_allowed_domains -> []
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        assert cs._allowed_domains == []
+        ol = cs.query_one("#allow_list", OptionList)
+        assert ol.get_option_at_index(0).id == ""  # (unrestricted) placeholder
 
 
 async def test_create_screen_env_editor(monkeypatch):
@@ -5380,7 +5466,12 @@ async def test_create_screen_images_unavailable(monkeypatch):
         raise OSError("images endpoint down")
 
     app = KlangkApp(
-        _create_state(create=create, list_images=boom, allow_autostart=boom)
+        _create_state(
+            create=create,
+            list_images=boom,
+            allow_autostart=boom,
+            default_allowed_domains=boom,
+        )
     )
     async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
@@ -5388,6 +5479,7 @@ async def test_create_screen_images_unavailable(monkeypatch):
         await pilot.pause()
         cs = app.screen
         assert cs._allowed == []
+        assert cs._allowed_domains == []  # fetch failed -> empty seed
         assert cs.query_one("#auto_start", Checkbox).display is False
         cs.query_one("#name").value = "ws"
         cs._create()


### PR DESCRIPTION
## Summary

When `KLANGKD_NETFILTER_DEFAULT_DOMAINS` is set, the TUI create-workspace form now seeds its **Netfilter** (allowed-domains) tab with those domains — matching the Flutter web UI, which already pre-fills them via `defaultAllowedDomains`. Closes #1931.

The seeded entries are a **starting set** the user can edit or remove before creating. With no deploy default the list still starts empty (no regression). The **edit form is unaffected** (it shows the workspace's persisted allow-list).

## Why a new client method (not `fetch_config`)

The issue suggested mirroring `allow_autostart()` via `fetch_config`. That doesn't work here: `netfilter_default_domains` is **auth-gated** on `/api/v1/config` (only added to the payload for authenticated callers — see `api/__init__.py`), and `fetch_config` is the **pre-auth** probe (sends no token), so it can't see the field. `allow_autostart` works that way because *it* is on the public payload; `netfilter_default_domains` is not.

So this adds an **authed** path:

- `KlangkClient.config()` — authed `GET /api/v1/config` (token attached via the existing `_request`/`_headers` path; mirrors `list_images`).
- `TuiState.default_allowed_domains()` — reads `netfilter_default_domains` through `self.client().config()`; returns `[]` for a non-list/absent value.
- `_do_create` fetches it alongside `list_images`/`allow_autostart` (same try/except → empty-list fallback) and passes it to `CreateWorkspaceScreen`.
- `CreateWorkspaceScreen.__init__` gains a `default_allowed_domains` param and seeds `self._allowed_domains` (rendered by the existing `_render_allowed_domains` on mount).

## Acceptance criteria

- [x] With `KLANGKD_NETFILTER_DEFAULT_DOMAINS` set, the create form's Netfilter tab shows those domains pre-populated.
- [x] With it unset, the list still starts empty (no regression).
- [x] Seeded entries are editable/removable (starting set, not a floor) — parity with the Flutter dialog.
- [x] Edit form is not affected.
- [x] `test_tui.py` / `test_cli.py` cover the seeded and unset cases.

## Tests

- `test_config_returns_authed_payload` — `KlangkClient.config()` GETs `/api/v1/config`.
- `test_default_allowed_domains` — list / non-list / absent → correct return.
- `test_create_screen_images_unavailable` — `_do_create` fetch failure → empty seed (exception branch covered via the existing `boom` stub).
- `test_create_screen_seeds_default_allowed_domains` — seeded render (option ids `a0`/`a1`, not the placeholder) + remove + add-on-top.
- `test_create_screen_allowed_domains_empty_when_no_default` — no default → empty + `(unrestricted)` placeholder.

## Changelog

Added entry under `## [Unreleased]` → **Added**.

Full Python suite: **3848 passed, 100% coverage** (`-n auto`, both dirs).
