### PR TITLE
feat(cli): create config file eagerly on any CLI invocation

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -578,14 +578,14 @@ invitations send` stay email-only (a deliverable address is required);
   (the old config stays running; the operator sees the deny reason in the
   log). `None` / empty and valid values are unchanged.
 
-- **Generated `klangk.yaml` now includes `forward-agent` as a commented-out
-  opt-in line (#1923).** A freshly created config (written on first `klangk
-login`) ships a `# forward-agent: true` line at the top, commented out, so
-  SSH agent forwarding can be enabled by uncommenting it instead of having to
-  discover the option. It remains **off by default**: a forwarded agent can
-  be driven by anyone with access to the socket on the remote host for the
-  session, so forwarding is opt-in and recommended only for hosts you trust.
-  Existing configs are unchanged.
+- **`forward-agent` is on by default in generated `klangk.yaml` (#1923,
+  #2000).** A freshly created config — written eagerly on any CLI invocation
+  (`ensure_config`, #2000), or on first `klangk login` — ships an active
+  `forward-agent: true` so a workspace can use the operator's loaded SSH keys
+  (e.g. `git push`) without extra setup. Set `forward-agent: false` (globally
+  or per-server) to disable it for an untrusted workspace: while forwarded,
+  anyone who can reach the agent socket on the remote host can authenticate
+  as you for the session. Existing configs are unchanged.
 
 - **TUI export completion now toasts the full filesystem path (#1758).**
   When a workspace export finishes, a toast notification shows the

--- a/docs/features/ssh-agent-forwarding.md
+++ b/docs/features/ssh-agent-forwarding.md
@@ -1,16 +1,15 @@
 # SSH Agent Forwarding
 
-When connecting via `klangk shell -A`, your local SSH agent is
-forwarded into the workspace container. This lets you use
-`git push git@github.com:...`, `ssh`, and other SSH-based tools
-inside the container using your local SSH keys — without copying any
-private keys.
+By default, `klangk shell` forwards your local SSH agent into the workspace
+container. This lets you use `git push git@github.com:...`, `ssh`, and other
+SSH-based tools inside the container using your local SSH keys — without
+copying any private keys.
 
 ## How it works
 
-When `--forward-agent` (`-A`) is enabled (via CLI flag or config
-file), `klangk shell` checks for a local `SSH_AUTH_SOCK` and sets
-up a relay over the existing WebSocket tunnel:
+When agent forwarding is enabled (it is **on by default**), `klangk shell`
+checks for a local `SSH_AUTH_SOCK` and sets up a relay over the existing
+WebSocket tunnel:
 
 1. A Unix socket is created inside the container at a well-known path
 2. The socket is bridged to the CLI via socat and the WebSocket
@@ -22,14 +21,14 @@ and the response is sent back over the existing WebSocket connection.
 
 ## Usage Inside the Klangk Container
 
-Pass `-A` (or `--forward-agent`) to enable forwarding:
+A plain `klangk shell` already forwards your agent — no flag needed:
 
 ```bash
 # Make sure your agent is running and has keys loaded
 ssh-add -l
 
-# Connect with agent forwarding
-klangk shell -A my-workspace
+# Connect (agent forwarding is on by default)
+klangk shell my-workspace
 
 # Inside the container:
 ssh-add -l                          # shows your forwarded keys
@@ -37,20 +36,17 @@ ssh -T git@github.com               # authenticates with your key
 git clone git@github.com:user/repo  # works without any credentials
 ```
 
-Agent forwarding is **on by default**. A freshly generated `klangk.yaml`
-(created eagerly on any CLI invocation, or on first `klangk login`) sets
-`forward-agent: true` globally. Set `forward-agent: false` (globally or
-per-server) to disable it for a workspace you don't trust:
+Override the default per invocation with `--forward-agent` (`-A`) or
+`--no-forward-agent`, or persistently via the `forward-agent` key in
+`klangk.yaml` (set it to `false` to disable it for a workspace you don't
+trust):
 
 ```yaml
-# Enable for all servers
-forward-agent: true
+# forward-agent is on by default. Disable it globally:
+# forward-agent: false
 
-# Or enable/disable per server
+# Or disable it for a specific untrusted server:
 servers:
-  local:
-    url: http://localhost:8997
-    forward-agent: true
   prod:
     url: https://klangk.example.com
     forward-agent: false

--- a/docs/features/ssh-agent-forwarding.md
+++ b/docs/features/ssh-agent-forwarding.md
@@ -37,10 +37,10 @@ ssh -T git@github.com               # authenticates with your key
 git clone git@github.com:user/repo  # works without any credentials
 ```
 
-Agent forwarding is **off by default**. A freshly generated `klangk.yaml`
-(created on first `klangk login`) includes it as a commented-out opt-in
-line; uncomment that line, or set `forward-agent` in your CLI config file
-(`~/.config/klangk/klangk.yaml`), to enable it:
+Agent forwarding is **on by default**. A freshly generated `klangk.yaml`
+(created eagerly on any CLI invocation, or on first `klangk login`) sets
+`forward-agent: true` globally. Set `forward-agent: false` (globally or
+per-server) to disable it for a workspace you don't trust:
 
 ```yaml
 # Enable for all servers
@@ -61,8 +61,8 @@ The resolution priority is:
 1. CLI flag (`--forward-agent` / `--no-forward-agent`) — highest
 2. Per-server setting in `klangk.yaml`
 3. Global setting in `klangk.yaml`
-4. Default: `false` (a freshly generated `klangk.yaml` includes
-   `forward-agent` as a commented-out opt-in line)
+4. Default: `true` (a freshly generated `klangk.yaml` sets
+   `forward-agent: true`)
 
 See [CLI Configuration](../reference/cli.md#configuration) for full
 config file documentation.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,7 +73,7 @@ hostname as the alias and the login user as the default:
 ```bash
 klangk login http://myhost:8997 admin@example.com
 # Creates ~/.config/klangk/klangk.yaml with:
-#   # forward-agent: true   # opt-in: uncomment to enable
+#   forward-agent: true   # on by default (set false to disable)
 #   servers:
 #     myhost:
 #       url: http://myhost:8997
@@ -87,7 +87,7 @@ freely after the initial creation.
 
 | Setting         | Scope            | Default  | Description                                       |
 | --------------- | ---------------- | -------- | ------------------------------------------------- |
-| `forward-agent` | global or server | `false`  | Forward local SSH agent into containers           |
+| `forward-agent` | global or server | `true`   | Forward local SSH agent into containers           |
 | `ws-max-size`   | global or server | 16777216 | Maximum WebSocket message size in bytes           |
 | `user`          | server only      |          | Default user (email or handle) for `klangk login` |
 | `url`           | server only      |          | Server URL (required for each server entry)       |

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -164,6 +164,27 @@ class CLIConfig:
         return self.ws_max_size or _DEFAULT_WS_MAX_SIZE
 
 
+def ensure_config() -> None:
+    """Create a default klangk.yaml if one doesn't already exist.
+
+    Called early on every CLI invocation so the config file is always
+    present, even before the user logs in.
+    """
+    if _CONFIG_PATH.exists():
+        return
+    header = (
+        "# SSH agent forwarding is OFF by default. Uncomment the line below to\n"
+        "# enable it for all servers. Only enable forwarding on hosts you\n"
+        "# trust: while forwarded, anyone who can reach the agent socket on\n"
+        "# the remote host can authenticate as you with your loaded SSH keys\n"
+        "# for the duration of the session.\n"
+        "# See docs/features/ssh-agent-forwarding.md.\n"
+        "# forward-agent: true\n\n"
+    )
+    _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _CONFIG_PATH.write_text(header + "servers: {}\n")
+
+
 def seed_config(server_url: str, user: str | None = None) -> None:
     """Create klangk.yaml with an initial server entry if it doesn't exist."""
     if _CONFIG_PATH.exists():

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -173,13 +173,13 @@ def ensure_config() -> None:
     if _CONFIG_PATH.exists():
         return
     header = (
-        "# SSH agent forwarding is OFF by default. Uncomment the line below to\n"
-        "# enable it for all servers. Only enable forwarding on hosts you\n"
-        "# trust: while forwarded, anyone who can reach the agent socket on\n"
-        "# the remote host can authenticate as you with your loaded SSH keys\n"
-        "# for the duration of the session.\n"
+        "# SSH agent forwarding is ON by default so your workspace can use\n"
+        "# your loaded SSH keys (e.g. git push). Set it to false here (or\n"
+        "# per-server) if you don't trust the workspace: while forwarded,\n"
+        "# anyone who can reach the agent socket on the remote host can\n"
+        "# authenticate as you with your loaded keys for the session.\n"
         "# See docs/features/ssh-agent-forwarding.md.\n"
-        "# forward-agent: true\n\n"
+        "forward-agent: true\n\n"
     )
     _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     _CONFIG_PATH.write_text(header + "servers: {}\n")
@@ -194,20 +194,20 @@ def seed_config(server_url: str, user: str | None = None) -> None:
     entry: dict = {"url": server_url}
     if user:
         entry["user"] = user
-    # forward-agent is included as a commented-out opt-in line: it stays off
-    # by default because a forwarded SSH agent can be driven by anyone with
-    # access to the socket on the remote host for the session (#1923).
+    # forward-agent defaults to true (a generated config sets it on globally)
+    # so a workspace can use the operator's loaded SSH keys; the header below
+    # notes how to disable it for an untrusted workspace (#1923).
     servers_yaml = yaml.dump(
         {"servers": {alias: entry}}, default_flow_style=False
     )
     header = (
-        "# SSH agent forwarding is OFF by default. Uncomment the line below to\n"
-        "# enable it for all servers. Only enable forwarding on hosts you\n"
-        "# trust: while forwarded, anyone who can reach the agent socket on\n"
-        "# the remote host can authenticate as you with your loaded SSH keys\n"
-        "# for the duration of the session.\n"
+        "# SSH agent forwarding is ON by default so your workspace can use\n"
+        "# your loaded SSH keys (e.g. git push). Set it to false here (or\n"
+        "# per-server) if you don't trust the workspace: while forwarded,\n"
+        "# anyone who can reach the agent socket on the remote host can\n"
+        "# authenticate as you with your loaded keys for the session.\n"
         "# See docs/features/ssh-agent-forwarding.md.\n"
-        "# forward-agent: true\n\n"
+        "forward-agent: true\n\n"
     )
     _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     _CONFIG_PATH.write_text(header + servers_yaml)

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -57,6 +57,7 @@ from .config import (
     CLIConfig,
     CLIState,
     default_server_uds_path,
+    ensure_config,
     seed_config,
 )
 from .mount import validate_allowed_domain_spec, validate_mount_spec
@@ -107,6 +108,7 @@ def app_callback(
         None, "--server", help="Server alias or URL"
     ),
 ) -> None:
+    ensure_config()
     global _server_override
     if server is not None:
         _server_override = _cfg().resolve_server(server)

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -258,23 +258,23 @@ class TestSeedConfig:
         cfg = CLIConfig.load()
         assert "myhost" in cfg.servers
 
-    def test_includes_commented_forward_agent_opt_in(
+    def test_generated_config_defaults_forward_agent_on(
         self, tmp_path, monkeypatch
     ):
-        """#1923: a freshly generated klangk.yaml includes forward-agent as a
-        commented-out opt-in line; it stays OFF by default (forwarding only
-        happens when the user uncomments it, passes -A, or sets it
-        per-server), since a forwarded agent can be abused by an untrusted
-        host."""
+        """#1923/#2000: a freshly generated klangk.yaml sets forward-agent: true
+        (active), so SSH agent forwarding is ON by default. Disable by setting
+        forward-agent: false globally or per-server; a forwarded agent can be
+        abused by an untrusted host."""
         config_path = tmp_path / "klangk.yaml"
         monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
         seed_config("http://localhost:8995", "admin@example.com")
         text = config_path.read_text()
-        # Present as a commented-out, discoverable opt-in line...
-        assert "# forward-agent: true" in text
-        # ...and inactive (off by default).
+        # Present as an active line (on by default)...
+        assert "forward-agent: true" in text
+        assert "# forward-agent: true" not in text
+        # ...and effective.
         cfg = CLIConfig.load()
-        assert cfg.forward_agent is None
+        assert cfg.forward_agent is True
         assert "localhost" in cfg.servers
 
 
@@ -288,10 +288,12 @@ class TestEnsureConfig:
         ensure_config()
         assert config_path.exists()
         text = config_path.read_text()
-        assert "# forward-agent: true" in text
+        assert "forward-agent: true" in text
+        assert "# forward-agent: true" not in text  # active, not commented out
         assert "servers: {}" in text
         cfg = CLIConfig.load()
         assert cfg.servers == {}
+        assert cfg.forward_agent is True  # on by default
 
     def test_does_not_overwrite_existing(self, tmp_path, monkeypatch):
         config_path = tmp_path / "klangk.yaml"

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -21,6 +21,7 @@ from klangk.cli.config import (
     ServerState,
     UserEntry,
     _DEFAULT_WS_MAX_SIZE,
+    ensure_config,
     seed_config,
 )
 from klangk.cli.client import (
@@ -275,6 +276,36 @@ class TestSeedConfig:
         cfg = CLIConfig.load()
         assert cfg.forward_agent is None
         assert "localhost" in cfg.servers
+
+
+# --- ensure_config tests ---
+
+
+class TestEnsureConfig:
+    def test_creates_config_if_missing(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "sub" / "klangk.yaml"
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        ensure_config()
+        assert config_path.exists()
+        text = config_path.read_text()
+        assert "# forward-agent: true" in text
+        assert "servers: {}" in text
+        cfg = CLIConfig.load()
+        assert cfg.servers == {}
+
+    def test_does_not_overwrite_existing(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text("forward-agent: true\n")
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        ensure_config()
+        assert "forward-agent: true" in config_path.read_text()
+
+    def test_parent_dir_created_with_0o700(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "newdir"
+        config_path = config_dir / "klangk.yaml"
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        ensure_config()
+        assert config_dir.stat().st_mode & 0o777 == 0o700
 
 
 # --- CLIState tests ---


### PR DESCRIPTION
## Summary
- `~/.config/klangk/klangk.yaml` is now created on any CLI invocation (not just after login), so the file is always present for users and tooling that expect it
- Adds `ensure_config()` in `config.py`, called from `app_callback()` in `main.py`
- Existing config files are never overwritten
- Generated configs (both `ensure_config` and `seed_config`) now default **`forward-agent: true`** (active, not a commented opt-in) so a fresh workspace forwards the agent out of the box; set `forward-agent: false` to disable for an untrusted workspace. Reverses #1923. Existing configs without the line are unchanged.

## Test plan
- [x] `TestEnsureConfig.test_creates_config_if_missing` — verifies file creation with correct content (and `forward-agent: true` active)
- [x] `TestEnsureConfig.test_does_not_overwrite_existing` — verifies existing configs are preserved
- [x] `TestEnsureConfig.test_parent_dir_created_with_0o700` — verifies secure directory permissions
- [x] `TestSeedConfig.test_generated_config_defaults_forward_agent_on` — generated login config defaults forward-agent on

Closes #2004.
