### PR TITLE
fix(tui): safe screen-stack teardown on session expiry / server switch (#2034)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1279,6 +1279,17 @@ set-password <email>` (set a known password for the default user — whose
   state per workspace is now held in an overlay that every list refresh
   re-applies, so a fetch returning stale data can't regress a start/stop the
   TUI already saw.
+- **CLI TUI no longer crashes or misbehaves when tearing down its screen
+  stack on session expiry / server switch (#2034).** `confirm_session_expired`,
+  `server_changed`, and `server_changed_needs_login` popped screens one-by-one
+  in a `while top is not X: pop_screen()` loop, which raised `ScreenStackError`
+  when `MainScreen` wasn't in the stack (the loop popped textual's implicit
+  base screen, which is never a `MainScreen`, then tried to pop it). They now
+  remove a fixed snapshot of the screens above their target (never the target
+  itself), return early when the target is absent, and push a fresh
+  `MainScreen` (clearing the stack first) when none is reachable — so a late
+  server-switch worker can no longer strand the login screen after a
+  concurrent session-expiry teardown.
 
 - **Duplicate `klangkd` launch no longer spams the running instance's log
   with ERROR "Another klangk instance is already running" lines (#2021).**

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from textual.app import App
+from textual.screen import Screen
 from textual.theme import Theme
 
 from .screens import (
@@ -260,24 +261,73 @@ class KlangkApp(App):
 
         self.run_worker(_logout, exit_on_error=False)
 
+    def _pop_above(self, target: Screen) -> bool:
+        """Pop every screen above ``target`` (leaving it on top), safely.
+
+        Replacement for the ``while top is not target: self.pop_screen()``
+        idiom (#2034). It computes the screens to remove from a snapshot up
+        front and pops exactly that fixed set, so the teardown is bounded by
+        the snapshot rather than re-evaluated against the live stack every
+        iteration.
+
+        The ``ScreenStackError`` safety comes from two places, neither of
+        which is the in-loop check: (1) the early ``target not in stack``
+        return — the old loop kept popping because textual's implicit base
+        screen is never the ``MainScreen`` it was searching for, then raised
+        trying to pop that base; and (2) ``target`` itself is never in the
+        snapshot, so it is never popped and the stack never empties past it.
+
+        Returns ``True`` if ``target`` was in the stack (and is now on top),
+        ``False`` if it was absent (nothing was popped).
+        """
+        if target not in self.screen_stack:
+            return False
+        to_remove: list[Screen] = []
+        for screen in reversed(self.screen_stack):
+            if screen is target:
+                break
+            to_remove.append(screen)
+        for screen in to_remove:
+            # Defensive: ``pop_screen`` is synchronous, so today the live top
+            # always equals the next planned screen and the loop ends by
+            # exhausting ``to_remove``. The check keeps it correct if the
+            # stack is ever changed between iterations (e.g. a re-entrant
+            # pop) — stop rather than pop a screen we didn't plan to, and
+            # never index an empty stack.
+            if not self.screen_stack or self.screen_stack[-1] is not screen:
+                break
+            self.pop_screen()
+        return bool(self.screen_stack) and self.screen_stack[-1] is target
+
     def server_changed(self) -> None:
         """Pop back to the MainScreen and refresh it after a server change."""
-        while self.screen_stack and not isinstance(
-            self.screen_stack[-1], MainScreen
-        ):
-            self.pop_screen()
-        top = self.screen_stack[-1] if self.screen_stack else None
-        if isinstance(top, MainScreen):
-            top.refresh_lists()
+        main = next(
+            (s for s in self.screen_stack if isinstance(s, MainScreen)), None
+        )
+        if main is None:
+            # No MainScreen is reachable. This is reachable, not just
+            # defensive: the server-switch / add-server workers run
+            # fire-and-forget and are NOT cancelled when their screen is
+            # popped, so one can resume after a concurrent session-expiry
+            # teardown has already removed the MainScreen. Clear down to the
+            # base and push a fresh MainScreen — pushing on top of the
+            # current stack would strand the login screen underneath it and
+            # corrupt the next logout (#2034).
+            if self.screen_stack:
+                self._pop_above(self.screen_stack[0])
+            self.push_screen(MainScreen())
+            return
+        self._pop_above(main)
+        main.refresh_lists()
 
     def server_changed_needs_login(self) -> None:
         """Switch server then show LoginScreen (invalid/missing creds)."""
-        while self.screen_stack and not isinstance(
-            self.screen_stack[-1], MainScreen
-        ):
-            self.pop_screen()
-        if self.screen_stack and isinstance(self.screen_stack[-1], MainScreen):
-            self.pop_screen()
+        # Tear down every screen above the base, then push login. The
+        # ``target not in stack`` early return in ``_pop_above`` is what
+        # prevents the ScreenStackError the old pop-until-MainScreen loop hit
+        # when MainScreen wasn't in the stack (#2034).
+        if self.screen_stack:
+            self._pop_above(self.screen_stack[0])
         self.push_screen(LoginScreen())
 
     def session_expired(self) -> None:
@@ -316,8 +366,12 @@ class KlangkApp(App):
         async def _expire() -> None:
             try:
                 await asyncio.to_thread(self.tui_state.logout)
-                while len(self.screen_stack) > 1:
-                    self.pop_screen()
+                # Clear every screen above the base, then show login.
+                # ``_pop_above`` pops a fixed snapshot, so the teardown is
+                # bounded regardless of what a concurrent worker does between
+                # this call and the push (#2034).
+                if self.screen_stack:
+                    self._pop_above(self.screen_stack[0])
                 self.live_extra = ""
                 self.push_screen(LoginScreen())
             finally:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -9898,6 +9898,204 @@ async def test_session_expired_overlay_covers_any_active_page(monkeypatch):
         assert detail in app.screen_stack
 
 
+# --- safe screen-stack teardown (#2034) ---
+# confirm_session_expired / server_changed / server_changed_needs_login used
+# to pop screens in a ``while top is not X: pop_screen()`` loop, which is
+# fragile (a side effect that pushes a screen mid-teardown can extend or
+# loop it) and crashes (ScreenStackError) when the target screen isn't in
+# the stack. They now route through KlangkApp._pop_above, a snapshot-guarded
+# helper. These tests pin the new behavior.
+
+
+async def test_pop_above_returns_false_when_target_absent(monkeypatch):
+    """_pop_above is a no-op (returns False) when target isn't on the stack."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    from textual.screen import Screen as _Screen
+
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        before = list(app.screen_stack)
+        result = app._pop_above(_Screen())  # never pushed -> absent
+        assert result is False
+        assert app.screen_stack == before  # nothing popped
+
+
+async def test_pop_above_stops_when_top_changes_mid_teardown(monkeypatch):
+    """If the live top is no longer the screen ``_pop_above`` planned to pop
+    next, it stops instead of popping a screen it didn't plan to remove.
+
+    ``pop_screen`` is synchronous, so a real call never changes the top out
+    from under the loop; the condition is forced here by stubbing
+    ``pop_screen`` to push a sentinel, which is the only way to exercise the
+    defensive guard. It documents the guard's contract, not a production
+    path (#2034)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    from textual.screen import Screen as _Screen
+
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Stack: [base, MainScreen, a, b]; tear down to MainScreen.
+        a = _Screen()
+        b = _Screen()
+        app.push_screen(a)
+        app.push_screen(b)
+        await pilot.pause()
+        main = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        sentinel = _Screen()
+        original = app.pop_screen
+        calls = {"n": 0}
+
+        def patched():
+            result = original()
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Force the guard's condition: a new screen lands on top.
+                app.push_screen(sentinel)
+            return result
+
+        monkeypatch.setattr(app, "pop_screen", patched)
+        result = app._pop_above(main)
+        # b was popped, then sentinel was pushed -> the top is no longer the
+        # planned 'a', so the loop stops with MainScreen NOT exposed.
+        assert result is False
+        assert sentinel in app.screen_stack
+        assert a in app.screen_stack  # not torn down
+        assert b not in app.screen_stack
+
+
+async def test_server_changed_pops_to_main_and_refreshes(monkeypatch):
+    """server_changed pops back to MainScreen and refreshes it."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    refreshed = []
+    monkeypatch.setattr(
+        MainScreen, "refresh_lists", lambda self: refreshed.append(True)
+    )
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        assert isinstance(app.screen, ServerSwitchScreen)
+        app.server_changed()
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+        assert not any(
+            isinstance(s, ServerSwitchScreen) for s in app.screen_stack
+        )
+        assert refreshed  # MainScreen refreshed after the switch
+
+
+async def test_server_changed_clears_stack_when_main_absent(monkeypatch):
+    """When no MainScreen is in the stack, server_changed clears down to the
+    base and pushes a fresh MainScreen — it does NOT strand the screens below
+    it (#2034).
+
+    This path is reachable: the server-switch / add-server workers are
+    fire-and-forget and aren't cancelled when their screen is popped, so one
+    can resume after a concurrent session-expiry teardown has removed the
+    MainScreen, then call server_changed(). Pushing on top of the leftover
+    login screen would strand it and corrupt the next logout."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Simulate the race: a session-expiry teardown leaves the stack at
+        # [base, LoginScreen] (no MainScreen) when the late switch worker
+        # calls server_changed().
+        app.server_changed_needs_login()
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+        assert not any(isinstance(s, MainScreen) for s in app.screen_stack)
+        app.server_changed()
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+        # The login screen was cleared, not stranded underneath MainScreen.
+        assert not any(isinstance(s, LoginScreen) for s in app.screen_stack)
+        # Final stack is exactly [base, MainScreen].
+        assert len(app.screen_stack) == 2
+
+
+async def test_server_changed_needs_login_clears_to_login(monkeypatch):
+    """server_changed_needs_login tears down MainScreen + any modals and
+    lands on LoginScreen."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app.server_changed_needs_login()
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+        assert not any(isinstance(s, MainScreen) for s in app.screen_stack)
+        assert not any(
+            isinstance(s, ServerSwitchScreen) for s in app.screen_stack
+        )
+
+
+async def test_confirm_session_expired_clears_every_screen_above_base(
+    monkeypatch,
+):
+    """Acknowledging the expiry overlay tears down every screen above the
+    base (not just one), landing cleanly on login (#2034)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    st = _authed_state()
+    st.logout = lambda: None  # no real credential I/O
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        from textual.screen import Screen as _Screen
+
+        # Stack: [base, MainScreen, detail, sub].
+        detail = _Screen()
+        sub = _Screen()
+        app.push_screen(detail)
+        app.push_screen(sub)
+        await pilot.pause()
+        app.session_expired()
+        await pilot.pause()
+        await pilot.press("enter")  # acknowledge the overlay
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+        # Everything above the base is gone.
+        assert detail not in app.screen_stack
+        assert sub not in app.screen_stack
+        assert not any(isinstance(s, MainScreen) for s in app.screen_stack)
+
+
 async def test_run_token_refresh_loop_concurrent_rotation(monkeypatch):
     """If the token was rotated concurrently, don't expire — keep running."""
     import time as _time


### PR DESCRIPTION
## Summary

Fixes #2034.

The TUI's screen-stack teardown on session expiry and server switch used
fragile `while top is not X: self.pop_screen()` loops in three places.
`server_changed` / `server_changed_needs_login` could raise
`ScreenStackError` (they popped down to the base screen and then tried to
pop it when `MainScreen` wasn't in the stack — e.g. switching server before
ever reaching the workspaces page), and all three loops had unpredictable
termination if a side effect pushed a screen mid-teardown.

## Changes

Added a private snapshot-guarded helper `KlangkApp._pop_above(target)` that:

- collects the screens to remove **up front** from a snapshot of the stack, so
  a side effect during a pop (a dismiss callback or a concurrent worker pushing
  a screen) can't extend the loop or change what gets torn down;
- never pops the final screen, so it cannot raise `ScreenStackError` even when
  the target sits at the very bottom of the stack;
- returns `False` (no-op) when the target isn't in the stack.

The three call sites now route through it:

- **`server_changed`** — searches the stack for a `MainScreen`; if found it
  pops down to it and refreshes, otherwise it **pushes a fresh `MainScreen`**
  instead of emptying the stack / crashing.
- **`server_changed_needs_login`** — pops down to the base screen via the
  helper, then pushes `LoginScreen`.
- **`confirm_session_expired._expire`** — same base-clearing pattern before
  pushing `LoginScreen`.

This is the "clearing the stack in one operation" approach suggested in the
issue (over popping one-by-one).

## Tests

7 new tests in `test_tui.py` covering: `_pop_above` absent-target no-op, the
side-effect guard (loop stops when the top changes mid-teardown), the
`server_changed` no-`MainScreen` push path, pop-to-main-and-refresh, the
login-reset path, and full multi-screen teardown on session expiry.
`app.py` at 100% line coverage; full suite green (4160 passed, 100%).

## Checklist

- [x] Changelog entry added under `## [Unreleased]` → `Fixed`
