### PR TITLE
feat(workspace): open a new terminal from the tmux status bar (#2161)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,12 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **New terminal from the tmux status bar (#2161).** A clickable "+ new"
+  item in the workspace terminal's tmux status bar opens another terminal
+  via a native `tmux new-window`, working the same in `klangk shell` and the
+  browser. (The new terminal appearing as a Flutter tab is tracked in
+  #2171.)
+
 - **`klangkd.yaml` config file (#1645, #1649).** `klangkd` reads configuration
   from `$KLANGKD_CONFIG_DIR/klangkd.yaml` (default
   `~/.config/klangkd/klangkd.yaml`). A template is generated on first run.

--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -71,17 +71,23 @@ set -g mode-keys vi
 set -g allow-rename off
 set -g automatic-rename off
 
-# Status bar — subtle contextual framing: workspace name (left) and the
-# disconnect escape hint (right). @workspace_name is a global user option
+# Status bar — subtle contextual framing: workspace name + the CLI
+# disconnect hint on the left; a clickable "+ new" on the right that opens
+# another klangk terminal (#2161). @workspace_name is a global user option
 # set by the server on every terminal_start (idempotent, #1880). The hint
-# is the CLI's ~. escape: Enter, then ~. (#2006).
+# is the CLI's ~. escape: Enter, then ~. (#2006). The "+ new" click runs a
+# native tmux new-window — it works identically in `klangk shell` and the
+# browser terminal, since both are tmux clients on the same session (no
+# bridge/HTTP needed). Flutter tab-strip sync is separate (#2171).
 set -g status on
 set -g status-position bottom
 set -g status-style 'bg=colour236,fg=colour246'
-set -g status-left '#[fg=colour252] #{@workspace_name} '
-set -g status-left-length 40
-set -g status-right '#[fg=colour240]Exit: Enter, then ~. '
-set -g status-right-length 40
+set -g status-left '#[fg=colour252] #{@workspace_name} #[fg=colour240]Exit: Enter, then ~. '
+set -g status-left-length 60
+set -g status-right '#[fg=colour252,bold] + new '
+set -g status-right-length 20
+# Click the "+ new" status-right segment to open a new tmux window (#2161).
+bind-key -n MouseDown1StatusRight new-window
 
 # Keep sessions alive when clients detach.  Needed for session groups
 # (shared terminals) so spectator/collaborator sessions survive


### PR DESCRIPTION
## Summary

Adds a clickable **"+ new"** to the workspace terminal's tmux status bar. A click runs a native `tmux new-window`, so it works identically in `klangk shell` and the browser terminal — both are tmux clients on the same session, so **no bridge/HTTP endpoint is needed**.

## What changed

Just `src/containers/workspace/tmux.conf`:

- `status-right` → a prominent `+ new` segment.
- `status-left` → workspace name **+** the CLI disconnect hint (`Exit: Enter, then ~.`), with `status-left-length` bumped to fit.
- `bind-key -n MouseDown1StatusRight new-window` — click the "+ new" segment to open a terminal.

The new terminal is a normal tmux window in the session, so it's klangk-managed (visible in `klangk terminal ls`, shareable) and works in default and shared/joined sessions — the core acceptance criteria of #2161.

## Design note (why no bridge)

An earlier draft added a container→server bridge endpoint so the server could run `new_window` and broadcast. Since both `klangk shell` and the ghostty browser tab are just tmux clients, a native `new-window` covers both with no HTTP round-trip — so the bridge was dropped.

## Not in this PR (tracked in #2171)

The Flutter **tab strip** won't auto-add a tab for the new terminal yet: making the server learn about a tmux-side window change needs tmux window-event detection, which is the same machinery #2171 (active-tab sync) needs. That'll be done together with #2171.

## Verification

- `tmux.conf`-only change; pre-commit (markdownlint/prettier/trufflehog) passes.
- **Needs deploy verification:** confirm `MouseDown1StatusRight` actually fires on a click in the browser terminal (ghostty tab) after a rebuild — that's the one assumption (status-bar click forwarding) I couldn't exercise headless.

Addresses the core of #2161; Flutter tab-strip propagation tracked in #2171.
