### PR TITLE
feat(cli): add per-workspace settings flags to create and edit

### DIFF
--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -180,6 +180,7 @@ class Workspace:
     health: str | None = None
     health_message: str | None = None
     service_started_at: float | None = None
+    settings: dict | None = None
 
 
 def get_terminal_size() -> tuple[int, int]:
@@ -482,6 +483,7 @@ class KlangkClient:
             health_message=w.get("health_message"),
             allowed_domains=w.get("allowed_domains"),
             service_started_at=w.get("service_started_at"),
+            settings=w.get("settings"),
         )
 
     def create_workspace(
@@ -495,6 +497,7 @@ class KlangkClient:
         setup_state: str | None = None,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        settings: dict | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
         if image:
@@ -513,6 +516,8 @@ class KlangkClient:
             body["health_check"] = health_check
         if allowed_domains:
             body["allowed_domains"] = allowed_domains
+        if settings:
+            body["settings"] = settings
         resp = self.post("/api/v1/workspaces", json=body)
         self.check_auth(resp)
         self._raise_for_status(resp)

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -632,6 +632,20 @@ def create(
         "--allow",
         help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
     ),
+    idle_timeout: int | None = typer.Option(
+        None,
+        "--idle-timeout",
+        help="Idle timeout in seconds (0 = never idle out)",
+    ),
+    cpu_limit: float | None = typer.Option(
+        None, "--cpu-limit", help="CPU limit (e.g. 2.0)"
+    ),
+    memory_limit: str | None = typer.Option(
+        None, "--memory-limit", help="Memory limit (e.g. 4g, 512m)"
+    ),
+    pids_limit: int | None = typer.Option(
+        None, "--pids-limit", help="PIDs limit (e.g. 512)"
+    ),
 ) -> None:
     """Create a new workspace."""
     require_auth()
@@ -648,6 +662,9 @@ def create(
                 _err.print(f"[red]{err}[/red]")
                 raise typer.Exit(code=1)
     env_dict = _parse_env_list(env) if isinstance(env, list) else None
+    settings = _build_settings(
+        idle_timeout, cpu_limit, memory_limit, pids_limit
+    )
     try:
         ws = _client().create_workspace(
             name,
@@ -658,6 +675,7 @@ def create(
             env=env_dict,
             health_check=health_check,
             allowed_domains=allow or None,
+            settings=settings,
         )
     except httpx.HTTPStatusError as exc:
         detail = exc.response.json().get("detail", exc.response.text)
@@ -911,6 +929,25 @@ def _parse_env_list(env_list: list[str]) -> dict[str, str]:
     return result
 
 
+def _build_settings(
+    idle_timeout: int | None,
+    cpu_limit: float | None,
+    memory_limit: str | None,
+    pids_limit: int | None,
+) -> dict | None:
+    """Build a workspace settings dict from CLI flags, or None if all unset."""
+    settings: dict = {}
+    if idle_timeout is not None:
+        settings["idle_timeout"] = idle_timeout
+    if cpu_limit is not None:
+        settings["cpu_limit"] = cpu_limit
+    if memory_limit is not None:
+        settings["memory_limit"] = memory_limit
+    if pids_limit is not None:
+        settings["pids_limit"] = pids_limit
+    return settings or None
+
+
 def _prompt(label: str, current: str | None) -> str | _SENTINEL.__class__:
     """Prompt for a value, showing the current default.
 
@@ -960,6 +997,20 @@ def edit(
         "--allow",
         help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
     ),
+    idle_timeout: int | None = typer.Option(
+        None,
+        "--idle-timeout",
+        help="Idle timeout in seconds (0 = never idle out)",
+    ),
+    cpu_limit: float | None = typer.Option(
+        None, "--cpu-limit", help="CPU limit (e.g. 2.0)"
+    ),
+    memory_limit: str | None = typer.Option(
+        None, "--memory-limit", help="Memory limit (e.g. 4g, 512m)"
+    ),
+    pids_limit: int | None = typer.Option(
+        None, "--pids-limit", help="PIDs limit (e.g. 512)"
+    ),
 ) -> None:
     """Edit workspace settings.
 
@@ -983,6 +1034,10 @@ def edit(
         or isinstance(mount, list)
         or isinstance(env, list)
         or isinstance(allow, list)
+        or idle_timeout is not None
+        or cpu_limit is not None
+        or memory_limit is not None
+        or pids_limit is not None
     )
     if not has_flags:
         # Interactive mode
@@ -1166,6 +1221,14 @@ def edit(
                     _err.print(f"[red]{err}[/red]")
                     raise typer.Exit(code=1)
             body["allowed_domains"] = allow or None
+        edit_settings = _build_settings(
+            idle_timeout, cpu_limit, memory_limit, pids_limit
+        )
+        if edit_settings:
+            # Merge with existing settings so unspecified keys are preserved.
+            merged = dict(ws.settings or {})
+            merged.update(edit_settings)
+            body["settings"] = merged
 
     if not body:
         typer.echo("No changes.")

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -3534,6 +3534,23 @@ class TestCreateWorkspaceClient:
         body = mock_post.call_args.kwargs.get("json")
         assert body["setup_state"] == "pending"
 
+    def test_create_workspace_with_settings(self):
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "id": "ws-s",
+            "name": "s-ws",
+            "created_at": "2025-01-01",
+        }
+        with patch.object(client, "post", return_value=mock_resp) as mock_post:
+            client.create_workspace(
+                "s-ws",
+                settings={"cpu_limit": 1.5, "pids_limit": 256},
+            )
+        body = mock_post.call_args.kwargs.get("json")
+        assert body["settings"] == {"cpu_limit": 1.5, "pids_limit": 256}
+
     def test_set_setup_state(self):
         """set_setup_state PUTs the lifecycle field (#1033)."""
         client = KlangkClient("http://test:8995", "token")

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -2408,6 +2408,7 @@ class TestMainCLI:
             env={"FOO": "bar", "X": "1"},
             health_check=None,
             allowed_domains=None,
+            settings=None,
         )
 
     def test_create_with_command_flag(self, logged_in_cfg, monkeypatch):
@@ -2434,6 +2435,7 @@ class TestMainCLI:
             env=None,
             health_check=None,
             allowed_domains=None,
+            settings=None,
         )
 
     def test_create_with_invalid_env_flag(self, logged_in_cfg, monkeypatch):
@@ -2483,6 +2485,53 @@ class TestMainCLI:
             env=None,
             health_check=None,
             allowed_domains=["github.com:443", "pypi.org"],
+            settings=None,
+        )
+
+    def test_create_with_settings_flags(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="new-id", name="ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client = MagicMock()
+        client.create_workspace.return_value = ws
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app,
+            [
+                "create",
+                "ws",
+                "--idle-timeout",
+                "600",
+                "--cpu-limit",
+                "1.5",
+                "--memory-limit",
+                "4g",
+                "--pids-limit",
+                "256",
+            ],
+        )
+        assert result.exit_code == 0
+        client.create_workspace.assert_called_once_with(
+            "ws",
+            image=None,
+            service_command=None,
+            auto_start=False,
+            mounts=None,
+            env=None,
+            health_check=None,
+            allowed_domains=None,
+            settings={
+                "idle_timeout": 600,
+                "cpu_limit": 1.5,
+                "memory_limit": "4g",
+                "pids_limit": 256,
+            },
         )
 
     def test_create_with_invalid_allow_flag(self, logged_in_cfg, monkeypatch):
@@ -2866,6 +2915,44 @@ class TestMainCLI:
 
         body = client.put.call_args[1]["json"]
         assert body["auto_start"] is True
+
+    def test_edit_with_settings_flags(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            settings={"idle_timeout": 300},
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                [
+                    "edit",
+                    "my-ws",
+                    "--cpu-limit",
+                    "2.0",
+                    "--pids-limit",
+                    "1024",
+                ],
+            )
+            assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        # Existing idle_timeout is preserved, new fields are merged in.
+        assert body["settings"] == {
+            "idle_timeout": 300,
+            "cpu_limit": 2.0,
+            "pids_limit": 1024,
+        }
 
     def test_edit_restart_needed_decline(self, logged_in_cfg, monkeypatch):
         """Running ws + create-time field → warn, user declines restart."""


### PR DESCRIPTION
## Summary

- Add `--idle-timeout`, `--cpu-limit`, `--memory-limit`, `--pids-limit` flags to `klangk workspaces create` and `klangk workspaces edit`
- On edit, new settings values are merged with existing settings so unspecified keys are preserved
- Add `settings` field to the `Workspace` dataclass and `create_workspace` client method

Closes #2216

## Test plan

- [x] `test_create_with_settings_flags` — all four flags populate the settings dict
- [x] `test_edit_with_settings_flags` — new values merge with existing settings
- [x] `test_create_workspace_with_settings` — client method includes settings in POST body
- [x] Full backend suite passes (4168 tests, 100% coverage)