### PR TITLE
Nix flake for bare-metal installation

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,12 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Nix flake for bare-metal installation (#1948).** `nix run
+github:mcdonc/klangk` installs and runs klangkd with all runtime
+  dependencies (podman, caddy, tmux, git, GNU tar, etc.) provided by
+  Nix. The klangk wheel is pip-installed into a persistent venv on
+  first launch. Works on Linux and macOS (x86_64 + aarch64). See
+  [Getting Started](getting-started.md#run-using-nix).
 - **`allowed_domains` now accepts IPv4 CIDR ranges (#1935).** A workspace
   (or the deploy-wide `KLANGKD_NETFILTER_DEFAULT_DOMAINS`) may list an IP
   subnet like `10.0.0.0/8`, optionally scoped to a port as

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,45 @@ you set above.
 > meant for local dev on your own machine — a published port is not that.
 > See [Auth Modes](features/auth-modes.md).
 
+## Run Using Nix
+
+Install and run Klangk on bare metal (no Docker) with all runtime
+dependencies provided by Nix. Works on Linux and macOS.
+
+You need [Nix](https://nixos.org/download/) (with flakes enabled) and
+an OpenAI-compatible LLM API key.
+
+```bash
+# First run: creates a venv and pip-installs klangk from PyPI.
+# Subsequent runs reuse the existing venv (no network needed).
+nix run github:mcdonc/klangk
+```
+
+On first launch the wrapper creates a Python venv at
+`~/.local/share/klangk/venv` and installs the klangk wheel from PyPI.
+Nix provides every system-level dependency (podman, caddy, tmux, git,
+GNU tar, etc.) — no manual package installation required.
+
+To upgrade klangk to the latest PyPI release:
+
+```bash
+nix run github:mcdonc/klangk -- --upgrade
+```
+
+To drop into a shell with all deps on `PATH` (useful for manual
+`pip install` or running `klangkd doctor`):
+
+```bash
+nix develop github:mcdonc/klangk
+```
+
+!!! note "Podman setup"
+On **macOS**, podman runs inside a VM. You need to run
+`podman machine init && podman machine start` once before starting
+klangkd. On **Linux**, rootless podman requires subuid/subgid
+mappings for your user — see [Podman](reference/podman.md) for
+details.
+
 ## Run Using devenv
 
 For developing or modifying Klangk itself.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785110946,
+        "narHash": "sha256-WWuWxmXKzGZWryswWlijP3Mjp6aGy4Ngmeil5nGMMjk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d3498f786f97ac0bded21b34bae0bf3809b45aa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,138 @@
+# Nix flake for running klangk (server + client) with all runtime
+# dependencies on PATH.
+#
+# Quick start (creates a venv and pip-installs klangk on first run):
+#
+#   nix run github:mcdonc/klangk                # run klangkd
+#   nix run github:mcdonc/klangk#klangk         # run klangk CLI
+#   nix develop github:mcdonc/klangk            # shell with all deps
+#
+# The flake provides Python + every runtime binary klangkd needs (podman,
+# caddy, tmux, etc.) via Nix.  The klangk wheel itself is pip-installed
+# into a persistent venv at ~/.local/share/klangk/venv on first launch —
+# Nix handles the system deps, pip handles the Python deps.
+#
+# Supports x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin.
+# See #1948.
+{
+  description = "klangk — multi-user Pi coding agent (server + client)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        python = pkgs.python312;
+
+        # Runtime binaries that klangkd shells out to (podman, caddy, etc.).
+        # The list mirrors the klangkd doctor checks (#1612).
+        runtimeDeps =
+          with pkgs;
+          [
+            caddy
+            coreutils # GNU du (macOS BSD du lacks -b)
+            git
+            gnutar # macOS ships BSD tar; GNU tar required
+            gzip
+            openssl
+            podman
+            rsync
+            sqlite
+            tmux
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            # Rootless podman prerequisites — macOS uses podman machine
+            # instead of user namespaces.
+            fuse-overlayfs
+            slirp4netns
+            shadow # newuidmap / newgidmap
+          ];
+
+        runtimePath = pkgs.lib.makeBinPath runtimeDeps;
+
+        # Wrapper script: ensures a venv with klangk installed exists at
+        # ~/.local/share/klangk/venv, then execs the target binary.
+        # On first run (or after `--upgrade`), pip installs/upgrades the
+        # wheel from PyPI.  Subsequent runs just exec into the existing
+        # venv — no network needed.
+        mkLauncher =
+          binName:
+          pkgs.writeShellScriptBin binName ''
+            set -euo pipefail
+            export PATH="${runtimePath}:${python}/bin:$PATH"
+
+            KLANGK_DATA="''${XDG_DATA_HOME:-$HOME/.local/share}/klangk"
+            VENV="$KLANGK_DATA/venv"
+
+            if [ ! -f "$VENV/bin/${binName}" ]; then
+              echo "klangk: creating venv and installing klangk from PyPI..." >&2
+              mkdir -p "$KLANGK_DATA"
+              ${python}/bin/python3 -m venv "$VENV"
+              "$VENV/bin/pip" install --upgrade pip >/dev/null 2>&1
+              "$VENV/bin/pip" install klangk
+              echo "klangk: installed." >&2
+            fi
+
+            # Pass --upgrade to force a pip upgrade of the wheel.
+            if [ "''${1:-}" = "--upgrade" ]; then
+              shift
+              echo "klangk: upgrading klangk from PyPI..." >&2
+              "$VENV/bin/pip" install --upgrade klangk
+              echo "klangk: upgraded." >&2
+            fi
+
+            exec "$VENV/bin/${binName}" "$@"
+          '';
+
+        klangkd = mkLauncher "klangkd";
+        klangk = mkLauncher "klangk";
+
+        # Combined package with both binaries.
+        klangkPkg = pkgs.symlinkJoin {
+          name = "klangk";
+          paths = [
+            klangkd
+            klangk
+          ];
+        };
+      in
+      {
+        packages.default = klangkPkg;
+        packages.klangkd = klangkd;
+        packages.klangk = klangk;
+
+        apps.default = {
+          type = "app";
+          program = "${klangkd}/bin/klangkd";
+        };
+
+        apps.klangk = {
+          type = "app";
+          program = "${klangk}/bin/klangk";
+        };
+
+        # Dev shell with all runtime deps + Python — useful for
+        # contributors who want to pip-install klangk in editable mode
+        # or run klangkd doctor.
+        devShells.default = pkgs.mkShell {
+          packages = runtimeDeps ++ [ python ];
+          shellHook = ''
+            echo "klangk dev shell — Python ${python.version}, all runtime deps on PATH."
+            echo "  pip install klangk    # install from PyPI"
+            echo "  klangkd              # start the server"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` + `flake.lock` at repo root so `nix run github:mcdonc/klangk` installs and runs klangkd with all runtime deps (podman, caddy, tmux, git, GNU tar, etc.) provided by Nix
- The klangk wheel is pip-installed into a persistent venv (`~/.local/share/klangk/venv`) on first launch; subsequent runs reuse it with no network
- `--upgrade` flag triggers `pip install --upgrade klangk`
- Linux-only deps (fuse-overlayfs, slirp4netns, shadow) conditionally included; skipped on Darwin
- `nix develop` gives a shell with all deps for manual workflows
- Docs: "Run Using Nix" section added to Getting Started, changelog entry added

## Test plan

- [ ] `nix flake check` passes (verified)
- [ ] `nix build` produces working `klangkd` and `klangk` wrappers (verified)
- [ ] `nix run .` creates venv and starts klangkd on a host with podman configured
- [ ] `nix run .#klangk` runs the CLI
- [ ] `nix develop` drops into a shell with all runtime deps on PATH

Closes #1948.