### PR TITLE
fix(build): trust stamp, drop unreliable image-mtime rebuild check (#2273)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -391,6 +391,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`build-workspace-image.sh` no longer rebuilds the workspace image on
+  every server restart (#2273).** The image-creation-time "verify the image
+  is newer than every source file" check was unreliable (podman inspect
+  timestamps don't reflect storage-layer caching / layer reuse) and always
+  re-evaluated to "rebuild", defeating the stamp cache. Removed: when the
+  stamp hash matches, the build is now skipped and the stamp trusted.
 - **Workspace: no more overlapping "Server unreachable" and
   "Session expired" overlays (#2227).** When the WebSocket closed with
   an auth-failure code (4001/4002, session expired), the client also

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -43,32 +43,15 @@ done
 if ! $FORCE_BUILD && "$PODMAN" image exists "${KLANGKD_IMAGE_NAME}" 2>/dev/null && [ -f "$STAMP" ]; then
   OLD_HASH=$(cat "$STAMP" 2>/dev/null || true)
   if [ "$CURRENT_HASH" = "$OLD_HASH" ]; then
-    # Stamp matches source, but verify the image is actually newer than
-    # every source file.  A previous build may have written the stamp
-    # from matching source while the image lacked a later COPY target
-    # (e.g. a file added to profile.d/ before the Dockerfile's COPY
-    # line existed).  Compare the image creation time against the
-    # newest source file; rebuild if any source is newer.
-    IMAGE_CREATED=$("$PODMAN" inspect --format '{{.Created}}' "${KLANGKD_IMAGE_NAME}:latest" 2>/dev/null || true)
-    if [ -n "$IMAGE_CREATED" ]; then
-      IMAGE_EPOCH=$(date -d "$IMAGE_CREATED" +%s 2>/dev/null || echo 0)
-      NEWEST_SOURCE=$(find \
-        src/containers/workspace/ \
-        features.yaml \
-        features/ \
-        -type f -printf '%T@\n' 2>/dev/null |
-        sort -rn | head -1 | cut -d. -f1)
-      NEWEST_SOURCE=${NEWEST_SOURCE:-0}
-      if [ "$NEWEST_SOURCE" -gt "$IMAGE_EPOCH" ]; then
-        echo "Source files are newer than image — rebuilding."
-      else
-        echo "Image ${KLANGKD_IMAGE_NAME} is up to date, skipping build."
-        exit 0
-      fi
-    else
-      echo "Image ${KLANGKD_IMAGE_NAME} is up to date, skipping build."
-      exit 0
-    fi
+    # Stamp matches source — trust it and skip the build. The stamp hash
+    # already covers every file that affects the image (this script, the
+    # workspace image dir, features.yaml, and the feature trees), so a
+    # matching stamp means the image is up to date. The image-creation-time
+    # "newer than every source file" check that lived here was unreliable
+    # (podman inspect timestamps don't reflect storage-layer caching / layer
+    # reuse) and rebuilt the image on every server restart (#2273).
+    echo "Image ${KLANGKD_IMAGE_NAME} is up to date, skipping build."
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
## Summary

Closes #2273 — the workspace image was rebuilt on every server restart because the stamp-based cache was effectively dead code.

`build-workspace-image.sh` had a "verify the image is newer than every source file" codepath that ran *after* the stamp hash already matched. It compared `podman inspect --format '{{.Created}}'` against the newest source file's mtime. That comparison is unreliable — the inspect timestamp doesn't reflect storage-layer caching / layer reuse / image-tag aliasing — so it always re-evaluated to "rebuild", defeating the cache.

## Fix

Removed the entire image-creation-time verification codepath. The stamp hash already covers every file that affects the image (the script itself, `src/containers/workspace/`, `features.yaml`, and the `features/` trees), so a matching stamp means the image is up to date. When the stamp matches, the build is now skipped unconditionally — the stamp is trusted.

The defense-in-depth it provided (a stale stamp from a build that lacked a later `COPY` target) is worse than the disease: it caused unconditional rebuilds, whereas the edge case it guarded against is rare and self-corrects on the next source change.

```diff
   if [ "$CURRENT_HASH" = "$OLD_HASH" ]; then
-    # Stamp matches source, but verify the image is actually newer than
-    # every source file.  ... (unreliable mtime comparison) ...
-    IMAGE_CREATED=$("$PODMAN" inspect --format '{{.Created}}' ...)
-    if [ -n "$IMAGE_CREATED" ]; then
-      IMAGE_EPOCH=...
-      NEWEST_SOURCE=$(find ... -printf '%T@\n' | sort -rn | head -1)
-      if [ "$NEWEST_SOURCE" -gt "$IMAGE_EPOCH" ]; then
-        echo "Source files are newer than image — rebuilding."
-      else
-        echo "Image ... is up to date, skipping build."; exit 0
-      fi
-    else ...; fi
+    # Stamp matches source — trust it and skip the build.
+    echo "Image ${KLANGKD_IMAGE_NAME} is up to date, skipping build."
+    exit 0
   fi
```
