### PR TITLE
fix(tui): prevent infinite reconnect cycles after give-up (#2036)

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -239,9 +239,12 @@ class MainScreen(Screen):
         # Backend-reconnect state (#2012). ``_server_unreachable`` is True
         # while the list fetch is failing at the transport layer;
         # ``_reconnect_active`` guards against spawning a second poll loop.
+        # ``_gave_up`` is set when the reconnect loop exhausts its attempts;
+        # it prevents the heartbeat from re-arming a new loop (#2036).
         self._server_unreachable = False
         self._reconnect_attempt = 0
         self._reconnect_active = False
+        self._gave_up = False
         self.query_one("#filter_bar").display = False
         self._refresh_action_hints()
         self.refresh_lists()
@@ -266,6 +269,7 @@ class MainScreen(Screen):
         """
         if (
             self._server_unreachable
+            or self._gave_up
             or self not in self.app.screen_stack
             or not self.app.tui_state.is_authenticated()
         ):
@@ -881,6 +885,7 @@ class MainScreen(Screen):
     def _exit_unreachable(self) -> None:
         """Backend reachable again — clear the down state."""
         self._reconnect_attempt = 0
+        self._gave_up = False
         if self._server_unreachable:
             self._server_unreachable = False
             self.app.live_extra = ""
@@ -927,6 +932,7 @@ class MainScreen(Screen):
                 self._reconnect_attempt += 1
                 if self._reconnect_attempt > _MAX_RECONNECT_ATTEMPTS:
                     self._server_unreachable = False
+                    self._gave_up = True
                     self._render_unreachable(
                         "(server down — switch server or restart to reconnect)"
                     )

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3247,6 +3247,7 @@ async def test_reconnect_gives_up_after_cap(monkeypatch):
         await pilot.pause()
         main = next(s for s in app.screen_stack if isinstance(s, MainScreen))
         assert main._server_unreachable is False
+        assert main._gave_up is True
         owned_lv = main.query_one("#owned_list", ListView)
         label = _lv_texts(owned_lv)[0].lower()
         assert "server down" in label
@@ -3432,10 +3433,16 @@ async def test_heartbeat_tick_skips_when_down_or_unauthenticated(monkeypatch):
         screen._heartbeat_tick()
         assert fired == []
 
-        # Authenticated and up: fires a refresh.
+        # Gave up reconnecting: skip (don't re-arm a new loop, #2036).
+        screen._gave_up = True
         monkeypatch.setattr(
             screen.app.tui_state, "is_authenticated", lambda: True
         )
+        screen._heartbeat_tick()
+        assert fired == []
+
+        # Authenticated and up (not gave_up): fires a refresh.
+        screen._gave_up = False
         screen._heartbeat_tick()
         assert fired == [1]
 


### PR DESCRIPTION
## Summary
- Add a `_gave_up` flag set when the reconnect loop exhausts its attempt cap
- Heartbeat timer checks this flag and skips refresh when set, preventing re-arming a new reconnect loop
- Flag is cleared in `_exit_unreachable` so a recovered server gets a fresh retry budget

Closes #2036

## Test plan
- [x] All 4146 backend tests pass (100% coverage)
- [x] Existing `test_reconnect_gives_up_after_cap` updated to assert `_gave_up is True`
- [x] `test_heartbeat_tick_skips_when_down_or_unauthenticated` extended to verify heartbeat skips when `_gave_up`