### PR TITLE
fix(e2e): pin @playwright/test to nix browsers; drop revision pins

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -73,10 +73,18 @@ in
         ]
     );
 
-  # Point Playwright at the nix-provided browsers. The playwright.config.ts
-  # hardcodes the nix revision numbers (e.g. chromium-1223) so no remapping
-  # is needed — just set the path directly.
+  # Point Playwright at the nix-provided browsers. @playwright/test
+  # (src/frontend/e2e-tests/package.json) is pinned to the version whose browser
+  # revisions match these builds, so Playwright resolves each browser under
+  # PLAYWRIGHT_BROWSERS_PATH on its own — playwright.config.ts no longer hardcodes
+  # the revision numbers (#2182). SKIP_BROWSER_DOWNLOAD keeps `npm install` from
+  # fetching its own (mismatched) copy; the nix build is the source of truth.
+  # The enterShell block below fails fast if the @playwright/test chromium
+  # revision ever drifts from the nix build (e.g. a nixpkgs playwright-driver
+  # bump) — the symptom otherwise is a confusing "Executable doesn't exist" at
+  # test time.
   env.PLAYWRIGHT_BROWSERS_PATH = pkgs.playwright-driver.browsers;
+  env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
   env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
 
   tasks = {
@@ -316,11 +324,24 @@ in
     devenv tasks run klangk:flutter-build klangk:build-workspace-image
     cd src/frontend/e2e-tests
     npm install --silent
+
+    # Fail fast if @playwright/test's browser revisions don't match the nix
+    # playwright-driver.browsers (PLAYWRIGHT_BROWSERS_PATH) — otherwise the
+    # suite fails per-test with "Executable doesn't exist". See #2182.
+    if [ -n "''${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
+      _pwrev=$(python3 -c "import json;print(next(b['revision'] for b in json.load(open('node_modules/playwright-core/browsers.json'))['browsers'] if b['name']=='chromium'))" 2>/dev/null || true)
+      if [ -n "$_pwrev" ] && [ ! -d "$PLAYWRIGHT_BROWSERS_PATH/chromium-$_pwrev" ]; then
+        echo "ERROR: @playwright/test expects chromium-$_pwrev, which is not under PLAYWRIGHT_BROWSERS_PATH ($PLAYWRIGHT_BROWSERS_PATH)." >&2
+        echo "Bump @playwright/test in package.json to the version matching nixpkgs playwright-driver.browsers, then 'npm install'. See #2182." >&2
+        exit 1
+      fi
+    fi
+
     exec npx playwright test --reporter=list "$@"
   '';
 
   # Bare `playwright` command that always uses the LOCAL binary pinned in
-  # src/frontend/e2e-tests/package.json (@playwright/test 1.59.1). Use this
+  # src/frontend/e2e-tests/package.json (@playwright/test 1.60.0). Use this
   # instead of `npx playwright`, which resolves to a newer cached version
   # (1.61.x) and fails with "two different versions of @playwright/test".
   # All extra args are forwarded. e.g.
@@ -563,6 +584,21 @@ in
     MD034: false
     MD060: false
     MDLINT
+
+    # Playwright browser drift guard (#2182): @playwright/test's expected
+    # chromium revision must exist under the nix PLAYWRIGHT_BROWSERS_PATH, or
+    # every browser-launching test fails with "Executable doesn't exist". Only
+    # checked once node_modules is present, so a first shell entry is unaffected.
+    # test-frontend-e2e hard-fails on the same drift; this is the early warning.
+    if [ -n "''${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
+      _pwbj="$DEVENV_ROOT/src/frontend/e2e-tests/node_modules/playwright-core/browsers.json"
+      if [ -f "$_pwbj" ]; then
+        _pwrev=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(next(b['revision'] for b in d['browsers'] if b['name']=='chromium'))" "$_pwbj" 2>/dev/null || true)
+        if [ -n "$_pwrev" ] && [ ! -d "$PLAYWRIGHT_BROWSERS_PATH/chromium-$_pwrev" ]; then
+          echo "WARNING (@playwright/test vs nix browsers): @playwright/test expects chromium-$_pwrev, which is not under PLAYWRIGHT_BROWSERS_PATH ($PLAYWRIGHT_BROWSERS_PATH). Bump @playwright/test in src/frontend/e2e-tests/package.json to the version matching nixpkgs playwright-driver.browsers, then 'cd src/frontend/e2e-tests && npm install'. See #2182." >&2
+        fi
+      fi
+    fi
   '';
 
   claude.code.mcpServers = { };

--- a/src/frontend/e2e-tests/demo/README.md
+++ b/src/frontend/e2e-tests/demo/README.md
@@ -105,7 +105,7 @@ devenv shell -- playwright test \
 
 > **Run from the worktree root** (where `devenv.nix` lives), wrapped in
 > `devenv shell --`. Use the **`playwright`** command defined in `devenv.nix`
-> — it resolves to the local binary pinned to `@playwright/test@1.59.1`.
+> — it resolves to the local binary pinned to `@playwright/test@1.60.0`.
 > Do **not** use `npx playwright`, which grabs a newer cached version (1.61.x)
 > and fails with "two different versions of @playwright/test".
 

--- a/src/frontend/e2e-tests/demo/playwright.demo.config.ts
+++ b/src/frontend/e2e-tests/demo/playwright.demo.config.ts
@@ -17,7 +17,6 @@
 import { defineConfig } from "@playwright/test";
 
 const DEMO_URL = process.env.KLANGKBUILD_TEST_URL || "http://localhost:8996";
-const BROWSERS = process.env.PLAYWRIGHT_BROWSERS_PATH || "";
 // Logical viewport = the size Flutter lays out for = the Xvfb capture size in
 // record-demo.sh. Default native 1920x1080 (crisp, desktop-sized widgets). For
 // a 2x-bigger (but softer) render, set KLANGKBUILD_DEMO_VW=960 KLANGKBUILD_DEMO_VH=540
@@ -76,9 +75,11 @@ export default defineConfig({
     // quick dry check. A modest slowMo makes clicks read as deliberate on camera.
     launchOptions: {
       slowMo: Number(process.env.KLANGKBUILD_DEMO_SLOWMO || 50),
-      executablePath:
-        process.env.CHROME_PATH ||
-        `${BROWSERS}/chromium-1223/chrome-linux64/chrome`,
+      // @playwright/test is pinned (package.json) to the version matching the
+      // nix playwright-driver.browsers, so Playwright resolves chromium under
+      // PLAYWRIGHT_BROWSERS_PATH on its own — no hardcoded build pin (#2182).
+      // CHROME_PATH overrides for non-devenv runs.
+      executablePath: process.env.CHROME_PATH || undefined,
       // The recorder runs matchbox-window-manager under Xvfb, which force-
       // fullscreens the single app window to the exact screen size with no
       // decoration. --start-maximized hints matchbox to treat the browser as

--- a/src/frontend/e2e-tests/package-lock.json
+++ b/src/frontend/e2e-tests/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "klangk-e2e-tests",
       "devDependencies": {
-        "@playwright/test": "1.59.1",
+        "@playwright/test": "1.60.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/ws": "^8.18.1",
         "jsonwebtoken": "^9.0.3",
@@ -14,13 +14,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -202,13 +202,13 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/frontend/e2e-tests/package.json
+++ b/src/frontend/e2e-tests/package.json
@@ -7,7 +7,7 @@
     "install-browsers": "npx playwright install chromium"
   },
   "devDependencies": {
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "1.60.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/ws": "^8.18.1",
     "jsonwebtoken": "^9.0.3",

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -4,23 +4,18 @@ import { defineConfig } from "@playwright/test";
 const BACKEND_PORT = process.env.KLANGKBUILD_E2E_PORT || "18997";
 const BASE_URL =
   process.env.KLANGKBUILD_TEST_URL || `http://localhost:${BACKEND_PORT}`;
-const BROWSERS = process.env.PLAYWRIGHT_BROWSERS_PATH || "";
-
+// @playwright/test (package.json) is pinned to the version whose browser
+// revisions match the nix playwright-driver.browsers exposed via
+// PLAYWRIGHT_BROWSERS_PATH, so Playwright resolves each browser under PWP on
+// its own — no hardcoded build pin (the chromium-1223/firefox-1522/webkit-2287
+// pins this replaced broke on any nix driver bump, #2182). devenv.nix asserts
+// the @playwright/test chromium revision exists under PWP and fails fast if the
+// two drift. CHROME_PATH / FIREFOX_PATH / WEBKIT_PATH still override the path
+// for non-devenv runs (e.g. macOS, or the dist-smoke which `npx playwright
+// install`s its own browser with PWP unset).
 const chromiumUse = {
   launchOptions: {
-    // In devenv/NixOS, PLAYWRIGHT_BROWSERS_PATH points at the nix-bundled
-    // browsers and we pin the exact nix build (chromium-1223) — @playwright/test
-    // 1.59.1's default revision differs, so the pin is required there (#1193).
-    // When PLAYWRIGHT_BROWSERS_PATH is UNSET (e.g. the dist-smoke, which
-    // `npx playwright install`s its own browser on a stock runner), fall back
-    // to undefined so Playwright uses its default (the just-installed) browser
-    // instead of a non-existent /chromium-1223/... path. CHROME_PATH overrides
-    // both for local runs.
-    executablePath:
-      process.env.CHROME_PATH ||
-      (BROWSERS
-        ? `${BROWSERS}/chromium-1223/chrome-linux64/chrome`
-        : undefined),
+    executablePath: process.env.CHROME_PATH || undefined,
     args: ["--enable-unsafe-swiftshader"],
   },
 };
@@ -28,12 +23,7 @@ const chromiumUse = {
 const firefoxUse = {
   browserName: "firefox" as const,
   launchOptions: {
-    // CI (Linux) uses the default path; FIREFOX_PATH overrides it for local
-    // runs (e.g. macOS, where the binary is firefox/Nightly.app/...), mirroring
-    // CHROME_PATH above.
-    executablePath:
-      process.env.FIREFOX_PATH ||
-      (BROWSERS ? `${BROWSERS}/firefox-1522/firefox/firefox` : undefined),
+    executablePath: process.env.FIREFOX_PATH || undefined,
     // Allow navigator.clipboard read/write in automation without a prompt, so
     // the paste e2e can seed the clipboard. (The fix's own read path uses the
     // native `paste` event and needs no permission.)
@@ -47,15 +37,7 @@ const firefoxUse = {
 const webkitUse = {
   browserName: "webkit" as const,
   launchOptions: {
-    // The nix playwright-driver bundles webkit build 2287, but @playwright/test
-    // 1.59.1 looks for build 2272 by default ("Executable doesn't exist at
-    // .../webkit-2272/pw_run.sh"). Like chromium/firefox above, pin the path to
-    // the nix-provided build so Playwright uses it directly instead of its
-    // npm-version-derived revision. WEBKIT_PATH mirrors CHROME/FIREFOX_PATH
-    // for local overrides. See #1193.
-    executablePath:
-      process.env.WEBKIT_PATH ||
-      (BROWSERS ? `${BROWSERS}/webkit-2287/pw_run.sh` : undefined),
+    executablePath: process.env.WEBKIT_PATH || undefined,
   },
 };
 


### PR DESCRIPTION
Closes #2182.

## Problem

Local Playwright e2e runs failed at browser launch with:

```
Error: browserType.launch: Executable doesn't exist at
  ~/.cache/ms-playwright/chromium_headless_shell-1217/...
```

## Root cause

A **browser-revision mismatch**, not an env-propagation bug (the issue's original guess):

- `@playwright/test` **1.59.1** expects chromium **1217** / firefox **1511** / webkit **2272**.
- The nix `playwright-driver.browsers` ships chromium **1223** / firefox **1522** / webkit **2287** — i.e. **Playwright 1.60.0**'s browser set, even though `playwright-driver.version` reports `1.59.1`.

The hardcoded `executablePath` pins in `playwright.config.ts` (`chromium-1223`/`firefox-1522`/`webkit-2287`) papered over full chromium but not the headless shell, so any direct local invocation failed; they'd also silently break on any nixpkgs `playwright-driver` bump.

## Fix

- **Pin `@playwright/test` → 1.60.0** (`package.json` + lock) — exact match for the nix browser revisions, so Playwright resolves each browser natively under `PLAYWRIGHT_BROWSERS_PATH`.
- **Drop the hardcoded `executablePath` build pins** in `playwright.config.ts` and `demo/playwright.demo.config.ts`; keep the `CHROME_PATH`/`FIREFOX_PATH`/`WEBKIT_PATH` overrides for non-devenv runs (dist-smoke, macOS).
- **`devenv.nix`**: set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` (npm install no longer fetches a mismatched copy), and add a **drift guard** — a non-blocking warning in `enterShell` plus a hard-fail in `test-frontend-e2e` — that fires if the `@playwright/test` chromium revision ever drifts from the nix build, with a message pointing at the fix.

## Verification

Verified locally with a throwaway spec exercising all three browser projects (no server/global-setup): chromium, firefox, and webkit all launch and pass via native `PLAYWRIGHT_BROWSERS_PATH` resolution, and the drift guard fires correctly against a stale `node_modules`. The full `test-frontend-e2e` suite will run in CI on this PR.

```
✓  [chromium] nix browser launches under PLAYWRIGHT_BROWSERS_PATH (159ms)
✓  [webkit]   nix browser launches under PLAYWRIGHT_BROWSERS_PATH (2.1s)
✓  [firefox]  nix browser launches under PLAYWRIGHT_BROWSERS_PATH (1.5s)
```
