### PR TITLE
fix(settings): abort on malformed netfilter_default_domains (#1939)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -489,6 +489,16 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **A malformed `KLANGKD_NETFILTER_DEFAULT_DOMAINS` now refuses to start
+  (#1939).** A bad `host[:port]` spec or a non-list/non-string value used
+  to be logged at WARNING and silently ignored — the field fell back to
+  `None` and workspaces ran **unrestricted** with no operator-visible
+  failure (the warn-and-fallback posture from #1772). It now aborts
+  construction: the deploy refuses to boot until the value is fixed. A
+  SIGHUP reload with a bad value is denied and keeps the prior config
+  (the old config stays running; the operator sees the deny reason in the
+  log). `None` / empty and valid values are unchanged.
+
 - **Generated `klangk.yaml` now includes `forward-agent` as a commented-out
   opt-in line (#1923).** A freshly created config (written on first `klangk
 login`) ships a `# forward-agent: true` line at the top, commented out, so

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -652,8 +652,10 @@ class KlangkSettings(BaseSettings):
     #
     # Accepts either a comma-separated string (env var) or a real list
     # (YAML config file), normalized + validated at construction by
-    # _coerce_netfilter_default_domains. A malformed value warns and falls
-    # back to None (no default) rather than aborting the server (#1772).
+    # _coerce_netfilter_default_domains. A malformed value aborts startup
+    # (raises) rather than silently falling back to None — a SIGHUP reload
+    # with a bad value is denied and keeps the old config (#1939, reversing
+    # #1772).
     netfilter_default_domains: list[str] | None = None
     test_mode: str | None = None
     version_file: str | None = None
@@ -1029,14 +1031,18 @@ class KlangkSettings(BaseSettings):
         (no deploy default; workspaces unrestricted unless they declare their
         own).
 
-        A malformed value (a bad ``host[:port]`` spec, or a non-list/
-        non-string type) does NOT abort the server — it logs a loud warning
-        and falls back to ``None`` (no deploy default applied), so a typo in
-        the deploy-wide default can't take down a running server or kill a
-        SIGHUP reload (#1772). This matches the warn+fallback posture of
-        peer settings (e.g. ``image_pull_policy``) and netfilter's
-        fail-open-with-visibility design — a misconfigured deploy degrades
-        to unrestricted + a visible warning rather than refusing to run.
+        A malformed value — a wrong type (non-list / non-string) or a bad
+        ``host[:port]`` spec — **aborts startup** by raising ``ValueError``
+        (pydantic surfaces it as a ``ValidationError`` out of
+        ``KlangkSettings(...)``). This is a safety control: a deploy-wide
+        egress allow-list that silently disables itself on a typo leaves
+        workspaces running unrestricted while the operator believes egress
+        is filtered, so a misconfigured value must fail loudly. A SIGHUP
+        reload with a bad value is denied by ``_reload_settings``
+        (main.py), which catches the construction error and keeps the
+        runtime on the prior config. Reverses the warn-and-fallback posture
+        of #1772; matches the malformed→abort rule decided for the
+        container resource limits (#34).
         """
         if v is None:
             return None
@@ -1046,27 +1052,19 @@ class KlangkSettings(BaseSettings):
         elif isinstance(v, list):
             items = [str(s).strip() for s in v if str(s).strip()]
         else:
-            logger.warning(
-                "KLANGKD_NETFILTER_DEFAULT_DOMAINS=%r must be a list or a "
-                "comma-separated string (got %s); ignoring the deploy-wide "
-                "default (no default applied).",
-                v,
-                type(v).__name__,
+            raise ValueError(
+                f"KLANGKD_NETFILTER_DEFAULT_DOMAINS={v!r} must be a list or "
+                f"a comma-separated string (got {type(v).__name__})."
             )
-            return None
         if not items:
             return None
         try:
             return parse_allowed_domains(items)
         except ValueError as exc:
-            logger.warning(
-                "KLANGKD_NETFILTER_DEFAULT_DOMAINS=%r has an invalid spec "
-                "(%s); ignoring the deploy-wide default (no default "
-                "applied). Fix the value and reload to restore it.",
-                v,
-                exc,
-            )
-            return None
+            raise ValueError(
+                f"KLANGKD_NETFILTER_DEFAULT_DOMAINS={v!r} has an invalid "
+                f"spec: {exc}"
+            ) from exc
 
     @model_validator(mode="after")
     def _warn_on_deprecated_proxy_engine(self) -> "KlangkSettings":

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -194,33 +194,54 @@ class TestConfigFile:
             is None
         )
 
-    def test_netfilter_default_domains_invalid_warns_and_empties(self, caplog):
-        """#1772: a bad spec no longer aborts boot — it warns and falls back
-        to None (no deploy default), so a typo can't take the server down."""
-        with caplog.at_level("WARNING"):
-            s = make_settings(
+    def test_netfilter_default_domains_invalid_spec_rejected(self):
+        """#1939: a bad spec aborts construction (reverses the #1772
+        warn-and-fallback). A misconfigured deploy-wide egress allow-list
+        must fail loudly rather than silently leaving workspaces
+        unrestricted."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            make_settings(
                 {"KLANGKD_NETFILTER_DEFAULT_DOMAINS": "good.com,bad spec"}
             )
-        assert s.netfilter_default_domains is None
-        assert any("invalid spec" in r.message for r in caplog.records)
+        msg = str(exc_info.value)
+        assert "invalid spec" in msg
+        assert "KLANGKD_NETFILTER_DEFAULT_DOMAINS" in msg
 
-    def test_netfilter_default_domains_wrong_type_warns_and_empties(
-        self, tmp_path, caplog
-    ):
-        """#1772: a non-list/non-string value (e.g. a bare int from a
-        malformed YAML block) warns and falls back to None rather than
-        aborting construction."""
+    def test_netfilter_default_domains_wrong_type_rejected(self, tmp_path):
+        """#1939: a non-list/non-string value (e.g. a bare int from a
+        malformed YAML block) aborts construction instead of falling back
+        to None."""
+        from pydantic import ValidationError
+
         # YAML delivering a scalar int directly (a typo'd block like
         # `netfilter_default_domains: 42` instead of a list).
         cfg = tmp_path / "config.yaml"
         cfg.write_text("netfilter_default_domains: 42\n")
-        with caplog.at_level("WARNING"):
-            s = make_settings({}, config_file=str(cfg))
-        assert s.netfilter_default_domains is None
-        assert any(
-            "must be a list or a comma-separated string" in r.message
-            for r in caplog.records
+        with pytest.raises(ValidationError) as exc_info:
+            make_settings({}, config_file=str(cfg))
+        msg = str(exc_info.value)
+        assert "must be a list or a comma-separated string" in msg
+        assert "KLANGKD_NETFILTER_DEFAULT_DOMAINS" in msg
+
+    def test_netfilter_default_domains_malformed_aborts_reload(self):
+        """#1939: a malformed value introduced after startup (operator edits
+        KLANGKD_NETFILTER_DEFAULT_DOMAINS, then SIGHUPs) makes reload()
+        raise. ``_reload_settings`` (main.py) catches that (``except
+        Exception``) and denies the restart, keeping the runtime on the old
+        config — so a typo in a reload no longer silently drops the default."""
+        from pydantic import ValidationError
+
+        s = make_settings({})
+        # Simulate an operator edit + SIGHUP that introduces a bad value
+        # into the env mapping reload() re-reads.
+        s._reload_env["KLANGKD_NETFILTER_DEFAULT_DOMAINS"] = (
+            "good.com,bad spec"
         )
+        with pytest.raises(ValidationError) as exc_info:
+            s.reload()
+        assert "invalid spec" in str(exc_info.value)
 
     def test_netfilter_enabled_defaults_true(self):
         # #1774: netfilter is armed out of the box.


### PR DESCRIPTION
Closes #1939.

## What

`KLANGKD_NETFILTER_DEFAULT_DOMAINS` is a **deploy-wide egress allow-list** — a safety control applied to every workspace that doesn't declare its own. A malformed value (a bad `host[:port]` spec, or a non-list/non-string type) used to be logged at WARNING and **silently ignored**: the field fell back to `None` and workspaces ran **unrestricted** with no operator-visible failure. That's the warn-and-fallback posture from #1772 — and it's wrong for a safety control: a misconfigured allow-list that silently disables itself leaves the operator believing egress is filtered when it isn't.

This reverses #1772: a malformed value now **aborts construction**, matching the malformed→abort rule already decided for the container resource limits (#34).

## Change

In `settings.py`, `_coerce_netfilter_default_domains` (the `mode="before"` field validator) had two warn-and-`return None` paths — both now `raise ValueError`:

- **wrong type** (non-list / non-string, e.g. a typo'd YAML `netfilter_default_domains: 42`) → raises
- **invalid spec** (`parse_allowed_domains` raises `ValueError`) → raises (chained `from exc`)

Pydantic surfaces the `ValueError` as a `ValidationError` out of `KlangkSettings(...)`, so the deploy refuses to boot until the value is fixed. `None` / empty and valid values (comma-separated string, YAML list, CIDR) are unchanged.

## SIGHUP safety (unchanged)

`_reload_settings` (`main.py`) catches construction errors with `except Exception`, so a bad value introduced between startups (operator edits the env var and SIGHUPs) is **denied** — the restart is refused and the runtime keeps running on the old (valid) config. The operator sees the deny reason in the log. So raising is safe for both startup (refuses to boot) and reload (denied, old config kept).

## Tests

- `test_netfilter_default_domains_invalid_spec_rejected` — bad spec now raises (was: warns + `None`).
- `test_netfilter_default_domains_wrong_type_rejected` — wrong type now raises (was: warns + `None`).
- `test_netfilter_default_domains_malformed_aborts_reload` — new end-to-end test: a bad value introduced into the captured env after construction makes `reload()` raise (the path `_reload_settings` catches to deny the restart).
- Existing valid-input / `None`-handling tests unchanged; existing `test_reload_settings_returns_error_when_invalid` covers the deny mechanism.

Full Python suite green: **3887 passed, 100% coverage**.

## Changelog

`### Changed` entry added.
