### PR TITLE
klangkd: ship non-empty defaults for container CPU/memory/PIDs limits (#2030)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -564,6 +564,17 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **Container resource limits now ship non-empty by default (#2030).**
+  `container_cpu_limit` / `container_memory_limit` / `container_pids_limit`
+  default to `2.0` / `8g` / `512` (env `KLANGKD_CONTAINER_CPU_LIMIT` /
+  `_MEMORY_LIMIT` / `_PIDS_LIMIT`) instead of unset, so a fresh `klangkd`
+  deployment caps every workspace container out of the box (podman
+  `--cpus` / `--memory` / `--pids-limit`) and a runaway workspace can no
+  longer starve or OOM the host. The first-run generated `klangkd.yaml`
+  emits these uncommented (matching the defaults) for discoverability. Set a
+  field to an empty value to disable that one cap and restore unbounded
+  behavior for it. Malformed values still abort startup. Operators with an
+  explicit config are unaffected.
 - **TUI: session expiry now shows a prominent app-wide overlay, not a
   small inline label + fleeting toast (#2025).** When the access token is
   irrecoverably dead (auth failure on a workspace fetch/detail load, a

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -292,9 +292,9 @@ port: "8997"
 | `netfilter_enabled`          | `true`                          | `KLANGKD_NETFILTER_ENABLED`          |
 | `netfilter_hooks_dir`        | `<state_dir>/oci-hooks`         | `KLANGKD_NETFILTER_HOOKS_DIR`        |
 | `netfilter_default_domains`  | _(unset)_                       | `KLANGKD_NETFILTER_DEFAULT_DOMAINS`  |
-| `container_cpu_limit`        | _(unset)_                       | `KLANGKD_CONTAINER_CPU_LIMIT`        |
-| `container_memory_limit`     | _(unset)_                       | `KLANGKD_CONTAINER_MEMORY_LIMIT`     |
-| `container_pids_limit`       | _(unset)_                       | `KLANGKD_CONTAINER_PIDS_LIMIT`       |
+| `container_cpu_limit`        | `2.0`                           | `KLANGKD_CONTAINER_CPU_LIMIT`        |
+| `container_memory_limit`     | `8g`                            | `KLANGKD_CONTAINER_MEMORY_LIMIT`     |
+| `container_pids_limit`       | `512`                           | `KLANGKD_CONTAINER_PIDS_LIMIT`       |
 | `health_check_interval`      |                                 | `KLANGKD_HEALTH_CHECK_INTERVAL`      |
 | `health_check_startup_grace` |                                 | `KLANGKD_HEALTH_CHECK_STARTUP_GRACE` |
 | `health_check_timeout`       |                                 | `KLANGKD_HEALTH_CHECK_TIMEOUT`       |

--- a/klangkd.yaml.devenv
+++ b/klangkd.yaml.devenv
@@ -48,13 +48,16 @@ image_name: klangk-workspace
 
 # --- Container resource limits (#34) ---
 # Deploy-wide CPU / memory / PIDs caps applied to every workspace
-# container (podman --cpus / --memory / --pids-limit). Unset = no cap =
-# today's unbounded behavior; a malformed value aborts startup. A reload
-# applies to containers started after the reload (existing containers keep
-# their original cgroup limits for the rest of their life).
-# container_cpu_limit: 1.5
-# container_memory_limit: 2g
-# container_pids_limit: 512
+# container (podman --cpus / --memory / --pids-limit). These are the
+# built-in defaults (shown uncommented so they're discoverable, #2030); a
+# fresh install is bounded at 2 CPUs / 8g / 512 PIDs so a runaway
+# workspace can't take down the host. A malformed value aborts startup. A
+# reload applies to containers started after the reload (existing
+# containers keep their original cgroup limits for the rest of their
+# life). Set a field to empty ("" ) to disable just that one cap.
+container_cpu_limit: 2.0
+container_memory_limit: 8g
+container_pids_limit: 512
 
 # --- Per-workspace egress filtering (#1365) ---
 # Set to a directory the OCI runtime can read to enable opt-in per-workspace

--- a/src/klangk/klangk/first_run.py
+++ b/src/klangk/klangk/first_run.py
@@ -72,8 +72,11 @@ def _render_config() -> str:
     Intentionally a near-empty template — the admin identity is derived at
     runtime from the Unix user (settings default), and a password is only
     required when the operator switches to password mode. The file carries
-    discoverability + commented examples for the mode transitions, nothing
-    more. Settings not listed here use the in-code defaults.
+    discoverability + commented examples for the mode transitions, plus the
+    container resource-limit defaults emitted uncommented (they match the
+    in-code defaults; shown so an operator sees the caps in effect and
+    knows where to change them, #2030). Settings not listed here use the
+    in-code defaults.
     """
     timestamp = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
     return f"""# klangkd configuration — generated on first run ({timestamp}).
@@ -101,6 +104,16 @@ def _render_config() -> str:
 # default_password: "..."  # required when auth_modes is password/both
 # jwt_secret: change-me    # default is an insecure placeholder; mint a real
 #                          # secret for any non-local deployment
+#
+# --- Container resource limits (defaults shown; #34 / #2030) ---
+# Every workspace container is capped at 2 CPUs / 8g RAM / 512 PIDs so a
+# runaway workspace can't starve the host. These match the built-in
+# defaults, so editing or removing a line keeps that cap unless you set it
+# to empty (container_cpu_limit: "") to disable just that one. Podman
+# receives them as --cpus / --memory / --pids-limit.
+container_cpu_limit: 2.0
+container_memory_limit: 8g
+container_pids_limit: 512
 #
 # Full settings reference:
 #   https://mcdonc.github.io/klangk/reference/klangkd-config/

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -676,10 +676,12 @@ class KlangkSettings(BaseSettings):
     netfilter_default_domains: list[str] | None = None
     # Container resource limits (#34): deploy-wide CPU / memory / PIDs caps
     # passed to every workspace container as podman --cpus / --memory /
-    # --pids-limit. Unset (default) = no flag = today's unbounded behavior
-    # (no regression); a workspace exceeding a set limit is throttled /
-    # OOM-killed / fork-bomb-contained rather than taking down the host or
-    # neighbouring workspaces. Read at boot and on SIGHUP (reloadable) and
+    # --pids-limit. Ships with protective defaults (2 CPUs / 8g / 512 PIDs,
+    # #2030) so a fresh install is bounded out of the box — a workspace
+    # exceeding a limit is throttled / OOM-killed / fork-bomb-contained
+    # rather than taking down the host or its neighbours. Set a field to an
+    # empty value (env `""`) to explicitly disable that one cap and restore
+    # unbounded behavior for it. Read at boot and on SIGHUP (reloadable) and
     # passed through container.create_kwargs at every workspace start, so a
     # reload applies to containers started after the reload (existing
     # containers keep their original cgroup limits for the rest of their
@@ -688,9 +690,9 @@ class KlangkSettings(BaseSettings):
     # disabling the safety control — see each field's validator. Per-
     # workspace overrides (creator may go larger *or* smaller than the
     # deploy default, no clamping) are a follow-up (Phase 2).
-    container_cpu_limit: float | None = None
-    container_memory_limit: str | None = None
-    container_pids_limit: int | None = None
+    container_cpu_limit: float | None = 2.0
+    container_memory_limit: str | None = "8g"
+    container_pids_limit: int | None = 512
     test_mode: str | None = None
     version_file: str | None = None
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -648,17 +648,20 @@ class TestStartContainer:
         reg = container.ContainerRegistry(app_state)
         assert reg._egress_filter(["github.com"]) == (None, None, None)
 
-    async def test_resource_limits_unset_emit_no_flags(self, workspace):
-        # #34: with no deploy limits set, create_container gets None for
-        # all three (podman.create omits the flags entirely).
+    async def test_resource_limits_defaults_emit_flags(self, workspace):
+        # #2030: with no deploy limits configured, the built-in protective
+        # defaults (2 CPUs / 8g / 512 PIDs) still flow through to podman as
+        # --cpus / --memory / --pids-limit — a fresh install is bounded out
+        # of the box. (Setting an env var to "" disables one cap -> None ->
+        # no flag; see test_settings.py.)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         kwargs = p.create_container.call_args.kwargs
-        assert kwargs["cpus"] is None
-        assert kwargs["memory"] is None
-        assert kwargs["pids_limit"] is None
+        assert kwargs["cpus"] == 2.0
+        assert kwargs["memory"] == "8g"
+        assert kwargs["pids_limit"] == 512
 
     async def test_resource_limits_passed_through(
         self, workspace, monkeypatch
@@ -748,10 +751,16 @@ class TestStartContainer:
         assert kwargs["pids_limit"] == 512
 
     async def test_workspace_settings_override_when_no_deploy_default(
-        self, workspace
+        self, workspace, monkeypatch
     ):
         # No deploy default + an override -> the override applies; the
-        # other two limits stay None (no flag).
+        # other two limits stay None (no flag). The deploy defaults are
+        # non-empty out of the box now (#2030), so null them out here to
+        # exercise the genuine "no deploy default" path.
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_cpu_limit", None)
+        monkeypatch.setattr(settings, "container_memory_limit", None)
+        monkeypatch.setattr(settings, "container_pids_limit", None)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],

--- a/src/klangk/klangkd-tests/tests/test_first_run.py
+++ b/src/klangk/klangkd-tests/tests/test_first_run.py
@@ -125,6 +125,27 @@ class TestGenerateDefaultConfig:
         body = Path(path).read_text()
         assert "mcdonc.github.io/klangk" in body
 
+    def test_template_emits_container_resource_limits(self, tmp_path):
+        # #2030: a fresh first run must produce a config that caps workspace
+        # containers — the three resource-limit keys ship active
+        # (uncommented), matching the built-in defaults, so an operator
+        # sees the caps in effect and knows where to change them.
+        path = str(tmp_path / "klangkd.yaml")
+        first_run.generate_default_config(path)
+        body = Path(path).read_text()
+        assert "container_cpu_limit: 2.0" in body
+        assert "container_memory_limit: 8g" in body
+        assert "container_pids_limit: 512" in body
+        # They must be active config lines, not commented examples.
+        active = {
+            line.strip()
+            for line in body.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        }
+        assert "container_cpu_limit: 2.0" in active
+        assert "container_memory_limit: 8g" in active
+        assert "container_pids_limit: 512" in active
+
 
 class TestLauncherIntegration:
     """launcher._resolve_config_path(None) wires first-run generation in."""

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -256,12 +256,14 @@ class TestConfigFile:
 
     # --- Container resource limits (#34) ---
 
-    def test_container_limits_default_none(self):
-        # #34: unset = no cap = today's unbounded behavior.
+    def test_container_limits_default_to_protective_caps(self):
+        # #2030: a fresh config ships bounded — 2 CPUs / 8g / 512 PIDs —
+        # so a runaway workspace can't take down the host out of the box.
+        # Set a field to an empty env value to disable just that one cap.
         s = make_settings({})
-        assert s.container_cpu_limit is None
-        assert s.container_memory_limit is None
-        assert s.container_pids_limit is None
+        assert s.container_cpu_limit == 2.0
+        assert s.container_memory_limit == "8g"
+        assert s.container_pids_limit == 512
 
     def test_container_cpu_limit_from_env(self):
         s = make_settings({"KLANGKD_CONTAINER_CPU_LIMIT": "1.5"})


### PR DESCRIPTION
## Summary

Ships non-empty defaults for the three deploy-wide container resource limits added in #1941, so a fresh `klangkd` deployment caps every workspace container out of the box instead of running unbounded. Closes #2030.

Defaults (per #2030 discussion):

| Setting | Default | Env var |
| --- | --- | --- |
| `container_cpu_limit` | `2.0` (2 cores) | `KLANGKD_CONTAINER_CPU_LIMIT` |
| `container_memory_limit` | `8g` | `KLANGKD_CONTAINER_MEMORY_LIMIT` |
| `container_pids_limit` | `512` | `KLANGKD_CONTAINER_PIDS_LIMIT` |

Applied in **both** places the issue proposed:

- **In-code** (`settings.py`) — protects *every* boot path, including `--config=none` and env-only configs. A workspace exceeding a limit is throttled / OOM-killed / fork-bomb-contained rather than taking down the host. Set a field to an empty value (env `""`) to disable that one cap and restore unbounded behavior for it.
- **First-run template** (`first_run._render_config`) — the generated `klangkd.yaml` emits the three keys uncommented (matching the in-code defaults), so a fresh install is capped *and* the operator can see and edit the caps in their config file.

`container.py` already reads the values live off `app.state.settings` and only emits the podman flag when non-`None`, so the non-empty defaults take effect with no other plumbing.

## Acceptance criteria

- [x] A fresh `klangkd` first run produces a config that caps workspace containers (podman `--cpus` / `--memory` / `--pids-limit` flags emit at workspace start — covered by `test_template_emits_container_resource_limits` and `test_resource_limits_defaults_emit_flags`).
- [x] `docs/reference/klangkd-config.md` and `klangkd.yaml.devenv` updated (no longer `_(unset)_` / commented-only).
- [x] Malformed-value-aborts-startup behaviour from #1941 preserved (validators untouched, still tested).
- [x] Changelog `Changed` entry under `[Unreleased]`.

## Upgrade notes

Existing deployments with an explicit config are unaffected. Operators relying on the previous unbounded-by-default behaviour (no config file, env-only, or `--config=none`) will now get the caps applied on upgrade; set a field to empty to opt out of an individual cap.

## Test plan

- [x] `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 4153 passed, 100% coverage.

