### PR TITLE
feat(netfilter): add LOG rule for interactive egress mode in OCI hook (#2241)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,4 +1,4 @@
-name: Python Tests
+name: Backend Tests
 
 on:
   workflow_dispatch:

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,15 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Interactive egress consent mode (#2239, #2240, #2241).** Workspaces can now
+  set `egress_mode: "interactive"` (API/CLI). In this mode the OCI hook installs
+  an NFLOG rule that delivers blocked-connection metadata to userspace via a
+  netlink socket (group 5139), alongside the existing allow-list ACCEPT rules.
+  A future consent daemon will consume this feed to prompt a human for
+  allow/deny decisions; until the daemon ships, interactive mode behaves as
+  static filtering plus NFLOG observability — no prompts occur and unmatched
+  traffic is dropped. See `docs/features/egress-filtering.md`.
+
 - **`nix_seed` — per-workspace `/nix` with two backends (#2219, #2220).** The
   per-workspace `/nix` config is now one block — `nix_seed: {type, path}` —
   selecting a backend: `btrfs-snapshot` (a CoW snapshot of a seed btrfs

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -43,6 +43,35 @@ The hook runs **before** the container process starts, so the ruleset is in
 place and immutable before any user code runs — `CAP_NET_ADMIN` is dropped
 by the runtime before the container entrypoint executes.
 
+## Interactive egress mode (#2239)
+
+A workspace can set `egress_mode` to `"interactive"` (default is `"static"`)
+via the API or CLI. In interactive mode the OCI hook installs the same
+allow-list ACCEPT rules as static mode, but adds two additional rules at the
+end of the OUTPUT chain:
+
+1. A rate-limited **NFLOG** rule (`-j NFLOG --nflog-group 5139`) that
+   delivers blocked-packet metadata to userspace via a netlink socket.
+   The `--nflog-prefix` is `klangk-egress:<id>:` where `<id>` is the
+   first 12 characters of the OCI container id (the same short id shown
+   by `podman ps`). The consent daemon uses this prefix to correlate
+   packets with workspaces.
+2. An explicit **DROP** rule — redundant given the OUTPUT policy, but makes
+   the chain self-documenting and ensures NFLOG precedes DROP regardless
+   of future chain additions.
+
+Rate limiting (`--limit 5/sec --limit-burst 20`) prevents an adversarial
+container from flooding the NFLOG queue. Only the NFLOG notification is
+throttled — the DROP fires for every packet.
+
+> **Current status:** interactive mode today is **static filtering plus NFLOG
+> observability**. The consent daemon that would consume the NFLOG feed and
+> prompt a human to allow or deny blocked destinations **does not exist yet**
+> (#2242). Enabling interactive mode on a workspace will silently drop
+> unmatched traffic (exactly like static mode) while emitting NFLOG packets
+> that nothing is listening to. Do not enable interactive mode expecting
+> consent prompts — it is a building block for the upcoming consent system.
+
 ## Enabling it (operator)
 
 Netfilter is **armed by default**. At startup klangkd materializes the hook

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1080,7 +1080,9 @@ class ContainerRegistry:
         )
 
     def _egress_filter(
-        self, allowed_domains: list[str] | None
+        self,
+        allowed_domains: list[str] | None,
+        egress_mode: str = "static",
     ) -> tuple[dict[str, str] | None, list[str] | None, list[str] | None]:
         """Build ``(annotations, hooks_dirs, cap_drop)`` for egress (#1365).
 
@@ -1091,7 +1093,7 @@ class ContainerRegistry:
         nf = getattr(self.app.state, "netfilter", None)
         if nf is None:
             return None, None, None
-        return nf.create_kwargs(allowed_domains)
+        return nf.create_kwargs(allowed_domains, egress_mode=egress_mode)
 
     async def start_container(
         self,
@@ -1113,6 +1115,7 @@ class ContainerRegistry:
         service_command: str | None = None,
         allowed_domains: list[str] | None = None,
         workspace_settings: dict | None = None,
+        egress_mode: str = "static",
     ) -> tuple[str, str]:
         """Start (or restart) a Pi container for a workspace.
 
@@ -1142,6 +1145,7 @@ class ContainerRegistry:
                 service_command=service_command,
                 allowed_domains=allowed_domains,
                 workspace_settings=workspace_settings,
+                egress_mode=egress_mode,
             )
 
     async def _handle_existing_container(
@@ -1577,6 +1581,7 @@ class ContainerRegistry:
         service_command: str | None = None,
         allowed_domains: list[str] | None = None,
         workspace_settings: dict | None = None,
+        egress_mode: str = "static",
     ) -> tuple[str, str]:
         """Inner implementation of start_container (called under lock)."""
         t_start = time.monotonic()
@@ -1693,7 +1698,7 @@ class ContainerRegistry:
         # hooks running). The filtered container also drops NET_ADMIN
         # (#1773) so the entrypoint can't flush the ruleset.
         annotations, hooks_dirs, cap_drop = self._egress_filter(
-            allowed_domains
+            allowed_domains, egress_mode=egress_mode
         )
         if annotations is not None:
             create_kwargs["annotations"] = annotations

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -55,11 +55,25 @@ logger = logging.getLogger(__name__)
 ANNOTATION_KEY = "klangk.netfilter.rules"
 
 # OCI annotation carrying the egress mode (``static`` or ``interactive``).
-# When ``interactive``, the hook adds a rate-limited LOG rule before the
-# final DROP so the consent daemon can observe blocked destinations and
-# prompt a human (#2239). When absent or ``static``, no LOG rule is added
-# and the ruleset is fully immutable.
+# When ``interactive``, the hook adds a rate-limited NFLOG rule before the
+# final DROP so the consent daemon can observe blocked destinations via a
+# netlink queue and prompt a human (#2239). When absent or ``static``, no
+# NFLOG rule is added and the ruleset is fully immutable.
 ANNOTATION_EGRESS_MODE_KEY = "klangk.netfilter.egress_mode"
+
+# NFLOG group number used by the interactive-mode rule. The consent daemon
+# listens on this group via a netlink socket (no dmesg/journal parsing).
+# Picked to avoid the default 0 and common sniffing groups.
+NFLOG_GROUP = 5139
+
+# Log prefix format for NFLOG packets. The consent daemon parses this
+# prefix to correlate blocked packets with a container (and thus a
+# workspace). The tag is the first 12 characters of the OCI container id
+# (the authoritative id from the runtime state JSON, not the hostname).
+# iptables --nflog-prefix has a 64-byte cap; "klangk-egress:" (14) + 12 +
+# ":" (1) = 27 bytes — well within the limit.
+LOG_PREFIX_FMT = "klangk-egress:{tag}:"
+LOG_PREFIX_TAG_LEN = 12
 
 # Filenames written into the configured hooks dir.
 HOOK_JSON_NAME = "klangk-netfilter.json"
@@ -294,6 +308,12 @@ egress_mode=$(printf '%s' "$state" \
     | sed -n 's/.*"klangk.netfilter.egress_mode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 pid=$(printf '%s' "$state" \
     | sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+# The authoritative container id from the OCI runtime state JSON — used as
+# the NFLOG prefix tag so the consent daemon can correlate blocked packets
+# with a workspace. Truncated to 12 chars (podman short-id convention).
+_cid=$(printf '%s' "$state" \
+    | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | cut -c1-12)
 
 # Nothing to filter without a rules annotation or an init pid.
 [ -n "$rules" ] || exit 0
@@ -470,33 +490,32 @@ for _spec in "$@"; do
 done
 
 # Interactive egress consent mode (#2239). When egress_mode is
-# "interactive", add a rate-limited LOG rule so blocked destinations are
-# visible to the consent daemon (which tails /dev/kmsg or NFLOG). The
-# log prefix includes a workspace-specific tag extracted from the
-# klangk.netfilter.egress_mode annotation — the consent daemon parses
-# this prefix to correlate log lines to workspaces without maintaining
-# an IP→workspace map. The rate limit (5/sec, burst 20) caps log
-# flooding from adversarial containers — the DROP still fires for
-# every packet, only the LOG is throttled. An explicit final DROP
-# follows (redundant given the OUTPUT policy, but makes the chain
-# self-documenting and ensures LOG precedes DROP regardless of future
-# chain additions). In static mode (the default), no LOG rule is added
-# — the ruleset is fully immutable and identical to the pre-#2239
-# behavior.
+# "interactive", add a rate-limited NFLOG rule so blocked destinations
+# are delivered to the consent daemon via a netlink socket (group 5139).
+# NFLOG is the purpose-built iptables-to-userspace channel: it avoids
+# kernel ring-buffer noise (dmesg/journal), supports group multiplexing,
+# and the daemon needs only a netlink socket — no privileged journal
+# access or prefix-regex parsing.
 #
-# The log prefix uses the container ID (first 12 chars of the hostname,
-# which podman sets to the container's short ID by default) for
-# workspace correlation. klangk's container registry already knows
-# each container's ID, so the consent daemon maps
-# log-prefix → container_id → workspace_id.
+# The NFLOG prefix uses the first 12 chars of the OCI container id
+# (extracted from the runtime state JSON above, same as podman's short
+# id) for workspace correlation. klangk's container registry already
+# knows each container's ID, so the consent daemon maps
+# nflog-prefix → container_id → workspace_id.
+# Format: "klangk-egress:<12-char-id>:" (27 bytes, well within the
+# 64-byte --nflog-prefix cap).
+#
+# The rate limit (5/sec, burst 20) caps NFLOG flooding from adversarial
+# containers — the DROP still fires for every packet, only the NFLOG
+# notification is throttled. An explicit final DROP follows (redundant
+# given the OUTPUT policy, but makes the chain self-documenting and
+# ensures NFLOG precedes DROP regardless of future chain additions).
+# In static mode (the default), no NFLOG rule is added — the ruleset
+# is fully immutable and identical to the pre-#2239 behavior.
 if [ "$egress_mode" = "interactive" ]; then
-    # Use the container's hostname (podman sets it to the short container
-    # ID) as the tag in the log prefix for workspace correlation.
-    # KLANGK_NETFILTER_HOSTNAME overrides the path (for tests).
-    _hostname_file=${KLANGK_NETFILTER_HOSTNAME:-/proc/$pid/root/etc/hostname}
-    _cid=$(cat "$_hostname_file" 2>/dev/null || echo "unknown")
+    _tag=${_cid:-unknown}
     ipt -A OUTPUT -m limit --limit 5/sec --limit-burst 20 \
-        -j LOG --log-prefix "klangk-egress:${_cid}:" --log-uid
+        -j NFLOG --nflog-group 5139 --nflog-prefix "klangk-egress:${_tag}:"
     ipt -A OUTPUT -j DROP
 fi
 
@@ -757,8 +776,14 @@ class NetFilter:
 
         When ``egress_mode`` is ``"interactive"`` (#2239), the
         :data:`ANNOTATION_EGRESS_MODE_KEY` annotation is added so the OCI
-        hook installs a rate-limited LOG rule before the final DROP,
-        enabling the consent daemon to observe blocked destinations."""
+        hook installs a rate-limited NFLOG rule (group
+        :data:`NFLOG_GROUP`) before the final DROP, enabling the consent
+        daemon to observe blocked destinations via a netlink socket."""
+        _valid = ("static", "interactive")
+        if egress_mode not in _valid:
+            raise ValueError(
+                f"egress_mode must be one of {_valid!r}, got {egress_mode!r}"
+            )
         # Workspace overrides the deploy default; empty/None inherits it.
         domains = (
             list(allowed_domains)

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -54,6 +54,13 @@ logger = logging.getLogger(__name__)
 # presence, so a workspace without it is never filtered.
 ANNOTATION_KEY = "klangk.netfilter.rules"
 
+# OCI annotation carrying the egress mode (``static`` or ``interactive``).
+# When ``interactive``, the hook adds a rate-limited LOG rule before the
+# final DROP so the consent daemon can observe blocked destinations and
+# prompt a human (#2239). When absent or ``static``, no LOG rule is added
+# and the ruleset is fully immutable.
+ANNOTATION_EGRESS_MODE_KEY = "klangk.netfilter.egress_mode"
+
 # Filenames written into the configured hooks dir.
 HOOK_JSON_NAME = "klangk-netfilter.json"
 HOOK_SCRIPT_NAME = "klangk-netfilter.sh"
@@ -280,9 +287,11 @@ set -u
 
 state=$(cat)
 
-# Extract the annotation value + the init pid with sed (no jq dependency).
+# Extract the annotation values + the init pid with sed (no jq dependency).
 rules=$(printf '%s' "$state" \
     | sed -n 's/.*"klangk.netfilter.rules"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+egress_mode=$(printf '%s' "$state" \
+    | sed -n 's/.*"klangk.netfilter.egress_mode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 pid=$(printf '%s' "$state" \
     | sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
 
@@ -459,6 +468,37 @@ for _spec in "$@"; do
         ipt -A OUTPUT $_rule
     done
 done
+
+# Interactive egress consent mode (#2239). When egress_mode is
+# "interactive", add a rate-limited LOG rule so blocked destinations are
+# visible to the consent daemon (which tails /dev/kmsg or NFLOG). The
+# log prefix includes a workspace-specific tag extracted from the
+# klangk.netfilter.egress_mode annotation — the consent daemon parses
+# this prefix to correlate log lines to workspaces without maintaining
+# an IP→workspace map. The rate limit (5/sec, burst 20) caps log
+# flooding from adversarial containers — the DROP still fires for
+# every packet, only the LOG is throttled. An explicit final DROP
+# follows (redundant given the OUTPUT policy, but makes the chain
+# self-documenting and ensures LOG precedes DROP regardless of future
+# chain additions). In static mode (the default), no LOG rule is added
+# — the ruleset is fully immutable and identical to the pre-#2239
+# behavior.
+#
+# The log prefix uses the container ID (first 12 chars of the hostname,
+# which podman sets to the container's short ID by default) for
+# workspace correlation. klangk's container registry already knows
+# each container's ID, so the consent daemon maps
+# log-prefix → container_id → workspace_id.
+if [ "$egress_mode" = "interactive" ]; then
+    # Use the container's hostname (podman sets it to the short container
+    # ID) as the tag in the log prefix for workspace correlation.
+    # KLANGK_NETFILTER_HOSTNAME overrides the path (for tests).
+    _hostname_file=${KLANGK_NETFILTER_HOSTNAME:-/proc/$pid/root/etc/hostname}
+    _cid=$(cat "$_hostname_file" 2>/dev/null || echo "unknown")
+    ipt -A OUTPUT -m limit --limit 5/sec --limit-burst 20 \
+        -j LOG --log-prefix "klangk-egress:${_cid}:" --log-uid
+    ipt -A OUTPUT -j DROP
+fi
 
 exit 0
 """
@@ -691,7 +731,9 @@ class NetFilter:
         return True
 
     def create_kwargs(
-        self, allowed_domains: list[str] | None
+        self,
+        allowed_domains: list[str] | None,
+        egress_mode: str = "static",
     ) -> tuple[dict[str, str] | None, list[str] | None, list[str] | None]:
         """Build ``(annotations, hooks_dirs, cap_drop)`` for a container.
 
@@ -711,7 +753,12 @@ class NetFilter:
 
         ``cap_drop`` is :data:`DROPPED_CAPABILITIES` (``NET_ADMIN``) for a
         filtered container, so the entrypoint cannot flush the iptables
-        ruleset (#1773)."""
+        ruleset (#1773).
+
+        When ``egress_mode`` is ``"interactive"`` (#2239), the
+        :data:`ANNOTATION_EGRESS_MODE_KEY` annotation is added so the OCI
+        hook installs a rate-limited LOG rule before the final DROP,
+        enabling the consent daemon to observe blocked destinations."""
         # Workspace overrides the deploy default; empty/None inherits it.
         domains = (
             list(allowed_domains)
@@ -750,6 +797,8 @@ class NetFilter:
             )
             return None, None, None
         annotation = {ANNOTATION_KEY: render_rules_annotation(domains)}
+        if egress_mode == "interactive":
+            annotation[ANNOTATION_EGRESS_MODE_KEY] = egress_mode
         # macOS: ``--hooks-dir`` is silently ignored in remote mode.
         # Hooks are in the standard dir inside the VM (installed by
         # ``_install_hooks_in_vm``), discovered automatically by podman.

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -527,6 +527,7 @@ class Workspaces:
             service_command=ws.get("service_command"),
             allowed_domains=ws.get("allowed_domains"),
             workspace_settings=ws.get("settings"),
+            egress_mode=ws.get("egress_mode", "static"),
         )
         # Apply the per-workspace idle-timeout override from the settings
         # bag (#864), *only* when the workspace actually declares one.

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -299,6 +299,7 @@ class Connection:
             service_command=workspace.get("service_command"),
             allowed_domains=workspace.get("allowed_domains"),
             workspace_settings=workspace.get("settings"),
+            egress_mode=workspace.get("egress_mode", "static"),
         )
         self.container_status = container_status
         self.workspace_id = workspace_id

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -425,7 +425,7 @@ class TestNetFilterEnabled:
 # real against synthetic OCI state with shimmed nsenter/iptables/getent.
 
 
-def _state(rules, *, with_pid=True, egress_mode=None):
+def _state(rules, *, with_pid=True, egress_mode=None, container_id=None):
     """Build synthetic OCI container state JSON for the hook.
 
     ``rules`` is the ``klangk.netfilter.rules`` annotation value, or ``None``
@@ -433,9 +433,16 @@ def _state(rules, *, with_pid=True, egress_mode=None):
     (the other early-exit path). Otherwise ``pid`` is the running process's
     id so the hook's ``[ -e /proc/$pid/ns/net ]`` guard passes — the nsenter
     shim ignores the path anyway. ``egress_mode`` sets the
-    ``klangk.netfilter.egress_mode`` annotation (#2239).
+    ``klangk.netfilter.egress_mode`` annotation (#2239). ``container_id``
+    sets the top-level ``id`` field (the authoritative container id that the
+    hook truncates to 12 chars for the NFLOG prefix).
     """
     s = {}
+    if container_id is not None:
+        s["id"] = container_id
+    else:
+        # Default: a 64-char hex id (realistic podman container id).
+        s["id"] = "abc123def456" + "0" * 52
     if with_pid:
         s["pid"] = os.getpid()
     if rules is not None:
@@ -453,7 +460,6 @@ def _run_hook(
     resolv=None,
     hosts=None,
     sysctl_rc=0,
-    hostname=None,
 ):
     """Execute ``nf.HOOK_SCRIPT`` against ``state``; return recorded iptables
     invocations (each a ``list[str]`` of argv).
@@ -481,9 +487,6 @@ def _run_hook(
     )
     resolv_file.write_text(resolv or "")
     hosts_file.write_text(hosts or "")
-    hostname_file = tmp_path / "hostname"
-    if hostname is not False:
-        hostname_file.write_text(hostname or "abcdef123456")
     # getent ahosts <host> shim: emit realistic `IP STREAM host` rows (real
     # getent prints "<ip> STREAM <host>" / DGRAM / RAW, NOT a bare IP), so a
     # resolve()-regex anchored to end-of-line gets caught here instead of in
@@ -578,7 +581,6 @@ def _run_hook(
     # /proc/$pid/root.
     env["KLANGK_NETFILTER_RESOLV"] = str(resolv_file)
     env["KLANGK_NETFILTER_HOSTS"] = str(hosts_file)
-    env["KLANGK_NETFILTER_HOSTNAME"] = str(hostname_file)
     sh = shutil.which("sh") or "/bin/sh"
     proc = subprocess.run(
         [sh, str(hook)],
@@ -970,70 +972,105 @@ class TestHookScriptExecutable:
     reason="Hook script requires /proc and iptables/nsenter (Linux-only)",
 )
 class TestHookScriptInteractiveMode:
-    """Tests for the interactive egress mode LOG rule (#2239)."""
+    """Tests for the interactive egress mode NFLOG rule (#2239)."""
 
-    def test_static_mode_no_log_rule(self, tmp_path):
-        # Static mode (default) must NOT add a LOG rule — identical to
+    def test_static_mode_no_nflog_rule(self, tmp_path):
+        # Static mode (default) must NOT add an NFLOG rule — identical to
         # pre-#2239 behavior.
         calls = _run_hook(
             tmp_path,
             _state("github.com:443", egress_mode="static"),
             getent_map={"github.com": ["140.82.112.4"]},
         )
-        log_calls = [c for c in calls if "LOG" in c]
-        assert log_calls == []
+        nflog_calls = [c for c in calls if "NFLOG" in c]
+        assert nflog_calls == []
 
-    def test_no_egress_mode_annotation_no_log_rule(self, tmp_path):
-        # Missing annotation (old containers) must not add LOG.
+    def test_static_mode_no_explicit_drop(self, tmp_path):
+        # Static mode must NOT add an explicit -A OUTPUT -j DROP — the
+        # default OUTPUT policy handles it. An explicit DROP would be
+        # redundant and misleading.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443", egress_mode="static"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        explicit_drops = [
+            c for c in calls if c == ["-A", "OUTPUT", "-j", "DROP"]
+        ]
+        assert explicit_drops == []
+
+    def test_no_egress_mode_annotation_no_nflog_rule(self, tmp_path):
+        # Missing annotation (old containers) must not add NFLOG.
         calls = _run_hook(
             tmp_path,
             _state("github.com:443"),
             getent_map={"github.com": ["140.82.112.4"]},
         )
-        log_calls = [c for c in calls if "LOG" in c]
-        assert log_calls == []
+        nflog_calls = [c for c in calls if "NFLOG" in c]
+        assert nflog_calls == []
 
-    def test_interactive_mode_adds_log_and_drop(self, tmp_path):
+    def test_interactive_mode_adds_nflog_and_drop(self, tmp_path):
+        cid = "abc123def456" + "0" * 52
         calls = _run_hook(
             tmp_path,
-            _state("github.com:443", egress_mode="interactive"),
+            _state(
+                "github.com:443",
+                egress_mode="interactive",
+                container_id=cid,
+            ),
             getent_map={"github.com": ["140.82.112.4"]},
-            hostname="abc123def456",
         )
-        # The LOG rule should be present with rate limiting and the
-        # container-id-based prefix.
-        log_calls = [c for c in calls if "LOG" in c]
-        assert len(log_calls) == 1
-        log_call = log_calls[0]
-        assert "-A" in log_call
-        assert "OUTPUT" in log_call
-        assert "--limit" in log_call
-        assert "5/sec" in log_call
-        assert "--limit-burst" in log_call
-        assert "20" in log_call
-        assert "--log-prefix" in log_call
-        # Prefix includes the container hostname
-        prefix_idx = log_call.index("--log-prefix") + 1
-        assert log_call[prefix_idx] == "klangk-egress:abc123def456:"
-        assert "--log-uid" in log_call
-        # An explicit DROP should follow the LOG
+        # The NFLOG rule should be present with rate limiting and the
+        # container-id-based prefix (first 12 chars).
+        nflog_calls = [c for c in calls if "NFLOG" in c]
+        assert len(nflog_calls) == 1
+        nf_call = nflog_calls[0]
+        assert "-A" in nf_call
+        assert "OUTPUT" in nf_call
+        assert "--limit" in nf_call
+        assert "5/sec" in nf_call
+        assert "--limit-burst" in nf_call
+        assert "20" in nf_call
+        assert "--nflog-prefix" in nf_call
+        # Prefix uses first 12 chars of the container id
+        prefix_idx = nf_call.index("--nflog-prefix") + 1
+        assert nf_call[prefix_idx] == "klangk-egress:abc123def456:"
+        assert "--nflog-group" in nf_call
+        assert str(nf.NFLOG_GROUP) in nf_call
+        # An explicit DROP should follow the NFLOG
         drop_calls = [c for c in calls if c == ["-A", "OUTPUT", "-j", "DROP"]]
         assert len(drop_calls) == 1
 
-    def test_interactive_mode_drop_after_log(self, tmp_path):
-        # The explicit DROP must come AFTER the LOG rule in the chain.
+    def test_interactive_mode_drop_after_nflog(self, tmp_path):
+        # The explicit DROP must come AFTER the NFLOG rule in the chain.
         calls = _run_hook(
             tmp_path,
             _state("github.com:443", egress_mode="interactive"),
             getent_map={"github.com": ["140.82.112.4"]},
         )
-        log_idx = next(i for i, c in enumerate(calls) if "LOG" in c)
+        nflog_idx = next(i for i, c in enumerate(calls) if "NFLOG" in c)
         drop_idx = next(
             i
             for i, c in enumerate(calls)
             if c == ["-A", "OUTPUT", "-j", "DROP"]
         )
-        assert drop_idx > log_idx
+        assert drop_idx > nflog_idx
+
+    def test_interactive_mode_accept_before_nflog(self, tmp_path):
+        # ACCEPT rules for seed domains must come BEFORE the NFLOG rule
+        # so permitted traffic is never logged as blocked.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443", egress_mode="interactive"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        accept_indices = [
+            i for i, c in enumerate(calls) if "-A" in c and "ACCEPT" in c
+        ]
+        nflog_idx = next(i for i, c in enumerate(calls) if "NFLOG" in c)
+        assert all(a < nflog_idx for a in accept_indices), (
+            "All ACCEPT rules must precede the NFLOG rule"
+        )
 
     def test_interactive_mode_seed_rules_still_applied(self, tmp_path):
         # Pre-approved allowed_domains are still installed as ACCEPT rules
@@ -1051,18 +1088,55 @@ class TestHookScriptInteractiveMode:
         assert "140.82.112.4" in dests
         assert "151.101.0.0" in dests
 
-    def test_interactive_mode_hostname_fallback(self, tmp_path):
-        # If hostname file is missing, fall back to "unknown".
+    def test_interactive_mode_truncates_long_container_id(self, tmp_path):
+        # A full 64-char container id is truncated to 12 chars in the
+        # NFLOG prefix.
+        long_id = "a1b2c3d4e5f6" + "9" * 52
         calls = _run_hook(
             tmp_path,
-            _state("a.example:443", egress_mode="interactive"),
+            _state(
+                "a.example:443",
+                egress_mode="interactive",
+                container_id=long_id,
+            ),
             getent_map={"a.example": ["1.2.3.4"]},
-            hostname=False,
         )
-        log_calls = [c for c in calls if "LOG" in c]
-        assert len(log_calls) == 1
-        prefix_idx = log_calls[0].index("--log-prefix") + 1
-        assert log_calls[0][prefix_idx] == "klangk-egress:unknown:"
+        nflog_calls = [c for c in calls if "NFLOG" in c]
+        assert len(nflog_calls) == 1
+        prefix_idx = nflog_calls[0].index("--nflog-prefix") + 1
+        assert nflog_calls[0][prefix_idx] == "klangk-egress:a1b2c3d4e5f6:"
+
+    def test_interactive_mode_missing_container_id(self, tmp_path):
+        # If the OCI state has no "id" field, the prefix falls back to
+        # "unknown".
+        calls = _run_hook(
+            tmp_path,
+            _state(
+                "a.example:443",
+                egress_mode="interactive",
+                container_id="",
+            ),
+            getent_map={"a.example": ["1.2.3.4"]},
+        )
+        nflog_calls = [c for c in calls if "NFLOG" in c]
+        assert len(nflog_calls) == 1
+        prefix_idx = nflog_calls[0].index("--nflog-prefix") + 1
+        assert nflog_calls[0][prefix_idx] == "klangk-egress:unknown:"
+
+    def test_bogus_egress_mode_no_nflog(self, tmp_path):
+        # A typo like "intreactive" must NOT install NFLOG — the hook
+        # fails closed (no observability, just drop via policy).
+        calls = _run_hook(
+            tmp_path,
+            _state("a.example:443", egress_mode="intreactive"),
+            getent_map={"a.example": ["1.2.3.4"]},
+        )
+        nflog_calls = [c for c in calls if "NFLOG" in c]
+        assert nflog_calls == []
+        explicit_drops = [
+            c for c in calls if c == ["-A", "OUTPUT", "-j", "DROP"]
+        ]
+        assert explicit_drops == []
 
 
 class TestCreateKwargsEgressMode:
@@ -1100,6 +1174,14 @@ class TestCreateKwargsEgressMode:
         nf_obj.install_hooks()
         ann, _, _ = nf_obj.create_kwargs(["github.com:443"])
         assert nf.ANNOTATION_EGRESS_MODE_KEY not in ann
+
+    def test_bogus_egress_mode_raises(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
+        nf_obj.install_hooks()
+        with pytest.raises(ValueError, match="intreactive"):
+            nf_obj.create_kwargs(["github.com:443"], egress_mode="intreactive")
 
 
 # --- macOS / podman machine support (#1959) ---

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -425,25 +425,35 @@ class TestNetFilterEnabled:
 # real against synthetic OCI state with shimmed nsenter/iptables/getent.
 
 
-def _state(rules, *, with_pid=True):
+def _state(rules, *, with_pid=True, egress_mode=None):
     """Build synthetic OCI container state JSON for the hook.
 
     ``rules`` is the ``klangk.netfilter.rules`` annotation value, or ``None``
     to omit the annotation (early-exit path). ``with_pid=False`` omits ``pid``
     (the other early-exit path). Otherwise ``pid`` is the running process's
     id so the hook's ``[ -e /proc/$pid/ns/net ]`` guard passes — the nsenter
-    shim ignores the path anyway.
+    shim ignores the path anyway. ``egress_mode`` sets the
+    ``klangk.netfilter.egress_mode`` annotation (#2239).
     """
     s = {}
     if with_pid:
         s["pid"] = os.getpid()
     if rules is not None:
-        s["annotations"] = {nf.ANNOTATION_KEY: rules}
+        annotations = {nf.ANNOTATION_KEY: rules}
+        if egress_mode is not None:
+            annotations[nf.ANNOTATION_EGRESS_MODE_KEY] = egress_mode
+        s["annotations"] = annotations
     return json.dumps(s)
 
 
 def _run_hook(
-    tmp_path, state, getent_map=None, resolv=None, hosts=None, sysctl_rc=0
+    tmp_path,
+    state,
+    getent_map=None,
+    resolv=None,
+    hosts=None,
+    sysctl_rc=0,
+    hostname=None,
 ):
     """Execute ``nf.HOOK_SCRIPT`` against ``state``; return recorded iptables
     invocations (each a ``list[str]`` of argv).
@@ -471,6 +481,9 @@ def _run_hook(
     )
     resolv_file.write_text(resolv or "")
     hosts_file.write_text(hosts or "")
+    hostname_file = tmp_path / "hostname"
+    if hostname is not False:
+        hostname_file.write_text(hostname or "abcdef123456")
     # getent ahosts <host> shim: emit realistic `IP STREAM host` rows (real
     # getent prints "<ip> STREAM <host>" / DGRAM / RAW, NOT a bare IP), so a
     # resolve()-regex anchored to end-of-line gets caught here instead of in
@@ -561,9 +574,11 @@ def _run_hook(
 
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
-    # Point the hook at our temp resolv.conf/hosts instead of /proc/$pid/root.
+    # Point the hook at our temp resolv.conf/hosts/hostname instead of
+    # /proc/$pid/root.
     env["KLANGK_NETFILTER_RESOLV"] = str(resolv_file)
     env["KLANGK_NETFILTER_HOSTS"] = str(hosts_file)
+    env["KLANGK_NETFILTER_HOSTNAME"] = str(hostname_file)
     sh = shutil.which("sh") or "/bin/sh"
     proc = subprocess.run(
         [sh, str(hook)],
@@ -945,6 +960,146 @@ class TestHookScriptExecutable:
         assert _accept_rules(calls) == [
             ["-A", "OUTPUT", "-d", "10.5.0.0/8", "-j", "ACCEPT"],
         ]
+
+
+# --- interactive egress consent mode (#2239) ---
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Hook script requires /proc and iptables/nsenter (Linux-only)",
+)
+class TestHookScriptInteractiveMode:
+    """Tests for the interactive egress mode LOG rule (#2239)."""
+
+    def test_static_mode_no_log_rule(self, tmp_path):
+        # Static mode (default) must NOT add a LOG rule — identical to
+        # pre-#2239 behavior.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443", egress_mode="static"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        log_calls = [c for c in calls if "LOG" in c]
+        assert log_calls == []
+
+    def test_no_egress_mode_annotation_no_log_rule(self, tmp_path):
+        # Missing annotation (old containers) must not add LOG.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        log_calls = [c for c in calls if "LOG" in c]
+        assert log_calls == []
+
+    def test_interactive_mode_adds_log_and_drop(self, tmp_path):
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443", egress_mode="interactive"),
+            getent_map={"github.com": ["140.82.112.4"]},
+            hostname="abc123def456",
+        )
+        # The LOG rule should be present with rate limiting and the
+        # container-id-based prefix.
+        log_calls = [c for c in calls if "LOG" in c]
+        assert len(log_calls) == 1
+        log_call = log_calls[0]
+        assert "-A" in log_call
+        assert "OUTPUT" in log_call
+        assert "--limit" in log_call
+        assert "5/sec" in log_call
+        assert "--limit-burst" in log_call
+        assert "20" in log_call
+        assert "--log-prefix" in log_call
+        # Prefix includes the container hostname
+        prefix_idx = log_call.index("--log-prefix") + 1
+        assert log_call[prefix_idx] == "klangk-egress:abc123def456:"
+        assert "--log-uid" in log_call
+        # An explicit DROP should follow the LOG
+        drop_calls = [c for c in calls if c == ["-A", "OUTPUT", "-j", "DROP"]]
+        assert len(drop_calls) == 1
+
+    def test_interactive_mode_drop_after_log(self, tmp_path):
+        # The explicit DROP must come AFTER the LOG rule in the chain.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443", egress_mode="interactive"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        log_idx = next(i for i, c in enumerate(calls) if "LOG" in c)
+        drop_idx = next(
+            i
+            for i, c in enumerate(calls)
+            if c == ["-A", "OUTPUT", "-j", "DROP"]
+        )
+        assert drop_idx > log_idx
+
+    def test_interactive_mode_seed_rules_still_applied(self, tmp_path):
+        # Pre-approved allowed_domains are still installed as ACCEPT rules
+        # even in interactive mode.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443,pypi.org", egress_mode="interactive"),
+            getent_map={
+                "github.com": ["140.82.112.4"],
+                "pypi.org": ["151.101.0.0"],
+            },
+        )
+        accept = _accept_rules(calls)
+        dests = [c[3] for c in accept]
+        assert "140.82.112.4" in dests
+        assert "151.101.0.0" in dests
+
+    def test_interactive_mode_hostname_fallback(self, tmp_path):
+        # If hostname file is missing, fall back to "unknown".
+        calls = _run_hook(
+            tmp_path,
+            _state("a.example:443", egress_mode="interactive"),
+            getent_map={"a.example": ["1.2.3.4"]},
+            hostname=False,
+        )
+        log_calls = [c for c in calls if "LOG" in c]
+        assert len(log_calls) == 1
+        prefix_idx = log_calls[0].index("--log-prefix") + 1
+        assert log_calls[0][prefix_idx] == "klangk-egress:unknown:"
+
+
+class TestCreateKwargsEgressMode:
+    """Tests for create_kwargs with egress_mode parameter (#2239)."""
+
+    def test_static_mode_no_egress_mode_annotation(
+        self, tmp_path, monkeypatch
+    ):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
+        nf_obj.install_hooks()
+        ann, _, _ = nf_obj.create_kwargs(
+            ["github.com:443"], egress_mode="static"
+        )
+        assert nf.ANNOTATION_EGRESS_MODE_KEY not in ann
+
+    def test_interactive_mode_adds_egress_mode_annotation(
+        self, tmp_path, monkeypatch
+    ):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
+        nf_obj.install_hooks()
+        ann, _, _ = nf_obj.create_kwargs(
+            ["github.com:443"], egress_mode="interactive"
+        )
+        assert ann[nf.ANNOTATION_EGRESS_MODE_KEY] == "interactive"
+        assert ann[nf.ANNOTATION_KEY] == "github.com:443"
+
+    def test_default_egress_mode_is_static(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        monkeypatch.setattr(nf.platform, "system", lambda: "Linux")
+        nf_obj.install_hooks()
+        ann, _, _ = nf_obj.create_kwargs(["github.com:443"])
+        assert nf.ANNOTATION_EGRESS_MODE_KEY not in ann
 
 
 # --- macOS / podman machine support (#1959) ---


### PR DESCRIPTION
## Summary

- When `egress_mode` is `interactive`, the OCI hook installs a rate-limited LOG rule (`5/sec`, burst `20`) before an explicit DROP, so blocked destinations are visible to the consent daemon
- Log prefix includes the container hostname (`klangk-egress:<container_id>:`) for workspace correlation
- New `ANNOTATION_EGRESS_MODE_KEY` annotation passes egress_mode from workspace → container registry → netfilter → OCI hook
- `egress_mode` threaded through `start_container` → `_start_container_inner` → `_egress_filter` → `create_kwargs`
- Static mode (default) is completely unchanged — no LOG rule, identical to pre-#2239 behavior
- Hostname file path overridable via `KLANGK_NETFILTER_HOSTNAME` env var (for tests)

## Test plan

- [x] 9 new tests: static/interactive LOG rule, drop-after-log ordering, seed rules still applied, hostname fallback, create_kwargs annotation presence/absence
- [x] All 119 netfilter tests pass
- [x] All 93 workspace + egress consent tests pass

Closes #2241