### PR TITLE
feat(settings): bump default container_pids_limit from 512 to 16384

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -167,6 +167,14 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **`container_pids_limit` default raised to 16384 (#2160).** The
+  deploy-wide workspace process-count cap shipped at 512 (#2030), which
+  build-heavy workloads (nix/devenv flake evaluation, libgit2 threaded
+  packfile/git-cache unpacking) exceed on multi-core hosts, failing with
+  `pthread_create` EAGAIN. The default is now 16384; still bounded and
+  overridable per-deploy (`klangkd.yaml` / `KLANGKD_CONTAINER_PIDS_LIMIT`)
+  or per-workspace (`pids_limit`, #864).
+
 - **Bumped `@earendil-works/pi-coding-agent` to `0.83.0` (#2049).**
 
 - **`none` auth mode unsupported with Docker host image (#1391).** The Docker

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -295,7 +295,7 @@ port: "8997"
 | `netfilter_default_domains`  | _(unset)_                       | `KLANGKD_NETFILTER_DEFAULT_DOMAINS`  |
 | `container_cpu_limit`        | `2.0`                           | `KLANGKD_CONTAINER_CPU_LIMIT`        |
 | `container_memory_limit`     | `8g`                            | `KLANGKD_CONTAINER_MEMORY_LIMIT`     |
-| `container_pids_limit`       | `512`                           | `KLANGKD_CONTAINER_PIDS_LIMIT`       |
+| `container_pids_limit`       | `16384`                         | `KLANGKD_CONTAINER_PIDS_LIMIT`       |
 | `health_check_interval`      |                                 | `KLANGKD_HEALTH_CHECK_INTERVAL`      |
 | `health_check_startup_grace` |                                 | `KLANGKD_HEALTH_CHECK_STARTUP_GRACE` |
 | `health_check_timeout`       |                                 | `KLANGKD_HEALTH_CHECK_TIMEOUT`       |

--- a/src/klangk/klangk/first_run.py
+++ b/src/klangk/klangk/first_run.py
@@ -106,14 +106,14 @@ def _render_config() -> str:
 #                          # secret for any non-local deployment
 #
 # --- Container resource limits (defaults shown; #34 / #2030) ---
-# Every workspace container is capped at 2 CPUs / 8g RAM / 512 PIDs so a
+# Every workspace container is capped at 2 CPUs / 8g RAM / 16384 PIDs so a
 # runaway workspace can't starve the host. These match the built-in
 # defaults, so editing or removing a line keeps that cap unless you set it
 # to empty (container_cpu_limit: "") to disable just that one. Podman
 # receives them as --cpus / --memory / --pids-limit.
 container_cpu_limit: 2.0
 container_memory_limit: 8g
-container_pids_limit: 512
+container_pids_limit: 16384
 #
 # Full settings reference:
 #   https://mcdonc.github.io/klangk/reference/klangkd-config/

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -691,7 +691,7 @@ class KlangkSettings(BaseSettings):
     netfilter_default_domains: list[str] | None = None
     # Container resource limits (#34): deploy-wide CPU / memory / PIDs caps
     # passed to every workspace container as podman --cpus / --memory /
-    # --pids-limit. Ships with protective defaults (2 CPUs / 8g / 512 PIDs,
+    # --pids-limit. Ships with protective defaults (2 CPUs / 8g / 16384 PIDs,
     # #2030) so a fresh install is bounded out of the box — a workspace
     # exceeding a limit is throttled / OOM-killed / fork-bomb-contained
     # rather than taking down the host or its neighbours. Set a field to an
@@ -707,7 +707,7 @@ class KlangkSettings(BaseSettings):
     # deploy default, no clamping) are a follow-up (Phase 2).
     container_cpu_limit: float | None = 2.0
     container_memory_limit: str | None = "8g"
-    container_pids_limit: int | None = 512
+    container_pids_limit: int | None = 16384
     test_mode: str | None = None
     version_file: str | None = None
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -685,7 +685,7 @@ class TestStartContainer:
 
     async def test_resource_limits_defaults_emit_flags(self, workspace):
         # #2030: with no deploy limits configured, the built-in protective
-        # defaults (2 CPUs / 8g / 512 PIDs) still flow through to podman as
+        # defaults (2 CPUs / 8g / 16384 PIDs) still flow through to podman as
         # --cpus / --memory / --pids-limit — a fresh install is bounded out
         # of the box. (Setting an env var to "" disables one cap -> None ->
         # no flag; see test_settings.py.)
@@ -696,7 +696,7 @@ class TestStartContainer:
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 2.0
         assert kwargs["memory"] == "8g"
-        assert kwargs["pids_limit"] == 512
+        assert kwargs["pids_limit"] == 16384
 
     async def test_ping_cap_add_emitted_by_default(self, workspace):
         # #2045: enable_ping defaults to True, so the workspace container

--- a/src/klangk/klangkd-tests/tests/test_first_run.py
+++ b/src/klangk/klangkd-tests/tests/test_first_run.py
@@ -135,7 +135,7 @@ class TestGenerateDefaultConfig:
         body = Path(path).read_text()
         assert "container_cpu_limit: 2.0" in body
         assert "container_memory_limit: 8g" in body
-        assert "container_pids_limit: 512" in body
+        assert "container_pids_limit: 16384" in body
         # They must be active config lines, not commented examples.
         active = {
             line.strip()
@@ -144,7 +144,7 @@ class TestGenerateDefaultConfig:
         }
         assert "container_cpu_limit: 2.0" in active
         assert "container_memory_limit: 8g" in active
-        assert "container_pids_limit: 512" in active
+        assert "container_pids_limit: 16384" in active
 
 
 class TestLauncherIntegration:

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -265,13 +265,13 @@ class TestConfigFile:
     # --- Container resource limits (#34) ---
 
     def test_container_limits_default_to_protective_caps(self):
-        # #2030: a fresh config ships bounded — 2 CPUs / 8g / 512 PIDs —
+        # #2030: a fresh config ships bounded — 2 CPUs / 8g / 16384 PIDs —
         # so a runaway workspace can't take down the host out of the box.
         # Set a field to an empty env value to disable just that one cap.
         s = make_settings({})
         assert s.container_cpu_limit == 2.0
         assert s.container_memory_limit == "8g"
-        assert s.container_pids_limit == 512
+        assert s.container_pids_limit == 16384
 
     def test_container_cpu_limit_from_env(self):
         s = make_settings({"KLANGKD_CONTAINER_CPU_LIMIT": "1.5"})


### PR DESCRIPTION
Closes #2160.

## What

Bumps the default `container_pids_limit` from **512** to **16384**.

## Why

The 512 cap (#2030) is too low for build-heavy workloads on multi-core hosts. nix/devenv flake evaluation and libgit2's threaded packfile / git-cache unpacking scale to `nproc`; on a 64-core container they exceed 512 threads and fail with `pthread_create` EAGAIN (manifesting as `writing packfile: -1, unable to create thread`, or a glibc `FUTEX_OWNER_DIED` robust-mutex assertion in libgit2). This is not OOM — measured `pids.max=512`, peak memory 2.7g of an 8g cap, `oom_kill=0`. 16384 gives generous headroom for per-core fan-out while still bounding fork bombs. Confirmed in the issue: raising the workspace `pids_limit` to 8192 makes the same devenv install complete cleanly at default parallelism.

## Changes

- `src/klangk/klangk/settings.py:710` — `container_pids_limit` default `512` → `16384`.
- `src/klangk/klangk/first_run.py:116` — generated `klangkd.yaml` template `512` → `16384` (keeps template == built-in default).
- `docs/reference/klangkd-config.md` — config reference default `512` → `16384`.
- `docs/changes.md` — `### Changed` entry.
- Comment strings ("512 PIDs") in the two source files + the two default-asserting tests updated to `16384 PIDs`.

Tests that use `512`/`1024` as **explicit** values (env/yaml parsing, per-workspace override roundtrip, podman flag construction) are unchanged — they're testing the mechanism, not the default. Only the three tests that assert the **default** value are updated:

- `test_container.py::test_resource_limits_defaults_emit_flags` — `pids_limit == 16384`.
- `test_settings.py` defaults test — `container_pids_limit == 16384`.
- `test_first_run.py::test_template_emits_container_resource_limits` — generated YAML contains `container_pids_limit: 16384`.

## Verification

Full unit suite green at 100% coverage (the CI way, `-n auto`): `4139 passed in 79.21s`. Operators can still override per-deploy (`klangkd.yaml` / `KLANGKD_CONTAINER_PIDS_LIMIT`) or per-workspace (`pids_limit`, #864).
