### PR TITLE
feat(klangkd): LiteLLM aggregator sidecar for multi-provider LLM routing

### DIFF
--- a/docs/architecture/llm-proxy.md
+++ b/docs/architecture/llm-proxy.md
@@ -20,3 +20,78 @@ location /llm-proxy/ {
 ```
 
 In CI, `devenv processes up -d` starts the proxy before E2E tests run.
+
+## Multiple models from one provider
+
+If the upstream pointed to by `KLANGKD_LLM_BASE_URL` serves multiple models (e.g. OpenAI's API exposes `gpt-4o`, `gpt-4o-mini`, `o3`; or a self-hosted vLLM/Ollama instance serving several models), **no klangk changes are needed**. The `llm-proxy-models.ts` extension calls `GET /models` on the proxy, discovers every model the upstream advertises, and registers them all with Pi. The user picks any discovered model from Pi's model selector.
+
+## Multiple providers (LLM aggregator sidecar)
+
+To route to **multiple distinct providers** (e.g. OpenAI + Anthropic + a local Ollama, each with its own base URL and API key), klangk can run a **LiteLLM aggregator sidecar** (#2046). The sidecar is a podman container (`ghcr.io/berriai/litellm`) that exposes a single OpenAI-compatible endpoint and routes per-request by `model` name. The existing proxy plumbing and model discovery work unchanged.
+
+### How it works
+
+1. The operator configures `KLANGKD_LLM_AGGREGATOR_MODELS` with a list of `provider/model:api_base:api_key` entries.
+2. At startup, klangk renders a LiteLLM `config.yaml` from those entries and runs the LiteLLM container with that config (config-only mode, no DB, no UI).
+3. `KLANGKD_LLM_BASE_URL` points at the sidecar (`http://127.0.0.1:4000/v1`).
+4. The proxy forwards `/llm-proxy/` to the sidecar, which routes to the correct provider based on the `model` field in each request.
+5. `llm-proxy-models.ts` calls `/models` on the sidecar and discovers all models across all configured providers.
+
+### Configuration
+
+Set these environment variables (or their equivalents in `klangkd.yaml`):
+
+```bash
+# Required: list of provider/model entries (comma-separated).
+# Format: litellm_model:api_base:api_key
+#   - litellm_model: provider/model in LiteLLM notation
+#   - api_base: provider API base URL (empty = use provider default)
+#   - api_key: provider API key (empty = keyless, e.g. local Ollama)
+KLANGKD_LLM_AGGREGATOR_MODELS="openai/gpt-4o::sk-xxx,anthropic/claude-sonnet-4::sk-ant-xxx,ollama/llama3:http://gpu:11434:"
+
+# Point the proxy at the sidecar.
+KLANGKD_LLM_BASE_URL="http://127.0.0.1:4000/v1"
+
+# Optional: master key for the LiteLLM sidecar (default: empty = no auth).
+KLANGKD_LLM_AGGREGATOR_MASTER_KEY="sk-master"
+
+# Optional: host port the sidecar listens on (default: 4000).
+KLANGKD_LLM_AGGREGATOR_PORT=4000
+
+# Optional: container image (default: ghcr.io/berriai/litellm:main-stable).
+KLANGKD_LLM_AGGREGATOR_IMAGE="ghcr.io/berriai/litellm:main-stable"
+```
+
+Or in `klangkd.yaml`:
+
+```yaml
+llm-base-url: "http://127.0.0.1:4000/v1"
+llm-aggregator-models:
+  - "openai/gpt-4o::sk-xxx"
+  - "anthropic/claude-sonnet-4::sk-ant-xxx"
+  - "ollama/llama3:http://gpu:11434:"
+llm-aggregator-master-key: "sk-master"
+```
+
+### Architecture
+
+```text
+Pi container
+  → host.containers.internal:8995/llm-proxy/chat/completions
+    → reverse proxy (caddy/nginx)
+      → http://127.0.0.1:4000/v1/chat/completions   (LiteLLM sidecar)
+        → routes by "model" field in request body:
+          → openai/gpt-4o    → https://api.openai.com/v1
+          → anthropic/...    → https://api.anthropic.com/v1
+          → ollama/llama3    → http://gpu:11434
+```
+
+The sidecar is supervised by `LiteLLMWatchdog` (mirroring `ProxyWatchdog`): it respawns on unexpected exit with exponential backoff, and is stopped cleanly on shutdown. Settings changes via SIGHUP trigger a container restart with the re-rendered config.
+
+### Provider defaults
+
+When `api_base` is empty, the following providers use their well-known API base URLs automatically: `openai`, `anthropic`, `cohere`, `mistral`, `groq`, `together_ai`, `deepseek`, `fireworks_ai`. For any other provider (or a custom endpoint), supply the full `api_base`.
+
+### Packaging decision
+
+LiteLLM pulls a large dependency tree. To avoid polluting klangk's Python venv, the sidecar runs as a **podman container** using the official `ghcr.io/berriai/litellm` image. This is the cleanest NixOS-friendly route and reuses the podman infrastructure klangk already depends on for workspaces.

--- a/docs/architecture/llm-proxy.md
+++ b/docs/architecture/llm-proxy.md
@@ -62,7 +62,7 @@ KLANGKD_LLM_AGGREGATOR_PORT=4000
 KLANGKD_LLM_AGGREGATOR_IMAGE="ghcr.io/berriai/litellm:main-stable"
 ```
 
-Or in `klangkd.yaml`:
+Or in `klangkd.yaml` (colon-delimited strings):
 
 ```yaml
 llm-base-url: "http://127.0.0.1:4000/v1"
@@ -72,6 +72,22 @@ llm-aggregator-models:
   - "ollama/llama3:http://gpu:11434:"
 llm-aggregator-master-key: "sk-master"
 ```
+
+Or using the dict format (recommended for `klangkd.yaml` — supports `file:` and `cmd:` indirection on secrets so API keys stay out of the config file):
+
+```yaml
+llm-base-url: "http://127.0.0.1:4000/v1"
+llm-aggregator-models:
+  - id: openai/gpt-4o
+    api-key: "cmd:pass show openai/api-key"
+  - id: anthropic/claude-sonnet-4
+    api-key: "file:/run/secrets/anthropic-key"
+  - id: ollama/llama3
+    base-url: "http://gpu:11434"
+llm-aggregator-master-key: "sk-master"
+```
+
+Each dict entry has `id` (required), `base-url` (optional — omit to use provider default), and `api-key` (optional — omit for keyless providers like local Ollama). Both `api-key` and `base-url` support `file:<path>` and `cmd:<command>` indirection.
 
 ### Architecture
 
@@ -86,7 +102,7 @@ Pi container
           → ollama/llama3    → http://gpu:11434
 ```
 
-The sidecar is supervised by `LiteLLMWatchdog` (mirroring `ProxyWatchdog`): it respawns on unexpected exit with exponential backoff, and is stopped cleanly on shutdown. Settings changes via SIGHUP trigger a container restart with the re-rendered config.
+The sidecar is supervised by `LiteLLMWatchdog` (mirroring `ProxyWatchdog`): it respawns on unexpected exit with exponential backoff, and is stopped cleanly on shutdown. Settings changes via SIGHUP trigger a container restart with the re-rendered config only when aggregator settings actually changed (other SIGHUP changes are ignored). Removing all models via SIGHUP stops the sidecar. The container port is bound to `127.0.0.1` (loopback only) so the sidecar is not reachable from the LAN.
 
 ### Provider defaults
 

--- a/src/klangk/klangk/litellm.py
+++ b/src/klangk/klangk/litellm.py
@@ -228,7 +228,7 @@ class LiteLLMWatchdog:
             self._app.state.settings.state_dir, "litellm-config.yaml"
         )
 
-    async def _watch(self, conf_path: str) -> None:  # pragma: no cover
+    async def _watch(self, conf_path: str) -> None:
         """Create, start, and respawn the LiteLLM container on exit."""
         backoff = 1.0
         while not self._stopping:
@@ -281,7 +281,7 @@ class LiteLLMWatchdog:
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 30.0)
 
-    async def _wait_for_exit(self) -> None:  # pragma: no cover
+    async def _wait_for_exit(self) -> None:
         """Poll until the container is no longer running."""
         podman = self._app.state.podman
         while not self._stopping:
@@ -301,7 +301,7 @@ class LiteLLMWatchdog:
                 return
             await asyncio.sleep(2.0)
 
-    async def _remove_container(self) -> None:  # pragma: no cover
+    async def _remove_container(self) -> None:
         """Remove the sidecar container if it exists."""
         podman = self._app.state.podman
         try:
@@ -314,7 +314,7 @@ class LiteLLMWatchdog:
         settings = self._app.state.settings
         if not settings.llm_aggregator_models:
             return
-        if os.environ.get("_KLANGKD_DISABLE_LITELLM"):  # pragma: no cover
+        if os.environ.get("_KLANGKD_DISABLE_LITELLM"):
             return
         conf_path = self._config_path()
         self._renderer.write_config(conf_path)
@@ -325,7 +325,7 @@ class LiteLLMWatchdog:
         """Stop the sidecar container and cancel the watchdog."""
         self._stopping = True
         task = self._task
-        if task is not None:  # pragma: no cover
+        if task is not None:
             task.cancel()
             try:
                 await task

--- a/src/klangk/klangk/litellm.py
+++ b/src/klangk/klangk/litellm.py
@@ -15,9 +15,9 @@ Architecture mirrors :mod:`klangk.proxy` (``ProxyRenderer`` + ``ProxyWatchdog``)
 - :class:`LiteLLMWatchdog` owns the podman container lifecycle
   (create / start / stop / remove) and supervises it with a respawn loop.
 
-The container runs on the host network (``--network=host``) so that the proxy
-can reach it at ``127.0.0.1:<port>`` without port-forwarding complexity, and
-so LiteLLM can reach provider endpoints directly.
+The container publishes its port on ``127.0.0.1`` only (loopback) so that
+the proxy can reach it at ``127.0.0.1:<port>`` while the sidecar is not
+reachable from the LAN.
 """
 
 from __future__ import annotations
@@ -31,13 +31,12 @@ import yaml
 logger = logging.getLogger(__name__)
 
 _CONTAINER_NAME = "klangk-litellm"
-_CONTAINER_LABEL = "klangk.managed=true"
+_CONTAINER_LABELS = {"klangk.managed": "true"}
 
 # Provider defaults: well-known providers whose api_base can be omitted.
 _PROVIDER_DEFAULTS: dict[str, str] = {
     "openai": "https://api.openai.com/v1",
     "anthropic": "https://api.anthropic.com/v1",
-    "azure": "",  # requires explicit api_base
     "cohere": "https://api.cohere.ai/v1",
     "mistral": "https://api.mistral.ai/v1",
     "groq": "https://api.groq.com/openai/v1",
@@ -179,19 +178,36 @@ class LiteLLMWatchdog:
         self._renderer = LiteLLMRenderer(app)
         self._task: asyncio.Task | None = None
         self._stopping = False
+        self._pending_reload = False
 
     def reconfigure(self, app) -> None:
+        old = self._app.state.settings
         self._app = app
         self._renderer.reconfigure(app)
-        self._pending_reload = True
+        new = app.state.settings
+        if (
+            old.llm_aggregator_models != new.llm_aggregator_models
+            or old.llm_aggregator_master_key != new.llm_aggregator_master_key
+            or old.llm_aggregator_port != new.llm_aggregator_port
+            or old.llm_aggregator_image != new.llm_aggregator_image
+        ):
+            self._pending_reload = True
 
-    async def apply_pending_reload(self) -> None:  # pragma: no cover
+    async def apply_pending_reload(self) -> None:
         """Restart the sidecar container if settings changed."""
-        if not getattr(self, "_pending_reload", False):
+        if not self._pending_reload:
             return
         self._pending_reload = False
         settings = self._app.state.settings
         if not settings.llm_aggregator_models:
+            self._stopping = True
+            if self._task is not None:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+                self._task = None
             await self._remove_container()
             return
         # Stop + restart with new config.
@@ -222,11 +238,10 @@ class LiteLLMWatchdog:
             image = settings.llm_aggregator_image
 
             try:
-                await self._remove_container()
                 container_id = await podman.create_container(
                     _CONTAINER_NAME,
                     image,
-                    labels={"klangk.managed": "true"},
+                    labels=_CONTAINER_LABELS,
                     binds=[f"{conf_path}:/app/config.yaml:ro,Z"],
                     env=[
                         f"LITELLM_MASTER_KEY={settings.llm_aggregator_master_key}",
@@ -234,7 +249,7 @@ class LiteLLMWatchdog:
                         "STORE_MODEL_IN_DB=False",
                         "LITELLM_LOG=ERROR",
                     ],
-                    publish=[(port, 4000)],
+                    publish=[("127.0.0.1", port, 4000)],
                     pull="missing",
                     replace=True,
                 )
@@ -299,7 +314,7 @@ class LiteLLMWatchdog:
         settings = self._app.state.settings
         if not settings.llm_aggregator_models:
             return
-        if os.environ.get("_KLANGKD_DISABLE_PROXY"):  # pragma: no cover
+        if os.environ.get("_KLANGKD_DISABLE_LITELLM"):  # pragma: no cover
             return
         conf_path = self._config_path()
         self._renderer.write_config(conf_path)

--- a/src/klangk/klangk/litellm.py
+++ b/src/klangk/klangk/litellm.py
@@ -1,0 +1,320 @@
+"""LiteLLM aggregator sidecar: renderer + watchdog (#2046).
+
+When the operator configures ``KLANGKD_LLM_AGGREGATOR_MODELS``, klangk runs a
+LiteLLM container as a supervised sidecar.  The container exposes a single
+OpenAI-compatible endpoint that routes per-request by ``model`` name to the
+configured providers.  The proxy's ``KLANGKD_LLM_BASE_URL`` should point at
+this sidecar (``http://127.0.0.1:<port>/v1``); the existing ``/llm-proxy/``
+block and ``llm-proxy-models.ts`` model discovery keep working unchanged.
+
+Architecture mirrors :mod:`klangk.proxy` (``ProxyRenderer`` + ``ProxyWatchdog``):
+
+- :class:`LiteLLMRenderer` is a pure function of the merged settings.  It
+  emits a ``config.yaml`` that LiteLLM reads at startup (config-only mode,
+  no DB, no UI).
+- :class:`LiteLLMWatchdog` owns the podman container lifecycle
+  (create / start / stop / remove) and supervises it with a respawn loop.
+
+The container runs on the host network (``--network=host``) so that the proxy
+can reach it at ``127.0.0.1:<port>`` without port-forwarding complexity, and
+so LiteLLM can reach provider endpoints directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_CONTAINER_NAME = "klangk-litellm"
+_CONTAINER_LABEL = "klangk.managed=true"
+
+# Provider defaults: well-known providers whose api_base can be omitted.
+_PROVIDER_DEFAULTS: dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+    "anthropic": "https://api.anthropic.com/v1",
+    "azure": "",  # requires explicit api_base
+    "cohere": "https://api.cohere.ai/v1",
+    "mistral": "https://api.mistral.ai/v1",
+    "groq": "https://api.groq.com/openai/v1",
+    "together_ai": "https://api.together.xyz/v1",
+    "deepseek": "https://api.deepseek.com/v1",
+    "fireworks_ai": "https://api.fireworks.ai/inference/v1",
+}
+
+
+def parse_model_entry(entry: str) -> dict:
+    """Parse a ``provider/model:api_base:api_key`` string into a LiteLLM
+    ``model_list`` entry dict.
+
+    The format uses the **first** colon as the model/api_base boundary and
+    the **last** colon as the api_base/api_key boundary::
+
+        litellm_model:api_base:api_key
+
+    ``litellm_model`` is in LiteLLM's ``provider/model`` notation (e.g.
+    ``openai/gpt-4o``, ``anthropic/claude-sonnet-4``,
+    ``ollama/llama3``).  ``api_base`` can be empty to use the provider's
+    default.  ``api_key`` can be empty for keyless providers (e.g. local
+    Ollama).  Because URLs contain ``://``, a naive ``split(":")`` would
+    break; the first/last boundary rule handles this correctly:
+
+    - ``openai/gpt-4o::sk-xxx`` → model ``openai/gpt-4o``, base ``""``,
+      key ``sk-xxx``
+    - ``ollama/llama3:http://gpu:11434:`` → model ``ollama/llama3``,
+      base ``http://gpu:11434``, key ``""``
+
+    Returns a dict suitable for inclusion in LiteLLM's ``model_list``.
+    """
+    # Split on first colon → (model, rest), then split rest on last colon
+    # → (api_base, api_key).  This keeps URLs intact in api_base.
+    first_colon = entry.find(":")
+    if first_colon == -1:
+        litellm_model = entry
+        api_base = ""
+        api_key = ""
+    else:
+        litellm_model = entry[:first_colon]
+        rest = entry[first_colon + 1 :]
+        last_colon = rest.rfind(":")
+        if last_colon == -1:
+            api_base = rest
+            api_key = ""
+        else:
+            api_base = rest[:last_colon]
+            api_key = rest[last_colon + 1 :]
+
+    # Derive a human-friendly model_name (the name clients use in the
+    # request body's "model" field).  Use the part after the provider
+    # slash if present.
+    if "/" in litellm_model:
+        provider, model_name = litellm_model.split("/", 1)
+    else:
+        provider = ""
+        model_name = litellm_model
+
+    # Resolve api_base from provider defaults if not explicit.
+    if not api_base and provider in _PROVIDER_DEFAULTS:
+        api_base = _PROVIDER_DEFAULTS[provider]
+
+    params: dict = {
+        "model": litellm_model,
+    }
+    if api_base:
+        params["api_base"] = api_base
+    if api_key:
+        params["api_key"] = api_key
+
+    return {
+        "model_name": model_name,
+        "litellm_params": params,
+    }
+
+
+class LiteLLMRenderer:
+    """Renders a LiteLLM ``config.yaml`` from klangk settings.
+
+    Pure function of ``app.state.settings`` — no side effects beyond
+    writing the config file to disk.
+    """
+
+    def __init__(self, app) -> None:
+        self._app = app
+
+    def reconfigure(self, app) -> None:
+        self._app = app
+
+    def render_config(self) -> str:
+        """Return the YAML content for LiteLLM's ``config.yaml``."""
+        settings = self._app.state.settings
+        models = settings.llm_aggregator_models
+        if not models:
+            return ""
+
+        model_list = [parse_model_entry(entry) for entry in models]
+
+        config: dict = {
+            "model_list": model_list,
+        }
+
+        master_key = settings.llm_aggregator_master_key
+        if master_key:
+            config["general_settings"] = {
+                "master_key": master_key,
+            }
+
+        return yaml.dump(config, default_flow_style=False, sort_keys=False)
+
+    def write_config(self, conf_path: str) -> None:
+        """Render and write the config to *conf_path*."""
+        content = self.render_config()
+        if not content:
+            return
+        with open(
+            os.open(conf_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600),
+            "w",
+        ) as f:
+            f.write(content)
+        logger.debug("litellm config written to %s", conf_path)
+
+
+class LiteLLMWatchdog:
+    """Owns the LiteLLM sidecar container and its supervision (#2046).
+
+    Mirrors :class:`klangk.proxy.ProxyWatchdog`: constructed with
+    ``app``, stored on ``app.state.litellm_watchdog``; the lifespan
+    calls ``.start()`` / ``.stop()``.
+
+    The sidecar is a podman container (``ghcr.io/berriai/litellm``),
+    not a native process, to avoid pulling LiteLLM's large dependency
+    tree into klangk's venv.
+    """
+
+    def __init__(self, app) -> None:
+        self._app = app
+        self._renderer = LiteLLMRenderer(app)
+        self._task: asyncio.Task | None = None
+        self._stopping = False
+
+    def reconfigure(self, app) -> None:
+        self._app = app
+        self._renderer.reconfigure(app)
+        self._pending_reload = True
+
+    async def apply_pending_reload(self) -> None:  # pragma: no cover
+        """Restart the sidecar container if settings changed."""
+        if not getattr(self, "_pending_reload", False):
+            return
+        self._pending_reload = False
+        settings = self._app.state.settings
+        if not settings.llm_aggregator_models:
+            await self._remove_container()
+            return
+        # Stop + restart with new config.
+        await self._remove_container()
+        conf_path = self._config_path()
+        self._renderer.write_config(conf_path)
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._stopping = False
+        self._task = asyncio.create_task(self._watch(conf_path))
+
+    def _config_path(self) -> str:
+        return os.path.join(
+            self._app.state.settings.state_dir, "litellm-config.yaml"
+        )
+
+    async def _watch(self, conf_path: str) -> None:  # pragma: no cover
+        """Create, start, and respawn the LiteLLM container on exit."""
+        backoff = 1.0
+        while not self._stopping:
+            podman = self._app.state.podman
+            settings = self._app.state.settings
+            port = settings.llm_aggregator_port
+            image = settings.llm_aggregator_image
+
+            try:
+                await self._remove_container()
+                container_id = await podman.create_container(
+                    _CONTAINER_NAME,
+                    image,
+                    labels={"klangk.managed": "true"},
+                    binds=[f"{conf_path}:/app/config.yaml:ro,Z"],
+                    env=[
+                        f"LITELLM_MASTER_KEY={settings.llm_aggregator_master_key}",
+                        "DATABASE_URL=",
+                        "STORE_MODEL_IN_DB=False",
+                        "LITELLM_LOG=ERROR",
+                    ],
+                    publish=[(port, 4000)],
+                    pull="missing",
+                    replace=True,
+                )
+                await podman.start_container(container_id)
+                logger.info(
+                    "litellm sidecar started (container %s) on port %d",
+                    container_id[:12],
+                    port,
+                )
+            except Exception:
+                logger.exception(
+                    "litellm sidecar failed to start; retrying in %.1fs",
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+                continue
+
+            # Wait for the container to exit.
+            backoff = 1.0
+            await self._wait_for_exit()
+
+            if self._stopping:
+                return
+            logger.warning(
+                "litellm sidecar exited unexpectedly; restarting in %.1fs",
+                backoff,
+            )
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+
+    async def _wait_for_exit(self) -> None:  # pragma: no cover
+        """Poll until the container is no longer running."""
+        podman = self._app.state.podman
+        while not self._stopping:
+            try:
+                rc, out, _err = await podman.run(
+                    [
+                        "inspect",
+                        "--format",
+                        "{{.State.Running}}",
+                        _CONTAINER_NAME,
+                    ],
+                    check=False,
+                )
+                if rc != 0 or out.strip().lower() != "true":
+                    return
+            except Exception:
+                return
+            await asyncio.sleep(2.0)
+
+    async def _remove_container(self) -> None:  # pragma: no cover
+        """Remove the sidecar container if it exists."""
+        podman = self._app.state.podman
+        try:
+            await podman.remove_container(_CONTAINER_NAME)
+        except Exception:
+            logger.debug("litellm container removal (expected on first start)")
+
+    async def start(self) -> None:
+        """Render config and start the LiteLLM sidecar if configured."""
+        settings = self._app.state.settings
+        if not settings.llm_aggregator_models:
+            return
+        if os.environ.get("_KLANGKD_DISABLE_PROXY"):  # pragma: no cover
+            return
+        conf_path = self._config_path()
+        self._renderer.write_config(conf_path)
+        self._stopping = False
+        self._task = asyncio.create_task(self._watch(conf_path))
+
+    async def stop(self) -> None:
+        """Stop the sidecar container and cancel the watchdog."""
+        self._stopping = True
+        task = self._task
+        if task is not None:  # pragma: no cover
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+            await self._remove_container()

--- a/src/klangk/klangk/litellm.py
+++ b/src/klangk/klangk/litellm.py
@@ -269,17 +269,17 @@ class LiteLLMWatchdog:
                 continue
 
             # Wait for the container to exit.
-            backoff = 1.0
             await self._wait_for_exit()
 
             if self._stopping:
                 return
+            # Reset backoff — the container ran (start succeeded).
+            backoff = 1.0
             logger.warning(
                 "litellm sidecar exited unexpectedly; restarting in %.1fs",
                 backoff,
             )
             await asyncio.sleep(backoff)
-            backoff = min(backoff * 2, 30.0)
 
     async def _wait_for_exit(self) -> None:
         """Poll until the container is no longer running."""

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -21,6 +21,7 @@ from . import (
     container,
     emailsvc,
     files,
+    litellm as litellm_mod,
     model,
     proxy as proxy_mod,
     caddy as caddy_mod,
@@ -476,6 +477,7 @@ class Lifecycle:
             "sockets",
             "container_registry",
             "proxy_watchdog",
+            "litellm_watchdog",
             "terminal",
             "oidc",
             "features",
@@ -515,6 +517,18 @@ class Lifecycle:
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "SIGHUP: caddy config reload failed (skipped): %s", exc
+                )
+        # #2046: LiteLLM watchdog reconfigure flags a container restart
+        # if aggregator settings changed; apply it now (async).
+        litellm_wd = getattr(app.state, "litellm_watchdog", None)
+        if litellm_wd is not None and hasattr(
+            litellm_wd, "apply_pending_reload"
+        ):
+            try:
+                await litellm_wd.apply_pending_reload()
+            except Exception as exc:  # noqa: BLE001  # pragma: no cover
+                logger.warning(
+                    "SIGHUP: litellm config reload failed (skipped): %s", exc
                 )
         # #1610: remount frontend_dir if it changed.
         if old.frontend_dir != new.frontend_dir:
@@ -698,6 +712,8 @@ async def lifespan(app: FastAPI):
     # Start the proxy (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.proxy_watchdog.start()
+    # Start the LiteLLM aggregator sidecar if configured (#2046).
+    await app.state.litellm_watchdog.start()
     logger.info("Klangk backend started")
 
     # uvicorn only handles SIGINT/SIGTERM, so SIGHUP is ours to claim:
@@ -713,6 +729,7 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
+        await app.state.litellm_watchdog.stop()
         await app.state.proxy_watchdog.stop()
         await app.state.lifecycle.runtime_shutdown()
         await app.state.lifecycle.process_shutdown()
@@ -900,6 +917,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
     else:
         app.state.proxy_watchdog = proxy_mod.ProxyWatchdog(app)
+    # #2046: LiteLLM aggregator sidecar — supervised podman container that
+    # provides a single OpenAI-compatible endpoint routing to multiple
+    # providers. Opt-in via KLANGKD_LLM_AGGREGATOR_MODELS.
+    app.state.litellm_watchdog = litellm_mod.LiteLLMWatchdog(app)
     # #1480: Terminal(app_state) groups the ~25 tmux-session
     # management functions that share a Podman dependency. Reaches podman,
     # the registry, and settings through the single app_state reference.

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -259,7 +259,7 @@ class Podman:
         labels: dict[str, str] | None = None,
         binds: list[str] | None = None,
         tmpfs: dict[str, str] | None = None,
-        publish: list[tuple[int, int]] | None = None,
+        publish: list[tuple[int, int] | tuple[str, int, int]] | None = None,
         add_hosts: list[str] | None = None,
         dns: list[str] | None = None,
         env: list[str] | None = None,
@@ -278,7 +278,8 @@ class Podman:
     ) -> str:
         """Create a container and return its id.
 
-        ``publish`` is a list of ``(host_port, container_port)`` pairs.
+        ``publish`` is a list of ``(host_port, container_port)`` or
+        ``(bind_addr, host_port, container_port)`` tuples.
         ``replace=True`` removes an existing container with the same name.
         ``annotations``/``hooks_dir`` carry per-workspace OCI hooks (e.g.
         the netfilter egress filter, #1365): each annotation becomes a
@@ -325,8 +326,13 @@ class Podman:
             args += ["-v", bind]
         for path, opts in (tmpfs or {}).items():
             args += ["--tmpfs", f"{path}:{opts}"]
-        for host_port, container_port in publish or []:
-            args += ["-p", f"{host_port}:{container_port}"]
+        for entry in publish or []:
+            if len(entry) == 3:
+                bind, host_port, container_port = entry
+                args += ["-p", f"{bind}:{host_port}:{container_port}"]
+            else:
+                host_port, container_port = entry
+                args += ["-p", f"{host_port}:{container_port}"]
         for host in add_hosts or []:
             args += ["--add-host", host]
         for server in dns or []:

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -720,6 +720,19 @@ class KlangkSettings(BaseSettings):
     llm_base_url: str | None = None
     llm_api_key: str = ""
     llm_model: str = ""
+    # --- LLM aggregator (LiteLLM sidecar, #2046) ---
+    # When set, klangk renders a LiteLLM config.yaml and runs a LiteLLM
+    # container as a sidecar.  The proxy's KLANGKD_LLM_BASE_URL should
+    # then point at the sidecar (http://127.0.0.1:<port>/v1).
+    # Each entry is "provider/model:api_base:api_key" — e.g.
+    #   openai/gpt-4o::sk-xxx          (api_base defaults to provider)
+    #   anthropic/claude-sonnet-4::sk-ant-xxx
+    #   ollama/llama3:http://gpu:11434:
+    # Comma-separated in the env var; a YAML list in klangkd.yaml.
+    llm_aggregator_models: list[str] | None = None
+    llm_aggregator_master_key: str = ""
+    llm_aggregator_port: int = 4000
+    llm_aggregator_image: str = "ghcr.io/berriai/litellm:main-stable"
 
     # --- OIDC ---
     oidc_config: str | None = None
@@ -1224,6 +1237,38 @@ class KlangkSettings(BaseSettings):
                 f"KLANGKD_CONTAINER_PIDS_LIMIT={v!r} must be > 0."
             )
         return value
+
+    @field_validator("llm_aggregator_models", mode="before")
+    @classmethod
+    def _coerce_llm_aggregator_models(cls, v):
+        """Accept comma-separated string (env) or list (YAML) (#2046).
+
+        Each entry is ``provider/model:api_base:api_key``. A bare
+        ``provider/model::key`` uses the provider's default API base. An
+        empty value or ``None`` → ``None`` (aggregator disabled).
+        """
+        if v is None:
+            return None
+        if isinstance(v, str):
+            items = [s.strip() for s in v.split(",")]
+            items = [i for i in items if i]
+        elif isinstance(v, list):
+            items = [str(s).strip() for s in v if str(s).strip()]
+        else:  # pragma: no cover
+            raise ValueError(
+                f"KLANGKD_LLM_AGGREGATOR_MODELS={v!r} must be a list or "
+                f"a comma-separated string (got {type(v).__name__})."
+            )
+        if not items:
+            return None
+        for item in items:
+            if item.count(":") < 2:
+                raise ValueError(
+                    f"KLANGKD_LLM_AGGREGATOR_MODELS entry {item!r} must be "
+                    f"'provider/model:api_base:api_key' (need at least two "
+                    f"colons separating the three fields)."
+                )
+        return items
 
     @model_validator(mode="after")
     def _warn_on_deprecated_proxy_engine(self) -> "KlangkSettings":

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -1243,31 +1243,56 @@ class KlangkSettings(BaseSettings):
     def _coerce_llm_aggregator_models(cls, v):
         """Accept comma-separated string (env) or list (YAML) (#2046).
 
-        Each entry is ``provider/model:api_base:api_key``. A bare
-        ``provider/model::key`` uses the provider's default API base. An
-        empty value or ``None`` → ``None`` (aggregator disabled).
+        Each entry is either:
+
+        - A colon-delimited string: ``provider/model:api_base:api_key``
+          (a bare ``provider/model::key`` uses the provider's default
+          API base).
+        - A dict with ``id`` (required), ``base-url``/``base_url``,
+          and ``api-key``/``api_key``.  The dict form lets values use
+          ``file:`` / ``cmd:`` indirection so secrets stay out of config.
+
+        An empty value or ``None`` → ``None`` (aggregator disabled).
         """
         if v is None:
             return None
         if isinstance(v, str):
-            items = [s.strip() for s in v.split(",")]
-            items = [i for i in items if i]
+            raw = [s.strip() for s in v.split(",")]
+            raw = [i for i in raw if i]
         elif isinstance(v, list):
-            items = [str(s).strip() for s in v if str(s).strip()]
+            raw = [i for i in v if i]
         else:  # pragma: no cover
             raise ValueError(
                 f"KLANGKD_LLM_AGGREGATOR_MODELS={v!r} must be a list or "
                 f"a comma-separated string (got {type(v).__name__})."
             )
-        if not items:
+        if not raw:
             return None
-        for item in items:
-            if item.count(":") < 2:
-                raise ValueError(
-                    f"KLANGKD_LLM_AGGREGATOR_MODELS entry {item!r} must be "
-                    f"'provider/model:api_base:api_key' (need at least two "
-                    f"colons separating the three fields)."
-                )
+        items: list[str] = []
+        for entry in raw:
+            if isinstance(entry, dict):
+                model_id = entry.get("id")
+                if not model_id:
+                    raise ValueError(
+                        "KLANGKD_LLM_AGGREGATOR_MODELS dict entry must "
+                        "have an 'id' key."
+                    )
+                base_url = entry.get("base-url") or entry.get("base_url", "")
+                api_key = entry.get("api-key") or entry.get("api_key", "")
+                # Resolve file:/cmd: indirection on secrets.
+                api_key = _resolve_indirection(api_key, "api-key") or ""
+                base_url = _resolve_indirection(base_url, "base-url") or ""
+                items.append(f"{model_id}:{base_url}:{api_key}")
+            else:
+                item = str(entry).strip()
+                if item.count(":") < 2:
+                    raise ValueError(
+                        f"KLANGKD_LLM_AGGREGATOR_MODELS entry {item!r} "
+                        f"must be 'provider/model:api_base:api_key' "
+                        f"(need at least two colons separating the three "
+                        f"fields)."
+                    )
+                items.append(item)
         return items
 
     @model_validator(mode="after")

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
@@ -104,6 +104,7 @@ def clean_env(**overrides: str) -> dict[str, str]:
         env["XDG_STATE_HOME"] = f"{overrides['HOME']}/.local/state"
     # E2E baseline defaults.
     env["_KLANGKD_DISABLE_PROXY"] = "1"
+    env["_KLANGKD_DISABLE_LITELLM"] = "1"
     env.setdefault("KLANGKD_AUTH_MODES", "password")
     env.update(overrides)
     return env

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -41,9 +41,11 @@ def _disable_proxy(monkeypatch):
     The lifespan's proxy watchdog is unconditional in real runs; tests boot
     the app (often via the lifespan) and never want a real proxy (nginx)
     process.
-    Sets the internal, non-user-facing ``_KLANGKD_DISABLE_PROXY`` kill switch.
+    Sets the internal, non-user-facing ``_KLANGKD_DISABLE_PROXY`` and
+    ``_KLANGKD_DISABLE_LITELLM`` kill switches.
     """
     monkeypatch.setenv("_KLANGKD_DISABLE_PROXY", "1")
+    monkeypatch.setenv("_KLANGKD_DISABLE_LITELLM", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/src/klangk/klangkd-tests/tests/test_litellm.py
+++ b/src/klangk/klangkd-tests/tests/test_litellm.py
@@ -623,6 +623,43 @@ class TestLiteLLMWatchdog:
         create_calls = [c for c in podman.calls if c[0] == "create"]
         assert len(create_calls) == 2
 
+    async def test_watch_backoff_resets_after_successful_run(self):
+        """Backoff resets to 1.0 after each successful container run,
+        so repeated unexpected exits don't escalate the delay."""
+        podman = _FakePodman()
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s, podman=podman)
+
+        sleep_durations = []
+
+        async def _tracking_sleep(duration):
+            sleep_durations.append(duration)
+            # Don't actually sleep.
+
+        exit_count = 0
+
+        async def _fake_wait():
+            nonlocal exit_count
+            exit_count += 1
+            if exit_count >= 3:
+                wd._stopping = True
+
+        wd._wait_for_exit = _fake_wait
+        conf_path = wd._config_path()
+        wd._renderer.write_config(conf_path)
+
+        orig_asyncio_sleep = asyncio.sleep
+        asyncio.sleep = _tracking_sleep
+        try:
+            await wd._watch(conf_path)
+        finally:
+            asyncio.sleep = orig_asyncio_sleep
+
+        # Each respawn should sleep 1.0 (reset), not 1.0 then 2.0.
+        assert sleep_durations == [1.0, 1.0]
+
     async def test_watch_retries_on_create_failure(self):
         """_watch retries with backoff when create_container fails."""
         podman = _FakePodman()

--- a/src/klangk/klangkd-tests/tests/test_litellm.py
+++ b/src/klangk/klangkd-tests/tests/test_litellm.py
@@ -148,6 +148,106 @@ class TestSettingsValidator:
         os.unlink(f.name)
         assert s.llm_aggregator_models == ["openai/gpt-4o::sk-xxx"]
 
+    def test_dict_entry_from_yaml(self):
+        """YAML dict entries with id/base-url/api-key are accepted."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(
+                {
+                    "llm-aggregator-models": [
+                        {
+                            "id": "openai/gpt-4o",
+                            "api-key": "sk-xxx",
+                        }
+                    ]
+                },
+                f,
+            )
+            f.flush()
+            s = make_settings({}, config_file=f.name)
+        os.unlink(f.name)
+        assert s.llm_aggregator_models == ["openai/gpt-4o::sk-xxx"]
+
+    def test_dict_entry_with_base_url(self):
+        """Dict entry with explicit base-url."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(
+                {
+                    "llm-aggregator-models": [
+                        {
+                            "id": "ollama/llama3",
+                            "base-url": "http://gpu:11434",
+                            "api-key": "",
+                        }
+                    ]
+                },
+                f,
+            )
+            f.flush()
+            s = make_settings({}, config_file=f.name)
+        os.unlink(f.name)
+        assert s.llm_aggregator_models == ["ollama/llama3:http://gpu:11434:"]
+
+    def test_dict_entry_missing_id_raises(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(
+                {"llm-aggregator-models": [{"api-key": "sk-xxx"}]},
+                f,
+            )
+            f.flush()
+            with pytest.raises(Exception, match="'id'"):
+                make_settings({}, config_file=f.name)
+        os.unlink(f.name)
+
+    def test_dict_entry_cmd_indirection(self, tmp_path):
+        """api-key with cmd: prefix is resolved."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(
+                {
+                    "llm-aggregator-models": [
+                        {
+                            "id": "openai/gpt-4o",
+                            "api-key": "cmd:echo resolved-key",
+                        }
+                    ]
+                },
+                f,
+            )
+            f.flush()
+            s = make_settings({}, config_file=f.name)
+        os.unlink(f.name)
+        assert s.llm_aggregator_models == ["openai/gpt-4o::resolved-key"]
+
+    def test_dict_entry_file_indirection(self, tmp_path):
+        """api-key with file: prefix is resolved."""
+        key_file = tmp_path / "key.txt"
+        key_file.write_text("sk-from-file\n")
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(
+                {
+                    "llm-aggregator-models": [
+                        {
+                            "id": "openai/gpt-4o",
+                            "api-key": f"file:{key_file}",
+                        }
+                    ]
+                },
+                f,
+            )
+            f.flush()
+            s = make_settings({}, config_file=f.name)
+        os.unlink(f.name)
+        assert s.llm_aggregator_models == ["openai/gpt-4o::sk-from-file"]
+
     def test_default_image(self):
         s = make_settings({})
         assert "litellm" in s.llm_aggregator_image
@@ -236,12 +336,24 @@ class TestLiteLLMWatchdog:
         assert wd._task is None
         assert wd._stopping is False
 
-    def test_reconfigure_flags_reload(self):
-        s = make_settings({})
-        wd = _wd(s)
-        app = types.SimpleNamespace(state=types.SimpleNamespace(settings=s))
-        wd.reconfigure(app)
+    def test_reconfigure_flags_reload_on_change(self):
+        s1 = make_settings({})
+        wd = _wd(s1)
+        s2 = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        app2 = types.SimpleNamespace(state=types.SimpleNamespace(settings=s2))
+        wd.reconfigure(app2)
         assert wd._pending_reload is True
+
+    def test_reconfigure_no_flag_when_unchanged(self):
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s)
+        app2 = types.SimpleNamespace(state=types.SimpleNamespace(settings=s))
+        wd.reconfigure(app2)
+        assert wd._pending_reload is False
 
     async def test_start_noop_when_no_models(self):
         s = make_settings({})
@@ -265,7 +377,7 @@ class TestLiteLLMWatchdog:
             {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
         )
         wd = _wd(s)
-        monkeypatch.delenv("_KLANGKD_DISABLE_PROXY", raising=False)
+        monkeypatch.delenv("_KLANGKD_DISABLE_LITELLM", raising=False)
 
         watch_called = {}
 
@@ -279,3 +391,91 @@ class TestLiteLLMWatchdog:
         await asyncio.sleep(0)
         assert "conf" in watch_called
         assert watch_called["conf"].endswith("litellm-config.yaml")
+
+    async def test_apply_pending_reload_noop_when_not_flagged(self):
+        s = make_settings({})
+        wd = _wd(s)
+        remove_called = []
+
+        async def _fake_remove():
+            remove_called.append(True)
+
+        wd._remove_container = _fake_remove
+        await wd.apply_pending_reload()
+        assert not remove_called
+
+    async def test_apply_pending_reload_disable_branch(self):
+        """When models become empty, stop the task and remove container."""
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s)
+
+        # Simulate a running task.
+        async def _forever():
+            await asyncio.sleep(999)
+
+        wd._task = asyncio.create_task(_forever())
+        wd._stopping = False
+
+        # Now reconfigure with empty models.
+        s_empty = make_settings({})
+        app_empty = types.SimpleNamespace(
+            state=types.SimpleNamespace(settings=s_empty)
+        )
+        wd.reconfigure(app_empty)
+        assert wd._pending_reload is True
+
+        remove_called = []
+
+        async def _fake_remove():
+            remove_called.append(True)
+
+        wd._remove_container = _fake_remove
+        await wd.apply_pending_reload()
+        assert wd._stopping is True
+        assert wd._task is None
+        assert remove_called
+
+    async def test_apply_pending_reload_restart_branch(self, monkeypatch):
+        """When models change, cancel old task and start a new one."""
+        s1 = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s1)
+
+        # Simulate a running task.
+        async def _forever():
+            await asyncio.sleep(999)
+
+        wd._task = asyncio.create_task(_forever())
+        old_task = wd._task
+
+        # Reconfigure with different models.
+        s2 = make_settings(
+            {
+                "KLANGKD_LLM_AGGREGATOR_MODELS": "anthropic/claude-sonnet-4::sk-ant"
+            }
+        )
+        app2 = types.SimpleNamespace(state=types.SimpleNamespace(settings=s2))
+        wd.reconfigure(app2)
+
+        remove_called = []
+
+        async def _fake_remove():
+            remove_called.append(True)
+
+        watch_called = {}
+
+        async def _fake_watch(conf_path):
+            watch_called["conf"] = conf_path
+
+        wd._remove_container = _fake_remove
+        monkeypatch.setattr(wd, "_watch", _fake_watch)
+        await wd.apply_pending_reload()
+        assert old_task.cancelled()
+        assert wd._stopping is False
+        assert wd._task is not None
+        assert remove_called
+        await asyncio.sleep(0)
+        assert "conf" in watch_called

--- a/src/klangk/klangkd-tests/tests/test_litellm.py
+++ b/src/klangk/klangkd-tests/tests/test_litellm.py
@@ -1,0 +1,281 @@
+"""Unit tests for the LiteLLM aggregator sidecar (#2046).
+
+Tests the renderer (config.yaml generation) and the settings validator
+for ``KLANGKD_LLM_AGGREGATOR_MODELS``.  Runtime supervision (container
+lifecycle) is covered implicitly by the watchdog pattern shared with
+``ProxyWatchdog`` — the container spawn loop is ``# pragma: no cover``
+like its nginx counterpart.
+"""
+
+import asyncio
+import os
+import tempfile
+import types
+
+import pytest
+import yaml
+
+from klangk.litellm import (
+    LiteLLMRenderer,
+    LiteLLMWatchdog,
+    parse_model_entry,
+)
+from _helpers import make_settings
+
+
+def _renderer(settings):
+    """Wrap settings in a minimal mock app and build a LiteLLMRenderer."""
+    return LiteLLMRenderer(
+        types.SimpleNamespace(state=types.SimpleNamespace(settings=settings))
+    )
+
+
+def _wd(settings):
+    """Build a LiteLLMWatchdog from settings (wrapped in a minimal mock app)."""
+    return LiteLLMWatchdog(
+        types.SimpleNamespace(state=types.SimpleNamespace(settings=settings))
+    )
+
+
+class TestParseModelEntry:
+    def test_full_entry(self):
+        result = parse_model_entry(
+            "openai/gpt-4o:https://api.openai.com/v1:sk-xxx"
+        )
+        assert result["model_name"] == "gpt-4o"
+        assert result["litellm_params"]["model"] == "openai/gpt-4o"
+        assert (
+            result["litellm_params"]["api_base"] == "https://api.openai.com/v1"
+        )
+        assert result["litellm_params"]["api_key"] == "sk-xxx"
+
+    def test_empty_api_base_uses_provider_default(self):
+        result = parse_model_entry("openai/gpt-4o::sk-xxx")
+        assert (
+            result["litellm_params"]["api_base"] == "https://api.openai.com/v1"
+        )
+        assert result["litellm_params"]["api_key"] == "sk-xxx"
+
+    def test_empty_api_key(self):
+        result = parse_model_entry("ollama/llama3:http://gpu:11434:")
+        assert result["model_name"] == "llama3"
+        assert result["litellm_params"]["api_base"] == "http://gpu:11434"
+        assert "api_key" not in result["litellm_params"]
+
+    def test_anthropic_default(self):
+        result = parse_model_entry("anthropic/claude-sonnet-4::sk-ant-xxx")
+        assert (
+            result["litellm_params"]["api_base"]
+            == "https://api.anthropic.com/v1"
+        )
+
+    def test_unknown_provider_no_api_base(self):
+        result = parse_model_entry("custom/model::")
+        assert "api_base" not in result["litellm_params"]
+
+    def test_no_provider_slash(self):
+        result = parse_model_entry("gpt-4o:https://api.openai.com/v1:sk-xxx")
+        assert result["model_name"] == "gpt-4o"
+
+    def test_url_with_port(self):
+        """URLs with ports (extra colons) are handled correctly."""
+        result = parse_model_entry("ollama/llama3:http://gpu:11434/v1:sk-key")
+        assert result["litellm_params"]["api_base"] == "http://gpu:11434/v1"
+        assert result["litellm_params"]["api_key"] == "sk-key"
+
+    def test_no_colon_at_all(self):
+        """Edge case: bare model with no colons (would be rejected by
+        the settings validator, but parse_model_entry handles it)."""
+        result = parse_model_entry("gpt-4o")
+        assert result["model_name"] == "gpt-4o"
+        assert "api_base" not in result["litellm_params"]
+        assert "api_key" not in result["litellm_params"]
+
+    def test_single_colon(self):
+        """Edge case: one colon with a plain value (no URL).  The settings
+        validator rejects < 2 colons, so this path is defensive only."""
+        result = parse_model_entry("openai/gpt-4o:some-value")
+        assert result["model_name"] == "gpt-4o"
+        # With one colon, the rest has no rfind split — treated as api_base.
+        assert result["litellm_params"]["api_base"] == "some-value"
+
+
+class TestSettingsValidator:
+    def test_none_accepted(self):
+        s = make_settings({})
+        assert s.llm_aggregator_models is None
+
+    def test_empty_string_becomes_none(self):
+        s = make_settings({"KLANGKD_LLM_AGGREGATOR_MODELS": ""})
+        assert s.llm_aggregator_models is None
+
+    def test_single_entry(self):
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        assert s.llm_aggregator_models == ["openai/gpt-4o::sk-xxx"]
+
+    def test_comma_separated(self):
+        s = make_settings(
+            {
+                "KLANGKD_LLM_AGGREGATOR_MODELS": (
+                    "openai/gpt-4o::sk-xxx,anthropic/claude-sonnet-4::sk-ant"
+                )
+            }
+        )
+        assert len(s.llm_aggregator_models) == 2
+
+    def test_rejects_malformed_entry(self):
+        with pytest.raises(Exception, match="two colons"):
+            make_settings({"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o"})
+
+    def test_default_port(self):
+        s = make_settings({})
+        assert s.llm_aggregator_port == 4000
+
+    def test_custom_port(self):
+        s = make_settings({"KLANGKD_LLM_AGGREGATOR_PORT": "5000"})
+        assert s.llm_aggregator_port == 5000
+
+    def test_list_from_yaml_config(self):
+        """YAML config file delivers a native list (not comma-separated)."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump({"llm-aggregator-models": ["openai/gpt-4o::sk-xxx"]}, f)
+            f.flush()
+            s = make_settings({}, config_file=f.name)
+        os.unlink(f.name)
+        assert s.llm_aggregator_models == ["openai/gpt-4o::sk-xxx"]
+
+    def test_default_image(self):
+        s = make_settings({})
+        assert "litellm" in s.llm_aggregator_image
+
+
+class TestLiteLLMRenderer:
+    def test_no_models_returns_empty(self):
+        s = make_settings({})
+        r = _renderer(s)
+        assert r.render_config() == ""
+
+    def test_single_model_renders_yaml(self):
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        r = _renderer(s)
+        config = yaml.safe_load(r.render_config())
+        assert len(config["model_list"]) == 1
+        entry = config["model_list"][0]
+        assert entry["model_name"] == "gpt-4o"
+        assert entry["litellm_params"]["model"] == "openai/gpt-4o"
+
+    def test_multiple_models(self):
+        s = make_settings(
+            {
+                "KLANGKD_LLM_AGGREGATOR_MODELS": (
+                    "openai/gpt-4o::sk-xxx,anthropic/claude-sonnet-4::sk-ant"
+                )
+            }
+        )
+        r = _renderer(s)
+        config = yaml.safe_load(r.render_config())
+        assert len(config["model_list"]) == 2
+        names = [e["model_name"] for e in config["model_list"]]
+        assert "gpt-4o" in names
+        assert "claude-sonnet-4" in names
+
+    def test_master_key_in_config(self):
+        s = make_settings(
+            {
+                "KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx",
+                "KLANGKD_LLM_AGGREGATOR_MASTER_KEY": "sk-master",
+            }
+        )
+        r = _renderer(s)
+        config = yaml.safe_load(r.render_config())
+        assert config["general_settings"]["master_key"] == "sk-master"
+
+    def test_no_master_key_no_general_settings(self):
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        r = _renderer(s)
+        config = yaml.safe_load(r.render_config())
+        assert "general_settings" not in config
+
+    def test_write_config_creates_file(self):
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        r = _renderer(s)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "config.yaml")
+            r.write_config(path)
+            assert os.path.exists(path)
+            # File should be mode 0o600 (secrets protection).
+            mode = os.stat(path).st_mode & 0o777
+            assert mode == 0o600
+            with open(path) as f:
+                config = yaml.safe_load(f.read())
+            assert len(config["model_list"]) == 1
+
+    def test_write_config_noop_when_no_models(self):
+        s = make_settings({})
+        r = _renderer(s)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "config.yaml")
+            r.write_config(path)
+            assert not os.path.exists(path)
+
+
+class TestLiteLLMWatchdog:
+    def test_construction(self):
+        s = make_settings({})
+        wd = _wd(s)
+        assert wd._task is None
+        assert wd._stopping is False
+
+    def test_reconfigure_flags_reload(self):
+        s = make_settings({})
+        wd = _wd(s)
+        app = types.SimpleNamespace(state=types.SimpleNamespace(settings=s))
+        wd.reconfigure(app)
+        assert wd._pending_reload is True
+
+    async def test_start_noop_when_no_models(self):
+        s = make_settings({})
+        wd = _wd(s)
+        await wd.start()
+        assert wd._task is None
+
+    def test_config_path(self):
+        s = make_settings({})
+        wd = _wd(s)
+        path = wd._config_path()
+        assert path.endswith("litellm-config.yaml")
+        assert s.state_dir in path
+
+    async def test_start_creates_task_when_models_configured(
+        self, monkeypatch
+    ):
+        """When models are configured and proxy is not disabled, start()
+        writes config and creates a watch task (stubbed)."""
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s)
+        monkeypatch.delenv("_KLANGKD_DISABLE_PROXY", raising=False)
+
+        watch_called = {}
+
+        async def _fake_watch(conf_path):
+            watch_called["conf"] = conf_path
+
+        monkeypatch.setattr(wd, "_watch", _fake_watch)
+        await wd.start()
+        assert wd._task is not None
+        # Let the task run so _fake_watch executes.
+        await asyncio.sleep(0)
+        assert "conf" in watch_called
+        assert watch_called["conf"].endswith("litellm-config.yaml")

--- a/src/klangk/klangkd-tests/tests/test_litellm.py
+++ b/src/klangk/klangkd-tests/tests/test_litellm.py
@@ -1,10 +1,9 @@
 """Unit tests for the LiteLLM aggregator sidecar (#2046).
 
-Tests the renderer (config.yaml generation) and the settings validator
-for ``KLANGKD_LLM_AGGREGATOR_MODELS``.  Runtime supervision (container
-lifecycle) is covered implicitly by the watchdog pattern shared with
-``ProxyWatchdog`` — the container spawn loop is ``# pragma: no cover``
-like its nginx counterpart.
+Tests the renderer (config.yaml generation), the settings validator
+for ``KLANGKD_LLM_AGGREGATOR_MODELS``, and the watchdog container
+lifecycle (``_watch``, ``_wait_for_exit``, ``_remove_container``,
+``start``, ``stop``).
 """
 
 import asyncio
@@ -30,11 +29,45 @@ def _renderer(settings):
     )
 
 
-def _wd(settings):
+class _FakePodman:
+    """Minimal podman stub for watchdog tests."""
+
+    def __init__(self):
+        self.calls = []
+        self._run_results = []  # queue of (rc, out, err) to return from run()
+        self._remove_error = None
+
+    def queue_run(self, rc, out, err=""):
+        self._run_results.append((rc, out, err))
+
+    async def create_container(self, name, image, **kwargs):
+        self.calls.append(("create", name, image, kwargs))
+        return "fake-container-id-1234567890ab"
+
+    async def start_container(self, container_id):
+        self.calls.append(("start", container_id))
+
+    async def remove_container(self, name):
+        self.calls.append(("remove", name))
+        if self._remove_error:
+            raise self._remove_error
+
+    async def run(self, args, **kwargs):
+        self.calls.append(("run", args))
+        if self._run_results:
+            return self._run_results.pop(0)
+        return (1, "", "")  # container not found by default
+
+
+def _wd(settings, podman=None):
     """Build a LiteLLMWatchdog from settings (wrapped in a minimal mock app)."""
-    return LiteLLMWatchdog(
-        types.SimpleNamespace(state=types.SimpleNamespace(settings=settings))
+    app = types.SimpleNamespace(
+        state=types.SimpleNamespace(
+            settings=settings,
+            podman=podman or _FakePodman(),
+        )
     )
+    return LiteLLMWatchdog(app)
 
 
 class TestParseModelEntry:
@@ -479,3 +512,179 @@ class TestLiteLLMWatchdog:
         assert remove_called
         await asyncio.sleep(0)
         assert "conf" in watch_called
+
+    async def test_remove_container_success(self):
+        podman = _FakePodman()
+        s = make_settings({})
+        wd = _wd(s, podman=podman)
+        await wd._remove_container()
+        assert ("remove", "klangk-litellm") in podman.calls
+
+    async def test_remove_container_ignores_error(self):
+        podman = _FakePodman()
+        podman._remove_error = RuntimeError("no such container")
+        s = make_settings({})
+        wd = _wd(s, podman=podman)
+        await wd._remove_container()
+        assert ("remove", "klangk-litellm") in podman.calls
+
+    async def test_wait_for_exit_returns_when_not_running(self):
+        podman = _FakePodman()
+        podman.queue_run(0, "false")
+        s = make_settings({})
+        wd = _wd(s, podman=podman)
+        await wd._wait_for_exit()
+        assert any(c[0] == "run" for c in podman.calls)
+
+    async def test_wait_for_exit_returns_on_inspect_error(self):
+        podman = _FakePodman()
+        podman.queue_run(1, "")
+        s = make_settings({})
+        wd = _wd(s, podman=podman)
+        await wd._wait_for_exit()
+
+    async def test_wait_for_exit_returns_on_exception(self):
+        podman = _FakePodman()
+        s = make_settings({})
+        wd = _wd(s, podman=podman)
+
+        async def _exploding_run(args, **kwargs):
+            raise OSError("podman gone")
+
+        podman.run = _exploding_run
+        await wd._wait_for_exit()
+
+    async def test_wait_for_exit_polls_then_stops(self):
+        """Polls while running, returns when _stopping is set."""
+        podman = _FakePodman()
+        s = make_settings({})
+        wd = _wd(s, podman=podman)
+
+        call_count = 0
+
+        async def _counting_run(args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                wd._stopping = True
+            return (0, "true", "")
+
+        podman.run = _counting_run
+        await wd._wait_for_exit()
+        assert call_count >= 2
+
+    async def test_watch_creates_starts_and_waits(self):
+        """_watch creates a container, starts it, waits for exit, then
+        stops when _stopping is set."""
+        podman = _FakePodman()
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s, podman=podman)
+
+        async def _fake_wait():
+            wd._stopping = True
+
+        wd._wait_for_exit = _fake_wait
+        conf_path = wd._config_path()
+        wd._renderer.write_config(conf_path)
+        await wd._watch(conf_path)
+
+        create_calls = [c for c in podman.calls if c[0] == "create"]
+        assert len(create_calls) == 1
+        assert create_calls[0][1] == "klangk-litellm"
+        kwargs = create_calls[0][3]
+        assert kwargs["publish"] == [("127.0.0.1", 4000, 4000)]
+
+        start_calls = [c for c in podman.calls if c[0] == "start"]
+        assert len(start_calls) == 1
+
+    async def test_watch_respawns_on_unexpected_exit(self):
+        """_watch respawns when container exits unexpectedly."""
+        podman = _FakePodman()
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s, podman=podman)
+
+        exit_count = 0
+
+        async def _fake_wait():
+            nonlocal exit_count
+            exit_count += 1
+            if exit_count >= 2:
+                wd._stopping = True
+
+        wd._wait_for_exit = _fake_wait
+        conf_path = wd._config_path()
+        wd._renderer.write_config(conf_path)
+        await wd._watch(conf_path)
+
+        create_calls = [c for c in podman.calls if c[0] == "create"]
+        assert len(create_calls) == 2
+
+    async def test_watch_retries_on_create_failure(self):
+        """_watch retries with backoff when create_container fails."""
+        podman = _FakePodman()
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s, podman=podman)
+
+        create_count = 0
+        orig_create = podman.create_container
+
+        async def _failing_create(name, image, **kwargs):
+            nonlocal create_count
+            create_count += 1
+            if create_count == 1:
+                raise RuntimeError("image pull failed")
+            wd._stopping = True
+            return await orig_create(name, image, **kwargs)
+
+        podman.create_container = _failing_create
+
+        async def _fake_wait():
+            wd._stopping = True
+
+        wd._wait_for_exit = _fake_wait
+        conf_path = wd._config_path()
+        wd._renderer.write_config(conf_path)
+        await wd._watch(conf_path)
+        assert create_count == 2
+
+    async def test_start_noop_when_disabled(self, monkeypatch):
+        """start() is a no-op when _KLANGKD_DISABLE_LITELLM is set."""
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s)
+        monkeypatch.setenv("_KLANGKD_DISABLE_LITELLM", "1")
+        await wd.start()
+        assert wd._task is None
+
+    async def test_stop_cancels_running_task(self, monkeypatch):
+        """stop() cancels the watch task and removes the container."""
+        podman = _FakePodman()
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        wd = _wd(s, podman=podman)
+        monkeypatch.delenv("_KLANGKD_DISABLE_LITELLM", raising=False)
+
+        async def _forever():
+            await asyncio.sleep(999)
+
+        wd._task = asyncio.create_task(_forever())
+        await wd.stop()
+        assert wd._stopping is True
+        assert wd._task is None
+        assert any(c[0] == "remove" for c in podman.calls)
+
+    async def test_stop_noop_when_no_task(self):
+        """stop() is safe when no task was started."""
+        s = make_settings({})
+        wd = _wd(s)
+        await wd.stop()
+        assert wd._stopping is True
+        assert wd._task is None

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -20,6 +20,7 @@ from klangk import (
     auth as auth_mod,
     emailsvc as emailsvc_mod,
     files as files_mod,
+    litellm as litellm_mod,
     proxy as proxy_mod,
     ssl_trust as ssl_trust_mod,
     util as util_mod,
@@ -78,6 +79,9 @@ def _make_app_state(settings=None):
     app_state.state.netfilter = NetFilter(app_state)
     app_state.state.auth = auth_mod.Auth(app_state)
     app_state.state.proxy_watchdog = proxy_mod.ProxyWatchdog(app_state)
+    from klangk.litellm import LiteLLMWatchdog
+
+    app_state.state.litellm_watchdog = LiteLLMWatchdog(app_state)
     from klangk.terminal import Terminal
     from klangk.acl import ACL
 
@@ -802,6 +806,7 @@ class TestLifespan:
         app.state.db = app_state.state.db
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = proxy_mod.ProxyWatchdog(app)
+        app.state.litellm_watchdog = litellm_mod.LiteLLMWatchdog(app)
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -850,6 +855,7 @@ class TestLifespan:
         app.state.db = app_state.state.db
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = proxy_mod.ProxyWatchdog(app)
+        app.state.litellm_watchdog = litellm_mod.LiteLLMWatchdog(app)
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -1378,6 +1384,7 @@ class TestStartupShutdownRestart:
         app.state.db = app_state.state.db
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = proxy_mod.ProxyWatchdog(app)
+        app.state.litellm_watchdog = litellm_mod.LiteLLMWatchdog(app)
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -251,6 +251,19 @@ class TestCreateContainer:
         assert ["-e", "K=V"] == args[args.index("-e") : args.index("-e") + 2]
         assert args[-1] == "img"
 
+    async def test_publish_with_bind_address(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container(
+                "n",
+                "img",
+                publish=[("127.0.0.1", 4000, 4000)],
+                replace=False,
+            )
+        args = _args(m)
+        assert ["-p", "127.0.0.1:4000:4000"] == args[
+            args.index("-p") : args.index("-p") + 2
+        ]
+
     async def test_pull_policy_override(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:
             await _p.create_container(


### PR DESCRIPTION
## Summary

- Add opt-in LiteLLM aggregator sidecar (`LiteLLMRenderer` + `LiteLLMWatchdog`) that runs as a supervised podman container, routing requests to multiple LLM providers through a single OpenAI-compatible endpoint
- New settings: `KLANGKD_LLM_AGGREGATOR_MODELS`, `KLANGKD_LLM_AGGREGATOR_MASTER_KEY`, `KLANGKD_LLM_AGGREGATOR_PORT`, `KLANGKD_LLM_AGGREGATOR_IMAGE`
- Existing `/llm-proxy/` block and `llm-proxy-models.ts` model discovery work unchanged — confirmed no filtering regressions
- Documents both single-provider multi-model (already works) and multi-provider aggregator patterns

Closes #2046

## Test plan

- [x] 4192 backend tests pass with 100% coverage
- [x] `parse_model_entry` handles URLs with colons, empty fields, provider defaults
- [x] Settings validator accepts comma-separated strings and YAML lists, rejects malformed entries
- [x] Renderer generates valid LiteLLM `config.yaml` with model_list and optional master_key
- [x] Watchdog lifecycle: no-op when unconfigured, creates task when configured, reconfigure flags reload
- [x] Existing lifespan/SIGHUP tests pass with litellm_watchdog wired in