### PR TITLE
fix(egress): address network sidecar review findings (#2275-#2282)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -430,6 +430,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   `dns-proxy listening` line and refuses to start the workspace (fail-closed)
   if the proxy exits or never binds.
 
+- **Network sidecar: the DNS proxy no longer dies on a single transient
+  failure (#2278).** A failed `iptables` call (learning an IP) or a `sendto`
+  to a vanished client used to escape the proxy's main loop and kill PID 1,
+  leaving the workspace without DNS while learned allow-rules persisted. The
+  learn+respond path now swallows such errors so one bad packet drops only that
+  response.
+
 - **`build-workspace-image.sh` no longer rebuilds the workspace image on
   every server restart (#2273).** The image-creation-time "verify the image
   is newer than every source file" check was unreliable (podman inspect

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -422,6 +422,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Network sidecar: a filtered workspace now waits for the sidecar's DNS
+  proxy to be ready before starting (#2277).** Previously the workspace joined
+  the sidecar's netns the instant it was started, before the entrypoint had
+  applied `iptables -P OUTPUT DROP` or the proxy had bound — a window of
+  unrestricted egress. The sidecar start now polls for the proxy's
+  `dns-proxy listening` line and refuses to start the workspace (fail-closed)
+  if the proxy exits or never binds.
+
 - **`build-workspace-image.sh` no longer rebuilds the workspace image on
   every server restart (#2273).** The image-creation-time "verify the image
   is newer than every source file" check was unreliable (podman inspect

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -505,6 +505,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Security
 
+- **Network sidecar: filtered workspaces with `allow_sudo` now drop `net_raw`
+  (#2276).** A filtered workspace whose user can `sudo` to root could bypass
+  the egress filter via `SO_MARK` (root would have the `net_raw` that
+  `enable_ping` grants). The create path now drops `net_raw` from the bounding
+  set so even root can't acquire it, keeping the filter enforced; the setuid-ping
+  bridge is disabled for such workspaces (the trade for keeping the filter on).
+
 - **`git-credential-klangk`: secrets redacted from debug output (#1938).**
 
 - **Read-only terminal input whitelist (#1716).** Spectators can no longer

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -556,6 +556,19 @@ netfilter_default_domains:
   Fastly, CloudFront, Cloudflare) stays reachable without restarting the
   container. Static CIDR ranges (`10.0.0.0/8`) are installed as a single
   stable `-d <ip>/<plen>` rule with no resolution (#1935).
+- **A CNAME can widen egress to an attacker-steerable IP — on all ports.**
+  The proxy allow-lists every A record in a response, including those reached
+  via a CNAME chain, and a learned IP is reachable on **all ports** (no
+  per-domain port scoping yet, #2256). If an allowed domain CNAMEs to a host an
+  attacker controls (or to a shared CDN frontend), that IP becomes reachable
+  on every port for the workspace's life. Prefer `host:port` specs and avoid
+  allow-listing domains whose CNAME targets you don't control (#2279).
+- **Learned IPs are never revoked.** A resolved IP is allow-listed with no TTL
+  and is not removed when a domain is dropped from `allowed_domains` — it
+  stays reachable until the workspace is recreated (the sidecar is rebuilt
+  fresh on each start). Removing a domain from a _running_ workspace's
+  allow-list does not revoke egress to IPs it already resolved; recreate the
+  workspace to fully revoke (#2256, #2281).
 - **DNS is redirected to the sidecar's proxy, not blocked.** Outbound
   `:53` is `REDIRECT`ed to the sidecar's FQDN DNS proxy, which resolves
   against a real upstream and allow-lists the IPs at runtime; a denied

--- a/src/containers/network/Dockerfile
+++ b/src/containers/network/Dockerfile
@@ -2,7 +2,7 @@
 # container that shares a filtered workspace's network namespace.
 #
 # Build context is this directory (proxy.py + entrypoint.sh are COPY'd in).
-FROM alpine:latest
+FROM alpine:3.21
 RUN apk add --no-cache iptables python3 py3-pip \
     && pip install --no-cache-dir --break-system-packages "dnspython>=2.7,<3"
 COPY proxy.py /proxy.py

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -27,6 +27,18 @@ $IPT -P OUTPUT DROP
 # iptables package. The sidecar owns the netns (shared with the workspace
 # via --network container:), so this is the authoritative v6 deny (#2255).
 $IPT6 -P OUTPUT DROP
+# Defense-in-depth (#2275): also disable the v6 stack in this netns. Unlike
+# the createContainer-hook sysctl that was dropped (it ran before pasta
+# configured the netns and broke pasta's v6 address setup), this runs in the
+# sidecar entrypoint — AFTER pasta has configured the netns — so it just
+# removes the v6 addresses rather than blocking setup. Best-effort: rootless
+# per-netns ipv6 sysctl writability isn't guaranteed, and a silent no-op is
+# fine because the ip6tables DROP above is the certain backstop. Written via
+# procfs so no extra package (sysctl is in Alpine's procps, not installed).
+if [ -w /proc/sys/net/ipv6/conf/all/disable_ipv6 ]; then
+  echo 1 >/proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null ||
+    echo "egress-sidecar: could not disable IPv6 stack (relying on ip6tables DROP)" >&2
+fi
 # Loopback by *destination* (not -o lo): REDIRECT keeps the packet's original
 # output interface, so -o lo misses the redirected :53 packet under a DROP policy.
 $IPT -A OUTPUT -d 127.0.0.0/8 -j ACCEPT

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -151,6 +151,32 @@ def check_mark() -> None:
         probe.close()
 
 
+def _respond_allowed(
+    s: socket.socket, resp: bytes, addr: tuple[str, int], qname: str
+) -> None:
+    """Learn the response's A-record IPs + send it, swallowing transient errors.
+
+    A failure here (a transient ``iptables`` error in :func:`allow_ip`, or a
+    ``sendto`` to a vanished client) must drop only this one response — not
+    kill the proxy. If it escaped :func:`main` the sidecar's PID 1 would exit,
+    DNS would be dead for the workspace, and the learned ``ACCEPT`` rules would
+    persist (a partial fail-open: previously-resolved hosts stay reachable).
+    #2278.
+    """
+    try:
+        ips = a_records(resp)
+    except Exception:
+        ips = []
+    try:
+        for ip in ips:
+            allow_ip(ip)
+        if DEBUG:
+            print(f"allow {qname} -> {ips}", flush=True)
+        s.sendto(resp, addr)
+    except Exception:
+        pass
+
+
 def main() -> None:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(("127.0.0.1", LISTEN_PORT))
@@ -187,15 +213,7 @@ def main() -> None:
             us.close()
             continue
         us.close()
-        try:
-            ips = a_records(resp)
-        except Exception:
-            ips = []
-        for ip in ips:
-            allow_ip(ip)
-        if DEBUG:
-            print(f"allow {qname} -> {ips}", flush=True)
-        s.sendto(resp, addr)
+        _respond_allowed(s, resp, addr, qname)
 
 
 if __name__ == "__main__":

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1802,6 +1802,12 @@ class ContainerRegistry:
         # requested, so a missing/unstartable network sidecar raises
         # instead. With no allowed_domains the workspace starts
         # unrestricted (no filtering requested).
+        # #2276 (B): whether net_raw must be dropped for this workspace. A
+        # filtered workspace whose user can sudo to root would let root use the
+        # net_raw that enable_ping grants to setsockopt(SO_MARK) and bypass the
+        # egress filter; dropping net_raw (from the bounding set) closes that
+        # for root too. Applied in the cap_add/cap_drop logic after this branch.
+        drop_net_raw = False
         if allowed_domains:
             if not self._network_sidecar_enabled():
                 raise podman.PodmanError(
@@ -1831,22 +1837,54 @@ class ContainerRegistry:
             # Remember this workspace has a live network sidecar so its stop
             # tears the network sidecar down (#2254).
             self._ws_with_network_sidecar.add(workspace_id)
+            # #2276 (B): if sudo is also granted, the klangk user can `sudo`
+            # to root. Root would have the net_raw that enable_ping grants in
+            # its effective set and could setsockopt(SO_MARK) to skip the nat
+            # REDIRECT and reach the upstream directly — the #2264 bypass. Drop
+            # net_raw from the bounding set so even root can't acquire it
+            # (NET_ADMIN is never granted, so SO_MARK — which needs one of the
+            # two — fails for everyone). podman rejects a cap in both --cap-add
+            # and --cap-drop, so this also suppresses the enable_ping net_raw
+            # add below. Cost: the setuid-ping bridge breaks for this workspace
+            # (ping disabled) — the trade for keeping the filter enforced.
+            if allow_sudo:
+                drop_net_raw = True
+                logger.info(
+                    "workspace %s is egress-filtered with allow_sudo on; "
+                    "dropping net_raw so sudo->root cannot SO_MARK-bypass "
+                    "the egress filter — ping (setuid) is disabled for this "
+                    "workspace (#2276)",
+                    workspace_id[:8],
+                )
 
-        # #2045: grant the container CAP_NET_RAW so unprivileged ``ping``
-        # works (a setuid ping binary in the base image bridges the cap to
-        # the non-root klangk user). The ping_group_range / setcap
-        # alternatives don't work rootless — see #2045 for the full
-        # analysis. CAP_NET_RAW does NOT let a filtered workspace escape
-        # egress filtering: raw-socket packets still traverse the netfilter
-        # OUTPUT chain (default DROP + dest-IP allowlist), and in rootless
-        # pasta/slirp only forwards TCP/UDP/ICMP — so it grants neither
-        # bridge sniffing/ARP (no shared L2) nor egress to disallowed
-        # hosts. Applies to newly-created containers only: a SIGHUP reload
-        # changes the setting for future workspaces; a running container
-        # keeps its existing cap set until recreated. Read live off
-        # settings (the app-ownership rule). Default on.
-        if self.app.state.settings.enable_ping:
+        # #2045: grant the container CAP_NET_RAW so unprivileged ``ping`` works
+        # (a setuid ping binary in the base image bridges the cap to the non-root
+        # klangk user). The ping_group_range / setcap alternatives don't work
+        # rootless — see #2045 for the full analysis.
+        #
+        # Why this is safe for a *filtered* workspace (#2276): the guard against
+        # the #2264 SO_MARK bypass is NOT that "raw packets traverse netfilter"
+        # (the old rationale here, which was wrong) — it is that the klangk user
+        # is non-root. CAP_NET_RAW added here is only in the container's
+        # *bounding* set; capabilities become *effective* only for uid 0, so the
+        # non-root klangk user cannot setsockopt(SO_MARK) (EPERM) and cannot skip
+        # the nat REDIRECT to reach the upstream directly. ping still works
+        # because the setuid ping binary is root-owned.
+        #
+        # #2276 (B): if the filtered workspace also grants allow_sudo, the
+        # klangk user can `sudo` to root, which WOULD have net_raw effective and
+        # could SO_MARK — so drop net_raw instead of adding it (see drop_net_raw
+        # above). NET_ADMIN is never granted (not in the default cap set), so
+        # with net_raw dropped neither root nor the user can SO_MARK and the
+        # filter holds even under sudo. ping is disabled for such workspaces.
+        #
+        # Applies to newly-created containers only: a SIGHUP reload changes the
+        # setting for future workspaces. Read live off settings (the app-ownership
+        # rule). Default on.
+        if self.app.state.settings.enable_ping and not drop_net_raw:
             create_kwargs["cap_add"] = ["net_raw"]
+        if drop_net_raw:
+            create_kwargs["cap_drop"] = ["net_raw"]
 
         logger.info(
             "workspace-open: build env vars, volumes, and "

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -28,6 +28,15 @@ DEFAULT_PORTS_PER_WORKSPACE = 5
 
 HEALTH_MESSAGE_MAX_BYTES = 512
 
+# Network sidecar readiness (#2277): the sidecar's proxy prints
+# "dns-proxy listening" once bound. _start_network_sidecar polls the sidecar's
+# logs for it before returning, so a workspace never joins a netns whose OUTPUT
+# policy is still ACCEPT (the entrypoint hasn't run -P OUTPUT DROP yet) — a
+# fail-open window. Module-level so the timeout path is unit-testable fast.
+_NETWORK_SIDECAR_READY_TIMEOUT = 30.0
+_NETWORK_SIDECAR_READY_POLL = 0.3
+_NETWORK_SIDECAR_READY_TOKEN = "dns-proxy listening"
+
 _VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
 
 _VALID_MOUNT_OPTIONS = {
@@ -1156,6 +1165,35 @@ class ContainerRegistry:
                 pull="missing",
             )
             await self.app.state.podman.start_container(cid)
+            # #2277: wait for the proxy to be listening before returning, so the
+            # workspace never joins a netns whose OUTPUT is still ACCEPT
+            # (entrypoint mid-flight) — a fail-open window. The proxy prints
+            # "dns-proxy listening" once bound; poll its logs. Fail-closed: if
+            # the sidecar exits first or the proxy never binds, raise so the
+            # caller refuses to start the workspace rather than run it unfiltered.
+            deadline = time.monotonic() + _NETWORK_SIDECAR_READY_TIMEOUT
+            ready = False
+            while time.monotonic() < deadline:
+                logs = await self.app.state.podman.container_logs(cid)
+                if _NETWORK_SIDECAR_READY_TOKEN in logs:
+                    ready = True
+                    break
+                state = await self.app.state.podman.inspect_container(cid)
+                status = (state or {}).get("State", {}).get("Status", "")
+                if status in ("exited", "stopped"):
+                    raise podman.PodmanError(
+                        500,
+                        f"network sidecar {name} exited before the DNS proxy "
+                        f"was ready; logs:\n{logs}",
+                    )
+                await asyncio.sleep(_NETWORK_SIDECAR_READY_POLL)
+            if not ready:
+                raise podman.PodmanError(
+                    500,
+                    f"network sidecar {name} DNS proxy did not become ready "
+                    f"within {_NETWORK_SIDECAR_READY_TIMEOUT:.0f}s; the "
+                    "workspace would join an unfiltered netns",
+                )
             logger.info(
                 "network sidecar started for %s: %s (%s)",
                 workspace_id[:8],

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -36,6 +36,11 @@ HEALTH_MESSAGE_MAX_BYTES = 512
 _NETWORK_SIDECAR_READY_TIMEOUT = 30.0
 _NETWORK_SIDECAR_READY_POLL = 0.3
 _NETWORK_SIDECAR_READY_TOKEN = "dns-proxy listening"
+# fwmark the sidecar's proxy stamps on its upstream socket and the entrypoint
+# matches in its nat/filter rules (#2264). Single source of truth, passed to the
+# sidecar via KLANGKNETWORK_EGRESS_MARK so proxy.py and entrypoint.sh (which
+# both default to 75) can't diverge (#2282).
+_NETWORK_SIDECAR_MARK = 75
 
 _VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
 
@@ -1139,6 +1144,10 @@ class ContainerRegistry:
             # host.containers.internal). The network sidecar allow-lists it statically
             # — it's a /etc/hosts entry the FQDN proxy can't learn (#2254 B1).
             f"KLANGKNETWORK_EGRESS_BACKEND_PORT={self.app.state.settings.egress_port}",
+            # Single source of truth for the fwmark both proxy.py and
+            # entrypoint.sh use (#2264, #2282): they default to 75, but pass it
+            # explicitly so the two can't diverge.
+            f"KLANGKNETWORK_EGRESS_MARK={_NETWORK_SIDECAR_MARK}",
         ]
         if egress_mode == "interactive":
             env.append("KLANGKNETWORK_EGRESS_MODE=interactive")

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -251,6 +251,17 @@ class Podman:
         data = json.loads(out)
         return data[0] if data else None
 
+    async def container_logs(self, container_id: str) -> str:
+        """Return the container's combined stdout/stderr logs (empty if gone).
+
+        Used to wait for a container's entrypoint to signal readiness (e.g. the
+        network sidecar's proxy prints ``dns-proxy listening`` once bound) —
+        ``podman start`` returns the moment the container reaches "running",
+        which is before the entrypoint has finished its setup (#2277).
+        """
+        rc, out, _err = await self.run(["logs", container_id], check=False)
+        return out if rc == 0 else ""
+
     async def create_container(
         self,
         name: str,

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -13,16 +13,19 @@ outcomes are deterministic (no internet dependency):
   anything else  -> NXDOMAIN
 
 A "workspace" container shares the network sidecar's netns
-(``--network container:<network-sidecar>``, ``--cap-drop net_raw`` — as klangk
-launches a filtered workspace) and must:
+(``--network container:<network-sidecar>``, launched as root with
+``--cap-add net_raw`` and gosu-dropped to the non-root klangk user — exactly
+how klangk launches a filtered workspace when ``enable_ping`` is on) and must:
 
   * resolve ``allowed.test`` to 1.2.3.4 (the proxy forwards to the upstream,
     learns the IP, returns it — proving the mark-based loop-avoidance works),
   * be **unable** to query the upstream directly: a direct ``@<upstream>
     exfil.test`` is REDIRECTed to the proxy (not the upstream) and denied ->
     NXDOMAIN, never 6.6.6.6. This is the #2264 fix — the mark scopes upstream
-    access to the proxy; the workspace lacks CAP_NET_RAW/NET_ADMIN and cannot
-    mark, so all its :53 traffic is forced through the allow-listing proxy.
+    access to the proxy; the workspace's non-root user has net_raw only in its
+    *bounding* set (not effective), so it cannot ``setsockopt(SO_MARK)`` to skip
+    the REDIRECT, and all its :53 traffic is forced through the allow-listing
+    proxy. (#2276 — see test_somark_bypass_blocked_under_production_caps.)
 
 Requires: ``podman`` + Linux (NET_ADMIN netns + iptables). Skips otherwise.
 
@@ -103,7 +106,14 @@ serve()
 # one line: "A <ip>,<ip>..." | "NXDOMAIN" | "ERR ...".
 _WS_QUERY_PY = """\
 import sys
+import os
 import dns.resolver
+
+# Replicate production (#2276): start as root, gosu-drop to the non-root klangk
+# user (uid 1000) — the drop clears effective caps, so the workspace cannot
+# setsockopt(SO_MARK). See _SOMARK_PROBE_PY for the explicit bypass probe.
+os.setgid(1000)
+os.setuid(1000)
 
 name = sys.argv[1]
 server = sys.argv[2] if len(sys.argv) > 2 else "1.1.1.1"
@@ -119,6 +129,71 @@ except dns.resolver.NXDOMAIN:
     print("NXDOMAIN")
 except Exception as exc:
     print("ERR " + type(exc).__name__ + " " + str(exc))
+"""
+
+# The #2264/#2276 bypass probe: arm a UDP socket with SO_MARK and, if it
+# succeeds, send a DNS query DIRECTLY to the upstream (a marked packet skips the
+# nat REDIRECT, which RETURNs marked traffic, and matches the filter's marked
+# upstream ACCEPT). Prints one line:
+#   "SO_MARK_EPERM"                   the workspace user lacks an *effective*
+#                                     cap (production: non-root) — bypass CLOSED
+#   "DIRECT <ip>,<ip>..." | "DIRECT EMPTY"  SO_MARK succeeded and the query
+#                                     reached the upstream directly — bypass OPEN
+#   "DIRECT_ERR <ExcType>"            SO_MARK succeeded but the query failed
+#                                     (e.g. the filter dropped it) — not an exfil
+# A filtered workspace's non-root user must get SO_MARK_EPERM; seeing the exfil
+# IP (6.6.6.6) in a DIRECT line means the bypass is open.
+_SOMARK_PROBE_PY = """\
+import socket
+import sys
+import os
+import dns.message
+
+name = sys.argv[1]
+server = sys.argv[2]
+mark = int(sys.argv[3]) if len(sys.argv) > 3 else 75
+# Replicate production (#2276). By default gosu-drop to the non-root klangk user
+# (uid 1000): the workspace starts as root (PID 1) then drops, which clears the
+# effective+permitted cap sets, so CAP_NET_RAW (in the bounding set via
+# enable_ping) is NOT effective and setsockopt(SO_MARK) must fail. Pass a 4th
+# arg ("root") to STAY root instead — used by the filtered+sudo test, where the
+# workspace's net_raw is dropped (#2276 B) so even root cannot SO_MARK.
+# (Launching with --user 1000:1000 instead of the in-process drop would be a
+# *naive* repro that lies: podman promotes cap-add'd caps to AMBIENT for a
+# non-root init, making the cap effective and the bypass falsely look open.)
+if len(sys.argv) <= 4:
+    os.setgid(1000)
+    os.setuid(1000)
+
+q = dns.message.make_query(name, "A")
+wire = q.to_wire()
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, mark)
+except PermissionError:
+    print("SO_MARK_EPERM")
+    sys.exit(0)
+
+# Marked: this packet skips the nat REDIRECT and matches the filter's marked
+# upstream ACCEPT — if the upstream answers, the bypass is open.
+s.settimeout(4)
+try:
+    s.sendto(wire, (server, 53))
+    data, _ = s.recvfrom(65535)
+    resp = dns.message.from_wire(data)
+    ips = [
+        r.address
+        for rr in resp.answer
+        if rr.rdtype == 1
+        for r in rr
+    ]
+    if ips:
+        print("DIRECT " + ",".join(ips))
+    else:
+        print("DIRECT EMPTY")
+except Exception as exc:
+    print("DIRECT_ERR " + type(exc).__name__)
 """
 
 
@@ -153,11 +228,19 @@ def env():
     tmp = tempfile.mkdtemp(prefix="netc-e2e-")
     fu = os.path.join(tmp, "fake_upstream.py")
     wq = os.path.join(tmp, "ws_query.py")
+    sm = os.path.join(tmp, "somark_probe.py")
     with open(fu, "w") as fh:
         fh.write(_FAKE_UPSTREAM_PY)
     with open(wq, "w") as fh:
         fh.write(_WS_QUERY_PY)
-    yield {"image": tag, "fake_upstream": fu, "ws_query": wq}
+    with open(sm, "w") as fh:
+        fh.write(_SOMARK_PROBE_PY)
+    yield {
+        "image": tag,
+        "fake_upstream": fu,
+        "ws_query": wq,
+        "somark_probe": sm,
+    }
     _podman("rmi", "-f", tag, check=False, timeout=60)
     shutil.rmtree(tmp, ignore_errors=True)
 
@@ -262,8 +345,14 @@ def _query(env, stack, name, server=None):
     """Run a one-shot workspace container sharing the network sidecar's netns.
 
     Returns the ws_query.py stdout (one line: 'A ...' / 'NXDOMAIN' / 'ERR ...').
-    --cap-drop net_raw mirrors how klangk launches a filtered workspace (#2264):
-    the workspace must be unable to set SO_MARK.
+
+    Mirrors how klangk launches a filtered workspace (#2264, #2276): the
+    container starts as root with CAP_NET_RAW in the *bounding* set (enable_ping
+    default True), then gosu-drops to the non-root klangk user (uid 1000) — the
+    drop clears effective caps, so the workspace cannot setsockopt(SO_MARK) to
+    skip the nat REDIRECT (the #2264 bypass); ping still works via the setuid
+    binary. The drop is done in-process by ws_query.py; the explicit SO_MARK
+    bypass attempt is test_somark_bypass_blocked_under_production_caps.
     """
     _, network_sidecar = stack
     args = ["/wq.py", name]
@@ -274,10 +363,44 @@ def _query(env, stack, name, server=None):
         "--rm",
         "--network",
         f"container:{network_sidecar}",
-        "--cap-drop",
+        "--cap-add",
         "net_raw",
         "-v",
         f"{env['ws_query']}:/wq.py:ro",
+        "--entrypoint",
+        "python3",
+        env["image"],
+        *args,
+        timeout=60,
+    )
+    return out.stdout.strip()
+
+
+def _probe_somark(
+    env, stack, name, server, *, mark=75, as_root=False, cap_drop=False
+):
+    """Run the SO_MARK bypass probe as a filtered workspace.
+
+    Returns the probe's stdout (see _SOMARK_PROBE_PY).
+
+    * ``as_root``: stay root in the probe (simulate ``sudo``->root) instead of
+      gosu-dropping to uid 1000 (the normal non-root workspace user).
+    * ``cap_drop``: launch with ``--cap-drop net_raw`` (the filtered+sudo
+      config, #2276 B) instead of ``--cap-add net_raw`` (enable_ping).
+    """
+    _, network_sidecar = stack
+    caps = ["--cap-drop", "net_raw"] if cap_drop else ["--cap-add", "net_raw"]
+    args = ["/probe.py", name, server, str(mark)]
+    if as_root:
+        args.append("root")  # 4th arg => probe stays root (sudo->root)
+    out = _podman(
+        "run",
+        "--rm",
+        "--network",
+        f"container:{network_sidecar}",
+        *caps,
+        "-v",
+        f"{env['somark_probe']}:/probe.py:ro",
         "--entrypoint",
         "python3",
         env["image"],
@@ -383,3 +506,45 @@ class TestNetworkSidecarE2E:
         finally:
             _podman("rm", "-f", nc, check=False, timeout=60)
             _podman("network", "rm", net, check=False, timeout=60)
+
+    def test_somark_bypass_blocked_under_production_caps(self, env, stack):
+        # #2276: a filtered workspace runs as the NON-ROOT user with net_raw
+        # only in its bounding set (not effective), so it cannot setsockopt
+        # (SO_MARK) to skip the nat REDIRECT and reach the upstream directly
+        # (the #2264 bypass). The probe arms a UDP socket with SO_MARK=75 and
+        # queries the upstream directly; under production caps it must get
+        # SO_MARK_EPERM (the user lacks the effective cap) and NEVER the exfil IP.
+        upstream_ip, _ = stack
+        out = _probe_somark(env, stack, "exfil.test", upstream_ip)
+        assert "6.6.6.6" not in out, (
+            f"SO_MARK bypass OPEN under production caps — exfil IP reached:\n"
+            f"{out}"
+        )
+        assert out.startswith("SO_MARK_EPERM"), (
+            f"expected SO_MARK_EPERM (non-root user lacks effective net_raw), "
+            f"got:\n{out}"
+        )
+
+    def test_somark_bypass_closed_for_filtered_sudo_workspace(
+        self, env, stack
+    ):
+        # #2276 (B): a filtered+sudo workspace drops net_raw (the (B) fix) so
+        # even root (via sudo) cannot SO_MARK. Run the probe AS ROOT (simulate
+        # sudo->root) against a workspace launched with --cap-drop net_raw; it
+        # must get SO_MARK_EPERM, never the exfil IP. This pins the invariant
+        # the fix relies on: net_raw is not in the bounding set, so root has no
+        # more egress power than the non-root user for filtered traffic. NET_ADMIN
+        # is never granted, so dropping net_raw alone closes SO_MARK (which needs
+        # NET_ADMIN or NET_RAW) — if a future change grants either, this fails.
+        upstream_ip, _ = stack
+        out = _probe_somark(
+            env, stack, "exfil.test", upstream_ip, as_root=True, cap_drop=True
+        )
+        assert "6.6.6.6" not in out, (
+            f"SO_MARK bypass OPEN for filtered+sudo root — exfil IP reached:\n"
+            f"{out}"
+        )
+        assert out.startswith("SO_MARK_EPERM"), (
+            f"expected SO_MARK_EPERM (net_raw dropped; root can't mark), "
+            f"got:\n{out}"
+        )

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -803,6 +803,12 @@ class TestStartContainer:
             e.startswith("KLANGKNETWORK_EGRESS_BACKEND_PORT=")
             for e in creates[0]["env"]
         )
+        # #2282: the fwmark is passed explicitly (single source of truth) so
+        # proxy.py and entrypoint.sh can't diverge.
+        assert any(
+            e.startswith("KLANGKNETWORK_EGRESS_MARK=")
+            for e in creates[0]["env"]
+        ), creates[0]["env"]
         assert creates[1]["network"] == "container:net-cid"
         assert "annotations" not in creates[1]
         # #2254 B1: --add-host is rejected and --publish is discarded under

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -559,6 +559,9 @@ def patch_podman(registry=None, **overrides):
     """
     defaults = {
         "inspect_container": AsyncMock(return_value=None),
+        "container_logs": AsyncMock(
+            return_value="dns-proxy listening on 127.0.0.1:15353"
+        ),
         "create_container": AsyncMock(return_value="new-cid"),
         "start_container": AsyncMock(),
         "wait_for_container_ready": AsyncMock(),
@@ -861,6 +864,82 @@ class TestStartContainer:
             "ping" in rec.message.lower() and "#2276" in rec.message
             for rec in caplog.records
         ), [rec.message for rec in caplog.records]
+
+    async def test_start_network_sidecar_raises_if_proxy_exits_before_ready(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2277: if the sidecar exits before the DNS proxy binds, refuse to
+        # start (fail-closed) rather than let the workspace join a netns whose
+        # OUTPUT is still ACCEPT (entrypoint mid-flight).
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+
+        async def _fake_create(name, image, **kw):
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry,
+            create_container=AsyncMock(side_effect=_fake_create),
+            container_logs=AsyncMock(return_value=""),
+            inspect_container=AsyncMock(
+                return_value={"State": {"Status": "exited"}}
+            ),
+        ):
+            with pytest.raises(podman.PodmanError):
+                await self.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                )
+
+    async def test_start_network_sidecar_raises_on_readiness_timeout(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2277: if the proxy never prints its listening line within the
+        # readiness window, refuse to start (fail-closed). Monkeypatch the
+        # timeout/poll constants small so the test doesn't wait 30s.
+        import klangk.container as _c_mod
+
+        monkeypatch.setattr(_c_mod, "_NETWORK_SIDECAR_READY_TIMEOUT", 0.05)
+        monkeypatch.setattr(_c_mod, "_NETWORK_SIDECAR_READY_POLL", 0.01)
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+
+        async def _fake_create(name, image, **kw):
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry,
+            create_container=AsyncMock(side_effect=_fake_create),
+            container_logs=AsyncMock(return_value=""),
+            inspect_container=AsyncMock(
+                return_value={"State": {"Status": "running"}}
+            ),
+        ):
+            with pytest.raises(podman.PodmanError):
+                await self.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                )
 
     async def test_network_sidecar_failure_refuses_to_start(
         self, workspace, tmp_path, monkeypatch

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -810,6 +810,58 @@ class TestStartContainer:
         assert "dns" not in creates[1]
         assert "dns_search" not in creates[1]
 
+    async def test_filtered_workspace_with_allow_sudo_drops_net_raw(
+        self, workspace, tmp_path, monkeypatch, caplog
+    ):
+        # #2276 (B): a filtered workspace (allowed_domains) created with
+        # allow_sudo on would let the klangk user sudo to root and use the
+        # net_raw that enable_ping grants to setsockopt(SO_MARK), bypassing
+        # the egress filter. Instead drop net_raw from the bounding set so even
+        # root can't acquire it (NET_ADMIN is never granted) — the filter holds,
+        # at the cost of ping (setuid) for this workspace.
+        import logging
+
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "allow_sudo", "true"
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            with caplog.at_level(logging.INFO, logger="klangk.container"):
+                await self.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                )
+        ws = creates[1]  # creates[0] is the network sidecar
+        # net_raw is dropped, not added (podman rejects a cap in both).
+        assert ws["cap_drop"] == ["net_raw"]
+        assert "net_raw" not in ws.get("cap_add", [])
+        # The ping-loss is logged once at create time so an operator chasing
+        # broken ping isn't guessing.
+        assert any(
+            "ping" in rec.message.lower() and "#2276" in rec.message
+            for rec in caplog.records
+        ), [rec.message for rec in caplog.records]
+
     async def test_network_sidecar_failure_refuses_to_start(
         self, workspace, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -195,6 +195,18 @@ class TestInspectContainer:
             assert await _p.inspect_container("c") is None
 
 
+class TestContainerLogs:
+    async def test_returns_stdout_on_success(self):
+        with patch(EXEC, _exec(("dns-proxy listening\n", "", 0))):
+            assert await _p.container_logs("c") == "dns-proxy listening\n"
+
+    async def test_returns_empty_on_failure(self):
+        # check=False -> a nonzero exit (e.g. container gone) yields "", not a
+        # raise, so the readiness poll treats a vanished sidecar as not-yet-ready.
+        with patch(EXEC, _exec(("", "no such container", 1))):
+            assert await _p.container_logs("c") == ""
+
+
 class TestCreateContainer:
     async def test_minimal(self):
         with patch(EXEC, _exec(("abc123\n", "", 0))) as m:

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1,0 +1,113 @@
+"""Unit tests for the network sidecar's DNS proxy (``src/containers/network/proxy.py``).
+
+``proxy.py`` is a standalone sidecar script — it lives under
+``src/containers/network/`` (NOT in the ``klangk`` package, so it is not
+coverage-gated) and is normally only exercised end-to-end by the real-podman
+e2e. These tests import it as a module and drive its helpers directly.
+``main()`` only runs under ``__name__ == "__main__"``, so importing is safe
+(module level just reads env vars + builds the allow-list).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# proxy.py is a container script, not an importable package module — load it
+# straight from its source path. test_proxy.py is at
+# src/klangk/klangkd-tests/tests/, so parents[3] is the repo "src/".
+_PROXY_PATH = (
+    Path(__file__).resolve().parents[3] / "containers" / "network" / "proxy.py"
+)
+
+
+def _install_dns_stubs() -> None:
+    """Stub dnspython so proxy.py imports in the server venv.
+
+    dnspython is a sidecar-only dependency (installed in the network sidecar
+    image, not the server's venv). proxy.py imports ``dns.message`` /
+    ``dns.rcode`` / ``dns.rdatatype`` at module level; stub them so the import
+    succeeds. The tests below monkeypatch the functions that actually use dnspython
+    (a_records etc.), so the stubs only need to exist, not work.
+    """
+    if "dns" in sys.modules:
+        return
+    dns = types.ModuleType("dns")
+    message = types.ModuleType("dns.message")
+    message.from_wire = lambda *a, **k: None
+    message.make_response = lambda *a, **k: None
+    message.make_query = lambda *a, **k: None
+    rcode = types.ModuleType("dns.rcode")
+    rcode.NXDOMAIN = 3
+    rdatatype = types.ModuleType("dns.rdatatype")
+    rdatatype.A = 1
+    dns.message = message
+    dns.rcode = rcode
+    dns.rdatatype = rdatatype
+    sys.modules.update(
+        {
+            "dns": dns,
+            "dns.message": message,
+            "dns.rcode": rcode,
+            "dns.rdatatype": rdatatype,
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def proxy():
+    """Load proxy.py as an isolated module (with dnspython stubbed)."""
+    _install_dns_stubs()
+    spec = importlib.util.spec_from_file_location(
+        "klangk_test_proxy", _PROXY_PATH
+    )
+    assert spec and spec.loader, f"could not load {_PROXY_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestRespondAllowedSwallowsFailures:
+    """#2278: a transient failure in allow_ip or sendto must drop only the one
+    response, not kill the proxy (an escaped raise would take down PID 1,
+    leaving learned ACCEPT rules in place with DNS dead — a partial
+    fail-open)."""
+
+    def test_allow_ip_failure_does_not_propagate(self, proxy, monkeypatch):
+        # allow_ip shells out to iptables; a transient failure there must not
+        # escape _respond_allowed.
+        monkeypatch.setattr(proxy, "a_records", lambda wire: ["1.2.3.4"])
+
+        def _boom(ip):
+            raise RuntimeError("iptables transient failure")
+
+        monkeypatch.setattr(proxy, "allow_ip", _boom)
+        s = MagicMock()
+        # Must not raise.
+        proxy._respond_allowed(s, b"resp", ("127.0.0.1", 1234), "allowed.test")
+
+    def test_sendto_failure_does_not_propagate(self, proxy, monkeypatch):
+        # sendto to a vanished client must not escape _respond_allowed.
+        monkeypatch.setattr(proxy, "a_records", lambda wire: ["1.2.3.4"])
+        monkeypatch.setattr(proxy, "allow_ip", lambda ip: None)  # no iptables
+        s = MagicMock()
+        s.sendto.side_effect = OSError("client gone")
+        # Must not raise.
+        proxy._respond_allowed(s, b"resp", ("127.0.0.1", 1234), "allowed.test")
+
+    def test_happy_path_still_sends(self, proxy, monkeypatch):
+        # Sanity: with no failure, _respond_allowed learns the IPs + sends.
+        monkeypatch.setattr(
+            proxy, "a_records", lambda wire: ["1.2.3.4", "5.6.7.8"]
+        )
+        learned = []
+        monkeypatch.setattr(proxy, "allow_ip", learned.append)
+        s = MagicMock()
+        proxy._respond_allowed(s, b"resp", ("127.0.0.1", 1234), "allowed.test")
+        assert learned == ["1.2.3.4", "5.6.7.8"]
+        s.sendto.assert_called_once_with(b"resp", ("127.0.0.1", 1234))


### PR DESCRIPTION
## Summary

Addresses the findings of the independent adversarial review of the network sidecar (the review of #2248), filed as **#2275–#2282**. Stacked on `issue-2255-fqdn` (which already incorporated the IPv6 `ip6tables` deny, the interactive NFLOG consent mode, and the dead-netfilter cleanup).

## Changes

- **#2275 — IPv6 defense-in-depth.** Re-adds `sysctl disable_ipv6` in the sidecar *entrypoint* (runs after pasta configures the netns, so it doesn't break v6 setup — distinct from the createContainer-hook sysctl the base deliberately dropped). The `ip6tables -P OUTPUT DROP` deny and its e2e test come from the base; this is the extra stack-disable layer.
- **#2276 — SO_MARK bypass safety.** Makes the real-podman e2e faithful: workspace containers start as root with `--cap-add net_raw` (the production bounding set) and gosu-drop to the non-root user in-process. Adds a SO_MARK-armed bypass probe (`test_somark_bypass_blocked_under_production_caps`). For filtered+`allow_sudo` workspaces, drops `net_raw` from the bounding set so even `sudo`→root can't `SO_MARK` (`test_somark_bypass_closed_for_filtered_sudo_workspace`). Corrects the `container.py` rationale comment.
- **#2277 — readiness barrier.** `_start_network_sidecar` now polls the sidecar logs for `dns-proxy listening` (via a new `podman.container_logs`) before returning, so a workspace never joins a netns whose `OUTPUT` is still `ACCEPT` (entrypoint mid-flight). Fail-closed: a sidecar that exits or never binds refuses to start the workspace.
- **#2278 — proxy fault tolerance.** Extracts the learn+respond tail into `_respond_allowed`, which swallows transient `iptables`/`sendto` errors so one bad packet no longer kills the sidecar's PID 1 (which would leave learned `ACCEPT` rules in place with DNS dead). New `test_proxy.py`.
- **#2282 (a)+(b) — hardening nits.** Pins the sidecar base `alpine:latest` → `alpine:3.21`; passes `KLANGKNETWORK_EGRESS_MARK` explicitly from a single constant so `proxy.py` and `entrypoint.sh` can't diverge.
- **#2279 + #2281 — docs.** Documents the CNAME-widening and learned-IP-staleness security caveats in `egress-filtering.md`.

## Already done by the base branch (`issue-2255-fqdn`)

- **#2280** (dead netfilter OCI-hook machinery) — `netfilter.py`/`test_netfilter.py` gutted.
- **#2282(c)** — stale `count_pending` docstring already corrected.

## Test

- **Unit:** 100% coverage on the `klangk` package (4295 passed, `-n auto`).
- **E2E (real rootless podman):** 8/8 — including the two new SO_MARK bypass tests and the IPv6/interactive-mode tests from the base.
- Grounded the #2276 fix empirically: confirmed the bypass is real under `--cap-add net_raw` (root → `SO_MARK_OK`), that `--cap-add` + `--cap-drop` of the same cap is a hard podman error (hence the add is suppressed), and that root's default caps lack `net_raw`/`net_admin` so dropping `net_raw` alone closes `SO_MARK`.

Closes #2275, #2276, #2277, #2278, #2279, #2281, #2282. (#2280 and #2282(c) are addressed by the base branch.)
