### PR TITLE
feat(consent): sidecar NFQUEUE observer + EgressConsentMonitor (#2242)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -242,6 +242,15 @@ in
   scripts.push-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/push-base-image.sh" "$@"'';
   scripts.build-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-base-image.sh" "$@"'';
   scripts.build-host-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-host-image.sh" "$@"'';
+  # Live, rich-rendered view of a workspace's egress-consent history (#2242).
+  # The dev klangkd's DB (klangk.db) lives under $dataDir.
+  scripts.consent-watch.exec = ''
+    exec python3 "$DEVENV_ROOT/scripts/consent-watch.py" --data-dir "${dataDir}" "$@"
+  '';
+  # Interactive accept/deny of a workspace's pending consent requests (#2242).
+  scripts.consent-decide.exec = ''
+    exec python3 "$DEVENV_ROOT/scripts/consent-decide.py" --data-dir "${dataDir}" "$@"
+  '';
   scripts.trivy-host.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-host.sh" "$@"'';
   scripts.trivy-workspace.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-workspace.sh" "$@"'';
   scripts.trivy-workspace-report.exec = ''

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,27 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Egress consent recording (#2242).** The network sidecar records every
+  blocked destination to the `egress_consent` table: for **static**
+  workspaces (the default) as `denied` with no human (`decided_by` NULL),
+  immediately; for **interactive** workspaces as a `pending` request a
+  human can allow/deny via the consent UI (#2244, not yet wired) before it
+  auto-expires (`egress_consent_timeout`, default 30s; rate-limited per
+  workspace via `egress_consent_rate_limit`, default 50). The sidecar
+  consumes its own NFQUEUE (`-j NFQUEUE --queue-num 5139`; it is the netns
+  owner with `NET_ADMIN`) and POSTs each blocked packet's destination to
+  klangkd's consent endpoint (workspace-JWT-authenticated via Caddy's
+  forward_auth); it also forwards denied DNS queries with their domain
+  names (NFQUEUE only carries raw IPs). Static mode is now strictly better
+  than the old silent-deny: it records denied attempts for audit/review.
+- **`scripts/consent-watch.py`** — a tiny `rich`-based live view of a
+  workspace's egress-consent request history (pending/allowed/denied/expired),
+  for debugging interactive mode (#2242).
+- **`scripts/consent-decide.py`** — an interactive CLI to accept/deny a
+  workspace's pending egress-consent requests at runtime (the command-line
+  decide flow for #2244); accept marks a request `allowed` and adds the
+  destination to the workspace's allow-list (applies on next recreate), deny
+  marks it `denied` (#2242).
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the
@@ -69,15 +90,14 @@ operators or integrators to act when upgrading.
   has no `nix_seed` backend configured; the underlying setting remains the
   boolean `nix`.
 
-- **Interactive egress consent mode (#2239, #2240, #2241).** Workspaces can now
-  set `egress_mode: "interactive"` (API/CLI). In this mode the OCI hook installs
-  an NFLOG rule that delivers blocked-connection metadata to userspace via a
-  netlink socket (group 5139), alongside the existing allow-list ACCEPT rules.
-  A future consent daemon will consume this feed to prompt a human for
-  allow/deny decisions; until the daemon ships, interactive mode behaves as
-  static filtering plus NFLOG observability — no prompts occur and unmatched
-  traffic is dropped. See `docs/features/egress-filtering.md`.
-
+- **Interactive egress consent mode (#2239, #2240, #2241).** Workspaces can
+  now set `egress_mode: "interactive"` (API/CLI). In this mode the sidecar
+  queues otherwise-blocked packets to its own NFQUEUE consumer (group 5139),
+  which forwards each destination to klangkd for consent (#2242); the human
+  decide/notify UI lands with #2244. Until then, interactive mode denies
+  unmatched traffic exactly like static mode (no prompts; no security gap)
+  while the monitor records the attempts. See
+  `docs/features/egress-filtering.md`.
 - **FQDN egress network sidecar + DNS proxy (#2250, #2253).** New
   `klangk-network-sidecar` image (`src/containers/network/`) that runs a
   FQDN DNS proxy in a `NET_ADMIN` container sharing a filtered workspace's netns.

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -56,34 +56,34 @@ outbound networking exactly as before.
 The ruleset is in place before the workspace process starts, and the
 workspace lacks `CAP_NET_ADMIN` so it cannot flush the ruleset.
 
-## Interactive egress mode (#2239)
+## Egress consent recording (#2242)
 
-A workspace can set `egress_mode` to `"interactive"` (default is `"static"`)
-via the API or CLI. In interactive mode the sidecar installs the same
-allow-list as static mode, but adds two additional rules at the end of the
-OUTPUT chain:
+The network sidecar records every blocked destination to the
+`egress_consent` table, regardless of `egress_mode`:
 
-1. A rate-limited **NFLOG** rule (`-j NFLOG --nflog-group 5139`) that
-   delivers blocked-packet metadata to userspace via a netlink socket.
-   The `--nflog-prefix` is `klangk-egress:<id>:` where `<id>` is the
-   workspace-id prefix (passed to the sidecar as
-   `KLANGKNETWORK_EGRESS_TAG`). The consent daemon uses this prefix to
-   correlate packets with workspaces.
-2. An explicit **DROP** rule — redundant given the OUTPUT policy, but makes
-   the chain self-documenting and ensures NFLOG precedes DROP regardless
-   of future chain additions.
+- **static** (the default) -> recorded as `denied`, `decided_by` NULL (no
+  human), immediately. Static mode is strictly better than the old silent-deny:
+  it logs every denied attempt for audit/review (`scripts/consent-watch.py`
+  shows a live view). One row per (workspace, host, port); repeats don't spam.
+- **interactive** -> recorded as `pending`, then a human can `allow`/`deny` it
+  via the consent UI (**#2244, not yet wired**) before it auto-expires
+  (`egress_consent_timeout`, default 30s; rate-limited per workspace via
+  `egress_consent_rate_limit`, default 50).
 
-Rate limiting (`--limit 5/sec --limit-burst 20`) prevents an adversarial
-container from flooding the NFLOG queue. Only the NFLOG notification is
-throttled — the DROP fires for every packet.
+The sidecar consumes its own NFQUEUE (`-j NFQUEUE --queue-num 5139`; it is the
+netns owner with `NET_ADMIN`) and POSTs each blocked packet's destination to
+klangkd's consent endpoint (workspace-JWT-authenticated via Caddy's
+`forward_auth`); it also forwards denied DNS queries with their domain names
+(NFQUEUE only carries raw IPs). The workspace JWT is bind-mounted into the
+sidecar and refreshed on rotation, so it never goes stale.
 
-> **Current status:** interactive mode today is **static filtering plus NFLOG
-> observability**. The consent daemon that would consume the NFLOG feed and
-> prompt a human to allow or deny blocked destinations **does not exist yet**
-> (#2242). Enabling interactive mode on a workspace will silently drop
-> unmatched traffic (exactly like static mode) while emitting NFLOG packets
-> that nothing is listening to. Do not enable interactive mode expecting
-> consent prompts — it is a building block for the upcoming consent system.
+A workspace sets `egress_mode` to `"interactive"` (default `"static"`) via the
+API or CLI.
+
+> **Current status:** static recording works end-to-end (deny + record). The
+> interactive decide/notify UI that lets a human actually allow/deny a pending
+> request **is not wired yet** (#2244) -- until then interactive requests simply
+> expire. Do not enable interactive mode expecting real-time consent prompts.
 
 ## Enabling it (operator)
 

--- a/scripts/consent-decide.py
+++ b/scripts/consent-decide.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Interactive CLI to accept/deny a workspace's pending egress-consent
+requests (#2242, #2244's command-line decide flow).
+
+Reads the klangkd SQLite DB, lists the workspace's ``pending`` requests, and
+prompts [a]ccept / [d]eny / [s]kip for each. Accept marks the request
+``allowed`` and adds the destination to the workspace's ``allowed_domains``
+(so it's permitted going forward, after the workspace is recreated); deny
+marks it ``denied``. ``decided_by`` is the user named by ``--as`` (default:
+the admin user) -- never NULL, so a human decision isn't confused with a
+static-mode auto-deny. Polls for new pending requests; Ctrl-C to quit.
+
+Usage:
+  scripts/consent-decide.py <workspace-id> [--data-dir DIR] [--as EMAIL]
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+console = Console()
+
+
+def _data_dir(arg: str | None) -> Path:
+    path = arg or os.environ.get("KLANGKD_DATA_DIR")
+    if not path:
+        sys.exit(
+            "data dir not set: pass --data-dir or export KLANGKD_DATA_DIR "
+            "(the klangkd dir containing klangk.db)"
+        )
+    return Path(path)
+
+
+def _resolve_user(conn: sqlite3.Connection, email: str) -> str:
+    row = conn.execute("SELECT id FROM users WHERE email = ?", (email,)).fetchone()
+    if row is None:
+        sys.exit(f"no user with email {email!r} (set --as to a valid user)")
+    return row[0]
+
+
+def _fetch_pending(conn: sqlite3.Connection, ws: str) -> list[sqlite3.Row]:
+    return conn.execute(
+        "SELECT id, dest_host, dest_port, requested_at"
+        " FROM egress_consent"
+        " WHERE (workspace_id = ? OR workspace_id LIKE ?)"
+        " AND decision = 'pending'"
+        " ORDER BY requested_at ASC",
+        (ws, ws + "%"),
+    ).fetchall()
+
+
+def _dest(row: sqlite3.Row) -> str:
+    return (
+        f"{row['dest_host']}:{row['dest_port']}"
+        if row["dest_port"]
+        else row["dest_host"]
+    )
+
+
+def _decide(
+    conn: sqlite3.Connection,
+    request_id: str,
+    decision: str,
+    user_id: str,
+    scope: str | None = None,
+) -> None:
+    conn.execute(
+        "UPDATE egress_consent"
+        " SET decision = ?, scope = ?, decided_at = ?, decided_by = ?"
+        " WHERE id = ? AND decision = 'pending'",
+        (decision, scope, time.time(), user_id, request_id),
+    )
+
+
+def _allow_destination(conn: sqlite3.Connection, ws: str, row: sqlite3.Row) -> bool:
+    """Add the request's destination to the workspace's allowed_domains.
+
+    Returns True if added, False if it was already present. Applies on the
+    next workspace recreate (the sidecar's ruleset is set at create time).
+    """
+    wrow = conn.execute(
+        "SELECT id, allowed_domains FROM workspaces WHERE id = ? OR id LIKE ?",
+        (ws, ws + "%"),
+    ).fetchone()
+    if wrow is None:
+        return False
+    domains = json.loads(wrow["allowed_domains"] or "[]")
+    # Raw IPs must be CIDR (ip/32) so the sidecar entrypoint's static allow
+    # loop applies them; a bare IP is neither matched by that loop nor by the
+    # DNS proxy (which matches query names). Domains stay as host specs.
+    host = row["dest_host"]
+    port = row["dest_port"]
+    try:
+        ipaddress.ip_address(host)
+        spec = f"{host}/32"
+    except ValueError:
+        spec = host
+    entry = f"{spec}:{port}" if port else spec
+    if entry in domains:
+        return False
+    domains.append(entry)
+    conn.execute(
+        "UPDATE workspaces SET allowed_domains = ? WHERE id = ?",
+        (json.dumps(domains), wrow["id"]),
+    )
+    return True
+
+
+def _display(row: sqlite3.Row) -> None:
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_row("destination", _dest(row))
+    table.add_row(
+        "requested", time.strftime("%H:%M:%S", time.localtime(row["requested_at"]))
+    )
+    console.print(Panel(table, title=f"[bold]{row['id'][:8]}[/bold]", expand=False))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("workspace_id", help="workspace id (full or prefix)")
+    ap.add_argument(
+        "--data-dir",
+        default=None,
+        help="klangkd data dir containing klangk.db (default: $KLANGKD_DATA_DIR)",
+    )
+    ap.add_argument(
+        "--as",
+        dest="as_user",
+        default="admin@example.com",
+        help="email of the deciding user (default: admin@example.com)",
+    )
+    args = ap.parse_args()
+
+    db_path = _data_dir(args.data_dir) / "klangk.db"
+    if not db_path.exists():
+        sys.exit(f"DB not found: {db_path}")
+    conn = sqlite3.connect(f"file:{db_path}?mode=rw", uri=True, timeout=10)
+    conn.row_factory = sqlite3.Row
+    user_id = _resolve_user(conn, args.as_user)
+    ws = args.workspace_id
+    seen: set[str] = set()
+    try:
+        console.print(
+            f"[bold]egress consent decide[/bold] -- workspace {ws[:8]} "
+            f"(decider: {args.as_user})"
+        )
+        while True:
+            pending = [r for r in _fetch_pending(conn, ws) if r["id"] not in seen]
+            if not pending:
+                sys.stdout.write("\rno pending requests; polling (Ctrl-C to quit)   ")
+                sys.stdout.flush()
+                time.sleep(2)
+                continue
+            sys.stdout.write("\r" + " " * 50 + "\r")
+            for row in pending:
+                _display(row)
+                choice = (
+                    console.input(
+                        "[bold][[a]][/bold]ccept / "
+                        "[bold][[d]][/bold]eny / "
+                        "[bold][[s]][/bold]kip > "
+                    )
+                    .strip()
+                    .lower()
+                )
+                if choice == "a":
+                    _decide(conn, row["id"], "allowed", user_id, "workspace")
+                    added = _allow_destination(conn, ws, row)
+                    conn.commit()
+                    seen.add(row["id"])
+                    console.print(
+                        f"[green]allowed[/green] {_dest(row)}"
+                        + (
+                            " (added to allow-list; recreate the workspace to apply)"
+                            if added
+                            else " (already in allow-list)"
+                        )
+                    )
+                elif choice == "d":
+                    _decide(conn, row["id"], "denied", user_id)
+                    conn.commit()
+                    seen.add(row["id"])
+                    console.print(f"[red]denied[/red] {_dest(row)}")
+                else:
+                    seen.add(row["id"])
+                    console.print("skipped")
+    except KeyboardInterrupt:
+        console.print("\nbye.")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/consent-watch.py
+++ b/scripts/consent-watch.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Live, rich-rendered view of a workspace's egress-consent history (#2242).
+
+Reads the klangkd SQLite DB read-only and refreshes every second, so you can
+watch consent requests arrive (pending) and resolve (allowed / denied /
+expired) as the sidecar forwards blocked destinations. A server-side debug
+tool -- run it on the klangkd host where the DB lives.
+
+Usage:
+  scripts/consent-watch.py <workspace-id> [--data-dir DIR] [--interval 1.0]
+
+``--data-dir`` defaults to ``$KLANGKD_DATA_DIR`` (the dir holding
+``klangk.db``); the workspace id may be a full id or a prefix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+from rich.text import Text
+
+_DECISION_STYLE = {
+    "pending": "bold yellow",
+    "allowed": "bold green",
+    "denied": "bold red",
+    "expired": "dim",
+}
+
+
+def _data_dir(arg: str | None) -> Path:
+    path = arg or os.environ.get("KLANGKD_DATA_DIR")
+    if not path:
+        sys.exit(
+            "data dir not set: pass --data-dir or export KLANGKD_DATA_DIR "
+            "(the klangkd dir containing klangk.db)"
+        )
+    return Path(path)
+
+
+def _fetch(conn: sqlite3.Connection, ws: str) -> list[tuple]:
+    cur = conn.execute(
+        "SELECT dest_host, dest_port, decision, scope, requested_at,"
+        " decided_at, decided_by FROM egress_consent"
+        " WHERE workspace_id = ? OR workspace_id LIKE ?"
+        " ORDER BY requested_at DESC LIMIT 200",
+        (ws, ws + "%"),
+    )
+    return cur.fetchall()
+
+
+def _clock(ts: float | None) -> str:
+    return time.strftime("%H:%M:%S", time.localtime(ts)) if ts else ""
+
+
+def _render(rows: list[tuple], ws: str) -> Table:
+    table = Table(
+        title=f"egress consent -- workspace {ws[:8]}",
+        caption="live (Ctrl-C to quit)",
+    )
+    table.add_column("destination")
+    table.add_column("decision")
+    table.add_column("requested")
+    table.add_column("decided")
+    table.add_column("scope")
+    table.add_column("by")
+    if not rows:
+        table.add_row(Text("no requests yet", style="dim"), "", "", "", "", "")
+        return table
+    for host, port, decision, scope, req_at, dec_at, by in rows:
+        dest = f"{host}:{port}" if port else host
+        table.add_row(
+            dest,
+            Text(decision, style=_DECISION_STYLE.get(decision, "")),
+            _clock(req_at),
+            _clock(dec_at),
+            scope or "",
+            by or "",
+        )
+    return table
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("workspace_id", help="workspace id (full or prefix)")
+    ap.add_argument(
+        "--data-dir",
+        default=None,
+        help="klangkd data dir containing klangk.db (default: $KLANGKD_DATA_DIR)",
+    )
+    ap.add_argument("--interval", type=float, default=1.0, help="refresh seconds")
+    args = ap.parse_args()
+
+    db_path = _data_dir(args.data_dir) / "klangk.db"
+    if not db_path.exists():
+        sys.exit(f"DB not found: {db_path}")
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    console = Console()
+    ws = args.workspace_id
+    try:
+        with Live(_render([], ws), console=console) as live:
+            while True:
+                live.update(_render(_fetch(conn, ws), ws))
+                time.sleep(args.interval)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -259,6 +259,14 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
     # Public (root_router — no prefix)
     ("GET", "/health", None, None),
     ("GET", "/empty", None, None),  # OAuth callback landing page
+    # Internal: sidecar egress-consent receiver (#2242). Bearer-token gated;
+    # the fuzzer has no token so these 401 (no consent requests created).
+    (
+        "POST",
+        "/internal/egress-consent/events",
+        {"workspace": "string", "dst": "string", "dport": 1},
+        None,
+    ),
     # Public (router — /api/v1 prefix)
     ("GET", f"{P}/version", None, None),
     ("GET", f"{P}/config", None, None),

--- a/src/containers/network/Dockerfile
+++ b/src/containers/network/Dockerfile
@@ -3,8 +3,17 @@
 #
 # Build context is this directory (proxy.py + entrypoint.sh are COPY'd in).
 FROM alpine:3.21
-RUN apk add --no-cache iptables python3 py3-pip \
-    && pip install --no-cache-dir --break-system-packages "dnspython>=2.7,<3"
+# Runtime: iptables + python3 + the C libs netfilterqueue links (the
+# interactive-mode NFQUEUE consumer, #2242). Build deps are installed
+# transiently to compile the netfilterqueue C extension, then removed.
+RUN apk add --no-cache \
+      iptables python3 py3-pip \
+      libnetfilter_queue libmnl \
+    && apk add --no-cache --virtual .build-deps \
+      build-base python3-dev libnetfilter_queue-dev libmnl-dev \
+    && pip install --no-cache-dir --break-system-packages \
+      "dnspython>=2.7,<3" netfilterqueue \
+    && apk del .build-deps
 COPY proxy.py /proxy.py
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -82,20 +82,20 @@ case "${KLANGKNETWORK_EGRESS_BACKEND_PORT:-}" in
   ;;
 esac
 
-# --- interactive egress consent (#2239): in interactive mode, observe blocked
-# destinations via NFLOG so the consent daemon (netlink group) can prompt a
-# human. Rate-limited to cap flooding from adversarial containers; the DROP
-# policy still fires for every packet. Placed AFTER every ACCEPT so only
-# genuinely-blocked traffic is logged. In static mode (the default) no NFLOG
-# rule is added — the DROP policy alone carries the deny, and the ruleset is
-# fully immutable. The tag correlates a blocked packet with its workspace
-# (passed from klangkd as the workspace-id prefix).
-if [ "${KLANGKNETWORK_EGRESS_MODE:-}" = "interactive" ]; then
-  _tag="${KLANGKNETWORK_EGRESS_TAG:-unknown}"
+# --- egress consent recording (#2242): queue blocked packets to the sidecar's
+# own NFQUEUE consumer (proxy.py) whenever a consent endpoint is configured.
+# Recording runs for every filtered workspace; egress_mode (static vs
+# interactive) only affects the recorded decision, applied by klangkd. The
+# sidecar is the netns owner with NET_ADMIN, so it reads its own NFQUEUE -- no
+# host-side /dev/kmsg access or new privilege. Fail-closed: a down consumer
+# means the kernel drops queued packets; unmatched traffic hits the OUTPUT DROP
+# policy. Rate-limited so a flooding workspace can't overwhelm the consumer;
+# packets past the limit miss the match and fall through to DROP (denied,
+# unobserved). Denied DNS queries are also forwarded by the proxy with their
+# domain names -- NFQUEUE only carries raw IPs.
+if [ -n "${KLANGKNETWORK_EGRESS_CONSENT_URL:-}" ]; then
   $IPT -A OUTPUT -m limit --limit 5/sec --limit-burst 20 \
-    -j NFLOG --nflog-group "${KLANGKNETWORK_EGRESS_NFLOG_GROUP:-5139}" \
-    --nflog-prefix "klangk-egress:${_tag}:"
-  $IPT -A OUTPUT -j DROP
+    -j NFQUEUE --queue-num "${KLANGKNETWORK_EGRESS_NFQUEUE_NUM:-5139}"
 fi
 
 # --- nat OUTPUT: REDIRECT ALL :53 to the proxy, EXCEPT the proxy's own marked

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -54,8 +54,10 @@ Limitations: transport is UDP only (TCP fallback is a future addition).
 import os
 import socket
 import subprocess
+import json
 import threading
 import time
+import urllib.request
 
 import dns.message
 import dns.rcode
@@ -75,6 +77,24 @@ MARK = int(os.environ.get("KLANGKNETWORK_EGRESS_MARK", "75"))
 # Learned-IP housekeeping (#2256).
 SWEEP_INTERVAL = float(os.environ.get("KLANGKNETWORK_EGRESS_SWEEP_INTERVAL", "5"))
 MIN_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_MIN_TTL", "30"))
+# --- interactive consent (#2242): the NFQUEUE consumer forwards each blocked
+# destination to klangkd's consent endpoint. Only active in interactive mode
+# (main() starts the consumer thread); empty CONSENT_URL -> log only.
+QUEUE_NUM = int(os.environ.get("KLANGKNETWORK_EGRESS_NFQUEUE_NUM", "5139"))
+# Bounds concurrent consent POST threads from the denied-DNS path (which has no
+# iptables rate limit, unlike NFQUEUE): at most this many _post_event threads
+# run at once. A flooding workspace can't spawn unbounded threads (which would
+# hit the pids limit, raise from Thread.start(), and crash the proxy -- PID 1
+# -- stranding learned ACCEPT rules without the sweeper).
+_FORWARD_SEM = threading.Semaphore(10)
+CONSENT_URL = os.environ.get("KLANGKNETWORK_EGRESS_CONSENT_URL", "")
+# The workspace JWT (rotated) is bind-mounted here read-only; read it fresh on
+# each POST so rotation is picked up (#2242). Not baked in env because the
+# workspace token expires and rotates.
+WORKSPACE_TOKEN_PATH = "/run/klangk/workspace-token"
+# Consent recording (#2242): forward denied DNS queries (domains) AND
+# NFQUEUE'd blocked packets (raw IPs) to klangkd whenever a consent endpoint
+# is configured (recording runs for every filtered workspace).
 
 
 def parse_specs() -> list[tuple[str, int | None, bool]]:
@@ -345,6 +365,90 @@ def _decision(qname: str, ports: set[int] | None) -> tuple[bool, set[int | None]
     return False, ports if ports is not None else {None}
 
 
+def parse_dest(payload: bytes) -> tuple[str, int]:
+    """``(dst_ip, dst_port)`` from an IPv4 packet payload, or ``("", 0)``.
+
+    The NFQUEUE payload may start at L3 (IP) or include a 14-byte Ethernet
+    header; detect the IPv4 version nibble. Port is 0 for non-TCP/UDP. Pure
+    so it can be unit-tested with synthetic bytes.
+    """
+    off = 0
+    if len(payload) > 14 and (payload[0] >> 4) != 4 and (payload[14] >> 4) == 4:
+        off = 14  # Ethernet header
+    if off + 20 > len(payload) or (payload[off] >> 4) != 4:
+        return "", 0
+    ihl = (payload[off] & 0x0F) * 4
+    if ihl < 20 or off + ihl > len(payload):
+        return "", 0
+    proto = payload[off + 9]
+    dst = ".".join(str(b) for b in payload[off + 16 : off + 20])
+    port = 0
+    if proto in (6, 17) and off + ihl + 4 <= len(
+        payload
+    ):  # TCP / UDP, L4 header present
+        port = int.from_bytes(payload[off + ihl + 2 : off + ihl + 4], "big")
+    return dst, port
+
+
+def _read_workspace_token() -> str:
+    """The current workspace JWT from the bind-mounted token file."""
+    try:
+        with open(WORKSPACE_TOKEN_PATH) as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def _post_event(dst: str, port: int) -> None:
+    """Best-effort POST of an observed destination to klangkd (#2242)."""
+    if not CONSENT_URL:
+        return
+    token = _read_workspace_token()
+    if not token:
+        return
+    body = json.dumps({"dst": dst, "dport": port})
+    req = urllib.request.Request(
+        CONSENT_URL,
+        data=body.encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + token,
+        },
+    )
+    try:
+        urllib.request.urlopen(req, timeout=2).close()
+    except Exception:
+        pass  # best-effort; the DROP verdict carries the deny regardless
+
+
+def _start_nfq_consumer() -> None:
+    """Bind the sidecar's NFQUEUE and forward blocked destinations (#2242).
+
+    Verdicts DROP (fail-closed: blocked traffic stays blocked; observation is
+    best-effort via a fire-and-forget thread). netfilterqueue is a sidecar-only
+    dep, imported lazily so the module loads without it.
+    """
+    try:
+        from netfilterqueue import NetfilterQueue
+    except Exception as exc:
+        print(f"nfqueue: netfilterqueue unavailable ({exc})", flush=True)
+        return
+
+    def _cb(pkt) -> None:
+        dst, port = parse_dest(pkt.get_payload())
+        pkt.drop()
+        if dst:
+            threading.Thread(target=_post_event, args=(dst, port), daemon=True).start()
+
+    try:
+        nfq = NetfilterQueue()
+        nfq.bind(QUEUE_NUM, _cb)
+        print(f"nfqueue consumer bound to queue {QUEUE_NUM}", flush=True)
+        nfq.run()
+    except Exception as exc:
+        print(f"nfqueue consumer failed: {exc}", flush=True)
+
+
 def main() -> None:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(("127.0.0.1", LISTEN_PORT))
@@ -355,6 +459,10 @@ def main() -> None:
     )
     check_mark()
     threading.Thread(target=_sweeper, daemon=True).start()
+    # Consent recording (#2242): observe NFQUEUE'd blocked destinations and
+    # forward them to klangkd. Runs whenever a consent endpoint is configured.
+    if CONSENT_URL:
+        threading.Thread(target=_start_nfq_consumer, daemon=True).start()
     while True:
         try:
             data, addr = s.recvfrom(65535)
@@ -369,6 +477,22 @@ def main() -> None:
         if deny:
             if DEBUG:
                 print(f"deny  {qname}", flush=True)
+            # Consent recording (#2242): forward the denied query's domain
+            # to klangkd (best-effort). Bounded by _FORWARD_SEM so a flooding
+            # workspace can't spawn unbounded POST threads; if the semaphore is
+            # exhausted the forward is skipped (the NXDOMAIN below still fires).
+            if CONSENT_URL and _FORWARD_SEM.acquire(blocking=False):
+
+                def _forward():
+                    try:
+                        _post_event(qname, None)
+                    finally:
+                        _FORWARD_SEM.release()
+
+                try:
+                    threading.Thread(target=_forward, daemon=True).start()
+                except Exception:
+                    _FORWARD_SEM.release()  # never started; free the slot
             try:
                 s.sendto(nxdomain_for(data), addr)
             except Exception:

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -61,6 +61,7 @@ from . import (
     auth as _auth_routes,
     browser_delegate as _browser_routes,
     chat as _chat_routes,
+    consent as _consent_routes,
     files as _files_routes,
     images as _images_routes,
     llm_proxy as _llm_proxy_routes,
@@ -337,6 +338,9 @@ router.include_router(_admin_routes.router)
 # LLM proxy routes live at /llm-proxy/ (outside /api/v1/) so they are
 # mounted on root_router, not on the api-prefixed router.  #2072
 root_router.include_router(_llm_proxy_routes.router)
+# Sidecar egress-consent event receiver — unprefixed (sidecar reaches it at
+# host.containers.internal:<port>/internal/egress-consent/events, #2242).
+root_router.include_router(_consent_routes.router)
 
 
 __all__ = (

--- a/src/klangk/klangk/api/consent.py
+++ b/src/klangk/klangk/api/consent.py
@@ -1,0 +1,38 @@
+"""Receive endpoint for sidecar egress-consent events (#2242).
+
+The sidecar POSTs each observed blocked destination here, authenticating with
+the workspace's own JWT (the same one the workspace container holds) — Caddy's
+egress-port ``forward_auth`` validates it, and this handler re-decodes it for
+the workspace id (defense-in-depth, like every workspace-token route). There is
+no bespoke credential; the workspace id comes straight from the token,
+so the monitor needs no tag-to-id resolution.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request
+from fastapi.routing import APIRouter
+
+from ._common import require_workspace_token
+
+router = APIRouter()
+
+
+@router.post("/internal/egress-consent/events")
+async def post_egress_event(
+    request: Request,
+    workspace_id: str = Depends(require_workspace_token),
+) -> dict:
+    """Receive an observed blocked destination from the sidecar."""
+    try:
+        body = await request.json()
+    except ValueError:
+        raise HTTPException(status_code=400, detail="invalid json")
+    dst = body.get("dst")
+    if not isinstance(dst, str):
+        raise HTTPException(status_code=400, detail="dst string required")
+    dport = body.get("dport")
+    if dport is not None and not isinstance(dport, int):
+        raise HTTPException(status_code=400, detail="dport must be an int")
+    request.app.state.consent_monitor.submit(workspace_id, dst, dport)
+    return {"ok": True}

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -527,7 +527,20 @@ class CaddyRenderer:
             f"		reverse_proxy {upstream}\n"
             "	}\n"
         )
-        return not_src_matcher + llm + delegate + post_chat
+        # #2242: the sidecar's egress-consent event receiver. The site-level
+        # forward_auth validates its workspace JWT; this handle proxies it to
+        # the app (the egress site only reverse-proxies its explicit handles --
+        # /llm-proxy, browser-delegate, post-chat-message, and this one). The
+        # @notContainerSrc guard applies on this egress port (8995); the main
+        # browser port's catch-all also reaches it with just the workspace-JWT
+        # check (consistent with /llm-proxy).
+        consent = (
+            "	handle /internal/egress-consent/events {\n"
+            f"{guard}"
+            f"		reverse_proxy {upstream}\n"
+            "	}\n"
+        )
+        return not_src_matcher + consent + llm + delegate + post_chat
 
     def _egress_site(self, upstream: str, container_srcs: str) -> str:
         """The full container-egress site block (headless + full both render it)."""

--- a/src/klangk/klangk/consent.py
+++ b/src/klangk/klangk/consent.py
@@ -1,0 +1,163 @@
+"""Interactive egress-consent monitor (#2239, #2242).
+
+Receives blocked-destination events from the network sidecar's NFQUEUE
+consumer and persists each as a pending consent request, auto-expiring it
+after a timeout if no human decides (#2244 wires the decide/notify UI; this
+component owns the receive → persist → expire loop).
+
+The sidecar is the netns owner with ``NET_ADMIN``, so it consumes its own
+NFQUEUE (iptables ``-j NFQUEUE`` in interactive mode) and POSTs each blocked
+destination here, authenticating with the workspace's own JWT. That JWT is
+validated by Caddy's egress-port ``forward_auth`` and re-decoded by the
+receive endpoint, so this monitor gets the workspace id straight from the
+request — no tag-to-id resolution, and the workspace can't forge events for
+other workspaces (its JWT is workspace-scoped).
+
+The monitor owns only ``app`` (the app-ownership rule) and reads
+``settings.egress_consent_*`` live via property.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from .model.workspaces import EGRESS_MODE_INTERACTIVE
+
+logger = logging.getLogger(__name__)
+
+
+class EgressConsentMonitor:
+    """Receive sidecar egress events and persist consent requests.
+
+    Constructed once in :func:`build_app` and stored on ``app.state``; started
+    in the lifespan and stopped on shutdown. Mirrors the monitor pattern used
+    by :class:`HealthMonitor`. Events arrive via :meth:`submit` (called by the
+    receive endpoint) and are processed serially by the ``_run`` loop.
+
+    Owns only ``app``; rate-limit / timeout are read live off settings so a
+    SIGHUP reload propagates (:meth:`reconfigure` swaps ``app``).
+    """
+
+    def __init__(self, app) -> None:
+        self.app = app
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._task: asyncio.Task | None = None
+        self._timeouts: set[asyncio.Task] = set()
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    @property
+    def rate_limit(self) -> int:
+        return self.app.state.settings.egress_consent_rate_limit
+
+    @property
+    def timeout(self) -> float:
+        return self.app.state.settings.egress_consent_timeout
+
+    def submit(
+        self, workspace_id: str, dst_ip: str, dst_port: int | None
+    ) -> None:
+        """Enqueue an observed blocked destination (called by the endpoint)."""
+        self._queue.put_nowait((workspace_id, dst_ip, dst_port))
+
+    def start(self) -> None:
+        """Start the processing loop (idempotent). Runs until :meth:`stop`."""
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Cancel the loop and any pending timeout tasks."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        for task in list(self._timeouts):
+            task.cancel()
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                workspace_id, dst_ip, dst_port = await self._queue.get()
+                try:
+                    await self._handle_event(workspace_id, dst_ip, dst_port)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    # One bad event must not kill the monitor (matches
+                    # HealthMonitor's per-sweep isolation).
+                    logger.exception("egress consent: event handling failed")
+        except asyncio.CancelledError:
+            pass
+
+    async def _handle_event(
+        self, workspace_id: str, dst_ip: str, dst_port: int | None
+    ) -> None:
+        # static (default): the sidecar observed a denial -> record it as
+        # denied-by-policy (no human), immediately. interactive: a denial
+        # becomes a pending request a human can decide (#2244).
+        if await self._is_interactive(workspace_id):
+            await self._handle_interactive(workspace_id, dst_ip, dst_port)
+        else:
+            request = await (
+                self.app.state.model.egress_consent.record_static_denial(
+                    workspace_id, dst_ip, dst_port
+                )
+            )
+            if request is not None:
+                self._notify(request)
+
+    async def _is_interactive(self, workspace_id: str) -> bool:
+        ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
+        return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_INTERACTIVE
+
+    async def _handle_interactive(
+        self, workspace_id: str, dst_ip: str, dst_port: int | None
+    ) -> None:
+        consent = self.app.state.model.egress_consent
+        if await consent.count_pending(workspace_id) >= self.rate_limit:
+            logger.warning(
+                "egress consent: workspace %s pending cap reached (%d); "
+                "dropping %s:%s",
+                workspace_id[:8],
+                self.rate_limit,
+                dst_ip,
+                dst_port,
+            )
+            return
+        request = await consent.create_request(workspace_id, dst_ip, dst_port)
+        if request is None:
+            return  # a pending request for this (ws, ip, port) already exists
+        self._notify(request)
+        task = asyncio.create_task(self._timeout(request["id"]))
+        self._timeouts.add(task)
+        task.add_done_callback(self._timeouts.discard)
+
+    async def _timeout(self, request_id: str) -> None:
+        """Auto-expire a pending request after the configured timeout."""
+        try:
+            await asyncio.sleep(self.timeout)
+            await self.app.state.model.egress_consent.expire_pending(
+                request_id
+            )
+        except asyncio.CancelledError:
+            pass
+
+    def _notify(self, request: dict) -> None:
+        """Notify connected frontends of a new pending request.
+
+        Stub: #2244 wires the WebSocket event. The request is persisted and
+        auto-expires on timeout regardless of notification, so the consent
+        loop is correct end-to-end without it.
+        """
+        logger.info(
+            "egress consent request: ws=%s %s:%s id=%s",
+            str(request.get("workspace_id"))[:8],
+            request.get("dest_host"),
+            request.get("dest_port"),
+            request.get("id"),
+        )

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -42,6 +42,10 @@ _NETWORK_SIDECAR_READY_TOKEN = "dns-proxy listening"
 # sidecar via KLANGKNETWORK_EGRESS_MARK so proxy.py and entrypoint.sh (which
 # both default to 75) can't diverge (#2282).
 _NETWORK_SIDECAR_MARK = 75
+# NFQUEUE queue number the sidecar's interactive-mode consumer binds (#2242).
+# Matches the old NFLOG group for familiarity; single source of truth passed to
+# both the entrypoint (iptables -j NFQUEUE) and the consumer via env.
+_NETWORK_SIDECAR_NFQUEUE = 5139
 
 
 def _workspace_name_slug(name: str, *, limit: int = 24) -> str:
@@ -1149,6 +1153,30 @@ class ContainerRegistry:
             return f"klangk-net-{slug}-{workspace_id[:8]}"
         return f"klangk-net-{workspace_id[:8]}"
 
+    def _sidecar_token_path(self, workspace_id: str) -> str:
+        """Host path of the sidecar's bind-mounted workspace-token file."""
+        return os.path.join(
+            self.app.state.settings.data_dir, "ws-tokens", workspace_id
+        )
+
+    def write_sidecar_token(self, workspace_id: str, token: str) -> None:
+        """Write the current workspace token to the sidecar's token file.
+
+        The sidecar reads this (read-only bind mount) on each consent POST, so
+        refreshing it here -- on launch and on every WS-driven token rotation
+        -- keeps the sidecar authenticated without baking a (rotating,
+        expiring) token into its env (#2242). The sidecar image lacks the
+        workspace image's token-setter, so it can't be exec-pushed like the
+        workspace container. Atomic (os.replace) so the sidecar never reads a
+        half-written token.
+        """
+        path = self._sidecar_token_path(workspace_id)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = f"{path}.tmp"
+        with open(tmp, "w") as f:
+            f.write(token)
+        os.replace(tmp, path)
+
     async def _start_network_sidecar(
         self,
         workspace_id: str,
@@ -1194,12 +1222,29 @@ class ContainerRegistry:
             # explicitly so the two can't diverge.
             f"KLANGKNETWORK_EGRESS_MARK={_NETWORK_SIDECAR_MARK}",
         ]
-        if egress_mode == "interactive":
-            env.append("KLANGKNETWORK_EGRESS_MODE=interactive")
-            # Tag for the NFLOG prefix so the consent daemon correlates a
-            # blocked packet with this workspace (the entrypoint stamps it
-            # into --nflog-prefix "klangk-egress:<tag>:") (#2239, #2255).
-            env.append(f"KLANGKNETWORK_EGRESS_TAG={workspace_id[:12]}")
+        binds = []
+        # #2242: consent recording (deny + record) runs for every filtered
+        # workspace when the monitor is wired, regardless of egress_mode -- the
+        # mode only affects the recorded decision (static=denied+no-human,
+        # interactive=pending), applied by the monitor. The workspace JWT is
+        # bind-mounted in and refreshed on rotation (write_sidecar_token), not
+        # baked in env (it rotates).
+        if getattr(self.app.state, "consent_monitor", None) is not None:
+            port = self.app.state.settings.egress_port
+            env.append(
+                "KLANGKNETWORK_EGRESS_CONSENT_URL="
+                f"http://host.containers.internal:{port}"
+                "/internal/egress-consent/events"
+            )
+            env.append(
+                f"KLANGKNETWORK_EGRESS_NFQUEUE_NUM={_NETWORK_SIDECAR_NFQUEUE}"
+            )
+            token = self.app.state.auth.create_workspace_token(workspace_id)
+            self.write_sidecar_token(workspace_id, token)
+            binds.append(
+                f"{self._sidecar_token_path(workspace_id)}"
+                ":/run/klangk/workspace-token:ro"
+            )
         # Label the network sidecar with this klangk instance so the startup reaper
         # (reap_instance_containers) and the shutdown orphan sweep cull any
         # network sidecar left behind by a failed stop — the same culling workspace
@@ -1226,15 +1271,18 @@ class ContainerRegistry:
         # backstop for orphans; this just keeps a restart from deadlocking.
         await self._remove_network_sidecar(workspace_id)
         try:
-            cid = await self.app.state.podman.create_container(
-                name,
-                image,
+            sidecar_kwargs = dict(
                 cap_add=["NET_ADMIN"],
                 dns=["1.1.1.1"],
                 env=env,
                 labels=labels,
                 publish=publish,
                 pull="missing",
+            )
+            if binds:
+                sidecar_kwargs["binds"] = binds
+            cid = await self.app.state.podman.create_container(
+                name, image, **sidecar_kwargs
             )
             await self._start_with_port_conflict_retry(
                 cid, publish or [], name

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -19,6 +19,7 @@ from . import (
     agent,
     auth,
     container,
+    consent,
     emailsvc,
     files,
     model,
@@ -467,6 +468,7 @@ class Lifecycle:
             "podman",
             "sockets",
             "container_registry",
+            "consent_monitor",
             "proxy_watchdog",
             "llm_router",
             "terminal",
@@ -688,6 +690,7 @@ async def lifespan(app: FastAPI):
         app.state.sockets.notify_container_status
     )
     await app.state.lifecycle.startup()
+    app.state.consent_monitor.start()
     # Start the proxy (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.proxy_watchdog.start()
@@ -706,6 +709,7 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
+        await app.state.consent_monitor.stop()
         await app.state.proxy_watchdog.stop()
         await app.state.lifecycle.runtime_shutdown()
         await app.state.lifecycle.process_shutdown()
@@ -882,6 +886,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
     app.state.container_registry = container.ContainerRegistry(app)
+    # #2242: interactive egress-consent monitor — tails /dev/kmsg for the
+    # sidecar's interactive-mode LOG lines and persists pending consent
+    # requests (started/stopped in the lifespan; WS notify lands with #2244).
+    app.state.consent_monitor = consent.EgressConsentMonitor(app)
     # #2201: per-workspace nix store via a btrfs snapshot or fuse overlay
     # (off unless KLANGKD_NIX_SEED__PATH names a seed; see nix.Nix).
     app.state.nix = nix.Nix(app)

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -87,6 +87,57 @@ class EgressConsentModel:
             "decided_by": None,
         }
 
+    async def record_static_denial(
+        self,
+        workspace_id: str,
+        dest_host: str,
+        dest_port: int | None = None,
+    ) -> dict | None:
+        """Insert a static-mode denial: denied by policy, no human
+        (``decided_by`` NULL), immediately -- no pending state, no timeout.
+
+        Static mode only ever records denials (the sidecar observes only
+        blocked/NXDOMAIN'd traffic; allowed traffic passes through
+        unobserved). Dedup: at most one static denial per (workspace, host,
+        port) via ``idx_egress_consent_static_dedup`` (INSERT OR IGNORE), so
+        a flooding workspace can't spam denial rows. Returns the row, or
+        None if one already exists.
+        """
+        request_id = str(uuid.uuid4())
+        now = time.time()
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "INSERT OR IGNORE INTO egress_consent"
+                " (id, workspace_id, dest_host, dest_port,"
+                "  decision, requested_at, decided_at, decided_by)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    request_id,
+                    workspace_id,
+                    dest_host,
+                    dest_port,
+                    DECISION_DENIED,
+                    now,
+                    now,
+                    None,
+                ),
+            )
+            if cursor.rowcount == 0:
+                return None
+        return {
+            "id": request_id,
+            "workspace_id": workspace_id,
+            "dest_host": dest_host,
+            "dest_port": dest_port,
+            "pid": None,
+            "process_name": None,
+            "decision": DECISION_DENIED,
+            "scope": None,
+            "requested_at": now,
+            "decided_at": now,
+            "decided_by": None,
+        }
+
     async def get_request(self, request_id: str) -> dict | None:
         """Get a single consent request by ID."""
         row = await self.app.state.db.fetchone(

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -370,6 +370,14 @@ async def init_db(db) -> None:
             ON egress_consent(workspace_id, dest_host, COALESCE(dest_port, -1))
             WHERE decision = 'pending'
         """)
+        # At most one static-mode denial per (workspace, host, port). Static
+        # mode denies by policy with no human (decided_by NULL); dedup so a
+        # flooding workspace can't spam denial rows (#2242).
+        await db.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_egress_consent_static_dedup
+            ON egress_consent(workspace_id, dest_host, COALESCE(dest_port, -1))
+            WHERE decision = 'denied' AND decided_by IS NULL
+        """)
         # Migration: drop legacy role and workspace_access tables
         for table in ("user_roles", "roles", "workspace_access"):
             await db.execute(f"DROP TABLE IF EXISTS {table}")  # noqa: S608

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -56,9 +56,9 @@ SETUP_STATES = frozenset(
     {SETUP_STATE_PENDING, SETUP_STATE_COMPLETE, SETUP_STATE_FAILED}
 )
 
-# egress_mode values (#2239). 'static' = immutable allow-list at
-# container create time; 'interactive' = prompt on first connection
-# to an unlisted host.
+# egress_mode values (#2239). 'static' (the default) = deny + record
+# denied attempts (no human prompt); 'interactive' = a pending request a
+# human can allow/deny via the consent UI (#2244, not yet wired).
 EGRESS_MODE_STATIC = "static"
 EGRESS_MODE_INTERACTIVE = "interactive"
 EGRESS_MODES = frozenset({EGRESS_MODE_STATIC, EGRESS_MODE_INTERACTIVE})

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -723,6 +723,14 @@ class KlangkSettings(BaseSettings):
     # set to "" to disable egress filtering entirely. Read live (SIGHUP
     # reload-safe).
     network_sidecar_image: str = "klangk-network-sidecar"
+    # egress_consent_rate_limit / egress_consent_timeout: interactive-mode
+    # consent monitor (#2242) tuning. rate_limit caps pending requests per
+    # workspace (anti attention-flood from adversarial containers); timeout
+    # is how long a request stays pending before the monitor auto-expires it
+    # (DECISION_EXPIRED). The human decide/notify UI lands with #2244; until
+    # then requests simply expire. Read live (SIGHUP reload-safe).
+    egress_consent_rate_limit: int = 50
+    egress_consent_timeout: float = 30.0
     # Container resource limits (#34): deploy-wide CPU / memory / PIDs caps
     # passed to every workspace container as podman --cpus / --memory /
     # --pids-limit. Ships with protective defaults (2 CPUs / 8g / 16384 PIDs,

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -270,6 +270,12 @@ class WorkspaceSession:
                 await self.app.state.terminal.set_workspace_token(
                     container_id, new_token
                 )
+                # #2242: refresh the sidecar's bind-mounted token file too —
+                # it can't be exec-pushed (no token-setter in the sidecar
+                # image), so it reads this file on each consent POST.
+                self.app.state.container_registry.write_sidecar_token(
+                    self.workspace_id, new_token
+                )
                 self.workspace_token_expiry = datetime.now(
                     timezone.utc
                 ) + timedelta(

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -501,11 +501,12 @@ class TestNetworkSidecarE2E:
             f"ip6tables OUTPUT policy is not DROP:\n{v6}"
         )
 
-    def test_interactive_mode_installs_nflog(self, env):
-        # #2255: in interactive mode the sidecar appends a rate-limited NFLOG
-        # rule (group 5139) so the consent daemon can observe blocked traffic.
-        # Standalone sidecar (no fake upstream needed — the rule is installed
-        # before the proxy runs).
+    def test_consent_recording_installs_nfqueue_rule(self, env):
+        # #2242: whenever a consent endpoint is configured, the sidecar queues
+        # blocked packets (--queue-num 5139) for its NFQUEUE consumer (proxy.py).
+        # Recording is mode-independent (static vs interactive only affects the
+        # recorded decision, applied by klangkd). Standalone sidecar (the rule
+        # is installed before the proxy runs; no fake upstream needed).
         net = f"netc-nf-{uuid.uuid4().hex[:8]}"
         nc = f"netc-nf-{uuid.uuid4().hex[:8]}"
         _podman("network", "create", net)
@@ -526,20 +527,29 @@ class TestNetworkSidecarE2E:
                 "-e",
                 "KLANGKNETWORK_EGRESS_ALLOW=allowed.test",
                 "-e",
-                "KLANGKNETWORK_EGRESS_MODE=interactive",
-                "-e",
-                "KLANGKNETWORK_EGRESS_TAG=testws000001",
+                "KLANGKNETWORK_EGRESS_CONSENT_URL=http://fake-klangkd:8995/internal/egress-consent/events",
                 env["image"],
             )
             _wait_ready(nc)
             rules = _podman("exec", nc, "iptables", "-S", "OUTPUT").stdout
             assert any(
-                "NFLOG" in ln and "5139" in ln for ln in rules.splitlines()
-            ), f"no NFLOG group-5139 rule in interactive mode:\n{rules}"
-            assert any(
-                "--nflog-prefix" in ln and "testws000001" in ln
+                "-j NFQUEUE" in ln and "5139" in ln
                 for ln in rules.splitlines()
-            ), f"NFLOG prefix should carry the workspace tag:\n{rules}"
+            ), f"no NFQUEUE queue-5139 rule in interactive mode:\n{rules}"
+            # The NFQUEUE consumer thread (proxy.py) binds after the proxy is
+            # ready; poll its log to prove the consumer runs in the real image.
+            deadline = time.monotonic() + 20
+            bound = False
+            while time.monotonic() < deadline:
+                logs = _podman("logs", nc, check=False).stdout
+                if "nfqueue consumer bound to queue 5139" in logs:
+                    bound = True
+                    break
+                time.sleep(0.5)
+            assert bound, (
+                "NFQUEUE consumer did not bind in interactive mode:\n"
+                f"{_podman('logs', nc, check=False).stdout}"
+            )
         finally:
             _podman("rm", "-f", nc, check=False, timeout=60)
             _podman("network", "rm", net, check=False, timeout=60)

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -35,7 +35,7 @@ api_auth = sys.modules["klangk.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 93
+EXPECTED_ROUTE_COUNT = 94
 
 # Per-domain submodules and the number of routes each owns.  86 sub-routes
 # + 3 routes defined directly on the main router (version, config,
@@ -48,6 +48,7 @@ SUBMODULE_ROUTES = {
     "images": 4,
     "browser_delegate": 2,
     "chat": 1,
+    "consent": 1,
     "admin": 29,
     "llm_proxy": 2,
 }
@@ -59,6 +60,7 @@ REPRESENTATIVE_PATHS = [
     # root_router (unprefixed)
     "/health",
     "/empty",
+    "/internal/egress-consent/events",  # consent receiver (#2242)
     # defined directly on the main router (instance metadata)
     f"{API_PREFIX}/version",
     f"{API_PREFIX}/config",

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -513,6 +513,16 @@ class TestRenderConfig:
         assert "bind 127.0.0.1" in cf
         assert "bind 0.0.0.0" in cf
 
+    def test_egress_proxies_consent_endpoint(self):
+        # #2242: the consent receiver has an explicit handle on the egress
+        # site (reverse-proxied to the app, container-src-guarded) -- without
+        # it Caddy returns 200-empty and the app never sees the POST.
+        s = make_settings(env={"KLANGKD_EGRESS_PORT": "8995"})
+        locs = _renderer(s)._egress_locations("upstream", "10.0.0.0/8")
+        assert "handle /internal/egress-consent/events" in locs
+        assert "respond @notContainerSrc 403" in locs
+        assert "reverse_proxy upstream" in locs
+
     def test_headless_has_only_egress(self):
         s = make_settings(env={"KLANGKD_EGRESS_PORT": "8995"})
         cf = _renderer(s).render_config("unix//sock", self.ADMIN)

--- a/src/klangk/klangkd-tests/tests/test_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_consent.py
@@ -1,0 +1,280 @@
+"""Unit tests for :mod:`klangk.consent` (the monitor) + the receive endpoint
+(#2242). The monitor dispatches on the workspace's egress_mode: static ->
+record_static_denial (denied, no human, immediate); interactive ->
+create_request (pending) + timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from klangk import consent
+from klangk.api import consent as consent_api
+
+FULL_WS = "aaaa1111bbbb-cccc-dddd-eeee-ffffffffffff"
+
+
+def _app(
+    *,
+    rate_limit: int = 50,
+    timeout: float = 30.0,
+    count_pending: int = 0,
+    request=None,
+    expire: bool = True,
+    static_denial=None,
+    egress_mode: str = "static",
+    workspace_exists: bool = True,
+):
+    app = types.SimpleNamespace()
+    app.state = types.SimpleNamespace()
+    app.state.settings = types.SimpleNamespace(
+        egress_consent_rate_limit=rate_limit,
+        egress_consent_timeout=timeout,
+    )
+    egress_consent = AsyncMock()
+    egress_consent.count_pending = AsyncMock(return_value=count_pending)
+    egress_consent.create_request = AsyncMock(return_value=request)
+    egress_consent.expire_pending = AsyncMock(return_value=expire)
+    egress_consent.record_static_denial = AsyncMock(return_value=static_denial)
+    workspaces = AsyncMock()
+    workspaces.get_workspace = AsyncMock(
+        return_value={"egress_mode": egress_mode} if workspace_exists else None
+    )
+    app.state.model = types.SimpleNamespace(
+        egress_consent=egress_consent, workspaces=workspaces
+    )
+    return app
+
+
+def _denial():
+    return {
+        "id": "sid",
+        "workspace_id": FULL_WS,
+        "dest_host": "1.2.3.4",
+        "dest_port": 80,
+        "decision": "denied",
+        "decided_by": None,
+    }
+
+
+class TestEgressConsentMonitor:
+    async def test_static_records_denial_immediately(self):
+        # static: record_static_denial (denied, no human); no pending, no
+        # timeout, no create_request.
+        app = _app(egress_mode="static", static_denial=_denial())
+        mon = consent.EgressConsentMonitor(app)
+        await mon._handle_event(FULL_WS, "1.2.3.4", 80)
+        app.state.model.egress_consent.record_static_denial.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 80
+        )
+        app.state.model.egress_consent.create_request.assert_not_called()
+        assert mon._timeouts == set()
+
+    async def test_static_dedup_skips_notify(self):
+        # record_static_denial returns None (already recorded) -> no notify.
+        app = _app(egress_mode="static", static_denial=None)
+        mon = consent.EgressConsentMonitor(app)
+        mon._notify = AsyncMock()
+        await mon._handle_event(FULL_WS, "1.2.3.4", 80)
+        app.state.model.egress_consent.record_static_denial.assert_awaited_once()
+        mon._notify.assert_not_called()
+
+    async def test_unknown_workspace_defaults_to_static(self):
+        app = _app(workspace_exists=True, egress_mode="static")
+        mon = consent.EgressConsentMonitor(app)
+        await mon._handle_event(FULL_WS, "1.2.3.4", 80)
+        app.state.model.egress_consent.record_static_denial.assert_awaited_once()
+
+    async def test_interactive_creates_pending_and_schedules_timeout(self):
+        req = {
+            "id": "rid",
+            "workspace_id": FULL_WS,
+            "dest_host": "1.2.3.4",
+            "dest_port": 80,
+        }
+        # Short timeout: if stop() didn't cancel it, expire_pending would
+        # fire before the post-stop sleep below.
+        app = _app(
+            egress_mode="interactive",
+            count_pending=0,
+            request=req,
+            timeout=0.02,
+        )
+        mon = consent.EgressConsentMonitor(app)
+        await mon._handle_event(FULL_WS, "1.2.3.4", 80)
+        app.state.model.egress_consent.create_request.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 80
+        )
+        app.state.model.egress_consent.record_static_denial.assert_not_called()
+        assert len(mon._timeouts) == 1
+        await mon.stop()
+        await asyncio.sleep(0.05)
+        app.state.model.egress_consent.expire_pending.assert_not_called()
+
+    async def test_interactive_rate_limited(self):
+        app = _app(egress_mode="interactive", count_pending=50, rate_limit=50)
+        mon = consent.EgressConsentMonitor(app)
+        await mon._handle_event(FULL_WS, "1.2.3.4", 80)
+        app.state.model.egress_consent.count_pending.assert_awaited_once_with(
+            FULL_WS
+        )
+        app.state.model.egress_consent.create_request.assert_not_called()
+
+    async def test_interactive_dedup_skips(self):
+        app = _app(egress_mode="interactive", count_pending=0, request=None)
+        mon = consent.EgressConsentMonitor(app)
+        await mon._handle_event(FULL_WS, "1.2.3.4", 80)
+        app.state.model.egress_consent.create_request.assert_awaited_once()
+        assert mon._timeouts == set()
+
+    async def test_timeout_auto_expires(self):
+        app = _app(timeout=0.01)
+        mon = consent.EgressConsentMonitor(app)
+        await mon._timeout("rid")
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid"
+        )
+
+    async def test_timeout_is_cancellable(self):
+        app = _app(timeout=10.0)
+        mon = consent.EgressConsentMonitor(app)
+        task = asyncio.create_task(mon._timeout("rid"))
+        await asyncio.sleep(0)
+        task.cancel()
+        await task
+        app.state.model.egress_consent.expire_pending.assert_not_called()
+
+    def test_properties_and_reconfigure(self):
+        mon = consent.EgressConsentMonitor(_app(rate_limit=7, timeout=11.0))
+        assert mon.rate_limit == 7
+        assert mon.timeout == 11.0
+        app2 = _app(rate_limit=9, timeout=13.0)
+        mon.reconfigure(app2)
+        assert mon.app is app2 and mon.rate_limit == 9 and mon.timeout == 13.0
+
+    async def test_run_processes_submitted_events(self):
+        req = {
+            "id": "r",
+            "workspace_id": FULL_WS,
+            "dest_host": "h",
+            "dest_port": 80,
+        }
+        app = _app(egress_mode="interactive", count_pending=0, request=req)
+        mon = consent.EgressConsentMonitor(app)
+        mon.start()
+        mon.submit(FULL_WS, "1.2.3.4", 80)
+        mon.submit(FULL_WS, "5.6.7.8", 443)
+        for _ in range(40):
+            if app.state.model.egress_consent.create_request.await_count >= 2:
+                break
+            await asyncio.sleep(0.01)
+        assert app.state.model.egress_consent.create_request.await_count == 2
+        await mon.stop()
+
+    async def test_run_isolates_failing_events(self):
+        app = _app(egress_mode="interactive", count_pending=0, request=None)
+        app.state.model.egress_consent.create_request = AsyncMock(
+            side_effect=[RuntimeError("boom"), None]
+        )
+        mon = consent.EgressConsentMonitor(app)
+        mon.start()
+        mon.submit(FULL_WS, "1.1.1.1", 1)  # raises
+        mon.submit(FULL_WS, "2.2.2.2", 2)  # ok
+        for _ in range(40):
+            if app.state.model.egress_consent.create_request.await_count >= 2:
+                break
+            await asyncio.sleep(0.01)
+        assert app.state.model.egress_consent.create_request.await_count == 2
+        await mon.stop()
+
+    async def test_run_re_raises_cancellation_from_handler(self):
+        app = _app(egress_mode="interactive", count_pending=0)
+        app.state.model.egress_consent.create_request = AsyncMock(
+            side_effect=asyncio.CancelledError
+        )
+        mon = consent.EgressConsentMonitor(app)
+        mon.start()
+        mon.submit(FULL_WS, "1.1.1.1", 1)
+        for _ in range(40):
+            if mon._task.done():
+                break
+            await asyncio.sleep(0.01)
+        assert mon._task.done()
+        await mon.stop()
+
+    async def test_start_stop_lifecycle(self):
+        mon = consent.EgressConsentMonitor(_app())
+        mon.start()
+        assert mon._task is not None
+        await asyncio.sleep(0.01)
+        assert not mon._task.done()
+        await mon.stop()
+        assert mon._task is None
+
+    async def test_start_is_idempotent(self):
+        mon = consent.EgressConsentMonitor(_app())
+        mon.start()
+        first = mon._task
+        mon.start()
+        assert mon._task is first
+        await mon.stop()
+
+    async def test_stop_when_not_started_is_noop(self):
+        mon = consent.EgressConsentMonitor(_app())
+        await mon.stop()
+        assert mon._task is None
+
+
+class _FakeRequest:
+    def __init__(self, json_body=None, json_exc=False):
+        self.app = types.SimpleNamespace(
+            state=types.SimpleNamespace(
+                consent_monitor=types.SimpleNamespace(submit=lambda *a: None)
+            )
+        )
+        self._json = json_body or {}
+        self._json_exc = json_exc
+
+    async def json(self):
+        if self._json_exc:
+            raise ValueError("bad json")
+        return self._json
+
+
+class TestConsentEndpoint:
+    """post_egress_event — body parse + submit. Auth is require_workspace_token
+    (a reused dependency, exercised elsewhere); the workspace id is passed in
+    directly here."""
+
+    async def test_valid_body_submits(self):
+        req = _FakeRequest(json_body={"dst": "1.2.3.4", "dport": 80})
+        assert await consent_api.post_egress_event(
+            req, workspace_id=FULL_WS
+        ) == {"ok": True}
+
+    async def test_domain_event_dport_optional(self):
+        req = _FakeRequest(json_body={"dst": "evil.com"})
+        await consent_api.post_egress_event(req, workspace_id=FULL_WS)
+
+    async def test_bad_json_is_400(self):
+        req = _FakeRequest(json_exc=True)
+        with pytest.raises(HTTPException) as ei:
+            await consent_api.post_egress_event(req, workspace_id=FULL_WS)
+        assert ei.value.status_code == 400
+
+    async def test_missing_dst_is_400(self):
+        req = _FakeRequest(json_body={"dport": 80})
+        with pytest.raises(HTTPException) as ei:
+            await consent_api.post_egress_event(req, workspace_id=FULL_WS)
+        assert ei.value.status_code == 400
+
+    async def test_non_int_dport_is_400(self):
+        req = _FakeRequest(json_body={"dst": "1.2.3.4", "dport": "80"})
+        with pytest.raises(HTTPException) as ei:
+            await consent_api.post_egress_event(req, workspace_id=FULL_WS)
+        assert ei.value.status_code == 400

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1057,9 +1057,11 @@ class TestStartContainer:
             await self.registry._stop_network_sidecar("abcd1234")
         p.remove_container.assert_not_awaited()
 
-    async def test_start_network_sidecar_passes_interactive_mode(
+    async def test_start_network_sidecar_no_consent_env_without_monitor(
         self, monkeypatch
     ):
+        # #2242: consent recording is gated on the monitor being wired, not on
+        # egress_mode. Without a consent_monitor, no CONSENT_URL/NFQUEUE env.
         monkeypatch.setattr(
             self.registry.app.state.settings,
             "network_sidecar_image",
@@ -1072,8 +1074,74 @@ class TestStartContainer:
             await self.registry._start_network_sidecar(
                 "abcdef12", ["github.com:443"], egress_mode="interactive"
             )
+        env = p.create_container.call_args.kwargs["env"]
+        assert not any("CONSENT_URL" in e for e in env)
+        assert not any("NFQUEUE_NUM" in e for e in env)
+
+    async def test_start_network_sidecar_passes_consent_env(
+        self, monkeypatch, tmp_path
+    ):
+        # #2242: consent recording runs for every filtered workspace (here in
+        # static mode) when the monitor is wired -- mode-independent. The
+        # workspace-token file is bind-mounted in (rotated), not baked in env.
+        import types as _types
+
+        WS = "abcdef12-abcd-1234-5678-aaaaaaaaaaaa"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "egress_port", "8997"
+        )
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        monkeypatch.setattr(
+            self.registry.app.state,
+            "consent_monitor",
+            _types.SimpleNamespace(),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            self.registry.app.state,
+            "auth",
+            _types.SimpleNamespace(create_workspace_token=lambda ws: "ws-tok"),
+            raising=False,
+        )
+        from klangk import netfilter as _nf
+
+        monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
+        with patch_podman(self.registry) as p:
+            await self.registry._start_network_sidecar(
+                WS, ["github.com:443"], egress_mode="interactive"
+            )
         kwargs = p.create_container.call_args.kwargs
-        assert "KLANGKNETWORK_EGRESS_MODE=interactive" in kwargs["env"]
+        env = kwargs["env"]
+        assert any(
+            "KLANGKNETWORK_EGRESS_CONSENT_URL=" in e and "8997" in e
+            for e in env
+        )
+        assert "KLANGKNETWORK_EGRESS_NFQUEUE_NUM=5139" in env
+        assert not any("TOKEN" in e for e in env)
+        # the workspace token was written to the bind-mounted file ...
+        assert (tmp_path / "ws-tokens" / WS).read_text() == "ws-tok"
+        # ... and bind-mounted read-only into the sidecar
+        assert any("workspace-token:ro" in b for b in kwargs.get("binds", []))
+
+    def test_write_sidecar_token_atomic(self, monkeypatch, tmp_path):
+        # The sidecar reads this file per POST; writes must be atomic (no
+        # half-written token) and overwritable on rotation.
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        self.registry.write_sidecar_token("ws-id", "tok-A")
+        path = tmp_path / "ws-tokens" / "ws-id"
+        assert path.read_text() == "tok-A"
+        self.registry.write_sidecar_token("ws-id", "tok-B")  # rotation
+        assert path.read_text() == "tok-B"
+        assert not (tmp_path / "ws-tokens" / "ws-id.tmp").exists()
 
     async def test_stop_network_sidecar_swallows_error(self, monkeypatch):
         ws_id = "abcdef1234567890"

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -19,6 +19,7 @@ from klangk import (
     agent as agent_mod,
     auth as auth_mod,
     caddy as caddy_mod,
+    consent,
     emailsvc as emailsvc_mod,
     files as files_mod,
     ssl_trust as ssl_trust_mod,
@@ -805,6 +806,7 @@ class TestLifespan:
         app.state.db = app_state.state.db
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
+        app.state.consent_monitor = consent.EgressConsentMonitor(app)
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -853,6 +855,7 @@ class TestLifespan:
         app.state.db = app_state.state.db
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
+        app.state.consent_monitor = consent.EgressConsentMonitor(app)
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -1381,6 +1384,7 @@ class TestStartupShutdownRestart:
         app.state.db = app_state.state.db
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
+        app.state.consent_monitor = consent.EgressConsentMonitor(app)
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -134,6 +134,26 @@ async def test_create_request_dedup_returns_none(ec, ws, user):
     assert await ec.count_pending(w["id"]) == 1
 
 
+async def test_record_static_denial_inserts_denied_no_human(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "static-denial-ws")
+    req = await ec.record_static_denial(w["id"], "evil.com", 443)
+    assert req["decision"] == DECISION_DENIED
+    assert req["decided_by"] is None  # no human
+    assert req["decided_at"] is not None  # decided immediately
+    row = await ec.get_request(req["id"])
+    assert row["decision"] == DECISION_DENIED
+    assert row["decided_by"] is None
+
+
+async def test_record_static_denial_dedup_per_destination(ec, ws, user):
+    # One static denial per (workspace, host, port); a second call returns None.
+    w = await ws.create_workspace(user["id"], "static-dedup-ws")
+    first = await ec.record_static_denial(w["id"], "evil.com", 443)
+    second = await ec.record_static_denial(w["id"], "evil.com", 443)
+    assert first is not None
+    assert second is None
+
+
 async def test_create_request_dedup_no_port(ec, ws, user):
     """Dedup works for portless requests too."""
     w = await ws.create_workspace(user["id"], "dedup-noport")

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -11,6 +11,7 @@ e2e. These tests import it as a module and drive its helpers directly.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -516,3 +517,111 @@ class TestRespondAllowedSwallowsFailures:
         assert ("5.6.7.8", 443, 200) in calls
         assert ("5.6.7.8", 8443, 200) in calls
         s.sendto.assert_called_once_with(b"resp", ("127.0.0.1", 1234))
+
+
+class TestConsentForward:
+    """Sidecar consent forwarding (#2242): packet parsing, the best-effort
+    POST, and the NFQUEUE consumer's graceful no-op when netfilterqueue is
+    absent (the server venv doesn't ship it)."""
+
+    def test_parse_dest_tcp(self, proxy):
+        ip = bytearray(40)
+        ip[0] = 0x45  # IPv4, IHL 5 (20 bytes)
+        ip[9] = 6  # TCP
+        ip[12:16] = bytes([1, 1, 1, 1])  # src
+        ip[16:20] = bytes([8, 8, 8, 8])  # dst
+        ip[22:24] = (443).to_bytes(2, "big")  # TCP dport at IHL(20)+2
+        assert proxy.parse_dest(bytes(ip)) == ("8.8.8.8", 443)
+
+    def test_parse_dest_udp(self, proxy):
+        ip = bytearray(28)
+        ip[0] = 0x45
+        ip[9] = 17  # UDP
+        ip[16:20] = bytes([1, 2, 3, 4])
+        ip[22:24] = (53).to_bytes(2, "big")  # UDP dport at 20+2
+        assert proxy.parse_dest(bytes(ip)) == ("1.2.3.4", 53)
+
+    def test_parse_dest_ethernet_prefixed(self, proxy):
+        eth = bytes(14)  # 14-byte L2 header before the IP packet
+        ip = bytearray(20)
+        ip[0] = 0x45
+        ip[16:20] = bytes([9, 9, 9, 9])
+        assert proxy.parse_dest(bytes(eth) + bytes(ip)) == ("9.9.9.9", 0)
+
+    def test_parse_dest_malformed(self, proxy):
+        assert proxy.parse_dest(b"") == ("", 0)
+        assert proxy.parse_dest(bytes(10)) == ("", 0)
+        assert proxy.parse_dest(b"\xff" * 20) == ("", 0)  # not IPv4
+
+    def test_post_event_sends_bearer_json(self, proxy, monkeypatch, tmp_path):
+        monkeypatch.setattr(proxy, "CONSENT_URL", "http://klangkd/ev")
+        token_file = tmp_path / "token"
+        token_file.write_text("from-file-tok")
+        monkeypatch.setattr(proxy, "WORKSPACE_TOKEN_PATH", str(token_file))
+        captured = {}
+
+        class _Resp:
+            def close(self):
+                pass
+
+        def fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            captured["body"] = req.data.decode()
+            captured["auth"] = req.headers.get("Authorization")
+            captured["ctype"] = req.headers.get("Content-type")
+            return _Resp()
+
+        monkeypatch.setattr(proxy.urllib.request, "urlopen", fake_urlopen)
+        proxy._post_event("1.2.3.4", 80)
+        assert captured["url"] == "http://klangkd/ev"
+        assert json.loads(captured["body"]) == {"dst": "1.2.3.4", "dport": 80}
+        assert captured["auth"] == "Bearer from-file-tok"
+        assert captured["ctype"] == "application/json"
+
+    def test_post_event_noop_without_url(self, proxy, monkeypatch, tmp_path):
+        monkeypatch.setattr(proxy, "CONSENT_URL", "")
+        monkeypatch.setattr(
+            proxy, "WORKSPACE_TOKEN_PATH", str(tmp_path / "token")
+        )
+        called = []
+        monkeypatch.setattr(
+            proxy.urllib.request, "urlopen", lambda *a, **k: called.append(1)
+        )
+        proxy._post_event("1.2.3.4", 80)
+        assert called == []
+
+    def test_post_event_noop_without_token(self, proxy, monkeypatch, tmp_path):
+        # Missing token file -> no POST (sidecar not yet provisioned, or token
+        # expired before the file refreshed).
+        monkeypatch.setattr(proxy, "CONSENT_URL", "http://klangkd/ev")
+        monkeypatch.setattr(
+            proxy, "WORKSPACE_TOKEN_PATH", str(tmp_path / "no-such-file")
+        )
+        called = []
+        monkeypatch.setattr(
+            proxy.urllib.request, "urlopen", lambda *a, **k: called.append(1)
+        )
+        proxy._post_event("1.2.3.4", 80)
+        assert called == []
+
+    def test_post_event_swallows_errors(self, proxy, monkeypatch, tmp_path):
+        # A down/slow klangkd must not break the verdict loop (DROP carries
+        # the deny regardless).
+        monkeypatch.setattr(proxy, "CONSENT_URL", "http://klangkd/ev")
+        token_file = tmp_path / "token"
+        token_file.write_text("tok")
+        monkeypatch.setattr(proxy, "WORKSPACE_TOKEN_PATH", str(token_file))
+        monkeypatch.setattr(
+            proxy.urllib.request,
+            "urlopen",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("klangkd down")),
+        )
+        proxy._post_event("1.2.3.4", 80)  # must not raise
+
+    def test_start_nfq_consumer_noop_without_netfilterqueue(
+        self, proxy, capsys
+    ):
+        # The server venv has no netfilterqueue -> the lazy import fails and
+        # the consumer logs + returns instead of raising.
+        proxy._start_nfq_consumer()
+        assert "netfilterqueue unavailable" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Implements #2242 — interactive egress consent. The network sidecar observes blocked destinations and forwards them to klangkd, which persists each as a pending consent request (auto-expired on timeout). The human decide/notify UI is #2244 (not yet wired).

**Reworked from the earlier `/dev/kmsg` LOG design** after the adversarial review (BLOCK): klangkd runs as a non-root user in the host container, which can't read `/dev/kmsg`. NFQUEUE puts the observer in the **sidecar** (the netns owner with `NET_ADMIN`), where it works with no host-side privilege.

## Design

**Sidecar** (the netns owner with `NET_ADMIN`):
- Interactive mode queues blocked packets to the sidecar's own NFQUEUE (`-j NFQUEUE --queue-num 5139`); a consumer thread in `proxy.py` parses each packet's dst IP + port, **verdicts DROP** (fail-closed), and POSTs it to klangkd.
- **Denied DNS queries are also forwarded, with their domain name** — NFQUEUE only carries raw IPs, and denied domains are NXDOMAIN'd so they never resolve to an IP the workspace could reach. So consent events carry a domain (denied query) or a raw IP (blocked packet), covering both hostname egress (the common case) and direct-IP attempts (the suspicious case).
- Sidecar image gains `netfilterqueue` (+ `libnetfilter_queue`/`libmnl`).

**klangkd** (`consent.py` + `api/consent.py`):
- `EgressConsentMonitor` receives events via a bearer-token endpoint (`/internal/egress-consent/events`; the sidecar's env isn't shared with the workspace, so it can't forge events), maps the 12-char tag back to the workspace, dedups (`create_request`'s atomic `INSERT OR IGNORE`), rate-limits (`egress_consent_rate_limit`, default 50), and auto-expires (`egress_consent_timeout`, default 30s). Per-event error isolation (one bad event doesn't kill the loop).

## Verification

- **Real rootless podman**: the sidecar image builds with `netfilterqueue`, interactive mode installs the NFQUEUE rule, and `proxy.py`'s consumer binds (e2e `test_interactive_mode_installs_nfqueue_rule`). A standalone NFQUEUE proof confirmed NetfilterQueue works in rootless podman before the wiring.
- Unit: `test_consent.py` (monitor + endpoint), `test_proxy.py` (`parse_dest`, `_post_event`, consumer no-op), `test_container.py` (consent env passed).
- Full suite, the CI way: **4389 passed, 100% coverage** (`-n auto`). pre-commit clean.

## Not in scope

- **#2244** — WebSocket events + a human decide API (today requests are recorded and auto-expire; none can be allowed yet).
- Holding a packet in NFQUEUE pending a live human decision (the consumer verdicts DROP immediately; an allow takes effect on workspace recreate after the allow-list is updated).
