### PR TITLE
fix(logger): stop LiteLLM double-logging (#2087)

### DIFF
--- a/src/klangk/klangk/logger.py
+++ b/src/klangk/klangk/logger.py
@@ -133,6 +133,12 @@ def _apply(level: int) -> None:
     for name, lvl in _THIRD_PARTY_LEVELS.items():
         logging.getLogger(name).setLevel(lvl)
 
+    # LiteLLM attaches its own handlers; stop propagation so its log
+    # records don't also reach klangk's root handler (double-logging,
+    # #2087).
+    for name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"):
+        logging.getLogger(name).propagate = False
+
 
 def configure_defaults() -> None:
     """Configure root logging with default (pre-settings) values.

--- a/src/klangk/klangkd-tests/tests/test_logger.py
+++ b/src/klangk/klangkd-tests/tests/test_logger.py
@@ -191,6 +191,13 @@ class TestConfigure:
         logger_mod.configure(_make_settings("DEBUG"))
         assert len(_klangk_handlers(clean_root)) == 1
 
+    def test_litellm_loggers_do_not_propagate(self, clean_root):
+        """LiteLLM loggers have propagate=False so their records don't
+        reach klangk's root handler (double-logging, #2087)."""
+        logger_mod.configure(_make_settings())
+        for name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"):
+            assert logging.getLogger(name).propagate is False
+
     def test_reconfigure_reapplies_third_party_levels(self, clean_root):
         # Sabotage a third-party logger to prove configure resets it.
         logging.getLogger("httpx").setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary

- Set `propagate=False` on LiteLLM's loggers (`LiteLLM`, `LiteLLM Router`, `LiteLLM Proxy`) so their log records don't reach klangk's root handler
- LiteLLM attaches its own handlers, so its output still appears once; only the propagated duplicate is suppressed

Closes #2087

## Test plan

- [x] New test verifies all three LiteLLM loggers have `propagate=False` after `configure()`
- [x] 4121 backend tests pass, 100% coverage