### PR TITLE
fix(workspace): suppress reconnect overlay when login is required (#2227)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -322,6 +322,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace: no more overlapping "Server unreachable" and
+  "Session expired" overlays (#2227).** When the WebSocket closed with
+  an auth-failure code (4001/4002, session expired), the client also
+  flagged itself disconnected, so the workspace's reconnect overlay
+  painted on top of the re-login surface. The client now marks the
+  disconnect as auth-caused and the workspace suppresses the reconnect
+  overlay in that case, leaving only the re-login path.
+
 - **New terminals from the Flutter "+" are named "bash" (#2179).** A
   terminal created from the browser tab-bar "+" was named with a
   consecutive number ("1", "2", …), inconsistent with window 0 ("bash")

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -449,7 +449,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
               onRestart: _restartContainer,
               onBack: () => context.go('/workspaces'),
             ),
-          if (_disconnected && !_containerStopped)
+          if (_disconnected && !_containerStopped && !wsClient.authFailed)
             buildDisconnectedOverlay(
               reconnecting: wsClient.reconnecting,
               reconnectAttempt: wsClient.reconnectAttempt,

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -50,6 +50,13 @@ class WsClient extends ChangeNotifier implements ChatServices {
   int _reconnectAttempt = 0;
   int get reconnectAttempt => _reconnectAttempt;
 
+  /// Whether the last disconnect was caused by an auth failure (WebSocket
+  /// close codes 4001/4002). The UI reads this to suppress the "Server
+  /// unreachable" reconnect overlay and surface only the re-login path, so
+  /// the two never overlap (#2227). Reset on a successful connect.
+  bool _authFailed = false;
+  bool get authFailed => _authFailed;
+
   Timer? _reconnectTimer;
 
   /// Whether auto-reconnect should be attempted on disconnect.
@@ -303,6 +310,7 @@ class WsClient extends ChangeNotifier implements ChatServices {
       debugPrint('[WsClient] channel.ready failed: $e ${DateTime.now()}');
       final code = _channel?.closeCode;
       if (code == 4001 || code == 4002) {
+        _authFailed = true;
         _errorController.add('Session expired, please log in again');
         _auth?.logout();
       } else {
@@ -312,6 +320,9 @@ class WsClient extends ChangeNotifier implements ChatServices {
       return;
     }
 
+    // A fresh successful connection clears any prior auth-failure flag
+    // (#2227); reconnect overlays may show again if this connection drops.
+    _authFailed = false;
     _connected = true;
     // Close cleanly on page unload so Firefox's FailDelayManager doesn't
     // treat it as a failure and throttle the next connection by up to 60s.
@@ -388,8 +399,17 @@ class WsClient extends ChangeNotifier implements ChatServices {
         terminalWindows = [];
         sharedTerminals = [];
         final code = _channel?.closeCode;
+        final authFailure = code == 4001 || code == 4002;
+        // Set the auth-failure flag BEFORE notifyListeners so the UI (which
+        // rebuilds on this notification) suppresses the reconnect overlay
+        // immediately and shows only the re-login path (#2227).
+        if (authFailure) {
+          _authFailed = true;
+          _reconnecting = false;
+          _reconnectAttempt = 0;
+        }
         notifyListeners();
-        if (code == 4001 || code == 4002) {
+        if (authFailure) {
           _errorController.add('Session expired, please log in again');
           _auth?.logout();
         } else {
@@ -405,9 +425,15 @@ class WsClient extends ChangeNotifier implements ChatServices {
         presenceUsers = [];
         terminalWindows = [];
         sharedTerminals = [];
-        notifyListeners();
         final code = _channel?.closeCode;
-        if (code == 4001 || code == 4002) {
+        final authFailure = code == 4001 || code == 4002;
+        if (authFailure) {
+          _authFailed = true;
+          _reconnecting = false;
+          _reconnectAttempt = 0;
+        }
+        notifyListeners();
+        if (authFailure) {
           _auth?.logout();
         } else {
           _scheduleReconnect();

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -341,6 +341,7 @@ void main() {
       expect(client.connected, isFalse);
       expect(errors.length, 1);
       expect(errors[0], 'Session expired, please log in again');
+      expect(client.authFailed, isTrue);
       client.dispose();
     });
 
@@ -591,6 +592,7 @@ void main() {
 
       expect(client.reconnecting, isFalse);
       expect(client.reconnectAttempt, 0);
+      expect(client.authFailed, isTrue);
 
       client.disconnect();
       client.dispose();
@@ -996,6 +998,7 @@ void main() {
       expect(client.reconnecting, isFalse);
       expect(client.reconnectAttempt, 0);
       expect(errors, contains('Session expired, please log in again'));
+      expect(client.authFailed, isTrue);
 
       client.disconnect();
       client.dispose();
@@ -1023,6 +1026,7 @@ void main() {
       expect(client.reconnecting, isFalse);
       expect(client.reconnectAttempt, 0);
       expect(errors, contains('Session expired, please log in again'));
+      expect(client.authFailed, isTrue);
 
       client.disconnect();
       client.dispose();


### PR DESCRIPTION
## What

Fixes #2227.

When a workspace's WebSocket closed with an auth-failure code (4001/4002 — session expired / token invalid), the client flagged itself **disconnected** (driving the "Server unreachable / Reconnecting…" overlay) **and** emitted the session-expired / `logout()` path (driving the re-login surface). Both painted at once and overlapped. Only the re-login path should show — reconnecting can't succeed until the user re-authenticates.

## How

- **`WsClient` (`ws_client.dart`):** added an `authFailed` flag.
  - Set **before** `notifyListeners()` in all three auth-failure paths (initial-connect failure, `onDone`, `onError`), and the reconnect state (`reconnecting`/`reconnectAttempt`) is cleared there too, so the flag is already true when the UI rebuilds on that notification.
  - Reset to `false` on a successful connect.
- **`WorkspacePage` (`workspace_page.dart`):** the disconnected overlay is now gated on `&& !wsClient.authFailed`, so when the disconnect cause is an auth failure the reconnect overlay is suppressed and only the re-login surface remains.

## Verification

- Added `authFailed` assertions to the four existing auth-close tests (connect-failure 4001, server-error 4002, server-close 4001, server-close 4002).
- `flutter test --coverage` — **830 passed**, `ws_client.dart` at **100%**.
- `workspace_page.dart` is not in the coverage report (no test pumps the full page — only the extracted overlay builders are unit-tested, as before); the `authFailed` getter it depends on is fully covered.

Closes #2227.
