### PR TITLE
test(tui-e2e): poll for rename to land instead of racing the _save worker

### DIFF
--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -10,6 +10,7 @@ Run with: devenv shell -- test-cli-e2e -k TestTuiE2E
 import os
 import sys
 import tempfile
+import time
 
 import asyncio
 
@@ -141,6 +142,29 @@ def _api_get_workspace(base_url, token, ws_id):
         if ws["id"] == ws_id:
             return ws
     raise ValueError(f"Workspace {ws_id} not found")
+
+
+def _api_wait_for_workspace_name(base_url, token, ws_id, name, timeout=15.0):
+    """Poll the API until workspace ``ws_id``'s name becomes ``name``.
+
+    The TUI edit form persists in a background worker (``_save`` ->
+    ``run_worker(_do_save)``), so a rename lands asynchronously and reading
+    the API immediately after ``_save()`` races the worker's PUT (#2185).
+    Poll until it lands instead of asserting on a single read.
+    """
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = _api_get_workspace(base_url, token, ws_id)
+        if last["name"] == name:
+            return last
+        time.sleep(0.1)
+    assert last is not None
+    assert last["name"] == name, (
+        f"workspace {ws_id} name never became {name!r} within {timeout}s "
+        f"(last={last['name']!r})"
+    )
+    return last
 
 
 # ── tests ───────────────────────────────────────────────────────────────
@@ -500,8 +524,10 @@ class TestTuiE2E:
                 await _settle(app, pilot)
                 await pilot.pause()
 
-            # Verify via API.
-            ws = _api_get_workspace(base_url, token, ws_id)
+            # The edit form persists via a background worker (_save ->
+            # run_worker(_do_save)), so a rename lands asynchronously; poll
+            # until it shows up rather than racing the worker's PUT (#2185).
+            ws = _api_wait_for_workspace_name(base_url, token, ws_id, new_name)
             assert ws["name"] == new_name
         finally:
             _api_delete_workspace(base_url, token, ws_id)


### PR DESCRIPTION
Closes #2185.

## Problem

`test_tui_e2e::TestTuiE2E::test_edit_rename_persists` was flaky in CI — it read the API immediately after `EditWorkspaceScreen._save()` and asserted the workspace had been renamed, but on a loaded runner it saw the **old** name:

```
AssertionError: assert 'tui-ren-36651' == 'tui-renamed-53621'
src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py:505
```

(1 failed, 79 passed on https://github.com/mcdonc/klangk/actions/runs/31076391395)

## Root cause

`_save()` does not persist inline — it dispatches the PUT in a background worker:

```python
def _save(self) -> None:
    ...
    self.run_worker(self._do_save(name, body, ws, restart_needed), ...)

async def _do_save(self, name, body, ws, restart_needed) -> None:
    await asyncio.to_thread(self.app.tui_state.update_workspace, ws.id, **body)
```

The test only waited via `_settle` (two `pilot.pause()` calls — its own docstring notes it can't reliably await workers because of the long-running `_status_loop`). Two pauses aren't a dependable wait for a worker that does a blocking HTTP round-trip in a thread, so the API read could race the rename. The product code is correct — `update_workspace` PUTs the full body including `name`.

## Fix

Test-only. Add `_api_wait_for_workspace_name(base_url, token, ws_id, name, timeout=15.0)`, which polls `GET /api/v1/workspaces/<id>` until the name matches (with a bounded timeout and a clear assertion message), and use it in the rename assertion so the test waits for the rename to actually land instead of racing the worker.

## Verification

- `test_edit_rename_persists` passes.
- Full `test_tui_e2e.py` suite (15 tests) green.
