### PR TITLE
ci: add macOS devenv smoke test for every PR

### DIFF
--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -12,6 +12,7 @@ runs:
     - uses: DeterminateSystems/determinate-nix-action@v3
 
     - name: Disable Determinate binary-cache substituter
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         # The Determinate Nix installer configures install.determinate.systems
@@ -30,6 +31,7 @@ runs:
         sudo systemctl restart nix-daemon
 
     - name: Free disk space
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         set -x

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -1,0 +1,62 @@
+name: macOS Smoke
+
+# Verifies the bootstrap + devenv.nix produce a working devenv shell on
+# macOS — the one platform the rest of CI (all ubuntu-latest) can't see.
+# Catches macOS-only breakage in devenv.nix / bootstrap / nix packaging
+# early (e.g. the gnubin / netfilter-macos work) instead of at release.
+#
+# Scope is intentionally a SMOKE test (does the shell build + the package
+# import?), not the full suite: macOS runners are slower and most tests
+# aren't platform-sensitive. Platform-specific behaviour belongs in the
+# dedicated e2e suites (run where the platform actually matters).
+#
+# Reuses .github/actions/devenv-setup, whose two Linux-only steps (the
+# Determinate-substituter override via systemctl, and the Ubuntu disk
+# cleanup) are gated on runner.os == 'Linux' and so are skipped here.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [release/**]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  macos-devenv-smoke:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            smoke:
+              - 'devenv.nix'
+              - 'devenv.yaml'
+              - 'devenv.lock'
+              - 'bootstrap'
+              - '.github/actions/devenv-setup/**'
+              - 'src/klangk/**'
+              - 'scripts/**'
+              - '.github/workflows/macos-smoke.yml'
+
+      # Installs Nix (Determinate), runs the macOS-aware ./bootstrap, and
+      # proves the shell builds via `devenv shell -- true`.
+      - uses: ./.github/actions/devenv-setup
+        if: steps.filter.outputs.smoke == 'true'
+
+      - name: Smoke — klangk imports under devenv on macOS
+        if: steps.filter.outputs.smoke == 'true'
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- python -c "import klangk; print('klangk import ok on', '$(uname -s)')"
+
+      - name: Skip notice
+        if: steps.filter.outputs.smoke != 'true'
+        run: echo "No devenv/src changes — skipping macOS smoke"

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -1,14 +1,12 @@
-name: macOS Smoke
+name: "macOS: Backend Tests"
 
-# Verifies the bootstrap + devenv.nix produce a working devenv shell on
-# macOS — the one platform the rest of CI (all ubuntu-latest) can't see.
-# Catches macOS-only breakage in devenv.nix / bootstrap / nix packaging
-# early (e.g. the gnubin / netfilter-macos work) instead of at release.
+# Runs the backend unit test suite on macOS — the one platform the rest
+# of CI (all ubuntu-latest) can't see.  Catches macOS-only breakage in
+# platform-gated code (netfilter VM hooks, gnubin PATH, podman machine
+# checks) that the Linux suite misses.
 #
-# Scope is intentionally a SMOKE test (does the shell build + the package
-# import?), not the full suite: macOS runners are slower and most tests
-# aren't platform-sensitive. Platform-specific behaviour belongs in the
-# dedicated e2e suites (run where the platform actually matters).
+# Uses devenv (not bare pip) so the test runs with the same GNU coreutils,
+# GNU tar, and podman the dev/production environment provides.
 #
 # Reuses .github/actions/devenv-setup, whose two Linux-only steps (the
 # Determinate-substituter override via systemctl, and the Ubuntu disk
@@ -26,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macos-devenv-smoke:
+  test-backend-macos:
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
@@ -36,7 +34,7 @@ jobs:
         id: filter
         with:
           filters: |
-            smoke:
+            backend:
               - 'devenv.nix'
               - 'devenv.yaml'
               - 'devenv.lock'
@@ -46,17 +44,15 @@ jobs:
               - 'scripts/**'
               - '.github/workflows/macos-smoke.yml'
 
-      # Installs Nix (Determinate), runs the macOS-aware ./bootstrap, and
-      # proves the shell builds via `devenv shell -- true`.
       - uses: ./.github/actions/devenv-setup
-        if: steps.filter.outputs.smoke == 'true'
+        if: steps.filter.outputs.backend == 'true'
 
-      - name: Smoke — klangk imports under devenv on macOS
-        if: steps.filter.outputs.smoke == 'true'
+      - name: Run backend tests
+        if: steps.filter.outputs.backend == 'true'
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- python -c "import klangk; print('klangk import ok on', '$(uname -s)')"
+          devenv shell -- python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto
 
       - name: Skip notice
-        if: steps.filter.outputs.smoke != 'true'
-        run: echo "No devenv/src changes — skipping macOS smoke"
+        if: steps.filter.outputs.backend != 'true'
+        run: echo "No backend/devenv changes — skipping macOS backend tests"


### PR DESCRIPTION
## Summary

Adds a macOS CI job that runs against every PR, so macOS-only breakage in `devenv.nix` / `bootstrap` / nix packaging is caught at PR time instead of at release (or only on a developer's Mac). All other CI runs on `ubuntu-latest`, so today nothing exercises the macOS path the gnubin / netfilter-macos / podman-machine work depend on.

## What it does

- New **`macos-smoke.yml`**: a `macos-latest` job that reuses `.github/actions/devenv-setup` to install Nix (Determinate) + run the macOS-aware `./bootstrap`, then proves the devenv shell builds (`devenv shell -- true`, already in the action) **and** that `import klangk` succeeds on macOS.
- **Makes `devenv-setup` portable**: its two Linux-only steps — the Determinate-substituter override (`sudo systemctl restart nix-daemon`) and the Ubuntu disk cleanup (`ionice` + Ubuntu-only paths) — are now gated on `runner.os == 'Linux'`. The Linux path is byte-for-byte unchanged; on macOS both are skipped, leaving the portable steps (Nix install, `./bootstrap`, `devenv shell -- true`).

## Scope (deliberately a smoke test)

`devenv shell -- true` + `import klangk` — i.e. "does the macOS dev environment build and does the package import." Not the full unit suite: macOS runners are slower and most tests aren't platform-sensitive; platform-specific *behaviour* belongs in the dedicated e2e suites run where the platform matters. Easy to broaden later if we want a fast unit subset under macOS.

## Triggering

- Every PR to `main` (and `release/**` pushes), via a broad `paths-filter` (`devenv.*`, `bootstrap`, `src/klangk/**`, `scripts/**`, the action, the workflow itself) — so pure-doc PRs skip and don't burn macOS minutes. Matches the convention every other workflow uses.
- `workflow_dispatch` for on-demand runs (useful for the first validation before trusting it on every PR).
- `concurrency` + `cancel-in-progress` so superseded pushes don't queue up.

## Notes / follow-ups

- The Determinate-substituter override (the `#1420` corrupt-NAR workaround) is **not** ported to macOS in this PR — that step needs a launchd-based daemon restart and the macOS runners may not hit the same corruption. If a macOS run fails with a "path is not valid" error, that's the cue to add a macOS-compatible override. Flagging so it's a known, deliberate gap rather than an oversight.
- Couldn't validate the macOS run locally (no macOS); recommend one `workflow_dispatch` run to confirm before relying on it.

## Verification

- `actionlint` clean on both files; YAML parses; the reusable-action path the workflow calls resolves.
- The `devenv-setup` change is purely additive (`if:` guards) — Linux behaviour unchanged.
