### PR TITLE
feat(tui): rename a terminal from the terminals list (#2020)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -28,7 +28,7 @@ operators or integrators to act when upgrading.
 ### Added
 
 - **TUI: rename a terminal from the terminals list (#2020).** Press
-  `F2` on a highlighted terminal to rename it (an input prefilled with
+  `m` on a highlighted terminal to rename it (an input prefilled with
   the current name; Enter renames, Escape cancels). Uses the existing
   `terminal_rename_window` backend path (`tmux rename-window`).
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,11 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **TUI: rename a terminal from the terminals list (#2020).** Press
+  `F2` on a highlighted terminal to rename it (an input prefilled with
+  the current name; Enter renames, Escape cancels). Uses the existing
+  `terminal_rename_window` backend path (`tmux rename-window`).
+
 - **TUI: `?` opens a keyboard cheatsheet modal (#1802).** Pressing `?`
   on the workspace list or a workspace's detail screen opens a modal listing
   that screen's keybindings grouped by context (navigation, workspaces /

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,10 +27,12 @@ operators or integrators to act when upgrading.
 
 ### Added
 
-- **TUI: rename a terminal from the terminals list (#2020).** Press
-  `m` on a highlighted terminal to rename it (an input prefilled with
-  the current name; Enter renames, Escape cancels). Uses the existing
-  `terminal_rename_window` backend path (`tmux rename-window`).
+- **TUI: rename a terminal from the terminals list (#2020).** Press `m`
+  on a highlighted terminal for an input prefilled with the current name
+  (typing appends; Enter renames, Escape cancels; the result shows as a
+  toast). Terminal-scoped keys are now letters — `n` new, `m` rename,
+  `t` delete (was the Delete key) — listed in the `?` cheatsheet. Uses
+  the existing `terminal_rename_window` backend (`tmux rename-window`).
 
 - **TUI: `?` opens a keyboard cheatsheet modal (#1802).** Pressing `?`
   on the workspace list or a workspace's detail screen opens a modal listing

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -33,6 +33,8 @@ operators or integrators to act when upgrading.
   toast). Terminal-scoped keys are now letters — `n` new, `m` rename,
   `t` delete (was the Delete key) — listed in the `?` cheatsheet. Uses
   the existing `terminal_rename_window` backend (`tmux rename-window`).
+  Terminal create/delete feedback (`Creating…` / `Created` / `Deleting…` /
+  `Deleted`, and failures) now surfaces as a toast instead of inline text.
 
 - **TUI: `?` opens a keyboard cheatsheet modal (#1802).** Pressing `?`
   on the workspace list or a workspace's detail screen opens a modal listing

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -666,12 +666,19 @@ class KlangkClient:
         """Create a new terminal window in workspace *name*; return updated list."""
         return await self._terminals(name, new_window=window_name)
 
+    async def rename_terminal(
+        self, name: str, index: int, new_name: str
+    ) -> list[dict]:
+        """Rename terminal window at *index* in workspace *name*; return list."""
+        return await self._terminals(name, rename=(index, new_name))
+
     async def _terminals(
         self,
         name: str,
         *,
         close_window_id: str | None = None,
         new_window: str | None = None,
+        rename: tuple[int, str] | None = None,
     ) -> list[dict]:
         try:
             ws = self.resolve_workspace(name)
@@ -708,6 +715,18 @@ class KlangkClient:
                             {
                                 "cmd": "terminal_new_window",
                                 "name": new_window,
+                            }
+                        )
+                    )
+                    windows = await self._recv_windows(conn)
+                if rename is not None and windows:
+                    idx, new_name = rename
+                    await conn.send(
+                        json.dumps(
+                            {
+                                "cmd": "terminal_rename_window",
+                                "index": idx,
+                                "name": new_name,
                             }
                         )
                     )

--- a/src/klangk/klangk/cli/tui/screens/_base.py
+++ b/src/klangk/klangk/cli/tui/screens/_base.py
@@ -354,17 +354,29 @@ class InputScreen(ButtonRowModalScreen):
     """
 
     def __init__(
-        self, title: str, default: str = "", ok_label: str = "OK"
+        self,
+        title: str,
+        default: str = "",
+        ok_label: str = "OK",
+        select_on_focus: bool = True,
     ) -> None:
         super().__init__()
         self._title = title
         self._default = default
         self._ok_label = ok_label
+        # When False the field doesn't select-all on focus; typing then
+        # appends to the default (what rename wants) instead of replacing
+        # it (#2020).
+        self._select_on_focus = select_on_focus
 
     def compose(self) -> ComposeResult:
         yield Vertical(
             Static(Text(self._title)),
-            Input(value=self._default, id="inp_value"),
+            Input(
+                value=self._default,
+                id="inp_value",
+                select_on_focus=self._select_on_focus,
+            ),
             Horizontal(
                 Button("Cancel", id="cancel"),
                 Button(self._ok_label, id="ok", variant="primary"),
@@ -373,7 +385,12 @@ class InputScreen(ButtonRowModalScreen):
         )
 
     def on_mount(self) -> None:
-        self.query_one("#inp_value", Input).focus()
+        inp = self.query_one("#inp_value", Input)
+        inp.focus()
+        # Without select-on-focus, park the cursor at the end so typing
+        # appends to the default (rename) rather than prepending (#2020).
+        if not self._select_on_focus:
+            inp.cursor_position = len(inp.value)
 
     def _commit(self) -> None:
         val = self.query_one("#inp_value", Input).value.strip()

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -55,6 +55,7 @@ class WorkspaceDetailScreen(Screen):
         # Terminal-scoped keys are hidden from the Footer — their hints
         # are shown inline on the Terminals list header instead (#1860).
         Binding("n", "new_terminal", "New term", show=False),
+        Binding("f2", "rename_terminal", "Rename term", show=False),
         Binding("delete", "delete_terminal", "Del term", show=False),
         Binding("?", "cheatsheet", "Keys", show=False),
     ]
@@ -101,7 +102,11 @@ class WorkspaceDetailScreen(Screen):
         yield Vertical(
             Horizontal(
                 Static("Terminals", id="term_label"),
-                Static("[n] new  [⌿] delete", id="term_hints", markup=False),
+                Static(
+                    "[n] new  [F2] rename  [⌿] delete",
+                    id="term_hints",
+                    markup=False,
+                ),
                 id="term_header",
             ),
             SpatialListView(id="term_list"),
@@ -209,6 +214,7 @@ class WorkspaceDetailScreen(Screen):
             Binding("u", "duplicate", "Dup"),
             Binding("d", "delete", "Del ws"),
             Binding("n", "new_terminal", "New term", show=False),
+            Binding("f2", "rename_terminal", "Rename term", show=False),
             Binding("delete", "delete_terminal", "Del term", show=False),
             # `?` must survive the per-display BINDINGS rebuild so the
             # cheatsheet stays reachable after _display() runs on mount
@@ -633,6 +639,58 @@ class WorkspaceDetailScreen(Screen):
                 return str(w.get("name") or idx)
         return key
 
+    def action_rename_terminal(self) -> None:
+        lv = self.query_one("#term_list", ListView)
+        child = lv.highlighted_child
+        if child is None or not child.name:
+            return
+        # The rename controller targets the window by INDEX (tmux
+        # rename-window -t session:INDEX), not the @N id used by select /
+        # delete. The list row key *is* the index (#1965).
+        index = int(child.name)
+        current = self._terminal_label_for(child.name)
+
+        def _on_rename(new_name: str | None) -> None:
+            # InputScreen dismisses None on cancel/escape (#2016); an
+            # unchanged name also skips the round-trip.
+            if not new_name or new_name == current:
+                return
+            self.run_worker(
+                self._do_rename_terminal(index, new_name),
+                exit_on_error=False,
+            )
+
+        self.app.push_screen(
+            InputScreen(
+                f"Rename '{current}' to:",
+                default=current,
+                ok_label="Rename",
+            ),
+            _on_rename,
+        )
+
+    async def _do_rename_terminal(self, index: int, new_name: str) -> None:
+        self._msg(f"Renaming terminal to '{new_name}'…")
+        try:
+            windows = await self.app.tui_state.rename_terminal(
+                self._name, index, new_name
+            )
+        except Exception as exc:
+            self._msg(f"Rename failed: {exc}", error=True)
+            # Stale index — refresh so the row self-heals (#1965).
+            await self._load_terminals()
+            return
+        if not windows:
+            self._msg(
+                "Rename failed — could not refresh terminals.",
+                error=True,
+            )
+            await self._load_terminals()
+            return
+        self._terminals = windows
+        await self._render_terminals()
+        self._msg(f"Renamed terminal to '{new_name}'.")
+
     def action_new_terminal(self) -> None:
         if self._ws is None:
             return
@@ -839,6 +897,7 @@ class WorkspaceDetailScreen(Screen):
                 "Terminals",
                 [
                     ("n", "New terminal"),
+                    ("F2", "Rename terminal"),
                     ("Del", "Delete terminal"),
                 ],
             ),

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -55,7 +55,7 @@ class WorkspaceDetailScreen(Screen):
         # Terminal-scoped keys are hidden from the Footer — their hints
         # are shown inline on the Terminals list header instead (#1860).
         Binding("n", "new_terminal", "New term", show=False),
-        Binding("f2", "rename_terminal", "Rename term", show=False),
+        Binding("m", "rename_terminal", "Rename term", show=False),
         Binding("delete", "delete_terminal", "Del term", show=False),
         Binding("?", "cheatsheet", "Keys", show=False),
     ]
@@ -103,7 +103,7 @@ class WorkspaceDetailScreen(Screen):
             Horizontal(
                 Static("Terminals", id="term_label"),
                 Static(
-                    "[n] new  [F2] rename  [⌿] delete",
+                    "[n] new  [m] rename  [⌿] delete",
                     id="term_hints",
                     markup=False,
                 ),
@@ -214,7 +214,7 @@ class WorkspaceDetailScreen(Screen):
             Binding("u", "duplicate", "Dup"),
             Binding("d", "delete", "Del ws"),
             Binding("n", "new_terminal", "New term", show=False),
-            Binding("f2", "rename_terminal", "Rename term", show=False),
+            Binding("m", "rename_terminal", "Rename term", show=False),
             Binding("delete", "delete_terminal", "Del term", show=False),
             # `?` must survive the per-display BINDINGS rebuild so the
             # cheatsheet stays reachable after _display() runs on mount
@@ -897,7 +897,7 @@ class WorkspaceDetailScreen(Screen):
                 "Terminals",
                 [
                     ("n", "New terminal"),
-                    ("F2", "Rename terminal"),
+                    ("m", "Rename terminal"),
                     ("Del", "Delete terminal"),
                 ],
             ),

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -56,7 +56,7 @@ class WorkspaceDetailScreen(Screen):
         # are shown inline on the Terminals list header instead (#1860).
         Binding("n", "new_terminal", "New term", show=False),
         Binding("m", "rename_terminal", "Rename term", show=False),
-        Binding("delete", "delete_terminal", "Del term", show=False),
+        Binding("t", "delete_terminal", "Del term", show=False),
         Binding("?", "cheatsheet", "Keys", show=False),
     ]
 
@@ -103,7 +103,7 @@ class WorkspaceDetailScreen(Screen):
             Horizontal(
                 Static("Terminals", id="term_label"),
                 Static(
-                    "[n] new  [m] rename  [⌿] delete",
+                    "[n] new  [m] rename  [t] delete",
                     id="term_hints",
                     markup=False,
                 ),
@@ -215,7 +215,7 @@ class WorkspaceDetailScreen(Screen):
             Binding("d", "delete", "Del ws"),
             Binding("n", "new_terminal", "New term", show=False),
             Binding("m", "rename_terminal", "Rename term", show=False),
-            Binding("delete", "delete_terminal", "Del term", show=False),
+            Binding("t", "delete_terminal", "Del term", show=False),
             # `?` must survive the per-display BINDINGS rebuild so the
             # cheatsheet stays reachable after _display() runs on mount
             # (#1802).
@@ -665,31 +665,34 @@ class WorkspaceDetailScreen(Screen):
                 f"Rename '{current}' to:",
                 default=current,
                 ok_label="Rename",
+                select_on_focus=False,
             ),
             _on_rename,
         )
 
     async def _do_rename_terminal(self, index: int, new_name: str) -> None:
-        self._msg(f"Renaming terminal to '{new_name}'…")
         try:
             windows = await self.app.tui_state.rename_terminal(
                 self._name, index, new_name
             )
         except Exception as exc:
-            self._msg(f"Rename failed: {exc}", error=True)
+            self.app.notify(
+                f"Rename failed: {exc}", severity="error", timeout=8
+            )
             # Stale index — refresh so the row self-heals (#1965).
             await self._load_terminals()
             return
         if not windows:
-            self._msg(
+            self.app.notify(
                 "Rename failed — could not refresh terminals.",
-                error=True,
+                severity="error",
+                timeout=8,
             )
             await self._load_terminals()
             return
         self._terminals = windows
         await self._render_terminals()
-        self._msg(f"Renamed terminal to '{new_name}'.")
+        self.app.notify(f"Renamed terminal to '{new_name}'.")
 
     def action_new_terminal(self) -> None:
         if self._ws is None:
@@ -898,7 +901,7 @@ class WorkspaceDetailScreen(Screen):
                 [
                     ("n", "New terminal"),
                     ("m", "Rename terminal"),
-                    ("Del", "Delete terminal"),
+                    ("t", "Delete terminal"),
                 ],
             ),
         ]

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -605,13 +605,15 @@ class WorkspaceDetailScreen(Screen):
         # label is a friendly name for messages; falls back to the id
         # when not supplied (e.g. direct test calls).
         display = label if label is not None else window_id
-        self._msg(f"Deleting terminal {display}…")
+        self.app.notify(f"Deleting terminal {display}…")
         try:
             windows = await self.app.tui_state.close_terminal(
                 self._name, window_id
             )
         except Exception as exc:
-            self._msg(f"Delete failed: {exc}", error=True)
+            self.app.notify(
+                f"Delete failed: {exc}", severity="error", timeout=8
+            )
             # The id may no longer exist server-side — refresh so the
             # dead row self-heals instead of failing on every retry (#1965).
             await self._load_terminals()
@@ -619,14 +621,16 @@ class WorkspaceDetailScreen(Screen):
         if not windows:
             # The last terminal is protected client-side, so an empty result
             # here means the close/refresh failed — don't claim success.
-            self._msg(
-                "Delete failed — could not refresh terminals.", error=True
+            self.app.notify(
+                "Delete failed — could not refresh terminals.",
+                severity="error",
+                timeout=8,
             )
             await self._load_terminals()
             return
         self._terminals = windows
         await self._render_terminals()
-        self._msg(f"Deleted terminal {display}.")
+        self.app.notify(f"Deleted terminal {display}.")
 
     def _terminal_label_for(self, key: str) -> str:
         """Friendly label for a list row: the window name, or the key."""
@@ -709,22 +713,26 @@ class WorkspaceDetailScreen(Screen):
         else:
             candidate = f"term-{len(self._terminals)}"  # pragma: no cover
 
-        self._msg(f"Creating terminal '{candidate}'…")
+        self.app.notify(f"Creating terminal '{candidate}'…")
         try:
             windows = await self.app.tui_state.create_terminal(
                 self._name, candidate
             )
         except Exception as exc:
-            self._msg(f"Create failed: {exc}", error=True)
+            self.app.notify(
+                f"Create failed: {exc}", severity="error", timeout=8
+            )
             return
         if not windows:
-            self._msg(
-                "Create failed — could not refresh terminals.", error=True
+            self.app.notify(
+                "Create failed — could not refresh terminals.",
+                severity="error",
+                timeout=8,
             )
             return
         self._terminals = windows
         await self._render_terminals()
-        self._msg(f"Created terminal '{candidate}'.")
+        self.app.notify(f"Created terminal '{candidate}'.")
 
     # --- actions ---
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -225,6 +225,11 @@ class TuiState:
     async def create_terminal(self, name: str, window_name: str) -> list[dict]:
         return await self.client().create_terminal(name, window_name)
 
+    async def rename_terminal(
+        self, name: str, index: int, new_name: str
+    ) -> list[dict]:
+        return await self.client().rename_terminal(name, index, new_name)
+
     # --- auth mode (probed live via /config) ---
 
     def auth_mode(self) -> str:

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1418,6 +1418,55 @@ class TestKlangkClient:
         assert len(new_cmds) == 1
         assert new_cmds[0]["name"] == "term-1"
 
+    def test_rename_terminal(self):
+        client = KlangkClient("http://test:8995", "token")
+        ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
+        client.resolve_workspace = MagicMock(return_value=ws)
+        messages = [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "main", "id": "@0"},
+                        {"index": 1, "name": "build", "id": "@1"},
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "main", "id": "@0"},
+                        {"index": 1, "name": "ci", "id": "@1"},
+                    ],
+                }
+            ),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(side_effect=messages)
+        mock_ws.send = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+        with patch(
+            "klangk.cli.transport.websockets.connect",
+            return_value=mock_ws,
+        ):
+            windows = asyncio.run(client.rename_terminal("alpha", 1, "ci"))
+        assert len(windows) == 2
+        assert windows[1]["name"] == "ci"
+        # Verify terminal_rename_window was sent with index + name
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        rename_cmds = [
+            s for s in sent if s.get("cmd") == "terminal_rename_window"
+        ]
+        assert len(rename_cmds) == 1
+        assert rename_cmds[0]["index"] == 1
+        assert rename_cmds[0]["name"] == "ci"
+
     def test_list_workspaces_parses_response(self):
         client = KlangkClient("http://test:8995", "valid-token")
         mock_resp = MagicMock()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4074,9 +4074,10 @@ async def test_detail_terminal_actions_inline_not_in_footer(monkeypatch):
 
         # (b) Terminal keys still exist (so the keys work) but are hidden
         # from the Footer.
-        assert "n" in bindings and "delete" in bindings
+        assert "n" in bindings and "m" in bindings and "t" in bindings
         assert bindings["n"].show is False
-        assert bindings["delete"].show is False
+        assert bindings["m"].show is False
+        assert bindings["t"].show is False
 
         # (c) Workspace-scoped keys remain visible ...
         for key in ("e", "r", "s", "u", "d"):
@@ -5775,6 +5776,10 @@ async def test_detail_rename_terminal(monkeypatch):
         await pilot.pause()
         d = app.screen
         d.query_one("#term_list").index = 1
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         d.action_rename_terminal()
         await pilot.pause()
         # InputScreen pushed, prefilled with the current name "build".
@@ -5785,9 +5790,7 @@ async def test_detail_rename_terminal(monkeypatch):
         for _ in range(4):
             await pilot.pause()
         assert renamed == {"name": "alpha", "index": 1, "new": "ci"}
-        assert "Renamed terminal to 'ci'" in str(
-            d.query_one("#detail_msg").render()
-        )
+        assert any("Renamed terminal to 'ci'" in m for m in notified)
 
 
 async def test_detail_rename_terminal_no_selection(monkeypatch):
@@ -5864,13 +5867,17 @@ async def test_detail_rename_terminal_failure(monkeypatch):
         await pilot.pause()
         d = app.screen
         d.query_one("#term_list").index = 1
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         d.action_rename_terminal()
         await pilot.pause()
         app.screen.query_one("#inp_value", Input).value = "ci"
         app.screen.on_button_pressed(FakeBtnPress("ok"))
         for _ in range(4):
             await pilot.pause()
-        assert "Rename failed" in str(d.query_one("#detail_msg").render())
+        assert any("Rename failed" in m for m in notified)
 
 
 async def test_detail_rename_terminal_empty_result(monkeypatch):
@@ -5892,13 +5899,47 @@ async def test_detail_rename_terminal_empty_result(monkeypatch):
         await pilot.pause()
         d = app.screen
         d.query_one("#term_list").index = 1
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         d.action_rename_terminal()
         await pilot.pause()
         app.screen.query_one("#inp_value", Input).value = "ci"
         app.screen.on_button_pressed(FakeBtnPress("ok"))
         for _ in range(4):
             await pilot.pause()
-        assert "could not refresh" in str(d.query_one("#detail_msg").render())
+        assert any("could not refresh" in m for m in notified)
+
+
+async def test_detail_rename_terminal_appends_to_default(monkeypatch):
+    """The rename input appends (select_on_focus=False): typing into a
+    prefilled 'build' field yields 'build2', not a replace (#2020)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(list_terminals=_async_terms, rename_terminal=_async_empty)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        d.action_rename_terminal()
+        await pilot.pause()
+        assert isinstance(app.screen, InputScreen)
+        inp = app.screen.query_one("#inp_value", Input)
+        assert inp.value == "build"
+        await pilot.press("2")
+        await pilot.pause()
+        assert inp.value == "build2"  # appended, not replaced
+        app.screen.dismiss(None)
 
 
 # ---------------------------------------------------------------------------
@@ -9235,7 +9276,19 @@ async def test_detail_screen_cheatsheet_modal():
         await pilot.pause()
         assert isinstance(app.screen, CheatsheetScreen)
         text = _cheatsheet_text(app.screen)
-        for key in ("Esc", "Enter", "e", "r", "s", "u", "d", "x", "n", "Del"):
+        for key in (
+            "Esc",
+            "Enter",
+            "e",
+            "r",
+            "s",
+            "u",
+            "d",
+            "x",
+            "n",
+            "m",
+            "t",
+        ):
             assert key in text, f"missing {key!r} in cheatsheet"
         assert "Back to workspace list" in text
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -617,6 +617,28 @@ async def test_create_terminal_delegates(monkeypatch, redirect_xdg):
     assert len(result) == 2
 
 
+async def test_rename_terminal_delegates(monkeypatch, redirect_xdg):
+
+    renamed = {}
+
+    async def fake_rename(name, index, new_name):
+        renamed.update(name=name, index=index, new=new_name)
+        return [
+            {"index": 0, "name": "main"},
+            {"index": 1, "name": new_name},
+        ]
+
+    from unittest.mock import MagicMock
+
+    fake_client = MagicMock()
+    fake_client.rename_terminal = fake_rename
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(t, "client", lambda: fake_client)
+    result = await t.rename_terminal("ws1", 1, "ci")
+    assert renamed == {"name": "ws1", "index": 1, "new": "ci"}
+    assert len(result) == 2
+
+
 def test_login_password_success(monkeypatch, redirect_xdg):
     captured = {}
 
@@ -5726,6 +5748,157 @@ async def test_detail_new_terminal_no_workspace(monkeypatch):
         d = app.screen
         d.action_new_terminal()  # _ws is None -> no-op
         await app.workers.wait_for_complete()
+
+
+async def test_detail_rename_terminal(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    renamed = {}
+
+    async def _rename(name, index, new_name):
+        renamed.update(name=name, index=index, new=new_name)
+        return [
+            {"index": 0, "name": "main", "id": "@0"},
+            {"index": 1, "name": new_name, "id": "@1"},
+        ]
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(list_terminals=_async_terms, rename_terminal=_rename)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        d.action_rename_terminal()
+        await pilot.pause()
+        # InputScreen pushed, prefilled with the current name "build".
+        assert isinstance(app.screen, InputScreen)
+        assert app.screen.query_one("#inp_value", Input).value == "build"
+        app.screen.query_one("#inp_value", Input).value = "ci"
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        for _ in range(4):
+            await pilot.pause()
+        assert renamed == {"name": "alpha", "index": 1, "new": "ci"}
+        assert "Renamed terminal to 'ci'" in str(
+            d.query_one("#detail_msg").render()
+        )
+
+
+async def test_detail_rename_terminal_no_selection(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(list_terminals=_async_terms, rename_terminal=_async_empty)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = None
+        d.action_rename_terminal()  # nothing highlighted -> no-op
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # No InputScreen pushed — still on the detail screen.
+        assert app.screen is d
+
+
+async def test_detail_rename_terminal_cancel(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    renamed = []
+
+    async def _rename(*a, **k):
+        renamed.append(True)
+        return []
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(list_terminals=_async_terms, rename_terminal=_rename)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        d.action_rename_terminal()
+        await pilot.pause()
+        assert isinstance(app.screen, InputScreen)
+        app.screen.on_button_pressed(FakeBtnPress("cancel"))  # -> None
+        for _ in range(3):
+            await pilot.pause()
+        assert renamed == []
+        assert app.screen is d
+
+
+async def test_detail_rename_terminal_failure(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    async def _rename(name, index, new_name):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(list_terminals=_async_terms, rename_terminal=_rename)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        d.action_rename_terminal()
+        await pilot.pause()
+        app.screen.query_one("#inp_value", Input).value = "ci"
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        for _ in range(4):
+            await pilot.pause()
+        assert "Rename failed" in str(d.query_one("#detail_msg").render())
+
+
+async def test_detail_rename_terminal_empty_result(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    async def _rename(name, index, new_name):
+        return []
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(list_terminals=_async_terms, rename_terminal=_rename)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        d.action_rename_terminal()
+        await pilot.pause()
+        app.screen.query_one("#inp_value", Input).value = "ci"
+        app.screen.on_button_pressed(FakeBtnPress("ok"))
+        for _ in range(4):
+            await pilot.pause()
+        assert "could not refresh" in str(d.query_one("#detail_msg").render())
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -5099,14 +5099,16 @@ async def test_detail_delete_terminal(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         d.query_one("#term_list").index = 1
         d.action_delete_terminal()
         for _ in range(3):
             await pilot.pause()
         assert closed.get("i") == "@1"
-        assert "Deleted terminal build" in str(
-            d.query_one("#detail_msg").render()
-        )
+        assert any("Deleted terminal build" in m for m in notified)
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 1
 
 
@@ -5183,9 +5185,13 @@ async def test_detail_delete_terminal_refreshes_on_server_failure(
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         before = calls["list"]
         await d._do_delete_terminal("@1")
-        assert "Delete failed" in str(d.query_one("#detail_msg").render())
+        assert any("Delete failed" in m for m in notified)
         # Failure triggered a refresh.
         assert calls["list"] > before
 
@@ -5216,22 +5222,22 @@ async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         d.query_one("#term_list").index = 1
         d.action_delete_terminal()
         # While close_terminal is blocked on the gate, the in-flight
-        # message must already be visible.
+        # toast must already have fired.
         for _ in range(3):
             await pilot.pause()
-        assert "Deleting terminal build" in str(
-            d.query_one("#detail_msg").render()
-        )
-        # Releasing the close call replaces it with the success message.
+        assert any("Deleting terminal build" in m for m in notified)
+        # Releasing the close call fires the success toast.
         gate.set()
         for _ in range(3):
             await pilot.pause()
-        assert "Deleted terminal build" in str(
-            d.query_one("#detail_msg").render()
-        )
+        assert any("Deleted terminal build" in m for m in notified)
 
 
 async def test_detail_delete_terminal_failure(monkeypatch):
@@ -5252,9 +5258,13 @@ async def test_detail_delete_terminal_failure(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         await d._do_delete_terminal("@1")  # close raises
         await app.workers.wait_for_complete()
-        assert "Delete failed" in str(d.query_one("#detail_msg").render())
+        assert any("Delete failed" in m for m in notified)
 
 
 def test_detail_window_id_for_resolves_index_and_falls_back():
@@ -5627,12 +5637,16 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         before = calls["list"]
         await d._do_delete_terminal("@1")
         await app.workers.wait_for_complete()
         # Let the refresh's clear/append reconcile in the DOM.
         await pilot.pause()
-        assert "Delete failed" in str(d.query_one("#detail_msg").render())
+        assert any("Delete failed" in m for m in notified)
         assert (
             len(d.query_one("#term_list", ListView).query(ListItem)) == 2
         )  # unchanged
@@ -5669,13 +5683,17 @@ async def test_detail_new_terminal(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         d.action_new_terminal()
         for _ in range(5):
             await pilot.pause()
         await app.workers.wait_for_complete()
         assert created["name"] == "term-2"
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 3
-        assert "Created terminal" in str(d.query_one("#detail_msg").render())
+        assert any("Created terminal" in m for m in notified)
 
 
 async def test_detail_new_terminal_failure(monkeypatch):
@@ -5700,9 +5718,13 @@ async def test_detail_new_terminal_failure(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         await d._do_new_terminal()
         await app.workers.wait_for_complete()
-        assert "Create failed" in str(d.query_one("#detail_msg").render())
+        assert any("Create failed" in m for m in notified)
 
 
 async def test_detail_new_terminal_empty_result(monkeypatch):
@@ -5727,9 +5749,13 @@ async def test_detail_new_terminal_empty_result(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
+        notified = []
+        monkeypatch.setattr(
+            app, "notify", lambda *a, **k: notified.append(a[0] if a else "")
+        )
         await d._do_new_terminal()
         await app.workers.wait_for_complete()
-        assert "Create failed" in str(d.query_one("#detail_msg").render())
+        assert any("Create failed" in m for m in notified)
 
 
 async def test_detail_new_terminal_no_workspace(monkeypatch):


### PR DESCRIPTION
## Summary

The workspace-detail terminals list could open (Enter) and delete a terminal but not rename one — even though the backend already supported it (`terminal_rename_window` → `tmux rename-window`). This wires up the rename action, switches the terminal-scoped keys to plain letters, and moves terminal create/delete/rename feedback to toasts.

**Press `m` on a highlighted terminal** → an input prefilled with the current name; **Enter** renames, **Escape** cancels.

## Changes

- **Rename input appends, not replaces.** The prefilled input was selecting-all on focus (Textual's `select_on_focus=True` default), so typing `2` after `bash` *replaced* it → `2` instead of appending `bash2`. `InputScreen` now takes a `select_on_focus` flag; the rename dialog passes `False` and parks the cursor at the end, so typing appends.
- **Terminal feedback is a toast.** Create / delete / rename in-flight (`Creating…` / `Deleting…`), success, and failure messages now use `self.app.notify(...)` instead of the inline `#detail_msg` text. (The action-level guards — "Can't delete the last terminal", "no longer exists" — stay inline.)
- **Terminal-scoped keys are letters** — `n` new, `m` rename, `t` delete (was the Delete/⌫ key) — shown in the inline term hint and the `?` cheatsheet.
- **`client.py`** — `rename_terminal(name, index, new_name)` + a `rename=(index, name)` branch in `_terminals` sending `terminal_rename_window` with `{index, name}` (the controller keys on the window index, not the `@N` id).
- **`tui/state.py`** — `rename_terminal` wrapper.

## Tests
- Client round-trip, state delegation.
- 7 rename screen tests — success (toast), no-selection no-op, cancel (no round-trip), server failure (error toast), empty result (error toast), and an **append-behavior** test (typing `2` into `build` → `build2`).
- Switched the 8 delete/create terminal tests to capture the toast.
- Updated the two tests that asserted the old `Del`/`delete` keys.
- Full backend suite: **4117 passed, 100% coverage** (`-n auto`).

Closes #2020.
