### PR TITLE
doctor: drop fuse-overlayfs/slirp4netns standalone checks

### DIFF
--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -149,14 +149,6 @@ _PACKAGE_HINTS: dict[str, dict[str, str]] = {
         "dnf": "shadow-utils",
         "apt": "uidmap",
     },
-    "fuse-overlayfs": {
-        "dnf": "fuse-overlayfs",
-        "apt": "fuse-overlayfs",
-    },
-    "slirp4netns": {
-        "dnf": "slirp4netns",
-        "apt": "slirp4netns",
-    },
 }
 
 
@@ -450,23 +442,15 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
 
     # 2. Rootless podman prereqs
     if platform.system() != "Darwin":
-        # Linux: check newuidmap, fuse-overlayfs, slirp4netns
-        for name, check_cmd in [
-            # newuidmap is a suid helper that only works when called by
-            # unshare/podman — it always exits non-zero when invoked
-            # directly. Just verify it's on PATH; the end-to-end rootless
-            # podman check below validates it actually works.
-            ("newuidmap", []),
-            ("fuse-overlayfs", ["fuse-overlayfs", "--version"]),
-            ("slirp4netns", ["slirp4netns", "--version"]),
-        ]:
-            # These are warnings if podman itself works — podman may use
-            # alternatives (pasta instead of slirp4netns, native overlay
-            # instead of fuse-overlayfs).
-            result = check_binary(name, check_cmd, manager)
-            if not result.ok:
-                result.is_warning = True
-            report.add(result)
+        # Linux: check newuidmap (suid helper for rootless user
+        # namespaces). fuse-overlayfs and slirp4netns are no longer
+        # checked — modern podman (4.x+) uses native kernel overlayfs
+        # and pasta respectively; the end-to-end rootless check below
+        # validates that storage and networking actually work (#1950).
+        result = check_binary("newuidmap", [], manager)
+        if not result.ok:
+            result.is_warning = True
+        report.add(result)
 
         report.add(check_subuid(user))
     else:  # pragma: no cover

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -340,26 +340,38 @@ class TestRunDoctor:
         assert isinstance(report, DoctorReport)
         assert len(report.results) > 0
 
-    def test_missing_rootless_prereq_is_warning(self):
-        """A missing rootless prereq (e.g. fuse-overlayfs) is a warning, not
-        an error — modern podman may not need it."""
+    def test_no_fuse_overlayfs_or_slirp4netns_checks(self):
+        """fuse-overlayfs and slirp4netns are not checked — modern podman
+        uses native overlay and pasta; the end-to-end rootless check is
+        sufficient (#1950)."""
+        with patch("platform.system", return_value="Linux"):
+            report = run_doctor()
+
+        names = [r.name for r in report.results]
+        assert "fuse-overlayfs" not in names
+        assert "slirp4netns" not in names
+
+    def test_missing_newuidmap_is_warning(self):
+        """A missing newuidmap is a warning, not an error — the end-to-end
+        rootless podman check is the definitive gate."""
         original_which = shutil.which
 
-        def which_hiding_fuse(name):
-            if name == "fuse-overlayfs":
+        def which_hiding_newuidmap(name):
+            if name == "newuidmap":
                 return None
             return original_which(name)
 
         with (
             patch("platform.system", return_value="Linux"),
-            patch("klangk.doctor.shutil.which", side_effect=which_hiding_fuse),
+            patch(
+                "klangk.doctor.shutil.which",
+                side_effect=which_hiding_newuidmap,
+            ),
         ):
             report = run_doctor()
 
-        fuse_results = [
-            r for r in report.results if r.name == "fuse-overlayfs"
-        ]
-        assert len(fuse_results) == 1
-        r = fuse_results[0]
+        results = [r for r in report.results if r.name == "newuidmap"]
+        assert len(results) == 1
+        r = results[0]
         assert not r.ok
         assert r.is_warning


### PR DESCRIPTION
## Summary

- Remove standalone `fuse-overlayfs` and `slirp4netns` binary checks from `klangkd doctor`
- Remove their entries from the `_PACKAGE_HINTS` table
- Modern podman (4.x+) uses native kernel overlayfs (kernels >= 5.11) and pasta — these legacy helpers are no longer required
- The end-to-end rootless podman check (`podman run --rm busybox true`) already validates that storage and networking work; if it passes, the specific driver is irrelevant
- `newuidmap` check remains (as a warning, not an error)

## Test plan

- [ ] `test-backend` passes (3956 passed, 100% coverage)
- [ ] New test verifies `fuse-overlayfs` and `slirp4netns` are not in the check results
- [ ] New test verifies missing `newuidmap` is a warning, not an error
- [ ] NixOS/Fedora/Ubuntu systems with modern podman see no spurious warnings

Closes #1950.