### PR TITLE
fix(api): return 400, not 500, for a bad bind mount on start/restart (#2157)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -448,6 +448,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Starting/restarting a workspace with a bad bind mount returns a 400, not
+  a 500 (#2157).** A workspace whose extra mount points at a nonexistent host
+  path previously raised an unhandled `ValueError` from the volume pre-check,
+  surfacing as a 500 traceback. The `/workspaces/{id}/start` and `/restart`
+  endpoints now catch it and return HTTP 400 with the message (e.g. "Bind mount
+  source does not exist: /path"), matching the create/update endpoints and
+  the WebSocket start path. The pre-check stays (it catches typos); it just no
+  longer 500s in the HTTP path.
+
 - **Network sidecar start recovers from host-port conflicts (#2293).** Since
   #2291 a filtered workspace publishes its host ports on the network sidecar,
   so a bind conflict there could fail the workspace start with no retry (unlike

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -533,7 +533,12 @@ async def restart_workspace(
     await wshandler.reset_workspace_state(app.state.sockets, workspace_id)
     # Start a fresh container; the service command fires via the
     # create choke point in start_container.
-    await app.state.workspaces.start_workspace(workspace)
+    try:
+        await app.state.workspaces.start_workspace(workspace)
+    except ValueError as exc:
+        # User-config error (e.g. a bind-mount source path that doesn't
+        # exist) — surface as a 400, not an unhandled 500 (#2157).
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "restarted"}
 
 
@@ -605,7 +610,13 @@ async def start_workspace(
         raise HTTPException(status_code=404, detail="Workspace not found")
     if app.state.container_registry.get_state(workspace_id) is not None:
         return {"status": "already_running"}
-    await app.state.workspaces.start_workspace(workspace)
+    try:
+        await app.state.workspaces.start_workspace(workspace)
+    except ValueError as exc:
+        # User-config error (e.g. a bind-mount source path that doesn't
+        # exist) — surface as a 400, not an unhandled 500 (#2157). The WS
+        # start path sends an error frame for the same condition.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "started"}
 
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2098,6 +2098,41 @@ class TestWorkspaceRoutes:
         # Clean up registry state.
         registry.states.pop(ws_id, None)
 
+    async def test_restart_returns_400_on_user_config_error(
+        self, client, app, user, registry
+    ):
+        # A user-config problem on restart surfaces as a 400, not a 500
+        # (#2157). The existing container is still stopped+removed first.
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "bad-mount-restart"},
+        )
+        ws_id = create_resp.json()["id"]
+        registry.track_activity("cid-rst", ws_id)
+        with (
+            patch.object(
+                registry,
+                "stop_and_remove_container",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                app.state.workspaces,
+                "start_workspace",
+                new_callable=AsyncMock,
+                side_effect=ValueError(
+                    "Bind mount source does not exist: /nonexistent/path"
+                ),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/restart", headers=headers
+            )
+        assert resp.status_code == 400
+        assert "Bind mount source does not exist" in resp.json()["detail"]
+        registry.states.pop(ws_id, None)
+
     async def test_restart_not_found(self, client, user, app_state):
         headers = await _auth_headers(client)
         fake_id = "fake-restart-id"
@@ -2229,6 +2264,30 @@ class TestWorkspaceRoutes:
         assert resp.json()["status"] == "already_running"
         mock_start.assert_not_awaited()
         registry.states.pop(ws_id, None)
+
+    async def test_start_returns_400_on_user_config_error(
+        self, client, app, user
+    ):
+        # A user-config problem (e.g. a bind-mount source path that doesn't
+        # exist) surfaces as a 400, not an unhandled 500 (#2157).
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "bad-mount"}
+        )
+        ws_id = create_resp.json()["id"]
+        with patch.object(
+            app.state.workspaces,
+            "start_workspace",
+            new_callable=AsyncMock,
+            side_effect=ValueError(
+                "Bind mount source does not exist: /nonexistent/path"
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/start", headers=headers
+            )
+        assert resp.status_code == 400
+        assert "Bind mount source does not exist" in resp.json()["detail"]
 
     async def test_stop_not_found(self, client, user, app_state):
         headers = await _auth_headers(client)


### PR DESCRIPTION
## Summary

Closes #2157. Starting or restarting a workspace whose extra bind mount points at a **nonexistent host path** previously raised an unhandled `ValueError` from the volume pre-check (`container.py:_ensure_volumes`), surfacing as a **500 Internal Server Error** traceback. The WebSocket start path and the create/update endpoints already handled the condition (error frame / HTTP 400); only the HTTP `/start` and `/restart` paths did not.

## Root cause

`_ensure_volumes` deliberately pre-checks bind-mount sources (`elif not os.path.exists(source): raise ValueError(...)`) — a typo guard. `workspaces.start_workspace` propagates that `ValueError`, and the `/workspaces/{id}/start` + `/restart` endpoints called it with no `try/except`, so it became a raw 500. (The WS connect path catches it at `connection.py:425` → `send_error`; the create endpoint's eager auto-start swallows it with a logged warning.)

## Fix

Wrap the two `start_workspace` calls in `api/workspaces.py` (`/start` and `/restart`) in `try/except ValueError → HTTPException(400, detail=str(exc))`, mirroring the existing create/update handlers. The pre-check stays (it still catches typos); it just no longer 500s in the HTTP path. I went with a clear 4xx rather than auto-creating the directory, since the existing pre-check signals intent to catch typos and silently `mkdir -p`-ing a typo'd path on the host would defeat that.

### Files
- `src/klangk/klangk/api/workspaces.py` — `try/except ValueError → 400` on `/start` and `/restart`.
- `src/klangk/klangkd-tests/tests/test_api.py` — `test_start_returns_400_on_user_config_error`, `test_restart_returns_400_on_user_config_error` (mock `start_workspace` to raise the `ValueError`, assert 400 + detail).
- `docs/changes.md` — `### Fixed` entry.

## Verification

- New + existing start/restart tests: 5/5 pass.
- Full suite the CI way (`-n auto`, coverage): **4377 passed, 100% coverage**.
- pre-commit clean.
