### PR TITLE
fix(git-credential): redact secrets from debug output (code-scanning #172)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1252,6 +1252,14 @@ extra 'all'`** (#1679). The declaration was `typer[all]>=0.12.0`, but the
   `allowed_domains` / `KLANGKD_NETFILTER_DEFAULT_DOMAINS` (an IPv6
   destination is no longer reachable from a filtered container anyway).
 
+- **`git-credential-klangk`: redact secrets from debug output (#1938).**
+  When `GIT_CREDENTIAL_KLANGK_DEBUG` is set, the helper previously logged
+  the bridge response and the git credential input verbatim to stderr,
+  either of which can carry the user's password/PAT. Debug logs now mask
+  values for sensitive keys (`password`, `token`, `access_token`,
+  `secret`). The credential is still delivered to git over stdout as
+  before — only the stderr debug trace is redacted.
+
 - **Read-only ("spectate") terminal input is now a strict whitelist of
   the protocol responses tmux needs to initialize, instead of "any ESC
   byte" (#1716).** The old gate let a read-only joiner pass any string

--- a/features/git-credential/tools/git-credential-klangk
+++ b/features/git-credential/tools/git-credential-klangk
@@ -38,6 +38,26 @@ def _debug(msg):
         print(f"git-credential-klangk: {msg}", file=sys.stderr)
 
 
+# Credential/response keys whose values must never appear in debug output.
+_SENSITIVE_KEYS = {"password", "token", "access_token", "secret"}
+
+
+def _redact(obj):
+    """Return a copy of ``obj`` with sensitive values masked for debug logs.
+
+    Applied to anything passed to ``_debug`` so a debug run can't leak a
+    credential that was in the bridge response or the git credential input.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: "***" if k.lower() in _SENSITIVE_KEYS else _redact(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact(v) for v in obj]
+    return obj
+
+
 def _get_workspace_token():
     """Read the current workspace token via klangk-workspace-token."""
     try:
@@ -118,8 +138,9 @@ def post_bridge(operation, cred, browser_id, timeout=None, extra=None):
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             body = resp.read()
-            _debug(f"bridge response: {body[:500]}")
-            return json.loads(body)
+            parsed = json.loads(body)
+            _debug(f"bridge response: {json.dumps(_redact(parsed))[:500]}")
+            return parsed
     except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as e:
         _debug(f"bridge error: {e}")
         return None
@@ -212,7 +233,7 @@ def _handle_device_flow(cred, browser_id):
                 _debug("device flow: got token")
                 # Tell browser to dismiss the code UI.
                 done_resp = post_bridge("device_flow_done", cred, browser_id)
-                _debug(f"device_flow_done response: {done_resp}")
+                _debug(f"device_flow_done response: {_redact(done_resp)}")
                 return ("x-access-token", token)
 
         if error == "authorization_pending":
@@ -274,7 +295,7 @@ def main():
         sys.exit(1)
 
     cred = read_credential_input()
-    _debug(f"cred input: {cred}")
+    _debug(f"cred input: {_redact(cred)}")
 
     if operation == "get":
         # Try GitHub device flow first if configured and host is GitHub.

--- a/src/klangk/klangkd-tests/tests/test_git_credential.py
+++ b/src/klangk/klangkd-tests/tests/test_git_credential.py
@@ -334,3 +334,51 @@ class TestStoreAndErase:
         )
         # store/erase are best-effort
         assert result.returncode == 0
+
+
+class TestDebugRedaction:
+    """Debug output must never leak the password (code-scanning alert 172)."""
+
+    def test_get_does_not_log_bridge_password(
+        self, bridge_server, fake_browser_id
+    ):
+        server, port = bridge_server
+        _BridgeHandler.response_body = json.dumps(
+            {"username": "octocat", "password": "ghp_SUPERSECRET"}
+        ).encode()
+
+        result = run_helper(
+            "get",
+            "protocol=https\nhost=github.com\n\n",
+            env_override={
+                "KLANGKWS_BRIDGE_URL": f"http://127.0.0.1:{port}",
+                "GIT_CREDENTIAL_KLANGK_DEBUG": "1",
+            },
+            extra_path=str(fake_browser_id),
+        )
+
+        # The credential is still delivered to git via stdout...
+        assert "password=ghp_SUPERSECRET" in result.stdout
+        # ...but never appears in the debug output on stderr.
+        assert "ghp_SUPERSECRET" not in result.stderr
+        assert '"password": "***"' in result.stderr
+
+    def test_store_does_not_log_input_password(
+        self, bridge_server, fake_browser_id
+    ):
+        server, port = bridge_server
+
+        result = run_helper(
+            "store",
+            "protocol=https\nhost=github.com\n"
+            "username=octocat\npassword=ghp_SUPERSECRET\n\n",
+            env_override={
+                "KLANGKWS_BRIDGE_URL": f"http://127.0.0.1:{port}",
+                "GIT_CREDENTIAL_KLANGK_DEBUG": "1",
+            },
+            extra_path=str(fake_browser_id),
+        )
+
+        assert result.returncode == 0
+        assert "ghp_SUPERSECRET" not in result.stderr
+        assert "'password': '***'" in result.stderr


### PR DESCRIPTION
## Context

Code-scanning alert [#172](https://github.com/mcdonc/klangk/security/code-scanning/172) (`py/clear-text-logging-sensitive-data`, high) flags `features/git-credential/tools/git-credential-klangk:309`:

```python
print(f"password={password}")
```

## The flagged line is a false positive

This file is a **git credential helper**. Git's `get` protocol *requires* the helper to emit `username=…` and `password=…` lines to **stdout** — git reads the credential back from the helper's stdout ([gitcredentials docs](https://git-scm.com/docs/gitcredentials)). That `print` is IPC with git, not logging; the helper's logging channel is **stderr** (the `_debug` helper writes there). So the rule's "logging sink" heuristic misfires on the protocol output. **Alert #172 will be dismissed as a false positive** with this justification.

## The real fix in this PR

While reviewing the file, two *genuine* debug-mode leaks were found that the scanner missed. With `GIT_CREDENTIAL_KLANGK_DEBUG` set, the helper logged to stderr verbatim:

- the **bridge response** for `get` — which carries the `password`/PAT, and
- the **git credential input** on `store` — which also carries the `password`.

This PR adds a `_redact()` helper that masks values for sensitive keys (`password`, `token`, `access_token`, `secret`) and applies it at every `_debug` site that handles credential-bearing data (the bridge response, the `device_flow_done` response, and the credential input). The credential is still delivered to git over stdout unchanged — only the stderr debug trace is redacted.

## Tests

New `TestDebugRedaction` class (`src/klangk/klangkd-tests/tests/test_git_credential.py`) drives the helper as a subprocess with `GIT_CREDENTIAL_KLANGK_DEBUG=1` and asserts for both `get` and `store`:

- the password is still delivered to git on **stdout**, and
- the password never appears in the **stderr** debug output (the redaction marker `***` does).

Full Python suite green: `3851 passed`, `100%` coverage.

## Changelog

Entry added under `### Security` in `docs/changes.md`.
