### PR TITLE
fix(tests): resolve macOS CI test failures from AF_UNIX path limits (#1983)

### DIFF
--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -268,6 +268,8 @@ class TestMainCLI:
     def test_server_url_falls_back_to_default_uds(self, tmp_path, monkeypatch):
         """When the default klangkd UDS exists, server_url() uses it (#1676)."""
         import socket as _socket
+        import tempfile
+        from pathlib import Path
 
         from klangk.cli import main
 
@@ -277,10 +279,12 @@ class TestMainCLI:
         monkeypatch.setattr("klangk.cli.config._STATE_PATH", state_path)
         config_path.write_text("")
         CLIState().save()  # no active server, no --server
-        # Bind a real AF_UNIX socket at the default-derived path.
-        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        # Use a short temp dir so the socket path stays under the 104-char
+        # AF_UNIX sun_path limit on macOS (#1983).
+        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
         monkeypatch.delenv("KLANGK_STATE_DIR", raising=False)
-        sock_dir = tmp_path / "klangkd"
+        sock_dir = short_tmp / "klangkd"
         sock_dir.mkdir()
         sock_path = sock_dir / "klangk.sock"
         srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -295,6 +299,8 @@ class TestMainCLI:
     ):
         """KLANGK_STATE_DIR relocates the default UDS (#1676)."""
         import socket as _socket
+        import tempfile
+        from pathlib import Path
 
         from klangk.cli import main
 
@@ -304,8 +310,9 @@ class TestMainCLI:
         monkeypatch.setattr("klangk.cli.config._STATE_PATH", state_path)
         config_path.write_text("")
         CLIState().save()
-        custom_state = tmp_path / "custom-state"
-        custom_state.mkdir()
+        # Use a short temp dir so the socket path stays under the 104-char
+        # AF_UNIX sun_path limit on macOS (#1983).
+        custom_state = Path(tempfile.mkdtemp(prefix="ks-"))
         monkeypatch.setenv("KLANGK_STATE_DIR", str(custom_state))
         sock_path = custom_state / "klangk.sock"
         srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -358,6 +365,8 @@ class TestMainCLI:
     ):
         """A plain absolute KLANGK_SOCKET is used when it exists (#1676)."""
         import socket as _socket
+        import tempfile
+        from pathlib import Path
 
         from klangk.cli import main
 
@@ -367,9 +376,11 @@ class TestMainCLI:
         monkeypatch.setattr("klangk.cli.config._STATE_PATH", state_path)
         config_path.write_text("")
         CLIState().save()
-        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))  # ensure default
-        # path is absent so only KLANGK_SOCKET could resolve
-        sock_path = tmp_path / "relocated.sock"
+        # Use a short temp dir so the socket path stays under the 104-char
+        # AF_UNIX sun_path limit on macOS (#1983).
+        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
+        sock_path = short_tmp / "relocated.sock"
         srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         srv.bind(str(sock_path))
         monkeypatch.setenv("KLANGK_SOCKET", str(sock_path))
@@ -383,6 +394,8 @@ class TestMainCLI:
     ):
         """active-server wins even when the default UDS exists."""
         import socket as _socket
+        import tempfile
+        from pathlib import Path
 
         from klangk.cli import main
 
@@ -391,9 +404,11 @@ class TestMainCLI:
         monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
         monkeypatch.setattr("klangk.cli.config._STATE_PATH", state_path)
         config_path.write_text("")
-        # Bind a default UDS so the fallback *would* fire …
-        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        sock_dir = tmp_path / "klangkd"
+        # Use a short temp dir so the socket path stays under the 104-char
+        # AF_UNIX sun_path limit on macOS (#1983).
+        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
+        sock_dir = short_tmp / "klangkd"
         sock_dir.mkdir()
         srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         srv.bind(str(sock_dir / "klangk.sock"))
@@ -409,6 +424,8 @@ class TestMainCLI:
     ):
         """--server override wins even when the default UDS exists."""
         import socket as _socket
+        import tempfile
+        from pathlib import Path
 
         from klangk.cli import main
 
@@ -418,8 +435,11 @@ class TestMainCLI:
         monkeypatch.setattr("klangk.cli.config._STATE_PATH", state_path)
         config_path.write_text("")
         CLIState().save()
-        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        sock_dir = tmp_path / "klangkd"
+        # Use a short temp dir so the socket path stays under the 104-char
+        # AF_UNIX sun_path limit on macOS (#1983).
+        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
+        sock_dir = short_tmp / "klangkd"
         sock_dir.mkdir()
         srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         srv.bind(str(sock_dir / "klangk.sock"))

--- a/src/klangk/klangkd-tests/tests/_helpers.py
+++ b/src/klangk/klangkd-tests/tests/_helpers.py
@@ -8,6 +8,7 @@ yet available.
 
 from __future__ import annotations
 
+import os
 import tempfile
 
 from klangk.settings import KlangkSettings
@@ -56,6 +57,16 @@ def make_settings(
         "KLANGKD_STATE_DIR", tempfile.mkdtemp(prefix="klangk-state-")
     )
     env.setdefault("KLANGKD_DATA_DIR", tempfile.mkdtemp(prefix="klangk-data-"))
+    # On macOS the default socket paths derived from state_dir
+    # (<state_dir>/klangk.sock, <state_dir>/caddy-admin.sock) may exceed the
+    # 104-char AF_UNIX sun_path limit because tempfile paths resolve through
+    # /private/var/folders/... Set short socket paths so the settings
+    # validator passes (#1983).
+    _sock_dir = tempfile.mkdtemp(prefix="ks-")
+    env.setdefault("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
+    env.setdefault(
+        "KLANGKD_CADDY_ADMIN_SOCKET", os.path.join(_sock_dir, "caddy.sock")
+    )
     return KlangkSettings(env=env, config_file=config_file)
 
 

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for backend unit tests."""
 
 import os
+import tempfile
 
 # Must be set before coverage.py initialises in each xdist worker so that
 # code executed inside SQLAlchemy's greenlet context is tracked.
@@ -51,6 +52,16 @@ def temp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("KLANGKD_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("KLANGKD_CUSTOMIZE_DIR", str(tmp_path / "customize"))
     monkeypatch.delenv("KLANGKD_IMAGE_PULL_POLICY", raising=False)
+    # On macOS the default socket paths derived from tmp_path
+    # (<tmp_path>/state/klangk.sock, <tmp_path>/state/caddy-admin.sock)
+    # may exceed the 104-char AF_UNIX sun_path limit because pytest tmp
+    # paths resolve through /private/var/folders/... Set short socket
+    # paths so the settings validator passes (#1983).
+    _sock_dir = tempfile.mkdtemp(prefix="ks-")
+    monkeypatch.setenv("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
+    monkeypatch.setenv(
+        "KLANGKD_CADDY_ADMIN_SOCKET", os.path.join(_sock_dir, "caddy.sock")
+    )
     # Build the per-test DB from the new env so the engine cache and db_path
     # point at the per-test temp dir (#1452: no import-time globals). Stash it
     # in the per-test holder so the ``app_state`` fixture (and any

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import types
 
 import pytest
@@ -584,6 +585,10 @@ def _calls_from(log_path):
     return calls
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Hook script requires /proc and iptables/nsenter (Linux-only)",
+)
 class TestHookScriptExecutable:
     def test_host_port_emits_split_argv(self, tmp_path):
         # B1 regression: the ACCEPT rule must reach iptables as separate


### PR DESCRIPTION
## Summary

- Fix 19 pre-existing macOS CI test failures caused by long pytest temp paths exceeding the 104-byte `AF_UNIX` socket path limit on macOS
- `make_settings()` helper and `temp_data_dir` fixture now use short socket paths via `tempfile.mkdtemp(prefix="ks-")`
- Skip `TestHookScriptExecutable` on macOS (requires Linux-only `/proc`, `iptables`, `nsenter`)
- CLI tests that bind AF_UNIX sockets use shorter temp dirs on macOS

Closes #1983

## Test plan
- [ ] `test-backend-macos` CI job passes (was 19 failures)
- [ ] `test-backend-linux` CI job still passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)