### PR TITLE
feat(tui): detail status messages as toasts; errors stay inline (#2019)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -555,6 +555,15 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI: workspace detail success/in-progress messages are now toasts, not
+  persistent in-page text (#2019).** `Starting container…`, `Container
+started.`, and the other operational feedback messages (`Restart/Stop/Start
+requested.`, terminal create/delete, `Duplicated …`) now appear as
+  auto-dismissing toast notifications instead of lingering on the page. The
+  terminals list (one selected) already signals container readiness, so the
+  status line no longer needs to stay. Errors still render inline (red) so
+  the reason for a failure stays readable.
+
 - **TUI now defaults to the `klangk` theme again (#2003).** Reverts the
   #1904 default: the CLI TUI selects the custom `klangk` theme (GitHub-dark
   palette matching the web UI) out of the box instead of Textual's built-in

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -327,9 +327,20 @@ class WorkspaceDetailScreen(Screen):
             self._display()
 
     def _msg(self, text: str, *, error: bool = False) -> None:
-        self.query_one("#detail_msg", Static).update(
-            Text(text, style="red" if error else "")
-        )
+        """Show transient operational feedback on the detail screen (#2019).
+
+        Errors persist inline (red) so the user can read why an action failed
+        — consistent with the export-failure path (#1758). Success /
+        in-progress feedback is shown as an auto-dismissing toast instead of
+        lingering on the page: the terminals list (one selected) already
+        signals container readiness, so a persistent status line is noise.
+        """
+        if error:
+            self.query_one("#detail_msg", Static).update(
+                Text(text, style="red")
+            )
+        else:
+            self.app.notify(text)
 
     def action_edit(self) -> None:
         if self._ws is None:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -186,6 +186,25 @@ def _wsobj(name, **k):
     return Workspace(id="id-" + name, name=name, created_at="x", **k)
 
 
+def _attach_notify_spy(app) -> list:
+    """Spy on ``app.notify`` and return the list of toasted messages (#2019).
+
+    Operational success / in-progress feedback on the detail screen is now
+    shown via auto-dismissing toasts (``app.notify``) rather than a lingering
+    in-page line; tests assert on the captured messages. Mirrors the inline
+    pattern the export test used for its completion toast (#1758).
+    """
+    notified: list = []
+    orig = app.notify
+
+    def spy(message="", *a, **k):
+        notified.append(message)
+        return orig(message, *a, **k)
+
+    app.notify = spy
+    return notified
+
+
 def _detail_value(body: str, label: str) -> str | None:
     """Return the value-column text for ``label``'s row in the workspace
     detail table, or None if no such row.
@@ -2303,16 +2322,7 @@ async def test_detail_export_flow_with_progress(monkeypatch):
     st.find_workspace = lambda n: a
     st.export_workspace = fake_export
     app = KlangkApp(st)
-    # Spy on app.notify so we can assert the completion toast (#1758):
-    # a resolved absolute filesystem path is toasted on success.
-    notified = []
-    orig_notify = app.notify
-
-    def spy_notify(message="", *a, **k):
-        notified.append(message)
-        return orig_notify(message, *a, **k)
-
-    app.notify = spy_notify
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -3866,6 +3876,7 @@ async def test_detail_restart_confirm_cancel_error(monkeypatch):
     st.find_workspace = lambda n: a
     st.restart_workspace = lambda n: restarted.__setitem__("r", n)
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -3883,9 +3894,7 @@ async def test_detail_restart_confirm_cancel_error(monkeypatch):
         await pilot.pause()
         await app.workers.wait_for_complete()
         assert restarted.get("r") == "alpha"
-        assert "Restart requested" in str(
-            app.screen.query_one("#detail_msg").render()
-        )
+        assert any("Restart requested" in m for m in notified)
         # service_started_at reset on restart (#1814).
         assert a.service_started_at is not None
         # error
@@ -3913,13 +3922,12 @@ async def test_detail_auto_starts_stopped_workspace(monkeypatch):
     st.find_workspace = lambda n: a
     st.restart_workspace = lambda n: started.append(n)
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         assert started == ["alpha"]
-        assert "Container started" in str(
-            app.screen.query_one("#detail_msg").render()
-        )
+        assert any("Container started" in m for m in notified)
 
 
 async def test_detail_auto_start_skipped_when_running(monkeypatch):
@@ -3972,6 +3980,7 @@ async def test_detail_stop_when_running(monkeypatch):
     st.find_workspace = lambda n: a
     st.stop_workspace = lambda n: stopped.__setitem__("s", n)
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -3982,9 +3991,7 @@ async def test_detail_stop_when_running(monkeypatch):
         await pilot.pause()
         await app.workers.wait_for_complete()
         assert stopped.get("s") == "alpha"
-        assert "Stop requested" in str(
-            app.screen.query_one("#detail_msg").render()
-        )
+        assert any("Stop requested" in m for m in notified)
         # After stop, binding label should toggle to "Start".
         labels = [b.description for b in app.screen.BINDINGS if b.key == "s"]
         assert labels == ["Start"]
@@ -4006,6 +4013,7 @@ async def test_detail_start_when_stopped(monkeypatch):
     st.find_workspace = lambda n: a
     st.start_workspace = lambda n: started.__setitem__("s", n)
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -4013,9 +4021,7 @@ async def test_detail_start_when_stopped(monkeypatch):
         app.screen.action_stop()
         await app.workers.wait_for_complete()
         assert started.get("s") == "alpha"
-        assert "Start requested" in str(
-            app.screen.query_one("#detail_msg").render()
-        )
+        assert any("Start requested" in m for m in notified)
         # After start, binding label should toggle to "Stop".
         labels = [b.description for b in app.screen.BINDINGS if b.key == "s"]
         assert labels == ["Stop"]
@@ -4278,6 +4284,7 @@ async def test_detail_duplicate_ok_cancel_input_error(monkeypatch):
     st.find_workspace = lambda n: a
     st.duplicate_workspace = lambda n, nn: duped.__setitem__("d", (n, nn))
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -4295,9 +4302,7 @@ async def test_detail_duplicate_ok_cancel_input_error(monkeypatch):
         await pilot.pause()
         await app.workers.wait_for_complete()
         assert duped.get("d") == ("alpha", "alpha-copy")
-        assert "Duplicated" in str(
-            app.screen.query_one("#detail_msg").render()
-        )
+        assert any("Duplicated" in m for m in notified)
         # ok via input submit (enter)
         app.screen.action_duplicate()
         await pilot.pause()
@@ -5070,6 +5075,7 @@ async def test_detail_delete_terminal(monkeypatch):
     st = _ws(list_terminals=_async_terms, close_terminal=_close)
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -5081,9 +5087,7 @@ async def test_detail_delete_terminal(monkeypatch):
         for _ in range(3):
             await pilot.pause()
         assert closed.get("i") == "@1"
-        assert "Deleted terminal build" in str(
-            d.query_one("#detail_msg").render()
-        )
+        assert any("Deleted terminal build" in m for m in notified)
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 1
 
 
@@ -5187,6 +5191,7 @@ async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
     st = _ws(list_terminals=_async_terms, close_terminal=_close)
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -5196,19 +5201,15 @@ async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
         d.query_one("#term_list").index = 1
         d.action_delete_terminal()
         # While close_terminal is blocked on the gate, the in-flight
-        # message must already be visible.
+        # toast must already have fired.
         for _ in range(3):
             await pilot.pause()
-        assert "Deleting terminal build" in str(
-            d.query_one("#detail_msg").render()
-        )
-        # Releasing the close call replaces it with the success message.
+        assert any("Deleting terminal build" in m for m in notified)
+        # Releasing the close call fires the success toast.
         gate.set()
         for _ in range(3):
             await pilot.pause()
-        assert "Deleted terminal build" in str(
-            d.query_one("#detail_msg").render()
-        )
+        assert any("Deleted terminal build" in m for m in notified)
 
 
 async def test_detail_delete_terminal_failure(monkeypatch):
@@ -5640,6 +5641,7 @@ async def test_detail_new_terminal(monkeypatch):
     )
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
+    notified = _attach_notify_spy(app)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
@@ -5652,7 +5654,7 @@ async def test_detail_new_terminal(monkeypatch):
         await app.workers.wait_for_complete()
         assert created["name"] == "term-2"
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 3
-        assert "Created terminal" in str(d.query_one("#detail_msg").render())
+        assert any("Created terminal" in m for m in notified)
 
 
 async def test_detail_new_terminal_failure(monkeypatch):


### PR DESCRIPTION
## Summary

Closes #2019.

On the workspace detail screen, operational status messages — `Starting container…`,
`Container started.`, `Restart/Stop/Start requested.`, terminal created/deleted,
`Duplicated …` — used to render as persistent **in-page text** the same color as the
rest of the page (easy to miss, and then lingered). 

This PR makes **success / in-progress** messages show as **auto-dismissing
`app.notify()` toasts**; **errors stay inline (red)** so the reason for a failure
stays readable. The terminals list (one selected) already signals container
readiness, so a persistent success line is noise — a transient toast is enough.

## Changes

- **`workspace_detail.py` — `_msg()`** now branches on the `error` flag:
  - `error=False` (success / in-progress) → `self.app.notify(text)` toast.
  - `error=True` (error) → unchanged: inline red text in `#detail_msg`.
- The single `_msg()` chokepoint converts **every** caller at once (auto-start,
  restart, stop, start, delete/duplicate workspace, terminal create/delete). The
  `error=` flag already encodes the success-vs-error distinction exactly, so no
  call-site changes were needed.
- `#detail_msg` is **retained** (errors still render there).

## Design decisions

- **Toasts for success, inline for errors.** This matches the convention this
  file already used for export (#1758): export *success* → toast
  (`Exported to …`), export *failure* → inline red. This PR extends that same
  convention to the rest of `_msg`'s callers.
- **Errors persist on purpose.** An auto-dismissing error could vanish before the
  user reads why their action failed.
- **Why toasts (not just a color change).** The terminal list with one terminal
  selected already communicates "container ready", so a lingering
  `Container started.` line is redundant.

## Tests

Added a shared `_attach_notify_spy(app)` helper (mirrors the inline spy the export
test already used for its completion toast) and converted the 7 affected tests to
assert on the toasted messages via `any(sub in m for m in notified)` — the same
substring pattern the export test uses. The error-path tests (which assert on
`#detail_msg` inline text) are unchanged, since errors still render inline.

Refactored the existing export test to use the new helper too (removes the
duplicated inline spy).

## Verification

- Full Python suite with `-n auto` (as CI): **4109 passed, 100% coverage**.
- `ruff check` clean on changed files (the remaining `# noqa: allow-deferred-import`
  warnings are pre-existing on `main`).

## Changelog

`### Changed` entry under `[Unreleased]`.
