### PR TITLE
test(egress): prove egress_consent CHECK + dedup enforce at the DB layer (#2251)

### DIFF
--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -1,6 +1,9 @@
 """Tests for ``EgressConsentModel`` and the ``egress_mode`` workspace field (#2239)."""
 
+import sqlite3
+
 import pytest
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from klangk.model.egress_consent import (
     DECISION_ALLOWED,
@@ -328,3 +331,102 @@ async def test_cascade_delete_on_workspace_delete(ec, ws, user):
     await ec.create_request(w["id"], "a.com", 443)
     await ws.delete_workspace(w["id"], user["id"])
     assert await ec.list_requests(w["id"]) == []
+
+
+# -- DB-level integrity (CHECK constraints + partial unique index) --
+#
+# The CHECK constraints + partial unique index are the structural backstop:
+# a code path that bypasses EgressConsentModel (raw SQL) still can't land a
+# bad decision/scope or a duplicate pending prompt. These prove the
+# constraints are enforced at the storage layer, independent of decide()'s
+# Python validation (#2251). They mirror the idiom in
+# test_main.test_users_handle_has_unique_constraint.
+
+
+async def test_db_check_rejects_invalid_decision_on_insert(
+    ws, user, db, app_state
+):
+    w = await ws.create_workspace(user["id"], "chk-ins-ws")
+    async with app_state.state.db.transaction() as conn:
+        with pytest.raises(SAIntegrityError) as exc_info:
+            await conn.execute(
+                "INSERT INTO egress_consent"
+                " (id, workspace_id, dest_host, decision, requested_at)"
+                " VALUES (?, ?, ?, 'bogus', ?)",
+                ("r1", w["id"], "a.com", 0.0),
+            )
+    assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
+
+
+async def test_db_check_rejects_invalid_decision_on_update(
+    ws, user, db, app_state
+):
+    w = await ws.create_workspace(user["id"], "chk-upd-ws")
+    async with app_state.state.db.transaction() as conn:
+        await conn.execute(
+            "INSERT INTO egress_consent"
+            " (id, workspace_id, dest_host, requested_at)"
+            " VALUES (?, ?, ?, ?)",
+            ("r2", w["id"], "a.com", 0.0),
+        )
+        with pytest.raises(SAIntegrityError) as exc_info:
+            await conn.execute(
+                "UPDATE egress_consent SET decision = 'bogus' WHERE id = ?",
+                ("r2",),
+            )
+    assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
+
+
+async def test_db_check_rejects_invalid_scope(ws, user, db, app_state):
+    w = await ws.create_workspace(user["id"], "chk-scope-ws")
+    async with app_state.state.db.transaction() as conn:
+        await conn.execute(
+            "INSERT INTO egress_consent"
+            " (id, workspace_id, dest_host, requested_at)"
+            " VALUES (?, ?, ?, ?)",
+            ("r3", w["id"], "a.com", 0.0),
+        )
+        with pytest.raises(SAIntegrityError) as exc_info:
+            await conn.execute(
+                "UPDATE egress_consent SET scope = 'nonsense' WHERE id = ?",
+                ("r3",),
+            )
+    assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
+
+
+async def test_db_check_accepts_null_and_legal_scopes(ws, user, db, app_state):
+    """scope NULL (the default) + each legal value pass the CHECK."""
+    w = await ws.create_workspace(user["id"], "chk-scope-ok")
+    legal = [None, "once", "workspace", "deploy"]
+    async with app_state.state.db.transaction() as conn:
+        for i, scope in enumerate(legal):
+            await conn.execute(
+                "INSERT INTO egress_consent"
+                " (id, workspace_id, dest_host, scope, requested_at)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (f"ok-{i}", w["id"], f"h{i}.com", scope, 0.0),
+            )
+
+
+async def test_db_partial_unique_index_rejects_duplicate_pending(
+    ws, user, db, app_state
+):
+    """The partial unique index is the real backstop behind INSERT OR IGNORE:
+    a plain second INSERT of a pending for the same (workspace, host, port)
+    raises — dedup is structural, not just app-level (#2251)."""
+    w = await ws.create_workspace(user["id"], "chk-uniq-ws")
+    async with app_state.state.db.transaction() as conn:
+        await conn.execute(
+            "INSERT INTO egress_consent"
+            " (id, workspace_id, dest_host, dest_port, requested_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("u1", w["id"], "a.com", 443, 0.0),
+        )
+        with pytest.raises(SAIntegrityError) as exc_info:
+            await conn.execute(
+                "INSERT INTO egress_consent"
+                " (id, workspace_id, dest_host, dest_port, requested_at)"
+                " VALUES (?, ?, ?, ?, ?)",
+                ("u2", w["id"], "a.com", 443, 0.0),
+            )
+    assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)


### PR DESCRIPTION
## Summary

Closes #2251. The `egress_consent` integrity hardening (CHECK constraints on `decision`/`scope`, the partial unique index `idx_egress_consent_pending_dedup`, and `decide()` validation) **already shipped in #2248** — but no test proved the constraints enforce at the **storage layer**. Every existing test routes through `EgressConsentModel.decide()`, which raises `ValueError` *before* hitting the DB, so a CHECK that's never exercised at the DB level is just a comment. This PR adds the missing raw-SQL integrity tests.

## Why

The issue's framing is "tamper-resistant at the DB level" — defense in depth so a future code path that bypasses the model (direct SQL) still can't land a bad `decision`/`scope` or a duplicate pending prompt. Proving SQLite rejects those is the actual integrity guarantee, distinct from the app-layer validation.

## Changes

Test-only (`src/klangk/klangkd-tests/tests/test_model_egress_consent.py`). Five new tests mirror the existing `test_main.test_users_handle_has_unique_constraint` idiom — raw `db.execute(...)` inside `app_state.state.db.transaction()`, asserting `SAIntegrityError` whose `.orig` is `sqlite3.IntegrityError`:

- `test_db_check_rejects_invalid_decision_on_insert` — raw INSERT with `decision='bogus'` → rejected.
- `test_db_check_rejects_invalid_decision_on_update` — raw UPDATE to `'bogus'` → rejected.
- `test_db_check_rejects_invalid_scope` — raw UPDATE `scope='nonsense'` → rejected.
- `test_db_check_accepts_null_and_legal_scopes` — `NULL` + `once`/`workspace`/`deploy` all pass the CHECK.
- `test_db_partial_unique_index_rejects_duplicate_pending` — a plain second INSERT of a pending for the same `(workspace, host, port)` raises, proving the dedup index is the real backstop behind `INSERT OR IGNORE`.

No schema or model changes (those landed in #2248).

## Verification

- New tests: 5/5 pass.
- Full suite the CI way (`-n auto`, coverage): **4316 passed, 100% coverage**.
- ruff clean.
