### PR TITLE
feat: auto-discover Homebrew gnubin paths on macOS

### DIFF
--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -238,8 +238,8 @@ def check_gnu_tar(manager: str | None) -> CheckResult:
         hint = install_hint("tar", manager)
         if manager == "brew":
             hint = (
-                "brew install gnu-tar, then add "
-                "$(brew --prefix)/opt/gnu-tar/libexec/gnubin to PATH"
+                "brew install gnu-tar (klangkd auto-discovers the "
+                "gnubin path at startup)"
             )
         return CheckResult(
             name="tar (GNU)",
@@ -267,8 +267,8 @@ def check_gnu_du(manager: str | None) -> CheckResult:
         hint = install_hint("du", manager)
         if manager == "brew":
             hint = (
-                "brew install coreutils, then add "
-                "$(brew --prefix)/opt/coreutils/libexec/gnubin to PATH"
+                "brew install coreutils (klangkd auto-discovers the "
+                "gnubin path at startup)"
             )
         return CheckResult(
             name="du (GNU)",

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -33,6 +33,9 @@ proxy ownership), and #1645 (first-run generation) for the full rationale.
 from __future__ import annotations
 
 import os
+import platform
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -137,6 +140,48 @@ def _check_pid_preflight(settings: KlangkSettings) -> int | None:
     return pid
 
 
+def _prepend_gnubin_paths() -> None:  # pragma: no cover
+    """On macOS, prepend Homebrew gnubin dirs to ``PATH`` (#1947).
+
+    macOS ships BSD ``du`` and ``tar`` whose flags are incompatible with
+    klangkd's usage (``du -b``, ``tar --transform``).  Homebrew's
+    ``coreutils`` and ``gnu-tar`` install GNU binaries under g-prefixed
+    names (``gdu``, ``gtar``) and provide ``libexec/gnubin`` directories
+    that shadow the BSD originals.
+
+    This runs once at startup — before any subprocess is spawned — so
+    every callsite (including bare ``subprocess.run(["du", ...])`` and
+    the ``subprocess_env()``-based podman calls) inherits the fixed PATH.
+    No-op on Linux or when ``brew`` is absent.
+    """
+    if platform.system() != "Darwin":
+        return
+    brew = shutil.which("brew")
+    if not brew:
+        return
+    try:
+        result = subprocess.run(
+            [brew, "--prefix"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        prefix = result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        return
+    if not prefix:
+        return
+    gnubin_dirs = [
+        os.path.join(prefix, "opt", "coreutils", "libexec", "gnubin"),
+        os.path.join(prefix, "opt", "gnu-tar", "libexec", "gnubin"),
+    ]
+    existing = [d for d in gnubin_dirs if os.path.isdir(d)]
+    if existing:
+        os.environ["PATH"] = (
+            os.pathsep.join(existing) + os.pathsep + os.environ.get("PATH", "")
+        )
+
+
 @app.callback()
 def main(  # pragma: no cover
     ctx: typer.Context,
@@ -154,6 +199,7 @@ def main(  # pragma: no cover
     ),
 ) -> None:
     """Start the klangk server (config + uvicorn + proxy)."""
+    _prepend_gnubin_paths()
     if ctx.invoked_subcommand is not None:
         return  # defer to the subcommand (e.g. ``doctor``)
     resolved = _resolve_config_path(config)


### PR DESCRIPTION
## Summary

Fixes #1947. On macOS, BSD `du` and `tar` lack GNU-specific flags klangkd needs (`du -b`, `tar --transform`). Homebrew's `coreutils` and `gnu-tar` install GNU versions under `libexec/gnubin` directories.

- At startup, `_prepend_gnubin_paths()` detects macOS + Homebrew, locates the gnubin dirs via `brew --prefix`, and prepends them to `PATH` before any subprocess is spawned
- No-op on Linux or when `brew` is absent
- Doctor hints updated: users just need `brew install coreutils gnu-tar`, no manual PATH editing needed

This replicates what devenv/nix already does transparently for non-devenv macOS users.

## Test plan

- [x] `klangkd doctor` shows GNU du and tar on macOS with brew coreutils installed
- [x] Verified `du -b` and `tar --transform` resolve to GNU versions after PATH prepend
- [ ] CI (Linux) — no behavior change expected (function is no-op on non-Darwin)