### PR TITLE
fix(litellm): drop unsupported params so provider calls don't 400

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1313,6 +1313,15 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **LiteLLM sidecar drops unsupported params instead of 400ing
+  (stopgap for the param side of #2066).** Clients (Pi) send OpenAI-style
+  params that not every provider supports (e.g. `max_completion_tokens` on
+  `zai/glm-*`), which LiteLLM rejected with a 400 `UnsupportedParamsError`.
+  The rendered config now sets `litellm_settings.drop_params: true` so
+  unsupported params are silently dropped per provider. The generic,
+  per-model fix (per-model `supported-params` + context-window metadata) is
+  tracked in #2066.
+
 - **LiteLLM aggregator sidecar no longer flaps on startup (#2062).**
   Three defects prevented the sidecar from ever serving: (1) the watchdog
   passed `DATABASE_URL=` (empty), which LiteLLM treats as an invalid scheme

--- a/src/klangk/klangk/litellm.py
+++ b/src/klangk/klangk/litellm.py
@@ -146,6 +146,11 @@ class LiteLLMRenderer:
             "model_list": model_list,
         }
 
+        # drop_params: clients (Pi) send OpenAI-style params that not every
+        # provider supports (e.g. max_completion_tokens on zai/glm-*). Drop
+        # unsupported params silently instead of 400ing the whole request.
+        config["litellm_settings"] = {"drop_params": True}
+
         # Optional master_key: when set, LiteLLM enforces bearer auth on the
         # sidecar (the proxy must send the same value as llm_api_key). When
         # unset (the default) the sidecar is no-auth, protected by the

--- a/src/klangk/klangkd-tests/tests/test_litellm.py
+++ b/src/klangk/klangkd-tests/tests/test_litellm.py
@@ -329,6 +329,17 @@ class TestLiteLLMRenderer:
         config = yaml.safe_load(r.render_config())
         assert config["general_settings"]["master_key"] == "sk-master"
 
+    def test_drop_params_always_set(self):
+        """Rendered config sets litellm_settings.drop_params so unsupported
+        client params (e.g. max_completion_tokens on zai) are dropped
+        silently instead of 400ing the whole request."""
+        s = make_settings(
+            {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}
+        )
+        r = _renderer(s)
+        config = yaml.safe_load(r.render_config())
+        assert config["litellm_settings"]["drop_params"] is True
+
     def test_no_master_key_no_general_settings(self):
         s = make_settings(
             {"KLANGKD_LLM_AGGREGATOR_MODELS": "openai/gpt-4o::sk-xxx"}


### PR DESCRIPTION
Stopgap for the param side of #2066.

## What

Requests through the LiteLLM sidecar 400'd when the client sent a param the upstream provider doesn't advertise as supported:

```
litellm.UnsupportedParamsError: zai does not support parameters: ['max_completion_tokens'], for model=glm-5.2.
```

Pi (and other OpenAI-style clients) send params like `max_completion_tokens` that not every provider supports. LiteLLM's per-provider allowlist rejected it for `zai`. The rendered config now sets `litellm_settings.drop_params: true`, so unsupported params are silently dropped per provider instead of failing the whole request.

This is the right default for an aggregator that proxies to providers with differing param support. The **generic, per-model fix** (declare `supported-params` + context-window metadata per model, so `/v1/models` is accurate) is tracked in #2066; this PR unblocks usage now.

## Change

- `src/klangk/klangk/litellm.py` — `LiteLLMRenderer.render_config` emits `litellm_settings: {drop_params: True}`.
- `test_litellm.py` — `test_drop_params_always_set` asserts it's always present.
- `docs/changes.md` — Fixed entry.

## Smoke test

Rendered the config with the fixed renderer from this branch (using a real `klangkd.yaml` + the real ZAI key) and ran the sidecar, then fired a real chat completion carrying `max_completion_tokens`:

- ✅ `litellm_settings: {drop_params: True}` is in the rendered config.
- ✅ The request **no longer 400s** with `UnsupportedParamsError` — it reaches the provider. (It then returned a `429 Insufficient balance` from ZAI, which is the key's account balance, not a code issue.)

## Test plan

- [x] `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` → **4229 passed, 100% coverage**.
- [x] `test_drop_params_always_set` added.
- [x] Manual end-to-end smoke test against `zai/glm-5.2` (above).
