### PR TITLE
feat(features): allow a feature to contribute a workspace tab (#1975)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,16 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Feature-contributed workspace tabs (#1975).** A feature can now
+  contribute a workspace tab (mounted in the workspace tab strip) by
+  declaring a `WorkspaceTabPlugin` (title + icon + builder), separately
+  from `ToolPlugin`. A feature package may declare either or both — e.g. a
+  `chat` feature contributes both a chat tab and agent tool handlers. Tabs
+  mount only when their feature is active (the existing
+  `KLANGKD_FEATURES_ENABLE` active-set filter). Bumps the
+  `klangk_plugin_api` dependency to `v0.3.0`, which adds the new
+  `WorkspaceTabPlugin` / `WorkspaceTabRegistry` API.
+
 - **Per-workspace behavioral settings via a JSON `settings` bag (#864).**
   A workspace may now override several deploy-wide tuning knobs on a
   per-workspace basis, with the precedence **workspace override > deploy

--- a/features/beep/klangk/pubspec.yaml
+++ b/features/beep/klangk/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0

--- a/features/bobdobbs/klangk/pubspec.yaml
+++ b/features/bobdobbs/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0
 
 flutter:
   assets:

--- a/features/boingball/klangk/pubspec.yaml
+++ b/features/boingball/klangk/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0
   http: ^1.2.0

--- a/features/celebrate/klangk/pubspec.yaml
+++ b/features/celebrate/klangk/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0

--- a/features/git-credential/klangk/pubspec.yaml
+++ b/features/git-credential/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0
 
 dev_dependencies:
   flutter_test:

--- a/features/soliplex/klangk/pubspec.yaml
+++ b/features/soliplex/klangk/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/scripts/import_dart_features.py
+++ b/scripts/import_dart_features.py
@@ -55,14 +55,26 @@ FEATURE_API_DEP = {
     "klangk_plugin_api": {
         "git": {
             "url": "https://github.com/mcdonc/klangk-plugin-api.git",
-            "ref": "v0.2.0",
+            "ref": "v0.3.0",
         }
     }
 }
 
 
 def find_features(features_dir):
-    """Scan features/*/klangk/ for Dart packages, return metadata."""
+    """Scan features/*/klangk/ for Dart packages, return metadata.
+
+    A feature compiles in if its ``feature.dart`` declares at least one
+    component — a ``ToolPlugin`` (tool handlers / app-bar action / overlay)
+    and/or a ``WorkspaceTabPlugin`` (a workspace tab, #1975). Most features
+    declare a single ``ToolPlugin``; a feature may declare both (e.g. a
+    ``chat`` feature contributes both a chat tab and agent tool handlers), or
+    only a tab. Each entry records the tool and tab class names so
+    :func:`generate_dart` can emit separate aggregators and
+    :func:`collect_feature_metadata` can surface the feature in
+    ``features.json`` even when it declares no tool handlers (a tab-only
+    feature still appears in the compiled-in manifest).
+    """
     features = []
     if not os.path.isdir(features_dir):
         return features
@@ -84,19 +96,23 @@ def find_features(features_dir):
         with open(feature_dart) as f:
             source = f.read()
 
-        matches = re.findall(r"class\s+(\w+)\s+extends\s+ToolPlugin", source)
-        if not matches:
+        tool_classes = re.findall(r"class\s+(\w+)\s+extends\s+ToolPlugin", source)
+        tab_classes = re.findall(
+            r"class\s+(\w+)\s+extends\s+WorkspaceTabPlugin", source
+        )
+        # A feature with neither component isn't a klangk feature — skip it.
+        if not tool_classes and not tab_classes:
             continue
 
-        for class_name in matches:
-            features.append(
-                {
-                    "name": name,
-                    "package_name": package_name,
-                    "dart_dir": dart_dir,
-                    "class_name": class_name,
-                }
-            )
+        features.append(
+            {
+                "name": name,
+                "package_name": package_name,
+                "dart_dir": dart_dir,
+                "tool_classes": tool_classes,
+                "tab_classes": tab_classes,
+            }
+        )
 
     return features
 
@@ -280,7 +296,8 @@ def generate_dart(features):
     lines.append("List<ToolPlugin> createAllFeatures() {")
     lines.append("  return [")
     for p in features:
-        lines.append(f"    {p['class_name']}(),")
+        for cls in p["tool_classes"]:
+            lines.append(f"    {cls}(),")
     lines.append("  ];")
     lines.append("}")
     lines.append("")
@@ -291,7 +308,25 @@ def generate_dart(features):
     lines.append("List<({String name, ToolPlugin feature})> createAllNamedFeatures() {")
     lines.append("  return [")
     for p in features:
-        lines.append(f"    (name: {p['name']!r}, feature: {p['class_name']}()),")
+        for cls in p["tool_classes"]:
+            lines.append(f"    (name: {p['name']!r}, feature: {cls}()),")
+    lines.append("  ];")
+    lines.append("}")
+    lines.append("")
+    lines.append(
+        "// ({name, tab}) records for the workspace-tab active-set filter (#1975): "
+    )
+    lines.append(
+        "// a feature's tab mounts only when the feature is active. A feature may "
+    )
+    lines.append("// contribute a tab with no ToolPlugin (tab-only), or both.")
+    lines.append(
+        "List<({String name, WorkspaceTabPlugin tab})> createAllNamedWorkspaceTabs() {"
+    )
+    lines.append("  return [")
+    for p in features:
+        for cls in p["tab_classes"]:
+            lines.append(f"    (name: {p['name']!r}, tab: {cls}()),")
     lines.append("  ];")
     lines.append("}")
     lines.append("")
@@ -369,7 +404,7 @@ def main(argv=None):
     with open(output_path, "w") as f:
         f.write(output)
 
-    names = [p["class_name"] for p in features]
+    names = [c for p in features for c in (p["tool_classes"] + p["tab_classes"])]
     print(
         f"Generated Dart pubspec at {os.path.join(dart_pkg_dir, 'pubspec.yaml')} "
         f"with {len(features)} feature(s)"

--- a/scripts/stub_dart_features.sh
+++ b/scripts/stub_dart_features.sh
@@ -43,7 +43,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0
 EOF
 
 cat >"$STUB_DIR/lib/klangk_features.dart" <<'EOF'
@@ -53,6 +53,10 @@ List<ToolPlugin> createAllFeatures() => [];
 // Empty named-features list — the active-set filter in main.dart iterates
 // this (createAllNamedFeatures) and registers nothing (#1655).
 List<({String name, ToolPlugin feature})> createAllNamedFeatures() => [];
+// Empty named-workspace-tabs list — the active-set filter in main.dart
+// iterates this (createAllNamedWorkspaceTabs) and mounts no feature tabs
+// (#1975).
+List<({String name, WorkspaceTabPlugin tab})> createAllNamedWorkspaceTabs() => [];
 EOF
 
 # Write overrides file and symlink into frontend

--- a/scripts/tests/test_build_pipeline.py
+++ b/scripts/tests/test_build_pipeline.py
@@ -185,6 +185,13 @@ class TestPipelineRuns:
                 f"{name} has no klangk/ dir but leaked into the Dart aggregator"
             )
 
+        # The workspace-tab aggregator (#1975) is always emitted, even when
+        # no checked-in feature declares a WorkspaceTabPlugin today — its
+        # absence would break main.dart's active-set filter at runtime.
+        assert "createAllNamedWorkspaceTabs()" in source, (
+            "createAllNamedWorkspaceTabs() aggregator not emitted"
+        )
+
     def test_named_aggregator_names_match_feature_names(self, tmp_path, monkeypatch):
         """createAllNamedFeatures() emits records whose `name` matches the
         feature name in features.yaml — the link the runtime's active-set
@@ -208,6 +215,86 @@ class TestPipelineRuns:
         )
         for name, cls in EXPECTED_DART_FEATURES.items():
             assert named_map[name] == cls
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 1b: the workspace-tab aggregator (#1975). The checked-in features all
+# declare ToolPlugin only, so the real-pipeline tests above can't reach the
+# tab-bearing code paths. These exercise find_features / generate_dart /
+# collect_feature_metadata directly against synthetic feature trees covering
+# the three shapes a feature can take: tool-only, tab-only, and both.
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestWorkspaceTabAggregator:
+    """createAllNamedWorkspaceTabs() (#1975): a feature may contribute a
+    workspace tab with or without a ToolPlugin."""
+
+    def _write_feature(self, root, name, source):
+        """Write a minimal features/<name>/klangk/ tree with feature.dart."""
+        dart_dir = root / name / "klangk"
+        (dart_dir / "lib").mkdir(parents=True, exist_ok=True)
+        (dart_dir / "pubspec.yaml").write_text(f"name: klangk_feature_{name}\n")
+        (dart_dir / "lib" / "feature.dart").write_text(source)
+
+    def test_tab_only_feature_is_discovered_and_emitted(self, tmp_path):
+        """A feature whose only component is a WorkspaceTabPlugin is
+        discovered (tool_classes empty), surfaces in features.json metadata,
+        and emits a createAllNamedWorkspaceTabs() entry — but does NOT appear
+        in createAllFeatures / createAllNamedFeatures."""
+        src = (
+            "import 'package:klangk_plugin_api/klangk_plugin_api.dart';\n"
+            "class NotesTab extends WorkspaceTabPlugin {}\n"
+        )
+        self._write_feature(tmp_path, "notes", src)
+
+        features = import_dart_features.find_features(str(tmp_path))
+        assert len(features) == 1
+        feat = features[0]
+        assert feat["name"] == "notes"
+        assert feat["tool_classes"] == []
+        assert feat["tab_classes"] == ["NotesTab"]
+
+        # A tab-only feature still appears in the features.json manifest
+        # (collect_feature_metadata iterates features, not tool_classes).
+        meta, _keys = import_dart_features.collect_feature_metadata(
+            features, str(tmp_path)
+        )
+        assert [m["name"] for m in meta] == ["notes"]
+
+        dart = import_dart_features.generate_dart(features)
+        assert "createAllNamedWorkspaceTabs()" in dart
+        assert "(name: 'notes', tab: NotesTab())," in dart
+        # The tab class appears exactly once — only in the tab aggregator,
+        # never leaked into createAllFeatures / createAllNamedFeatures.
+        assert dart.count("NotesTab()") == 1, "tab class leaked into a tool aggregator"
+
+    def test_both_tool_and_tab_feature(self, tmp_path):
+        """A feature declaring both a ToolPlugin and a WorkspaceTabPlugin
+        surfaces in BOTH aggregators under the same feature name — the shape
+        the eventual `chat` feature will take (#1976)."""
+        src = (
+            "import 'package:klangk_plugin_api/klangk_plugin_api.dart';\n"
+            "class ChatFeature extends ToolPlugin {}\n"
+            "class ChatTab extends WorkspaceTabPlugin {}\n"
+        )
+        self._write_feature(tmp_path, "chat", src)
+
+        features = import_dart_features.find_features(str(tmp_path))
+        assert len(features) == 1
+        feat = features[0]
+        assert feat["tool_classes"] == ["ChatFeature"]
+        assert feat["tab_classes"] == ["ChatTab"]
+
+        dart = import_dart_features.generate_dart(features)
+        assert "(name: 'chat', feature: ChatFeature())," in dart
+        assert "(name: 'chat', tab: ChatTab())," in dart
+
+    def test_neither_component_is_skipped(self, tmp_path):
+        """A feature declaring neither ToolPlugin nor WorkspaceTabPlugin is
+        not a klangk feature — find_features skips it entirely."""
+        self._write_feature(tmp_path, "notafeature", "class SomeRandomClass {}\n")
+        assert import_dart_features.find_features(str(tmp_path)) == []
 
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../terminal/ghostty_terminal.dart';
 import '../file_viewer/file_viewer_panel.dart';
 import '../chat/workspace_chat.dart';
@@ -14,6 +15,12 @@ class IdeLayout extends StatefulWidget {
   final Widget? settings;
   final Widget? sharing;
   final Widget? debug;
+
+  /// Feature-contributed workspace tabs (#1975). Each entry contributes a
+  /// tab (title + icon + builder) to the strip; only active features' tabs
+  /// are passed in (the active-set filter lives in main.dart, which registers
+  /// into WorkspaceTabRegistry). Defaults to none.
+  final List<WorkspaceTabPlugin> featureTabs;
   final int chatUnread;
   final bool chatMentioned;
   final GlobalKey<GhosttyTerminalState>? terminalKey;
@@ -36,6 +43,7 @@ class IdeLayout extends StatefulWidget {
     this.settings,
     this.sharing,
     this.debug,
+    this.featureTabs = const [],
     this.chatUnread = 0,
     this.chatMentioned = false,
     this.terminalKey,
@@ -191,6 +199,13 @@ class IdeLayoutState extends State<IdeLayout> {
         badge: widget.chatUnread > 0 ? widget.chatUnread : null,
         badgeHighlight: widget.chatMentioned,
       );
+    }
+    // Feature-contributed workspace tabs (#1975). Mounted after the built-in
+    // content tabs (Terminal/Files/Chat) so chat stays at its hardcoded index
+    // (see _selectTab), and before config tabs (Sharing/Settings). Each tab's
+    // feature is already active-filtered before it reaches here.
+    for (final tab in widget.featureTabs) {
+      addTab(tab.title, tab.icon, tab.build(context));
     }
     if (widget.sharing != null) {
       addTab('Sharing', Icons.people_outline, widget.sharing!);

--- a/src/frontend/lib/main.dart
+++ b/src/frontend/lib/main.dart
@@ -32,6 +32,17 @@ Future<void> main() async {
     }
   }
 
+  // Feature-contributed workspace tabs (#1975): the same active-set filter
+  // as tool plugins — a feature's tab mounts only when the feature is
+  // active. A feature may contribute a tab with no tool handlers
+  // (tab-only), or both a tab and tool handlers.
+  final tabRegistry = WorkspaceTabRegistry();
+  for (final entry in createAllNamedWorkspaceTabs()) {
+    if (activeFeatureNames.contains(entry.name)) {
+      tabRegistry.register(entry.tab);
+    }
+  }
+
   if (kIsWeb) {
     // libghostty's VT runs as WebAssembly in the browser; load it once before
     // any terminal is built. The bundled binary must match the resolved

--- a/src/frontend/lib/main.dart
+++ b/src/frontend/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flterm/flterm.dart';
-import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
@@ -8,6 +8,7 @@ import 'package:klangk_features/klangk_features.dart';
 import 'package:provider/provider.dart';
 import 'app.dart';
 import 'auth/auth_service.dart';
+import 'workspace_tab_filter.dart';
 import 'ws/ws_client.dart';
 import 'utils/web_helpers_stub.dart'
     if (dart.library.js_interop) 'utils/web_helpers_web.dart';
@@ -133,23 +134,4 @@ Future<Set<String>> _resolveActiveFeatures() async {
     ...createAllNamedFeatures().map((e) => e.name),
     ...createAllNamedWorkspaceTabs().map((e) => e.name),
   };
-}
-
-/// Registers a feature's workspace tab into the [WorkspaceTabRegistry] only
-/// when the feature is in [activeFeatureNames] — the tab analogue of the
-/// tool-plugin active-set filter in `main()` (#1975). Extracted to a
-/// top-level helper so the filter is unit-testable as a regression guard;
-/// `main()` passes the generated `createAllNamedWorkspaceTabs()` aggregator
-/// output.
-@visibleForTesting
-void registerActiveWorkspaceTabs(
-  Iterable<({String name, WorkspaceTabPlugin tab})> allTabs,
-  Set<String> activeFeatureNames,
-) {
-  final tabRegistry = WorkspaceTabRegistry();
-  for (final entry in allTabs) {
-    if (activeFeatureNames.contains(entry.name)) {
-      tabRegistry.register(entry.tab);
-    }
-  }
 }

--- a/src/frontend/lib/main.dart
+++ b/src/frontend/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flterm/flterm.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
@@ -35,13 +35,13 @@ Future<void> main() async {
   // Feature-contributed workspace tabs (#1975): the same active-set filter
   // as tool plugins — a feature's tab mounts only when the feature is
   // active. A feature may contribute a tab with no tool handlers
-  // (tab-only), or both a tab and tool handlers.
-  final tabRegistry = WorkspaceTabRegistry();
-  for (final entry in createAllNamedWorkspaceTabs()) {
-    if (activeFeatureNames.contains(entry.name)) {
-      tabRegistry.register(entry.tab);
-    }
-  }
+  // (tab-only), or both a tab and tool handlers. The filter lives in
+  // [registerActiveWorkspaceTabs] (a top-level helper) so it is unit-testable
+  // — the tool-plugin filter is the same shape but inlined.
+  registerActiveWorkspaceTabs(
+    createAllNamedWorkspaceTabs(),
+    activeFeatureNames,
+  );
 
   if (kIsWeb) {
     // libghostty's VT runs as WebAssembly in the browser; load it once before
@@ -126,5 +126,30 @@ Future<Set<String>> _resolveActiveFeatures() async {
   }
 
   // 3. No manifest, no knob — every compiled-in feature active (back-compat).
-  return createAllNamedFeatures().map((e) => e.name).toSet();
+  // Union tools + tabs: a tab-only feature has no createAllNamedFeatures()
+  // entry, so deriving the active set from tools alone would silently drop
+  // its tab (#1975).
+  return {
+    ...createAllNamedFeatures().map((e) => e.name),
+    ...createAllNamedWorkspaceTabs().map((e) => e.name),
+  };
+}
+
+/// Registers a feature's workspace tab into the [WorkspaceTabRegistry] only
+/// when the feature is in [activeFeatureNames] — the tab analogue of the
+/// tool-plugin active-set filter in `main()` (#1975). Extracted to a
+/// top-level helper so the filter is unit-testable as a regression guard;
+/// `main()` passes the generated `createAllNamedWorkspaceTabs()` aggregator
+/// output.
+@visibleForTesting
+void registerActiveWorkspaceTabs(
+  Iterable<({String name, WorkspaceTabPlugin tab})> allTabs,
+  Set<String> activeFeatureNames,
+) {
+  final tabRegistry = WorkspaceTabRegistry();
+  for (final entry in allTabs) {
+    if (activeFeatureNames.contains(entry.name)) {
+      tabRegistry.register(entry.tab);
+    }
+  }
 }

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -390,6 +390,15 @@ class _WorkspacePageState extends State<WorkspacePage> {
     for (final feature in _features) {
       feature.dispose();
     }
+    // Mirror tool plugins: release feature-tab resources on workspace close
+    // (#1975). The registry is a singleton populated once in main(), so this
+    // calls per-tab dispose() — not disposeAll() — to avoid clearing tabs
+    // that the next workspace page (same app session) will reuse. Tab plugins
+    // with real resources (e.g. the eventual chat tab's controller) must
+    // tolerate being re-registered, same as tool plugins already do.
+    for (final tab in _featureTabs) {
+      tab.dispose();
+    }
     super.dispose();
   }
 

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -76,6 +76,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
   List<String> _workspacePermissions = [];
   late final ToolPluginRegistry _featureRegistry;
   late final List<ToolPlugin> _features;
+  late final List<WorkspaceTabPlugin> _featureTabs;
   late final FileRendererRegistry _fileRenderers;
   WorkspaceConnector? _connector;
 
@@ -126,6 +127,9 @@ class _WorkspacePageState extends State<WorkspacePage> {
     _featureRegistry = ToolPluginRegistry();
     // Features are registered once in main() — reuse them here.
     _features = _featureRegistry.plugins.toList();
+    // Feature-contributed workspace tabs are likewise registered once in
+    // main() (active-filtered) — reuse the singleton registry (#1975).
+    _featureTabs = WorkspaceTabRegistry().tabs;
     _fileRenderers = buildFileRendererRegistry(_features);
     _fetchWorkspaceName();
     WidgetsBinding.instance.addPostFrameCallback((_) => _connectToWorkspace());
@@ -482,6 +486,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
         userHome: wsClient.userHome,
         registry: _fileRenderers,
       ),
+      featureTabs: _featureTabs,
       terminal: TerminalTabsView(
         wsClient: wsClient,
         terminalKey: _terminalKey,

--- a/src/frontend/lib/workspace_tab_filter.dart
+++ b/src/frontend/lib/workspace_tab_filter.dart
@@ -1,0 +1,27 @@
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// Registers a feature's workspace tab into the [WorkspaceTabRegistry] only
+/// when the feature is in [activeFeatureNames] — the tab analogue of the
+/// tool-plugin active-set filter inlined in `main()` (#1975).
+///
+/// Lives in its own module (not `main.dart`) so it is unit-testable in
+/// isolation: importing `main.dart` from a test pulls the entire app graph
+/// (app shell, workspace page, auth/debug/sharing panels, …) into the
+/// coverage instrument set, and those aren't unit-tested — which would break
+/// the frontend's 100% coverage gate. This module imports only the plugin
+/// API, so its transitive closure is tiny and fully coverable. `main()`
+/// passes the generated `createAllNamedWorkspaceTabs()` aggregator output.
+///
+/// `activeFeatureNames` is a [Set], so [Set.contains] is exact-name equality
+/// (not substring) — "git" does not activate "git-credential", same as tools.
+void registerActiveWorkspaceTabs(
+  Iterable<({String name, WorkspaceTabPlugin tab})> allTabs,
+  Set<String> activeFeatureNames,
+) {
+  final tabRegistry = WorkspaceTabRegistry();
+  for (final entry in allTabs) {
+    if (activeFeatureNames.contains(entry.name)) {
+      tabRegistry.register(entry.tab);
+    }
+  }
+}

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.2.0
+      ref: v0.3.0
   # Path set by import_dart_features.py — do not edit this line
   klangk_features:
     path: PLACEHOLDER

--- a/src/frontend/test/workspace_tab_feature_test.dart
+++ b/src/frontend/test/workspace_tab_feature_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/layout/ide_layout.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// A feature that contributes ONLY a workspace tab (no ToolPlugin) — the
+/// shape #1975 adds framework support for. Mirrors how the eventual `chat`
+/// feature will declare a tab alongside (or instead of) tool handlers.
+class _TabOnlyFeature extends WorkspaceTabPlugin {
+  @override
+  String get title => 'Notes';
+
+  @override
+  IconData get icon => Icons.note_outlined;
+
+  @override
+  Widget build(BuildContext context) =>
+      const Center(child: Text('notes panel'));
+}
+
+Widget _harness({List<WorkspaceTabPlugin> tabs = const []}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 1000,
+        height: 700,
+        child: IdeLayout(
+          fileViewer: const SizedBox(),
+          terminal: const SizedBox(),
+          featureTabs: tabs,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  // The active-set filter lives in main.dart: it resolves the deploy's active
+  // features and registers only those tabs into WorkspaceTabRegistry, which
+  // the workspace page passes to IdeLayout. So "registered into the registry"
+  // IS "active". These tests assert IdeLayout mounts a tab that reaches it
+  // (active) and omits one that does not (inactive).
+
+  group('feature-contributed workspace tabs', () {
+    testWidgets('mounts an active feature tab in the workspace shell',
+        (tester) async {
+      await tester.pumpWidget(_harness(tabs: [_TabOnlyFeature()]));
+      await tester.pumpAndSettle();
+
+      // The feature's tab title is rendered in the tab strip.
+      expect(find.text('Notes'), findsOneWidget);
+
+      // Selecting the tab mounts its content widget.
+      await tester.tap(find.text('Notes'));
+      await tester.pumpAndSettle();
+      expect(find.text('notes panel'), findsOneWidget);
+    });
+
+    testWidgets('an inactive feature tab is absent from the workspace shell',
+        (tester) async {
+      // No tabs passed in — the feature is inactive (main() did not register
+      // it), so its tab must not appear anywhere.
+      await tester.pumpWidget(_harness());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Notes'), findsNothing);
+      expect(find.text('notes panel'), findsNothing);
+    });
+
+    testWidgets('a tab-only feature needs no ToolPlugin', (tester) async {
+      // Smoke-check the framework shape: a feature whose only component is a
+      // WorkspaceTabPlugin is a valid, registrable tab (no tool handlers
+      // required). This is what lets a tab-only feature ship.
+      final tab = _TabOnlyFeature();
+      expect(tab, isA<WorkspaceTabPlugin>());
+      // It is NOT a ToolPlugin — the two are deliberately independent.
+      expect(tab is ToolPlugin, isFalse);
+      await tester.pumpWidget(_harness(tabs: [tab]));
+      await tester.pumpAndSettle();
+      expect(find.text('Notes'), findsOneWidget);
+    });
+  });
+}

--- a/src/frontend/test/workspace_tab_registry_test.dart
+++ b/src/frontend/test/workspace_tab_registry_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:klangk_frontend/main.dart';
+import 'package:klangk_frontend/workspace_tab_filter.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 /// Minimal tab plugin for filter tests — identity matters (the registry keeps

--- a/src/frontend/test/workspace_tab_registry_test.dart
+++ b/src/frontend/test/workspace_tab_registry_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/main.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// Minimal tab plugin for filter tests — identity matters (the registry keeps
+/// the same instances main() registered), so each test builds distinct ones.
+class _FakeTab extends WorkspaceTabPlugin {
+  _FakeTab(this.title);
+  final String title;
+  @override
+  IconData get icon => Icons.tab;
+  @override
+  Widget build(BuildContext context) => Text(title);
+}
+
+void main() {
+  // The registry is a process-global singleton shared between main()
+  // (register) and the workspace page (read). Reset it around each test so
+  // ordering and cross-test leakage can't matter.
+  setUp(WorkspaceTabRegistry().disposeAll);
+  tearDown(WorkspaceTabRegistry().disposeAll);
+
+  group('registerActiveWorkspaceTabs (active-set filter, #1975)', () {
+    test('registers only tabs whose feature is in the active set', () {
+      final a = _FakeTab('a');
+      final b = _FakeTab('b');
+      final c = _FakeTab('c');
+
+      registerActiveWorkspaceTabs(
+        [
+          (name: 'alpha', tab: a),
+          (name: 'beta', tab: b),
+          (name: 'gamma', tab: c),
+        ],
+        {'alpha', 'gamma'},
+      );
+
+      // Only active features' tabs land in the singleton registry, in order.
+      expect(WorkspaceTabRegistry().tabs, [a, c]);
+    });
+
+    test('an empty active set registers nothing', () {
+      registerActiveWorkspaceTabs(
+        [(name: 'alpha', tab: _FakeTab('a'))],
+        <String>{},
+      );
+      expect(WorkspaceTabRegistry().tabs, isEmpty);
+    });
+
+    test('exact-name match — "git" does not activate "git-credential"', () {
+      // activeFeatureNames is a Set<String>, so .contains() is exact-name
+      // equality (not substring) — mirrors the tool-plugin comment in main().
+      final git = _FakeTab('git');
+      final gitCred = _FakeTab('git-credential');
+
+      registerActiveWorkspaceTabs(
+        [
+          (name: 'git', tab: git),
+          (name: 'git-credential', tab: gitCred),
+        ],
+        {'git'},
+      );
+
+      expect(WorkspaceTabRegistry().tabs, [git]);
+    });
+
+    test(
+        'main() register is visible to the workspace-page read '
+        '(singleton wiring invariant)', () {
+      // workspace_page.dart reads `WorkspaceTabRegistry().tabs` from a
+      // different constructor call than main()'s register — that only works
+      // because the registry is a singleton. Register via the helper and read
+      // via a fresh instance to prove the two share state.
+      final tab = _FakeTab('wired');
+      registerActiveWorkspaceTabs(
+        [(name: 'wired', tab: tab)],
+        {'wired'},
+      );
+      expect(identical(WorkspaceTabRegistry(), WorkspaceTabRegistry()), isTrue);
+      expect(WorkspaceTabRegistry().tabs.last, tab);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds framework support for **feature-contributed workspace tabs** (#1975): a feature can now declare a `WorkspaceTabPlugin` (title + icon + builder) that mounts in the workspace tab strip, separately from `ToolPlugin`. A feature may declare either, both (e.g. the eventual `chat` feature contributes a chat tab *and* agent tool handlers), or only a tab. Tabs mount only when their feature is active (the existing `KLANGKD_FEATURES_ENABLE` active-set filter).

This unblocks the chat-extraction issue (#1976), where the hardcoded `WorkspaceChat` tab becomes the `chat` feature's `WorkspaceTabPlugin`.

### Dependency (external, already shipped)

Bumps `klangk_plugin_api` → **`v0.3.0`**, which adds the new `WorkspaceTabPlugin` + `WorkspaceTabRegistry` API (mirrors the existing `FileRendererPlugin` pattern). Shipped via **[mcdonc/klangk-plugin-api#5](https://github.com/mcdonc/klangk-plugin-api/pull/5)** (merged, tagged `v0.3.0`).

### Changes

- **`scripts/import_dart_features.py`** — discover `extends WorkspaceTabPlugin` alongside `extends ToolPlugin`; emit a `createAllNamedWorkspaceTabs()` aggregator. A **tab-only** feature (no `ToolPlugin`) now compiles in and appears in `features.json` (previously skipped).
- **`src/frontend/lib/main.dart`** — register active features' tabs into `WorkspaceTabRegistry`, using the same active-set filter as tool plugins.
- **`src/frontend/lib/layout/ide_layout.dart`** — mount feature tabs in the strip after the built-in content tabs (Terminal/Files/Chat); a feature's tab is absent when its feature is inactive.
- **`src/frontend/lib/workspace/workspace_page.dart`** — pass the registry's tabs into `IdeLayout`.
- **`scripts/stub_dart_features.sh`** — emit the empty `createAllNamedWorkspaceTabs()` + bump the plugin_api ref so `flutter test` resolves without the full codegen.

## Acceptance

- ✅ A tab-only feature compiles in, appears in `features.json`, and its tab mounts when active (verified with a throwaway fixture: discovered → emitted in the aggregator → present in `features.json`; mounting via the new widget test).
- ✅ The tab is absent when the feature is removed from `KLANGKD_FEATURES_ENABLE` (active-set filter in `main.dart` skips registration).
- ✅ `flutter test --coverage` — **948 passed** (incl. 3 new tests).

## Test plan

- New `test/workspace_tab_feature_test.dart`: mounts an active feature tab in the workspace shell; omits an inactive one; confirms a tab-only feature needs no `ToolPlugin`.
- Emitter verified directly against the repo's real feature trees (6 tool features still discovered; `createAllNamedWorkspaceTabs()` emitted) and against a tab-only fixture (discovered + in `features.json` + in the aggregator).
- Full suite: `devenv --quiet -O dotenv.enable:bool false shell -- flutter test --coverage` → **948 passed**.

Part of #1685. Closes #1975.
