### PR TITLE
Make backend reachability a single signal (drive the unreachable overlay from the status WS)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -582,6 +582,16 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI: backend reachability is now driven by the status WebSocket (#2052).**
+  The TUI previously ran two competing reachability signals — a REST
+  heartbeat poll and the status WS — which could disagree. The REST
+  heartbeat and its reconnect loop are removed; the status WS connection
+  lifecycle (with protocol pings tightened to 10 s / 10 s) is now the single
+  signal that drives the "server unreachable" overlay and reconnect. A
+  transient drop gets one silent grace retry before the overlay appears; on
+  (re)connect the overlay clears and the list refreshes; after a bounded
+  attempt cap the loop gives up and tells the user to switch server.
+
 - **Bumped `@earendil-works/pi-coding-agent` in the workspace image from
   `0.79.9` to `0.83.0` (#2049).** The in-container coding agent is now the
   latest published release.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -586,11 +586,20 @@ invitations send` stay email-only (a deliverable address is required);
   The TUI previously ran two competing reachability signals — a REST
   heartbeat poll and the status WS — which could disagree. The REST
   heartbeat and its reconnect loop are removed; the status WS connection
-  lifecycle (with protocol pings tightened to 10 s / 10 s) is now the single
-  signal that drives the "server unreachable" overlay and reconnect. A
-  transient drop gets one silent grace retry before the overlay appears; on
-  (re)connect the overlay clears and the list refreshes; after a bounded
-  attempt cap the loop gives up and tells the user to switch server.
+  lifecycle is now the single signal that drives the "server unreachable"
+  overlay and reconnect. The TUI client pings the server every 10 s (10 s
+  pong timeout) — tighter than the library default — so a wedged /
+  half-open connection is detected without REST polling; the server-side
+  ping interval is unchanged. A transient drop gets one silent grace retry
+  before the overlay appears; on (re)connect the overlay clears and the list
+  refreshes; after a bounded attempt cap the loop gives up and tells the
+  user to switch server. A transient REST list-fetch failure while the WS is
+  connected no longer falsely flags the server unreachable (the WS proves
+  reachability); the last good list is kept and refreshed on the next
+  broadcast / reconnect. Note the attempt cap is hit only by a backend that
+  can't establish a connection at all — a flapping backend that completes
+  the handshake then drops resets its counter on each connect and stays in
+  the silent grace retry.
 
 - **Bumped `@earendil-works/pi-coding-agent` in the workspace image from
   `0.79.9` to `0.83.0` (#2049).** The in-container coding agent is now the

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -238,6 +238,12 @@ class MainScreen(Screen):
         self._server_unreachable = False
         self._reconnect_attempt = 0
         self._gave_up = False
+        # True only while the status WS is actively connected (set in
+        # ``_on_ws_connected``, cleared when the connection drops). Lets a
+        # transport-failed REST list fetch distinguish a real outage (WS also
+        # down) from a transient REST blip while the backend is reachable
+        # (#2052).
+        self._ws_connected = False
         # Latest ``container_status`` running state per workspace id (#2032).
         # Recorded on every broadcast and re-applied onto each fresh fetch in
         # ``_populate_workspaces``, so a refresh whose snapshot raced behind a
@@ -817,7 +823,14 @@ class MainScreen(Screen):
             self.app.session_expired()
             return
         except ServerUnreachable:
-            self._enter_unreachable()
+            # The WS connection lifecycle is the single reachability signal
+            # (#2052). A transport failure on this REST fetch only means the
+            # server is down if the WS agrees: if the WS is currently
+            # connected the backend is reachable and this is a transient REST
+            # blip, so keep the last list (the next broadcast / reconnect
+            # refreshes it) rather than falsely flagging the server down.
+            if not self._ws_connected:
+                self._enter_unreachable()
             return
         # Success — clear any prior unreachable state and render the lists.
         # ``_populate_workspaces`` re-applies ``_running_overlay`` so a stale
@@ -913,7 +926,14 @@ class MainScreen(Screen):
         self.app.set_server_down(self._down_overlay_message())
 
     def _exit_unreachable(self) -> None:
-        """Backend reachable again — clear the down state."""
+        """Backend reachable again — clear the down state.
+
+        Resets the reconnect counter on a confirmed connection. Note a
+        flapping backend (one that completes the WS handshake then drops)
+        resets on every connect, so it stays in the silent grace retry and
+        never reaches ``_MAX_RECONNECT_ATTEMPTS`` — the cap is hit only by a
+        backend that can't establish a connection at all (#2052).
+        """
         self._reconnect_attempt = 0
         self._gave_up = False
         if self._server_unreachable:
@@ -927,8 +947,8 @@ class MainScreen(Screen):
         if gave_up:
             return (
                 "⛔ Server down\n\n"
-                "Couldn't reach the backend after repeated attempts;"
-                " it will keep retrying.\n"
+                "Couldn't reach the backend after repeated attempts."
+                " Reconnect paused — switch server or restart to retry.\n"
                 "[c] switch server   [Esc] dismiss"
             )
         if self._reconnect_attempt <= 0:
@@ -1083,6 +1103,9 @@ class MainScreen(Screen):
                     self._reconnect_attempt + 1,
                     exc,
                 )
+            # The connection is over (clean close or error) — the backend is
+            # no longer WS-reachable from this screen's point of view.
+            self._ws_connected = False
             # Connection lost (clean close or error). Reconnect with bounded
             # backoff; the top-of-iteration guard catches a screen pop that
             # lands during the backoff sleep.
@@ -1122,6 +1145,7 @@ class MainScreen(Screen):
         the list so a reconnect boundary also catches a REST-only
         degradation (#2052).
         """
+        self._ws_connected = True
         self._exit_unreachable()
         self.refresh_lists()
 

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -57,13 +57,7 @@ _TOKEN_REFRESH_POLL = 60  # check every 60 seconds
 _MAX_RECONNECT_ATTEMPTS = 25
 _MAX_BACKOFF_SECONDS = 5
 
-# How often the always-on reachability heartbeat re-fetches the workspace
-# list while the backend is up, so a drop is detected regardless of whether
-# the status WS notices (#2012). A timer (not a worker), so it doesn't keep
-# ``app.workers.wait_for_complete()`` pending in tests.
-_HEARTBEAT_SECONDS = 15
-
-# Indirection so tests can advance the reconnect loop without real delays
+# Indirection so tests can advance the WS reconnect loop without real delays
 # (and without patching the global ``asyncio.sleep``, which Textual's own
 # event loop depends on).
 _reconnect_sleep = asyncio.sleep
@@ -236,14 +230,13 @@ class MainScreen(Screen):
         self._owned_all: list = []
         self._shared_all: list = []
         self._filter_text = ""
-        # Backend-reconnect state (#2012). ``_server_unreachable`` is True
-        # while the list fetch is failing at the transport layer;
-        # ``_reconnect_active`` guards against spawning a second poll loop.
-        # ``_gave_up`` is set when the reconnect loop exhausts its attempts;
-        # it prevents the heartbeat from re-arming a new loop (#2036).
+        # Reachability state (#2012, #2052). The status WebSocket connection
+        # lifecycle is the single reachability signal: ``_server_unreachable``
+        # is True while the WS can't stay connected; ``_reconnect_attempt``
+        # counts consecutive WS connection losses; ``_gave_up`` is set when the
+        # WS reconnect loop exhausts its attempts.
         self._server_unreachable = False
         self._reconnect_attempt = 0
-        self._reconnect_active = False
         self._gave_up = False
         # Latest ``container_status`` running state per workspace id (#2032).
         # Recorded on every broadcast and re-applied onto each fresh fetch in
@@ -262,34 +255,14 @@ class MainScreen(Screen):
         self._running_overlay: dict[str, bool] = {}
         self.query_one("#filter_bar").display = False
         self._refresh_action_hints()
+        # One-time list load. There is no reachability heartbeat and no REST
+        # poll thereafter (#2052): the status WS connection lifecycle — started
+        # just below — is the single reachability signal, and ``workspaces_changed``
+        # broadcasts plus the WS reconnect keep the list fresh.
         self.refresh_lists()
-        # Always-on reachability heartbeat: re-fetches the list on a timer
-        # while the backend is up so a drop is detected uniformly — at first
-        # display, mid-session, and after navigating back — without relying
-        # on the status WS (#2012). One mechanism, one UI.
-        self._heartbeat_timer = self.set_interval(
-            _HEARTBEAT_SECONDS, self._heartbeat_tick
-        )
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
             self.app.run_worker(self._token_refresh_loop, name="token-refresh")
-
-    def _heartbeat_tick(self) -> None:
-        """Periodic reachability probe (#2012).
-
-        Re-fetches the list only while the backend is believed up; once a
-        fetch fails, ``_enter_unreachable`` takes over with the (faster)
-        reconnect loop. Skips when unauthenticated or once the screen has
-        left the stack (logout / server switch).
-        """
-        if (
-            self._server_unreachable
-            or self._gave_up
-            or self not in self.app.screen_stack
-            or not self.app.tui_state.is_authenticated()
-        ):
-            return
-        self.refresh_lists()
 
     def on_tabbed_content_tab_activated(self, event) -> None:
         """Focus the first workspace row when switching tabs (#1792)."""
@@ -907,24 +880,37 @@ class MainScreen(Screen):
         self._refresh_status()
 
     def _enter_unreachable(self) -> None:
-        """Backend unreachable — surface it and start a reconnect loop."""
-        # Fresh attempt counter for this outage (so a heartbeat that re-arms
-        # the reconnect after a prior give-up gets a full retry budget again).
-        self._reconnect_attempt = 0
-        if not self._server_unreachable:
-            self._server_unreachable = True
-            self._render_unreachable("(server unreachable — retrying…)")
-            self.app.set_server_down(self._down_overlay_message())
-        if not self._reconnect_active:
-            self._reconnect_active = True
-            # Own group so refresh_lists (group "default", exclusive) can't
-            # cancel it; the ``_reconnect_active`` flag prevents duplicates.
-            self.run_worker(
-                self._reconnect_loop,
-                name="reconnect",
-                group="reconnect",
-                exit_on_error=False,
-            )
+        """Mark the backend unreachable and surface the overlay (idempotent).
+
+        The status WS connection lifecycle is the single reachability signal
+        (#2052): this is called from the WS reconnect loop (on a sustained
+        connection loss) and from a transport-failed list fetch. Per-attempt
+        status-bar / overlay text is refreshed by the caller via
+        :meth:`_refresh_unreachable_display` so the attempt counter advances.
+        """
+        if self._server_unreachable:
+            return
+        self._server_unreachable = True
+        self._render_unreachable("(server unreachable — retrying…)")
+        self._refresh_unreachable_display()
+
+    def _unreachable_status_extra(self) -> str:
+        """Status-bar suffix for the current reconnect attempt (#2052)."""
+        if self._reconnect_attempt <= 0:
+            return "server: unreachable, reconnecting…"
+        return (
+            f"server: unreachable, retrying "
+            f"(attempt {self._reconnect_attempt}/"
+            f"{_MAX_RECONNECT_ATTEMPTS})…"
+        )
+
+    def _refresh_unreachable_display(self) -> None:
+        """Refresh the status-bar extra + overlay message for the current
+        reconnect attempt. Called on entry and on every WS reconnect retry so
+        the attempt counter in the UI advances (#2052)."""
+        self.app.live_extra = self._unreachable_status_extra()
+        self._refresh_status()
+        self.app.set_server_down(self._down_overlay_message())
 
     def _exit_unreachable(self) -> None:
         """Backend reachable again — clear the down state."""
@@ -958,58 +944,6 @@ class MainScreen(Screen):
             "The page will reload when the backend returns.\n"
             "[c] switch server   [Esc] dismiss"
         )
-
-    async def _reconnect_loop(self) -> None:
-        """Poll the backend with bounded backoff until it's reachable again,
-        an auth failure surfaces, or the attempt cap is hit.
-
-        Mirrors the Flutter WS client's auto-reconnect
-        (``ws_client._scheduleReconnect`` / ``_backoffDelay``). Drives the
-        same fetch path as a normal refresh, so initial-display-down and
-        mid-session-disconnect both self-heal without a re-login.
-        """
-        try:
-            while self._server_unreachable:
-                # Screen popped (logout / server switch) — stop polling.
-                if self not in self.app.screen_stack:
-                    return
-                self._reconnect_attempt += 1
-                if self._reconnect_attempt > _MAX_RECONNECT_ATTEMPTS:
-                    self._server_unreachable = False
-                    self._gave_up = True
-                    self._render_unreachable(
-                        "(server down — switch server or restart to reconnect)"
-                    )
-                    self.app.live_extra = "server: down (gave up reconnecting)"
-                    self._refresh_status()
-                    self.app.set_server_down(
-                        self._down_overlay_message(gave_up=True)
-                    )
-                    return
-                delay = _reconnect_backoff(self._reconnect_attempt)
-                self.app.live_extra = (
-                    f"server: unreachable, retrying "
-                    f"(attempt {self._reconnect_attempt}/"
-                    f"{_MAX_RECONNECT_ATTEMPTS})…"
-                )
-                self._refresh_status()
-                self.app.set_server_down(self._down_overlay_message())
-                await _reconnect_sleep(delay)
-                if self not in self.app.screen_stack:
-                    return
-                try:
-                    owned, shared = await self._fetch_lists()
-                except ServerUnreachable:
-                    continue
-                except AuthError:
-                    self._server_unreachable = False
-                    self.app.session_expired()
-                    return
-                self._exit_unreachable()
-                self._populate_workspaces(owned, shared)
-                return
-        finally:
-            self._reconnect_active = False
 
     async def _safe_list(self, *, owned: bool) -> list:
         state = self.app.tui_state
@@ -1110,39 +1044,86 @@ class MainScreen(Screen):
             self.app.push_screen(WorkspaceDetailScreen(name))
 
     async def _status_loop(self) -> None:
+        """Single reachability signal: maintain the status WS and drive the
+        unreachable overlay from its lifecycle (#2052).
+
+        On a sustained connection loss the reconnect loop surfaces the
+        overlay with bounded backoff and a hard attempt cap; on (re)connect
+        it clears the overlay and refreshes the list. There is no REST
+        reachability poll — the WS protocol pings (lowered to 10 s / 10 s)
+        detect a wedged / half-open connection, and a reconnect-triggered
+        list refresh catches a REST-only degradation lazily.
+        """
         state = self.app.tui_state
         url = state.current_url()
         token = state.token()
         if not url or not token:
             return
-        retries = 0
         while True:
             token = state.token()
             if not token:
                 self.app.session_expired()
                 return
+            # Screen popped (logout / server switch) — stop reconnecting.
+            if self not in self.app.screen_stack:
+                return
             try:
                 await listen_for_status(
-                    url, token, on_event=self._on_status_event
+                    url,
+                    token,
+                    on_event=self._on_status_event,
+                    on_connect=self._on_ws_connected,
                 )
-                # Clean close (server restart, idle timeout) — reset
-                # backoff since the connection was healthy.
-                retries = 0
-                self.app.live_extra = "status: reconnecting…"
-                self._refresh_status()
-                await asyncio.sleep(2)
-                continue
             except AuthError:
                 self.app.session_expired()
                 return
             except Exception as exc:
-                # Transient error — back off and retry indefinitely.
-                retries += 1
-                logger.debug("Status WS error (attempt %d): %s", retries, exc)
+                logger.debug(
+                    "Status WS error (attempt %d): %s",
+                    self._reconnect_attempt + 1,
+                    exc,
+                )
+            # Connection lost (clean close or error). Reconnect with bounded
+            # backoff; the top-of-iteration guard catches a screen pop that
+            # lands during the backoff sleep.
+            if self not in self.app.screen_stack:
+                return
+            self._reconnect_attempt += 1
+            if self._reconnect_attempt > _MAX_RECONNECT_ATTEMPTS:
+                self._gave_up = True
+                self._server_unreachable = False
+                self._render_unreachable(
+                    "(server down — switch server or restart to reconnect)"
+                )
+                self.app.live_extra = "server: down (gave up reconnecting)"
+                self._refresh_status()
+                self.app.set_server_down(
+                    self._down_overlay_message(gave_up=True)
+                )
+                return
+            delay = _reconnect_backoff(self._reconnect_attempt)
+            if self._reconnect_attempt == 1:
+                # Grace: a transient drop / clean close (server restart, idle
+                # timeout) gets one silent quick retry before the overlay
+                # appears, so a healthy restart doesn't flash "server down".
                 self.app.live_extra = "status: reconnecting…"
                 self._refresh_status()
-                await asyncio.sleep(_reconnect_backoff(retries))
-                continue
+            else:
+                self._enter_unreachable()
+                self._refresh_unreachable_display()
+            await _reconnect_sleep(delay)
+
+    def _on_ws_connected(self) -> None:
+        """The status WS (re)connected — the backend is reachable again.
+
+        Called once per connection by :func:`listen_for_status` (via its
+        ``on_connect`` callback) before any frames are read. Clears the
+        unreachable overlay, resets the reconnect counter, and re-fetches
+        the list so a reconnect boundary also catches a REST-only
+        degradation (#2052).
+        """
+        self._exit_unreachable()
+        self.refresh_lists()
 
     async def _token_refresh_loop(self) -> None:
         """Proactively refresh the access token before it expires."""

--- a/src/klangk/klangk/cli/tui/ws.py
+++ b/src/klangk/klangk/cli/tui/ws.py
@@ -6,6 +6,12 @@ the web UI and ``klangk monitor`` consume (``workspaces_changed``,
 status reflects live workspace/container state. Reconnection is the
 caller's concern — the ``monitor`` command owns the battle-tested
 reconnect loop; this is the lean listener the TUI runs as a worker.
+
+The WS connection is the TUI's single reachability signal (#2052): its
+lifecycle (connect / drop) drives the unreachable overlay in
+:class:`~klangk.cli.tui.screens.main.MainScreen`, so we ping on a short
+interval to detect a wedged / half-open connection fast without any REST
+polling. The server side is lowered to match (``launcher.py``).
 """
 
 from __future__ import annotations
@@ -15,20 +21,42 @@ from collections.abc import Callable
 
 from ..transport import ws_connect
 
+# Protocol-level liveness for the TUI's status WS (#2052). The client pings
+# the server every ``_WS_PING_INTERVAL`` seconds and expects a pong within
+# ``_WS_PING_TIMEOUT``; a wedged / half-open connection is dropped within
+# ~interval+timeout, which ``_status_loop`` turns into the unreachable
+# overlay. Tighter than the ``websockets`` default (20/20) so a silent drop
+# surfaces in ~20s with no REST polling.
+_WS_PING_INTERVAL = 10
+_WS_PING_TIMEOUT = 10
+
 
 async def listen_for_status(
     server_url: str,
     token: str,
     on_event: Callable[[dict], object],
     *,
+    on_connect: Callable[[], object] | None = None,
     max_size: int | None = None,
 ) -> None:
     """Connect to ``/ws`` and call ``on_event(event)`` for each broadcast.
 
+    ``on_connect`` (if given) is invoked once after the connection is
+    established, before any frames are read — the TUI uses it to clear the
+    unreachable overlay and refresh the workspace list on (re)connect (#2052).
+
     Non-JSON and non-object frames are skipped (the server occasionally
     sends control/ack frames).
     """
-    async with ws_connect(server_url, token=token, max_size=max_size) as ws:
+    async with ws_connect(
+        server_url,
+        token=token,
+        max_size=max_size,
+        ping_interval=_WS_PING_INTERVAL,
+        ping_timeout=_WS_PING_TIMEOUT,
+    ) as ws:
+        if on_connect is not None:
+            on_connect()
         async for raw in ws:
             try:
                 event = json.loads(raw)

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -340,13 +340,14 @@ def main(  # pragma: no cover
             # also rewrite client would double-resolve.
             proxy_headers=False,
             ws_max_size=ws_max_size,
-            # Tighter than uvicorn's default (20/20) so a wedged / half-open
-            # client connection is dropped fast — the TUI treats the status
-            # WS lifecycle as its single reachability signal and pings back on
-            # the same interval, so a silent drop surfaces in ~20s with no
-            # REST polling (#2052).
-            ws_ping_interval=10,
-            ws_ping_timeout=10,
+            # Server stays at uvicorn's default (20/20). The TUI detects a
+            # wedged / half-open connection via its own client-side pings
+            # (set in ``cli/tui/ws.py``, 10s/10s) — its single reachability
+            # signal (#2052) — so there's no need to tighten the server
+            # globally (which would also affect the web UI and `klangk
+            # monitor`).
+            ws_ping_interval=20,
+            ws_ping_timeout=20,
         )
     except OSError as exc:
         logger.error(

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -340,8 +340,13 @@ def main(  # pragma: no cover
             # also rewrite client would double-resolve.
             proxy_headers=False,
             ws_max_size=ws_max_size,
-            ws_ping_interval=20,
-            ws_ping_timeout=20,
+            # Tighter than uvicorn's default (20/20) so a wedged / half-open
+            # client connection is dropped fast — the TUI treats the status
+            # WS lifecycle as its single reachability signal and pings back on
+            # the same interval, so a silent drop surfaces in ~20s with no
+            # REST polling (#2052).
+            ws_ping_interval=10,
+            ws_ping_timeout=10,
         )
     except OSError as exc:
         logger.error(

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1093,34 +1093,45 @@ async def test_status_loop_clean_close_reconnects(monkeypatch):
 
 
 async def test_status_loop_resets_backoff_after_success(monkeypatch):
-    """After a successful connection (clean close), the error retry counter
-    resets so subsequent failures get a fresh backoff sequence (#2033)."""
+    """A successful WS connection (on_connect) resets the reconnect counter so
+    subsequent failures get a fresh backoff sequence (#2033, #2052)."""
     import asyncio as _asyncio
 
     _real_sleep = _asyncio.sleep
-    sleeps = []
 
-    async def _spy_sleep(t):
-        sleeps.append(t)
+    async def _nowait(_t):
         await _real_sleep(0)
 
-    monkeypatch.setattr(_asyncio, "sleep", _spy_sleep)
+    monkeypatch.setattr(_asyncio, "sleep", _nowait)
 
-    # Sequence: 2 errors, then 1 success (clean close), then 2 more errors,
-    # then token drops. If retries reset, the second batch of errors uses the
-    # same low-backoff values as the first.
+    # Spy on the backoff arg (= _reconnect_attempt after each increment) so we
+    # can see the counter climb, reset on connect, then re-climb.
+    orig_backoff = scr_main._reconnect_backoff
+    seen = []
+
+    def spy_backoff(attempt):
+        seen.append(attempt)
+        return orig_backoff(attempt)
+
+    monkeypatch.setattr(scr_main, "_reconnect_backoff", spy_backoff)
+
     calls = {"n": 0}
 
     async def mixed(*a, **k):
         calls["n"] += 1
         n = calls["n"]
         if n <= 2:
-            raise RuntimeError("err")  # first 2 errors
+            raise RuntimeError("err")  # first 2 connection failures
         if n == 3:
-            return None  # success — clean close
+            # Backend returns: connect (fires _on_ws_connected -> reset),
+            # then clean close.
+            on_connect = k.get("on_connect")
+            if on_connect is not None:
+                on_connect()
+            return None
         if n <= 5:
-            raise RuntimeError("err")  # 2 more errors after reset
-        return None  # another clean close before token drops
+            raise RuntimeError("err")  # 2 more failures after reset
+        return None  # clean close before token drops
 
     monkeypatch.setattr(scr_main, "listen_for_status", mixed)
     tokens = iter(["tok"] * 8 + [None])
@@ -1128,10 +1139,18 @@ async def test_status_loop_resets_backoff_after_success(monkeypatch):
     expired = []
     monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
     async with app.run_test() as pilot:
+        # Neutralise the list refresh _on_ws_connected triggers, so the
+        # counter reset under test is the only thing touching
+        # _reconnect_attempt.
+        monkeypatch.setattr(app.screen, "refresh_lists", lambda: None)
         await _real_status_loop(app.screen)
         await pilot.pause()
     assert expired
     assert calls["n"] >= 5
+    # Without the reset the counter climbs 1,2,3,4,5,6. The success at call 3
+    # collapses it back to 0, so the third backoff is a fresh attempt 1.
+    assert seen[:2] == [1, 2]
+    assert seen[2] == 1
 
 
 async def test_login_password_flow_success(monkeypatch):
@@ -3371,6 +3390,53 @@ async def test_main_screen_server_down_shows_indicator(monkeypatch):
         # App-wide overlay covers whatever page is active (#2012).
         assert isinstance(app.screen, ServerDownScreen)
         assert "server unreachable" in app.screen._message.lower()
+
+
+async def test_rest_blip_while_ws_up_keeps_list(monkeypatch):
+    """A transient REST list-fetch failure while the status WS is connected
+    does NOT flag the server unreachable — the WS proves the backend is
+    reachable, so the last good list is kept and refreshed on the next
+    broadcast / reconnect (#2052)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    alpha = _wsobj("alpha")
+    up = {"yes": True}
+
+    def owned():
+        if up["yes"]:
+            return [alpha]
+        raise httpx.ConnectError("refused")
+
+    app = KlangkApp(
+        _ws(list_owned_workspaces=owned, list_shared_workspaces=owned)
+    )
+    async with app.run_test() as pilot:
+        screen = app.screen
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # WS is connected; list populated.
+        screen._ws_connected = True
+        assert (
+            "alpha" in _lv_texts(screen.query_one("#owned_list", ListView))[0]
+        )
+        assert screen._server_unreachable is False
+        # A REST blip while the WS is up must NOT flag the server unreachable…
+        up["yes"] = False
+        screen.refresh_lists()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen._server_unreachable is False
+        assert not isinstance(app.screen, ServerDownScreen)
+        # …and the last good list is retained (not replaced with an
+        # "unreachable" label or cleared to "no workspaces").
+        assert (
+            "alpha" in _lv_texts(screen.query_one("#owned_list", ListView))[0]
+        )
 
 
 async def test_main_screen_http_error_is_not_unreachable(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -858,6 +858,7 @@ class FakeCM:
 
 async def test_listen_for_status_filters_and_forwards(monkeypatch):
     collected = []
+    connected = []
     frames = [
         '{"type": "workspaces_changed"}',
         "not-json",
@@ -867,7 +868,13 @@ async def test_listen_for_status_filters_and_forwards(monkeypatch):
     monkeypatch.setattr(
         ws_mod, "ws_connect", lambda *a, **k: FakeCM(FakeWS(frames))
     )
-    await listen_for_status("/sock", "tok", on_event=collected.append)
+    await listen_for_status(
+        "/sock",
+        "tok",
+        on_event=collected.append,
+        on_connect=lambda: connected.append(1),
+    )
+    assert connected == [1]  # fires once after connect, before any frames
     assert collected == [
         {"type": "workspaces_changed"},
         {"type": "service_health"},
@@ -3329,15 +3336,19 @@ def test_is_unreachable_classifies_transport_errors():
 
 
 async def test_main_screen_server_down_shows_indicator(monkeypatch):
-    """A transport failure (server unreachable) shows a "server down" state,
-    not a misleading "no workspaces" — and kicks off a visible reconnect (#2012)."""
+    """A transport failure on the mount-time list fetch enters the 'server
+    down' state — an explicit 'server unreachable' row instead of a misleading
+    'no workspaces' — and surfaces the app-wide overlay (#2012, #2052).
+
+    The WS loop is now the single reachability signal (#2052); the autouse
+    fixture stubs it here, so this test drives only the mount-time REST fetch.
+    The attempt-counter / reconnect path is exercised by the dedicated
+    ``_status_loop`` tests below."""
 
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    # Park the reconnect loop mid-backoff so we can assert the in-flight state.
-    monkeypatch.setattr(scr_main, "_reconnect_backoff", lambda attempt: 999.0)
 
     def down():
         raise httpx.ConnectError("refused")
@@ -3346,11 +3357,10 @@ async def test_main_screen_server_down_shows_indicator(monkeypatch):
         _ws(list_owned_workspaces=down, list_shared_workspaces=down)
     )
     async with app.run_test() as pilot:
-        # Let the initial refresh fail, enter unreachable, and run the
-        # reconnect loop up to its (parked) backoff sleep. Don't call
-        # wait_for_complete() — the loop is intentionally parked mid-backoff.
-        for _ in range(8):
-            await pilot.pause()
+        # Let the mount-time refresh_lists fail and enter unreachable.
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
         main = next(s for s in app.screen_stack if isinstance(s, MainScreen))
         assert main._server_unreachable is True
         owned_lv = main.query_one("#owned_list", ListView)
@@ -3358,7 +3368,6 @@ async def test_main_screen_server_down_shows_indicator(monkeypatch):
         assert "server unreachable" in _lv_texts(owned_lv)[0].lower()
         assert "server unreachable" in _lv_texts(shared_lv)[0].lower()
         assert "unreachable" in (app.live_extra or "").lower()
-        assert "attempt 1" in (app.live_extra or "")
         # App-wide overlay covers whatever page is active (#2012).
         assert isinstance(app.screen, ServerDownScreen)
         assert "server unreachable" in app.screen._message.lower()
@@ -3402,13 +3411,10 @@ async def _fast_reconnect(monkeypatch):
 
 
 async def test_reconnect_recovers_when_server_returns(monkeypatch):
-    """Once the backend comes back, the reconnect loop repopulates the lists
-    without a logout/relogin (#2012)."""
+    """Once the backend comes back, the status WS reconnects and its
+    on-connect callback clears the unreachable state and repopulates the
+    lists — no logout/relogin needed (#2012, #2052)."""
 
-    async def noop(*a, **k):
-        return None
-
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
     await _fast_reconnect(monkeypatch)
 
     calls = {"n": 0}
@@ -3416,34 +3422,63 @@ async def test_reconnect_recovers_when_server_returns(monkeypatch):
 
     def owned():
         calls["n"] += 1
-        # Initial owned+shared fetch (calls 1-2) fails -> enter unreachable;
-        # the reconnect loop's fetch (call 3+) succeeds.
-        if calls["n"] <= 2:
+        # Mount fetch (call 1) fails -> enter unreachable; the recovery
+        # fetch from _on_ws_connected (call 2+) succeeds.
+        if calls["n"] <= 1:
             raise httpx.ConnectError("refused")
         return [alpha]
 
+    ws_calls = {"n": 0}
+
+    async def ws_script(*a, **k):
+        ws_calls["n"] += 1
+        if ws_calls["n"] == 1:
+            raise RuntimeError("ws refused")  # still down
+        # Backend is back: connect (fires _on_ws_connected -> recovery),
+        # then clean close.
+        on_connect = k.get("on_connect")
+        if on_connect is not None:
+            on_connect()
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", ws_script)
+    tokens = iter(["tok"] * 3 + [None])
     app = KlangkApp(
-        _ws(list_owned_workspaces=owned, list_shared_workspaces=owned)
+        _ws(
+            list_owned_workspaces=owned,
+            list_shared_workspaces=owned,
+            token=lambda: next(tokens),
+        )
     )
+    expired = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
     async with app.run_test() as pilot:
+        # Mount fetch fails -> unreachable (overlay pushed, so grab the
+        # MainScreen explicitly, not app.screen).
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause()
-        screen = app.screen
+        screen = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        assert screen._server_unreachable is True
+        # Drive the WS loop: attempt 1 fails (grace), attempt 2 reconnects
+        # (fires _on_ws_connected -> clears unreachable + refreshes lists).
+        await _real_status_loop(screen)
+        await app.workers.wait_for_complete()  # let recovery refresh finish
+        await pilot.pause()
         assert screen._server_unreachable is False
-        assert app.live_extra == ""
         assert (
             "alpha" in _lv_texts(screen.query_one("#owned_list", ListView))[0]
         )
 
 
 async def test_reconnect_gives_up_after_cap(monkeypatch):
-    """After the attempt cap the loop stops and tells the user to act (#2012)."""
+    """After the attempt cap the WS reconnect loop stops and tells the user
+    to act (#2012, #2052)."""
 
-    async def noop(*a, **k):
-        return None
+    async def fail(*a, **k):
+        raise RuntimeError("ws refused")
 
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "listen_for_status", fail)
     monkeypatch.setattr(scr_main, "_MAX_RECONNECT_ATTEMPTS", 2)
     await _fast_reconnect(monkeypatch)
 
@@ -3458,6 +3493,10 @@ async def test_reconnect_gives_up_after_cap(monkeypatch):
         await app.workers.wait_for_complete()
         await pilot.pause()
         main = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        # Drive the WS loop: it burns through the (low) attempt cap and
+        # returns on its own via the give-up branch (no token-drop bound).
+        await _real_status_loop(main)
+        await pilot.pause()
         assert main._server_unreachable is False
         assert main._gave_up is True
         owned_lv = main.query_one("#owned_list", ListView)
@@ -3529,88 +3568,95 @@ async def test_server_down_overlay_c_opens_switch_server(monkeypatch):
 
 async def test_server_down_overlay_covers_any_active_page(monkeypatch):
     """The app-level overlay lands on top of whatever screen is active — not
-    just the workspaces page — so a drop while a detail/form page is open is
-    still signalled everywhere (#2012)."""
+    just the workspaces page — so a WS-detected drop while a detail/form page
+    is open is still signalled everywhere (#2012, #2052)."""
 
-    async def noop(*a, **k):
-        return None
+    async def fail(*a, **k):
+        raise RuntimeError("ws refused")
 
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    monkeypatch.setattr(scr_main, "_reconnect_backoff", lambda attempt: 999.0)
+    monkeypatch.setattr(scr_main, "listen_for_status", fail)
+    await _fast_reconnect(monkeypatch)
 
-    up = {"yes": True}
     alpha = _wsobj("alpha")
 
     def owned():
-        if up["yes"]:
-            return [alpha]
-        raise httpx.ConnectError("refused")
+        return [alpha]
 
+    tokens = iter(["tok"] * 10 + [None])
     app = KlangkApp(
-        _ws(list_owned_workspaces=owned, list_shared_workspaces=owned)
+        _ws(
+            list_owned_workspaces=owned,
+            list_shared_workspaces=owned,
+            token=lambda: next(tokens),
+        )
     )
+    expired = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
     async with app.run_test() as pilot:
-        for _ in range(6):
-            await pilot.pause()
+        # Initial REST fetch succeeds; lists populate.
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
         # Navigate "away" from the workspaces page onto a detail/form page.
         from textual.screen import Screen as _Screen
 
         detail = _Screen()
         app.push_screen(detail)
-        for _ in range(3):
-            await pilot.pause()
+        await pilot.pause()
         assert app.screen is detail
-        # Backend drops; the heartbeat (on the still-mounted MainScreen)
-        # detects it and pushes the overlay on TOP of the detail page.
-        up["yes"] = False
-        next(
-            s for s in app.screen_stack if isinstance(s, MainScreen)
-        )._heartbeat_tick()
-        for _ in range(8):
-            await pilot.pause()
+        # The status WS can't connect (server down); the WS reconnect loop
+        # (run on the still-mounted MainScreen) detects it and pushes the
+        # overlay on TOP of the detail page. Token drops to None to bound the
+        # loop (session_expired is stubbed so it doesn't replace the overlay).
+        main = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        await _real_status_loop(main)
+        await pilot.pause()
         assert isinstance(app.screen, ServerDownScreen)
         # The detail page is still in the stack, underneath the overlay.
         assert detail in app.screen_stack
 
 
-async def test_heartbeat_detects_drop_after_initial_load(monkeypatch):
-    """The reachability heartbeat re-fetches the list on a timer, so a backend
-    that drops after the page is already shown (mid-session, or while a detail
-    page was open) surfaces "server unreachable" on the next tick — one
-    mechanism covering every detection path (#2012)."""
+async def test_ws_detects_drop_after_initial_load(monkeypatch):
+    """The status WS is the single reachability signal (#2052): a backend that
+    drops after the page is already shown surfaces 'server unreachable' when
+    the WS reconnect loop's second attempt fails — one mechanism covering the
+    mid-session drop."""
 
-    async def noop(*a, **k):
-        return None
+    async def fail(*a, **k):
+        raise RuntimeError("ws refused")
 
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    # Park the reconnect loop so the heartbeat tick is what we exercise.
-    monkeypatch.setattr(scr_main, "_reconnect_backoff", lambda attempt: 999.0)
+    monkeypatch.setattr(scr_main, "listen_for_status", fail)
+    await _fast_reconnect(monkeypatch)
 
-    up = {"yes": True}
     alpha = _wsobj("alpha")
 
     def owned():
-        if up["yes"]:
-            return [alpha]
-        raise httpx.ConnectError("refused")
+        return [alpha]
 
+    tokens = iter(["tok"] * 8 + [None])
     app = KlangkApp(
-        _ws(list_owned_workspaces=owned, list_shared_workspaces=owned)
+        _ws(
+            list_owned_workspaces=owned,
+            list_shared_workspaces=owned,
+            token=lambda: next(tokens),
+        )
     )
+    expired = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
     async with app.run_test() as pilot:
         screen = app.screen
-        for _ in range(6):
-            await pilot.pause()
+        # Initial REST fetch succeeds; lists populate, not unreachable.
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
         assert screen._server_unreachable is False
         assert (
             "alpha" in _lv_texts(screen.query_one("#owned_list", ListView))[0]
         )
-
-        # Backend drops; the next heartbeat tick re-fetches and detects it.
-        up["yes"] = False
-        screen._heartbeat_tick()
-        for _ in range(8):
-            await pilot.pause()
+        # The status WS can't connect (server down); the reconnect loop
+        # detects it on the second failed attempt and surfaces unreachable.
+        await _real_status_loop(screen)
+        await pilot.pause()
         assert screen._server_unreachable is True
         assert (
             "server unreachable"
@@ -3618,89 +3664,47 @@ async def test_heartbeat_detects_drop_after_initial_load(monkeypatch):
         )
 
 
-async def test_heartbeat_tick_skips_when_down_or_unauthenticated(monkeypatch):
-    """The heartbeat is a no-op once unreachable (the reconnect loop owns
-    retry) or once unauthenticated (#2012)."""
+async def test_status_loop_exits_when_screen_popped(monkeypatch):
+    """If the MainScreen leaves the stack (logout / server switch) while the
+    WS loop is running, the top-of-iteration guard stops it instead of
+    mutating a dead screen (#2052)."""
 
-    async def noop(*a, **k):
-        return None
+    async def fail(*a, **k):
+        raise RuntimeError("ws died")
 
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    app = KlangkApp(_authed_state())
-    async with app.run_test():
-        screen = app.screen
-        fired = []
-        monkeypatch.setattr(screen, "refresh_lists", lambda: fired.append(1))
-
-        # Already unreachable: skip (reconnect loop handles retry).
-        screen._server_unreachable = True
-        screen._heartbeat_tick()
-        assert fired == []
-
-        # Unauthenticated: skip.
-        screen._server_unreachable = False
-        monkeypatch.setattr(
-            screen.app.tui_state, "is_authenticated", lambda: False
-        )
-        screen._heartbeat_tick()
-        assert fired == []
-
-        # Gave up reconnecting: skip (don't re-arm a new loop, #2036).
-        screen._gave_up = True
-        monkeypatch.setattr(
-            screen.app.tui_state, "is_authenticated", lambda: True
-        )
-        screen._heartbeat_tick()
-        assert fired == []
-
-        # Authenticated and up (not gave_up): fires a refresh.
-        screen._gave_up = False
-        screen._heartbeat_tick()
-        assert fired == [1]
-
-
-async def test_reconnect_loop_exits_when_screen_popped(monkeypatch):
-    """If the MainScreen leaves the stack (logout / server switch) while a
-    reconnect is pending, the loop stops instead of mutating a dead screen
-    (#2012). Covers the top-of-iteration guard."""
-
-    async def noop(*a, **k):
-        return None
-
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "listen_for_status", fail)
     await _fast_reconnect(monkeypatch)
     app = KlangkApp(_ws())  # list contents irrelevant — loop returns early
     async with app.run_test():
         screen = app.screen
         assert isinstance(screen, MainScreen)
-        screen._server_unreachable = True
-        screen._reconnect_active = True
         # Pretend the screen was already removed (e.g. logout completed).
         from textual.app import App as _App
 
         monkeypatch.setattr(_App, "screen_stack", property(lambda self: []))
-        await scr_main.MainScreen._reconnect_loop(screen)
-        assert screen._reconnect_active is False  # finally ran
+        expired = []
+        monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
+        await _real_status_loop(screen)
+        assert expired == []  # screen-pop exit, not session_expired
 
 
-async def test_reconnect_loop_exits_when_screen_popped_during_backoff(
+async def test_status_loop_exits_when_screen_popped_during_backoff(
     monkeypatch,
 ):
-    """A screen pop during the backoff sleep is caught by the post-sleep
-    guard — the loop exits without a fetch or a render (#2012)."""
+    """A screen pop during the backoff sleep is caught by the next
+    iteration's top guard — the loop exits without a render on the dead
+    screen (#2052)."""
 
-    async def noop(*a, **k):
-        return None
+    async def fail(*a, **k):
+        raise RuntimeError("ws died")
 
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "listen_for_status", fail)
     monkeypatch.setattr(scr_main, "_reconnect_backoff", lambda attempt: 0.0)
     rendered: list = []
     app = KlangkApp(_ws())
     async with app.run_test():
         screen = app.screen
         assert isinstance(screen, MainScreen)
-        screen._server_unreachable = True
-        screen._reconnect_active = True
 
         async def pop_during_sleep(_delay):
             # Simulate the screen being popped while the loop is parked.
@@ -3714,38 +3718,54 @@ async def test_reconnect_loop_exits_when_screen_popped_during_backoff(
         monkeypatch.setattr(
             screen, "_render_unreachable", lambda *a, **k: rendered.append(1)
         )
-        await scr_main.MainScreen._reconnect_loop(screen)
-        assert screen._reconnect_active is False
-        assert rendered == []  # never rendered on the dead screen
+        await _real_status_loop(screen)
+        # iter 1 fails -> grace (no render) -> sleep pops the screen; iter 2's
+        # top guard exits before a second attempt can render on the dead
+        # screen.
+        assert rendered == []
 
 
 async def test_reconnect_auth_failure_redirects_to_login(monkeypatch):
-    """An auth failure surfacing during reconnect triggers session_expired (#2012)."""
+    """An auth failure surfacing on the status WS triggers session_expired
+    (#2012, #2052)."""
 
-    async def noop(*a, **k):
-        return None
-
-    monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    await _fast_reconnect(monkeypatch)
-
-    calls = {"n": 0}
-
-    def fn():
-        calls["n"] += 1
-        # Initial fetch (calls 1-2) fails as unreachable; the loop's fetch
-        # then raises AuthError.
-        if calls["n"] <= 2:
-            raise httpx.ConnectError("refused")
+    async def auth_fail(*a, **k):
         raise AuthError("expired")
 
-    app = KlangkApp(_ws(list_owned_workspaces=fn, list_shared_workspaces=fn))
+    monkeypatch.setattr(scr_main, "listen_for_status", auth_fail)
+    await _fast_reconnect(monkeypatch)
+    app = KlangkApp(_ws())
     expired = []
     monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-        assert expired  # reconnect saw AuthError -> session_expired
+    async with app.run_test():
+        await _real_status_loop(app.screen)
+        assert expired  # WS saw AuthError -> session_expired
+
+
+async def test_status_loop_exits_when_screen_popped_after_listen(monkeypatch):
+    """A screen pop that lands while listen_for_status is in flight (so it
+    returns normally) is caught by the post-listen guard — the loop exits
+    without a reconnect attempt on the dead screen (#2052)."""
+
+    from textual.app import App as _App
+
+    async def pop_then_close(*a, **k):
+        # Screen popped (logout) while "reading frames"; listen returns.
+        monkeypatch.setattr(_App, "screen_stack", property(lambda self: []))
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", pop_then_close)
+    await _fast_reconnect(monkeypatch)
+    app = KlangkApp(_ws())
+    rendered = []
+    async with app.run_test():
+        screen = app.screen
+        monkeypatch.setattr(
+            screen, "_render_unreachable", lambda *a, **k: rendered.append(1)
+        )
+        await _real_status_loop(screen)
+        # Post-listen guard fired before the reconnect branch could run.
+        assert rendered == []
 
 
 async def test_focus_visible_list_on_mount(monkeypatch):


### PR DESCRIPTION
## Summary

The TUI ran two competing backend-reachability signals — a REST heartbeat poll and the status WebSocket — that could disagree on whether the backend was up. This consolidates reachability into a single signal: the status WS connection lifecycle. Closes #2052.

## Changes

- **Removed** the REST heartbeat (`_heartbeat_timer` / `_heartbeat_tick` / `_HEARTBEAT_SECONDS`) and the REST-driven `_reconnect_loop`.
- **`_status_loop` is now the single reachability signal.** It maintains the status WS and drives the unreachable overlay from its lifecycle:
  - A transient drop (clean close or error) gets **one silent grace retry** before the overlay appears, so a healthy server restart doesn't flash "server down".
  - On the second+ loss it enters unreachable with bounded backoff.
  - On **(re)connect**, `_on_ws_connected` clears the overlay and refreshes the list (also catching a REST-only degradation lazily).
  - After `_MAX_RECONNECT_ATTEMPTS` (25) it **gives up** and tells the user to switch server.
- **Protocol pings tightened** to 10 s interval / 10 s timeout (client `ws.py` + server `launcher.py`) so a wedged/half-open connection is detected in ~20 s with no REST polling.

## Test plan

- [x] Rewrote the 9 tests that encoded the old heartbeat / `_reconnect_loop` model to drive `_status_loop` directly (via the saved `_real_status_loop` ref) with a scripted `listen_for_status` + token sequencing.
- [x] Deleted the obsolete `test_heartbeat_tick_skips_when_down_or_unauthenticated`.
- [x] Added `test_status_loop_exits_when_screen_popped_after_listen` (post-listen screen-pop guard) and extended `test_listen_for_status_filters_and_forwards` to cover the new `on_connect` callback.
- [x] `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — **4168 passed, 100% coverage**.

## Notes

- `enable_ping`-style runtime swap is unaffected; this is a TUI-only change (CLI subpackage, no server-side changes).
