### PR TITLE
ci: run CI on PRs targeting any branch, not just main

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [release/**]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [release/**]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [release/**]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -14,7 +14,6 @@ on:
   push:
     branches: [release/**]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [release/**]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/fuzz-check.yml
+++ b/.github/workflows/fuzz-check.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [release/**]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -20,7 +20,6 @@ on:
   push:
     branches: [release/**]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -3,7 +3,6 @@ name: "E2E: Sandbox Tests"
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     paths:
       - "sandboxes/**"
       - ".github/workflows/sandbox-e2e-tests.yml"


### PR DESCRIPTION
## Summary

Cherry-pick of `11db409c` (from `worktree-egress-consent`): removes the `branches: [main]` filter from the `pull_request` triggers across the test/e2e workflows, so PRs targeting **any** base branch run CI — not just PRs into `main`.

## Why

The sidecar FQDN-egress work (#2250 → #2253–#2256) will be stacked as PRs targeting `worktree-egress-consent`. Without this change those stacked PRs get no CI (the trigger currently fires only for PRs into `main`). Landing this on `main` first means the sidecar PRs run the full test suite.
