### PR TITLE
feat(workspace): sync Flutter terminal tabs with tmux via control-mode watcher (#2171, #2161)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -297,6 +297,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   Clipboard API is secure-context-only). Copy now falls back to
   `document.execCommand('copy')` in insecure contexts.
 
+- **Terminal tab strip stays in sync with tmux (#2171, #2161).** A new
+  terminal added from the tmux status bar now appears as a tab on every
+  connected Flutter client, a closed terminal's tab closes everywhere, and
+  switching the active tmux window switches the active Flutter tab. Driven by
+  a persistent per-workspace tmux control-mode watcher (no per-tick polling).
+
 ### Security
 
 - **`git-credential-klangk`: secrets redacted from debug output (#1938).**

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -301,11 +301,20 @@ class _WorkspacePageState extends State<WorkspacePage> {
       if (wsClient.terminalWindows.isNotEmpty) {
         final ids =
             wsClient.terminalWindows.map((w) => w['id'] as String?).toSet();
-        if (_selectedOwnWindowId == null) {
-          // First load — select window 0 (grouped sessions start there).
-          _selectedOwnWindowId = wsClient.terminalWindows[0]['id'] as String?;
-        } else if (!ids.contains(_selectedOwnWindowId)) {
-          // Selected window was closed — fall back to first window.
+        // Follow tmux's active window so the Flutter tab matches the
+        // status-bar selection (#2171); else keep the current selection when
+        // it still exists, else default to window 0.
+        String? activeId;
+        for (final w in wsClient.terminalWindows) {
+          if (w['active'] == true) {
+            activeId = w['id'] as String?;
+            break;
+          }
+        }
+        if (activeId != null) {
+          _selectedOwnWindowId = activeId;
+        } else if (_selectedOwnWindowId == null ||
+            !ids.contains(_selectedOwnWindowId)) {
           _selectedOwnWindowId = wsClient.terminalWindows[0]['id'] as String?;
         }
       }

--- a/src/klangk/klangk/window_watcher.py
+++ b/src/klangk/klangk/window_watcher.py
@@ -1,0 +1,127 @@
+"""Persistent tmux control-mode client that reports workspace window changes.
+
+One :class:`WindowEventWatcher` per workspace keeps every connected client's
+terminal tab strip in sync with tmux. A detached ``tmux -C`` control client
+emits ``%unlinked-window-add`` / ``%window-close`` / ``%session-window-changed``
+events whenever a window is added, closed, or the active window switches —
+and (verified empirically) these fire for any session on the tmux server, not
+just the control client's own. The watcher hands each event to a callback so
+the caller can debounce the burst into a single ``terminal_windows`` re-broadcast
+— meaning podman execs happen only on real changes, not on a per-tick poll
+(#2161 / #2171).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from .podman import Podman, subprocess_env
+
+logger = logging.getLogger(__name__)
+
+# Control-mode events that mean "the window set or the active window may have
+# changed". %output (pane bytes), %begin/%end (command framing), and the
+# control client's own %window-add / %session-changed are deliberately ignored
+# so its idle pane never trips a re-sync.
+_WINDOW_EVENT_PREFIXES = (
+    "%unlinked-window-add",
+    "%unlinked-window-close",
+    "%window-close",
+    "%session-window-changed",
+)
+
+
+def is_window_event(line: str) -> bool:
+    """True if a control-mode ``line`` indicates a window/active change."""
+    return line.startswith(_WINDOW_EVENT_PREFIXES)
+
+
+class WindowEventWatcher:
+    """A long-lived ``tmux -C`` control client for one container.
+
+    :meth:`start` spawns it (idempotent); :meth:`stop` tears it down.
+    ``on_change`` is called synchronously from the reader task once per
+    relevant event; callers debounce.
+    """
+
+    def __init__(self, podman: Podman, container_id: str, on_change) -> None:
+        self._podman = podman
+        self._container_id = container_id
+        self._on_change = on_change
+        self._proc: asyncio.subprocess.Process | None = None
+        self._task: asyncio.Task | None = None
+        # Unique per-watcher session name so a stale client from a prior
+        # instance (e.g. across a container restart) never collides.
+        self._ctrl_session = f"__klangk_ctrl-{uuid.uuid4().hex[:8]}"
+
+    async def start(
+        self,
+    ) -> None:  # pragma: no cover - subprocess; integration
+        if self._task is not None and not self._task.done():
+            return
+        self._proc = await asyncio.create_subprocess_exec(
+            self._podman.bin,
+            "exec",
+            "-i",
+            self._container_id,
+            "tmux",
+            "-C",
+            "new-session",
+            "-s",
+            self._ctrl_session,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+            env=subprocess_env(),
+        )
+        self._task = asyncio.create_task(self._read_loop())
+
+    async def _read_loop(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            while True:
+                raw = await proc.stdout.readline()
+                if not raw:
+                    return  # pragma: no cover - subprocess exited
+                if is_window_event(raw.decode(errors="replace").strip()):
+                    self._on_change()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover
+            logger.exception("WindowEventWatcher read loop error")
+
+    async def stop(self) -> None:  # pragma: no cover - subprocess; integration
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+        proc = self._proc
+        self._proc = None
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=3)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+        if proc is not None:
+            try:
+                await self._podman.exec_container(
+                    self._container_id,
+                    ["tmux", "kill-session", "-t", self._ctrl_session],
+                )
+            except Exception:  # pragma: no cover
+                pass

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from .. import model
+from ..window_watcher import WindowEventWatcher
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
 from .constants import (
     agent_conversations,
@@ -104,6 +105,12 @@ class WorkspaceSession:
         # Workspace token renewal tracking.
         self.workspace_token_expiry: datetime | None = None
         self._token_renewal_task: asyncio.Task | None = None
+        # Window-sync via a persistent tmux control-mode client: last
+        # list_windows snapshot per user_id, so we re-broadcast only on a
+        # real change (#2161 / #2171).
+        self._last_windows: dict[str, list] = {}
+        self._window_watcher: WindowEventWatcher | None = None
+        self._window_sync_handle: asyncio.TimerHandle | None = None
 
     async def reset(self) -> None:
         self.subscribers.clear()
@@ -121,6 +128,14 @@ class WorkspaceSession:
                 pass
         self._token_renewal_task = None
         self.workspace_token_expiry = None
+        if self._window_sync_handle is not None:
+            self._window_sync_handle.cancel()
+            self._window_sync_handle = None
+        watcher = self._window_watcher
+        self._window_watcher = None
+        if watcher is not None:
+            asyncio.create_task(watcher.stop())  # pragma: no cover
+        self._last_windows.clear()
 
     async def add_subscriber(
         self,
@@ -144,6 +159,7 @@ class WorkspaceSession:
                 and self.workspace_token_expiry is None
             ):
                 self.start_token_renewal(token_expiry)
+            self.start_window_sync()
 
     async def remove_subscriber(self, sock: SafeWebSocket) -> bool:
         """Unregister a connection (acquires lock).
@@ -169,6 +185,64 @@ class WorkspaceSession:
         self._token_renewal_task = asyncio.create_task(
             self._token_renewal_loop()
         )
+
+    def start_window_sync(self) -> None:
+        """Start (once) the tmux control-mode window-change watcher so every
+        client's tab strip stays in sync with tmux (#2161 / #2171)."""
+        if self._window_watcher is not None or self.app is None:
+            return
+        if self.container_id is None:
+            return
+        self._window_watcher = WindowEventWatcher(
+            self.app.state.podman,
+            self.container_id,
+            self._schedule_window_sync,
+        )
+        asyncio.create_task(self._window_watcher.start())  # pragma: no cover
+
+    def _schedule_window_sync(self) -> None:
+        """Debounce a burst of control-mode events into one re-sync."""
+        if self._window_sync_handle is not None:
+            self._window_sync_handle.cancel()
+        loop = asyncio.get_running_loop()
+        self._window_sync_handle = loop.call_later(
+            0.15, self._dispatch_window_sync
+        )
+
+    def _dispatch_window_sync(self) -> None:
+        self._window_sync_handle = None
+        asyncio.create_task(self._sync_windows_once())  # pragma: no cover
+
+    async def _sync_windows_once(self) -> None:
+        """Re-broadcast ``terminal_windows`` to each connected user when tmux's
+        windows changed (add/close/active) so every client's tab strip updates.
+        """
+        if self.app is None or not self.container_id or not self.subscribers:
+            return
+        sockets = self.app.state.sockets
+        terminal = self.app.state.terminal
+        user_ids: set[str] = set()
+        for sock in list(self.subscribers):
+            conn = sockets.connections.get(sock)
+            uid = conn.user.get("id") if conn else None
+            if uid and uid != model.AGENT_USER_ID:
+                user_ids.add(uid)
+        for uid in user_ids:
+            try:
+                windows = await terminal.list_windows(self.container_id, uid)
+            except Exception:  # pragma: no cover - container mid-restart
+                continue
+            if self._last_windows.get(uid) == windows:
+                continue
+            self._last_windows[uid] = windows
+            msg = {"type": "terminal_windows", "windows": windows}
+            for sock in list(self.subscribers):
+                conn = sockets.connections.get(sock)
+                if conn and conn.user.get("id") == uid:
+                    try:
+                        sock.send_json(msg)
+                    except WS_ERRORS:
+                        pass
 
     async def _token_renewal_loop(self) -> None:
         """Periodically renew the workspace token before it expires."""

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -1,0 +1,123 @@
+"""Tests for WorkspaceSession's tmux window-sync (debounce + re-broadcast)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from klangk.wshandler.session import WorkspaceSession
+
+
+def _session_with_user(user_id: str = "u1"):
+    sock = MagicMock()
+    sock.send_json = MagicMock()
+    conn = MagicMock()
+    conn.user = {"id": user_id}
+    sockets = MagicMock()
+    sockets.connections = {sock: conn}
+    terminal = MagicMock()
+    app = MagicMock()
+    app.state.sockets = sockets
+    app.state.terminal = terminal
+    sess = WorkspaceSession("ws", app)
+    sess.container_id = "cid"
+    sess.subscribers.add(sock)
+    return sess, sock, terminal
+
+
+async def test_sync_broadcasts_on_change_then_skips_unchanged():
+    sess, sock, terminal = _session_with_user()
+    windows = [{"id": "@0", "index": 0, "name": "bash", "active": True}]
+    terminal.list_windows = AsyncMock(return_value=windows)
+
+    await sess._sync_windows_once()
+    sock.send_json.assert_called_once_with(
+        {"type": "terminal_windows", "windows": windows}
+    )
+
+    # Same windows again → no re-broadcast.
+    sock.send_json.reset_mock()
+    await sess._sync_windows_once()
+    sock.send_json.assert_not_called()
+
+
+async def test_sync_broadcasts_when_active_window_changes():
+    sess, sock, terminal = _session_with_user()
+    terminal.list_windows = AsyncMock(
+        return_value=[{"id": "@0", "index": 0, "name": "bash", "active": True}]
+    )
+    await sess._sync_windows_once()
+
+    # Active switches to window @1 → change detected → re-broadcast.
+    sock.send_json.reset_mock()
+    terminal.list_windows = AsyncMock(
+        return_value=[
+            {"id": "@0", "index": 0, "name": "bash", "active": False},
+            {"id": "@1", "index": 1, "name": "1", "active": True},
+        ]
+    )
+    await sess._sync_windows_once()
+    sock.send_json.assert_called_once()
+
+
+async def test_sync_swallows_dead_socket():
+    # A subscriber whose socket just died (send_json raises a WS_ERRORS
+    # member) must not abort the broadcast.
+    sess, sock, terminal = _session_with_user()
+    terminal.list_windows = AsyncMock(
+        return_value=[{"id": "@0", "index": 0, "name": "bash", "active": True}]
+    )
+    sock.send_json.side_effect = RuntimeError("dead socket")
+    await sess._sync_windows_once()  # no raise
+
+
+async def test_schedule_window_sync_debounces_bursts():
+    sess, _sock, _terminal = _session_with_user()
+    calls: list[int] = []
+    sess._sync_windows_once = AsyncMock(side_effect=lambda: calls.append(1))
+
+    sess._schedule_window_sync()
+    first = sess._window_sync_handle
+    sess._schedule_window_sync()  # burst — must cancel the first, reschedule
+    assert first is not None and first.cancelled()
+
+    await asyncio.sleep(0.3)  # past the 0.15s debounce
+    assert calls == [1]
+
+
+async def test_sync_noop_without_container_or_subscribers():
+    sess, _sock, terminal = _session_with_user()
+    terminal.list_windows = AsyncMock(return_value=[])
+    sess.container_id = None
+    await sess._sync_windows_once()  # no container → no-op
+    assert terminal.list_windows.await_count == 0
+
+
+async def test_start_window_sync_creates_watcher_once():
+    sess, _sock, _terminal = _session_with_user()
+    with patch("klangk.wshandler.session.WindowEventWatcher") as wc:
+        wc.return_value.start = AsyncMock()
+        sess.start_window_sync()
+        assert wc.call_count == 1
+        sess.start_window_sync()  # idempotent — no second watcher
+        assert wc.call_count == 1
+        await asyncio.sleep(0.05)  # let the start task drain
+
+
+def test_start_window_sync_noop_without_container():
+    sess, _sock, _terminal = _session_with_user()
+    sess.container_id = None
+    sess.start_window_sync()
+    assert sess._window_watcher is None
+
+
+async def test_reset_cancels_pending_sync_and_stops_watcher():
+    sess, _sock, _terminal = _session_with_user()
+    with patch("klangk.wshandler.session.WindowEventWatcher") as wc:
+        wc.return_value.start = AsyncMock()
+        wc.return_value.stop = AsyncMock()
+        sess.start_window_sync()
+        # arm a pending sync handle so reset's cancel branch runs
+        loop = asyncio.get_running_loop()
+        sess._window_sync_handle = loop.call_later(10, lambda: None)
+        await sess.reset()
+        assert sess._window_watcher is None
+        assert sess._window_sync_handle is None

--- a/src/klangk/klangkd-tests/tests/test_window_watcher.py
+++ b/src/klangk/klangkd-tests/tests/test_window_watcher.py
@@ -1,0 +1,68 @@
+"""Tests for the tmux control-mode window watcher."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from klangk.window_watcher import WindowEventWatcher, is_window_event
+
+
+def test_is_window_event_matches_relevant_events():
+    assert is_window_event("%unlinked-window-add @10")
+    assert is_window_event("%unlinked-window-close @10")
+    assert is_window_event("%window-close @10")
+    assert is_window_event("%session-window-changed $0 @10")
+
+
+def test_is_window_event_ignores_noise():
+    # Pane output, the control client's own window, and command framing
+    # must never trip a re-sync.
+    assert not is_window_event("%output %9 some bytes")
+    assert not is_window_event("%window-add @9")
+    assert not is_window_event("%session-changed $5 __klangk_ctrl-abc")
+    assert not is_window_event("%begin 1 1 0")
+    assert not is_window_event("%end 1 1 0")
+    assert not is_window_event("")
+    assert not is_window_event("not a control line at all")
+
+
+async def test_read_loop_dispatches_only_relevant_events():
+    calls: list[int] = []
+    watcher = WindowEventWatcher(MagicMock(), "cid", lambda: calls.append(1))
+    lines = [
+        b"%output %9 noise\n",
+        b"%window-add @9\n",  # control client's own window — ignored
+        b"%unlinked-window-add @10\n",  # relevant
+        b"%session-window-changed $0 @10\n",  # relevant
+        b"%begin 1 1 0\n",
+        b"",  # EOF
+    ]
+    stdout = MagicMock()
+    stdout.readline = AsyncMock(side_effect=lines)
+    watcher._proc = MagicMock(stdout=stdout, returncode=None)
+    await watcher._read_loop()
+    assert calls == [1, 1]
+
+
+async def test_read_loop_ignores_dead_socket():
+    # No stdout / no proc → no-op, no crash.
+    watcher = WindowEventWatcher(MagicMock(), "cid", lambda: None)
+    watcher._proc = None
+    await watcher._read_loop()  # returns immediately
+
+
+async def test_read_loop_propagates_cancellation():
+    watcher = WindowEventWatcher(MagicMock(), "cid", lambda: None)
+
+    async def block_forever():
+        await asyncio.Future()  # never resolves; cancellation lands here
+
+    stdout = MagicMock()
+    stdout.readline = block_forever
+    watcher._proc = MagicMock(stdout=stdout, returncode=None)
+    task = asyncio.create_task(watcher._read_loop())
+    await asyncio.sleep(0)  # let it start awaiting readline
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
## Summary

Supersedes #2173, which GitHub auto-closed when its base branch (#2172's) was deleted on merge. Same change, rebased onto `main`.

The Flutter terminal tab strip now stays in sync with tmux: a terminal added from the tmux status bar appears as a tab on every connected client, a closed terminal's tab closes everywhere, and switching the active tmux window switches the active Flutter tab. Fixes #2171; delivers #2161's tab-propagation AC.

## How it works

- **`WindowEventWatcher`** — one persistent `tmux -C` control-mode client per workspace. It reacts only to `%unlinked-window-add` / `%unlinked-window-close` / `%window-close` / `%session-window-changed` (ignoring `%output`), debounced (150ms) into a single `list_windows` + `terminal_windows` broadcast — so podman execs happen only on real changes, not on a per-tick poll.
- **`WorkspaceSession`** owns the lifecycle (start on first subscriber, stop on reset); the Flutter tab strip now follows the `active` window.

## Verified

- Empirically spiked that a control client sees the user session's window events globally.
- Full Python suite: **4136 passed, 100% coverage** (incl. new `test_window_watcher.py` + `test_session_sync.py`); `flutter analyze` clean.
- **Deploy-verified**: on a running workspace, an externally-triggered `tmux new-window` arrived as a `terminal_windows` frame at a connected Playwright client (new window appeared, `active:true`).
