### PR TITLE
feat(doctor): warn when ip command is missing for subnet auto-detection (#2089)

### DIFF
--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -483,6 +483,19 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
     report.add(check_gnu_tar(manager))
     report.add(check_gnu_du(manager))
 
+    # 1b. Optional: ip command for container subnet auto-detection (#2089)
+    if platform.system() != "Darwin":
+        ip_result = check_binary("ip", ["ip", "-V"], manager)
+        if not ip_result.ok:
+            ip_result.is_warning = True
+            ip_result.message = (
+                "ip not found — container subnet auto-detection will fall "
+                "back to broad RFC1918 ranges (172.16/12 + 10/8). Install "
+                "iproute2 for precise detection, or set "
+                "KLANGKD_CONTAINER_SUBNETS explicitly."
+            )
+        report.add(ip_result)
+
     # 2. Rootless podman prereqs
     if platform.system() != "Darwin":
         # Linux: check newuidmap (suid helper for rootless user

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -382,6 +382,32 @@ class TestRunDoctor:
         assert "fuse-overlayfs" not in names
         assert "slirp4netns" not in names
 
+    def test_missing_ip_is_warning(self):
+        """A missing ip command is a warning — container subnet detection
+        falls back to RFC1918 ranges (#2089)."""
+        original_which = shutil.which
+
+        def which_hiding_ip(name):
+            if name == "ip":
+                return None
+            return original_which(name)
+
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "klangk.doctor.shutil.which",
+                side_effect=which_hiding_ip,
+            ),
+        ):
+            report = run_doctor()
+
+        results = [r for r in report.results if r.name == "ip"]
+        assert len(results) == 1
+        r = results[0]
+        assert not r.ok
+        assert r.is_warning
+        assert "RFC1918" in r.message
+
     def test_missing_newuidmap_is_warning(self):
         """A missing newuidmap is a warning, not an error — the end-to-end
         rootless podman check is the definitive gate."""


### PR DESCRIPTION
## Summary

`klangkd doctor` now checks for the `ip` binary on Linux. Missing `ip` is a warning — container subnet auto-detection falls back to broad RFC1918 ranges (172.16/12 + 10/8), which may expose the LLM proxy to LAN peers. The warning suggests installing iproute2 or setting `KLANGKD_CONTAINER_SUBNETS` explicitly.

## Test plan

- [x] New test: `test_missing_ip_is_warning`
- [x] Full backend test suite: 4122 passed, 100% coverage

Closes #2089