### PR TITLE
fix(container): sidecar start recovers from host-port conflicts (#2293)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -448,6 +448,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Network sidecar start recovers from host-port conflicts (#2293).** Since
+  #2291 a filtered workspace publishes its host ports on the network sidecar,
+  so a bind conflict there could fail the workspace start with no retry (unlike
+  the non-filtered workspace path, which self-heals). The sidecar start now
+  shares the workspace path's port-conflict recovery: it removes the stale
+  holder and retries with back-off.
+
 - **Stopping a workspace now tears down its network sidecar even when the
   workspace isn't tracked in the in-memory registry (#2286).** A workspace
   started by autostart or a prior klangkd session, then stopped from the TUI

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1802,7 +1802,7 @@ class ContainerRegistry:
         publish: list[tuple[int, int]],
         container_name: str,
         *,
-        hooks_dir: str | None = None,
+        hooks_dir: list[str] | None = None,
     ) -> None:
         """Start a container, recovering from host-port bind conflicts (#2293).
 

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1236,7 +1236,9 @@ class ContainerRegistry:
                 publish=publish,
                 pull="missing",
             )
-            await self.app.state.podman.start_container(cid)
+            await self._start_with_port_conflict_retry(
+                cid, publish or [], name
+            )
             # #2277: wait for the proxy to be listening before returning, so the
             # workspace never joins a netns whose OUTPUT is still ACCEPT
             # (entrypoint mid-flight) — a fail-open window. The proxy prints
@@ -1696,33 +1698,9 @@ class ContainerRegistry:
         # for any future --hooks-dir consumer.
         _hooks_dirs = create_kwargs.get("hooks_dir")
         t_podman_start = time.monotonic()
-        try:
-            await self.app.state.podman.start_container(
-                cid, hooks_dir=_hooks_dirs
-            )
-        except podman.PodmanError as exc:
-            if not self._is_port_conflict(exc):
-                raise
-            await self._resolve_port_conflict(
-                cid, container_name, publish, self.app.state.podman
-            )
-            # Retry with back-off; ports may linger in TIME_WAIT after
-            # the previous container's pasta process exits.
-            last_exc = exc
-            for delay in (0.5, 1.5):
-                await asyncio.sleep(delay)
-                try:
-                    await self.app.state.podman.start_container(
-                        cid, hooks_dir=_hooks_dirs
-                    )
-                    last_exc = None
-                    break
-                except podman.PodmanError as retry_exc:
-                    if not self._is_port_conflict(retry_exc):
-                        raise
-                    last_exc = retry_exc
-            if last_exc is not None:
-                raise last_exc
+        await self._start_with_port_conflict_retry(
+            cid, publish, container_name, hooks_dir=_hooks_dirs
+        )
         logger.info(
             "workspace-open: boot container (podman start): %.3fs",
             time.monotonic() - t_podman_start,
@@ -1817,6 +1795,55 @@ class ContainerRegistry:
                         stale_id[:12],
                         del_exc,
                     )
+
+    async def _start_with_port_conflict_retry(
+        self,
+        cid: str,
+        publish: list[tuple[int, int]],
+        container_name: str,
+        *,
+        hooks_dir: str | None = None,
+    ) -> None:
+        """Start a container, recovering from host-port bind conflicts (#2293).
+
+        On a port-conflict ``PodmanError`` (a TOCTOU between the DB
+        allocator's ``socket.bind`` probe and pasta's bind), remove stale
+        instance containers holding the conflicting host ports
+        (:meth:`_resolve_port_conflict`, which skips ``cid`` itself) and retry
+        with back-off — ports may linger in TIME_WAIT after the previous
+        container's pasta process exits. Shared by the workspace create path
+        (:meth:`_create_and_start`) and the network sidecar start, so a
+        filtered workspace — whose host ports are published on the sidecar
+        (#2291) — self-heals the same way a non-filtered one does. Fails
+        closed: an unresolved conflict re-raises.
+        """
+        try:
+            await self.app.state.podman.start_container(
+                cid, hooks_dir=hooks_dir
+            )
+        except podman.PodmanError as exc:
+            if not self._is_port_conflict(exc):
+                raise
+            await self._resolve_port_conflict(
+                cid, container_name, publish, self.app.state.podman
+            )
+            # Retry with back-off; ports may linger in TIME_WAIT after the
+            # previous container's pasta process exits.
+            last_exc = exc
+            for delay in (0.5, 1.5):
+                await asyncio.sleep(delay)
+                try:
+                    await self.app.state.podman.start_container(
+                        cid, hooks_dir=hooks_dir
+                    )
+                    last_exc = None
+                    break
+                except podman.PodmanError as retry_exc:
+                    if not self._is_port_conflict(retry_exc):
+                        raise
+                    last_exc = retry_exc
+            if last_exc is not None:
+                raise last_exc
 
     async def _start_container_inner(
         self,

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -796,7 +796,7 @@ class TestStartContainer:
         # with its workspace (supersedes the old klangk.network-sidecar).
         assert kwargs["labels"]["klangk.workspace"] == ws_id
         assert kwargs["labels"]["klangk.role"] == "network-sidecar"
-        p.start_container.assert_awaited_once_with("new-cid")
+        p.start_container.assert_awaited_once_with("new-cid", hooks_dir=None)
 
     async def test_start_network_sidecar_publishes_host_ports(
         self, monkeypatch
@@ -840,6 +840,66 @@ class TestStartContainer:
                 ws_id, ["github.com:443"]
             )
         assert p.create_container.call_args.kwargs["publish"] is None
+
+    async def test_start_network_sidecar_recovers_from_port_conflict(
+        self, monkeypatch
+    ):
+        # #2293: the sidecar start reuses the workspace path's port-conflict
+        # recovery. A host-port bind conflict (a TOCTOU between the DB
+        # allocator's probe and pasta's bind) removes the stale holder and
+        # retries, instead of failing the filtered workspace's start.
+        ws_id = "abcdef1234567890"
+        conflict_port = 18080
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        from klangk import netfilter as _nf
+
+        monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
+
+        start_calls = []
+
+        async def start_side_effect(cid, **kwargs):
+            start_calls.append(cid)
+            if len(start_calls) == 1:
+                raise podman.PodmanError(
+                    500,
+                    f"Bind for 0.0.0.0:{conflict_port} failed: "
+                    "port is already allocated",
+                )
+
+        async def list_side_effect(label):
+            # clear-on-start (klangk.workspace=) finds no stale sidecar; the
+            # port-conflict resolver (klangk.instance=) finds the holder.
+            if label.startswith("klangk.instance="):
+                return [{"Id": "stale-cid", "Labels": {}}]
+            return []
+
+        stale_info = {
+            "HostConfig": {
+                "PortBindings": {
+                    "8000/tcp": [{"HostPort": str(conflict_port)}]
+                }
+            }
+        }
+        with patch_podman(
+            self.registry,
+            start_container=AsyncMock(side_effect=start_side_effect),
+            list_containers=AsyncMock(side_effect=list_side_effect),
+            inspect_container=AsyncMock(return_value=stale_info),
+        ) as p:
+            cid = await self.registry._start_network_sidecar(
+                ws_id, ["github.com:443"], publish=[(conflict_port, 8000)]
+            )
+        assert cid == "new-cid"
+        # The conflict was retried (initial + 1 retry).
+        assert len(start_calls) == 2
+        # The stale holder of conflict_port was removed.
+        assert "stale-cid" in [
+            c.args[0] for c in p.remove_container.call_args_list
+        ]
 
     async def test_start_network_sidecar_clears_lingering_by_label(
         self, monkeypatch


### PR DESCRIPTION
## What

Give the network sidecar start the same host-port-conflict recovery the workspace path has (#2293).

## Why

Before #2291 a filtered workspace published nothing, so the sidecar could never
hit a host-port bind conflict. #2291 moved the workspace's host ports onto the
sidecar, so a bind failure there is now possible — but the sidecar start
(`_start_network_sidecar` → `podman.start_container`) had no recovery, while the
workspace path (`_create_and_start`) removes the stale holder and retries with
back-off. The gap is a TOCTOU between the DB allocator's `socket.bind` probe and
pasta's bind (tiny window, but real). It fails **closed** (the workspace refuses
to start rather than run unfiltered), so this is a robustness/availability fix,
not a security one.

## Change

- Extract `_start_with_port_conflict_retry(cid, publish, container_name, *, hooks_dir=None)`
  from `_create_and_start`: on a port-conflict `PodmanError`, call
  `_resolve_port_conflict` (removes stale instance containers holding the
  conflicting host ports; its `stale_id == cid` guard protects the container
  itself), then retry with the existing `(0.5, 1.5)` back-off. Re-raises on an
  unresolved conflict or a non-conflict error.
- `_create_and_start` (workspace) and `_start_network_sidecar` (sidecar) both
  call it. The sidecar passes `publish or []` (it may publish nothing) and no
  `hooks_dir`.

## Safety

- The sidecar starts **before** the workspace, so `_resolve_port_conflict`
  (which scans `klangk.instance` containers) cannot remove the workspace
  container — it doesn't exist yet.
- A sidecar that publishes nothing can't conflict, so the recovery path is a
  no-op for it (no stale removal; `start_container` just succeeds).

## Tests

- New `test_start_network_sidecar_recovers_from_port_conflict`: the sidecar's
  first `start_container` raises a port conflict; the stale holder is removed
  and the start retried, then readiness proceeds normally.
- The existing workspace port-conflict suite (10 tests in
  `TestStartContainerPortConflict`) still passes against the extracted helper —
  the workspace behavior is unchanged.
- Full suite: `klangkd-tests` + `klangkc-tests`, **100% coverage**, 4375 pass.

Closes #2293.
