### PR TITLE
test(cli-e2e): poll for workspace in test_create_workspace_via_tui (#2214)

### DIFF
--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -407,38 +407,41 @@ class TestTuiE2E:
                 await pilot.pause()
                 await pilot.pause()
 
-                # Wait for the async create to complete.
-                for _ in range(10):
-                    await pilot.pause()
-
-                # After creation the TUI may navigate to the detail screen
-                # or show a confirm dialog. Handle both.
+                # Give the async create a moment to dispatch, then dismiss
+                # any confirm dialog that may block navigation.
+                await pilot.pause()
+                await pilot.pause()
                 if isinstance(app.screen, ConfirmScreen):
                     app.screen.dismiss(True)
-                    for _ in range(5):
-                        await pilot.pause()
+                    await pilot.pause()
 
-                # Workspace was created — verify via API.
-                r = httpx.get(
-                    f"{base_url}/api/v1/workspaces",
-                    headers={"Authorization": f"Bearer {token}"},
-                    timeout=30,
-                )
-                r.raise_for_status()
-                ws_names = [w["name"] for w in r.json()]
-                assert ws_name in ws_names
-
-                # Find the workspace ID for cleanup.
-                r = httpx.get(
-                    f"{base_url}/api/v1/workspaces",
-                    headers={"Authorization": f"Bearer {token}"},
-                    timeout=30,
-                )
-                r.raise_for_status()
-                for w in r.json():
-                    if w["name"] == ws_name:
-                        ws_id = w["id"]
+                # Workspace creation is async; poll the API until the workspace
+                # appears rather than guessing a fixed wait window (CI runners
+                # vary in load). The poll also captures the workspace id for
+                # cleanup, replacing the separate follow-up GET.
+                deadline = time.monotonic() + 30.0
+                last_names: list[str] = []
+                while True:
+                    await pilot.pause()
+                    r = httpx.get(
+                        f"{base_url}/api/v1/workspaces",
+                        headers={"Authorization": f"Bearer {token}"},
+                        timeout=30,
+                    )
+                    r.raise_for_status()
+                    for w in r.json():
+                        if w["name"] == ws_name:
+                            ws_id = w["id"]
+                            break
+                    if ws_id is not None:
                         break
+                    if time.monotonic() >= deadline:
+                        raise AssertionError(
+                            f"workspace {ws_name!r} not created within 30s; "
+                            f"current workspaces: {last_names!r}"
+                        )
+                    last_names = [w["name"] for w in r.json()]
+                    await asyncio.sleep(0.25)
         finally:
             if ws_id:
                 _api_delete_workspace(base_url, token, ws_id)


### PR DESCRIPTION
## Summary

Harden the flaky `test_create_workspace_via_tui` CLI e2e test (#2214).

The test submitted the create form, waited a fixed `for _ in range(10): await pilot.pause()`, then issued a single `httpx.get(/api/v1/workspaces)` and asserted the new workspace was present. Under CI load the async create didn't finish inside the fixed window, so the list came back empty: `AssertionError: assert 'tui-create-55399' in []` (flaked on #2204's `test-cli-e2e`; rerun passed).

## Fix

Replace the fixed wait + single GET with a **bounded poll** (30s deadline, 0.25s interval) that waits for the workspace to actually appear, capturing its id in the same pass (dropping the redundant follow-up GET). On timeout it fails with the current workspace list in the message for diagnosis.

## Verification

- `test-cli-e2e -k test_create_workspace_via_tui` — **4 consecutive passes** (14–26s each); previously intermittent.
- `ruff` + `py_compile` clean. Test-only change (no production code touched), so the unit suites are unaffected.

Closes #2214.
