### PR TITLE
fix(terminal): pass KLANGKWS_USER_ID/HANDLE to tmux via -e

### DIFF
--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -312,14 +312,16 @@ class Terminal:
         session_name: str,
         user_home: str | None = None,
         ssh_agent_socket: str | None = None,
+        user_id: str | None = None,
+        user_handle: str | None = None,
     ) -> bool:
         """Ensure a detached base tmux session exists for *session_name*.
 
         Idempotent: returns ``True`` if the session was freshly created,
-        ``False`` if it already existed or could not be created. HOME and
-        SSH_AUTH_SOCK are passed as tmux ``-e`` flags (part of the command,
-        not podman's), so the session's window-0 shell sources the right
-        profile.
+        ``False`` if it already existed or could not be created. HOME,
+        SSH_AUTH_SOCK, and user identity vars are passed as tmux ``-e``
+        flags (part of the command, not podman's), so the session's
+        window-0 shell inherits them (#2259).
         """
         if await self.has_tmux_session(container_id, session_name):
             return False
@@ -328,6 +330,10 @@ class Terminal:
             env_args += ["-e", f"HOME={user_home}"]
         if ssh_agent_socket is not None:
             env_args += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
+        if user_id is not None:
+            env_args += ["-e", f"KLANGKWS_USER_ID={user_id}"]
+        if user_handle is not None:
+            env_args += ["-e", f"KLANGKWS_USER_HANDLE={user_handle}"]
         try:
             await self.podman.exec_container(
                 container_id,
@@ -357,6 +363,8 @@ class Terminal:
         session_name: str,
         user_home: str | None = None,
         ssh_agent_socket: str | None = None,
+        user_id: str | None = None,
+        user_handle: str | None = None,
     ) -> bool:
         """Ensure the firing user's base tmux session + window 0 exist.
 
@@ -368,7 +376,12 @@ class Terminal:
         regardless of setup state (#1133).
         """
         return await self._ensure_tmux_session(
-            container_id, session_name, user_home, ssh_agent_socket
+            container_id,
+            session_name,
+            user_home,
+            ssh_agent_socket,
+            user_id=user_id,
+            user_handle=user_handle,
         )
 
     async def set_workspace_name(
@@ -930,6 +943,8 @@ class TerminalSession:
                 self.session_name,
                 user_home=self.user_home,
                 ssh_agent_socket=self.ssh_agent_socket,
+                user_id=self.user_id,
+                user_handle=self.user_handle,
             )
         # Set @workspace_name globally so every grouped session's status
         # bar picks it up.  Runs on every terminal_start (idempotent)

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -123,6 +123,8 @@ def build_shell_command(
     read_only: bool = False,
     tmux_enabled: bool = True,
     ssh_agent_socket: str | None = None,
+    user_id: str | None = None,
+    user_handle: str | None = None,
 ) -> tuple[list[str], str | None]:
     """Build the shell command for a terminal session.
 
@@ -162,6 +164,10 @@ def build_shell_command(
         tmux_env = ["-e", f"HOME={user_home}"]
     if ssh_agent_socket is not None:
         tmux_env += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
+    if user_id is not None:
+        tmux_env += ["-e", f"KLANGKWS_USER_ID={user_id}"]
+    if user_handle is not None:
+        tmux_env += ["-e", f"KLANGKWS_USER_HANDLE={user_handle}"]
     if session_name is not None:
         if join_session is not None:
             # Join an existing session group.  Use a unique session name
@@ -947,6 +953,8 @@ class TerminalSession:
             read_only=self.read_only,
             tmux_enabled=self._terminal.tmux_enabled(),
             ssh_agent_socket=self.ssh_agent_socket,
+            user_id=self.user_id,
+            user_handle=self.user_handle,
         )
         work_dir = "/home"
         argv = _build_exec_argv(self.container_id, env, shell_cmd, work_dir)

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -256,11 +256,14 @@ class TestStart:
         assert "KLANGKWS_USER_HANDLE=alice" in fake.argv
         # Work dir is always /home (bash cd's to $HOME on login)
         assert fake.argv[fake.argv.index("-w") + 1] == "/home"
-        # HOME is also passed to tmux via -e so child shells inherit it
+        # HOME + user identity are also passed to tmux via -e so child
+        # shells inherit them (#2259).
         tmux_idx = fake.argv.index("tmux")
         tmux_tail = fake.argv[tmux_idx:]
         assert "-e" in tmux_tail
         assert "HOME=/home/alice" in tmux_tail
+        assert "KLANGKWS_USER_ID=uid-123" in tmux_tail
+        assert "KLANGKWS_USER_HANDLE=alice" in tmux_tail
         # Grouped session: -t targets the base session, -s is a unique name
         assert "-t" in tmux_tail
         assert tmux_tail[tmux_tail.index("-t") + 1] == "uid-123"

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -1318,7 +1318,7 @@ class TestEnsureBaseSession:
         assert created is False
 
     async def test_env_args_passed(self):
-        """HOME and SSH_AUTH_SOCK are passed as tmux -e flags."""
+        """HOME, SSH_AUTH_SOCK, and user identity are passed as tmux -e flags."""
 
         with patch.object(
             _mock_pod,
@@ -1331,10 +1331,14 @@ class TestEnsureBaseSession:
                 "my-session",
                 user_home="/home/u",
                 ssh_agent_socket="/tmp/agent.sock",
+                user_id="uid-123",
+                user_handle="alice",
             )
         new_cmd = mock_exec.call_args_list[1].args[1]
         assert "HOME=/home/u" in new_cmd
         assert "SSH_AUTH_SOCK=/tmp/agent.sock" in new_cmd
+        assert "KLANGKWS_USER_ID=uid-123" in new_cmd
+        assert "KLANGKWS_USER_HANDLE=alice" in new_cmd
 
 
 class TestSetWorkspaceName:


### PR DESCRIPTION
## Summary

- `KLANGKWS_USER_ID` and `KLANGKWS_USER_HANDLE` were not available in browser terminal shells despite being set on the `podman exec -e` invocation.
- **Root cause:** the shell is spawned by the detached **base** tmux session (`ensure_base_session` / `_ensure_tmux_session`), which only passed `HOME` and `SSH_AUTH_SOCK` via tmux `-e`. The grouped session that the WebSocket connection creates joins the base session but doesn't spawn a new shell — so its `-e` flags never reach the shell process.
- Pass `user_id` and `user_handle` through `ensure_base_session` → `_ensure_tmux_session` and into the tmux `-e` flags on both the base and grouped sessions.

Fixes #2259

## Test plan

- [x] `test_env_args_passed` asserts `KLANGKWS_USER_ID` and `KLANGKWS_USER_HANDLE` in the base session's tmux command
- [x] `test_user_home_sets_home_env` asserts both vars in the grouped session's tmux `-e` tail
- [x] 134 terminal tests pass