### PR TITLE
fix(tui): select terminal by window id, not index (#1954)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1124,6 +1124,15 @@ set-password <email>` (set a known password for the default user — whose
   even when empty), and a background terminals refresh no longer yanks
   focus out of an open confirm dialog onto the list.
 
+- **TUI: selecting a terminal in the workspace detail screen no
+  longer creates a phantom second window (#1954).** The detail list keyed
+  each row by the window's _index_, which `klangk shell` then matched as
+  a window _name_; the index (`0`) matched no window named `0`, so the
+  backend created a new tmux window named `0` and the status bar showed
+  both `0:bash` and `1:0`. Selecting now passes the window's stable id
+  (`@N`), which attaches to the existing window without creating a
+  duplicate.
+
 - **TUI: workspace id and date are now separate, fixed-width columns with
   clear spacing between them in the workspaces list (#1907).** Both were
   `width: auto` and the date had no left padding, so a row's short id and

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1131,7 +1131,12 @@ set-password <email>` (set a known password for the default user — whose
   backend created a new tmux window named `0` and the status bar showed
   both `0:bash` and `1:0`. Selecting now passes the window's stable id
   (`@N`), which attaches to the existing window without creating a
-  duplicate.
+  duplicate. Selecting a row whose window can no longer be resolved by
+  id (stale list, or the window was deleted server-side between refresh
+  and selection) now refuses to spawn and refreshes the list, and a
+  shell that exits non-zero likewise triggers a refresh — so a dead row
+  self-heals instead of silently creating a duplicate or failing on
+  every re-select (#1955 review).
 
 - **TUI: workspace id and date are now separate, fixed-width columns with
   clear spacing between them in the workspaces list (#1907).** Both were

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -1119,13 +1119,26 @@ async def ws_shell(
                             f"Failed to join: {msg.get('message')}"
                         )
             else:
-                # Own window by name
-                match = next(
-                    (w for w in own_windows if w.get("name") == window),
-                    None,
-                )
+                # Own window: by id (@N) or by name. An id targets the
+                # exact tmux window and must never create a new one
+                # (#1954); a name selects an existing window or creates
+                # one with that name.
+                if window.startswith("@"):
+                    match = next(
+                        (w for w in own_windows if w.get("id") == window),
+                        None,
+                    )
+                    if match is None:
+                        raise ConnectionError(
+                            f"Window '{window}' no longer exists"
+                        )
+                else:
+                    match = next(
+                        (w for w in own_windows if w.get("name") == window),
+                        None,
+                    )
                 if match is None:
-                    # Create the window if it doesn't exist.
+                    # Name with no match — create the window.
                     await ws.send(
                         json.dumps(
                             {

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -446,30 +446,59 @@ class WorkspaceDetailScreen(Screen):
         # The list item is keyed by the window INDEX, but the shell must
         # target the window by its stable id (@N) so the backend selects
         # the existing window instead of creating a duplicate named after
-        # the index (#1954).
+        # the index (#1954). If no id can be resolved — stale list, or a
+        # server contract violation (terminal.list_windows always sets
+        # id) — refuse to spawn and refresh instead: falling back to the
+        # raw index would reproduce the duplicate-window bug.
         target = self._window_id_for(terminal)
+        if target is None:
+            self._msg(
+                "Terminal no longer exists — refreshing list.", error=True
+            )
+            self.run_worker(self._load_terminals, exit_on_error=False)
+            return
         cmd = [sys.executable, "-m", "klangk.cli.main"]
         server = self.app.tui_state.current_url()
         if server:
             cmd += ["--server", server]
         cmd += ["shell", self._name, target]
         with self.app.suspend():
-            subprocess.run(cmd)
+            completed = subprocess.run(cmd)
+        if completed.returncode != 0:
+            # The shell exited non-zero — most likely the window was
+            # deleted server-side between list refresh and selection.
+            # Refresh so the dead row self-heals instead of failing
+            # identically on every re-select (#1955 review).
+            self.run_worker(self._load_terminals, exit_on_error=False)
 
-    def _window_id_for(self, key: str) -> str:
+    def _window_id_for(self, key: str) -> str | None:
         """Resolve a list-item key (window index) to the window's id (@N).
 
-        Falls back to the raw key when it is not an index or the window
-        can't be found, so a non-numeric selector keeps prior behaviour.
+        Returns the id when the key is an index present in the current
+        window list. Returns None otherwise — callers must NOT spawn a
+        shell with None, since falling back to the raw index would
+        reproduce the #1954 duplicate-window bug.
         """
         try:
             idx = int(key)
         except (TypeError, ValueError):
-            return key
+            return None
         for w in self._terminals:
-            if w.get("index") == idx and w.get("id"):
-                return str(w["id"])
-        return key
+            if w.get("index") == idx:
+                wid = w.get("id")
+                if wid:
+                    return str(wid)
+                # Matched by index but the server omitted the window id —
+                # a contract violation (terminal.list_windows always sets
+                # id from tmux's #{window_id}). Log loudly rather than
+                # silently degrade to the index (#1955 review).
+                logger.warning(
+                    "Terminal index %s has no window id; refusing to "
+                    "select by index (would create a duplicate, #1954).",
+                    idx,
+                )
+                return None
+        return None
 
     def action_delete_terminal(self) -> None:
         lv = self.query_one("#term_list", ListView)

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -443,13 +443,33 @@ class WorkspaceDetailScreen(Screen):
         terminal = getattr(event.item, "name", "") or ""
         if not terminal or self._ws is None:
             return
+        # The list item is keyed by the window INDEX, but the shell must
+        # target the window by its stable id (@N) so the backend selects
+        # the existing window instead of creating a duplicate named after
+        # the index (#1954).
+        target = self._window_id_for(terminal)
         cmd = [sys.executable, "-m", "klangk.cli.main"]
         server = self.app.tui_state.current_url()
         if server:
             cmd += ["--server", server]
-        cmd += ["shell", self._name, terminal]
+        cmd += ["shell", self._name, target]
         with self.app.suspend():
             subprocess.run(cmd)
+
+    def _window_id_for(self, key: str) -> str:
+        """Resolve a list-item key (window index) to the window's id (@N).
+
+        Falls back to the raw key when it is not an index or the window
+        can't be found, so a non-numeric selector keeps prior behaviour.
+        """
+        try:
+            idx = int(key)
+        except (TypeError, ValueError):
+            return key
+        for w in self._terminals:
+            if w.get("index") == idx and w.get("id"):
+                return str(w["id"])
+        return key
 
     def action_delete_terminal(self) -> None:
         lv = self.query_one("#term_list", ListView)

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -339,6 +339,139 @@ class TestWsShell:
         assert "terminal_select_window" in cmds
 
     @pytest.mark.asyncio
+    async def test_ws_shell_select_own_window_by_id(self):
+        """window=@N selects the exact window; never creates (#1954)."""
+        from klangk.cli.client import ws_shell
+
+        ws_mock = MagicMock()
+
+        async def fake_enter(self):
+            return ws_mock
+
+        async def fake_exit(self, *args):
+            return None
+
+        ws_mock.__aenter__ = fake_enter
+        ws_mock.__aexit__ = fake_exit
+        ws_mock.send = AsyncMock()
+        ws_mock.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "container_ready"}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            },
+                            {
+                                "id": "@1",
+                                "index": 1,
+                                "name": "build",
+                                "active": False,
+                            },
+                        ],
+                    }
+                ),
+                json.dumps({"type": "terminal_output", "data": "$ "}),
+                Exception("stop"),
+            ]
+        )
+
+        with (
+            patch(
+                "klangk.cli.transport.websockets.connect",
+                return_value=ws_mock,
+            ),
+            patch("termios.tcgetattr", return_value=None),
+            patch("termios.tcsetattr"),
+            patch("tty.setraw"),
+        ):
+            try:
+                await ws_shell(
+                    "http://localhost",
+                    "token",
+                    "ws1",
+                    window="@0",
+                )
+            except Exception:
+                pass
+
+        sent = [json.loads(c[0][0]) for c in ws_mock.send.call_args_list]
+        cmds = [m.get("cmd") for m in sent]
+        # Selects the existing @0 window ...
+        select_msgs = [
+            s for s in sent if s.get("cmd") == "terminal_select_window"
+        ]
+        assert len(select_msgs) == 1
+        assert select_msgs[0]["window_id"] == "@0"
+        # ... and must NOT create a new window (the index-as-name bug).
+        assert "terminal_new_window" not in cmds
+
+    @pytest.mark.asyncio
+    async def test_ws_shell_select_own_window_missing_id_raises(self):
+        """window=@N for a vanished window raises, never creates (#1954)."""
+        from klangk.cli.client import ws_shell
+
+        ws_mock = MagicMock()
+
+        async def fake_enter(self):
+            return ws_mock
+
+        async def fake_exit(self, *args):
+            return None
+
+        ws_mock.__aenter__ = fake_enter
+        ws_mock.__aexit__ = fake_exit
+        ws_mock.send = AsyncMock()
+        ws_mock.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "container_ready"}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            },
+                        ],
+                    }
+                ),
+                Exception("stop"),
+            ]
+        )
+
+        with (
+            patch(
+                "klangk.cli.transport.websockets.connect",
+                return_value=ws_mock,
+            ),
+            patch("termios.tcgetattr", return_value=None),
+            patch("termios.tcsetattr"),
+            patch("tty.setraw"),
+            patch("klangk.cli.client.reset_terminal"),
+            patch("klangk.cli.client.drain_stdin"),
+        ):
+            with pytest.raises(ConnectionError, match="no longer exists"):
+                await ws_shell(
+                    "http://localhost",
+                    "token",
+                    "ws1",
+                    window="@9",
+                )
+
+        sent = [json.loads(c[0][0]) for c in ws_mock.send.call_args_list]
+        cmds = [m.get("cmd") for m in sent]
+        assert "terminal_new_window" not in cmds
+        assert "terminal_select_window" not in cmds
+
+    @pytest.mark.asyncio
     async def test_ws_shell_join_shared_terminal(self):
         """window=handle:name joins a shared terminal."""
         from klangk.cli.client import ws_shell

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4931,7 +4931,12 @@ async def test_detail_delete_terminal_failure(monkeypatch):
 
 
 def test_detail_window_id_for_resolves_index_and_falls_back():
-    """Select target resolves a window index to its stable @N id (#1954)."""
+    """Select target resolves a window index to its stable @N id (#1954).
+
+    Non-resolvable keys return None so the caller refuses to spawn —
+    falling back to the raw index would reproduce the duplicate-window
+    bug (#1955 review).
+    """
     d = WorkspaceDetailScreen("alpha")
     d._terminals = [
         {"index": 0, "name": "main", "id": "@0"},
@@ -4939,10 +4944,23 @@ def test_detail_window_id_for_resolves_index_and_falls_back():
     ]
     assert d._window_id_for("0") == "@0"
     assert d._window_id_for("1") == "@1"
-    # Unknown index falls back to the raw key.
-    assert d._window_id_for("9") == "9"
-    # Non-numeric selector is returned unchanged.
-    assert d._window_id_for("build") == "build"
+    # Unknown index → None (don't risk selecting by index).
+    assert d._window_id_for("9") is None
+    # Non-numeric selector → None.
+    assert d._window_id_for("build") is None
+
+
+def test_detail_window_id_for_warns_when_id_missing(caplog):
+    """A window matching the index but lacking an id is a server-contract
+    violation — refuse to select and log loudly (#1955 review)."""
+    d = WorkspaceDetailScreen("alpha")
+    d._terminals = [{"index": 0, "name": "main"}]  # no "id"
+    with caplog.at_level(
+        "WARNING",
+        logger="klangk.cli.tui.screens.workspace_detail",
+    ):
+        assert d._window_id_for("0") is None
+    assert "no window id" in caplog.text
 
 
 async def test_detail_terminal_select_spawns_shell(monkeypatch):
@@ -4956,7 +4974,12 @@ async def test_detail_terminal_select_spawns_shell(monkeypatch):
     st.current_url = lambda: "https://x.example"
     spawned = []
     monkeypatch.setattr(
-        scr_detail.subprocess, "run", lambda cmd, **k: spawned.append(cmd)
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: (
+            spawned.append(cmd)
+            or scr_detail.subprocess.CompletedProcess(cmd, 0)
+        ),
     )
 
     from contextlib import contextmanager
@@ -4984,6 +5007,99 @@ async def test_detail_terminal_select_spawns_shell(monkeypatch):
             "alpha",
             "@0",
         ]
+
+
+async def test_detail_terminal_select_refuses_when_id_unresolvable(
+    monkeypatch,
+):
+    """A row whose index has no resolvable id refuses to spawn and
+    refreshes the list, rather than risking a duplicate (#1955 review)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+    spawned = []
+    monkeypatch.setattr(
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: spawned.append(cmd),
+    )
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_suspend():
+        yield
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        monkeypatch.setattr(app, "suspend", fake_suspend)
+        refreshed = []
+
+        async def fake_load():
+            refreshed.append(True)
+
+        monkeypatch.setattr(app.screen, "_load_terminals", fake_load)
+        # Index 9 isn't in the list → no resolvable id → refuse + refresh.
+        app.screen.on_list_view_selected(FakeSelected("9"))
+        await pilot.pause()
+        await pilot.pause()
+        assert spawned == []
+        assert refreshed == [True]
+
+
+async def test_detail_terminal_select_failed_spawn_refreshes_list(
+    monkeypatch,
+):
+    """A non-zero shell exit (e.g. window vanished server-side mid-spawn)
+    triggers a list refresh so the dead row self-heals (#1955 review)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+    monkeypatch.setattr(
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: scr_detail.subprocess.CompletedProcess(cmd, 1),
+    )
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_suspend():
+        yield
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        monkeypatch.setattr(app, "suspend", fake_suspend)
+        refreshed = []
+
+        async def fake_load():
+            refreshed.append(True)
+
+        monkeypatch.setattr(app.screen, "_load_terminals", fake_load)
+        app.screen.on_list_view_selected(FakeSelected("0"))
+        await pilot.pause()
+        await pilot.pause()
+        assert refreshed == [True]
 
 
 async def test_detail_terminal_select_empty_name_ignored(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4930,6 +4930,21 @@ async def test_detail_delete_terminal_failure(monkeypatch):
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
 
 
+def test_detail_window_id_for_resolves_index_and_falls_back():
+    """Select target resolves a window index to its stable @N id (#1954)."""
+    d = WorkspaceDetailScreen("alpha")
+    d._terminals = [
+        {"index": 0, "name": "main", "id": "@0"},
+        {"index": 1, "name": "build", "id": "@1"},
+    ]
+    assert d._window_id_for("0") == "@0"
+    assert d._window_id_for("1") == "@1"
+    # Unknown index falls back to the raw key.
+    assert d._window_id_for("9") == "9"
+    # Non-numeric selector is returned unchanged.
+    assert d._window_id_for("build") == "build"
+
+
 async def test_detail_terminal_select_spawns_shell(monkeypatch):
     async def noop(*a, **k):
         return None
@@ -4967,7 +4982,7 @@ async def test_detail_terminal_select_spawns_shell(monkeypatch):
             "https://x.example",
             "shell",
             "alpha",
-            "0",
+            "@0",
         ]
 
 


### PR DESCRIPTION
## Summary

Selecting a terminal in the TUI's workspace-detail screen created a phantom second tmux window named `0` inside the container, so the terminal status bar showed both `0:bash` and `1:0` — and each selection added another duplicate. Fixes #1954.

## Root cause

The detail screen keyed each terminal list row by the window's **index** and passed that to `klangk shell`:

```python
# workspace_detail.py (before)
cmd += ["shell", self._name, terminal]   # terminal == "0"  (the index)
```

But `ws_shell` matched the arg against window **names**, not indices. The only window was named `"bash"`, not `"0"`, so the match failed and the client fell through to "create the window if it doesn't exist", issuing `terminal_new_window` with `name="0"`.

## Fix

Two source changes:

- `cli/tui/screens/workspace_detail.py` — `on_list_view_selected` now resolves the row's index to the window's stable **id** (`@N`, never reused within a server lifetime) via a new `_window_id_for` helper before spawning the shell.
- `cli/client.py` `ws_shell` — an `@`-prefixed arg is matched by window id and selected directly, and is **never** used to create a window (raises `ConnectionError` if that id no longer exists). Name-based selection (and its create-if-missing behaviour) is unchanged.

## Verification

- Full Python suite passes with `-n auto`: **3953 passed, 100% coverage**.
- New tests: `ws_shell` selecting an `@N` id selects without creating; a missing `@N` id raises without creating; TUI `_window_id_for` index→id resolution + fallbacks; the existing select-spawns-shell test now expects `@0`.
- End-to-end `expect` repro against the running dev server:
  - **Before** (`klangk shell <ws> 0`): status bar `0:bash-  1:0*`, re-enumerate → `[(0, 'bash'), (1, '0')]`.
  - **After** (`klangk shell <ws> @0`): status bar `0:bash*`, re-enumerate → `[(0, 'bash', '@0')]` — no phantom window.

## Notes

- The `select_window` controller already preferred `window_id` over `index` (controllers.py:888), and `terminal.select_window` already accepts `@N` ids (terminal.py), so no server-side change was needed — this is purely the client passing the right selector.
- The `close_terminal`/`delete_terminal` path still uses the index, which works because `close_window` looks up the window by index. Left as-is to keep the change minimal; happy to migrate it to ids too if preferred.
