### PR TITLE
feat(nix): per-workspace /nix via fuse-overlayfs + the nix_seed config block (#2219)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -46,7 +46,7 @@ in
     with pkgs;
     [
       bash # explicit bash for shell scripts (CI /bin/sh may be dash)
-      coreutils # GNU du (macOS BSD du lacks -b)
+      coreutils # GNU du -b + stat -f -c %T (macOS BSD lacks both)
       docker-client
       expect
       flutter
@@ -70,6 +70,7 @@ in
           su
           util-linux
           matchbox # kiosk WM for the demo video recorder (record-demo.sh)
+          fuse-overlayfs # rootless per-workspace /nix via the plain-dir seed backend (#2219)
         ]
     );
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,20 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`nix_seed` — per-workspace `/nix` with two backends (#2219, #2220).** The
+  per-workspace `/nix` config is now one block — `nix_seed: {type, path}` —
+  selecting a backend: `btrfs-snapshot` (a CoW snapshot of a seed btrfs
+  subvolume) or `fuse-overlayfs` (the default; a `fuse-overlayfs` overlay of a
+  plain-directory seed — works on any filesystem, no privileged helper; needs
+  `fuse-overlayfs` + `fusermount3` + `/dev/fuse`). Omit `nix_seed` to disable
+  (nix is image-only). The fuse backend suits a bare-metal Linux host; it does
+  not work where podman is nested (host-container, macOS — see #2221). See
+  `docs/features/nix.md`.
+- **`klangkd doctor` verifies GNU `stat` (#2220).** The nix btrfs-snapshot
+  backend validates the seed is on btrfs via `stat -f -c %T`; doctor now checks
+  GNU coreutils `stat` is on PATH (Linux) so a missing or BSD `stat` surfaces at
+  pre-flight. `coreutils` (which provides `stat`) is explicit in `devenv.nix`.
+
 - **Shared base `/nix` store seed (`scripts/build-nix-seed.sh`) (#2200).**
   A reproducible build step that produces a self-consistent `/nix` tree (the
   store, the nix DB, and a base profile with nix and devenv) and an
@@ -39,8 +53,9 @@ operators or integrators to act when upgrading.
   deployed alongside klangk as a host-side tree rather than baked into a
   workspace image. Run via `devenv shell -- build-nix-seed`. Consumed by #2201.
 
-- **Per-workspace `/nix` via btrfs snapshots (#2201, #2202, #2208).** When
-  `nix_btrfs_subvolume` names a seed btrfs subvolume, a workspace with the
+- **Per-workspace `/nix` via btrfs snapshots (#2201, #2202, #2208).** With
+  `nix_seed.type: btrfs-snapshot` and a seed btrfs subvolume at `nix_seed.path`,
+  a workspace with the
   per-workspace `nix` setting enabled gets a writable, isolated `/nix` as a
   btrfs snapshot of the seed: snapshotted on first start, reused across
   restarts, deleted on workspace delete; the snapshot's `/nix` and `nix.conf`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -67,8 +67,8 @@ operators or integrators to act when upgrading.
 - **Per-workspace nix feature flag (#2202).** A workspace `nix` setting
   (boolean) gates the per-workspace `/nix` mount, settable at create time via a
   "Nix" checkbox in the create-workspace dialog (shown only when the server
-  has `nix_btrfs_subvolume` configured) or via the API. Workspaces without it
-  are unaffected; with no `nix_btrfs_subvolume`, nix is image-only.
+  has `nix_seed` configured) or via the API. Workspaces without it are
+  unaffected; with no `nix_seed`, nix is image-only.
 
 - **Shared terminals in the TUI (#2164).** The workspace detail screen
   now lists shared terminals visible to you (other users' shared windows

--- a/docs/features/nix.md
+++ b/docs/features/nix.md
@@ -26,7 +26,7 @@ devenv shell -- build-nix-seed [out-dir]
 `scripts/build-nix-seed.sh` builds a throwaway sandbox image that performs a
 single-user nix install + devenv, then extracts `/nix` and `/etc/nix/nix.conf`
 into a deployable tree at `out-dir` (default `./nix-base`, or
-`$KLANGKD_NIX_SEED_DIR`). Output layout:
+`$KLANGK_NIX_SEED_OUT`). Output layout:
 
 ```text
 <out>/

--- a/docs/features/nix.md
+++ b/docs/features/nix.md
@@ -71,52 +71,100 @@ See [#2198](https://github.com/mcdonc/klangk/issues/2198) (Design section) for t
 investigation that compared overlay / hardlinks / zfs / btrfs and settled on
 btrfs.
 
-## How workspaces consume it (#2201, #2208)
+## How workspaces consume it (#2201, #2208, #2219, #2220)
 
-Each nix-enabled workspace gets a writable, isolated `/nix` as a **btrfs
-snapshot** of the seed subvolume — instant, copy-on-write (only the
-workspace's changes consume space), and fully isolated. klangkd snapshots the
-seed on first start, reuses the snapshot across restarts, and deletes it on
-workspace delete. The snapshot's `/nix` and `nix.conf` are bind-mounted into
-the container.
+Each nix-enabled workspace gets a writable, isolated `/nix` derived from the
+shared seed. klangkd provisions it on first start, reuses it across restarts,
+and deletes it on workspace delete; the `/nix` and `nix.conf` are bind-mounted
+into the container. Configure it with one block — `nix_seed` — grouping the
+seed path and the backend that consumes it:
 
-A btrfs snapshot is reachable through the parent mount (no separate mount),
-and btrfs lets a non-root user snapshot a subvolume it can write to — so this
-needs **no privileged helper**. That's the deciding advantage over zfs, whose
+```yaml
+nix_seed:
+  type: btrfs-snapshot # or fuse-overlayfs (the default)
+  path: /path/to/seed
+```
+
+Omit `nix_seed` entirely (or leave `path` unset) to disable the feature — nix
+is then image-only (pick the nix image `klangk-workspace-nix` for its baked
+`/nix`). The two backends:
+
+- **`btrfs-snapshot`** — the seed is a btrfs subvolume; each workspace gets a
+  CoW snapshot (instant, only the workspace's changes consume space). A
+  snapshot is reachable through the parent mount and btrfs lets a non-root
+  user snapshot a subvolume it can write to, so this needs **no privileged
+  helper**. Requires a btrfs filesystem mounted with `user_subvol_rm_allowed`.
+  The CoW-optimised choice where btrfs is available.
+- **`fuse-overlayfs`** (the default) — the seed is a plain directory (the
+  `build-nix-seed` output, on any filesystem); each workspace gets a
+  `fuse-overlayfs` overlay with the seed as the read-only lower layer and a
+  per-workspace upper layer that captures writes (new store paths, profile/db
+  updates). Also **no privileged helper** — needs `fuse-overlayfs` +
+  `fusermount3` + `/dev/fuse`.
+
+Both need no privileged helper — that's the deciding advantage over zfs, whose
 non-root mount is impossible on Linux ([openzfs/zfs#10648](https://github.com/openzfs/zfs/discussions/10648))
 and would force a `cap_sys_admin` helper (#2210). (The #2201 spike, PR #2205,
-compared the options; #2210 is closed as not-needed for the btrfs path.)
+compared the options; #2210 is closed as not-needed.)
+
+> **Where the fuse backend works.** `fuse-overlayfs` suits a bare-metal Linux
+> host (podman runs on the host — no userns nesting between klangkd's FUSE
+> mount and the workspace container). It does **not** work where podman is
+> nested — the rootless runtime can't bind a process-owned FUSE mount into a
+> workspace container's userns (host-container and macOS deployments; see
+> #2221). Use `btrfs-snapshot` there if you have btrfs, otherwise the nix
+> image.
 
 ### Enable it
 
-1. Build the seed (#2200) and load it into a btrfs subvolume:
+1. Build the seed (#2200):
 
    ```sh
    devenv shell -- build-nix-seed /tmp/nix-base
-   scripts/load-nix-seed-btrfs.sh /tmp/nix-base /steam2/btrfs/klangk-nix
    ```
 
-   `/steam2/btrfs` must be a btrfs filesystem **mounted with
-   `user_subvol_rm_allowed`** and writable by the klangkd user (so the same
-   non-root user can snapshot _and_ delete). On NixOS, set
-   `fileSystems."/steam2/btrfs".options = [ "user_subvol_rm_allowed" ];`.
+2. Pick a backend, prepare the seed for it, and set `nix_seed` (in
+   `klangkd.yaml`, or env `KLANGKD_NIX_SEED__TYPE` / `KLANGKD_NIX_SEED__PATH`):
+   - **`btrfs-snapshot`** — load the seed into a subvolume:
 
-2. Point klangkd at the seed subvolume (in `klangkd.yaml` or env):
+     ```sh
+     scripts/load-nix-seed-btrfs.sh /tmp/nix-base /steam2/btrfs/klangk-nix
+     ```
 
-   ```yaml
-   nix_btrfs_subvolume: /steam2/btrfs/klangk-nix/seed
-   ```
+     `/steam2/btrfs` must be a btrfs filesystem **mounted with
+     `user_subvol_rm_allowed`** and writable by the klangkd user (so the same
+     non-root user can snapshot _and_ delete). On NixOS:
+     `fileSystems."/steam2/btrfs".options = [ "user_subvol_rm_allowed" ];`.
 
-   This advertises nix availability (the create-workspace dialog shows a
-   "Nix" checkbox). It does **not** force any image — image selection stays
-   the user's.
+     ```yaml
+     nix_seed:
+       type: btrfs-snapshot
+       path: /steam2/btrfs/klangk-nix/seed
+     ```
+
+   - **`fuse-overlayfs`** (no btrfs) — use the seed directory directly (no
+     loader step):
+
+     ```yaml
+     nix_seed:
+       path: /var/lib/klangk/nix-base # type defaults to fuse-overlayfs
+     ```
+
+     The host needs `fuse-overlayfs`, `fusermount3`, and a writable
+     `/dev/fuse` (on NixOS, `fuse-overlayfs` is in the dev shell; `fusermount3`
+     ships as a setuid wrapper; `/dev/fuse` is world-rw by default). Per-workspace
+     overlays land as siblings of the seed dir (`<seed parent>/ws-<id>`).
+
+   Either backend advertises nix availability (the create-workspace dialog
+   shows a "Nix" checkbox). It does **not** force any image — image selection
+   stays the user's. A `btrfs-snapshot` seed whose path isn't on a btrfs
+   filesystem fails fast at startup with a clear error.
 
 3. Per workspace, tick **Nix** when creating it (or set `nix: true` in its
-   settings via the API). That workspace then gets a `/nix` snapshot on start.
+   settings via the API). That workspace then gets a `/nix` on start.
 
-Workspaces without the `nix` setting are untouched. Without
-`nix_btrfs_subvolume`, the checkbox is hidden and nix is image-only: pick the
-nix image (`klangk-workspace-nix`) for its baked `/nix` (the non-btrfs fallback).
+Workspaces without the `nix` setting are untouched. With `nix_seed` unset, the
+checkbox is hidden and nix is image-only.
 
 nix/devenv are on `$PATH` by default: klangkd sets `KLANGKWS_NIX=1`, and the
 default workspace image's `/etc/profile.d/z-klangk-nix.sh` (baked in #2199)
@@ -125,9 +173,17 @@ image with no manual step. (The flag is orthogonal to image selection.)
 
 ### Restart persistence
 
-The snapshot is a btrfs subvolume, so it survives container stop/start —
-packages a user installs persist across restarts. Deleting the workspace (not
-just stopping it) deletes the snapshot. Updating the seed (re-run
-`build-nix-seed` + `load-nix-seed-btrfs.sh`) does not affect existing
-snapshots — btrfs snapshots are independent CoW copies, so they keep their
-data; new workspaces get the new seed.
+The per-workspace `/nix` survives container stop/start — packages a user
+installs persist across restarts. Deleting the workspace (not just stopping
+it) tears it down (btrfs subvolume delete, or `fusermount3 -u` + remove the
+overlay). Updating the seed does not affect existing per-workspace `/nix` —
+btrfs snapshots are independent CoW copies, and fuse-overlayfs uppers carry
+their own copy-up of anything changed — so they keep their data; new
+workspaces get the new seed.
+
+One difference across backends on a **klangkd restart**: a btrfs snapshot is
+just a directory reachable through the parent mount, so it is still there;
+a fuse-overlayfs mount is a FUSE handle owned by the klangkd process, so it
+does not survive the process — klangkd re-mounts it on the workspace's next
+start (the upper dir + installed packages persist, only the mount is
+re-created).

--- a/docs/features/nix.md
+++ b/docs/features/nix.md
@@ -26,7 +26,7 @@ devenv shell -- build-nix-seed [out-dir]
 `scripts/build-nix-seed.sh` builds a throwaway sandbox image that performs a
 single-user nix install + devenv, then extracts `/nix` and `/etc/nix/nix.conf`
 into a deployable tree at `out-dir` (default `./nix-base`, or
-`$KLANGK_NIX_SEED_OUT`). Output layout:
+`$KLANGKBUILD_NIX_SEED_DIR`). Output layout:
 
 ```text
 <out>/

--- a/scripts/build-nix-seed.sh
+++ b/scripts/build-nix-seed.sh
@@ -4,7 +4,7 @@
 # or loaded into a zfs dataset for per-workspace cloning.
 #
 # Output layout at $OUT (default ./nix-base, overridable via $1 or
-# $KLANGK_NIX_SEED_OUT):
+# $KLANGKBUILD_NIX_SEED_DIR):
 #   $OUT/nix/        store + var/db + the base profile (nix, devenv, cachix)
 #   $OUT/nix.conf    flakes/nix-command + pre-configured binary caches
 #
@@ -20,7 +20,7 @@ PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
 source "$SCRIPT_DIR/_podman_common.sh"
 
 IMAGE="klangk-nix-seed:latest"
-OUT="${1:-${KLANGK_NIX_SEED_OUT:-$PWD/nix-base}}"
+OUT="${1:-${KLANGKBUILD_NIX_SEED_DIR:-$PWD/nix-base}}"
 shift # remaining args (e.g. --no-cache) pass through to podman build
 
 echo "==> Building nix-seed sandbox image"

--- a/scripts/build-nix-seed.sh
+++ b/scripts/build-nix-seed.sh
@@ -4,7 +4,7 @@
 # or loaded into a zfs dataset for per-workspace cloning.
 #
 # Output layout at $OUT (default ./nix-base, overridable via $1 or
-# $KLANGKD_NIX_SEED_DIR):
+# $KLANGK_NIX_SEED_OUT):
 #   $OUT/nix/        store + var/db + the base profile (nix, devenv, cachix)
 #   $OUT/nix.conf    flakes/nix-command + pre-configured binary caches
 #
@@ -20,7 +20,7 @@ PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
 source "$SCRIPT_DIR/_podman_common.sh"
 
 IMAGE="klangk-nix-seed:latest"
-OUT="${1:-${KLANGKD_NIX_SEED_DIR:-$PWD/nix-base}}"
+OUT="${1:-${KLANGK_NIX_SEED_OUT:-$PWD/nix-base}}"
 shift # remaining args (e.g. --no-cache) pass through to podman build
 
 echo "==> Building nix-seed sandbox image"

--- a/scripts/load-nix-seed-btrfs.sh
+++ b/scripts/load-nix-seed-btrfs.sh
@@ -43,4 +43,7 @@ echo "==> Populating from $SEED_TREE"
 chmod -R u+w "$SEED_TREE" 2>/dev/null || true
 cp -a "$SEED_TREE/nix" "$SEED_TREE/nix.conf" "$SEED"/
 
-echo "==> Done. Set: nix_btrfs_subvolume: $SEED"
+echo "==> Done. Set in klangkd.yaml:"
+echo "  nix_seed:"
+echo "    type: btrfs-snapshot"
+echo "    path: $SEED"

--- a/scripts/load-nix-seed-btrfs.sh
+++ b/scripts/load-nix-seed-btrfs.sh
@@ -7,7 +7,7 @@
 #   <btrfs-parent>  a directory on a btrfs filesystem mounted with
 #                   `user_subvol_rm_allowed`, writable by the caller, e.g.
 #                   /steam2/btrfs/klangk-nix. The seed subvolume lands at
-#                   <btrfs-parent>/seed; set KLANGKD_NIX_BTRFS_SUBVOLUME to it.
+#                   <btrfs-parent>/seed; set nix_seed to it (type: btrfs-snapshot, path: <btrfs-parent>/seed).
 #
 # No root needed — btrfs lets a user create/snapshot subvolumes it can write to,
 # and `user_subvol_rm_allowed` lets it delete them. (Contrast zfs: non-root mount

--- a/src/klangk/klangk/api/images.py
+++ b/src/klangk/klangk/api/images.py
@@ -29,9 +29,10 @@ async def list_images(
         "default": app.state.container_registry.image_name,
         "allowed": sorted(app.state.container_registry.allowed_images),
         # #2202: whether the per-workspace nix flag can trigger the per-workspace
-        # /nix mount. The create UI shows the "nix" toggle only when true; the
-        # flag is inert otherwise (workspaces use the nix image's baked /nix).
-        "nix_available": app.state.nix.btrfs_configured,
+        # /nix mount. The create UI shows the "nix" toggle only when a backend
+        # is configured (btrfs snapshot or fuse-overlayfs, #2219); the flag is
+        # inert otherwise (workspaces use the nix image's baked /nix).
+        "nix_available": app.state.nix.configured,
     }
 
 

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1365,10 +1365,10 @@ class ContainerRegistry:
         """Bind specs + env for the workspace's per-workspace /nix (#2201), or ([], []).
 
         Only when the workspace has its per-workspace ``nix`` setting enabled
-        (#2202) AND a nix backend is configured (``nix_btrfs_subvolume``) does
-        ensure_workspace_nix snapshot the seed and return a mountpoint; the
-        snapshot's /nix + nix.conf
-        are bind-mounted into the container, and KLANGKWS_NIX=1 is set so the
+        (#2202) AND a nix backend is configured (``nix_seed``, #2219/#2220) does
+        ensure_workspace_nix provision the per-workspace
+        /nix and return a mountpoint; the mountpoint's /nix + nix.conf are
+        bind-mounted into the container, and KLANGKWS_NIX=1 is set so the
         baked /etc/profile.d activation (see src/containers/workspace/Dockerfile)
         puts nix on PATH by default. Image selection is untouched.
 

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -148,6 +148,8 @@ _PACKAGE_HINTS: dict[str, dict[str, str]] = {
         "dnf": "coreutils",
         "apt": "coreutils",
         "brew": "coreutils",
+        "zypper": "coreutils",
+        "pacman": "coreutils",
     },
     # Rootless podman prereqs
     "newuidmap": {

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -144,6 +144,11 @@ _PACKAGE_HINTS: dict[str, dict[str, str]] = {
         "apt": "coreutils",
         "brew": "coreutils",
     },
+    "stat": {
+        "dnf": "coreutils",
+        "apt": "coreutils",
+        "brew": "coreutils",
+    },
     # Rootless podman prereqs
     "newuidmap": {
         "dnf": "shadow-utils",
@@ -269,6 +274,35 @@ def check_gnu_du(manager: str | None) -> CheckResult:
             hint=hint,
         )
     return CheckResult(name="du (GNU)", ok=True, message=f"GNU du ok ({path})")
+
+
+def check_gnu_stat(manager: str | None) -> CheckResult:
+    """Check that stat is GNU coreutils (supports ``-f -c %T`` for fstype).
+
+    The nix btrfs-snapshot backend uses ``stat -f -c %T <seed>`` to verify the
+    seed path is on btrfs (``Nix._ensure_btrfs``). GNU coreutils only — BSD
+    ``stat`` parses ``-f`` differently. Linux-only in ``run_doctor`` (the btrfs
+    backend doesn't apply on macOS).
+    """
+    path = shutil.which("stat")
+    if not path:  # pragma: no cover
+        return CheckResult(
+            name="stat (GNU)",
+            ok=False,
+            message="stat not found on PATH",
+            hint=install_hint("stat", manager),
+        )
+    rc, out, _err = _run(["stat", "-f", "-c", "%T", "/"])
+    if rc != 0 or not out.strip():
+        return CheckResult(
+            name="stat (GNU)",
+            ok=False,
+            message="stat does not support -f -c %T (need GNU coreutils)",
+            hint=install_hint("stat", manager),
+        )
+    return CheckResult(
+        name="stat (GNU)", ok=True, message=f"GNU stat ok ({path})"
+    )
 
 
 def check_subuid(user: str) -> CheckResult:
@@ -482,6 +516,10 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
     # GNU tar and GNU du (special: must verify GNU, not just present)
     report.add(check_gnu_tar(manager))
     report.add(check_gnu_du(manager))
+    # GNU stat: only the nix btrfs-snapshot backend needs `stat -f -c %T`
+    # (Linux-only); not required on macOS.
+    if platform.system() != "Darwin":
+        report.add(check_gnu_stat(manager))
 
     # 1b. Optional: ip command for container subnet auto-detection (#2089)
     if platform.system() != "Darwin":

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -886,8 +886,8 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
     app.state.container_registry = container.ContainerRegistry(app)
-    # #2201: per-workspace nix store via btrfs snapshots (off unless
-    # KLANGKD_NIX_BTRFS_SUBVOLUME names a seed subvolume).
+    # #2201: per-workspace nix store via a btrfs snapshot or fuse overlay
+    # (off unless KLANGKD_NIX_SEED__PATH names a seed; see nix.Nix).
     app.state.nix = nix.Nix(app)
     # Slice 2b (#1463): proxy watchdog is an owned CaddyWatchdog instance
     # (Caddy is the sole reverse-proxy engine in 2.X, #1642) with

--- a/src/klangk/klangk/nix.py
+++ b/src/klangk/klangk/nix.py
@@ -56,7 +56,11 @@ def _rmtree_rw(path: str) -> None:
 
     def _onerror(func, p: str, _exc) -> None:
         try:
-            os.chmod(os.path.dirname(p), stat.S_IRWXU)
+            # chmod the failing entry's parent so unlink/rmdir can proceed.
+            # Skip when p is the rmtree root: its parent is the shared seed
+            # parent dir (sibling to every ws-*), which is not ours to chmod.
+            if p != path:
+                os.chmod(os.path.dirname(p), stat.S_IRWXU)
             os.chmod(p, stat.S_IRWXU)
             func(p)
         except OSError as exc:
@@ -125,14 +129,27 @@ class Nix:
     # --- subprocess helper ---------------------------------------------------
 
     async def _run(
-        self, args: list[str], *, check: bool = True
+        self, args: list[str], *, check: bool = True, timeout: float = 30.0
     ) -> tuple[int, str, str]:
-        proc = await asyncio.create_subprocess_exec(
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        out, err = await proc.communicate()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            # Missing fuse-overlayfs / fusermount3 / btrfs / stat — surface a
+            # clear NixError, not a raw FileNotFoundError out of container start.
+            raise NixError(
+                f"{args[0]} not found on PATH — install the nix backend "
+                f"tooling and re-run `klangkd doctor`"
+            ) from exc
+        try:
+            out, err = await asyncio.wait_for(proc.communicate(), timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise NixError(f"{' '.join(args)} timed out after {timeout}s")
         rc = proc.returncode if proc.returncode is not None else 1
         out_s, err_s = out.decode(), err.decode()
         if check and rc != 0:
@@ -243,10 +260,25 @@ class Nix:
             )
             if rc != 0:
                 logger.warning(
-                    "nix: fusermount3 -u %s failed (rc=%s): %s",
+                    "nix: fusermount3 -u %s failed (rc=%s): %s; trying lazy",
                     merged,
                     rc,
                     err.strip(),
                 )
-        # upper holds read-only store paths; _rmtree_rw chmods them away.
+                # Lazy unmount so a busy mount doesn't pin the ws dir.
+                rc2, _, err2 = await self._run(
+                    ["fusermount3", "-u", "-z", merged], check=False
+                )
+                if rc2 != 0:
+                    logger.warning(
+                        "nix: lazy fusermount3 -u %s failed (rc=%s): %s; "
+                        "ws dir left as an orphan for the operator",
+                        merged,
+                        rc2,
+                        err2.strip(),
+                    )
+        # upper holds read-only store paths; _rmtree_rw chmods them away. If
+        # the mount is still live (both unmounts failed), rmtree best-effort-
+        # skips the busy mountpoint (logged via _onerror) — the ws dir is then
+        # an orphan the operator must clean up (umount + rm).
         _rmtree_rw(ws)

--- a/src/klangk/klangk/nix.py
+++ b/src/klangk/klangk/nix.py
@@ -1,19 +1,32 @@
-"""Per-workspace nix store via btrfs snapshots (#2201, #2208).
+"""Per-workspace nix store (#2201, #2208, #2220).
 
-When a workspace has the per-workspace ``nix`` setting enabled and
-``KLANGKD_NIX_BTRFS_SUBVOLUME`` names a seed btrfs subvolume, the workspace
-gets a writable, isolated ``/nix`` as a **btrfs snapshot** of the seed. The
-seed is built by #2200 (``build-nix-seed``) and loaded into a btrfs subvolume
-by ``scripts/load-nix-seed-btrfs.sh``. ``ContainerRegistry`` binds the
-snapshot's ``/nix`` (and ``nix.conf``) into the workspace container; on
-workspace delete, ``Workspaces`` removes the snapshot.
+A workspace with the per-workspace ``nix`` setting gets a writable, isolated
+``/nix`` derived from a shared seed, via one of two interchangeable backends
+selected by ``nix_seed.type`` (see :class:`klangk.settings.NixSeedConfig`):
 
-btrfs (unlike zfs) lets a non-root user snapshot a subvolume it can write to,
-and a snapshot is reachable through the parent mount (no separate mount), so
-this needs **no privileged helper** — unlike the zfs-clone path, which would
-need a ``cap_sys_admin`` mount helper (see #2210 and openzfs/zfs#10648: non-root
-zfs mount is impossible on Linux). Requires the btrfs filesystem be mounted
-with ``user_subvol_rm_allowed`` so the same non-root user can delete snapshots.
+- **btrfs-snapshot** — the seed is a btrfs subvolume; each workspace gets a CoW
+  snapshot. A snapshot is reachable through the parent mount and btrfs lets a
+  non-root user snapshot a subvolume it can write to, so this needs **no
+  privileged helper** (unlike zfs, whose non-root mount is impossible on Linux
+  — openzfs/zfs#10648). Requires a btrfs filesystem mounted with
+  ``user_subvol_rm_allowed``. The CoW-optimised choice.
+- **fuse-overlayfs** (the default) — the seed is a plain directory overlaid per
+  workspace via ``fuse-overlayfs`` (seed = read-only lower, per-workspace upper
+  captures writes). Works on **any** filesystem, no privileged helper (needs
+  ``fuse-overlayfs`` + ``fusermount3`` + ``/dev/fuse``).
+
+Both return a *mountpoint* — a directory holding ``nix/`` and ``nix.conf`` —
+that ``ContainerRegistry`` binds into the container as ``/nix`` (+
+``/etc/nix/nix.conf``). On workspace delete, ``Workspaces`` tears it down. The
+per-workspace ``nix`` flag (checked by the caller) opts a given workspace in;
+this module only decides whether a backend is configured (``nix_seed.path``
+set). Omit ``nix_seed`` entirely to disable the feature (nix is then image-only).
+
+Caveat: the fuse backend suits a bare-metal Linux host (podman runs on the host,
+no userns nesting between the FUSE mount and the workspace container). It does
+**not** work where podman is nested — the rootless runtime can't bind a
+process-owned FUSE mount into a workspace container's userns (host-container and
+macOS deployments; see #2221). There, fall back to the nix image's baked ``/nix``.
 """
 
 from __future__ import annotations
@@ -21,50 +34,100 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shutil
+import stat
 
 logger = logging.getLogger(__name__)
 
 
 class NixError(RuntimeError):
-    """A btrfs operation or configuration problem in the nix subsystem."""
+    """A btrfs/fuse operation or configuration problem in the nix subsystem."""
+
+
+def _rmtree_rw(path: str) -> None:
+    """``shutil.rmtree`` that survives read-only store files/dirs.
+
+    nix store paths are 0444 files inside 0555 dirs; a plain ``rmtree`` aborts
+    because unlinking a file needs write on its parent dir. The ``onerror``
+    makes the failing entry's parent (and the entry) user-writable, then retries
+    the failed op. If it still can't (genuinely stuck), it logs and moves on so
+    cleanup of a half-deleted workspace is best-effort.
+    """
+
+    def _onerror(func, p: str, _exc) -> None:
+        try:
+            os.chmod(os.path.dirname(p), stat.S_IRWXU)
+            os.chmod(p, stat.S_IRWXU)
+            func(p)
+        except OSError as exc:
+            logger.warning(
+                "nix: could not remove %s during cleanup: %s", p, exc
+            )
+
+    shutil.rmtree(path, onerror=_onerror)
 
 
 class Nix:
-    """Owns the per-workspace btrfs-snapshot lifecycle for ``/nix``.
+    """Owns the per-workspace ``/nix`` lifecycle.
 
-    Constructed once in ``main.build_app`` as ``app.state.nix``. btrfs calls go
-    through ``asyncio.create_subprocess_exec``; existence checks are plain
-    ``os.path`` queries (a snapshot is a directory reachable through the parent
-    btrfs mount, so there is no mount step and no separate mountpoint lookup).
+    Constructed once in ``main.build_app`` as ``app.state.nix``. Subprocess
+    calls (``btrfs`` / ``fuse-overlayfs`` / ``fusermount3`` / ``stat``) go
+    through ``asyncio.create_subprocess_exec``; existence/mount checks are plain
+    ``os.path`` queries. ``ensure_workspace_nix`` / ``destroy_workspace_nix``
+    dispatch to the configured backend (``nix_seed.type``).
     """
 
     def __init__(self, app):
         self.app = app
 
-    @property
-    def btrfs_configured(self) -> bool:
-        """Whether the btrfs-snapshot path is available (a seed subvolume is set).
-
-        The per-workspace ``nix`` flag (checked by the caller) decides whether a
-        *given* workspace opts in; this only says the deploy can serve it.
-        """
-        return bool(self.app.state.settings.nix_btrfs_subvolume)
+    # --- configuration / dispatch -------------------------------------------
 
     @property
-    def seed(self) -> str:
-        # Path to the seed btrfs subvolume, e.g. /steam2/btrfs/klangk-nix/seed.
-        # ``btrfs_configured`` already requires this set.
-        return self.app.state.settings.nix_btrfs_subvolume or ""
+    def configured(self) -> bool:
+        """Whether a nix backend is configured (``nix_seed.path`` is set)."""
+        return bool(self.app.state.settings.nix_seed.path)
+
+    @property
+    def _seed(self) -> str:
+        return self.app.state.settings.nix_seed.path or ""
+
+    @property
+    def _type(self) -> str:
+        return self.app.state.settings.nix_seed.type
 
     def _ws_path(self, workspace_id: str) -> str:
-        # Sibling of the seed: <seed's parent>/ws-<workspace_id>.
-        return os.path.join(os.path.dirname(self.seed), f"ws-{workspace_id}")
+        # Sibling of the seed: <seed's parent>/ws-<workspace_id>. Same layout
+        # for both backends (a btrfs snapshot or a fuse overlay work-dir).
+        return os.path.join(os.path.dirname(self._seed), f"ws-{workspace_id}")
 
-    async def _btrfs(
+    async def ensure_workspace_nix(self, workspace_id: str) -> str | None:
+        """Ensure a writable ``/nix`` for *workspace_id*; return its mountpoint.
+
+        The mountpoint holds ``nix/`` (bind-mounted into the container as
+        ``/nix``) and ``nix.conf``. Returns ``None`` when no backend is
+        configured. Idempotent: reuses an existing snapshot/fuse mount.
+        """
+        if not self.configured:
+            return None
+        if self._type == "btrfs-snapshot":
+            return await self._ensure_btrfs(workspace_id)
+        return await self._ensure_fuse(workspace_id)
+
+    async def destroy_workspace_nix(self, workspace_id: str) -> None:
+        """Tear down the per-workspace ``/nix``. No-op if absent/unconfigured."""
+        if not self.configured:
+            return
+        if self._type == "btrfs-snapshot":
+            await self._destroy_btrfs(workspace_id)
+        else:
+            await self._destroy_fuse(workspace_id)
+
+    # --- subprocess helper ---------------------------------------------------
+
+    async def _run(
         self, args: list[str], *, check: bool = True
     ) -> tuple[int, str, str]:
         proc = await asyncio.create_subprocess_exec(
-            "btrfs",
             *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -74,25 +137,27 @@ class Nix:
         out_s, err_s = out.decode(), err.decode()
         if check and rc != 0:
             raise NixError(
-                f"btrfs {' '.join(args)} failed (rc={rc}): {err_s.strip()}"
+                f"{' '.join(args)} failed (rc={rc}): {err_s.strip()}"
             )
         return rc, out_s, err_s
 
-    async def ensure_workspace_nix(self, workspace_id: str) -> str | None:
-        """Ensure a writable ``/nix`` btrfs snapshot for *workspace_id*.
+    # --- btrfs-snapshot backend ---------------------------------------------
 
-        Returns the snapshot's path (bind-mounted into the container as /nix),
-        or ``None`` when btrfs is not configured. Idempotent: reuses an existing
-        snapshot across restarts (it lives at the path, reachable via the parent
-        mount — no separate mount needed).
-        """
-        if not self.btrfs_configured:
-            return None
-        if not os.path.isdir(self.seed):
+    async def _ensure_btrfs(self, workspace_id: str) -> str:
+        seed = self._seed
+        if not os.path.isdir(seed):
             raise NixError(
-                f"seed subvolume {self.seed} not found — build the seed "
+                f"seed subvolume {seed} not found — build the seed "
                 f"(devenv shell -- build-nix-seed) and load it "
                 f"(scripts/load-nix-seed-btrfs.sh) first"
+            )
+        fstype = (await self._run(["stat", "-f", "-c", "%T", seed]))[1].strip()
+        if fstype != "btrfs":
+            raise NixError(
+                f"nix_seed.type is btrfs-snapshot but the seed {seed} is on "
+                f"{fstype}, not btrfs — either load the seed into a btrfs "
+                f"subvolume (scripts/load-nix-seed-btrfs.sh) or switch to "
+                f"type: fuse-overlayfs"
             )
         ws = self._ws_path(workspace_id)
         if not os.path.exists(ws):
@@ -101,18 +166,15 @@ class Nix:
                 workspace_id,
                 ws,
             )
-            await self._btrfs(["subvolume", "snapshot", self.seed, ws])
+            await self._run(["btrfs", "subvolume", "snapshot", seed, ws])
         return ws
 
-    async def destroy_workspace_nix(self, workspace_id: str) -> None:
-        """Delete the per-workspace snapshot (on workspace delete). No-op if absent."""
-        if not self.btrfs_configured:
-            return
+    async def _destroy_btrfs(self, workspace_id: str) -> str | None:
         ws = self._ws_path(workspace_id)
         if not os.path.exists(ws):
-            return
-        rc, _, err = await self._btrfs(
-            ["subvolume", "delete", ws], check=False
+            return None
+        rc, _, err = await self._run(
+            ["btrfs", "subvolume", "delete", ws], check=False
         )
         if rc != 0:
             logger.warning(
@@ -121,3 +183,70 @@ class Nix:
                 rc,
                 err.strip(),
             )
+        return None
+
+    # --- fuse-overlayfs backend ---------------------------------------------
+
+    async def _ensure_fuse(self, workspace_id: str) -> str:
+        seed = self._seed
+        if not os.path.isdir(os.path.join(seed, "nix")):
+            raise NixError(
+                f"seed directory {seed}/nix not found — build the seed "
+                f"(devenv shell -- build-nix-seed) and point nix_seed.path "
+                f"at its output first"
+            )
+        ws = self._ws_path(workspace_id)
+        merged = os.path.join(ws, "nix")
+        if os.path.ismount(merged):
+            # A live fuse mount is reused — but a prior klangkd crash can leave
+            # a stale mount that's still "mounted" yet unusable. Probe it and
+            # re-mount if the probe fails.
+            try:
+                os.listdir(merged)
+            except OSError:
+                logger.warning(
+                    "nix: stale fuse mount at %s; re-mounting", merged
+                )
+                await self._run(["fusermount3", "-u", merged], check=False)
+                await self._mount_fuse(seed, ws, merged)
+        else:
+            await self._mount_fuse(seed, ws, merged)
+        return ws
+
+    async def _mount_fuse(self, seed: str, ws: str, merged: str) -> None:
+        os.makedirs(os.path.join(ws, "upper"), exist_ok=True)
+        os.makedirs(os.path.join(ws, "work"), exist_ok=True)
+        os.makedirs(merged, exist_ok=True)
+        await self._run(
+            [
+                "fuse-overlayfs",
+                merged,
+                "-o",
+                f"lowerdir={seed}/nix,upperdir={ws}/upper,workdir={ws}/work",
+            ]
+        )
+        # The container binds <mountpoint>/nix.conf; seed provides it. Copy so
+        # the mountpoint is self-contained (a symlink would resolve through the
+        # seed path, which need not be visible inside the container's view).
+        shutil.copyfile(
+            os.path.join(seed, "nix.conf"), os.path.join(ws, "nix.conf")
+        )
+
+    async def _destroy_fuse(self, workspace_id: str) -> None:
+        ws = self._ws_path(workspace_id)
+        if not os.path.exists(ws):
+            return
+        merged = os.path.join(ws, "nix")
+        if os.path.ismount(merged):
+            rc, _, err = await self._run(
+                ["fusermount3", "-u", merged], check=False
+            )
+            if rc != 0:
+                logger.warning(
+                    "nix: fusermount3 -u %s failed (rc=%s): %s",
+                    merged,
+                    rc,
+                    err.strip(),
+                )
+        # upper holds read-only store paths; _rmtree_rw chmods them away.
+        _rmtree_rw(ws)

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -35,7 +35,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, ClassVar, Mapping
+from typing import Any, ClassVar, Literal, Mapping
 
 
 import getpass
@@ -47,7 +47,13 @@ from pydantic_settings import (
     SettingsConfigDict,
     YamlConfigSettingsSource,
 )
-from pydantic import PrivateAttr, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
 
 # netfilter.py is pure-stdlib (no settings import), so this top-level import
 # is cycle-safe. Used by the netfilter_default_domains field validator below.
@@ -318,6 +324,27 @@ class _KebabYamlConfigSettingsSource(YamlConfigSettingsSource):
         }
 
 
+class NixSeedConfig(BaseModel):
+    """Per-workspace ``/nix`` seed config (#2198, #2201, #2220).
+
+    One seed path consumed by one of two backends (selected by ``type``).
+    Omit ``nix_seed`` entirely — or leave ``path`` unset — to disable the
+    feature; nix is then image-only (pick the nix image ``klangk-workspace-nix``
+    for its baked ``/nix``). Image selection is always the user's; this never
+    forces an image.
+    """
+
+    # How to consume the seed. "btrfs-snapshot": a CoW btrfs-subvolume snapshot
+    # per workspace (needs a btrfs filesystem mounted with
+    # user_subvol_rm_allowed). "fuse-overlayfs": a fuse-overlayfs overlay per
+    # workspace (any filesystem; the default).
+    type: Literal["btrfs-snapshot", "fuse-overlayfs"] = "fuse-overlayfs"
+    # Path to the seed tree (build-nix-seed output: holds nix/ + nix.conf). For
+    # "btrfs-snapshot" it must be a btrfs subvolume (loaded by
+    # scripts/load-nix-seed-btrfs.sh); for "fuse-overlayfs", a plain directory.
+    path: str | None = None
+
+
 class KlangkSettings(BaseSettings):
     """Typed configuration for all ``KLANGKD_*`` environment variables.
 
@@ -360,8 +387,11 @@ class KlangkSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="KLANGKD_",
         extra="ignore",
-        # Do NOT set env_nested_delimiter — KLANGKD_ACCESS_TOKEN_HOURS is a
-        # flat field (access_token_hours), not a nested table.
+        # env_nested_delimiter="__" lets the nix_seed sub-model read
+        # KLANGKD_NIX_SEED__TYPE / KLANGKD_NIX_SEED__PATH. Safe for the flat
+        # fields: every field name is single-underscore snake_case, so no flat
+        # env var contains "__" and none is misparsed as a nested table.
+        env_nested_delimiter="__",
     )
 
     def __init__(
@@ -633,14 +663,13 @@ class KlangkSettings(BaseSettings):
     allow_autostart: str = ""
     allow_sudo: str = ""
     container_subnets: str | None = None
-    # Nix workspace feature (#2198): nix_btrfs_subvolume is the path to a seed
-    # btrfs subvolume (built by #2200, loaded by scripts/load-nix-seed-btrfs.sh)
-    # on a btrfs filesystem mounted with user_subvol_rm_allowed. When set, a
-    # workspace with the per-workspace `nix` setting enabled gets a writable,
-    # isolated /nix as a btrfs snapshot of the seed (#2201, #2208, #2202).
-    # Unset -> nix is image-only (the nix image's baked /nix, no snapshot).
-    # Image selection is always the user's; this never overrides it.
-    nix_btrfs_subvolume: str | None = None
+    # Nix workspace feature (#2198, #2201, #2220): per-workspace /nix from a
+    # shared seed. ``nix_seed`` groups the seed path + the backend that
+    # consumes it (see NixSeedConfig). Omit ``nix_seed`` entirely — or leave
+    # its ``path`` unset — to disable the feature; nix is then image-only (pick
+    # the nix image ``klangk-workspace-nix`` for its baked ``/nix``). Image
+    # selection is always the user's; this never overrides it.
+    nix_seed: NixSeedConfig = Field(default_factory=NixSeedConfig)
     userns: str = "keep-id:uid=1000,gid=1000"
     # enable_ping: allow unprivileged ICMP echo (``ping``) inside workspace
     # containers (#2045) by granting the container CAP_NET_RAW; a setuid

--- a/src/klangk/klangk/workspace_settings.py
+++ b/src/klangk/klangk/workspace_settings.py
@@ -201,7 +201,8 @@ SCHEMA: dict[str, Callable[[str, Any], Any]] = {
     "memory_limit": _coerce_memory,
     "pids_limit": _coerce_positive_int,
     # #2202: per-workspace nix flag — triggers the per-workspace /nix mount
-    # (Nix.ensure_workspace_nix) when nix_btrfs_subvolume is configured.
+    # (Nix.ensure_workspace_nix) when a backend is configured (``nix_seed``,
+    # #2219/#2220).
     "nix": _coerce_bool,
 }
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -3888,8 +3888,8 @@ async def test_nix_binds_empty_without_flag():
 
 
 async def test_nix_binds_empty_when_btrfs_not_configured():
-    """Flag on but btrfs not configured -> ensure returns None -> no bind/env."""
-    app_state = _make_app_state()  # no nix_btrfs_subvolume -> not configured
+    """Flag on but nix not configured -> ensure returns None -> no bind/env."""
+    app_state = _make_app_state()  # no nix_seed -> not configured
     reg = app_state.state.container_registry
     assert await reg._nix_binds("ws1", {"nix": True}) == ([], [])
 

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -11,6 +11,7 @@ from klangk.doctor import (
     DoctorReport,
     check_binary,
     check_gnu_du,
+    check_gnu_stat,
     check_gnu_tar,
     check_podman_policy,
     check_subuid,
@@ -208,6 +209,34 @@ class TestCheckGnuDu:
     def test_missing_du(self):
         with patch("klangk.doctor.shutil.which", return_value=None):
             r = check_gnu_du("apt")
+            assert not r.ok
+            assert "not found" in r.message
+
+
+class TestCheckGnuStat:
+    def test_gnu_stat(self):
+        with (
+            patch("shutil.which", return_value="/usr/bin/stat"),
+            patch("klangk.doctor._run", return_value=(0, "ext4\n", "")),
+        ):
+            r = check_gnu_stat("apt")
+            assert r.ok
+
+    def test_bsd_stat(self):
+        with (
+            patch("shutil.which", return_value="/usr/bin/stat"),
+            patch(
+                "klangk.doctor._run",
+                return_value=(1, "", "stat: illegal option -- f"),
+            ),
+        ):
+            r = check_gnu_stat("brew")
+            assert not r.ok
+            assert "coreutils" in r.hint
+
+    def test_missing_stat(self):
+        with patch("klangk.doctor.shutil.which", return_value=None):
+            r = check_gnu_stat("apt")
             assert not r.ok
             assert "not found" in r.message
 

--- a/src/klangk/klangkd-tests/tests/test_nix.py
+++ b/src/klangk/klangkd-tests/tests/test_nix.py
@@ -1,9 +1,10 @@
-"""Unit tests for ``klangk.nix`` — the per-workspace btrfs-snapshot lifecycle (#2201).
+"""Unit tests for ``klangk.nix`` — the per-workspace /nix lifecycle (#2201, #2220).
 
-The btrfs subprocess calls and filesystem existence checks are faked (no real
-btrfs needed); these cover the btrfs-configured gating, snapshot/delete
-idempotency, and error paths. The per-workspace ``nix`` flag is the caller's
-gate (container.py) — the module only cares whether btrfs is configured.
+Two backends (btrfs-snapshot, fuse-overlayfs) selected by ``nix_seed.type``.
+The btrfs/fuse subprocess calls and filesystem existence checks are faked (no
+real btrfs/fuse needed); the fuse FS ops (makedirs/copyfile/rmtree) run on a
+real tmp_path. The per-workspace ``nix`` flag is the caller's gate
+(container.py) — the module only cares whether ``nix_seed.path`` is set.
 """
 
 from types import SimpleNamespace
@@ -29,26 +30,38 @@ class _Proc:
         return self._out, self._err
 
 
-def _app(subvol=None):
-    env = {"KLANGKD_NIX_BTRFS_SUBVOLUME": subvol} if subvol else {}
+def _app(seed=None, type=None):
+    """A KlangkSettings-backed app with nix_seed configured (or not).
+
+    ``type`` omitted -> the fuse-overlayfs default. ``seed`` omitted ->
+    nix_seed unset (feature disabled).
+    """
+    env = {}
+    if seed:
+        env["KLANGKD_NIX_SEED__PATH"] = seed
+    if type:
+        env["KLANGKD_NIX_SEED__TYPE"] = type
     settings = make_settings(env=env)
     return SimpleNamespace(state=SimpleNamespace(settings=settings))
 
 
-def _patch(
+def _patch_btrfs(
     monkeypatch,
     *,
     seed_exists=True,
     ws_exists=False,
+    fstype="btrfs",
     btrfs_rc=0,
     btrfs_err=b"",
 ):
-    """Fake the btrfs subprocess + os.path existence checks. Returns call list."""
+    """Fake the btrfs/stat subprocess + os.path existence. Returns call list."""
     calls = []
 
     async def fake_exec(*args, **kwargs):
         calls.append(args)
-        return _Proc(btrfs_rc, b"", btrfs_err)
+        if args[0] == "stat":  # the fstype check (stat -f -c %T <seed>)
+            return _Proc(0, fstype.encode(), b"")
+        return _Proc(btrfs_rc, b"", btrfs_err)  # btrfs ...
 
     monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(nix.os.path, "isdir", lambda p: seed_exists)
@@ -56,64 +69,90 @@ def _patch(
     return calls
 
 
-# --- gating -----------------------------------------------------------------
+# --- gating ----------------------------------------------------------------
 
 
-async def test_no_op_when_btrfs_not_configured(monkeypatch):
-    calls = _patch(monkeypatch)
-    n = Nix(_app())
-    assert n.btrfs_configured is False
+async def test_no_op_when_not_configured(monkeypatch):
+    calls = _patch_btrfs(monkeypatch)
+    n = Nix(_app())  # no nix_seed
+    assert n.configured is False
     assert await n.ensure_workspace_nix("ws1") is None
     await n.destroy_workspace_nix("ws1")
     assert calls == []
 
 
-# --- ensure_workspace_nix ---------------------------------------------------
+async def test_path_set_without_type_is_fuse(monkeypatch, tmp_path):
+    # nix_seed.path set, type omitted -> default fuse-overlayfs (not btrfs).
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "nix").mkdir()
+    (seed / "nix.conf").write_text("x")
+    calls = []
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(args)
+        return _Proc(0)
+
+    monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(nix.os.path, "ismount", lambda p: False)
+    n = Nix(_app(str(seed)))
+    assert n._type == "fuse-overlayfs"
+    await n.ensure_workspace_nix("ws1")
+    assert any(a[0] == "fuse-overlayfs" for a in calls)
+    assert not any(a[0] == "btrfs" for a in calls)
 
 
-async def test_ensure_snapshots_when_missing(monkeypatch):
-    calls = _patch(monkeypatch, seed_exists=True, ws_exists=False)
-    n = Nix(_app(SEED))
-    assert n.btrfs_configured is True
+# --- btrfs-snapshot backend -------------------------------------------------
+
+
+async def test_btrfs_ensure_snapshots_when_missing(monkeypatch):
+    calls = _patch_btrfs(monkeypatch, seed_exists=True, ws_exists=False)
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
+    assert n.configured is True
     assert await n.ensure_workspace_nix("ws1") == WS
     snap = [a for a in calls if a[1:3] == ("subvolume", "snapshot")]
     # source=seed, dest=ws — a swap would overwrite the shared seed.
     assert snap and snap[0][3] == SEED and snap[0][4] == WS
 
 
-async def test_ensure_reuses_existing(monkeypatch):
-    calls = _patch(monkeypatch, seed_exists=True, ws_exists=True)
-    n = Nix(_app(SEED))
+async def test_btrfs_ensure_reuses_existing(monkeypatch):
+    calls = _patch_btrfs(monkeypatch, seed_exists=True, ws_exists=True)
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
     assert await n.ensure_workspace_nix("ws1") == WS
     assert not any(a[1:3] == ("subvolume", "snapshot") for a in calls)
 
 
-async def test_ensure_raises_when_seed_missing(monkeypatch):
-    _patch(monkeypatch, seed_exists=False)
-    n = Nix(_app(SEED))
+async def test_btrfs_ensure_raises_when_seed_missing(monkeypatch):
+    _patch_btrfs(monkeypatch, seed_exists=False)
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
     with pytest.raises(NixError, match="seed subvolume"):
         await n.ensure_workspace_nix("ws1")
 
 
-async def test_ensure_raises_when_snapshot_fails(monkeypatch):
-    _patch(
+async def test_btrfs_ensure_raises_when_seed_not_on_btrfs(monkeypatch):
+    # type is btrfs-snapshot but the seed path is on a non-btrfs filesystem.
+    _patch_btrfs(monkeypatch, seed_exists=True, fstype="ext4")
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
+    with pytest.raises(NixError, match="not btrfs"):
+        await n.ensure_workspace_nix("ws1")
+
+
+async def test_btrfs_ensure_raises_when_snapshot_fails(monkeypatch):
+    _patch_btrfs(
         monkeypatch,
         seed_exists=True,
         ws_exists=False,
         btrfs_rc=1,
         btrfs_err=b"read-only filesystem",
     )
-    n = Nix(_app(SEED))
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
     with pytest.raises(NixError, match="read-only filesystem"):
         await n.ensure_workspace_nix("ws1")
 
 
-# --- destroy_workspace_nix --------------------------------------------------
-
-
-async def test_destroy_succeeds(monkeypatch):
-    calls = _patch(monkeypatch, ws_exists=True, btrfs_rc=0)
-    n = Nix(_app(SEED))
+async def test_btrfs_destroy_succeeds(monkeypatch):
+    calls = _patch_btrfs(monkeypatch, ws_exists=True, btrfs_rc=0)
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
     await n.destroy_workspace_nix("ws1")
     delete = [a for a in calls if a[1:3] == ("subvolume", "delete")]
     assert (
@@ -121,16 +160,206 @@ async def test_destroy_succeeds(monkeypatch):
     )  # deletes the ws snapshot, never the seed
 
 
-async def test_destroy_noop_when_missing(monkeypatch):
-    calls = _patch(monkeypatch, ws_exists=False)
-    n = Nix(_app(SEED))
+async def test_btrfs_destroy_noop_when_missing(monkeypatch):
+    calls = _patch_btrfs(monkeypatch, ws_exists=False)
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
     await n.destroy_workspace_nix("ws1")
     assert calls == []  # no btrfs call
 
 
-async def test_destroy_warns_on_error(monkeypatch, caplog):
-    _patch(monkeypatch, ws_exists=True, btrfs_rc=1, btrfs_err=b"busy")
-    n = Nix(_app(SEED))
+async def test_btrfs_destroy_warns_on_error(monkeypatch, caplog):
+    _patch_btrfs(monkeypatch, ws_exists=True, btrfs_rc=1, btrfs_err=b"busy")
+    n = Nix(_app(SEED, type="btrfs-snapshot"))
     with caplog.at_level("WARNING", logger="klangk.nix"):
         await n.destroy_workspace_nix("ws1")
     assert any("btrfs subvolume delete" in r.message for r in caplog.records)
+
+
+# --- fuse-overlayfs backend -------------------------------------------------
+#
+# The fuse subprocess calls (fuse-overlayfs / fusermount3) are faked; the
+# filesystem ops (makedirs/copyfile/rmtree) run on a real tmp_path. ismount is
+# patched because a tmp_path dir is never a real mount.
+
+
+def _fuse_seed(tmp_path):
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "nix").mkdir()
+    (seed / "nix.conf").write_text(
+        "experimental-features = nix-command flakes\n"
+    )
+    return seed
+
+
+def _patch_fuse(monkeypatch, *, mounted=False, stale=False, rc=0, err=b""):
+    """Fake the fuse subprocess + ismount. Returns the call list."""
+    calls = []
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(args)
+        return _Proc(rc, b"", err)
+
+    monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(nix.os.path, "ismount", lambda p: mounted)
+    if stale:
+
+        def _boom(p):
+            raise OSError("stale fuse handle")
+
+        monkeypatch.setattr(nix.os, "listdir", _boom)
+    return calls
+
+
+async def test_fuse_ensure_mounts_when_missing(monkeypatch, tmp_path):
+    seed = _fuse_seed(tmp_path)
+    calls = _patch_fuse(monkeypatch, mounted=False)
+    n = Nix(_app(str(seed), type="fuse-overlayfs"))
+    assert n.configured is True
+    ws = await n.ensure_workspace_nix("ws1")
+    assert ws == str(tmp_path / "ws-ws1")
+    fuse_calls = [a for a in calls if a[0] == "fuse-overlayfs"]
+    assert len(fuse_calls) == 1
+    assert fuse_calls[0][1] == str(tmp_path / "ws-ws1" / "nix")
+    assert f"lowerdir={seed}/nix" in fuse_calls[0][3]
+    # mountpoint scaffolded + nix.conf copied alongside the merged mount
+    assert (tmp_path / "ws-ws1" / "upper").is_dir()
+    assert (tmp_path / "ws-ws1" / "work").is_dir()
+    assert (tmp_path / "ws-ws1" / "nix").is_dir()
+    assert (
+        (tmp_path / "ws-ws1" / "nix.conf")
+        .read_text()
+        .startswith("experimental-features")
+    )
+
+
+async def test_fuse_ensure_reuses_live_mount(monkeypatch, tmp_path):
+    seed = _fuse_seed(tmp_path)
+    merged = tmp_path / "ws-ws1" / "nix"
+    merged.mkdir(parents=True)  # an existing (live) mount target
+    calls = _patch_fuse(
+        monkeypatch, mounted=True
+    )  # ismount True; probe listdir OK
+    n = Nix(_app(str(seed)))
+    ws = await n.ensure_workspace_nix("ws1")
+    assert ws == str(tmp_path / "ws-ws1")
+    # reused — no remount, no nix.conf re-copy
+    assert not any(a[0] == "fuse-overlayfs" for a in calls)
+
+
+async def test_fuse_ensure_remounts_when_stale(monkeypatch, tmp_path):
+    seed = _fuse_seed(tmp_path)
+    merged = tmp_path / "ws-ws1" / "nix"
+    merged.mkdir(parents=True)
+    calls = _patch_fuse(monkeypatch, mounted=True, stale=True)
+    n = Nix(_app(str(seed)))
+    await n.ensure_workspace_nix("ws1")
+    assert any(a[:2] == ("fusermount3", "-u") for a in calls)  # unmount stale
+    assert any(a[0] == "fuse-overlayfs" for a in calls)  # then remount
+
+
+async def test_fuse_ensure_raises_when_seed_missing(monkeypatch, tmp_path):
+    seed = tmp_path / "seed"
+    seed.mkdir()  # but no seed/nix
+    _patch_fuse(monkeypatch)
+    n = Nix(_app(str(seed)))
+    with pytest.raises(NixError, match="seed directory"):
+        await n.ensure_workspace_nix("ws1")
+
+
+async def test_fuse_ensure_raises_when_mount_fails(monkeypatch, tmp_path):
+    seed = _fuse_seed(tmp_path)
+    _patch_fuse(
+        monkeypatch, mounted=False, rc=1, err=b"fuse-overlayfs: no /dev/fuse"
+    )
+    n = Nix(_app(str(seed)))
+    with pytest.raises(NixError, match="no /dev/fuse"):
+        await n.ensure_workspace_nix("ws1")
+
+
+async def test_fuse_destroy_unmounts(monkeypatch, tmp_path):
+    seed = _fuse_seed(tmp_path)
+    ws = tmp_path / "ws-ws1"
+    (ws / "nix").mkdir(parents=True)
+    (ws / "upper").mkdir()
+    (ws / "nix.conf").write_text("x")
+    calls = _patch_fuse(monkeypatch, mounted=True)
+    n = Nix(_app(str(seed)))
+    await n.destroy_workspace_nix("ws1")
+    assert any(a[:2] == ("fusermount3", "-u") for a in calls)
+    assert not ws.exists()
+
+
+async def test_fuse_destroy_not_mounted(monkeypatch, tmp_path):
+    seed = _fuse_seed(tmp_path)
+    ws = tmp_path / "ws-ws1"
+    (ws / "upper").mkdir(parents=True)
+    (ws / "nix.conf").write_text("x")
+    calls = _patch_fuse(monkeypatch, mounted=False)
+    n = Nix(_app(str(seed)))
+    await n.destroy_workspace_nix("ws1")
+    assert not any(a[0] == "fusermount3" for a in calls)
+    assert not ws.exists()
+
+
+async def test_fuse_destroy_missing_is_noop(monkeypatch, tmp_path):
+    seed = _fuse_seed(tmp_path)
+    calls = _patch_fuse(monkeypatch)
+    n = Nix(_app(str(seed)))
+    await n.destroy_workspace_nix("ws1")  # no ws dir
+    assert calls == []
+
+
+async def test_fuse_destroy_removes_readonly_store_files(
+    monkeypatch, tmp_path
+):
+    # nix store paths are read-only (0444 files / 0555 dirs); _rmtree_rw must
+    # chmod them away so destroy completes.
+    seed = _fuse_seed(tmp_path)
+    ws = tmp_path / "ws-ws1"
+    ro = ws / "upper" / "store" / "abc-path" / "bin" / "hello"
+    ro.parent.mkdir(parents=True)
+    ro.write_text("x")
+    ro.chmod(0o444)
+    ro.parent.chmod(0o555)
+    _patch_fuse(monkeypatch, mounted=False)
+    n = Nix(_app(str(seed)))
+    await n.destroy_workspace_nix("ws1")
+    assert not ws.exists()
+
+
+async def test_fuse_destroy_warns_on_unmount_error(
+    monkeypatch, tmp_path, caplog
+):
+    seed = _fuse_seed(tmp_path)
+    ws = tmp_path / "ws-ws1"
+    (ws / "nix").mkdir(parents=True)
+    (ws / "nix.conf").write_text("x")
+    _patch_fuse(monkeypatch, mounted=True, rc=1, err=b"mount busy")
+    n = Nix(_app(str(seed)))
+    with caplog.at_level("WARNING", logger="klangk.nix"):
+        await n.destroy_workspace_nix("ws1")
+    assert any("fusermount3 -u" in r.message for r in caplog.records)
+
+
+async def test_rmtree_rw_logs_when_retry_fails(monkeypatch, tmp_path, caplog):
+    # Cover the onerror's except branch: a retry that still fails logs a warning
+    # instead of raising (best-effort cleanup). We capture the onerror _rmtree_rw
+    # hands to shutil.rmtree and invoke it with a failing op.
+    target = tmp_path / "tree"
+    target.mkdir()
+    captured = {}
+
+    def fake_rmtree(path, onerror=None):
+        captured["onerror"] = onerror  # don't actually remove
+
+    monkeypatch.setattr(nix.shutil, "rmtree", fake_rmtree)
+    with caplog.at_level("WARNING", logger="klangk.nix"):
+        nix._rmtree_rw(str(target))
+        # Simulate rmtree hitting a stuck entry: onerror retries, the retry fails.
+
+        def _boom(_p):
+            raise OSError("stuck")
+
+        captured["onerror"](_boom, str(target / "x"), None)
+    assert any("could not remove" in r.message for r in caplog.records)

--- a/src/klangk/klangkd-tests/tests/test_nix.py
+++ b/src/klangk/klangkd-tests/tests/test_nix.py
@@ -335,11 +335,61 @@ async def test_fuse_destroy_warns_on_unmount_error(
     ws = tmp_path / "ws-ws1"
     (ws / "nix").mkdir(parents=True)
     (ws / "nix.conf").write_text("x")
-    _patch_fuse(monkeypatch, mounted=True, rc=1, err=b"mount busy")
+    calls = _patch_fuse(monkeypatch, mounted=True, rc=1, err=b"mount busy")
     n = Nix(_app(str(seed)))
     with caplog.at_level("WARNING", logger="klangk.nix"):
         await n.destroy_workspace_nix("ws1")
     assert any("fusermount3 -u" in r.message for r in caplog.records)
+    # A failed unmount falls back to a lazy one so a busy mount doesn't pin
+    # the ws dir (#2220 review).
+    assert any(a[:3] == ("fusermount3", "-u", "-z") for a in calls)
+
+
+class _SlowProc:
+    """A proc whose communicate() never resolves — for the _run timeout test."""
+
+    def __init__(self):
+        self.killed = False
+        self.returncode = None
+
+    async def communicate(self):
+        await nix.asyncio.sleep(999)  # cancelled by wait_for on timeout
+
+    def kill(self):
+        self.killed = True
+
+    async def wait(self):
+        return 0
+
+
+async def test_run_raises_nixerror_when_binary_missing(monkeypatch, tmp_path):
+    """A missing fuse-overlayfs/btrfs/fusermount3 surfaces as NixError, not a
+    raw FileNotFoundError out of container start (#2220 review)."""
+    seed = _fuse_seed(tmp_path)
+
+    async def boom(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", args[0])
+
+    monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", boom)
+    monkeypatch.setattr(nix.os.path, "ismount", lambda p: False)
+    n = Nix(_app(str(seed), type="fuse-overlayfs"))
+    with pytest.raises(NixError, match="fuse-overlayfs not found"):
+        await n.ensure_workspace_nix("ws1")
+
+
+async def test_run_timeout_raises_nixerror_and_kills(monkeypatch):
+    """A wedged fuse-overlayfs/fusermount3 times out + is killed, not hung
+    (#2220 review)."""
+    proc = _SlowProc()
+
+    async def fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", fake_exec)
+    n = Nix(_app("/seed", type="fuse-overlayfs"))
+    with pytest.raises(NixError, match="timed out"):
+        await n._run(["fuse-overlayfs"], timeout=0.05)
+    assert proc.killed
 
 
 async def test_rmtree_rw_logs_when_retry_fails(monkeypatch, tmp_path, caplog):

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -1271,3 +1271,28 @@ class TestLLMModelsValidator:
     def test_invalid_string_entry_raises(self):
         with pytest.raises(Exception, match="two colons"):
             make_settings({"KLANGKD_LLM_MODELS": "openai/gpt-4o"})
+
+
+class TestNixSeedConfig:
+    """nix_seed: {type, path} — the repo's first nested settings model (#2220)."""
+
+    def test_bogus_type_rejected(self):
+        """An invalid nix_seed.type aborts construction (the Literal enum)."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            make_settings({"KLANGKD_NIX_SEED__TYPE": "zfs"})
+
+    def test_yaml_block_form(self, tmp_path):
+        """The nix_seed: {type, path} YAML block parses (nested model)."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("nix_seed:\n  type: btrfs-snapshot\n  path: /seed\n")
+        s = make_settings({}, config_file=str(cfg))
+        assert s.nix_seed.type == "btrfs-snapshot"
+        assert s.nix_seed.path == "/seed"
+
+    def test_disabled_when_omitted(self):
+        """Omitting nix_seed entirely -> not configured (image-only)."""
+        s = make_settings({})
+        assert s.nix_seed.path is None
+        assert s.nix_seed.type == "fuse-overlayfs"  # the default


### PR DESCRIPTION
## Summary

A per-workspace `/nix` backend alongside the btrfs-snapshot path, stacked on **#2209**. Closes #2219.

Configure it with one structured block — **`nix_seed: {type, path}`** — selecting the backend explicitly:

```yaml
nix_seed:
  type: btrfs-snapshot   # or fuse-overlayfs (the default)
  path: /path/to/seed
```

- **`btrfs-snapshot`** — the seed is a btrfs subvolume; each workspace gets a CoW snapshot (needs btrfs + `user_subvol_rm_allowed`). The CoW-optimised choice.
- **`fuse-overlayfs`** (the default) — the seed is a plain directory (the `build-nix-seed` output, any filesystem); each workspace gets a `fuse-overlayfs` overlay (seed = read-only lower, per-workspace upper captures writes). No privileged helper (`fuse-overlayfs` + `fusermount3` + `/dev/fuse`).

**Omit `nix_seed` entirely (or leave `path` unset) to disable the feature** — nix is then image-only. `type` is a validated enum; a `btrfs-snapshot` seed whose path isn't on btrfs fails fast at startup. Env: `KLANGKD_NIX_SEED__TYPE` / `KLANGKD_NIX_SEED__PATH`.

This collapses the earlier two sibling settings (`nix_btrfs_subvolume` + `nix_seed_dir`) into one explicit `type` selector — no implicit "btrfs wins" precedence. `NixSeedConfig` is the first nested settings model (`env_nested_delimiter="__"`, safe because no flat field uses `__`).

The #2201 spike rejected non-btrfs options assuming rootless overlayfs was a hard blocker. `fuse-overlayfs` (host-side, FUSE) covers `/nix` where the kernel rootless path was rejected — and (unlike hardlinks, which the spike also tried) it isn't blocked by the seed being a btrfs subvolume (hardlinks can't cross subvolume boundaries — `EXDEV`).

> **Scope limit (found while testing):** the fuse backend suits a **bare-metal Linux host** (podman runs on the host — no userns nesting between klangkd's FUSE mount and the workspace container). It does **not** work where podman is nested — rootless podman can't bind a process-owned FUSE mount into a workspace container's userns (verified: `crun: cannot stat ... Permission denied`; not fixed by `allow_other`). Affects the **host-container** and **macOS** deployments (see #2221). There, use `btrfs-snapshot` if you have btrfs, otherwise the nix image's baked `/nix` (#2199).

## What it does

- `nix.Nix` dispatches by `nix_seed.type` (btrfs-snapshot | fuse-overlayfs). `ensure_workspace_nix` / `destroy_workspace_nix` route to the configured backend.
- **fuse backend**: per-workspace `fuse-overlayfs` mount (lower=seed/nix, upper=per-ws), bind-mounted into the container as `/nix`. Idempotent — reuses a live mount, re-mounts a stale one (probes `listdir`); on a klangkd restart the FUSE handle is re-created (upper dir + installed packages persist). Destroy: `fusermount3 -u` + `_rmtree_rw` (chmods read-only store dirs' parents so `rmtree` completes).
- **btrfs backend**: unchanged snapshot/delete, plus a `stat -f -c %T` fstype check (clear error if the seed path isn't on btrfs).
- `container._nix_binds` **unchanged** — both backends return the same mountpoint contract (a dir with `nix/` + `nix.conf`). `api/images` advertises `nix_available` via the backend-agnostic `configured`.

## Verification

- **End-to-end on a zfs (non-btrfs) seed** (`nix_seed: {path: /home/chrism/klangk-nix-seed}`): instant mount; container bound to the fused `/nix` runs `nix 2.35.1` + `devenv 2.2.1` (read-through); `nix-store --add` copy-ups into the per-workspace `upper/` (+ `upper/var/nix/db`) while the seed lower stays read-only; clean `fusermount3 -u`.
- **Host-container limit verified**: rootless podman can't bind a FUSE mount into a workspace container's userns (`crun` can't stat the bind source; not fixed by `allow_other`) — see #2221.
- **Unit**: `nix.py` + `settings.py` at **100%**; 21 nix tests (btrfs + fuse + the new seed-not-on-btrfs case); full unit suite **4187 passed, 100% coverage**.
- `devenv.nix`: `fuse-overlayfs` in the Linux package set.

## What's here

- `settings.py` — `NixSeedConfig` (`type` Literal + `path`) + `nix_seed` field (first nested model; `env_nested_delimiter="__"`).
- `nix.py` — `type`-based dispatch + btrfs fstype validation + `_rmtree_rw`.
- `api/images.py`, `container.py`, `workspace_settings.py` — backend-agnostic `configured` / wording.
- `test_nix.py` — reworked for `nix_seed`.
- `docs/features/nix.md` + `docs/changes.md` + `scripts/load-nix-seed-btrfs.sh`.

Closes #2219. Stacked on #2209 (base `issue-2202-feat`); re-target to `main` when the stack beneath merges.
