### PR TITLE
feat(egress): FQDN egress sidecar image + DNS proxy (#2253)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -63,6 +63,15 @@ operators or integrators to act when upgrading.
   static filtering plus NFLOG observability — no prompts occur and unmatched
   traffic is dropped. See `docs/features/egress-filtering.md`.
 
+- **FQDN egress sidecar image + DNS proxy (#2250, #2253).** New
+  `klangk-egress-sidecar` image (`src/containers/egress-sidecar/`) that runs a
+  FQDN DNS proxy in a `NET_ADMIN` container sharing a filtered workspace's netns.
+  It intercepts the workspace's DNS (nat REDIRECT of its configured resolvers),
+  applies an allow-list, forwards allowed queries to a distinct upstream, and
+  allow-lists the resolved IPs at runtime — solving DNS round-robin (a filtered
+  workspace reaches an allowed domain on whatever IP it actually resolves). Part
+  of the FQDN egress build (#2250); klangk lifecycle wiring is #2254.
+
 - **`nix_seed` — per-workspace `/nix` with two backends (#2219, #2220).** The
   per-workspace `/nix` config is now one block — `nix_seed: {type, path}` —
   selecting a backend: `btrfs-snapshot` (a CoW snapshot of a seed btrfs

--- a/src/containers/egress-sidecar/Dockerfile
+++ b/src/containers/egress-sidecar/Dockerfile
@@ -3,7 +3,8 @@
 #
 # Build context is this directory (proxy.py + entrypoint.sh are COPY'd in).
 FROM alpine:latest
-RUN apk add --no-cache iptables python3
+RUN apk add --no-cache iptables python3 py3-pip \
+    && pip install --no-cache-dir --break-system-packages dnspython
 COPY proxy.py /proxy.py
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/src/containers/egress-sidecar/Dockerfile
+++ b/src/containers/egress-sidecar/Dockerfile
@@ -1,0 +1,10 @@
+# Egress sidecar image (#2253) — runs the FQDN DNS proxy in a NET_ADMIN
+# container that shares a filtered workspace's network namespace.
+#
+# Build context is this directory (proxy.py + entrypoint.sh are COPY'd in).
+FROM alpine:latest
+RUN apk add --no-cache iptables python3
+COPY proxy.py /proxy.py
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/src/containers/egress-sidecar/README.md
+++ b/src/containers/egress-sidecar/README.md
@@ -1,0 +1,65 @@
+# Egress sidecar — FQDN DNS proxy (#2250, #2253)
+
+This image runs the per-workspace egress DNS proxy for FQDN-based egress
+filtering. A **filtered** workspace runs as two containers sharing one network
+namespace: this sidecar (`--cap-add NET_ADMIN`, owns the iptables ruleset +
+the DNS proxy) and the workspace (`--network container:<sidecar>`,
+unprivileged). Unfiltered workspaces are unaffected (single container).
+
+## How it works
+
+1. `entrypoint.sh` installs a default-deny `OUTPUT` ruleset + a nat `REDIRECT`
+   of the workspace's configured DNS resolvers (`:53`) to the proxy's listen
+   port (`127.0.0.1:15353`).
+2. `proxy.py` applies the FQDN allow-list, forwards allowed queries to a
+   **different** upstream, learns the A-record IPs, and inserts
+   `iptables -I OUTPUT 1 -d <ip> -j ACCEPT` for each — so the workspace can
+   reach exactly the IPs it resolved (solving DNS round-robin). Denied names
+   get NXDOMAIN.
+
+The destination-based REDIRECT (only the workspace's resolvers) + a distinct
+upstream is the loop-avoidance: the proxy's own forwards aren't redirected.
+
+## Build
+
+```bash
+podman build -t klangk-egress-sidecar -f src/containers/egress-sidecar/Dockerfile src/containers/egress-sidecar
+```
+
+## Run (klangk wires this via #2254)
+
+```bash
+podman run -d --name <ws>-egress --cap-add NET_ADMIN \
+  --dns 1.1.1.1 \
+  -e KLANGK_EGRESS_ALLOW=github.com:443,pypi.org \
+  -e KLANGK_EGRESS_UPSTREAM=8.8.8.8 \
+  klangk-egress-sidecar
+podman run -d --name <ws> --network container:<ws>-egress <workspace-image> ...
+```
+
+Constraint: `KLANGK_EGRESS_UPSTREAM` (default `8.8.8.8`) **must differ** from the
+workspace's configured resolvers (the sidecar's `--dns`, which the workspace
+inherits) — otherwise the proxy's forwards loop back into itself. `entrypoint.sh`
+skips any nameserver equal to the upstream as a guard.
+
+## Configuration (env)
+
+| var                         | default    | meaning                                           |
+| --------------------------- | ---------- | ------------------------------------------------- |
+| `KLANGK_EGRESS_ALLOW`       | _(empty)_  | comma-separated allow-list: `host[:port]` or CIDR |
+| `KLANGK_EGRESS_UPSTREAM`    | `8.8.8.8`  | real upstream the proxy forwards to               |
+| `KLANGK_EGRESS_LISTEN_PORT` | `15353`    | UDP port the proxy listens on                     |
+| `KLANGK_EGRESS_IPTABLES`    | `iptables` | iptables binary path                              |
+| `KLANGK_EGRESS_DEBUG`       | unset      | if set, log each allow/deny decision              |
+
+## Limitations (#2256)
+
+Learned IPs are allow-listed on **all** ports (no per-domain port scoping yet),
+wildcard domains aren't supported, and learned IPs never expire (no TTL cleanup).
+
+## References
+
+- #2250 (FQDN egress epic), #2253 (this image), #2254 (klangk lifecycle wiring),
+  #2255 (migrate the filter into the sidecar), #2256 (allow-list semantics).
+- Spike validation: the sidecar natively sharing the netns intercepts the
+  workspace's DNS; the full forward/learn/allow + NXDOMAIN chain is proven.

--- a/src/containers/egress-sidecar/entrypoint.sh
+++ b/src/containers/egress-sidecar/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Egress sidecar startup (#2253): install the OUTPUT ruleset + the nat REDIRECT,
+# then run the FQDN DNS proxy. Runs in the sidecar (NET_ADMIN) which shares the
+# workspace's network namespace.
+#
+# Loop-avoidance: the nat REDIRECT targets the workspace's configured resolvers
+# (read from this sidecar's /etc/resolv.conf — the workspace inherits them via
+# --network container:<sidecar>); the proxy forwards to a DIFFERENT upstream
+# ($KLANGK_EGRESS_UPSTREAM), which the REDIRECT must not match. Any nameserver
+# equal to the upstream is skipped (would loop).
+set -eu
+
+UPSTREAM="${KLANGK_EGRESS_UPSTREAM:-8.8.8.8}"
+IPT="${KLANGK_EGRESS_IPTABLES:-iptables}"
+LISTEN_PORT="${KLANGK_EGRESS_LISTEN_PORT:-15353}"
+
+# --- filter OUTPUT: default-deny + the paths the workspace + proxy need ---
+$IPT -P OUTPUT DROP
+# Loopback by *destination* (not -o lo): REDIRECT keeps the packet's original
+# output interface, so -o lo misses the redirected :53 packet under a DROP policy.
+$IPT -A OUTPUT -d 127.0.0.0/8 -j ACCEPT
+$IPT -A OUTPUT -o lo -j ACCEPT
+$IPT -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+$IPT -A OUTPUT -d "$UPSTREAM" -p udp --dport 53 -j ACCEPT
+$IPT -A OUTPUT -d "$UPSTREAM" -p tcp --dport 53 -j ACCEPT
+
+# --- static CIDR allow-specs (host specs are learned dynamically by the proxy).
+# A "host:port" CIDR like 10.0.0.0/8:443 is stripped to its CIDR; per-domain
+# port scoping is #2256.
+IFS=','
+for spec in ${KLANGK_EGRESS_ALLOW:-}; do
+  case "$spec" in
+  */*)
+    cidr=${spec%%:*}
+    $IPT -A OUTPUT -d "$cidr" -j ACCEPT
+    ;;
+  esac
+done
+unset IFS
+
+# --- nat OUTPUT: REDIRECT each configured resolver (:53) to the proxy ---
+grep -E '^nameserver' /etc/resolv.conf | awk '{print $2}' | while read -r ns; do
+  [ "$ns" = "$UPSTREAM" ] && continue
+  $IPT -t nat -A OUTPUT -d "$ns" -p udp --dport 53 -j REDIRECT --to-ports "$LISTEN_PORT"
+  $IPT -t nat -A OUTPUT -d "$ns" -p tcp --dport 53 -j REDIRECT --to-ports "$LISTEN_PORT"
+done
+
+exec python3 /proxy.py

--- a/src/containers/egress-sidecar/proxy.py
+++ b/src/containers/egress-sidecar/proxy.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""FQDN egress DNS proxy — runs in the egress sidecar (#2250, #2253).
+
+The sidecar shares the workspace's network namespace (the workspace runs
+``--network container:<this sidecar>``). The sidecar's ``entrypoint.sh`` installs
+a nat REDIRECT of the workspace's configured DNS resolvers (:53) to this proxy's
+listen port; this proxy applies an FQDN allow-list, forwards allowed queries to a
+*different* upstream (so the REDIRECT does not loop), learns the A-record IPs from
+the responses, and inserts ``iptables -I OUTPUT 1 -d <ip> -j ACCEPT`` for each so
+the workspace can reach exactly the IPs it resolved — solving DNS round-robin.
+Denied names get NXDOMAIN.
+
+Configuration (env):
+  KLANGK_EGRESS_ALLOW       comma-separated allow-list: ``host[:port]`` or CIDR
+                            specs. CIDR specs are applied statically by the
+                            entrypoint; this proxy matches only the host specs
+                            (exact or suffix).
+  KLANGK_EGRESS_UPSTREAM    the real upstream resolver the proxy forwards to
+                            (default ``8.8.8.8``). MUST differ from the
+                            workspace's configured (redirected) resolvers or the
+                            proxy's forwards loop back into itself.
+  KLANGK_EGRESS_LISTEN_PORT UDP port to listen on (default ``15353``).
+  KLANGK_EGRESS_IPTABLES    iptables binary (default ``iptables``).
+  KLANGK_EGRESS_DEBUG       if set, log each allow/deny decision.
+
+Limitations (tracked in #2256): a learned IP is allow-listed on *all* ports (no
+per-domain port scoping yet), no wildcard domains, and learned IPs are never
+cleaned up (no TTL expiry).
+"""
+
+import os
+import socket
+import struct
+import subprocess
+
+UPSTREAM = (os.environ.get("KLANGK_EGRESS_UPSTREAM", "8.8.8.8"), 53)
+LISTEN_PORT = int(os.environ.get("KLANGK_EGRESS_LISTEN_PORT", "15353"))
+IPT = os.environ.get("KLANGK_EGRESS_IPTABLES", "iptables")
+DEBUG = bool(os.environ.get("KLANGK_EGRESS_DEBUG"))
+
+
+def host_specs() -> list[str]:
+    """Host specs (suffix-match targets) from KLANGK_EGRESS_ALLOW.
+
+    CIDR specs (``10.0.0.0/8``) are excluded — the entrypoint applies those
+    statically. ``host:port`` specs are stripped to the host part.
+    """
+    out = []
+    for spec in os.environ.get("KLANGK_EGRESS_ALLOW", "").split(","):
+        spec = spec.strip()
+        if not spec or "/" in spec:
+            continue
+        host = spec.split(":", 1)[0].lower()
+        if host:
+            out.append(host)
+    return out
+
+
+ALLOWED = host_specs()
+
+
+def parse_qname(msg: bytes) -> str:
+    """The queried domain (lowercased), from a DNS wire-format message."""
+    i = 12  # skip the 12-byte header
+    labels = []
+    while i < len(msg) and msg[i] != 0:
+        n = msg[i]
+        labels.append(msg[i + 1 : i + 1 + n].decode("ascii", "ignore"))
+        i += 1 + n
+    return ".".join(labels).lower()
+
+
+def parse_a_ips(msg: bytes) -> list[str]:
+    """IPv4 A-record addresses from a DNS response (dotted-quad strings)."""
+    ancount = struct.unpack("!H", msg[6:8])[0]
+    i = 12
+    while i < len(msg) and msg[i] != 0:  # skip the question QNAME
+        i += 1 + msg[i]
+    i += 5  # null + QTYPE(2) + QCLASS(2)
+    ips = []
+    for _ in range(ancount):
+        if i >= len(msg):
+            break
+        if msg[i] & 0xC0 == 0xC0:  # compressed name pointer
+            i += 2
+        else:
+            while i < len(msg) and msg[i] != 0:
+                i += 1 + msg[i]
+            i += 1
+        if i + 10 > len(msg):
+            break
+        rtype, _rclass, _ttl, rdlen = struct.unpack("!HHIH", msg[i : i + 10])
+        i += 10
+        if rtype == 1 and rdlen == 4:  # A
+            ips.append(".".join(str(b) for b in msg[i : i + 4]))
+        i += rdlen
+    return ips
+
+
+def build_nxdomain(query: bytes) -> bytes:
+    """An NXDOMAIN response for the given query (preserves id + question)."""
+    return query[:2] + b"\x81\x83" + query[4:6] + b"\x00\x00\x00\x00" + query[12:]
+
+
+def allowed(qname: str) -> bool:
+    return any(qname == h or qname.endswith("." + h) for h in ALLOWED)
+
+
+def allow_ip(ip: str) -> None:
+    """Insert an allow-rule at the top of OUTPUT for a learned IP."""
+    subprocess.run(
+        [IPT, "-I", "OUTPUT", "1", "-d", ip, "-j", "ACCEPT"],
+        capture_output=True,
+    )
+
+
+def main() -> None:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", LISTEN_PORT))
+    print(
+        f"dns-proxy listening on 127.0.0.1:{LISTEN_PORT} "
+        f"(upstream={UPSTREAM[0]}, allowed={ALLOWED})",
+        flush=True,
+    )
+    while True:
+        try:
+            data, addr = s.recvfrom(4096)
+        except Exception:
+            continue
+        try:
+            qname = parse_qname(data)
+        except Exception:
+            continue
+        if not allowed(qname):
+            if DEBUG:
+                print(f"deny  {qname}", flush=True)
+            s.sendto(build_nxdomain(data), addr)
+            continue
+        us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        us.settimeout(3)
+        try:
+            us.sendto(data, UPSTREAM)
+            resp, _ = us.recvfrom(4096)
+        except Exception:
+            us.close()
+            continue
+        us.close()
+        ips = parse_a_ips(resp)
+        for ip in ips:
+            allow_ip(ip)
+        if DEBUG:
+            print(f"allow {qname} -> {ips}", flush=True)
+        s.sendto(resp, addr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/containers/egress-sidecar/proxy.py
+++ b/src/containers/egress-sidecar/proxy.py
@@ -10,6 +10,11 @@ the responses, and inserts ``iptables -I OUTPUT 1 -d <ip> -j ACCEPT`` for each s
 the workspace can reach exactly the IPs it resolved — solving DNS round-robin.
 Denied names get NXDOMAIN.
 
+DNS wire parsing is delegated to **dnspython** (rather than hand-rolled byte
+slicing) so EDNS, CNAME chains, TCP-sized responses, and malformed packets are
+handled correctly — a parser bug in a security component is dangerous, and a
+maintained library removes that risk.
+
 Configuration (env):
   KLANGK_EGRESS_ALLOW       comma-separated allow-list: ``host[:port]`` or CIDR
                             specs. CIDR specs are applied statically by the
@@ -25,13 +30,17 @@ Configuration (env):
 
 Limitations (tracked in #2256): a learned IP is allow-listed on *all* ports (no
 per-domain port scoping yet), no wildcard domains, and learned IPs are never
-cleaned up (no TTL expiry).
+cleaned up (no TTL expiry). Transport is UDP only (TCP fallback is a future
+addition).
 """
 
 import os
 import socket
-import struct
 import subprocess
+
+import dns.message
+import dns.rcode
+import dns.rdatatype
 
 UPSTREAM = (os.environ.get("KLANGK_EGRESS_UPSTREAM", "8.8.8.8"), 53)
 LISTEN_PORT = int(os.environ.get("KLANGK_EGRESS_LISTEN_PORT", "15353"))
@@ -59,47 +68,36 @@ def host_specs() -> list[str]:
 ALLOWED = host_specs()
 
 
-def parse_qname(msg: bytes) -> str:
-    """The queried domain (lowercased), from a DNS wire-format message."""
-    i = 12  # skip the 12-byte header
-    labels = []
-    while i < len(msg) and msg[i] != 0:
-        n = msg[i]
-        labels.append(msg[i + 1 : i + 1 + n].decode("ascii", "ignore"))
-        i += 1 + n
-    return ".".join(labels).lower()
+def query_name(wire: bytes) -> str:
+    """The queried domain (lowercased, no trailing dot) from a DNS wire message."""
+    msg = dns.message.from_wire(wire)
+    if not msg.question:
+        return ""
+    return msg.question[0].name.to_text().rstrip(".").lower()
 
 
-def parse_a_ips(msg: bytes) -> list[str]:
-    """IPv4 A-record addresses from a DNS response (dotted-quad strings)."""
-    ancount = struct.unpack("!H", msg[6:8])[0]
-    i = 12
-    while i < len(msg) and msg[i] != 0:  # skip the question QNAME
-        i += 1 + msg[i]
-    i += 5  # null + QTYPE(2) + QCLASS(2)
+def a_records(wire: bytes) -> list[str]:
+    """IPv4 A-record addresses from a DNS response wire (dotted-quad strings).
+
+    Walks the answer section (following CNAME chains transparently — the A
+    records for the canonical name are in the answer too) and returns only
+    A-record IPs.
+    """
+    msg = dns.message.from_wire(wire)
     ips = []
-    for _ in range(ancount):
-        if i >= len(msg):
-            break
-        if msg[i] & 0xC0 == 0xC0:  # compressed name pointer
-            i += 2
-        else:
-            while i < len(msg) and msg[i] != 0:
-                i += 1 + msg[i]
-            i += 1
-        if i + 10 > len(msg):
-            break
-        rtype, _rclass, _ttl, rdlen = struct.unpack("!HHIH", msg[i : i + 10])
-        i += 10
-        if rtype == 1 and rdlen == 4:  # A
-            ips.append(".".join(str(b) for b in msg[i : i + 4]))
-        i += rdlen
+    for rrset in msg.answer:
+        if rrset.rdtype == dns.rdatatype.A:
+            for rdata in rrset:
+                ips.append(rdata.address)
     return ips
 
 
-def build_nxdomain(query: bytes) -> bytes:
-    """An NXDOMAIN response for the given query (preserves id + question)."""
-    return query[:2] + b"\x81\x83" + query[4:6] + b"\x00\x00\x00\x00" + query[12:]
+def nxdomain_for(wire: bytes) -> bytes:
+    """An NXDOMAIN response wire for the given query wire."""
+    query = dns.message.from_wire(wire)
+    resp = dns.message.make_response(query)
+    resp.set_rcode(dns.rcode.NXDOMAIN)
+    return resp.to_wire()
 
 
 def allowed(qname: str) -> bool:
@@ -124,28 +122,34 @@ def main() -> None:
     )
     while True:
         try:
-            data, addr = s.recvfrom(4096)
+            data, addr = s.recvfrom(65535)
         except Exception:
             continue
         try:
-            qname = parse_qname(data)
+            qname = query_name(data)
         except Exception:
-            continue
-        if not allowed(qname):
+            continue  # malformed/unparseable query -> drop
+        if not qname or not allowed(qname):
             if DEBUG:
                 print(f"deny  {qname}", flush=True)
-            s.sendto(build_nxdomain(data), addr)
+            try:
+                s.sendto(nxdomain_for(data), addr)
+            except Exception:
+                pass
             continue
         us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         us.settimeout(3)
         try:
             us.sendto(data, UPSTREAM)
-            resp, _ = us.recvfrom(4096)
+            resp, _ = us.recvfrom(65535)
         except Exception:
             us.close()
             continue
         us.close()
-        ips = parse_a_ips(resp)
+        try:
+            ips = a_records(resp)
+        except Exception:
+            ips = []
         for ip in ips:
             allow_ip(ip)
         if DEBUG:


### PR DESCRIPTION
feat(egress): FQDN egress sidecar image + DNS proxy (#2253)

Add the klangk-egress-sidecar image (src/containers/egress-sidecar/): an
NET_ADMIN container that shares a filtered workspace's netns and runs a FQDN
DNS proxy. The entrypoint installs a default-deny OUTPUT ruleset + a
destination-based nat REDIRECT of the workspace's configured resolvers (:53) to
the proxy (loop-avoidance: the proxy forwards to a distinct upstream, and any
nameserver equal to the upstream is skipped). The proxy applies an allow-list,
forwards allowed queries, allow-lists the resolved IPs at runtime (solving DNS
round-robin — the workspace reaches an allowed domain on whatever IP it actually
resolves), and NXDOMAINs denied names.

Validated end-to-end with the built image: a workspace on
--network container:<sidecar> resolves + reaches github.com:443 (on its
runtime-resolved IP), and gets NXDOMAIN for denied names.

Part of the FQDN egress build (#2250). klangk lifecycle wiring is #2254; the
filter migrates into the sidecar in #2255; allow-list semantics (port scoping,
wildcards, TTL) are #2256.
