### PR TITLE
fix(frontend): browser terminals over plain HTTP (#2162)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -278,6 +278,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 - **`klangk invite` → `klangk admin invitations send` (#1374).**
 
+### Fixed
+
+- **Browser terminals over plain HTTP (#2162).** In the browser UI,
+  workspace terminals never started (the pane stayed blank, no shell prompt)
+  on deployments served over plain HTTP to a non-localhost host — they only
+  worked over HTTPS or localhost. Fixed; terminals now start over plain HTTP
+  too.
+
 ### Security
 
 - **`git-credential-klangk`: secrets redacted from debug output (#1938).**

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -86,6 +86,24 @@ void capturePageQuery() {
   }
 }
 
+/// RFC 4122 v4 UUID from `crypto.getRandomValues`.
+///
+/// `window.crypto.randomUUID()` is secure-context-only (HTTPS / `localhost`);
+/// over plain HTTP to a remote host it is `undefined`, which threw inside
+/// `getBrowserId` and prevented `terminal_start` from being sent (the blank
+/// browser terminal, #2162). `crypto.getRandomValues` is available in all
+/// contexts, so this works on plain-HTTP deployments too.
+String _randomUuidV4() {
+  final b =
+      (web.window.crypto.getRandomValues(Uint8List(16).toJS) as JSUint8Array)
+          .toDart;
+  b[6] = (b[6] & 0x0f) | 0x40; // version 4
+  b[8] = (b[8] & 0x3f) | 0x80; // variant (RFC 4122)
+  final h = b.map((e) => e.toRadixString(16).padLeft(2, '0')).join();
+  return '${h.substring(0, 8)}-${h.substring(8, 12)}-'
+      '${h.substring(12, 16)}-${h.substring(16, 20)}-${h.substring(20)}';
+}
+
 /// Return a stable browser tab ID from sessionStorage.
 ///
 /// Survives page refresh (same tab) but is unique per tab.
@@ -96,7 +114,7 @@ String getBrowserId(String instanceId) {
   final key = 'klangk.$instanceId.browser_id';
   var id = web.window.sessionStorage.getItem(key);
   if (id == null || id.isEmpty) {
-    id = web.window.crypto.randomUUID();
+    id = _randomUuidV4();
     web.window.sessionStorage.setItem(key, id);
   }
   return id;


### PR DESCRIPTION
## Summary

Fixes #2162 — in the browser UI, workspace terminals never started (blank pane, no shell prompt) on deployments served over **plain HTTP to a non-localhost host**.

## Root cause

`getBrowserId` (`src/frontend/lib/utils/web_helpers_web.dart`) generated the browser tab id with `window.crypto.randomUUID()`, a **secure-context-only** API (HTTPS / `localhost`). Over `http://<remote-host>` it is `undefined`, so the call threw:

```
NoSuchMethodError: method not found: 'randomUUID' (window.crypto.randomUUID is not a function)
    at Object.getBrowserId                          (main.dart.js)
    at WsClient.sendTerminalStart$2$cols$rows
    at GhosttyTerminalState._startTerminal$0
    at _TerminalViewState._handleResize$2
```

`sendTerminalStart` never completed, so `terminal_start` was never sent over `/ws` — the server never started a session and the pane stayed blank. Captured **bidirectional** WS traffic confirmed it: the browser sent `workspace_connect` / `ui_ready` / `terminal_resize` but **no `terminal_start`**.

This explains the whole symptom set: reproduces on any browser, `klangk shell` (CLI) works (no `randomUUID`), and the e2e suite passes (localhost is a secure context even over HTTP).

## Fix

Generate the browser id via `crypto.getRandomValues` (RFC 4122 v4), which is available in **all** contexts. `flutter analyze` is clean. Changelog entry added under `[Unreleased] → Fixed`.

## Verification

Reproduced and root-caused with a Playwright bidirectional-WS + console capture against `bizon:8997` (the repro specs/config were scratch and are not part of this PR). After a frontend rebuild + redeploy, the same repro should show `terminal_start` sent and a `~$` prompt in the pane.

Fixes #2162.
