### PR TITLE
fix(tui): retry the status WebSocket indefinitely (#2033)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1240,6 +1240,14 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **The TUI's live status feed no longer dies after 3 reconnect
+  failures (#2033).** `_status_loop` capped retries at 3, after which
+  live updates (container status, workspace changes, service health)
+  stopped for the whole session with no recovery short of re-login. It
+  now retries indefinitely with the same bounded backoff the workspace-list
+  reconnect uses (≤5s), resetting after a healthy connection, and exits
+  only on auth failure (session expiry).
+
 - **Duplicate `klangkd` launch no longer spams the running instance's log
   with ERROR "Another klangk instance is already running" lines (#2021).**
   The _losing_ (second) process still reports why it exits, but now

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -1072,8 +1072,7 @@ class MainScreen(Screen):
         if not url or not token:
             return
         retries = 0
-        max_retries = 3
-        while retries <= max_retries:
+        while True:
             token = state.token()
             if not token:
                 self.app.session_expired()
@@ -1082,8 +1081,9 @@ class MainScreen(Screen):
                 await listen_for_status(
                     url, token, on_event=self._on_status_event
                 )
-                # Clean close (server restart, idle timeout) — reconnect.
-                retries += 1
+                # Clean close (server restart, idle timeout) — reset
+                # backoff since the connection was healthy.
+                retries = 0
                 self.app.live_extra = "status: reconnecting…"
                 self._refresh_status()
                 await asyncio.sleep(2)
@@ -1092,23 +1092,13 @@ class MainScreen(Screen):
                 self.app.session_expired()
                 return
             except Exception as exc:
-                # Transient error — back off (exponential) and retry.
+                # Transient error — back off and retry indefinitely.
                 retries += 1
-                if retries > max_retries:
-                    logger.debug(
-                        "Status WS gave up after %d retries: %s",
-                        max_retries,
-                        exc,
-                    )
-                    break
+                logger.debug("Status WS error (attempt %d): %s", retries, exc)
                 self.app.live_extra = "status: reconnecting…"
                 self._refresh_status()
-                await asyncio.sleep(min(2 * (2 ** (retries - 1)), 30))
+                await asyncio.sleep(_reconnect_backoff(retries))
                 continue
-        self.app.live_extra = (
-            "status: disconnected (switch server to reconnect)"
-        )
-        self._refresh_status()
 
     async def _token_refresh_loop(self) -> None:
         """Proactively refresh the access token before it expires."""

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1030,27 +1030,35 @@ async def test_status_loop_no_token_returns_early(monkeypatch):
         await _real_status_loop(app.screen)  # no token -> early return
 
 
-async def test_status_loop_handles_disconnect(monkeypatch):
+async def test_status_loop_retries_indefinitely_on_error(monkeypatch):
+    """Transient errors trigger unlimited retries; the loop only exits when
+    the token disappears (session_expired)."""
+    attempts = {"n": 0}
+
     async def boom(*a, **k):
+        attempts["n"] += 1
         raise RuntimeError("ws died")
 
     monkeypatch.setattr(scr_main, "listen_for_status", boom)
-    # The exponential backoff sleeps (2s, 4s, 8s) are incidental to the
-    # disconnect -> give-up flow under test; neutralize them so the loop
-    # exhausts its retries without burning ~14s of wall-clock (#1989).
     import asyncio as _asyncio
 
     _real_sleep = _asyncio.sleep
 
     async def _no_wait(_t):
-        await _real_sleep(0)  # yield once, no real delay
+        await _real_sleep(0)
 
     monkeypatch.setattr(_asyncio, "sleep", _no_wait)
-    app = KlangkApp(_authed_state())
+    # Token present for more than 3 iterations (old limit), then removed.
+    tokens = iter(["tok"] * 7 + [None])
+    app = KlangkApp(_authed_state(token=lambda: next(tokens)))
+    expired = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
     async with app.run_test() as pilot:
         await _real_status_loop(app.screen)
         await pilot.pause()
-        assert "status: disconnected" in app.live_extra
+    # Must have retried more than the old 3-retry cap.
+    assert attempts["n"] > 3
+    assert expired
 
 
 async def test_status_loop_clean_close_reconnects(monkeypatch):
@@ -1075,6 +1083,48 @@ async def test_status_loop_clean_close_reconnects(monkeypatch):
     # The clean-close reconnect branch ran before the token dropped.
     assert "status: reconnecting" in (app.live_extra or "")
     assert expired  # iteration 2 saw no token -> session_expired
+
+
+async def test_status_loop_resets_backoff_after_success(monkeypatch):
+    """After a successful connection (clean close), the error retry counter
+    resets so subsequent failures get a fresh backoff sequence (#2033)."""
+    import asyncio as _asyncio
+
+    _real_sleep = _asyncio.sleep
+    sleeps = []
+
+    async def _spy_sleep(t):
+        sleeps.append(t)
+        await _real_sleep(0)
+
+    monkeypatch.setattr(_asyncio, "sleep", _spy_sleep)
+
+    # Sequence: 2 errors, then 1 success (clean close), then 2 more errors,
+    # then token drops. If retries reset, the second batch of errors uses the
+    # same low-backoff values as the first.
+    calls = {"n": 0}
+
+    async def mixed(*a, **k):
+        calls["n"] += 1
+        n = calls["n"]
+        if n <= 2:
+            raise RuntimeError("err")  # first 2 errors
+        if n == 3:
+            return None  # success — clean close
+        if n <= 5:
+            raise RuntimeError("err")  # 2 more errors after reset
+        return None  # another clean close before token drops
+
+    monkeypatch.setattr(scr_main, "listen_for_status", mixed)
+    tokens = iter(["tok"] * 8 + [None])
+    app = KlangkApp(_authed_state(token=lambda: next(tokens)))
+    expired = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
+    async with app.run_test() as pilot:
+        await _real_status_loop(app.screen)
+        await pilot.pause()
+    assert expired
+    assert calls["n"] >= 5
 
 
 async def test_login_password_flow_success(monkeypatch):


### PR DESCRIPTION
## Summary

`_status_loop` capped reconnect attempts at 3 (`max_retries = 3`), after which the live status feed (`container_status`, `workspaces_changed`, `service_health`) was **permanently dead for the session** — no recovery short of re-login. A transient blip that outlasted the 3 rapid retries (e.g. a server restart taking >30s) silently killed live updates.

## Fix

Switch the loop to `while True` using `_reconnect_backoff` — the same bounded exponential the workspace-list `_reconnect_loop` uses (capped at `_MAX_BACKOFF_SECONDS = 5`), with the counter **reset on a clean close** so a healthy connection gets a fresh backoff sequence. The loop still exits only on auth failure (`token` gone / `AuthError`) — i.e. session expiry, not a transient error.

```python
retries = 0
while True:
    ...
    try:
        await listen_for_status(url, token, on_event=self._on_status_event)
        retries = 0          # healthy — reset backoff
        ...
    except AuthError:
        self.app.session_expired(); return
    except Exception as exc:
        retries += 1
        await asyncio.sleep(_reconnect_backoff(retries))   # no cap
        continue
```

## Tests
- `test_status_loop_retries_indefinitely_on_error` — asserts retries exceed the old 3-cap (token held for 7 iterations, then dropped → `session_expired`).
- `test_status_loop_resets_backoff_after_success` — verifies the counter resets after a clean close (2 errors → success → 2 errors uses the same low backoff).
- Full backend suite: **4147 passed, 100% coverage** (`-n auto`), rebased on #2038 (no conflict — #2038 touches `_reconnect_loop`, this touches `_status_loop`).

Closes #2033.
