### PR TITLE
refactor(config): rename klangkd.yaml.example to klangkd.yaml.devenv (#1504)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -8,7 +8,7 @@ let
   # klangkd binds a UDS and owns the proxy (nginx) as a child (#1396); the old
   # two-process layout (uvicorn + scripts/nginx.sh) is collapsed into this
   # single entry. Dev config lives in klangkd.yaml (gitignored);
-  # copy from klangkd.yaml.example if missing.
+  # seeded from klangkd.yaml.devenv on first shell entry if missing.
   backendCmd = ''
     python3 -m klangk.launcher --config="$DEVENV_ROOT/klangkd.yaml"
   '';
@@ -202,7 +202,7 @@ in
   );
   env.KLANGKD_VERSION_FILE = versionFile;
   # state_dir / frontend_dir live in klangkd.yaml (cmd:-indirected to
-  # $DEVENV_STATE / $DEVENV_ROOT) — see klangkd.yaml.example. IMAGE_NAME and
+  # $DEVENV_STATE / $DEVENV_ROOT) — see klangkd.yaml.devenv. IMAGE_NAME and
   # VERSION_FILE stay as env because the build scripts
   # (build-workspace-image.sh, build-host-image.sh) read them and don't parse
   # the YAML (#1788).
@@ -503,8 +503,8 @@ in
 
   enterShell = ''
     if [ ! -f "$DEVENV_ROOT/klangkd.yaml" ]; then
-      cp "$DEVENV_ROOT/klangkd.yaml.example" "$DEVENV_ROOT/klangkd.yaml"
-      echo "Created klangkd.yaml from klangkd.yaml.example — edit it to taste."
+      cp "$DEVENV_ROOT/klangkd.yaml.devenv" "$DEVENV_ROOT/klangkd.yaml"
+      echo "Created klangkd.yaml from klangkd.yaml.devenv — edit it to taste."
     fi
     # Ensure the frontend_dir key exists in an existing klangkd.yaml. devenv
     # used to export KLANGKD_FRONTEND_DIR; it now lives in klangkd.yaml (#1788),

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -524,6 +524,15 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **`klangkd.yaml.example` renamed to `klangkd.yaml.devenv` (#1504).** The
+  repo-root template is devenv-only (its `state_dir`/`data_dir` are
+  `cmd:`-indirected to `$DEVENV_STATE`), not a deployment template. The new
+  name states that. Docs no longer tell operators to copy it: a real
+  deployment runs `klangkd` with no `--config` and it generates the config at
+  `$KLANGKD_CONFIG_DIR/klangkd.yaml` on first run (#1645). `devenv.nix` still
+  seeds `klangkd.yaml` from `klangkd.yaml.devenv` on first shell entry.
+  Integrators that referenced `klangkd.yaml.example` by name must update.
+
 - **A malformed `KLANGKD_NETFILTER_DEFAULT_DOMAINS` now refuses to start
   (#1939).** A bad `host[:port]` spec or a non-list/non-string value used
   to be logged at WARNING and silently ignored — the field fell back to

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -6,7 +6,7 @@
 
 `$DEVENV_STATE` refers to `<project root>/.devenv/state` — this is where devenv stores runtime data.
 
-For local development, settings live in `klangkd.yaml` (gitignored; copy from `klangkd.yaml.example`). Environment variables override config-file values.
+For local development, settings live in `klangkd.yaml` (gitignored; `devenv.nix` seeds it from `klangkd.yaml.devenv` on first shell entry). Environment variables override config-file values.
 
 **`file:` prefix:** Any env var can be prefixed with `file:` to read the value from a file (e.g. `KLANGKD_JWT_SECRET=file:/run/secrets/jwt`). The file contents are stripped of leading/trailing whitespace. This works with secret management tools like agenix/sops that write decrypted secrets to files. If the file cannot be read, construction **fails** with a `ValidationError` — see [#1461](https://github.com/mcdonc/klangk/issues/1461) (fail-fast at boot, not silently at use time).
 

--- a/klangkd.yaml.devenv
+++ b/klangkd.yaml.devenv
@@ -1,10 +1,14 @@
-# Local dev config for klangkd.
+# Devenv-only config for klangkd. This is NOT a deployment template.
 #
-# Copy to klangkd.yaml (gitignored) and edit:
-#   cp klangkd.yaml.example klangkd.yaml
+# devenv.nix copies it to klangkd.yaml (gitignored) on first shell entry, and
+# the backend runs `klangkd --config klangkd.yaml`. The values below are
+# devenv-specific (cmd:-indirected to $DEVENV_STATE / $DEVENV_ROOT) and will
+# NOT work outside the devenv shell.
 #
-# klangkd reads this via: klangkd --config klangkd.yaml
-# devenv's backend process does this automatically.
+# For a real deployment, do not copy this file: run `klangkd` with no
+# --config and it generates a deployment-suitable config at
+# $KLANGKD_CONFIG_DIR/klangkd.yaml (default ~/.config/klangkd/klangkd.yaml)
+# on first run (#1645, #1649). See docs/reference/klangkd-config.md.
 
 # port: the browser/proxy port. Set it for full/browser mode (UI at
 # http://localhost:8997). Leave unset for headless mode (no browser listener;


### PR DESCRIPTION
## Summary

Resolves #1504. The repo-root template is **devenv-only** (its `state_dir` / `data_dir` are `cmd:`-indirected to `$DEVENV_STATE`), not a deployment template — so rename it so the name states that, and stop telling operators to copy it.

## Changes

- **Rename `klangkd.yaml.example` → `klangkd.yaml.devenv`** (`git mv`, 79% similarity). Rewrote the header to mark it devenv-only and point operators at first-run generation instead of a `cp` instruction.
- **`devenv.nix`** — `enterShell` now copies `klangkd.yaml.devenv` → `klangkd.yaml`; the two comments referencing the template are updated to the new name.
- **`docs/reference/environment.md`** — replaced "copy from `klangkd.yaml.example`" with "`devenv.nix` seeds it from `klangkd.yaml.devenv` on first shell entry".
- **`docs/changes.md`** — `### Changed` entry added.

The operator flow for a real deployment is unchanged and already documented: run `klangkd` with no `--config` and it generates the config at `$KLANGKD_CONFIG_DIR/klangkd.yaml` (default `~/.config/klangkd/klangkd.yaml`) on first run (`first_run.generate_default_config`, #1645 / #1649). `docs/reference/klangkd-config.md` already covers this, so no change there.

## Acceptance (from #1504)

- [x] The file is named `klangkd.yaml.devenv`; no `klangkd.yaml.example` remains in the tracked tree.
- [x] No reference to the old name remains in `devenv.nix`, the template header, or `docs/reference/environment.md` (the only remaining hits are historical `docs/changes.md` entries under released notes — out of scope per the issue).
- [x] No doc or comment instructs an operator to `cp` the template to `klangkd.yaml`.
- [x] Docs point operators at first-run generation, not copying.
- [x] devenv still works: verified `enterShell` regenerates `klangkd.yaml` from `klangkd.yaml.devenv` with the new header, and the backend still uses `klangkd --config klangkd.yaml`.
- [x] No test regressions, no warnings.

## Verification

- Full Python suite (CI command, `-n auto`): **4077 passed, 100% coverage, no warnings**.
- `pre-commit run` on all four changed files: nixfmt / markdownlint / prettier / trufflehog / binary-integrity all **Passed** (yamllint/ruff/shellcheck correctly skipped — no matching file types).
- Confirmed no test references the renamed file (the one grep hit is an unrelated `from-yaml.example.com` URL in `test_features.py`).
- Rebased onto latest `origin/main` (0 behind).

Closes #1504.
