### PR TITLE
Bump pi-coding-agent to 0.83.0 and install process-compose in workspace container

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,11 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`process-compose` supervisor installed in the workspace container (#2049).**
+  The workspace image now ships the `process-compose` binary at
+  `/usr/local/bin/process-compose` (arch-aware build, pinned to `v1.120.0`),
+  so a managed set of processes can be run inside the container. The base
+  image's `supervisor` (supervisord) is unaffected.
 - **TUI: rename a terminal from the terminals list (#2020).** Press `m`
   on a highlighted terminal for an input prefilled with the current name
   (typing appends; Enter renames, Escape cancels; the result shows as a
@@ -564,6 +569,9 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **Bumped `@earendil-works/pi-coding-agent` in the workspace image from
+  `0.79.9` to `0.83.0` (#2049).** The in-container coding agent is now the
+  latest published release.
 - **`none` auth mode is declared an unsupported configuration with the
   published Docker host image (#1391).** `none` (no-login single-user,
   loopback-only) is safe only when solely the operator's loopback can reach

--- a/docs/features/container-packages.md
+++ b/docs/features/container-packages.md
@@ -64,6 +64,15 @@ so common development tasks work out of the box.
 - **Pi** (`@earendil-works/pi-coding-agent`) — terminal-based coding
   agent; see [AI Coding Harnesses](ai-coding-harnesses.md)
 
+## Process Supervisors
+
+- **process-compose** (`/usr/local/bin/process-compose`) — standalone
+  process supervisor for running a managed set of processes inside the
+  workspace container. See the
+  [process-compose docs](https://f1bonacc1.github.io/process-compose/).
+- `supervisor` (supervisord) — Python-based supervisor, installed via apt
+  in the base image.
+
 ## Installing Additional Packages
 
 By default the `klangk` user does **not** have root access.

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -3,7 +3,7 @@ FROM $WORKSPACE_BASE_IMAGE
 
 # Install Pi coding agent globally. This layer is expensive (~30s) and
 # rarely changes, so it goes first.
-RUN npm install -g @earendil-works/pi-coding-agent@0.79.9 \
+RUN npm install -g @earendil-works/pi-coding-agent@0.83.0 \
     && mkdir -p /opt/klangk/pi-agent/extensions /opt/klangk/pi-agent/skills
 
 # Copy full feature repos and symlink discoverable pieces into central dirs.
@@ -36,6 +36,15 @@ COPY builtin-extensions/ /opt/klangk/pi-agent/extensions/
 RUN curl -LsSf https://astral.sh/uv/0.11.23/install.sh | sh \
     && mv /root/.local/bin/uv /usr/local/bin/uv \
     && mv /root/.local/bin/uvx /usr/local/bin/uvx
+
+# Install process-compose supervisor (standalone Go binary, arch-aware).
+# Extracts the single binary from the release tarball into /usr/local/bin
+# so it is on PATH for all login and non-login shells.
+ARG PROCESS_COMPOSE_VERSION=1.120.0
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://github.com/F1bonacc1/process-compose/releases/download/v${PROCESS_COMPOSE_VERSION}/process-compose_linux_${ARCH}.tar.gz" \
+       | tar -xz -C /usr/local/bin process-compose \
+    && chmod +x /usr/local/bin/process-compose
 
 # Entrypoint, agent context file, bash defaults (change frequently during dev)
 COPY agent-context.md /opt/klangk/agent-context.md


### PR DESCRIPTION
## Summary

Closes #2049.

- Bumps `@earendil-works/pi-coding-agent` in the workspace image from
  `0.79.9` → `0.83.0` (latest published).
- Installs the `process-compose` supervisor (`v1.120.0`, arch-aware, pinned)
  at `/usr/local/bin/process-compose` in the workspace container, so a managed
  set of processes can be run inside the container.

## Layering decision

`process-compose` is installed in the **workspace `Dockerfile`**, not
`Dockerfile.base`. It's a standalone downloaded Go binary — same pattern as
the `uv` install right above it — and keeping it here avoids a base-image
rebuild + GHCR push + `WORKSPACE_BASE_IMAGE` ARG bump just to take effect. The
base image's existing `supervisor` (supervisord) is unchanged.

## Changes

- `src/containers/workspace/Dockerfile`
  - `@earendil-works/pi-coding-agent@0.79.9` → `@0.83.0`
  - New `process-compose` install layer (curl the release tarball, extract the
    single binary via `dpkg --print-architecture`).
- `docs/features/container-packages.md` — new "Process Supervisors" section
  (process-compose + supervisor).
- `docs/changes.md` — `Added` (process-compose) and `Changed` (agent bump)
  entries under `[Unreleased]`.

## Verification

- Confirmed the release tarball layout: `tar -tzf` lists `process-compose` at
  the root, and the extracted binary prints `Version: v1.120.0`.
- Confirmed `0.83.0` is the latest published
  (`npm view @earendil-works/pi-coding-agent version`).
- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto`
  → **4162 passed, 100% coverage**.

## Acceptance criteria (from #2049)

- [x] Workspace container builds with `@earendil-works/pi-coding-agent` at the
      latest version (`0.83.0`).
- [x] `process-compose` is installed and on `PATH` inside the workspace
      container (`/usr/local/bin/process-compose`).
- [x] Docs that reference the agent version are updated.
