### PR TITLE
feat(tui): list + launch shared terminals from the workspace detail page (#2164)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Shared terminals in the TUI (#2164).** The workspace detail screen
+  now lists shared terminals visible to you (other users' shared windows
+  and the agent's `service` window), below your own terminals. Selecting
+  one runs `klangk shell <ws> <handle>:<window>`, joining it via the same
+  `join_shared_terminal` path the browser uses. Arrow down from your own
+  terminals into the shared list; the `[n]`/`[m]`/`[t]` own-terminal
+  keys no-op while the shared list is focused.
+
 - **New terminal from the tmux status bar (#2161).** A clickable "+ new"
   item in the workspace terminal's tmux status bar opens another terminal
   via a native `tmux new-window`, working the same in `klangk shell` and the

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -658,6 +658,29 @@ class KlangkClient:
         """
         return await self._terminals(name)
 
+    async def list_shared_terminals(self, name: str) -> list[dict]:
+        """Return shared terminals visible in workspace *name*.
+
+        Other users' shared windows plus the agent's ``service`` window —
+        the same set the browser renders as shared tabs. Drives the
+        workspace WebSocket and issues the ``list_shared_terminals``
+        command (no terminal session needed). Returns ``[]`` on any
+        failure (including the ``spectate-on-shared-terminals`` permission
+        being absent) so the TUI degrades to an empty shared list.
+        """
+        try:
+            ws = self.resolve_workspace(name)
+            async with ws_connect(
+                self.server_url, token=self.token or ""
+            ) as conn:
+                await wait_container_ready(conn, ws.id)
+                await conn.send(json.dumps({"cmd": "ui_ready"}))
+                await self._drain_until_ready(conn)
+                await conn.send(json.dumps({"cmd": "list_shared_terminals"}))
+                return await self._recv_shared_terminals(conn)
+        except Exception:
+            return []
+
     async def close_terminal(self, name: str, window_id: str) -> list[dict]:
         """Close terminal window *window_id* (@N) in *name*; return list."""
         return await self._terminals(name, close_window_id=window_id)
@@ -772,6 +795,24 @@ class KlangkClient:
             if msg.get("type") == "error":
                 # Surface server errors immediately instead of looping
                 # until the 30s timeout (#1966 review).
+                raise ConnectionError(msg.get("message", "terminal error"))
+
+    @staticmethod
+    async def _recv_shared_terminals(
+        conn, timeout: float = 30.0
+    ) -> list[dict]:
+        """Read frames until a ``shared_terminals`` frame arrives."""
+        loop = asyncio.get_event_loop()
+        end = loop.time() + timeout
+        while True:
+            remaining = end - loop.time()
+            if remaining <= 0:  # pragma: no cover
+                raise asyncio.TimeoutError
+            raw = await asyncio.wait_for(conn.recv(), timeout=remaining)
+            msg = json.loads(raw)
+            if msg.get("type") == "shared_terminals":
+                return msg.get("terminals") or []
+            if msg.get("type") == "error":
                 raise ConnectionError(msg.get("message", "terminal error"))
 
     def export_workspace(

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -78,6 +78,20 @@ class WorkspaceDetailScreen(Screen):
         height: auto;
         max-height: 14;
     }
+    WorkspaceDetailScreen #shared_header {
+        height: 1;
+        margin-top: 1;
+        margin-bottom: 0;
+    }
+    WorkspaceDetailScreen #shared_label {
+        text-style: bold;
+        width: auto;
+        color: $accent;
+    }
+    WorkspaceDetailScreen #shared_term_list {
+        height: auto;
+        max-height: 10;
+    }
     WorkspaceDetailScreen #detail_body {
         margin-top: 1;
     }
@@ -88,6 +102,10 @@ class WorkspaceDetailScreen(Screen):
         self._name = name
         self._ws = None
         self._terminals: list[dict] = []
+        # Shared terminals visible to this user in the workspace (others'
+        # shared windows + the agent's service window). Loaded alongside
+        # own terminals so the detail page can list + launch them (#2164).
+        self._shared_terminals: list[dict] = []
         self._missing = False
         self._load_error: str | None = None
         # Serializes terminal-list renders. Adding/removing a terminal fires
@@ -99,6 +117,13 @@ class WorkspaceDetailScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
+        # Spatial nav (#1781): Down off the last own-terminal row enters
+        # the shared-terminal list; Up off its first row returns to the
+        # own-terminal list. Tab remains a fallback.
+        term_list = SpatialListView(id="term_list")
+        term_list.SPATIAL_DOWN_TARGET = "#shared_term_list"
+        shared_list = SpatialListView(id="shared_term_list")
+        shared_list.SPATIAL_UP_TARGET = "#term_list"
         yield Vertical(
             Horizontal(
                 Static("Terminals", id="term_label"),
@@ -109,7 +134,17 @@ class WorkspaceDetailScreen(Screen):
                 ),
                 id="term_header",
             ),
-            SpatialListView(id="term_list"),
+            term_list,
+            Horizontal(
+                Static("Shared terminals", id="shared_label"),
+                Static(
+                    "Enter to visit",
+                    id="shared_hints",
+                    markup=False,
+                ),
+                id="shared_header",
+            ),
+            shared_list,
             Static("", id="detail_body"),
             Static("", id="detail_msg"),
             id="detail_box",
@@ -129,6 +164,12 @@ class WorkspaceDetailScreen(Screen):
         lv.append(ListItem(Label(Text("(loading terminals…)")), name=""))
         if lv.index is None:
             lv.index = 0  # highlight the placeholder so the list is selected by default
+        # Seed the shared-terminal list too, so spatial Down off the last
+        # own-terminal row always lands on a real row (#2164).
+        slv = self.query_one("#shared_term_list", ListView)
+        slv.append(ListItem(Label(Text("(loading shared…)")), name=""))
+        if slv.index is None:
+            slv.index = 0
         self.call_after_refresh(self._focus_term_list)
 
     def on_show(self) -> None:
@@ -145,10 +186,18 @@ class WorkspaceDetailScreen(Screen):
 
         Skipped while a modal sits on top (app.screen is not self) so a
         background terminals_changed reload never yanks focus out of the
-        foreground dialog. The list is the screen's primary interactive
-        widget, so always prefer it when this screen is active.
+        foreground dialog. Also skipped when the shared-terminal list
+        already has focus, so the 5s uptime tick / a reload doesn't pull
+        the user off it (#2164). The list is the screen's primary
+        interactive widget, so default to it otherwise.
         """
         if self.app.screen is not self:
+            return
+        focused = self.focused
+        if focused is not None and getattr(focused, "id", None) in (
+            "term_list",
+            "shared_term_list",
+        ):
             return
         self.query_one("#term_list", ListView).focus()
 
@@ -157,6 +206,7 @@ class WorkspaceDetailScreen(Screen):
         if self._ws is not None and not self._ws.running:
             await self._start_if_stopped()
         self.run_worker(self._load_terminals, exit_on_error=False)
+        self.run_worker(self._load_shared_terminals, exit_on_error=False)
 
     async def _load(self) -> None:
         try:
@@ -530,8 +580,75 @@ class WorkspaceDetailScreen(Screen):
             if lv.index is None:
                 lv.index = 0
 
+    async def _load_shared_terminals(self) -> None:
+        """Fetch the workspace's shared terminals (others' shared windows +
+        the agent's service window) and render them (#2164)."""
+        try:
+            terminals = await self.app.tui_state.list_shared_terminals(
+                self._name
+            )
+        except AuthError:
+            self.app.session_expired()
+            return
+        except Exception:
+            terminals = []
+        # Exclude my own shared windows — they're already in the own-terminals
+        # list above; showing them again here would be noise. The service
+        # window and other users' shared windows stay.
+        my_id = self._current_user_id()
+        self._shared_terminals = [
+            t for t in (terminals or []) if t.get("user_id") != my_id
+        ]
+        await self._render_shared_terminals()
+
+    async def _render_shared_terminals(self) -> None:
+        async with self._render_lock:
+            lv = self.query_one("#shared_term_list", ListView)
+            await lv.clear()
+            if not self._shared_terminals:
+                items = [ListItem(Label(Text("(none)")), name="")]
+            else:
+                items = [
+                    ListItem(
+                        Label(Text(self._shared_terminal_label(t))),
+                        # Key by the join target the shell expects:
+                        # ``handle:window_name``.
+                        name=self._shared_terminal_key(t),
+                    )
+                    for t in self._shared_terminals
+                ]
+            mount = lv.extend(items)
+            await mount
+            if lv.index is None:
+                lv.index = 0
+
+    @staticmethod
+    def _shared_terminal_label(t: dict) -> str:
+        # The agent's service window is presented distinctly, mirroring the
+        # browser's "Service" tab (#1159).
+        if t.get("is_service"):
+            return f"Service  ({t.get('window_name') or '?'})"
+        handle = t.get("handle") or "?"
+        win = t.get("window_name") or "?"
+        return f"{handle}: {win}"
+
+    @staticmethod
+    def _shared_terminal_key(t: dict) -> str:
+        return f"{t.get('handle') or '?'}:{t.get('window_name') or '?'}"
+
+    def _current_user_id(self) -> str | None:
+        """The authenticated user's id, for filtering own shared windows.
+
+        Cached on the app's tui_state (fetched once via /auth/me). Returns
+        None if it can't be resolved, in which case nothing is filtered.
+        """
+        return self.app.tui_state.current_user_id()
+
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Suspend the TUI and spawn ``klangk shell`` for the selected terminal."""
+        if event.control.id == "shared_term_list":
+            self._launch_shared_terminal(event)
+            return
         terminal = getattr(event.item, "name", "") or ""
         if not terminal or self._ws is None:
             return
@@ -570,6 +687,36 @@ class WorkspaceDetailScreen(Screen):
             # identically on every re-select (#1955 review).
             self.run_worker(self._load_terminals, exit_on_error=False)
 
+    def _launch_shared_terminal(self, event: ListView.Selected) -> None:
+        """Join the selected shared terminal via ``klangk shell <ws> <handle>:<win>``.
+
+        Reuses the existing ``join_shared_terminal`` server path (the same
+        one the browser uses) — no new server code (#2164). The list item
+        is keyed by the join target, so it's passed straight through.
+        """
+        target = getattr(event.item, "name", "") or ""
+        if not target or self._ws is None:
+            return
+        # A shared window named with a colon would confuse the
+        # ``handle:window`` parser; refuse rather than mis-target.
+        if ":" not in target or target.count(":") != 1:
+            self._msg("Invalid shared terminal — refreshing.", error=True)
+            self.run_worker(self._load_shared_terminals, exit_on_error=False)
+            return
+        cmd = [sys.executable, "-m", "klangk.cli.main"]
+        server = self.app.tui_state.current_url()
+        if server:
+            cmd += ["--server", server]
+        cmd += ["shell", self._name, target]
+        with self.app.suspend():
+            sys.stdout.write("\033[2J\033[H")
+            sys.stdout.flush()
+            completed = subprocess.run(cmd)
+        if completed.returncode != 0:
+            # The shared window may have been unshared/closed server-side
+            # between refresh and selection — refresh the shared list.
+            self.run_worker(self._load_shared_terminals, exit_on_error=False)
+
     def _window_id_for(self, key: str) -> str | None:
         """Resolve a list-item key (window index) to the window's id (@N).
 
@@ -599,7 +746,22 @@ class WorkspaceDetailScreen(Screen):
                 return None
         return None
 
+    def _own_list_focused(self) -> bool:
+        """True when #term_list (not the shared list) has focus.
+
+        The [n]/[m]/[t] bindings are own-terminal actions; they must not
+        fire while the shared-terminal list is focused, or they'd act on
+        the own list's stale highlighted row (e.g. delete the wrong
+        terminal) — a footgun once two lists share the screen (#2164).
+        """
+        focused = self.focused
+        return focused is not None and getattr(focused, "id", None) == (
+            "term_list"
+        )
+
     def action_delete_terminal(self) -> None:
+        if not self._own_list_focused():
+            return
         lv = self.query_one("#term_list", ListView)
         child = lv.highlighted_child
         if child is None:
@@ -668,6 +830,8 @@ class WorkspaceDetailScreen(Screen):
         return key
 
     def action_rename_terminal(self) -> None:
+        if not self._own_list_focused():
+            return
         lv = self.query_one("#term_list", ListView)
         child = lv.highlighted_child
         if child is None or not child.name:

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -137,11 +137,6 @@ class WorkspaceDetailScreen(Screen):
             term_list,
             Horizontal(
                 Static("Shared terminals", id="shared_label"),
-                Static(
-                    "Enter to visit",
-                    id="shared_hints",
-                    markup=False,
-                ),
                 id="shared_header",
             ),
             shared_list,
@@ -594,8 +589,12 @@ class WorkspaceDetailScreen(Screen):
             terminals = []
         # Exclude my own shared windows — they're already in the own-terminals
         # list above; showing them again here would be noise. The service
-        # window and other users' shared windows stay.
-        my_id = self._current_user_id()
+        # window and other users' shared windows stay. ``current_user_id``
+        # does a synchronous /auth/me fetch, so run it off the event loop
+        # (run_worker runs the coroutine on the loop, thread=False) to
+        # avoid freezing the TUI on the first detail-page open (#2164
+        # review).
+        my_id = await asyncio.to_thread(self._current_user_id)
         self._shared_terminals = [
             t for t in (terminals or []) if t.get("user_id") != my_id
         ]
@@ -887,6 +886,8 @@ class WorkspaceDetailScreen(Screen):
         self.app.notify(f"Renamed terminal to '{new_name}'.")
 
     def action_new_terminal(self) -> None:
+        if not self._own_list_focused():
+            return
         if self._ws is None:
             return
         self.run_worker(self._do_new_terminal, exit_on_error=False)

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -59,6 +59,11 @@ class TuiState:
     def __init__(self, server_url: str | None = None) -> None:
         # ``--server`` override; otherwise the active server from state.
         self._server_override = server_url
+        # Cached /auth/me user id for the active server, so the detail
+        # screen can filter a user's own shared windows out of the shared
+        # list without a /me hit on every render. Refetched on server switch.
+        self._user_id: str | None = None
+        self._user_id_url: str | None = None
 
     # --- fresh config / state each call ---
 
@@ -104,6 +109,41 @@ class TuiState:
         if url is None:
             return None
         return self.state().get_email(url)
+
+    def current_user_id(self) -> str | None:
+        """The authenticated user's id for the active server (cached).
+
+        Fetched once via /auth/me; refetched if the active server changes.
+        Returns None if it can't be resolved (no token, unreachable) so
+        callers can degrade (e.g. skip filtering).
+        """
+        url = self.current_url()
+        if url is None:
+            return None
+        if self._user_id is not None and self._user_id_url == url:
+            return self._user_id
+        token = self.token()
+        if token is None:
+            return None
+        try:
+            resp = http_request(
+                url,
+                "GET",
+                "/api/v1/auth/me",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=5.0,
+            )
+        except httpx.HTTPError:
+            return None
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        uid = data.get("id") if isinstance(data, dict) else None
+        if isinstance(uid, str):
+            self._user_id = uid
+            self._user_id_url = url
+            return uid
+        return None
 
     def is_authenticated(self) -> bool:
         url = self.current_url()
@@ -218,6 +258,9 @@ class TuiState:
 
     async def list_terminals(self, name: str) -> list[dict]:
         return await self.client().list_terminals(name)
+
+    async def list_shared_terminals(self, name: str) -> list[dict]:
+        return await self.client().list_shared_terminals(name)
 
     async def close_terminal(self, name: str, window_id: str) -> list[dict]:
         return await self.client().close_terminal(name, window_id)

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -373,6 +373,11 @@ class TuiState:
         if url is not None:
             state.clear_credentials(url)
             state.save()
+        # Drop the cached /auth/me id so a re-login as a different identity
+        # on the same server isn't served the previous user's id (#2164
+        # review: the cache is keyed by URL, not identity).
+        self._user_id = None
+        self._user_id_url = None
 
     # --- server switching / adding ---
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1233,6 +1233,83 @@ class TestKlangkClient:
         client.resolve_workspace = MagicMock(side_effect=RuntimeError("nope"))
         assert asyncio.run(client.list_terminals("alpha")) == []
 
+    def test_list_shared_terminals(self):
+        client = KlangkClient("http://test:8995", "token")
+        ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
+        client.resolve_workspace = MagicMock(return_value=ws)
+        shared = [
+            {
+                "user_id": "agent",
+                "handle": "clanker",
+                "window_name": "service-cmd",
+                "window_id": "@0",
+                "is_service": True,
+            },
+            {
+                "user_id": "alice",
+                "handle": "alice",
+                "window_name": "build",
+                "window_id": "@1",
+                "is_service": False,
+            },
+        ]
+        messages = [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps({"type": "shared_terminals", "terminals": shared}),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(side_effect=messages)
+        mock_ws.send = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+        with patch(
+            "klangk.cli.transport.websockets.connect",
+            return_value=mock_ws,
+        ):
+            result = asyncio.run(client.list_shared_terminals("alpha"))
+        assert result == shared
+        # The client issued the list_shared_terminals command (not a
+        # terminal_start) — it doesn't open a session to enumerate.
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        cmds = {m.get("cmd") for m in sent}
+        # The client issued the list_shared_terminals command (not a
+        # terminal_start) — it doesn't open a session to enumerate.
+        assert "list_shared_terminals" in cmds
+        assert "terminal_start" not in cmds
+
+    def test_list_shared_terminals_failure(self):
+        # resolve_workspace raising -> graceful empty list
+        client = KlangkClient("http://test:8995", "token")
+        client.resolve_workspace = MagicMock(side_effect=RuntimeError("nope"))
+        assert asyncio.run(client.list_shared_terminals("alpha")) == []
+
+    def test_list_shared_terminals_error_frame(self):
+        # A server ``error`` frame (e.g. spectate permission denied) ->
+        # graceful empty list, not a hang until timeout.
+        client = KlangkClient("http://test:8995", "token")
+        ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
+        client.resolve_workspace = MagicMock(return_value=ws)
+        messages = [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps({"type": "error", "message": "Permission denied"}),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(side_effect=messages)
+        mock_ws.send = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+        with patch(
+            "klangk.cli.transport.websockets.connect",
+            return_value=mock_ws,
+        ):
+            assert asyncio.run(client.list_shared_terminals("alpha")) == []
+
     def test_close_terminal(self):
         client = KlangkClient("http://test:8995", "token")
         ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -105,10 +105,11 @@ class FakeOptionSelected:
 
 
 class FakeSelected:
-    """Stand-in for ListView.Selected carrying an item name."""
+    """Stand-in for ListView.Selected carrying an item name + source list."""
 
-    def __init__(self, name):
+    def __init__(self, name, control_id="term_list"):
         self.item = type("Item", (), {"name": name})()
+        self.control = type("Ctrl", (), {"id": control_id})()
 
 
 def _lv_texts(list_view):
@@ -153,6 +154,8 @@ def _authed_state(**extra):
         list_owned_workspaces=lambda: [],
         list_shared_workspaces=lambda: [],
         list_terminals=_async_empty,
+        list_shared_terminals=_async_empty,
+        current_user_id=lambda: None,
         close_terminal=_async_empty,
         restart_workspace=lambda n: None,
         # Stubbed so MainScreen._do_create doesn't make a real (timing-out)
@@ -174,6 +177,8 @@ def _ws(owned=None, shared=None, **extra):
         list_owned_workspaces=lambda: owned or [],
         list_shared_workspaces=lambda: shared or [],
         list_terminals=_async_empty,
+        list_shared_terminals=_async_empty,
+        current_user_id=lambda: None,
         close_terminal=_async_empty,
         restart_workspace=lambda n: None,
         # Stubbed so MainScreen._do_create doesn't make a real (timing-out)
@@ -427,6 +432,135 @@ def test_reentry_auth_persists(redirect_xdg):
     assert t2.is_authenticated()
     assert t2.current_url() == "https://srv.example"
     assert t2.token() == "tok123"
+
+
+def test_current_user_id_cached(monkeypatch, redirect_xdg):
+    from unittest.mock import MagicMock
+
+    add_server_to_config("srv", "https://srv.example")
+    st = CLIState()
+    st.set_credentials("https://srv.example", "me@x", "tok123")
+    st.save()
+    t = TuiState()
+    calls = []
+
+    def fake_req(url, method, path, **k):
+        calls.append(url)
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"id": "user-123", "email": "me@x"}
+        return r
+
+    monkeypatch.setattr(tui_state_mod, "http_request", fake_req)
+    assert t.current_user_id() == "user-123"
+    # Cached — a second call must not refetch.
+    assert t.current_user_id() == "user-123"
+    assert len(calls) == 1
+
+
+def test_current_user_id_no_server(redirect_xdg):
+    # Nothing configured -> current_url() is None -> None.
+    assert TuiState().current_user_id() is None
+
+
+def test_current_user_id_no_token(redirect_xdg):
+    # Server configured + active, but no credentials -> token() is None.
+    add_server_to_config("srv", "https://srv.example")
+    st = CLIState()
+    st.active_server = "https://srv.example"
+    st.save()
+    assert TuiState().current_user_id() is None
+
+
+def test_current_user_id_failures(monkeypatch, redirect_xdg):
+    import httpx
+    from unittest.mock import MagicMock
+
+    add_server_to_config("srv", "https://srv.example")
+    st = CLIState()
+    st.set_credentials("https://srv.example", "me@x", "tok123")
+    st.save()
+
+    def mk(*, status=200, body=None, exc=None):
+        def fake_req(url, method, path, **k):
+            if exc is not None:
+                raise exc
+            r = MagicMock()
+            r.status_code = status
+            r.json.return_value = body if body is not None else {}
+            return r
+
+        return fake_req
+
+    # HTTP error -> None.
+    t = TuiState()
+    monkeypatch.setattr(
+        tui_state_mod, "http_request", mk(exc=httpx.HTTPError("x"))
+    )
+    assert t.current_user_id() is None
+    # Non-200 -> None.
+    monkeypatch.setattr(tui_state_mod, "http_request", mk(status=401))
+    assert TuiState().current_user_id() is None
+    # 200 but id not a string -> None.
+    monkeypatch.setattr(
+        tui_state_mod, "http_request", mk(status=200, body={"id": 123})
+    )
+    assert TuiState().current_user_id() is None
+    # 200 but body not a dict -> None.
+    monkeypatch.setattr(
+        tui_state_mod, "http_request", mk(status=200, body=["nope"])
+    )
+    assert TuiState().current_user_id() is None
+
+
+def test_current_user_id_refetch_on_server_switch(monkeypatch, redirect_xdg):
+    from unittest.mock import MagicMock
+
+    add_server_to_config("a", "https://a.example")
+    add_server_to_config("b", "https://b.example")
+    st = CLIState()
+    st.set_credentials("https://a.example", "me@x", "tok1")
+    st.set_credentials("https://b.example", "me@x", "tok2")
+    st.save()
+    t = TuiState()
+    seen = []
+
+    def fake_req(url, method, path, **k):
+        seen.append(url)
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"id": "id-" + url}
+        return r
+
+    monkeypatch.setattr(tui_state_mod, "http_request", fake_req)
+    st.active_server = "https://a.example"
+    st.save()
+    assert t.current_user_id() == "id-https://a.example"
+    st.active_server = "https://b.example"
+    st.save()
+    # Different active server -> cache miss -> refetch.
+    assert t.current_user_id() == "id-https://b.example"
+    assert len(seen) == 2
+
+
+def test_list_shared_terminals_delegates(monkeypatch):
+    """TuiState.list_shared_terminals delegates to the client."""
+
+    t = TuiState("https://x.example")
+    captured = []
+
+    class FakeClient:
+        async def list_shared_terminals(self, name):
+            captured.append(name)
+            return [{"handle": "a", "window_name": "w"}]
+
+    monkeypatch.setattr(t, "client", lambda: FakeClient())
+    import asyncio
+
+    assert asyncio.run(t.list_shared_terminals("alpha")) == [
+        {"handle": "a", "window_name": "w"}
+    ]
+    assert captured == ["alpha"]
 
 
 def test_known_servers_roundtrip(redirect_xdg):
@@ -6250,6 +6384,319 @@ async def test_detail_terminal_select_empty_name_ignored(monkeypatch):
         await pilot.pause()
         app.screen.on_list_view_selected(FakeSelected(""))
         assert spawned == []
+
+
+async def _async_shared(*a, **k):
+    """Async stub returning a mixed shared-terminal list (service + other
+    user + the caller's own shared window)."""
+    return [
+        {
+            "user_id": "agent",
+            "handle": "clanker",
+            "window_name": "service-cmd",
+            "window_id": "@0",
+            "is_service": True,
+        },
+        {
+            "user_id": "alice-id",
+            "handle": "alice",
+            "window_name": "build",
+            "window_id": "@1",
+            "is_service": False,
+        },
+        {
+            "user_id": "me",
+            "handle": "me",
+            "window_name": "notes",
+            "window_id": "@2",
+            "is_service": False,
+        },
+    ]
+
+
+async def test_detail_shared_terminals_listed_and_filtered(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(
+        list_shared_terminals=_async_shared,
+        current_user_id=lambda: "me",
+    )
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_shared_terminals()
+        await pilot.pause()
+        rows = _lv_texts(app.screen.query_one("#shared_term_list", ListView))
+    # Service window is labelled distinctly; alice's window is shown by
+    # handle:window; my own shared window ("me: notes") is filtered out.
+    assert any("Service" in r for r in rows)
+    assert any("alice: build" in r for r in rows)
+    assert not any("notes" in r for r in rows)
+
+
+async def test_detail_shared_terminal_select_joins(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_shared_terminals=_async_shared)
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+    spawned = []
+    monkeypatch.setattr(
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: (
+            spawned.append(cmd)
+            or scr_detail.subprocess.CompletedProcess(cmd, 0)
+        ),
+    )
+    import io
+    import sys
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_suspend():
+        saved = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            yield
+        finally:
+            sys.stdout = saved
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        monkeypatch.setattr(app, "suspend", fake_suspend)
+        # Selecting a shared row issues ``klangk shell <ws> <handle>:<win>``
+        # — the same join_shared_terminal path the browser uses (#2164).
+        app.screen.on_list_view_selected(
+            FakeSelected("alice:build", control_id="shared_term_list")
+        )
+        assert len(spawned) == 1
+        assert spawned[0][-3:] == ["shell", "alpha", "alice:build"]
+
+
+async def test_detail_shared_terminal_select_bad_key_refreshes(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    refreshed = []
+    st = _ws(list_shared_terminals=_async_shared)
+    st.find_workspace = lambda n: a
+    spawned = []
+    monkeypatch.setattr(
+        scr_detail.subprocess, "run", lambda cmd, **k: spawned.append(cmd)
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        orig = app.screen._load_shared_terminals
+
+        async def _refresh():
+            refreshed.append(1)
+
+        app.screen._load_shared_terminals = _refresh
+        # A row keyed without a ``handle:window`` colon must not spawn a
+        # shell — refresh the shared list instead.
+        app.screen.on_list_view_selected(
+            FakeSelected("bogus", control_id="shared_term_list")
+        )
+        await pilot.pause()
+        assert spawned == []
+        assert refreshed == [1]
+        app.screen._load_shared_terminals = orig
+
+
+async def _async_boom(*a, **k):
+    raise RuntimeError("boom")
+
+
+async def test_detail_load_shared_terminals_auth_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws()
+    st.find_workspace = lambda n: a
+
+    async def _auth_err(*a, **k):
+        raise scr_detail.AuthError
+
+    st.list_shared_terminals = _auth_err
+    app = KlangkApp(st)
+    expired = []
+    async with app.run_test() as pilot:
+        # Patch session_expired BEFORE push: the mount worker also calls
+        # _load_shared_terminals (and would hit the AuthError), so it must
+        # not push the real SessionExpiredScreen out from under us.
+        monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_shared_terminals()
+        await pilot.pause()
+    assert expired  # AuthError -> session_expired invoked
+
+
+async def test_detail_load_shared_terminals_generic_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_shared_terminals=_async_boom)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        # A generic exception degrades to an empty shared list.
+        await app.screen._load_shared_terminals()
+        await pilot.pause()
+        assert app.screen._shared_terminals == []
+
+
+async def test_detail_shared_terminal_select_no_ws_ignored(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    st = _ws()
+    # No workspace -> _ws stays None -> shared launch is a no-op.
+    spawned = []
+    monkeypatch.setattr(
+        scr_detail.subprocess, "run", lambda cmd, **k: spawned.append(cmd)
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        app.screen._ws = None
+        app.screen.on_list_view_selected(
+            FakeSelected("alice:build", control_id="shared_term_list")
+        )
+        # Empty target is also ignored.
+        app.screen.on_list_view_selected(
+            FakeSelected("", control_id="shared_term_list")
+        )
+        assert spawned == []
+
+
+async def test_detail_shared_terminal_failed_spawn_refreshes(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_shared_terminals=_async_shared)
+    st.find_workspace = lambda n: a
+    spawned = []
+    monkeypatch.setattr(
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: (
+            spawned.append(cmd)
+            or scr_detail.subprocess.CompletedProcess(cmd, 1)
+        ),
+    )
+    import io
+    import sys
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_suspend():
+        saved = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            yield
+        finally:
+            sys.stdout = saved
+
+    refreshed = []
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        monkeypatch.setattr(app, "suspend", fake_suspend)
+
+        async def _refresh():
+            refreshed.append(1)
+
+        app.screen._load_shared_terminals = _refresh
+        # A non-zero shell exit refreshes the shared list (the window may
+        # have been unshared server-side).
+        app.screen.on_list_view_selected(
+            FakeSelected("alice:build", control_id="shared_term_list")
+        )
+        await pilot.pause()
+        assert len(spawned) == 1
+        assert refreshed == [1]
+
+
+async def test_detail_term_modify_actions_noop_when_shared_focused(
+    monkeypatch,
+):
+    """[n]/[m]/[t] must not act on the own-terminal list while the shared
+    list is focused (#2164) — otherwise they'd delete/rename the wrong
+    terminal."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    closed = []
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    st.close_terminal = lambda *a, **k: closed.append(1)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        # Focus the shared list — the modify actions must no-op.
+        app.screen.query_one("#shared_term_list", ListView).focus()
+        await pilot.pause()
+        app.screen.action_delete_terminal()
+        app.screen.action_rename_terminal()
+        await pilot.pause()
+        assert closed == []
+
+
+async def test_detail_focus_defaults_to_own_list(monkeypatch):
+    """When neither list has focus, _focus_term_list reclaims it for the
+    own-terminal list (the screen's primary widget)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        # Move focus off both lists, then reclaim.
+        app.screen.query_one("Footer").focus()
+        await pilot.pause()
+        app.screen._focus_term_list()
+        await pilot.pause()
+        assert app.focused is not None
+        assert app.focused.id == "term_list"
 
 
 async def test_main_screen_title(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -543,6 +543,36 @@ def test_current_user_id_refetch_on_server_switch(monkeypatch, redirect_xdg):
     assert len(seen) == 2
 
 
+def test_current_user_id_cleared_on_logout(monkeypatch, redirect_xdg):
+    from unittest.mock import MagicMock
+
+    add_server_to_config("srv", "https://srv.example")
+    st = CLIState()
+    st.set_credentials("https://srv.example", "me@x", "tok123")
+    st.active_server = "https://srv.example"
+    st.save()
+    t = TuiState()
+    seen = []
+    ids = iter(["user-A", "user-B"])
+
+    def fake_req(url, method, path, **k):
+        seen.append(url)
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"id": next(ids)}
+        return r
+
+    monkeypatch.setattr(tui_state_mod, "http_request", fake_req)
+    assert t.current_user_id() == "user-A"
+    # User A logs out, then user B logs in on the SAME server (same URL).
+    # logout must drop the cached id so B isn't served A's id (#2164 review).
+    t.logout()
+    st.set_credentials("https://srv.example", "b@x", "tokB")
+    st.save()
+    assert t.current_user_id() == "user-B"
+    assert len(seen) == 2
+
+
 def test_list_shared_terminals_delegates(monkeypatch):
     """TuiState.list_shared_terminals delegates to the client."""
 
@@ -6657,22 +6687,26 @@ async def test_detail_term_modify_actions_noop_when_shared_focused(
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     a = _wsobj("alpha", running=True)
     closed = []
+    created = []
     st = _ws(list_terminals=_async_terms)
     st.find_workspace = lambda n: a
     st.close_terminal = lambda *a, **k: closed.append(1)
+    st.create_terminal = lambda *a, **k: created.append(1)
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         await app.screen._load_terminals()
         await pilot.pause()
-        # Focus the shared list — the modify actions must no-op.
+        # Focus the shared list — all three modify actions must no-op.
         app.screen.query_one("#shared_term_list", ListView).focus()
         await pilot.pause()
         app.screen.action_delete_terminal()
         app.screen.action_rename_terminal()
+        app.screen.action_new_terminal()
         await pilot.pause()
         assert closed == []
+        assert created == []
 
 
 async def test_detail_focus_defaults_to_own_list(monkeypatch):
@@ -6690,9 +6724,11 @@ async def test_detail_focus_defaults_to_own_list(monkeypatch):
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
-        # Move focus off both lists, then reclaim.
-        app.screen.query_one("Footer").focus()
+        # Move focus off both lists, then reclaim. (Footer.focus() is a no-op
+        # in textual, so clear focus directly to reach the reclaim branch.)
+        app.screen.set_focus(None)
         await pilot.pause()
+        assert app.screen.focused is None
         app.screen._focus_term_list()
         await pilot.pause()
         assert app.focused is not None


### PR DESCRIPTION
## Summary

- **#2164** — the workspace detail screen in the TUI now lists **shared terminals** (other users' shared windows + the agent's `service` window) in a second list below your own terminals. Selecting one runs `klangk shell <ws> <handle>:<window>`, joining it via the existing `join_shared_terminal` server path — **no new server code**.

This is the client-only path we settled on (vs. the earlier link-window/bounded-join server prototype, which was reverted): the join mechanism already exists and is shared by the browser and the CLI, so surfacing shared terminals in the TUI is purely a TUI/client change.

## What changed

- **`KlangkClient.list_shared_terminals(name)`** — drives the workspace WebSocket and issues the `list_shared_terminals` command (no terminal session opened). Degrades to `[]` on any failure, including the `spectate-on-shared-terminals` permission being absent.
- **`TuiState.current_user_id()`** — caches `/auth/me` once per server so the caller's own shared windows are filtered out of the shared list (they're already in the own-terminal list).
- **`WorkspaceDetailScreen`** — a `#shared_term_list` below `#term_list`, loaded alongside own terminals. The shared list is a `SpatialListView` with up/down targets, so arrows move between the two lists without Tab (Tab remains a fallback). The `[n]`/`[m]`/`[t]` own-terminal bindings no-op while the shared list is focused, so they can't act on (e.g. delete) the wrong terminal. `_focus_term_list` no longer yanks focus off the shared list on the 5s uptime tick / reloads.

## Note on the join UX

Joining still uses the grouped-session model (same as the browser today), so the warts we discussed (in-shell drift, `+ new` polluting the owner's session, seeing the owner's unshared windows) are unchanged here — this PR doesn't touch the join model. The link-window bounded join is a separate, optional hardening (would affect the browser too) that I can spike separately if you want it.

## Verification

- Full Python suite **4157 passed @ 100% coverage** (`-n auto`, the CI way).
- No frontend changes (frontend is byte-identical to main; not re-run).
- New tests: client `list_shared_terminals` (success / failure / error-frame); TuiState `current_user_id` (cached / server-switch refetch / no-server / no-token / http-error / non-200 / non-str-id); detail screen shared-list rendering + filtering, selection join, bad-key refresh, AuthError/generic-error load paths, failed-spawn refresh, modify-action guards when shared focused, and focus-defaults-to-own-list.

Closes #2164.
