### PR TITLE
ci: rename 'Python Tests' workflow to 'Backend Tests'

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,4 +1,4 @@
-name: Python Tests
+name: Backend Tests
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Cherry-pick of `3d665b9a` (from `worktree-egress-consent`): renames the workflow in `.github/workflows/backend-tests.yml` from `Python Tests` to `Backend Tests`. (The `branches: [main]` removal from #2257 already landed on `main`; this is the remaining rename.)
