### PR TITLE
fix(launcher): detect cross-deploy port collisions at startup

### DIFF
--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -36,6 +36,7 @@ import logging
 import os
 import platform
 import shutil
+import socket
 import subprocess
 import sys
 from pathlib import Path
@@ -201,6 +202,24 @@ def _mark_refusal_reported(marker: Path, winner_pid: int) -> None:
         pass
 
 
+def _check_port_preflight(host: str, port: int) -> bool:
+    """Return True if *host*:*port* already has a listener.
+
+    A connect-probe catches cross-deploy collisions that the PID-file
+    check cannot see (different ``state_dir`` → different instance-id →
+    separate PID files, so neither klangkd knows about the other).
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    try:
+        sock.connect((host, port))
+        return True
+    except (ConnectionRefusedError, OSError):
+        return False
+    finally:
+        sock.close()
+
+
 def _prepend_gnubin_paths() -> None:  # pragma: no cover
     """On macOS, prepend Homebrew gnubin dirs to ``PATH`` (#1947).
 
@@ -308,6 +327,34 @@ def main(  # pragma: no cover
             if marker is not None:
                 _mark_refusal_reported(marker, existing)
         sys.exit(1)
+
+    # Port-probe check: catch cross-deploy collisions the PID-file
+    # guard misses (#2211). Two klangkd instances from different
+    # checkouts (different $DEVENV_STATE → different state_dir →
+    # separate instance-id / PID files) never see each other's PID
+    # file. But they share the same TCP ports (browser + egress)
+    # through Caddy — probe those before starting. The proxy hasn't
+    # started yet, so a live listener on our configured port means
+    # another klangkd (or its proxy) already owns it.
+    for port_str, label in (
+        (settings.port, "browser"),
+        (settings.egress_port, "egress"),
+    ):
+        if port_str is None:
+            continue
+        port_int = int(port_str)
+        listen_host = (
+            settings.listen if label == "browser" else settings.egress_listen
+        )
+        if _check_port_preflight(listen_host, port_int):
+            logger.error(
+                "Another process is already listening on %s:%d (%s port) "
+                "— refusing to start. Is another klangkd running?",
+                listen_host,
+                port_int,
+                label,
+            )
+            sys.exit(1)
 
     # Bind the UDS. A stale socket from a kill -9'd process makes the
     # bind fail with EADDRINUSE — unlink first (the pidfile guard in the

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1915,6 +1915,44 @@ class TestCheckPidPreflight:
         assert _check_pid_preflight(settings) is None
 
 
+class TestCheckPortPreflight:
+    """Tests for launcher._check_port_preflight (#2211)."""
+
+    def test_no_listener_returns_false(self):
+        from klangk.launcher import _check_port_preflight
+
+        # Pick a high port unlikely to be in use.
+        assert _check_port_preflight("127.0.0.1", 59123) is False
+
+    def test_live_listener_returns_true(self):
+        import socket as _socket
+
+        from klangk.launcher import _check_port_preflight
+
+        srv = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        srv.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        try:
+            assert _check_port_preflight("127.0.0.1", port) is True
+        finally:
+            srv.close()
+
+    def test_connection_refused_returns_false(self):
+        import socket as _socket
+
+        from klangk.launcher import _check_port_preflight
+
+        # Bind then close — port is free but was recently used.
+        srv = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        srv.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        port = srv.getsockname()[1]
+        srv.close()
+        assert _check_port_preflight("127.0.0.1", port) is False
+
+
 class TestLauncherPidPreflightGracefulExit:
     """The launcher's ``main()`` must log and ``sys.exit(1)`` — not crash with
     ``ImportError`` — when a second instance collides with a running one (#1993).


### PR DESCRIPTION
## Summary

- The existing PID-file guard is scoped per `instance-id` (in `data_dir`), so two klangkd instances from different checkouts (different `$DEVENV_STATE` → different `state_dir`) never see each other's PID file
- Add a TCP connect-probe preflight check on the configured browser and egress ports before starting — a live listener causes the launcher to refuse with a clear error
- The port probe runs after the PID check but before binding the UDS or starting Caddy

Closes #2211

## Test plan

- [x] Unit tests for `_check_port_preflight` (no listener, live listener, connection refused)
- [x] Full backend suite passes (4165 tests)