### PR TITLE
fix(tests): resolve remaining macOS CI failures in caddy, proxy, container, netfilter (#1983)

### DIFF
--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -12,6 +12,8 @@ import asyncio
 import logging
 import os
 import signal
+import sys
+import tempfile
 import types
 from unittest.mock import AsyncMock, Mock
 
@@ -1120,9 +1122,24 @@ class TestFindProxyBin:
 
 class TestWatchdogPaths:
     def test_admin_socket_under_state_dir(self, tmp_path):
-        s = make_settings({"KLANGKD_STATE_DIR": str(tmp_path)})
+        # On macOS, pytest tmp_path resolves through /private/var/folders/...
+        # which can exceed the 104-byte AF_UNIX sun_path limit. Use a short
+        # temp dir so the socket path passes the settings validator (#1983).
+        if sys.platform == "darwin":
+            state = tempfile.mkdtemp(prefix="ks-")
+            sock = os.path.join(state, "caddy-admin.sock")
+            s = make_settings(
+                {
+                    "KLANGKD_STATE_DIR": state,
+                    "KLANGKD_CADDY_ADMIN_SOCKET": sock,
+                }
+            )
+        else:
+            state = str(tmp_path)
+            sock = str(tmp_path / "caddy-admin.sock")
+            s = make_settings({"KLANGKD_STATE_DIR": state})
         wd = _wd(s)
-        assert wd.admin_socket == str(tmp_path / "caddy-admin.sock")
+        assert wd.admin_socket == sock
 
     def test_admin_socket_override(self, tmp_path):
         """KLANGKD_CADDY_ADMIN_SOCKET overrides the default path (#1636) — read
@@ -1141,11 +1158,23 @@ class TestWatchdogPaths:
         """The Caddy bind address is the bare unix//<path> with NO |0600 mode
         suffix (that's version-fragile — #1709; mode enforced via os.chmod).
         The bare path (admin_socket) is what httpx dials."""
-        s = make_settings({"KLANGKD_STATE_DIR": str(tmp_path)})
+        if sys.platform == "darwin":
+            state = tempfile.mkdtemp(prefix="ks-")
+            sock = os.path.join(state, "caddy-admin.sock")
+            s = make_settings(
+                {
+                    "KLANGKD_STATE_DIR": state,
+                    "KLANGKD_CADDY_ADMIN_SOCKET": sock,
+                }
+            )
+        else:
+            state = str(tmp_path)
+            sock = str(tmp_path / "caddy-admin.sock")
+            s = make_settings({"KLANGKD_STATE_DIR": state})
         wd = _wd(s)
-        assert wd.admin_bind_address == f"unix//{tmp_path}/caddy-admin.sock"
+        assert wd.admin_bind_address == f"unix//{sock}"
         assert "|0600" not in wd.admin_bind_address
-        assert wd.admin_socket == str(tmp_path / "caddy-admin.sock")
+        assert wd.admin_socket == sock
 
     def test_find_proxy_bin_delegates_to_renderer(self, monkeypatch):
         s = make_settings({"KLANGKD_PROXY_BIN": "/x/caddy"})
@@ -1244,10 +1273,16 @@ class TestWatchdogStart:
     @pytest.mark.asyncio
     async def test_start_runs_prepare_and_spawns(self, monkeypatch, tmp_path):
         """When enabled, start() resolves the bin + schedules the watchdog."""
+        # On macOS, pytest tmp_path can exceed the AF_UNIX sun_path limit;
+        # use a short temp dir for the state + socket (#1983).
+        if sys.platform == "darwin":
+            state = tempfile.mkdtemp(prefix="ks-")
+        else:
+            state = str(tmp_path)
         s = make_settings(
             env={
-                "KLANGKD_STATE_DIR": str(tmp_path),
-                "KLANGKD_SOCKET": str(tmp_path / "klangk.sock"),
+                "KLANGKD_STATE_DIR": state,
+                "KLANGKD_SOCKET": os.path.join(state, "klangk.sock"),
                 "KLANGKD_EGRESS_PORT": "19999",
             }
         )

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -604,6 +604,11 @@ class TestStartContainer:
             "netfilter_hooks_dir",
             str(tmp_path / "hooks"),
         )
+        # On macOS, install_hooks() tries to SSH into the podman VM;
+        # force Linux so the local-only path is exercised (#1983).
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(_nf_mod.platform, "system", lambda: "Linux")
         # #1771: create_kwargs only trusts a dir whose hook is actually
         # installed, so arm it before starting the container.
         self.registry.app.state.netfilter.install_hooks()

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -220,7 +220,10 @@ class TestNetFilterInstallHooks:
         # #1774: netfilter_enabled=False -> install_hooks is a noop.
         assert nf.NetFilter(_app(enabled=False)).install_hooks() is None
 
-    def test_writes_script_and_json(self, tmp_path):
+    def test_writes_script_and_json(self, tmp_path, monkeypatch):
+        # On macOS, install_hooks() tries to SSH into the podman VM;
+        # force Linux so the local-only path is exercised (#1983).
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
         path = str(tmp_path / "hooks")
         installed = nf.NetFilter(_app(hooks_dir=path)).install_hooks()
         assert installed == os.path.realpath(path)
@@ -236,7 +239,10 @@ class TestNetFilterInstallHooks:
             data = json.load(f)
         assert data["hook"]["path"] == os.path.abspath(script)
 
-    def test_idempotent(self, tmp_path):
+    def test_idempotent(self, tmp_path, monkeypatch):
+        # On macOS, install_hooks() tries to SSH into the podman VM;
+        # force Linux so the local-only path is exercised (#1983).
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
         path = str(tmp_path / "hooks")
         nf_obj = nf.NetFilter(_app(hooks_dir=path))
         nf_obj.install_hooks()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -9,6 +9,8 @@ import asyncio
 import os
 import re
 import socket
+import sys
+import tempfile
 from unittest.mock import Mock
 
 import pytest
@@ -873,10 +875,16 @@ class TestWatchdogGate:
         unit-tested."""
         from klangk.proxy import ProxyWatchdog
 
-        sock = str(tmp_path / "klangk.sock")
+        # On macOS, pytest tmp_path can exceed the AF_UNIX sun_path limit;
+        # use a short temp dir for the state + socket (#1983).
+        if sys.platform == "darwin":
+            state = tempfile.mkdtemp(prefix="ks-")
+        else:
+            state = str(tmp_path)
+        sock = os.path.join(state, "klangk.sock")
         s = make_settings(
             env={
-                "KLANGKD_STATE_DIR": str(tmp_path),
+                "KLANGKD_STATE_DIR": state,
                 "KLANGKD_SOCKET": sock,
                 "KLANGKD_EGRESS_PORT": "19999",
             }
@@ -896,13 +904,16 @@ class TestWatchdogGate:
         monkeypatch.setattr(ProxyWatchdog, "_watch", _fake_watch)
         wd = _wd(s)
         await wd.start()
+        from pathlib import Path
+
+        state_p = Path(state)
         try:
             assert wd._task is not None
             assert wd._stopping is False
-            assert (tmp_path / "nginx.conf").is_file()
+            assert (state_p / "nginx.conf").is_file()
             await wd._task
             assert spawned["bin"] == "/fake/nginx"
-            assert spawned["conf"] == str(tmp_path / "nginx.conf")
+            assert spawned["conf"] == str(state_p / "nginx.conf")
         finally:
             # UDS mode is now per-Util-instance (_wd builds a fresh one each
             # call), so there's no module global to reset (#1503).
@@ -913,10 +924,22 @@ class TestPrepareProxy:
     """ProxyWatchdog._prepare() renders nginx.conf with UDS upstream (#1400)."""
 
     def test_renders_config_and_returns_paths(self, monkeypatch, tmp_path):
+        # On macOS, pytest tmp_path resolves through /private/var/folders/...
+        # which can exceed the 104-byte AF_UNIX sun_path limit. Use a short
+        # temp dir for the state + socket so the settings validator passes
+        # (#1983). nginx.conf is written into state_dir, so assertions
+        # reference the same dir.
+        if sys.platform == "darwin":
+            state = tempfile.mkdtemp(prefix="ks-")
+        else:
+            state = str(tmp_path)
+        from pathlib import Path
 
+        state_p = Path(state)
         s = make_settings(
             env={
-                "KLANGKD_STATE_DIR": str(tmp_path),
+                "KLANGKD_STATE_DIR": state,
+                "KLANGKD_SOCKET": str(state_p / "klangk.sock"),
                 "KLANGKD_EGRESS_PORT": "19999",
                 "KLANGKD_LLM_BASE_URL": "http://127.0.0.1:11434",
             }
@@ -928,10 +951,10 @@ class TestPrepareProxy:
         wd = _wd(s)
         bin_path, conf_path = wd._prepare()
         assert bin_path == "/fake/nginx"
-        assert conf_path == str(tmp_path / "nginx.conf")
-        assert (tmp_path / "nginx.conf").is_file()
-        conf = (tmp_path / "nginx.conf").read_text()
-        uds_path = str(tmp_path / "klangk.sock")
+        assert conf_path == str(state_p / "nginx.conf")
+        assert (state_p / "nginx.conf").is_file()
+        conf = (state_p / "nginx.conf").read_text()
+        uds_path = str(state_p / "klangk.sock")
         assert f"proxy_pass http://unix:{uds_path}:" in conf
 
 


### PR DESCRIPTION
## Summary

- Fix 6 remaining macOS CI test failures after #1984/#1986
- Caddy/proxy tests: use short `KLANGKD_STATE_DIR` and explicit socket paths on macOS to stay under the 104-byte `sun_path` limit
- Netfilter/container tests: monkeypatch `platform.system` to `"Linux"` so the VM-copy branch is skipped in unit tests

Closes #1983

## Test plan
- [ ] `test-backend-macos` CI job passes
- [ ] `test-backend` (Linux) CI job still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)