### PR TITLE
netfilter: disable IPv6 in filtered containers (IPv4-only egress)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1235,6 +1235,23 @@ extra 'all'`** (#1679). The declaration was `typer[all]>=0.12.0`, but the
 
 ### Security
 
+- **Filtered workspace containers now have IPv6 disabled, closing an
+  egress-filter bypass (#1936).** The netfilter hook previously installed
+  only `iptables` (IPv4) rules; `ip6tables`'s `OUTPUT` policy stayed at
+  its default `ACCEPT`, so any IPv6 egress bypassed the allow-list
+  whenever a container had IPv6 connectivity (and nearly every common
+  host publishes a AAAA record). The hook now sets
+  `net.ipv6.conf.all.disable_ipv6=1` (turns IPv6 off in the container
+  network namespace) **and** `ip6tables -P OUTPUT DROP` (a routing-level
+  default-deny that holds even if the sysctl write fails), and resolves
+  `allowed_domains` to IPv4 only (AAAA records returned by DNS are
+  ignored). **Breaking:** the `[ipv6]:port` literal grammar (e.g.
+  `[::1]`, `[2001:db8::1]:443`) is removed from both the server
+  (`parse_allowed_domains`) and the CLI/TUI (`validate_allowed_domain_spec`)
+  validators — such entries are now rejected; remove them from
+  `allowed_domains` / `KLANGKD_NETFILTER_DEFAULT_DOMAINS` (an IPv6
+  destination is no longer reachable from a filtered container anyway).
+
 - **Read-only ("spectate") terminal input is now a strict whitelist of
   the protocol responses tmux needs to initialize, instead of "any ESC
   byte" (#1716).** The old gate let a read-only joiner pass any string

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -30,6 +30,13 @@ starts.
    the backend gateway (`host.containers.internal`, resolved from the
    container's `/etc/hosts`), and the resolved allowed destinations are
    `ACCEPT`ed. Everything else is dropped.
+5. **IPv6 is disabled** in the container's network namespace — the hook
+   sets `net.ipv6.conf.all.disable_ipv6=1` (turns the protocol off) and
+   `ip6tables -P OUTPUT DROP` (a routing-level default-deny that holds
+   even if the sysctl write fails). Only IPv4 egress is possible, so the
+   allow-list cannot be bypassed over IPv6 (#1936). `allowed_domains`
+   therefore accepts only hostnames and IPv4 addresses (no `[ipv6]`
+   literals), and AAAA records returned by DNS are ignored.
 
 The hook runs **before** the container process starts, so the ruleset is in
 place and immutable before any user code runs — `CAP_NET_ADMIN` is dropped
@@ -42,11 +49,14 @@ script (`klangk-netfilter.sh`) and its config (`klangk-netfilter.json`)
 into a hooks directory and registers the OCI `createContainer` hook — no
 configuration is required for the common case.
 
-1. Ensure `iptables`, `getent`, and `nsenter` are available where the OCI
-   runtime executes (the host, or the Docker-in-Docker outer container —
-   _not_ the workspace image). The documented DinD deployment already has
-   `CAP_SYS_ADMIN` + `seccomp=unconfined`, which provides the necessary
-   privileges.
+1. Ensure `iptables`, `ip6tables`, `sysctl`, `getent`, and `nsenter` are
+   available where the OCI runtime executes (the host, or the
+   Docker-in-Docker outer container — _not_ the workspace image). The
+   documented DinD deployment already has `CAP_SYS_ADMIN` +
+   `seccomp=unconfined`, which provides the necessary privileges.
+   (`ip6tables` + `sysctl` disable IPv6 in the container netns, #1936;
+   if either is absent the hook logs a warning and falls back to the
+   other mechanism, but both should be present for defense-in-depth.)
 2. The hooks dir defaults to `<state_dir>/oci-hooks`
    (`KLANGKD_STATE_DIR`/`oci-hooks`). Override
    `KLANGKD_NETFILTER_HOOKS_DIR` only when the OCI runtime can't see
@@ -139,6 +149,9 @@ curl -X PUT https://klangkd/api/v1/workspaces/<id> \
 
 - `host` allows all ports to that host.
 - `host:port` allows a single TCP port (port must be 1–65535).
+- IPv6 literals (e.g. `[::1]`, `[2001:db8::1]:443`) are **not** accepted
+  — IPv6 is disabled inside filtered containers, so a v6 destination is
+  neither reachable nor enforceable (#1936).
 - Each entry is validated server-side; malformed entries are rejected with
   HTTP 400.
 - An empty list (or `null`) **inherits the deploy-wide default**
@@ -491,6 +504,14 @@ netfilter_default_domains:
 
 ## Caveats
 
+- **IPv6 is disabled — IPv4 egress only.** The hook turns IPv6 off in the
+  container's network namespace (`net.ipv6.conf.all.disable_ipv6=1`) and
+  default-denies IPv6 `OUTPUT` via `ip6tables`, so the allow-list can't
+  be bypassed over v6 (#1936). Hostnames resolve to IPv4 only (AAAA
+  records are ignored), and `[ipv6]:port` literals are rejected by the
+  validator. Trade-off: a workspace that genuinely needs IPv6 egress
+  cannot use the filter — clear `allowed_domains` (and the deploy-wide
+  default) to run it unrestricted.
 - **DNS resolution at creation time — restart on IP change.** iptables
   matches IPs, so hostnames are resolved once when the container is
   created. If a service rotates IPs (common with CDNs like Fastly,

--- a/src/containers/host/Dockerfile
+++ b/src/containers/host/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       nginx \
       passt \
       podman \
+      procps \
       rsync \
       sqlite3 \
       supervisor \

--- a/src/klangk/klangk/cli/mount.py
+++ b/src/klangk/klangk/cli/mount.py
@@ -49,27 +49,27 @@ def validate_mount_spec(spec: str) -> str | None:
 
 
 # An egress allowed-domain entry: ``host`` or ``host:port`` (DNS name or
-# IPv4), or a bracketed IPv6 literal (``[::1]`` / ``[2001:db8::1]:443``).
+# IPv4). IPv6 literals are rejected — IPv6 is disabled inside filtered
+# containers (#1936), so a v6 destination is neither reachable nor
+# enforceable, and the bracket grammar (``[::1]:443``) has been removed.
 # This catches gross typos client-side; the server
 # (:func:`klangk.netfilter.parse_allowed_domains`) does the authoritative
 # check (#1365, #1745).
 _ALLOWED_DOMAIN_RE = re.compile(
-    r"^(?:"
-    r"\[[0-9a-fA-F:.]+\](?::\d{1,5})?"  # [ipv6] or [ipv6]:port
-    r"|"
-    r"[^\[\]/\s:]+(?::\d{1,5})?"  # host or host:port
-    r")$"
+    r"^[^\[\]/\s:]+(?::\d{1,5})?$"  # host or host:port (IPv4 / DNS)
 )
 
 
 def validate_allowed_domain_spec(spec: str) -> str | None:
     """Validate an egress allowed-domain entry (``host`` or ``host:port``).
 
-    Returns None if valid, or an error message. Accepts a DNS name or IP
-    (IPv4, or a bracketed IPv6 literal like ``[::1]`` / ``[::1]:443``),
-    optionally followed by ``:port``. Empty / whitespace / stray slashes
-    are rejected. Mirrors the Flutter ``validateAllowedDomainSpec`` and the
-    TUI editor; the server does the authoritative validation (#1365, #1745).
+    Returns None if valid, or an error message. Accepts a DNS name or IPv4
+    address, optionally followed by ``:port``. Empty / whitespace / stray
+    slashes / IPv6 literals (``[::1]``) are rejected — IPv6 is disabled
+    inside filtered containers (#1936), so a v6 destination is neither
+    reachable nor enforceable. Mirrors the Flutter
+    ``validateAllowedDomainSpec`` and the TUI editor; the server does the
+    authoritative validation (#1365, #1745).
     """
     s = spec.strip()
     if not s:
@@ -77,6 +77,6 @@ def validate_allowed_domain_spec(spec: str) -> str | None:
     if not _ALLOWED_DOMAIN_RE.match(s):
         return (
             f"Invalid allowed-domain {spec!r}: "
-            "expected host or host:port (IPv6 in brackets)"
+            "expected host or host:port (IPv4 only)"
         )
     return None

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -83,18 +83,17 @@ STANDARD_HOOK_DIRS = (
     "/etc/containers/oci/hooks.d",
 )
 
-# A hostname or IP (v4/v6), optionally bracketed for v6, with an optional
-# trailing ``:port``. Deliberately permissive on the host grammar — the
-# hook does the real DNS resolution; this just rejects gross mistakes
-# (empty specs, whitespace, non-numeric ports, stray slashes) so a typo in
-# the API is rejected at the boundary rather than failing silently inside
-# the container netns.
+# A hostname or IPv4 address with an optional trailing ``:port``.
+# Deliberately permissive on the host grammar — the hook does the real DNS
+# resolution; this just rejects gross mistakes (empty specs, whitespace,
+# non-numeric ports, stray slashes) so a typo in the API is rejected at the
+# boundary rather than failing silently inside the container netns. IPv6
+# literals are **not** accepted: IPv6 is disabled inside filtered containers
+# (#1936), so a v6 destination is neither reachable nor enforceable, and
+# the bracket grammar (``[::1]:443``) has been removed.
 _DOMAIN_RE = re.compile(
     r"^[A-Za-z0-9](?:[A-Za-z0-9.\-]*[A-Za-z0-9])?"  # hostname / IPv4
     r"(?::[0-9]{1,5})?$"  # optional :port
-)
-_DOMAIN_BRACKET_RE = re.compile(
-    r"^\[[0-9A-Fa-f:.]+\](?::[0-9]{1,5})?$"  # [ipv6](:port)?
 )
 
 
@@ -103,19 +102,11 @@ def _valid_domain_spec(spec: str) -> bool:
         return False
     if "/" in spec:
         return False
-    if not (_DOMAIN_RE.match(spec) or _DOMAIN_BRACKET_RE.match(spec)):
+    if not _DOMAIN_RE.match(spec):
         return False
     # The regex accepts up to 5 digits; additionally reject ports > 65535.
     if ":" in spec:
-        # For bracketed IPv6 ([::1]:port), the port follows ']:'.
-        # For host:port, the port follows the last ':'.
-        if spec.startswith("["):
-            idx = spec.rfind("]:")
-            port_str = (
-                spec[idx + 2 :] if idx >= 0 and idx + 2 < len(spec) else None
-            )
-        else:
-            port_str = spec.rsplit(":", 1)[1]
+        port_str = spec.rsplit(":", 1)[1]
         if port_str and port_str.isdigit() and int(port_str) > 65535:
             return False
     return True
@@ -208,46 +199,41 @@ pid=$(printf '%s' "$state" \
 [ -n "$pid" ] || exit 0
 [ -e "/proc/$pid/ns/net" ] || exit 0
 
-# iptables inside the container's network namespace. Failures are logged
-# to stderr (captured by the OCI runtime) but do not abort the hook — the
-# default-DROP policy below is the fail-closed posture for a misconfigured
-# deploy, and a partial ruleset is still better than none.
+# iptables / ip6tables inside the container's network namespace. Failures
+# are logged to stderr (captured by the OCI runtime) but do not abort the
+# hook — the default-DROP policy below is the fail-closed posture for a
+# misconfigured deploy, and a partial ruleset is still better than none.
 ipt() {
     nsenter --net="/proc/$pid/ns/net" iptables "$@" || \
         echo "klangk-netfilter: iptables $* failed" >&2
 }
-
-# Resolve a hostname to unique A/AAAA IPs, one per line.
-resolve() {
-    getent ahosts "$1" 2>/dev/null | awk '{print $1}' | sort -u
+ipt6() {
+    nsenter --net="/proc/$pid/ns/net" ip6tables "$@" || \
+        echo "klangk-netfilter: ip6tables $* failed" >&2
 }
 
-# Print one ACCEPT rule per resolved IP for a host[:port] spec. Handles
-# bracketed IPv6 literals ([::1], [2001:db8::1]:443) — the brackets are
-# stripped and the optional ]:port suffix parsed — as well as plain
-# hostnames/IPv4 with an optional :port. A non-numeric port is skipped
-# defensively (the API validator rejects these, but the hook never trusts
-# the annotation blindly).
+# Resolve a hostname to unique IPv4 A records, one per line. AAAA (IPv6)
+# records are filtered out: IPv6 is disabled in the container netns (#1936),
+# so a v6 address is neither reachable nor installable in iptables (which
+# is v4-only and would reject `-d <v6>`, logging noise to stderr).
+resolve() {
+    getent ahosts "$1" 2>/dev/null \
+        | awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ {print $1}' \
+        | sort -u
+}
+
+# Print one ACCEPT rule per resolved IPv4 for a host[:port] spec. A
+# non-numeric port is skipped defensively (the API validator rejects
+# these, but the hook never trusts the annotation blindly). Bracketed
+# IPv6 literals are no longer accepted — IPv6 is disabled in the
+# container netns, so the v6 grammar has been removed (#1936).
 accept_rules() {
     _spec=$1
-    _host=
+    # hostname / IPv4, optional :port.
+    _host=${_spec%%:*}
     _port=
     case "$_spec" in
-        "["*"]"*)
-            # [ipv6] or [ipv6]:port — drop the brackets + parse the port.
-            _host=${_spec%%]*}        # "[ipv6"  (strip ](:port) suffix)
-            _host=${_host#?}          # "ipv6"   (strip leading [)
-            case "$_spec" in
-                *"]:"*) _port=${_spec##*:} ;;
-            esac
-            ;;
-        *)
-            # hostname / IPv4, optional :port.
-            _host=${_spec%%:*}
-            case "$_spec" in
-                *:*) _port=${_spec##*:} ;;
-            esac
-            ;;
+        *:*) _port=${_spec##*:} ;;
     esac
     [ -n "$_host" ] || return 0
     # Defensive: skip a non-numeric port rather than emit a bad rule.
@@ -269,6 +255,23 @@ accept_rules() {
 ipt -P OUTPUT DROP
 ipt -A OUTPUT -o lo -j ACCEPT
 ipt -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# Disable IPv6 egress entirely (#1936). The v4 ruleset above is the real
+# filter, but ip6tables' OUTPUT policy defaults to ACCEPT — without this,
+# any IPv6 egress bypasses the allow-list whenever the container has IPv6
+# connectivity (and nearly every common host publishes a AAAA record).
+# Two mechanisms, defense-in-depth:
+#   1. sysctl net.ipv6.conf.{all,default}.disable_ipv6=1 turns IPv6 OFF in
+#      this netns (removes v6 addresses; the container cannot speak v6).
+#   2. ip6tables -P OUTPUT DROP is a routing-level default-deny that holds
+#      even if the sysctl write fails (ip6tables missing, or the knob not
+#      writable). Each failure is logged, not fatal — together they close
+#      the v6 bypass; neither alone is fully trustworthy on every deploy.
+nsenter --net="/proc/$pid/ns/net" sysctl -qw \
+    net.ipv6.conf.all.disable_ipv6=1 \
+    net.ipv6.conf.default.disable_ipv6=1 2>/dev/null || \
+    echo "klangk-netfilter: sysctl ipv6 disable failed (relying on ip6tables DROP)" >&2
+ipt6 -P OUTPUT DROP
 
 # DNS: allow :53 ONLY to the container's configured resolvers (read from
 # its /etc/resolv.conf via /proc/$pid/root — the OCI runtime has set up the

--- a/src/klangk/klangkc-tests/tests/test_mount.py
+++ b/src/klangk/klangkc-tests/tests/test_mount.py
@@ -78,9 +78,12 @@ class TestValidateAllowedDomainSpec:
         assert validate_allowed_domain_spec("10.0.0.1") is None
         assert validate_allowed_domain_spec("10.0.0.1:53") is None
 
-    def test_valid_bracketed_ipv6(self):
-        assert validate_allowed_domain_spec("[::1]") is None
-        assert validate_allowed_domain_spec("[2001:db8::1]:443") is None
+    def test_rejects_ipv6_bracket_literals(self):
+        # IPv6 is disabled inside filtered containers (#1936), so bracketed
+        # v6 literals are no longer accepted.
+        assert validate_allowed_domain_spec("[::1]") is not None
+        assert validate_allowed_domain_spec("[2001:db8::1]:443") is not None
+        assert validate_allowed_domain_spec("[::1]:443") is not None
 
     def test_rejects_empty(self):
         assert validate_allowed_domain_spec("") is not None

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -49,8 +49,6 @@ class TestParseAllowedDomains:
             "10.0.0.1:53",
             "sub.domain.example.com:8080",
             "a.com:65535",  # max valid port
-            "[::1]",
-            "[2001:db8::1]:443",
         ],
     )
     def test_valid_specs(self, spec):
@@ -63,6 +61,8 @@ class TestParseAllowedDomains:
             "a.com:abc",  # non-numeric port
             "a.com:123456",  # port too long (>5 digits)
             "a.com:99999",  # port > 65535
+            "[::1]",  # IPv6 literal — IPv6 disabled in containers (#1936)
+            "[2001:db8::1]:443",  # bracketed IPv6 — no longer accepted
             "[::1]:70000",  # bracketed IPv6, port > 65535
             "/etc/passwd",  # slash
             "-leading",  # leading hyphen rejected by host grammar
@@ -358,7 +358,9 @@ def _state(rules, *, with_pid=True):
     return json.dumps(s)
 
 
-def _run_hook(tmp_path, state, getent_map=None, resolv=None, hosts=None):
+def _run_hook(
+    tmp_path, state, getent_map=None, resolv=None, hosts=None, sysctl_rc=0
+):
     """Execute ``nf.HOOK_SCRIPT`` against ``state``; return recorded iptables
     invocations (each a ``list[str]`` of argv).
 
@@ -385,7 +387,10 @@ def _run_hook(tmp_path, state, getent_map=None, resolv=None, hosts=None):
     )
     resolv_file.write_text(resolv or "")
     hosts_file.write_text(hosts or "")
-    # getent ahosts <host> shim: resolve from the | map, else echo the host.
+    # getent ahosts <host> shim: emit realistic `IP STREAM host` rows (real
+    # getent prints "<ip> STREAM <host>" / DGRAM / RAW, NOT a bare IP), so a
+    # resolve()-regex anchored to end-of-line gets caught here instead of in
+    # production (#1937 review). Resolve from the | map, else echo the host.
     (bin_dir / "getent").write_text(
         "#!/bin/sh\n"
         f'map="{map_file}"\n'
@@ -393,22 +398,30 @@ def _run_hook(tmp_path, state, getent_map=None, resolv=None, hosts=None):
         'if [ -f "$map" ]; then\n'
         '  while IFS="|" read -r h ips; do\n'
         '    if [ "$h" = "$host" ]; then\n'
-        '      printf "%s\\n" "$ips" | tr "," "\\n"\n'
+        '      printf "%s\\n" "$ips" | tr "," "\\n" \\\n'
+        '        | while IFS= read -r ip; do printf "%s STREAM %s\\n" "$ip" "$host"; done\n'
         "      exit 0\n"
         "    fi\n"
         '  done < "$map"\n'
         "fi\n"
-        'printf "%s\\n" "$host"\n'
+        'printf "%s STREAM %s\\n" "$host" "$host"\n'
     )
     (bin_dir / "getent").chmod(0o755)
-    # nsenter shim: drop the --net flag + the "iptables" token, then re-exec
-    # the iptables shim with the remaining args (the real netns is irrelevant
-    # to what we're asserting, which is the argv the hook builds).
+    # nsenter shim: drop --net, then dispatch on the command token. The
+    # hook drives three commands through nsenter — iptables (v4 rules),
+    # ip6tables, and sysctl (#1936 disables IPv6 in the container netns) —
+    # so a blind "shift twice, exec iptables" would force ip6tables/sysctl
+    # argv through the iptables recorder and corrupt the v4 assertions.
     (bin_dir / "nsenter").write_text(
         "#!/bin/sh\n"
         "shift  # --net=/proc/.../ns/net\n"
-        'shift  # "iptables"\n'
-        'exec iptables "$@"\n'
+        'cmd="$1"; shift\n'
+        'case "$cmd" in\n'
+        '  iptables) exec iptables "$@" ;;\n'
+        '  ip6tables) exec ip6tables "$@" ;;\n'
+        '  sysctl) exec sysctl "$@" ;;\n'
+        '  *) echo "nsenter shim: unknown command $cmd" >&2; exit 1 ;;\n'
+        "esac\n"
     )
     (bin_dir / "nsenter").chmod(0o755)
     # iptables shim: record argv, one arg per line, blank line between calls.
@@ -422,6 +435,33 @@ def _run_hook(tmp_path, state, getent_map=None, resolv=None, hosts=None):
         "exit 0\n"
     )
     (bin_dir / "iptables").chmod(0o755)
+    # ip6tables shim (#1936): records to its own log so v6 calls don't
+    # pollute the v4 iptables assertions.
+    ip6_record = tmp_path / "ip6tables.log"
+    (bin_dir / "ip6tables").write_text(
+        "#!/bin/sh\n"
+        f'rec="{ip6_record}"\n'
+        'for a in "$@"; do\n'
+        '  printf "%s\\n" "$a" >>"$rec"\n'
+        "done\n"
+        'printf "\\n" >>"$rec"\n'
+        "exit 0\n"
+    )
+    (bin_dir / "ip6tables").chmod(0o755)
+    # sysctl shim (#1936): records the disable_ipv6 argv, exits sysctl_rc
+    # (default 0; tests pass sysctl_rc=1 to exercise the hook's fallback to
+    # ip6tables DROP when the sysctl write fails — #1937 review).
+    sysctl_record = tmp_path / "sysctl.log"
+    (bin_dir / "sysctl").write_text(
+        "#!/bin/sh\n"
+        f'rec="{sysctl_record}"\n'
+        'for a in "$@"; do\n'
+        '  printf "%s\\n" "$a" >>"$rec"\n'
+        "done\n"
+        'printf "\\n" >>"$rec"\n'
+        f"exit {sysctl_rc}\n"
+    )
+    (bin_dir / "sysctl").chmod(0o755)
 
     hook = bin_dir / "klangk-netfilter.sh"
     hook.write_text(nf.HOOK_SCRIPT)
@@ -443,6 +483,9 @@ def _run_hook(tmp_path, state, getent_map=None, resolv=None, hosts=None):
     assert proc.returncode == 0, (
         f"hook exited {proc.returncode}\nstderr:\n{proc.stderr}"
     )
+    # Capture stderr so tests can assert the hook's warning echoes (e.g. the
+    # sysctl-failed fallback message) — #1937 review.
+    (tmp_path / "hook.stderr").write_text(proc.stderr)
     if not record.exists():
         return []
     calls = []
@@ -457,6 +500,19 @@ def _run_hook(tmp_path, state, getent_map=None, resolv=None, hosts=None):
 def _accept_rules(calls):
     """The per-destination ACCEPT invocations: [-A, OUTPUT, -d, <ip>, ...]."""
     return [c for c in calls if c[:3] == ["-A", "OUTPUT", "-d"]]
+
+
+def _calls_from(log_path):
+    """Parse a shim's blank-line-separated argv log into a list of calls."""
+    if not log_path.exists():
+        return []
+    calls = []
+    for block in log_path.read_text().split("\n\n"):
+        args = block.split("\n")
+        if args == [""]:
+            continue
+        calls.append(args)
+    return calls
 
 
 class TestHookScriptExecutable:
@@ -530,53 +586,18 @@ class TestHookScriptExecutable:
             ],
         ]
 
-    def test_bracketed_ipv6_with_port(self, tmp_path):
-        # B2 regression: [2001:db8::1]:443 is blessed by the API validator
-        # but the hook's ':' suffix-splitting mangled it (_host="[2001").
-        # Brackets must be stripped and the port parsed.
-        calls = _run_hook(
-            tmp_path,
-            _state("[2001:db8::1]:443"),
-            getent_map={"2001:db8::1": ["2001:db8::1"]},
-        )
-        assert _accept_rules(calls) == [
-            [
-                "-A",
-                "OUTPUT",
-                "-d",
-                "2001:db8::1",
-                "-p",
-                "tcp",
-                "--dport",
-                "443",
-                "-j",
-                "ACCEPT",
-            ],
-        ]
-
-    def test_bracketed_ipv6_without_port(self, tmp_path):
-        # B2: [::1] (no port) — brackets stripped, no --dport emitted.
-        calls = _run_hook(
-            tmp_path,
-            _state("[::1]"),
-            getent_map={"::1": ["::1"]},
-        )
-        assert _accept_rules(calls) == [
-            ["-A", "OUTPUT", "-d", "::1", "-j", "ACCEPT"],
-        ]
-
     def test_multiple_specs_all_applied_in_order(self, tmp_path):
         # The whole CSV is split and each spec yields its rules.
         calls = _run_hook(
             tmp_path,
-            _state("github.com:443,pypi.org,[::1]"),
+            _state("github.com:443,pypi.org,10.0.0.1"),
             getent_map={
                 "github.com": ["140.82.112.4"],
                 "pypi.org": ["151.101.0.0"],
             },
         )
         dests = [c[3] for c in _accept_rules(calls)]
-        assert dests == ["140.82.112.4", "151.101.0.0", "::1"]
+        assert dests == ["140.82.112.4", "151.101.0.0", "10.0.0.1"]
 
     def test_host_without_port_allows_all_ports(self, tmp_path):
         calls = _run_hook(
@@ -664,3 +685,80 @@ class TestHookScriptExecutable:
             hosts="127.0.0.1 localhost\n",
         )
         assert not any("-d" in c and "10.0.2.2" in c for c in calls)
+
+    # --- #1936: IPv6 disabled in the container netns (v4-only egress) ---
+
+    def test_ipv6_disabled_via_sysctl(self, tmp_path):
+        # sysctl net.ipv6.conf.{all,default}.disable_ipv6=1 turns IPv6 OFF
+        # in the container netns so the v4-only allow-list can't be
+        # bypassed over v6 (ip6tables OUTPUT otherwise defaults to ACCEPT).
+        _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        sysctl = _calls_from(tmp_path / "sysctl.log")
+        # One call carrying both knobs (the hook batches them).
+        assert len(sysctl) == 1
+        argv = sysctl[0]
+        assert "net.ipv6.conf.all.disable_ipv6=1" in argv
+        assert "net.ipv6.conf.default.disable_ipv6=1" in argv
+
+    def test_ipv6_output_default_dropped(self, tmp_path):
+        # Belt-and-suspenders: ip6tables OUTPUT policy is DROP regardless of
+        # whether the sysctl write took, so v6 egress is default-denied even
+        # on a deploy where the sysctl knob can't be written.
+        _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        assert ["-P", "OUTPUT", "DROP"] in _calls_from(
+            tmp_path / "ip6tables.log"
+        )
+
+    def test_ipv6_drop_holds_when_sysctl_fails(self, tmp_path):
+        # The actual security property the changelog leans on: even if the
+        # sysctl write fails (sysctl absent, or the knob not writable),
+        # ip6tables -P OUTPUT DROP still fires so v6 egress is default-denied
+        # regardless. The hook logs the fallback and continues (non-fatal).
+        _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+            sysctl_rc=1,
+        )
+        assert ["-P", "OUTPUT", "DROP"] in _calls_from(
+            tmp_path / "ip6tables.log"
+        )
+        assert (
+            "sysctl ipv6 disable failed"
+            in (tmp_path / "hook.stderr").read_text()
+        )
+
+    def test_aaaa_records_filtered_from_resolution(self, tmp_path):
+        # A dual-stack host yields both A and AAAA records from getent; the
+        # hook emits an ACCEPT rule ONLY for the v4 address. v6 is disabled
+        # in the container (#1936) AND iptables is v4-only (it would reject
+        # `-d <v6>` and log noise), so AAAA records are filtered out.
+        calls = _run_hook(
+            tmp_path,
+            _state("dual.example:443"),
+            getent_map={"dual.example": ["140.82.112.4", "2001:db8::1"]},
+        )
+        assert _accept_rules(calls) == [
+            [
+                "-A",
+                "OUTPUT",
+                "-d",
+                "140.82.112.4",
+                "-p",
+                "tcp",
+                "--dport",
+                "443",
+                "-j",
+                "ACCEPT",
+            ],
+        ]
+        # No v6 ACCEPT attempt reached iptables (no noise, no leak).
+        assert not any("2001:db8::1" in c for c in calls)


### PR DESCRIPTION
## Summary

The netfilter egress filter only installed `iptables` (IPv4) rules;
`ip6tables`'s `OUTPUT` policy stayed at its default `ACCEPT`, so any IPv6
egress from a filtered container **bypassed the allow-list** whenever the
container had IPv6 connectivity — and nearly every commonly-allowed host
(`github.com`, `pypi.org`, …) publishes a AAAA record. This closes the
bypass by disabling IPv6 in the container netns and making egress IPv4-only.

Closes #1936 (chosen direction: disable IPv6, not dual-stack).

## Changes

**Hook** (`src/klangk/klangk/netfilter.py`, `HOOK_SCRIPT`):
- Disable IPv6 via `sysctl net.ipv6.conf.{all,default}.disable_ipv6=1`
  (turns the protocol off in the container netns) **and** set
  `ip6tables -P OUTPUT DROP` (a routing-level default-deny that holds
  even if the sysctl write fails). Defense-in-depth; each failure is
  logged, not fatal.
- `resolve()` now yields IPv4 A records only (AAAA filtered) — a v6
  address is neither reachable nor installable in `iptables` (v4-only),
  and `-d <v6>` just produced stderr noise.
- `accept_rules()` drops the bracketed-IPv6 literal branch; a new
  `ipt6()` helper parallels `ipt()`.

**Validators** (remove the `[ipv6]:port` grammar — acceptance criterion):
- `netfilter._valid_domain_spec`: `_DOMAIN_BRACKET_RE` removed; the v4
  regex rejects bracket literals.
- `cli.mount.validate_allowed_domain_spec`: `_ALLOWED_DOMAIN_RE`
  narrowed to `host` / `host:port` (IPv4 / DNS); error message updated.

**Docs** (`docs/features/egress-filtering.md`):
- *How it works* — IPv6 disabled (sysctl + `ip6tables` DROP), v4 only.
- *API spec* — IPv6 literals not accepted.
- *Enabling it* — `ip6tables` + `sysctl` added to the host-side
  requirements (with the defense-in-depth note).
- *Caveats* — IPv4-only trade-off (a workspace that needs IPv6 egress
  can't use the filter).

**Changelog** — `### Security` entry with a **Breaking** callout for the
removed bracket grammar.

## Tests

- New: `test_ipv6_disabled_via_sysctl`, `test_ipv6_output_default_dropped`,
  `test_aaaa_records_filtered_from_resolution` (hook); the
  `_run_hook` harness now shims `ip6tables`/`sysctl` via a dispatching
  `nsenter` shim and records them to separate logs.
- Removed: the two bracketed-IPv6 hook tests (`[2001:db8::1]:443`,
  `[::1]`); the grammar is gone.
- Updated: `test_multiple_specs_all_applied_in_order` no longer uses
  `[::1]`; both validator suites now assert IPv6 literals are rejected.

## Verification

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto`
  → **3850 passed**, **100% coverage** (matches CI).
- Pre-commit hooks green (ruff, ruff-format, markdownlint, prettier,
  trufflehog, shellcheck).
- Branch based on `origin/main` (`04f6c571`); no divergence.

## Follow-up (out of scope here)

The Flutter frontend's `validateAllowedDomainSpec` (referenced by
`cli/mount.py`'s docstring as the mirror) likely still accepts IPv6
brackets. The server does authoritative validation and rejects them on
submit (fail-safe), but the UI mirror should be narrowed for parity —
tracked separately, not blocking this fix.
