### PR TITLE
feat(tui): zebra-stripe the workspace-detail property block

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -178,8 +178,8 @@ operators or integrators to act when upgrading.
 - **TUI workspace-detail rows are zebra-striped (#2193).** The
   `id / running / uptime / mounts / …` property block on
   `WorkspaceDetailScreen` now alternates row backgrounds (theme `surface`
-  over `background`) for readability; a multi-line value keeps one
-  background across its wrapped lines.
+  over `background`) for readability; key names are bold and right-aligned,
+  and a multi-line value keeps one background across its wrapped lines.
 
 - **`container_pids_limit` default raised to 16384 (#2160).** The
   deploy-wide workspace process-count cap shipped at 512 (#2030), which

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -175,6 +175,12 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **TUI workspace-detail rows are zebra-striped (#2193).** The
+  `id / running / uptime / mounts / …` property block on
+  `WorkspaceDetailScreen` now alternates row backgrounds (theme `surface`
+  over `background`) for readability; a multi-line value keeps one
+  background across its wrapped lines.
+
 - **`container_pids_limit` default raised to 16384 (#2160).** The
   deploy-wide workspace process-count cap shipped at 512 (#2030), which
   build-heavy workloads (nix/devenv flake evaluation, libgit2 threaded

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -287,9 +287,11 @@ class WorkspaceDetailScreen(Screen):
         self.BINDINGS = self._bindings_list("Stop" if ws.running else "Start")
         self.refresh_bindings()
         # Render the detail as a two-column table so every value lines up in
-        # the same column regardless of label length (#1910). Wrapped in Text()
-        # so values that look like markup (e.g. an image named "[img]") render
-        # literally instead of being parsed as Textual markup.
+        # the same column regardless of label length (#1910). Parsed with
+        # Text.from_ansi (not Text()) so the zebra row backgrounds (#2193)
+        # survive; from_ansi reads ANSI escapes only, so values that look like
+        # markup (e.g. an image named "[img]") still render literally rather
+        # than being parsed as Textual markup.
         #
         # Render at the body widget's *actual* content width, not the screen
         # width: the screen has horizontal chrome (borders/margins/scroll
@@ -304,7 +306,9 @@ class WorkspaceDetailScreen(Screen):
             or self.size.width
             or 80
         )
-        body.update(Text(self._render_detail(self._detail_rows(ws), width)))
+        body.update(
+            Text.from_ansi(self._render_detail(self._detail_rows(ws), width))
+        )
 
     @staticmethod
     def _detail_rows(ws) -> list[tuple[str, str]]:
@@ -362,24 +366,36 @@ class WorkspaceDetailScreen(Screen):
 
         The label column auto-sizes to the longest label, so every value
         starts at the same column; the value column folds long values to fit
-        ``width`` instead of running off the right edge."""
+        ``width`` instead of running off the right edge. Rows are
+        zebra-striped (alternating ``surface`` background) for readability
+        (#2193); the caller must parse the result with ``Text.from_ansi``
+        so the row backgrounds survive into the ``Static``."""
+        # row_styles cycles once per add_row, so a multi-line value (service
+        # command, mounts) keeps one background for the whole logical row
+        # rather than striping per wrapped line (#2193). The stripe is the
+        # theme `surface` (#161B22) over the screen `background` (#0D1117);
+        # see KLANGK_THEME in app.py.
         table = Table(
             show_header=False,
             box=None,
             pad_edge=False,
             padding=(0, 1),
             expand=True,
+            row_styles=("", "on #161B22"),
         )
         table.add_column("label", no_wrap=True)
         table.add_column("value", overflow="fold", ratio=1)
         for label, value in rows:
             table.add_row(label, value)
         buf = StringIO()
+        # Emit truecolor ANSI so the row backgrounds survive into the
+        # Static via Text.from_ansi (#2193); markup=False keeps values like
+        # "[img]" literal, highlight=False disables Rich auto-highlighting.
         Console(
             file=buf,
             width=width,
-            force_terminal=False,
-            no_color=True,
+            force_terminal=True,
+            color_system="truecolor",
             highlight=False,
             markup=False,
         ).print(table, end="")

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -383,7 +383,9 @@ class WorkspaceDetailScreen(Screen):
             expand=True,
             row_styles=("", "on #161B22"),
         )
-        table.add_column("label", no_wrap=True)
+        # Key names (left column) are right-aligned and bold so each
+        # label's right edge lines up just before its value (#2193).
+        table.add_column("label", no_wrap=True, justify="right", style="bold")
         table.add_column("value", overflow="fold", ratio=1)
         for label, value in rows:
             table.add_row(label, value)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -7,6 +7,7 @@ and the ``add_server_to_config`` helper — under the 100% coverage gate.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import httpx
@@ -216,28 +217,38 @@ def _detail_value(body: str, label: str) -> str | None:
     """Return the value-column text for ``label``'s row in the workspace
     detail table, or None if no such row.
 
-    The detail body renders as a two-column table (#1910): a label at the
-    start of a line, then a column of padding (>=2 spaces), then the value.
-    A label is matched only when it's followed by that padding gap, so
-    ``health`` doesn't match the ``health note`` / ``health check`` rows.
-    Multi-line value cells (mounts / environment / allowed domains) are
-    rejoined with newlines."""
-    lines = body.splitlines()
+    The detail body renders as a two-column table (#1910): a label, then a
+    column of padding (>=2 spaces), then the value. Labels are bold and
+    right-aligned, and rows carry zebra-stripe ANSI, so both are normalized
+    away before parsing (#2193). A label is matched only when it's followed
+    by that padding gap, so ``health`` doesn't match the ``health note`` /
+    ``health check`` rows. Multi-line value cells (mounts / environment /
+    allowed domains) are rejoined with newlines; a continuation is indented
+    past its label's right edge, which also stops right-aligned label rows
+    from being read as continuations."""
+    lines = [re.sub(r"\x1b\[[0-9;]*m", "", ln) for ln in body.splitlines()]
     for i, line in enumerate(lines):
-        if not line.startswith(label):
+        stripped = line.lstrip()
+        if not stripped.startswith(label):
             continue
-        rest = line[len(label) :]
+        rest = stripped[len(label) :]
         # "health" must not match "health note" (rest starts with a word,
         # not the column gap). The gap is always >=2 spaces.
         if rest.strip() and not rest[:2].isspace():
             continue
+        label_leading = len(line) - len(line.lstrip(" "))
         parts = [rest.strip()] if rest.strip() else []
         for cont in lines[i + 1 :]:
-            if not cont[:1].isspace():
+            cont_leading = len(cont) - len(cont.lstrip(" "))
+            # A continuation is indented past the label's right edge
+            # (label_leading + len(label)); the next row's right-aligned
+            # label sits at or before that edge, so it ends the scan.
+            if cont_leading <= label_leading + len(label):
                 break
             if cont.strip():
                 parts.append(cont.strip())
         return "\n".join(parts)
+    return None
     return None
 
 
@@ -4671,12 +4682,16 @@ async def test_detail_renders_aligned_two_column_table(monkeypatch):
             assert _detail_value(body, label) is not None, label
             line = next(
                 ln
-                for ln in body.splitlines()
-                if ln.startswith(label)
-                and ln[len(label) : len(label) + 2].isspace()
+                for ln in (
+                    re.sub(r"\x1b\[[0-9;]*m", "", x) for x in body.splitlines()
+                )
+                if ln.lstrip().startswith(label)
+                and ln.lstrip()[len(label) : len(label) + 2].isspace()
             )
-            rest = line[len(label) :]
-            starts.add(len(label) + len(rest) - len(rest.lstrip()))
+            lead = len(line) - len(line.lstrip())
+            after_label = line.lstrip()[len(label) :]
+            gap = len(after_label) - len(after_label.lstrip())
+            starts.add(lead + len(label) + gap)
         assert len(starts) == 1, f"detail values don't align: {starts}"
 
 
@@ -10948,7 +10963,9 @@ def test_render_detail_indents_wrapped_values_to_value_column():
         )
     ]
     out = WorkspaceDetailScreen._render_detail(rows, 60)
-    lines = out.splitlines()
+    # _render_detail emits ANSI (zebra row backgrounds + bold labels, #2193);
+    # strip it so these assertions check column layout, not styling.
+    lines = [re.sub(r"\x1b\[[0-9;]*m", "", ln) for ln in out.splitlines()]
     # First line: label, then the start of the value.
     assert lines[0].startswith("service command  cd /app/meetmin")
     # The value wrapped onto further lines...
@@ -11038,3 +11055,34 @@ def test_render_detail_zebra_stripes():
     assert len(plain) == 2
     # markup safety: "[img]" is not eaten as Textual/Rich markup by from_ansi
     assert "[img]" in Text.from_ansi(out).plain
+
+
+def test_render_detail_label_column_bold_and_right_aligned():
+    """Key names are bold and right-aligned; values are neither (#2193)."""
+    rows = [("id", "abc"), ("running", "yes"), ("uptime", "2h 0m")]
+    out = WorkspaceDetailScreen._render_detail(rows, width=40)
+    t = Text.from_ansi(out)
+
+    def is_bold_at(substr: str) -> bool:
+        idx = t.plain.index(substr)
+        end = idx + len(substr)
+        return any(
+            s.style and s.style.bold and not (end <= s.start or idx >= s.end)
+            for s in t.spans
+        )
+
+    # labels are bold, values are not
+    assert is_bold_at("id")
+    assert is_bold_at("running")
+    assert is_bold_at("uptime")
+    assert not is_bold_at("abc")
+    assert not is_bold_at("yes")
+
+    # right-aligned: every label's right edge sits at the same column
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", out)
+    end_cols = set()
+    for lab in ("id", "running", "uptime"):
+        pos = plain.index(lab)
+        line_start = plain.rfind("\n", 0, pos) + 1
+        end_cols.add(pos + len(lab) - line_start)
+    assert len(end_cols) == 1

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -11011,3 +11011,30 @@ async def test_detail_display_renders_at_body_width_not_screen_width(
     # (otherwise this regression can't occur and the test is meaningless).
     assert captured["width"] == body_w
     assert body_w < screen_w
+
+
+def test_render_detail_zebra_stripes():
+    """The workspace-detail table zebra-stripes alternating rows; a
+    multi-line value inherits its row's stripe on every wrapped line; and
+    markup-like values (e.g. "[img]") stay literal through the ANSI
+    round-trip into the Static (#2193)."""
+    rows = [
+        ("id", "abc"),  # even -> base
+        ("running", "yes"),  # odd  -> stripe
+        ("image", "[img]"),  # even -> base (markup-like value)
+        ("mounts", "/a\n/b"),  # odd  -> stripe (multi-line)
+    ]
+    out = WorkspaceDetailScreen._render_detail(rows, width=40)
+    # #161B22 == rgb(22, 27, 34); the truecolor background params, robust to
+    # how Rich groups the escape sequence.
+    bg = "48;2;22;27;34"
+    lines = out.splitlines()
+    striped = [ln for ln in lines if bg in ln]
+    plain = [ln for ln in lines if bg not in ln]
+    # "running" (1 line) + "mounts" (2 wrapped lines) are striped = 3;
+    # "id" (1) + "image" (1) are base = 2. The multi-line value shares the
+    # row's stripe on both wrapped lines.
+    assert len(striped) == 3
+    assert len(plain) == 2
+    # markup safety: "[img]" is not eaten as Textual/Rich markup by from_ansi
+    assert "[img]" in Text.from_ansi(out).plain


### PR DESCRIPTION
Closes #2193.

## What

Reworks the workspace-detail property block (`id / running / health / uptime / image / service command / auto-start / mounts`) on `WorkspaceDetailScreen` for readability:

- **Zebra-striped rows** — alternating row backgrounds, theme `surface` (`#161B22`) over `background` (`#0D1117`).
- **Bold, right-aligned key names** — each label's right edge lines up just before its value.

A multi-line value keeps one background (and one logical row) across all its wrapped lines.

## How

All at the Rich layer of `_render_detail` (`workspace_detail.py`):

- `Table(..., row_styles=("", "on #161B22"))` — cycles per `add_row`, so a multi-line cell inherits its row's stripe on every wrapped line.
- `add_column("label", no_wrap=True, justify="right", style="bold")` — the column style composes with `row_styles`, so a striped row's label is both bold and background-tinted; right-alignment puts every label's right edge at the value column.
- `Console(force_terminal=True, color_system="truecolor", ...)` (was `force_terminal=False, no_color=True`) so the styling is emitted as ANSI instead of stripped.
- Call site switched from `Text(rendered)` to `Text.from_ansi(rendered)` so the styling survives into the `Static`. `from_ansi` reads ANSI only, so the existing "values like `[img]` render literally, not as markup" property is preserved.

## Interaction with #2190 (the no-rewrap `rstrip`)

The render does `"\n".join(line.rstrip() ...)`. A striped line ends in the ANSI reset escape (`\x1b[0m`), so `rstrip()` leaves it intact — the background fills the full row width and the #2190 "render at body content width, no re-wrap" guarantee still holds.

## Verification

- New unit tests: `test_render_detail_zebra_stripes` (background on alternating rows; multi-line value carries it on every wrapped line; `[img]` stays literal) and `test_render_detail_label_column_bold_and_right_aligned` (labels bold + right-aligned; values neither).
- Updated the existing detail-screen test helpers/assertions (`_detail_value`, `test_render_detail_indents_wrapped_values_to_value_column`, `test_detail_renders_aligned_two_column_table`) to normalize away the ANSI and account for right-aligned labels.
- Full unit suite green at 100% coverage (the CI way, `-n auto`): `4162 passed`.
- Detail-screen e2e (`test_workspace_detail_focus.py`): `3 passed`.
