### PR TITLE
fix(tui): close/delete terminal by stable window id, not index (#1965)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1136,6 +1136,17 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **TUI: closing/deleting a terminal in the workspace detail screen
+  now targets the window by its stable id (`@N`) instead of the row
+  index (#1965).** The close path sent `terminal_close_window` with the
+  list row's _index_, which is the same stale-selector class that #1954
+  fixed for selection: with tmux `renumber-windows` off, another surface
+  closing then creating a window reuses the freed index, so a stale TUI
+  list could send `kill-window` against the _wrong_ window. Closing now
+  resolves the row to its `@N` id (the way selection does) and never
+  closes by index; a row whose id can't be resolved, or a close that
+  fails server-side, refuses to close and refreshes the list instead.
+
 - **TUI: the workspace detail screen's Terminals list is now reachable via
   the keyboard on entry (#1956).** The screen relied on an implicit focus
   transfer that left the list mouse-only — Down/Tab could not reach it.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1146,6 +1146,10 @@ set-password <email>` (set a known password for the default user — whose
   resolves the row to its `@N` id (the way selection does) and never
   closes by index; a row whose id can't be resolved, or a close that
   fails server-side, refuses to close and refreshes the list instead.
+  The terminal client now surfaces server `error` frames promptly
+  (previously a failed close hung ~30s waiting for a window list that
+  never came), and the deleting/deleted status messages show the
+  window's name rather than its raw `@N` id.
 
 - **TUI: the workspace detail screen's Terminals list is now reachable via
   the keyboard on entry (#1956).** The screen relied on an implicit focus

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -658,9 +658,9 @@ class KlangkClient:
         """
         return await self._terminals(name)
 
-    async def close_terminal(self, name: str, index: int) -> list[dict]:
-        """Close terminal window *index* in *name*; return the updated list."""
-        return await self._terminals(name, close_index=index)
+    async def close_terminal(self, name: str, window_id: str) -> list[dict]:
+        """Close terminal window *window_id* (@N) in *name*; return list."""
+        return await self._terminals(name, close_window_id=window_id)
 
     async def create_terminal(self, name: str, window_name: str) -> list[dict]:
         """Create a new terminal window in workspace *name*; return updated list."""
@@ -670,7 +670,7 @@ class KlangkClient:
         self,
         name: str,
         *,
-        close_index: int | None = None,
+        close_window_id: str | None = None,
         new_window: str | None = None,
     ) -> list[dict]:
         try:
@@ -692,12 +692,12 @@ class KlangkClient:
                     )
                 )
                 windows = await self._recv_windows(conn)
-                if close_index is not None and windows:
+                if close_window_id is not None and windows:
                     await conn.send(
                         json.dumps(
                             {
                                 "cmd": "terminal_close_window",
-                                "index": close_index,
+                                "window_id": close_window_id,
                             }
                         )
                     )

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -750,6 +750,10 @@ class KlangkClient:
             msg = json.loads(raw)
             if msg.get("type") == "terminal_windows":
                 return msg.get("windows") or []
+            if msg.get("type") == "error":
+                # Surface server errors immediately instead of looping
+                # until the 30s timeout (#1966 review).
+                raise ConnectionError(msg.get("message", "terminal error"))
 
     def export_workspace(
         self,

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -519,12 +519,18 @@ class WorkspaceDetailScreen(Screen):
             )
             self.run_worker(self._load_terminals, exit_on_error=False)
             return
+        label = self._terminal_label_for(child.name)
         self.run_worker(
-            self._do_delete_terminal(window_id), exit_on_error=False
+            self._do_delete_terminal(window_id, label), exit_on_error=False
         )
 
-    async def _do_delete_terminal(self, window_id: str) -> None:
-        self._msg(f"Deleting terminal {window_id}…")
+    async def _do_delete_terminal(
+        self, window_id: str, label: str | None = None
+    ) -> None:
+        # label is a friendly name for messages; falls back to the id
+        # when not supplied (e.g. direct test calls).
+        display = label if label is not None else window_id
+        self._msg(f"Deleting terminal {display}…")
         try:
             windows = await self.app.tui_state.close_terminal(
                 self._name, window_id
@@ -545,7 +551,18 @@ class WorkspaceDetailScreen(Screen):
             return
         self._terminals = windows
         self._render_terminals()
-        self._msg(f"Deleted terminal {window_id}.")
+        self._msg(f"Deleted terminal {display}.")
+
+    def _terminal_label_for(self, key: str) -> str:
+        """Friendly label for a list row: the window name, or the key."""
+        try:
+            idx = int(key)
+        except (TypeError, ValueError):
+            return key
+        for w in self._terminals:
+            if w.get("index") == idx:
+                return str(w.get("name") or idx)
+        return key
 
     def action_new_terminal(self) -> None:
         if self._ws is None:

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -510,17 +510,30 @@ class WorkspaceDetailScreen(Screen):
         if len(self._terminals) <= 1:
             self._msg("Can't delete the last terminal.", error=True)
             return
-        index = int(child.name)
-        self.run_worker(self._do_delete_terminal(index), exit_on_error=False)
+        # Target the window by its stable id (@N), not the row index —
+        # a stale list could otherwise close the wrong window (#1965).
+        window_id = self._window_id_for(child.name)
+        if window_id is None:
+            self._msg(
+                "Terminal no longer exists — refreshing list.", error=True
+            )
+            self.run_worker(self._load_terminals, exit_on_error=False)
+            return
+        self.run_worker(
+            self._do_delete_terminal(window_id), exit_on_error=False
+        )
 
-    async def _do_delete_terminal(self, index: int) -> None:
-        self._msg(f"Deleting terminal {index}…")
+    async def _do_delete_terminal(self, window_id: str) -> None:
+        self._msg(f"Deleting terminal {window_id}…")
         try:
             windows = await self.app.tui_state.close_terminal(
-                self._name, index
+                self._name, window_id
             )
         except Exception as exc:
             self._msg(f"Delete failed: {exc}", error=True)
+            # The id may no longer exist server-side — refresh so the
+            # dead row self-heals instead of failing on every retry (#1965).
+            await self._load_terminals()
             return
         if not windows:
             # The last terminal is protected client-side, so an empty result
@@ -528,10 +541,11 @@ class WorkspaceDetailScreen(Screen):
             self._msg(
                 "Delete failed — could not refresh terminals.", error=True
             )
+            await self._load_terminals()
             return
         self._terminals = windows
         self._render_terminals()
-        self._msg(f"Deleted terminal {index}.")
+        self._msg(f"Deleted terminal {window_id}.")
 
     def action_new_terminal(self) -> None:
         if self._ws is None:

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -219,8 +219,8 @@ class TuiState:
     async def list_terminals(self, name: str) -> list[dict]:
         return await self.client().list_terminals(name)
 
-    async def close_terminal(self, name: str, index: int) -> list[dict]:
-        return await self.client().close_terminal(name, index)
+    async def close_terminal(self, name: str, window_id: str) -> list[dict]:
+        return await self.client().close_terminal(name, window_id)
 
     async def create_terminal(self, name: str, window_name: str) -> list[dict]:
         return await self.client().create_terminal(name, window_name)

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -905,7 +905,8 @@ class TerminalController:
             return
 
         session_name = self.tmux_session_name()
-        index = msg.get("index", 0)
+        # Prefer @N window_id (stable); fall back to index for compat (#1965).
+        target: int | str = msg.get("window_id") or msg.get("index", 0)
         try:
             terminal = self._conn.app.state.terminal
             windows = await terminal.list_windows(
@@ -920,7 +921,7 @@ class TerminalController:
             windows = await terminal.close_window(
                 self._conn.container_id,
                 session_name,
-                index,
+                target,
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -288,12 +288,12 @@ class _WebSession:
         self.selected_window_id = window_id
         await asyncio.sleep(0.5)
 
-    async def close_window(self, index):
+    async def close_window(self, window_id):
         await self.ws.send(
             json.dumps(
                 {
                     "cmd": "terminal_close_window",
-                    "index": index,
+                    "window_id": window_id,
                 }
             )
         )
@@ -491,7 +491,7 @@ puts "AFTER=$a1"
                 None,
             )
             if extra:
-                await web.close_window(extra["index"])
+                await web.close_window(extra["id"])
             await asyncio.sleep(2)
             await web.disconnect()
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1270,6 +1270,76 @@ class TestKlangkClient:
         ):
             assert asyncio.run(client.close_terminal("alpha", "@0")) == []
 
+    def test_recv_windows_raises_on_error_frame(self):
+        """_recv_windows surfaces a server error frame immediately instead
+        of looping to its 30s timeout (#1966 review)."""
+        from klangk.cli.client import KlangkClient
+
+        mock_conn = MagicMock()
+        mock_conn.recv = AsyncMock(
+            side_effect=[json.dumps({"type": "error", "message": "boom"})]
+        )
+        with pytest.raises(ConnectionError, match="boom"):
+            asyncio.run(KlangkClient._recv_windows(mock_conn))
+
+    def test_recv_windows_error_default_message(self):
+        """An error frame with no message uses a default (#1966 review)."""
+        from klangk.cli.client import KlangkClient
+
+        mock_conn = MagicMock()
+        mock_conn.recv = AsyncMock(side_effect=[json.dumps({"type": "error"})])
+        with pytest.raises(ConnectionError, match="terminal error"):
+            asyncio.run(KlangkClient._recv_windows(mock_conn))
+
+    def test_close_terminal_server_error_returns_empty(self):
+        """A server error on close returns [] promptly (no 30s hang) and
+        still sends the close cmd by window_id (#1966 review)."""
+        client = KlangkClient("http://test:8995", "token")
+        ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
+        client.resolve_workspace = MagicMock(return_value=ws)
+        messages = [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "main", "id": "@0"},
+                        {"index": 1, "name": "build", "id": "@1"},
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "error",
+                    "message": "Failed to close window: no such window",
+                }
+            ),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(side_effect=messages)
+        mock_ws.send = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+        with patch(
+            "klangk.cli.transport.websockets.connect",
+            return_value=mock_ws,
+        ):
+            result = asyncio.run(client.close_terminal("alpha", "@1"))
+        # Error surfaced as [] (via _terminals' except), not a hang.
+        assert result == []
+        # _recv_windows stopped at the error frame — it did not loop past
+        # the provided frames looking for another terminal_windows.
+        assert mock_ws.recv.await_count == len(messages)
+        sent = [json.loads(c[0][0]) for c in mock_ws.send.call_args_list]
+        close_msgs = [
+            s for s in sent if s.get("cmd") == "terminal_close_window"
+        ]
+        assert len(close_msgs) == 1
+        assert close_msgs[0]["window_id"] == "@1"
+
     def test_create_terminal(self):
         client = KlangkClient("http://test:8995", "token")
         ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1236,8 +1236,16 @@ class TestKlangkClient:
             "klangk.cli.transport.websockets.connect",
             return_value=mock_ws,
         ):
-            windows = asyncio.run(client.close_terminal("alpha", 1))
+            windows = asyncio.run(client.close_terminal("alpha", "@1"))
         assert len(windows) == 1  # one closed
+        # Close targets the window by its stable @N id, never the index (#1965).
+        sent = [json.loads(c[0][0]) for c in mock_ws.send.call_args_list]
+        close_msgs = [
+            s for s in sent if s.get("cmd") == "terminal_close_window"
+        ]
+        assert len(close_msgs) == 1
+        assert close_msgs[0]["window_id"] == "@1"
+        assert "index" not in close_msgs[0]
 
     def test_close_terminal_no_windows(self):
         # close on a workspace reporting no windows -> no close sent, []
@@ -1260,7 +1268,7 @@ class TestKlangkClient:
             "klangk.cli.transport.websockets.connect",
             return_value=mock_ws,
         ):
-            assert asyncio.run(client.close_terminal("alpha", 0)) == []
+            assert asyncio.run(client.close_terminal("alpha", "@0")) == []
 
     def test_create_terminal(self):
         client = KlangkClient("http://test:8995", "token")

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1765,9 +1765,9 @@ def test_tui_state_terminal_methods(monkeypatch, redirect_xdg):
     st = TuiState("https://x.example")
     monkeypatch.setattr(st, "client", lambda: fake)
     assert asyncio.run(st.list_terminals("a")) == [{"index": 0, "name": "m"}]
-    assert asyncio.run(st.close_terminal("a", 0)) == []
+    assert asyncio.run(st.close_terminal("a", "@0")) == []
     fake.list_terminals.assert_called_once_with("a")
-    fake.close_terminal.assert_called_once_with("a", 0)
+    fake.close_terminal.assert_called_once_with("a", "@0")
 
 
 async def test_main_screen_lists_and_status(monkeypatch):
@@ -4841,8 +4841,8 @@ async def test_detail_delete_terminal(monkeypatch):
 
     closed = {}
 
-    async def _close(name, index):
-        closed["i"] = index
+    async def _close(name, window_id):
+        closed["i"] = window_id
         return [{"index": 0, "name": "main", "id": "@0"}]
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
@@ -4860,9 +4860,91 @@ async def test_detail_delete_terminal(monkeypatch):
         d.action_delete_terminal()
         for _ in range(3):
             await pilot.pause()
-        assert closed.get("i") == 1
-        assert "Deleted terminal 1" in str(d.query_one("#detail_msg").render())
+        assert closed.get("i") == "@1"
+        assert "Deleted terminal @1" in str(
+            d.query_one("#detail_msg").render()
+        )
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 1
+
+
+async def test_detail_delete_terminal_refuses_when_id_unresolvable(
+    monkeypatch,
+):
+    """A row whose window has no resolvable id refuses to close and
+    refreshes the list, rather than risking the wrong window (#1965)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    calls = {"close": 0, "list": 0}
+
+    async def _terms_no_id(*a, **k):
+        calls["list"] += 1
+        return [
+            {"index": 0, "name": "main", "id": "@0"},
+            {"index": 1, "name": "build"},  # no id — contract violation
+        ]
+
+    async def _close(name, window_id):
+        calls["close"] += 1
+        return []
+
+    st = _ws(list_terminals=_terms_no_id, close_terminal=_close)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        before = calls["list"]
+        d.action_delete_terminal()
+        for _ in range(4):
+            await pilot.pause()
+        # No close sent, and the list was refreshed.
+        assert calls["close"] == 0
+        assert calls["list"] > before
+        assert "no longer exists" in str(d.query_one("#detail_msg").render())
+
+
+async def test_detail_delete_terminal_refreshes_on_server_failure(
+    monkeypatch,
+):
+    """A close that fails server-side (id gone) refreshes the list so the
+    dead row self-heals (#1965)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    calls = {"list": 0}
+
+    async def _tracked_terms(*a, **k):
+        calls["list"] += 1
+        return await _async_terms(*a, **k)
+
+    async def _close(name, window_id):
+        raise RuntimeError("no such window")
+
+    st = _ws(list_terminals=_tracked_terms, close_terminal=_close)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        before = calls["list"]
+        await d._do_delete_terminal("@1")
+        assert "Delete failed" in str(d.query_one("#detail_msg").render())
+        # Failure triggered a refresh.
+        assert calls["list"] > before
 
 
 async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
@@ -4876,7 +4958,7 @@ async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
 
     gate = asyncio.Event()
 
-    async def _close(name, index):
+    async def _close(name, window_id):
         await gate.wait()
         return [{"index": 0, "name": "main", "id": "@0"}]
 
@@ -4897,21 +4979,23 @@ async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
         # message must already be visible.
         for _ in range(3):
             await pilot.pause()
-        assert "Deleting terminal 1" in str(
+        assert "Deleting terminal @1" in str(
             d.query_one("#detail_msg").render()
         )
         # Releasing the close call replaces it with the success message.
         gate.set()
         for _ in range(3):
             await pilot.pause()
-        assert "Deleted terminal 1" in str(d.query_one("#detail_msg").render())
+        assert "Deleted terminal @1" in str(
+            d.query_one("#detail_msg").render()
+        )
 
 
 async def test_detail_delete_terminal_failure(monkeypatch):
     async def noop(*a, **k):
         return None
 
-    async def _close(name, index):
+    async def _close(name, window_id):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
@@ -4925,7 +5009,7 @@ async def test_detail_delete_terminal_failure(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
-        await d._do_delete_terminal(1)  # close raises
+        await d._do_delete_terminal("@1")  # close raises
         await app.workers.wait_for_complete()
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
 
@@ -5239,7 +5323,7 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
     async def noop(*a, **k):
         return None
 
-    async def _close(name, index):
+    async def _close(name, window_id):
         return []  # close / refresh failed
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
@@ -5253,7 +5337,7 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
-        await d._do_delete_terminal(1)
+        await d._do_delete_terminal("@1")
         await app.workers.wait_for_complete()
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
         assert (

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4861,7 +4861,7 @@ async def test_detail_delete_terminal(monkeypatch):
         for _ in range(3):
             await pilot.pause()
         assert closed.get("i") == "@1"
-        assert "Deleted terminal @1" in str(
+        assert "Deleted terminal build" in str(
             d.query_one("#detail_msg").render()
         )
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 1
@@ -4979,14 +4979,14 @@ async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
         # message must already be visible.
         for _ in range(3):
             await pilot.pause()
-        assert "Deleting terminal @1" in str(
+        assert "Deleting terminal build" in str(
             d.query_one("#detail_msg").render()
         )
         # Releasing the close call replaces it with the success message.
         gate.set()
         for _ in range(3):
             await pilot.pause()
-        assert "Deleted terminal @1" in str(
+        assert "Deleted terminal build" in str(
             d.query_one("#detail_msg").render()
         )
 
@@ -5045,6 +5045,20 @@ def test_detail_window_id_for_warns_when_id_missing(caplog):
     ):
         assert d._window_id_for("0") is None
     assert "no window id" in caplog.text
+
+
+def test_detail_terminal_label_for():
+    """Delete-message label prefers the window name, falling back to the
+    index/key (#1966 review UX nit)."""
+    d = WorkspaceDetailScreen("alpha")
+    d._terminals = [
+        {"index": 0, "name": "main", "id": "@0"},
+        {"index": 1, "name": "", "id": "@1"},  # empty name → index
+    ]
+    assert d._terminal_label_for("0") == "main"
+    assert d._terminal_label_for("1") == "1"  # empty name falls back
+    assert d._terminal_label_for("9") == "9"  # unknown index
+    assert d._terminal_label_for("build") == "build"  # non-numeric
 
 
 async def test_detail_terminal_select_spawns_shell(monkeypatch):
@@ -5326,9 +5340,15 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
     async def _close(name, window_id):
         return []  # close / refresh failed
 
+    calls = {"list": 0}
+
+    async def _tracked_terms(*a, **k):
+        calls["list"] += 1
+        return await _async_terms(*a, **k)
+
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     a = _wsobj("alpha")
-    st = _ws(list_terminals=_async_terms, close_terminal=_close)
+    st = _ws(list_terminals=_tracked_terms, close_terminal=_close)
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
     async with app.run_test() as pilot:
@@ -5337,12 +5357,15 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        before = calls["list"]
         await d._do_delete_terminal("@1")
         await app.workers.wait_for_complete()
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
         assert (
             len(d.query_one("#term_list", ListView).query(ListItem)) == 2
         )  # unchanged
+        # The empty-result failure triggered a list refresh (#1966 review).
+        assert calls["list"] > before
 
 
 async def test_detail_new_terminal(monkeypatch):

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -5368,6 +5368,56 @@ class TestTerminalWindowHandlers:
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "error"
 
+    async def test_close_window_by_id(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        two_windows = [
+            {"id": "@0", "index": 0, "name": "bash", "active": True},
+            {"id": "@1", "index": 1, "name": "aux", "active": False},
+        ]
+        with (
+            patch.object(_mock_term, "list_windows", return_value=two_windows),
+            patch.object(
+                _mock_term,
+                "close_window",
+                return_value=[
+                    {"id": "@0", "index": 0, "name": "bash", "active": True}
+                ],
+            ),
+        ):
+            await conn.handle_terminal_close_window({"window_id": "@1"})
+            # Targeted the window by its stable id, not an index (#1965).
+            assert _mock_term.close_window.call_args[0][2] == "@1"
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "terminal_windows"
+
+    async def test_close_window_prefers_window_id(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        two_windows = [
+            {"id": "@0", "index": 0, "name": "bash", "active": True},
+            {"id": "@1", "index": 1, "name": "aux", "active": False},
+        ]
+        with (
+            patch.object(_mock_term, "list_windows", return_value=two_windows),
+            patch.object(
+                _mock_term,
+                "close_window",
+                return_value=[
+                    {"id": "@0", "index": 0, "name": "bash", "active": True}
+                ],
+            ),
+        ):
+            # Both present → window_id wins over index (#1965).
+            await conn.handle_terminal_close_window(
+                {"window_id": "@1", "index": 0}
+            )
+            assert _mock_term.close_window.call_args[0][2] == "@1"
+
     async def test_rename_window(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)


### PR DESCRIPTION
## Summary

Closes #1965.

The TUI's close/delete-terminal path targeted the tmux window by **index**, not its stable `@N` id — the same stale-selector class of bug #1954 / #1955 fixed for *selection*. With tmux `renumber-windows` off, `new-window` reuses the lowest freed index, so a stale TUI list could `kill-window` the **wrong** window. This routes the close path through the stable id, mirroring `select_window`'s `window_id` preference.

The server side was already ready — `terminal.close_window(container_id, session_name, target)` accepts an `@N` id and its docstring calls it "_preferred, globally unique_". No tmux-layer change.

## Changes

- **`wshandler/controllers.py`** `close_window`: prefer `msg["window_id"]` over `msg["index"]` (index kept as a back-compat fallback), mirroring `select_window` (`controllers.py:888`).
- **`cli/client.py`** `close_terminal(name, window_id)` / `_terminals`: the `terminal_close_window` wire message now carries `window_id`, not `index`.
- **`cli/tui/state.py`** `close_terminal(name, window_id)`: passes the id through.
- **`cli/tui/screens/workspace_detail.py`** `action_delete_terminal` / `_do_delete_terminal`: resolve the highlighted row to its `@N` id via `_window_id_for` (the helper added in #1955) before closing. A row whose id can't be resolved (stale list / contract violation), or a close that fails server-side (id gone), **refuses to close and refreshes the list** instead of risking the wrong window — same self-heal pattern selection now uses.

## Verification

- Full Python suite the CI way: **4062 passed, 100% coverage** (`-n auto`), no warnings.
- New/updated tests assert the **security property** at each layer:
  - **Client** (`test_cli.py`): `close_terminal` emits `terminal_close_window` with `window_id == "@1"` and **no** `index`.
  - **Server** (`test_wshandler.py`): `close_window` targets the `@N` id (`test_close_window_by_id`), and prefers `window_id` over `index` when both are present (`test_close_window_prefers_window_id`). The pre-existing `{"index": N}` tests still pass (back-compat fallback).
  - **TUI** (`test_tui.py`): a row whose window has no resolvable id refuses to close and refreshes (`test_detail_delete_terminal_refuses_when_id_unresolvable`); a close that fails server-side refreshes the list (`test_detail_delete_terminal_refreshes_on_server_failure`); existing delete tests updated to expect `@N` ids.
- E2E helper updated to close by `id`.

## Acceptance criteria (from #1965)

- [x] Closing targets the window by `@N` id, so a stale TUI list can't close the wrong window.
- [x] If the target id no longer exists server-side, close fails with a clear message and the TUI refreshes its list.
- [x] Tests assert the security property (id-based `kill-window` target, not stale index) plus the missing-id case.
- [x] Full Python suite passes with `-n auto`, 100% coverage.

Follow-up out of scope: none identified — this completes the index→id migration for both selection (#1954/#1955) and close (#1965).
