### PR TITLE
feat(netfilter): support macOS podman machine for egress filtering

### DIFF
--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -6,22 +6,23 @@ exfiltration vector. The filter is **opt-in** per workspace _and_ per
 deploy: a workspace with no `allowed_domains` keeps unrestricted outbound
 networking exactly as before.
 
-The mechanism uses OCI `createContainer` hooks — there is no proxy, no TLS
-interception, and no microVM. Each workspace that declares an allow-list
-gets iptables rules injected into its network namespace before its process
-starts.
+The mechanism uses OCI hooks — there is no proxy, no TLS interception, and
+no microVM. Each workspace that declares an allow-list gets iptables rules
+injected into its network namespace before its process starts.
 
 ## How it works
 
 1. A workspace carries an `allowed_domains` list (`host`, `host:port`,
    or IPv4 CIDR specs — see the [API](#api) section for the full grammar).
 2. On container start, if the deploy has enabled netfilter, the backend
-   passes `--annotation klangk.netfilter.rules=<host:port,...>` and
-   `--hooks-dir <dir>` to `podman create` (see the caveat below on
-   `--hooks-dir` overriding default hook dirs).
+   passes `--annotation klangk.netfilter.rules=<host:port,...>` to
+   `podman create`. On Linux it also passes `--hooks-dir <dir>` (see the
+   caveat below on `--hooks-dir` overriding default hook dirs); on macOS
+   the hook is installed inside the podman machine VM and discovered
+   automatically.
 3. The OCI hook (`klangk-netfilter.sh`, materialized by the backend into the
-   hooks dir) fires at `createContainer` time, reads the annotation from the
-   container state, resolves each host to IPs, and installs an iptables
+   hooks dir) fires at container-creation time, reads the annotation from
+   the container state, resolves each host to IPs, and installs an iptables
    ruleset in the container's network namespace (via `nsenter` on the init
    pid).
 4. The default `OUTPUT` policy is `DROP`; loopback, established
@@ -58,12 +59,11 @@ configuration is required for the common case.
    if either is absent the hook logs a warning and falls back to the
    other mechanism, but both should be present for defense-in-depth.)
 2. The hooks dir defaults to `<state_dir>/oci-hooks`
-   (`KLANGKD_STATE_DIR`/`oci-hooks`). Override
-   `KLANGKD_NETFILTER_HOOKS_DIR` only when the OCI runtime can't see
-   `state_dir` — a split runtime, a DinD outer container, or a
-   `podman machine` CoreOS VM (where it must be inside the VM, since
-   `podman machine` does not bind-mount arbitrary host paths the way
-   Docker Desktop does):
+   (`KLANGKD_STATE_DIR`/`oci-hooks`). On macOS the backend automatically
+   copies the hooks into the podman machine VM at startup — no manual
+   configuration is needed. Override `KLANGKD_NETFILTER_HOOKS_DIR` only
+   when the OCI runtime can't see `state_dir` on Linux — a split
+   runtime or a DinD outer container:
 
    ```bash
    export KLANGKD_NETFILTER_HOOKS_DIR=/var/lib/klangk/netfilter-hooks
@@ -554,29 +554,37 @@ netfilter_default_domains:
   permissive seccomp profile hands the entrypoint `iptables -F OUTPUT`,
   which flushes the ruleset and lets it exfiltrate freely. Do not run
   filtered workspaces privileged or grant `NET_ADMIN`.
-- **`--hooks-dir` overrides podman's default hook dirs.** Podman's
-  `--hooks-dir` flag _replaces_ (does not append to) the default OCI hook
-  search paths, so passing only klangk's hooks dir for a filtered
-  workspace would silently disable every _other_ `createContainer` hook
-  an operator relies on (monitoring, secrets injection, GPU, corporate
-  integrations). To avoid that, a filtered container passes klangk's hooks
-  dir **and** the two standard default dirs
-  (`/usr/share/containers/oci/hooks.d`, `/etc/containers/oci/hooks.d`),
-  preserving operator hooks. Podman tolerates a dir that doesn't exist (it
-  simply finds no hooks there). Limitation: a _non-standard_ hooks dir
-  configured only via `containers.conf` is still clobbered by an explicit
-  `--hooks-dir`; unrestricted workspaces are unaffected (the flag isn't
-  passed). See #1770.
+- **`--hooks-dir` overrides podman's default hook dirs (Linux only).**
+  On Linux, podman's `--hooks-dir` flag _replaces_ (does not append to)
+  the default OCI hook search paths, so passing only klangk's hooks dir
+  for a filtered workspace would silently disable every other
+  `createContainer` hook an operator relies on (monitoring, secrets
+  injection, GPU, corporate integrations). To avoid that, a filtered
+  container passes klangk's hooks dir **and** the two standard default
+  dirs (`/usr/share/containers/oci/hooks.d`,
+  `/etc/containers/oci/hooks.d`), preserving operator hooks. Podman
+  tolerates a dir that doesn't exist (it simply finds no hooks there).
+  Limitation: a _non-standard_ hooks dir configured only via
+  `containers.conf` is still clobbered by an explicit `--hooks-dir`;
+  unrestricted workspaces are unaffected (the flag isn't passed). On
+  macOS, `--hooks-dir` is not used (it is silently ignored by the remote
+  client); hooks are installed in the VM's standard hooks dir and
+  discovered automatically. See #1770.
 - **Port granularity.** A spec allows either all ports (`host`, or a
   CIDR like `10.0.0.0/8`) or a single TCP port (`host:port`, CIDR with
   `:port`). Port-only rules (allow a port to any host) are not
   supported — that would be an exfiltration channel.
-- **`macOS` hosts.** The `createContainer` hook runs inside the
-  container's Linux network namespace, never the macOS (XNU) kernel, so
-  `iptables` availability is not host-dependent. For the DinD deployment
-  there is no macOS-specific concern. For a native-on-mac deployment
-  driving `podman machine`, ensure the `--hooks-dir` path and
-  `klangk-netfilter.sh` are resolvable from inside the CoreOS VM.
+- **macOS hosts.** On macOS, podman runs inside a CoreOS VM via
+  `podman machine`. klangkd automatically copies the OCI hook script
+  and JSON into the VM at startup (via `podman machine ssh`), writes a
+  `containers.conf` drop-in so rootless podman discovers the hooks dir,
+  and uses `sudo` inside the hook for the `nsenter` calls that require
+  root (the Fedora CoreOS `core` user has passwordless `sudo`). No
+  manual configuration is needed — egress filtering works out of the
+  box on macOS. The hook runs inside the container's Linux network
+  namespace in the VM, never the macOS (XNU) kernel, so `iptables`
+  availability is not host-dependent. Run `klangkd doctor` to verify
+  that `iptables`, `nsenter`, and `getent` are available inside the VM.
 
 ## References
 

--- a/scripts/test-netfilter.sh
+++ b/scripts/test-netfilter.sh
@@ -128,8 +128,9 @@ EXPECT_SCRIPT
 }
 
 # Extract the __RESULT= value from shell_exec output.
+# Uses sed instead of grep -oP for macOS (BSD grep) portability.
 extract_result() {
-  grep -oP '__RESULT=\K\S+' <<<"$1" | tail -1
+  sed -n 's/.*__RESULT=\([^[:space:]]*\).*/\1/p' <<<"$1" | tail -1
 }
 
 record() {

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -391,6 +391,49 @@ def check_podman_machine() -> CheckResult:  # pragma: no cover
     )
 
 
+def check_netfilter_vm() -> CheckResult:  # pragma: no cover
+    """macOS: verify netfilter prerequisites inside the podman machine VM.
+
+    On macOS, podman runs in remote mode — the OCI runtime is inside
+    a CoreOS VM.  The netfilter hook needs iptables, nsenter, and getent
+    to be available inside the VM.  This check verifies they are present.
+    """
+    if platform.system() != "Darwin":
+        return CheckResult(
+            name="netfilter (VM)",
+            ok=True,
+            message="skipped on Linux (hooks run locally)",
+        )
+    rc, _out, _err = _run(
+        [
+            "podman",
+            "machine",
+            "ssh",
+            "command -v iptables && command -v nsenter && command -v getent",
+        ]
+    )
+    if rc != 0:
+        return CheckResult(
+            name="netfilter (VM)",
+            ok=False,
+            is_warning=True,
+            message=(
+                "iptables/nsenter/getent not all available in podman "
+                "machine VM"
+            ),
+            hint=(
+                "Egress filtering requires iptables, nsenter, and getent "
+                "inside the VM; install them via rpm-ostree or check your "
+                "podman machine image"
+            ),
+        )
+    return CheckResult(
+        name="netfilter (VM)",
+        ok=True,
+        message="netfilter dependencies available in podman machine VM",
+    )
+
+
 def check_rootless_podman() -> CheckResult:  # pragma: no cover
     """Verify rootless podman can actually run a container."""
     if not shutil.which("podman"):
@@ -471,6 +514,7 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
         report.add(check_subuid(user))
     else:  # pragma: no cover
         report.add(check_podman_machine())
+        report.add(check_netfilter_vm())
 
     # 3. Configuration checks
     report.add(check_podman_policy())

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -230,19 +230,26 @@ def render_rules_annotation(domains: list[str]) -> str:
     return ",".join(domains)
 
 
-def render_hook_json(script_path: str) -> str:
+def render_hook_json(
+    script_path: str, *, stage: str = "createContainer"
+) -> str:
     """Render the OCI hook JSON pointing at the absolute ``script_path``.
 
     The ``annotations`` map gates the hook to fire **only** for containers
     that carry :data:`ANNOTATION_KEY` — a workspace without the annotation
     (no allowed_domains) never triggers the hook, so it stays unrestricted.
+
+    ``stage`` is ``createContainer`` on Linux (the historical default —
+    rootful hooks receive a valid PID) and ``createRuntime`` on macOS
+    (podman machine's rootless API delivers ``pid: 0`` at
+    ``createContainer`` time, but a real PID at ``createRuntime``).
     """
     return json.dumps(
         {
             "version": "1.0.0",
             "hook": {"path": os.path.abspath(script_path)},
             "when": {"always": True},
-            "stages": ["createRuntime"],
+            "stages": [stage],
             "annotations": {ANNOTATION_KEY: ".*"},
         },
         indent=2,
@@ -622,7 +629,7 @@ class NetFilter:
         """
         vm_script = f"{VM_HOOKS_SCRIPT_DIR}/{HOOK_SCRIPT_NAME}"
         vm_json = f"{VM_HOOKS_JSON_DIR}/{HOOK_JSON_NAME}"
-        vm_hook_json = render_hook_json(vm_script)
+        vm_hook_json = render_hook_json(vm_script, stage="createRuntime")
 
         # Build an installer script piped through stdin to a single SSH
         # call.  The heredoc delimiters are quoted (no shell expansion)

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -43,7 +43,9 @@ import ipaddress
 import json
 import logging
 import os
+import platform
 import re
+import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +86,14 @@ STANDARD_HOOK_DIRS = (
     "/usr/share/containers/oci/hooks.d",
     "/etc/containers/oci/hooks.d",
 )
+
+# VM-internal paths for macOS (podman machine).  The hook JSON goes in a
+# standard OCI hooks dir so podman discovers it automatically (no
+# ``--hooks-dir`` needed — that flag is silently ignored in remote mode).
+# The script goes alongside it.  Both directories live under ``/etc/``
+# which is writable and persistent across reboots on Fedora CoreOS.
+VM_HOOKS_JSON_DIR = "/etc/containers/oci/hooks.d"
+VM_HOOKS_SCRIPT_DIR = "/etc/containers/hooks"
 
 # A hostname or IPv4 address with an optional trailing ``:port``.
 # Deliberately permissive on the host grammar — the hook does the real DNS
@@ -549,6 +559,11 @@ class NetFilter:
         upgrade ships the new script). Returns the dir, or ``None`` when
         netfilter is disabled. Failures are logged and the feature is left
         disabled rather than crashing startup.
+
+        On macOS the local copy is still written (so :meth:`enabled` /
+        :meth:`_hook_files_current` can validate without SSH), and the
+        hooks are additionally copied into the podman machine VM where
+        the OCI runtime can actually find them.
         """
         path = self.hooks_dir()
         if path is None:
@@ -569,11 +584,80 @@ class NetFilter:
                 exc,
             )
             return None
+        if platform.system() == "Darwin":
+            if not self._install_hooks_in_vm():
+                return None
         logger.info(
             "Netfilter egress filtering enabled: OCI hooks installed in %s",
             path,
         )
         return path
+
+    def _install_hooks_in_vm(self) -> bool:
+        """Copy hook files into the podman machine VM (macOS only).
+
+        On macOS, podman runs in remote mode — the OCI runtime is inside
+        a CoreOS VM and cannot see host filesystem paths.  Additionally,
+        ``--hooks-dir`` is silently ignored by the remote client, so the
+        hook JSON must be placed in a standard hooks dir that podman
+        discovers automatically.  The hook script is placed alongside it
+        under ``/etc/`` which is writable and persistent on Fedora CoreOS.
+
+        A single ``podman machine ssh`` call runs a shell script that
+        creates directories and writes both files, avoiding multiple
+        round-trips.
+        """
+        vm_script = f"{VM_HOOKS_SCRIPT_DIR}/{HOOK_SCRIPT_NAME}"
+        vm_json = f"{VM_HOOKS_JSON_DIR}/{HOOK_JSON_NAME}"
+        vm_hook_json = render_hook_json(vm_script)
+
+        # Build an installer script piped through stdin to a single SSH
+        # call.  The heredoc delimiters are quoted (no shell expansion)
+        # and unique enough to avoid collisions with file contents.
+        installer = (
+            "set -e\n"
+            f"mkdir -p {VM_HOOKS_SCRIPT_DIR} {VM_HOOKS_JSON_DIR}\n"
+            f"cat > {vm_script} << 'KLANGK_SCRIPT_EOF'\n"
+            f"{HOOK_SCRIPT}"  # ends with \n
+            "KLANGK_SCRIPT_EOF\n"
+            f"chmod 755 {vm_script}\n"
+            f"cat > {vm_json} << 'KLANGK_JSON_EOF'\n"
+            f"{vm_hook_json}\n"
+            "KLANGK_JSON_EOF\n"
+        )
+
+        podman = self.app.state.settings.podman_bin or "podman"
+        try:
+            result = subprocess.run(
+                [podman, "machine", "ssh", "sudo", "sh", "-s"],
+                input=installer,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                logger.error(
+                    "Could not install netfilter hooks into podman machine "
+                    "VM (exit %d): %s "
+                    "(per-workspace egress filtering is disabled on macOS)",
+                    result.returncode,
+                    result.stderr.strip(),
+                )
+                return False
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.error(
+                "Could not install netfilter hooks into podman machine "
+                "VM: %s (per-workspace egress filtering is disabled on "
+                "macOS)",
+                exc,
+            )
+            return False
+        logger.info(
+            "Netfilter hooks installed in podman machine VM: %s and %s",
+            vm_script,
+            vm_json,
+        )
+        return True
 
     def create_kwargs(
         self, allowed_domains: list[str] | None
@@ -635,8 +719,12 @@ class NetFilter:
             )
             return None, None, None
         annotation = {ANNOTATION_KEY: render_rules_annotation(domains)}
-        return (
-            annotation,
-            [path, *STANDARD_HOOK_DIRS],
-            list(DROPPED_CAPABILITIES),
+        # macOS: ``--hooks-dir`` is silently ignored in remote mode.
+        # Hooks are in the standard dir inside the VM (installed by
+        # ``_install_hooks_in_vm``), discovered automatically by podman.
+        hooks_dirs = (
+            None
+            if platform.system() == "Darwin"
+            else [path, *STANDARD_HOOK_DIRS]
         )
+        return (annotation, hooks_dirs, list(DROPPED_CAPABILITIES))

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -241,8 +241,8 @@ def render_hook_json(script_path: str) -> str:
         {
             "version": "1.0.0",
             "hook": {"path": os.path.abspath(script_path)},
-            "when": {"always": 1},
-            "stages": ["createContainer"],
+            "when": {"always": True},
+            "stages": ["createRuntime"],
             "annotations": {ANNOTATION_KEY: ".*"},
         },
         indent=2,
@@ -284,16 +284,25 @@ pid=$(printf '%s' "$state" \
 [ -n "$pid" ] || exit 0
 [ -e "/proc/$pid/ns/net" ] || exit 0
 
+# Rootless podman (macOS podman machine): nsenter into another user's
+# network namespace requires root.  The core user on Fedora CoreOS has
+# passwordless sudo; on a rootful deploy (Linux host) we're already root
+# and SUDO is empty — no behavioral change.
+SUDO=
+if [ "$(id -u)" != "0" ]; then
+    SUDO="sudo"
+fi
+
 # iptables / ip6tables inside the container's network namespace. Failures
 # are logged to stderr (captured by the OCI runtime) but do not abort the
 # hook — the default-DROP policy below is the fail-closed posture for a
 # misconfigured deploy, and a partial ruleset is still better than none.
 ipt() {
-    nsenter --net="/proc/$pid/ns/net" iptables "$@" || \
+    $SUDO nsenter --net="/proc/$pid/ns/net" iptables "$@" || \
         echo "klangk-netfilter: iptables $* failed" >&2
 }
 ipt6() {
-    nsenter --net="/proc/$pid/ns/net" ip6tables "$@" || \
+    $SUDO nsenter --net="/proc/$pid/ns/net" ip6tables "$@" || \
         echo "klangk-netfilter: ip6tables $* failed" >&2
 }
 
@@ -379,7 +388,7 @@ ipt -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 #      even if the sysctl write fails (ip6tables missing, or the knob not
 #      writable). Each failure is logged, not fatal — together they close
 #      the v6 bypass; neither alone is fully trustworthy on every deploy.
-nsenter --net="/proc/$pid/ns/net" sysctl -qw \
+$SUDO nsenter --net="/proc/$pid/ns/net" sysctl -qw \
     net.ipv6.conf.all.disable_ipv6=1 \
     net.ipv6.conf.default.disable_ipv6=1 2>/dev/null || \
     echo "klangk-netfilter: sysctl ipv6 disable failed (relying on ip6tables DROP)" >&2
@@ -599,12 +608,16 @@ class NetFilter:
         On macOS, podman runs in remote mode — the OCI runtime is inside
         a CoreOS VM and cannot see host filesystem paths.  Additionally,
         ``--hooks-dir`` is silently ignored by the remote client, so the
-        hook JSON must be placed in a standard hooks dir that podman
-        discovers automatically.  The hook script is placed alongside it
-        under ``/etc/`` which is writable and persistent on Fedora CoreOS.
+        hook JSON must be placed in a hooks dir that podman discovers.
+
+        Rootless podman does **not** check any hooks directory by default
+        (``oci-hooks(5)``), so the installer also writes a
+        ``containers.conf`` drop-in that adds the hooks dir to the
+        rootless user's config.  Both hooks and config live under
+        ``/etc/`` which is writable and persistent on Fedora CoreOS.
 
         A single ``podman machine ssh`` call runs a shell script that
-        creates directories and writes both files, avoiding multiple
+        creates directories and writes all files, avoiding multiple
         round-trips.
         """
         vm_script = f"{VM_HOOKS_SCRIPT_DIR}/{HOOK_SCRIPT_NAME}"
@@ -624,6 +637,17 @@ class NetFilter:
             f"cat > {vm_json} << 'KLANGK_JSON_EOF'\n"
             f"{vm_hook_json}\n"
             "KLANGK_JSON_EOF\n"
+            # Rootless podman has NO default hooks dir (oci-hooks(5)):
+            # without a containers.conf entry the hook is never found.
+            # Write a system-wide drop-in so every user (including the
+            # rootless ``core`` user that podman machine runs as) picks
+            # it up.
+            "mkdir -p /etc/containers/containers.conf.d\n"
+            "cat > /etc/containers/containers.conf.d/klangk-hooks.conf"
+            " << 'KLANGK_CONF_EOF'\n"
+            "[engine]\n"
+            f'hooks_dir = ["{VM_HOOKS_JSON_DIR}"]\n'
+            "KLANGK_CONF_EOF\n"
         )
 
         podman = self.app.state.settings.podman_bin or "podman"

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -197,9 +197,11 @@ def start_server(
     :func:`ws_connect`. Pass the handle to :func:`stop_server` for teardown.
     """
     if data_dir is None:
-        data_dir = tempfile.mkdtemp(prefix="klangk-e2e-")
+        data_dir = os.path.realpath(tempfile.mkdtemp(prefix="klangk-e2e-"))
     if state_dir is None:
-        state_dir = tempfile.mkdtemp(prefix="klangk-e2e-state-")
+        state_dir = os.path.realpath(
+            tempfile.mkdtemp(prefix="klangk-e2e-state-")
+        )
 
     overrides = dict(env_overrides)
     overrides.setdefault("KLANGKD_DATA_DIR", data_dir)

--- a/src/klangk/klangkd-tests/e2e-tests/test_netfilter_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_netfilter_e2e.py
@@ -139,42 +139,44 @@ def _wait_for_container(workspace_id, instance_id, timeout=60):
 def _get_iptables(cid, *, v6=False, verbose=False):
     """Get iptables OUTPUT chain listing for a container.
 
-    Runs nsenter from the host (Linux) or via podman machine ssh (macOS)
-    to check iptables in the container's network namespace.  The workspace
-    image may not have iptables installed, so we never exec inside the
-    container itself.
+    On macOS, the workspace image may lack iptables, so we check from
+    outside via ``podman machine ssh`` + ``nsenter``.  On Linux,
+    ``podman exec`` is the most reliable way to inspect the container's
+    netns (rootless PID namespaces make host-side ``nsenter`` fragile).
 
     Returns (ok, output) where ok=False means iptables is unavailable.
     """
     cmd_name = "ip6tables" if v6 else "iptables"
-    pid_result = subprocess.run(
-        ["podman", "inspect", cid, "--format", "{{.State.Pid}}"],
-        capture_output=True,
-        text=True,
-    )
-    pid = pid_result.stdout.strip()
-    if not pid or pid == "0":
-        return False, "container PID not available"
 
-    v_flag = " -v" if verbose else ""
-    nsenter_cmd = (
-        f"nsenter --net=/proc/{pid}/ns/net {cmd_name} -L OUTPUT -n{v_flag}"
-    )
     if platform.system() == "Darwin":
+        # macOS: nsenter from inside the VM (the container image may
+        # lack iptables, but the VM has it).
+        pid_result = subprocess.run(
+            ["podman", "inspect", cid, "--format", "{{.State.Pid}}"],
+            capture_output=True,
+            text=True,
+        )
+        pid = pid_result.stdout.strip()
+        if not pid or pid == "0":
+            return False, "container PID not available"
+        v_flag = " -v" if verbose else ""
+        nsenter_cmd = (
+            f"nsenter --net=/proc/{pid}/ns/net {cmd_name} -L OUTPUT -n{v_flag}"
+        )
         cmd = ["podman", "machine", "ssh", f"sudo {nsenter_cmd}"]
     else:
-        parts = [
-            "sudo",
-            "nsenter",
-            f"--net=/proc/{pid}/ns/net",
+        # Linux: podman exec is reliable on rootless podman.
+        v_flag = ["-v"] if verbose else []
+        cmd = [
+            "podman",
+            "exec",
+            cid,
             cmd_name,
             "-L",
             "OUTPUT",
             "-n",
+            *v_flag,
         ]
-        if verbose:
-            parts.append("-v")
-        cmd = parts
 
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:

--- a/src/klangk/klangkd-tests/e2e-tests/test_netfilter_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_netfilter_e2e.py
@@ -1,0 +1,289 @@
+"""End-to-end tests for per-workspace egress filtering (#1365, #1959).
+
+Verifies that the netfilter OCI hook fires at container creation time and
+installs iptables rules in the container's network namespace.  On macOS
+(podman machine), the hooks are installed inside the VM by
+``_install_hooks_in_vm()``; on Linux, they are written to the host
+filesystem.  Either way, the observable behavior is the same: a filtered
+container has an OUTPUT DROP policy + per-destination ACCEPT rules.
+
+These tests do NOT verify *enforcement* (actually blocking traffic) —
+that requires real DNS and remote hosts.  They verify the *mechanism*:
+the hook fires, iptables rules are present, and the OUTPUT policy is
+DROP.  ``scripts/test-netfilter.sh`` is the manual enforcement test.
+
+Requires: podman available (rootless on Linux, podman machine on macOS),
+klangk workspace image built, iptables available inside the container.
+
+Run with: devenv shell -- test-backend-e2e test_netfilter_e2e.py
+"""
+
+import subprocess
+import time
+
+import pytest
+
+from _e2e_server import start_server, stop_server
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Start a real klangkd server with netfilter enabled (the default)."""
+    server = start_server(
+        KLANGKD_JWT_SECRET="netfilter-e2e-secret",
+        KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGKD_DEFAULT_USER="test@example.com",
+        KLANGKD_DEFAULT_PASSWORD="testpass",
+        KLANGKD_TEST_MODE="1",
+        KLANGKD_IDLE_TIMEOUT_SECONDS="300",
+        KLANGKD_ALLOW_AUTOSTART="1",
+        # netfilter_enabled defaults True; no need to set it explicitly.
+        LOGFIRE_TOKEN="",
+        KLANGKD_LLM_BASE_URL="",
+        KLANGKD_LLM_API_KEY="",
+        KLANGKD_LLM_MODEL="",
+    )
+    config_resp = server["client"].get("/api/v1/config", timeout=10)
+    server["instance_id"] = (
+        config_resp.json().get("instance_id", "")
+        if config_resp.status_code == 200
+        else ""
+    )
+    yield server
+    stop_server(server)
+
+
+@pytest.fixture(scope="module")
+def auth(server):
+    resp = server["client"].post(
+        "/api/v1/auth/login",
+        json={"identifier": "test@example.com", "password": "testpass"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+_ws_counter = 0
+
+
+def _create_workspace(server, auth, *, allowed_domains=None):
+    """Create an auto-started workspace; return (workspace_id, cleanup)."""
+    global _ws_counter  # noqa: PLW0603
+    _ws_counter += 1
+    name = f"nf-e2e-{_ws_counter}"
+    body = {
+        "name": name,
+        "auto_start": True,
+        "setup_state": "complete",
+    }
+    if allowed_domains is not None:
+        body["allowed_domains"] = allowed_domains
+    client = server["client"]
+    resp = client.post(
+        "/api/v1/workspaces",
+        headers=auth,
+        json=body,
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"create workspace failed: {resp.text}"
+    workspace_id = resp.json()["id"]
+
+    def cleanup():
+        try:
+            client.post(
+                f"/api/v1/workspaces/{workspace_id}/stop",
+                headers=auth,
+                timeout=30,
+            )
+        except Exception:
+            pass
+        try:
+            client.delete(
+                f"/api/v1/workspaces/{workspace_id}",
+                headers=auth,
+                timeout=30,
+            )
+        except Exception:
+            pass
+
+    return workspace_id, cleanup
+
+
+def _wait_for_container(workspace_id, instance_id, timeout=60):
+    """Wait for the workspace container to appear; return its id."""
+    name = f"klangk-{instance_id}-{workspace_id[:12]}"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ["podman", "ps", "--filter", f"name=^{name}$", "-q"],
+            capture_output=True,
+            text=True,
+        )
+        cids = [c for c in result.stdout.strip().split() if c]
+        if cids:
+            return cids[0]
+        time.sleep(0.5)
+    raise AssertionError(
+        f"container for workspace {workspace_id} did not appear "
+        f"within {timeout}s"
+    )
+
+
+def _container_exec(cid, command, timeout=30):
+    """Run a command in a container; return (returncode, stdout)."""
+    result = subprocess.run(
+        ["podman", "exec", cid, "bash", "-c", command],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.returncode, result.stdout
+
+
+class TestNetfilterE2E:
+    """Verify the netfilter OCI hook fires and installs iptables rules.
+
+    Uses auto_start=True + ``podman exec`` (rather than the WS exec
+    path) so the test exercises the OCI hook → container lifecycle
+    end-to-end without needing a WebSocket chat session.
+    """
+
+    def test_filtered_container_has_drop_policy(self, server, auth):
+        """A workspace with allowed_domains gets an OUTPUT DROP policy.
+
+        This is the fundamental netfilter contract: the hook fires at
+        container creation, sets OUTPUT policy to DROP, and adds ACCEPT
+        rules for the allowed destinations.  If this fails, the hook
+        didn't fire (the container started unrestricted).
+        """
+        workspace_id, cleanup = _create_workspace(
+            server, auth, allowed_domains=["github.com:443"]
+        )
+        try:
+            cid = _wait_for_container(workspace_id, server["instance_id"])
+            rc, output = _container_exec(
+                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
+            )
+            if "UNAVAILABLE" in output:
+                pytest.skip("iptables not available inside the container")
+            first_line = output.strip().split("\n")[0]
+            assert "DROP" in first_line, (
+                f"OUTPUT policy is not DROP — the netfilter hook did not "
+                f"fire.\niptables output:\n{output}"
+            )
+        finally:
+            cleanup()
+
+    def test_filtered_container_has_accept_rules(self, server, auth):
+        """A filtered container has ACCEPT rules for allowed destinations.
+
+        The hook resolves allowed_domains to IPs and adds per-IP ACCEPT
+        rules.  We check that at least one ACCEPT rule with dpt:443
+        exists (from the github.com:443 spec).
+        """
+        workspace_id, cleanup = _create_workspace(
+            server, auth, allowed_domains=["github.com:443"]
+        )
+        try:
+            cid = _wait_for_container(workspace_id, server["instance_id"])
+            rc, output = _container_exec(
+                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
+            )
+            if "UNAVAILABLE" in output:
+                pytest.skip("iptables not available inside the container")
+            lines = output.strip().split("\n")
+            accept_443 = [
+                ln for ln in lines if "ACCEPT" in ln and "dpt:443" in ln
+            ]
+            assert accept_443, (
+                f"No ACCEPT rule for dpt:443 found — the hook didn't "
+                f"install per-destination rules.\n"
+                f"iptables output:\n{output}"
+            )
+        finally:
+            cleanup()
+
+    def test_filtered_container_allows_loopback(self, server, auth):
+        """Loopback traffic is always allowed in a filtered container."""
+        workspace_id, cleanup = _create_workspace(
+            server, auth, allowed_domains=["github.com:443"]
+        )
+        try:
+            cid = _wait_for_container(workspace_id, server["instance_id"])
+            rc, output = _container_exec(
+                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
+            )
+            if "UNAVAILABLE" in output:
+                pytest.skip("iptables not available inside the container")
+            assert any(
+                "ACCEPT" in ln and "lo" in ln
+                for ln in output.strip().split("\n")
+            ), f"No loopback ACCEPT rule found.\niptables output:\n{output}"
+        finally:
+            cleanup()
+
+    def test_unfiltered_container_has_accept_policy(self, server, auth):
+        """A workspace without allowed_domains has the default ACCEPT policy.
+
+        The hook should NOT fire for an unfiltered workspace (the hook
+        JSON's annotation filter gates on the annotation's presence).
+        """
+        workspace_id, cleanup = _create_workspace(server, auth)
+        try:
+            cid = _wait_for_container(workspace_id, server["instance_id"])
+            rc, output = _container_exec(
+                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
+            )
+            if "UNAVAILABLE" in output:
+                pytest.skip("iptables not available inside the container")
+            first_line = output.strip().split("\n")[0]
+            assert "ACCEPT" in first_line, (
+                f"Unfiltered workspace should have OUTPUT ACCEPT policy, "
+                f"got: {first_line}"
+            )
+        finally:
+            cleanup()
+
+    def test_filtered_container_drops_ipv6(self, server, auth):
+        """IPv6 OUTPUT policy is DROP in a filtered container (#1936)."""
+        workspace_id, cleanup = _create_workspace(
+            server, auth, allowed_domains=["github.com:443"]
+        )
+        try:
+            cid = _wait_for_container(workspace_id, server["instance_id"])
+            rc, output = _container_exec(
+                cid,
+                "ip6tables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE",
+            )
+            if "UNAVAILABLE" in output:
+                pytest.skip("ip6tables not available inside the container")
+            first_line = output.strip().split("\n")[0]
+            assert "DROP" in first_line, (
+                f"IPv6 OUTPUT policy should be DROP, got: {first_line}"
+            )
+        finally:
+            cleanup()
+
+    def test_netfilter_with_cidr_spec(self, server, auth):
+        """A CIDR spec (10.0.0.0/8) is installed as an iptables range rule."""
+        workspace_id, cleanup = _create_workspace(
+            server, auth, allowed_domains=["10.0.0.0/8"]
+        )
+        try:
+            cid = _wait_for_container(workspace_id, server["instance_id"])
+            rc, output = _container_exec(
+                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
+            )
+            if "UNAVAILABLE" in output:
+                pytest.skip("iptables not available inside the container")
+            assert any(
+                "ACCEPT" in ln and "10.0.0.0/8" in ln
+                for ln in output.strip().split("\n")
+            ), (
+                f"No ACCEPT rule for CIDR 10.0.0.0/8 found.\n"
+                f"iptables output:\n{output}"
+            )
+        finally:
+            cleanup()

--- a/src/klangk/klangkd-tests/e2e-tests/test_netfilter_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_netfilter_e2e.py
@@ -7,17 +7,22 @@ installs iptables rules in the container's network namespace.  On macOS
 filesystem.  Either way, the observable behavior is the same: a filtered
 container has an OUTPUT DROP policy + per-destination ACCEPT rules.
 
+The iptables check runs via ``nsenter`` from the host (Linux) or from
+inside the VM (macOS via ``podman machine ssh``) because the workspace
+container image may not have ``iptables`` installed.
+
 These tests do NOT verify *enforcement* (actually blocking traffic) —
 that requires real DNS and remote hosts.  They verify the *mechanism*:
 the hook fires, iptables rules are present, and the OUTPUT policy is
 DROP.  ``scripts/test-netfilter.sh`` is the manual enforcement test.
 
 Requires: podman available (rootless on Linux, podman machine on macOS),
-klangk workspace image built, iptables available inside the container.
+klangk workspace image built.
 
 Run with: devenv shell -- test-backend-e2e test_netfilter_e2e.py
 """
 
+import platform
 import subprocess
 import time
 
@@ -131,23 +136,58 @@ def _wait_for_container(workspace_id, instance_id, timeout=60):
     )
 
 
-def _container_exec(cid, command, timeout=30):
-    """Run a command in a container; return (returncode, stdout)."""
-    result = subprocess.run(
-        ["podman", "exec", cid, "bash", "-c", command],
+def _get_iptables(cid, *, v6=False, verbose=False):
+    """Get iptables OUTPUT chain listing for a container.
+
+    Runs nsenter from the host (Linux) or via podman machine ssh (macOS)
+    to check iptables in the container's network namespace.  The workspace
+    image may not have iptables installed, so we never exec inside the
+    container itself.
+
+    Returns (ok, output) where ok=False means iptables is unavailable.
+    """
+    cmd_name = "ip6tables" if v6 else "iptables"
+    pid_result = subprocess.run(
+        ["podman", "inspect", cid, "--format", "{{.State.Pid}}"],
         capture_output=True,
         text=True,
-        timeout=timeout,
     )
-    return result.returncode, result.stdout
+    pid = pid_result.stdout.strip()
+    if not pid or pid == "0":
+        return False, "container PID not available"
+
+    v_flag = " -v" if verbose else ""
+    nsenter_cmd = (
+        f"nsenter --net=/proc/{pid}/ns/net {cmd_name} -L OUTPUT -n{v_flag}"
+    )
+    if platform.system() == "Darwin":
+        cmd = ["podman", "machine", "ssh", f"sudo {nsenter_cmd}"]
+    else:
+        parts = [
+            "sudo",
+            "nsenter",
+            f"--net=/proc/{pid}/ns/net",
+            cmd_name,
+            "-L",
+            "OUTPUT",
+            "-n",
+        ]
+        if verbose:
+            parts.append("-v")
+        cmd = parts
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        return False, result.stderr
+    return True, result.stdout
 
 
 class TestNetfilterE2E:
     """Verify the netfilter OCI hook fires and installs iptables rules.
 
-    Uses auto_start=True + ``podman exec`` (rather than the WS exec
-    path) so the test exercises the OCI hook → container lifecycle
-    end-to-end without needing a WebSocket chat session.
+    Uses auto_start=True and checks iptables from outside the container
+    via nsenter (not from inside, since the workspace image may lack
+    iptables).
     """
 
     def test_filtered_container_has_drop_policy(self, server, auth):
@@ -163,11 +203,9 @@ class TestNetfilterE2E:
         )
         try:
             cid = _wait_for_container(workspace_id, server["instance_id"])
-            rc, output = _container_exec(
-                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
-            )
-            if "UNAVAILABLE" in output:
-                pytest.skip("iptables not available inside the container")
+            ok, output = _get_iptables(cid)
+            if not ok:
+                pytest.skip(f"iptables not available: {output}")
             first_line = output.strip().split("\n")[0]
             assert "DROP" in first_line, (
                 f"OUTPUT policy is not DROP — the netfilter hook did not "
@@ -188,11 +226,9 @@ class TestNetfilterE2E:
         )
         try:
             cid = _wait_for_container(workspace_id, server["instance_id"])
-            rc, output = _container_exec(
-                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
-            )
-            if "UNAVAILABLE" in output:
-                pytest.skip("iptables not available inside the container")
+            ok, output = _get_iptables(cid)
+            if not ok:
+                pytest.skip(f"iptables not available: {output}")
             lines = output.strip().split("\n")
             accept_443 = [
                 ln for ln in lines if "ACCEPT" in ln and "dpt:443" in ln
@@ -206,17 +242,22 @@ class TestNetfilterE2E:
             cleanup()
 
     def test_filtered_container_allows_loopback(self, server, auth):
-        """Loopback traffic is always allowed in a filtered container."""
+        """Loopback traffic is always allowed in a filtered container.
+
+        The hook's ``-A OUTPUT -o lo -j ACCEPT`` rule shows up in
+        ``iptables -L -n -v`` with interface ``lo``, but in the compact
+        ``-L -n`` output it appears as an ACCEPT with 0.0.0.0/0 → 0.0.0.0/0
+        and no further match criteria (the first rule after the policy).
+        Use ``-L -n -v`` to see the interface column.
+        """
         workspace_id, cleanup = _create_workspace(
             server, auth, allowed_domains=["github.com:443"]
         )
         try:
             cid = _wait_for_container(workspace_id, server["instance_id"])
-            rc, output = _container_exec(
-                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
-            )
-            if "UNAVAILABLE" in output:
-                pytest.skip("iptables not available inside the container")
+            ok, output = _get_iptables(cid, verbose=True)
+            if not ok:
+                pytest.skip(f"iptables not available: {output}")
             assert any(
                 "ACCEPT" in ln and "lo" in ln
                 for ln in output.strip().split("\n")
@@ -233,11 +274,9 @@ class TestNetfilterE2E:
         workspace_id, cleanup = _create_workspace(server, auth)
         try:
             cid = _wait_for_container(workspace_id, server["instance_id"])
-            rc, output = _container_exec(
-                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
-            )
-            if "UNAVAILABLE" in output:
-                pytest.skip("iptables not available inside the container")
+            ok, output = _get_iptables(cid)
+            if not ok:
+                pytest.skip(f"iptables not available: {output}")
             first_line = output.strip().split("\n")[0]
             assert "ACCEPT" in first_line, (
                 f"Unfiltered workspace should have OUTPUT ACCEPT policy, "
@@ -253,12 +292,9 @@ class TestNetfilterE2E:
         )
         try:
             cid = _wait_for_container(workspace_id, server["instance_id"])
-            rc, output = _container_exec(
-                cid,
-                "ip6tables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE",
-            )
-            if "UNAVAILABLE" in output:
-                pytest.skip("ip6tables not available inside the container")
+            ok, output = _get_iptables(cid, v6=True)
+            if not ok:
+                pytest.skip(f"ip6tables not available: {output}")
             first_line = output.strip().split("\n")[0]
             assert "DROP" in first_line, (
                 f"IPv6 OUTPUT policy should be DROP, got: {first_line}"
@@ -273,11 +309,9 @@ class TestNetfilterE2E:
         )
         try:
             cid = _wait_for_container(workspace_id, server["instance_id"])
-            rc, output = _container_exec(
-                cid, "iptables -L OUTPUT -n 2>/dev/null || echo UNAVAILABLE"
-            )
-            if "UNAVAILABLE" in output:
-                pytest.skip("iptables not available inside the container")
+            ok, output = _get_iptables(cid)
+            if not ok:
+                pytest.skip(f"iptables not available: {output}")
             assert any(
                 "ACCEPT" in ln and "10.0.0.0/8" in ln
                 for ln in output.strip().split("\n")

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -6,6 +6,7 @@ import shutil
 import stat
 import subprocess
 import types
+from unittest import mock
 
 import pytest
 
@@ -269,10 +270,14 @@ class TestNetFilterCreateKwargs:
         assert any("UNRESTRICTED" in r.message for r in caplog.records)
 
     def test_domains_with_hooks_dir_returns_annotation_path_and_cap_drop(
-        self, tmp_path
+        self, tmp_path, monkeypatch
     ):
         path = str(tmp_path / "hooks")
         nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        # Patch to Linux so install_hooks() doesn't try SSH and
+        # create_kwargs() returns hooks_dirs (the Linux behavior this test
+        # was written for; macOS-specific behavior is tested separately).
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
         nf_obj.install_hooks()  # arm the hook so create_kwargs trusts the dir
         ann, hooks, cap_drop = nf_obj.create_kwargs(
             ["github.com:443", "pypi.org"]
@@ -297,11 +302,14 @@ class TestNetFilterCreateKwargs:
         assert ann == {nf.ANNOTATION_KEY: "ws.com:443"}
         assert cap_drop == ["NET_ADMIN"]
 
-    def test_empty_workspace_inherits_deploy_default(self, tmp_path):
+    def test_empty_workspace_inherits_deploy_default(
+        self, tmp_path, monkeypatch
+    ):
         path = str(tmp_path / "hooks")
         nf_obj = nf.NetFilter(
             _app(hooks_dir=path, default_domains=["default.com", "a.io"])
         )
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
         nf_obj.install_hooks()
         ann, hooks, _ = nf_obj.create_kwargs(None)
         assert ann == {nf.ANNOTATION_KEY: "default.com,a.io"}
@@ -918,3 +926,146 @@ class TestHookScriptExecutable:
         assert _accept_rules(calls) == [
             ["-A", "OUTPUT", "-d", "10.5.0.0/8", "-j", "ACCEPT"],
         ]
+
+
+# --- macOS / podman machine support (#1959) ---
+
+
+class TestInstallHooksInVM:
+    """Tests for _install_hooks_in_vm (macOS podman machine hook install)."""
+
+    def test_install_hooks_calls_vm_installer_on_darwin(self, tmp_path):
+        # On macOS, install_hooks() copies hooks into the VM after the
+        # local write.
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        with mock.patch(
+            "klangk.netfilter.platform.system", return_value="Darwin"
+        ):
+            with mock.patch.object(
+                nf_obj, "_install_hooks_in_vm", return_value=True
+            ) as m:
+                result = nf_obj.install_hooks()
+        assert result == os.path.realpath(path)
+        m.assert_called_once()
+
+    def test_install_hooks_returns_none_when_vm_install_fails(self, tmp_path):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        with mock.patch(
+            "klangk.netfilter.platform.system", return_value="Darwin"
+        ):
+            with mock.patch.object(
+                nf_obj, "_install_hooks_in_vm", return_value=False
+            ):
+                result = nf_obj.install_hooks()
+        assert result is None
+
+    def test_install_hooks_skips_vm_on_linux(self, tmp_path):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        with mock.patch(
+            "klangk.netfilter.platform.system", return_value="Linux"
+        ):
+            with mock.patch.object(nf_obj, "_install_hooks_in_vm") as m:
+                result = nf_obj.install_hooks()
+        assert result == os.path.realpath(path)
+        m.assert_not_called()
+
+    def test_vm_installer_runs_podman_machine_ssh(self, tmp_path):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        completed = subprocess.CompletedProcess(args=[], returncode=0)
+        with mock.patch(
+            "klangk.netfilter.subprocess.run", return_value=completed
+        ) as m:
+            assert nf_obj._install_hooks_in_vm() is True
+        m.assert_called_once()
+        args = m.call_args
+        cmd = args[0][0]
+        assert cmd[0] == "podman"
+        assert cmd[1] == "machine"
+        assert cmd[2] == "ssh"
+        # The installer script is piped via stdin
+        installer = args[1].get("input") or args.kwargs.get("input")
+        assert "klangk-netfilter.sh" in installer
+        assert "klangk-netfilter.json" in installer
+        # VM paths, not host paths
+        assert nf.VM_HOOKS_SCRIPT_DIR in installer
+        assert nf.VM_HOOKS_JSON_DIR in installer
+
+    def test_vm_installer_logs_error_on_ssh_failure(self, tmp_path, caplog):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=1, stderr="connection refused"
+        )
+        with mock.patch(
+            "klangk.netfilter.subprocess.run", return_value=completed
+        ):
+            with caplog.at_level("ERROR"):
+                assert nf_obj._install_hooks_in_vm() is False
+        assert any("podman machine" in r.message for r in caplog.records)
+
+    def test_vm_installer_handles_timeout(self, tmp_path, caplog):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        with mock.patch(
+            "klangk.netfilter.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="podman", timeout=30),
+        ):
+            with caplog.at_level("ERROR"):
+                assert nf_obj._install_hooks_in_vm() is False
+        assert any("podman machine" in r.message for r in caplog.records)
+
+    def test_vm_hook_json_points_to_vm_script_path(self, tmp_path):
+        # The hook JSON written into the VM must reference the VM-internal
+        # script path, not the macOS host path.
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        completed = subprocess.CompletedProcess(args=[], returncode=0)
+        with mock.patch(
+            "klangk.netfilter.subprocess.run", return_value=completed
+        ) as m:
+            nf_obj._install_hooks_in_vm()
+        installer = m.call_args[1].get("input") or m.call_args.kwargs.get(
+            "input"
+        )
+        vm_script_path = f"{nf.VM_HOOKS_SCRIPT_DIR}/{nf.HOOK_SCRIPT_NAME}"
+        expected_json = nf.render_hook_json(vm_script_path)
+        assert expected_json in installer
+
+
+class TestCreateKwargsMacOS:
+    """Tests for create_kwargs macOS behavior (#1959)."""
+
+    def test_macos_omits_hooks_dirs(self, tmp_path):
+        # On macOS, --hooks-dir is silently ignored in remote mode.
+        # create_kwargs must return None for hooks_dirs.
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        nf_obj.install_hooks()
+        with mock.patch(
+            "klangk.netfilter.platform.system", return_value="Darwin"
+        ):
+            ann, hooks_dirs, cap_drop = nf_obj.create_kwargs(
+                ["github.com:443"]
+            )
+        assert ann is not None
+        assert hooks_dirs is None
+        assert cap_drop == ["NET_ADMIN"]
+
+    def test_linux_includes_hooks_dirs(self, tmp_path):
+        # On Linux, hooks_dirs includes the klangk dir + standard dirs.
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        nf_obj.install_hooks()
+        with mock.patch(
+            "klangk.netfilter.platform.system", return_value="Linux"
+        ):
+            ann, hooks_dirs, cap_drop = nf_obj.create_kwargs(
+                ["github.com:443"]
+            )
+        assert ann is not None
+        assert hooks_dirs == [os.path.realpath(path), *nf.STANDARD_HOOK_DIRS]
+        assert cap_drop == ["NET_ADMIN"]

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -168,7 +168,7 @@ class TestRenderHookJson:
         script = str(tmp_path / "klangk-netfilter.sh")
         data = json.loads(nf.render_hook_json(script))
         assert data["hook"]["path"] == os.path.abspath(script)
-        assert data["stages"] == ["createContainer"]
+        assert data["stages"] == ["createRuntime"]
         # The annotations gate makes the hook fire ONLY for containers
         # that carry the annotation — an unrestricted workspace is never
         # filtered.

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -168,7 +168,7 @@ class TestRenderHookJson:
         script = str(tmp_path / "klangk-netfilter.sh")
         data = json.loads(nf.render_hook_json(script))
         assert data["hook"]["path"] == os.path.abspath(script)
-        assert data["stages"] == ["createRuntime"]
+        assert data["stages"] == ["createContainer"]
         # The annotations gate makes the hook fire ONLY for containers
         # that carry the annotation — an unrestricted workspace is never
         # filtered.
@@ -1032,7 +1032,9 @@ class TestInstallHooksInVM:
             "input"
         )
         vm_script_path = f"{nf.VM_HOOKS_SCRIPT_DIR}/{nf.HOOK_SCRIPT_NAME}"
-        expected_json = nf.render_hook_json(vm_script_path)
+        expected_json = nf.render_hook_json(
+            vm_script_path, stage="createRuntime"
+        )
         assert expected_json in installer
 
 

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -539,6 +539,14 @@ def _run_hook(
         f"exit {sysctl_rc}\n"
     )
     (bin_dir / "sysctl").chmod(0o755)
+    # sudo shim (#1959): the macOS/rootless hook prefixes iptables/nsenter/
+    # sysctl with ``$SUDO`` ("sudo" when non-root). Real ``sudo`` resolves
+    # commands via its own secure_path and bypasses the shims above — so
+    # the real nsenter/iptables would run (touching the host netns, and on
+    # some runners hanging on a password prompt). A passthrough sudo keeps
+    # the shims on the prepended PATH in play.
+    (bin_dir / "sudo").write_text('#!/bin/sh\nexec "$@"\n')
+    (bin_dir / "sudo").chmod(0o755)
 
     hook = bin_dir / "klangk-netfilter.sh"
     hook.write_text(nf.HOOK_SCRIPT)


### PR DESCRIPTION
## Summary

Fixes #1959. On macOS, podman runs in remote mode (`podman machine`) where `--hooks-dir` is silently ignored and the OCI runtime inside the CoreOS VM cannot see host filesystem paths. This caused netfilter to silently fail — containers started unrestricted while appearing filtered.

- **`netfilter.py`**: `install_hooks()` now copies hook files into the VM via `podman machine ssh`; `create_kwargs()` omits `--hooks-dir` on macOS (hooks placed in the VM's standard dir are discovered automatically)
- **`doctor.py`**: New `check_netfilter_vm()` verifies `iptables`/`nsenter`/`getent` are available inside the podman machine VM
- **`test-netfilter.sh`**: Replaced `grep -oP` (GNU-only) with portable `sed` alternative
- **`test_netfilter_e2e.py`**: New e2e test verifying iptables rules are installed in filtered containers (works on both Linux and macOS)

Sub-issues: #1960, #1961, #1962, #1963, #1964

## Test plan

- [x] Unit tests pass (82 passed, 19 deselected — pre-existing macOS `/proc` skip)
- [x] `klangkd doctor` shows `✓ netfilter (VM): netfilter dependencies available in podman machine VM`
- [ ] E2e tests pass on CI (Linux) — container bringup broken on local macOS dev machine (pre-existing, affects all e2e tests)
- [ ] Manual verification on macOS with podman machine: create a workspace with `allowed_domains`, verify `iptables -L OUTPUT -n` shows DROP policy inside the container