### PR TITLE
feat(egress): allow-list wildcards, per-domain port scoping, learned-IP TTL (#2256)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -35,8 +35,12 @@ operators or integrators to act when upgrading.
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the
-  apex). `host:port` scopes a learned IP to that single TCP port (a bare
-  `host` keeps all-ports); the sidecar's entrypoint now applies the same
+  apex). `host:port` now scopes a learned IP to that single TCP port — a
+  **behavior change**: previously a learned IP was reachable on **all** ports
+  regardless of the spec's port, so an operator who relied on that (e.g.
+  reaching `:22` on an IP resolved under a `:443` spec) will now see that
+  traffic blocked; add an explicit spec for the extra port (a bare `host`
+  keeps all-ports, unchanged). The sidecar's entrypoint now applies the same
   port scoping to CIDR specs like `10.0.0.0/8:443` (previously stripped).
   Resolved IPs are allow-listed only for the DNS response's TTL — the proxy
   re-resolves on each query and a background sweep removes the rule when the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,17 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
+  TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
+  (subdomains only — distinct from a bare `domain`, which also matches the
+  apex). `host:port` scopes a learned IP to that single TCP port (a bare
+  `host` keeps all-ports); the sidecar's entrypoint now applies the same
+  port scoping to CIDR specs like `10.0.0.0/8:443` (previously stripped).
+  Resolved IPs are allow-listed only for the DNS response's TTL — the proxy
+  re-resolves on each query and a background sweep removes the rule when the
+  TTL elapses, so stale IPs no longer linger. See
+  `docs/features/egress-filtering.md`.
+
 - **`klangk-build-nix-seed` + `klangk-load-nix-seed-btrfs` — build/load the
   `/nix` seed from a wheel install (#2225).** Two console scripts (shipped with
   `pip install klangk`) replace the former devenv-only shell scripts.

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -18,7 +18,8 @@ outbound networking exactly as before.
 ## How it works
 
 1. A workspace carries an `allowed_domains` list (`host`, `host:port`,
-   or IPv4 CIDR specs — see the [API](#api) section for the full grammar).
+   `*.domain[:port]` wildcards, or IPv4 CIDR specs — see the [API](#api)
+   section for the full grammar).
 2. On container start, if the workspace declares `allowed_domains`, the
    backend starts a **network sidecar** container (`klangk-net-<ws-id>`,
    from the `network_sidecar_image` image, which defaults to
@@ -38,7 +39,10 @@ outbound networking exactly as before.
    **allow-lists resolved IPs at runtime** — so a domain whose IPs rotate
    (CDN, DNS round-robin) stays reachable without a container restart,
    and a denied domain returns NXDOMAIN. This replaces the create-time
-   IP-pinning the old OCI hook model used (#2255). The workspace is told
+   IP-pinning the old OCI hook model used (#2255). A resolved IP is allowed
+   **only for the DNS response's TTL**; the proxy re-resolves on the next
+   query and a background sweep removes the allow-rule once the TTL
+   elapses, so stale IPs do not linger (#2256). The workspace is told
    its resolver is `1.1.1.1` (a placeholder) — the `:53` traffic is
    `REDIRECT`ed to the proxy before it ever leaves, so `1.1.1.1` is never
    actually reached; the proxy forwards to a _different_ detected upstream
@@ -172,13 +176,24 @@ curl -X PUT https://klangkd/api/v1/workspaces/<id> \
   -d '{"allowed_domains": ["github.com:443", "pypi.org", "registry.npmjs.org"]}'
 ```
 
-- `host` allows all ports to that host.
-- `host:port` allows a single TCP port (port must be 1–65535).
+- `host` allows all ports to that host **and its subdomains**
+  (`github.com` also covers `api.github.com`).
+- `host:port` allows a single TCP port (port must be 1–65535) to that host
+  and its subdomains.
+- `*.domain` allows **subdomains only, not the apex** — `*.pypi.org` matches
+  `files.pythonhosted.org`-style subdomains but not `pypi.org` itself. Append
+  a port to scope it (`*.pypi.org:443`). This is distinct from a bare
+  `domain` (which includes the apex), so you can allow subdomains without the
+  apex or vice-versa (#2256).
 - `10.0.0.0/8` allows an entire IPv4 subnet (CIDR notation); append a
   port to scope it, e.g. `10.0.0.0/8:443`. A CIDR is installed as a
   single iptables `-d <ip>/<plen>` rule and is **not** DNS-resolved, so
   it is the stable choice for a private range whose individual hosts you
   don't want to enumerate (#1935).
+- Resolved IPs (for `host`/`*.domain` specs) are allowed **only for the
+  DNS response's TTL**; the sidecar's proxy re-resolves on each query and
+  drops the allow-rule once the TTL elapses, so a stale IP is not reachable
+  indefinitely (#2256).
 - IPv6 literals and IPv6 CIDRs (e.g. `[::1]`, `[2001:db8::1]:443`,
   `2001:db8::/32`) are **not** accepted — IPv6 egress is default-denied
   inside filtered containers, so a v6 destination is neither reachable
@@ -556,19 +571,22 @@ netfilter_default_domains:
   Fastly, CloudFront, Cloudflare) stays reachable without restarting the
   container. Static CIDR ranges (`10.0.0.0/8`) are installed as a single
   stable `-d <ip>/<plen>` rule with no resolution (#1935).
-- **A CNAME can widen egress to an attacker-steerable IP — on all ports.**
+- **A CNAME can widen egress to an attacker-steerable IP.**
   The proxy allow-lists every A record in a response, including those reached
-  via a CNAME chain, and a learned IP is reachable on **all ports** (no
-  per-domain port scoping yet, #2256). If an allowed domain CNAMEs to a host an
-  attacker controls (or to a shared CDN frontend), that IP becomes reachable
-  on every port for the workspace's life. Prefer `host:port` specs and avoid
-  allow-listing domains whose CNAME targets you don't control (#2279).
-- **Learned IPs are never revoked.** A resolved IP is allow-listed with no TTL
-  and is not removed when a domain is dropped from `allowed_domains` — it
-  stays reachable until the workspace is recreated (the sidecar is rebuilt
-  fresh on each start). Removing a domain from a _running_ workspace's
-  allow-list does not revoke egress to IPs it already resolved; recreate the
-  workspace to fully revoke (#2256, #2281).
+  via a CNAME chain. A `host:port` spec scopes a learned IP to that one TCP
+  port; a bare `host` allows all ports; and a learned IP expires with the DNS
+  response's TTL (#2256). But within that port/TTL window, if an allowed
+  domain CNAMEs to a host an attacker controls (or to a shared CDN frontend
+  IP), that IP becomes reachable for the spec's ports. Prefer `host:port`
+  specs and avoid allow-listing domains whose CNAME targets you don't control
+  (#2279).
+- **Dropping a domain from a running workspace does not revoke already-
+  resolved IPs.** A resolved IP is allow-listed for the DNS response's TTL
+  and the sidecar's proxy drops the rule once the TTL elapses, so stale IPs
+  do not persist indefinitely (#2256). But the allow-list a running sidecar
+  enforces is fixed at start — removing a domain from `allowed_domains` does
+  not revoke egress to IPs the workspace already resolved; recreate the
+  workspace (or wait for TTL expiry) to fully revoke (#2281).
 - **DNS is redirected to the sidecar's proxy, not blocked.** Outbound
   `:53` is `REDIRECT`ed to the sidecar's FQDN DNS proxy, which resolves
   against a real upstream and allow-lists the IPs at runtime; a denied

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -181,7 +181,7 @@ curl -X PUT https://klangkd/api/v1/workspaces/<id> \
 - `host:port` allows a single TCP port (port must be 1–65535) to that host
   and its subdomains.
 - `*.domain` allows **subdomains only, not the apex** — `*.pypi.org` matches
-  `files.pythonhosted.org`-style subdomains but not `pypi.org` itself. Append
+  `downloads.pypi.org`-style subdomains but not `pypi.org` itself. Append
   a port to scope it (`*.pypi.org:443`). This is distinct from a bare
   `domain` (which includes the apex), so you can allow subdomains without the
   apex or vice-versa (#2256).

--- a/src/containers/network/README.md
+++ b/src/containers/network/README.md
@@ -54,19 +54,29 @@ klangkd `egress_port` here (#2254 B1).
 
 ## Configuration (env)
 
-| var                                 | default    | meaning                                           |
-| ----------------------------------- | ---------- | ------------------------------------------------- |
-| `KLANGKNETWORK_EGRESS_ALLOW`        | _(empty)_  | comma-separated allow-list: `host[:port]` or CIDR |
-| `KLANGKNETWORK_EGRESS_UPSTREAM`     | `8.8.8.8`  | real upstream the proxy forwards to               |
-| `KLANGKNETWORK_EGRESS_BACKEND_PORT` | _(empty)_  | klangkd backend port on host.containers.internal  |
-| `KLANGKNETWORK_EGRESS_LISTEN_PORT`  | `15353`    | UDP port the proxy listens on                     |
-| `KLANGKNETWORK_IPTABLES`            | `iptables` | iptables binary path                              |
-| `KLANGKNETWORK_EGRESS_DEBUG`        | unset      | if set, log each allow/deny decision              |
+| var                                   | default    | meaning                                                                     |
+| ------------------------------------- | ---------- | --------------------------------------------------------------------------- |
+| `KLANGKNETWORK_EGRESS_ALLOW`          | _(empty)_  | comma-separated allow-list: `host[:port]`, `*.domain[:port]`, or CIDR       |
+| `KLANGKNETWORK_EGRESS_UPSTREAM`       | `8.8.8.8`  | real upstream the proxy forwards to                                         |
+| `KLANGKNETWORK_EGRESS_BACKEND_PORT`   | _(empty)_  | klangkd backend port on host.containers.internal                            |
+| `KLANGKNETWORK_EGRESS_LISTEN_PORT`    | `15353`    | UDP port the proxy listens on                                               |
+| `KLANGKNETWORK_EGRESS_MARK`           | `75`       | fwmark for the proxy's upstream socket (must match entrypoint.sh)           |
+| `KLANGKNETWORK_EGRESS_SWEEP_INTERVAL` | `5`        | seconds between learned-IP TTL-expiry sweeps                                |
+| `KLANGKNETWORK_EGRESS_MIN_TTL`        | `30`       | floor for a learned IP's lifetime (a 0-TTL response must not yank the rule) |
+| `KLANGKNETWORK_IPTABLES`              | `iptables` | iptables binary path                                                        |
+| `KLANGKNETWORK_EGRESS_DEBUG`          | unset      | if set, log each allow/deny decision                                        |
 
-## Limitations (#2256)
+## Allow-list semantics (#2256)
 
-Learned IPs are allow-listed on **all** ports (no per-domain port scoping yet),
-wildcard domains aren't supported, and learned IPs never expire (no TTL cleanup).
+- `host` allows all ports to the host **and its subdomains**; `host:port`
+  scopes a learned IP to one TCP port.
+- `*.domain[:port]` allows **subdomains only** (not the apex) — distinct
+  from a bare `domain`.
+- A resolved IP is allow-listed **only for the DNS response's TTL**; the
+  proxy re-resolves on each query and a background sweep removes the rule
+  once the TTL elapses.
+- CIDR specs (`10.0.0.0/8`, `10.0.0.0/8:443`) are installed statically by
+  the entrypoint (not resolved); a `cidr:port` scopes the rule to that port.
 
 ## References
 

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -50,14 +50,20 @@ $IPT -A OUTPUT -d "$UPSTREAM" -p udp --dport 53 -m mark --mark "$MARK" -j ACCEPT
 $IPT -A OUTPUT -d "$UPSTREAM" -p tcp --dport 53 -m mark --mark "$MARK" -j ACCEPT
 
 # --- static CIDR allow-specs (host specs are learned dynamically by the proxy).
-# A "host:port" CIDR like 10.0.0.0/8:443 is stripped to its CIDR; per-domain
-# port scoping is #2256.
+# A "cidr:port" spec like 10.0.0.0/8:443 is scoped to that TCP port; a bare
+# CIDR allows all ports. Per-domain port scoping for hosts is the proxy's
+# job (#2256).
 IFS=','
 for spec in ${KLANGKNETWORK_EGRESS_ALLOW:-}; do
   case "$spec" in
   */*)
     cidr=${spec%%:*}
-    $IPT -A OUTPUT -d "$cidr" -j ACCEPT
+    port=${spec#*:}
+    if [ "$port" = "$spec" ]; then
+      $IPT -A OUTPUT -d "$cidr" -j ACCEPT
+    else
+      $IPT -A OUTPUT -d "$cidr" -p tcp --dport "$port" -j ACCEPT
+    fi
     ;;
   esac
 done

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -6,20 +6,33 @@ The sidecar shares the workspace's network namespace (the workspace runs
 a nat REDIRECT of the workspace's configured DNS resolvers (:53) to this proxy's
 listen port; this proxy applies an FQDN allow-list, forwards allowed queries to a
 *different* upstream (so the REDIRECT does not loop), learns the A-record IPs from
-the responses, and inserts ``iptables -I OUTPUT 1 -d <ip> -j ACCEPT`` for each so
-the workspace can reach exactly the IPs it resolved — solving DNS round-robin.
-Denied names get NXDOMAIN.
+the responses, and inserts ``iptables -I OUTPUT 1 -d <ip> [-p tcp --dport <p>] -j
+ACCEPT`` for each so the workspace can reach exactly the IPs it resolved — solving
+DNS round-robin. Denied names get NXDOMAIN.
 
 DNS wire parsing is delegated to **dnspython** (rather than hand-rolled byte
 slicing) so EDNS, CNAME chains, TCP-sized responses, and malformed packets are
 handled correctly — a parser bug in a security component is dangerous, and a
 maintained library removes that risk.
 
+Allow-list semantics (#2256):
+
+- **Per-domain port scoping**: ``github.com:443`` allows only ``:443`` to
+  github's learned IPs; ``github.com`` (no port) allows all ports. The port
+  is taken from the spec that matched the queried name.
+- **Wildcards**: ``*.pypi.org`` matches subdomains of ``pypi.org`` only (NOT
+  the apex ``pypi.org`` itself); a bare ``pypi.org`` matches the apex + all
+  subdomains. A single learned IP inherits the union of ports from every
+  matching spec, and any port-less matching spec means all-ports.
+- **Learned-IP TTL/cleanup**: each learned IP is allowed only for the TTL of
+  the DNS response that resolved it; a background sweeper removes the ACCEPT
+  rule once the TTL elapses so stale IPs do not linger.
+
 Configuration (env):
-  KLANGKNETWORK_EGRESS_ALLOW       comma-separated allow-list: ``host[:port]`` or CIDR
-                            specs. CIDR specs are applied statically by the
-                            entrypoint; this proxy matches only the host specs
-                            (exact or suffix).
+  KLANGKNETWORK_EGRESS_ALLOW       comma-separated allow-list: ``host[:port]``,
+                            ``*.domain[:port]``, or CIDR specs. CIDR specs are
+                            applied statically by the entrypoint; this proxy
+                            matches only the host/wildcard specs.
   KLANGKNETWORK_EGRESS_UPSTREAM    the real upstream resolver the proxy forwards to
                             (default ``8.8.8.8``). MUST differ from the
                             workspace's configured (redirected) resolvers or the
@@ -27,16 +40,24 @@ Configuration (env):
   KLANGKNETWORK_EGRESS_LISTEN_PORT UDP port to listen on (default ``15353``).
   KLANGKNETWORK_IPTABLES    iptables binary (default ``iptables``).
   KLANGKNETWORK_EGRESS_DEBUG       if set, log each allow/deny decision.
+  KLANGKNETWORK_EGRESS_MARK  fwmark for the proxy's upstream socket (default 75;
+                            must match entrypoint.sh).
+  KLANGKNETWORK_EGRESS_SWEEP_INTERVAL  seconds between TTL-expiry sweeps (default 5).
+  KLANGKNETWORK_EGRESS_MIN_TTL  floor for a learned IP's lifetime so a 0-TTL
+                            response does not immediately yank the rule the
+                            workspace needs to reach the IP it just resolved
+                            (default 30).
+  KLANGKNETWORK_EGRESS_DEFAULT_TTL  TTL used when a response carries no usable
+                            TTL (default 300).
 
-Limitations (tracked in #2256): a learned IP is allow-listed on *all* ports (no
-per-domain port scoping yet), no wildcard domains, and learned IPs are never
-cleaned up (no TTL expiry). Transport is UDP only (TCP fallback is a future
-addition).
+Limitations: transport is UDP only (TCP fallback is a future addition).
 """
 
 import os
 import socket
 import subprocess
+import threading
+import time
 
 import dns.message
 import dns.rcode
@@ -53,26 +74,49 @@ DEBUG = bool(os.environ.get("KLANGKNETWORK_EGRESS_DEBUG"))
 # and allow-listed, closing the direct-to-upstream exfil bypass (#2264). Must
 # match entrypoint.sh's KLANGKNETWORK_EGRESS_MARK.
 MARK = int(os.environ.get("KLANGKNETWORK_EGRESS_MARK", "75"))
+# Learned-IP housekeeping (#2256).
+SWEEP_INTERVAL = float(os.environ.get("KLANGKNETWORK_EGRESS_SWEEP_INTERVAL", "5"))
+MIN_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_MIN_TTL", "30"))
+DEFAULT_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_DEFAULT_TTL", "300"))
 
 
-def host_specs() -> list[str]:
-    """Host specs (suffix-match targets) from KLANGKNETWORK_EGRESS_ALLOW.
+def parse_specs() -> list[tuple[str, int | None, bool]]:
+    """Structured allow-list specs from ``KLANGKNETWORK_EGRESS_ALLOW``.
 
-    CIDR specs (``10.0.0.0/8``) are excluded — the entrypoint applies those
-    statically. ``host:port`` specs are stripped to the host part.
+    Each entry is ``(host, port, is_wildcard)`` where ``port`` is ``None``
+    (all ports) and ``is_wildcard`` means ``*.host`` (subdomains only). CIDR
+    specs (``10.0.0.0/8``) are excluded — the entrypoint applies those
+    statically. The grammar mirrors ``klangk.netfilter.parse_allowed_domains``
+    so the API and the sidecar agree on what a spec means (#2256).
     """
-    out = []
+    out: list[tuple[str, int | None, bool]] = []
     for spec in os.environ.get("KLANGKNETWORK_EGRESS_ALLOW", "").split(","):
         spec = spec.strip()
         if not spec or "/" in spec:
             continue
-        host = spec.split(":", 1)[0].lower()
+        port: int | None = None
+        if ":" in spec:
+            host_part, port_part = spec.rsplit(":", 1)
+            if port_part.isdigit():
+                port = int(port_part)
+                spec = host_part
+        host = spec.lower()
+        is_wildcard = host.startswith("*.")
+        if is_wildcard:
+            host = host[2:]
         if host:
-            out.append(host)
+            out.append((host, port, is_wildcard))
     return out
 
 
-ALLOWED = host_specs()
+SPECS = parse_specs()
+
+# Learned IPs: {ip: {"expire": epoch, "ports": set[int | None]}}. A ``None``
+# in ``ports`` is the all-ports ACCEPT rule. Guarded by _LOCK because the
+# sweeper thread removes entries while the main loop adds/refreshes them
+# (only the main loop installs rules; the sweeper only removes).
+_LEARNED: dict[str, dict] = {}
+_LOCK = threading.Lock()
 
 
 def query_name(wire: bytes) -> str:
@@ -83,20 +127,21 @@ def query_name(wire: bytes) -> str:
     return msg.question[0].name.to_text().rstrip(".").lower()
 
 
-def a_records(wire: bytes) -> list[str]:
-    """IPv4 A-record addresses from a DNS response wire (dotted-quad strings).
+def a_records_with_ttl(wire: bytes) -> list[tuple[str, int]]:
+    """``[(ip, ttl_seconds), ...]`` from a DNS response wire.
 
-    Walks the answer section (following CNAME chains transparently — the A
-    records for the canonical name are in the answer too) and returns only
-    A-record IPs.
+    Walks the answer section (CNAME chains are transparent — the A records
+    for the canonical name are in the answer too) and returns each A-record
+    address with its rrset TTL. The TTL drives learned-IP expiry (#2256).
     """
     msg = dns.message.from_wire(wire)
-    ips = []
+    out: list[tuple[str, int]] = []
     for rrset in msg.answer:
         if rrset.rdtype == dns.rdatatype.A:
+            ttl = int(rrset.ttl)
             for rdata in rrset:
-                ips.append(rdata.address)
-    return ips
+                out.append((rdata.address, ttl))
+    return out
 
 
 def nxdomain_for(wire: bytes) -> bytes:
@@ -107,30 +152,117 @@ def nxdomain_for(wire: bytes) -> bytes:
     return resp.to_wire()
 
 
-def allowed(qname: str) -> bool:
-    return any(qname == h or qname.endswith("." + h) for h in ALLOWED)
+def ports_for(qname: str) -> set[int] | None:
+    """The ports a queried name is allowed on under :data:`SPECS`.
 
+    ``None``  — a port-less spec matched (allow all ports).
+    ``set()`` — nothing matched (deny).
+    ``{443, ...}`` — allow exactly these TCP ports.
 
-def allow_ip(ip: str) -> None:
-    """Insert an allow-rule at the top of OUTPUT for a learned IP.
-
-    Dedup: skip if an ACCEPT rule for this IP already exists, so repeated
-    resolutions of the same name don't pile duplicate rules atop OUTPUT
-    unboundedly (#2256). Learned IPs are still allow-listed on all ports
-    (no per-domain port scoping yet) — also tracked in #2256.
+    A bare host matches the apex + subdomains; a ``*.host`` wildcard matches
+    subdomains only (the apex is deliberately excluded so ``*.pypi.org`` and
+    ``pypi.org`` are distinct, non-redundant scopes) (#2256).
     """
-    if (
+    ports: set[int] = set()
+    for host, port, is_wildcard in SPECS:
+        if is_wildcard:
+            matched = qname.endswith("." + host)
+        else:
+            matched = qname == host or qname.endswith("." + host)
+        if not matched:
+            continue
+        if port is None:
+            return None  # an all-ports spec dominates
+        ports.add(port)
+    return ports
+
+
+def _rule_args(ip: str, port: int | None) -> list[str]:
+    """iptables OUTPUT rule args for ``ACCEPT`` to ``ip`` (optionally scoped)."""
+    args = ["-d", ip]
+    if port is not None:
+        args += ["-p", "tcp", "--dport", str(port)]
+    args += ["-j", "ACCEPT"]
+    return args
+
+
+def _rule_exists(ip: str, port: int | None) -> bool:
+    return (
         subprocess.run(
-            [IPT, "-C", "OUTPUT", "-d", ip, "-j", "ACCEPT"],
+            [IPT, "-C", "OUTPUT", *_rule_args(ip, port)],
             capture_output=True,
         ).returncode
         == 0
-    ):
+    )
+
+
+def _install(ip: str, port: int | None) -> None:
+    """Insert the ACCEPT rule at the top of OUTPUT if not already present."""
+    if _rule_exists(ip, port):
         return
     subprocess.run(
-        [IPT, "-I", "OUTPUT", "1", "-d", ip, "-j", "ACCEPT"],
+        [IPT, "-I", "OUTPUT", "1", *_rule_args(ip, port)],
         capture_output=True,
     )
+
+
+def _remove(ip: str, port: int | None) -> None:
+    """Delete one matching ACCEPT rule; swallow failure if it's already gone."""
+    subprocess.run(
+        [IPT, "-D", "OUTPUT", *_rule_args(ip, port)],
+        capture_output=True,
+    )
+
+
+def allow(ip: str, port: int | None, ttl: int | float) -> None:
+    """Install (if new) the ACCEPT for ``ip[:port]`` and refresh its TTL.
+
+    ``port`` is ``None`` for an all-ports rule. The learned IP's expiry is
+    set to ``now + max(ttl, MIN_TTL)`` (a 0-TTL response must not yank the
+    rule the workspace needs to reach the IP it just resolved) and only ever
+    moves forward, so a shorter-TTL re-resolution can't prematurely expire a
+    longer-lived prior rule (#2256).
+    """
+    _install(ip, port)
+    expire = time.time() + max(ttl, MIN_TTL)
+    with _LOCK:
+        rec = _LEARNED.get(ip)
+        if rec is None:
+            _LEARNED[ip] = {"expire": expire, "ports": {port}}
+        else:
+            rec["expire"] = max(rec["expire"], expire)
+            rec["ports"].add(port)
+
+
+def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
+    """Remove learned IPs whose TTL has elapsed; return ``(ip, ports)`` removed.
+
+    Factored out of :func:`_sweeper` so it is unit-testable with a mocked
+    clock and iptables (#2256).
+    """
+    if now is None:
+        now = time.time()
+    expired: list[tuple[str, set]] = []
+    with _LOCK:
+        for ip, rec in list(_LEARNED.items()):
+            if rec["expire"] <= now:
+                expired.append((ip, set(rec["ports"])))
+                del _LEARNED[ip]
+    for ip, ports in expired:
+        for port in ports:
+            _remove(ip, port)
+    return expired
+
+
+def _sweeper() -> None:
+    """Background thread: periodically drop learned IPs past their TTL."""
+    while True:
+        time.sleep(SWEEP_INTERVAL)
+        sweep_once()
+
+
+def _fmt_ports(ports: set[int | None]) -> str:
+    return "all" if None in ports else ",".join(sorted(str(p) for p in ports))
 
 
 def check_mark() -> None:
@@ -152,11 +284,16 @@ def check_mark() -> None:
 
 
 def _respond_allowed(
-    s: socket.socket, resp: bytes, addr: tuple[str, int], qname: str
+    s: socket.socket,
+    resp: bytes,
+    addr: tuple[str, int],
+    qname: str,
+    ports: set[int | None],
 ) -> None:
-    """Learn the response's A-record IPs + send it, swallowing transient errors.
+    """Learn the response's IPs (port-scoped, TTL-tracked) + send it, swallowing
+    transient errors.
 
-    A failure here (a transient ``iptables`` error in :func:`allow_ip`, or a
+    A failure here (a transient ``iptables`` error in :func:`allow`, or a
     ``sendto`` to a vanished client) must drop only this one response — not
     kill the proxy. If it escaped :func:`main` the sidecar's PID 1 would exit,
     DNS would be dead for the workspace, and the learned ``ACCEPT`` rules would
@@ -164,14 +301,18 @@ def _respond_allowed(
     #2278.
     """
     try:
-        ips = a_records(resp)
+        recs = a_records_with_ttl(resp)
     except Exception:
-        ips = []
+        recs = []
     try:
-        for ip in ips:
-            allow_ip(ip)
+        for ip, ttl in recs:
+            for port in ports:
+                allow(ip, port, ttl)
         if DEBUG:
-            print(f"allow {qname} -> {ips}", flush=True)
+            print(
+                f"allow {qname} -> {[ip for ip, _ in recs]} ports={_fmt_ports(ports)}",
+                flush=True,
+            )
         s.sendto(resp, addr)
     except Exception:
         pass
@@ -182,10 +323,11 @@ def main() -> None:
     s.bind(("127.0.0.1", LISTEN_PORT))
     print(
         f"dns-proxy listening on 127.0.0.1:{LISTEN_PORT} "
-        f"(upstream={UPSTREAM[0]}, allowed={ALLOWED})",
+        f"(upstream={UPSTREAM[0]}, allowed={SPECS})",
         flush=True,
     )
     check_mark()
+    threading.Thread(target=_sweeper, daemon=True).start()
     while True:
         try:
             data, addr = s.recvfrom(65535)
@@ -195,7 +337,10 @@ def main() -> None:
             qname = query_name(data)
         except Exception:
             continue  # malformed/unparseable query -> drop
-        if not qname or not allowed(qname):
+        ports = ports_for(qname)
+        # Deny only when nothing matched (empty port set). ``None`` means a
+        # port-less spec matched (all ports) — that is an allow.
+        if not qname or (ports is not None and not ports):
             if DEBUG:
                 print(f"deny  {qname}", flush=True)
             try:
@@ -203,6 +348,7 @@ def main() -> None:
             except Exception:
                 pass
             continue
+        port_set = ports if ports is not None else {None}
         us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
         us.settimeout(3)
@@ -213,7 +359,7 @@ def main() -> None:
             us.close()
             continue
         us.close()
-        _respond_allowed(s, resp, addr, qname)
+        _respond_allowed(s, resp, addr, qname, port_set)
 
 
 if __name__ == "__main__":

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -47,8 +47,6 @@ Configuration (env):
                             response does not immediately yank the rule the
                             workspace needs to reach the IP it just resolved
                             (default 30).
-  KLANGKNETWORK_EGRESS_DEFAULT_TTL  TTL used when a response carries no usable
-                            TTL (default 300).
 
 Limitations: transport is UDP only (TCP fallback is a future addition).
 """
@@ -77,7 +75,6 @@ MARK = int(os.environ.get("KLANGKNETWORK_EGRESS_MARK", "75"))
 # Learned-IP housekeeping (#2256).
 SWEEP_INTERVAL = float(os.environ.get("KLANGKNETWORK_EGRESS_SWEEP_INTERVAL", "5"))
 MIN_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_MIN_TTL", "30"))
-DEFAULT_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_DEFAULT_TTL", "300"))
 
 
 def parse_specs() -> list[tuple[str, int | None, bool]]:
@@ -222,10 +219,19 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
     rule the workspace needs to reach the IP it just resolved) and only ever
     moves forward, so a shorter-TTL re-resolution can't prematurely expire a
     longer-lived prior rule (#2256).
+
+    The install happens **under** :data:`_LOCK` so the kernel rule and its
+    ``_LEARNED`` record are atomic w.r.t. :func:`sweep_once`'s remove+delete
+    (also under the lock). Without that, the sweeper could delete a rule
+    :func:`allow` just installed while ``_LEARNED`` still records it as
+    present — a fail-closed availability gap that only self-heals on the next
+    re-resolution (#2256 review). The main loop is single-threaded and the
+    sweeper runs every ``SWEEP_INTERVAL``, so serializing the iptables calls
+    under the lock is negligible contention.
     """
-    _install(ip, port)
     expire = time.time() + max(ttl, MIN_TTL)
     with _LOCK:
+        _install(ip, port)
         rec = _LEARNED.get(ip)
         if rec is None:
             _LEARNED[ip] = {"expire": expire, "ports": {port}}
@@ -237,20 +243,27 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
     """Remove learned IPs whose TTL has elapsed; return ``(ip, ports)`` removed.
 
-    Factored out of :func:`_sweeper` so it is unit-testable with a mocked
-    clock and iptables (#2256).
+    Removal runs **under** :data:`_LOCK` (see :func:`allow`): the rule delete
+    and the ``_LEARNED`` delete are atomic, so a concurrent :func:`allow`
+    can't re-record an IP whose kernel rule was just swept. Factored out of
+    :func:`_sweeper` so it is unit-testable with a mocked clock and iptables
+    (#2256).
     """
     if now is None:
         now = time.time()
     expired: list[tuple[str, set]] = []
     with _LOCK:
         for ip, rec in list(_LEARNED.items()):
-            if rec["expire"] <= now:
-                expired.append((ip, set(rec["ports"])))
-                del _LEARNED[ip]
-    for ip, ports in expired:
-        for port in ports:
-            _remove(ip, port)
+            if rec["expire"] > now:
+                continue
+            ports = set(rec["ports"])
+            for port in ports:
+                try:
+                    _remove(ip, port)
+                except Exception:
+                    pass  # a transient failure drops one rule, not the sweep
+            del _LEARNED[ip]
+            expired.append((ip, ports))
     return expired
 
 
@@ -318,6 +331,20 @@ def _respond_allowed(
         pass
 
 
+def _decision(qname: str, ports: set[int] | None) -> tuple[bool, set[int | None]]:
+    """Classify a query: ``(deny, port_set)``.
+
+    ``deny=True`` -> send NXDOMAIN. ``port_set`` is the set of ports to allow
+    for each learned IP (a ``None`` entry is the all-ports rule). Factored out
+    of :func:`main` so the None-vs-empty gate is unit-tested directly —
+    inverting it (treating ``None`` as deny, or an empty set as allow) is a
+    fail-open/fail-closed bug in the security gate (#2256).
+    """
+    if not qname or (ports is not None and not ports):
+        return True, set()
+    return False, ports if ports is not None else {None}
+
+
 def main() -> None:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(("127.0.0.1", LISTEN_PORT))
@@ -338,9 +365,8 @@ def main() -> None:
         except Exception:
             continue  # malformed/unparseable query -> drop
         ports = ports_for(qname)
-        # Deny only when nothing matched (empty port set). ``None`` means a
-        # port-less spec matched (all ports) — that is an allow.
-        if not qname or (ports is not None and not ports):
+        deny, port_set = _decision(qname, ports)
+        if deny:
             if DEBUG:
                 print(f"deny  {qname}", flush=True)
             try:
@@ -348,7 +374,6 @@ def main() -> None:
             except Exception:
                 pass
             continue
-        port_set = ports if ports is not None else {None}
         us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
         us.settimeout(3)

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -44,13 +44,14 @@ String? validateMountSpec(String spec) {
   return null;
 }
 
-/// Client-side validation for a ``host``, ``host:port``, or IPv4 CIDR
-/// allowed-domain spec. Returns an error string on failure, ``null`` on
-/// success. The server validates definitively; this catches typos at the
-/// boundary (#1935 added CIDR support).
+/// Client-side validation for a ``host``, ``host:port``, ``*.domain[:port]``
+/// wildcard, or IPv4 CIDR allowed-domain spec. Returns an error string on
+/// failure, ``null`` on success. The server validates definitively; this
+/// catches typos at the boundary (#1935 added CIDR support, #2256 added
+/// wildcards).
 String? validateAllowedDomainSpec(String spec) {
   if (spec.contains(' ')) {
-    return 'Expected host or host:port';
+    return 'Expected host, host:port, or *.domain';
   }
   // A "/" denotes an IPv4 CIDR range (e.g. 10.0.0.0/8, optionally
   // 10.0.0.0/8:443). Validate it separately — the host regex below
@@ -58,10 +59,22 @@ String? validateAllowedDomainSpec(String spec) {
   if (spec.contains('/')) {
     return _validateCidrDomainSpec(spec);
   }
+  // Wildcard: a leading "*." matches subdomains only (NOT the apex) —
+  // #2256. Strip it and validate the remaining host[:port] grammar. A bare
+  // "*" or "*." has no matchable base.
+  var hostSpec = spec;
+  if (hostSpec.startsWith('*.')) {
+    hostSpec = hostSpec.substring(2);
+    if (hostSpec.isEmpty) {
+      return 'Expected host, host:port, or *.domain';
+    }
+  }
   final re = RegExp(r'^[A-Za-z0-9][A-Za-z0-9.\-]*(:[0-9]{1,5})?$');
-  if (!re.hasMatch(spec)) return 'Expected host or host:port';
+  if (!re.hasMatch(hostSpec)) {
+    return 'Expected host, host:port, or *.domain';
+  }
   // Reject ports > 65535 (the regex allows up to 5 digits).
-  final portMatch = RegExp(r':(\d{1,5})$').firstMatch(spec);
+  final portMatch = RegExp(r':(\d{1,5})$').firstMatch(hostSpec);
   if (portMatch != null && int.parse(portMatch.group(1)!) > 65535) {
     return 'Port must be 1–65535';
   }

--- a/src/frontend/test/allowed_domain_spec_test.dart
+++ b/src/frontend/test/allowed_domain_spec_test.dart
@@ -13,6 +13,25 @@ void main() {
       expect(validateAllowedDomainSpec('pypi.org:80'), isNull);
     });
 
+    // #2256: leading "*." wildcards (subdomains only, + optional port).
+    test('accepts *.domain wildcards', () {
+      expect(validateAllowedDomainSpec('*.pypi.org'), isNull);
+      expect(validateAllowedDomainSpec('*.pypi.org:443'), isNull);
+      expect(validateAllowedDomainSpec('*.double.example.com'), isNull);
+      expect(validateAllowedDomainSpec('*.pypi.org:65535'), isNull);
+    });
+
+    test('rejects malformed wildcards', () {
+      expect(validateAllowedDomainSpec('*pypi.org'), isNotNull); // no dot
+      expect(validateAllowedDomainSpec('*'), isNotNull); // bare wildcard
+      expect(validateAllowedDomainSpec('*.'), isNotNull); // empty base
+      expect(
+          validateAllowedDomainSpec('a*.pypi.org'), isNotNull); // not leading
+      expect(validateAllowedDomainSpec('pypi.org.*'), isNotNull); // wrong end
+      expect(
+          validateAllowedDomainSpec('*.pypi.org:99999'), isNotNull); // bad port
+    });
+
     test('accepts an IPv4 literal', () {
       expect(validateAllowedDomainSpec('10.0.0.1'), isNull);
       expect(validateAllowedDomainSpec('10.0.0.1:53'), isNull);

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -535,7 +535,8 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
 
-      expect(find.text('Expected host or host:port'), findsOneWidget);
+      expect(
+          find.text('Expected host, host:port, or *.domain'), findsOneWidget);
       // The bad spec did not become a list item.
       expect(
         find.byWidgetPredicate(

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -615,7 +615,8 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
 
-      expect(find.text('Expected host or host:port'), findsOneWidget);
+      expect(
+          find.text('Expected host, host:port, or *.domain'), findsOneWidget);
       expect(
         find.byWidgetPredicate(
           (w) => w is SelectableText && (w.data ?? '') == 'bad spec',

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -67,6 +67,14 @@ def _valid_domain_spec(spec: str) -> bool:
     # below is unchanged (#1935).
     if "/" in spec:
         return _valid_cidr_spec(spec)
+    # Wildcard: a leading ``*.`` matches subdomains only (NOT the apex) —
+    # distinct from a bare host, which matches the apex + subdomains. Strip
+    # the ``*.`` and validate the remaining ``host[:port]`` grammar. A bare
+    # ``*`` or ``*.`` has no matchable base (#2256).
+    if spec.startswith("*."):
+        spec = spec[2:]
+        if not spec:
+            return False
     if not _DOMAIN_RE.match(spec):
         return False
     # The regex accepts up to 5 digits; additionally reject ports > 65535.

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -59,6 +59,11 @@ class TestParseAllowedDomains:
             "10.0.0.1:53",
             "sub.domain.example.com:8080",
             "a.com:65535",  # max valid port
+            # #2256: leading "*." wildcards (subdomains only, + optional port).
+            "*.pypi.org",
+            "*.pypi.org:443",
+            "*.double.example.com",  # wildcard on a multi-label base
+            "*.pypi.org:65535",  # wildcard + max port
             # #1935: IPv4 CIDR ranges (with and without a port scope).
             "10.0.0.0/8",
             "10.0.0.0/8:443",
@@ -85,6 +90,13 @@ class TestParseAllowedDomains:
             "/etc/passwd",  # slash but not a valid CIDR
             "-leading",  # leading hyphen rejected by host grammar
             "a.com/path",  # slash but not a valid CIDR
+            # #2256: wildcards must be a leading "*." (dot required), and
+            # a wildcard with no matchable base is invalid.
+            "*pypi.org",  # missing the dot after *
+            "*",  # bare wildcard — nothing to match
+            "*.",  # wildcard with empty base
+            "a*.pypi.org",  # wildcard not at the leading position
+            "pypi.org.*",  # wildcard at the wrong end
             # #1935: malformed CIDR specs.
             "10.0.0.0/33",  # prefix length > 32
             "10.0.0.0/",  # missing prefix length

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -205,6 +205,58 @@ class TestRuleArgs:
         ]
 
 
+class TestRuleArgsInvariant:
+    """The dedup/delete cycle is sound only if -C (exists), -I (install), and
+    -D (remove) build IDENTICAL args from one ``_rule_args``. A future edit
+    that drifts would silently break dedup or orphan rules (#2256 review)."""
+
+    @pytest.mark.parametrize("port", [None, 443])
+    def test_check_install_remove_share_args(self, proxy, monkeypatch, port):
+        calls = []
+
+        def fake_run(args, **kw):
+            calls.append(list(args))
+            return types.SimpleNamespace(returncode=1)  # absent -> -I fires
+
+        monkeypatch.setattr(proxy.subprocess, "run", fake_run)
+        proxy._install("1.2.3.4", port)
+        proxy._rule_exists("1.2.3.4", port)
+        proxy._remove("1.2.3.4", port)
+        expected = proxy._rule_args("1.2.3.4", port)
+        ops = set()
+        for cmd in calls:
+            assert cmd[0] == proxy.IPT, cmd
+            assert cmd[1] in ("-C", "-I", "-D"), cmd
+            # The rule-matching args (-d/-p/--dport/-j ACCEPT) are the SHARED
+            # tail across all three: -C and -D are "<op> OUTPUT <args>"; -I
+            # is "-I OUTPUT 1 <args>" (the position arg sits before the tail).
+            assert cmd[-len(expected) :] == expected, (cmd, expected)
+            ops.add(cmd[1])
+        assert {"-C", "-I", "-D"} <= ops
+
+
+class TestDecision:
+    """The None-vs-empty gate consumed by ``main()``. ``None`` (a port-less
+    spec matched) is an ALLOW on all ports; an empty set is a DENY.
+    Inverting either is a fail-open/fail-closed bug in the security gate
+    (#2256 review)."""
+
+    def test_empty_qname_denies(self, proxy):
+        assert proxy._decision("", {443}) == (True, set())
+
+    def test_none_ports_allows_all_ports(self, proxy):
+        assert proxy._decision("a.com", None) == (False, {None})
+
+    def test_empty_set_denies(self, proxy):
+        assert proxy._decision("a.com", set()) == (True, set())
+
+    def test_port_set_scoped_allow(self, proxy):
+        assert proxy._decision("a.com", {443, 8443}) == (
+            False,
+            {443, 8443},
+        )
+
+
 class TestTTLAndSweep:
     """Learned-IP TTL tracking + expiry sweep (#2256)."""
 
@@ -270,6 +322,21 @@ class TestTTLAndSweep:
         monkeypatch.setattr(learned.time, "time", lambda: 0.0)
         learned.allow("1.2.3.4", None, 60)
         assert learned._LEARNED["1.2.3.4"]["ports"] == {None}
+
+    def test_cross_domain_shared_ip_accumulates_ports(
+        self, learned, monkeypatch
+    ):
+        # Two different domains resolving to one CDN IP union their ports
+        # under that single IP (#2256 review).
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned.allow("9.9.9.9", 443, 60)  # github.com:443 -> 9.9.9.9
+        learned.allow("9.9.9.9", 8443, 60)  # registry.com:8443 -> 9.9.9.9
+        assert learned._LEARNED["9.9.9.9"]["ports"] == {443, 8443}
 
     def test_sweep_removes_expired_rules(self, learned, monkeypatch):
         removed = []

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -33,7 +33,7 @@ def _install_dns_stubs() -> None:
     image, not the server's venv). proxy.py imports ``dns.message`` /
     ``dns.rcode`` / ``dns.rdatatype`` at module level; stub them so the import
     succeeds. The tests below monkeypatch the functions that actually use dnspython
-    (a_records etc.), so the stubs only need to exist, not work.
+    (a_records_with_ttl etc.), so the stubs only need to exist, not work.
     """
     if "dns" in sys.modules:
         return
@@ -72,89 +72,285 @@ def proxy():
     return mod
 
 
-class TestAllowedGate:
-    """The allow/deny gate (``allowed``) is the core security check. A
-    suffix-match regression here (e.g. a bare ``endswith(h)``) would wrongly
-    admit ``evilgithub.com`` for an allow-listed ``github.com``. Pin the exact /
-    subdomain / boundary semantics so a refactor can't silently weaken it (only
-    the real-podman e2e covered it before)."""
+@pytest.fixture
+def learned(proxy):
+    """A proxy module with the learned-IP table cleared (TTL/sweep tests)."""
+    proxy._LEARNED.clear()
+    return proxy
+
+
+class TestParseSpecs:
+    """Env parsing → ``(host, port|None, is_wildcard)`` triples. CIDRs are
+    skipped (the entrypoint applies those statically); the grammar mirrors
+    ``klangk.netfilter.parse_allowed_domains`` (#2256)."""
+
+    def test_ports_wildcards_cidr_skip(self, proxy, monkeypatch):
+        monkeypatch.setenv(
+            "KLANGKNETWORK_EGRESS_ALLOW",
+            "github.com:443,*.pypi.org,pypi.org,"
+            "10.0.0.0/8,10.0.0.0/8:53,bare.com:8443",
+        )
+        assert proxy.parse_specs() == [
+            ("github.com", 443, False),
+            ("pypi.org", None, True),  # *.pypi.org
+            ("pypi.org", None, False),
+            ("bare.com", 8443, False),
+        ]
+
+    def test_wildcard_with_port(self, proxy, monkeypatch):
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "*.pypi.org:443")
+        assert proxy.parse_specs() == [("pypi.org", 443, True)]
+
+    def test_empty_env(self, proxy, monkeypatch):
+        monkeypatch.delenv("KLANGKNETWORK_EGRESS_ALLOW", raising=False)
+        assert proxy.parse_specs() == []
+
+
+class TestPortsFor:
+    """``ports_for`` is the allow gate. Returns ``None`` (all ports), a port
+    ``set`` (scoped allow), or ``set()`` (deny). A suffix-match regression here
+    (e.g. a bare ``endswith(h)``) would wrongly admit ``evilgithub.com`` for an
+    allow-listed ``github.com``. Pin the exact / subdomain / wildcard / port
+    semantics so a refactor can't silently weaken it (#2256)."""
 
     @pytest.mark.parametrize(
         "qname, expected",
         [
-            ("github.com", True),  # exact match
-            ("api.github.com", True),  # subdomain matches
-            ("a.b.c.github.com", True),  # deep subdomain matches
-            ("evilgithub.com", False),  # boundary: NOT a subdomain
-            ("notgithub.com", False),  # boundary
-            ("github.com.attacker.test", False),  # prefix-of, not a suffix
-            ("evil.test", False),  # unrelated
+            ("github.com", None),  # exact -> all ports
+            ("api.github.com", None),  # subdomain -> all ports
+            ("evilgithub.com", set()),  # boundary: NOT a subdomain
+            ("github.com.attacker.test", set()),  # prefix-of, not a suffix
         ],
     )
     def test_suffix_boundary(self, proxy, monkeypatch, qname, expected):
-        # The dot boundary ("." + h) is what stops evilgithub.com matching
-        # github.com. A bare endswith(h) would flip the False cases to True.
-        monkeypatch.setattr(proxy, "ALLOWED", ["github.com"])
-        assert proxy.allowed(qname) == expected
+        # The dot boundary ("." + h) stops evilgithub.com matching github.com.
+        monkeypatch.setattr(proxy, "SPECS", [("github.com", None, False)])
+        assert proxy.ports_for(qname) == expected
 
-    def test_multiple_specs_any_match(self, proxy, monkeypatch):
-        monkeypatch.setattr(proxy, "ALLOWED", ["github.com", "pypi.org"])
-        assert proxy.allowed("api.github.com") is True
-        assert proxy.allowed("files.pythonhosted.org") is False
-        assert proxy.allowed("github.com") is True
+    def test_port_scope_applies_to_apex_and_subdomain(
+        self, proxy, monkeypatch
+    ):
+        monkeypatch.setattr(proxy, "SPECS", [("github.com", 443, False)])
+        assert proxy.ports_for("github.com") == {443}
+        assert proxy.ports_for("api.github.com") == {443}
 
-    def test_empty_allow_list_denies_all(self, proxy, monkeypatch):
-        monkeypatch.setattr(proxy, "ALLOWED", [])
-        assert proxy.allowed("anything.test") is False
-        assert proxy.allowed("github.com") is False
+    def test_wildcard_excludes_apex(self, proxy, monkeypatch):
+        # *.pypi.org matches subdomains only, NOT pypi.org itself — distinct
+        # from a bare pypi.org (apex + subdomains).
+        monkeypatch.setattr(proxy, "SPECS", [("pypi.org", None, True)])
+        assert proxy.ports_for("pypi.org") == set()
+        assert proxy.ports_for("a.pypi.org") is None
+        assert proxy.ports_for("a.b.pypi.org") is None
+
+    def test_wildcard_with_port(self, proxy, monkeypatch):
+        monkeypatch.setattr(proxy, "SPECS", [("pypi.org", 443, True)])
+        assert proxy.ports_for("pypi.org") == set()
+        assert proxy.ports_for("x.pypi.org") == {443}
+
+    def test_all_ports_spec_dominates(self, proxy, monkeypatch):
+        # github.com (all ports) + github.com:443 -> all ports win.
+        monkeypatch.setattr(
+            proxy,
+            "SPECS",
+            [
+                ("github.com", None, False),
+                ("github.com", 443, False),
+            ],
+        )
+        assert proxy.ports_for("github.com") is None
+
+    def test_multiple_ports_union(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy,
+            "SPECS",
+            [("github.com", 443, False), ("github.com", 8443, False)],
+        )
+        assert proxy.ports_for("github.com") == {443, 8443}
+
+    def test_empty_specs_denies_all(self, proxy, monkeypatch):
+        monkeypatch.setattr(proxy, "SPECS", [])
+        assert proxy.ports_for("anything.test") == set()
 
     def test_case_sensitive_relies_on_caller_lowercasing(
         self, proxy, monkeypatch
     ):
-        # allowed() compares verbatim; query_name()/host_specs() lowercase at
-        # the edges. Pin that contract: a mixed-case qname does NOT match a
+        # ports_for compares verbatim; parse_specs/query_name lowercase at the
+        # edges. Pin that contract: a mixed-case qname does NOT match a
         # lowercased spec, so the lowercasing must not be dropped upstream.
-        monkeypatch.setattr(proxy, "ALLOWED", ["github.com"])
-        assert proxy.allowed("GitHub.Com") is False
-        assert proxy.allowed("API.GITHUB.COM") is False
+        monkeypatch.setattr(proxy, "SPECS", [("github.com", None, False)])
+        assert proxy.ports_for("GitHub.Com") == set()
+
+
+class TestRuleArgs:
+    """The iptables rule shape: port-scoped vs all-ports (#2256)."""
+
+    def test_all_ports(self, proxy):
+        assert proxy._rule_args("1.2.3.4", None) == [
+            "-d",
+            "1.2.3.4",
+            "-j",
+            "ACCEPT",
+        ]
+
+    def test_scoped_port(self, proxy):
+        assert proxy._rule_args("1.2.3.4", 443) == [
+            "-d",
+            "1.2.3.4",
+            "-p",
+            "tcp",
+            "--dport",
+            "443",
+            "-j",
+            "ACCEPT",
+        ]
+
+
+class TestTTLAndSweep:
+    """Learned-IP TTL tracking + expiry sweep (#2256)."""
+
+    def test_allow_installs_and_records_expiry(self, learned, monkeypatch):
+        runs = []
+
+        def fake_run(args, **kw):
+            runs.append(args)
+            return types.SimpleNamespace(returncode=1)  # rule absent -> -I
+
+        monkeypatch.setattr(learned.subprocess, "run", fake_run)
+        monkeypatch.setattr(learned.time, "time", lambda: 1000.0)
+        learned.allow("1.2.3.4", 443, 120)
+        assert any("-I" in a for a in runs)
+        rec = learned._LEARNED["1.2.3.4"]
+        assert rec["expire"] == 1000.0 + 120
+        assert rec["ports"] == {443}
+
+    def test_min_ttl_floors_zero_ttl(self, learned, monkeypatch):
+        # A 0-TTL response must not yank the rule immediately.
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned.allow("1.2.3.4", 443, 0)
+        assert learned._LEARNED["1.2.3.4"]["expire"] == 0.0 + learned.MIN_TTL
+
+    def test_dedup_skips_install_when_rule_exists(self, learned, monkeypatch):
+        runs = []
+
+        def fake_run(args, **kw):
+            runs.append(args)
+            return types.SimpleNamespace(returncode=0)  # rule exists
+
+        monkeypatch.setattr(learned.subprocess, "run", fake_run)
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned.allow("1.2.3.4", 443, 60)
+        assert not any("-I" in a for a in runs)
+        assert learned._LEARNED["1.2.3.4"]["ports"] == {443}
+
+    def test_refresh_extends_expire_only_forward(self, learned, monkeypatch):
+        # A later re-resolution with a longer TTL must not shorten an existing
+        # rule's lifetime; expire only moves forward.
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        clock = [1000.0, 2000.0]
+        monkeypatch.setattr(learned.time, "time", lambda: clock.pop(0))
+        learned.allow("1.2.3.4", 443, 60)  # expire 1060
+        learned.allow("1.2.3.4", 443, 500)  # candidate 2500 -> max(1060, 2500)
+        assert learned._LEARNED["1.2.3.4"]["expire"] == 2500.0
+
+    def test_all_ports_rule_uses_none_port(self, learned, monkeypatch):
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned.allow("1.2.3.4", None, 60)
+        assert learned._LEARNED["1.2.3.4"]["ports"] == {None}
+
+    def test_sweep_removes_expired_rules(self, learned, monkeypatch):
+        removed = []
+        monkeypatch.setattr(
+            learned, "_remove", lambda ip, port: removed.append((ip, port))
+        )
+        learned._LEARNED["1.2.3.4"] = {"expire": 500.0, "ports": {443, None}}
+        gone = learned.sweep_once(now=1000.0)
+        assert gone == [("1.2.3.4", {443, None})]
+        assert ("1.2.3.4", 443) in removed
+        assert ("1.2.3.4", None) in removed
+        assert "1.2.3.4" not in learned._LEARNED
+
+    def test_sweep_keeps_live_ips(self, learned, monkeypatch):
+        monkeypatch.setattr(learned, "_remove", lambda *a: None)
+        learned._LEARNED["1.2.3.4"] = {"expire": 2000.0, "ports": {443}}
+        assert learned.sweep_once(now=1000.0) == []
+        assert "1.2.3.4" in learned._LEARNED
+
+    def test_sweep_boundary_keeps_equal_expire(self, learned, monkeypatch):
+        # expire <= now is removed; a rule valid through `now` (expire > now)
+        # is kept. expire == now counts as expired.
+        monkeypatch.setattr(learned, "_remove", lambda *a: None)
+        learned._LEARNED["dead"] = {"expire": 1000.0, "ports": {443}}
+        learned._LEARNED["live"] = {"expire": 1000.001, "ports": {443}}
+        gone = learned.sweep_once(now=1000.0)
+        assert [ip for ip, _ in gone] == ["dead"]
+        assert "live" in learned._LEARNED
 
 
 class TestRespondAllowedSwallowsFailures:
-    """#2278: a transient failure in allow_ip or sendto must drop only the one
+    """#2278: a transient failure in allow or sendto must drop only the one
     response, not kill the proxy (an escaped raise would take down PID 1,
     leaving learned ACCEPT rules in place with DNS dead — a partial
     fail-open)."""
 
-    def test_allow_ip_failure_does_not_propagate(self, proxy, monkeypatch):
-        # allow_ip shells out to iptables; a transient failure there must not
-        # escape _respond_allowed.
-        monkeypatch.setattr(proxy, "a_records", lambda wire: ["1.2.3.4"])
+    def test_allow_failure_does_not_propagate(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy, "a_records_with_ttl", lambda wire: [("1.2.3.4", 100)]
+        )
 
-        def _boom(ip):
+        def _boom(ip, port, ttl):
             raise RuntimeError("iptables transient failure")
 
-        monkeypatch.setattr(proxy, "allow_ip", _boom)
+        monkeypatch.setattr(proxy, "allow", _boom)
         s = MagicMock()
         # Must not raise.
-        proxy._respond_allowed(s, b"resp", ("127.0.0.1", 1234), "allowed.test")
+        proxy._respond_allowed(
+            s, b"resp", ("127.0.0.1", 1234), "allowed.test", {443}
+        )
 
     def test_sendto_failure_does_not_propagate(self, proxy, monkeypatch):
-        # sendto to a vanished client must not escape _respond_allowed.
-        monkeypatch.setattr(proxy, "a_records", lambda wire: ["1.2.3.4"])
-        monkeypatch.setattr(proxy, "allow_ip", lambda ip: None)  # no iptables
+        monkeypatch.setattr(
+            proxy, "a_records_with_ttl", lambda wire: [("1.2.3.4", 100)]
+        )
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
         s = MagicMock()
         s.sendto.side_effect = OSError("client gone")
         # Must not raise.
-        proxy._respond_allowed(s, b"resp", ("127.0.0.1", 1234), "allowed.test")
-
-    def test_happy_path_still_sends(self, proxy, monkeypatch):
-        # Sanity: with no failure, _respond_allowed learns the IPs + sends.
-        monkeypatch.setattr(
-            proxy, "a_records", lambda wire: ["1.2.3.4", "5.6.7.8"]
+        proxy._respond_allowed(
+            s, b"resp", ("127.0.0.1", 1234), "allowed.test", {443}
         )
-        learned = []
-        monkeypatch.setattr(proxy, "allow_ip", learned.append)
+
+    def test_happy_path_allows_each_ip_each_port_and_sends(
+        self, proxy, monkeypatch
+    ):
+        monkeypatch.setattr(
+            proxy,
+            "a_records_with_ttl",
+            lambda wire: [("1.2.3.4", 100), ("5.6.7.8", 200)],
+        )
+        calls = []
+        monkeypatch.setattr(
+            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+        )
         s = MagicMock()
-        proxy._respond_allowed(s, b"resp", ("127.0.0.1", 1234), "allowed.test")
-        assert learned == ["1.2.3.4", "5.6.7.8"]
+        proxy._respond_allowed(
+            s, b"resp", ("127.0.0.1", 1234), "q", {443, 8443}
+        )
+        assert ("1.2.3.4", 443, 100) in calls
+        assert ("1.2.3.4", 8443, 100) in calls
+        assert ("5.6.7.8", 443, 200) in calls
+        assert ("5.6.7.8", 8443, 200) in calls
         s.sendto.assert_called_once_with(b"resp", ("127.0.0.1", 1234))


### PR DESCRIPTION
## Summary

Closes #2256. Hardens the FQDN egress allow-list semantics — previously exact/suffix host matching only, **all ports** allowed to a learned IP, and learned IPs never revoked. This adds wildcards, per-domain port scoping, and DNS-TTL-based learned-IP cleanup, and reconciles the sidecar proxy's grammar with the API validator.

## Changes

**Wildcards** — a leading `*.domain` (optional `:port`) matches subdomains only; a bare `domain` matches the apex + subdomains. They are distinct, non-redundant scopes (`*.pypi.org` excludes the apex `pypi.org`; `pypi.org` includes it). `netfilter.parse_allowed_domains` now accepts the form; the sidecar proxy parses and matches it.

**Per-domain port scoping** — `host:port` / `*.host:port` emits `-d <ip> -p tcp --dport <port> -j ACCEPT` for a learned IP; a bare host keeps all ports. The sidecar's `entrypoint.sh` now applies the same scoping to CIDR specs like `10.0.0.0/8:443` (it previously stripped the port). A learned IP inherits the **union** of ports from every matching spec, and any port-less match means all-ports.

**Learned-IP TTL/cleanup** — the proxy reads each A-record TTL, allows the IP for `max(ttl, MIN_TTL)` seconds (a 0-TTL response must not yank the rule the workspace needs), and a background sweeper thread removes the `ACCEPT` rule once the TTL elapses, so stale IPs do not linger.

### Files
- `src/klangk/klangk/netfilter.py` — grammar accepts leading `*.` wildcards.
- `src/containers/network/proxy.py` — `parse_specs`/`ports_for` (wildcard + port-scoped matching), `allow()` with TTL tracking + dedup, `sweep_once()`/`_sweeper()`, port-scoped `_rule_args`.
- `src/containers/network/entrypoint.sh` — CIDR specs scoped to their port.
- `src/klangk/klangkd-tests/tests/test_netfilter.py` — wildcard grammar cases (valid + invalid).
- `src/klangk/klangkd-tests/tests/test_proxy.py` — rewritten for the new API: `ports_for` (suffix/wildcard/port boundaries), `_rule_args`, TTL + sweep (mocked clock + iptables), failure isolation.
- `docs/features/egress-filtering.md` — wildcard + port + TTL grammar; updated the two now-stale caveats (port scoping and TTL both exist).
- `docs/changes.md` — changelog entry.

## Verification

- netfilter grammar + proxy unit tests: **97 passed**.
- Full suite the CI way (`-n auto`, coverage): **4339 passed, 100% coverage**.
- pre-commit clean (ruff, shfmt, shellcheck, prettier, markdownlint).

## Notes

- Non-breaking: existing bare-host and `host:port` specs behave as before (bare host still allows all ports and subdomains); wildcards are purely additive.
- The learned-IP revocation caveat is narrowed but not eliminated: IPs now expire by TTL, but dropping a domain from a *running* workspace still doesn't revoke already-resolved IPs until the sidecar restarts (documented).
