### PR TITLE
feat(tui): `?` keyboard cheatsheet modal (#1802)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,12 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **TUI: `?` opens a keyboard cheatsheet modal (#1802).** Pressing `?`
+  on the workspace list or a workspace's detail screen opens a modal listing
+  that screen's keybindings grouped by context (navigation, workspaces /
+  terminals, highlighted-row actions). The modal is dismissed with Escape
+  or by pressing `?` again. Content adapts to the current screen.
+
 - **Workspace tmux status bar shows the disconnect hint (#2006).** The
   status bar now surfaces `Exit: Enter, then ~.` — the CLI's `~.` escape to
   close a `klangk shell` session — so the escape is discoverable without

--- a/src/klangk/klangk/cli/tui/screens/__init__.py
+++ b/src/klangk/klangk/cli/tui/screens/__init__.py
@@ -5,6 +5,7 @@ continue to work unchanged.
 """
 
 from ._base import (
+    CheatsheetScreen,
     ConfirmScreen,
     DuplicateScreen,
     InputScreen,
@@ -24,6 +25,7 @@ from .workspace_form import CreateWorkspaceScreen, EditWorkspaceScreen
 
 __all__ = [
     "AddServerScreen",
+    "CheatsheetScreen",
     "ConfirmScreen",
     "CreateWorkspaceScreen",
     "DuplicateScreen",

--- a/src/klangk/klangk/cli/tui/screens/_base.py
+++ b/src/klangk/klangk/cli/tui/screens/_base.py
@@ -302,6 +302,72 @@ class InputScreen(ModalScreen):
             self._commit()
 
 
+class CheatsheetScreen(ModalScreen):
+    """A ``?`` keyboard cheatsheet modal (#1802).
+
+    Lists the active screen's keybindings grouped by context. Dismissed
+    with Escape or ``?`` (pressed again). Construct with ``sections`` — a
+    list of ``(group_title, [(display_key, description), ...])``; each
+    screen supplies its own (see ``MainScreen._cheatsheet_sections`` /
+    ``WorkspaceDetailScreen._cheatsheet_sections``) so the content adapts
+    to the current screen.
+    """
+
+    DEFAULT_CSS = """
+    CheatsheetScreen { align: center middle; }
+    CheatsheetScreen > Vertical {
+        width: 72;
+        max-width: 92%;
+        height: auto;
+        padding: 1 2;
+        border: round $primary;
+        background: $panel;
+    }
+    CheatsheetScreen #cs_title { text-style: bold; margin-bottom: 1; }
+    CheatsheetScreen .cs_group {
+        text-style: bold;
+        color: $accent;
+        margin-top: 1;
+    }
+    CheatsheetScreen .cs_row { height: 1; }
+    CheatsheetScreen .cs_key {
+        width: 12;
+        min-width: 12;
+        color: $text-muted;
+        text-style: bold;
+    }
+    CheatsheetScreen .cs_desc { width: 1fr; }
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_modal", "Close", show=False),
+        Binding("?", "dismiss_modal", "Close", show=False),
+    ]
+
+    def __init__(
+        self, sections: list[tuple[str, list[tuple[str, str]]]]
+    ) -> None:
+        super().__init__()
+        self._sections = sections
+
+    def compose(self) -> ComposeResult:
+        children: list = [Static(Text("Keyboard shortcuts"), id="cs_title")]
+        for title, items in self._sections:
+            children.append(Static(Text(title), classes="cs_group"))
+            for key, desc in items:
+                children.append(
+                    Horizontal(
+                        Static(Text(key), classes="cs_key"),
+                        Static(Text(desc), classes="cs_desc"),
+                        classes="cs_row",
+                    )
+                )
+        yield Vertical(*children, id="cs_box")
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)
+
+
 class TransferScreen(ModalScreen):
     """Runs a blocking transfer (export/import) in a worker thread while
     showing a live progress bar (#1758).

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -36,6 +36,7 @@ from ...auth import refresh_token as _refresh_token
 from ..widgets import StatusBar
 from ..ws import listen_for_status
 from ._base import (
+    CheatsheetScreen,
     ConfirmScreen,
     InputScreen,
     TransferScreen,
@@ -148,6 +149,7 @@ class MainScreen(Screen):
         Binding("u", "duplicate", "Dup", show=False),
         Binding("d", "delete", "Del", show=False),
         Binding("e", "edit", "Edit", show=False),
+        Binding("?", "cheatsheet", "Keys", show=False),
     ]
 
     def compose(self) -> ComposeResult:
@@ -564,6 +566,51 @@ class MainScreen(Screen):
 
     def action_logout(self) -> None:
         self.app.do_logout()
+
+    def action_cheatsheet(self) -> None:
+        """Open the ``?`` keyboard cheatsheet modal (#1802)."""
+        self.app.push_screen(CheatsheetScreen(self._cheatsheet_sections()))
+
+    @staticmethod
+    def _cheatsheet_sections() -> list[tuple[str, list[tuple[str, str]]]]:
+        """Keybindings shown in the cheatsheet, grouped by context (#1802).
+
+        Hand-written (not derived from ``BINDINGS``) so the display labels
+        read cleanly — e.g. ``Enter`` / ``↑ ↓`` rather than the raw binding
+        key strings. Kept in sync with the bindings above by the TUI tests,
+        which assert each key appears.
+        """
+        return [
+            (
+                "Navigation",
+                [
+                    ("↑ ↓", "Move rows; cross the tab strip (Up from row 1)"),
+                    ("Tab", "Cycle focus (Shift+Tab back)"),
+                    ("Enter", "Open the highlighted workspace"),
+                ],
+            ),
+            (
+                "Workspaces",
+                [
+                    ("c", "Switch server"),
+                    ("n", "New workspace"),
+                    ("i", "Import from archive"),
+                    ("o", "Cycle sort order"),
+                    ("/", "Filter by name or id"),
+                    ("l", "Log out"),
+                ],
+            ),
+            (
+                "Highlighted row",
+                [
+                    ("e", "Edit workspace"),
+                    ("r", "Restart"),
+                    ("s", "Stop / Start"),
+                    ("u", "Duplicate"),
+                    ("d", "Delete"),
+                ],
+            ),
+        ]
 
     def action_create(self) -> None:
         self.run_worker(self._do_create, exit_on_error=False)

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -30,6 +30,7 @@ from textual.widgets import (
 
 from ...client import AuthError, WorkspaceNotFoundError
 from ._base import (
+    CheatsheetScreen,
     ConfirmScreen,
     DuplicateScreen,
     InputScreen,
@@ -55,6 +56,7 @@ class WorkspaceDetailScreen(Screen):
         # are shown inline on the Terminals list header instead (#1860).
         Binding("n", "new_terminal", "New term", show=False),
         Binding("delete", "delete_terminal", "Del term", show=False),
+        Binding("?", "cheatsheet", "Keys", show=False),
     ]
 
     DEFAULT_CSS = """
@@ -175,6 +177,10 @@ class WorkspaceDetailScreen(Screen):
             Binding("d", "delete", "Del ws"),
             Binding("n", "new_terminal", "New term", show=False),
             Binding("delete", "delete_terminal", "Del term", show=False),
+            # `?` must survive the per-display BINDINGS rebuild so the
+            # cheatsheet stays reachable after _display() runs on mount
+            # (#1802).
+            Binding("?", "cheatsheet", "Keys", show=False),
         ]
 
     def _display(self) -> None:
@@ -742,6 +748,45 @@ class WorkspaceDetailScreen(Screen):
             ),
             self._on_export,
         )
+
+    def action_cheatsheet(self) -> None:
+        """Open the ``?`` keyboard cheatsheet modal (#1802)."""
+        self.app.push_screen(CheatsheetScreen(self._cheatsheet_sections()))
+
+    @staticmethod
+    def _cheatsheet_sections() -> list[tuple[str, list[tuple[str, str]]]]:
+        """Keybindings shown in the cheatsheet, grouped by context (#1802).
+
+        Hand-written display labels (see MainScreen._cheatsheet_sections
+        for the rationale); the TUI tests assert each key appears.
+        """
+        return [
+            (
+                "Navigation",
+                [
+                    ("Esc", "Back to workspace list"),
+                    ("Enter", "Open a terminal shell"),
+                ],
+            ),
+            (
+                "Workspace",
+                [
+                    ("e", "Edit"),
+                    ("r", "Restart"),
+                    ("s", "Stop / Start"),
+                    ("u", "Duplicate"),
+                    ("d", "Delete workspace"),
+                    ("x", "Export archive"),
+                ],
+            ),
+            (
+                "Terminals",
+                [
+                    ("n", "New terminal"),
+                    ("Del", "Delete terminal"),
+                ],
+            ),
+        ]
 
     def _on_export(self, path: str | None) -> None:
         if not path:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -48,6 +48,7 @@ from klangk.cli.config import (
 )
 from klangk.cli.tui.screens import (
     AddServerScreen,
+    CheatsheetScreen,
     ConfirmScreen,
     CreateWorkspaceScreen,
     DuplicateScreen,
@@ -8828,3 +8829,88 @@ async def test_edit_running_env_saved_before_restart_prompt(monkeypatch):
         assert await pilot.click("#no")
         await pilot.pause()
         assert captured["k"]["env"] == {"OLD": "x", "a": "1"}  # unchanged
+
+
+def _cheatsheet_text(screen) -> str:
+    """Join every rendered key/desc/group cell of a CheatsheetScreen."""
+    cells = []
+    for sel in (".cs_group", ".cs_key", ".cs_desc"):
+        for w in screen.query(sel):
+            cells.append(str(w.render()))
+    return " | ".join(cells)
+
+
+async def test_main_screen_cheatsheet_modal():
+    """`?` on the workspace list opens a cheatsheet of MainScreen bindings;
+    Escape or `?` again dismisses it (#1802)."""
+    a = _wsobj("alpha", running=True, service_started_at=1.0)
+    app = KlangkApp(_ws(owned=[a]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+        await pilot.press("?")
+        await pilot.pause()
+        assert isinstance(app.screen, CheatsheetScreen)
+        text = _cheatsheet_text(app.screen)
+        # Navigation + workspaces + highlighted-row bindings all shown.
+        for key in (
+            "↑ ↓",
+            "Tab",
+            "Enter",
+            "/",
+            "c",
+            "n",
+            "i",
+            "o",
+            "l",
+            "e",
+            "r",
+            "s",
+            "u",
+            "d",
+        ):
+            assert key in text, f"missing {key!r} in cheatsheet"
+        assert "Open the highlighted workspace" in text
+
+        # Escape dismisses.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+        # `?` opens again, and `?` again dismisses.
+        await pilot.press("?")
+        await pilot.pause()
+        assert isinstance(app.screen, CheatsheetScreen)
+        await pilot.press("?")
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+
+async def test_detail_screen_cheatsheet_modal():
+    """`?` on the detail screen opens a cheatsheet of WorkspaceDetailScreen
+    bindings; Escape dismisses (#1802). Also confirms the `?` binding survives
+    the per-display BINDINGS rebuild in _display()."""
+    a = _wsobj("alpha", running=True, service_started_at=1.0)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, WorkspaceDetailScreen)
+
+        await pilot.press("?")
+        await pilot.pause()
+        assert isinstance(app.screen, CheatsheetScreen)
+        text = _cheatsheet_text(app.screen)
+        for key in ("Esc", "Enter", "e", "r", "s", "u", "d", "x", "n", "Del"):
+            assert key in text, f"missing {key!r} in cheatsheet"
+        assert "Back to workspace list" in text
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(app.screen, WorkspaceDetailScreen)


### PR DESCRIPTION
## Summary

Closes #1802.

Adds a `?` keybinding on `MainScreen` and `WorkspaceDetailScreen` that opens a modal listing that screen's keybindings grouped by context. The modal dismisses with Escape or by pressing `?` again; content adapts to the current screen.

## Changes

- **`screens/_base.py`** — new `CheatsheetScreen(ModalScreen)`: renders grouped `(display_key, description)` rows, dismisses via `escape` or `?` (`action_dismiss_modal`). Each screen supplies its own sections, so the content is screen-specific.
- **`screens/main.py`** — `?` binding (`show=False`) + `action_cheatsheet` + `_cheatsheet_sections()` grouped as **Navigation** (↑↓, Tab, Enter), **Workspaces** (c, n, i, o, /, l), **Highlighted row** (e, r, s, u, d).
- **`screens/workspace_detail.py`** — `?` binding added to **both** the class `BINDINGS` **and** `_bindings_list()`, so it survives the per-display `BINDINGS` rebuild in `_display()` (which runs on mount and would otherwise drop the binding). Sections grouped as **Navigation** (Esc, Enter), **Workspace** (e, r, s, u, d, x), **Terminals** (n, Del).
- **`screens/__init__.py`** — re-exports `CheatsheetScreen`.

Sections are hand-written display labels (`Enter` / `↑ ↓` / `Esc`) rather than raw binding key strings, so they read cleanly.

## Notes

- `?` while a filter `Input` is focused still types into the input — character keys go to the focused widget before screen bindings, the same way the existing `/` binding coexists with typing `/` in the filter.
- Confirmed the binding fires: pressing `?` yields `event.key == "question_mark"`, which Textual resolves from the `?` binding.
- The binding is `show=False` on both screens (the existing footers are already full, especially the detail screen's 7 entries).

## Tests

Two Pilot tests in `test_tui.py`:
- `test_main_screen_cheatsheet_modal` — `?` on the workspace list opens the modal with all MainScreen bindings (↑↓, Tab, Enter, /, c, n, i, o, l, e, r, s, u, d); Escape dismisses; `?` opens again and `?` again dismisses.
- `test_detail_screen_cheatsheet_modal` — `?` on the detail screen opens the modal with all WorkspaceDetailScreen bindings (Esc, Enter, e, r, s, u, d, x, n, Del); Escape dismisses. Also implicitly verifies the `?` binding survives the `_display()` rebuild.

## Verification

- Full Python suite with `-n auto` (as CI): **4105 passed, 100% coverage**.
- `ruff check` clean on all changed files (the remaining `# noqa: allow-deferred-import` warnings are pre-existing on `main`; none introduced here).

## Changelog

`### Added` entry under `[Unreleased]`.
