### PR TITLE
fix(frontend): terminal copy over plain HTTP (#2166)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -286,6 +286,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   worked over HTTPS or localhost. Fixed; terminals now start over plain HTTP
   too.
 
+- **Terminal copy over plain HTTP (#2166).** Copying text from a browser
+  workspace terminal did nothing on plain-HTTP deployments (the async
+  Clipboard API is secure-context-only). Copy now falls back to
+  `document.execCommand('copy')` in insecure contexts.
+
 ### Security
 
 - **`git-credential-klangk`: secrets redacted from debug output (#1938).**

--- a/src/frontend/lib/browser/browser_delegate.dart
+++ b/src/frontend/lib/browser/browser_delegate.dart
@@ -3,6 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../ws/ws_client.dart';
 
 /// Handles browser_request messages from the backend bridge.
@@ -79,6 +81,13 @@ class BrowserDelegate {
       return {'error': 'missing text'};
     }
     try {
+      // Route through the web helper so copy works in an insecure context
+      // (plain HTTP) too: it falls back to execCommand('copy') when
+      // navigator.clipboard is unavailable (#2166). Non-web returns false and
+      // falls through to Clipboard.setData below.
+      if (await setClipboardText(text)) {
+        return {'status': 'ok'};
+      }
       await Clipboard.setData(ClipboardData(text: text));
       return {'status': 'ok'};
     } catch (e) {

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -44,6 +44,10 @@ void Function() installPageKeyListener(bool Function() shouldSuppress) => () {};
 /// Stub — no system clipboard outside the browser.
 Future<String?> readClipboardText() async => null;
 
+/// Stub — no system clipboard write outside the browser; signal "not handled"
+/// so the caller falls back to Flutter's `Clipboard.setData` (desktop/mobile).
+Future<bool> setClipboardText(String text) async => false;
+
 /// Stub — no beforeunload outside the browser.
 void Function() onBeforeUnload(void Function() callback) => () {};
 

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -180,6 +180,47 @@ Future<String?> readClipboardText() async {
   }
 }
 
+/// Write [text] to the system clipboard.
+///
+/// Prefers the async Clipboard API (`navigator.clipboard.writeText`), which
+/// is secure-context-only (HTTPS / `localhost`). Over plain HTTP to a remote
+/// host `navigator.clipboard` is `undefined`, so `writeText` is unavailable
+/// and terminal copy via the bridge silently failed (#2166). Fall back to
+/// `document.execCommand('copy')` against a transient `<textarea>`, which
+/// works in all contexts. Returns whether the copy succeeded.
+Future<bool> setClipboardText(String text) async {
+  // Prefer the async Clipboard API. It is secure-context-only (HTTPS /
+  // localhost); over plain HTTP `navigator.clipboard` is `undefined`, so the
+  // access below throws and we fall back to execCommand (#2166). The static
+  // type is non-nullable, so it can't be null-checked — rely on try/catch.
+  try {
+    await web.window.navigator.clipboard.writeText(text).toDart;
+    return true;
+  } catch (e) {
+    debugPrint('[WebHelpers] clipboard.writeText failed, falling back: $e');
+  }
+  return _execCommandCopy(text);
+}
+
+// `document.execCommand('copy')` is deprecated but is the only clipboard-write
+// path available in an insecure context (plain HTTP). It needs the document
+// focused and (modern browsers) a user gesture; the bridge copy originates
+// from the user's selection, so activation is typically still valid.
+bool _execCommandCopy(String text) {
+  final doc = web.document;
+  final ta = doc.createElement('textarea') as web.HTMLTextAreaElement;
+  ta.value = text;
+  ta.style
+    ..position = 'fixed'
+    ..top = '-9999px'
+    ..left = '-9999px';
+  doc.body?.appendChild(ta);
+  ta.select();
+  final ok = doc.execCommand('copy');
+  ta.remove();
+  return ok;
+}
+
 /// Register a callback to run when the page is about to unload (reload,
 /// close tab, navigate away). Used to send a clean WebSocket close frame
 /// so Firefox's FailDelayManager doesn't throttle the next connection.


### PR DESCRIPTION
## Summary

Fixes #2166 — copying text from a browser workspace terminal did nothing on deployments served over plain HTTP to a non-localhost host.

## Root cause

Terminal copy routes through tmux copy-pipe → the browser bridge `clipboard_write` → `BrowserDelegate._handleClipboardWrite` → `Clipboard.setData`, which on Flutter Web is `navigator.clipboard.writeText` — **secure-context-only** (HTTPS / `localhost`). Over plain HTTP `navigator.clipboard` is `undefined`, so the write failed silently. (Verified via Playwright on `bizon:8997`: `isSecureContext:false`, `navigator.clipboard` undefined, `writeText` undefined.)

## Fix

Route the write through a new `setClipboardText` web helper (`web_helpers_web.dart`) that:

1. Tries `navigator.clipboard.writeText` (unchanged behavior on HTTPS/localhost), and
2. Falls back to `document.execCommand('copy')` against a transient `<textarea>` when the Clipboard API is unavailable / throws (insecure context).

This mirrors the **paste** side, which already avoids the same trap by reading the native `paste` `ClipboardEvent` instead of `navigator.clipboard.readText`. Non-web returns `false` and falls through to `Clipboard.setData` as before (desktop/mobile unchanged).

## Verification

- `flutter analyze` clean; full frontend suite passes (`flutter test --coverage` — 830 tests, including the 4 existing `clipboard_write` cases).
- Same secure-context class as #2162 (already merged). Behavior over HTTPS/localhost is unchanged; the fallback covers plain HTTP.
- Manual end-to-end check (terminal copy over `http://bizon:8997`) after a frontend rebuild + redeploy.

Fixes #2166.
