### PR TITLE
perf(e2e): parallelize backend and CLI E2E suites with xdist

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -264,16 +264,13 @@ in
   '';
 
   # CLI E2E tests: start real server, run klangk commands.
-  # Ports are free-allocated (#1393), so xdist is no longer forcibly
-  # disabled. The suite runs serially by default (no -n) because the
-  # tests spawn real podman containers and within-suite parallelism is
-  # bounded by container concurrency. To opt into xdist:
-  #   test-cli-e2e -n auto --dist=loadscope
-  # (--dist=loadscope keeps each module/class-scoped server on one worker).
+  # Free-allocated ports + instance-scoped cleanup (#1393) make xdist
+  # safe with --dist=loadscope. Capped at 2 workers to limit podman
+  # contention (TUI and terminal-windows tests are latency-sensitive). #2059
   scripts.test-cli-e2e.exec = ''
     cd $DEVENV_ROOT
     exec python -m pytest src/klangk/klangkc-tests/e2e-tests \
-      -v --no-cov "$@"
+      -v --no-cov -n 2 --dist=loadscope "$@"
   '';
 
   scripts.test-terminal-windows-e2e.exec = ''
@@ -283,12 +280,14 @@ in
   '';
 
   # Backend E2E tests: start real server, run backend E2E tests.
-  # Same xdist story as test-cli-e2e (free ports, serial by default,
-  # opt-in with -n auto --dist=loadscope). See #1393.
+  # Free-allocated ports + instance-scoped cleanup (#1393) make xdist
+  # safe with --dist=loadscope. Capped at 2 workers: higher counts
+  # cause flaky failures in container-heavy tests (ssh-agent,
+  # service-command) due to podman resource contention. #2059
   scripts.test-backend-e2e.exec = ''
     cd $DEVENV_ROOT
     exec python -m pytest src/klangk/klangkd-tests/e2e-tests \
-      -v --no-cov "$@"
+      -v --no-cov -n 2 --dist=loadscope "$@"
   '';
 
   # Systemd user-service nginx e2e (#1729): runs klangkd with the nginx
@@ -311,12 +310,10 @@ in
 
   # Run the whole corpus as concurrently as is safe (#1393): the unit
   # suites combine into one parallel invocation (test-unit), then the
-  # e2e suites run. E2e suites are now concurrency-safe (free-allocated
-  # ports + instance-scoped container cleanup) so they could be
-  # backgrounded; they run serially here to bound podman/container
-  # resource usage. Requires podman + a built workspace image for the
-  # e2e steps (klangk:build-workspace-image). Passes through args to the
-  # e2e invocations only.
+  # e2e suites run with xdist (--dist=loadscope, 2 workers each).
+  # Requires podman + a built workspace image for the e2e steps
+  # (klangk:build-workspace-image). Passes through args to the e2e
+  # invocations only.
   scripts.test-all.exec = ''
     cd $DEVENV_ROOT
     set -e
@@ -324,9 +321,11 @@ in
     python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
       -v -n auto --no-cov "$@"
     echo "=== server e2e ==="
-    python -m pytest src/klangk/klangkd-tests/e2e-tests -v --no-cov "$@"
+    python -m pytest src/klangk/klangkd-tests/e2e-tests \
+      -v --no-cov -n 2 --dist=loadscope "$@"
     echo "=== client e2e ==="
-    python -m pytest src/klangk/klangkc-tests/e2e-tests -v --no-cov "$@"
+    python -m pytest src/klangk/klangkc-tests/e2e-tests \
+      -v --no-cov -n 2 --dist=loadscope "$@"
     echo "=== all green ==="
   '';
 

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -92,6 +92,7 @@ def _get_token(base_url):
     r = httpx.post(
         f"{base_url}/api/v1/auth/login",
         json={"identifier": "test@example.com", "password": "testpass"},
+        timeout=30,
     )
     r.raise_for_status()
     return r.json()["access_token"]
@@ -202,6 +203,7 @@ class _WebSession:
         self._ctx = websockets.connect(
             f"{ws_url}/ws?token={self.token}",
             max_size=16 * 1024 * 1024,
+            open_timeout=30,
         )
         self.ws = await self._ctx.__aenter__()
         await self.ws.send(
@@ -335,6 +337,7 @@ class TestTerminalWindows:
         r = httpx.get(
             f"{self._base_url}/api/v1/workspaces",
             headers={"Authorization": f"Bearer {self._token}"},
+            timeout=30,
         )
         self._ws_id = None
         for ws in r.json():

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -85,6 +85,7 @@ def token(base_url):
     r = httpx.post(
         f"{base_url}/api/v1/auth/login",
         json={"identifier": "tuiuser@example.com", "password": "tuipass"},
+        timeout=30,
     )
     r.raise_for_status()
     return r.json()["access_token"]
@@ -113,6 +114,7 @@ def _api_create_workspace(base_url, token, name):
         f"{base_url}/api/v1/workspaces",
         json={"name": name},
         headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
     )
     r.raise_for_status()
     return r.json()["id"]
@@ -123,6 +125,7 @@ def _api_delete_workspace(base_url, token, ws_id):
     httpx.delete(
         f"{base_url}/api/v1/workspaces/{ws_id}",
         headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
     )
 
 
@@ -131,6 +134,7 @@ def _api_get_workspace(base_url, token, ws_id):
     r = httpx.get(
         f"{base_url}/api/v1/workspaces",
         headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
     )
     r.raise_for_status()
     for ws in r.json():
@@ -394,6 +398,7 @@ class TestTuiE2E:
                 r = httpx.get(
                     f"{base_url}/api/v1/workspaces",
                     headers={"Authorization": f"Bearer {token}"},
+                    timeout=30,
                 )
                 r.raise_for_status()
                 ws_names = [w["name"] for w in r.json()]
@@ -403,6 +408,7 @@ class TestTuiE2E:
                 r = httpx.get(
                     f"{base_url}/api/v1/workspaces",
                     headers={"Authorization": f"Bearer {token}"},
+                    timeout=30,
                 )
                 r.raise_for_status()
                 for w in r.json():


### PR DESCRIPTION
## Summary

- Enable pytest-xdist (`-n 2 --dist=loadscope`) for `test-backend-e2e`, `test-cli-e2e`, and `test-all`
- Raise httpx timeouts (5s default → 30s) in TUI and terminal-windows E2E tests so they tolerate podman contention under parallel execution
- Add `open_timeout=30` to websocket connections in terminal-windows tests

## Measured speedups (local, 72-core machine)

| Suite | Serial | xdist `-n 2` | Speedup |
|---|---|---|---|
| Backend E2E (131 tests) | 6:45 | 4:17 | 1.6x |
| CLI E2E (81 tests) | 9:27 | 5:19 | 1.8x |

Higher worker counts (4+) caused flaky failures in container-heavy tests (ssh-agent, service-command, TUI) due to podman resource contention. 2 workers is the sweet spot — stable across repeated runs.

## Test plan

- [x] `test-backend-e2e` passes cleanly with `-n 2 --dist=loadscope` (3 consecutive runs)
- [x] `test-cli-e2e` passes cleanly with `-n 2 --dist=loadscope` (2 consecutive runs; only pre-existing flaky `test_web_sees_cli_created_windows` fails — also fails serially)
- [x] `test-backend` unit tests pass (100% coverage)

Closes #2059