### PR TITLE
chore(ci): remove dead KLANGK_LLM_API_KEY env var from e2e workflows

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      KLANGK_LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
       KLANGK_PODMAN_BIN: /usr/bin/podman
     steps:

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      KLANGK_LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
       KLANGK_PODMAN_BIN: /usr/bin/podman
     steps:

--- a/.github/workflows/frontend-e2e-cross-browser.yml
+++ b/.github/workflows/frontend-e2e-cross-browser.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      KLANGK_LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       KLANGK_JWT_SECRET: e2e-test-secret
       KLANGK_DEFAULT_USER: admin@plope.com
       KLANGK_DEFAULT_PASSWORD: admin

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      KLANGK_LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       KLANGK_JWT_SECRET: e2e-test-secret
       KLANGK_DEFAULT_USER: admin@plope.com
       KLANGK_DEFAULT_PASSWORD: admin

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -19,7 +19,6 @@ jobs:
     # several minutes each; they run sequentially in one job.
     timeout-minutes: 60
     env:
-      KLANGK_LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
       KLANGK_PODMAN_BIN: /usr/bin/podman
     steps:


### PR DESCRIPTION
## Summary

Remove the inert `KLANGK_LLM_API_KEY` (no `D`) env var from all 5 e2e CI workflows. Nothing reads this variable — the daemon uses `KLANGKD_LLM_API_KEY`, and the e2e suites use a fake upstream with inline dummy keys.

Closes #2090