### PR TITLE
fix(workspace): sync terminal renames via the control-mode watcher (#2175)

### DIFF
--- a/src/klangk/klangk/window_watcher.py
+++ b/src/klangk/klangk/window_watcher.py
@@ -24,10 +24,12 @@ logger = logging.getLogger(__name__)
 # Control-mode events that mean "the window set or the active window may have
 # changed". %output (pane bytes), %begin/%end (command framing), and the
 # control client's own %window-add / %session-changed are deliberately ignored
-# so its idle pane never trips a re-sync.
+# so its idle pane never trips a re-sync. %unlinked-window-renamed covers
+# tmux-side window renames (#2175).
 _WINDOW_EVENT_PREFIXES = (
     "%unlinked-window-add",
     "%unlinked-window-close",
+    "%unlinked-window-renamed",
     "%window-close",
     "%session-window-changed",
 )

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -908,6 +908,10 @@ class TerminalController:
             conn = self._conn.app.state.sockets.connections.get(sock)
             if conn and conn.user.get("id") == user_id:
                 sock.send_json(msg)
+        # Keep the control-mode watcher's diff baseline current so it doesn't
+        # re-broadcast the state we just pushed (a duplicate debounced frame
+        # raced the e2e terminal-tabs tests, #2174).
+        ws_session._last_windows[user_id] = windows
 
     def _notify_terminals_changed(
         self, windows: list[dict] | None = None

--- a/src/klangk/klangkd-tests/tests/test_window_watcher.py
+++ b/src/klangk/klangkd-tests/tests/test_window_watcher.py
@@ -11,6 +11,7 @@ from klangk.window_watcher import WindowEventWatcher, is_window_event
 def test_is_window_event_matches_relevant_events():
     assert is_window_event("%unlinked-window-add @10")
     assert is_window_event("%unlinked-window-close @10")
+    assert is_window_event("%unlinked-window-renamed @10 newname")
     assert is_window_event("%window-close @10")
     assert is_window_event("%session-window-changed $0 @10")
 
@@ -34,6 +35,7 @@ async def test_read_loop_dispatches_only_relevant_events():
         b"%output %9 noise\n",
         b"%window-add @9\n",  # control client's own window — ignored
         b"%unlinked-window-add @10\n",  # relevant
+        b"%unlinked-window-renamed @10 newname\n",  # relevant (rename)
         b"%session-window-changed $0 @10\n",  # relevant
         b"%begin 1 1 0\n",
         b"",  # EOF
@@ -42,7 +44,7 @@ async def test_read_loop_dispatches_only_relevant_events():
     stdout.readline = AsyncMock(side_effect=lines)
     watcher._proc = MagicMock(stdout=stdout, returncode=None)
     await watcher._read_loop()
-    assert calls == [1, 1]
+    assert calls == [1, 1, 1]
 
 
 async def test_read_loop_ignores_dead_socket():


### PR DESCRIPTION
## Summary

Two small terminal-tab-sync fixes:

1. **#2175** — renaming a tmux window from the status bar now updates the Flutter tab name immediately (previously only on the window's next click).
2. **#2174 regression** — `notify_user_terminal_windows` now updates the watcher's `_last_windows` baseline, so the control-mode watcher no longer re-broadcasts the state a command handler just pushed. The duplicate debounced frame was racing the e2e `terminal-tabs` tests (`close a terminal window`, `select-window switches the active window`).

## Changes

- `src/klangk/klangk/window_watcher.py` — add `%unlinked-window-renamed` to the event prefixes (confirmed via control-mode spike: renaming a window in another session emits `%unlinked-window-renamed @N <name>`).
- `src/klangk/klangk/wshandler/controllers.py` — `notify_user_terminal_windows` keeps the session `_last_windows` baseline current (dedupe).

## Verification

- Full Python suite: **4136 passed, 100% coverage**; `ruff` clean.
- The dedupe trace: handler broadcasts state X + records `_last_windows=X`; the watcher's debounced sync sees list_windows == X → skips. No duplicate frame, so the e2e `recvUntil` reads the handler's frame.
