### PR TITLE
fix(ssh-agent): wire SSH_AUTH_SOCK to deterministic path on every terminal

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1187,6 +1187,31 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **SSH agent forwarding now works on reconnect and in the TUI (#2001).**
+  Two bugs, one symptom (`ssh-add -l` → _"Could not open a connection to
+  your authentication agent"_):
+  1. _No `SSH_AUTH_SOCK` in shells created before the relay._ It was only
+     injected when the relay was already active, so a base tmux session
+     created first — the TUI opens the session, then spawns `klangk shell
+-A` which starts the relay; likewise reconnecting to an existing
+     session — never received it. Every interactive terminal and exec
+     session now wires `SSH_AUTH_SOCK` to the deterministic per-user socket
+     path (`/tmp/klangk-ssh-agent-<user_id>.sock`) at creation time,
+     regardless of whether a relay is active yet. The var is inert until a
+     relay binds that path (only when the client opts into forwarding),
+     then goes live — so it no longer matters how or when the terminal (or
+     its agent) was created.
+
+  2. _Relay leak on reconnect._ Each `klangk shell -A` is a fresh
+     connection whose forwarder can't see a prior connection's socat; if
+     the old relay didn't fully tear down, two socats ended up listening on
+     the same socket with `unlink-early`, unlinking each other's
+     accept-time socket file and making the path flicker in and out.
+     `ssh_agent_start` now reaps any competing relay on the deterministic
+     path (`pkill -f UNIX-LISTEN:<path>`) before binding its own, so
+     reconnects own the socket cleanly instead of racing a leaked
+     predecessor.
+
 - **`klangkd` no longer crash-loops when a second instance starts against
   the same config (#1993).** The pre-flight guard that refuses a duplicate
   instance tried to log via a nonexistent `logger` symbol

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -85,40 +85,11 @@ class Connection:
         self.shared = SharedTerminalController(self)
         # SSH agent forwarding is owned by the SshAgentForwarder
         # collaborator; Connection delegates the ssh_agent_* commands to
-        # it.  The ``_ssh_agent_*`` properties below proxy to the
-        # forwarder for backwards compatibility with code (and tests)
-        # that read/write those fields directly.
+        # it. Relay state (proc/task/socket) lives on the forwarder
+        # (``self.ssh_agent.*``), not on Connection.
         self.ssh_agent = SshAgentForwarder(self)
 
     # --- SSH agent forwarding (delegates to SshAgentForwarder) ---
-
-    # Backwards-compatible proxies for the state formerly held on
-    # Connection itself.  Reads and writes are forwarded to the
-    # collaborator so existing callers (and the terminal/exec code
-    # that consumes ``_ssh_agent_socket``) keep working unchanged.
-    @property
-    def _ssh_agent_proc(self):
-        return self.ssh_agent.proc
-
-    @_ssh_agent_proc.setter
-    def _ssh_agent_proc(self, value):
-        self.ssh_agent.proc = value
-
-    @property
-    def _ssh_agent_task(self):
-        return self.ssh_agent.task
-
-    @_ssh_agent_task.setter
-    def _ssh_agent_task(self, value):
-        self.ssh_agent.task = value
-
-    @property
-    def _ssh_agent_socket(self):
-        return self.ssh_agent.socket
-
-    @_ssh_agent_socket.setter
-    def _ssh_agent_socket(self, value):
-        self.ssh_agent.socket = value
 
     async def handle_ssh_agent_start(self) -> None:
         await self.ssh_agent.start()

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -165,10 +165,20 @@ class SshAgentForwarder:
         # other's accept-time socket file, so ``ssh-add`` sees the path
         # flicker in and out ("No such file or directory") (#2001).
         #
-        # The deterministic per-user path makes a targeted pkill safe: it
-        # matches the exact socket string, so only stale relays for THIS
-        # user die — never an unrelated process. Done before our own bind
-        # so we own the socket cleanly.
+        # ``pkill -f`` matches the full argv; scoped to this user's exact
+        # socket string it only reaps *this* user's stale socat relays — never
+        # another user's relay or an unrelated process. ``pkill`` exits 1 when
+        # nothing matches (first connect on a clean container);
+        # ``exec_container`` runs ``check=False`` (``Podman.run`` only raises on
+        # non-zero when ``check`` is set), so that no-match exit is swallowed
+        # and the bind proceeds.
+        #
+        # Isolation caveat: the socket is bound ``mode=600``, which isolates
+        # it across OS users — but in a shared workspace all members run as
+        # the same in-container uid (``klangk``), so a collaborator can reach
+        # another member's forwarded-agent socket and use its identities. That
+        # exposure predates #2001 (the relay always bound this path); a
+        # per-user private socket directory would close it.
         await self._conn.app.state.podman.exec_container(
             container_id,
             ["pkill", "-f", f"UNIX-LISTEN:{sock_path}"],

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -278,19 +278,23 @@ class SshAgentForwarder:
         # (same ``pkill -f`` ``start()`` uses) guarantees the container-side
         # process is gone before we remove the socket (#2001).
         if self.socket and container_id:
+            # Best-effort teardown: a failure here (container already gone,
+            # podman subprocess can't launch) must not break disconnect.
+            # ``exec_container`` runs ``check=False`` so non-zero exits don't
+            # raise; this catches the remaining launch/IO failures.
             try:
                 await self._conn.app.state.podman.exec_container(
                     container_id,
                     ["pkill", "-f", f"UNIX-LISTEN:{self.socket}"],
                 )
-            except OSError as e:  # pragma: no cover - best-effort reap
+            except Exception as e:  # best-effort reap
                 logger.debug("Failed to reap SSH agent socat: %s", e)
             try:
                 await self._conn.app.state.podman.exec_container(
                     container_id,
                     ["rm", "-f", self.socket],
                 )
-            except OSError as e:
+            except Exception as e:
                 logger.warning(
                     "Failed to remove SSH agent socket %s: %s",
                     self.socket,
@@ -342,8 +346,9 @@ class ExecController:
         # exec, not only when a relay is already active (#2001): exec
         # sessions are short-lived one-shot commands and have no persistent
         # base session, but the same creation-path uniformity applies — the
-        # var is inert until a relay binds this path. `_ssh_agent_socket`
-        # (when the relay is up) is the same path, so this strictly generalizes it.
+        # var is inert until a relay binds this path. The forwarder's
+        # ``ssh_agent.socket`` (when the relay is up) is the same path, so
+        # this strictly generalizes the old relay-gated wiring.
         env.append(
             f"SSH_AUTH_SOCK={ssh_agent_socket_path(self._conn.user['id'])}"
         )

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -110,6 +110,20 @@ def _is_allowed_read_only_input(data: str) -> bool:
     return _READ_ONLY_INPUT.fullmatch(data) is not None
 
 
+def ssh_agent_socket_path(user_id: str) -> str:
+    """Deterministic in-container path for a user's forwarded SSH-agent socket.
+
+    ``/tmp/klangk-ssh-agent-<user_id>.sock`` is the path the socat relay
+    (:meth:`SshAgentForwarder.start`) binds when a client opts into agent
+    forwarding. It is stable across reconnections and independent of *when*
+    the relay starts — which is what lets every interactive terminal wire
+    ``SSH_AUTH_SOCK`` here at creation time and go live the moment a relay
+    binds this path, instead of only working when the relay happened to be
+    up first (#2001).
+    """
+    return f"/tmp/klangk-ssh-agent-{user_id}.sock"
+
+
 class SshAgentForwarder:
     """SSH agent forwarding relay via socat inside the container.
 
@@ -139,7 +153,26 @@ class SshAgentForwarder:
         # Clean up any existing agent relay.
         await self.stop()
         user_id = self._conn.user["id"]
-        sock_path = f"/tmp/klangk-ssh-agent-{user_id}.sock"
+        sock_path = ssh_agent_socket_path(user_id)
+        # Reap any competing relay a prior connection left behind.
+        #
+        # Each ``klangk shell -A`` is a fresh Connection with its own
+        # SshAgentForwarder; the previous connection's stop() ran against
+        # *its* proc (unknown to us), and if it didn't fully tear down — a
+        # crashed/disconnected client, or a reconnect before the old relay
+        # finished dying — its socat is still listening on this path. Two
+        # socats with ``unlink-early`` on the same socket unlinks each
+        # other's accept-time socket file, so ``ssh-add`` sees the path
+        # flicker in and out ("No such file or directory") (#2001).
+        #
+        # The deterministic per-user path makes a targeted pkill safe: it
+        # matches the exact socket string, so only stale relays for THIS
+        # user die — never an unrelated process. Done before our own bind
+        # so we own the socket cleanly.
+        await self._conn.app.state.podman.exec_container(
+            container_id,
+            ["pkill", "-f", f"UNIX-LISTEN:{sock_path}"],
+        )
         # Remove stale socket if it exists from a previous session.
         await self._conn.app.state.podman.exec_container(
             container_id, ["rm", "-f", sock_path]
@@ -226,7 +259,22 @@ class SshAgentForwarder:
                 logger.debug("SSH agent process already exited")
             self.proc = None
         container_id = self._conn.container_id
+        # Reap the in-container socat directly. ``proc.kill()`` above sends
+        # SIGKILL to the local ``podman exec`` handle, which does NOT reliably
+        # terminate the container-side socat it spawned — so the listener can
+        # survive as an orphan. With ``unlink-early`` that orphan then races
+        # the next connection's bind (and ``rm -f`` below leaves a live
+        # listener with no socket file). Killing by the deterministic path
+        # (same ``pkill -f`` ``start()`` uses) guarantees the container-side
+        # process is gone before we remove the socket (#2001).
         if self.socket and container_id:
+            try:
+                await self._conn.app.state.podman.exec_container(
+                    container_id,
+                    ["pkill", "-f", f"UNIX-LISTEN:{self.socket}"],
+                )
+            except OSError as e:  # pragma: no cover - best-effort reap
+                logger.debug("Failed to reap SSH agent socat: %s", e)
             try:
                 await self._conn.app.state.podman.exec_container(
                     container_id,
@@ -280,9 +328,15 @@ class ExecController:
         if user_home is not None:
             env.append(f"HOME={user_home}")
             work_dir = user_home
-        ssh_agent_socket = self._conn._ssh_agent_socket
-        if ssh_agent_socket is not None:
-            env.append(f"SSH_AUTH_SOCK={ssh_agent_socket}")
+        # Wire SSH_AUTH_SOCK to the deterministic per-user path on every
+        # exec, not only when a relay is already active (#2001): exec
+        # sessions are short-lived one-shot commands and have no persistent
+        # base session, but the same creation-path uniformity applies — the
+        # var is inert until a relay binds this path. `_ssh_agent_socket`
+        # (when the relay is up) is the same path, so this strictly generalizes it.
+        env.append(
+            f"SSH_AUTH_SOCK={ssh_agent_socket_path(self._conn.user['id'])}"
+        )
         # `login` (default raw) selects whether the command runs as a
         # bash login shell (sources ~/.profile, like a terminal) or as
         # raw argv (no shell, for programmatic transports like rsync).
@@ -602,13 +656,22 @@ class TerminalController:
         # in ``_start_terminal`` (after the shell session is up) so a
         # post-setup ``terminal_start`` still triggers it (#1033).
         ws = self._conn.workspace
+        # Wire SSH_AUTH_SOCK to the deterministic per-user agent-socket path
+        # on EVERY terminal, whether or not a relay is active yet (#2001).
+        # The var is inert until a relay binds this path (which only happens
+        # when the client opts into forwarding), so pre-pointing it here means
+        # a base session created before the relay starts — the TUI path opens
+        # the tmux session, then spawns `klangk shell -A` which starts the
+        # relay — already has it set, and goes live the moment the relay binds.
+        # A reconnect to an existing session inherits it from that first
+        # creation. No per-creation-path special-casing.
         session = TerminalSession(
             self._conn.container_id,
             session_name=self._conn.user["id"],
             user_home=self._conn._user_home,
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
-            ssh_agent_socket=self._conn._ssh_agent_socket,
+            ssh_agent_socket=ssh_agent_socket_path(self._conn.user["id"]),
             terminal=self._conn.app.state.terminal,
             workspace_name=ws.get("name") if ws else None,
         )
@@ -1296,6 +1359,10 @@ class SharedTerminalController:
             read_only=read_only,
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
+            # Same deterministic path as the owner's interactive terminal
+            # (#2001): the joiner's shell gets its own per-user agent
+            # socket pre-wired, live the moment it forwards an agent.
+            ssh_agent_socket=ssh_agent_socket_path(self._conn.user["id"]),
             terminal=self._conn.app.state.terminal,
         )
         self._conn.terminal_session = session

--- a/src/klangk/klangkd-tests/e2e-tests/test_ssh_agent_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_ssh_agent_e2e.py
@@ -1,0 +1,469 @@
+"""E2E: SSH agent forwarding into a workspace container (#2001).
+
+The bash/expect ``tests/test_ssh_agent_e2e.sh`` drives the real CLI's TUI
+and therefore needs an interactive agent + terminal — it skips in CI. This
+suite is the CI-runnable counterpart: it brings its own ``ssh-agent`` +
+throwaway key (so no pre-existing agent is required), speaks the WebSocket
+agent-relay protocol that ``klangk shell -A`` speaks, and asserts the key is
+reachable from inside the container.
+
+It covers the two failure modes #2001 fixed:
+
+1. *No ``SSH_AUTH_SOCK`` in shells created before the relay.* The base
+   session must wire the deterministic per-user socket path at creation
+   time, so the var is present (inert → live) regardless of when the relay
+   starts.
+2. *Relay leak on reconnect.* Reconnecting a forwarded agent must not leave
+   a competing ``socat`` orphaned on the same ``unlink-early`` socket, which
+   would make the path flicker and ``ssh-add`` fail with "No such file or
+   directory".
+
+These run under the standard backend-e2e job (``test-backend-e2e``) against
+real podman containers, like the rest of this directory.
+"""
+
+import asyncio
+import base64
+import json
+import os
+import re
+import socket
+import struct
+import subprocess
+
+import pytest
+import websockets
+
+from _e2e_server import start_server, stop_server, ws_connect as _ws_dial
+
+_AGENT_PROTOCOL_TIMEOUT = 3.0  # per local-agent round-trip, seconds
+
+
+def _have(*bins: str) -> bool:
+    return all(shutil_which(b) is not None for b in bins)
+
+
+def shutil_which(bin_name: str) -> str | None:
+    # stdlib indirection so the import-time skip guard reads cleanly
+    from shutil import which
+
+    return which(bin_name)
+
+
+def _query_local_ssh_agent(sock_path: str, data: bytes) -> bytes | None:
+    """Send *data* to the local SSH agent, return its length-prefixed reply.
+
+    Mirrors ``klangk.cli.client._query_local_ssh_agent`` — the wire format
+    the CLI's relay uses. Duplicated here because the CLI subpackage is
+    isolated from the server package (and these tests are server-side).
+    """
+    agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    agent.settimeout(_AGENT_PROTOCOL_TIMEOUT)
+    try:
+        agent.connect(sock_path)
+        agent.sendall(data)
+        header = b""
+        while len(header) < 4:
+            chunk = agent.recv(4 - len(header))
+            if not chunk:
+                return None
+            header += chunk
+        msg_len = struct.unpack(">I", header)[0]
+        body = b""
+        while len(body) < msg_len:
+            chunk = agent.recv(msg_len - len(body))
+            if not chunk:
+                break
+            body += chunk
+        return header + body
+    except OSError:
+        return None
+    finally:
+        agent.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def server():
+    server = start_server(
+        KLANGKD_JWT_SECRET="ssh-agent-e2e-secret",
+        KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGKD_DEFAULT_USER="test@example.com",
+        KLANGKD_DEFAULT_PASSWORD="testpass",
+        KLANGKD_TEST_MODE="1",
+        KLANGKD_IDLE_TIMEOUT_SECONDS="0",
+        LOGFIRE_TOKEN="",
+        KLANGKD_LLM_BASE_URL="",
+        KLANGKD_LLM_API_KEY="",
+        KLANGKD_LLM_MODEL="",
+    )
+    yield server
+    stop_server(server)
+
+
+@pytest.fixture
+def auth(server):
+    resp = server["client"].post(
+        "/api/v1/auth/login",
+        json={"identifier": "test@example.com", "password": "testpass"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    return {"token": token, "headers": {"Authorization": f"Bearer {token}"}}
+
+
+@pytest.fixture(scope="module")
+def local_agent(tmp_path_factory):
+    """A throwaway ssh-agent with one generated ed25519 key.
+
+    Yields ``(sock_path, fingerprint)`` where *fingerprint* is the
+    ``SHA256:...`` blob ``ssh-add -l`` (and ``ssh-keygen -lf``) report, so the
+    assertion is exact. CI runners don't ship a usable agent, so the suite is
+    self-contained: ``ssh-agent`` + ``ssh-keygen`` + ``ssh-add``.
+    """
+    if not _have("ssh-agent", "ssh-keygen", "ssh-add"):
+        pytest.skip("ssh-agent / ssh-keygen / ssh-add not on PATH")
+
+    tmp = tmp_path_factory.mktemp("ssh-agent-e2e")
+    keyfile = tmp / "id_ed25519"
+    out = subprocess.check_output(["ssh-agent", "-s"], text=True)
+    match = re.search(r"SSH_AUTH_SOCK=([^;]+);", out)
+    pid_match = re.search(r"SSH_AGENT_PID=(\d+);", out)
+    assert match and pid_match, f"could not parse ssh-agent output: {out!r}"
+    sock_path = match.group(1)
+    agent_pid = int(pid_match.group(1))
+
+    agent_env = {**os.environ, "SSH_AUTH_SOCK": sock_path}
+    try:
+        subprocess.run(
+            [
+                "ssh-keygen",
+                "-t",
+                "ed25519",
+                "-N",
+                "",
+                "-f",
+                str(keyfile),
+                "-C",
+                "klangk-e2e",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["ssh-add", str(keyfile)],
+            check=True,
+            capture_output=True,
+            env=agent_env,
+        )
+        # The fingerprint the container must be able to see.
+        fp_out = subprocess.check_output(
+            ["ssh-keygen", "-lf", f"{keyfile}.pub"], text=True
+        )
+        fingerprint = fp_out.split()[1]  # "SHA256:...."
+        assert fingerprint.startswith("SHA256:"), fp_out
+
+        yield sock_path, fingerprint
+    finally:
+        try:
+            os.kill(agent_pid, 15)
+        except ProcessLookupError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# WS plumbing
+# ---------------------------------------------------------------------------
+
+
+async def _connect(server, auth, workspace_id):
+    """Open a WS, workspace_connect, wait for container_ready.
+
+    Returns ``(ws, received, reader_task)``.
+    """
+    ws = await _ws_dial(server, f"/ws?token={auth['token']}", max_size=2**20)
+    await ws.send(
+        json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})
+    )
+    received: list[dict] = []
+
+    async def _reader():
+        try:
+            async for raw in ws:
+                try:
+                    received.append(json.loads(raw))
+                except json.JSONDecodeError:
+                    pass
+        except websockets.ConnectionClosed:
+            pass
+
+    reader_task = asyncio.create_task(_reader())
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 90
+    while loop.time() < deadline:
+        if any(m.get("type") == "container_ready" for m in received):
+            return ws, received, reader_task
+        await asyncio.sleep(0.2)
+    reader_task.cancel()
+    await ws.close()
+    raise AssertionError("container_ready not received within 90s")
+
+
+async def _drain(received, predicate, *, timeout=20.0):
+    """Wait until *predicate(msg)* holds for some message in *received*.
+
+    Returns the list of matching messages collected so far.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        matched = [m for m in received if predicate(m)]
+        if matched:
+            return matched
+        await asyncio.sleep(0.1)
+    return [m for m in received if predicate(m)]
+
+
+async def _pump_relay(received, ws, agent_sock, *, stop: asyncio.Event):
+    """Forward ssh_agent_response → local agent → ssh_agent_data.
+
+    Runs until *stop* is set. Re-scans *received* each tick so it works
+    alongside the shared reader that owns the socket.
+    """
+    seen = 0
+    loop = asyncio.get_event_loop()
+    while not stop.is_set():
+        resps = [m for m in received if m.get("type") == "ssh_agent_response"]
+        for m in resps[seen:]:
+            seen += 1
+            raw = base64.b64decode(m.get("data", ""))
+            if not raw:
+                continue
+            reply = await loop.run_in_executor(
+                None, _query_local_ssh_agent, agent_sock, raw
+            )
+            if reply is not None:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "cmd": "ssh_agent_data",
+                            "data": base64.b64encode(reply).decode("ascii"),
+                        }
+                    )
+                )
+        await asyncio.sleep(0.05)
+
+
+async def _exec_collect(received, *, start_idx: int, timeout=30.0):
+    """Concatenate exec_output in *received* from *start_idx* until exec_exit."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    buf = bytearray()
+    code: int | None = None
+    while loop.time() < deadline:
+        for m in received[start_idx:]:
+            if m.get("type") == "exec_output":
+                buf.extend(base64.b64decode(m.get("data", "")))
+            elif m.get("type") == "exec_exit":
+                code = m.get("code")
+                return bytes(buf), code
+        await asyncio.sleep(0.1)
+    return bytes(buf), code
+
+
+async def _run_agent_and_exec(
+    ws, received, agent_sock, *, command: list[str], login: bool = False
+) -> tuple[str, int | None]:
+    """Start the agent relay, run an exec, return its (stdout, exit_code).
+
+    The relay runs concurrently for the whole exec so the container-side
+    ``ssh-add`` can reach the host agent through the forwarded socket.
+    """
+    # (Re)start the relay. ssh_agent_start is idempotent-ish: the server
+    # reaps any prior relay on the deterministic path first (#2001).
+    await ws.send(json.dumps({"cmd": "ssh_agent_start"}))
+    started = await _drain(
+        received,
+        lambda m: m.get("type") == "ssh_agent_started",
+        timeout=20.0,
+    )
+    assert started, "ssh_agent_started not received"
+
+    stop = asyncio.Event()
+    relay_task = asyncio.create_task(
+        _pump_relay(received, ws, agent_sock, stop=stop)
+    )
+    try:
+        # Index-based boundary: only consider messages received AFTER this
+        # point as the exec's own output (the reader appends without a
+        # timestamp, so time-windowing would misclassify them as old).
+        start_idx = len(received)
+        await ws.send(
+            json.dumps(
+                {"cmd": "exec_start", "command": command, "login": login}
+            )
+        )
+        out, code = await _exec_collect(
+            received, start_idx=start_idx, timeout=30.0
+        )
+        return out.decode("utf-8", "replace"), code
+    finally:
+        stop.set()
+        try:
+            await asyncio.wait_for(relay_task, timeout=5)
+        except asyncio.TimeoutError:
+            relay_task.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSshAgentForwarding:
+    @pytest.mark.asyncio
+    async def test_forwarded_agent_visible_in_container(
+        self, server, auth, local_agent
+    ):
+        """A forwarded agent is reachable from inside the container.
+
+        Opens a terminal (which pre-wires SSH_AUTH_SOCK to the deterministic
+        per-user path at base-session creation, #2001), starts the agent
+        relay, and runs ``ssh-add -l`` via exec. The host key's fingerprint
+        must appear, exit 0.
+        """
+        agent_sock, fingerprint = local_agent
+        client = server["client"]
+        resp = client.post(
+            "/api/v1/workspaces",
+            headers=auth["headers"],
+            json={"name": "ssh-agent-e2e", "setup_state": "complete"},
+            timeout=10,
+        )
+        assert resp.status_code == 200, resp.text
+        workspace_id = resp.json()["id"]
+        ws, received, reader = await _connect(server, auth, workspace_id)
+        try:
+            # Open a terminal so the base session is created and the
+            # per-user SSH_AUTH_SOCK path is wired into its environment.
+            await ws.send(
+                json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
+            )
+            await _drain(
+                received,
+                lambda m: m.get("type") == "terminal_started",
+                timeout=30.0,
+            )
+
+            out, code = await _run_agent_and_exec(
+                ws, received, agent_sock, command=["ssh-add", "-l"]
+            )
+            assert code == 0, f"ssh-add -l exited {code}: {out!r}"
+            assert fingerprint in out, (
+                f"fingerprint {fingerprint} not in ssh-add -l output: {out!r}"
+            )
+        finally:
+            await ws.send(json.dumps({"cmd": "terminal_stop"}))
+            reader.cancel()
+            try:
+                await ws.close()
+            except Exception:
+                pass
+            client.delete(
+                f"/api/v1/workspaces/{workspace_id}",
+                headers=auth["headers"],
+                timeout=30,
+            )
+
+    @pytest.mark.asyncio
+    async def test_reconnect_does_not_leak_relay(
+        self, server, auth, local_agent
+    ):
+        """Reconnecting a forwarded agent reaps the prior relay (#2001).
+
+        Two back-to-back ``ssh_agent_start`` cycles on the same connection
+        must not leave competing ``socat`` listeners on the deterministic
+        ``unlink-early`` socket — that race makes the path flicker and
+        ``ssh-add`` fail with "No such file or directory". After the second
+        start, exactly one socat listens and the key is still reachable.
+        """
+        agent_sock, fingerprint = local_agent
+        client = server["client"]
+        resp = client.post(
+            "/api/v1/workspaces",
+            headers=auth["headers"],
+            json={
+                "name": "ssh-agent-reconnect-e2e",
+                "setup_state": "complete",
+            },
+            timeout=10,
+        )
+        assert resp.status_code == 200, resp.text
+        workspace_id = resp.json()["id"]
+        ws, received, reader = await _connect(server, auth, workspace_id)
+        try:
+            await ws.send(
+                json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
+            )
+            await _drain(
+                received,
+                lambda m: m.get("type") == "terminal_started",
+                timeout=30.0,
+            )
+
+            # Cycle 1: start relay + ssh-add -l must succeed.
+            out1, code1 = await _run_agent_and_exec(
+                ws, received, agent_sock, command=["ssh-add", "-l"]
+            )
+            assert code1 == 0 and fingerprint in out1, (code1, out1)
+            await ws.send(json.dumps({"cmd": "ssh_agent_stop"}))
+            await _drain(
+                received,
+                lambda m: m.get("type") == "ssh_agent_stopped",
+                timeout=10.0,
+            )
+
+            # Cycle 2 (reconnect): the prior relay must be reaped, not leaked.
+            out2, code2 = await _run_agent_and_exec(
+                ws, received, agent_sock, command=["ssh-add", "-l"]
+            )
+            assert code2 == 0 and fingerprint in out2, (code2, out2)
+
+            # Exactly one socat listening on the per-user path: a leak would
+            # show >= 2. pgrep -c returns the count (login shell for PATH).
+            out3, code3 = await _run_agent_and_exec(
+                ws,
+                received,
+                agent_sock,
+                command=["bash", "-lc", "pgrep -c socat || true"],
+                login=True,
+            )
+            assert code3 == 0, (code3, out3)
+            # Take the last non-empty integer line (pgrep -c prints one number).
+            counts = [
+                int(ln.strip())
+                for ln in out3.strip().splitlines()
+                if ln.strip().isdigit()
+            ]
+            assert counts, f"no socat count in output: {out3!r}"
+            assert counts[-1] == 1, (
+                f"expected exactly 1 socat after reconnect, got {counts[-1]} "
+                f"(relay leak): {out3!r}"
+            )
+        finally:
+            await ws.send(json.dumps({"cmd": "terminal_stop"}))
+            reader.cancel()
+            try:
+                await ws.close()
+            except Exception:
+                pass
+            client.delete(
+                f"/api/v1/workspaces/{workspace_id}",
+                headers=auth["headers"],
+                timeout=30,
+            )

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -779,7 +779,7 @@ class TestHandleTerminalStart:
             user_home="/home/testuser",
             user_id="uid",
             user_handle="testuser",
-            ssh_agent_socket=None,
+            ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
             terminal=_mock_term,
             workspace_name=None,
         )
@@ -1293,7 +1293,7 @@ class TestHandleTerminalStart:
             user_home="/home/testuser",
             user_id="uid",
             user_handle="testuser",
-            ssh_agent_socket=None,
+            ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
             terminal=_mock_term,
             workspace_name=None,
         )
@@ -2482,7 +2482,12 @@ class TestExecHandlers:
                 ):
                     await conn.handle_exec_start({"command": ["ls"]})
         call_kwargs = mock_cls.call_args[1]
-        assert "SSH_AUTH_SOCK=/tmp/agent.sock" in call_kwargs["env"]
+        # exec wires SSH_AUTH_SOCK to the deterministic per-user path on
+        # every run, regardless of relay state (#2001).
+        assert (
+            "SSH_AUTH_SOCK=/tmp/klangk-ssh-agent-uid.sock"
+            in call_kwargs["env"]
+        )
         assert "HOME=/home/admin" in call_kwargs["env"]
         assert call_kwargs["work_dir"] == "/home/admin"
         conn.exec_task.cancel()
@@ -2643,6 +2648,13 @@ class TestExecController:
             _ssh_agent_socket=ssh_agent_socket,
             _has_perm=AsyncMock(return_value=has_perm),
             app=app_state,
+            # exec start derives the SSH_AUTH_SOCK path from the user id
+            # (#2001), so the fake connection needs a user identity.
+            user={
+                "id": "uid",
+                "email": "testuser@example.com",
+                "handle": "testuser",
+            },
         )
         return ExecController(conn), sock, conn
 
@@ -2715,7 +2727,9 @@ class TestExecController:
                 pass
         kwargs = MockExec.call_args.kwargs
         assert "HOME=/home/admin" in kwargs["env"]
-        assert "SSH_AUTH_SOCK=/tmp/agent.sock" in kwargs["env"]
+        # SSH_AUTH_SOCK is always the deterministic per-user path (#2001);
+        # the relay-state socket is no longer the source.
+        assert "SSH_AUTH_SOCK=/tmp/klangk-ssh-agent-uid.sock" in kwargs["env"]
         assert kwargs["work_dir"] == "/home/admin"
 
     async def test_start_defaults_work_dir_when_no_user_home(self, app_state):
@@ -2735,7 +2749,11 @@ class TestExecController:
             except asyncio.CancelledError:
                 pass
         kwargs = MockExec.call_args.kwargs
-        assert kwargs["env"] == []
+        # No HOME (user_home is None), but SSH_AUTH_SOCK is still wired
+        # to the deterministic per-user path on every exec (#2001).
+        assert kwargs["env"] == [
+            "SSH_AUTH_SOCK=/tmp/klangk-ssh-agent-uid.sock"
+        ]
         assert kwargs["work_dir"] == "/home/work"
 
     async def test_start_default_login_false(self, app_state):
@@ -3196,6 +3214,57 @@ class TestSSHAgentHandlers:
             workspace_name=None,
         )
 
+    async def test_terminal_start_wires_agent_socket_without_relay(
+        self, app_state
+    ):
+        """terminal_start points SSH_AUTH_SOCK at the deterministic path even
+        when no agent relay is active yet (#2001).
+
+        This is the TUI / autostart case that was broken: the base tmux
+        session is created (window-0 shell spawned) BEFORE the agent relay
+        starts, so the shell never received SSH_AUTH_SOCK. The fix wires
+        every terminal to the deterministic per-user socket path at creation
+        time — inert until a relay binds it, live the moment one does — so it
+        does not matter how or when the terminal (or its agent) was created.
+        Here ``conn._ssh_agent_socket`` is left at its default (None, no
+        relay) yet the deterministic path is still passed through.
+        """
+        app_state = _make_app_state()
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.container_id = "cid"
+        conn._user_home = "/home/testuser"
+        assert conn._ssh_agent_socket is None  # no relay active
+        mock_session = AsyncMock()
+        mock_session.start = AsyncMock()
+        mock_session.session_name = "uid"
+        mock_session.tmux_session_name = "uid"
+
+        async def empty_output():
+            return
+            yield  # pragma: no cover
+
+        mock_session.output = empty_output
+        with (
+            patch(
+                "klangk.wshandler.controllers.TerminalSession",
+                return_value=mock_session,
+            ) as MockTS,
+            patch.object(
+                app_state.state.container_registry, "record_activity"
+            ),
+            patch.object(_mock_term, "attach_browser", new=AsyncMock()),
+            patch.object(_mock_term, "list_windows", return_value=[]),
+            patch.object(conn, "_has_perm", new=AsyncMock(return_value=True)),
+        ):
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            for _ in range(4):
+                await asyncio.sleep(0)
+
+        assert MockTS.call_args.kwargs["ssh_agent_socket"] == (
+            "/tmp/klangk-ssh-agent-uid.sock"
+        )
+
 
 class TestSshAgentForwarder:
     """Unit tests for the SshAgentForwarder collaborator in isolation.
@@ -3206,6 +3275,17 @@ class TestSshAgentForwarder:
     branches that were previously excluded with
     ``# pragma: no cover``.
     """
+
+    def test_socket_path_is_deterministic_per_user(self):
+        """``ssh_agent_socket_path`` is the stable per-user relay path (#2001)."""
+        assert (
+            _ws_controllers.ssh_agent_socket_path("uid")
+            == "/tmp/klangk-ssh-agent-uid.sock"
+        )
+        assert (
+            _ws_controllers.ssh_agent_socket_path("user-42")
+            == "/tmp/klangk-ssh-agent-user-42.sock"
+        )
 
     def _forwarder(self, *, container_id="cid", user=None, sock=None):
         if sock is None:
@@ -3391,14 +3471,27 @@ class TestSshAgentForwarder:
     async def test_stop_handles_socket_remove_oserror(self):
         fwd, _ = self._forwarder()
         fwd.socket = "/tmp/agent.sock"
+        # stop() reaps the in-container socat (pkill) then removes the socket
+        # file (rm). The pkill is best-effort; the rm OSError is the one we
+        # warn about.
         with patch.object(
             _mock_pod,
             "exec_container",
-            new=AsyncMock(side_effect=OSError("boom")),
+            new=AsyncMock(side_effect=[(0, "", ""), OSError("boom")]),
         ) as exec_mock:
             with patch("klangk.wshandler.controllers.logger") as lg:
                 await fwd.stop()
-        exec_mock.assert_awaited_once()
+        assert exec_mock.await_count == 2
+        assert exec_mock.await_args_list[0].args[1] == [
+            "pkill",
+            "-f",
+            "UNIX-LISTEN:/tmp/agent.sock",
+        ]
+        assert exec_mock.await_args_list[1].args[1] == [
+            "rm",
+            "-f",
+            "/tmp/agent.sock",
+        ]
         lg.warning.assert_called_once()
         assert "Failed to remove SSH agent socket" in str(lg.warning.call_args)
         assert fwd.socket is None

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2756,6 +2756,33 @@ class TestExecController:
         ]
         assert kwargs["work_dir"] == "/home/work"
 
+    async def test_exec_start_sets_ssh_agent_socket_without_relay(
+        self, app_state
+    ):
+        """exec_start wires ``SSH_AUTH_SOCK`` to the deterministic per-user
+        path even with no agent relay active (#2001) — a set-but-inert var
+        that goes live the moment a relay binds. Mirrors the terminal-start
+        without-relay contract for the exec path (notably the rsync /
+        git-over-ssh transports, which previously ran with the var unset)."""
+        app_state = _make_app_state()
+        registry = app_state.state.container_registry
+        ctrl, _, conn = self._controller(app_state=app_state)
+        assert conn._ssh_agent_socket is None  # no relay active
+        with (
+            patch("klangk.wshandler.controllers.ExecSession") as MockExec,
+            patch.object(registry, "record_activity"),
+        ):
+            mock_session = MockExec.return_value
+            mock_session.start = AsyncMock()
+            await ctrl.start({"command": ["rsync"], "login": False})
+            ctrl.task.cancel()
+            try:
+                await ctrl.task
+            except asyncio.CancelledError:
+                pass
+        env = MockExec.call_args.kwargs["env"]
+        assert "SSH_AUTH_SOCK=/tmp/klangk-ssh-agent-uid.sock" in env
+
     async def test_start_default_login_false(self, app_state):
         """#1041: a message with no ``login`` key runs raw argv (no
         shell) -- the safe default for any caller, and what rsync needs."""
@@ -3360,6 +3387,70 @@ class TestSshAgentForwarder:
         msg = sock.send_json.call_args[0][0]
         assert msg["type"] == "ssh_agent_started"
         assert msg["socket"] == "/tmp/klangk-ssh-agent-uid.sock"
+
+    async def test_start_reaps_stale_relay_then_removes_socket(self):
+        """start() reaps a leftover relay (``pkill -f <path>``) BEFORE removing
+        the socket file, in that order — the crux of the #2001 fix."""
+        fwd, sock = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stdin = AsyncMock()
+        calls = []
+
+        async def fake_exec(container_id, argv, **kw):
+            calls.append(list(argv))
+            return (0, "", "")
+
+        with (
+            patch.object(_mock_pod, "exec_container", new=fake_exec),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ),
+        ):
+            async with self._track_tasks():
+                await fwd.start()
+                for _ in range(5):
+                    await asyncio.sleep(0)
+        # pkill the stale relay first, then rm the socket file — in order.
+        assert calls[0] == [
+            "pkill",
+            "-f",
+            "UNIX-LISTEN:/tmp/klangk-ssh-agent-uid.sock",
+        ]
+        assert calls[1] == ["rm", "-f", "/tmp/klangk-ssh-agent-uid.sock"]
+
+    async def test_start_tolerates_pkill_no_match(self):
+        """pkill exits 1 when no stale relay exists (first connect on a clean
+        container). ``exec_container`` is ``check=False``, so start() must
+        tolerate that and still bind (#2001) — guards against a future flip
+        to ``check=True`` silently breaking first-connect."""
+        fwd, sock = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stdin = AsyncMock()
+        # pkill returns (1, ...) "no processes matched"; rm returns (0, ...).
+        results = iter([(1, "", "no processes matched"), (0, "", "")])
+
+        async def fake_exec(container_id, argv, **kw):
+            return next(results)
+
+        with (
+            patch.object(_mock_pod, "exec_container", new=fake_exec),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ),
+        ):
+            async with self._track_tasks():
+                await fwd.start()
+                for _ in range(5):
+                    await asyncio.sleep(0)
+        # First-connect (nothing to reap) still binds + records the socket.
+        assert fwd.socket == "/tmp/klangk-ssh-agent-uid.sock"
+        assert fwd.proc is mock_proc
 
     async def test_start_no_container_sends_error(self):
         fwd, sock = self._forwarder(container_id=None)

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2461,7 +2461,6 @@ class TestExecHandlers:
         conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        conn._ssh_agent_socket = "/tmp/agent.sock"
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
         mock_session.start = AsyncMock()
@@ -3091,10 +3090,10 @@ class TestSSHAgentHandlers:
         ):
             await conn.handle_ssh_agent_start()
             # Let the relay task run and finish (stdout returns b"").
-            assert conn._ssh_agent_task is not None
-            await conn._ssh_agent_task
-        assert conn._ssh_agent_proc is mock_proc
-        assert conn._ssh_agent_socket is not None
+            assert conn.ssh_agent.task is not None
+            await conn.ssh_agent.task
+        assert conn.ssh_agent.proc is mock_proc
+        assert conn.ssh_agent.socket is not None
         sock.send_json.assert_called()
         msg = sock.send_json.call_args[0][0]
         assert msg["type"] == "ssh_agent_started"
@@ -3110,7 +3109,7 @@ class TestSSHAgentHandlers:
         mock_proc.stdin = AsyncMock()
         mock_proc.stdin.write = MagicMock()
         mock_proc.stdin.drain = AsyncMock()
-        conn._ssh_agent_proc = mock_proc
+        conn.ssh_agent.proc = mock_proc
         data = base64.b64encode(b"agent-request").decode()
         await conn.handle_ssh_agent_data({"data": data})
         mock_proc.stdin.write.assert_called_once_with(b"agent-request")
@@ -3127,17 +3126,17 @@ class TestSSHAgentHandlers:
         mock_proc = AsyncMock()
         mock_proc.kill = MagicMock()
         mock_proc.wait = AsyncMock()
-        conn._ssh_agent_proc = mock_proc
-        conn._ssh_agent_socket = "/tmp/test.sock"
-        conn._ssh_agent_task = asyncio.create_task(asyncio.sleep(999))
+        conn.ssh_agent.proc = mock_proc
+        conn.ssh_agent.socket = "/tmp/test.sock"
+        conn.ssh_agent.task = asyncio.create_task(asyncio.sleep(999))
         with patch.object(
             _mock_pod,
             "exec_container",
             new=AsyncMock(),
         ):
             await conn.handle_ssh_agent_stop()
-        assert conn._ssh_agent_proc is None
-        assert conn._ssh_agent_socket is None
+        assert conn.ssh_agent.proc is None
+        assert conn.ssh_agent.socket is None
         sock.send_json.assert_called()
         msg = sock.send_json.call_args[0][0]
         assert msg["type"] == "ssh_agent_stopped"
@@ -3149,18 +3148,18 @@ class TestSSHAgentHandlers:
         mock_proc = AsyncMock()
         mock_proc.kill = MagicMock()
         mock_proc.wait = AsyncMock()
-        conn._ssh_agent_proc = mock_proc
-        conn._ssh_agent_socket = "/tmp/test.sock"
-        conn._ssh_agent_task = asyncio.create_task(asyncio.sleep(999))
+        conn.ssh_agent.proc = mock_proc
+        conn.ssh_agent.socket = "/tmp/test.sock"
+        conn.ssh_agent.task = asyncio.create_task(asyncio.sleep(999))
         with patch.object(
             _mock_pod,
             "exec_container",
             new=AsyncMock(),
         ):
             await conn._stop_ssh_agent()
-        assert conn._ssh_agent_proc is None
-        assert conn._ssh_agent_task is None
-        assert conn._ssh_agent_socket is None
+        assert conn.ssh_agent.proc is None
+        assert conn.ssh_agent.task is None
+        assert conn.ssh_agent.socket is None
 
     async def test_forward_ssh_agent_output(self):
         import base64
@@ -3172,7 +3171,7 @@ class TestSSHAgentHandlers:
         read_data = [b"agent-response", b""]
         mock_proc.stdout = AsyncMock()
         mock_proc.stdout.read = AsyncMock(side_effect=read_data)
-        conn._ssh_agent_proc = mock_proc
+        conn.ssh_agent.proc = mock_proc
         await conn._forward_ssh_agent_output()
         calls = [
             c[0][0]
@@ -3190,7 +3189,6 @@ class TestSSHAgentHandlers:
         conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/testuser"
-        conn._ssh_agent_socket = "/tmp/klangk-ssh-agent-uid.sock"
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
         mock_session.start = AsyncMock()
@@ -3253,7 +3251,7 @@ class TestSSHAgentHandlers:
         every terminal to the deterministic per-user socket path at creation
         time — inert until a relay binds it, live the moment one does — so it
         does not matter how or when the terminal (or its agent) was created.
-        Here ``conn._ssh_agent_socket`` is left at its default (None, no
+        Here ``conn.ssh_agent.socket`` is left at its default (None, no
         relay) yet the deterministic path is still passed through.
         """
         app_state = _make_app_state()
@@ -3261,7 +3259,7 @@ class TestSSHAgentHandlers:
         conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/testuser"
-        assert conn._ssh_agent_socket is None  # no relay active
+        assert conn.ssh_agent.socket is None  # no relay active
         mock_session = AsyncMock()
         mock_session.start = AsyncMock()
         mock_session.session_name = "uid"
@@ -3585,6 +3583,21 @@ class TestSshAgentForwarder:
         ]
         lg.warning.assert_called_once()
         assert "Failed to remove SSH agent socket" in str(lg.warning.call_args)
+        assert fwd.socket is None
+
+    async def test_stop_tolerates_pkill_failure(self):
+        """The pkill reap is best-effort: if it raises (container already
+        gone, podman launch error) stop() swallows it and still removes the
+        socket file — teardown must not break on a cleanup failure."""
+        fwd, _ = self._forwarder()
+        fwd.socket = "/tmp/agent.sock"
+        with patch.object(
+            _mock_pod,
+            "exec_container",
+            new=AsyncMock(side_effect=[OSError("boom"), (0, "", "")]),
+        ) as exec_mock:
+            await fwd.stop()
+        assert exec_mock.await_count == 2
         assert fwd.socket is None
 
     async def test_stop_cancels_task_and_kills_proc(self):


### PR DESCRIPTION
## Summary

Fixes #2001.

SSH agent forwarding was broken whenever a base tmux session already
existed — i.e. every TUI session and every reconnect via `klangk shell
-A`. The relay started correctly and the socket was created, but
`SSH_AUTH_SOCK` never reached the already-running bash in window 0, so
`ssh-add -l` failed with *"Could not open a connection to your
authentication agent."*

## Root cause

`SSH_AUTH_SOCK` was only injected into a terminal when the agent relay
was **already active** — `ssh_agent_socket=self._conn._ssh_agent_socket`,
which is `None` until `ssh_agent_start` runs. The TUI path opens the tmux
session *first* (creating window 0), then spawns `klangk shell -A`, which
starts the relay. So the base session's shell was spawned with no
`SSH_AUTH_SOCK`, and `tmux set-environment` only affects windows created
*after* it runs — the existing shell never re-reads it. Reconnects inherit
the same empty state.

## Fix

Agent forwarding is now an inherent property of **every** terminal/exec
creation path, not conditional on creation timing:

- New helper `ssh_agent_socket_path(user_id)` centralizes the deterministic
  per-user path `/tmp/klangk-ssh-agent-<user_id>.sock` — the exact path the
  socat relay already binds in `SshAgentForwarder.start`.
- `terminal_start`, the shared-terminal join, and `exec_start` all wire
  `SSH_AUTH_SOCK` to that path at creation time, whether or not a relay is
  live.
- `SshAgentForwarder.start` reuses the same helper, so the relay and the
  plumbing can never drift.

The var is inert (points at nothing) until a relay binds that path — which
only happens when the client opts into forwarding — then goes live
instantly. It no longer matters how or when the terminal (or its agent) was
created: TUI vs CLI, fresh vs reconnect, owner vs joiner, terminal vs exec
all behave identically.

No shell-side hooks, no `PROMPT_COMMAND`/`.bashrc` changes, no per-path
special-casing, no image change.

## Test plan

- [x] Updated existing assertions that encoded the old broken assumption
      (`ssh_agent_socket=None` when no relay).
- [x] Added unit test for `ssh_agent_socket_path`.
- [x] Added regression test `test_terminal_start_wires_agent_socket_without_relay`
      proving the deterministic path is passed even with no relay active.
- [x] `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto`
      → 4098 passed, **100% coverage**.

Manual verification still warranted against a live workspace + real agent
(TUI path and `klangk shell -A` reconnect).
