### PR TITLE
feat(container): set USER/LOGNAME=klangk in workspace env (#2153)

### DIFF
--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1297,6 +1297,11 @@ class ContainerRegistry:
         env_vars.append(
             f"KLANGKWS_BRIDGE_URL=http://host.containers.internal:{egress_port}"
         )
+        # #2153: Set USER/LOGNAME so tools inside the container (git,
+        # shell prompts, sudo audit, Pi agent identity) see the correct
+        # UNIX user — containers have no login process to set these.
+        env_vars.append("USER=klangk")
+        env_vars.append("LOGNAME=klangk")
         if self.terminal_banner:
             env_vars.append(f"KLANGKWS_TERMINAL_BANNER={self.terminal_banner}")
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1077,6 +1077,20 @@ class TestStartContainer:
         # host.containers.internal must be resolvable
         assert "host.containers.internal:host-gateway" in kwargs["add_hosts"]
 
+    async def test_user_logname_env_vars(self, workspace, monkeypatch):
+        """USER/LOGNAME are set so tools inside the container see the
+        correct UNIX user (#2153)."""
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+            )
+        env = p.create_container.call_args.kwargs["env"]
+        env_dict = dict(e.split("=", 1) for e in env)
+        assert env_dict["USER"] == "klangk"
+        assert env_dict["LOGNAME"] == "klangk"
+
     async def test_workspace_token_written_to_container(
         self, workspace, app_state
     ):


### PR DESCRIPTION
Closes #2153.

## What

Add `USER=klangk` and `LOGNAME=klangk` to the workspace container env list (`container.py:1303-1304`), alongside the existing `KLANGKWS_*` vars. Containers have no login process to set these, so without this fix:

- git falls back to `<uid>@<hostname>` for commit author (e.g. `1000@host` instead of `klangk@host`)
- Shell prompts and dotfile frameworks show nothing or the wrong name
- sudo/doas audit logging has no `$USER`
- Pi and other agents may misidentify the user

The klangk HOME-per-application-user design (where `HOME` is set to `/home/.users/<uuid>`) is unaffected — `USER` is the UNIX identity (always `klangk`), `HOME` is the per-user workspace directory.

## Test plan

- [x] `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` → **4122 passed, 100% coverage**.
- [ ] Manual: create a workspace, `echo $USER` inside the shell → should print `klangk`.