### PR TITLE
fix(launcher): per-module logger so duplicate-instance pre-flight exits cleanly (#1993)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1172,6 +1172,16 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **`klangkd` no longer crash-loops when a second instance starts against
+  the same config (#1993).** The pre-flight guard that refuses a duplicate
+  instance tried to log via a nonexistent `logger` symbol
+  (`from klangk.logger import logger` — `klangk.logger` exposes only
+  `configure` / `configure_defaults`), raising `ImportError` before the
+  graceful `sys.exit(1)`. The process crashed and restarted under the
+  supervisor (and the already-running instance printed the same traceback)
+  instead of exiting cleanly. The launcher now uses a per-module
+  `logging.getLogger(__name__)` and logs + exits as intended.
+
 - **Chat read paths now require the `chat` permission (#1976).** When the
   chat surface moved into the (deploy-wide) `chat` feature tab, the
   per-user `_hasPerm('chat')` gate that hid the panel was lost. The send

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -32,6 +32,7 @@ proxy ownership), and #1645 (first-run generation) for the full rationale.
 
 from __future__ import annotations
 
+import logging
 import os
 import platform
 import shutil
@@ -46,10 +47,17 @@ import uvicorn
 # configuration is active during ``KlangkSettings(...)`` construction
 # (validators + the file:/cmd: indirection resolver log before any app
 # exists). ``build_app``'s ``configure(settings)`` later overrides the
-# level from ``KLANGKD_LOG_LEVEL`` (#1467).
-from klangk import logger  # noqa: F401
+# level from ``KLANGKD_LOG_LEVEL`` (#1467). Imported as a statement (not
+# ``from klangk import logger``) so the name ``logger`` stays free for the
+# per-module Logger below — ``klangk.logger`` exposes no ``logger`` symbol
+# (only ``configure`` / ``configure_defaults``), so the old
+# ``from klangk.logger import logger`` in the error paths raised ImportError
+# instead of logging and exiting (#1993).
+import klangk.logger  # noqa: F401
 from klangk import first_run
 from klangk.settings import KlangkSettings
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     add_completion=False,
@@ -229,8 +237,6 @@ def main(  # pragma: no cover
     # uvicorn binds — too late to protect the socket file.
     existing = _check_pid_preflight(settings)
     if existing is not None:
-        from klangk.logger import logger  # noqa: allow-deferred-import
-
         logger.error(
             "Another klangk instance (PID %d) is already running — "
             "refusing to start",
@@ -273,8 +279,6 @@ def main(  # pragma: no cover
             ws_ping_timeout=20,
         )
     except OSError as exc:
-        from klangk.logger import logger  # noqa: allow-deferred-import
-
         logger.error(
             "uvicorn failed to bind UDS at %s: %s — exiting", uds_path, exc
         )

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -4,6 +4,8 @@ import asyncio
 import os
 import signal
 import sqlite3
+import subprocess
+import sys
 import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1853,6 +1855,52 @@ class TestCheckPidPreflight:
             }
         )
         assert _check_pid_preflight(settings) is None
+
+
+class TestLauncherPidPreflightGracefulExit:
+    """The launcher's ``main()`` must log and ``sys.exit(1)`` — not crash with
+    ``ImportError`` — when a second instance collides with a running one (#1993).
+
+    ``_check_pid_preflight`` is unit-tested above; this exercises the *error
+    path that consumes it* (inside ``main()``, which is otherwise
+    ``# pragma: no cover``) by launching the real launcher in a subprocess
+    against a state/data dir that already records a live foreign PID.
+    """
+
+    def test_second_instance_exits_cleanly(self, tmp_path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("test-id")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        # A live foreign PID: this test process's parent is alive and is not
+        # the launcher's own PID (same trick as test_live_foreign_pid above).
+        live_pid = os.getppid()
+        (state_dir / "klangk-test-id.pid").write_text(str(live_pid))
+
+        # Strip inherited KLANGKD_* so the subprocess sees only what we set
+        # (env > file precedence; CI/dev shells carry KLANGKD_* vars that
+        # would otherwise override our planted dirs).
+        env = {
+            k: v for k, v in os.environ.items() if not k.startswith("KLANGKD_")
+        }
+        env["KLANGKD_STATE_DIR"] = str(state_dir)
+        env["KLANGKD_DATA_DIR"] = str(data_dir)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "klangk.launcher", "--config=none"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        # Graceful refusal, not a Python traceback.
+        assert result.returncode == 1, result.stderr
+        assert "Another klangk instance" in result.stderr
+        # The pre-fix bug crashed with ImportError before the message could
+        # be logged (``from klangk.logger import logger`` — no such symbol).
+        assert "ImportError" not in result.stderr
 
 
 class TestBuildApp:


### PR DESCRIPTION
## Summary

Fixes #1993.

When a second `klangkd` started against a config file already in use by a running instance, the PID pre-flight guard correctly detected the collision but then crashed with `ImportError: cannot import name 'logger' from 'klangk.logger'` instead of logging its refusal and exiting. The process crash-looped under the supervisor, and the already-running instance printed the same traceback.

## Root cause

`launcher.py`'s two error paths imported a `logger` symbol that does not exist:

```python
existing = _check_pid_preflight(settings)
if existing is not None:
    from klangk.logger import logger   # ← raises ImportError
    logger.error("Another klangk instance (PID %d) is already running — refusing to start", existing)
    sys.exit(1)
```

`klangk/logger.py` exposes only `configure` / `configure_defaults` (`__all__ = ["configure", "configure_defaults"]`) — there is no `logger` symbol. The documented convention (per `logger.py`'s own docstring) is a per-module `logger = logging.getLogger(__name__)`, never imported from `klangk.logger`. The same broken import sat in the UDS bind-failure handler, so that path would have crashed the same way on an `EADDRINUSE`.

## Fix

- Add a module-level `logger = logging.getLogger(__name__)` to `launcher.py`.
- Switch the side-effect import from `from klangk import logger` to `import klangk.logger` (statement form), so the name `logger` stays free for the per-module Logger while still applying `klangk.logger`'s import-time default config before `KlangkSettings` construction.
- Drop both broken `from klangk.logger import logger` deferred imports (pid-preflight + UDS-bind-failure paths). Both now use the module-level logger, so they `logger.error(...)` + `sys.exit(1)` as intended.

## Test

New `TestLauncherPidPreflightGracefulExit` in `test_main.py` launches the real launcher (`python -m klangk.launcher --config=none`) in a subprocess against a state/data dir that already records a live foreign PID, and asserts:

- exit code `1` (graceful refusal, not a Python traceback),
- stderr contains `"Another klangk instance"`,
- stderr does **not** contain `"ImportError"`.

This would have failed on the pre-fix code (the `ImportError` traceback printed, `logger.error` never ran).

## Verification

- Full Python suite with `-n auto` (as CI): **4094 passed, 100% coverage**.
- `ruff check` clean on both changed files (the two remaining `# noqa: allow-deferred-import` ruff warnings are pre-existing on `main`; this PR *removed* two of four).
- Manual repro: a second `klangkd --config=none` against a planted live PID now prints the refusal message and exits 1.

## Changelog

Added a `### Fixed` entry under `[Unreleased]`.
