### PR TITLE
test(proxy): pin a_records_with_ttl CNAME-chain extraction (#2279)

### DIFF
--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -367,6 +367,101 @@ class TestTTLAndSweep:
         assert "live" in learned._LEARNED
 
 
+class TestARecordsWithTtl:
+    """``a_records_with_ttl`` extracts every A record from a DNS response's
+    answer section — transparently across a CNAME chain — each paired with
+    its rrset TTL. That transparency is the bounded widening risk in
+    egress-filtering.md (#2279): an allow-listed domain that CNAMEs to an
+    attacker-controlled (or shared-CDN) host has that host's A record learned,
+    scoped to the declared port + TTL by #2256. Pin the extraction so a
+    refactor can't silently change which records are learned."""
+
+    class _RRset:
+        """A fake DNS rrset: an rdtype, a ttl, and an iterable of rdata."""
+
+        def __init__(self, rdtype, ttl, addresses):
+            # 1 == dns.rdatatype.A (the stub pins A=1); 5 is CNAME.
+            self.rdtype = rdtype
+            self.ttl = ttl
+            self._rdata = [types.SimpleNamespace(address=a) for a in addresses]
+
+        def __iter__(self):
+            return iter(self._rdata)
+
+    @staticmethod
+    def _msg(answer):
+        return types.SimpleNamespace(answer=answer)
+
+    def _wire(self, proxy, monkeypatch, answer):
+        """Stub ``dns.message.from_wire`` to return a response with ``answer``;
+        return throwaway wire bytes (the stub ignores them)."""
+        monkeypatch.setattr(
+            proxy.dns.message, "from_wire", lambda wire: self._msg(answer)
+        )
+        return b""
+
+    def test_cname_chain_yields_target_a_records(self, proxy, monkeypatch):
+        # cdn.example.com CNAME cdn-backend.fastly.net, then A 1.2.3.4.
+        wire = self._wire(
+            proxy,
+            monkeypatch,
+            [
+                self._RRset(5, 60, []),  # CNAME — skipped
+                self._RRset(1, 300, ["1.2.3.4"]),  # A — learned
+            ],
+        )
+        # The CNAME target's A record is extracted (CNAME transparency, #2279).
+        assert proxy.a_records_with_ttl(wire) == [("1.2.3.4", 300)]
+
+    def test_apex_and_cname_target_a_records_both_learned(
+        self, proxy, monkeypatch
+    ):
+        # Both the queried name's own A and the CNAME target's A sit in the
+        # answer; both are learned (the widening — two IPs for one query).
+        wire = self._wire(
+            proxy,
+            monkeypatch,
+            [
+                self._RRset(5, 60, []),
+                self._RRset(1, 300, ["10.0.0.1"]),
+                self._RRset(1, 300, ["10.0.0.2"]),
+            ],
+        )
+        assert proxy.a_records_with_ttl(wire) == [
+            ("10.0.0.1", 300),
+            ("10.0.0.2", 300),
+        ]
+
+    def test_multiple_a_in_one_rrset(self, proxy, monkeypatch):
+        wire = self._wire(
+            proxy,
+            monkeypatch,
+            [self._RRset(1, 60, ["1.1.1.1", "2.2.2.2"])],
+        )
+        assert proxy.a_records_with_ttl(wire) == [
+            ("1.1.1.1", 60),
+            ("2.2.2.2", 60),
+        ]
+
+    def test_ttl_is_per_rrset(self, proxy, monkeypatch):
+        wire = self._wire(
+            proxy,
+            monkeypatch,
+            [
+                self._RRset(1, 300, ["1.1.1.1"]),
+                self._RRset(1, 30, ["2.2.2.2"]),
+            ],
+        )
+        assert proxy.a_records_with_ttl(wire) == [
+            ("1.1.1.1", 300),
+            ("2.2.2.2", 30),
+        ]
+
+    def test_cname_only_yields_no_a_records(self, proxy, monkeypatch):
+        wire = self._wire(proxy, monkeypatch, [self._RRset(5, 60, [])])
+        assert proxy.a_records_with_ttl(wire) == []
+
+
 class TestRespondAllowedSwallowsFailures:
     """#2278: a transient failure in allow or sendto must drop only the one
     response, not kill the proxy (an escaped raise would take down PID 1,


### PR DESCRIPTION
## Summary

Test-only. Adds a focused `TestARecordsWithTtl` class to
`src/klangk/klangkd-tests/tests/test_proxy.py` that drives the sidecar DNS
proxy's `a_records_with_ttl` directly, pinning the CNAME-chain extraction
that #2279 is about.

## Context

`proxy.py:a_records_with_ttl` walks a DNS response's answer section
**transparently across CNAME chains** — the bounded widening risk
documented in `docs/features/egress-filtering.md` (#2279): an allow-listed
domain that CNAMEs to an attacker-controlled (or shared-CDN) host has that
host's A record learned, scoped to the declared port + TTL by #2256.

The existing `test_proxy.py` covered `ports_for` (port scoping) and
`sweep_once` (TTL expiry) thoroughly, but `a_records_with_ttl` was only ever
**stubbed** (the harness stubs dnspython, a sidecar-only dep). This PR drives
it directly by monkeypatching `dns.message.from_wire` with a fake answer
containing CNAME + A rrsets, pinning:

- A records reached via a CNAME chain are extracted (the core #2279 behavior);
- the queried name's own A **and** the CNAME target's A are both learned
  (the widening — two IPs for one query);
- multiple A records in one rrset;
- TTL is per-rrset;
- a CNAME-only answer yields no A records.

#2279's substantive concern (no port/TTL scoping) was fixed by #2292, and the
feature-docs caveat is accurate and references #2279; the harder fix
(validate CNAME targets against the allow-list) is impractical — it would
break legitimate CDN resolution. This PR pins the residual, documented
behavior so a refactor can't silently change which records are learned.

## Verification

- `test_proxy.py`: 39 passed (5 new).
- Full suite, the CI way: **4355 passed, 100% coverage** (`-n auto`).
- pre-commit clean (ruff auto-formatted; re-verified).
