### PR TITLE
fix(tui): default to klangk theme instead of ansi-light

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -544,6 +544,12 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI now defaults to the `klangk` theme again (#2003).** Reverts the
+  #1904 default: the CLI TUI selects the custom `klangk` theme (GitHub-dark
+  palette matching the web UI) out of the box instead of Textual's built-in
+  `ansi-light`. Textual's built-in themes remain registered and selectable
+  for users who prefer a terminal-palette-aware look.
+
 - **The clanker agent is now opt-in (off by default) (#1977).** The
   `pi --mode rpc` agent subprocess spawns only when the `chat` feature is
   active (`KLANGKD_FEATURES_ENABLE`) **and** the operator enables it via

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -22,13 +22,13 @@ from .state import TuiState
 # Theme.
 #
 # The custom `klangk` theme echoes the Flutter web UI's GitHub-dark-inspired
-# palette (src/frontend/lib/theme/colors.dart) and stays registered so a user
-# (or a future theme toggle) can switch to it. The app DEFAULT, however, is
-# Textual's built-in `ansi-light`: unlike the hard-coded klangk palette, the
-# `ansi-*` themes restrict themselves to the terminal's 16 ANSI colors, so the
-# TUI respects the user's actual terminal palette / shell theme instead of
-# imposing fixed RGB values, and renders correctly on a light-background
-# terminal (#1904).
+# palette (src/frontend/lib/theme/colors.dart) and is the app DEFAULT, keeping
+# the TUI visually consistent with the web UI. Textual's built-in themes stay
+# available for users who prefer them: `ansi-light`/`ansi-dark` restrict
+# themselves to the terminal's 16 ANSI colors, so they respect the user's
+# actual terminal palette / shell theme and render correctly on a
+# light-background terminal (#1904); flipping the default back to `klangk`
+# just changes which one is selected out of the box (#2003).
 #
 # klangk theme tokens:
 #   primary   — green (#238636): primary actions (login, create, start)
@@ -197,7 +197,7 @@ class KlangkApp(App):
         self.live_extra = ""
         self._expiring = False
         self.register_theme(KLANGK_THEME)
-        self.theme = "ansi-light"
+        self.theme = "klangk"
 
     def on_mount(self) -> None:
         self.title = "Klangk"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -848,10 +848,10 @@ async def test_app_opens_login_when_unauthenticated():
         assert isinstance(app.screen, LoginScreen)
 
 
-async def test_app_uses_ansi_light_theme():
-    """#1904: the TUI defaults to Textual's built-in ansi-light theme
-    (terminal-palette-aware) instead of the hard-coded klangk palette. The
-    klangk theme stays registered so it remains selectable."""
+async def test_app_uses_klangk_theme():
+    """#2003: the TUI defaults to the custom klangk theme (matching the web
+    UI's GitHub-dark palette) rather than Textual's built-in ansi-light. The
+    built-in themes stay registered so they remain selectable."""
     from klangk.cli.tui.app import KLANGK_THEME
 
     st = _st(
@@ -863,17 +863,17 @@ async def test_app_uses_ansi_light_theme():
     )
     app = KlangkApp(st)
     # The default is set in __init__, before run_test mounts the app.
-    assert app.theme == "ansi-light"
+    assert app.theme == "klangk"
     async with app.run_test() as pilot:
         await pilot.pause()
-        # Still ansi-light after mount (no on_mount override flips it).
-        assert app.theme == "ansi-light"
-        # The klangk theme stays registered — switching to it must not raise
-        # (Textual raises ThemeError for an unknown theme name).
-        app.theme = "klangk"
-        await pilot.pause()
+        # Still klangk after mount (no on_mount override flips it).
         assert app.theme == "klangk"
         assert KLANGK_THEME.name == "klangk"
+        # The built-in themes stay registered — switching to ansi-light must
+        # not raise (Textual raises ThemeError for an unknown theme name).
+        app.theme = "ansi-light"
+        await pilot.pause()
+        assert app.theme == "ansi-light"
 
 
 async def test_app_none_mode_auto_logs_in():


### PR DESCRIPTION
## Summary

Restores the custom `klangk` Textual theme as the CLI TUI default, reverting the #1904 default of `ansi-light`. The `klangk` theme matches the Flutter web UI's GitHub-dark palette, keeping the two surfaces visually consistent out of the box.

Closes #2003.

## Changes

- `src/klangk/klangk/cli/tui/app.py` — `KlangkApp.__init__` now sets `self.theme = "klangk"` instead of `"ansi-light"`. Textual's built-in themes stay registered and user-selectable. Updated the theme comment block to describe the new default and note both #1904 and #2003.
- `src/klangk/klangkc-tests/tests/test_tui.py` — renamed `test_app_uses_ansi_light_theme` → `test_app_uses_klangk_theme`; now asserts the `klangk` default and that `ansi-light` remains selectable (the inverse of the previous assertions).
- `docs/changes.md` — added a `### Changed` entry under `[Unreleased]`.

## Notes

This flips the default selected out of the box; the `klangk` theme was already registered (since #1904 kept it selectable), so no registration change was needed. Users who prefer the terminal-palette-aware look can still switch to `ansi-light`/`ansi-dark`.

## Test plan

- [x] Full Python suite (CI invocation): `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` → **4094 passed, 100% coverage**.
