### PR TITLE
fix(tmux): first wheel-up scrolls 1 line, not a half-page (#2149)

### DIFF
--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -28,7 +28,7 @@ set -gs terminal-features 'xterm*:extkeys'
 set -g mouse on
 
 # Mouse wheel enters copy mode for scrollback.
-bind -n WheelUpPane copy-mode -eu
+bind -n WheelUpPane copy-mode -e \; send-keys -X -N 1 scroll-up
 
 # Scroll one line per wheel tick in copy mode (default is 5, too fast).
 bind -T copy-mode WheelUpPane select-pane \; send-keys -X -N 1 scroll-up


### PR DESCRIPTION
Closes #2149.

## What

`src/containers/workspace/tmux.conf:31` — the root-table binding `copy-mode -eu` scrolled a half-page (~21 lines) on the first wheel-up entry into copy mode (the `-u` flag). Subsequent ticks scrolled 1 line via the copy-mode-table binding. Fix: drop `-u` and explicitly scroll 1 line on entry:

```diff
- bind -n WheelUpPane copy-mode -eu
+ bind -n WheelUpPane copy-mode -e \; send-keys -X -N 1 scroll-up
```

Now the first wheel-up enters copy mode AND scrolls 1 line — consistent with every later tick.

```diff
+ bind -n WheelUpPane copy-mode -e \; send-keys -X -N 1 scroll-up
```

No other bindings change; the copy-mode-table bindings (lines 34–37) still handle 1-line scrolls once in copy mode.

**Deploy:** baked into the workspace image — takes effect after a workspace-image rebuild.