### PR TITLE
fix(network): publish a filtered workspace's host ports on the sidecar (#2267)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -422,6 +422,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Network sidecar: filtered workspaces can host apps again (#2267).** A
+  filtered workspace shares the network sidecar's netns, so `--publish` on the
+  workspace itself was silently discarded by podman and configured host ports
+  (`KLANGKWS_PORT_MAPPINGS`) vanished with no warning. Host ports are now
+  published on the network sidecar instead (it owns the netns), forwarding into
+  the shared netns to the workspace's listener. IPv4 clients work; the sidecar
+  still kills IPv6 (#2277), so IPv6-only clients to a published port will fail
+  until that lands.
+
 - **Network sidecar: no longer leaks across a process restart (#2248
   review).** Reconnecting to a running filtered workspace after a klangkd
   restart now re-tracks its sidecar, so stopping the workspace tears the

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -2005,7 +2005,14 @@ class ContainerRegistry:
                     container_name,
                     resolved_image,
                     workspace_id,
-                    publish,
+                    # The workspace's OWN publish (what _resolve_port_conflict
+                    # scans for stale holders). A filtered workspace publishes
+                    # nothing (its ports moved to the sidecar, #2267), so pass
+                    # create_kwargs's actual publish (empty for filtered) rather
+                    # than the stale local -- otherwise a conflict on a filtered
+                    # workspace would scan the sidecar's ports and tear the
+                    # sidecar (and its netns) down.
+                    create_kwargs.get("publish", []),
                     allow_sudo,
                     create_kwargs,
                     health_check=health_check,

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1116,6 +1116,7 @@ class ContainerRegistry:
         workspace_id: str,
         allowed_domains: list[str],
         egress_mode: str = "static",
+        publish: list[tuple[int, int]] | None = None,
     ) -> str:
         """Create + start the FQDN network sidecar for a filtered workspace (#2254).
 
@@ -1125,7 +1126,12 @@ class ContainerRegistry:
         review B2). The network sidecar gets ``--cap-add NET_ADMIN`` + ``--dns 1.1.1.1``
         (the REDIRECT target the workspace inherits); the proxy forwards to a
         *different* detected upstream (loop avoidance). The allow-list + the
-        klangkd backend port are passed via env.
+        klangkd backend port are passed via env. ``publish`` (the host ports the
+        workspace requested) is published on the sidecar itself (#2267): the
+        workspace shares the sidecar's netns, so ``--publish`` is inert on the
+        workspace under ``--network container:`` but works on the netns owner,
+        forwarding into the shared netns to the workspace's listener — letting
+        filtered workspaces host apps.
         """
         image = self.app.state.settings.network_sidecar_image
         if not image:
@@ -1182,6 +1188,7 @@ class ContainerRegistry:
                 dns=["1.1.1.1"],
                 env=env,
                 labels=labels,
+                publish=publish,
                 pull="missing",
             )
             await self.app.state.podman.start_container(cid)
@@ -1905,7 +1912,7 @@ class ContainerRegistry:
                     "keep-id:uid=1000,gid=1000) or clear allowed_domains.",
                 )
             network_sidecar_id = await self._start_network_sidecar(
-                workspace_id, allowed_domains, egress_mode
+                workspace_id, allowed_domains, egress_mode, publish=publish
             )
             create_kwargs["network"] = f"container:{network_sidecar_id}"
             # --dns/--dns-search, --add-host, and --publish are all invalid
@@ -1916,6 +1923,12 @@ class ContainerRegistry:
             # still resolves host.containers.internal via the network sidecar's
             # /etc/hosts (podman populates it), and the network sidecar's iptables
             # statically allow-lists the backend port (entrypoint.sh, B1).
+            # #2267: the workspace's host ports are instead published on the
+            # network sidecar (passed to _start_network_sidecar above). The
+            # workspace shares the sidecar's netns, so the sidecar's --publish
+            # forwards into that netns and reaches the workspace's listener,
+            # letting filtered workspaces host apps (which --publish on the
+            # workspace itself cannot, under --network container:).
             create_kwargs.pop("dns", None)
             create_kwargs.pop("dns_search", None)
             create_kwargs.pop("add_hosts", None)

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import os
 import platform
 import shutil
+import socket
 import subprocess
 import tempfile
 import time
@@ -254,6 +255,16 @@ def _ip_of(name):
         name,
     )
     return out.stdout.strip()
+
+
+def _free_port():
+    """A free host TCP port for the sidecar to publish (best-effort; tiny
+    TOCTOU window before podman rebinds it)."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
 
 
 def _wait_ready(name, timeout=40):
@@ -582,3 +593,81 @@ class TestNetworkSidecarE2E:
             f"expected SO_MARK_EPERM (net_raw dropped; root can't mark), "
             f"got:\n{out}"
         )
+
+    def test_host_port_published_on_sidecar_reaches_workspace(self, env):
+        # #2267: a filtered workspace cannot publish host ports itself
+        # (--publish is discarded under --network container:), so klangk
+        # publishes them on the network sidecar instead. The workspace shares
+        # the sidecar's netns, so the sidecar's --publish forwards into it and
+        # reaches the workspace's listener. Prove end-to-end (real podman, real
+        # sidecar image + iptables) that a host port reaches a workspace
+        # listener THROUGH the sidecar's publish -- the whole point of routing
+        # publish onto the sidecar.
+        import urllib.request
+
+        host_port = _free_port()
+        net = f"netc-pp-{uuid.uuid4().hex[:8]}"
+        nc = f"netc-pp-nc-{uuid.uuid4().hex[:8]}"
+        ws = f"netc-pp-ws-{uuid.uuid4().hex[:8]}"
+        _podman("network", "create", net)
+        try:
+            # The sidecar owns the netns and publishes host_port -> :8000.
+            _podman(
+                "run",
+                "-d",
+                "--name",
+                nc,
+                "--network",
+                net,
+                "--cap-add",
+                "net_admin",
+                "--dns",
+                "1.1.1.1",
+                "--publish",
+                f"{host_port}:8000",
+                "-e",
+                "KLANGKNETWORK_EGRESS_UPSTREAM=8.8.8.8",
+                "-e",
+                "KLANGKNETWORK_EGRESS_ALLOW=allowed.test",
+                env["image"],
+            )
+            _wait_ready(nc)
+            # The workspace shares the sidecar's netns and binds :8000.
+            _podman(
+                "run",
+                "-d",
+                "--name",
+                ws,
+                "--network",
+                f"container:{nc}",
+                "--entrypoint",
+                "python3",
+                env["image"],
+                "-m",
+                "http.server",
+                "8000",
+                "--bind",
+                "0.0.0.0",
+            )
+            # Reach the workspace's listener through the SIDECAR's published
+            # port (127.0.0.1 avoids the IPv6 happy-eyeballs path the sidecar
+            # kills). Poll briefly for http.server to finish binding.
+            deadline = time.monotonic() + 8
+            code = None
+            while time.monotonic() < deadline:
+                try:
+                    with urllib.request.urlopen(
+                        f"http://127.0.0.1:{host_port}/", timeout=2
+                    ) as resp:
+                        code = resp.status
+                        break
+                except Exception:
+                    time.sleep(0.3)
+            assert code == 200, (
+                f"published port {host_port} did not reach the workspace "
+                f"listener (HTTP {code}); the sidecar must publish the "
+                f"workspace's host ports (#2267)."
+            )
+        finally:
+            _podman("rm", "-f", ws, nc, check=False, timeout=60)
+            _podman("network", "rm", net, check=False, timeout=60)

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -966,6 +966,51 @@ class TestStartContainer:
         # The workspace still publishes nothing under --network container:.
         assert "publish" not in creates[1]
 
+    async def test_filtered_workspace_no_ports_publishes_nothing_on_sidecar(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2267: a filtered workspace that requests NO host ports publishes
+        # nothing on the sidecar (publish=[]). Pinned because the empty-ports
+        # path produces [] (not None) and must neither emit a stray -p nor
+        # change the sidecar's network setup.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+
+        async def _fake_reconcile(workspace_id, num_ports):
+            return []
+
+        monkeypatch.setattr(self.registry, "_reconcile_ports", _fake_reconcile)
+
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                allowed_domains=["github.com:443"],
+                num_ports=0,
+            )
+        assert len(creates) == 2
+        # No host ports -> the sidecar publishes nothing.
+        assert creates[0]["publish"] == []
+        # The workspace publishes nothing (filtered, under --network container:).
+        assert "publish" not in creates[1]
+
     async def test_filtered_workspace_userns_isolates_netns(
         self, workspace, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -682,6 +682,49 @@ class TestStartContainer:
         assert kwargs["labels"]["klangk.network-sidecar"] == ws_id
         p.start_container.assert_awaited_once_with("new-cid")
 
+    async def test_start_network_sidecar_publishes_host_ports(
+        self, monkeypatch
+    ):
+        # #2267: the sidecar owns the netns the workspace shares, so the
+        # workspace's host ports are published on the sidecar (--publish is
+        # inert on the workspace under --network container:).
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        from klangk import netfilter as _nf
+
+        monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
+        with patch_podman(self.registry) as p:
+            cid = await self.registry._start_network_sidecar(
+                ws_id, ["github.com:443"], publish=[(18080, 8000)]
+            )
+        assert cid == "new-cid"
+        assert p.create_container.call_args.kwargs["publish"] == [
+            (18080, 8000)
+        ]
+
+    async def test_start_network_sidecar_default_publish_is_none(
+        self, monkeypatch
+    ):
+        # A filtered workspace with no host ports publishes nothing.
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        from klangk import netfilter as _nf
+
+        monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
+        with patch_podman(self.registry) as p:
+            await self.registry._start_network_sidecar(
+                ws_id, ["github.com:443"]
+            )
+        assert p.create_container.call_args.kwargs["publish"] is None
+
     async def test_start_network_sidecar_clears_lingering_same_named(
         self, monkeypatch
     ):
@@ -875,6 +918,53 @@ class TestStartContainer:
         assert "publish" not in creates[1]
         assert "dns" not in creates[1]
         assert "dns_search" not in creates[1]
+
+    async def test_filtered_workspace_publishes_host_ports_on_sidecar(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2267: a filtered workspace's host ports are published on the network
+        # sidecar (the netns owner), not the workspace. The workspace shares the
+        # sidecar's netns, so the sidecar's --publish forwards into it and reaches
+        # the workspace's listener -- letting filtered workspaces host apps.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+
+        # Deterministic host ports (the workspace requests two).
+        async def _fake_reconcile(workspace_id, num_ports):
+            return [18080, 18081]
+
+        monkeypatch.setattr(self.registry, "_reconcile_ports", _fake_reconcile)
+
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                allowed_domains=["github.com:443"],
+                num_ports=2,
+            )
+        assert len(creates) == 2
+        # Host ports land on the SIDECAR (container-side ports are
+        # CONTAINER_PORT_START+i = 8000/8001).
+        assert creates[0]["publish"] == [(18080, 8000), (18081, 8001)]
+        # The workspace still publishes nothing under --network container:.
+        assert "publish" not in creates[1]
 
     async def test_filtered_workspace_userns_isolates_netns(
         self, workspace, tmp_path, monkeypatch


### PR DESCRIPTION
## What

Filtered workspaces can host apps again. A filtered workspace shares the network sidecar's netns (`--network container:<sidecar>`), under which podman **silently discards `--publish`** on the workspace — so configured host ports (`KLANGKWS_PORT_MAPPINGS`) vanished with no warning and filtered workspaces could not host apps. Closes #2267.

## Fix (issue option a)

Publish the workspace's host ports on the **network sidecar** instead of the workspace. The sidecar owns the netns the workspace shares, so its `--publish host:container` forwards (via pasta) into that shared netns and reaches the workspace's listener — exactly where the workspace's app binds. The sidecar's existing iptables (`-P OUTPUT DROP` + `-m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT`) lets the response traffic back out.

Changes are local to the sidecar path:
- `_start_network_sidecar` gains a `publish` param, forwarded to the sidecar's `create_container`.
- The `if allowed_domains:` branch passes the already-computed `publish` list to the sidecar; the workspace's `publish` is still popped from its kwargs (as before) — it's inert under `--network container:`.

No new failure modes: host ports are DB-allocated (unique per workspace) and re-published on every restart (the sidecar is force-removed + recreated each start anyway).

## Grounding

Verified with **real podman + the real sidecar image** (real iptables + proxy): a sidecar with `--publish 18080:8000` + an allow-list, and a workspace sharing its netns binding `:8000` → `curl 127.0.0.1:18080` returns **HTTP 200** through the sidecar's publish, with the egress filter still denying blocked domains. Confirmed the listener binds in the shared netns, the host port is open via `passt`, and the sidecar reaches the listener via loopback.

## Tests

- 3 unit tests (`test_container.py`): the sidecar publishes the given ports; default `publish` is `None`; full `start_container` path → host ports land on the sidecar, the workspace gets none.
- 1 e2e test (`test_network_sidecar_e2e.py`): real podman, real sidecar image + iptables — a published port reaches a workspace listener through the sidecar.

## Caveat

IPv4 clients work. The sidecar intentionally kills IPv6 (`ip6tables -P OUTPUT DROP`, #2277), so an IPv6-only client to a published port fails until that lands. (A `localhost` client via happy-eyeballs falls back to IPv4 and works.)

## Changelog

Added a **Fixed** entry under `[Unreleased]`.
