### PR TITLE
fix(tui): autofocus terminals list on workspace detail screen (#1956)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1117,6 +1117,13 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **TUI: the workspace detail screen's Terminals list is now reachable via
+  the keyboard on entry (#1956).** The screen relied on an implicit focus
+  transfer that left the list mouse-only — Down/Tab could not reach it.
+  The list is now auto-focused on entry (with its first row highlighted
+  even when empty), and a background terminals refresh no longer yanks
+  focus out of an open confirm dialog onto the list.
+
 - **TUI: workspace id and date are now separate, fixed-width columns with
   clear spacing between them in the workspaces list (#1907).** Both were
   `width: auto` and the date had no left padding, so a row's short id and

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -106,6 +106,11 @@ class WorkspaceDetailScreen(Screen):
     def on_mount(self) -> None:
         self.run_worker(self._mount_async, exit_on_error=False)
         self._uptime_timer = self.set_interval(5, self._tick_uptime)
+        # Autofocus the Terminals list so the keyboard path reaches it on
+        # entry (spatial-nav rule, AGENTS.md). The list is the only focusable
+        # widget; without an explicit grab focus can stay on the underlying
+        # screen after push_screen, leaving the list mouse-only (#1956).
+        self.query_one("#term_list").focus()
 
     async def _mount_async(self) -> None:
         await self._load()
@@ -417,13 +422,19 @@ class WorkspaceDetailScreen(Screen):
         lv.clear()
         if not self._terminals:
             lv.append(ListItem(Label(Text("(no terminals)")), name=""))
-            return
-        for w in self._terminals:
-            idx = w.get("index", "")
-            name = w.get("name") or idx
-            lv.append(ListItem(Label(Text(f"{idx}  {name}")), name=str(idx)))
-        # Autofocus the first terminal (#1808).
-        lv.focus()
+        else:
+            for w in self._terminals:
+                idx = w.get("index", "")
+                name = w.get("name") or idx
+                lv.append(
+                    ListItem(Label(Text(f"{idx}  {name}")), name=str(idx))
+                )
+        # Keep focus on the list and highlight its first row (#1808, #1956).
+        # The focus grab is skipped when a modal (e.g. a confirm dialog) is
+        # open over this screen, so a background terminals_changed reload
+        # never yanks focus out of the foreground dialog.
+        if self.app.screen is self:
+            lv.focus()
         if lv.index is None:
             lv.index = 0
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4541,6 +4541,107 @@ async def test_detail_terminal_push_falls_back_on_malformed_windows(
         assert any("fetched" in str(it.render()) for it in lv.query(Label))
 
 
+async def test_detail_focuses_term_list_on_mount(monkeypatch):
+    """#1956: the Terminals list gets focus on entry and is navigable via
+    arrow keys (spatial-nav rule, AGENTS.md) — not mouse-only."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+
+    async def terms(_name):
+        return [{"index": 0, "name": "main"}, {"index": 1, "name": "build"}]
+
+    st = _ws(list_terminals=terms)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        lv = d.query_one("#term_list", ListView)
+        # Focus landed on the list with the first row highlighted.
+        assert app.focused is lv
+        assert lv.index == 0
+        # Arrow keys navigate within the list (reachable via keyboard).
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is lv
+        assert lv.index == 1
+
+
+async def test_detail_focuses_term_list_when_empty(monkeypatch):
+    """#1956: focus reaches the Terminals list on entry even when the
+    workspace has no terminals — the empty-render path keeps focus on the
+    list and highlights the placeholder row instead of stranding it."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws()  # list_terminals defaults to _async_empty -> no terminals
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        lv = d.query_one("#term_list", ListView)
+        assert app.focused is lv
+        assert lv.index == 0  # placeholder row highlighted, not None
+
+
+async def test_detail_terminals_reload_under_modal_keeps_focus(monkeypatch):
+    """#1956: a terminals_changed reload arriving while a modal (e.g. a
+    confirm dialog) is open over the detail screen must not yank focus
+    out of the modal onto the Terminals list."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_empty)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        # Open a confirm dialog over the detail screen.
+        app.push_screen(ConfirmScreen("sure?"))
+        await pilot.pause()
+        assert app.screen is not d  # modal on top
+        modal_focused = app.focused
+        # A terminals_changed push arrives while the modal is open.
+        d.apply_status_event(
+            {
+                "type": "terminals_changed",
+                "workspace_id": "id-alpha",
+                "windows": [
+                    {"index": 0, "name": "main"},
+                    {"index": 1, "name": "build"},
+                ],
+            }
+        )
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        lv = d.query_one("#term_list", ListView)
+        assert app.focused is not lv  # focus stayed in the modal
+        assert app.focused is modal_focused
+        # The list still updated underneath.
+        assert any("build" in str(it.render()) for it in lv.query(Label))
+
+
 async def test_detail_apply_status_event_ws_none(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

Fixes #1956.

The workspace detail screen was a focus trap on entry: its **Terminals list was unreachable via the keyboard** (Down/Tab did nothing; mouse-only). This violated the project's spatial-navigation rule (`AGENTS.md` → "TUI spatial navigation (no focus traps)").

## Root cause

`WorkspaceDetailScreen` relied entirely on textual's implicit *first-focusable-widget* transfer to land focus on the Terminals list, and declared no explicit focus management:

- Nothing on the screen grabbed focus onto the list on entry, so when the implicit transfer didn't take, focus stayed on the underlying screen and the list was mouse-only.
- `_render_terminals` only focused the list in its **populated** branch. The **empty** branch (the `(no terminals)` placeholder) returned without focusing *and* without setting `lv.index`, so even when the list had focus it showed no highlighted row.

## Fix

Per the spatial-nav rule, the screen now manages focus explicitly:

- **`on_mount` grabs focus onto `#term_list`** — the keyboard path reaches the list immediately on entry (it's the only focusable widget on the screen).
- **`_render_terminals` now keeps focus on the list and highlights the first row in both branches** (populated and the empty placeholder), so a reload never strands focus and the first row is always highlighted.
- **The focus grab in `_render_terminals` is guarded** (`self.app.screen is self`) so a background `terminals_changed` reload no longer yanks focus out of an open confirm dialog onto the list.

## Testing

- `test_detail_focuses_term_list_on_mount` — focus lands on the list on entry and arrow keys navigate within it.
- `test_detail_focuses_term_list_when_empty` — focus reaches the list even with no terminals; placeholder row is highlighted (`index == 0`, previously `None`).
- `test_detail_terminals_reload_under_modal_keeps_focus` — a `terminals_changed` reload under an open confirm dialog does not steal focus from the dialog.

Full Python suite passes with `-n auto` at **100% coverage** (3953 passed).

## Changelog

Added a `Fixed` entry under `[Unreleased]`.
