### PR TITLE
fix(tests): only override socket paths on macOS, not Linux (#1983)

### DIFF
--- a/src/klangk/klangkd-tests/tests/_helpers.py
+++ b/src/klangk/klangkd-tests/tests/_helpers.py
@@ -9,6 +9,7 @@ yet available.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 
 from klangk.settings import KlangkSettings
@@ -57,16 +58,17 @@ def make_settings(
         "KLANGKD_STATE_DIR", tempfile.mkdtemp(prefix="klangk-state-")
     )
     env.setdefault("KLANGKD_DATA_DIR", tempfile.mkdtemp(prefix="klangk-data-"))
-    # On macOS the default socket paths derived from state_dir
-    # (<state_dir>/klangk.sock, <state_dir>/caddy-admin.sock) may exceed the
+    # On macOS the default socket paths derived from state_dir may exceed the
     # 104-char AF_UNIX sun_path limit because tempfile paths resolve through
     # /private/var/folders/... Set short socket paths so the settings
     # validator passes (#1983).
-    _sock_dir = tempfile.mkdtemp(prefix="ks-")
-    env.setdefault("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
-    env.setdefault(
-        "KLANGKD_CADDY_ADMIN_SOCKET", os.path.join(_sock_dir, "caddy.sock")
-    )
+    if sys.platform == "darwin":
+        _sock_dir = tempfile.mkdtemp(prefix="ks-")
+        env.setdefault("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
+        env.setdefault(
+            "KLANGKD_CADDY_ADMIN_SOCKET",
+            os.path.join(_sock_dir, "caddy.sock"),
+        )
     return KlangkSettings(env=env, config_file=config_file)
 
 

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for backend unit tests."""
 
 import os
+import sys
 import tempfile
 
 # Must be set before coverage.py initialises in each xdist worker so that
@@ -52,16 +53,17 @@ def temp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("KLANGKD_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("KLANGKD_CUSTOMIZE_DIR", str(tmp_path / "customize"))
     monkeypatch.delenv("KLANGKD_IMAGE_PULL_POLICY", raising=False)
-    # On macOS the default socket paths derived from tmp_path
-    # (<tmp_path>/state/klangk.sock, <tmp_path>/state/caddy-admin.sock)
-    # may exceed the 104-char AF_UNIX sun_path limit because pytest tmp
-    # paths resolve through /private/var/folders/... Set short socket
-    # paths so the settings validator passes (#1983).
-    _sock_dir = tempfile.mkdtemp(prefix="ks-")
-    monkeypatch.setenv("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
-    monkeypatch.setenv(
-        "KLANGKD_CADDY_ADMIN_SOCKET", os.path.join(_sock_dir, "caddy.sock")
-    )
+    # On macOS the default socket paths derived from tmp_path may exceed the
+    # 104-char AF_UNIX sun_path limit because pytest tmp paths resolve
+    # through /private/var/folders/... Set short socket paths so the
+    # settings validator passes (#1983).
+    if sys.platform == "darwin":
+        _sock_dir = tempfile.mkdtemp(prefix="ks-")
+        monkeypatch.setenv("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
+        monkeypatch.setenv(
+            "KLANGKD_CADDY_ADMIN_SOCKET",
+            os.path.join(_sock_dir, "caddy.sock"),
+        )
     # Build the per-test DB from the new env so the engine cache and db_path
     # point at the per-test temp dir (#1452: no import-time globals). Stash it
     # in the per-test holder so the ``app_state`` fixture (and any


### PR DESCRIPTION
## Summary

- Fix regression from #1984: socket path overrides in `make_settings()` and `temp_data_dir` were unconditional, breaking Linux tests that expect socket paths derived from `KLANGKD_STATE_DIR`
- Guard the short socket path workaround with `sys.platform == "darwin"`

## Test plan
- [ ] `test-backend` (Linux) passes — no more caddy/proxy test failures
- [ ] `test-backend-macos` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)