### PR TITLE
feat(nix): per-workspace /nix via zfs clones (#2201)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -39,6 +39,15 @@ operators or integrators to act when upgrading.
   deployed alongside klangk as a host-side tree rather than baked into a
   workspace image. Run via `devenv run build-nix-seed`. Consumed by #2201.
 
+- **Per-workspace `/nix` via zfs clones (#2201).** When `nix_enabled` and
+  `nix_zfs_dataset` are set, each workspace gets a writable, isolated `/nix`
+  as a zfs clone of a shared, snapshotted seed dataset (from #2200): cloned on
+  first start, reused across restarts, destroyed on delete. The clone's `/nix`
+  and `nix.conf` are bind-mounted into the container (plain bind, no extra
+  caps). Requires a zfs pool + a one-time `zfs allow` delegation; off by
+  default so non-nix workspaces are unaffected. `scripts/load-nix-seed-zfs.sh`
+  loads the seed into a dataset. Per-workspace selection is #2202.
+
 - **Shared terminals in the TUI (#2164).** The workspace detail screen
   now lists shared terminals visible to you (other users' shared windows
   and the agent's `service` window), below your own terminals. Selecting

--- a/docs/features/nix.md
+++ b/docs/features/nix.md
@@ -47,10 +47,58 @@ the build and redeploy the tree. See the [overlay architecture note](../architec
 for how #2201 consumes an updated seed (re-clone for the zfs path; the DB is
 per-clone, so existing workspaces keep their view until re-cloned).
 
-## How workspaces consume it
+## How workspaces consume it (#2201)
 
-The per-workspace mount (#2201) layers a writable, isolated view of the seed
-on top of each nix-enabled workspace (overlay lowerdir, or — where a zfs pool
-is available — a clone of a seed snapshot). nix/devenv are off `$PATH` by
-default; the workspace image ships `/opt/klangk/bin/nix-activate.sh`, which a
-user sources to put nix and nix-installed programs on `$PATH`.
+Each nix-enabled workspace gets a writable, isolated `/nix` as a **zfs clone**
+of the seed snapshot — instant (~0.5 s), block-shared (only the workspace's
+changes consume space), and fully isolated from other workspaces. klangkd
+clones the seed on first start, reuses the clone across restarts, and destroys
+it on workspace delete. The clone's `/nix` and `nix.conf` are bind-mounted
+into the container.
+
+This replaces the overlayfs approach the issue body described — the #2201
+spike (PR #2205) found rootless podman rejects `--mount type=overlay`, and
+in-container overlay needs single-bind + `--cap-add SYS_ADMIN`; a zfs clone is
+plain-bind (no extra caps), faster, and the nix-DB copy-up gotcha doesn't
+apply (a clone is a real filesystem copy). zfs is required (a btrfs-snapshot
+variant is future work for non-zfs hosts).
+
+### Enable it
+
+1. Build the seed (#2200) and load it into a zfs dataset:
+
+   ```sh
+   devenv run build-nix-seed /tmp/nix-base
+   scripts/load-nix-seed-zfs.sh /tmp/nix-base d/klangk-nix
+   ```
+
+2. Delegate zfs clone/destroy to the klangkd user (no full root):
+
+   ```sh
+   sudo zfs allow <klangkd-user> create,clone,destroy,mount d/klangk-nix
+   ```
+
+3. Point klangkd at the dataset (in `klangkd.yaml` or env):
+
+   ```yaml
+   nix_enabled: "true"
+   nix_zfs_dataset: d/klangk-nix
+   ```
+
+With both set, every workspace gets a `/nix` clone on start; with either
+unset, workspaces are unaffected (the default). Per-workspace selection (the
+feature flag + UI) is #2202 — for now it's all-or-none per deploy.
+
+nix/devenv are off `$PATH` by default; the workspace image (#2199) ships
+`/opt/klangk/bin/nix-activate.sh`, which a user sources to put nix and
+nix-installed programs on `$PATH`.
+
+### Restart persistence
+
+The clone is a zfs dataset, so it survives container stop/start — packages a
+user installs persist across restarts. Destroying the workspace (delete, not
+stop) destroys the clone. Updating the seed (re-run `build-nix-seed` +
+`load-nix-seed-zfs.sh`) does not affect existing clones; new workspaces get
+the new seed. (The seed snapshot is immutable; reseeding requires `zfs destroy
+-r <parent>/seed` first, which orphans existing clones — re-create workspaces
+or point them at the new seed.)

--- a/scripts/load-nix-seed-zfs.sh
+++ b/scripts/load-nix-seed-zfs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Load #2200's nix seed tree into a zfs dataset and snapshot it at @base — the
+# immutable base that #2201's per-workspace clones (klangk.nix.Nix) are created
+# from.
+#
+# Usage: load-nix-seed-zfs.sh <seed-tree> <zfs-parent>
+#   <seed-tree>   output of `devenv run build-nix-seed` (holds nix/ and nix.conf)
+#   <zfs-parent>  zfs dataset parent, e.g. "d/klangk-nix". The seed lands at
+#                 <zfs-parent>/seed and is snapshotted at <zfs-parent>/seed@base.
+#
+# This is an OPERATOR setup step (run once, or to reseed). It needs zfs
+# create/mount/snapshot privilege — either run as root, or delegate once:
+#
+#   sudo zfs allow <klangkd-user> create,clone,destroy,mount,snapshot <pool>
+#
+# (the same delegation lets the klangkd runtime clone/destroy per-workspace
+# datasets without full root).
+#
+# Reseeding destroys the seed snapshot that existing workspace clones depend on;
+# the script refuses to clobber an existing seed — destroy it explicitly first.
+set -euo pipefail
+
+SEED_TREE="${1:?usage: load-nix-seed-zfs.sh <seed-tree> <zfs-parent>}"
+PARENT="${2:?usage: load-nix-seed-zfs.sh <seed-tree> <zfs-parent>}"
+
+require() { [ -e "$1" ] || {
+  echo "ERROR: $1 not found (run 'devenv run build-nix-seed' first)" >&2
+  exit 1
+}; }
+require "$SEED_TREE/nix"
+require "$SEED_TREE/nix.conf"
+
+SEED="${PARENT}/seed"
+if zfs list "$SEED" >/dev/null 2>&1; then
+  echo "ERROR: $SEED already exists — workspace clones may depend on its @base." >&2
+  echo "       To reseed: zfs destroy -r $SEED  (then rerun this script)." >&2
+  exit 1
+fi
+
+# Create the parent (if needed) and the seed dataset.
+zfs list "$PARENT" >/dev/null 2>&1 || zfs create "$PARENT"
+zfs create "$SEED"
+MNT="$(zfs list -H -o mountpoint "$SEED")"
+
+echo "==> Populating $SEED ($MNT) from $SEED_TREE"
+# store files are read-only (0444/0555); +w so cp can update on reseed paths.
+chmod -R u+w "$SEED_TREE" 2>/dev/null || true
+cp -a "$SEED_TREE/nix" "$SEED_TREE/nix.conf" "$MNT"/
+
+echo "==> Snapshotting $SEED@base (immutable base for per-workspace clones)"
+zfs snapshot "$SEED@base"
+
+echo "==> Done. Enable per-workspace nix with:"
+echo "    KLANGKD_NIX_ENABLED=true KLANGKD_NIX_ZFS_DATASET=$PARENT"

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1359,6 +1359,23 @@ class ContainerRegistry:
             elif not os.path.exists(source):
                 raise ValueError(f"Bind mount source does not exist: {source}")
 
+    async def _nix_binds(self, workspace_id: str) -> list[str]:
+        """Bind specs for the workspace's per-workspace /nix (#2201), or [].
+
+        ensure_workspace_nix clones the seed snapshot on first start (and
+        reuses the clone across restarts); the clone's /nix + nix.conf are
+        bind-mounted into the container. Empty (no bind) when nix is disabled.
+        """
+        mountpoint = await self.app.state.nix.ensure_workspace_nix(
+            workspace_id
+        )
+        if not mountpoint:
+            return []
+        return [
+            f"{mountpoint}/nix:/nix",
+            f"{mountpoint}/nix.conf:/etc/nix/nix.conf:ro",
+        ]
+
     @staticmethod
     def _build_mounts(
         home_path: str,
@@ -1604,6 +1621,9 @@ class ContainerRegistry:
         binds = self._build_mounts(
             home_path, config_path, extra_mounts, ssl_dir
         )
+        # #2201: when nix is enabled, bind the workspace's zfs-clone /nix (and
+        # the seed's nix.conf) into the container.
+        binds += await self._nix_binds(workspace_id)
 
         publish = [
             (host_port, CONTAINER_PORT_START + i)

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -25,6 +25,7 @@ from . import (
     caddy as caddy_mod,
     oidc,
     features,
+    nix,
     podman,
     netfilter,
     ssl_trust,
@@ -885,6 +886,9 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
     app.state.container_registry = container.ContainerRegistry(app)
+    # #2201: per-workspace nix store via zfs clones (off unless
+    # KLANGKD_NIX_ENABLED + KLANGKD_NIX_ZFS_DATASET are set).
+    app.state.nix = nix.Nix(app)
     # Slice 2b (#1463): proxy watchdog is an owned CaddyWatchdog instance
     # (Caddy is the sole reverse-proxy engine in 2.X, #1642) with
     # start()/stop()/reconfigure() methods called by the lifespan + SIGHUP.

--- a/src/klangk/klangk/nix.py
+++ b/src/klangk/klangk/nix.py
@@ -1,0 +1,135 @@
+"""Per-workspace nix store via zfs clones (#2201).
+
+When nix is enabled (``KLANGKD_NIX_ENABLED`` + ``KLANGKD_NIX_ZFS_DATASET``),
+each workspace gets a writable, isolated ``/nix`` as a **zfs clone** of a
+shared, snapshotted seed dataset. The seed is built by #2200
+(``scripts/build-nix-seed.sh``) and loaded into a zfs dataset + snapshotted at
+``@base`` by ``scripts/load-nix-seed-zfs.sh``. ``ContainerRegistry`` binds the
+clone's ``/nix`` (and ``nix.conf``) into the workspace container; on workspace
+delete, ``Workspaces`` destroys the clone.
+
+zfs clone/destroy/mount need privilege. Delegate just those operations to the
+klangkd user — no full root — with::
+
+    zfs allow <klangkd-user> create,destroy,clone,mount,list <dataset>
+
+Why zfs clones (not the overlayfs the #2201 issue body describes): the #2201
+spike (PR #2205) found rootless podman rejects ``--mount type=overlay``, and
+in-container overlay needs single-bind + ``--cap-add SYS_ADMIN``; a zfs clone
+is instant (~0.5 s), block-shared, plain-bind (no extra caps), and fully
+isolated — and the nix DB copy-up gotcha doesn't apply (a clone is a real
+filesystem copy, not an overlay). Where no zfs pool is available, leave
+``nix_enabled`` unset and the seed is consumed some other way (future work).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class NixError(RuntimeError):
+    """A zfs operation or configuration problem in the nix subsystem."""
+
+
+class Nix:
+    """Owns the per-workspace zfs-clone lifecycle for ``/nix``.
+
+    Constructed once in ``main.build_app`` as ``app.state.nix`` (#1426
+    ownership: takes ``app``, reads settings live). All zfs calls go through
+    ``asyncio.create_subprocess_exec`` so they don't block the event loop.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    @property
+    def enabled(self) -> bool:
+        s = self.app.state.settings
+        return bool((s.nix_enabled or "").strip()) and bool(s.nix_zfs_dataset)
+
+    @property
+    def dataset(self) -> str:
+        # ``enabled`` already requires this to be set, so callers reach here only
+        # with a real value; return it directly (no defensive raise to keep
+        # coverage honest).
+        return self.app.state.settings.nix_zfs_dataset or ""
+
+    def _seed(self) -> str:
+        return f"{self.dataset}/seed"
+
+    def _seed_snapshot(self) -> str:
+        return f"{self._seed()}@base"
+
+    def _ws(self, workspace_id: str) -> str:
+        return f"{self.dataset}/ws-{workspace_id}"
+
+    async def _zfs(
+        self, args: list[str], *, check: bool = True
+    ) -> tuple[int, str, str]:
+        proc = await asyncio.create_subprocess_exec(
+            "zfs",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await proc.communicate()
+        rc = proc.returncode if proc.returncode is not None else 1
+        out_s, err_s = out.decode(), err.decode()
+        if check and rc != 0:
+            raise NixError(
+                f"zfs {' '.join(args)} failed (rc={rc}): {err_s.strip()}"
+            )
+        return rc, out_s, err_s
+
+    async def _exists(self, name: str) -> bool:
+        rc, _, _ = await self._zfs(
+            ["list", "-H", "-o", "name", name], check=False
+        )
+        return rc == 0
+
+    async def ensure_workspace_nix(self, workspace_id: str) -> str | None:
+        """Ensure a writable ``/nix`` clone for *workspace_id*.
+
+        Returns the clone's mountpoint (to be bind-mounted into the container),
+        or ``None`` when nix is disabled (so callers can call unconditionally).
+        Idempotent: reuses an existing clone across container restarts.
+        """
+        if not self.enabled:
+            return None
+        if not await self._exists(self._seed_snapshot()):
+            raise NixError(
+                f"seed snapshot {self._seed_snapshot()} not found — build the "
+                f"seed (devenv run build-nix-seed) and load it "
+                f"(scripts/load-nix-seed-zfs.sh {self.dataset}) first"
+            )
+        ws = self._ws(workspace_id)
+        if not await self._exists(ws):
+            logger.info(
+                "nix: cloning seed for workspace %s -> %s", workspace_id, ws
+            )
+            await self._zfs(["clone", self._seed_snapshot(), ws])
+        _, out, _ = await self._zfs(["list", "-H", "-o", "mountpoint", ws])
+        mountpoint = out.strip()
+        if not mountpoint or mountpoint == "none":
+            raise NixError(
+                f"workspace nix clone {ws} has no mountpoint "
+                f"(set canmount=on on the seed dataset)"
+            )
+        return mountpoint
+
+    async def destroy_workspace_nix(self, workspace_id: str) -> None:
+        """Destroy the per-workspace clone (on workspace delete). No-op if absent."""
+        if not self.enabled:
+            return
+        ws = self._ws(workspace_id)
+        rc, _, err = await self._zfs(["destroy", "-r", ws], check=False)
+        if rc != 0 and "does not exist" not in err:
+            logger.warning(
+                "nix: zfs destroy %s failed (rc=%s): %s",
+                ws,
+                rc,
+                err.strip(),
+            )

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -633,6 +633,14 @@ class KlangkSettings(BaseSettings):
     allow_autostart: str = ""
     allow_sudo: str = ""
     container_subnets: str | None = None
+    # Nix workspace feature (#2198): when nix_enabled is truthy and
+    # nix_zfs_dataset names a zfs dataset holding the seed (built by #2200,
+    # loaded by scripts/load-nix-seed-zfs.sh), each workspace gets a writable,
+    # isolated /nix as a zfs clone of the seed snapshot (Nix module, #2201).
+    # Off by default; non-nix workspaces are untouched. Per-workspace selection
+    # is #2202.
+    nix_enabled: str = ""
+    nix_zfs_dataset: str | None = None
     userns: str = "keep-id:uid=1000,gid=1000"
     # enable_ping: allow unprivileged ICMP echo (``ping``) inside workspace
     # containers (#2045) by granting the container CAP_NET_RAW; a setuid

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -440,6 +440,9 @@ class Workspaces:
             workspace_id, user_id
         )
         if deleted:
+            # #2201: drop the per-workspace nix clone if nix is enabled
+            # (no-op otherwise).
+            await self.app.state.nix.destroy_workspace_nix(workspace_id)
             ws_dir = self.safe_path(workspace_id)
             await _async_rmtree(ws_dir, f"workspace {workspace_id}")
         return deleted

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -216,6 +216,7 @@ async def app_state(temp_data_dir):
     from klangk.auth import Auth
     from klangk.container import ContainerRegistry
     from klangk.emailsvc import EmailService
+    from klangk.nix import Nix
     from klangk.util import Util
     from klangk.workspaces import Workspaces
 
@@ -235,6 +236,8 @@ async def app_state(temp_data_dir):
     state.workspaces = Workspaces(app)
     state.email = EmailService(app)
     state.util = Util(app)
+    # #2201: Workspaces.delete_workspace reaches state.nix (no-op when disabled).
+    state.nix = Nix(app)
     # Wire DB + Model so every domain reached via
     # app.state.model.* resolves the per-test DB (#1578). With the
     # _current_db ContextVar gone, app.state.db is the single owner.

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -18,6 +18,7 @@ from klangk import (
     auth as auth_mod,
     files as files_mod,
     model,
+    nix as nix_mod,
     podman,
     terminal as terminal_mod,
     workspaces as ws_mod,
@@ -84,6 +85,8 @@ async def app(db, temp_data_dir):
     # #1365: create/update workspace validation reaches the netfilter
     # hooks-dir resolver.
     app.state.netfilter = netfilter_mod.NetFilter(app)
+    # #2201: Workspaces.delete_workspace reaches state.nix (no-op when disabled).
+    app.state.nix = nix_mod.Nix(app)
 
     app.state.auth = auth_mod.Auth(app)
     app.state.terminal = terminal_mod.Terminal(app)

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -14,6 +14,7 @@ from klangk import (
     auth as auth_mod,
     container,
     files as files_mod,
+    nix as nix_mod,
     podman,
     ssl_trust,
     util as util_mod,
@@ -61,6 +62,8 @@ def _make_app_state(registry=None, sockets=None):
     from klangk import netfilter as netfilter_mod
 
     app_state.state.netfilter = netfilter_mod.NetFilter(app_state)
+    # #2201: container start reaches app_state.state.nix for the /nix bind.
+    app_state.state.nix = nix_mod.Nix(app_state)
 
     app_state.state.auth = auth_mod.Auth(app_state)
     # #1572: ContainerRegistry reaches app_state.state.model.ports; Auth reaches
@@ -3870,3 +3873,27 @@ class TestRegistrySettingsDerived:
         reg.set_idle_timeout(120)
         assert reg.idle_timeout_seconds == 120
         assert reg.check_interval_seconds == max(10, min(60, 120 // 3))
+
+
+# --- nix /nix bind (#2201) --------------------------------------------------
+
+
+async def test_nix_binds_empty_when_disabled():
+    """No /nix bind when nix is disabled (the default)."""
+    app_state = _make_app_state()
+    binds = await app_state.state.container_registry._nix_binds("ws1")
+    assert binds == []
+
+
+async def test_nix_binds_mounts_clone_when_enabled():
+    """When nix is enabled, the clone's /nix + nix.conf are bind-mounted."""
+    app_state = _make_app_state()
+    app_state.state.nix.ensure_workspace_nix = AsyncMock(
+        return_value="/mnt/nix-ws1"
+    )
+    binds = await app_state.state.container_registry._nix_binds("ws1")
+    assert binds == [
+        "/mnt/nix-ws1/nix:/nix",
+        "/mnt/nix-ws1/nix.conf:/etc/nix/nix.conf:ro",
+    ]
+    app_state.state.nix.ensure_workspace_nix.assert_awaited_once_with("ws1")

--- a/src/klangk/klangkd-tests/tests/test_nix.py
+++ b/src/klangk/klangkd-tests/tests/test_nix.py
@@ -1,0 +1,194 @@
+"""Unit tests for ``klangk.nix`` — the per-workspace zfs-clone lifecycle (#2201).
+
+The zfs subprocess calls are faked (no real zfs/pool needed); these cover the
+gating, clone/destroy idempotency, and error paths.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from klangk import nix
+from klangk.nix import Nix, NixError
+
+from _helpers import make_settings
+
+
+class _Proc:
+    def __init__(self, rc, out=b"", err=b""):
+        self.returncode = rc
+        self._out = out
+        self._err = err
+
+    async def communicate(self):
+        return self._out, self._err
+
+
+def _app(nix_enabled="", nix_zfs_dataset=None):
+    env = {}
+    if nix_enabled:
+        env["KLANGKD_NIX_ENABLED"] = nix_enabled
+    if nix_zfs_dataset:
+        env["KLANGKD_NIX_ZFS_DATASET"] = nix_zfs_dataset
+    settings = make_settings(env=env)
+    return SimpleNamespace(state=SimpleNamespace(settings=settings))
+
+
+def _patch_zfs(monkeypatch, resolver):
+    """Patch ``asyncio.create_subprocess_exec``; resolver(args) -> (rc, out, err).
+
+    *args* excludes the leading ``zfs``. Returns the recorded call list.
+    """
+
+    calls = []
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(args)
+        rc, out, err = resolver(args[1:])
+        return _Proc(rc, out, err)
+
+    monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", fake_exec)
+    return calls
+
+
+# --- gating -----------------------------------------------------------------
+
+
+async def test_disabled_when_flag_unset(monkeypatch):
+    calls = _patch_zfs(monkeypatch, lambda a: (1, b"", b""))
+    n = Nix(_app())
+    assert n.enabled is False
+    assert await n.ensure_workspace_nix("ws1") is None
+    await n.destroy_workspace_nix("ws1")  # no-op
+    assert calls == []
+
+
+async def test_disabled_when_dataset_missing(monkeypatch):
+    _patch_zfs(monkeypatch, lambda a: (1, b"", b""))
+    n = Nix(_app(nix_enabled="true"))
+    assert n.enabled is False
+    assert await n.ensure_workspace_nix("ws1") is None
+
+
+# --- ensure_workspace_nix ---------------------------------------------------
+
+
+def _resolver(seed_snap_exists, ws_exists, mountpoint="/tank/nix/ws-ws1"):
+    def resolve(args):
+        if args[0] == "list":
+            field, target = args[3], args[4]
+            if field == "name":
+                if target.endswith("@base"):
+                    return (0 if seed_snap_exists else 1, b"", b"nope")
+                # ws dataset existence probe
+                return (0 if ws_exists else 1, b"", b"does not exist")
+            if field == "mountpoint":
+                return 0, mountpoint.encode() + b"\n", b""
+        if args[0] == "clone":
+            return 0, b"", b""
+        return 0, b"", b""
+
+    return resolve
+
+
+async def test_ensure_clones_when_missing(monkeypatch):
+    calls = _patch_zfs(
+        monkeypatch, _resolver(seed_snap_exists=True, ws_exists=False)
+    )
+    n = Nix(_app("true", "tank/nix"))
+    assert n.enabled is True
+    mp = await n.ensure_workspace_nix("ws1")
+    assert mp == "/tank/nix/ws-ws1"
+    assert any(c[1:][0] == "clone" for c in calls)
+
+
+async def test_ensure_reuses_existing_clone(monkeypatch):
+    calls = _patch_zfs(
+        monkeypatch, _resolver(seed_snap_exists=True, ws_exists=True)
+    )
+    n = Nix(_app("true", "tank/nix"))
+    mp = await n.ensure_workspace_nix("ws1")
+    assert mp == "/tank/nix/ws-ws1"
+    assert not any(c[1:][0] == "clone" for c in calls)  # no clone call
+
+
+async def test_ensure_raises_when_seed_snapshot_missing(monkeypatch):
+    _patch_zfs(monkeypatch, _resolver(seed_snap_exists=False, ws_exists=False))
+    n = Nix(_app("true", "tank/nix"))
+    with pytest.raises(NixError, match="seed snapshot"):
+        await n.ensure_workspace_nix("ws1")
+
+
+async def test_ensure_raises_when_mountpoint_none(monkeypatch):
+    _patch_zfs(
+        monkeypatch,
+        _resolver(seed_snap_exists=True, ws_exists=True, mountpoint="none"),
+    )
+    n = Nix(_app("true", "tank/nix"))
+    with pytest.raises(NixError, match="mountpoint"):
+        await n.ensure_workspace_nix("ws1")
+
+
+async def test_ensure_raises_when_clone_fails(monkeypatch):
+    def resolve(args):
+        if args[0] == "list":
+            if args[4].endswith("@base"):
+                return 0, b"", b""
+            return 1, b"", b"does not exist"  # ws missing
+        if args[0] == "clone":
+            return 1, b"", b"permission denied"
+        return 0, b"", b""
+
+    _patch_zfs(monkeypatch, resolve)
+    n = Nix(_app("true", "tank/nix"))
+    with pytest.raises(NixError, match="permission denied"):
+        await n.ensure_workspace_nix("ws1")
+
+
+# --- destroy_workspace_nix --------------------------------------------------
+
+
+def _destroy_resolver(ws_dataset, destroy_rc=0, destroy_err=b""):
+    def resolve(args):
+        if args[0] == "destroy":
+            assert args[2] == ws_dataset
+            return destroy_rc, b"", destroy_err
+        return 0, b"", b""
+
+    return resolve
+
+
+async def test_destroy_succeeds(monkeypatch):
+    calls = _patch_zfs(
+        monkeypatch, _destroy_resolver("tank/nix/ws-ws1", destroy_rc=0)
+    )
+    n = Nix(_app("true", "tank/nix"))
+    await n.destroy_workspace_nix("ws1")
+    assert any(c[1:][0] == "destroy" for c in calls)
+
+
+async def test_destroy_ignores_missing(monkeypatch):
+    calls = _patch_zfs(
+        monkeypatch,
+        _destroy_resolver(
+            "tank/nix/ws-ws1",
+            destroy_rc=1,
+            destroy_err=b"dataset does not exist",
+        ),
+    )
+    n = Nix(_app("true", "tank/nix"))
+    await n.destroy_workspace_nix("ws1")  # no warning, no raise
+    assert any(c[1:][0] == "destroy" for c in calls)
+
+
+async def test_destroy_warns_on_other_error(monkeypatch, caplog):
+    _patch_zfs(
+        monkeypatch,
+        _destroy_resolver(
+            "tank/nix/ws-ws1", destroy_rc=1, destroy_err=b"busy"
+        ),
+    )
+    n = Nix(_app("true", "tank/nix"))
+    with caplog.at_level("WARNING", logger="klangk.nix"):
+        await n.destroy_workspace_nix("ws1")
+    assert any("zfs destroy" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Implements **#2201** (host-side mount for per-workspace `/nix`), stacked on **#2206** (the seed, #2200). Part of the nix workspace feature (#2198). Closes #2201.

When `nix_enabled` + `nix_zfs_dataset` are set, each workspace gets a writable, isolated `/nix` as a **zfs clone** of a shared, snapshotted seed dataset. klangkd clones the seed on first start, reuses the clone across restarts, destroys it on delete; the clone's `/nix` + `nix.conf` are bind-mounted into the container (plain bind, no extra caps). Off by default — non-nix workspaces are untouched.

**Note: this deviates from the #2201 issue body**, which described an overlayfs mount. The #2201 spike (PR #2205) found rootless podman rejects `--mount type=overlay` and in-container overlay needs single-bind + `--cap-add SYS_ADMIN`; a zfs clone is instant, block-shared, plain-bind, fully isolated, and sidesteps the nix-DB copy-up gotcha. It meets the same acceptance criteria (rw `/nix`, per-workspace isolation, restart persistence, non-nix unaffected).

## What's here

- **`klangk/nix.py`** — `Nix` state object: the per-workspace zfs-clone lifecycle (`ensure_workspace_nix` / `destroy_workspace_nix`), shelling out to `zfs` via asyncio. Registered as `app.state.nix` in `build_app`.
- **`container.py`** — `_nix_binds()` adds the `/nix` + `/etc/nix/nix.conf` binds when nix is enabled.
- **`workspaces.py`** — `delete_workspace` destroys the clone.
- **settings** — `nix_enabled`, `nix_zfs_dataset`.
- **`scripts/load-nix-seed-zfs.sh`** — operator setup: load #2200's seed tree into a dataset and snapshot `@base`.
- **`docs/features/nix.md`** (enable / setup / persistence) + changelog.

## Verification

- `Nix` module unit-tested (`test_nix.py`, 100% of `nix.py`): gating, clone/reuse idempotency, destroy (success / missing / other-error), all error paths.
- Full suite green: **4174 passed, 100% coverage** (incl. the new container/workspaces nix branches via `test_nix_binds_*`).
- Module exercised against **real zfs** with delegated perms (`zfs allow chrism create,clone,destroy,mount d/...`): clone → mountpoint, reuse (no re-clone), destroy, idempotent re-destroy. (The seed→clone→bind→`nix` path was validated end-to-end in the #2201 spike.)

## Operation

Runtime needs a one-time delegation (no full root): `sudo zfs allow <klangkd-user> create,clone,destroy,mount <dataset>`. Requires a zfs pool; a btrfs-snapshot variant is future work for non-zfs hosts.

## Follow-ups

- **#2202** — per-workspace feature flag + UI selection (this PR is all-or-none per deploy; the global setting gates it).
- **#2203** — end-to-end `devenv shell` / `devenv up` validation once #2202 lands.

Stacked on #2206 (base branch `issue-2200-feat`); re-target to `main` when #2206 merges.
