### PR TITLE
fix(tui): arrow-key nav between buttons in confirm dialogs (#2016)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1214,6 +1214,11 @@ set-password <email>` (set a known password for the default user — whose
   (#2010).** `on_list_view_selected` clears the primary screen buffer
   inside the `suspend()` block before spawning `klangk shell`, so the
   stale content that briefly surfaced during the buffer swap is gone.
+- **Arrow keys now move between buttons in TUI dialogs (#2016).**
+  Confirm / Input / Duplicate dialogs (Cancel/OK, etc.) previously
+  required Tab to switch buttons — Left/Right now moves between sibling
+  buttons, and Up/Down steps between the input field and the button row
+  where present, per the spatial-navigation rule. Tab remains a fallback.
 - **TUI workspace-detail terminal list is now focused with the first
   terminal highlighted from the first frame (#1956).** Four intertwined
   bugs on the workspace-detail screen left the initial terminal

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1217,8 +1217,9 @@ set-password <email>` (set a known password for the default user — whose
 - **Arrow keys now move between buttons in TUI dialogs (#2016).**
   Confirm / Input / Duplicate dialogs (Cancel/OK, etc.) previously
   required Tab to switch buttons — Left/Right now moves between sibling
-  buttons, and Up/Down steps between the input field and the button row
-  where present, per the spatial-navigation rule. Tab remains a fallback.
+  buttons, Up/Down steps between the input field and the button row
+  where present, and Escape cancels. Per the spatial-navigation rule;
+  Tab remains a fallback.
 - **TUI workspace-detail terminal list is now focused with the first
   terminal highlighted from the first frame (#1956).** Four intertwined
   bugs on the workspace-detail screen left the initial terminal

--- a/src/klangk/klangk/cli/tui/screens/_base.py
+++ b/src/klangk/klangk/cli/tui/screens/_base.py
@@ -46,6 +46,7 @@ class ButtonRowModalScreen(ModalScreen[_ScreenResult]):
         Binding("right", "btn_right", show=False),
         Binding("up", "btn_up", show=False),
         Binding("down", "btn_down", show=False),
+        Binding("escape", "cancel", show=False),
     ]
 
     def _focus_id(self, widget_id: str) -> None:
@@ -77,15 +78,27 @@ class ButtonRowModalScreen(ModalScreen[_ScreenResult]):
         if self._focused_id() == self._INPUT and self._BUTTONS:
             self._focus_id(self._BUTTONS[0])
 
+    def action_cancel(self) -> None:
+        """Escape cancels the dialog (#2016)."""
+        self._dismiss_cancel()
+
+    def _dismiss_cancel(self) -> None:
+        """Dismiss as Cancel. Subclasses override to return their cancel
+        value (False for ConfirmScreen; None for Input/Duplicate)."""
+        self.dismiss(None)
+
 
 class ConfirmScreen(ButtonRowModalScreen[bool]):
     """A yes/no confirmation dialog. Dismisses with True on confirm.
 
     Arrows move between Cancel / confirm (Left/Right) — no Tab needed
-    (#2016).
+    (#2016). Escape dismisses as Cancel (False).
     """
 
     _BUTTONS = ["no", "yes"]
+
+    def _dismiss_cancel(self) -> None:
+        self.dismiss(False)
 
     DEFAULT_CSS = """
     ConfirmScreen { align: center middle; }

--- a/src/klangk/klangk/cli/tui/screens/_base.py
+++ b/src/klangk/klangk/cli/tui/screens/_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TypeVar
 
 from rich.text import Text
 
@@ -21,8 +22,70 @@ from textual.widgets import (
 )
 
 
-class ConfirmScreen(ModalScreen[bool]):
-    """A yes/no confirmation dialog. Dismisses with True on confirm."""
+_ScreenResult = TypeVar("_ScreenResult")
+
+
+class ButtonRowModalScreen(ModalScreen[_ScreenResult]):
+    """Spatial arrow navigation for a modal dialog with an optional input
+    field above a horizontal row of buttons (#2016).
+
+    Left/Right move between sibling buttons in reading order; Down from
+    the input enters the first button; Up from a button returns to the
+    input. Arrows are always sufficient to reach every option — Tab /
+    Shift-Tab remains a fallback (no focus traps, per AGENTS.md "TUI
+    spatial navigation (no focus traps)").
+    """
+
+    # Button ids left-to-right (reading order); optionally the id of an
+    # input field sitting above the row.
+    _BUTTONS: list[str] = []
+    _INPUT: str | None = None
+
+    BINDINGS = [
+        Binding("left", "btn_left", show=False),
+        Binding("right", "btn_right", show=False),
+        Binding("up", "btn_up", show=False),
+        Binding("down", "btn_down", show=False),
+    ]
+
+    def _focus_id(self, widget_id: str) -> None:
+        self.query_one(f"#{widget_id}").focus()
+
+    def _focused_id(self) -> str | None:
+        focused = self.focused
+        return focused.id if focused is not None else None
+
+    def _btn_step(self, step: int) -> None:
+        fid = self._focused_id()
+        if fid in self._BUTTONS:
+            pos = self._BUTTONS.index(fid)
+            nxt = pos + step
+            if 0 <= nxt < len(self._BUTTONS):
+                self._focus_id(self._BUTTONS[nxt])
+
+    def action_btn_left(self) -> None:
+        self._btn_step(-1)
+
+    def action_btn_right(self) -> None:
+        self._btn_step(1)
+
+    def action_btn_up(self) -> None:
+        if self._focused_id() in self._BUTTONS and self._INPUT:
+            self._focus_id(self._INPUT)
+
+    def action_btn_down(self) -> None:
+        if self._focused_id() == self._INPUT and self._BUTTONS:
+            self._focus_id(self._BUTTONS[0])
+
+
+class ConfirmScreen(ButtonRowModalScreen[bool]):
+    """A yes/no confirmation dialog. Dismisses with True on confirm.
+
+    Arrows move between Cancel / confirm (Left/Right) — no Tab needed
+    (#2016).
+    """
+
+    _BUTTONS = ["no", "yes"]
 
     DEFAULT_CSS = """
     ConfirmScreen { align: center middle; }
@@ -188,8 +251,15 @@ class WorkspaceListView(SpatialListView):
     SPATIAL_UP_TARGET = Tabs
 
 
-class DuplicateScreen(ModalScreen):
-    """Prompt for a new name to duplicate a workspace under."""
+class DuplicateScreen(ButtonRowModalScreen):
+    """Prompt for a new name to duplicate a workspace under.
+
+    Down from the name input enters the button row; Left/Right move
+    between Cancel / Dup (#2016).
+    """
+
+    _BUTTONS = ["cancel", "ok"]
+    _INPUT = "dup_name"
 
     DEFAULT_CSS = """
     DuplicateScreen { align: center middle; }
@@ -248,11 +318,16 @@ def _fmt_transfer(done: float, total: float | None) -> str:
     return f"{d} / {_human_bytes(total)}" if total else f"{d} (size unknown)"
 
 
-class InputScreen(ModalScreen):
+class InputScreen(ButtonRowModalScreen):
     """Generic single-line input prompt (title + default + OK/Cancel).
 
     Dismisses with the trimmed value on OK, or ``None`` on cancel (#1758).
+    Down from the input enters the button row; Left/Right move between
+    Cancel / OK (#2016).
     """
+
+    _BUTTONS = ["cancel", "ok"]
+    _INPUT = "inp_value"
 
     DEFAULT_CSS = """
     InputScreen { align: center middle; }

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2112,6 +2112,114 @@ async def test_input_screen_ok_cancel_and_enter(monkeypatch):
         assert cap["s"] == "z"
 
 
+async def test_confirm_screen_arrow_nav(monkeypatch):
+    """ConfirmScreen: Left/Right move between Cancel/confirm; arrows are
+    sufficient (no Tab needed) (#2016)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        app.push_screen(ConfirmScreen("Delete 'alpha'?"), lambda r: None)
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.query_one("#no").focus()
+        await pilot.pause()
+        assert app.screen.focused.id == "no"
+
+        # Right moves Cancel -> confirm.
+        await pilot.press("right")
+        await pilot.pause()
+        assert app.screen.focused.id == "yes"
+        # Right at the edge stays put.
+        await pilot.press("right")
+        await pilot.pause()
+        assert app.screen.focused.id == "yes"
+
+        # Left moves confirm -> Cancel.
+        await pilot.press("left")
+        await pilot.pause()
+        assert app.screen.focused.id == "no"
+        # Left at the edge stays put.
+        await pilot.press("left")
+        await pilot.pause()
+        assert app.screen.focused.id == "no"
+
+        # No input above the row — Up/Down are no-ops.
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.screen.focused.id == "no"
+        app.screen.dismiss(False)
+
+
+async def test_input_screen_arrow_nav(monkeypatch):
+    """InputScreen: Down leaves the input for the button row; Left/Right
+    move between Cancel/OK; Up returns to the input (#2016)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        app.push_screen(InputScreen("Path:"), lambda r: None)
+        await pilot.pause()
+        assert isinstance(app.screen, InputScreen)
+        assert app.screen.focused.id == "inp_value"
+
+        # Down from the input enters the first button (Cancel).
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.screen.focused.id == "cancel"
+
+        # Right moves Cancel -> OK; at the edge stays put.
+        await pilot.press("right")
+        await pilot.pause()
+        assert app.screen.focused.id == "ok"
+        await pilot.press("right")
+        await pilot.pause()
+        assert app.screen.focused.id == "ok"
+
+        # Up from a button returns to the input.
+        await pilot.press("left")
+        await pilot.pause()
+        assert app.screen.focused.id == "cancel"
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.screen.focused.id == "inp_value"
+        app.screen.dismiss(None)
+
+
+async def test_duplicate_screen_arrow_nav(monkeypatch):
+    """DuplicateScreen: Down from the name input enters the button row;
+    Left/Right move between Cancel/Dup (#2016)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        app.push_screen(DuplicateScreen("alpha"), lambda r: None)
+        await pilot.pause()
+        assert isinstance(app.screen, DuplicateScreen)
+        app.screen.query_one("#dup_name").focus()
+        await pilot.pause()
+        assert app.screen.focused.id == "dup_name"
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.screen.focused.id == "cancel"
+        await pilot.press("right")
+        await pilot.pause()
+        assert app.screen.focused.id == "ok"
+        app.screen.dismiss(None)
+
+
 async def test_transfer_screen_success_error_and_progress(monkeypatch):
     """TransferScreen drives the bar from the worker thread and reports
     success/failure via its dismiss value (#1758)."""

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2122,8 +2122,12 @@ async def test_confirm_screen_arrow_nav(monkeypatch):
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    cap = {}
     async with app.run_test() as pilot:
-        app.push_screen(ConfirmScreen("Delete 'alpha'?"), lambda r: None)
+        app.push_screen(
+            ConfirmScreen("Delete 'alpha'?"),
+            lambda r: cap.__setitem__("r", r),
+        )
         await pilot.pause()
         assert isinstance(app.screen, ConfirmScreen)
         app.screen.query_one("#no").focus()
@@ -2152,7 +2156,10 @@ async def test_confirm_screen_arrow_nav(monkeypatch):
         await pilot.press("down")
         await pilot.pause()
         assert app.screen.focused.id == "no"
-        app.screen.dismiss(False)
+        # Escape cancels (dismisses False) (#2016).
+        await pilot.press("escape")
+        await pilot.pause()
+        assert cap["r"] is False
 
 
 async def test_input_screen_arrow_nav(monkeypatch):
@@ -2165,8 +2172,12 @@ async def test_input_screen_arrow_nav(monkeypatch):
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    cap = {}
     async with app.run_test() as pilot:
-        app.push_screen(InputScreen("Path:"), lambda r: None)
+        app.push_screen(
+            InputScreen("Path:"),
+            lambda r: cap.__setitem__("r", r),
+        )
         await pilot.pause()
         assert isinstance(app.screen, InputScreen)
         assert app.screen.focused.id == "inp_value"
@@ -2191,7 +2202,10 @@ async def test_input_screen_arrow_nav(monkeypatch):
         await pilot.press("up")
         await pilot.pause()
         assert app.screen.focused.id == "inp_value"
-        app.screen.dismiss(None)
+        # Escape cancels (dismisses None) (#2016).
+        await pilot.press("escape")
+        await pilot.pause()
+        assert cap["r"] is None
 
 
 async def test_duplicate_screen_arrow_nav(monkeypatch):
@@ -2204,8 +2218,12 @@ async def test_duplicate_screen_arrow_nav(monkeypatch):
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
     app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    cap = {}
     async with app.run_test() as pilot:
-        app.push_screen(DuplicateScreen("alpha"), lambda r: None)
+        app.push_screen(
+            DuplicateScreen("alpha"),
+            lambda r: cap.__setitem__("r", r),
+        )
         await pilot.pause()
         assert isinstance(app.screen, DuplicateScreen)
         app.screen.query_one("#dup_name").focus()
@@ -2217,7 +2235,10 @@ async def test_duplicate_screen_arrow_nav(monkeypatch):
         await pilot.press("right")
         await pilot.pause()
         assert app.screen.focused.id == "ok"
-        app.screen.dismiss(None)
+        # Escape cancels (dismisses None) (#2016).
+        await pilot.press("escape")
+        await pilot.pause()
+        assert cap["r"] is None
 
 
 async def test_transfer_screen_success_error_and_progress(monkeypatch):


### PR DESCRIPTION
## Summary

The TUI's confirm/cancel dialogs (delete-workspace, delete-terminal, duplicate, input prompts) required Tab/Shift-Tab to move between buttons — arrow keys did nothing, violating the spatial-navigation rule in `AGENTS.md` ("arrows must always be sufficient to reach any element in reading order").

## Fix

Added a `ButtonRowModalScreen(ModalScreen[_ScreenResult])` base in `src/klangk/klangk/cli/tui/screens/_base.py`, and made `ConfirmScreen`, `InputScreen`, and `DuplicateScreen` subclass it. Each declares its `_BUTTONS` (ids, left-to-right reading order) and, where present, `_INPUT` (the id of an input field above the row):

- **Left/Right** move between sibling buttons in reading order.
- **Down** from the input enters the first button; **Up** from a button returns to the input (InputScreen / DuplicateScreen).
- Left/Right on the input are left to the field's own cursor handling (so text editing still works).
- Tab / Shift-Tab remains a fallback (unchanged).

### Why a `ModalScreen` base and not a bare mixin

Textual's `_merge_bindings` (`textual/dom.py:681`) only merges `BINDINGS` from classes that are **`DOMNode` subclasses** — a bare mixin like `class ButtonRowNav:` is skipped, so its bindings never register (verified empirically: `pilot.press("right")` was a no-op until the base became a `DOMNode`). The existing `TabSkipMixin` dodges this by using `on_key` instead of `BINDINGS`. Here a `ModalScreen` subclass base is the clean fit: it's a DOMNode, the bindings merge into subclasses, and it carries the shared action methods.

## Tests
- `test_confirm_screen_arrow_nav` — Left/Right between Cancel/confirm, boundary no-ops, Up/Down no-ops (no input row).
- `test_input_screen_arrow_nav` — Down (input→Cancel), Right (→OK), boundary, Left, Up (→input).
- `test_duplicate_screen_arrow_nav` — Down (input→Cancel), Right (→OK).
- Full backend suite: **4109 passed, 100% coverage** (`-n auto`).

## Scope

Covers the three modal dialogs named in the issue. The login screen also has a horizontal button pair (`#oidc`/`#login`), but it's a full screen (not a modal) and already uses `SpatialNavScreen` — left out of scope here.

Closes #2016.
