### PR TITLE
feat(nix): add nix-enabled workspace base image (#2199)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Nix-enabled workspace image (`Dockerfile-nix`) (#2199).** A variant of
+  the workspace image that layers single-user nix and devenv on top of the
+  full workspace image (Pi agent, features, `klangk-*` tooling) so a
+  nix-enabled workspace has everything it needs to run under `klangk`.
+  nix is off `$PATH` by default; source `/opt/klangk/bin/nix-activate.sh` to
+  put nix, devenv, and nix-installed programs on `$PATH`. Consumed by the
+  nix workspace feature (#2198); build locally with `scripts/build-nix-image.sh`.
+
 - **Shared terminals in the TUI (#2164).** The workspace detail screen
   now lists shared terminals visible to you (other users' shared windows
   and the agent's `service` window), below your own terminals. Selecting

--- a/scripts/build-nix-image.sh
+++ b/scripts/build-nix-image.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build the nix-enabled workspace image locally (single arch, loaded into
+# podman). Extends the full workspace image (Dockerfile — Pi agent, features,
+# klangk-* tooling) with single-user nix and devenv (#2199). Runtime /nix
+# overlay + PATH wiring is #2198.
+#
+# Builds for KLANGKBUILD_PLATFORM (the host arch by default) so the image
+# can be loaded and run locally.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
+PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
+# shellcheck source=_podman_common.sh disable=SC1091
+source "$SCRIPT_DIR/_podman_common.sh"
+
+WORKSPACE_IMAGE="${KLANGKD_IMAGE_NAME:-klangk-workspace}"
+
+# The nix image layers on the full workspace image, so make sure that base
+# exists locally first. Build it on demand if it's missing.
+if ! "$PODMAN" image exists "${WORKSPACE_IMAGE}:latest" 2>/dev/null; then
+  echo "==> Base workspace image ${WORKSPACE_IMAGE}:latest not found; building it"
+  "$SCRIPT_DIR/build-workspace-image.sh"
+fi
+
+COMMIT="$(git rev-parse --short HEAD)"
+CALVER="$(date -u +%Y.%m.%d)"
+VERSION="${CALVER}-${COMMIT}"
+IMAGE="klangk-workspace-nix"
+
+echo "==> Building nix workspace image $VERSION (${KLANGKBUILD_PLATFORM:-linux/amd64})"
+"$PODMAN" build \
+  "${SIG_POLICY_ARGS[@]}" \
+  --platform "${KLANGKBUILD_PLATFORM:-linux/amd64}" \
+  --build-arg WORKSPACE_IMAGE="${WORKSPACE_IMAGE}:latest" \
+  -f src/containers/workspace/Dockerfile-nix \
+  -t "$IMAGE:latest" \
+  -t "$IMAGE:$VERSION" \
+  "$@" src/containers/workspace/
+
+echo "==> Done: $IMAGE:$VERSION"
+"$PODMAN" images "$IMAGE" --format "  {{.Tag}}\t{{.Size}}"

--- a/src/containers/workspace/Dockerfile-nix
+++ b/src/containers/workspace/Dockerfile-nix
@@ -1,0 +1,71 @@
+# Nix-enabled workspace image.
+#
+# Extends the FULL workspace image (Dockerfile — Pi agent, feature repos, and
+# the klangk-* tooling: entrypoint, klangk-setup-pi, klangk-workspace-token,
+# klangk-setup-home, ...) with single-user nix and devenv. A nix-enabled
+# workspace needs that tooling to run under klangk, so this layers on top of
+# the workspace image, not the bare base.
+#
+# nix is NOT on PATH by default — users enter `nix shell` or `devenv shell`
+# to activate it. The /nix directory is expected to be overlay-mounted at
+# runtime (see #2198), but this image pre-populates it so the image works
+# standalone for testing.
+#
+# HOME caveat (klangk's per-user home scheme): every terminal runs as the
+# klangk unix user with $HOME = /home/.users/<user_id> (agent:
+# /home/<agent_handle>) — a SUBDIR of the /home bind-mount. The nix
+# single-user installer puts its profile at ~/.local/state/nix/profiles/profile
+# (under /home), which the runtime /home overlay hides. So after installing we
+# COPY the profile to /nix/nix-profile (part of the image rootfs, NOT overlaid
+# → visible/shared in every workspace) and /etc/profile.d/z-nix.sh recreates
+# the per-user ~/.nix-profile symlink at login.
+
+ARG WORKSPACE_IMAGE=klangk-workspace:latest
+FROM $WORKSPACE_IMAGE
+
+# Install nix in single-user mode as the klangk user.
+# Single-user means the klangk user owns /nix directly — no nix-daemon needed.
+# The --no-daemon flag skips systemd/launchd service setup.
+USER root
+RUN mkdir -p /nix && chown klangk:klangk /nix
+
+USER klangk
+# Install nix. The single-user installer puts the profile at
+# ~/.local/state/nix/profiles/profile (XDG default); we move it under /nix
+# below so it survives klangk's runtime /home overlay.
+RUN curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon
+
+# Enable flakes + nix-command system-wide BEFORE the profile installs below
+# need them. /etc/nix is not under /home, so it survives the runtime overlay
+# (a per-user ~/.config/nix/nix.conf would be hidden).
+USER root
+RUN mkdir -p /etc/nix \
+    && printf 'experimental-features = nix-command flakes\n' > /etc/nix/nix.conf
+
+# Install devenv via nix (USER must be set for cachix). These land in the
+# (still under-/home) profile; the move below carries them along.
+ENV USER=klangk
+USER klangk
+RUN export PATH="/home/.local/state/nix/profiles/profile/bin:$PATH" \
+    && nix profile install nixpkgs#cachix \
+    && cachix use devenv \
+    && nix profile install --accept-flake-config github:cachix/devenv/latest
+
+# Point /nix/nix-profile at the profile's STORE path so it survives the
+# runtime /home overlay. The profile chain is ~/.local/state/nix/profiles/
+# profile -> profile-1-link -> /nix/store/<hash>-profile (the real content);
+# the first two links live under /home (overlaid away at runtime), but the
+# store path is under /nix (not overlaid). Symlinking to the resolved store
+# path keeps the profile's inner symlinks (bin/nix -> /nix/store/...) valid.
+USER root
+RUN ln -s "$(readlink -f /home/.local/state/nix/profiles/profile)" /nix/nix-profile
+
+# Activation script at a well-known path. Source
+# `. /opt/klangk/bin/nix-activate.sh` to put nix + nix-installed programs on
+# PATH (nix is NOT on PATH by default, #2199). The script points
+# ~/.nix-profile at the shared /nix/nix-profile base (which nix follows, so
+# `nix profile install`-ed programs land there too) and prepends its bin to
+# PATH, ahead of every other bindir. Works for any user since $HOME is
+# klangk's per-user subdir.
+COPY nix-activate.sh /opt/klangk/bin/nix-activate.sh
+RUN chmod +x /opt/klangk/bin/nix-activate.sh

--- a/src/containers/workspace/nix-activate.sh
+++ b/src/containers/workspace/nix-activate.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# /opt/klangk/bin/nix-activate.sh — source to put nix + nix-installed
+# programs on PATH.
+#
+# Usage:
+#   . /opt/klangk/bin/nix-activate.sh
+#
+# nix/devenv are NOT on PATH by default (#2199). Sourcing this adds:
+#   - the shared base profile under /nix (nix, devenv, cachix) — it lives under
+#     /nix so it survives klangk's runtime /home overlay (the workspace mounts
+#     its own /home over the image's, hiding anything baked under /home);
+#   - the caller's per-user install profile (programs added via
+#     `nix profile install`), once it exists.
+# Re-sourcing is idempotent (no duplicate PATH entries). Works for any user —
+# $HOME is klangk's per-user subdir (/home/.users/<id>, or /home/<handle> for
+# the agent), and the script recreates ~/.nix-profile there on first use.
+
+# nix needs an explicit CA bundle; it does not read the Debian trust store.
+export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+# Recreate the conventional ~/.nix-profile symlink on first use. The image's
+# symlink lives under /home, which klangk overlays at runtime; point it at the
+# shared base profile under /nix instead. nix follows ~/.nix-profile, so
+# programs added via `nix profile install` land here too (and are thus on
+# PATH via the entry below).
+if [ ! -e "$HOME/.nix-profile" ]; then
+  ln -s /nix/nix-profile "$HOME/.nix-profile"
+fi
+
+# Prepend the base profile bin (nix, devenv, cachix, and anything later
+# added via `nix profile install`) to PATH, ahead of every other bindir,
+# unless already present.
+case ":${PATH:-}:" in
+*":/nix/nix-profile/bin:"*) ;;
+*) PATH="/nix/nix-profile/bin${PATH:+:$PATH}" ;;
+esac
+
+export PATH


### PR DESCRIPTION
## Summary

Adds a nix-enabled variant of the workspace base image, used when the nix workspace feature is enabled (#2198). Closes #2199.

- **`src/containers/workspace/Dockerfile.base-nix`** — extends the standard Debian/node workspace base (`Dockerfile.base`) with single-user nix and devenv pre-installed.
  - Single-user nix (`--no-daemon`); the `klangk` user owns `/nix` directly, no nix-daemon.
  - Binary caches configured: `cache.nixos.org` + `devenv.cachix.org` (`cachix use devenv`).
  - Flakes + nix-command enabled globally for the `klangk` user.
  - `~/.nix-profile/bin` is deliberately **not** on `$PATH`; nix/devenv are reachable by full path or via `nix shell` / `devenv shell` shell functions (`/etc/profile.d/z-nix.sh`). Runtime `/nix` overlay + PATH wiring is #2198's job.
- **`scripts/build-base-nix-image.sh`** — the nix analog of `build-base-image.sh`; tags `klangk-workspace-base-nix:latest` + a `CALVER-commit` version.

## Acceptance criteria — verified

All four criteria from #2199 verified against `podman build` output (Debian Trixie/node base):

| Check | Result |
| --- | --- |
| `podman build` produces a working image | ✅ builds clean via `scripts/build-base-nix-image.sh` |
| `nix --version` / `devenv --version` by full path | ✅ nix 2.35.1, devenv 2.2.1 |
| `nix profile install nixpkgs#hello` (single-user, no daemon) | ✅ installs, `hello` prints "Hello, world!" |
| Clone a `devenv.nix` repo, `devenv shell` works | ✅ builds env, package (`cowsay`) + env var (`GREETING`) present |

Plus: confirmed `$PATH` stays clean (no `~/.nix-profile/bin`), satisfying "Nix and devenv should NOT be on PATH by default."

Parent: #2198 (runtime `/nix` overlay + feature flag).


## Role for macOS / host-container users (the seed feature doesn't work there)

The per-workspace `/nix` **seed feature** (`nix_seed`, #2220) needs either btrfs
snapshots or `fuse-overlayfs` — **neither works under macOS or under the host
container** (rootless podman can't bind a process-owned FUSE mount into a
workspace container's userns; no btrfs in either place — see #2221, verified
against the host container). So the **nix-enabled workspace image is the nix
path for macOS and host-container users**, and this PR owns three things to
make that real:

1. **Publish `klangk-workspace-nix` at release time** (ghcr, alongside the
   base images) so macOS / host-image users can `podman pull` it instead of
   building from source — they have no devenv / source tree (cf. #2225, the
   same wheel-only constraint for the seed).
2. **Terminal UX parity with the seed feature.** A terminal in a nix-image
   container should behave like one in a seed-feature workspace: `nix`/`devenv`
   on `$PATH` by default — auto-activated via the same `/etc/profile.d` snippet
   the seed feature uses with `KLANGKWS_NIX=1` — **not** requiring a manual
   `. nix-activate.sh`. Today the nix image keeps `$PATH` clean and ships
   `nix-activate.sh` for manual sourcing; close that gap so image users get the
   same out-of-the-box `nix`/`devenv` experience as seed-feature users.
3. **Documentation.** `docs/features/nix.md` should state plainly that macOS
   and host-container users should pick the nix-enabled workspace image (not
   `nix_seed`), because neither backend works there — cross-link #2221.
4. **Persistence: a writable `/nix` volume is needed.** The nix image bakes
   `/nix` into the image layer (read-only); a user's `nix profile install`
   additions land in the container's ephemeral writable layer and are lost when
   the workspace container is recreated. For additions to persist across
   restarts, the workspace must mount a writable per-workspace `/nix` volume.
   Document this, and decide whether klangkd provisions that volume for
   nix-image workspaces (the way the seed feature provisions a per-workspace
   `/nix`) or the operator supplies it.

Parent: #2198.

