### PR TITLE
doctor: make remediation hints clearly actionable

### DIFF
--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -486,25 +486,45 @@ def format_report(report: DoctorReport) -> str:
         else:
             lines.append(f"  ✗ {r.name}: {r.message}")
         if r.hint:
-            lines.append(f"    → {r.hint}")
+            lines.append("")
+            lines.append(f"    Run:  {r.hint}")
+            lines.append("")
 
     lines.append("")
     errors = report.errors
     warnings = report.warnings
     ok_count = sum(1 for r in report.results if r.ok)
-
     if errors:
         lines.append(
-            f"{ok_count} passed, {len(errors)} errors, {len(warnings)} warnings"
+            f"{ok_count} passed, {len(errors)} errors,"
+            f" {len(warnings)} warnings"
         )
-        lines.append("")
-        lines.append("Fix the errors above before starting klangkd.")
     elif warnings:
         lines.append(f"{ok_count} passed, {len(warnings)} warnings")
-        lines.append("")
-        lines.append("All required checks passed (warnings are optional).")
     else:
         lines.append(f"All {ok_count} checks passed.")
+        return "\n".join(lines)
+
+    # Repeat each failure with its fix so the user doesn't have to
+    # scroll back up through a long check list (#1968).
+    lines.append("")
+    if errors:
+        lines.append("Errors (must fix before starting klangkd):")
+        lines.append("")
+        for r in errors:
+            lines.append(f"  ✗ {r.name}: {r.message}")
+            if r.hint:
+                lines.append(f"    Run:  {r.hint}")
+            lines.append("")
+
+    if warnings:
+        lines.append("Warnings (recommended but not required):")
+        lines.append("")
+        for r in warnings:
+            lines.append(f"  ⚠ {r.name}: {r.message}")
+            if r.hint:
+                lines.append(f"    Run:  {r.hint}")
+            lines.append("")
 
     return "\n".join(lines)
 

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -311,7 +311,21 @@ class TestFormatReport:
         output = format_report(report)
         assert "✗" in output
         assert "1 errors" in output
-        assert "fix it" in output
+        # Hint prefixed with "Run:" (#1968)
+        assert "Run:  fix it" in output
+
+    def test_error_hint_repeated_in_summary(self):
+        """Errors are repeated at the bottom with their hints so the
+        user doesn't have to scroll back up (#1968)."""
+        report = DoctorReport()
+        report.add(CheckResult(name="a", ok=True, message="ok"))
+        report.add(
+            CheckResult(name="b", ok=False, message="broken", hint="fix it")
+        )
+        output = format_report(report)
+        assert "Errors (must fix before starting klangkd):" in output
+        # The hint appears at least twice: inline and in the summary
+        assert output.count("Run:  fix it") >= 2
 
     def test_warnings(self):
         report = DoctorReport()
@@ -328,7 +342,24 @@ class TestFormatReport:
         output = format_report(report)
         assert "⚠" in output
         assert "1 warnings" in output
-        assert "All required checks passed" in output
+        assert "Warnings (recommended but not required):" in output
+        assert "Run:  optional" in output
+
+    def test_warning_hint_repeated_in_summary(self):
+        """Warnings are repeated at the bottom with their hints (#1968)."""
+        report = DoctorReport()
+        report.add(CheckResult(name="a", ok=True, message="ok"))
+        report.add(
+            CheckResult(
+                name="b",
+                ok=False,
+                message="meh",
+                is_warning=True,
+                hint="optional cmd",
+            )
+        )
+        output = format_report(report)
+        assert output.count("Run:  optional cmd") >= 2
 
 
 class TestRunDoctor:


### PR DESCRIPTION
## Summary

- Hints now prefixed with `Run:` instead of `→` so it's obvious they are commands to copy and execute
- Blank lines around hints give them visual weight
- Failed checks (errors and warnings) are repeated at the bottom of the report with their fixes, split into "Errors (must fix)" and "Warnings (recommended)" — no scrolling back up

## Before

```
  ⚠ podman policy: no container policy file found
    → mkdir -p ~/.config/containers && echo '...' > ~/.config/containers/policy.json

4 passed, 1 warnings

All required checks passed (warnings are optional).
```

## After

```
  ⚠ podman policy: no container policy file found

    Run:  mkdir -p ~/.config/containers && echo '...' > ~/.config/containers/policy.json

4 passed, 1 warnings

Warnings (recommended but not required):

  ⚠ podman policy: no container policy file found
    Run:  mkdir -p ~/.config/containers && echo '...' > ~/.config/containers/policy.json
```

## Test plan

- [ ] `test-backend` passes (4068 passed, 100% coverage)
- [ ] New tests verify hint format (`Run:` prefix) and summary repetition

Closes #1968.