### PR TITLE
feat(nix): build shared base /nix store seed (#2200)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -230,6 +230,7 @@ in
   scripts.push-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/push-base-image.sh" "$@"'';
   scripts.build-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-base-image.sh" "$@"'';
   scripts.build-host-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-host-image.sh" "$@"'';
+  scripts.build-nix-seed.exec = ''exec bash "$DEVENV_ROOT/scripts/build-nix-seed.sh" "$@"'';
   scripts.trivy-host.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-host.sh" "$@"'';
   scripts.trivy-workspace.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-workspace.sh" "$@"'';
   scripts.trivy-workspace-report.exec = ''

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,13 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Shared base `/nix` store seed (`scripts/build-nix-seed.sh`) (#2200).**
+  A reproducible build step that produces a self-consistent `/nix` tree (the
+  store, the nix DB, and a base profile with nix and devenv) and an
+  `/etc/nix/nix.conf` (flakes, nix-command, and pre-configured binary caches),
+  deployed alongside klangk as a host-side tree rather than baked into a
+  workspace image. Run via `devenv run build-nix-seed`. Consumed by #2201.
+
 - **Shared terminals in the TUI (#2164).** The workspace detail screen
   now lists shared terminals visible to you (other users' shared windows
   and the agent's `service` window), below your own terminals. Selecting

--- a/docs/features/nix.md
+++ b/docs/features/nix.md
@@ -1,0 +1,56 @@
+# Nix workspace feature
+
+Opt-in per-workspace [nix](https://nixos.org/) + [devenv](https://devenv.sh/),
+shared across workspaces without baking the ~1–2 GB nix store into every
+workspace image. Tracked under [#2198](https://github.com/mcdonc/klangk/issues/2198);
+this page covers the **shared base store** ([#2200](https://github.com/mcdonc/klangk/issues/2200))
+that the per-workspace mount ([#2201](https://github.com/mcdonc/klangk/issues/2201))
+layers on top of.
+
+## Shared base `/nix` store (the seed)
+
+A single, read-only, self-consistent `/nix` tree containing nix, devenv, and a
+matching nix database (`/nix/var/nix/db/db.sqlite`). It is built once and
+shared by every nix-enabled workspace, so the store is paid for once, not per
+workspace.
+
+The seed is **not** a container image — it is a host-side tree deployed
+alongside klangk (per [#2198](https://github.com/mcdonc/klangk/issues/2198): the
+store is built/populated as part of the devenv setup, not baked into an image).
+
+### Build it
+
+```sh
+devenv run build-nix-seed [out-dir]
+```
+
+`scripts/build-nix-seed.sh` builds a throwaway sandbox image that performs a
+single-user nix install + devenv, then extracts `/nix` and `/etc/nix/nix.conf`
+into a deployable tree at `out-dir` (default `./nix-base`, or
+`$KLANGKD_NIX_SEED_DIR`). Output layout:
+
+```text
+<out>/
+├── nix/          store + var/db + base profile (nix, devenv, cachix)
+└── nix.conf      flakes/nix-command + pre-configured binary caches
+```
+
+The script verifies nix and devenv run against the extracted store before
+reporting success.
+
+### Update it
+
+The seed only ever **grows** — nix store paths are content-addressed, so
+adding packages to a new seed never conflicts with existing per-workspace
+layers built on an older seed. To update (new nix, new devenv), just re-run
+the build and redeploy the tree. See the [overlay architecture note](../architecture/nix-workspace-overlay.md)
+for how #2201 consumes an updated seed (re-clone for the zfs path; the DB is
+per-clone, so existing workspaces keep their view until re-cloned).
+
+## How workspaces consume it
+
+The per-workspace mount (#2201) layers a writable, isolated view of the seed
+on top of each nix-enabled workspace (overlay lowerdir, or — where a zfs pool
+is available — a clone of a seed snapshot). nix/devenv are off `$PATH` by
+default; the workspace image ships `/opt/klangk/bin/nix-activate.sh`, which a
+user sources to put nix and nix-installed programs on `$PATH`.

--- a/scripts/build-nix-seed.sh
+++ b/scripts/build-nix-seed.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Build the shared base /nix store seed (#2200) and extract it to a deployable
+# host-side tree. The tree is consumed by #2201 — used as an overlayfs lowerdir
+# or loaded into a zfs dataset for per-workspace cloning.
+#
+# Output layout at $OUT (default ./nix-base, overridable via $1 or
+# $KLANGKD_NIX_SEED_DIR):
+#   $OUT/nix/        store + var/db + the base profile (nix, devenv, cachix)
+#   $OUT/nix.conf    flakes/nix-command + pre-configured binary caches
+#
+# The build runs in a throwaway container (the nix-seed sandbox image); the
+# container is a build sandbox only — its /nix is extracted, the image is not
+# shipped or baked into any workspace (#2198: store deployed alongside klangk,
+# not image-baked).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
+PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
+# shellcheck source=_podman_common.sh disable=SC1091
+source "$SCRIPT_DIR/_podman_common.sh"
+
+IMAGE="klangk-nix-seed:latest"
+OUT="${1:-${KLANGKD_NIX_SEED_DIR:-$PWD/nix-base}}"
+
+echo "==> Building nix-seed sandbox image"
+"$PODMAN" build \
+  "${SIG_POLICY_ARGS[@]}" \
+  --platform "${KLANGKBUILD_PLATFORM:-linux/amd64}" \
+  -f src/containers/nix-seed/Dockerfile \
+  -t "$IMAGE" \
+  src/containers/nix-seed/
+
+echo "==> Extracting /nix + nix.conf -> $OUT"
+# Clear any prior output first (store files are read-only, so +w before rm).
+mkdir -p "$OUT"
+chmod -R u+w "$OUT" 2>/dev/null || true
+rm -rf "${OUT:?}/nix" "${OUT:?}/nix.conf" "${OUT:?}/etc"
+# Extract directly into $OUT (same filesystem -> no cross-fs copy/unlink of the
+# read-only store files). Pulls /nix and /etc/nix/nix.conf from the sandbox fs.
+cid="$("$PODMAN" create --entrypoint /bin/true "$IMAGE")"
+"$PODMAN" export "$cid" | tar -x -C "$OUT" nix etc/nix/nix.conf
+"$PODMAN" rm "$cid" >/dev/null
+test -f "$OUT/etc/nix/nix.conf" || {
+  echo "ERROR: /etc/nix/nix.conf missing from image" >&2
+  exit 1
+}
+mv "$OUT/etc/nix/nix.conf" "$OUT/nix.conf"
+rmdir -p "$OUT/etc/nix" "$OUT/etc" 2>/dev/null || true
+
+# Restore read-write bits the seed tree needs to be usable on the host (nix
+# store files are 0444/0555; the owner still needs +w to, e.g., load the tree
+# into a dataset or move it).
+chmod -R u+w "$OUT/nix" || true
+
+echo "==> Verifying: nix runs against the extracted store"
+# shellcheck disable=SC2016  # the inline sh is run by the container, not expanded here
+"$PODMAN" run --rm --entrypoint /bin/sh \
+  -v "$OUT/nix:/nix:ro" \
+  -v "$OUT/nix.conf:/etc/nix/nix.conf:ro" \
+  debian:trixie-slim -c '
+    export PATH="/nix/nix-profile/bin:$PATH" NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    nix --version && devenv --version
+  '
+
+echo "==> Done: $OUT"
+echo "    $OUT/nix/      ($(du -sh "$OUT/nix" | cut -f1), $(find "$OUT/nix/store" -mindepth 1 -maxdepth 1 | wc -l) store entries)"
+echo "    $OUT/nix.conf  (flakes/nix-command + binary caches)"
+echo "Consume with #2201: overlay lowerdir, or load into a zfs dataset and snapshot."

--- a/src/containers/nix-seed/Dockerfile
+++ b/src/containers/nix-seed/Dockerfile
@@ -1,0 +1,61 @@
+# Build sandbox for the shared base /nix store seed (#2200).
+#
+# This image ONLY exists to produce a self-consistent /nix tree (store +
+# var/db + a base profile with nix and devenv) and an /etc/nix/nix.conf
+# (flakes/nix-command + the devenv binary cache pre-configured).
+# scripts/build-nix-seed.sh builds it and extracts both into a deployable
+# host-side tree that #2201 consumes — as an overlayfs lowerdir, or loaded
+# into a zfs dataset for cloning.
+#
+# It is a BUILD SANDBOX, not a workspace image: nothing here is baked into a
+# running workspace. The seed store is content-addressed, so the base image
+# choice (debian:trixie-slim) only affects the build environment, not the
+# resulting /nix content.
+
+FROM debian:trixie-slim
+
+ARG NIX_INSTALL_URL=https://nixos.org/nix/install
+ARG DEVENV_FLAKE=github:cachix/devenv/latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Single-user nix needs a non-root user that owns /nix (uid 1000 matches the
+# workspace's klangk user, so ownership lines up when the tree is consumed).
+RUN groupadd -g 1000 klangk \
+    && useradd -u 1000 -g 1000 -m -d /home -s /bin/bash klangk \
+    && mkdir -p /nix \
+    && chown klangk:klangk /nix /home
+
+# Enable flakes + nix-command system-wide (needed by the profile installs
+# below). Binary-cache config is added post-install via `cachix use` so the
+# devenv.cachix.org public key is always current (hardcoding it is fragile).
+RUN mkdir -p /etc/nix \
+    && printf 'experimental-features = nix-command flakes\n' > /etc/nix/nix.conf
+
+USER klangk
+# Single-user install (--no-daemon): the klangk user owns /nix directly — no
+# nix-daemon. Produces /nix/store + /nix/var/nix/db/db.sqlite, self-consistent.
+RUN curl -fsSL "$NIX_INSTALL_URL" | sh -s -- --no-daemon
+
+# Install devenv + cachix into the base profile. --accept-flake-config pulls
+# devenv's deps from devenv.cachix.org (substituter declared by the devenv
+# flake itself), avoiding a slow from-source build of its Rust closure.
+ENV USER=klangk
+RUN export PATH="/home/.local/state/nix/profiles/profile/bin:$PATH" \
+    && nix profile install nixpkgs#cachix \
+    && nix profile install --accept-flake-config "$DEVENV_FLAKE"
+
+# Pre-configure the devenv binary cache for consumers. `cachix use` writes to
+# /etc/nix/nix.conf only when it believes it is root; the ENV USER=klangk above
+# makes it think otherwise, so override USER for this one command.
+USER root
+RUN export PATH="/home/.local/state/nix/profiles/profile/bin:$PATH" \
+    && USER=root cachix use devenv
+
+# Expose the base profile at /nix/nix-profile, pointing at its STORE path (not
+# the /home symlink) so the extracted /nix tree is self-contained — the
+# installer's /home/.nix-profile lives under /home, which isn't part of the
+# seed tree consumers mount.
+RUN ln -s "$(readlink -f /home/.local/state/nix/profiles/profile)" /nix/nix-profile

--- a/zensical.toml
+++ b/zensical.toml
@@ -37,6 +37,7 @@ nav = [
     { "SSH Agent Forwarding" = "features/ssh-agent-forwarding.md" },
     { "GitHub HTTPS Authentication" = "features/github-authentication.md" },
     { "Debug Panel" = "features/debug-panel.md" },
+    { "Nix" = "features/nix.md" },
   ]},
   { "Sandboxes" = [
     { "Overview" = "sandboxes/index.md" },


### PR DESCRIPTION
## Summary

Implements **#2200** — a reproducible build step that produces the shared base `/nix` store seed (part of the nix workspace feature, #2198). Closes #2200.

The seed is a self-consistent `/nix` tree (store + nix DB + a base profile with nix and devenv) plus an `/etc/nix/nix.conf` (flakes/nix-command + the devenv binary cache pre-configured), deployed as a **host-side tree alongside klangk — not baked into a workspace image** (per #2198: store deployed, not image-baked). It is consumed by #2201 (per-workspace mount) as an overlay lowerdir or a zfs clone source.

## What's here

- **`src/containers/nix-seed/Dockerfile`** — a build *sandbox* (debian:trixie-slim) that does a single-user nix install + devenv + cachix, configures the devenv binary cache via `cachix use`, and exposes the base profile at `/nix/nix-profile` (its store path) so the extracted tree is self-contained. The image is a build vehicle only — its `/nix` is extracted; it is not shipped or baked into any workspace.
- **`scripts/build-nix-seed.sh`** (`devenv run build-nix-seed [out-dir]`) — builds the sandbox, extracts `/nix` + `nix.conf` into a deployable tree (default `./nix-base` or `$KLANGKD_NIX_SEED_DIR`), and verifies nix + devenv run against it.
- **`docs/features/nix.md`** (+ nav) — build / update / consume.

## Verification

Built and verified end-to-end:

```
$ devenv run build-nix-seed /d/nix-base-test
==> Done: /d/nix-base-test
    /d/nix-base-test/nix/      (1.4G, 9348 store entries)
    /d/nix-base-test/nix.conf  (flakes/nix-command + binary caches)
```

- `nix (Nix) 2.35.1` and `devenv 2.2.1` run against the extracted tree.
- `nix.conf` has both substituters and trusted keys (`cache.nixos.org`, `devenv.cachix.org`).
- `/nix/nix-profile` → the profile's store path, so the tree is self-contained (the installer's `/home/.nix-profile` lives under `/home`, which isn't part of the seed).
- An extracted `/nix` tree was already validated as a working overlay lowerdir and zfs-clone source in the #2201 spike (PR #2205).

Parent: #2198. Consumed by: #2201.
