### PR TITLE
docs: fix stale browser/ingress port 8995 → 8997

### DIFF
--- a/docs/deployment/customizing.md
+++ b/docs/deployment/customizing.md
@@ -331,7 +331,7 @@ Use the stock image with runtime customization (no features):
 
 ```bash
 docker run -d \
-  -p 8995:8995 \
+  -p 8997:8997 \
   -v ./data:/home/klangk/data \
   -v ./mount:/home/klangk/mount \
   --cap-add SYS_ADMIN \

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -15,7 +15,7 @@ build tools required.
 ```bash
 docker run -d \
   --name klangk \
-  -p 8995:8995 \
+  -p 8997:8997 \
   -v klangk-data:/home/klangk/data \
   --cap-add SYS_ADMIN \
   --device /dev/fuse \
@@ -32,11 +32,11 @@ docker run -d \
   ghcr.io/mcdonc/klangk/klangk-host:v1.0
 ```
 
-Open <http://localhost:8995> and log in with the email and password
+Open <http://localhost:8997> and log in with the email and password
 you set above.
 
 The examples pin `KLANGKD_AUTH_MODES=password` because a Docker image
-publishes its port (`-p 8995:8995`) and is network-reachable, while the
+publishes its port (`-p 8997:8997`) and is network-reachable, while the
 default mode (`none`) is loopback-only. See [Auth Modes](../features/auth-modes.md)
 and [#1391](https://github.com/mcdonc/klangk/issues/1391) for the
 no-login Docker story.
@@ -88,7 +88,7 @@ services:
   klangk:
     image: ghcr.io/mcdonc/klangk/klangk-host:v1.0
     ports:
-      - "8995:8995"
+      - "8997:8997"
     volumes:
       - klangk-data:/home/klangk/data
     cap_add:

--- a/docs/deployment/hosting.md
+++ b/docs/deployment/hosting.md
@@ -1,6 +1,6 @@
 # Hosting & Proxy
 
-**The reverse proxy (nginx) is the primary access point** (port 8995 locally). It proxies API/WebSocket to uvicorn and proxies hosted app URLs directly to container ports (no Python in the hosted app path).
+**The reverse proxy (nginx) is the primary access point** (port 8997 locally). It proxies API/WebSocket to uvicorn and proxies hosted app URLs directly to container ports (no Python in the hosted app path).
 
 - FastAPI serves API endpoints and Flutter frontend static files on port 8997 (not accessed directly by users).
 - Hosted app URLs (`/hosted/{workspace_id}/{port}/`) are handled by a proxy regex location that extracts the port and proxies to `127.0.0.1:{port}`.
@@ -13,7 +13,7 @@
 The devenv.nix runs the proxy as the primary access point:
 
 ```text
-klangk reverse proxy (port 8995)
+klangk reverse proxy (port 8997)
     ├── /hosted/{ws_id}/{port}/ → container port (direct proxy)
     └── /                       → Klangk backend (port 8997)
 ```
@@ -23,7 +23,7 @@ In production behind a reverse proxy with subpath:
 ```text
 outer nginx (443)
     ├── /klangk/hosted/{ws_id}/{port}/ → container port (direct proxy)
-    └── /klangk/                       → klangk proxy (port 8995)
+    └── /klangk/                       → klangk proxy (port 8997)
                                          └── / → uvicorn (port 8997)
 ```
 

--- a/docs/features/hosted-apps.md
+++ b/docs/features/hosted-apps.md
@@ -25,7 +25,7 @@ http://<hostname>:<KLANGKD_PORT>/hosted/<workspace_id>/<host_port>/
 For example, if your workspace ID is `abc123` and you run a server on container port 8000 (mapped to host port 9000):
 
 ```text
-http://localhost:8995/hosted/abc123/9000/
+http://localhost:8997/hosted/abc123/9000/
 ```
 
 WebSocket connections are supported — tools like Jupyter and Marimo work out of the box.
@@ -35,7 +35,7 @@ WebSocket connections are supported — tools like Jupyter and Marimo work out o
 | Variable                    | Example                   | Description                                   |
 | --------------------------- | ------------------------- | --------------------------------------------- |
 | `KLANGKWS_PORT_MAPPINGS`    | `8000:9000,8001:9001,...` | Container-to-host port mapping (CSV)          |
-| `KLANGKD_HOSTING_HOSTNAME`  | `localhost:8995`          | Hostname for constructing hosted app URLs     |
+| `KLANGKD_HOSTING_HOSTNAME`  | `localhost:8997`          | Hostname for constructing hosted app URLs     |
 | `KLANGKD_HOSTING_PROTO`     | `http`                    | Protocol for hosted app URLs                  |
 | `KLANGKD_HOSTING_BASE_PATH` | `/klangk`                 | Base path prefix (empty for root deployments) |
 
@@ -48,7 +48,7 @@ The easiest way to get a hosted app URL from the shell is the
 
 ```bash
 $ klangk-hosted-url 8000
-http://localhost:8995/hosted/abc123/9000/
+http://localhost:8997/hosted/abc123/9000/
 ```
 
 Pass the **container port** (8000-8004); it resolves the mapped host port via

--- a/docs/features/ssh-agent-forwarding.md
+++ b/docs/features/ssh-agent-forwarding.md
@@ -49,7 +49,7 @@ forward-agent: true
 # Or enable/disable per server
 servers:
   local:
-    url: http://localhost:8995
+    url: http://localhost:8997
     forward-agent: true
   prod:
     url: https://klangk.example.com

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ You need Docker (or Podman) and an OpenAI-compatible LLM API key.
 ```bash
 docker run -d \
   --name klangk \
-  -p 8995:8995 \
+  -p 8997:8997 \
   -v klangk-data:/home/klangk/data \
   --cap-add SYS_ADMIN \
   --device /dev/fuse \
@@ -28,10 +28,10 @@ docker run -d \
   ghcr.io/mcdonc/klangk/klangk-host:v1.0
 ```
 
-Open <http://localhost:8995> and log in with the email and password
+Open <http://localhost:8997> and log in with the email and password
 you set above.
 
-> A Docker container publishes its port (`-p 8995:8995`), making it
+> A Docker container publishes its port (`-p 8997:8997`), making it
 > network-reachable, so these examples set `KLANGKD_AUTH_MODES=password`
 > explicitly. The default mode is `none` (no-login, loopback-only), which is
 > meant for local dev on your own machine — a published port is not that.
@@ -82,7 +82,7 @@ devenv processes up --no-tui
 This sets up the dev shell (Python, Flutter, Dart, Node, podman,
 etc.), builds the workspace image and Flutter web app on first run,
 starts the proxy and the FastAPI backend, and watches for file changes.
-Open <http://localhost:8995>.
+Open <http://localhost:8997>.
 
 To run project commands like `test-backend` or
 `build-workspace-image` in a separate terminal, use `devenv shell`
@@ -97,7 +97,7 @@ instructions.
 ## Logging in
 
 Out of the box (the default `none` auth mode) there is **nothing to log in
-with** — open <http://localhost:8995> and you're already in, as the default
+with** — open <http://localhost:8997> and you're already in, as the default
 user (`KLANGKD_DEFAULT_USER`). The CLI likewise needs no `klangk login`.
 
 If you switched to a real auth mode (`password`, `oidc`, or `both` — e.g. the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,7 @@ ws-max-size: 33554432 # 32 MB (default 16 MB)
 # Named server aliases
 servers:
   local:
-    url: http://localhost:8995
+    url: http://localhost:8997
     user: admin@example.com # default user for login
   prod:
     url: https://klangk.example.com
@@ -63,7 +63,7 @@ server:
 ```yaml
 servers:
   myserver:
-    url: http://myhost:8995
+    url: http://myhost:8997
 ```
 
 You do not need to create `klangk.yaml` manually. On your first
@@ -71,12 +71,12 @@ You do not need to create `klangk.yaml` manually. On your first
 hostname as the alias and the login user as the default:
 
 ```bash
-klangk login http://myhost:8995 admin@example.com
+klangk login http://myhost:8997 admin@example.com
 # Creates ~/.config/klangk/klangk.yaml with:
 #   # forward-agent: true   # opt-in: uncomment to enable
 #   servers:
 #     myhost:
-#       url: http://myhost:8995
+#       url: http://myhost:8997
 #       user: admin@example.com
 ```
 
@@ -100,8 +100,8 @@ Auto-managed. Stores the active server, active user per server, and
 cached authentication tokens:
 
 ```yaml
-active-server: http://localhost:8995
-http://localhost:8995:
+active-server: http://localhost:8997
+http://localhost:8997:
   active-user: admin@example.com
   users:
     admin@example.com:
@@ -144,7 +144,7 @@ or a raw URL. It does not change `klangk-state.yaml`.
 ```bash
 # Authentication
 klangk login local                          # login to "local" alias (uses default user from config)
-klangk login http://localhost:8995          # login with a raw URL (prompts for user)
+klangk login http://localhost:8997          # login with a raw URL (prompts for user)
 klangk login prod chris@example.com         # login as a specific user
 klangk logout                               # logout from active server
 klangk logout prod                          # logout from a specific server


### PR DESCRIPTION
## Summary

Fixes stale **browser/ingress port `8995`** references across the docs — they should be **`8997`**. The host image bakes `port: "8997"` + `EXPOSE 8997` (browser/ingress) and `egress_port: "8995"` (container→host), but several docs still showed the pre-split browser port `8995` in user-facing places. The docs were actually half-migrated (e.g. `customizing.md` set `KLANGKD_PORT=8997` but published `-p 8995:8995`); this completes it.

## What changed

Only **browser/ingress** refs → `8997`, across:
- `docs/getting-started.md`, `docs/deployment/docker.md` — the `docker run -p 8997:8997` publish + `http://localhost:8997` + the compose `ports:` example.
- `docs/deployment/customizing.md` — `-p 8997:8997` (now consistent with the `KLANGKD_PORT=8997` it already set).
- `docs/deployment/hosting.md` — the access-point / diagram port labels.
- `docs/reference/cli.md` — CLI connect URLs.
- `docs/features/hosted-apps.md` — hosted-app URLs + `KLANGKD_HOSTING_HOSTNAME` default.
- `docs/features/ssh-agent-forwarding.md` — server URL example.

## What was NOT changed

- The **container-egress port** (`KLANGKD_EGRESS_PORT` / `egress_port`, default `8995`) — still `8995` everywhere (config tables, environment reference, docker-compose, the egress examples).
- `docs/changes.md` historical entries and `docs/architecture/index.md`'s egress label.

Spotted while updating #1391.
