### PR TITLE
feat(workspace): group create/edit form fields into sections (#2229)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -198,6 +198,15 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Workspace create/edit forms grouped into sections (#2229).** The
+  browser's "New workspace" dialog and the workspace settings panel now
+  group fields into the same logical sections the TUI form uses — General,
+  Mounts, Environment, Netfilter, Resources, Advanced — in that order, each
+  under its own titled pane. A section-nav strip above the fields jumps to a
+  section (the edit panel's strip is pinned; the create dialog's scrolls at
+  the top). The settings panel's config area is also wider. Field set and
+  validation are unchanged.
+
 - **Duplicate terminal tab names allowed (#2192).** Renaming a
   terminal tab to a name another tab already uses is no longer rejected.
   Tab names are display-only; window identity is the tmux window id (`@N`),

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -301,15 +301,22 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                   ),
                   if (widget.allowAutostart) ...[
                     const SizedBox(height: 8),
-                    CheckboxListTile(
-                      value: _autoStart,
-                      onChanged: (v) => setState(() => _autoStart = v ?? false),
-                      title: const Text('Auto start'),
-                      subtitle: const Text(
-                        'Start this workspace when the server starts',
+                    // Wrap in a transparent Material so the
+                    // CheckboxListTile's ink splash paints above the pane's
+                    // opaque background surface.
+                    Material(
+                      type: MaterialType.transparency,
+                      child: CheckboxListTile(
+                        value: _autoStart,
+                        onChanged: (v) =>
+                            setState(() => _autoStart = v ?? false),
+                        title: const Text('Auto start'),
+                        subtitle: const Text(
+                          'Start this workspace when the server starts',
+                        ),
+                        controlAffinity: ListTileControlAffinity.leading,
+                        contentPadding: EdgeInsets.zero,
                       ),
-                      controlAffinity: ListTileControlAffinity.leading,
-                      contentPadding: EdgeInsets.zero,
                     ),
                   ],
                 ],

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -238,236 +238,255 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       ),
       content: SizedBox(
         width: 1040,
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (_errorMessage != null) ...[
-                Text(
-                  _errorMessage!,
-                  style: TextStyle(color: Theme.of(context).colorScheme.error),
-                ),
-                const SizedBox(height: 12),
-              ],
-              WorkspaceSectionNav(
-                sections: [
-                  WorkspaceSection('General', _generalKey),
-                  WorkspaceSection('Mounts', _mountsKey),
-                  WorkspaceSection('Environment', _envKey),
-                  WorkspaceSection('Netfilter', _netfilterKey),
-                  WorkspaceSection('Resources', _resourcesKey),
-                  WorkspaceSection('Advanced', _advancedKey),
-                ],
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_errorMessage != null) ...[
+              Text(
+                _errorMessage!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
               ),
-              const SizedBox(height: 8),
-              WorkspaceSectionPane(
-                key: _generalKey,
-                icon: Icons.tune,
-                title: 'General',
-                children: [
-                  TextField(
-                    controller: _nameController,
-                    decoration: InputDecoration(
-                      labelText: 'Name',
-                      labelStyle: _labelStyle,
-                      floatingLabelStyle: _labelStyle,
-                      floatingLabelBehavior: FloatingLabelBehavior.always,
-                      border: const OutlineInputBorder(),
-                    ),
-                    autofocus: true,
-                    onSubmitted: (_) => _submit(),
-                  ),
-                  const SizedBox(height: 16),
-                  DropdownButtonFormField<String>(
-                    initialValue: _selectedImage,
-                    decoration: InputDecoration(
-                      labelText: 'Container Image',
-                      labelStyle: _labelStyle,
-                      floatingLabelStyle: _labelStyle,
-                      floatingLabelBehavior: FloatingLabelBehavior.always,
-                      border: const OutlineInputBorder(),
-                    ),
-                    items: widget.allowedImages
-                        .map(
-                          (img) => DropdownMenuItem(
-                            value: img,
-                            child: Text(img),
+              const SizedBox(height: 12),
+            ],
+            WorkspaceSectionNav(
+              sections: [
+                WorkspaceSection('General', _generalKey),
+                WorkspaceSection('Mounts', _mountsKey),
+                WorkspaceSection('Environment', _envKey),
+                WorkspaceSection('Netfilter', _netfilterKey),
+                WorkspaceSection('Resources', _resourcesKey),
+                WorkspaceSection('Advanced', _advancedKey),
+              ],
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    WorkspaceSectionPane(
+                      key: _generalKey,
+                      icon: Icons.tune,
+                      title: 'General',
+                      children: [
+                        TextField(
+                          controller: _nameController,
+                          decoration: InputDecoration(
+                            labelText: 'Name',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
                           ),
-                        )
-                        .toList(),
-                    onChanged: (v) => setState(
-                      () => _selectedImage = v ?? widget.defaultImage,
-                    ),
-                  ),
-                  if (widget.allowAutostart) ...[
-                    const SizedBox(height: 8),
-                    // Wrap in a transparent Material so the
-                    // CheckboxListTile's ink splash paints above the pane's
-                    // opaque background surface.
-                    Material(
-                      type: MaterialType.transparency,
-                      child: CheckboxListTile(
-                        value: _autoStart,
-                        onChanged: (v) =>
-                            setState(() => _autoStart = v ?? false),
-                        title: const Text('Auto start'),
-                        subtitle: const Text(
-                          'Start this workspace when the server starts',
+                          autofocus: true,
+                          onSubmitted: (_) => _submit(),
                         ),
-                        controlAffinity: ListTileControlAffinity.leading,
-                        contentPadding: EdgeInsets.zero,
-                      ),
+                        const SizedBox(height: 16),
+                        DropdownButtonFormField<String>(
+                          initialValue: _selectedImage,
+                          decoration: InputDecoration(
+                            labelText: 'Container Image',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                          ),
+                          items: widget.allowedImages
+                              .map(
+                                (img) => DropdownMenuItem(
+                                  value: img,
+                                  child: Text(img),
+                                ),
+                              )
+                              .toList(),
+                          onChanged: (v) => setState(
+                            () => _selectedImage = v ?? widget.defaultImage,
+                          ),
+                        ),
+                        if (widget.allowAutostart) ...[
+                          const SizedBox(height: 8),
+                          // Wrap in a transparent Material so the
+                          // CheckboxListTile's ink splash paints above the pane's
+                          // opaque background surface.
+                          Material(
+                            type: MaterialType.transparency,
+                            child: CheckboxListTile(
+                              value: _autoStart,
+                              onChanged: (v) =>
+                                  setState(() => _autoStart = v ?? false),
+                              title: const Text('Auto start'),
+                              subtitle: const Text(
+                                'Start this workspace when the server starts',
+                              ),
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: EdgeInsets.zero,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    WorkspaceSectionPane(
+                      key: _mountsKey,
+                      icon: Icons.folder_open,
+                      title: 'Mounts',
+                      children: _buildMountsEditor(),
+                    ),
+                    const SizedBox(height: 16),
+                    WorkspaceSectionPane(
+                      key: _envKey,
+                      icon: Icons.code,
+                      title: 'Environment',
+                      children: _buildEnvVarsEditor(),
+                    ),
+                    const SizedBox(height: 16),
+                    WorkspaceSectionPane(
+                      key: _netfilterKey,
+                      icon: Icons.shield,
+                      title: 'Netfilter',
+                      children: _buildAllowedDomainsEditor(),
+                    ),
+                    const SizedBox(height: 16),
+                    WorkspaceSectionPane(
+                      key: _resourcesKey,
+                      icon: Icons.speed,
+                      title: 'Resources',
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextField(
+                                controller: _idleTimeoutController,
+                                decoration: InputDecoration(
+                                  labelText: 'Idle Timeout (s)',
+                                  labelStyle: _labelStyle,
+                                  floatingLabelStyle: _labelStyle,
+                                  floatingLabelBehavior:
+                                      FloatingLabelBehavior.always,
+                                  border: const OutlineInputBorder(),
+                                  hintText: '0 = never',
+                                ),
+                                keyboardType: TextInputType.number,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: TextField(
+                                controller: _cpuLimitController,
+                                decoration: InputDecoration(
+                                  labelText: 'CPU Limit',
+                                  labelStyle: _labelStyle,
+                                  floatingLabelStyle: _labelStyle,
+                                  floatingLabelBehavior:
+                                      FloatingLabelBehavior.always,
+                                  border: const OutlineInputBorder(),
+                                  hintText: 'e.g. 2.0',
+                                ),
+                                keyboardType: TextInputType.number,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextField(
+                                controller: _memoryLimitController,
+                                decoration: InputDecoration(
+                                  labelText: 'Memory Limit',
+                                  labelStyle: _labelStyle,
+                                  floatingLabelStyle: _labelStyle,
+                                  floatingLabelBehavior:
+                                      FloatingLabelBehavior.always,
+                                  border: const OutlineInputBorder(),
+                                  hintText: 'e.g. 4g',
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: TextField(
+                                controller: _pidsLimitController,
+                                decoration: InputDecoration(
+                                  labelText: 'PIDs Limit',
+                                  labelStyle: _labelStyle,
+                                  floatingLabelStyle: _labelStyle,
+                                  floatingLabelBehavior:
+                                      FloatingLabelBehavior.always,
+                                  border: const OutlineInputBorder(),
+                                  hintText: 'e.g. 512',
+                                ),
+                                keyboardType: TextInputType.number,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    WorkspaceSectionPane(
+                      key: _advancedKey,
+                      icon: Icons.build,
+                      title: 'Advanced',
+                      children: [
+                        TextField(
+                          controller: _cmdController,
+                          decoration: InputDecoration(
+                            labelText: 'Service Shell Command',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                            hintText: 'Optional — runs on terminal open',
+                          ),
+                          onSubmitted: (_) => _submit(),
+                        ),
+                        const SizedBox(height: 16),
+                        TextField(
+                          controller: _healthCheckController,
+                          decoration: InputDecoration(
+                            labelText: 'Health Check Command',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                            hintText:
+                                'Optional — polled to gauge service health',
+                          ),
+                          onSubmitted: (_) => _submit(),
+                        ),
+                        // #2202: per-workspace nix flag (only when the
+                        // server has a btrfs seed subvolume). Independent
+                        // of the image choice — it mounts a shared /nix
+                        // snapshot into whatever image the user selected.
+                        if (widget.nixAvailable) ...[
+                          const SizedBox(height: 16),
+                          // Wrap in a transparent Material so the
+                          // CheckboxListTile's ink splash paints above the
+                          // pane's opaque background surface.
+                          Material(
+                            type: MaterialType.transparency,
+                            child: CheckboxListTile(
+                              value: _nixEnabled,
+                              onChanged: (v) =>
+                                  setState(() => _nixEnabled = v ?? false),
+                              title: const Text('Nix'),
+                              subtitle: const Text(
+                                'Mount a shared, writable /nix (btrfs snapshot) into this workspace',
+                              ),
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: EdgeInsets.zero,
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
                   ],
-                ],
-              ),
-              const SizedBox(height: 16),
-              WorkspaceSectionPane(
-                key: _mountsKey,
-                icon: Icons.folder_open,
-                title: 'Mounts',
-                children: _buildMountsEditor(),
-              ),
-              const SizedBox(height: 16),
-              WorkspaceSectionPane(
-                key: _envKey,
-                icon: Icons.code,
-                title: 'Environment',
-                children: _buildEnvVarsEditor(),
-              ),
-              const SizedBox(height: 16),
-              WorkspaceSectionPane(
-                key: _netfilterKey,
-                icon: Icons.shield,
-                title: 'Netfilter',
-                children: _buildAllowedDomainsEditor(),
-              ),
-              const SizedBox(height: 16),
-              WorkspaceSectionPane(
-                key: _resourcesKey,
-                icon: Icons.speed,
-                title: 'Resources',
-                children: [
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextField(
-                          controller: _idleTimeoutController,
-                          decoration: InputDecoration(
-                            labelText: 'Idle Timeout (s)',
-                            labelStyle: _labelStyle,
-                            floatingLabelStyle: _labelStyle,
-                            floatingLabelBehavior: FloatingLabelBehavior.always,
-                            border: const OutlineInputBorder(),
-                            hintText: '0 = never',
-                          ),
-                          keyboardType: TextInputType.number,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: TextField(
-                          controller: _cpuLimitController,
-                          decoration: InputDecoration(
-                            labelText: 'CPU Limit',
-                            labelStyle: _labelStyle,
-                            floatingLabelStyle: _labelStyle,
-                            floatingLabelBehavior: FloatingLabelBehavior.always,
-                            border: const OutlineInputBorder(),
-                            hintText: 'e.g. 2.0',
-                          ),
-                          keyboardType: TextInputType.number,
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextField(
-                          controller: _memoryLimitController,
-                          decoration: InputDecoration(
-                            labelText: 'Memory Limit',
-                            labelStyle: _labelStyle,
-                            floatingLabelStyle: _labelStyle,
-                            floatingLabelBehavior: FloatingLabelBehavior.always,
-                            border: const OutlineInputBorder(),
-                            hintText: 'e.g. 4g',
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: TextField(
-                          controller: _pidsLimitController,
-                          decoration: InputDecoration(
-                            labelText: 'PIDs Limit',
-                            labelStyle: _labelStyle,
-                            floatingLabelStyle: _labelStyle,
-                            floatingLabelBehavior: FloatingLabelBehavior.always,
-                            border: const OutlineInputBorder(),
-                            hintText: 'e.g. 512',
-                          ),
-                          keyboardType: TextInputType.number,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              WorkspaceSectionPane(
-                key: _advancedKey,
-                icon: Icons.build,
-                title: 'Advanced',
-                children: [
-                  TextField(
-                    controller: _cmdController,
-                    decoration: InputDecoration(
-                      labelText: 'Service Shell Command',
-                      labelStyle: _labelStyle,
-                      floatingLabelStyle: _labelStyle,
-                      floatingLabelBehavior: FloatingLabelBehavior.always,
-                      border: const OutlineInputBorder(),
-                      hintText: 'Optional — runs on terminal open',
-                    ),
-                    onSubmitted: (_) => _submit(),
-                  ),
-                  const SizedBox(height: 16),
-                  TextField(
-                    controller: _healthCheckController,
-                    decoration: InputDecoration(
-                      labelText: 'Health Check Command',
-                      labelStyle: _labelStyle,
-                      floatingLabelStyle: _labelStyle,
-                      floatingLabelBehavior: FloatingLabelBehavior.always,
-                      border: const OutlineInputBorder(),
-                      hintText: 'Optional — polled to gauge service health',
-                    ),
-                    onSubmitted: (_) => _submit(),
-                  ),
-                ],
-              ),
-              // #2202: per-workspace nix flag (only when the server has a
-              // btrfs seed subvolume). Independent of the image choice — it
-              // mounts a shared /nix snapshot into whatever image the user
-              // selected.
-              if (widget.nixAvailable) ...[
-                const SizedBox(height: 8),
-                CheckboxListTile(
-                  value: _nixEnabled,
-                  onChanged: (v) => setState(() => _nixEnabled = v ?? false),
-                  title: const Text('Nix'),
-                  subtitle: const Text(
-                    'Mount a shared, writable /nix (btrfs snapshot) into this workspace',
-                  ),
-                  controlAffinity: ListTileControlAffinity.leading,
-                  contentPadding: EdgeInsets.zero,
                 ),
-              ],
-            ],
-          ),
+              ),
+            ),
+          ],
         ),
       ),
       actions: [

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -237,7 +237,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
         style: TextStyle(color: KColors.textPrimary),
       ),
       content: SizedBox(
-        width: 520,
+        width: 1040,
         child: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -5,6 +5,7 @@ import '../auth/auth_service.dart';
 import '../theme/colors.dart';
 import 'workspace_list_page.dart'
     show validateMountSpec, validateAllowedDomainSpec;
+import 'workspace_section_nav.dart';
 
 /// Dialog for creating a new workspace. Fields, top to bottom:
 /// Name, Mounts, Environment Variables, Service shell command, Health
@@ -73,6 +74,16 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   String? _mountError;
   String? _envError;
   String? _allowedDomainsError;
+
+  // Section anchors for the section-nav strip (#2229): each key is attached
+  // to the pane that opens the section so tapping a nav label scrolls it
+  // into view via Scrollable.ensureVisible.
+  final _generalKey = GlobalKey();
+  final _mountsKey = GlobalKey();
+  final _envKey = GlobalKey();
+  final _netfilterKey = GlobalKey();
+  final _resourcesKey = GlobalKey();
+  final _advancedKey = GlobalKey();
 
   final _labelStyle = TextStyle(
     color: KColors.textPrimary,
@@ -226,10 +237,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
         style: TextStyle(color: KColors.textPrimary),
       ),
       content: SizedBox(
-        width: 400,
+        width: 520,
         child: SingleChildScrollView(
           child: Column(
-            mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               if (_errorMessage != null) ...[
@@ -239,150 +249,196 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                 ),
                 const SizedBox(height: 12),
               ],
-              TextField(
-                controller: _nameController,
-                decoration: InputDecoration(
-                  labelText: 'Name',
-                  labelStyle: _labelStyle,
-                  floatingLabelStyle: _labelStyle,
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  border: const OutlineInputBorder(),
-                ),
-                autofocus: true,
-                onSubmitted: (_) => _submit(),
-              ),
-              ..._buildMountsEditor(),
-              ..._buildEnvVarsEditor(),
-              ..._buildAllowedDomainsEditor(),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _cmdController,
-                decoration: InputDecoration(
-                  labelText: 'Service Shell Command',
-                  labelStyle: _labelStyle,
-                  floatingLabelStyle: _labelStyle,
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  border: const OutlineInputBorder(),
-                  hintText: 'Optional — runs on terminal open',
-                ),
-                onSubmitted: (_) => _submit(),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _healthCheckController,
-                decoration: InputDecoration(
-                  labelText: 'Health Check Command',
-                  labelStyle: _labelStyle,
-                  floatingLabelStyle: _labelStyle,
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  border: const OutlineInputBorder(),
-                  hintText: 'Optional — polled to gauge service health',
-                ),
-                onSubmitted: (_) => _submit(),
-              ),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<String>(
-                initialValue: _selectedImage,
-                decoration: InputDecoration(
-                  labelText: 'Container Image',
-                  labelStyle: _labelStyle,
-                  floatingLabelStyle: _labelStyle,
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  border: const OutlineInputBorder(),
-                ),
-                items: widget.allowedImages
-                    .map(
-                      (img) => DropdownMenuItem(value: img, child: Text(img)),
-                    )
-                    .toList(),
-                onChanged: (v) =>
-                    setState(() => _selectedImage = v ?? widget.defaultImage),
-              ),
-              if (widget.allowAutostart) ...[
-                const SizedBox(height: 8),
-                CheckboxListTile(
-                  value: _autoStart,
-                  onChanged: (v) => setState(() => _autoStart = v ?? false),
-                  title: const Text('Auto start'),
-                  subtitle: const Text(
-                    'Start this workspace when the server starts',
-                  ),
-                  controlAffinity: ListTileControlAffinity.leading,
-                  contentPadding: EdgeInsets.zero,
-                ),
-              ],
-              const SizedBox(height: 16),
-              const Text(
-                'Resource Limits',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 14,
-                ),
+              WorkspaceSectionNav(
+                sections: [
+                  WorkspaceSection('General', _generalKey),
+                  WorkspaceSection('Mounts', _mountsKey),
+                  WorkspaceSection('Environment', _envKey),
+                  WorkspaceSection('Netfilter', _netfilterKey),
+                  WorkspaceSection('Resources', _resourcesKey),
+                  WorkspaceSection('Advanced', _advancedKey),
+                ],
               ),
               const SizedBox(height: 8),
-              Row(
+              WorkspaceSectionPane(
+                key: _generalKey,
+                icon: Icons.tune,
+                title: 'General',
                 children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _idleTimeoutController,
-                      decoration: InputDecoration(
-                        labelText: 'Idle Timeout (s)',
-                        labelStyle: _labelStyle,
-                        floatingLabelStyle: _labelStyle,
-                        floatingLabelBehavior: FloatingLabelBehavior.always,
-                        border: const OutlineInputBorder(),
-                        hintText: '0 = never',
-                      ),
-                      keyboardType: TextInputType.number,
+                  TextField(
+                    controller: _nameController,
+                    decoration: InputDecoration(
+                      labelText: 'Name',
+                      labelStyle: _labelStyle,
+                      floatingLabelStyle: _labelStyle,
+                      floatingLabelBehavior: FloatingLabelBehavior.always,
+                      border: const OutlineInputBorder(),
+                    ),
+                    autofocus: true,
+                    onSubmitted: (_) => _submit(),
+                  ),
+                  const SizedBox(height: 16),
+                  DropdownButtonFormField<String>(
+                    initialValue: _selectedImage,
+                    decoration: InputDecoration(
+                      labelText: 'Container Image',
+                      labelStyle: _labelStyle,
+                      floatingLabelStyle: _labelStyle,
+                      floatingLabelBehavior: FloatingLabelBehavior.always,
+                      border: const OutlineInputBorder(),
+                    ),
+                    items: widget.allowedImages
+                        .map(
+                          (img) => DropdownMenuItem(
+                            value: img,
+                            child: Text(img),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (v) => setState(
+                      () => _selectedImage = v ?? widget.defaultImage,
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: TextField(
-                      controller: _cpuLimitController,
-                      decoration: InputDecoration(
-                        labelText: 'CPU Limit',
-                        labelStyle: _labelStyle,
-                        floatingLabelStyle: _labelStyle,
-                        floatingLabelBehavior: FloatingLabelBehavior.always,
-                        border: const OutlineInputBorder(),
-                        hintText: 'e.g. 2.0',
+                  if (widget.allowAutostart) ...[
+                    const SizedBox(height: 8),
+                    CheckboxListTile(
+                      value: _autoStart,
+                      onChanged: (v) => setState(() => _autoStart = v ?? false),
+                      title: const Text('Auto start'),
+                      subtitle: const Text(
+                        'Start this workspace when the server starts',
                       ),
-                      keyboardType: TextInputType.number,
+                      controlAffinity: ListTileControlAffinity.leading,
+                      contentPadding: EdgeInsets.zero,
                     ),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 16),
+              WorkspaceSectionPane(
+                key: _mountsKey,
+                icon: Icons.folder_open,
+                title: 'Mounts',
+                children: _buildMountsEditor(),
+              ),
+              const SizedBox(height: 16),
+              WorkspaceSectionPane(
+                key: _envKey,
+                icon: Icons.code,
+                title: 'Environment',
+                children: _buildEnvVarsEditor(),
+              ),
+              const SizedBox(height: 16),
+              WorkspaceSectionPane(
+                key: _netfilterKey,
+                icon: Icons.shield,
+                title: 'Netfilter',
+                children: _buildAllowedDomainsEditor(),
+              ),
+              const SizedBox(height: 16),
+              WorkspaceSectionPane(
+                key: _resourcesKey,
+                icon: Icons.speed,
+                title: 'Resources',
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _idleTimeoutController,
+                          decoration: InputDecoration(
+                            labelText: 'Idle Timeout (s)',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                            hintText: '0 = never',
+                          ),
+                          keyboardType: TextInputType.number,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: TextField(
+                          controller: _cpuLimitController,
+                          decoration: InputDecoration(
+                            labelText: 'CPU Limit',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                            hintText: 'e.g. 2.0',
+                          ),
+                          keyboardType: TextInputType.number,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _memoryLimitController,
+                          decoration: InputDecoration(
+                            labelText: 'Memory Limit',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                            hintText: 'e.g. 4g',
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: TextField(
+                          controller: _pidsLimitController,
+                          decoration: InputDecoration(
+                            labelText: 'PIDs Limit',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                            hintText: 'e.g. 512',
+                          ),
+                          keyboardType: TextInputType.number,
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),
-              const SizedBox(height: 12),
-              Row(
+              const SizedBox(height: 16),
+              WorkspaceSectionPane(
+                key: _advancedKey,
+                icon: Icons.build,
+                title: 'Advanced',
                 children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _memoryLimitController,
-                      decoration: InputDecoration(
-                        labelText: 'Memory Limit',
-                        labelStyle: _labelStyle,
-                        floatingLabelStyle: _labelStyle,
-                        floatingLabelBehavior: FloatingLabelBehavior.always,
-                        border: const OutlineInputBorder(),
-                        hintText: 'e.g. 4g',
-                      ),
+                  TextField(
+                    controller: _cmdController,
+                    decoration: InputDecoration(
+                      labelText: 'Service Shell Command',
+                      labelStyle: _labelStyle,
+                      floatingLabelStyle: _labelStyle,
+                      floatingLabelBehavior: FloatingLabelBehavior.always,
+                      border: const OutlineInputBorder(),
+                      hintText: 'Optional — runs on terminal open',
                     ),
+                    onSubmitted: (_) => _submit(),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: TextField(
-                      controller: _pidsLimitController,
-                      decoration: InputDecoration(
-                        labelText: 'PIDs Limit',
-                        labelStyle: _labelStyle,
-                        floatingLabelStyle: _labelStyle,
-                        floatingLabelBehavior: FloatingLabelBehavior.always,
-                        border: const OutlineInputBorder(),
-                        hintText: 'e.g. 512',
-                      ),
-                      keyboardType: TextInputType.number,
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _healthCheckController,
+                    decoration: InputDecoration(
+                      labelText: 'Health Check Command',
+                      labelStyle: _labelStyle,
+                      floatingLabelStyle: _labelStyle,
+                      floatingLabelBehavior: FloatingLabelBehavior.always,
+                      border: const OutlineInputBorder(),
+                      hintText: 'Optional — polled to gauge service health',
                     ),
+                    onSubmitted: (_) => _submit(),
                   ),
                 ],
               ),
@@ -420,9 +476,6 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
 
   List<Widget> _buildMountsEditor() {
     return [
-      const SizedBox(height: 16),
-      Text('Mounts', style: _labelStyle),
-      const SizedBox(height: 8),
       ..._mounts.asMap().entries.map(
             (e) => Padding(
               padding: const EdgeInsets.only(bottom: 4),
@@ -486,9 +539,6 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
 
   List<Widget> _buildEnvVarsEditor() {
     return [
-      const SizedBox(height: 16),
-      Text('Environment Variables', style: _labelStyle),
-      const SizedBox(height: 8),
       ..._envVars.entries.toList().asMap().entries.map(
             (e) => Padding(
               padding: const EdgeInsets.only(bottom: 4),
@@ -554,9 +604,6 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
 
   List<Widget> _buildAllowedDomainsEditor() {
     return [
-      const SizedBox(height: 16),
-      Text('Allowed Domains', style: _labelStyle),
-      const SizedBox(height: 8),
       ..._allowedDomains.asMap().entries.map(
             (e) => Padding(
               padding: const EdgeInsets.only(bottom: 4),

--- a/src/frontend/lib/workspace/workspace_section_nav.dart
+++ b/src/frontend/lib/workspace/workspace_section_nav.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// Pairs a section's nav label with the [GlobalKey] attached to the widget
+/// that begins the section in the scroll body, so [WorkspaceSectionNav] can
+/// scroll to it via [Scrollable.ensureVisible].
+class WorkspaceSection {
+  final String label;
+  final GlobalKey key;
+
+  const WorkspaceSection(this.label, this.key);
+}
+
+/// Horizontal section navigator for the workspace create/edit forms.
+///
+/// Mirrors the TUI create/edit form tab strip (#2229): the form body groups
+/// fields into logical sections (General, Mounts, Environment, Netfilter,
+/// Resources, Advanced); tapping a label scrolls the enclosing [Scrollable]
+/// to that section so the user can jump between sections instead of hunting
+/// through one long scroll. Unlike a [TabBar] the section bodies stay
+/// mounted in a single scroll, so every field remains reachable and the
+/// forms' identity-based field finders keep working.
+class WorkspaceSectionNav extends StatelessWidget {
+  final List<WorkspaceSection> sections;
+
+  const WorkspaceSectionNav({super.key, required this.sections});
+
+  Future<void> _scrollTo(GlobalKey key) async {
+    final ctx = key.currentContext;
+    if (ctx == null) return;
+    await Scrollable.ensureVisible(
+      ctx,
+      alignment: 0.0,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: KColors.borderDefault),
+        ),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            for (final s in sections)
+              Padding(
+                padding: const EdgeInsets.only(right: 8, bottom: 8),
+                child: InkWell(
+                  onTap: () => _scrollTo(s.key),
+                  borderRadius: BorderRadius.circular(16),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 6,
+                    ),
+                    decoration: BoxDecoration(
+                      color: KColors.bgCanvas,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(color: KColors.borderDefault),
+                    ),
+                    child: Text(
+                      s.label,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: KColors.textSecondary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A titled surface pane used to group related controls in the workspace
+/// create/edit forms (one per logical section: General, Mounts, …). Matches
+/// the visual treatment the settings panel already used for its cards, now
+/// shared with the create dialog so the two forms look alike.
+class WorkspaceSectionPane extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final Color? titleColor;
+  final List<Widget> children;
+
+  const WorkspaceSectionPane({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.titleColor,
+    required this.children,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        border: Border.all(color: KColors.borderDefault),
+        borderRadius: BorderRadius.circular(8),
+        color: KColors.bgSurface,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 18, color: titleColor ?? KColors.textSecondary),
+              const SizedBox(width: 8),
+              Text(
+                title,
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 14,
+                  color: titleColor,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          ...children,
+        ],
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
+import 'workspace_section_nav.dart';
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import 'workspace_list_page.dart' show validateAllowedDomainSpec;
@@ -292,6 +293,24 @@ class _SettingsFormState extends State<_SettingsForm> {
   bool _saving = false;
   bool _exporting = false;
 
+  // Section anchors for the config section-nav strip (#2229): each key is
+  // attached to the pane that opens the section so a nav-label tap scrolls
+  // it into view.
+  final _generalKey = GlobalKey();
+  final _mountsKey = GlobalKey();
+  final _envKey = GlobalKey();
+  final _netfilterKey = GlobalKey();
+  final _resourcesKey = GlobalKey();
+  final _advancedKey = GlobalKey();
+  late final List<WorkspaceSection> _sections = [
+    WorkspaceSection('General', _generalKey),
+    WorkspaceSection('Mounts', _mountsKey),
+    WorkspaceSection('Environment', _envKey),
+    WorkspaceSection('Netfilter', _netfilterKey),
+    WorkspaceSection('Resources', _resourcesKey),
+    WorkspaceSection('Advanced', _advancedKey),
+  ];
+
   @override
   void initState() {
     super.initState();
@@ -489,33 +508,65 @@ class _SettingsFormState extends State<_SettingsForm> {
       fontWeight: FontWeight.bold,
     );
 
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16),
-      child: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 500),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (widget.saveMessage != null) ...[
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.saveMessage != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 _buildSaveMessage(),
                 if (widget.pendingRestart) ...[
                   const SizedBox(height: 8),
                   _buildRestartNotice(),
                 ],
-                const SizedBox(height: 16),
               ],
-              _buildConfigCard(labelStyle),
-              const SizedBox(height: 16),
-              _buildExportCard(),
-              const SizedBox(height: 16),
-              _buildTransferCard(),
-              const SizedBox(height: 16),
-              _buildDangerZoneCard(),
-            ],
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: WorkspaceSectionNav(sections: _sections),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 760),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildGeneralPane(labelStyle),
+                    const SizedBox(height: 16),
+                    _buildMountsPane(labelStyle),
+                    const SizedBox(height: 16),
+                    _buildEnvPane(labelStyle),
+                    const SizedBox(height: 16),
+                    _buildNetfilterPane(labelStyle),
+                    const SizedBox(height: 16),
+                    _buildResourcesPane(labelStyle),
+                    const SizedBox(height: 16),
+                    _buildAdvancedPane(labelStyle),
+                    const SizedBox(height: 16),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: _buildSaveButton(),
+                    ),
+                    const SizedBox(height: 16),
+                    _buildExportCard(),
+                    const SizedBox(height: 16),
+                    _buildTransferCard(),
+                    const SizedBox(height: 16),
+                    _buildDangerZoneCard(),
+                  ],
+                ),
+              ),
+            ),
           ),
         ),
-      ),
+      ],
     );
   }
 
@@ -569,42 +620,19 @@ class _SettingsFormState extends State<_SettingsForm> {
     required String title,
     Color? titleColor,
     required List<Widget> children,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        border: Border.all(color: KColors.borderDefault),
-        borderRadius: BorderRadius.circular(8),
-        color: KColors.bgSurface,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(icon, size: 18, color: titleColor ?? KColors.textSecondary),
-              const SizedBox(width: 8),
-              Text(
-                title,
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 14,
-                  color: titleColor,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          ...children,
-        ],
-      ),
-    );
-  }
+  }) =>
+      WorkspaceSectionPane(
+        icon: icon,
+        title: title,
+        titleColor: titleColor,
+        children: children,
+      );
 
-  Widget _buildConfigCard(TextStyle labelStyle) {
-    return _card(
-      icon: Icons.settings,
-      title: 'Workspace Configuration',
+  Widget _buildGeneralPane(TextStyle labelStyle) {
+    return WorkspaceSectionPane(
+      key: _generalKey,
+      icon: Icons.tune,
+      title: 'General',
       children: [
         TextField(
           controller: _nameCtrl,
@@ -613,34 +641,6 @@ class _SettingsFormState extends State<_SettingsForm> {
             labelStyle: labelStyle,
             floatingLabelBehavior: FloatingLabelBehavior.always,
             border: const OutlineInputBorder(),
-          ),
-        ),
-        const SizedBox(height: 16),
-        _buildMountsEditor(labelStyle),
-        const SizedBox(height: 16),
-        _buildEnvVarsEditor(labelStyle),
-        const SizedBox(height: 16),
-        _buildAllowedDomainsEditor(labelStyle),
-        const SizedBox(height: 16),
-        TextField(
-          controller: _cmdCtrl,
-          decoration: InputDecoration(
-            labelText: 'Service Shell Command',
-            labelStyle: labelStyle,
-            floatingLabelBehavior: FloatingLabelBehavior.always,
-            border: const OutlineInputBorder(),
-            hintText: 'Optional — runs on terminal open',
-          ),
-        ),
-        const SizedBox(height: 16),
-        TextField(
-          controller: _healthCheckCtrl,
-          decoration: InputDecoration(
-            labelText: 'Health Check Command',
-            labelStyle: labelStyle,
-            floatingLabelBehavior: FloatingLabelBehavior.always,
-            border: const OutlineInputBorder(),
-            hintText: 'Optional — polled to gauge service health',
           ),
         ),
         const SizedBox(height: 16),
@@ -662,8 +662,7 @@ class _SettingsFormState extends State<_SettingsForm> {
         if (widget.allowAutostart) ...[
           const SizedBox(height: 8),
           // Wrap in a transparent Material so the CheckboxListTile's ink
-          // splash paints above this card's opaque background surface
-          // (the _card() Container would otherwise hide it).
+          // splash paints above the pane's opaque background surface.
           Material(
             type: MaterialType.transparency,
             child: CheckboxListTile(
@@ -678,12 +677,43 @@ class _SettingsFormState extends State<_SettingsForm> {
             ),
           ),
         ],
-        const SizedBox(height: 16),
-        const Text(
-          'Resource Limits',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
-        ),
-        const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  Widget _buildMountsPane(TextStyle labelStyle) {
+    return WorkspaceSectionPane(
+      key: _mountsKey,
+      icon: Icons.folder_open,
+      title: 'Mounts',
+      children: [_buildMountsEditor(labelStyle)],
+    );
+  }
+
+  Widget _buildEnvPane(TextStyle labelStyle) {
+    return WorkspaceSectionPane(
+      key: _envKey,
+      icon: Icons.code,
+      title: 'Environment',
+      children: [_buildEnvVarsEditor(labelStyle)],
+    );
+  }
+
+  Widget _buildNetfilterPane(TextStyle labelStyle) {
+    return WorkspaceSectionPane(
+      key: _netfilterKey,
+      icon: Icons.shield,
+      title: 'Netfilter',
+      children: [_buildAllowedDomainsEditor(labelStyle)],
+    );
+  }
+
+  Widget _buildResourcesPane(TextStyle labelStyle) {
+    return WorkspaceSectionPane(
+      key: _resourcesKey,
+      icon: Icons.speed,
+      title: 'Resources',
+      children: [
         Row(
           children: [
             Expanded(
@@ -746,31 +776,60 @@ class _SettingsFormState extends State<_SettingsForm> {
             ),
           ],
         ),
+      ],
+    );
+  }
+
+  Widget _buildAdvancedPane(TextStyle labelStyle) {
+    return WorkspaceSectionPane(
+      key: _advancedKey,
+      icon: Icons.build,
+      title: 'Advanced',
+      children: [
+        TextField(
+          controller: _cmdCtrl,
+          decoration: InputDecoration(
+            labelText: 'Service Shell Command',
+            labelStyle: labelStyle,
+            floatingLabelBehavior: FloatingLabelBehavior.always,
+            border: const OutlineInputBorder(),
+            hintText: 'Optional — runs on terminal open',
+          ),
+        ),
         const SizedBox(height: 16),
-        Align(
-          alignment: Alignment.centerRight,
-          child: FilledButton.icon(
-            onPressed: _saving ? null : _save,
-            icon: _saving
-                ? const SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: Colors.white,
-                    ),
-                  )
-                : const Icon(Icons.save, size: 18),
-            label: const Text('Save'),
+        TextField(
+          controller: _healthCheckCtrl,
+          decoration: InputDecoration(
+            labelText: 'Health Check Command',
+            labelStyle: labelStyle,
+            floatingLabelBehavior: FloatingLabelBehavior.always,
+            border: const OutlineInputBorder(),
+            hintText: 'Optional — polled to gauge service health',
           ),
         ),
       ],
     );
   }
 
+  Widget _buildSaveButton() {
+    return FilledButton.icon(
+      onPressed: _saving ? null : _save,
+      icon: _saving
+          ? const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: Colors.white,
+              ),
+            )
+          : const Icon(Icons.save, size: 18),
+      label: const Text('Save'),
+    );
+  }
+
   Widget _buildMountsEditor(TextStyle labelStyle) {
     return _buildEditableList(
-      label: 'Mounts',
       labelStyle: labelStyle,
       hint: '/host/path:/container/path',
       controller: _mountCtrl,
@@ -788,7 +847,6 @@ class _SettingsFormState extends State<_SettingsForm> {
 
   Widget _buildEnvVarsEditor(TextStyle labelStyle) {
     return _buildEditableList(
-      label: 'Environment Variables',
       labelStyle: labelStyle,
       hint: 'KEY=VALUE',
       controller: _envCtrl,
@@ -809,7 +867,6 @@ class _SettingsFormState extends State<_SettingsForm> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _buildEditableList(
-          label: 'Allowed Domains',
           labelStyle: labelStyle,
           hint: 'github.com:443',
           controller: _allowedDomainsCtrl,
@@ -876,7 +933,6 @@ class _SettingsFormState extends State<_SettingsForm> {
   /// inline error. The two editors only differ in label, hint, and the
   /// item text/remove callback.
   Widget _buildEditableList({
-    required String label,
     required TextStyle labelStyle,
     required String hint,
     required TextEditingController controller,
@@ -887,8 +943,6 @@ class _SettingsFormState extends State<_SettingsForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: labelStyle),
-        const SizedBox(height: 8),
         ...items,
         if (error != null) ...[
           Text(

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -534,7 +534,7 @@ class _SettingsFormState extends State<_SettingsForm> {
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
             child: Center(
               child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 760),
+                constraints: const BoxConstraints(maxWidth: 1500),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -238,6 +238,7 @@ void main() {
       await tester.pump(); // dialog renders
 
       await tester.enterText(_mountInput(), 'invalid');
+      await tester.ensureVisible(find.byIcon(Icons.add).first);
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
 
@@ -253,10 +254,12 @@ void main() {
       await tester.pump(); // dialog renders
 
       await tester.enterText(_mountInput(), '/a:/b');
+      await tester.ensureVisible(find.byIcon(Icons.add).first);
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
       expect(find.text('/a:/b'), findsOneWidget);
 
+      await tester.ensureVisible(find.byIcon(Icons.close).first);
       await tester.tap(find.byIcon(Icons.close).first);
       await tester.pump();
       expect(find.text('/a:/b'), findsNothing);
@@ -496,6 +499,7 @@ void main() {
       await tester.pump();
 
       // Remove pypi.org (the second chip's close button).
+      await tester.ensureVisible(find.byIcon(Icons.close).at(1));
       await tester.tap(find.byIcon(Icons.close).at(1));
       await tester.pump();
       expect(find.text('pypi.org'), findsNothing);
@@ -647,12 +651,14 @@ void main() {
 
       // First: invalid mount to trigger error
       await tester.enterText(_mountInput(), 'bad');
+      await tester.ensureVisible(find.byIcon(Icons.add).first);
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
       expect(find.textContaining('Expected'), findsOneWidget);
 
       // Then: valid mount clears error
       await tester.enterText(_mountInput(), '/a:/b');
+      await tester.ensureVisible(find.byIcon(Icons.add).first);
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
       expect(find.textContaining('Expected'), findsNothing);

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -2018,6 +2018,7 @@ void main() {
       // The FAB also has an add icon, so find the one inside the dialog
       final addIcons = find.byIcon(Icons.add);
       // The mount add icon is at index 1 (after FAB at 0, before env at 2)
+      await tester.ensureVisible(addIcons.at(1));
       await tester.tap(addIcons.at(1));
       await tester.pumpAndSettle();
 
@@ -2026,11 +2027,13 @@ void main() {
 
       // Add a second mount
       await tester.enterText(_dialogMountInput(), 'nix-vol:/nix');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
       expect(find.text('nix-vol:/nix'), findsOneWidget);
 
       // Remove the first mount via its X button
+      await tester.ensureVisible(find.byIcon(Icons.close).first);
       await tester.tap(find.byIcon(Icons.close).first);
       await tester.pumpAndSettle();
       expect(find.text('/host/src:/work/src'), findsNothing);
@@ -2214,18 +2217,21 @@ void main() {
 
       // Try adding env var without = sign
       await tester.enterText(_dialogEnvInput(), 'NOEQ');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(2));
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.textContaining('Expected KEY=VALUE'), findsOneWidget);
 
       // Try adding env var with empty key
       await tester.enterText(_dialogEnvInput(), '=value');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(2));
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.textContaining('Key cannot be empty'), findsOneWidget);
 
       // Valid env var clears error
       await tester.enterText(_dialogEnvInput(), 'A=1');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(2));
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.textContaining('Key cannot'), findsNothing);
@@ -2280,6 +2286,7 @@ void main() {
 
       // Add an env var
       await tester.enterText(_dialogEnvInput(), 'FOO=bar');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(2));
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
 

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -170,7 +170,9 @@ void main() {
       await tester.pumpWidget(_buildPanel());
       await tester.pumpAndSettle();
 
-      expect(find.text('Workspace Configuration'), findsOneWidget);
+      // Config area renders as sectioned panes (#2229); the General pane
+      // icon is present when the config loaded.
+      expect(find.byIcon(Icons.tune), findsOneWidget);
       // Name field is pre-filled.
       expect(find.text('my-ws'), findsOneWidget);
       // Service command is pre-filled.
@@ -197,8 +199,25 @@ void main() {
       await tester.pumpWidget(_buildPanel());
       await tester.pumpAndSettle();
 
-      // Falls back to default image; panel still renders.
-      expect(find.text('Workspace Configuration'), findsOneWidget);
+      // Falls back to default image; panel still renders its sections.
+      expect(find.byIcon(Icons.tune), findsOneWidget);
+    });
+
+    testWidgets('section nav jumps to the chosen section', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // The Netfilter section's domain input starts below the fold.
+      final domainInput = find.byWidgetPredicate(
+        (w) => w is TextField && w.decoration?.hintText == 'github.com:443',
+      );
+      expect(domainInput.hitTestable(), findsNothing);
+
+      // Tapping the nav pill scrolls the section into view (#2229).
+      await tester.tap(find.text('Netfilter').first);
+      await tester.pumpAndSettle();
+
+      expect(domainInput.hitTestable(), findsOneWidget);
     });
   });
 
@@ -357,6 +376,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('example.com:443'), findsOneWidget);
+      await tester.ensureVisible(find.byIcon(Icons.close));
       await tester.tap(find.byIcon(Icons.close));
       await tester.pump();
 
@@ -583,6 +603,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Remove the existing domain so the save differs from the loaded ws.
+      await tester.ensureVisible(find.byIcon(Icons.close).first);
       await tester.tap(find.byIcon(Icons.close).first);
       await tester.pump();
 
@@ -778,6 +799,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Trigger the notice by removing the existing domain.
+      await tester.ensureVisible(find.byIcon(Icons.close).first);
       await tester.tap(find.byIcon(Icons.close).first);
       await tester.pump();
 


### PR DESCRIPTION
## What

Resolves #2229.

The TUI's add/edit workspace forms group fields into clean, navigable sections. The browser's New Workspace dialog and the workspace settings panel were one long, ungrouped scroll. This brings the web UI to the same structure.

## Changes

Both forms now group their fields into the same six sections the TUI uses, in the same order, each under a titled pane:

| Section | Fields |
|---|---|
| **General** | Name, Container Image, Auto start |
| **Mounts** | mounts editor |
| **Environment** | env-var editor |
| **Netfilter** | allowed-domains editor (+ egress-not-enforced notice) |
| **Resources** | idle timeout, CPU, memory, PIDs |
| **Advanced** | service shell command, health check |

A **section-nav strip** lets you jump to a section:
- **Settings panel (edit):** the strip is pinned above the scroll.
- **Create dialog (add):** the strip sits at the top of the dialog's scroll.

The settings panel's config area is also **wider** (was capped at 500px).

Shared widgets (`WorkspaceSectionNav`, `WorkspaceSectionPane`) back both forms; the settings panel's existing `_card` now delegates to the shared pane. Field set, validation, save/restart logic, and the Export / Transfer / Danger Zone cards are unchanged.

## Why not a `TabBar`

A `TabBarView` lazily builds only the active tab, which would break the forms' identity-based field finders (tests match fields by `hintText`/`labelText` and several tap later sections) and require a large test rewrite for no real gain. The section-nav + single scroll keeps every field mounted and reachable, matches the TUI's "section" structure, and adds real between-section navigation.

## Verification

- `flutter test --coverage` → **832 passed**; the three touched files (`workspace_section_nav.dart`, `create_workspace_dialog.dart`, `workspace_settings_panel.dart`) at **100%**.
- Added a `section nav jumps to the chosen section` test (tap a nav pill → the off-screen section scrolls into view).
- Existing tests that tap later sections gained `ensureVisible` (those sections now sit below the fold, as expected for a sectioned layout).

Closes #2229.
