### PR TITLE
test: add pytest-testmon for scoped local test iteration (#2288)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ Thumbs.db
 # Claude
 .claude/
 .coverage
+# pytest-testmon line->test map (local iteration only, #2288). Written to
+# the pytest rootdir (src/klangk/.testmondata).
+.testmondata
 src/frontend/coverage/
 
 # E2E test artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,25 @@ path with no test will fail the build. When iterating
 fast on one file you can scope with `-k` / a path and add `--no-cov`, but
 re-run the full suite **with** coverage (and `-n auto`) before committing.
 
+For tight edit/test loops, `pytest-testmon` (in the `test` extra) selects
+only the tests whose coverage touches your changed lines. Run the
+`testmon` task — it baselines the line→test map into
+`src/klangk/.testmondata` on the first clean-tree run, then re-runs just
+the affected subset (~10s vs ~60s):
+
+```bash
+devenv --quiet -O dotenv.enable:bool false shell -- testmon
+```
+
+`--no-cov` is intentional: a scoped run only exercises a fraction of the
+package, so the 100% gate does not apply to it. Re-run the full suite
+**with** coverage (the `test-backend` task) before committing — testmon is
+a local accelerator only; CI always runs the full suite. The data file is
+per-worktree (rootdir-relative) and gitignored; concurrent `testmon` runs
+in the same worktree serialize on sqlite's busy-lock (a brief stall, not
+corruption). Delete `src/klangk/.testmondata` after a large refactor or
+branch switch to re-baseline.
+
 ## Verifying behavior empirically (avoid repro loops)
 
 When you need to confirm a runtime behavior empirically, **add a temporary

--- a/devenv.nix
+++ b/devenv.nix
@@ -272,6 +272,20 @@ in
       -v -n auto --no-cov "$@"
   '';
 
+  # Scoped run: re-run only tests whose coverage touches changed source
+  # lines (pytest-testmon). Inert on CI — CI runs the full suite via
+  # test-backend; this is the local tight-loop accelerator (#2288).
+  # First run on a clean tree baselines the line->test map into
+  # src/klangk/.testmondata (~the same cost as test-unit); after that, a
+  # one-file edit re-runs just the affected subset (~10s vs ~60s). Delete
+  # src/klangk/.testmondata after a large refactor / branch switch to
+  # re-baseline.
+  scripts.testmon.exec = ''
+    cd $DEVENV_ROOT
+    exec python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
+      -v -n auto --no-cov --testmon "$@"
+  '';
+
   # CLI E2E tests: start real server, run klangk commands.
   # Free-allocated ports + instance-scoped cleanup (#1393) make xdist
   # safe with --dist=loadscope. Capped at 2 workers to limit podman

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -40,6 +40,11 @@ test = [
     "pytest-cov>=6.0.0",
     "pytest-xdist>=3.0.0",
     "pytest-timeout>=2.3.0",
+    # Selects only tests whose coverage touches changed source lines, for
+    # fast local iteration. Optional in spirit: CI runs the full suite the
+    # documented way (`-n auto`, full coverage); this powers the local
+    # `--testmon` scoped loop (#2288).
+    "pytest-testmon>=2.0.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1107,6 +1107,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-testmon" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
@@ -1126,6 +1127,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
+    { name = "pytest-testmon", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.3.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
@@ -1870,6 +1872,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108, upload-time = "2025-12-01T07:30:24.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199, upload-time = "2025-12-01T07:30:23.623Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `pytest-testmon` to the test toolchain so local edit/test loops re-run only the tests whose coverage touches changed source lines, instead of the full ~4300-test suite every time. Closes #2288.

## Why

The full Python suite runs in ~57s at 100% coverage. That's fast for a suite this size, but paying it on every local edit is the main perceived test-tax. `AGENTS.md` already permits scoped iteration (`-k` / a path + `--no-cov`), but there's no automatic way to run *only the tests affected by your change* — you hand-pick paths/keywords or re-run everything. testmon builds a line→test coverage map and selects the affected subset automatically.

Verified end-to-end on this tree:
- A one-covered-line edit selects ~11 tests in ~10s vs ~60s for the full suite, with correct selection (the tests actually covering the changed line).
- Works with the existing `COVERAGE_CORE=sysmon` coverage core and `pytest-xdist` (`-n auto`).
- Inert unless `--testmon` is passed — the normal CI run is unchanged (the plugin doesn't affect collection when its flag isn't used).

## Changes

- **`src/klangk/pyproject.toml`** — `pytest-testmon>=2.0.0` added to the `test` extra. Bundled (not a separate extra) because the plugin is inert without `--testmon`; CI installs it but never invokes it.
- **`devenv.nix`** — a `testmon` task: both unit suites, `--no-cov -n auto --testmon`. `--no-cov` is intentional: a scoped run only exercises a fraction of the package, so the 100% gate does not apply to it (re-run the full suite via `test-backend` before committing).
- **`AGENTS.md`** — documents the `testmon` loop under "Running tests": local-only accelerator, baseline-then-scoped, re-run full coverage before commit, and the re-baseline-on-refactor note.
- **`.gitignore`** — `.testmondata`. Per-worktree (rootdir-relative at `src/klangk/.testmondata`), so each worktree is isolated; concurrent runs in the same workspace serialize on sqlite's busy-lock (a brief stall, not corruption).
- **`uv.lock`** — regenerated.

## Usage

```bash
# First run on a clean tree baselines the map (~same cost as test-unit):
devenv --quiet -O dotenv.enable:bool false shell -- testmon
# Subsequent runs re-run only the affected subset:
devenv --quiet -O dotenv.enable:bool false shell -- testmon
# Before committing, the full suite with coverage (unchanged):
devenv --quiet -O dotenv.enable:bool false shell -- test-backend
```

Delete `src/klangk/.testmondata` after a large refactor or branch switch to re-baseline.

## Notes

- CI is **unchanged** — it runs the full suite the documented way; testmon is a local-only accelerator.
- testmon 2.2.0 supports pytest 9 (this repo is on 9.1.1) and `coverage<8,>=6` (this repo is on 7.14.2).
