### PR TITLE
refactor(proxy): extract shared helpers into proxy_common (#2080)

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -51,9 +51,9 @@ from pathlib import Path
 
 import httpx
 
-# Reuse the pure host-IP / loopback probes from the nginx renderer — both
-# engines auto-detect the pasta-NAT container source set the same way.
-from klangk.proxy import (
+# Pure host-IP / loopback probes + fallback subnets shared by every proxy
+# engine (both auto-detect the pasta-NAT container source set the same way).
+from klangk.proxy_common import (
     _FALLBACK_ACL_SUBNETS,
     _FALLBACK_DENY_SUBNETS,
     _is_loopback,
@@ -624,8 +624,8 @@ class CaddyRenderer:
 
 
 # The preexec body (new session for killpg + PR_SET_PDEATHSIG) is identical for
-# every proxy engine — reuse the nginx watchdog's rather than duplicate it.
-from klangk.proxy import _proxy_preexec as _caddy_preexec  # noqa: E402
+# every proxy engine — import the shared impl rather than duplicate it.
+from klangk.proxy_common import _proxy_preexec as _caddy_preexec  # noqa: E402
 
 
 def _caddy_supports_full_global_block(bin_path: str) -> bool:

--- a/src/klangk/klangk/proxy.py
+++ b/src/klangk/klangk/proxy.py
@@ -28,38 +28,27 @@ settings.
 from __future__ import annotations
 
 import asyncio
-import ctypes
-import ctypes.util
 import ipaddress
 import logging
 import os
 import signal
 import shutil
 import stat
-import subprocess
-import sys
 from pathlib import Path
 
-
-logger = logging.getLogger(__name__)
-
-# Loopback ranges excluded from the catch-all deny (CONTAINER_DENY) — local
-# browsers connect via loopback and must reach the full UI/API. Matches the
-# ``_is_loopback`` helper in the old nginx.sh (127.0.0.0/8 + ::1).
-_LOOPBACK_NETS = (
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("::1/128"),
+# Pure helpers shared with the Caddy engine live in :mod:`klangk.proxy_common`
+# (#1642). Re-exported here so existing ``from klangk.proxy import …`` callers
+# (and this module's own use) keep working until the nginx engine is removed.
+from klangk.proxy_common import (
+    _FALLBACK_ACL_SUBNETS,
+    _FALLBACK_DENY_SUBNETS,
+    _is_loopback,
+    _proxy_preexec,
+    detect_host_ipv4s,
 )
 
 
-def _is_loopback(addr: str) -> bool:
-    """True for any address in 127.0.0.0/8 or ::1."""
-    try:
-        ip = ipaddress.ip_address(addr)
-    except ValueError:
-        return False
-    return any(ip in net for net in _LOOPBACK_NETS)
-
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Upstream constructors (pure — no settings)
@@ -84,32 +73,6 @@ def uds_upstream(socket_path: str) -> str:
 # ---------------------------------------------------------------------------
 # Environment probes (auto-detection, not settings)
 # ---------------------------------------------------------------------------
-
-
-def detect_host_ipv4s() -> list[str]:
-    """Auto-detect this host's IPv4 addresses (the pasta-NAT container source set).
-
-    Podman rootless default (pasta) shares the host network via userspace NAT,
-    so container traffic to ``host.containers.internal`` arrives from the
-    host's own IPv4. ``ip -4 addr show`` lists them (including 127.0.0.1 from
-    ``lo`` — wanted for CONTAINER_ACL, filtered out of CONTAINER_DENY below).
-    Returns ``[]`` on failure (caller falls back to RFC1918 ranges).
-    """
-    try:
-        out = subprocess.check_output(
-            ["ip", "-4", "addr", "show"], text=True, stderr=subprocess.DEVNULL
-        )
-    except (OSError, subprocess.CalledProcessError, FileNotFoundError):
-        return []
-    addrs: list[str] = []
-    for line in out.splitlines():
-        line = line.strip()
-        if line.startswith("inet "):
-            # "inet 192.168.1.5/24 ..."
-            token = line.split()[1]
-            ip = token.split("/")[0]
-            addrs.append(ip)
-    return addrs
 
 
 def stdout_is_reopenable() -> bool:
@@ -137,13 +100,6 @@ def stdout_is_reopenable() -> bool:
         # fd 1 unusable — assume reopenable to preserve legacy behavior.
         return True
     return not stat.S_ISSOCK(st.st_mode)
-
-
-# Fallback subnets when auto-detection yields nothing (mirrors nginx.sh):
-# 172.16/12 + 10/8 (common container ranges), explicitly NOT 192.168/16
-# (most common LAN range — allowing it would expose the LLM proxy to peers).
-_FALLBACK_ACL_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8", "127.0.0.1"]
-_FALLBACK_DENY_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8"]
 
 
 # ---------------------------------------------------------------------------
@@ -776,31 +732,6 @@ http {{
         if found:
             return found
         return "/usr/sbin/nginx"
-
-
-_PR_SET_PDEATHSIG = 1
-_HAS_PDEATHSIG = sys.platform == "linux"
-if _HAS_PDEATHSIG:  # pragma: no cover – linux-only
-    _libc = ctypes.CDLL(
-        ctypes.util.find_library("c") or "libc.so.6", use_errno=True
-    )
-
-
-def _proxy_preexec() -> None:  # pragma: no cover  – runs in forked child
-    """New session (for killpg) + auto-SIGTERM when parent dies (#1533).
-
-    ``os.setsid()`` puts nginx in its own process group so ``stop()`` can
-    ``os.killpg`` the entire tree on clean shutdown.
-
-    On Linux, ``prctl(PR_SET_PDEATHSIG, SIGTERM)`` asks the kernel to send
-    SIGTERM to the nginx master if klangkd dies without calling ``stop()``
-    (e.g. SIGKILL).  nginx handles SIGTERM by forwarding SIGQUIT to its
-    workers, so the whole tree exits.  macOS has no equivalent; on unclean
-    shutdown, orphaned nginx processes must be cleaned up externally.
-    """
-    os.setsid()
-    if _HAS_PDEATHSIG:
-        _libc.prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)
 
 
 class ProxyWatchdog:

--- a/src/klangk/klangk/proxy_common.py
+++ b/src/klangk/klangk/proxy_common.py
@@ -1,0 +1,104 @@
+"""Pure helpers shared by the reverse-proxy engines (#1642).
+
+These historically lived in :mod:`klangk.proxy` (the nginx engine); they are
+extracted here so the nginx engine can be removed in 2.X without taking the
+Caddy engine's dependencies with it. Both engines use them unchanged:
+
+- host-IPv4 auto-detection (:func:`detect_host_ipv4s`) and the loopback probe
+  (:func:`_is_loopback`), plus the fallback ACL/deny subnets used when
+  auto-detection yields nothing;
+- :func:`_proxy_preexec` — the fork-time setup (new session for ``killpg`` +
+  ``PR_SET_PDEATHSIG``) shared by every engine's child-process watchdog.
+
+Nothing here reads settings or renders config — pure helpers only.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import ipaddress
+import os
+import signal
+import subprocess
+import sys
+
+
+# Loopback ranges excluded from the catch-all deny (CONTAINER_DENY) — local
+# browsers connect via loopback and must reach the full UI/API. Matches the
+# ``_is_loopback`` helper in the old nginx.sh (127.0.0.0/8 + ::1).
+_LOOPBACK_NETS = (
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+)
+
+
+def _is_loopback(addr: str) -> bool:
+    """True for any address in 127.0.0.0/8 or ::1."""
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return any(ip in net for net in _LOOPBACK_NETS)
+
+
+def detect_host_ipv4s() -> list[str]:
+    """Auto-detect this host's IPv4 addresses (the pasta-NAT container source set).
+
+    Podman rootless default (pasta) shares the host network via userspace NAT,
+    so container traffic to ``host.containers.internal`` arrives from the
+    host's own IPv4. ``ip -4 addr show`` lists them (including 127.0.0.1 from
+    ``lo`` — wanted for CONTAINER_ACL, filtered out of CONTAINER_DENY below).
+    Returns ``[]`` on failure (caller falls back to RFC1918 ranges).
+    """
+    try:
+        out = subprocess.check_output(
+            ["ip", "-4", "addr", "show"], text=True, stderr=subprocess.DEVNULL
+        )
+    except (OSError, subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    addrs: list[str] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith("inet "):
+            # "inet 192.168.1.5/24 ..."
+            token = line.split()[1]
+            ip = token.split("/")[0]
+            addrs.append(ip)
+    return addrs
+
+
+# Fallback subnets when auto-detection yields nothing (mirrors nginx.sh):
+# 172.16/12 + 10/8 (common container ranges), explicitly NOT 192.168/16
+# (most common LAN range — allowing it would expose the LLM proxy to peers).
+_FALLBACK_ACL_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8", "127.0.0.1"]
+_FALLBACK_DENY_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8"]
+
+
+# ---------------------------------------------------------------------------
+# Fork-time preexec (shared by every engine's child-process watchdog)
+# ---------------------------------------------------------------------------
+
+_PR_SET_PDEATHSIG = 1
+_HAS_PDEATHSIG = sys.platform == "linux"
+if _HAS_PDEATHSIG:  # pragma: no cover  – linux-only
+    _libc = ctypes.CDLL(
+        ctypes.util.find_library("c") or "libc.so.6", use_errno=True
+    )
+
+
+def _proxy_preexec() -> None:  # pragma: no cover  – runs in forked child
+    """New session (for killpg) + auto-SIGTERM when parent dies (#1533).
+
+    ``os.setsid()`` puts the proxy child in its own process group so ``stop()``
+    can ``os.killpg`` the entire tree on clean shutdown.
+
+    On Linux, ``prctl(PR_SET_PDEATHSIG, SIGTERM)`` asks the kernel to send
+    SIGTERM to the proxy child if klangkd dies without calling ``stop()``
+    (e.g. SIGKILL).  The child forwards SIGTERM to its workers, so the whole
+    tree exits.  macOS has no equivalent; on unclean shutdown, orphaned proxy
+    processes must be cleaned up externally.
+    """
+    os.setsid()
+    if _HAS_PDEATHSIG:
+        _libc.prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -645,12 +645,13 @@ class TestFindProxyBin:
 class TestDetectHostIPv4s:
     def test_subprocess_failure_returns_empty(self, monkeypatch):
         """When the ip command fails, returns [] (caller uses fallback)."""
-        import klangk.proxy as proxy_mod
+        # detect_host_ipv4s lives in klangk.proxy_common (#1642).
+        import klangk.proxy_common as proxy_common
 
         def _raise(*a, **kw):
             raise FileNotFoundError("no ip")
 
-        monkeypatch.setattr(proxy_mod.subprocess, "check_output", _raise)
+        monkeypatch.setattr(proxy_common.subprocess, "check_output", _raise)
         assert detect_host_ipv4s() == []
 
 


### PR DESCRIPTION
Part 1/5 of the nginx retirement (#1642). Implements #2080.

## What

Extracts the five pure helpers the Caddy engine imports from the nginx engine (`proxy.py`) into a new shared module `klangk.proxy_common`, so `proxy.py` can be deleted (#2081) without taking the Caddy engine's dependencies with it.

Moved (with their private deps):
- `detect_host_ipv4s`
- `_is_loopback` (+ `_LOOPBACK_NETS`)
- `_FALLBACK_ACL_SUBNETS`, `_FALLBACK_DENY_SUBNETS`
- `_proxy_preexec` (+ the prctl machinery: `_PR_SET_PDEATHSIG`, `_HAS_PDEATHSIG`, `_libc`)

## No behavior change (pure refactor)

- `proxy.py` **re-exports** the five from `proxy_common`, so every existing `from klangk.proxy import …` caller (and `proxy.py`'s own internal use) keeps working.
- `caddy.py` now imports them from `klangk.proxy_common`.
- Verified the functions are identical objects: `proxy._is_loopback is proxy_common._is_loopback` → `True`.
- No changelog entry (pure internal refactor, per the changelog rules).

## Test plan

- [x] `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` → **4214 passed, 100% coverage** (incl. the new `proxy_common.py`).
- [x] One stale test patch repointed: `test_proxy.py::test_subprocess_failure_returns_empty` now patches `proxy_common.subprocess` (where `detect_host_ipv4s` lives).
- [x] Import sanity: `klangk.proxy`, `klangk.caddy`, `klangk.proxy_common` all load; re-export identity confirmed.

Unblocks #2081 (delete `proxy.py`).
