### PR TITLE
fix(workspace): handle recycled container cleanly on terminal start (#2178)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -286,6 +286,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Recycled-container race on terminal start (#2178).** When the
+  workspace container was recycled between terminal start and the
+  initial window sync, the server logged a full `TerminalError`
+  traceback on every occurrence and the client got no initial terminal
+  tab list. The "container gone" condition is now detected and handled
+  cleanly: a single warning line, the dead session is torn down, and the
+  client gets a user-visible error so it can reopen the terminal.
+
 - **Browser terminals over plain HTTP (#2162).** In the browser UI,
   workspace terminals never started (the pane stayed blank, no shell prompt)
   on deployments served over plain HTTP to a non-localhost host — they only

--- a/src/klangk/klangk/exceptions.py
+++ b/src/klangk/klangk/exceptions.py
@@ -9,5 +9,16 @@ class TerminalError(RuntimeError):
     """A tmux or terminal operation failed."""
 
 
+class ContainerGoneError(TerminalError):
+    """The container a terminal/tmux operation targeted no longer exists.
+
+    Raised when ``podman exec`` reports the container is gone (e.g.
+    "no container with name or ID ... found"). Distinct from a plain
+    tmux failure so callers can treat a recycled container as an
+    expected, recoverable condition instead of logging a traceback
+    (#2178).
+    """
+
+
 class SendmailError(RuntimeError):
     """The sendmail subprocess exited with a non-zero status."""

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -21,8 +21,8 @@ import termios
 import tty
 from collections.abc import AsyncGenerator
 
-from .podman import Podman, subprocess_env
-from .exceptions import TerminalError
+from .podman import Podman, classify, subprocess_env
+from .exceptions import ContainerGoneError, TerminalError
 from .model.workspaces import SETUP_STATE_COMPLETE
 from .util import BoundedOutputQueue
 
@@ -559,6 +559,14 @@ class Terminal:
             if "No such file or directory" in stderr and attempt < 2:
                 await asyncio.sleep(0.5)
                 continue
+            # "container gone" is a recoverable condition (the container
+            # was recycled between terminal start and this call), not a
+            # tmux/server failure — surface it distinctly so callers can
+            # avoid tracebacking an expected race (#2178).
+            if classify(stderr) == 404:
+                raise ContainerGoneError(
+                    f"container {container_id!r} is gone: {stderr.strip()}"
+                )
             raise TerminalError(f"tmux command failed: {stderr.strip()}")
         return ""  # pragma: no cover
 

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from fastapi import WebSocketDisconnect
 
 from .. import model
-from ..exceptions import TerminalError
+from ..exceptions import ContainerGoneError, TerminalError
 from ..podman import ExecSession
 from ..terminal import (
     TerminalSession,
@@ -727,6 +727,31 @@ class TerminalController:
                 conn.sock.send_json({"type": "terminal_started"})
                 try:
                     await ctrl._sync_windows()
+                except ContainerGoneError as e:
+                    # The container was recycled between session start and
+                    # the window sync — an expected race, not a tmux
+                    # failure. Don't traceback it: log a clean warning,
+                    # stop the now-dead session, and tell the client so it
+                    # can re-trigger workspace open against the fresh
+                    # container (#2178).
+                    logger.warning(
+                        "_start_terminal: container gone before window "
+                        "sync (user=%s container=%s): %s",
+                        conn.user.get("email"),
+                        conn.container_id,
+                        e,
+                    )
+                    await session.stop()
+                    conn.app.state.container_registry.revoke_browser(conn.sock)
+                    conn.browser_id = None
+                    try:
+                        send_error(
+                            conn.sock,
+                            "Container was recycled; reopening terminal",
+                        )
+                    except WS_ERRORS:
+                        pass
+                    return
                 except (TerminalError, OSError):
                     logger.exception("_start_terminal: window list failed")
                 ctrl._send_shared_terminals()

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from klangk.exceptions import TerminalError
+from klangk.exceptions import ContainerGoneError, TerminalError
 from klangk.terminal import (
     CONTAINER_USER,
     SERVICE_SESSION,
@@ -773,6 +773,23 @@ class TestTmuxCommand:
             with pytest.raises(TerminalError, match="error msg"):
                 await _terminal.tmux_command("cid", "sess", ["bad-cmd"])
         assert mock_exec.await_count == 1  # no retry on non-socket errors
+
+    async def test_raises_container_gone_on_missing_container(self):
+        # podman reports the container no longer exists — a recoverable
+        # recycle race, surfaced as a distinct exception (#2178).
+        stderr = (
+            'Error: no container with name or ID "abc" found: '
+            "no such container"
+        )
+        with patch.object(
+            _mock_pod,
+            "exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "", stderr),
+        ) as mock_exec:
+            with pytest.raises(ContainerGoneError, match="is gone"):
+                await _terminal.tmux_command("cid", "sess", ["list-windows"])
+        assert mock_exec.await_count == 1  # no retry for a gone container
 
     async def test_retries_on_socket_not_found(self):
         with (

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -26,7 +26,7 @@ from klangk import (
     container,
     workspaces as ws_mod,
 )
-from klangk.exceptions import TerminalError
+from klangk.exceptions import ContainerGoneError, TerminalError
 from klangk.model.chat import ChatModel
 from _helpers import make_settings
 from klangk.wshandler import (
@@ -1064,6 +1064,139 @@ class TestHandleTerminalStart:
             isinstance(m, dict) and m.get("type") == "terminal_started"
             for m in sent
         )
+        conn.terminal_task.cancel()
+        try:
+            await conn.terminal_task
+        except asyncio.CancelledError:
+            pass
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
+
+    async def test_start_container_gone_recovers_cleanly(self, app_state):
+        """A recycled container during window sync is handled cleanly (#2178).
+
+        When the container vanishes between terminal start and the window
+        sync, the handler must NOT traceback an expected race: it logs a
+        warning, stops the dead session, revokes the browser, and sends the
+        client a user-visible error (no terminal_windows frame, no
+        traceback in the log).
+        """
+        app_state = _make_app_state()
+        registry = app_state.state.container_registry
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+
+        async def _perm(*a):
+            return True
+
+        conn._has_perm = _perm  # type: ignore[method-assign]
+        registry.track_activity("cid", "ws")
+
+        with (
+            patch.object(_ws_controllers, "TerminalSession") as MockTS,
+            patch.object(
+                _mock_term,
+                "list_windows",
+                side_effect=ContainerGoneError("container gone"),
+            ),
+            patch.object(_ws_controllers, "logger") as mock_logger,
+        ):
+            mock_session = _mock_terminal()
+            MockTS.return_value = mock_session
+
+            async def fake_output():
+                return
+                yield
+
+            mock_session.output = fake_output
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            await asyncio.sleep(0)
+
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        # terminal_started went out before the sync attempt
+        assert any(
+            isinstance(m, dict) and m.get("type") == "terminal_started"
+            for m in sent
+        )
+        # a user-visible error was sent (clean recovery, not a silent drop)
+        assert any(
+            isinstance(m, dict)
+            and m.get("type") == "error"
+            and "recycled" in m.get("message", "")
+            for m in sent
+        )
+        # no window/shared-terminal frames after the dead sync
+        assert not any(
+            isinstance(m, dict) and m.get("type") == "terminal_windows"
+            for m in sent
+        )
+        # clean warning, never a traceback
+        mock_logger.warning.assert_called()
+        mock_logger.exception.assert_not_called()
+        # dead session torn down and browser unregistered
+        mock_session.stop.assert_awaited()
+        assert conn.browser_id is None
+        conn.terminal_task.cancel()
+        try:
+            await conn.terminal_task
+        except asyncio.CancelledError:
+            pass
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
+
+    async def test_start_container_gone_send_error_fails(self, app_state):
+        """A send_error failure during container-gone recovery is swallowed (#2178).
+
+        The client socket may already be closed by the time we report the
+        recycled-container error; that must not escape the recovery path.
+        """
+        app_state = _make_app_state()
+        registry = app_state.state.container_registry
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+
+        async def _perm(*a):
+            return True
+
+        conn._has_perm = _perm  # type: ignore[method-assign]
+        registry.track_activity("cid", "ws")
+
+        # terminal_started send must succeed; only the recovery error send
+        # raises (the socket is gone by then).
+        def _send_json(msg):
+            if isinstance(msg, dict) and msg.get("type") == "error":
+                raise WebSocketDisconnect
+
+        sock.send_json.side_effect = _send_json
+
+        with (
+            patch.object(_ws_controllers, "TerminalSession") as MockTS,
+            patch.object(
+                _mock_term,
+                "list_windows",
+                side_effect=ContainerGoneError("container gone"),
+            ),
+        ):
+            mock_session = _mock_terminal()
+            MockTS.return_value = mock_session
+
+            async def fake_output():
+                return
+                yield
+
+            mock_session.output = fake_output
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            await asyncio.sleep(0)
+
+        # recovery completed despite the closed socket
+        mock_session.stop.assert_awaited()
+        assert conn.browser_id is None
         conn.terminal_task.cancel()
         try:
             await conn.terminal_task


### PR DESCRIPTION
## Summary

- **#2178** — when the workspace container is recycled between terminal start and the initial window sync, `podman exec` reports the container no longer exists. Previously this surfaced as a `TerminalError` that `_start_terminal` caught with `logger.exception` — a **full traceback on every occurrence**, and the client got `terminal_started` but **no initial `terminal_windows` frame and no error signal**.

## Root cause

Not a tmux-session race. `_sync_windows` runs `podman exec <conn.container_id> tmux list-windows` against a stale `container_id` left over from a container recycle (idle-stop + recreate, or a concurrent restart). The real stderr was:

```
tmux command failed: Error: no container with name or ID "237…889" found: no such container
```

## Change

- **`tmux_command`** now classifies the podman stderr (`podman.classify`) and raises a distinct **`ContainerGoneError`** (subclass of `TerminalError`, so existing `except TerminalError` handlers are unchanged) when the container is gone (status 404).
- **`_start_terminal`** catches `ContainerGoneError` **before** the generic `(TerminalError, OSError)` path and recovers cleanly instead of tracebacking:
  - a single `logger.warning(...)` line — **no traceback** for an expected race;
  - the dead session is stopped;
  - the browser registration is revoked and `browser_id` cleared;
  - the client gets a user-visible error (`Container was recycled; reopening terminal`) so it can re-trigger workspace open against the fresh container.

This matches the "fail the terminal cleanly with a user-visible error" direction from the issue, and the explicit requirement that *the log shouldn't carry a full traceback for an expected "container gone" condition*.

## Verification

- Full Python suite **4139 passed @ 100% coverage** (`-n auto`, the CI way).
- Frontend suite **830 passed** (no frontend changes — unaffected, run for parity).
- New tests: `tmux_command` container-gone classification; `_start_terminal` clean recovery (asserts `warning` called, `exception` not called, error sent, session torn down, browser unregistered); and the `send_error`-already-closed branch.

Closes #2178.
