### PR TITLE
Server-side feature resolver: Features.is_enabled() (#1974)

### DIFF
--- a/src/klangk/klangk/features.py
+++ b/src/klangk/klangk/features.py
@@ -158,6 +158,75 @@ class Features:
             if isinstance(f, dict)
         ]
 
+    def is_enabled(self, name: str) -> bool:
+        """True if feature *name* is active for this deploy.
+
+        Server-side activation resolver (#1974): the backend can now ask
+        "is feature X on?" the same way the frontend does — the prerequisite
+        for feature-gating server-side subsystems (e.g. the clanker agent
+        subprocess, #1685) instead of bespoke env vars like
+        ``KLANGKD_AGENT_DISABLED``.
+
+        Canonical semantics — mirrors ``_resolveActiveFeatures`` in
+        ``src/frontend/lib/main.dart`` so the server gates on the **same**
+        active set the UI resolves (drift between the two would gate the
+        agent on a different set than the UI shows):
+
+        - ``KLANGKD_FEATURES_ENABLE`` unset **or** blank/whitespace → the
+          manifest's ``defaults`` list (the stock set). A blank value is
+          treated as unset, exactly as the frontend treats a blank string
+          read from ``/api/config`` (its ``v.trim().isNotEmpty`` guard).
+        - any non-blank value → exactly that comma-separated list, split on
+          ``,``, each entry trimmed, empties dropped. No ``*`` form, and
+          **not** additive over ``defaults`` (an explicit list replaces the
+          stock set entirely).
+        - no usable deploy list and no usable ``defaults`` → every
+          compiled-in feature (the manifest's ``features`` array) is active
+          — the back-compat fallback the frontend uses for a source deploy
+          with no built manifest. The server's compiled-in inventory *is*
+          the manifest, so with no manifest at all nothing is active (a safe
+          default for the rare server-without-built-frontend case).
+
+        Reads ``self.app.state.settings.features_enable`` live at call time
+        (app ownership rule — no cached snapshot), so a SIGHUP reload of the
+        knob is picked up without a :meth:`reconfigure` call; only a manifest
+        change (``frontend_dir``) needs ``reconfigure``.
+        """
+        return name in self._active_feature_names()
+
+    def _active_feature_names(self) -> set[str]:
+        """The deploy's active-feature set, per :meth:`is_enabled`.
+
+        Computed fresh on every call (no caching) so a settings reload of
+        ``KLANGKD_FEATURES_ENABLE`` propagates immediately. The active set is
+        a handful of names, so recomputing per call is cheap.
+        """
+        raw = self.app.state.settings.features_enable
+        if raw is not None and raw.strip():
+            # Explicit deploy-chosen list: exact comma-separated membership.
+            # Trim each entry and drop empties (e.g. "a,,b", a trailing comma).
+            return {
+                part
+                for part in (entry.strip() for entry in raw.split(","))
+                if part
+            }
+        defaults = self._manifest.get("defaults", [])
+        if isinstance(defaults, list):
+            names = {d for d in defaults if isinstance(d, str)}
+            if names:
+                return names
+        # No deploy list and no usable defaults → every compiled-in feature
+        # active (back-compat, mirroring the frontend's step-3 fallback for
+        # a source deploy with no built manifest). Skip non-dict entries,
+        # missing names, and empty names.
+        return {
+            name
+            for f in self._manifest.get("features", [])
+            if isinstance(f, dict)
+            and isinstance((name := f.get("name")), str)
+            and name
+        }
+
     def container_env(self) -> dict[str, str]:
         """Return env vars to inject into workspace containers.
 

--- a/src/klangk/klangkd-tests/tests/test_features.py
+++ b/src/klangk/klangkd-tests/tests/test_features.py
@@ -1027,6 +1027,239 @@ class TestFeaturesEnable:
         assert p.features_enable() == "soliplex"
 
 
+class TestIsEnabled:
+    """is_enabled(name) resolves the active-feature set server-side (#1974),
+    mirroring _resolveActiveFeatures in main.dart so the server gates on the
+    same set the UI shows. Prerequisite for feature-gating backend subsystems
+    (the clanker agent, #1685) instead of bespoke env vars."""
+
+    def test_unset_uses_defaults_membership(self, tmp_path):
+        # Unset → manifest defaults: a default feature is active; a compiled-in
+        # but non-default feature is not.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [
+                    {"name": "celebrate"},
+                    {"name": "beep"},
+                ],
+                "defaults": ["celebrate"],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path)
+        assert p.is_enabled("celebrate") is True
+        assert p.is_enabled("beep") is False
+
+    def test_unset_no_defaults_uses_compiled_in(self, tmp_path):
+        # defaults empty/missing → back-compat: every compiled-in feature active.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [
+                    {"name": "celebrate"},
+                    {"name": "beep"},
+                ],
+                "defaults": [],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path)
+        assert p.is_enabled("celebrate") is True
+        assert p.is_enabled("beep") is True
+        assert p.is_enabled("not-compiled-in") is False
+
+    def test_explicit_list_exact_membership_not_additive(self, tmp_path):
+        # An explicit list replaces the defaults entirely — celebrate is a
+        # default but is dropped because it's not in the explicit list.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [
+                    {"name": "celebrate"},
+                    {"name": "beep"},
+                ],
+                "defaults": ["celebrate", "beep"],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path, env={"KLANGKD_FEATURES_ENABLE": "beep"})
+        assert p.is_enabled("beep") is True
+        assert p.is_enabled("celebrate") is False
+
+    def test_explicit_list_trims_and_drops_empties(self, tmp_path):
+        p = _features(
+            tmp_path,
+            env={"KLANGKD_FEATURES_ENABLE": " beep , ,celebrate "},
+        )
+        assert p.is_enabled("beep") is True
+        assert p.is_enabled("celebrate") is True
+
+    def test_blank_string_treated_as_unset(self, tmp_path):
+        # A blank KLANGKD_FEATURES_ENABLE is treated as unset (mirrors the
+        # frontend's `v.trim().isNotEmpty` guard) → defaults active. There is
+        # thus no way to express "empty active set" via the knob — by design,
+        # so server and UI agree.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [{"name": "celebrate"}],
+                "defaults": ["celebrate"],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path, env={"KLANGKD_FEATURES_ENABLE": ""})
+        assert p.is_enabled("celebrate") is True
+
+    def test_whitespace_string_treated_as_unset(self, tmp_path):
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [{"name": "celebrate"}],
+                "defaults": ["celebrate"],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path, env={"KLANGKD_FEATURES_ENABLE": "   "})
+        assert p.is_enabled("celebrate") is True
+
+    def test_star_is_literal_not_wildcard(self, tmp_path):
+        # `*` is a literal feature name, not a wildcard — it only matches a
+        # feature literally named `*`. An explicit "*" therefore deactivates
+        # every real feature.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [{"name": "celebrate"}],
+                "defaults": ["celebrate"],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path, env={"KLANGKD_FEATURES_ENABLE": "*"})
+        assert p.is_enabled("celebrate") is False
+        assert p.is_enabled("*") is True
+
+    def test_no_manifest_nothing_active(self, tmp_path):
+        # No features.json → no compiled-in inventory → nothing active. Safe
+        # default for the rare server-without-built-frontend case.
+        p = _features(tmp_path)
+        assert p.is_enabled("celebrate") is False
+
+    def test_non_list_defaults_falls_back_to_compiled_in(self, tmp_path):
+        # A malformed (non-list) defaults → fall through to the compiled-in
+        # fallback, matching the frontend's `if (defaults is List)` guard.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [{"name": "celebrate"}],
+                "defaults": "not-a-list",
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path)
+        assert p.is_enabled("celebrate") is True
+
+    def test_defaults_non_string_entries_filtered(self, tmp_path):
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [{"name": "celebrate"}],
+                "defaults": ["celebrate", 42, None],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path)
+        assert p.is_enabled("celebrate") is True
+
+    def test_compiled_in_fallback_skips_bad_entries(self, tmp_path):
+        # No deploy list, no usable defaults → every compiled-in feature
+        # active; the fallback skips non-dict entries, missing names, and
+        # empty names.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [
+                    "not-a-dict",
+                    {"name": "celebrate"},
+                    {"no_name": True},
+                    {"name": ""},
+                    {"name": "beep"},
+                ],
+                "defaults": [],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path)
+        assert p.is_enabled("celebrate") is True
+        assert p.is_enabled("beep") is True
+        assert p.is_enabled("") is False
+
+    def test_settings_swap_reflected_without_reconfigure(self, tmp_path):
+        # is_enabled reads settings.features_enable live (app ownership rule)
+        # — a settings reload is picked up WITHOUT a reconfigure() call, since
+        # only the manifest (frontend_dir) needs reconfigure, not the knob.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [
+                    {"name": "celebrate"},
+                    {"name": "beep"},
+                ],
+                "defaults": ["celebrate"],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path)  # unset → celebrate active, beep not
+        assert p.is_enabled("celebrate") is True
+        assert p.is_enabled("beep") is False
+        # Swap the settings object on app.state (simulating a SIGHUP reload).
+        p.app.state.settings = make_settings(
+            {
+                "KLANGKD_FRONTEND_DIR": str(tmp_path),
+                "KLANGKD_FEATURES_ENABLE": "beep",
+            }
+        )
+        assert p.is_enabled("beep") is True
+        assert p.is_enabled("celebrate") is False
+
+    def test_reconfigure_picks_up_new_defaults(self, tmp_path):
+        # reconfigure() re-reads the manifest; a changed defaults list is
+        # reflected in is_enabled.
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [
+                    {"name": "celebrate"},
+                    {"name": "beep"},
+                ],
+                "defaults": ["celebrate"],
+                "container_env_keys": [],
+            },
+        )
+        p = _features(tmp_path)
+        assert p.is_enabled("celebrate") is True
+        assert p.is_enabled("beep") is False
+        _write_manifest(
+            tmp_path,
+            {
+                "features": [
+                    {"name": "celebrate"},
+                    {"name": "beep"},
+                ],
+                "defaults": ["beep"],
+                "container_env_keys": [],
+            },
+        )
+        new_app_state = types.SimpleNamespace(
+            state=types.SimpleNamespace(
+                settings=make_settings({"KLANGKD_FRONTEND_DIR": str(tmp_path)})
+            )
+        )
+        p.reconfigure(new_app_state)
+        assert p.is_enabled("beep") is True
+        assert p.is_enabled("celebrate") is False
+
+
 class TestReconfigure:
     """reconfigure() re-reads the manifest on a SIGHUP settings reload
     (frontend_dir may have changed)."""


### PR DESCRIPTION
## Summary

Adds `Features.is_enabled(name)` — the **server-side** feature activation resolver (#1974). Today the server only *forwards* `KLANGKD_FEATURES_ENABLE` verbatim to the frontend; it never interprets it, so backend subsystems have no way to ask "is feature X on?". This is the prerequisite for feature-gating server-side subsystems (the clanker agent subprocess, #1685) instead of bespoke env vars like `KLANGKD_AGENT_DISABLED`.

The resolver mirrors `_resolveActiveFeatures` in `src/frontend/lib/main.dart` so the server gates on the **same** active set the UI resolves — drift between the two would gate the agent on a different set than the UI shows:

- `KLANGKD_FEATURES_ENABLE` unset **or** blank/whitespace → the manifest's `defaults` list (a blank value is treated as unset, matching the frontend's `v.trim().isNotEmpty` guard).
- any non-blank value → exact comma-separated membership (split on `,`, trimmed, empties dropped). No `*` form, and **not** additive over `defaults`.
- no usable list and no usable `defaults` → every compiled-in feature active (the back-compat fallback the frontend uses for a source deploy with no built manifest).

Reconfigure-safe: reads `self.app.state.settings.features_enable` live at call time (app ownership rule — no cached snapshot), so a SIGHUP reload of the knob propagates without a `reconfigure()` call; only a manifest change (`frontend_dir`) needs `reconfigure`.

This PR only adds the resolver + tests. Wiring it into agent gating, settings migration, and docs lands in the dependent issues (#1976–#1980).

## Test plan

- New `TestIsEnabled` in `test_features.py` covers every branch: unset→defaults, unset-no-defaults→compiled-in, explicit-list exact membership (non-additive), trim/drop-empties, blank & whitespace treated as unset, `*` literal not wildcard, no-manifest→nothing-active, non-list/empty/non-string `defaults` fallbacks, compiled-in-fallback type guards, live settings-swap (no reconfigure needed), and `reconfigure()` picking up new defaults.
- Full suite: `4090 passed`, **100% coverage** (`python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto`).

Part of #1685. Closes #1974.
