### PR TITLE
fix(tui): keep workspace-detail value column from wrapping into the label column (#2190)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -302,6 +302,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **TUI workspace detail: long values no longer wrap into the label
+  column (#2190).** The detail table was rendered at the screen width,
+  but the value panel is narrower (screen chrome), so the panel re-wrapped
+  the pre-folded lines and dropped the value column's hanging indent —
+  wrapped continuation lines fell back under the labels. The table is now
+  rendered at the panel's actual content width (and trailing padding is
+  stripped), so every wrapped line stays aligned in the value column.
+
 - **Recycled-container race on terminal start (#2178).** When the
   workspace container was recycled between terminal start and the
   initial window sync, the server logged a full `TerminalError`

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -290,7 +290,20 @@ class WorkspaceDetailScreen(Screen):
         # the same column regardless of label length (#1910). Wrapped in Text()
         # so values that look like markup (e.g. an image named "[img]") render
         # literally instead of being parsed as Textual markup.
-        width = self.size.width or 80
+        #
+        # Render at the body widget's *actual* content width, not the screen
+        # width: the screen has horizontal chrome (borders/margins/scroll
+        # gutter), so #detail_body is markedly narrower than self.size.width.
+        # Rendering at the wider screen width produces full-width lines that
+        # the narrower Static then re-wraps, which destroys the value column's
+        # hanging indent — wrapped continuation lines fall back to the left
+        # margin under the labels (#2190).
+        width = (
+            body.container_size.width
+            or body.size.width
+            or self.size.width
+            or 80
+        )
         body.update(Text(self._render_detail(self._detail_rows(ws), width)))
 
     @staticmethod
@@ -370,7 +383,11 @@ class WorkspaceDetailScreen(Screen):
             highlight=False,
             markup=False,
         ).print(table, end="")
-        return buf.getvalue()
+        # Strip trailing whitespace per line: Rich pads each row to the full
+        # table width, and a line exactly at the Static's width can still get
+        # re-wrapped by a 1-char gutter, which would drop the hanging indent.
+        # Content-width lines never trigger that re-wrap (#2190).
+        return "\n".join(line.rstrip() for line in buf.getvalue().splitlines())
 
     def _tick_uptime(self) -> None:
         """Refresh the display periodically to update the uptime counter."""

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -10935,3 +10935,79 @@ async def test_detail_screen_cheatsheet_modal():
         await pilot.press("escape")
         await pilot.pause()
         assert isinstance(app.screen, WorkspaceDetailScreen)
+
+
+def test_render_detail_indents_wrapped_values_to_value_column():
+    """A long value folds onto continuation lines aligned under the value
+    column (a hanging indent), not back at column 0 under the label (#2190)."""
+    rows = [
+        (
+            "service command",
+            "cd /app/meetmin && devenv shell -- meetmin-ingest-multi "
+            "--root /app/custrag/ --watch --workers 4",
+        )
+    ]
+    out = WorkspaceDetailScreen._render_detail(rows, 60)
+    lines = out.splitlines()
+    # First line: label, then the start of the value.
+    assert lines[0].startswith("service command  cd /app/meetmin")
+    # The value wrapped onto further lines...
+    assert len(lines) > 1
+    # ...and each continuation line is indented into the value column
+    # (past the label column + padding), never back at column 0.
+    indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    for cont in lines[1:]:
+        assert cont.startswith(" " * indent), (
+            f"continuation not aligned to value column: {cont!r}"
+        )
+        assert cont == cont.rstrip(), (
+            f"trailing whitespace would risk a re-wrap: {cont!r}"
+        )
+
+
+async def test_detail_display_renders_at_body_width_not_screen_width(
+    monkeypatch,
+):
+    """#detail_body is narrower than the screen (horizontal chrome); _display
+    must render the detail table at the body's content width, or the Static
+    re-wraps the pre-folded lines and drops the value-column indent (#2190)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj(
+        "alpha",
+        running=True,
+        service_command=(
+            "cd /app/meetmin && devenv shell -- meetmin-ingest-multi "
+            "--root /app/custrag/ --watch --workers 4"
+        ),
+    )
+    st = _ws()
+    st.find_workspace = lambda n: a
+    captured = {}
+    real = WorkspaceDetailScreen._render_detail
+
+    def spy(rows, width):
+        captured["width"] = width
+        return real(rows, width)
+
+    monkeypatch.setattr(
+        WorkspaceDetailScreen, "_render_detail", staticmethod(spy)
+    )
+    app = KlangkApp(st)
+    async with app.run_test(size=(130, 40)) as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load()
+        await pilot.pause()
+        app.screen._display()
+        await pilot.pause()
+        body = app.screen.query_one("#detail_body", Static)
+        screen_w = app.screen.size.width
+        body_w = body.container_size.width
+    # Rendered at the body's width, and the body is narrower than the screen
+    # (otherwise this regression can't occur and the test is meaningless).
+    assert captured["width"] == body_w
+    assert body_w < screen_w


### PR DESCRIPTION
## Summary

- **#2190** — on the TUI workspace detail screen, long values (e.g. `service command`) wrapped into the label column instead of staying aligned in the value column. Now wrapped continuation lines keep the value column's hanging indent.

## Root cause

`_display` rendered the two-column table at **`self.size.width` (the screen width)**, but the `#detail_body` panel is markedly narrower than the screen — horizontal chrome (borders/margins/scroll gutter) measured it at **92 vs 130 columns**. So `_render_detail` produced full-width (130-col) lines, and the narrower (92-col) Static then **re-wrapped** those pre-folded lines — which destroyed the value column's hanging indent and dropped continuation lines back to the left margin under the labels.

(Rich's `fold` itself is correct — verified by rendering directly; the bug was purely the width mismatch causing a second wrap.)

## Fix

- Render the table at the panel's actual content width: `body.container_size.width`, falling back through `body.size.width` → `self.size.width` → 80.
- Strip trailing per-line padding from `_render_detail`'s output, so a borderline-width line never triggers a destructive re-wrap on a 1-char gutter.

After the fix, a long `service command` renders as:
```
service command  cd /app/meetmin && devenv shell -- meetmin-ingest-multi --root
                 /app/custrag/ --watch --workers 4
```
— every wrapped line aligned in the value column. Applies to all values.

## Verification

- Full Python suite **4160 passed @ 100% coverage** (`-n auto`).
- No frontend changes.
- Tests: `_render_detail` indents wrapped continuation lines into the value column (hanging indent, no trailing whitespace); `_display` renders at the body's content width, not the screen width (regression guard — fails if anyone reverts to `self.size.width`).

Closes #2190.
