### PR TITLE
fix(tui): catch AuthError before broad except in edit-prep and terminal load (#2035)

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -622,6 +622,9 @@ class MainScreen(Screen):
         except WorkspaceNotFoundError:
             self._flash(f"Workspace '{name}' not found.")
             return
+        except AuthError:
+            self.app.session_expired()
+            return
         except Exception as exc:
             self._flash(f"Could not load workspace: {exc}")
             return
@@ -629,10 +632,16 @@ class MainScreen(Screen):
             data = await asyncio.to_thread(state.list_images)
             default = data.get("default", "") or ""
             allowed = list(data.get("allowed") or [])
+        except AuthError:
+            self.app.session_expired()
+            return
         except Exception:
             default, allowed = "", []
         try:
             allow_autostart = await asyncio.to_thread(state.allow_autostart)
+        except AuthError:
+            self.app.session_expired()
+            return
         except Exception:
             allow_autostart = False
         self.app.push_screen(

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -365,10 +365,16 @@ class WorkspaceDetailScreen(Screen):
             data = await asyncio.to_thread(state.list_images)
             default = data.get("default", "") or ""
             allowed = list(data.get("allowed") or [])
+        except AuthError:
+            self.app.session_expired()
+            return
         except Exception:
             default, allowed = "", []
         try:
             allow_autostart = await asyncio.to_thread(state.allow_autostart)
+        except AuthError:
+            self.app.session_expired()
+            return
         except Exception:
             allow_autostart = False
         self.app.push_screen(
@@ -478,6 +484,9 @@ class WorkspaceDetailScreen(Screen):
     async def _load_terminals(self) -> None:
         try:
             windows = await self.app.tui_state.list_terminals(self._name)
+        except AuthError:
+            self.app.session_expired()
+            return
         except Exception:
             windows = []
         self._terminals = windows or []

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2542,6 +2542,74 @@ async def test_main_screen_action_edit_load_fallbacks(monkeypatch):
         assert isinstance(app2.screen, EditWorkspaceScreen)
 
 
+async def test_main_screen_edit_find_auth_error_shows_overlay(monkeypatch):
+    """AuthError in find_workspace during _do_edit (main screen) triggers
+    session-expired overlay (#2035)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha")
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: (_ for _ in ()).throw(AuthError("expired"))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_edit()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionExpiredScreen)
+
+
+async def test_main_screen_edit_auth_error_shows_overlay(monkeypatch):
+    """AuthError in list_images during _do_edit (main screen) triggers
+    session-expired overlay instead of opening the form with defaults (#2035)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha")
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.list_images = lambda: (_ for _ in ()).throw(AuthError("expired"))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_edit()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionExpiredScreen)
+
+
+async def test_main_screen_edit_autostart_auth_error_shows_overlay(
+    monkeypatch,
+):
+    """AuthError fetching allow_autostart in _do_edit (main screen) triggers
+    the session-expired overlay (#2035)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha")
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.list_images = lambda: {"default": "base", "allowed": ["base"]}
+    st.allow_autostart = lambda: (_ for _ in ()).throw(AuthError("expired"))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        m = await _highlight_first(pilot, app)
+        m.action_edit()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionExpiredScreen)
+
+
 async def test_main_screen_on_edited_refreshes(monkeypatch):
     async def noop(*a, **k):
         return None
@@ -6049,6 +6117,90 @@ async def test_detail_auth_expired_shows_overlay(monkeypatch):
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionExpiredScreen)
+
+
+async def test_detail_load_terminals_auth_error_shows_overlay(monkeypatch):
+    """AuthError in _load_terminals triggers the session-expired overlay
+    instead of silently showing an empty terminal list (#2035)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+
+    async def bad_terminals(n):
+        raise AuthError("expired")
+
+    st.list_terminals = bad_terminals
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionExpiredScreen)
+
+
+async def test_detail_edit_auth_error_in_images_shows_overlay(monkeypatch):
+    """AuthError fetching images in _do_edit (detail screen) triggers the
+    session-expired overlay instead of opening the form with defaults (#2035)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.list_images = lambda: (_ for _ in ()).throw(AuthError("expired"))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # Trigger edit from the detail screen.
+        screen = next(
+            s for s in app.screen_stack if isinstance(s, WorkspaceDetailScreen)
+        )
+        screen.run_worker(screen._do_edit, exit_on_error=False)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionExpiredScreen)
+
+
+async def test_detail_edit_auth_error_in_autostart_shows_overlay(monkeypatch):
+    """AuthError fetching allow_autostart in _do_edit (detail screen) triggers
+    the session-expired overlay (#2035)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.list_images = lambda: {"default": "base", "allowed": ["base"]}
+    st.allow_autostart = lambda: (_ for _ in ()).throw(AuthError("expired"))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        screen = next(
+            s for s in app.screen_stack if isinstance(s, WorkspaceDetailScreen)
+        )
+        screen.run_worker(screen._do_edit, exit_on_error=False)
         await app.workers.wait_for_complete()
         await pilot.pause()
         assert isinstance(app.screen, SessionExpiredScreen)


### PR DESCRIPTION
## Summary
- Add explicit `except AuthError` clauses before broad `except Exception` fallbacks in `_load_terminals`, `_do_edit` (detail screen), and `_do_edit` (main screen)
- Previously `AuthError` was silently swallowed, showing empty terminals or opening the edit form with wrong defaults instead of the session-expired overlay
- Covers all three call sites: `find_workspace`, `list_images`, and `allow_autostart`

Closes #2035

## Test plan
- [x] All 4152 backend tests pass (100% coverage)
- [x] New tests: `test_detail_load_terminals_auth_error_shows_overlay`, `test_detail_edit_auth_error_in_images_shows_overlay`, `test_detail_edit_auth_error_in_autostart_shows_overlay`, `test_main_screen_edit_find_auth_error_shows_overlay`, `test_main_screen_edit_auth_error_shows_overlay`, `test_main_screen_edit_autostart_auth_error_shows_overlay`