### PR TITLE
docs(docker): declare none auth mode unsupported; image uses password (#1391)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -564,6 +564,18 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **`none` auth mode is declared an unsupported configuration with the
+  published Docker host image (#1391).** `none` (no-login single-user,
+  loopback-only) is safe only when solely the operator's loopback can reach
+  `/auth/local`; a `docker run -p` published port is network-reachable, so
+  the image cannot use it — the bind-safety gate refuses a non-loopback
+  bind, and even with `KLANGKD_ALLOW_INSECURE_NO_AUTH=1` the proxy
+  `/auth/local` ACL denies the port-forwarded request with `403`. **The
+  Docker host image uses `KLANGKD_AUTH_MODES=password`** (or `oidc`/`both`)
+  by default; all Docker examples pin it. For a no-login single-user
+  experience, run klangk locally (devenv or the bare binary) instead of the
+  published image. This replaces the previous "until #1391 lands"
+  placeholder language in the Docker docs.
 - **Container resource limits now ship non-empty by default (#2030).**
   `container_cpu_limit` / `container_memory_limit` / `container_pids_limit`
   default to `2.0` / `8g` / `512` (env `KLANGKD_CONTAINER_CPU_LIMIT` /
@@ -1208,9 +1220,9 @@ set-password <email>` (set a known password for the default user — whose
   bind unless `KLANGKD_ALLOW_INSECURE_NO_AUTH=1` — but it is a behavior change
   on upgrade: **set `KLANGKD_AUTH_MODES=password` (or `oidc`/`both`) explicitly
   before redeploying if you relied on the old default.** Note: `none` mode is
-  not yet supported with the published Docker host image (a published port
-  isn't loopback) — the Docker examples set `KLANGKD_AUTH_MODES=password`; see
-  #1391.
+  an unsupported configuration with the published Docker host image (a
+  published port isn't loopback) — the Docker image uses
+  `KLANGKD_AUTH_MODES=password`; see #1391.
 - **OIDC settings no longer change the auth mode (#1419).** Previously, when
   `KLANGKD_AUTH_MODES` was unset **and** an OIDC provider was configured, the
   resolved default was silently promoted to `both` (the "OIDC turns auth on"

--- a/docs/deployment/customizing.md
+++ b/docs/deployment/customizing.md
@@ -208,26 +208,27 @@ See the [OIDC documentation](../reference/oidc.md) for the config file format.
 ### Deployment profiles (auth modes)
 
 `KLANGKD_AUTH_MODES` selects the deployment profile — same binary, different
-config. For a **no-login local-dev** server (single user, your own browser),
-use `none` — it auto-issues a token for the seeded default user and must bind
-loopback:
-
-```bash
-docker run -d \
-  -e KLANGKD_AUTH_MODES=none \
-  ...
-```
+config. The published host image uses **`password`** as its supported mode
+(`oidc` and `both` are also supported). The `none` (no-login local-dev)
+profile is **unsupported with the published Docker host image** — see the
+note below.
 
 See [Auth Modes](../features/auth-modes.md) for the full
 local-dev / customer-locked / team mapping.
 
-> **Note for Docker users:** `none` is loopback-only by design, and a
-> `docker run -p` published port isn't loopback — so `none` mode does not
-> yet work with the published host image (the proxy `/auth/local` ACL denies
-> the port-forwarded request). For the Docker image, set
-> `KLANGKD_AUTH_MODES=password` (or `oidc`/`both`) until #1391 lands.
-> Locally (devenv, or running the binary on your own machine) `none` works
-> out of the box.
+> **`none` mode is unsupported in the Docker host image.** `none` is
+> loopback-only by design (it freely issues an admin token with no
+> password, so its security model is "only the operator's loopback can
+> reach it"), and a `docker run -p` published port isn't loopback. The
+> bind-safety gate refuses to boot `none` on a non-loopback bind, and even
+> with `KLANGKD_ALLOW_INSECURE_NO_AUTH=1` the proxy `/auth/local` ACL still
+> denies the port-forwarded request with `403` (the request appears at the
+> container as the Docker bridge IP, not `127.0.0.1`). The image therefore
+> runs `KLANGKD_AUTH_MODES=password` (or `oidc`/`both`) — set
+> `KLANGKD_DEFAULT_PASSWORD` accordingly. For a no-login single-user
+> experience, run klangk locally (devenv, or the bare binary on your own
+> machine), where `none` works out of the box. See
+> [#1391](https://github.com/mcdonc/klangk/issues/1391).
 
 ## Building a Custom Image (Features)
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -35,11 +35,31 @@ docker run -d \
 Open <http://localhost:8997> and log in with the email and password
 you set above.
 
-The examples pin `KLANGKD_AUTH_MODES=password` because a Docker image
-publishes its port (`-p 8997:8997`) and is network-reachable, while the
-default mode (`none`) is loopback-only. See [Auth Modes](../features/auth-modes.md)
-and [#1391](https://github.com/mcdonc/klangk/issues/1391) for the
-no-login Docker story.
+The published host image uses **password auth** — the examples pin
+`KLANGKD_AUTH_MODES=password`, and that is the supported configuration
+for the image. The default mode for a local install is `none`
+(no-login, loopback-only), but **`none` is an unsupported configuration
+with the published Docker host image.** The image publishes its port
+(`-p 8997:8997`), making it network-reachable, while `none` mode is
+loopback-only by design — it freely issues an admin token with no
+password, so its entire security model is "only the operator's loopback
+can reach it." Two independent gates refuse it in Docker:
+
+1. **Bind-safety gate.** `none` mode won't boot on a non-loopback bind
+   (publishing the port requires binding a non-loopback address like
+   `0.0.0.0`). Setting `KLANGKD_ALLOW_INSECURE_NO_AUTH=1` overrides this —
+   but only to warn you and expose a free-admin-token endpoint to the
+   whole network.
+2. **Proxy `/auth/local` ACL.** Even past the bind gate, a host browser
+   reaching the container through the published port-forward appears at
+   the container as the Docker bridge/gateway IP (e.g. `172.17.0.1`),
+   not `127.0.0.1`, so the loopback-only ACL denies `/api/v1/auth/local`
+   with `403`.
+
+For a no-login single-user experience, run klangk locally (devenv, or
+the bare binary on your own machine) instead of the published image.
+See [Auth Modes](../features/auth-modes.md) and
+[#1391](https://github.com/mcdonc/klangk/issues/1391).
 
 ## What the flags do
 

--- a/docs/features/auth-modes.md
+++ b/docs/features/auth-modes.md
@@ -93,6 +93,20 @@ after first boot is done via the in-app UI or `klangk admin users *`.
 `none` is the foundation for a no-friction single-user dev/test loop —
 without standing up the multi-user tier or logging in each session.
 
+> **Not supported with the published Docker host image.** The host image
+> publishes its browser port (`-p 8997:8997`), which is network-reachable,
+> while `none` is loopback-only by design — the freely-issued admin token
+> is safe only when solely the operator's loopback can reach
+> `/auth/local`. Two gates refuse it in Docker: the bind-safety gate won't
+> let `none` boot on a non-loopback bind, and even with
+> `KLANGKD_ALLOW_INSECURE_NO_AUTH=1` the proxy `/auth/local` ACL still
+> denies the port-forwarded request with `403` (the request appears at the
+> container as the Docker bridge IP, not `127.0.0.1`). The image therefore
+> runs `password` (or `oidc`/`both`). For a no-login single-user
+> experience, run klangk locally (devenv, or the bare binary on your own
+> machine) instead of the published image. See
+> [#1391](https://github.com/mcdonc/klangk/issues/1391).
+
 In `none` mode the server freely issues a JWT for the seeded default user
 (`KLANGKD_DEFAULT_USER`, defaulting to `admin@example.com`) with no credentials
 required from the caller:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,10 +32,15 @@ Open <http://localhost:8997> and log in with the email and password
 you set above.
 
 > A Docker container publishes its port (`-p 8997:8997`), making it
-> network-reachable, so these examples set `KLANGKD_AUTH_MODES=password`
-> explicitly. The default mode is `none` (no-login, loopback-only), which is
-> meant for local dev on your own machine — a published port is not that.
-> See [Auth Modes](features/auth-modes.md).
+> network-reachable, so the published host image uses
+> `KLANGKD_AUTH_MODES=password` — that is the supported configuration for
+> the image. The default mode is `none` (no-login, loopback-only), which is
+> **unsupported with the published Docker host image**: it is meant for
+> local dev on your own machine, where the port is not published, and it
+> freely issues an admin token with no password. For the no-login
+> single-user experience, run klangk locally via devenv (below) instead.
+> See [Auth Modes](features/auth-modes.md) and
+> [#1391](https://github.com/mcdonc/klangk/issues/1391).
 
 ## Run Using devenv
 


### PR DESCRIPTION
## Summary

Documents [#1391](https://github.com/mcdonc/klangk/issues/1391): `KLANGKD_AUTH_MODES=none` (no-login, loopback-only) is now declared an **unsupported configuration** with the published Docker host image. The image uses **password auth** by default — every Docker example already pins `KLANGKD_AUTH_MODES=password`, and this PR makes that the documented, supported posture rather than a temporary "until #1391 lands" workaround.

## Why `none` can't work in Docker

The image publishes its browser port (`-p 8997:8997`), making it network-reachable, while `none` mode is loopback-only by design — it freely issues an admin token with no password, so its entire security model is "only the operator's loopback can reach `/auth/local`." Two independent gates refuse it:

1. **Bind-safety gate** — `none` won't boot on a non-loopback bind (publishing the port requires binding `0.0.0.0`). `KLANGKD_ALLOW_INSECURE_NO_AUTH=1` overrides this, but only to warn and expose a free-admin-token endpoint to the whole network.
2. **Proxy `/auth/local` ACL** — even past the bind gate, a host browser reaching the container through the published port-forward appears at the container as the Docker bridge/gateway IP (e.g. `172.17.0.1`), not `127.0.0.1`, so the loopback-only ACL denies `/api/v1/auth/local` with `403`.

For a no-login single-user experience, the docs now direct users to run klangk locally (devenv, or the bare binary) instead of the published image.

## Changes

- **`docs/deployment/docker.md`** — replaced the brief "until #1391" note with a full explanation of why the image uses password auth and why `none` is unsupported (both gates).
- **`docs/deployment/customizing.md`** — removed the misleading `docker run ... KLANGKD_AUTH_MODES=none` example; rewrote the "Note for Docker users" admonition to declare `none` unsupported.
- **`docs/getting-started.md`** — strengthened the admonition to call `none` unsupported in the published image and point at devenv.
- **`docs/features/auth-modes.md`** — added a prominent admonition at the top of the "No-auth mode (`none`)" section.
- **`docs/changes.md`** — added a `Changed` entry under `[Unreleased]`, and updated the existing `Breaking` note from "not yet supported" to "an unsupported configuration."

Docs-only; no code or behavior change.
