### PR TITLE
feat(container): correlate workspace + sidecar, findable by name (#2286)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -448,6 +448,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Stopping a workspace now tears down its network sidecar even when the
+  workspace isn't tracked in the in-memory registry (#2286).** A workspace
+  started by autostart or a prior klangkd session, then stopped from the TUI
+  (or `/stop`, `/delete`, `/restart`), previously left its network sidecar
+  running until the next start or the startup reaper. The stop path now takes
+  the workspace id directly from the endpoint and removes the sidecar by label.
+
 - **Network sidecar: filtered workspaces can host apps again (#2267).** A
   filtered workspace shares the network sidecar's netns, so `--publish` on the
   workspace itself was silently discarded by podman and configured host ports

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -268,6 +268,20 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Workspace + network sidecar container names and labels (#2286).** A
+  workspace and its network sidecar now share a `klangk.workspace=<id>` label
+  (plus `klangk.role=workspace|network-sidecar`) so one
+  `podman ps --filter label=klangk.workspace=<id>` returns the pair, and both
+  container names embed the slugified workspace name + a shared
+  `workspace_id[:8]` tail so `podman ps | grep <partial-name>` finds both.
+  This **renames** the old write-only labels `klangk.workspace-id` and
+  `klangk.network-sidecar` (never read by production) to the shared
+  `klangk.workspace` key. Container names/labels are immutable post-create, so
+  a renamed workspace shows its old slug until the container restarts;
+  correlation via `klangk.workspace` is unaffected (the id never changes).
+  Sidecar removal is now label-based (not by name), making it robust to renames
+  and process restarts.
+
 - **Egress filtering enforcement moved into the network sidecar (#2255).**
   The per-workspace egress ruleset — default-deny OUTPUT, loopback,
   established, the DNS REDIRECT + FQDN proxy, static CIDR allows, the
@@ -485,7 +499,7 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 - **Per-workspace egress filtering now actually fires on rootless podman
   (#1365).** The OCI hook ran at the `createContainer` stage but drove
   iptables through `nsenter` on the init pid — at that stage the hook is
-  _already_ inside the container network namespace (and pid is 0), so no
+  already inside the container network namespace (and pid is 0), so no
   rules were installed and filtered workspaces ran unrestricted. The hook
   now calls `iptables`/`ip6tables` directly. (The former
   `sysctl net.ipv6.conf.*.disable_ipv6=1` was dropped — at createContainer

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -269,18 +269,15 @@ operators or integrators to act when upgrading.
 ### Changed
 
 - **Workspace + network sidecar container names and labels (#2286).** A
-  workspace and its network sidecar now share a `klangk.workspace=<id>` label
-  (plus `klangk.role=workspace|network-sidecar`) so one
-  `podman ps --filter label=klangk.workspace=<id>` returns the pair, and both
-  container names embed the slugified workspace name + a shared
-  `workspace_id[:8]` tail so `podman ps | grep <partial-name>` finds both.
-  This **renames** the old write-only labels `klangk.workspace-id` and
-  `klangk.network-sidecar` (never read by production) to the shared
-  `klangk.workspace` key. Container names/labels are immutable post-create, so
-  a renamed workspace shows its old slug until the container restarts;
-  correlation via `klangk.workspace` is unaffected (the id never changes).
-  Sidecar removal is now label-based (not by name), making it robust to renames
-  and process restarts.
+  workspace and its network sidecar now share a `klangk.workspace=<id>` +
+  `klangk.role` label (so one `podman ps --filter label=klangk.workspace=<id>`
+  returns the pair), and both container names embed the slugified workspace name
+  on a shared `id[:8]` tail so `podman ps | grep <partial-name>` finds both.
+  This renames the old write-only labels `klangk.workspace-id` /
+  `klangk.network-sidecar` to the shared key, and sidecar removal is now
+  label-based (robust to renames/restarts). A renamed workspace keeps its old
+  slug until the container restarts; correlation via `klangk.workspace` is
+  unaffected.
 
 - **Egress filtering enforcement moved into the network sidecar (#2255).**
   The per-workspace egress ruleset — default-deny OUTPUT, loopback,

--- a/scripts/run-pi-container.sh
+++ b/scripts/run-pi-container.sh
@@ -15,7 +15,7 @@ docker run -it --rm \
   --name "klangk-test-container" \
   --label "klangk.managed=true" \
   --label "klangk.instance=default" \
-  --label "klangk.workspace-id=$WORKSPACE_ID" \
+  --label "klangk.workspace=$WORKSPACE_ID" \
   --read-only \
   --tmpfs /tmp:rw,noexec,nosuid,size=256m \
   --tmpfs /run:rw,noexec,nosuid,size=16m \

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -426,7 +426,7 @@ function podmanEnv(): NodeJS.ProcessEnv {
 export function dockerContainersForWorkspace(workspaceId: string): string[] {
   const podman = process.env.KLANGKD_PODMAN_BIN || "podman";
   const output = execSync(
-    `${podman} ps --filter "label=klangk.workspace=${workspaceId}" --format "{{.ID}}"`,
+    `${podman} ps --filter "label=klangk.workspace=${workspaceId}" --filter "label=klangk.role=workspace" --format "{{.ID}}"`,
     { encoding: "utf-8", env: podmanEnv() },
   );
   return output.trim().split("\n").filter(Boolean);

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -426,7 +426,7 @@ function podmanEnv(): NodeJS.ProcessEnv {
 export function dockerContainersForWorkspace(workspaceId: string): string[] {
   const podman = process.env.KLANGKD_PODMAN_BIN || "podman";
   const output = execSync(
-    `${podman} ps --filter "label=klangk.workspace-id=${workspaceId}" --format "{{.ID}}"`,
+    `${podman} ps --filter "label=klangk.workspace=${workspaceId}" --format "{{.ID}}"`,
     { encoding: "utf-8", env: podmanEnv() },
   );
   return output.trim().split("\n").filter(Boolean);

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -480,7 +480,9 @@ async def delete_workspace(
     # shared state; the agent subprocess runs inside the container, so
     # stopping the container kills it either way.
     if cid:
-        await app.state.container_registry.stop_and_remove_container(cid)
+        await app.state.container_registry.stop_and_remove_container(
+            cid, workspace_id=workspace_id
+        )
     await wshandler.reset_workspace_state(app.state.sockets, workspace_id)
 
     deleted = await app.state.workspaces.delete_workspace(
@@ -525,7 +527,9 @@ async def restart_workspace(
         else workspace.get("container_id")
     )
     if cid:
-        await app.state.container_registry.stop_and_remove_container(cid)
+        await app.state.container_registry.stop_and_remove_container(
+            cid, workspace_id=workspace_id
+        )
     await wshandler.reset_workspace_state(app.state.sockets, workspace_id)
     # Start a fresh container; the service command fires via the
     # create choke point in start_container.
@@ -559,7 +563,9 @@ async def stop_workspace(
         await app.state.container_registry.notify_workspace_killed(
             workspace_id
         )
-        await app.state.container_registry.stop_and_remove_container(cid)
+        await app.state.container_registry.stop_and_remove_container(
+            cid, workspace_id=workspace_id
+        )
         # Notify live WS viewers that the container was stopped on purpose
         # so the UI shows "stopped" rather than "disconnected" (re-homed
         # from the retired WS ``shutdown_container`` handler). Only when a

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import re
 import time
 
 from . import podman
@@ -41,6 +42,20 @@ _NETWORK_SIDECAR_READY_TOKEN = "dns-proxy listening"
 # sidecar via KLANGKNETWORK_EGRESS_MARK so proxy.py and entrypoint.sh (which
 # both default to 75) can't diverge (#2282).
 _NETWORK_SIDECAR_MARK = 75
+
+
+def _workspace_name_slug(name: str, *, limit: int = 24) -> str:
+    """Sanitize a workspace name for embedding in a container name (#2286).
+
+    Podman container names must match ``[a-zA-Z0-9][a-zA-Z0-9_.-]*``. Lowercase,
+    collapse runs of non-``[a-z0-9]`` to a single ``-``, trim the ends, and cap
+    the length. Returns ``""`` for names that reduce to nothing (empty,
+    all-symbols) — callers fall back to an id-only name. The slug is decorative:
+    uniqueness always comes from the instance id + workspace id, never the slug.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", (name or "").lower().strip())
+    return slug[:limit].strip("-")
+
 
 _VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
 
@@ -1107,8 +1122,18 @@ class ContainerRegistry:
             self.app.state.settings.network_sidecar_image
         )
 
-    def _network_sidecar_name(self, workspace_id: str) -> str:
-        """Derive the network sidecar name from the workspace ID (#2254)."""
+    def _network_sidecar_name(self, workspace_id: str, slug: str = "") -> str:
+        """Derive the network sidecar name (#2254, #2286).
+
+        Carries the slugified workspace name (when there is one) so
+        ``podman ps | grep <partial-name>`` surfaces the sidecar next to its
+        workspace, and uses the same ``workspace_id[:8]`` tail as the workspace
+        container name so an id-prefix grep matches the pair. Removal is by the
+        ``klangk.workspace`` label (see :meth:`_remove_network_sidecar`), not by
+        name — so a stale slug (after a rename) can't strand an orphan.
+        """
+        if slug:
+            return f"klangk-net-{slug}-{workspace_id[:8]}"
         return f"klangk-net-{workspace_id[:8]}"
 
     async def _start_network_sidecar(
@@ -1117,6 +1142,7 @@ class ContainerRegistry:
         allowed_domains: list[str],
         egress_mode: str = "static",
         publish: list[tuple[int, int]] | None = None,
+        slug: str = "",
     ) -> str:
         """Create + start the FQDN network sidecar for a filtered workspace (#2254).
 
@@ -1138,7 +1164,7 @@ class ContainerRegistry:
             raise podman.PodmanError(
                 500, "network_sidecar_image is not configured"
             )
-        name = self._network_sidecar_name(workspace_id)
+        name = self._network_sidecar_name(workspace_id, slug)
         # Pick an upstream that differs from the REDIRECT target (1.1.1.1).
         nf = getattr(self.app.state, "netfilter", None)
         resolvers = nf.resolvers() if nf else []
@@ -1167,19 +1193,25 @@ class ContainerRegistry:
         # containers get (#2254 review).
         labels = {
             "klangk.instance": self.app.state.util.instance_id(),
-            "klangk.network-sidecar": workspace_id,
+            # #2286: a shared klangk.workspace label + a klangk.role label let
+            # one `podman ps --filter label=klangk.workspace=<id>` correlate
+            # the sidecar with its workspace; the slug is mirrored for
+            # exact-match filtering. (Supersedes the old write-only
+            # klangk.network-sidecar.)
+            "klangk.workspace": workspace_id,
+            "klangk.role": "network-sidecar",
+            "klangk.workspace-name": slug,
         }
-        # #2265: a same-named sidecar from a prior generation may linger
-        # (an unclean stop, or the workspace container was killed externally
-        # so stop_and_remove_container never ran for it). The sidecar name is
-        # deterministic per workspace, so create_container would collide and
-        # the caller would fail-closed. Idempotently clear any existing
-        # same-named container first; the instance reaper is the backstop for
-        # orphans, but this keeps a restart from deadlocking on a stale name.
-        try:
-            await self.app.state.podman.remove_container(name, force=True)
-        except podman.PodmanError:
-            pass  # no existing sidecar to clear — expected on a fresh start
+        # #2265: a sidecar from a prior generation may linger (an unclean
+        # stop, or the workspace container was killed externally so
+        # stop_and_remove_container never ran for it). Clear it before create
+        # so create_container doesn't collide and the caller doesn't
+        # fail-closed. Removal is by the klangk.workspace label (#2286), not
+        # the name — the name now carries the workspace-name slug, which may
+        # differ from a prior generation's (a rename) and can't be
+        # reconstructed from the id alone. The instance reaper is the
+        # backstop for orphans; this just keeps a restart from deadlocking.
+        await self._remove_network_sidecar(workspace_id)
         try:
             cid = await self.app.state.podman.create_container(
                 name,
@@ -1237,15 +1269,57 @@ class ContainerRegistry:
             raise
 
     async def _stop_network_sidecar(self, workspace_id: str) -> None:
-        """Best-effort remove the network sidecar for a workspace (#2254)."""
+        """Best-effort remove the network sidecar for a workspace (#2254, #2286).
+
+        Delegates to :meth:`_remove_network_sidecar` (label-based) so a sidecar
+        whose name carries a now-stale slug (a renamed or deleted workspace) is
+        still found and removed.
+        """
         if not self._network_sidecar_enabled():
             return
-        name = self._network_sidecar_name(workspace_id)
+        await self._remove_network_sidecar(workspace_id)
+
+    async def _remove_network_sidecar(self, workspace_id: str) -> None:
+        """Best-effort remove this workspace's network sidecar by label (#2286).
+
+        Keyed on ``klangk.workspace=<workspace_id>`` +
+        ``klangk.role=network-sidecar`` rather than the container name: the name
+        now carries the slugified workspace name, which can't be reconstructed
+        from the id alone after a rename, a delete (cascade), or a process
+        restart (the in-memory set is gone). Label-based removal finds the
+        sidecar regardless, leaves the workspace container (role=workspace)
+        untouched, and is 404-tolerant.
+        """
         try:
-            await self.app.state.podman.remove_container(name, force=True)
-            logger.info("network sidecar removed: %s", name)
-        except podman.PodmanError:
-            pass  # network sidecar may not exist (or already removed)
+            containers = await self.app.state.podman.list_containers(
+                f"klangk.workspace={workspace_id}"
+            )
+        except (podman.PodmanError, OSError) as exc:
+            logger.warning(
+                "cannot list containers to remove network sidecar for %s: %s",
+                workspace_id[:8],
+                exc,
+            )
+            return
+        for c in containers:
+            labels = c.get("Labels") or {}
+            if labels.get("klangk.role") != "network-sidecar":
+                continue
+            ident = c.get("Id") or c.get("ID") or ""
+            if not ident:
+                names = c.get("Names") or []
+                ident = names[0] if names else ""
+            if not ident:
+                continue
+            try:
+                await self.app.state.podman.remove_container(ident, force=True)
+                logger.info(
+                    "network sidecar removed for %s: %s",
+                    workspace_id[:8],
+                    ident[:12],
+                )
+            except podman.PodmanError:
+                pass  # already gone — expected
 
     async def start_container(
         self,
@@ -1832,7 +1906,20 @@ class ContainerRegistry:
             for i, host_port in enumerate(host_ports)
         ]
         iid = self.app.state.util.instance_id()
-        container_name = f"klangk-{iid}-{workspace_id[:12]}"
+        # #2286: embed the slugified workspace name in the container + sidecar
+        # names so `podman ps | grep <partial-name>` finds a workspace and its
+        # sidecar together. The slug is decorative (uniqueness is iid + id); a
+        # missing/empty name falls back to an id-only name. Both names use the
+        # same workspace_id[:8] tail so an id-prefix grep matches the pair.
+        ws_row = await self.app.state.model.workspaces.get_workspace_by_id(
+            workspace_id
+        )
+        slug = _workspace_name_slug((ws_row or {}).get("name") or "")
+        container_name = (
+            f"klangk-{iid}-{slug}-{workspace_id[:8]}"
+            if slug
+            else f"klangk-{iid}-{workspace_id[:8]}"
+        )
         allow_sudo = self.app.state.settings.allow_sudo.strip().lower() in (
             "1",
             "true",
@@ -1843,7 +1930,13 @@ class ContainerRegistry:
             labels={
                 "klangk.managed": "true",
                 "klangk.instance": iid,
-                "klangk.workspace-id": workspace_id,
+                # #2286: shared label + role so one `podman ps --filter
+                # label=klangk.workspace=<id>` correlates the workspace with its
+                # network sidecar; the slug mirrors the name for exact-match
+                # filtering. (Supersedes the old write-only klangk.workspace-id.)
+                "klangk.workspace": workspace_id,
+                "klangk.role": "workspace",
+                "klangk.workspace-name": slug,
             },
             binds=binds,
             tmpfs={
@@ -1912,7 +2005,11 @@ class ContainerRegistry:
                     "keep-id:uid=1000,gid=1000) or clear allowed_domains.",
                 )
             network_sidecar_id = await self._start_network_sidecar(
-                workspace_id, allowed_domains, egress_mode, publish=publish
+                workspace_id,
+                allowed_domains,
+                egress_mode,
+                publish=publish,
+                slug=slug,
             )
             create_kwargs["network"] = f"container:{network_sidecar_id}"
             # --dns/--dns-search, --add-host, and --publish are all invalid

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -2162,7 +2162,9 @@ class ContainerRegistry:
         )
         return container_id, "created"
 
-    async def stop_and_remove_container(self, container_id: str) -> None:
+    async def stop_and_remove_container(
+        self, container_id: str, workspace_id: str | None = None
+    ) -> None:
         """Stop and remove a container.
 
         The slow ``self.app.state.podman.remove_container`` call for the
@@ -2172,10 +2174,14 @@ class ContainerRegistry:
         :meth:`start_container` uses -- so a concurrent start for the same
         workspace cannot observe a half-cleaned registry (#1258) and cannot
         have its freshly-started sidecar removed out from under it (#2265).
-        Under the lock we re-check that ``container_id`` still maps to this
-        workspace: a racing ``start_container`` may already have re-bound
-        the workspace to a fresh container, in which case we must not tear
-        down the new state (or revoke its browsers, or remove its sidecar).
+        Under the lock we re-check (via the live registry state) that this is
+        still the workspace's container: a racing ``start_container`` may
+        already have re-bound the workspace to a fresh container, in which case
+        we must not tear down the new state (or revoke its browsers, or remove
+        its sidecar). ``workspace_id`` lets a caller that knows the workspace
+        (the /stop, /delete endpoints) supply it directly, so a container
+        started by autostart or a prior klangkd session -- not in the in-memory
+        registry -- still gets its network sidecar torn down on stop (#2286).
 
         The per-workspace lock entry is deliberately *not* popped. Popping
         it while another coroutine is waiting on (or holding) that exact
@@ -2194,26 +2200,29 @@ class ContainerRegistry:
                 container_id,
                 e,
             )
-        ws_id = self._cid_to_wsid.get(container_id)
+        # The caller (/stop, /delete) knows the workspace_id even when this
+        # container isn't tracked in the in-memory registry (started by autostart
+        # or a prior klangkd session, stopped without a connect in this process).
+        ws_id = workspace_id or self._cid_to_wsid.get(container_id)
         if ws_id:
             async with self._get_workspace_lock(ws_id):
-                # Re-verify under the lock: a racing start_container may
-                # have re-bound this workspace to a new container while we
-                # waited for the lock. Only tear down state we still own.
-                # The re-verify now also guards the network sidecar teardown
-                # (#2265): a racing start that re-bound the workspace owns a
-                # fresh sidecar generation, so this (old) stop must not remove
-                # it -- doing so would leave the new container joined to a
-                # removed netns. The sidecar teardown runs under the lock for
-                # the same reason start holds it for sidecar I/O: the two must
-                # not interleave on the network sidecar's netns lifecycle.
-                if self._cid_to_wsid.get(container_id) == ws_id:
-                    # Remove the network sidecar only if this workspace
-                    # actually started one, so a non-filtered workspace stop
-                    # doesn't fire a speculative remove (#2254).
-                    if ws_id in self._ws_with_network_sidecar:
-                        self._ws_with_network_sidecar.discard(ws_id)
-                        await self._stop_network_sidecar(ws_id)
+                # Re-verify under the lock: a racing start_container may have
+                # re-bound this workspace to a new container while we waited.
+                # Only tear down state we still own. The check uses the live
+                # registry state (not the reverse cid map) so it can tell a
+                # re-bound workspace (state's container_id differs -- leave the
+                # fresh sidecar generation alone, #2265) from an untracked one
+                # (no state -- no racing start possible, so its sidecar is safe
+                # to remove by label even though it isn't in the in-memory set).
+                current = self.states.get(ws_id)
+                if current is None or current.container_id == container_id:
+                    # Remove the network sidecar (label-based, idempotent -- a
+                    # no-op for non-filtered workspaces or when egress is
+                    # disabled). Done for every non-rebound stop so a sidecar
+                    # started by autostart / a prior session is cleaned up even
+                    # if it isn't tracked in _ws_with_network_sidecar (#2286).
+                    self._ws_with_network_sidecar.discard(ws_id)
+                    await self._stop_network_sidecar(ws_id)
                     self._cid_to_wsid.pop(container_id, None)
                     self.revoke_workspace_browsers(ws_id)
                     self.states.pop(ws_id, None)
@@ -2256,7 +2265,9 @@ class ContainerRegistry:
         for ws in workspaces:
             if ws["container_id"]:
                 await self.notify_workspace_killed(ws["id"])
-                await self.stop_and_remove_container(ws["container_id"])
+                await self.stop_and_remove_container(
+                    ws["container_id"], workspace_id=ws["id"]
+                )
 
     # --- Pre-warm ---
 

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -57,6 +57,19 @@ def _workspace_name_slug(name: str, *, limit: int = 24) -> str:
     return slug[:limit].strip("-")
 
 
+def _workspace_container_name(iid: str, workspace_id: str, slug: str) -> str:
+    """The workspace container name: iid + slugified name + id[:8] (#2286).
+
+    Falls back to an id-only name when the slug is empty (all-symbol / missing
+    name). Uniqueness is iid + id; the slug is decorative. The network sidecar
+    name (:meth:`ContainerRegistry._network_sidecar_name`) shares the id[:8]
+    tail so an id-prefix grep matches the pair.
+    """
+    if slug:
+        return f"klangk-{iid}-{slug}-{workspace_id[:8]}"
+    return f"klangk-{iid}-{workspace_id[:8]}"
+
+
 _VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
 
 _VALID_MOUNT_OPTIONS = {
@@ -1294,7 +1307,9 @@ class ContainerRegistry:
             containers = await self.app.state.podman.list_containers(
                 f"klangk.workspace={workspace_id}"
             )
-        except (podman.PodmanError, OSError) as exc:
+        except (podman.PodmanError, OSError, ValueError) as exc:
+            # ValueError: corrupted ps JSON (json.loads in list_containers) —
+            # best-effort removal must never raise into the caller.
             logger.warning(
                 "cannot list containers to remove network sidecar for %s: %s",
                 workspace_id[:8],
@@ -1915,11 +1930,7 @@ class ContainerRegistry:
             workspace_id
         )
         slug = _workspace_name_slug((ws_row or {}).get("name") or "")
-        container_name = (
-            f"klangk-{iid}-{slug}-{workspace_id[:8]}"
-            if slug
-            else f"klangk-{iid}-{workspace_id[:8]}"
-        )
+        container_name = _workspace_container_name(iid, workspace_id, slug)
         allow_sudo = self.app.state.settings.allow_sudo.strip().lower() in (
             "1",
             "true",
@@ -2195,7 +2206,7 @@ class ContainerRegistry:
                 # it -- doing so would leave the new container joined to a
                 # removed netns. The sidecar teardown runs under the lock for
                 # the same reason start holds it for sidecar I/O: the two must
-                # not interleave on the deterministic sidecar name.
+                # not interleave on the network sidecar's netns lifecycle.
                 if self._cid_to_wsid.get(container_id) == ws_id:
                     # Remove the network sidecar only if this workspace
                     # actually started one, so a non-filtered workspace stop

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -437,7 +437,10 @@ class Connection:
         )
         status = getattr(self, "container_status", "created")
         container_name, ports_str = format_container_info(
-            workspace_id, ports, self.app.state.util.instance_id()
+            workspace_id,
+            ports,
+            self.app.state.util.instance_id(),
+            (self.workspace or {}).get("name") or "",
         )
         status_msg = {
             "connected": f"Connected to running container "
@@ -539,7 +542,10 @@ class Connection:
             workspace_id
         )
         container_name, ports_str = format_container_info(
-            workspace_id, ports, self.app.state.util.instance_id()
+            workspace_id,
+            ports,
+            self.app.state.util.instance_id(),
+            (self.workspace or {}).get("name") or "",
         )
         status_msg = f"Container restarted {container_name}{ports_str}"
 

--- a/src/klangk/klangk/wshandler/helpers.py
+++ b/src/klangk/klangk/wshandler/helpers.py
@@ -3,6 +3,7 @@
 import logging
 
 from .. import model
+from ..container import _workspace_container_name, _workspace_name_slug
 from .safe_websocket import SafeWebSocket
 from .constants import log_ws_msg
 from .session import WebSocketState
@@ -169,10 +170,16 @@ def format_idle_timeout(seconds: int | float) -> str:
 
 
 def format_container_info(
-    workspace_id: str, ports: list, instance_id: str
+    workspace_id: str, ports: list, instance_id: str, workspace_name: str = ""
 ) -> tuple[str, str]:
-    """Return (container_name, ports_str) for status messages."""
-    name = f"klangk-{instance_id}-{workspace_id[:12]}"
+    """Return (container_name, ports_str) for status messages.
+
+    The name mirrors the real container name (slugified workspace name +
+    id[:8], #2286) so an operator can ``podman ps | grep`` the name shown here
+    and find the container.
+    """
+    slug = _workspace_name_slug(workspace_name)
+    name = _workspace_container_name(instance_id, workspace_id, slug)
     ports_str = f" (ports {','.join(str(p) for p in ports)})" if ports else ""
     return name, ports_str
 

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1778,7 +1778,7 @@ class TestContainerReplace:
                     "--filter",
                     "label=klangk.instance=cli-e2e",
                     "--filter",
-                    "label=klangk.workspace-id",
+                    "label=klangk.workspace",
                     "--format",
                     "{{.ID}}",
                 ],

--- a/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
@@ -63,15 +63,6 @@ def server():
         LOGFIRE_TOKEN="",
     )
 
-    # Fetch auto-generated instance ID from the running server (used by
-    # _container_id_for_workspace for deterministic container-name lookups).
-    config_resp = server["client"].get("/api/v1/config", timeout=10)
-    server["instance_id"] = (
-        config_resp.json().get("instance_id", "")
-        if config_resp.status_code == 200
-        else ""
-    )
-
     yield server
 
     stop_server(server)
@@ -100,20 +91,24 @@ def _rm_containers(instance_id):
         )
 
 
-def _container_id_for_workspace(workspace_id, instance_id):
-    """Return the running container id for a specific workspace.
+def _container_id_for_workspace(workspace_id):
+    """Return the running workspace container id for a workspace.
 
-    The container name is deterministic (``klangk-{instance_id}-{ws[:12]}``),
-    so filtering by name targets the exact workspace -- never a stale
-    container left over from another test/run under the same instance.
+    Looked up by the ``klangk.workspace`` correlation label + ``role=workspace``
+    (#2286) rather than the container name: the name now carries the slugified
+    workspace name and uses ``id[:8]``, so reconstructing it is fragile, and
+    ``role=workspace`` excludes the network sidecar (which shares the label).
+    Targets the exact workspace -- never a stale container from another
+    test/run.
     """
-    name = f"klangk-{instance_id}-{workspace_id[:12]}"
     result = subprocess.run(
         [
             "podman",
             "ps",
             "--filter",
-            f"name=^{name}$",
+            f"label=klangk.workspace={workspace_id}",
+            "--filter",
+            "label=klangk.role=workspace",
             "-q",
         ],
         capture_output=True,
@@ -274,15 +269,13 @@ class TestAgentHomeE2E:
             # Wait for the eagerly-started container to be running.
             # create_workspace awaits start_workspace, so the
             # container is up by the time the POST returned; poll as a
-            # belt-and-suspenders against scheduling latency.  Filter by
-            # the deterministic container name so we target THIS
-            # workspace's container, never a stale one.
+            # belt-and-suspenders against scheduling latency.  Filter by the
+            # klangk.workspace label so we target THIS workspace's container,
+            # never a stale one.
             cids = []
             deadline = time.monotonic() + 60
             while time.monotonic() < deadline:
-                cids = _container_id_for_workspace(
-                    workspace_id, server["instance_id"]
-                )
+                cids = _container_id_for_workspace(workspace_id)
                 if cids:
                     break
                 time.sleep(0.5)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1968,7 +1968,9 @@ class TestWorkspaceRoutes:
             )
         assert resp.status_code == 200
         mock_stop_agent.assert_awaited_once_with(ws_id)
-        mock_rm.assert_awaited_once_with("fake-container-id")
+        mock_rm.assert_awaited_once_with(
+            "fake-container-id", workspace_id=ws_id
+        )
 
     async def test_delete_workspace_cleans_up_groups(
         self, client, app, user, registry, app_state
@@ -2087,7 +2089,7 @@ class TestWorkspaceRoutes:
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "restarted"
-        mock_stop.assert_awaited_once_with("cid-restart")
+        mock_stop.assert_awaited_once_with("cid-restart", workspace_id=ws_id)
         # #1244: restart re-starts the container (not just stop+remove),
         # so the service command re-fires at the create choke point and
         # the workspace recovers.
@@ -2148,7 +2150,7 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 200
         assert resp.json()["status"] == "stopped"
         mock_killed.assert_awaited_once_with(ws_id)
-        mock_stop.assert_awaited_once_with("cid-stop")
+        mock_stop.assert_awaited_once_with("cid-stop", workspace_id=ws_id)
         # REST /stop tears down the Pi RPC subprocess for the workspace
         # (via reset_workspace_state -> reset_workspace); lock the contract.
         mock_stop_session.assert_awaited_once_with(ws_id)

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -604,6 +604,31 @@ def _sudo_call(p):
     )
 
 
+class TestWorkspaceNameSlug:
+    """Pure-function tests for container._workspace_name_slug (#2286)."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("my-dev-env", "my-dev-env"),
+            ("My Cool WS", "my-cool-ws"),
+            ("  a__b!!c  ", "a-b-c"),
+            ("UPPER", "upper"),
+            ("a.b/c:d", "a-b-c-d"),
+            ("!!!---!!!", ""),
+            ("", ""),
+            ("x" * 40, "x" * 24),
+            ("café", "caf"),  # non-ascii collapses
+            ("name with   multiple   gaps", "name-with-multiple-gaps"),
+        ],
+    )
+    def test_slug(self, name, expected):
+        assert container._workspace_name_slug(name) == expected
+
+    def test_slug_none_is_empty(self):
+        assert container._workspace_name_slug(None) == ""
+
+
 class TestStartContainer:
     def setup_method(self):
         app_state = _make_app_state()
@@ -632,6 +657,94 @@ class TestStartContainer:
         assert "annotations" not in kwargs
         assert "hooks_dir" not in kwargs
         assert "cap_drop" not in kwargs
+
+    # --- #2286: correlation + human-readable names ---
+
+    async def test_workspace_container_name_includes_slug_and_labels(
+        self, workspace
+    ):
+        # #2286: the workspace container name carries the slugified workspace
+        # name (for `podman ps | grep <partial-name>`) and a shared
+        # klangk.workspace + klangk.role=workspace label (for correlation with
+        # the sidecar).
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        iid = self.registry.app.state.util.instance_id()
+        slug = container._workspace_name_slug(workspace["name"])
+        kwargs = p.create_container.call_args.kwargs
+        assert p.create_container.call_args.args[0] == (
+            f"klangk-{iid}-{slug}-{workspace['id'][:8]}"
+        )
+        assert kwargs["labels"]["klangk.workspace"] == workspace["id"]
+        assert kwargs["labels"]["klangk.role"] == "workspace"
+        assert kwargs["labels"]["klangk.workspace-name"] == slug
+
+    async def test_empty_workspace_name_falls_back_to_id_only_name(self, user):
+        # #2286: a name that slugifies to nothing (all symbols) falls back to
+        # an id-only name so the container is still valid + unique.
+        ws = await self.registry.app.state.model.workspaces.create_workspace(
+            user["id"], "!!!"
+        )
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                ws["id"], "/tmp/ws", "/tmp/home"
+            )
+        iid = self.registry.app.state.util.instance_id()
+        assert p.create_container.call_args.args[0] == (
+            f"klangk-{iid}-{ws['id'][:8]}"
+        )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["labels"]["klangk.workspace-name"] == ""
+
+    async def test_filtered_start_correlates_workspace_and_sidecar(
+        self, workspace, monkeypatch
+    ):
+        # #2286: a workspace and its sidecar share a klangk.workspace label,
+        # carry the same slug + workspace_id[:8] tail in their names (so a
+        # partial-name or id-prefix grep matches the pair), and are
+        # distinguishable by klangk.role.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, **kw})
+            return "net-cid" if name.startswith("klangk-net-") else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                allowed_domains=["github.com:443"],
+            )
+        assert len(creates) == 2
+        sidecar, ws_container = creates[0], creates[1]
+        iid = self.registry.app.state.util.instance_id()
+        slug = container._workspace_name_slug(workspace["name"])
+        tail = workspace["id"][:8]
+        # Both names carry the slug and the same id[:8] tail.
+        assert sidecar["name"] == f"klangk-net-{slug}-{tail}"
+        assert ws_container["name"] == f"klangk-{iid}-{slug}-{tail}"
+        # Shared correlation label + role distinction.
+        assert sidecar["labels"]["klangk.workspace"] == workspace["id"]
+        assert ws_container["labels"]["klangk.workspace"] == workspace["id"]
+        assert sidecar["labels"]["klangk.role"] == "network-sidecar"
+        assert ws_container["labels"]["klangk.role"] == "workspace"
+        assert sidecar["labels"]["klangk.workspace-name"] == slug
+        assert ws_container["labels"]["klangk.workspace-name"] == slug
 
     # --- #2254: FQDN network sidecar lifecycle ---
 
@@ -679,7 +792,10 @@ class TestStartContainer:
             kwargs["labels"]["klangk.instance"]
             == self.registry.app.state.util.instance_id()
         )
-        assert kwargs["labels"]["klangk.network-sidecar"] == ws_id
+        # #2286: shared klangk.workspace + role labels correlate the sidecar
+        # with its workspace (supersedes the old klangk.network-sidecar).
+        assert kwargs["labels"]["klangk.workspace"] == ws_id
+        assert kwargs["labels"]["klangk.role"] == "network-sidecar"
         p.start_container.assert_awaited_once_with("new-cid")
 
     async def test_start_network_sidecar_publishes_host_ports(
@@ -725,13 +841,14 @@ class TestStartContainer:
             )
         assert p.create_container.call_args.kwargs["publish"] is None
 
-    async def test_start_network_sidecar_clears_lingering_same_named(
+    async def test_start_network_sidecar_clears_lingering_by_label(
         self, monkeypatch
     ):
-        # #2265: _start_network_sidecar force-removes any same-named sidecar
-        # left by a prior generation before creating, so a restart (or an
-        # external kill that left the old sidecar running) does not collide
-        # on the deterministic name and fail-closed.
+        # #2265 + #2286: _start_network_sidecar removes any sidecar from a
+        # prior generation before creating, so a restart (or an external kill
+        # that left the old sidecar running) does not collide and fail-closed.
+        # Removal is by the klangk.workspace label + role=network-sidecar, so a
+        # sidecar whose name carries a now-stale slug (a rename) is still found.
         ws_id = "abcdef1234567890"
         monkeypatch.setattr(
             self.registry.app.state.settings,
@@ -741,24 +858,35 @@ class TestStartContainer:
         from klangk import netfilter as _nf
 
         monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
-        with patch_podman(self.registry) as p:
+        stale = {
+            "Id": "stale-cid",
+            "Names": ["klangk-net-oldslug-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            self.registry, list_containers=AsyncMock(return_value=[stale])
+        ) as p:
             await self.registry._start_network_sidecar(
                 ws_id, ["github.com:443"]
             )
-        sidecar_name = self.registry._network_sidecar_name(ws_id)
-        # The lingering same-named sidecar is force-removed before the create.
-        assert p.remove_container.await_args_list[0].args == (sidecar_name,)
+        # The stale sidecar is found by label and removed by id (not by the
+        # stale-slug name) before the create.
+        p.list_containers.assert_awaited_with(f"klangk.workspace={ws_id}")
+        assert p.remove_container.await_args_list[0].args == ("stale-cid",)
         assert p.remove_container.await_args_list[0].kwargs == {"force": True}
         # And the fresh sidecar is still created + started.
         assert p.create_container.await_count == 1
-        assert p.create_container.call_args.args[0] == sidecar_name
 
     async def test_start_network_sidecar_ignores_force_remove_error(
         self, monkeypatch
     ):
-        # #2265: the pre-create force-remove of a lingering same-named sidecar
-        # is best-effort -- if it errors (the name is already gone, or podman
-        # hiccups), the except swallows it and the create proceeds normally.
+        # #2265 + #2286: the pre-create removal of a lingering sidecar is
+        # best-effort -- if the per-container remove errors (the id is already
+        # gone, or podman hiccups), _remove_network_sidecar swallows it and
+        # the create proceeds normally.
         ws_id = "abcdef1234567890"
         monkeypatch.setattr(
             self.registry.app.state.settings,
@@ -768,8 +896,17 @@ class TestStartContainer:
         from klangk import netfilter as _nf
 
         monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
+        stale = {
+            "Id": "stale-cid",
+            "Names": ["klangk-net-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
         with patch_podman(
             self.registry,
+            list_containers=AsyncMock(return_value=[stale]),
             remove_container=AsyncMock(
                 side_effect=podman.PodmanError(500, "not found")
             ),
@@ -814,17 +951,43 @@ class TestStartContainer:
                 "abcd1234", ["github.com:443"]
             )
 
-    async def test_stop_network_sidecar_removes_by_name(self, monkeypatch):
+    async def test_stop_network_sidecar_removes_by_label(self, monkeypatch):
+        # #2286: stop removes the sidecar by its klangk.workspace label +
+        # role=network-sidecar, leaving the workspace container alone and
+        # working even when the sidecar's name carries a stale slug.
+        ws_id = "abcdef1234567890"
         monkeypatch.setattr(
             self.registry.app.state.settings,
             "network_sidecar_image",
             "img",
         )
-        with patch_podman(self.registry) as p:
-            await self.registry._stop_network_sidecar("abcdef12")
-        p.remove_container.assert_awaited_with(
-            "klangk-net-abcdef12", force=True
-        )
+        sidecar = {
+            "Id": "net-cid",
+            "Names": ["klangk-net-renamed-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        workspace_container = {
+            "Id": "ws-cid",
+            "Names": ["klangk-renamed-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[sidecar, workspace_container]
+            ),
+        ) as p:
+            await self.registry._stop_network_sidecar(ws_id)
+        p.list_containers.assert_awaited_with(f"klangk.workspace={ws_id}")
+        # Only the sidecar (by id) is removed; the workspace container is left
+        # for stop_and_remove_container's own remove call.
+        p.remove_container.assert_awaited_once_with("net-cid", force=True)
 
     async def test_stop_network_sidecar_noop_when_disabled(self, monkeypatch):
         monkeypatch.setattr(
@@ -853,6 +1016,36 @@ class TestStartContainer:
         assert "KLANGKNETWORK_EGRESS_MODE=interactive" in kwargs["env"]
 
     async def test_stop_network_sidecar_swallows_error(self, monkeypatch):
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "img",
+        )
+        sidecar = {
+            "Id": "net-cid",
+            "Names": ["klangk-net-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(return_value=[sidecar]),
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(500, "not found")
+            ),
+        ):
+            # The per-container remove error is swallowed (sidecar gone).
+            await self.registry._stop_network_sidecar(ws_id)
+
+    async def test_remove_network_sidecar_swallows_list_error(
+        self, monkeypatch
+    ):
+        # #2286: if list_containers itself errors (podman down), removal is
+        # best-effort: log + return, never raise, and never call remove.
+        ws_id = "abcdef1234567890"
         monkeypatch.setattr(
             self.registry.app.state.settings,
             "network_sidecar_image",
@@ -860,11 +1053,48 @@ class TestStartContainer:
         )
         with patch_podman(
             self.registry,
-            remove_container=AsyncMock(
-                side_effect=podman.PodmanError(500, "not found")
+            list_containers=AsyncMock(
+                side_effect=podman.PodmanError(500, "podman down")
             ),
-        ):
-            await self.registry._stop_network_sidecar("abcdef12")
+        ) as p:
+            await self.registry._remove_network_sidecar(ws_id)
+        p.remove_container.assert_not_awaited()
+
+    async def test_remove_network_sidecar_uses_name_when_no_id(
+        self, monkeypatch
+    ):
+        # #2286: a sidecar missing the Id/ID field is still removed by its
+        # (first) name; a sidecar with neither id nor name is skipped.
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "img",
+        )
+        no_id_with_name = {
+            "Names": ["klangk-net-slug-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        no_id_no_name = {
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[no_id_with_name, no_id_no_name]
+            ),
+        ) as p:
+            await self.registry._remove_network_sidecar(ws_id)
+        # The name-only entry is removed by its name; the empty entry skipped.
+        p.remove_container.assert_awaited_once_with(
+            "klangk-net-slug-abcdef12", force=True
+        )
 
     async def test_filtered_workspace_uses_network_sidecar_when_enabled(
         self, workspace, tmp_path, monkeypatch
@@ -1260,8 +1490,18 @@ class TestStartContainer:
                 return "net-cid"
             raise podman.PodmanError(500, "workspace image pull failed")
 
+        net_sidecar = {
+            "Id": "net-cid",
+            "Names": [f"klangk-net-{workspace['id'][:8]}"],
+            "Labels": {
+                "klangk.workspace": workspace["id"],
+                "klangk.role": "network-sidecar",
+            },
+        }
         with patch_podman(
-            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+            self.registry,
+            create_container=AsyncMock(side_effect=_fake_create),
+            list_containers=AsyncMock(return_value=[net_sidecar]),
         ) as p:
             with pytest.raises(podman.PodmanError):
                 await self.registry.start_container(
@@ -1270,9 +1510,9 @@ class TestStartContainer:
                     "/tmp/home",
                     allowed_domains=["github.com:443"],
                 )
-        # The sidecar was removed on the workspace-create failure.
-        expected_name = f"klangk-net-{workspace['id'][:8]}"
-        p.remove_container.assert_awaited_with(expected_name, force=True)
+        # #2286: the sidecar was removed (by label/id) on the workspace-create
+        # failure.
+        p.remove_container.assert_awaited_with("net-cid", force=True)
         # And the workspace is no longer tracked as having a live sidecar.
         assert workspace["id"] not in self.registry._ws_with_network_sidecar
 
@@ -2053,7 +2293,9 @@ class TestStartContainer:
         args, kwargs = p.create_container.call_args
         assert args[1] == self.registry.image_name
         assert kwargs["labels"]["klangk.managed"] == "true"
-        assert kwargs["labels"]["klangk.workspace-id"] == workspace["id"]
+        # #2286: shared label + role (supersedes klangk.workspace-id).
+        assert kwargs["labels"]["klangk.workspace"] == workspace["id"]
+        assert kwargs["labels"]["klangk.role"] == "workspace"
         assert kwargs["init"] is True
         assert kwargs["interactive"] is True
 
@@ -2907,13 +3149,23 @@ class TestStopContainer:
         )
         self.registry.track_activity("cid", "ws1234567890")
         self.registry._ws_with_network_sidecar.add("ws1234567890")
-        with patch_podman(self.registry) as p:
+        net_sidecar = {
+            "Id": "net-cid",
+            "Names": ["klangk-net-ws123456"],
+            "Labels": {
+                "klangk.workspace": "ws1234567890",
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(return_value=[net_sidecar]),
+        ) as p:
             await self.registry.stop_and_remove_container("cid")
         removes = [c.args[0] for c in p.remove_container.await_args_list]
         assert "cid" in removes  # the workspace container
-        assert (
-            "klangk-net-ws123456" in removes
-        )  # the network sidecar (<ws[:8]>)
+        # #2286: the sidecar is removed by id (label-based), not by name.
+        assert "net-cid" in removes
         assert "ws1234567890" not in self.registry._ws_with_network_sidecar
 
     async def test_stop_prunes_orphaned_service_session_locks(self):
@@ -3501,7 +3753,7 @@ class TestReapInstanceContainers:
                 return_value=[
                     {
                         "Id": "orphan-123",
-                        "Labels": {"klangk.workspace-id": "ws-orphan"},
+                        "Labels": {"klangk.workspace": "ws-orphan"},
                     }
                 ]
             ),
@@ -3555,7 +3807,7 @@ class TestReapInstanceContainers:
                 return_value=[
                     {
                         "Id": "orphan-bad",
-                        "Labels": {"klangk.workspace-id": "ws-bad"},
+                        "Labels": {"klangk.workspace": "ws-bad"},
                     }
                 ]
             ),

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -3138,10 +3138,9 @@ class TestStopContainer:
     async def test_stop_removes_network_sidecar_when_workspace_had_one(
         self, monkeypatch
     ):
-        # #2254: a workspace that started a network sidecar (tracked in
-        # _ws_with_network_sidecar) tears the network sidecar down on stop — named
-        # klangk-net-<ws[:8]>. A non-filtered workspace (not in the
-        # set) must NOT fire a speculative network sidecar remove.
+        # #2254: a workspace that started a network sidecar tears it down on
+        # stop (removed by label, #2286). A non-filtered workspace's stop calls
+        # _stop_network_sidecar too, but it's a no-op (no sidecar found).
         monkeypatch.setattr(
             self.registry.app.state.settings,
             "network_sidecar_image",
@@ -3167,6 +3166,43 @@ class TestStopContainer:
         # #2286: the sidecar is removed by id (label-based), not by name.
         assert "net-cid" in removes
         assert "ws1234567890" not in self.registry._ws_with_network_sidecar
+
+    async def test_stop_tears_down_sidecar_for_untracked_workspace(
+        self, monkeypatch
+    ):
+        # #2286 follow-up: a workspace started by autostart or a prior klangkd
+        # session isn't in the in-memory registry (_cid_to_wsid / states). When
+        # /stop stops it (passing workspace_id), the sidecar must still be torn
+        # down -- previously it leaked until the next start's clear-on-start or
+        # the startup reaper. (Reproduces the TUI-stop-doesn't-stop-sidecar bug.)
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        net_sidecar = {
+            "Id": "net-cid",
+            "Names": [f"klangk-net-{ws_id[:8]}"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        # NOTE: no track_activity -> not in _cid_to_wsid / states (untracked),
+        # mirroring a workspace started outside this process.
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(return_value=[net_sidecar]),
+        ) as p:
+            await self.registry.stop_and_remove_container(
+                "cid-from-db", workspace_id=ws_id
+            )
+        removes = [c.args[0] for c in p.remove_container.await_args_list]
+        # The workspace container is removed ...
+        assert "cid-from-db" in removes
+        # ... and so is the sidecar, found by label despite no in-memory tracking.
+        assert "net-cid" in removes
 
     async def test_stop_prunes_orphaned_service_session_locks(self):
         # stop_and_remove_container sweeps the per-container service-firing

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -11067,3 +11067,37 @@ class TestTokenRenewalFailureLogged:
                 await task
             except asyncio.CancelledError:
                 pass
+
+
+class TestFormatContainerInfo:
+    """format_container_info must mirror the real container name (#2286).
+
+    The status-message name is what users see and grep in `podman ps`, so it
+    must equal what container.py stamps on the container.
+    """
+
+    def test_named_workspace_matches_real_container_name(self):
+        from klangk.container import (
+            _workspace_container_name,
+            _workspace_name_slug,
+        )
+        from klangk.wshandler import format_container_info
+
+        ws_id = "abcdef1234567890"
+        iid = "inst1"
+        name, ports_str = format_container_info(
+            ws_id, [9000, 9001], iid, "My Dev Env"
+        )
+        slug = _workspace_name_slug("My Dev Env")
+        assert name == _workspace_container_name(iid, ws_id, slug)
+        assert name == f"klangk-{iid}-{slug}-{ws_id[:8]}"
+        assert ports_str == " (ports 9000,9001)"
+
+    def test_symbol_only_name_falls_back_to_id_only(self):
+        from klangk.wshandler import format_container_info
+
+        ws_id = "abcdef1234567890"
+        iid = "inst1"
+        name, ports_str = format_container_info(ws_id, [], iid, "!!!")
+        assert name == f"klangk-{iid}-{ws_id[:8]}"
+        assert ports_str == ""


### PR DESCRIPTION
## What

Make a workspace container and its network sidecar correlate under one label
query and be findable in `podman ps` by partial workspace name (#2286).

## Changes

1. **Shared correlation label.** Both containers now carry `klangk.workspace=<id>`
   (full id) + `klangk.role=workspace|network-sidecar`. One
   `podman ps --filter label=klangk.workspace=<id>` returns the pair. This
   **renames** the old write-only labels `klangk.workspace-id` and
   `klangk.network-sidecar` (never read by production — only asserted in tests;
   the reaper keys off `klangk.instance`, unchanged).

2. **Consistent truncation.** Both names now use `workspace_id[:8]` (the
   workspace container dropped `[:12]`), so an id-prefix `grep` matches the pair.

3. **Human-readable names.** Both names embed the slugified workspace name:
   - workspace: `klangk-{iid}-{slug}-{id[:8]}`
   - sidecar:   `klangk-net-{slug}-{id[:8]}`

   so `podman ps | grep my-dev-env` surfaces both. The slug is sanitized
   (lowercase, `[a-z0-9-]`, capped at 24 chars); empty/garbage names fall back
   to an id-only name. Uniqueness is unchanged (still `iid` + `id[:8]`).

4. **Label-based sidecar removal.** Because the sidecar name now depends on the
   (possibly-stale) workspace name, `_stop_network_sidecar` and the `#2265`
   clear-on-start no longer reconstruct the name — they find the sidecar by
   `klangk.workspace=<id>` + `role=network-sidecar` and remove it by id. This is
   independently more robust: a sidecar left after a rename, a workspace delete
   (cascade), or a process restart (empty in-memory set) is still found, since
   the label persists on the container.

## Caveat

Container names and labels are immutable post-create, so a **renamed** workspace
shows its old slug until the container restarts (recreate). Correlation via
`klangk.workspace=<id>` never goes stale (the id is immutable).

## Backward compat

Safe. The renamed labels were never read by production code. Old running
containers (pre-upgrade) are still reaped via `klangk.instance`; new containers
pick up the new labels on next start.

## Tests

- New `TestWorkspaceNameSlug` (parametrized sanitization + empty/None).
- Slug flows into both names via a filtered start; shared label + role on both;
  consistent `id[:8]` tail; empty-name → id-only fallback.
- Label-based removal: finds sidecar by id, leaves the workspace container, is
  404-tolerant, swallows `list_containers` errors, falls back to `Names[0]`
  when `Id` is absent, skips entries with neither.
- Updated the prior name-based removal tests + the 4 stale label assertions
  (`test_container.py`, `test_cli_e2e.py`, frontend `helpers.ts`).
- Full suite: `klangkd-tests` + `klangkc-tests`, **100% coverage**, 4371 pass.

Closes #2286.
