### PR TITLE
fix(tests): stop leaking temp dirs in /tmp from make_settings

### DIFF
--- a/src/klangk/klangkd-tests/tests/_helpers.py
+++ b/src/klangk/klangkd-tests/tests/_helpers.py
@@ -54,10 +54,18 @@ def make_settings(
     value in ``env`` to override.
     """
     env = dict(env or {})
+    # Fall back to os.environ (set by the autouse temp_data_dir fixture) before
+    # creating orphan mkdtemp dirs that are never cleaned up.
     env.setdefault(
-        "KLANGKD_STATE_DIR", tempfile.mkdtemp(prefix="klangk-state-")
+        "KLANGKD_STATE_DIR",
+        os.environ.get("KLANGKD_STATE_DIR")
+        or tempfile.mkdtemp(prefix="klangk-state-"),
     )
-    env.setdefault("KLANGKD_DATA_DIR", tempfile.mkdtemp(prefix="klangk-data-"))
+    env.setdefault(
+        "KLANGKD_DATA_DIR",
+        os.environ.get("KLANGKD_DATA_DIR")
+        or tempfile.mkdtemp(prefix="klangk-data-"),
+    )
     # On macOS the default socket paths derived from state_dir may exceed the
     # 104-char AF_UNIX sun_path limit because tempfile paths resolve through
     # /private/var/folders/... Set short socket paths so the settings


### PR DESCRIPTION
## Summary

- `make_settings()` in the backend test helper called `tempfile.mkdtemp()` for `KLANGKD_STATE_DIR` and `KLANGKD_DATA_DIR` on every invocation, but the created directories were never cleaned up
- Each test run leaked ~8K orphan dirs, accumulating ~7M+ entries in `/tmp` over time
- Now falls back to `os.environ` (already set by the autouse `temp_data_dir` fixture) before resorting to `mkdtemp`

## Test plan

- [x] All 4160 backend tests pass
- [x] 100% coverage maintained