### PR TITLE
feat(workspaces): per-workspace settings bag with global fallbacks (#864, phases 1-2)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,21 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Per-workspace behavioral settings via a JSON `settings` bag (#864).**
+  A workspace may now override several deploy-wide tuning knobs on a
+  per-workspace basis, with the precedence **workspace override > deploy
+  default > none**. The overrides live in a single JSON `settings` column
+  on the workspace (one column, one migration, one resolution path) rather
+  than one column per setting. This release wires up:
+  `idle_timeout`, `bridge_timeout`, `cpu_limit`, `memory_limit`, and
+  `pids_limit`. Resource-limit overrides are applied as-is with no
+  clamping (#34) — a creator may go larger _or_ smaller than the deploy
+  default. Set them at create time (`POST /workspaces`), via full replace
+  (`PUT /workspaces/{id}` with a `settings` field), or via partial merge
+  (`PATCH /workspaces/{id}/settings`, where a `null` value deletes a key
+  and reverts it to the deploy default). Unknown setting names and
+  malformed values are rejected at the API boundary (HTTP 400).
+
 - **`allowed_domains` now accepts IPv4 CIDR ranges (#1935).** A workspace
   (or the deploy-wide `KLANGKD_NETFILTER_DEFAULT_DOMAINS`) may list an IP
   subnet like `10.0.0.0/8`, optionally scoped to a port as

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -36,7 +36,11 @@ operators or integrators to act when upgrading.
   `idle_timeout`, `bridge_timeout`, `cpu_limit`, `memory_limit`, and
   `pids_limit`. Resource-limit overrides are applied as-is with no
   clamping (#34) — a creator may go larger _or_ smaller than the deploy
-  default. Set them at create time (`POST /workspaces`), via full replace
+  default, and are **not bounded by `KLANGKD_CONTAINER_*`** (an owner who
+  sets an override escapes the deploy-wide budget). An `idle_timeout` of
+  `0` means "never idle out" (pin the workspace alive), matching the
+  auto_start boot pin; the other limits must be strictly positive.
+  Set them at create time (`POST /workspaces`), via full replace
   (`PUT /workspaces/{id}` with a `settings` field), or via partial merge
   (`PATCH /workspaces/{id}/settings`, where a `null` value deletes a key
   and reverts it to the deploy default). Unknown setting names and

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -333,6 +333,12 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
         {"name": "string", "image": "string"},
         None,
     ),
+    (
+        "PATCH",
+        f"{P}/workspaces/{{workspace_id}}/settings",
+        {"idle_timeout": "int", "cpu_limit": "float"},
+        None,
+    ),
     ("DELETE", f"{P}/workspaces/{{workspace_id}}", None, None),
     (
         "POST",

--- a/src/klangk/klangk/api/browser_delegate.py
+++ b/src/klangk/klangk/api/browser_delegate.py
@@ -99,14 +99,24 @@ async def browser_delegate_stream(
     For long-running actions (RAG + LLM), the browser pushes incremental
     browser_chunk messages and a terminal browser_response.  Each is streamed
     to the caller immediately, so there is no single bounded round-trip — the
-    only limit is the per-chunk idle timeout.
+    only limit is the per-chunk idle timeout, which resolves per-workspace
+    (#864): the workspace's ``settings.bridge_timeout`` override > the
+    ``KLANGKD_BRIDGE_TIMEOUT_SECONDS`` deploy default > 30s.
     """
     session, target_sock, payload = _resolve_bridge_target(
         body, app.state.container_registry, app.state.sockets
     )
+    # Fetch the workspace so its settings.bridge_timeout override can apply.
+    # One DB lookup per stream request — these are not high-frequency
+    # (one per browser-delegated long-running action from the container).
+    workspace = await app.state.model.workspaces.get_workspace_by_id(
+        workspace_id
+    )
     return StreamingResponse(
         session.dispatch_browser_request_stream_to(
-            target_sock, payload, app.state.util.bridge_idle_timeout()
+            target_sock,
+            payload,
+            app.state.util.bridge_idle_timeout_for(workspace),
         ),
         media_type="application/x-ndjson",
     )

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -31,6 +31,10 @@ from .. import (
     netfilter as netfilter_mod,
     wshandler,
 )
+from ..workspace_settings import (
+    validate_settings,
+    validate_settings_patch,
+)
 from ._common import get_app_dep
 from ..model import (
     ACTION_ALLOW,
@@ -195,6 +199,7 @@ class CreateWorkspaceRequest(BaseModel):
     setup_state: Literal["pending", "complete", "failed"] | None = None
     health_check: str | None = None
     allowed_domains: list[str] | None = None
+    settings: dict | None = None
 
 
 @router.post("/workspaces")
@@ -224,6 +229,10 @@ async def create_workspace(
             raise HTTPException(status_code=400, detail=mount_err)
     allowed_domains = _validate_allowed_domains(body.allowed_domains, app)
     try:
+        settings = validate_settings(body.settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    try:
         ws = await app.state.workspaces.create_workspace(
             user["id"],
             body.name,
@@ -235,6 +244,7 @@ async def create_workspace(
             setup_state=body.setup_state or "complete",
             health_check=body.health_check,
             allowed_domains=allowed_domains,
+            settings=settings,
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -274,6 +284,7 @@ class UpdateWorkspaceRequest(BaseModel):
     setup_state: Literal["pending", "complete", "failed"] | None = None
     health_check: str | None = None
     allowed_domains: list[str] | None = None
+    settings: dict | None = None
 
 
 @router.put("/workspaces/{workspace_id}")
@@ -307,6 +318,14 @@ async def update_workspace(
         fields["allowed_domains"] = _validate_allowed_domains(
             fields["allowed_domains"], app
         )
+    # settings is a full-replace on PUT (None = clear the whole bag).
+    # ``exclude_unset=True`` means the key is present only when the client
+    # sent it; a missing ``settings`` key leaves the bag untouched.
+    if "settings" in fields:
+        try:
+            fields["settings"] = validate_settings(fields["settings"])
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not fields:
         raise HTTPException(status_code=400, detail="No fields to update")
     workspace = await app.state.model.workspaces.get_workspace(workspace_id)
@@ -343,6 +362,46 @@ async def update_workspace(
     return {"status": "updated"}
 
 
+class UpdateWorkspaceSettingsRequest(BaseModel):
+    """Body for ``PATCH /workspaces/{id}/settings`` (#864).
+
+    A flat map of setting key → value. A ``null`` value deletes that key
+    (reverts it to the deploy-wide default); any other value sets/replaces
+    the override. Keys not present in the patch are left untouched. This is
+    a partial-merge (read-modify-write), not a full replace — use
+    ``PUT /workspaces/{id}`` with a full ``settings`` dict for that.
+    """
+
+    model_config = {"extra": "allow"}
+
+
+@router.patch("/workspaces/{workspace_id}/settings")
+async def update_workspace_settings(
+    workspace_id: str,
+    body: UpdateWorkspaceSettingsRequest,
+    user: dict = Depends(acl.has_permission("edit", workspace_resource)),
+    app=Depends(get_app_dep),
+):
+    """Partial-merge update of the per-workspace ``settings`` bag (#864).
+
+    Each key in the body sets/replaces that override; a ``null`` value
+    deletes the key (reverting to the deploy default). Returns the
+    post-merge settings dict (or ``None`` if the bag is now empty).
+    """
+    try:
+        patch = validate_settings_patch(body.model_dump())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    # The ``edit`` ACL dependency has already established the caller may
+    # modify this workspace (and rejected nonexistent workspaces as 403),
+    # so a ``None`` return here means only that the patch emptied the bag
+    # — not that the workspace is missing.
+    merged = await app.state.model.workspaces.update_workspace_settings(
+        workspace_id, user["id"], patch
+    )
+    return {"settings": merged}
+
+
 class DuplicateWorkspaceRequest(BaseModel):
     name: str
 
@@ -368,6 +427,7 @@ async def duplicate_workspace(
             env=source.get("env"),
             health_check=source.get("health_check"),
             allowed_domains=source.get("allowed_domains"),
+            settings=source.get("settings"),
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -793,6 +853,7 @@ async def _extract_archive_metadata(
         "env": env,
         "health_check": metadata.get("health_check"),
         "allowed_domains": metadata.get("allowed_domains"),
+        "settings": metadata.get("settings"),
     }
 
 
@@ -854,6 +915,16 @@ async def import_workspace(
         allowed_domains = _validate_allowed_domains(
             meta.get("allowed_domains"), app
         )
+        # Re-validate imported settings — an archive from this instance is
+        # trusted, but the bag may predate a schema change or carry a value
+        # the current deploy rejects. Validate rather than persist blindly.
+        try:
+            settings = validate_settings(meta.get("settings"))
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Archive settings are invalid: {exc}",
+            ) from exc
 
         try:
             ws = await app.state.workspaces.create_workspace(
@@ -866,6 +937,7 @@ async def import_workspace(
                 env=meta["env"],
                 health_check=meta["health_check"],
                 allowed_domains=allowed_domains,
+                settings=settings,
             )
         except SAIntegrityError:
             raise HTTPException(

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -392,12 +392,17 @@ async def update_workspace_settings(
         patch = validate_settings_patch(body.model_dump())
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    # The ``edit`` ACL dependency has already established the caller may
-    # modify this workspace (and rejected nonexistent workspaces as 403),
-    # so a ``None`` return here means only that the patch emptied the bag
-    # — not that the workspace is missing.
+    # Resolve the *owner* (not the caller) — the model's settings merge is
+    # owner-scoped (``WHERE id = ? AND user_id = ?``), and a shared non-owner
+    # with the ``edit`` ACE must be able to patch settings just as they can
+    # PUT other fields. The ``edit`` ACL dependency has already gated access
+    # (and rejected nonexistent workspaces as 403), so a missing row here is
+    # a race, not a normal path.
+    workspace = await app.state.model.workspaces.get_workspace(workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
     merged = await app.state.model.workspaces.update_workspace_settings(
-        workspace_id, user["id"], patch
+        workspace_id, workspace["user_id"], patch
     )
     return {"settings": merged}
 

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -6,6 +6,7 @@ import os
 import time
 
 from . import podman
+from . import workspace_settings as ws_settings
 from .podman import PodmanError
 
 logger = logging.getLogger(__name__)
@@ -1040,6 +1041,39 @@ class ContainerRegistry:
             setup_state=setup_state,
         )
 
+    def _resolve_cpu_limit(
+        self, workspace_settings: dict | None
+    ) -> float | None:
+        """Per-workspace CPU limit (``--cpus``), #864 / #34.
+
+        Workspace override > deploy default > None (no flag, unbounded).
+        Override semantics (#34): a deploy-wide value is a plain default,
+        not a cap or floor — a creator may go larger *or* smaller, applied
+        as-is with no clamping.
+        """
+        return ws_settings.resolve_cpu_limit(
+            {"settings": workspace_settings},
+            self.app.state.settings.container_cpu_limit,
+        )
+
+    def _resolve_memory_limit(
+        self, workspace_settings: dict | None
+    ) -> str | None:
+        """Per-workspace memory limit (``--memory``), #864 / #34."""
+        return ws_settings.resolve_memory_limit(
+            {"settings": workspace_settings},
+            self.app.state.settings.container_memory_limit,
+        )
+
+    def _resolve_pids_limit(
+        self, workspace_settings: dict | None
+    ) -> int | None:
+        """Per-workspace PIDs limit (``--pids-limit``), #864 / #34."""
+        return ws_settings.resolve_pids_limit(
+            {"settings": workspace_settings},
+            self.app.state.settings.container_pids_limit,
+        )
+
     def _egress_filter(
         self, allowed_domains: list[str] | None
     ) -> tuple[dict[str, str] | None, list[str] | None, list[str] | None]:
@@ -1073,6 +1107,7 @@ class ContainerRegistry:
         setup_state: str | None = None,
         service_command: str | None = None,
         allowed_domains: list[str] | None = None,
+        workspace_settings: dict | None = None,
     ) -> tuple[str, str]:
         """Start (or restart) a Pi container for a workspace.
 
@@ -1101,6 +1136,7 @@ class ContainerRegistry:
                 setup_state=setup_state,
                 service_command=service_command,
                 allowed_domains=allowed_domains,
+                workspace_settings=workspace_settings,
             )
 
     async def _handle_existing_container(
@@ -1505,6 +1541,7 @@ class ContainerRegistry:
         setup_state: str | None = None,
         service_command: str | None = None,
         allowed_domains: list[str] | None = None,
+        workspace_settings: dict | None = None,
     ) -> tuple[str, str]:
         """Inner implementation of start_container (called under lock)."""
         t_start = time.monotonic()
@@ -1596,9 +1633,9 @@ class ContainerRegistry:
             init=True,
             interactive=True,
             userns=self.app.state.settings.userns,
-            cpus=self.app.state.settings.container_cpu_limit,
-            memory=self.app.state.settings.container_memory_limit,
-            pids_limit=self.app.state.settings.container_pids_limit,
+            cpus=self._resolve_cpu_limit(workspace_settings),
+            memory=self._resolve_memory_limit(workspace_settings),
+            pids_limit=self._resolve_pids_limit(workspace_settings),
             pull=self.image_pull_policy(),
         )
 

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -148,6 +148,14 @@ async def init_db(db) -> None:
                 -- comma-joined host[:port] specs; NULL = unrestricted
                 -- egress (see KLANGKD_NETFILTER_HOOKS_DIR, #1365)
                 allowed_domains TEXT,
+                -- JSON dict of per-workspace behavioral overrides
+                -- (idle_timeout, bridge_timeout, cpu_limit,
+                -- memory_limit, pids_limit, ...). NULL = no overrides;
+                -- missing keys fall back to the deploy-wide default
+                -- (#864). Structural fields (image/mounts/env/...
+                -- and the behavioral allowed_domains) stay as their own
+                -- columns.
+                settings TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 UNIQUE(user_id, name),
                 -- (C) the system agent must never own a workspace.
@@ -201,6 +209,14 @@ async def init_db(db) -> None:
             await db.execute(
                 "ALTER TABLE workspaces ADD COLUMN allowed_domains TEXT"
             )
+        # Migration: add settings column (#864). NULL by default so
+        # existing workspaces keep inheriting every deploy-wide default
+        # (no per-workspace overrides). One JSON bag holds every
+        # behavioral override (idle_timeout, bridge_timeout, cpu_limit,
+        # memory_limit, pids_limit, ...) so future settings need no new
+        # column/migration. Structural fields stay as dedicated columns.
+        if "settings" not in ws_cols:
+            await db.execute("ALTER TABLE workspaces ADD COLUMN settings TEXT")
         await db.execute("""
             CREATE TABLE IF NOT EXISTS port_allocations (
                 port INTEGER PRIMARY KEY,

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -101,6 +101,7 @@ class WorkspacesModel:
         setup_state: str,
         health_check: str | None,
         allowed_domains: list[str] | None = None,
+        settings: dict | None = None,
     ) -> dict:
         """INSERT a workspace row on ``db`` and return the new workspace dict.
 
@@ -114,12 +115,13 @@ class WorkspacesModel:
         allowed_domains_json = (
             json.dumps(allowed_domains) if allowed_domains else None
         )
+        settings_json = json.dumps(settings) if settings else None
         await db.execute(
             "INSERT INTO workspaces"
             " (id, user_id, name, image, service_command, auto_start,"
             " setup_state, health_check, mounts, env, allowed_domains,"
-            " created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " settings, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 workspace_id,
                 user_id,
@@ -132,6 +134,7 @@ class WorkspacesModel:
                 mounts_json,
                 env_json,
                 allowed_domains_json,
+                settings_json,
                 created_at,
             ),
         )
@@ -147,6 +150,7 @@ class WorkspacesModel:
             "mounts": mounts,
             "env": env,
             "allowed_domains": allowed_domains,
+            "settings": settings,
             "num_ports": DEFAULT_PORTS_PER_WORKSPACE,
             "created_at": created_at,
         }
@@ -227,6 +231,7 @@ class WorkspacesModel:
         setup_state: str = SETUP_STATE_COMPLETE,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        settings: dict | None = None,
     ) -> dict:
         """Create a workspace row AND seed its owner ACE + role groups.
 
@@ -259,6 +264,7 @@ class WorkspacesModel:
                 setup_state=setup_state,
                 health_check=health_check,
                 allowed_domains=allowed_domains,
+                settings=settings,
             )
             await self._seed_workspace_acl(db, ws, user_id)
             return ws
@@ -275,6 +281,7 @@ class WorkspacesModel:
         setup_state: str = SETUP_STATE_COMPLETE,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        settings: dict | None = None,
     ) -> dict:
         """Insert a workspace row only (no ACL seeding).
 
@@ -298,6 +305,7 @@ class WorkspacesModel:
                 setup_state=setup_state,
                 health_check=health_check,
                 allowed_domains=allowed_domains,
+                settings=settings,
             )
 
     async def list_workspaces(
@@ -328,7 +336,7 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT id, name, container_id, image, service_command,"
                 " auto_start, setup_state, health_check, mounts, env,"
-                " allowed_domains, created_at"
+                " allowed_domains, settings, created_at"
                 " FROM workspaces"
                 f" {where} {order_by} LIMIT ? OFFSET ?",
                 tuple(params),
@@ -350,6 +358,9 @@ class WorkspacesModel:
                     "env": json.loads(row["env"]) if row["env"] else None,
                     "allowed_domains": json.loads(row["allowed_domains"])
                     if row["allowed_domains"]
+                    else None,
+                    "settings": json.loads(row["settings"])
+                    if row["settings"]
                     else None,
                     "created_at": row["created_at"],
                 }
@@ -396,7 +407,7 @@ class WorkspacesModel:
                 "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
                 " w.service_command, w.auto_start, w.setup_state,"
                 " w.health_check, w.mounts, w.env, w.allowed_domains,"
-                " w.created_at,"
+                " w.settings, w.created_at,"
                 " u.email AS owner_email"
                 " FROM workspaces w"
                 " JOIN acl_entries ae ON ae.resource = '/workspaces/' || w.id"
@@ -436,6 +447,9 @@ class WorkspacesModel:
                     "allowed_domains": json.loads(row["allowed_domains"])
                     if row["allowed_domains"]
                     else None,
+                    "settings": json.loads(row["settings"])
+                    if row["settings"]
+                    else None,
                     "created_at": row["created_at"],
                     "owner_email": row["owner_email"],
                 }
@@ -462,7 +476,7 @@ class WorkspacesModel:
                 cursor = await db.execute(
                     "SELECT id, user_id, name, container_id, num_ports, image,"
                     " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env, allowed_domains"
+                    " mounts, env, allowed_domains, settings"
                     " FROM workspaces WHERE id = ? AND user_id = ?",
                     (workspace_id, user_id),
                 )
@@ -470,7 +484,7 @@ class WorkspacesModel:
                 cursor = await db.execute(
                     "SELECT id, user_id, name, container_id, num_ports, image,"
                     " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env, allowed_domains"
+                    " mounts, env, allowed_domains, settings"
                     " FROM workspaces WHERE id = ?",
                     (workspace_id,),
                 )
@@ -493,6 +507,9 @@ class WorkspacesModel:
                 "allowed_domains": json.loads(row["allowed_domains"])
                 if row["allowed_domains"]
                 else None,
+                "settings": json.loads(row["settings"])
+                if row["settings"]
+                else None,
             }
 
     async def get_workspace_by_id(self, workspace_id: str) -> dict | None:
@@ -500,7 +517,7 @@ class WorkspacesModel:
         row = await self.app.state.db.fetchone(
             "SELECT id, user_id, name, container_id, num_ports, image,"
             " service_command, setup_state, health_check, mounts, env,"
-            " allowed_domains"
+            " allowed_domains, settings"
             " FROM workspaces WHERE id = ?",
             (workspace_id,),
         )
@@ -520,6 +537,9 @@ class WorkspacesModel:
             "env": json.loads(row["env"]) if row["env"] else None,
             "allowed_domains": json.loads(row["allowed_domains"])
             if row["allowed_domains"]
+            else None,
+            "settings": json.loads(row["settings"])
+            if row["settings"]
             else None,
         }
 
@@ -608,6 +628,48 @@ class WorkspacesModel:
                 (container_id, workspace_id),
             )
 
+    async def update_workspace_settings(
+        self,
+        workspace_id: str,
+        user_id: str,
+        patch: dict,
+    ) -> dict | None:
+        """Partial-merge update of the ``settings`` bag (#864).
+
+        Read-modify-write: loads the current settings, applies *patch*
+        (each key set/replace, ``None`` value deletes that key), and writes
+        the merged result back. Returns the post-merge settings dict (or
+        ``None`` if the bag is now empty), or ``None`` if the workspace
+        wasn't found / isn't owned by *user_id*.
+
+        *patch* must already be validated + normalized by
+        :func:`klangk.workspace_settings.validate_settings_patch` — this
+        method trusts the keys are known and the non-null values are
+        coerced. It owns only the merge + persistence + the empty-bag →
+        NULL mapping.
+        """
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT settings FROM workspaces WHERE id = ? AND user_id = ?",
+                (workspace_id, user_id),
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+            current = json.loads(row["settings"]) if row["settings"] else {}
+            for key, value in patch.items():
+                if value is None:
+                    current.pop(key, None)
+                else:
+                    current[key] = value
+            settings_json = json.dumps(current) if current else None
+            await db.execute(
+                "UPDATE workspaces SET settings = ?"
+                " WHERE id = ? AND user_id = ?",
+                (settings_json, workspace_id, user_id),
+            )
+            return current if current else None
+
     async def update_workspace(
         self,
         workspace_id: str,
@@ -625,6 +687,7 @@ class WorkspacesModel:
             "mounts",
             "env",
             "allowed_domains",
+            "settings",
         }
         to_set = {}
         for k, v in fields.items():
@@ -634,7 +697,7 @@ class WorkspacesModel:
                 if v not in SETUP_STATES:
                     raise ValueError(f"Invalid setup_state: {v!r}")
                 to_set[k] = v
-            elif k in ("mounts", "env", "allowed_domains"):
+            elif k in ("mounts", "env", "allowed_domains", "settings"):
                 to_set[k] = json.dumps(v) if v is not None else None
             elif k == "auto_start":
                 to_set[k] = 1 if v else 0
@@ -754,7 +817,7 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT id, user_id, name, container_id, num_ports, image,"
                 " service_command, auto_start, setup_state, health_check,"
-                " mounts, env, allowed_domains"
+                " mounts, env, allowed_domains, settings"
                 " FROM workspaces WHERE auto_start = 1",
             )
             rows = await cursor.fetchall()
@@ -776,6 +839,9 @@ class WorkspacesModel:
                     "env": json.loads(row["env"]) if row["env"] else None,
                     "allowed_domains": json.loads(row["allowed_domains"])
                     if row["allowed_domains"]
+                    else None,
+                    "settings": json.loads(row["settings"])
+                    if row["settings"]
                     else None,
                 }
                 for row in rows

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -39,6 +39,13 @@ _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
     ],
 }
 
+# Upper bound on compare-and-swap retries for the settings-bag merge
+# (:meth:`WorkspacesModel.update_workspace_settings`). Under normal load the
+# first attempt wins; under contention we loop, re-merging on the latest blob
+# each time. SQLite serializes writers, so this only loops when two PATCHes
+# genuinely race — 8 is far beyond anything realistic.
+_SETTINGS_CAS_RETRIES = 8
+
 # setup_state lifecycle values (#1033). A workspace always holds
 # exactly one. Descriptive, not proscriptive: created in whichever
 # state matches reality.
@@ -636,11 +643,18 @@ class WorkspacesModel:
     ) -> dict | None:
         """Partial-merge update of the ``settings`` bag (#864).
 
-        Read-modify-write: loads the current settings, applies *patch*
-        (each key set/replace, ``None`` value deletes that key), and writes
-        the merged result back. Returns the post-merge settings dict (or
-        ``None`` if the bag is now empty), or ``None`` if the workspace
-        wasn't found / isn't owned by *user_id*.
+        Compare-and-swap on the raw settings blob: load it, merge *patch* in
+        Python (each key set/replace, ``None`` value deletes that key), and
+        UPDATE only if the blob is unchanged since the read
+        (``settings IS ?`` is NULL-safe, unlike ``=``). If another writer
+        committed in between, ``rowcount`` is 0 and the loop re-reads the
+        latest blob and re-applies the patch on that base — so two
+        concurrent PATCHes to *different* keys can't clobber each other (the
+        classic read-modify-write lost-update).
+
+        Returns the post-merge settings dict (or ``None`` if the bag is now
+        empty), or ``None`` if the workspace wasn't found / isn't owned by
+        *user_id*.
 
         *patch* must already be validated + normalized by
         :func:`klangk.workspace_settings.validate_settings_patch` — this
@@ -648,27 +662,36 @@ class WorkspacesModel:
         coerced. It owns only the merge + persistence + the empty-bag →
         NULL mapping.
         """
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT settings FROM workspaces WHERE id = ? AND user_id = ?",
-                (workspace_id, user_id),
-            )
-            row = await cursor.fetchone()
-            if row is None:
-                return None
-            current = json.loads(row["settings"]) if row["settings"] else {}
-            for key, value in patch.items():
-                if value is None:
-                    current.pop(key, None)
-                else:
-                    current[key] = value
-            settings_json = json.dumps(current) if current else None
-            await db.execute(
-                "UPDATE workspaces SET settings = ?"
-                " WHERE id = ? AND user_id = ?",
-                (settings_json, workspace_id, user_id),
-            )
-            return current if current else None
+        for _ in range(_SETTINGS_CAS_RETRIES):
+            async with self.app.state.db.transaction() as db:
+                cursor = await db.execute(
+                    "SELECT settings FROM workspaces"
+                    " WHERE id = ? AND user_id = ?",
+                    (workspace_id, user_id),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    return None
+                old_blob = row["settings"]
+                current = json.loads(old_blob) if old_blob else {}
+                for key, value in patch.items():
+                    if value is None:
+                        current.pop(key, None)
+                    else:
+                        current[key] = value
+                new_blob = json.dumps(current) if current else None
+                cursor = await db.execute(
+                    "UPDATE workspaces SET settings = ?"
+                    " WHERE id = ? AND user_id = ? AND settings IS ?",
+                    (new_blob, workspace_id, user_id, old_blob),
+                )
+                if cursor.rowcount == 1:
+                    return current if current else None
+                # rowcount 0 — settings changed under us (or the row went
+                # away); loop re-reads the latest blob and re-applies.
+        raise RuntimeError(  # pragma: no cover - only under extreme contention
+            f"settings CAS retry exhausted for workspace {workspace_id}"
+        )
 
     async def update_workspace(
         self,

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -17,6 +17,8 @@ import uuid
 from pathlib import Path
 from typing import TypeVar
 
+from . import workspace_settings as bridge_ws_settings
+
 T = TypeVar("T")
 
 # Versioned API prefix — used by api.py (router mount) and acl.py
@@ -567,11 +569,26 @@ class Util:
         long-but-progressing stream never times out. Override with
         KLANGKD_BRIDGE_TIMEOUT_SECONDS (the settings field is parsed here).
         """
+        return self.bridge_idle_timeout_for(None)
+
+    def bridge_idle_timeout_for(self, workspace: dict | None) -> float:
+        """Resolve the bridge idle timeout for a specific workspace (#864).
+
+        Precedence: workspace ``settings.bridge_timeout`` override >
+        ``KLANGKD_BRIDGE_TIMEOUT_SECONDS`` deploy default > 30.0s. Returns
+        the resolved value as a float (always non-None — a stream always
+        has some bound). A garbage deploy value is swallowed to the 30.0s
+        default, matching the historical behavior.
+        """
         raw = self.app.state.settings.bridge_timeout_seconds
         try:
-            return float(raw) if raw else 30.0
+            deploy_default = float(raw) if raw else None
         except (TypeError, ValueError):
-            return 30.0
+            deploy_default = None
+        resolved = bridge_ws_settings.resolve_bridge_timeout(
+            workspace, deploy_default
+        )
+        return float(resolved) if resolved is not None else 30.0
 
 
 class BoundedOutputQueue(asyncio.Queue[T | None]):

--- a/src/klangk/klangk/workspace_settings.py
+++ b/src/klangk/klangk/workspace_settings.py
@@ -1,0 +1,338 @@
+"""Per-workspace behavioral settings: validation + resolution (#864).
+
+This is the resolution layer for the JSON ``settings`` bag on the
+workspaces table. Every per-workspace behavioral override (idle timeout,
+bridge timeout, CPU / memory / PIDs limits, ...) lives in that one bag,
+not in its own column — one column, one migration, one resolution path.
+Structural fields (``image`` / ``mounts`` / ``env`` / ``default_command``)
+and the behavioral ``allowed_domains`` column (which predates this
+decision, #1365) stay as dedicated columns.
+
+Precedence everywhere is **workspace override > deploy default > none**,
+matching how ``allowed_domains`` already resolves (a workspace's non-empty
+list overrides ``KLANGKD_NETFILTER_DEFAULT_DOMAINS``).
+
+Two responsibilities:
+
+- :func:`validate_settings` — schema gate. Rejects unknown keys and
+  malformed values (typed coercion) so a typo'd setting name or a bogus
+  value fails loudly at the API boundary (HTTP 400), not silently at use
+  time. Returns a normalized dict (or ``None`` for an empty/``None``
+  input) safe to ``json.dumps`` into the column.
+
+- :func:`resolve` — precedence lookup. ``resolve(workspace, key,
+  deploy_default)`` returns the workspace's override for *key* when set,
+  else *deploy_default*, else ``None``. Typed resolvers
+  (:func:`resolve_idle_timeout`, :func:`resolve_bridge_timeout`,
+  :func:`resolve_cpu_limit`, :func:`resolve_memory_limit`,
+  :func:`resolve_pids_limit`) bind a settings key to its deploy default
+  for the common call sites.
+
+This module is deliberately pure (no ``app`` / ``app_state``): the deploy
+defaults are passed *in* by the caller, read live off
+``app.state.settings.<field>`` at call time (the #1608 ownership rule —
+never cache a subobject of ``app`` on an instance). That also makes the
+resolution helpers trivial to test.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+# Container memory-limit syntax (mirrors the ``KLANGKD_CONTAINER_MEMORY_LIMIT``
+# regex in settings.py / #34): matches docker/go-units ParseSize grammar —
+# a positive number (decimals ok) with an optional unit suffix (single base
+# unit k/m/g/t/p, case-insensitive, optional trailing b). Rejects 0 (podman
+# treats --memory=0 as "no limit", same ambiguity the PIDs validator
+# rejects). Syntax guard only — podman is the authority on what the runtime
+# can actually apply.
+_MEMORY_LIMIT_RE = re.compile(r"^(?P<num>\d+(\.\d+)?)[kKmMgGtTpP]?[bB]?$")
+
+
+def _coerce_int(key: str, value: Any) -> int:
+    """Coerce a settings value to a positive ``int``.
+
+    Accepts an actual int or a numeric string (``"512"``); rejects floats,
+    booleans, non-numeric strings, and non-positive values. A PIDs limit /
+    idle / bridge timeout of 0 is meaningful only for idle_timeout (0 =
+    never idle out), so the "positive" gate is *not* applied here — callers
+    that need ``> 0`` enforce it at the deploy default instead.
+    """
+    if isinstance(
+        value, bool
+    ):  # bool is a subclass of int — reject explicitly
+        raise ValueError(f"settings.{key} must be an integer, not a boolean")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        raise ValueError(
+            f"settings.{key} must be an integer, got non-integer float"
+            f" {value!r}"
+        )
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            raise ValueError(f"settings.{key} must not be empty")
+        try:
+            # int("1.5") raises — that's what we want (reject non-integer
+            # strings); int("0x10", base=10) is the documented base-10 parse.
+            return int(s, base=10)
+        except ValueError as exc:
+            raise ValueError(
+                f"settings.{key} must be an integer, got {value!r}"
+            ) from exc
+    raise ValueError(
+        f"settings.{key} must be an integer, got {type(value).__name__}"
+    )
+
+
+def _coerce_positive_int(key: str, value: Any) -> int:
+    n = _coerce_int(key, value)
+    if n <= 0:
+        raise ValueError(
+            f"settings.{key} must be a positive integer, got {n!r}"
+        )
+    return n
+
+
+def _coerce_float(key: str, value: Any) -> float:
+    """Coerce a settings value to a positive ``float`` (CPU limit)."""
+    if isinstance(value, bool):
+        raise ValueError(f"settings.{key} must be a number, not a boolean")
+    if isinstance(value, (int, float)):
+        f = float(value)
+    elif isinstance(value, str):
+        s = value.strip()
+        if not s:
+            raise ValueError(f"settings.{key} must not be empty")
+        try:
+            f = float(s)
+        except ValueError as exc:
+            raise ValueError(
+                f"settings.{key} must be a number, got {value!r}"
+            ) from exc
+    else:
+        raise ValueError(
+            f"settings.{key} must be a number, got {type(value).__name__}"
+        )
+    if f <= 0:
+        raise ValueError(
+            f"settings.{key} must be a positive number, got {f!r}"
+        )
+    return f
+
+
+def _coerce_memory(key: str, value: Any) -> str:
+    """Coerce a settings value to a podman memory-limit string (``2g``)."""
+    if not isinstance(value, str):
+        # Allow an integer/float of bare bytes for ergonomics, then
+        # re-stringify so the stored bag always carries the podman form.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"settings.{key} must be a size string (e.g. '2g', '512m'),"
+                f" got {type(value).__name__}"
+            )
+        value = str(int(value))
+    value = value.strip()
+    m = _MEMORY_LIMIT_RE.match(value)
+    if not m:
+        raise ValueError(
+            f"settings.{key}={value!r} is not a valid memory size:"
+            " expected a positive number with an optional unit"
+            " (k/m/g/t/p, optional trailing b), e.g. '2g' or '512mb'"
+        )
+    # Reject 0 — podman treats --memory=0 as "no limit", the same
+    # ambiguity the PIDs validator rejects (an explicit 0 must not silently
+    # mean "unlimited"). Matches settings.py's memory-limit validator.
+    if float(m.group("num")) == 0:
+        raise ValueError(
+            f"settings.{key}={value!r} is not a valid memory size:"
+            " must be a positive number"
+        )
+    return value
+
+
+# Schema: each known settings key maps to a normalizer that validates +
+# coerces the value (raising ``ValueError`` on a bad value) and returns the
+# normalized form to store. Keys not in this dict are rejected by
+# :func:`validate_settings`. Add a setting here to make it settable.
+SCHEMA: dict[str, Callable[[str, Any], Any]] = {
+    "idle_timeout": _coerce_positive_int,
+    "bridge_timeout": _coerce_positive_int,
+    "cpu_limit": _coerce_float,
+    "memory_limit": _coerce_memory,
+    "pids_limit": _coerce_positive_int,
+}
+
+# The known setting keys, exported for callers that want to enumerate the
+# schema (e.g. an API that lists what a workspace may override).
+KNOWN_SETTINGS = frozenset(SCHEMA)
+
+
+def validate_settings(
+    settings: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Validate + normalize a full per-workspace ``settings`` bag.
+
+    Full-replace semantics (the :class:`CreateWorkspaceRequest` /
+    :class:`UpdateWorkspaceRequest` path): the input *is* the complete bag.
+    Rejects unknown keys and malformed values (a non-positive timeout, a
+    non-numeric CPU limit, a malformed memory size, ...) by raising
+    ``ValueError``; the API boundary translates that into HTTP 400. Returns
+    a new dict of normalized values (so the stored bag always carries
+    coerced forms — ``"512"`` → ``512``), or ``None`` when the input is
+    ``None`` or empty (no overrides → NULL column).
+
+    An explicit ``null`` for a key is dropped (in a full-replace bag it's
+    meaningless noise — just omit the key). Use
+    :func:`validate_settings_patch` for partial-merge semantics where
+    ``null`` means "delete this key".
+
+    A non-dict input (a list, a string) is rejected: the bag is always a
+    JSON object.
+    """
+    normalized = _validate_settings_dict(settings)
+    if not normalized:
+        return None
+    return normalized
+
+
+def validate_settings_patch(
+    patch: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Validate + normalize a partial-merge ``settings`` patch.
+
+    PATCH semantics (the ``PATCH /workspaces/{id}/settings`` path): each
+    key in *patch* is either a value (set/replace that override) or
+    ``None`` (delete that override, reverting it to the deploy default).
+    Returns the validated patch with ``None`` deletion markers preserved,
+    so the model merge step can distinguish "set to X" from "clear."
+
+    Raises ``ValueError`` on unknown keys / malformed non-null values
+    (translated to HTTP 400 at the API boundary). An empty patch (``None``
+    or ``{}``) raises ``ValueError`` — a PATCH that changes nothing is a
+    client error, not a silent no-op.
+    """
+    if patch is None:
+        raise ValueError("settings patch must not be empty")
+    if not isinstance(patch, dict):
+        raise ValueError(
+            "settings patch must be a JSON object (dict), got"
+            f" {type(patch).__name__}"
+        )
+    if not patch:
+        raise ValueError("settings patch must not be empty")
+    result: dict[str, Any] = {}
+    for key, value in patch.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                f"settings keys must be strings, got {type(key).__name__}"
+            )
+        normalizer = SCHEMA.get(key)
+        if normalizer is None:
+            raise ValueError(
+                f"Unknown setting {key!r}; known settings: "
+                f"{sorted(KNOWN_SETTINGS)}"
+            )
+        # None is the deletion marker — preserved through validation so
+        # the model merge can act on it. Everything else is coerced.
+        if value is None:
+            result[key] = None
+        else:
+            result[key] = normalizer(key, value)
+    return result
+
+
+def _validate_settings_dict(
+    settings: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Shared validation core for :func:`validate_settings`.
+
+    Returns the normalized dict (null values dropped) — the caller decides
+    whether an empty result maps to ``None`` (full-replace) or is an error
+    (patch). Kept private because the two public entry points differ on
+    that empty-handling and on null semantics.
+    """
+    if settings is None:
+        return {}
+    if not isinstance(settings, dict):
+        raise ValueError(
+            "settings must be a JSON object (dict), got"
+            f" {type(settings).__name__}"
+        )
+    normalized: dict[str, Any] = {}
+    for key, value in settings.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                f"settings keys must be strings, got {type(key).__name__}"
+            )
+        normalizer = SCHEMA.get(key)
+        if normalizer is None:
+            raise ValueError(
+                f"Unknown setting {key!r}; known settings: "
+                f"{sorted(KNOWN_SETTINGS)}"
+            )
+        if value is None:
+            continue
+        normalized[key] = normalizer(key, value)
+    return normalized
+
+
+def resolve(
+    workspace: dict | None,
+    key: str,
+    deploy_default: Any,
+) -> Any:
+    """Resolve a setting with **workspace override > deploy default > none**.
+
+    ``workspace`` is a workspace dict (the shape returned by
+    :class:`~klangk.model.workspaces.WorkspacesModel`); its ``settings`` key
+    holds the parsed bag (or ``None``). If the workspace sets ``key``, that
+    value wins; otherwise *deploy_default* is returned; if that too is
+    ``None`` the result is ``None`` (no limit / unset).
+
+    Mirrors how ``allowed_domains`` resolves: a non-empty workspace value
+    overrides the deploy-wide default, never merges with it.
+    """
+    bag = (workspace or {}).get("settings") or {}
+    if key in bag:
+        return bag[key]
+    return deploy_default
+
+
+def resolve_idle_timeout(
+    workspace: dict | None, deploy_default: int | None
+) -> int | None:
+    """Resolve the per-workspace idle-timeout setting (seconds)."""
+    return resolve(workspace, "idle_timeout", deploy_default)
+
+
+def resolve_bridge_timeout(
+    workspace: dict | None, deploy_default: float | None
+) -> float | None:
+    """Resolve the per-workspace browser-delegate bridge timeout (seconds)."""
+    return resolve(workspace, "bridge_timeout", deploy_default)
+
+
+def resolve_cpu_limit(
+    workspace: dict | None, deploy_default: float | None
+) -> float | None:
+    """Resolve the per-workspace CPU limit (``--cpus``, float)."""
+    return resolve(workspace, "cpu_limit", deploy_default)
+
+
+def resolve_memory_limit(
+    workspace: dict | None, deploy_default: str | None
+) -> str | None:
+    """Resolve the per-workspace memory limit (``--memory``, size string)."""
+    return resolve(workspace, "memory_limit", deploy_default)
+
+
+def resolve_pids_limit(
+    workspace: dict | None, deploy_default: int | None
+) -> int | None:
+    """Resolve the per-workspace PIDs limit (``--pids-limit``, int)."""
+    return resolve(workspace, "pids_limit", deploy_default)

--- a/src/klangk/klangk/workspace_settings.py
+++ b/src/klangk/klangk/workspace_settings.py
@@ -51,13 +51,14 @@ _MEMORY_LIMIT_RE = re.compile(r"^(?P<num>\d+(\.\d+)?)[kKmMgGtTpP]?[bB]?$")
 
 
 def _coerce_int(key: str, value: Any) -> int:
-    """Coerce a settings value to a positive ``int``.
+    """Coerce a settings value to an ``int`` (no sign gating).
 
     Accepts an actual int or a numeric string (``"512"``); rejects floats,
-    booleans, non-numeric strings, and non-positive values. A PIDs limit /
-    idle / bridge timeout of 0 is meaningful only for idle_timeout (0 =
-    never idle out), so the "positive" gate is *not* applied here — callers
-    that need ``> 0`` enforce it at the deploy default instead.
+    booleans, and non-numeric strings. Does **not** reject 0 or negatives —
+    callers compose this with the sign check they need:
+    :func:`_coerce_positive_int` (``> 0``) for pids / bridge timeout, or
+    :func:`_coerce_nonnegative_int` (``>= 0``) for idle_timeout, where ``0``
+    means "never idle out" (the idle reaper guards with ``timeout > 0``).
     """
     if isinstance(
         value, bool
@@ -94,6 +95,21 @@ def _coerce_positive_int(key: str, value: Any) -> int:
     if n <= 0:
         raise ValueError(
             f"settings.{key} must be a positive integer, got {n!r}"
+        )
+    return n
+
+
+def _coerce_nonnegative_int(key: str, value: Any) -> int:
+    """Coerce a settings value to a non-negative ``int`` (``>= 0``).
+
+    For ``idle_timeout``: ``0`` is meaningful (never idle out — the idle
+    reaper's ``timeout > 0`` guard skips reaping when the timeout is 0),
+    but a negative timeout is nonsense.
+    """
+    n = _coerce_int(key, value)
+    if n < 0:
+        raise ValueError(
+            f"settings.{key} must be a non-negative integer, got {n!r}"
         )
     return n
 
@@ -160,7 +176,7 @@ def _coerce_memory(key: str, value: Any) -> str:
 # normalized form to store. Keys not in this dict are rejected by
 # :func:`validate_settings`. Add a setting here to make it settable.
 SCHEMA: dict[str, Callable[[str, Any], Any]] = {
-    "idle_timeout": _coerce_positive_int,
+    "idle_timeout": _coerce_nonnegative_int,
     "bridge_timeout": _coerce_positive_int,
     "cpu_limit": _coerce_float,
     "memory_limit": _coerce_memory,

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -203,6 +203,7 @@ class Workspaces:
             "env": ws.get("env"),
             "health_check": ws.get("health_check"),
             "allowed_domains": ws.get("allowed_domains"),
+            "settings": ws.get("settings"),
             "num_ports": ws.get("num_ports", 5),
         }
 
@@ -369,6 +370,7 @@ class Workspaces:
         setup_state: str | None = None,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        settings: dict | None = None,
     ) -> dict:
         workspace = (
             await self.app.state.model.workspaces.create_workspace_with_acl(
@@ -382,6 +384,7 @@ class Workspaces:
                 setup_state=setup_state or model.SETUP_STATE_COMPLETE,
                 health_check=health_check,
                 allowed_domains=allowed_domains,
+                settings=settings,
             )
         )
         home = self.home_path(workspace["id"])
@@ -514,7 +517,22 @@ class Workspaces:
             setup_state=ws.get("setup_state"),
             service_command=ws.get("service_command"),
             allowed_domains=ws.get("allowed_domains"),
+            workspace_settings=ws.get("settings"),
         )
+        # Apply the per-workspace idle-timeout override from the settings
+        # bag (#864), *only* when the workspace actually declares one.
+        # When no override is present we leave the container state's
+        # idle_timeout at None so ``get_idle_timeout()`` lazily falls back
+        # to the live deploy default — that keeps a SIGHUP settings reload
+        # effective for running containers (a materialized value would
+        # freeze it). The auto_start boot path pins the container alive
+        # (0) after this call returns, so a service workspace never idles
+        # out regardless of its settings bag.
+        bag = ws.get("settings") or {}
+        if "idle_timeout" in bag:
+            self.app.state.container_registry.set_workspace_idle_timeout(
+                workspace_id, bag["idle_timeout"]
+            )
         return cid, status
 
     async def auto_start_workspaces(self) -> int:

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2350,7 +2350,7 @@ class TestWorkspaceRoutes:
             headers=headers,
         )
         assert resp.status_code == 400
-        assert "positive" in resp.json()["detail"]
+        assert "non-negative" in resp.json()["detail"]
 
     async def test_update_workspace_settings_full_replace(self, client, user):
         headers = await _auth_headers(client)
@@ -2411,6 +2411,68 @@ class TestWorkspaceRoutes:
         assert match[0]["settings"] == {
             "idle_timeout": 600,
             "pids_limit": 512,
+        }
+
+    async def test_patch_workspace_settings_by_shared_editor(
+        self, client, user, app_state
+    ):
+        """A shared non-owner with the ``edit`` ACE can PATCH settings (#864).
+
+        Regression for the original PATCH handler, which passed the
+        *caller's* id into the owner-scoped model merge and silently
+        no-op'd (200 with ``settings: null``) for any non-owner — while
+        the sibling PUT update path worked fine for the same editor. The
+        handler now resolves the owner (like PUT) before calling the model.
+        """
+        headers = await _auth_headers(client)
+        # Create a second, non-owner user and log in as them.
+        other = await app_state.state.model.users.create_user(
+            "other@example.com",
+            auth_mod.hash_password("otherpass"),
+            verified=True,
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"identifier": "other@example.com", "password": "otherpass"},
+        )
+        other_headers = {
+            "Authorization": f"Bearer {login.json()['access_token']}"
+        }
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "shared-edit", "settings": {"idle_timeout": 300}},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        # Grant the other user the `edit` permission explicitly (no default
+        # role group ships `edit` — only owners get `*`).
+        await app_state.state.model.acl.add_acl_entry(
+            f"/workspaces/{ws_id}",
+            other["id"],
+            model.ACTION_ALLOW,
+            "edit",
+            model.PRINCIPAL_USER,
+            user_id=other["id"],
+        )
+        # As the shared editor, PATCH a setting.
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/settings",
+            json={"idle_timeout": 600, "cpu_limit": 2.0},
+            headers=other_headers,
+        )
+        assert resp.status_code == 200
+        # The pre-fix bug returned ``settings: null`` here (the merge
+        # no-op'd). It must return the merged bag.
+        assert resp.json()["settings"] == {
+            "idle_timeout": 600,
+            "cpu_limit": 2.0,
+        }
+        # And the row must actually have changed — confirm via the owner.
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["settings"] == {
+            "idle_timeout": 600,
+            "cpu_limit": 2.0,
         }
 
     async def test_patch_workspace_settings_delete_key(self, client, user):
@@ -2519,7 +2581,7 @@ class TestWorkspaceRoutes:
             headers=headers,
         )
         assert resp.status_code == 400
-        assert "positive" in resp.json()["detail"]
+        assert "non-negative" in resp.json()["detail"]
 
     async def test_patch_workspace_settings_missing_workspace(
         self, client, user
@@ -2534,6 +2596,33 @@ class TestWorkspaceRoutes:
         # workspace is rejected as 403 (no edit permission) — existence is
         # not leaked. Same posture as the PUT update endpoint.
         assert resp.status_code == 403
+
+    async def test_patch_workspace_settings_not_found(
+        self, client, user, app_state
+    ):
+        """ACL grants edit but the workspace doesn't exist -> 404 (#864).
+
+        Mirrors ``test_delete_not_found``: the ``edit`` ACE on a nonexistent
+        resource lets the caller past the ACL guard, then the handler's
+        owner resolution finds no row and returns 404 (a race / stale id,
+        not a normal path).
+        """
+        headers = await _auth_headers(client)
+        fake_id = "fake-patch-id"
+        await app_state.state.model.acl.add_acl_entry(
+            f"/workspaces/{fake_id}",
+            0,
+            model.ACTION_ALLOW,
+            "edit",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        resp = await client.patch(
+            f"/api/v1/workspaces/{fake_id}/settings",
+            json={"idle_timeout": 300},
+            headers=headers,
+        )
+        assert resp.status_code == 404
 
     async def test_update_workspace_env(self, client, user):
         # Regression: a partial PUT of env (e.g. adding a new var from the

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2303,6 +2303,238 @@ class TestWorkspaceRoutes:
         match = [w for w in resp.json() if w["id"] == ws_id]
         assert match[0]["allowed_domains"] == ["github.com:443"]
 
+    async def test_create_workspace_with_settings(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={
+                "name": "tuned",
+                "settings": {
+                    "idle_timeout": 300,
+                    "cpu_limit": "1.5",
+                    "memory_limit": "2g",
+                },
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        ws_id = resp.json()["id"]
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        # Numeric strings coerced to typed values.
+        assert match[0]["settings"] == {
+            "idle_timeout": 300,
+            "cpu_limit": 1.5,
+            "memory_limit": "2g",
+        }
+
+    async def test_create_workspace_rejects_unknown_setting(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "bad", "settings": {"nonsense": 1}},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "Unknown setting" in resp.json()["detail"]
+
+    async def test_create_workspace_rejects_bad_setting_value(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "bad", "settings": {"idle_timeout": -5}},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "positive" in resp.json()["detail"]
+
+    async def test_update_workspace_settings_full_replace(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={
+                "name": "replaceable",
+                "settings": {"idle_timeout": 300},
+            },
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        # Full replace via PUT: the new bag overwrites the old.
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"settings": {"cpu_limit": 2.0}},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["settings"] == {"cpu_limit": 2.0}
+        # settings=None on PUT clears the whole bag.
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"settings": None},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["settings"] is None
+
+    async def test_patch_workspace_settings_merge(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={
+                "name": "mergeable",
+                "settings": {"idle_timeout": 300},
+            },
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        # PATCH adds a key + replaces an existing one (merge, not replace).
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/settings",
+            json={"idle_timeout": 600, "pids_limit": 512},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["settings"] == {
+            "idle_timeout": 600,
+            "pids_limit": 512,
+        }
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["settings"] == {
+            "idle_timeout": 600,
+            "pids_limit": 512,
+        }
+
+    async def test_patch_workspace_settings_delete_key(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={
+                "name": "deletable",
+                "settings": {
+                    "idle_timeout": 300,
+                    "cpu_limit": 1.5,
+                },
+            },
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        # null value deletes just that key.
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/settings",
+            json={"idle_timeout": None},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["settings"] == {"cpu_limit": 1.5}
+
+    async def test_patch_workspace_settings_delete_last_key(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "last-key", "settings": {"idle_timeout": 300}},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/settings",
+            json={"idle_timeout": None},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["settings"] is None
+
+    async def test_patch_workspace_settings_rejects_empty(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "empty-patch"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/settings",
+            json={},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "empty" in resp.json()["detail"]
+
+    async def test_patch_workspace_settings_rejects_unknown_key(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "unknown-key"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/settings",
+            json={"bogus": 1},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "Unknown setting" in resp.json()["detail"]
+
+    async def test_patch_workspace_settings_rejects_bad_value(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "bad-value"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/settings",
+            json={"cpu_limit": "fast"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_update_workspace_rejects_bad_settings(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "put-bad"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"settings": {"idle_timeout": -5}},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "positive" in resp.json()["detail"]
+
+    async def test_patch_workspace_settings_missing_workspace(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.patch(
+            "/api/v1/workspaces/does-not-exist/settings",
+            json={"idle_timeout": 300},
+            headers=headers,
+        )
+        # The ACL "edit" guard runs before the handler, so a nonexistent
+        # workspace is rejected as 403 (no edit permission) — existence is
+        # not leaked. Same posture as the PUT update endpoint.
+        assert resp.status_code == 403
+
     async def test_update_workspace_env(self, client, user):
         # Regression: a partial PUT of env (e.g. adding a new var from the
         # TUI/Flutter edit form) must persist and round-trip through GET.
@@ -6654,6 +6886,7 @@ class TestWorkspaceMetadata:
             "env": {"FOO": "bar"},
             "health_check": None,
             "allowed_domains": None,
+            "settings": None,
             "num_ports": 3,
         }
 
@@ -7079,6 +7312,74 @@ class TestWorkspaceExportImport:
         )
         assert resp.status_code == 400
         assert "missing instance_id" in resp.json()["detail"]
+
+    async def test_import_rejects_invalid_settings(self, client, user):
+        """Archives with an invalid settings bag are rejected (#864).
+
+        An archive from this instance is trusted on provenance, but its
+        settings bag is re-validated — it may predate a schema change or
+        carry a value the current deploy rejects.
+        """
+        import io
+        import json
+        import tarfile
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps(
+                self._meta(
+                    name="bad-settings-import",
+                    settings={"idle_timeout": -5},
+                )
+            ).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+        buf.seek(0)
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces/import",
+            headers=headers,
+            files={
+                "file": ("archive.tar.gz", buf.getvalue(), "application/gzip")
+            },
+        )
+        assert resp.status_code == 400
+        assert "Archive settings are invalid" in resp.json()["detail"]
+
+    async def test_import_roundtrips_settings(self, client, user):
+        """A valid settings bag survives export -> import (#864)."""
+        import io
+        import json
+        import tarfile
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps(
+                self._meta(
+                    name="settings-roundtrip",
+                    settings={"idle_timeout": 300, "cpu_limit": 1.5},
+                )
+            ).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+        buf.seek(0)
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces/import",
+            headers=headers,
+            files={
+                "file": ("archive.tar.gz", buf.getvalue(), "application/gzip")
+            },
+        )
+        assert resp.status_code == 200
+        ws_id = resp.json()["id"]
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["settings"] == {"idle_timeout": 300, "cpu_limit": 1.5}
 
     async def test_import_notifies_importer(self, client, user, sockets):
         import io

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -35,15 +35,15 @@ api_auth = sys.modules["klangk.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 90
+EXPECTED_ROUTE_COUNT = 91
 
-# Per-domain submodules and the number of routes each owns.  83 sub-routes
+# Per-domain submodules and the number of routes each owns.  84 sub-routes
 # + 3 routes defined directly on the main router (version, config,
-# my-permissions) + 2 on the root router (health, empty) == 88.
+# my-permissions) + 2 on the root router (health, empty) == 89.
 SUBMODULE_ROUTES = {
     "auth": 15,
     "oidc_auth": 2,
-    "workspaces": 26,
+    "workspaces": 27,
     "files": 6,
     "images": 4,
     "browser_delegate": 2,

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -667,6 +667,106 @@ class TestStartContainer:
         assert kwargs["memory"] == "2g"
         assert kwargs["pids_limit"] == 512
 
+    async def test_workspace_settings_override_resource_limits(
+        self, workspace, monkeypatch
+    ):
+        # #864: a workspace's settings.cpu_limit / memory_limit /
+        # pids_limit override the deploy-wide defaults (override >
+        # default > none), applied as-is with no clamping (#34).
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_cpu_limit", 1.5)
+        monkeypatch.setattr(settings, "container_memory_limit", "2g")
+        monkeypatch.setattr(settings, "container_pids_limit", 512)
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                workspace_settings={
+                    "cpu_limit": 4.0,
+                    "memory_limit": "8g",
+                    "pids_limit": 2048,
+                },
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["cpus"] == 4.0
+        assert kwargs["memory"] == "8g"
+        assert kwargs["pids_limit"] == 2048
+
+    async def test_workspace_settings_override_can_go_smaller(
+        self, workspace, monkeypatch
+    ):
+        # #34: a deploy default is a plain default, not a cap or floor —
+        # a creator may go larger OR smaller. A smaller override is
+        # applied as-is (no clamping up to the deploy value).
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_cpu_limit", 4.0)
+        monkeypatch.setattr(settings, "container_pids_limit", 2048)
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                workspace_settings={"cpu_limit": 0.5, "pids_limit": 100},
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["cpus"] == 0.5
+        assert kwargs["pids_limit"] == 100
+
+    async def test_workspace_settings_partial_override_falls_back(
+        self, workspace, monkeypatch
+    ):
+        # Override applies per-key: a bag that sets only cpu_limit leaves
+        # memory + pids at the deploy default.
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_cpu_limit", 1.5)
+        monkeypatch.setattr(settings, "container_memory_limit", "2g")
+        monkeypatch.setattr(settings, "container_pids_limit", 512)
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                workspace_settings={"cpu_limit": 3.0},
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["cpus"] == 3.0
+        assert kwargs["memory"] == "2g"
+        assert kwargs["pids_limit"] == 512
+
+    async def test_workspace_settings_override_when_no_deploy_default(
+        self, workspace
+    ):
+        # No deploy default + an override -> the override applies; the
+        # other two limits stay None (no flag).
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                workspace_settings={"cpu_limit": 2.0},
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["cpus"] == 2.0
+        assert kwargs["memory"] is None
+        assert kwargs["pids_limit"] is None
+
+    async def test_workspace_settings_empty_bag_uses_deploy_default(
+        self, workspace, monkeypatch
+    ):
+        # An empty/None bag is a no-op: deploy defaults apply unchanged.
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_cpu_limit", 1.5)
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                workspace_settings={},
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["cpus"] == 1.5
+
     async def test_sudo_disabled_by_default(self, workspace):
         with patch_podman(self.registry) as p:
             await self.registry.start_container(

--- a/src/klangk/klangkd-tests/tests/test_model.py
+++ b/src/klangk/klangkd-tests/tests/test_model.py
@@ -259,6 +259,78 @@ class TestMigration:
             assert mounts is None
             assert env is None
 
+    async def test_migrate_workspaces_adds_settings(
+        self, temp_data_dir, app_state
+    ):
+        """init_db adds the ``settings`` column to tables that predate #864.
+
+        The JSON ``settings`` bag ships in CREATE TABLE for fresh installs
+        but also has an ADD COLUMN migration so DBs created before it
+        shipped gain the column (NULL by default = no overrides, inheriting
+        every deploy-wide default). Existing rows must survive untouched.
+        """
+        db_path = get_test_db().db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = await aiosqlite.connect(str(db_path))
+        try:
+            await db.execute("""
+                CREATE TABLE users (
+                    id TEXT PRIMARY KEY,
+                    email TEXT UNIQUE NOT NULL,
+                    password_hash TEXT,
+                    verified INTEGER NOT NULL DEFAULT 0,
+                    provider TEXT NOT NULL DEFAULT 'local',
+                    external_id TEXT,
+                    handle TEXT UNIQUE,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            """)
+            await db.execute(
+                "INSERT INTO users (id, email, password_hash, verified)"
+                " VALUES ('u1', 'owner@example.com', 'hash', 1)"
+            )
+            # Pre-settings workspaces table — has every column that existed
+            # *before* settings shipped, but NOT settings itself.
+            await db.execute("""
+                CREATE TABLE workspaces (
+                    id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL REFERENCES users(id),
+                    name TEXT NOT NULL,
+                    container_id TEXT,
+                    num_ports INTEGER NOT NULL DEFAULT 5,
+                    image TEXT,
+                    service_command TEXT,
+                    auto_start INTEGER NOT NULL DEFAULT 0,
+                    setup_state TEXT NOT NULL DEFAULT 'complete',
+                    health_check TEXT,
+                    mounts TEXT,
+                    env TEXT,
+                    allowed_domains TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    UNIQUE(user_id, name)
+                )
+            """)
+            await db.execute(
+                "INSERT INTO workspaces (id, user_id, name)"
+                " VALUES ('ws1', 'u1', 'old-ws')"
+            )
+            await db.commit()
+        finally:
+            await db.close()
+
+        await app_state.state.model.init_db()
+
+        async with app_state.state.db.transaction() as conn:
+            cursor = await conn.execute("PRAGMA table_info(workspaces)")
+            cols = {row[1] for row in await cursor.fetchall()}
+            assert "settings" in cols
+
+            cursor = await conn.execute(
+                "SELECT settings FROM workspaces WHERE id = 'ws1'"
+            )
+            (settings,) = await cursor.fetchone()
+            assert settings is None
+
 
 class TestUsers:
     async def test_create_user(self, db, app_state):

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -10,6 +10,7 @@ ContextVar DB) with the schema initialized.
 
 import pytest
 
+from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_USER
 from klangk.model.workspaces import (
     SETUP_STATE_COMPLETE,
     SETUP_STATE_PENDING,
@@ -275,3 +276,150 @@ async def test_list_auto_start_workspaces(ws, user):
     started = await ws.list_auto_start_workspaces()
     assert [w["name"] for w in started] == ["auto"]
     assert started[0]["auto_start"] is True
+
+
+# --- per-workspace settings bag (#864) ---
+
+
+SETTINGS_BAG = {
+    "idle_timeout": 300,
+    "bridge_timeout": 60,
+    "cpu_limit": 1.5,
+    "memory_limit": "2g",
+    "pids_limit": 512,
+}
+
+
+async def test_settings_roundtrip(ws, user):
+    # Create persists the bag; get/get_by_id/list all surface it.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "tuned", settings=SETTINGS_BAG
+    )
+    assert ws_row["settings"] == SETTINGS_BAG
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["settings"] == SETTINGS_BAG
+    by_id = await ws.get_workspace_by_id(ws_row["id"])
+    assert by_id["settings"] == SETTINGS_BAG
+    listing = await ws.list_workspaces(user["id"])
+    assert listing["items"][0]["settings"] == SETTINGS_BAG
+
+
+async def test_settings_default_none(ws, user):
+    # No settings -> NULL -> surfaces as None (no overrides).
+    ws_row = await ws.create_workspace(user["id"], "plain")
+    assert ws_row["settings"] is None
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["settings"] is None
+    by_id = await ws.get_workspace_by_id(ws_row["id"])
+    assert by_id["settings"] is None
+    listing = await ws.list_workspaces(user["id"])
+    assert listing["items"][0]["settings"] is None
+
+
+async def test_settings_in_shared_listing(ws, app_state, user):
+    # list_shared_workspaces surfaces the bag too.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "shared-tuned", settings={"idle_timeout": 120}
+    )
+    other = await app_state.state.model.users.create_user("other@x.com", "pw")
+    resource = f"/workspaces/{ws_row['id']}"
+    await app_state.state.model.acl.add_acl_entry(
+        resource,
+        100,
+        ACTION_ALLOW,
+        "terminal",
+        PRINCIPAL_USER,
+        user_id=other["id"],
+    )
+    shared = await ws.list_shared_workspaces(other["id"])
+    assert shared["items"][0]["settings"] == {"idle_timeout": 120}
+
+
+async def test_settings_updateable_via_full_replace(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "editable")
+    assert (
+        await ws.update_workspace(
+            ws_row["id"],
+            user["id"],
+            settings={"idle_timeout": 300, "cpu_limit": 2},
+        )
+        is True
+    )
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["settings"] == {"idle_timeout": 300, "cpu_limit": 2}
+    # Full-replace: setting settings=None clears the whole bag.
+    assert (
+        await ws.update_workspace(ws_row["id"], user["id"], settings=None)
+        is True
+    )
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["settings"] is None
+
+
+async def test_update_workspace_settings_merge(ws, user):
+    # PATCH-style read-modify-write merge.
+    ws_row = await ws.create_workspace(
+        user["id"], "mergeable", settings={"idle_timeout": 300}
+    )
+    # Add a key + replace an existing one.
+    merged = await ws.update_workspace_settings(
+        ws_row["id"],
+        user["id"],
+        {"idle_timeout": 600, "cpu_limit": 1.5},
+    )
+    assert merged == {"idle_timeout": 600, "cpu_limit": 1.5}
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["settings"] == {"idle_timeout": 600, "cpu_limit": 1.5}
+
+
+async def test_update_workspace_settings_delete_key(ws, user):
+    ws_row = await ws.create_workspace(
+        user["id"],
+        "deletable",
+        settings={"idle_timeout": 300, "cpu_limit": 1.5},
+    )
+    # None value deletes just that key (reverts to deploy default).
+    merged = await ws.update_workspace_settings(
+        ws_row["id"],
+        user["id"],
+        {"idle_timeout": None},
+    )
+    assert merged == {"cpu_limit": 1.5}
+
+
+async def test_update_workspace_settings_delete_last_key_nulls_column(
+    ws, user
+):
+    ws_row = await ws.create_workspace(
+        user["id"], "last-key", settings={"idle_timeout": 300}
+    )
+    merged = await ws.update_workspace_settings(
+        ws_row["id"],
+        user["id"],
+        {"idle_timeout": None},
+    )
+    # Bag is now empty -> column NULL -> None.
+    assert merged is None
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["settings"] is None
+
+
+async def test_update_workspace_settings_missing_workspace(ws, user):
+    # Nonexistent workspace / wrong owner -> None.
+    assert (
+        await ws.update_workspace_settings(
+            "missing", user["id"], {"idle_timeout": 300}
+        )
+        is None
+    )
+
+
+async def test_settings_in_auto_start_listing(ws, user):
+    await ws.create_workspace(
+        user["id"],
+        "auto-tuned",
+        auto_start=True,
+        settings={"idle_timeout": 120},
+    )
+    started = await ws.list_auto_start_workspaces()
+    assert started[0]["settings"] == {"idle_timeout": 120}

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -8,6 +8,8 @@ the agent-principal / setup-state guards. Mirrors the #1573
 ContextVar DB) with the schema initialized.
 """
 
+import asyncio
+
 import pytest
 
 from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_USER
@@ -412,6 +414,41 @@ async def test_update_workspace_settings_missing_workspace(ws, user):
         )
         is None
     )
+
+
+async def test_update_workspace_settings_concurrent_no_lost_update(ws, user):
+    # Regression for the read-modify-write lost-update on the settings bag
+    # (#1951 review, I1): concurrent PATCHes to *different* keys must all
+    # land, not last-writer-wins on the whole blob. The merge uses
+    # compare-and-swap (UPDATE ... WHERE settings IS <old_blob>), so a
+    # concurrent writer that changed the blob between our SELECT and UPDATE
+    # is detected via rowcount=0 and the patch is re-read + re-merged on the
+    # latest base. NullPool gives each transaction a fresh connection to the
+    # same on-disk SQLite file, so the SELECT/UPDATE interleaving is real.
+    ws_row = await ws.create_workspace(
+        user["id"], "concurrent", settings={"idle_timeout": 300}
+    )
+    ws_id = ws_row["id"]
+    uid = user["id"]
+    # Five patches to five distinct keys, fired concurrently.
+    await asyncio.gather(
+        ws.update_workspace_settings(ws_id, uid, {"cpu_limit": 1.5}),
+        ws.update_workspace_settings(ws_id, uid, {"pids_limit": 256}),
+        ws.update_workspace_settings(ws_id, uid, {"memory_limit": "512m"}),
+        ws.update_workspace_settings(ws_id, uid, {"bridge_timeout": 60}),
+        ws.update_workspace_settings(ws_id, uid, {"idle_timeout": 0}),
+    )
+    got = await ws.get_workspace(ws_id, uid)
+    # Every override survived — no key was dropped by a concurrent writer.
+    # (Without CAS, the last writer's stale-base blob would clobber the
+    # others and only its own key + the original idle_timeout would remain.)
+    assert got["settings"] == {
+        "idle_timeout": 0,
+        "cpu_limit": 1.5,
+        "pids_limit": 256,
+        "memory_limit": "512m",
+        "bridge_timeout": 60,
+    }
 
 
 async def test_settings_in_auto_start_listing(ws, user):

--- a/src/klangk/klangkd-tests/tests/test_util.py
+++ b/src/klangk/klangkd-tests/tests/test_util.py
@@ -819,3 +819,46 @@ class TestPortDiscovery:
             assert b != a, "free_port reused a port that is currently bound"
         finally:
             held.close()
+
+
+class TestBridgeIdleTimeout:
+    """Per-workspace bridge idle timeout resolution (#864)."""
+
+    def test_default_is_30s(self):
+        u = _util()
+        assert u.bridge_idle_timeout() == 30.0
+
+    def test_deploy_default_from_env(self):
+        u = _util({"KLANGKD_BRIDGE_TIMEOUT_SECONDS": "60"})
+        assert u.bridge_idle_timeout() == 60.0
+
+    def test_garbage_deploy_value_falls_back_to_30s(self):
+        u = _util({"KLANGKD_BRIDGE_TIMEOUT_SECONDS": "soon"})
+        assert u.bridge_idle_timeout() == 30.0
+
+    def test_workspace_override_wins(self):
+        u = _util({"KLANGKD_BRIDGE_TIMEOUT_SECONDS": "60"})
+        ws = {"settings": {"bridge_timeout": 120}}
+        assert u.bridge_idle_timeout_for(ws) == 120.0
+
+    def test_workspace_override_with_no_deploy_default(self):
+        u = _util()
+        ws = {"settings": {"bridge_timeout": 90}}
+        assert u.bridge_idle_timeout_for(ws) == 90.0
+
+    def test_no_override_falls_back_to_deploy_default(self):
+        u = _util({"KLANGKD_BRIDGE_TIMEOUT_SECONDS": "45"})
+        assert u.bridge_idle_timeout_for({"settings": None}) == 45.0
+        assert u.bridge_idle_timeout_for({}) == 45.0
+        assert u.bridge_idle_timeout_for(None) == 45.0
+
+    def test_no_override_no_deploy_default_is_30s(self):
+        u = _util()
+        assert u.bridge_idle_timeout_for({"settings": None}) == 30.0
+        assert u.bridge_idle_timeout_for(None) == 30.0
+
+    def test_other_settings_key_does_not_affect_bridge(self):
+        # An override for a different key must not leak into bridge resolution.
+        u = _util({"KLANGKD_BRIDGE_TIMEOUT_SECONDS": "60"})
+        ws = {"settings": {"idle_timeout": 300}}
+        assert u.bridge_idle_timeout_for(ws) == 60.0

--- a/src/klangk/klangkd-tests/tests/test_workspace_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_workspace_settings.py
@@ -71,15 +71,34 @@ def test_validate_settings_rejects_non_string_key():
 @pytest.mark.parametrize(
     "key,value",
     [
-        ("idle_timeout", 0),
-        ("idle_timeout", -10),
         ("pids_limit", 0),
+        ("pids_limit", -5),
         ("bridge_timeout", -1),
+        ("bridge_timeout", 0),
     ],
 )
-def test_validate_settings_rejects_non_positive_timeout(key, value):
+def test_validate_settings_rejects_non_positive(key, value):
+    # pids_limit and bridge_timeout require a strictly positive int — 0 is
+    # not meaningful for either (a 0 pids limit would fork-bomb the workspace
+    # instantly; a 0 bridge timeout is nonsense), unlike idle_timeout.
     with pytest.raises(ValueError, match="must be a positive"):
         ws.validate_settings({key: value})
+
+
+def test_validate_settings_rejects_negative_idle_timeout():
+    # idle_timeout: 0 means "never idle out" (the idle reaper guards with
+    # `timeout > 0`), so only negatives are rejected — as a non-negative,
+    # not a positive, int.
+    with pytest.raises(ValueError, match="must be a non-negative"):
+        ws.validate_settings({"idle_timeout": -10})
+
+
+def test_validate_settings_accepts_zero_idle_timeout():
+    # 0 = pin the workspace alive forever (never idle out), the per-workspace
+    # equivalent of the auto_start boot path pinning a service alive.
+    assert ws.validate_settings({"idle_timeout": 0}) == {"idle_timeout": 0}
+    # Also coerced from a numeric string.
+    assert ws.validate_settings({"idle_timeout": "0"}) == {"idle_timeout": 0}
 
 
 def test_validate_settings_rejects_non_integer_timeout():
@@ -161,7 +180,7 @@ def test_patch_rejects_unknown_key():
 
 
 def test_patch_rejects_bad_value():
-    with pytest.raises(ValueError, match="must be a positive"):
+    with pytest.raises(ValueError, match="must be a non-negative"):
         ws.validate_settings_patch({"idle_timeout": -1})
 
 

--- a/src/klangk/klangkd-tests/tests/test_workspace_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_workspace_settings.py
@@ -1,0 +1,272 @@
+"""Unit tests for the per-workspace ``settings`` resolution layer (#864).
+
+Covers :mod:`klangk.workspace_settings` — the validation gate and the
+precedence resolver (workspace override > deploy default > none). Pure
+function tests (no DB / app_state).
+"""
+
+import pytest
+
+from klangk import workspace_settings as ws
+
+
+# --- validate_settings (full-replace semantics) ---
+
+
+def test_validate_settings_none_returns_none():
+    assert ws.validate_settings(None) is None
+
+
+def test_validate_settings_empty_returns_none():
+    assert ws.validate_settings({}) is None
+
+
+def test_validate_settings_all_null_returns_none():
+    # Full-replace bag where every key is null = empty bag = None.
+    assert ws.validate_settings({"idle_timeout": None}) is None
+
+
+def test_validate_settings_coerces_numeric_strings():
+    out = ws.validate_settings(
+        {"idle_timeout": "300", "pids_limit": "512", "cpu_limit": "1.5"}
+    )
+    assert out == {"idle_timeout": 300, "pids_limit": 512, "cpu_limit": 1.5}
+
+
+def test_validate_settings_preserves_memory_string():
+    out = ws.validate_settings({"memory_limit": "2g"})
+    assert out == {"memory_limit": "2g"}
+
+
+def test_validate_settings_drops_null_keeps_others():
+    out = ws.validate_settings(
+        {"idle_timeout": 300, "cpu_limit": None, "pids_limit": 512}
+    )
+    assert out == {"idle_timeout": 300, "pids_limit": 512}
+
+
+def test_validate_settings_rejects_unknown_key():
+    with pytest.raises(ValueError, match="Unknown setting 'nonsense'"):
+        ws.validate_settings({"nonsense": 1})
+
+
+def test_validate_settings_lists_known_keys_on_error():
+    with pytest.raises(ValueError) as exc:
+        ws.validate_settings({"bogus": 1})
+    msg = str(exc.value)
+    assert "idle_timeout" in msg
+    assert "cpu_limit" in msg
+
+
+def test_validate_settings_rejects_non_dict():
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        ws.validate_settings(["idle_timeout", 300])  # type: ignore[arg-type]
+
+
+def test_validate_settings_rejects_non_string_key():
+    with pytest.raises(ValueError, match="keys must be strings"):
+        ws.validate_settings({1: 300})  # type: ignore[dict-item]
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("idle_timeout", 0),
+        ("idle_timeout", -10),
+        ("pids_limit", 0),
+        ("bridge_timeout", -1),
+    ],
+)
+def test_validate_settings_rejects_non_positive_timeout(key, value):
+    with pytest.raises(ValueError, match="must be a positive"):
+        ws.validate_settings({key: value})
+
+
+def test_validate_settings_rejects_non_integer_timeout():
+    with pytest.raises(ValueError, match="must be an integer"):
+        ws.validate_settings({"idle_timeout": 1.5})
+
+
+def test_validate_settings_rejects_non_numeric_string_timeout():
+    with pytest.raises(ValueError, match="must be an integer"):
+        ws.validate_settings({"idle_timeout": "soon"})
+
+
+def test_validate_settings_rejects_bool_timeout():
+    # bool is a subclass of int; the gate rejects it explicitly.
+    with pytest.raises(ValueError, match="not a boolean"):
+        ws.validate_settings({"idle_timeout": True})
+
+
+def test_validate_settings_rejects_zero_cpu():
+    with pytest.raises(ValueError, match="must be a positive number"):
+        ws.validate_settings({"cpu_limit": 0})
+
+
+def test_validate_settings_rejects_non_numeric_cpu():
+    with pytest.raises(ValueError, match="must be a number"):
+        ws.validate_settings({"cpu_limit": "fast"})
+
+
+def test_validate_settings_rejects_bad_memory_unit():
+    with pytest.raises(ValueError, match="not a valid memory size"):
+        ws.validate_settings({"memory_limit": "2gib"})
+
+
+def test_validate_settings_rejects_zero_memory():
+    with pytest.raises(ValueError, match="not a valid memory size"):
+        ws.validate_settings({"memory_limit": "0"})
+
+
+@pytest.mark.parametrize("val", ["2g", "2G", "512m", "512mb", "1024", "1.5g"])
+def test_validate_settings_accepts_memory_forms(val):
+    assert ws.validate_settings({"memory_limit": val}) == {"memory_limit": val}
+
+
+def test_validate_settings_accepts_int_bytes_memory():
+    # Bare-bytes int is coerced to a string for podman.
+    assert ws.validate_settings({"memory_limit": 524288000}) == {
+        "memory_limit": "524288000"
+    }
+
+
+# --- validate_settings_patch (merge semantics) ---
+
+
+def test_patch_rejects_none():
+    with pytest.raises(ValueError, match="must not be empty"):
+        ws.validate_settings_patch(None)
+
+
+def test_patch_rejects_empty():
+    with pytest.raises(ValueError, match="must not be empty"):
+        ws.validate_settings_patch({})
+
+
+def test_patch_preserves_null_as_deletion_marker():
+    out = ws.validate_settings_patch({"cpu_limit": None})
+    assert out == {"cpu_limit": None}
+
+
+def test_patch_coerces_values():
+    out = ws.validate_settings_patch(
+        {"idle_timeout": "300", "cpu_limit": None}
+    )
+    assert out == {"idle_timeout": 300, "cpu_limit": None}
+
+
+def test_patch_rejects_unknown_key():
+    with pytest.raises(ValueError, match="Unknown setting 'nope'"):
+        ws.validate_settings_patch({"nope": 1})
+
+
+def test_patch_rejects_bad_value():
+    with pytest.raises(ValueError, match="must be a positive"):
+        ws.validate_settings_patch({"idle_timeout": -1})
+
+
+def test_patch_rejects_non_dict():
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        ws.validate_settings_patch("idle_timeout=300")  # type: ignore[arg-type]
+
+
+# --- resolve + typed resolvers ---
+
+
+def test_resolve_workspace_override_wins():
+    ws_dict = {"settings": {"idle_timeout": 300}}
+    assert ws.resolve(ws_dict, "idle_timeout", 60) == 300
+
+
+def test_resolve_falls_back_to_deploy_default():
+    ws_dict = {"settings": {"idle_timeout": 300}}
+    assert ws.resolve(ws_dict, "bridge_timeout", 30) == 30
+
+
+def test_resolve_returns_none_when_neither_set():
+    ws_dict = {"settings": {"idle_timeout": 300}}
+    assert ws.resolve(ws_dict, "cpu_limit", None) is None
+
+
+def test_resolve_handles_missing_settings_bag():
+    assert ws.resolve({}, "idle_timeout", 60) == 60
+    assert ws.resolve({"settings": None}, "idle_timeout", 60) == 60
+
+
+def test_resolve_handles_none_workspace():
+    assert ws.resolve(None, "idle_timeout", 60) == 60
+
+
+def test_resolve_does_not_merge_override_and_default():
+    # Override replaces the default entirely (no merge), like allowed_domains.
+    ws_dict = {"settings": {"allowed": ["x"]}}
+    assert ws.resolve(ws_dict, "allowed", ["y"]) == ["x"]
+
+
+def test_typed_resolvers_bind_keys():
+    ws_dict = {"settings": {"idle_timeout": 120, "cpu_limit": 2.0}}
+    assert ws.resolve_idle_timeout(ws_dict, 60) == 120
+    assert ws.resolve_idle_timeout({"settings": None}, 60) == 60
+    assert ws.resolve_idle_timeout({"settings": {}}, None) is None
+    assert ws.resolve_bridge_timeout(ws_dict, 30.0) == 30.0
+    assert ws.resolve_cpu_limit(ws_dict, 1.0) == 2.0
+    assert ws.resolve_memory_limit(ws_dict, "1g") == "1g"
+    assert ws.resolve_pids_limit(ws_dict, 100) == 100
+
+
+def test_known_settings_has_all_documented_keys():
+    assert ws.KNOWN_SETTINGS == frozenset(
+        {
+            "idle_timeout",
+            "bridge_timeout",
+            "cpu_limit",
+            "memory_limit",
+            "pids_limit",
+        }
+    )
+
+
+# --- coercer edge cases (full branch coverage) ---
+
+
+def test_coerce_int_accepts_integer_valued_float():
+    # A float that is a whole number is accepted (300.0 -> 300).
+    assert ws.validate_settings({"idle_timeout": 300.0}) == {
+        "idle_timeout": 300
+    }
+
+
+def test_coerce_int_rejects_empty_string():
+    with pytest.raises(ValueError, match="must not be empty"):
+        ws.validate_settings({"idle_timeout": "   "})
+
+
+def test_coerce_int_rejects_wrong_type():
+    # A list (or any non-int/float/str) is rejected.
+    with pytest.raises(ValueError, match="must be an integer"):
+        ws.validate_settings({"idle_timeout": [300]})  # type: ignore[list-item]
+
+
+def test_coerce_float_rejects_bool():
+    with pytest.raises(ValueError, match="not a boolean"):
+        ws.validate_settings({"cpu_limit": True})
+
+
+def test_coerce_float_rejects_empty_string():
+    with pytest.raises(ValueError, match="must not be empty"):
+        ws.validate_settings({"cpu_limit": ""})
+
+
+def test_coerce_float_rejects_wrong_type():
+    with pytest.raises(ValueError, match="must be a number"):
+        ws.validate_settings({"cpu_limit": [1.5]})  # type: ignore[list-item]
+
+
+def test_coerce_memory_rejects_wrong_type():
+    with pytest.raises(ValueError, match="must be a size string"):
+        ws.validate_settings({"memory_limit": ["2g"]})  # type: ignore[list-item]
+
+
+def test_patch_rejects_non_string_key():
+    with pytest.raises(ValueError, match="keys must be strings"):
+        ws.validate_settings_patch({1: 300})  # type: ignore[dict-item]

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -637,3 +637,38 @@ class TestStartWorkspace:
             assert registry.states[ws["id"]].idle_timeout is None
         finally:
             registry.states.pop(ws["id"], None)
+
+
+async def test_idle_timeout_zero_pins_alive(user, app_state):
+    """``settings.idle_timeout: 0`` means "never idle out" (#864).
+
+    The schema accepts 0 for idle_timeout specifically (pids / bridge stay
+    strictly positive); the apply path is membership-based
+    (``"idle_timeout" in bag``), so 0 is materialized onto the container
+    state — and the idle reaper's ``timeout > 0`` guard then skips it,
+    pinning the workspace alive forever.
+    """
+    registry = app_state.state.container_registry
+    ws = await app_state.state.workspaces.create_workspace(
+        user["id"],
+        "start-ws-idle-zero",
+        settings={"idle_timeout": 0},
+    )
+    from klangk.container import ContainerState
+
+    registry.states[ws["id"]] = ContainerState(ws["id"], "cid-0", registry)
+    try:
+        with patch.object(
+            registry,
+            "start_container",
+            new_callable=AsyncMock,
+            return_value=("cid-0", "created"),
+        ) as mock_start:
+            await app_state.state.workspaces.start_workspace(ws)
+        # 0 is materialized (not treated as "absent" by a truthiness check).
+        assert registry.states[ws["id"]].idle_timeout == 0
+        assert mock_start.call_args.kwargs["workspace_settings"] == {
+            "idle_timeout": 0
+        }
+    finally:
+        registry.states.pop(ws["id"], None)

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -579,3 +579,61 @@ class TestStartWorkspace:
             assert registry.states[ws["id"]].idle_timeout == default_timeout
         finally:
             registry.states.pop(ws["id"], None)
+
+    async def test_idle_timeout_override_is_applied(self, user, app_state):
+        """A settings.idle_timeout override pins the container state (#864).
+
+        Only an explicit override is materialized onto the container state;
+        when no override is present the state stays None so
+        ``get_idle_timeout()`` lazily reads the live deploy default
+        (reload-safe). See ``test_does_not_pin_idle_timeout`` for that path.
+        """
+        registry = app_state.state.container_registry
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"],
+            "start-ws-idle-override",
+            settings={"idle_timeout": 600},
+        )
+        from klangk.container import ContainerState
+
+        registry.states[ws["id"]] = ContainerState(ws["id"], "cid-z", registry)
+        try:
+            with patch.object(
+                registry,
+                "start_container",
+                new_callable=AsyncMock,
+                return_value=("cid-z", "created"),
+            ) as mock_start:
+                await app_state.state.workspaces.start_workspace(ws)
+            # The override is materialized onto the live state.
+            assert registry.states[ws["id"]].idle_timeout == 600
+            # The settings bag is threaded through to start_container so
+            # resource limits resolve per-workspace too.
+            assert mock_start.call_args.kwargs["workspace_settings"] == {
+                "idle_timeout": 600
+            }
+        finally:
+            registry.states.pop(ws["id"], None)
+
+    async def test_no_idle_override_stays_lazy(self, user, app_state):
+        """No idle_timeout in the bag -> state stays None (lazy fallback)."""
+        registry = app_state.state.container_registry
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"],
+            "start-ws-no-override",
+            settings={"cpu_limit": 2.0},  # other key set, not idle
+        )
+        from klangk.container import ContainerState
+
+        registry.states[ws["id"]] = ContainerState(ws["id"], "cid-w", registry)
+        try:
+            with patch.object(
+                registry,
+                "start_container",
+                new_callable=AsyncMock,
+                return_value=("cid-w", "created"),
+            ):
+                await app_state.state.workspaces.start_workspace(ws)
+            assert registry.states[ws["id"]].idle_timeout is None
+        finally:
+            registry.states.pop(ws["id"], None)


### PR DESCRIPTION
## Summary

Implements **Phases 1-2** of #864 — per-workspace behavioral settings via a JSON `settings` bag on the workspaces table, with the precedence **workspace override > deploy default > none**. One column, one migration, one resolution path (`workspace_settings.resolve`) instead of a column per setting.

Per the issue's own "Implementation order," Phases 3-4 (hosted-app settings, sandbox CLI) are deliberately out of scope — they "follow as separate efforts."

## What's wired up

The five settings catalogued in the issue are now overrideable per-workspace: `idle_timeout`, `bridge_timeout`, `cpu_limit`, `memory_limit`, `pids_limit`.

### Phase 1 — Foundation (DB + Resolution + API)
- **`model/schema.py`** — new `settings TEXT` column + `ADD COLUMN` migration (NULL = no overrides, inheriting every deploy default).
- **`model/workspaces.py`** — `settings` threaded through all CRUD/listing queries (`list`, `list_shared`, `get`, `get_by_id`, `list_auto_start`); new `update_workspace_settings()` read-modify-write merge.
- **`workspace_settings.py`** (new) — `validate_settings` / `validate_settings_patch` schema gate (rejects unknown keys + malformed values with HTTP 400) and typed resolvers (`resolve_idle_timeout`, `resolve_bridge_timeout`, `resolve_cpu_limit`, `resolve_memory_limit`, `resolve_pids_limit`).
- **`api/workspaces.py`** — `settings` on `CreateWorkspaceRequest` / `UpdateWorkspaceRequest`; new **`PATCH /workspaces/{id}/settings`** for partial-merge updates (a `null` value deletes a key, reverting it to the deploy default); threaded through duplicate + export/import.

### Phase 2 — Runtime wiring
- **`container.py`** — `workspace_settings` param on `start_container` / `_start_container_inner`; cpu/memory/pids limits resolved per-workspace (override > default > none, applied as-is with **no clamping** per #34 — a creator may go larger *or* smaller).
- **`workspaces.py`** — applies the `settings.idle_timeout` override on container start. Only materialized onto the container state when the workspace actually declares one, so the lazy deploy-default fallback (`get_idle_timeout()` reads the live registry value) stays **reload-safe** — a SIGHUP settings swap still applies to running containers. The boot/auto_start pin (0) still wins for service workspaces.
- **`util.py` + `api/browser_delegate.py`** — per-workspace `bridge_timeout` via `bridge_idle_timeout_for(workspace)`; `browser_delegate_stream` resolves it from the workspace's bag.

## API surface

```bash
# Set at create time
POST /workspaces
  {"name": "tuned", "settings": {"idle_timeout": 300, "cpu_limit": "1.5"}}

# Full replace (None clears the whole bag)
PUT /workspaces/{id}
  {"settings": {"cpu_limit": 2.0}}

# Partial merge (null deletes one key, reverting to deploy default)
PATCH /workspaces/{id}/settings
  {"idle_timeout": 600, "cpu_limit": null}
```

Unknown setting names and malformed values (a non-positive timeout, a non-numeric CPU limit, a malformed memory size, …) are rejected at the API boundary with HTTP 400, not silently swallowed.

## Design notes

- **Naming deviation:** the issue suggested a new `settings.py`, but that name is already taken (the global `KlangkSettings` pydantic model). The resolution module is `workspace_settings.py` to avoid the collision. Internal naming — no user-visible impact.
- **`allowed_domains` stays a dedicated column** — it predates this decision (#1365) and its migration into the bag is tracked separately (it touches the netfilter resolution path). `env` / `image` / `mounts` / `default_command` are structural (define *what* the workspace *is*) and stay columns too.
- **Idle-timeout laziness:** the override is only pinned onto the container state when declared; otherwise the state stays `None` and falls back live to the deploy default, preserving the existing reload behavior. Resource limits (cpu/memory/pids) are materialized at container create time regardless — they can't be retroactively re-applied to a running cgroup anyway (same as the existing deploy-wide limits).
- The pure resolution module takes deploy defaults as a *parameter* (read live off `app.state.settings.<field>` by the caller), so it never caches a subobject of `app` — consistent with the #1608 ownership rule.

## Test coverage

100% on the `klangk` package; 4040 Python tests pass (frontend tests pass too). New coverage:
- `test_workspace_settings.py` — validation gate + precedence resolver (43 unit tests)
- `test_model_workspaces.py` — settings roundtrip across all queries + merge/delete semantics
- `test_model.py` — `ADD COLUMN` migration for pre-`settings` DBs
- `test_container.py` — per-workspace resource-limit resolution (override, partial override, smaller-than-default, no-deploy-default)
- `test_workspaces.py` — idle_timeout override applied vs lazy fallback
- `test_util.py` — per-workspace bridge-timeout resolution
- `test_api.py` — create/update/PATCH happy paths + validation rejections + import roundtrip/rejection

Closes #864 (Phases 1-2).
