### PR TITLE
fix(terminal): name new windows from the Flutter '+' 'bash' instead of numbers (#2179)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -308,6 +308,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **New terminals from the Flutter "+" are named "bash" (#2179).** A
+  terminal created from the browser tab-bar "+" was named with a
+  consecutive number ("1", "2", …), inconsistent with window 0 ("bash")
+  and the tmux status-bar "+". The server's no-name default is now
+  "bash" (tmux permits duplicate window names, so the duplicate guard
+  that protects explicit names is skipped for the default).
+
 - **TUI workspace detail: long values no longer wrap into the label
   column (#2190).** The detail table was rendered at the screen width,
   but the value panel is narrower (screen chrome), so the panel re-wrapped

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -183,10 +183,11 @@ operators or integrators to act when upgrading.
   identified by its window id rather than matched by name. `klangk shell`
   now errors on an ambiguous name (listing the candidate `@N` ids) instead
   of silently picking the first, accepts `@N` and `handle:@N` for exact
-  targeting, and `klangk terminal ls` shows an `ID` column. The TUI's
-  `[n]` new-terminal action no longer invents a sequential `term-N` label;
-  it creates the window unnamed, so the server names it `bash` like every
-  other new terminal.
+  targeting, and `klangk terminal ls` shows an `ID` column. `klangk terminal
+share`/`unshare` likewise accept `@N` and reject an ambiguous name. The
+  TUI's `[n]` new-terminal action no longer invents a sequential `term-N`
+  label; it creates the window unnamed, so the server names it `bash` like
+  every other new terminal.
 
 - **TUI workspace-detail rows are zebra-striped (#2193).** The
   `id / running / uptime / mounts / …` property block on

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -175,6 +175,19 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Duplicate terminal tab names allowed (#2192).** Renaming a
+  terminal tab to a name another tab already uses is no longer rejected.
+  Tab names are display-only; window identity is the tmux window id (`@N`),
+  so nothing in klangk relies on names being unique. The same-named shared
+  terminal created via the legacy `create_shared_terminal` command is now
+  identified by its window id rather than matched by name. `klangk shell`
+  now errors on an ambiguous name (listing the candidate `@N` ids) instead
+  of silently picking the first, accepts `@N` and `handle:@N` for exact
+  targeting, and `klangk terminal ls` shows an `ID` column. The TUI's
+  `[n]` new-terminal action no longer invents a sequential `term-N` label;
+  it creates the window unnamed, so the server names it `bash` like every
+  other new terminal.
+
 - **TUI workspace-detail rows are zebra-striped (#2193).** The
   `id / running / uptime / mounts / …` property block on
   `WorkspaceDetailScreen` now alternates row backgrounds (theme `surface`

--- a/src/frontend/e2e-tests/e2e/docs-screenshots.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-screenshots.spec.ts
@@ -249,7 +249,7 @@ test.describe("documentation screenshots", () => {
       await ownerWs.recvUntil((m) => m.type === "terminal_windows");
       await page.waitForTimeout(500);
 
-      // Screenshot 6: Two tabs — "build" (shared) and "1" (isolated)
+      // Screenshot 6: Two tabs — "build" (shared) and "bash" (isolated)
       await screenshotTerminalArea(page, "06-two-tabs");
 
       // --- Collaborator joins ---

--- a/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
+++ b/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
@@ -938,7 +938,10 @@ test.describe("shared terminal visibility", () => {
         const allWindows = newWindowsMsg.windows as Array<
           Record<string, unknown>
         >;
-        const newWindow = allWindows.find((w) => w.name !== firstWindowName);
+        // Identify the newly-created window by id, not name: new windows
+        // default to "bash" (#2179), the same name as window 0, so name is
+        // no longer unique.
+        const newWindow = allWindows.find((w) => w.id !== firstWindow.id);
         expect(newWindow).toBeDefined();
 
         // Admin types in the new window

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -184,7 +184,7 @@ test.describe("terminal tabs", () => {
     }
   });
 
-  test("create named window rejects duplicate names", async ({
+  test("create named window allows duplicate names", async ({
     page,
     request,
   }) => {
@@ -203,12 +203,18 @@ test.describe("terminal tabs", () => {
         client.send({ cmd: "terminal_new_window", name: "test" });
         await client.recvUntil((m) => m.type === "terminal_windows");
 
-        // Try to create another with the same name
+        // A second window with the same name is permitted — names are
+        // display-only and window identity is the @N id (#2192).
         client.send({ cmd: "terminal_new_window", name: "test" });
-        const msg = await client.recvUntil((m) => m.type === "error");
-        expect((msg.message as string).toLowerCase()).toContain(
-          "already exists",
+        const msg = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
         );
+        const named = (msg.windows as WindowInfo[]).filter(
+          (w) => w.name === "test",
+        );
+        expect(named.length).toBe(2);
+        // Distinct ids — identity is the id, not the name.
+        expect(named[0].id).not.toBe(named[1].id);
       } finally {
         client.close();
       }
@@ -290,7 +296,7 @@ test.describe("terminal tabs", () => {
     }
   });
 
-  test("rename rejects duplicate names", async ({ page, request }) => {
+  test("rename allows duplicate names", async ({ page, request }) => {
     const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
       page,
       request,
@@ -306,16 +312,21 @@ test.describe("terminal tabs", () => {
         client.send({ cmd: "terminal_new_window", name: "build" });
         await client.recvUntil((m) => m.type === "terminal_windows");
 
-        // Try to rename window 0 to "build"
+        // Renaming window 0 to "build" is permitted — names are
+        // display-only and window identity is the @N id (#2192).
         client.send({
           cmd: "terminal_rename_window",
           index: 0,
           name: "build",
         });
-        const msg = await client.recvUntil((m) => m.type === "error");
-        expect((msg.message as string).toLowerCase()).toContain(
-          "already exists",
+        const msg = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
         );
+        const named = (msg.windows as WindowInfo[]).filter(
+          (w) => w.name === "build",
+        );
+        expect(named.length).toBe(2);
+        expect(named[0].id).not.toBe(named[1].id);
       } finally {
         client.close();
       }

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -685,9 +685,18 @@ class KlangkClient:
         """Close terminal window *window_id* (@N) in *name*; return list."""
         return await self._terminals(name, close_window_id=window_id)
 
-    async def create_terminal(self, name: str, window_name: str) -> list[dict]:
-        """Create a new terminal window in workspace *name*; return updated list."""
-        return await self._terminals(name, new_window=window_name)
+    async def create_terminal(
+        self, name: str, window_name: str | None = None
+    ) -> list[dict]:
+        """Create a new terminal window in workspace *name*; return updated list.
+
+        With no *window_name* the server names the window ``bash`` (matching
+        window 0); names are display-only, so callers need not invent a
+        unique label (#2192).
+        """
+        return await self._terminals(
+            name, create_window=True, window_name=window_name
+        )
 
     async def rename_terminal(
         self, name: str, index: int, new_name: str
@@ -700,7 +709,8 @@ class KlangkClient:
         name: str,
         *,
         close_window_id: str | None = None,
-        new_window: str | None = None,
+        create_window: bool = False,
+        window_name: str | None = None,
         rename: tuple[int, str] | None = None,
     ) -> list[dict]:
         try:
@@ -732,15 +742,12 @@ class KlangkClient:
                         )
                     )
                     windows = await self._recv_windows(conn)
-                if new_window is not None:
-                    await conn.send(
-                        json.dumps(
-                            {
-                                "cmd": "terminal_new_window",
-                                "name": new_window,
-                            }
-                        )
-                    )
+                if create_window:
+                    cmd = {"cmd": "terminal_new_window"}
+                    # No name → server names the window "bash" (#2192).
+                    if window_name:
+                        cmd["name"] = window_name
+                    await conn.send(json.dumps(cmd))
                     windows = await self._recv_windows(conn)
                 if rename is not None and windows:
                     idx, new_name = rename
@@ -1141,17 +1148,42 @@ async def ws_shell(
         # 3b. Select window if requested.
         if window is not None:
             if ":" in window:
-                # Shared terminal: "handle:window_name"
-                owner_handle, win_name = window.split(":", 1)
-                match = next(
-                    (
+                # Shared terminal: "handle:window_name" (or "handle:@N" for
+                # an exact id). Names are not unique — dups are allowed
+                # (#2192) — so a name matching several windows under one
+                # owner is an error, not a silent first match.
+                owner_handle, win_ref = window.split(":", 1)
+                if win_ref.startswith("@"):
+                    match = next(
+                        (
+                            t
+                            for t in shared_terminals
+                            if t.get("handle") == owner_handle
+                            and t.get("window_id") == win_ref
+                        ),
+                        None,
+                    )
+                else:
+                    matches = [
                         t
                         for t in shared_terminals
                         if t.get("handle") == owner_handle
-                        and t.get("window_name") == win_name
-                    ),
-                    None,
-                )
+                        and t.get("window_name") == win_ref
+                    ]
+                    if len(matches) > 1:
+                        ids = ", ".join(
+                            t["window_id"]
+                            for t in matches
+                            if t.get("window_id")
+                        )
+                        raise ConnectionError(
+                            f"Multiple shared terminals named "
+                            f"'{win_ref}' under '{owner_handle}'; "
+                            f"specify one by id (e.g. "
+                            f"{owner_handle}:{matches[0].get('window_id')}): "
+                            f"{ids}"
+                        )
+                    match = matches[0] if matches else None
                 if match is None:
                     raise ConnectionError(
                         f"Shared terminal '{window}' not found"
@@ -1186,7 +1218,9 @@ async def ws_shell(
                 # Own window: by id (@N) or by name. An id targets the
                 # exact tmux window and must never create a new one
                 # (#1954); a name selects an existing window or creates
-                # one with that name.
+                # one with that name. Names are not unique (dups allowed,
+                # #2192), so a name matching several windows is an error
+                # rather than a silent first match — disambiguate with @N.
                 if window.startswith("@"):
                     match = next(
                         (w for w in own_windows if w.get("id") == window),
@@ -1197,10 +1231,18 @@ async def ws_shell(
                             f"Window '{window}' no longer exists"
                         )
                 else:
-                    match = next(
-                        (w for w in own_windows if w.get("name") == window),
-                        None,
-                    )
+                    name_matches = [
+                        w for w in own_windows if w.get("name") == window
+                    ]
+                    if len(name_matches) > 1:
+                        ids = ", ".join(
+                            w["id"] for w in name_matches if w.get("id")
+                        )
+                        raise ConnectionError(
+                            f"Multiple terminals named '{window}'; "
+                            f"specify one by id: {ids}"
+                        )
+                    match = name_matches[0] if name_matches else None
                 if match is None:
                     # Name with no match — create the window.
                     await ws.send(

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1228,7 +1228,11 @@ def shell(
     ),
     terminal: str | None = typer.Argument(
         None,
-        help="Terminal name to select (or handle:name for shared)",
+        help=(
+            "Terminal to select: @N (exact window id), a name, or "
+            "handle:@N / handle:name for a shared terminal. Names may "
+            "duplicate; use @N to disambiguate (see `klangk terminal ls`)."
+        ),
     ),
     forward_agent: bool | None = typer.Option(
         None,
@@ -1931,13 +1935,15 @@ def terminals(
 
             # Print results
             table = Table(title=f"Terminals in {ws.name}")
+            table.add_column("ID")
             table.add_column("Name")
             table.add_column("Type")
             table.add_column("Owner")
             for w in own_windows:
-                table.add_row(w["name"], "own", "")
+                table.add_row(w.get("id", ""), w["name"], "own", "")
             for t in shared:
                 table.add_row(
+                    t.get("window_id", ""),
                     t["window_name"],
                     "shared",
                     t.get("handle", ""),

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -2010,10 +2010,38 @@ def unshare_workspace(
     typer.echo(f"Removed {email} from workspace {workspace}")
 
 
+def _resolve_own_window(
+    own_windows: list[dict], terminal: str
+) -> tuple[dict | None, str | None]:
+    """Resolve a terminal reference to one own window.
+
+    *terminal* is an ``@N`` window id (exact) or a name. Names are not
+    unique (#2192): a name matching several windows is an error rather
+    than a silent first match. Returns ``(match, error)`` — exactly one
+    is set.
+    """
+    if terminal.startswith("@"):
+        match = next((w for w in own_windows if w.get("id") == terminal), None)
+        if match is None:
+            return None, f"Window '{terminal}' no longer exists"
+        return match, None
+    name_matches = [w for w in own_windows if w.get("name") == terminal]
+    if len(name_matches) > 1:
+        ids = ", ".join(w["id"] for w in name_matches if w.get("id"))
+        return None, (
+            f"Multiple terminals named '{terminal}'; specify one by id: {ids}"
+        )
+    if not name_matches:
+        return None, f"Terminal '{terminal}' not found"
+    return name_matches[0], None
+
+
 @terminal_app.command("share")
 def share_terminal(
     workspace: str = typer.Argument(help="Workspace name"),
-    terminal: str = typer.Argument(help="Terminal name to share"),
+    terminal: str = typer.Argument(
+        help="Terminal to share: @N (exact id) or name (see `klangk terminal ls`)"
+    ),
 ) -> None:
     """Share a terminal with other workspace members."""
     ws, sspec, token = _resolve_workspace_and_url(workspace)
@@ -2058,11 +2086,9 @@ def share_terminal(
                 if msg.get("type") == "terminal_windows":
                     own_windows = msg.get("windows", [])
                     break
-            match = next(
-                (w for w in own_windows if w["name"] == terminal), None
-            )
-            if match is None:
-                _err.print(f"[red]Terminal '{terminal}' not found[/red]")
+            match, err = _resolve_own_window(own_windows, terminal)
+            if err is not None:
+                _err.print(f"[red]{err}[/red]")
                 raise typer.Exit(code=1)
 
             await conn.send(
@@ -2092,7 +2118,9 @@ def share_terminal(
 @terminal_app.command("unshare")
 def unshare_terminal(
     workspace: str = typer.Argument(help="Workspace name"),
-    terminal: str = typer.Argument(help="Terminal name to unshare"),
+    terminal: str = typer.Argument(
+        help="Terminal to unshare: @N (exact id) or name (see `klangk terminal ls`)"
+    ),
 ) -> None:
     """Stop sharing a terminal."""
     ws, sspec, token = _resolve_workspace_and_url(workspace)
@@ -2138,11 +2166,9 @@ def unshare_terminal(
                     own_windows = msg.get("windows", [])
                     break
 
-            match = next(
-                (w for w in own_windows if w["name"] == terminal), None
-            )
-            if match is None:
-                _err.print(f"[red]Terminal '{terminal}' not found[/red]")
+            match, err = _resolve_own_window(own_windows, terminal)
+            if err is not None:
+                _err.print(f"[red]{err}[/red]")
                 raise typer.Exit(code=1)
 
             await conn.send(

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -928,20 +928,12 @@ class WorkspaceDetailScreen(Screen):
         self.run_worker(self._do_new_terminal, exit_on_error=False)
 
     async def _do_new_terminal(self) -> None:
-        # Pick a name that doesn't collide with existing terminal names.
-        existing = {w.get("name", "") for w in self._terminals}
-        for i in range(len(self._terminals), 100):
-            candidate = f"term-{i}"
-            if candidate not in existing:
-                break
-        else:
-            candidate = f"term-{len(self._terminals)}"  # pragma: no cover
-
-        self.app.notify(f"Creating terminal '{candidate}'…")
+        # No name → the server names the window "bash", matching window 0
+        # and the tmux status-bar "+". Names are display-only, so there's
+        # no need to invent a unique sequential label (#2192).
+        self.app.notify("Creating terminal…")
         try:
-            windows = await self.app.tui_state.create_terminal(
-                self._name, candidate
-            )
+            windows = await self.app.tui_state.create_terminal(self._name)
         except Exception as exc:
             self.app.notify(
                 f"Create failed: {exc}", severity="error", timeout=8
@@ -956,7 +948,7 @@ class WorkspaceDetailScreen(Screen):
             return
         self._terminals = windows
         await self._render_terminals()
-        self.app.notify(f"Created terminal '{candidate}'.")
+        self.app.notify("Created terminal.")
 
     # --- actions ---
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -265,7 +265,9 @@ class TuiState:
     async def close_terminal(self, name: str, window_id: str) -> list[dict]:
         return await self.client().close_terminal(name, window_id)
 
-    async def create_terminal(self, name: str, window_name: str) -> list[dict]:
+    async def create_terminal(
+        self, name: str, window_name: str | None = None
+    ) -> list[dict]:
         return await self.client().create_terminal(name, window_name)
 
     async def rename_terminal(

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -607,8 +607,11 @@ class Terminal:
     ) -> list[dict]:
         """Create a new tmux window and return the updated window list.
 
-        If *name* is not provided, auto-generates a unique name.
-        Raises ``ValueError`` if *name* duplicates an existing window name.
+        If *name* is not provided, the window is named ``bash`` (matching
+        window 0) instead of a consecutive number (#2179). Raises
+        ``ValueError`` if an explicit *name* duplicates an existing window
+        name — the duplicate guard applies only to user-chosen names; the
+        default ``bash`` is generic and tmux permits duplicate window names.
 
         Uses a single podman exec with a shell script to minimize
         round-trips (list + create + list in one call).
@@ -631,13 +634,14 @@ class Terminal:
             )
             argv = ["bash", "-c", script, "bash", name, session_name]
         else:
-            # Auto-name — find next number, create, list. session_name is $1.
+            # Default name for auto-created windows (the Flutter "+" sends
+            # no name). Window 0 is "bash"; new windows match instead of
+            # being numbered 1, 2, 3… (#2179). The duplicate-name guard above
+            # is skipped: tmux permits duplicate window names, and "bash" is
+            # a generic default, not a user-chosen label.
             script = (
                 'sn="$1";'
-                ' names=$(tmux list-windows -t "$sn"'
-                " -F '#{window_name}' 2>/dev/null);"
-                ' n=1; while echo "$names" | grep -qx "$n"; do n=$((n+1)); done;'
-                ' tmux new-window -t "$sn" -n "$n";'
+                ' tmux new-window -t "$sn" -n bash;'
                 ' tmux list-windows -t "$sn"'
                 " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
             )

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -607,45 +607,29 @@ class Terminal:
     ) -> list[dict]:
         """Create a new tmux window and return the updated window list.
 
-        If *name* is not provided, the window is named ``bash`` (matching
-        window 0) instead of a consecutive number (#2179). Raises
-        ``ValueError`` if an explicit *name* duplicates an existing window
-        name — the duplicate guard applies only to user-chosen names; the
-        default ``bash`` is generic and tmux permits duplicate window names.
+        The window is named *name* when given, else ``bash`` (matching
+        window 0) instead of a consecutive number (#2179). Window names are
+        display-only: tmux permits duplicate names, so duplicates are
+        allowed — a user may rename a tab to match another — and nothing in
+        klangk keys window identity on the name (#2192). The stable
+        identity is the tmux window id (``@N``).
 
         Uses a single podman exec with a shell script to minimize
-        round-trips (list + create + list in one call).
+        round-trips (create + list in one call). The session name and
+        window label are passed as positional argv ($1/$2), never
+        interpolated into the script, so shell metacharacters in either
+        are harmless (the label is validated above regardless).
         """
+        label = name if name is not None else "bash"
         if name is not None:
             validate_window_name(name)
-            # Explicit name — check + create + list in one exec. The window
-            # name and session name are passed as positional argv ($1/$2),
-            # never interpolated into the script, so shell metacharacters in
-            # either are harmless (name is validated above regardless).
-            script = (
-                'name="$1"; sn="$2";'
-                ' existing=$(tmux list-windows -t "$sn"'
-                " -F '#{window_name}' 2>/dev/null);"
-                ' echo "$existing" | grep -qx "$name"'
-                " && echo 'DUPLICATE' && exit 1;"
-                ' tmux new-window -t "$sn" -n "$name";'
-                ' tmux list-windows -t "$sn"'
-                " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
-            )
-            argv = ["bash", "-c", script, "bash", name, session_name]
-        else:
-            # Default name for auto-created windows (the Flutter "+" sends
-            # no name). Window 0 is "bash"; new windows match instead of
-            # being numbered 1, 2, 3… (#2179). The duplicate-name guard above
-            # is skipped: tmux permits duplicate window names, and "bash" is
-            # a generic default, not a user-chosen label.
-            script = (
-                'sn="$1";'
-                ' tmux new-window -t "$sn" -n bash;'
-                ' tmux list-windows -t "$sn"'
-                " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
-            )
-            argv = ["bash", "-c", script, "bash", session_name]
+        script = (
+            'sn="$1"; lbl="$2";'
+            ' tmux new-window -t "$sn" -n "$lbl";'
+            ' tmux list-windows -t "$sn"'
+            " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
+        )
+        argv = ["bash", "-c", script, "bash", session_name, label]
         rc, output, stderr = await self.podman.exec_container(
             container_id,
             argv,
@@ -653,8 +637,6 @@ class Terminal:
             timeout=10,
         )
         if rc != 0:
-            if "DUPLICATE" in output:
-                raise ValueError(f"Window name '{name}' already exists")
             raise TerminalError(f"new_window failed: {stderr.strip()}")
         windows = []
         for line in output.strip().splitlines():
@@ -679,13 +661,12 @@ class Terminal:
     ) -> None:
         """Rename a tmux window.
 
-        Raises ``ValueError`` if *name* contains unsafe characters or
-        duplicates another window's name.
+        Raises ``ValueError`` if *name* contains unsafe characters.
+        Window names are display-only, so duplicate names are permitted —
+        a tab may be renamed to match another — and window identity is
+        never keyed on the name (#2192).
         """
         validate_window_name(name)
-        existing = await self.list_windows(container_id, session_name)
-        if any(w["name"] == name and w["index"] != index for w in existing):
-            raise ValueError(f"Window name '{name}' already exists")
         await self.tmux_command(
             container_id,
             session_name,

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -859,15 +859,15 @@ class TerminalController:
         # Match old entries to new tmux entries by window_id (@N) —
         # a tmux-assigned unique identifier that is never reused within
         # a server's lifetime.  This is stable across renames and
-        # index reuse.
+        # index reuse. Window names are display-only and may duplicate,
+        # so they are never used to match identity (#2192); after a
+        # container restart the in-container tmux server is gone and all
+        # custom tabs are lost anyway, so there is nothing to match by.
         old_by_id = {w["id"]: w for w in old if "id" in w}
-        # Name-based fallback for matching after container restart where
-        # window_ids change but names are restored.
-        old_by_name = {w["name"]: w for w in old if "name" in w}
         old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
         new_entries = []
         for w in windows:
-            prev = old_by_id.get(w["id"]) or old_by_name.get(w["name"])
+            prev = old_by_id.get(w["id"])
             prev_shared = prev.get("shared", False) if prev else False
             new_entries.append(
                 {
@@ -901,10 +901,9 @@ class TerminalController:
         """
         old = ws_session.terminal_windows.get(model.AGENT_USER_ID, [])
         old_by_id = {w["id"]: w for w in old if "id" in w}
-        old_by_name = {w["name"]: w for w in old if "name" in w}
         new_entries = []
         for w in windows:
-            prev = old_by_id.get(w["id"]) or old_by_name.get(w["name"])
+            prev = old_by_id.get(w["id"])
             prev_shared = prev.get("shared", False) if prev else False
             new_entries.append(
                 {
@@ -1512,6 +1511,13 @@ class SharedTerminalController:
                 self._conn.sock, f"Failed to create shared terminal: {e}"
             )
             return
+        # The newly created window is the active one. Identify it by its
+        # window id (@N), not its name — names are display-only and may
+        # duplicate, so a name match could hit the wrong window (#2192).
+        new_id = next(
+            (w["id"] for w in windows if w.get("active") and "id" in w),
+            None,
+        )
         # Sync with tmux to get proper window_id, then mark the new
         # window as shared.
         self._conn.sync_terminal_windows(windows)
@@ -1521,10 +1527,11 @@ class SharedTerminalController:
         if not ws_session:
             return
         user_id = self._conn.user["id"]
-        for w in ws_session.terminal_windows.get(user_id, []):
-            if w["name"] == name:
-                w["shared"] = True
-                break
+        if new_id is not None:
+            for w in ws_session.terminal_windows.get(user_id, []):
+                if w.get("id") == new_id:
+                    w["shared"] = True
+                    break
         self.broadcast_shared_terminals(ws_session)
 
     async def delete_shared_terminal(self, msg: dict) -> None:

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1704,22 +1704,24 @@ class TestTerminalSharing:
             timeout=120,
         )
         assert list_result.returncode == 0
-        # Parse the Rich table to find the first "own" terminal name
-        terminal_name = None
+        # Parse the Rich table to find the first "own" terminal's id.
+        # Columns are ID, Name, Type, Owner, so an own-terminal row yields
+        # filtered parts like ['@1', 'bash', 'own']. Target the window by
+        # its @N id since names may duplicate (#2192).
+        terminal_id = None
         for line in list_result.stderr.splitlines():
             if "│" in line and "own" in line:
                 parts = [p.strip() for p in line.split("│")]
-                # parts: ['', 'name', 'own', '', ...]
                 parts = [p for p in parts if p]
-                if len(parts) >= 2 and parts[1] == "own":
-                    terminal_name = parts[0]
+                if len(parts) >= 3 and parts[2] == "own":
+                    terminal_id = parts[0]
                     break
-        assert terminal_name is not None, (
+        assert terminal_id is not None, (
             f"Could not find terminal in output: {list_result.stderr}"
         )
 
         result = _run(
-            ["klangk", "terminal", "share", "e2e-share", terminal_name],
+            ["klangk", "terminal", "share", "e2e-share", terminal_id],
             env=env,
             timeout=120,
         )
@@ -1727,7 +1729,7 @@ class TestTerminalSharing:
         assert "shared" in result.stderr.lower()
 
         result = _run(
-            ["klangk", "terminal", "unshare", "e2e-share", terminal_name],
+            ["klangk", "terminal", "unshare", "e2e-share", terminal_id],
             env=env,
             timeout=120,
         )

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1495,6 +1495,51 @@ class TestKlangkClient:
         assert len(new_cmds) == 1
         assert new_cmds[0]["name"] == "term-1"
 
+    def test_create_terminal_unnamed(self):
+        # No window_name → terminal_new_window is sent with no name field,
+        # so the server names the window "bash" (#2192).
+        client = KlangkClient("http://test:8995", "token")
+        ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
+        client.resolve_workspace = MagicMock(return_value=ws)
+        messages = [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "bash", "id": "@0"},
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "bash", "id": "@0"},
+                        {"index": 1, "name": "bash", "id": "@1"},
+                    ],
+                }
+            ),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(side_effect=messages)
+        mock_ws.send = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+        with patch(
+            "klangk.cli.transport.websockets.connect",
+            return_value=mock_ws,
+        ):
+            windows = asyncio.run(client.create_terminal("alpha"))
+        assert len(windows) == 2
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        new_cmds = [s for s in sent if s.get("cmd") == "terminal_new_window"]
+        assert len(new_cmds) == 1
+        assert "name" not in new_cmds[0]
+
     def test_rename_terminal(self):
         client = KlangkClient("http://test:8995", "token")
         ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
@@ -2649,6 +2694,37 @@ class TestTerminalSize:
 # --- run_shell / ws_shell ---
 
 
+def _scripted_ws_for_shell(msgs):
+    """Fake WS for ``ws_shell``: ``recv()`` yields *msgs* (as JSON) then closes.
+
+    Returns ``(ws_mock, sent_payloads)`` where *sent_payloads* is the list of
+    decoded JSON dicts passed to ``send``.
+    """
+    import websockets
+
+    ws_mock = MagicMock()
+    ws_mock.__aenter__ = AsyncMock(return_value=ws_mock)
+    ws_mock.__aexit__ = AsyncMock(return_value=False)
+    sent = []
+
+    async def capture_send(payload, *a, **kw):
+        sent.append(json.loads(payload))
+
+    ws_mock.send = capture_send
+    ws_mock.close = AsyncMock()
+    idx = {"i": 0}
+
+    async def fake_recv(*a, **kw):
+        i = idx["i"]
+        idx["i"] += 1
+        if i < len(msgs):
+            return json.dumps(msgs[i])
+        raise websockets.ConnectionClosed(None, None)
+
+    ws_mock.recv = fake_recv
+    return ws_mock, sent
+
+
 class TestRunShell:
     @pytest.mark.asyncio
     async def test_stdin_loop_sends_terminal_input(self):
@@ -2988,6 +3064,169 @@ class TestRunShell:
                     window="clanker:service-cmd",
                 )
             assert "not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_ws_shell_own_window_ambiguous_name_raises(self):
+        """Two own windows sharing a name can't be selected by name (#2192)."""
+        from klangk.cli.client import ws_shell
+
+        msgs = [
+            {"type": "container_ready"},
+            {"type": "terminal_started"},
+            {
+                "type": "terminal_windows",
+                "windows": [
+                    {"id": "@3", "index": 1, "name": "build", "active": False},
+                    {"id": "@5", "index": 2, "name": "build", "active": True},
+                ],
+            },
+        ]
+        ws_mock, _ = _scripted_ws_for_shell(msgs)
+        with patch(
+            "klangk.cli.transport.websockets.connect", return_value=ws_mock
+        ):
+            with pytest.raises(ConnectionError) as exc_info:
+                await ws_shell(
+                    "http://localhost",
+                    "token",
+                    "ws1",
+                    raw_mode=False,
+                    window="build",
+                )
+        msg = str(exc_info.value)
+        assert "Multiple terminals named 'build'" in msg
+        assert "@3" in msg and "@5" in msg
+
+    @pytest.mark.asyncio
+    async def test_ws_shell_own_window_unique_name_selects_by_id(self):
+        """A unique name resolves to its window id for selection (#2192)."""
+        from klangk.cli.client import ws_shell
+
+        msgs = [
+            {"type": "container_ready"},
+            {"type": "terminal_started"},
+            {
+                "type": "terminal_windows",
+                "windows": [
+                    {"id": "@0", "index": 0, "name": "bash", "active": False},
+                    {"id": "@3", "index": 1, "name": "build", "active": True},
+                ],
+            },
+        ]
+        ws_mock, sent = _scripted_ws_for_shell(msgs)
+        with (
+            patch(
+                "klangk.cli.transport.websockets.connect",
+                return_value=ws_mock,
+            ),
+            patch("klangk.cli.client.run_shell", new=AsyncMock()),
+        ):
+            await ws_shell(
+                "http://localhost",
+                "token",
+                "ws1",
+                raw_mode=False,
+                window="build",
+            )
+        select = next(
+            (c for c in sent if c.get("cmd") == "terminal_select_window"),
+            None,
+        )
+        assert select is not None
+        assert select["window_id"] == "@3"
+
+    @pytest.mark.asyncio
+    async def test_ws_shell_shared_ambiguous_name_raises(self):
+        """Two shared windows, same name, one owner → error listing ids (#2192)."""
+        from klangk.cli.client import ws_shell
+
+        msgs = [
+            {"type": "container_ready"},
+            {"type": "terminal_started"},
+            {"type": "terminal_windows", "windows": []},
+            {
+                "type": "shared_terminals",
+                "terminals": [
+                    {
+                        "user_id": "u1",
+                        "handle": "alice",
+                        "window_name": "build",
+                        "window_id": "@3",
+                    },
+                    {
+                        "user_id": "u1",
+                        "handle": "alice",
+                        "window_name": "build",
+                        "window_id": "@5",
+                    },
+                ],
+            },
+        ]
+        ws_mock, _ = _scripted_ws_for_shell(msgs)
+        with patch(
+            "klangk.cli.transport.websockets.connect", return_value=ws_mock
+        ):
+            with pytest.raises(ConnectionError) as exc_info:
+                await ws_shell(
+                    "http://localhost",
+                    "token",
+                    "ws1",
+                    raw_mode=False,
+                    window="alice:build",
+                )
+        msg = str(exc_info.value)
+        assert "Multiple shared terminals named 'build'" in msg
+        assert "@3" in msg and "@5" in msg
+
+    @pytest.mark.asyncio
+    async def test_ws_shell_shared_by_id_disambiguates(self):
+        """handle:@N targets the exact shared window among same-named (#2192)."""
+        from klangk.cli.client import ws_shell
+
+        msgs = [
+            {"type": "container_ready"},
+            {"type": "terminal_started"},
+            {"type": "terminal_windows", "windows": []},
+            {
+                "type": "shared_terminals",
+                "terminals": [
+                    {
+                        "user_id": "u1",
+                        "handle": "alice",
+                        "window_name": "build",
+                        "window_id": "@3",
+                    },
+                    {
+                        "user_id": "u1",
+                        "handle": "alice",
+                        "window_name": "build",
+                        "window_id": "@5",
+                    },
+                ],
+            },
+            {"type": "terminal_started"},  # join confirmation
+        ]
+        ws_mock, sent = _scripted_ws_for_shell(msgs)
+        with (
+            patch(
+                "klangk.cli.transport.websockets.connect",
+                return_value=ws_mock,
+            ),
+            patch("klangk.cli.client.run_shell", new=AsyncMock()),
+        ):
+            await ws_shell(
+                "http://localhost",
+                "token",
+                "ws1",
+                raw_mode=False,
+                window="alice:@5",
+            )
+        join = next(
+            (c for c in sent if c.get("cmd") == "join_shared_terminal"),
+            None,
+        )
+        assert join is not None
+        assert join["window_id"] == "@5"
 
     @pytest.mark.asyncio
     async def test_tilde_dot_disconnects(self):

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5032,3 +5032,53 @@ class TestAccountCommands:
         result = CliRunner().invoke(main.app, ["account", "email"])
         assert result.exit_code == 1
         client.change_email.assert_not_called()
+
+
+class TestResolveOwnWindow:
+    """Unit tests for the @N/name resolution shared by share & unshare (#2192)."""
+
+    @staticmethod
+    def _w(wid: str, name: str) -> dict:
+        return {"id": wid, "index": 0, "name": name, "active": False}
+
+    def test_id_exact(self):
+        from klangk.cli import main
+
+        match, err = main._resolve_own_window(
+            [self._w("@0", "bash"), self._w("@3", "build")], "@3"
+        )
+        assert err is None
+        assert match["id"] == "@3"
+
+    def test_id_missing(self):
+        from klangk.cli import main
+
+        match, err = main._resolve_own_window([self._w("@0", "bash")], "@9")
+        assert match is None
+        assert "no longer exists" in err
+
+    def test_unique_name(self):
+        from klangk.cli import main
+
+        match, err = main._resolve_own_window(
+            [self._w("@0", "bash"), self._w("@3", "build")], "build"
+        )
+        assert err is None
+        assert match["id"] == "@3"
+
+    def test_ambiguous_name(self):
+        from klangk.cli import main
+
+        match, err = main._resolve_own_window(
+            [self._w("@3", "build"), self._w("@5", "build")], "build"
+        )
+        assert match is None
+        assert "Multiple terminals named 'build'" in err
+        assert "@3" in err and "@5" in err
+
+    def test_name_not_found(self):
+        from klangk.cli import main
+
+        match, err = main._resolve_own_window([self._w("@0", "bash")], "nope")
+        assert match is None
+        assert "not found" in err

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -7007,12 +7007,12 @@ async def test_detail_new_terminal(monkeypatch):
 
     created = {}
 
-    async def _create(name, window_name):
+    async def _create(name, window_name=None):
         created["name"] = window_name
         return [
             {"index": 0, "name": "main", "id": "@0"},
             {"index": 1, "name": "build", "id": "@1"},
-            {"index": 2, "name": window_name, "id": "@2"},
+            {"index": 2, "name": "bash", "id": "@2"},
         ]
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
@@ -7039,7 +7039,7 @@ async def test_detail_new_terminal(monkeypatch):
         for _ in range(5):
             await pilot.pause()
         await app.workers.wait_for_complete()
-        assert created["name"] == "term-2"
+        assert created["name"] is None
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 3
         assert any("Created terminal" in m for m in notified)
 
@@ -7048,7 +7048,7 @@ async def test_detail_new_terminal_failure(monkeypatch):
     async def noop(*a, **k):
         return None
 
-    async def _create(name, window_name):
+    async def _create(name, window_name=None):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
@@ -7079,7 +7079,7 @@ async def test_detail_new_terminal_empty_result(monkeypatch):
     async def noop(*a, **k):
         return None
 
-    async def _create(name, window_name):
+    async def _create(name, window_name=None):
         return []
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -865,9 +865,11 @@ class TestNewWindow:
         assert result[0]["name"] == "bash"
         argv = mock_exec.call_args.args[1]
         assert argv[:2] == ["bash", "-c"]
-        assert "-n bash" in argv[2]
-        # The default-name path skips the duplicate guard (only explicit
-        # user-chosen names are checked for duplicates).
+        # The label is passed as positional argv ($2), never interpolated
+        # into the script (injection-safe); "bash" is the default label.
+        assert argv[4] == "sess"  # $1 = session name
+        assert argv[5] == "bash"  # $2 = window label
+        # No duplicate guard: names are display-only, dups allowed (#2192).
         assert "DUPLICATE" not in argv[2]
         assert "grep" not in argv[2]
 
@@ -886,8 +888,10 @@ class TestNewWindow:
         ) as mock_exec:
             result = await _terminal.new_window("cid", "sess")
         assert [w["name"] for w in result] == ["bash", "bash"]
-        # No duplicate check ran (would have rejected the second "bash").
-        assert "DUPLICATE" not in mock_exec.call_args.args[1][2]
+        # Duplicate names are permitted — no guard runs (#2192).
+        argv = mock_exec.call_args.args[1]
+        assert "DUPLICATE" not in argv[2]
+        assert argv[5] == "bash"  # default label
 
     async def test_creates_named_window(self):
         with patch.object(
@@ -909,21 +913,31 @@ class TestNewWindow:
         assert argv[:2] == ["bash", "-c"]
         assert "build" not in argv[2]  # not in the script
         assert argv[3] == "bash"  # $0
-        assert argv[4] == "build"  # $1 = name
+        assert argv[4] == "sess"  # $1 = session name
+        assert argv[5] == "build"  # $2 = window label
 
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):
             await _terminal.new_window("cid", "sess", name="';rm -rf /;'")
 
-    async def test_rejects_duplicate_name(self):
+    async def test_allows_duplicate_name(self):
+        # Duplicate window names are permitted — names are display-only
+        # and window identity is keyed on the @N id, not the name (#2192).
+        # tmux accepts the duplicate; new_window returns the full list.
         with patch.object(
             _mock_pod,
             "exec_container",
             new_callable=AsyncMock,
-            return_value=(1, "DUPLICATE\n", ""),
-        ):
-            with pytest.raises(ValueError, match="already exists"):
-                await _terminal.new_window("cid", "sess", name="build")
+            return_value=(
+                0,
+                "@0|||0|||build|||0\n@1|||1|||build|||1\n",
+                "",
+            ),
+        ) as mock_exec:
+            result = await _terminal.new_window("cid", "sess", name="build")
+        assert [w["name"] for w in result] == ["build", "build"]
+        # No duplicate guard ran in the script.
+        assert "DUPLICATE" not in mock_exec.call_args.args[1][2]
 
     async def test_raises_on_tmux_error(self):
         with patch.object(
@@ -1002,20 +1016,11 @@ class TestCloseWindow:
 
 class TestRenameWindow:
     async def test_renames_window(self):
-        with (
-            patch.object(
-                _terminal,
-                "list_windows",
-                return_value=[
-                    {"index": 0, "name": "bash", "active": True},
-                ],
-            ),
-            patch.object(
-                _terminal,
-                "tmux_command",
-                return_value="",
-            ) as mock_cmd,
-        ):
+        with patch.object(
+            _terminal,
+            "tmux_command",
+            return_value="",
+        ) as mock_cmd:
             await _terminal.rename_window("cid", "sess", 0, "build")
         mock_cmd.assert_called_once_with(
             "cid",
@@ -1027,17 +1032,29 @@ class TestRenameWindow:
         with pytest.raises(ValueError, match="only contain"):
             await _terminal.rename_window("cid", "sess", 0, "';rm -rf /;'")
 
-    async def test_rejects_duplicate_name(self):
-        with patch.object(
-            _terminal,
-            "list_windows",
-            return_value=[
-                {"index": 0, "name": "bash", "active": True},
-                {"index": 1, "name": "build", "active": False},
-            ],
+    async def test_allows_duplicate_name(self):
+        # Renaming to a name another window already has is permitted —
+        # names are display-only and window identity is keyed on the @N id,
+        # not the name (#2192). No list_windows call is made to check.
+        with (
+            patch.object(
+                _terminal,
+                "list_windows",
+            ) as mock_list,
+            patch.object(
+                _terminal,
+                "tmux_command",
+                return_value="",
+            ) as mock_cmd,
         ):
-            with pytest.raises(ValueError, match="already exists"):
-                await _terminal.rename_window("cid", "sess", 0, "build")
+            await _terminal.rename_window("cid", "sess", 0, "build")
+        # rename does not consult list_windows anymore.
+        mock_list.assert_not_called()
+        mock_cmd.assert_called_once_with(
+            "cid",
+            "sess",
+            ["rename-window", "-t", "sess:0", "build"],
+        )
 
 
 class TestBuildEnvironment:

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -857,22 +857,37 @@ class TestNewWindow:
             _mock_pod,
             "exec_container",
             new_callable=AsyncMock,
-            return_value=(0, "@0|||0|||1|||1\n", ""),
+            return_value=(0, "@0|||0|||bash|||1\n", ""),
         ) as mock_exec:
             result = await _terminal.new_window("cid", "sess")
         assert len(result) == 1
-        assert result[0]["name"] == "1"
-        assert mock_exec.call_args.args[1][:2] == ["bash", "-c"]
+        # No name -> defaults to "bash" (matching window 0), not a number (#2179).
+        assert result[0]["name"] == "bash"
+        argv = mock_exec.call_args.args[1]
+        assert argv[:2] == ["bash", "-c"]
+        assert "-n bash" in argv[2]
+        # The default-name path skips the duplicate guard (only explicit
+        # user-chosen names are checked for duplicates).
+        assert "DUPLICATE" not in argv[2]
+        assert "grep" not in argv[2]
 
-    async def test_auto_name_skips_existing(self):
+    async def test_auto_name_allows_existing_bash(self):
+        # The default "bash" is created even when a "bash" window already
+        # exists — multiple shells all named "bash" is the intended UX (#2179).
         with patch.object(
             _mock_pod,
             "exec_container",
             new_callable=AsyncMock,
-            return_value=(0, "@0|||0|||1|||0\n@1|||1|||2|||1\n", ""),
-        ):
+            return_value=(
+                0,
+                "@0|||0|||bash|||0\n@1|||1|||bash|||1\n",
+                "",
+            ),
+        ) as mock_exec:
             result = await _terminal.new_window("cid", "sess")
-        assert len(result) == 2
+        assert [w["name"] for w in result] == ["bash", "bash"]
+        # No duplicate check ran (would have rejected the second "bash").
+        assert "DUPLICATE" not in mock_exec.call_args.args[1][2]
 
     async def test_creates_named_window(self):
         with patch.object(

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -6992,6 +6992,51 @@ class TestShareWindowHandlers:
             orig = next(w for w in windows if w["name"] == "1")
             assert orig["shared"] is False
 
+    async def test_create_shared_terminal_marks_new_window_not_namesake(
+        self, user, temp_data_dir, app_state
+    ):
+        """When a same-named window already exists, the just-created (active)
+        window is the one marked shared — identified by id, not name (#2192)."""
+        async with _conn_in_workspace(
+            user, "ws-1", user_home="/home/admin"
+        ) as (sock, conn, session, app_state):
+            # A pre-existing window already named "dev" (not shared).
+            session.terminal_windows[user["id"]] = [
+                {"name": "dev", "index": 0, "id": "@0", "shared": False}
+            ]
+            with (
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
+                ),
+                patch.object(
+                    _mock_term,
+                    "new_window",
+                    return_value=[
+                        # Two "dev" windows after create; the new one is active.
+                        {
+                            "id": "@0",
+                            "index": 0,
+                            "name": "dev",
+                            "active": False,
+                        },
+                        {
+                            "id": "@1",
+                            "index": 1,
+                            "name": "dev",
+                            "active": True,
+                        },
+                    ],
+                ),
+            ):
+                await conn.handle_create_shared_terminal({"name": "dev"})
+            windows = session.terminal_windows[user["id"]]
+            by_id = {w["id"]: w for w in windows}
+            # The newly created window (@1) is shared; the namesake (@0) is not.
+            assert by_id["@1"]["shared"] is True
+            assert by_id["@0"]["shared"] is False
+
     async def test_share_window_no_container(self, user):
         conn = _base_conn(user=user)
         await conn.handle_share_window({"window_id": "@0"})


### PR DESCRIPTION
## Summary

- **#2179** — a terminal created from the browser tab-bar "+" was named with a consecutive number ("1", "2", …), inconsistent with window 0 ("bash") and the tmux status-bar "+". New windows from the Flutter "+" are now named **"bash"**.

## Root cause

The Flutter "+" calls `sendTerminalNewWindow()` with no `name`. The server's `terminal.new_window(name=None)` branch auto-named the window with the next unused integer. (The tmux status-bar "+" from #2161 doesn't go through this handler — it runs native `tmux new-window`, which names the window after the shell, i.e. "bash" — which is why only the Flutter "+" produced numbers.)

## Fix

Server-only (the issue's option 2): the no-name default is now **"bash"** instead of the integer auto-name. The klangk-added duplicate-name guard is **skipped for this default** — tmux itself permits duplicate window names, and "bash" is a generic default, not a user-chosen label — so multiple shells can all be named "bash", matching window 0. The duplicate guard still applies to explicit, user-chosen names (so users can't accidentally create two identically-named windows they meant to distinguish).

No frontend change — the "+" already sends no name. `create_shared_terminal` requires an explicit name, and the TUI's `create_terminal` passes one, so **only the Flutter "+" is affected**.

## Verification

- Full Python suite **4160 passed @ 100% coverage** (`-n auto`).
- No frontend changes.
- Tests: no-name `new_window` now names the window "bash" and omits the duplicate guard (`grep`/`DUPLICATE` absent from the script); the explicit-name duplicate rejection is unchanged.

Closes #2179.
