### PR TITLE
docs(hosted-apps): note egress-filtering interop via the network sidecar

### DIFF
--- a/docs/features/hosted-apps.md
+++ b/docs/features/hosted-apps.md
@@ -14,6 +14,9 @@ Hosted apps are accessible to anyone who can reach the Klangk server. Do not ser
 2. When a container starts, the port mappings are injected as `KLANGKWS_PORT_MAPPINGS` (e.g., `8000:9000,8001:9001,...`).
 3. The proxy proxies requests from `/hosted/{workspace_id}/{port}/` directly to the container — no Python in the request path.
 
+!!! note
+**Works with egress filtering.** A workspace with an `allowed_domains` allow-list runs behind the [network sidecar](egress-filtering.md), which owns the shared network namespace; host ports are published on the sidecar (not the workspace — `--publish` is silently discarded under `--network container:`) and forward into the shared netns to the workspace's listener, so hosting works the same as for unrestricted workspaces (#2267). IPv4 clients are reachable; the sidecar default-denies IPv6, so IPv6-only clients to a published port fail (#2277).
+
 ## Accessing hosted apps
 
 Start any HTTP server on a container port (8000-8004), then visit:


### PR DESCRIPTION
## Summary

Doc-only follow-on to #2291. `docs/features/hosted-apps.md` didn't mention
that an egress-filtered workspace (one with an `allowed_domains` allow-list)
can still host apps — host ports are published on the network sidecar rather
than the workspace (`--publish` is silently discarded under
`--network container:`), forwarding into the shared netns to the workspace's
listener (#2267, implemented in #2291). Adds a note stating this plus the
IPv6 caveat (#2277).

No code or behavior change; pre-commit clean (prettier + markdownlint).

## Context

Surfaced while investigating #2270, which turned out to be fully implemented
by #2291 (all three acceptance criteria met: sidecar-publish mechanism +
`test_start_network_sidecar_publishes_host_ports` + real-podman e2e
`test_host_port_published_on_sidecar_reaches_workspace`; AC2
`test_start_network_sidecar_default_publish_is_none`; AC3
`test_start_network_sidecar_failure_raises`). This PR just fills the one
end-user doc gap.
