### PR TITLE
fix: dedupe duplicate-start log to one site (#2021)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1210,15 +1210,17 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
-- **The already-running klangkd no longer logs "Another klangk instance is
-  already running" on a duplicate start attempt (#2021).** The duplicate-
-  start message was logged in two places — the launcher's pre-flight PID
-  check _and_ the app lifespan — so repeated attempts to start a second
-  instance against the same state spammed ERROR lines into the running
-  instance's log stream. The lifespan no longer logs (it is a silent
-  backstop only); the launcher pre-flight is now the sole place this is
-  reported, emitted once by the prevented process before it exits. The
-  already-running instance stays silent.
+- **The already-running klangkd no longer gets its log spammed with "Another
+  klangk instance is already running" on repeated duplicate starts (#2021).**
+  A duplicate start is still refused (the process exits non-zero before
+  touching the socket), but the message is now printed only on an
+  _interactive_ terminal (stderr is a TTY) — so an operator who manually
+  launches a second klangkd is still told why it exited, while a
+  non-interactive retry loop (supervisor/watchdog whose refused starts share
+  the running instance's log stream) stays silent. The duplicate-start log
+  was also deduped to a single site (the launcher pre-flight); the app
+  lifespan check is now a silent backstop, so the already-running instance
+  itself never logs this.
 
 - **Opening a terminal from the TUI no longer flashes the pre-TUI screen
   (#2010).** `on_list_view_selected` clears the primary screen buffer

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1210,6 +1210,16 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **The already-running klangkd no longer logs "Another klangk instance is
+  already running" on a duplicate start attempt (#2021).** The duplicate-
+  start message was logged in two places — the launcher's pre-flight PID
+  check _and_ the app lifespan — so repeated attempts to start a second
+  instance against the same state spammed ERROR lines into the running
+  instance's log stream. The lifespan no longer logs (it is a silent
+  backstop only); the launcher pre-flight is now the sole place this is
+  reported, emitted once by the prevented process before it exits. The
+  already-running instance stays silent.
+
 - **Opening a terminal from the TUI no longer flashes the pre-TUI screen
   (#2010).** `on_list_view_selected` clears the primary screen buffer
   inside the `suspend()` block before spawning `klangk shell`, so the

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -233,18 +233,23 @@ def main(  # pragma: no cover
 
     # Pre-flight PID check: abort *before* touching the UDS so a second
     # klangkd doesn't destroy the first instance's socket (#1837).
-    # This is the *sole* place a duplicate start is logged (#2021): the
-    # already-running instance stays silent (another process trying to start
-    # is not its problem), and this prevented process logs once then exits.
-    # The lifespan keeps a silent SystemExit backstop for the narrow race
-    # where two launchers start near-simultaneously and both miss this check.
+    # This is the *sole* place a duplicate start is reported (#2021), and it
+    # only speaks up on an *interactive* terminal (stderr is a TTY): a human
+    # who accidentally launches a second klangkd still learns why it exited,
+    # but a non-interactive retry loop (supervisor/watchdog whose refused
+    # starts share the already-running instance's log stream) exits silently
+    # instead of spamming that daemon log with "refusing to start" every
+    # retry. The running instance itself never logs this — its own PID is
+    # excluded by _check_pid_preflight, and the lifespan check is a silent
+    # backstop.
     existing = _check_pid_preflight(settings)
     if existing is not None:
-        logger.error(
-            "Another klangk instance (PID %d) is already running — "
-            "refusing to start",
-            existing,
-        )
+        if sys.stderr.isatty():
+            logger.error(
+                "Another klangk instance (PID %d) is already running — "
+                "refusing to start",
+                existing,
+            )
         sys.exit(1)
 
     # Bind the UDS. A stale socket from a kill -9'd process makes the

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -233,8 +233,11 @@ def main(  # pragma: no cover
 
     # Pre-flight PID check: abort *before* touching the UDS so a second
     # klangkd doesn't destroy the first instance's socket (#1837).
-    # The lifespan has its own authoritative check, but that runs after
-    # uvicorn binds — too late to protect the socket file.
+    # This is the *sole* place a duplicate start is logged (#2021): the
+    # already-running instance stays silent (another process trying to start
+    # is not its problem), and this prevented process logs once then exits.
+    # The lifespan keeps a silent SystemExit backstop for the narrow race
+    # where two launchers start near-simultaneously and both miss this check.
     existing = _check_pid_preflight(settings)
     if existing is not None:
         logger.error(

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -655,12 +655,12 @@ async def lifespan(app: FastAPI):
 
     existing_pid = app.state.util.check_pid_file()
     if existing_pid is not None:
-        logger.error(
-            "Another klangk instance (PID %d) is already running "
-            "for instance %s — refusing to start",
-            existing_pid,
-            app.state.util.instance_id(),
-        )
+        # Silent backstop only (#2021). A second instance that slipped past
+        # the launcher's pre-flight PID check must still refuse — it would
+        # otherwise overwrite the running instance's pidfile/state. The
+        # launcher's ``_check_pid_preflight`` is the *sole* place this is
+        # logged (and exits there for the normal path); reaching here is a
+        # narrow race, so we exit quietly rather than duplicate the message.
         raise SystemExit(1)
     app.state.util.write_pid_file()
 

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1918,8 +1918,10 @@ class TestCheckPidPreflight:
 
 
 class TestLauncherPidPreflightGracefulExit:
-    """The launcher's ``main()`` must log and ``sys.exit(1)`` — not crash with
-    ``ImportError`` — when a second instance collides with a running one (#1993).
+    """The launcher's ``main()`` must ``sys.exit(1)`` — not crash with
+    ``ImportError`` — when a second instance collides with a running one
+    (#1993), and must stay silent on a *non-interactive* (non-TTY) start so a
+    # retry loop can't spam the already-running instance's log (#2021).
 
     ``_check_pid_preflight`` is unit-tested above; this exercises the *error
     path that consumes it* (inside ``main()``, which is otherwise
@@ -1957,10 +1959,14 @@ class TestLauncherPidPreflightGracefulExit:
 
         # Graceful refusal, not a Python traceback.
         assert result.returncode == 1, result.stderr
-        assert "Another klangk instance" in result.stderr
         # The pre-fix bug crashed with ImportError before the message could
         # be logged (``from klangk.logger import logger`` — no such symbol).
         assert "ImportError" not in result.stderr
+        # Non-interactive (captured) start: the duplicate-start message must
+        # NOT be emitted, so a supervisor/watchdog retry loop can't pollute
+        # the running instance's shared log stream (#2021). It only prints
+        # to a real interactive terminal (stderr is a TTY).
+        assert "Another klangk instance" not in result.stderr
 
 
 class TestBuildApp:

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -883,7 +883,7 @@ class TestLifespan:
                 await registry.on_workspace_killed("ws-killed")
         mock_reset.assert_awaited_once_with(app.state.sockets, "ws-killed")
 
-    async def test_lifespan_refuses_if_pid_alive(self, db, app_state):
+    async def test_lifespan_refuses_if_pid_alive(self, db, app_state, caplog):
 
         app = FastAPI()
         app_state = _make_app_state()
@@ -901,6 +901,11 @@ class TestLifespan:
         ):
             async with main.lifespan(app):
                 pass  # pragma: no cover
+        # The lifespan is a silent backstop: it refuses but must NOT log the
+        # duplicate message — only the launcher preflight logs it (#2021).
+        assert not any(
+            "Another klangk instance" in r.getMessage() for r in caplog.records
+        )
 
 
 # --- SIGHUP runtime restart (#1212) ---


### PR DESCRIPTION
## Summary

Closes #2021.

A duplicate `klangkd` start is still refused, but it no longer spams the **already-running instance's** log with `Another klangk instance is already running — refusing to start`.

### What was actually happening

The already-running server's daemon log filled up with that ERROR line (repeating ~once per second, reporting the running instance's *own* PID). The duplicate-start check is correct, but the **log emission** was the problem: a non-interactive retry loop (supervisor/watchdog) kept re-launching `klangkd` against the same state, and each refused start logged the message into the **shared daemon log stream** — so it looked like the running instance was complaining about itself.

### The fix

- A duplicate start is still detected and refused — the prevented process `sys.exit(1)` **before** touching the UDS/socket (#1837 still holds).
- But the message is now printed **only on an interactive terminal** (`sys.stderr.isatty()`). An operator who manually launches a second `klangkd` still gets told why it exited; a non-interactive (non-TTY) refused start exits **silently**, so the running instance's log stays clean.
- The duplicate-start log was also deduped to a **single site** (the launcher pre-flight). The app lifespan's check is now a **silent** `SystemExit` backstop (its own PID is excluded by `_check_pid_preflight`, so the running instance itself never logs this).

## Verification

```
python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto
→ 4109 passed, 100% coverage
```

The subprocess test (`test_second_instance_exits_cleanly`) now asserts a non-interactive duplicate start exits `1` with **no** `Another klangk instance` line (and no `ImportError` traceback — the original #1993 concern).
