### PR TITLE
fix(coverage): exclude linux-only pdeathsig block from macOS coverage (#1983)

### DIFF
--- a/src/klangk/klangk/proxy.py
+++ b/src/klangk/klangk/proxy.py
@@ -840,7 +840,7 @@ http {{
 
 _PR_SET_PDEATHSIG = 1
 _HAS_PDEATHSIG = sys.platform == "linux"
-if _HAS_PDEATHSIG:
+if _HAS_PDEATHSIG:  # pragma: no cover – linux-only
     _libc = ctypes.CDLL(
         ctypes.util.find_library("c") or "libc.so.6", use_errno=True
     )


### PR DESCRIPTION
## Summary

- Add `# pragma: no cover` to the `if _HAS_PDEATHSIG:` block in `proxy.py` — this ctypes/libc init only runs on Linux, leaving line 844 uncovered on macOS CI (99.99% < 100% required)

## Test plan
- [ ] `test-backend-macos` coverage reaches 100%
- [ ] `test-backend` (Linux) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)