### PR TITLE
Nix flake: build klangk from source via buildPythonApplication (no venv)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -47,10 +47,11 @@ operators or integrators to act when upgrading.
   malformed values are rejected at the API boundary (HTTP 400).
 
 - **Nix flake for bare-metal installation (#1948).** `nix run
-github:mcdonc/klangk` installs and runs klangkd with all runtime
-  dependencies (podman, caddy, tmux, git, GNU tar, etc.) provided by
-  Nix. The klangk wheel is pip-installed into a persistent venv on
-  first launch. Works on Linux and macOS (x86_64 + aarch64). See
+github:mcdonc/klangk` builds klangk from source via Nix's Python
+  tooling and resolves every Python dependency (fastapi, sqlalchemy,
+  textual, …) from nixpkgs — no virtualenv, no `pip install`. Nix also
+  provides the system-level dependencies (podman, caddy, tmux, git,
+  GNU tar, etc.). Works on Linux and macOS (x86_64 + aarch64). See
   [Getting Started](getting-started.md#run-using-nix).
 - **`allowed_domains` now accepts IPv4 CIDR ranges (#1935).** A workspace
   (or the deploy-wide `KLANGKD_NETFILTER_DEFAULT_DOMAINS`) may list an IP

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -46,6 +46,12 @@ operators or integrators to act when upgrading.
   and reverts it to the deploy default). Unknown setting names and
   malformed values are rejected at the API boundary (HTTP 400).
 
+- **Nix flake for bare-metal installation (#1948).** `nix run
+github:mcdonc/klangk` installs and runs klangkd with all runtime
+  dependencies (podman, caddy, tmux, git, GNU tar, etc.) provided by
+  Nix. The klangk wheel is pip-installed into a persistent venv on
+  first launch. Works on Linux and macOS (x86_64 + aarch64). See
+  [Getting Started](getting-started.md#run-using-nix).
 - **`allowed_domains` now accepts IPv4 CIDR ranges (#1935).** A workspace
   (or the deploy-wide `KLANGKD_NETFILTER_DEFAULT_DOMAINS`) may list an IP
   subnet like `10.0.0.0/8`, optionally scoped to a port as

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,31 +39,39 @@ you set above.
 
 ## Run Using Nix
 
-Install and run Klangk on bare metal (no Docker) with all runtime
-dependencies provided by Nix. Works on Linux and macOS.
+Install and run Klangk on bare metal (no Docker) with **every**
+dependency — the klangk Python package itself, its Python deps,
+and the system binaries it shells out to — provided by Nix. Works
+on Linux and macOS.
 
 You need [Nix](https://nixos.org/download/) (with flakes enabled) and
 an OpenAI-compatible LLM API key.
 
 ```bash
-# First run: creates a venv and pip-installs klangk from PyPI.
-# Subsequent runs reuse the existing venv (no network needed).
 nix run github:mcdonc/klangk
 ```
 
-On first launch the wrapper creates a Python venv at
-`~/.local/share/klangk/venv` and installs the klangk wheel from PyPI.
-Nix provides every system-level dependency (podman, caddy, tmux, git,
-GNU tar, etc.) — no manual package installation required.
+The flake builds klangk from source via Nix's Python tooling and
+resolves all Python dependencies (fastapi, sqlalchemy, textual, …)
+from nixpkgs — there is no virtualenv and no `pip install`. Nix also
+provides every system-level dependency (podman, caddy, tmux, git,
+GNU tar, etc.). Once built, `nix run` needs no network access.
 
-To upgrade klangk to the latest PyPI release:
+!!! note "No bundled UI"
+The flake build skips the compiled Flutter web UI (the release
+PyPI wheel ships it; the flake source doesn't carry the gitignored
+build artifact). To serve the UI, build the frontend separately and
+point `KLANGKD_FRONTEND_DIR` at it, or `pip install klangk` from
+PyPI for the all-in-one wheel.
+
+To run the client:
 
 ```bash
-nix run github:mcdonc/klangk -- --upgrade
+nix run github:mcdonc/klangk#klangk
 ```
 
-To drop into a shell with all deps on `PATH` (useful for manual
-`pip install` or running `klangkd doctor`):
+To drop into a shell with all deps on `PATH` (useful for an editable
+`pip install -e src/klangk` or running `klangkd` directly):
 
 ```bash
 nix develop github:mcdonc/klangk

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,45 @@ you set above.
 > meant for local dev on your own machine — a published port is not that.
 > See [Auth Modes](features/auth-modes.md).
 
+## Run Using Nix
+
+Install and run Klangk on bare metal (no Docker) with all runtime
+dependencies provided by Nix. Works on Linux and macOS.
+
+You need [Nix](https://nixos.org/download/) (with flakes enabled) and
+an OpenAI-compatible LLM API key.
+
+```bash
+# First run: creates a venv and pip-installs klangk from PyPI.
+# Subsequent runs reuse the existing venv (no network needed).
+nix run github:mcdonc/klangk
+```
+
+On first launch the wrapper creates a Python venv at
+`~/.local/share/klangk/venv` and installs the klangk wheel from PyPI.
+Nix provides every system-level dependency (podman, caddy, tmux, git,
+GNU tar, etc.) — no manual package installation required.
+
+To upgrade klangk to the latest PyPI release:
+
+```bash
+nix run github:mcdonc/klangk -- --upgrade
+```
+
+To drop into a shell with all deps on `PATH` (useful for manual
+`pip install` or running `klangkd doctor`):
+
+```bash
+nix develop github:mcdonc/klangk
+```
+
+!!! note "Podman setup"
+On **macOS**, podman runs inside a VM. You need to run
+`podman machine init && podman machine start` once before starting
+klangkd. On **Linux**, rootless podman requires subuid/subgid
+mappings for your user — see [Podman](reference/podman.md) for
+details.
+
 ## Run Using devenv
 
 For developing or modifying Klangk itself.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785110946,
+        "narHash": "sha256-WWuWxmXKzGZWryswWlijP3Mjp6aGy4Ngmeil5nGMMjk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d3498f786f97ac0bded21b34bae0bf3809b45aa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,18 @@
 # Nix flake for running klangk (server + client) with all runtime
 # dependencies on PATH.
 #
-# Quick start (creates a venv and pip-installs klangk on first run):
+# Quick start:
 #
 #   nix run github:mcdonc/klangk                # run klangkd
 #   nix run github:mcdonc/klangk#klangk         # run klangk CLI
 #   nix develop github:mcdonc/klangk            # shell with all deps
 #
-# The flake provides Python + every runtime binary klangkd needs (podman,
-# caddy, tmux, etc.) via Nix.  The klangk wheel itself is pip-installed
-# into a persistent venv at ~/.local/share/klangk/venv on first launch —
-# Nix handles the system deps, pip handles the Python deps.
+# Everything — the klangk Python package itself *and* every Python
+# dependency — is built by Nix from nixpkgs. There is no venv and no
+# pip install: `nix run` produces a working klangkd with no network
+# access on first run, and `nix build` produces a self-contained
+# closure. Nix also provides the system binaries klangkd shells out to
+# (podman, caddy, tmux, git, GNU tar, …).
 #
 # Supports x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin.
 # See #1948.
@@ -33,11 +35,51 @@
       let
         pkgs = import nixpkgs { inherit system; };
 
-        python = pkgs.python312;
+        # nixpkgs' pythonPackages, with the check phase disabled on the
+        # direct deps. Some of them (notably fastapi) ship heavy
+        # test-only toolchains (inline-snapshot, dirty-equals, …) whose
+        # own transitive deps (pint → uncertainties → scipy) aren't in the
+        # binary cache for the current nixpkgs-unstable revision and rebuild
+        # from source — where scipy hits a known flaky hypothesis test.
+        # Skipping the check phase drops that whole subtree from the build
+        # closure; the runtime deps are unaffected. (See #1948.)
+        pythonPackages = pkgs.python312Packages.overrideScope (
+          final: prev: {
+            fastapi = prev.fastapi.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            starlette = prev.starlette.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            pydantic-settings = prev.pydantic-settings.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            typer = prev.typer.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            httpx = prev.httpx.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            textual = prev.textual.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            sqlalchemy = prev.sqlalchemy.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            logfire = prev.logfire.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+            # Safety net: if scipy still ends up in the closure (a new dep
+            # adds it), skip its flaky test suite rather than fail the build.
+            scipy = prev.scipy.overridePythonAttrs (_: {
+              doCheck = false;
+            });
+          }
+        );
 
         # Runtime binaries that klangkd shells out to (podman, caddy, etc.).
         # The list mirrors the klangkd doctor checks (#1612).
-        runtimeDeps =
+        runtimeBins =
           with pkgs;
           [
             caddy
@@ -59,78 +101,152 @@
             shadow # newuidmap / newgidmap
           ];
 
-        runtimePath = pkgs.lib.makeBinPath runtimeDeps;
+        # klangk built from this flake's source via Nix's Python tooling.
+        # All Python deps are resolved from nixpkgs — no venv, no pip,
+        # no network access at build or install time. The resulting
+        # derivation exposes the `klangkd` and `klangk` entry points
+        # directly; we wrap them with the runtime binaries below.
+        klangkRaw = pythonPackages.buildPythonApplication {
+          pname = "klangk";
+          # The release version comes from git tags via hatch-vcs (see
+          # src/klangk/pyproject.toml). The flake's source filter strips
+          # .git, so hatch-vcs can't compute a version here — postPatch
+          # below rewrites pyproject.toml to pin a static dev version.
+          # The canonical versioned artifact is the PyPI wheel built in
+          # the release workflow.
+          version = "0.0.0.dev0";
+          pyproject = true;
+          src = ./src/klangk;
 
-        # Wrapper script: ensures a venv with klangk installed exists at
-        # ~/.local/share/klangk/venv, then execs the target binary.
-        # On first run (or after `--upgrade`), pip installs/upgrades the
-        # wheel from PyPI.  Subsequent runs just exec into the existing
-        # venv — no network needed.
-        mkLauncher =
-          binName:
-          pkgs.writeShellScriptBin binName ''
-            set -euo pipefail
-            export PATH="${runtimePath}:${python}/bin:$PATH"
-
-            KLANGK_DATA="''${XDG_DATA_HOME:-$HOME/.local/share}/klangk"
-            VENV="$KLANGK_DATA/venv"
-
-            if [ ! -f "$VENV/bin/${binName}" ]; then
-              echo "klangk: creating venv and installing klangk from PyPI..." >&2
-              mkdir -p "$KLANGK_DATA"
-              ${python}/bin/python3 -m venv "$VENV"
-              "$VENV/bin/pip" install --upgrade pip >/dev/null 2>&1
-              "$VENV/bin/pip" install klangk
-              echo "klangk: installed." >&2
-            fi
-
-            # Pass --upgrade to force a pip upgrade of the wheel.
-            if [ "''${1:-}" = "--upgrade" ]; then
-              shift
-              echo "klangk: upgrading klangk from PyPI..." >&2
-              "$VENV/bin/pip" install --upgrade klangk
-              echo "klangk: upgraded." >&2
-            fi
-
-            exec "$VENV/bin/${binName}" "$@"
-          '';
-
-        klangkd = mkLauncher "klangkd";
-        klangk = mkLauncher "klangk";
-
-        # Combined package with both binaries.
-        klangkPkg = pkgs.symlinkJoin {
-          name = "klangk";
-          paths = [
-            klangkd
-            klangk
+          build-system = [
+            pythonPackages.hatchling
+            pythonPackages.hatch-vcs
           ];
+
+          # Python runtime deps — resolved entirely from nixpkgs, mirroring
+          # the `dependencies` list in src/klangk/pyproject.toml. Extras
+          # (`uvicorn[standard]`, `logfire[fastapi]`) are spelled out
+          # explicitly since nixpkgs' pythonPackages uses individual
+          # packages rather than PEP 508 extras.
+          dependencies = with pythonPackages; [
+            fastapi
+            pydantic-settings
+            typer
+            aiosqlite
+            sqlalchemy
+            bcrypt
+            python-jose
+            cryptography
+            python-multipart
+            starlette
+            aiosmtplib
+            jinja2
+            logfire
+            pyyaml
+            httpx
+            textual
+            # uvicorn[standard] extras:
+            uvicorn
+            httptools
+            uvloop
+            watchfiles
+            websockets
+            # logfire[fastapi] extras:
+            opentelemetry-api
+            opentelemetry-sdk
+            opentelemetry-instrumentation-fastapi
+          ];
+
+          # The flake's source filter strips .git (so hatch-vcs can't
+          # derive a version) and the gitignored Flutter web build (so
+          # the hatch_build_frontend.py hook would refuse to build a
+          # UI-less wheel, #1600). Patch pyproject.toml to:
+          #   1. pin a static version, and
+          #   2. drop the frontend build hook reference.
+          # The resulting klangkd serves UI from KLANGKD_FRONTEND_DIR
+          # (pointed at a separately built frontend) or runs UI-less;
+          # the PyPI wheel remains the canonical UI-shipping artifact.
+          postPatch =
+            let
+              dropFrontendHook = pkgs.writeScript "drop-frontend-hook.py" ''
+                import re
+                import sys
+                from pathlib import Path
+
+                p = Path(sys.argv[1])
+                text = p.read_text()
+                # Pin a static version (replaces `dynamic = ["version"]`).
+                text = text.replace(
+                    'dynamic = ["version"]',
+                    'version = "0.0.0.dev0"',
+                )
+                # Drop the frontend build hook section. Matches the section
+                # header and its `path = ...` line; comments above it are
+                # left in place (harmless orphan).
+                text = re.sub(
+                    r'\n\[tool\.hatch\.build\.hooks\.custom\]\n'
+                    r'path = "hatch_build_frontend\.py"\n',
+                    '\n',
+                    text,
+                )
+                p.write_text(text)
+              '';
+            in
+            ''
+              ${pythonPackages.python.interpreter} ${dropFrontendHook} pyproject.toml
+            '';
+
+          # No tests in this build — they need the [test] extra (pytest et
+          # al) and a different invocation (see AGENTS.md). Run them via
+          # devenv instead.
+          doCheck = false;
+
+          pythonImportsCheck = [ "klangk" ];
+        };
+
+        # Wrap the entry points so the runtime binaries klangkd shells
+        # out to (podman, caddy, tmux, …) are on PATH. buildPythonApplication
+        # already produces klangkd/klangk scripts; we re-wrap via
+        # makeWrapper to augment PATH.
+        klangkPkg = pkgs.symlinkJoin {
+          name = "klangk-${klangkRaw.version}";
+          paths = [ klangkRaw ];
+          buildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            for bin in klangkd klangk; do
+              wrapProgram "$out/bin/$bin" \
+                --prefix PATH : ${pkgs.lib.makeBinPath runtimeBins}
+            done
+          '';
         };
       in
       {
         packages.default = klangkPkg;
-        packages.klangkd = klangkd;
-        packages.klangk = klangk;
+        packages.klangkd = klangkPkg;
+        packages.klangk = klangkPkg;
 
         apps.default = {
           type = "app";
-          program = "${klangkd}/bin/klangkd";
+          program = "${klangkPkg}/bin/klangkd";
         };
 
         apps.klangk = {
           type = "app";
-          program = "${klangk}/bin/klangk";
+          program = "${klangkPkg}/bin/klangk";
         };
 
-        # Dev shell with all runtime deps + Python — useful for
-        # contributors who want to pip-install klangk in editable mode
-        # or run klangkd doctor.
         devShells.default = pkgs.mkShell {
-          packages = runtimeDeps ++ [ python ];
+          packages =
+            runtimeBins
+            ++ [ pkgs.python312 ]
+            ++ (with pythonPackages; [
+              hatchling
+              hatch-vcs
+            ]);
           shellHook = ''
-            echo "klangk dev shell — Python ${python.version}, all runtime deps on PATH."
-            echo "  pip install klangk    # install from PyPI"
-            echo "  klangkd              # start the server"
+            echo "klangk dev shell — Python ${pkgs.python312.version}, all runtime deps on PATH."
+            echo "  pip install -e src/klangk   # editable install for hacking"
+            echo "  klangkd                     # start the server"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,138 @@
+# Nix flake for running klangk (server + client) with all runtime
+# dependencies on PATH.
+#
+# Quick start (creates a venv and pip-installs klangk on first run):
+#
+#   nix run github:mcdonc/klangk                # run klangkd
+#   nix run github:mcdonc/klangk#klangk         # run klangk CLI
+#   nix develop github:mcdonc/klangk            # shell with all deps
+#
+# The flake provides Python + every runtime binary klangkd needs (podman,
+# caddy, tmux, etc.) via Nix.  The klangk wheel itself is pip-installed
+# into a persistent venv at ~/.local/share/klangk/venv on first launch —
+# Nix handles the system deps, pip handles the Python deps.
+#
+# Supports x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin.
+# See #1948.
+{
+  description = "klangk — multi-user Pi coding agent (server + client)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        python = pkgs.python312;
+
+        # Runtime binaries that klangkd shells out to (podman, caddy, etc.).
+        # The list mirrors the klangkd doctor checks (#1612).
+        runtimeDeps =
+          with pkgs;
+          [
+            caddy
+            coreutils # GNU du (macOS BSD du lacks -b)
+            git
+            gnutar # macOS ships BSD tar; GNU tar required
+            gzip
+            openssl
+            podman
+            rsync
+            sqlite
+            tmux
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            # Rootless podman prerequisites — macOS uses podman machine
+            # instead of user namespaces.
+            fuse-overlayfs
+            slirp4netns
+            shadow # newuidmap / newgidmap
+          ];
+
+        runtimePath = pkgs.lib.makeBinPath runtimeDeps;
+
+        # Wrapper script: ensures a venv with klangk installed exists at
+        # ~/.local/share/klangk/venv, then execs the target binary.
+        # On first run (or after `--upgrade`), pip installs/upgrades the
+        # wheel from PyPI.  Subsequent runs just exec into the existing
+        # venv — no network needed.
+        mkLauncher =
+          binName:
+          pkgs.writeShellScriptBin binName ''
+            set -euo pipefail
+            export PATH="${runtimePath}:${python}/bin:$PATH"
+
+            KLANGK_DATA="''${XDG_DATA_HOME:-$HOME/.local/share}/klangk"
+            VENV="$KLANGK_DATA/venv"
+
+            if [ ! -f "$VENV/bin/${binName}" ]; then
+              echo "klangk: creating venv and installing klangk from PyPI..." >&2
+              mkdir -p "$KLANGK_DATA"
+              ${python}/bin/python3 -m venv "$VENV"
+              "$VENV/bin/pip" install --upgrade pip >/dev/null 2>&1
+              "$VENV/bin/pip" install klangk
+              echo "klangk: installed." >&2
+            fi
+
+            # Pass --upgrade to force a pip upgrade of the wheel.
+            if [ "''${1:-}" = "--upgrade" ]; then
+              shift
+              echo "klangk: upgrading klangk from PyPI..." >&2
+              "$VENV/bin/pip" install --upgrade klangk
+              echo "klangk: upgraded." >&2
+            fi
+
+            exec "$VENV/bin/${binName}" "$@"
+          '';
+
+        klangkd = mkLauncher "klangkd";
+        klangk = mkLauncher "klangk";
+
+        # Combined package with both binaries.
+        klangkPkg = pkgs.symlinkJoin {
+          name = "klangk";
+          paths = [
+            klangkd
+            klangk
+          ];
+        };
+      in
+      {
+        packages.default = klangkPkg;
+        packages.klangkd = klangkd;
+        packages.klangk = klangk;
+
+        apps.default = {
+          type = "app";
+          program = "${klangkd}/bin/klangkd";
+        };
+
+        apps.klangk = {
+          type = "app";
+          program = "${klangk}/bin/klangk";
+        };
+
+        # Dev shell with all runtime deps + Python — useful for
+        # contributors who want to pip-install klangk in editable mode
+        # or run klangkd doctor.
+        devShells.default = pkgs.mkShell {
+          packages = runtimeDeps ++ [ python ];
+          shellHook = ''
+            echo "klangk dev shell — Python ${python.version}, all runtime deps on PATH."
+            echo "  pip install klangk    # install from PyPI"
+            echo "  klangkd              # start the server"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

Alternative take on #1949 / #1948: instead of pip-installing the klangk wheel into a persistent venv at `~/.local/share/klangk/venv` on first launch, the flake builds klangk from source via Nix's Python tooling and resolves **every** Python dependency from nixpkgs. No venv, no `pip install`, no network access at build/install/run time.

`nix run github:mcdonc/klangk` produces a working `klangkd` whose entire closure is in the Nix store.

### What changed in `flake.nix`

- `python312Packages.buildPythonApplication` builds klangk from `./src/klangk`; all Python deps (fastapi, sqlalchemy, textual, …) come from nixpkgs. `uvicorn[standard]` and `logfire[fastapi]` extras are spelled out explicitly (`httptools`, `uvloop`, `watchfiles`, `opentelemetry-*`).
- A scope override disables the check phase on the direct deps (`fastapi`, `starlette`, `sqlalchemy`, …). This is load-bearing: `fastapi`'s `nativeCheckInputs` pull in `inline-snapshot`/`dirty-equals` → `pint` → `uncertainties` → `scipy 1.18.0`, which isn't in the binary cache for the current `nixpkgs-unstable` rev and fails a flaky hypothesis test when rebuilt from source. `scipy` is also overridden as a safety net.
- `postPatch` rewrites `pyproject.toml` to pin a static `0.0.0.dev0` version (the flake source filter strips `.git`, so `hatch-vcs` can't derive one) and drops the `[tool.hatch.build.hooks.custom]` reference (the gitignored Flutter web artifact is absent; the hook would otherwise refuse a UI-less wheel build, #1600).
- The runtime binaries klangkd shells out to (podman, caddy, tmux, git, GNU tar, …) are wrapped onto `PATH` via `symlinkJoin` + `makeWrapper`.

### Trade-off vs. #1949

The flake-built `klangkd` ships **no web UI** (the release PyPI wheel is the canonical UI-shipping artifact; the flake source doesn't carry the gitignored Flutter build). To serve the UI, point `KLANGKD_FRONTEND_DIR` at a separately built frontend, or `pip install klangk` from PyPI for the all-in-one wheel. A follow-up will build the Flutter web bundle inside the flake so `nix run` serves the UI out of the box too.

### Test plan

- [x] `nix flake check` passes for all four systems (x86_64/aarch64 × linux/darwin)
- [x] `nix build .#default` produces working `klangkd` and `klangk` wrappers
- [x] `nix run .#klangk -- --help` resolves and runs the CLI
- [x] All 13 runtime binaries (podman, caddy, tmux, gnutar, coreutils, git, gzip, openssl, rsync, sqlite, + fuse-overlayfs/slirp4netns/shadow on Linux) are wrapped into `PATH`
- [ ] `nix run .` starts klangkd on a host with podman configured
- [ ] `nix develop` drops into a shell with all runtime deps on `PATH`

Closes #1948 (alternative to #1949).
