### PR TITLE
fix(litellm): stop sidecar flapping; load config; default port 8996

### DIFF
--- a/docs/architecture/llm-proxy.md
+++ b/docs/architecture/llm-proxy.md
@@ -33,7 +33,7 @@ To route to **multiple distinct providers** (e.g. OpenAI + Anthropic + a local O
 
 1. The operator configures `KLANGKD_LLM_AGGREGATOR_MODELS` with a list of `provider/model:api_base:api_key` entries.
 2. At startup, klangk renders a LiteLLM `config.yaml` from those entries and runs the LiteLLM container with that config (config-only mode, no DB, no UI).
-3. `KLANGKD_LLM_BASE_URL` points at the sidecar (`http://127.0.0.1:4000/v1`).
+3. `KLANGKD_LLM_BASE_URL` points at the sidecar (`http://127.0.0.1:8996/v1`).
 4. The proxy forwards `/llm-proxy/` to the sidecar, which routes to the correct provider based on the `model` field in each request.
 5. `llm-proxy-models.ts` calls `/models` on the sidecar and discovers all models across all configured providers.
 
@@ -50,13 +50,18 @@ Set these environment variables (or their equivalents in `klangkd.yaml`):
 KLANGKD_LLM_AGGREGATOR_MODELS="openai/gpt-4o::sk-xxx,anthropic/claude-sonnet-4::sk-ant-xxx,ollama/llama3:http://gpu:11434:"
 
 # Point the proxy at the sidecar.
-KLANGKD_LLM_BASE_URL="http://127.0.0.1:4000/v1"
+KLANGKD_LLM_BASE_URL="http://127.0.0.1:8996/v1"
 
-# Optional: master key for the LiteLLM sidecar (default: empty = no auth).
+# Optional: master key for the LiteLLM sidecar. Default is empty (no auth —
+# the sidecar is protected by its 127.0.0.1 bind + the proxy's IP filtering).
+# When set, LiteLLM enforces bearer auth: set KLANGKD_LLM_API_KEY to the SAME
+# value (the proxy sends it as the bearer). Works DB-less — a matching key is
+# accepted in-memory.
 KLANGKD_LLM_AGGREGATOR_MASTER_KEY="sk-master"
 
-# Optional: host port the sidecar listens on (default: 4000).
-KLANGKD_LLM_AGGREGATOR_PORT=4000
+# Optional: host port the sidecar is published on (default: 8996; LiteLLM
+# always listens on 4000 inside the container).
+KLANGKD_LLM_AGGREGATOR_PORT=8996
 
 # Optional: container image (default: ghcr.io/berriai/litellm:main-stable).
 KLANGKD_LLM_AGGREGATOR_IMAGE="ghcr.io/berriai/litellm:main-stable"
@@ -65,7 +70,7 @@ KLANGKD_LLM_AGGREGATOR_IMAGE="ghcr.io/berriai/litellm:main-stable"
 Or in `klangkd.yaml` (colon-delimited strings):
 
 ```yaml
-llm-base-url: "http://127.0.0.1:4000/v1"
+llm-base-url: "http://127.0.0.1:8996/v1"
 llm-aggregator-models:
   - "openai/gpt-4o::sk-xxx"
   - "anthropic/claude-sonnet-4::sk-ant-xxx"
@@ -76,7 +81,7 @@ llm-aggregator-master-key: "sk-master"
 Or using the dict format (recommended for `klangkd.yaml` — supports `file:` and `cmd:` indirection on secrets so API keys stay out of the config file):
 
 ```yaml
-llm-base-url: "http://127.0.0.1:4000/v1"
+llm-base-url: "http://127.0.0.1:8996/v1"
 llm-aggregator-models:
   - id: openai/gpt-4o
     api-key: "cmd:pass show openai/api-key"
@@ -95,14 +100,14 @@ Each dict entry has `id` (required), `base-url` (optional — omit to use provid
 Pi container
   → host.containers.internal:8995/llm-proxy/chat/completions
     → reverse proxy (caddy/nginx)
-      → http://127.0.0.1:4000/v1/chat/completions   (LiteLLM sidecar)
+      → http://127.0.0.1:8996/v1/chat/completions   (LiteLLM sidecar)
         → routes by "model" field in request body:
           → openai/gpt-4o    → https://api.openai.com/v1
           → anthropic/...    → https://api.anthropic.com/v1
           → ollama/llama3    → http://gpu:11434
 ```
 
-The sidecar is supervised by `LiteLLMWatchdog` (mirroring `ProxyWatchdog`): it respawns on unexpected exit with exponential backoff, and is stopped cleanly on shutdown. Settings changes via SIGHUP trigger a container restart with the re-rendered config only when aggregator settings actually changed (other SIGHUP changes are ignored). Removing all models via SIGHUP stops the sidecar. The container port is bound to `127.0.0.1` (loopback only) so the sidecar is not reachable from the LAN.
+The sidecar is supervised by `LiteLLMWatchdog` (mirroring `ProxyWatchdog`): it respawns on unexpected exit with exponential backoff, and is stopped cleanly on shutdown. Settings changes via SIGHUP trigger a container restart with the re-rendered config only when aggregator settings actually changed (other SIGHUP changes are ignored). Removing all models via SIGHUP stops the sidecar. The container port is bound to `127.0.0.1` (loopback only) so the sidecar is not reachable from the LAN. By default the sidecar runs without a master key (no-auth, relying on the loopback bind + the proxy's IP filtering); set `KLANGKD_LLM_AGGREGATOR_MASTER_KEY` (and `KLANGKD_LLM_API_KEY` to the same value) for optional bearer auth.
 
 ### Provider defaults
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1313,6 +1313,19 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **LiteLLM aggregator sidecar no longer flaps on startup (#2062).**
+  Three defects prevented the sidecar from ever serving: (1) the watchdog
+  passed `DATABASE_URL=` (empty), which LiteLLM treats as an invalid scheme
+  and exits on — now omitted entirely (config-only mode needs no DB);
+  (2) the watchdog never passed `--config`, so the mounted `config.yaml`
+  (the provider/model list) was never loaded — the container command now
+  passes `--config /app/config.yaml` (`Podman.create_container` gained a
+  `command` override for this); (3) the default host port changed from
+  `4000` to `8996`. The sidecar runs no-auth by default (protected by its
+  `127.0.0.1` bind + the proxy's IP filtering); `KLANGKD_LLM_AGGREGATOR_MASTER_KEY`
+  is optional and works DB-less — when set, set `KLANGKD_LLM_API_KEY` to the
+  same value so the proxy authenticates.
+
 - **The TUI's live status feed no longer dies after 3 reconnect
   failures (#2033).** `_status_loop` capped retries at 3, after which
   live updates (container status, workspace changes, service health)

--- a/src/klangk/klangk/litellm.py
+++ b/src/klangk/klangk/litellm.py
@@ -17,7 +17,13 @@ Architecture mirrors :mod:`klangk.proxy` (``ProxyRenderer`` + ``ProxyWatchdog``)
 
 The container publishes its port on ``127.0.0.1`` only (loopback) so that
 the proxy can reach it at ``127.0.0.1:<port>`` while the sidecar is not
-reachable from the LAN.
+reachable from the LAN. By default the sidecar runs **without** a LiteLLM
+master key (no-auth) and is protected by the loopback bind plus the proxy's
+IP filtering; an operator may set ``KLANGKD_LLM_AGGREGATOR_MASTER_KEY`` for
+belt-and-suspenders bearer auth (LiteLLM accepts the matching master key
+in-memory — no database required; the proxy must then send the same value
+as ``KLANGKD_LLM_API_KEY``). Only the per-provider keys in ``model_list``
+are stored, so LiteLLM can present them when proxying to each upstream.
 """
 
 from __future__ import annotations
@@ -140,6 +146,12 @@ class LiteLLMRenderer:
             "model_list": model_list,
         }
 
+        # Optional master_key: when set, LiteLLM enforces bearer auth on the
+        # sidecar (the proxy must send the same value as llm_api_key). When
+        # unset (the default) the sidecar is no-auth, protected by the
+        # loopback bind + proxy IP filtering. master_key auth is DB-less: a
+        # matching bearer is accepted in-memory; only an *unknown* key would
+        # need a DB (which we don't configure) (#2062).
         master_key = settings.llm_aggregator_master_key
         if master_key:
             config["general_settings"] = {
@@ -236,6 +248,18 @@ class LiteLLMWatchdog:
             settings = self._app.state.settings
             port = settings.llm_aggregator_port
             image = settings.llm_aggregator_image
+            # No DATABASE_URL: LiteLLM treats an empty/missing-scheme
+            # DATABASE_URL as fatal and exits (#2062); config-only mode needs
+            # no DB. LITELLM_MASTER_KEY is passed only when the operator set
+            # one: with a master_key LiteLLM enforces bearer auth (the proxy
+            # must send the same value as llm_api_key); without one (the
+            # default) the sidecar is no-auth, protected by the loopback bind
+            # + proxy IP filtering.
+            env = ["STORE_MODEL_IN_DB=False", "LITELLM_LOG=ERROR"]
+            if settings.llm_aggregator_master_key:
+                env.append(
+                    f"LITELLM_MASTER_KEY={settings.llm_aggregator_master_key}"
+                )
 
             try:
                 container_id = await podman.create_container(
@@ -243,13 +267,19 @@ class LiteLLMWatchdog:
                     image,
                     labels=_CONTAINER_LABELS,
                     binds=[f"{conf_path}:/app/config.yaml:ro,Z"],
-                    env=[
-                        f"LITELLM_MASTER_KEY={settings.llm_aggregator_master_key}",
-                        "DATABASE_URL=",
-                        "STORE_MODEL_IN_DB=False",
-                        "LITELLM_LOG=ERROR",
-                    ],
+                    env=env,
                     publish=[("127.0.0.1", port, 4000)],
+                    # Override the image Cmd: it defaults to just
+                    # ``--port 4000`` with no ``--config``, so without this the
+                    # mounted /app/config.yaml is never loaded (#2062).
+                    command=[
+                        "--config",
+                        "/app/config.yaml",
+                        "--host",
+                        "0.0.0.0",
+                        "--port",
+                        "4000",
+                    ],
                     pull="missing",
                     replace=True,
                 )

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -276,12 +276,16 @@ class Podman:
         cpus: float | None = None,
         memory: str | None = None,
         pids_limit: int | None = None,
+        command: list[str] | None = None,
     ) -> str:
         """Create a container and return its id.
 
         ``publish`` is a list of ``(host_port, container_port)`` or
         ``(bind_addr, host_port, container_port)`` tuples.
         ``replace=True`` removes an existing container with the same name.
+        ``command`` (optional ``list[str]``) overrides the image ``Cmd``:
+        the args are appended after the image name (e.g. LiteLLM's
+        ``--config /app/config.yaml``).
         ``annotations``/``hooks_dir`` carry per-workspace OCI hooks (e.g.
         the netfilter egress filter, #1365): each annotation becomes a
         ``--annotation key=value`` flag, and each ``hooks_dir`` entry becomes
@@ -343,6 +347,7 @@ class Podman:
         for entry in env or []:
             args += ["-e", entry]
         args.append(image)
+        args += command or []
         _rc, out, _err = await self.run(args, timeout=120.0)
         return out.strip()
 

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -742,7 +742,7 @@ class KlangkSettings(BaseSettings):
     # Comma-separated in the env var; a YAML list in klangkd.yaml.
     llm_aggregator_models: list[str] | None = None
     llm_aggregator_master_key: str = ""
-    llm_aggregator_port: int = 4000
+    llm_aggregator_port: int = 8996
     llm_aggregator_image: str = "ghcr.io/berriai/litellm:main-stable"
 
     # --- OIDC ---

--- a/src/klangk/klangkd-tests/tests/test_litellm.py
+++ b/src/klangk/klangkd-tests/tests/test_litellm.py
@@ -164,7 +164,7 @@ class TestSettingsValidator:
 
     def test_default_port(self):
         s = make_settings({})
-        assert s.llm_aggregator_port == 4000
+        assert s.llm_aggregator_port == 8996
 
     def test_custom_port(self):
         s = make_settings({"KLANGKD_LLM_AGGREGATOR_PORT": "5000"})
@@ -594,10 +594,52 @@ class TestLiteLLMWatchdog:
         assert len(create_calls) == 1
         assert create_calls[0][1] == "klangk-litellm"
         kwargs = create_calls[0][3]
-        assert kwargs["publish"] == [("127.0.0.1", 4000, 4000)]
+        # Host port is llm_aggregator_port (default 8996); container port is
+        # always 4000 (LiteLLM's internal port).
+        assert kwargs["publish"] == [("127.0.0.1", 8996, 4000)]
+        # #2062: --config is passed (else the mounted config is never loaded)
+        # and no fatal empty DATABASE_URL is set.
+        assert kwargs["command"] == [
+            "--config",
+            "/app/config.yaml",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "4000",
+        ]
+        assert "DATABASE_URL=" not in kwargs["env"]
+        # Default (no master_key) -> no LITELLM_MASTER_KEY env (no-auth).
+        assert not any(
+            e.startswith("LITELLM_MASTER_KEY") for e in kwargs["env"]
+        )
 
         start_calls = [c for c in podman.calls if c[0] == "start"]
         assert len(start_calls) == 1
+
+    async def test_watch_passes_master_key_env_when_set(self):
+        """When a master_key is configured, the sidecar env includes
+        LITELLM_MASTER_KEY so LiteLLM enforces bearer auth (#2062)."""
+        podman = _FakePodman()
+        s = make_settings(
+            {
+                "KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx",
+                "KLANGKD_LLM_AGGREGATOR_MASTER_KEY": "sk-master",
+            }
+        )
+        wd = _wd(s, podman=podman)
+
+        async def _fake_wait():
+            wd._stopping = True
+
+        wd._wait_for_exit = _fake_wait
+        conf_path = wd._config_path()
+        wd._renderer.write_config(conf_path)
+        await wd._watch(conf_path)
+
+        create_calls = [c for c in podman.calls if c[0] == "create"]
+        env = create_calls[0][3]["env"]
+        assert "LITELLM_MASTER_KEY=sk-master" in env
+        assert "DATABASE_URL=" not in env
 
     async def test_watch_respawns_on_unexpected_exit(self):
         """_watch respawns when container exits unexpectedly."""

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -268,6 +268,22 @@ class TestCreateContainer:
             args.index("-p") : args.index("-p") + 2
         ]
 
+    async def test_command_appended_after_image(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container(
+                "n",
+                "img",
+                command=["--config", "/app/config.yaml"],
+                replace=False,
+            )
+        args = _args(m)
+        # command args follow the image name (override the image Cmd) (#2062).
+        assert args[args.index("img") :] == [
+            "img",
+            "--config",
+            "/app/config.yaml",
+        ]
+
     async def test_pull_policy_override(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:
             await _p.create_container(


### PR DESCRIPTION
Closes #2062.

## What

The LiteLLM aggregator sidecar (#2046 / #2048) flapped endlessly on startup and never served a request. Three defects, each verified against the real `ghcr.io/bertriai/litellm:main-stable` image:

1. **Flap — fatal empty `DATABASE_URL=`.** `_watch` passed env `DATABASE_URL=` (empty); LiteLLM parses that as an unsupported scheme (`<missing scheme>`) and exits (~30s) → the watchdog recreated it in a flap loop. **Fix:** omit `DATABASE_URL` entirely (config-only mode needs no DB). Verified: with it omitted, `/health/readiness` → 200 and the container stays up.
2. **Config never loaded — no `--config`.** The image runs `litellm --port 4000` (entrypoint `exec litellm "$@"`, Cmd `[--port 4000]`), so the mounted `/app/config.yaml` was never referenced and `model_list` was empty. **Fix:** `Podman.create_container` gains a `command` override; the watchdog passes `--config /app/config.yaml --host 0.0.0.0 --port 4000`. Verified: with `--config`, startup logs print every configured model and `/v1/models` lists them.
3. **Default host-published port `4000` → `8996`** (8995 egress, 8996 LiteLLM, 8997 browser). The container still listens on 4000 internally.

## Auth

The sidecar is **no-auth by default**, protected by its `127.0.0.1` bind plus the proxy's IP filtering. `KLANGKD_LLM_AGGREGATOR_MASTER_KEY` is **optional** and works DB-less: LiteLLM accepts a matching bearer in-memory (only an *unknown* key would need a DB, which we don't configure). The earlier "No connected db" report was the unknown-key lookup path, not a master_key limitation. When a master key is set, the operator must set `KLANGKD_LLM_API_KEY` to the same value so caddy's bearer authenticates.

## Test plan

- [x] `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` → **4228 passed, 100% coverage**.
- [x] New/updated: `test_command_appended_after_image` (podman `command` override); `test_watch_passes_master_key_env_when_set`; expanded `_watch` assertions (no `DATABASE_URL=`, `--config` passed, no master_key env by default); `test_default_port` → 8996.
- [x] Manual (real image): sidecar runs stably with `DATABASE_URL` omitted + `--config`; `/v1/models` returns the configured models; matching master_key bearer → 200; no master_key → no-auth (bearer ignored).
