### PR TITLE
docs(changelog): remove pytest test-extra entry (#2129)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -504,18 +504,6 @@ browser-fetch, celebrate, git-credential` (#1700).** `DEFAULT_FEATURES`
     `KLANGKD_STATE_DIR` explicitly and are unaffected).
     CI doesn't set either env var and runs hermetically, so it's unaffected.
 
-- **The pytest toolchain is now an optional `test` extra, not a runtime
-  dependency (#1673).** `src/klangk/pyproject.toml` moves `pytest`,
-  `pytest-asyncio`, `pytest-cov`, `pytest-xdist`, and `pytest-timeout` out
-  of `dependencies` into `[project.optional-dependencies] test`. A plain
-  `pip install klangk` (or `pip install klangk==<tag>` from PyPI) no longer
-  pulls in pytest + its transitive deps (pluggy, iniconfig, packaging,
-  coverage, execnet — ~a dozen packages / several MB with no runtime role).
-  Dev and CI installs opt in explicitly: `pip install klangk[test]`, or
-  `uv sync --extra test` (the path the devenv shell and `backend-tests.yml`
-  now use). **Integrator action:** if you install `klangk` into an env where
-  you also run the test suite, add the `[test]` extra.
-
 - **`KLANGKD_STATE_DIR` now defaults to `$XDG_STATE_HOME/klangk` (#1644).**
   The runtime-state directory (UDS socket, rendered proxy config, pid file,
   DB) defaults to `~/.local/state/klangk` when no explicit value is supplied,


### PR DESCRIPTION
## Summary

- Remove the pytest `[test]` extra changelog entry from Changed — internal packaging detail

Closes #2129

## Test plan

- [x] Docs-only change