### PR TITLE
fix(tui): synchronize status WS state mutation vs list refresh (#2032)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1248,6 +1248,15 @@ set-password <email>` (set a known password for the default user — whose
   reconnect uses (≤5s), resetting after a healthy connection, and exits
   only on auth failure (session expiry).
 
+- **CLI TUI workspace list no longer briefly disagrees with the detail
+  screen after a start/stop (#2032).** A `container_status` broadcast
+  (start/stop) from the status WebSocket and a list refresh could race: the
+  refresh's snapshot, taken before the broadcast, would momentarily
+  overwrite the list's just-updated running dot. The latest observed running
+  state per workspace is now held in an overlay that every list refresh
+  re-applies, so a fetch returning stale data can't regress a start/stop the
+  TUI already saw.
+
 - **Duplicate `klangkd` launch no longer spams the running instance's log
   with ERROR "Another klangk instance is already running" lines (#2021).**
   The _losing_ (second) process still reports why it exits, but now

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -245,6 +245,21 @@ class MainScreen(Screen):
         self._reconnect_attempt = 0
         self._reconnect_active = False
         self._gave_up = False
+        # Latest ``container_status`` running state per workspace id (#2032).
+        # Recorded on every broadcast and re-applied onto each fresh fetch in
+        # ``_populate_workspaces``, so a refresh whose snapshot raced behind a
+        # start/stop broadcast can't regress the list's running dot. This is
+        # the fix for the lost-update: the fetch runs as an ``await`` (network
+        # I/O), so a broadcast landing mid-fetch mutates the *old* snapshot
+        # object and would be clobbered when the refresh installs a stale one;
+        # the overlay carries the freshest state across that boundary.
+        # Intentionally unpruned — entries are ``uuid -> bool`` and bounded by
+        # the distinct workspaces seen this session; ids are never reused, so a
+        # stale entry (a since-deleted workspace) simply never matches a fresh
+        # object and is inert. (Pruning against ``_ws_by_id`` would be wrong:
+        # it would drop a pending entry for a workspace that hasn't appeared
+        # in any fetch yet.)
+        self._running_overlay: dict[str, bool] = {}
         self.query_one("#filter_bar").display = False
         self._refresh_action_hints()
         self.refresh_lists()
@@ -815,7 +830,6 @@ class MainScreen(Screen):
         )
 
     async def _refresh_lists_async(self) -> None:
-        self._ws_by_id: dict[str, object] = {}
         try:
             owned, shared = await self._fetch_lists()
         except AuthError:
@@ -833,6 +847,8 @@ class MainScreen(Screen):
             self._enter_unreachable()
             return
         # Success — clear any prior unreachable state and render the lists.
+        # ``_populate_workspaces`` re-applies ``_running_overlay`` so a stale
+        # snapshot can't regress a just-observed start/stop (#2032).
         self._exit_unreachable()
         self._populate_workspaces(owned, shared)
 
@@ -850,6 +866,9 @@ class MainScreen(Screen):
 
     def _populate_workspaces(self, owned: list, shared: list) -> None:
         """Cache + render a freshly fetched set of workspace lists."""
+        # Re-apply the latest container_status running state so a fetch that
+        # raced behind a start/stop broadcast can't regress the list (#2032).
+        self._apply_running_overlay(owned + shared)
         self._owned_all = owned
         self._shared_all = shared
         self._ws_by_id = {}
@@ -862,6 +881,22 @@ class MainScreen(Screen):
         if not self._initial_focus_done:
             self._initial_focus_done = True
             self._focus_visible_list()
+
+    def _apply_running_overlay(self, workspaces: list) -> None:
+        """Overlay the latest ``container_status`` running state onto a fresh
+        fetch (#2032).
+
+        A ``container_status`` broadcast can land while a list refresh is in
+        flight; the fetch may return a snapshot taken before the start/stop,
+        so without this overlay the list would briefly flip back to the stale
+        state (a running dot disagreeing with the detail screen).
+        """
+        if not self._running_overlay:
+            return
+        for ws in workspaces:
+            wid = str(getattr(ws, "id", "") or "")
+            if wid and wid in self._running_overlay:
+                ws.running = self._running_overlay[wid]
 
     def _render_unreachable(self, label: str) -> None:
         """Show *label* as the only row in both workspace lists."""
@@ -1131,10 +1166,17 @@ class MainScreen(Screen):
     def _update_running(self, workspace_id: str, running: bool) -> None:
         """Update a single workspace's ● icon in-place (#1791).
 
-        ``container_status`` events fire on start/stop; we patch the
-        list item's label without re-fetching the whole list (which
-        would lose selection and scroll position).
+        ``container_status`` events fire on start/stop; we patch the list
+        item's label without re-fetching the whole list (which would lose
+        selection and scroll position). The freshest running state is also
+        recorded in ``_running_overlay`` so a list refresh whose snapshot
+        raced behind this broadcast can't regress it (#2032).
         """
+        # Record the freshest running state regardless of whether the
+        # workspace is currently in the snapshot — it may land in the next
+        # refresh, where _populate_workspaces will re-apply it.
+        if workspace_id:
+            self._running_overlay[workspace_id] = running
         ws = getattr(self, "_ws_by_id", {}).get(workspace_id)
         if ws is None:
             return

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3191,6 +3191,100 @@ async def test_update_running_no_label(monkeypatch):
         m._update_running(a.id, False)
 
 
+async def test_status_running_not_regressed_by_stale_refresh(monkeypatch):
+    """A container_status running update isn't clobbered by a list refresh
+    that races behind it (#2032).
+
+    The fetch always returns a stale ``running=False`` snapshot; after a
+    ``container_status(running=True)`` broadcast, every subsequent refresh
+    must keep the list's running dot (the running overlay is re-applied).
+    """
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+
+    def stale_owned():
+        # Each fetch returns a NEW snapshot that's behind the broadcast.
+        return [_wsobj("alpha", running=False)]
+
+    st = _ws(owned=[_wsobj("alpha", running=False)])
+    st.list_owned_workspaces = stale_owned
+    st.list_shared_workspaces = lambda: []
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        # Backend reports the workspace is now running.
+        m._on_status_event(
+            {
+                "type": "container_status",
+                "workspace_id": "id-alpha",
+                "running": True,
+            }
+        )
+        await pilot.pause()
+        # A refresh lands stale data (running=False) — must not regress.
+        m.refresh_lists()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        ws = m._ws_by_id.get("id-alpha")
+        assert ws is not None
+        assert ws.running is True
+        # The overlay carries the freshest state across the refresh.
+        assert m._running_overlay.get("id-alpha") is True
+
+
+async def test_status_running_overlay_applied_on_first_refresh(monkeypatch):
+    """A container_status that lands before the workspace is in the snapshot
+    is recorded and applied when the refresh brings it in (#2032)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+
+    calls = {"n": 0}
+
+    def owned():
+        calls["n"] += 1
+        # First fetch (mount): no workspaces yet.
+        if calls["n"] == 1:
+            return []
+        # Later fetches: the workspace exists but the snapshot is stale
+        # (running=False, behind the broadcast).
+        return [_wsobj("alpha", running=False)]
+
+    st = _ws(owned=[])
+    st.list_owned_workspaces = owned
+    st.list_shared_workspaces = lambda: []
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        # Broadcast arrives before the workspace is in the snapshot.
+        m._on_status_event(
+            {
+                "type": "container_status",
+                "workspace_id": "id-alpha",
+                "running": True,
+            }
+        )
+        await pilot.pause()
+        # The refresh that brings the workspace in re-applies the overlay.
+        m.refresh_lists()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        ws = m._ws_by_id.get("id-alpha")
+        assert ws is not None
+        assert ws.running is True
+
+
 async def test_main_screen_list_error_shows_placeholder(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

Fixes #2032. The status-WS callback (`_on_status_event` / `_update_running`) mutated the shared workspace snapshot while a list refresh was in flight: a `container_status` (start/stop) broadcast would land during the refresh's network fetch, mutate the *old* snapshot object, and then be clobbered when the refresh installed a stale snapshot — a lost update that briefly made the list's running dot disagree with the detail screen.

## Fix

`MainScreen._running_overlay` records the latest `container_status` running state per workspace id; `_populate_workspaces` re-applies it onto every fresh fetch via `_apply_running_overlay`, so a stale snapshot can never regress a start/stop the TUI already observed. This is the complete fix for the lost-update: the overlay carries the freshest state across the network-fetch `await` boundary.

The overlay is intentionally unpruned — entries are `uuid → bool`, bounded by the distinct workspaces seen this session, and stale entries are inert (UUIDs are never reused). A naive prune against `_ws_by_id` would be wrong (it would drop a pending entry for a workspace not yet fetched). Documented in a code comment.

> **Note:** an earlier revision of this PR also added an `asyncio.Lock`, but an adversarial review correctly identified it as inert in single-threaded asyncio (the lock bodies were fully synchronous, so the lock never contended). The lock and the associated async machinery were removed; `_running_overlay` is the real fix. See the review comment for details.

## Test plan

- New: `test_status_running_not_regressed_by_stale_refresh` — a fetch that always returns stale `running=False` can't regress a `container_status(running=True)`.
- New: `test_status_running_overlay_applied_on_first_refresh` — a broadcast landing before the workspace is in the snapshot is applied when the refresh brings it in.
- Full suite: **4155 passed, 100% coverage** (`-n auto`, matching CI).

## Changelog

Added a `Fixed` entry under `[Unreleased]`.
