### PR TITLE
feat(consent): live-decider registry + decider WebSocket gate (#2308)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -53,6 +53,14 @@ operators or integrators to act when upgrading.
   decide flow for #2244); accept marks a request `allowed` and adds the
   destination to the workspace's allow-list (applies on next recreate), deny
   marks it `denied` (#2242).
+- **Consent decider registry + `/ws/consent-decider` (#2308).** Interactive
+  egress consent is now runtime state: a workspace's blocked egress is held
+  for a decision only while a consent decider is registered for it (or
+  deploy-wide), over a new decider WebSocket (`consent_decider_timeout`,
+  default 45s, reaps silent deciders). **Behavior change:** an `interactive`
+  workspace with no decider registered now records blocked egress as a
+  static denial instead of queuing it — it needs a live decider to queue.
+  The decider client itself lands with #2310.
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the

--- a/src/klangk/klangk/consent.py
+++ b/src/klangk/klangk/consent.py
@@ -112,8 +112,14 @@ class EgressConsentMonitor:
                 self._notify(request)
 
     async def _is_interactive(self, workspace_id: str) -> bool:
+        # #2308: interactivity is runtime state -- a workspace is interactive
+        # only while a live consent decider is registered for it (or
+        # deploy-wide), AND the workspace has opted in (egress_mode). No
+        # decider -> static behavior (clean denial, no held connection).
         ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
-        return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_INTERACTIVE
+        if not ws or ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
+            return False
+        return self.app.state.consent_deciders.has_decider(workspace_id)
 
     async def _handle_interactive(
         self, workspace_id: str, dst_ip: str, dst_port: int | None

--- a/src/klangk/klangk/consent_deciders.py
+++ b/src/klangk/klangk/consent_deciders.py
@@ -1,0 +1,146 @@
+"""Runtime registry of live consent deciders (#2308).
+
+A workspace is treated as "interactive" (its blocked egress is held for a
+human decision, #2311) exactly while **at least one consent decider** is
+registered for it -- or deploy-wide. Interactivity is therefore *runtime
+state*, not the stored ``egress_mode`` flag: a decider connects (#2310, over
+the decider WebSocket) -> the workspace becomes interactive; the decider
+disconnects -> it reverts to static allow-list behavior. With no decider,
+blocked egress just fails (clean denial, no hanging connection -- the #2308
+model).
+
+The registry supports **N concurrent deciders** per workspace (several CLI
+sessions + Flutter clients at once): it is a collection keyed by decider id,
+``has_decider`` is true when >= 1 is live, and a pending request is fanned out
+to all of them (first decision wins -- wired in #2244).
+
+Liveness is driven by the decider WebSocket: connect -> ``register``, client
+ping -> ``touch``, disconnect -> ``deregister``; a background reaper (sweeping
+at half the timeout) drops any decider whose last ping exceeds
+``settings.consent_decider_timeout``, so a crashed/half-open client is reaped
+within ~1.5× the timeout -- a workspace can be stranded in interactive mode
+for at most that long, not indefinitely.
+
+Owns only ``app`` (the app-ownership rule); the timeout is read live via
+property so a SIGHUP reload propagates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class ConsentDeciderRegistry:
+    """Tracks live consent deciders; the gate for interactive egress (#2308).
+
+    Constructed once in :func:`build_app` and stored on ``app.state``; the
+    reaper is started in the lifespan and stopped on shutdown.
+    """
+
+    def __init__(self, app) -> None:
+        self.app = app
+        # decider_id -> {"ws": workspace_id | None, "seen": monotonic, "email"}
+        # workspace_id None = deploy-wide (decides for every workspace).
+        self._deciders: dict[str, dict] = {}
+        self._reaper: asyncio.Task | None = None
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    @property
+    def timeout(self) -> float:
+        return self.app.state.settings.consent_decider_timeout
+
+    def register(
+        self, decider_id: str, workspace_id: str | None, email: str | None
+    ) -> None:
+        """Register a live decider (connect). Idempotent on decider_id."""
+        self._deciders[decider_id] = {
+            "ws": workspace_id,
+            "seen": time.monotonic(),
+            "email": email,
+        }
+        logger.info(
+            "consent decider registered: scope=%s decider=%s",
+            workspace_id[:8] if workspace_id else "deploy",
+            decider_id[:8],
+        )
+
+    def deregister(self, decider_id: str) -> None:
+        """Drop a decider (disconnect). No-op if unknown."""
+        if self._deciders.pop(decider_id, None) is not None:
+            logger.info(
+                "consent decider deregistered: decider=%s", decider_id[:8]
+            )
+
+    def touch(self, decider_id: str) -> None:
+        """Mark a decider live (client ping)."""
+        entry = self._deciders.get(decider_id)
+        if entry is not None:
+            entry["seen"] = time.monotonic()
+
+    def has_decider(self, workspace_id: str) -> bool:
+        """True iff >= 1 live decider is registered for this workspace or deploy-wide."""
+        now = time.monotonic()
+        cutoff = self.timeout
+        for entry in self._deciders.values():
+            scope = entry["ws"]
+            if (scope is None or scope == workspace_id) and (
+                now - entry["seen"] <= cutoff
+            ):
+                return True
+        return False
+
+    def deciders_for(self, workspace_id: str) -> list[str]:
+        """Ids of live deciders for this workspace or deploy-wide (#2244 fanout)."""
+        now = time.monotonic()
+        cutoff = self.timeout
+        return [
+            did
+            for did, entry in self._deciders.items()
+            if (entry["ws"] is None or entry["ws"] == workspace_id)
+            and (now - entry["seen"] <= cutoff)
+        ]
+
+    def start(self) -> None:
+        """Start the liveness reaper (idempotent). Runs until :meth:`stop`."""
+        if self._reaper is None:
+            self._reaper = asyncio.create_task(self._reap_loop())
+
+    async def stop(self) -> None:
+        """Stop the reaper and clear all registrations."""
+        if self._reaper is not None:
+            self._reaper.cancel()
+            try:
+                await self._reaper
+            except asyncio.CancelledError:
+                pass
+            self._reaper = None
+        self._deciders.clear()
+
+    async def _reap_loop(self) -> None:
+        """Periodically drop deciders not pinged within the timeout.
+
+        Cancelled by :meth:`stop`; the CancelledError propagates out of the
+        sleep and is retrieved by stop()'s await (the standard cancelled-task
+        pattern), so stop()'s catch fires.
+        """
+        while True:
+            await asyncio.sleep(max(self.timeout / 2, 0.05))
+            now = time.monotonic()
+            stale = [
+                did
+                for did, entry in self._deciders.items()
+                if now - entry["seen"] > self.timeout
+            ]
+            for did in stale:
+                self._deciders.pop(did, None)
+                logger.info(
+                    "consent decider reaped (no ping within %.0fs): %s",
+                    self.timeout,
+                    did[:8],
+                )

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -20,6 +20,7 @@ from . import (
     auth,
     container,
     consent,
+    consent_deciders,
     emailsvc,
     files,
     model,
@@ -49,7 +50,7 @@ from .model import (
     SYSTEM_EVERYONE,
 )
 from .model import AGENT_USER_ID
-from .wshandler import handle_websocket
+from .wshandler import handle_consent_decider, handle_websocket
 
 logger = logging.getLogger(__name__)
 
@@ -469,6 +470,7 @@ class Lifecycle:
             "sockets",
             "container_registry",
             "consent_monitor",
+            "consent_deciders",
             "proxy_watchdog",
             "llm_router",
             "terminal",
@@ -691,6 +693,7 @@ async def lifespan(app: FastAPI):
     )
     await app.state.lifecycle.startup()
     app.state.consent_monitor.start()
+    app.state.consent_deciders.start()
     # Start the proxy (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.proxy_watchdog.start()
@@ -710,6 +713,7 @@ async def lifespan(app: FastAPI):
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
         await app.state.consent_monitor.stop()
+        await app.state.consent_deciders.stop()
         await app.state.proxy_watchdog.stop()
         await app.state.lifecycle.runtime_shutdown()
         await app.state.lifecycle.process_shutdown()
@@ -890,6 +894,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # sidecar's interactive-mode LOG lines and persists pending consent
     # requests (started/stopped in the lifespan; WS notify lands with #2244).
     app.state.consent_monitor = consent.EgressConsentMonitor(app)
+    app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(app)
     # #2201: per-workspace nix store via a btrfs snapshot or fuse overlay
     # (off unless KLANGKD_NIX_SEED__PATH names a seed; see nix.Nix).
     app.state.nix = nix.Nix(app)
@@ -964,6 +969,13 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket):  # pragma: no cover
         await handle_websocket(ws, app)
+
+    @app.websocket("/ws/consent-decider")
+    async def consent_decider_endpoint(ws: WebSocket):  # pragma: no cover
+        # #2308: a live consent decider registers here; its connection
+        # lifecycle drives the ConsentDeciderRegistry (the interactive-mode
+        # gate). Event content lands with #2244.
+        await handle_consent_decider(ws, app)
 
     # Frontend UI dir, resolved from settings (#1456, #1600). Mounted only
     # when it exists; a packaged/installed klangkd ships the UI inside the

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -731,6 +731,14 @@ class KlangkSettings(BaseSettings):
     # then requests simply expire. Read live (SIGHUP reload-safe).
     egress_consent_rate_limit: int = 50
     egress_consent_timeout: float = 30.0
+    # consent_decider_timeout (#2308): a consent decider (a live client that
+    # can approve/deny held egress) is registered while its WebSocket is
+    # connected and pinging. This is the liveness window -- a decider whose
+    # last ping is older than this is reaped (its registration dropped), so
+    # an unclean disconnect (crash, network drop) can't leave a workspace
+    # falsely "interactive" with a dead decider. Read live (SIGHUP
+    # reload-safe).
+    consent_decider_timeout: float = 45.0
     # Container resource limits (#34): deploy-wide CPU / memory / PIDs caps
     # passed to every workspace container as podman --cpus / --memory /
     # --pids-limit. Ships with protective defaults (2 CPUs / 8g / 16384 PIDs,

--- a/src/klangk/klangk/wshandler/__init__.py
+++ b/src/klangk/klangk/wshandler/__init__.py
@@ -58,6 +58,7 @@ from .agent_mention import (
     handle_agent_mention as handle_agent_mention,
     mentions_agent as mentions_agent,
 )
+from .decider import handle_consent_decider as handle_consent_decider
 from .dispatch import (
     _WS_CONNECTION_COMMANDS as _WS_CONNECTION_COMMANDS,
     _WS_STATE_COMMANDS as _WS_STATE_COMMANDS,

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -1,0 +1,81 @@
+"""Consent-decider WebSocket endpoint (#2308).
+
+A decider (a live client that can approve/deny held egress -- the ``klangk``
+CLI in #2310, or a Flutter client) connects here to register its live presence
+for a workspace (or deploy-wide). The connection lifecycle drives the
+:class:`~klangk.consent_deciders.ConsentDeciderRegistry`: connect -> register,
+client ``ping`` -> touch (liveness), disconnect -> deregister. While at least
+one decider is registered the workspace is "interactive" (its blocked egress is
+held for a decision, #2311); with none, it reverts to static allow-list.
+
+This endpoint owns **registration + liveness only**. The event content --
+pushing held requests down and receiving verdicts -- lands with #2244 and is
+carried over this same socket; until then the only client message is ``ping``.
+
+Auth mirrors the main ``/ws`` handler: a user JWT in the ``token`` query param.
+Scope is ``?workspace=<id>`` (workspace-scoped); omit it for a deploy-wide
+decider. Authorization to decide for a workspace is enforced when decision
+power arrives (#2244); presence registration itself grants no decision power.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+from .. import auth
+
+
+async def handle_consent_decider(websocket: WebSocket, app) -> None:
+    """Register a consent decider for its connection lifetime."""
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=4001, reason="Missing token")
+        return
+    result = await app.state.auth.get_user_from_token(token)
+    if result is auth.Auth.TOKEN_EXPIRED:
+        await websocket.close(code=4002, reason="Token expired")
+        return
+    if result is None:
+        await websocket.close(code=4001, reason="Invalid token")
+        return
+    user = result
+    workspace = websocket.query_params.get("workspace")  # None = deploy-wide
+    # TODO(#2244): authorize workspace membership here. Today any authenticated
+    # user can register a decider for any workspace (or deploy-wide); presence
+    # alone grants no decision power, but it flips an interactive workspace
+    # from static-deny to held-pending. #2244 must enforce membership before
+    # granting any decision power.
+
+    await websocket.accept()
+    decider_id = str(uuid.uuid4())
+    registry = app.state.consent_deciders
+    try:
+        # register inside the try so the finally-deregister invariant holds
+        # structurally rather than relying on register() not raising.
+        registry.register(decider_id, workspace, user.get("email"))
+        while True:
+            # Starlette raises RuntimeError ("WebSocket is not connected...")
+            # on a client disconnect during receive_text(); treat it the same
+            # as WebSocketDisconnect.
+            try:
+                raw = await websocket.receive_text()
+            except (WebSocketDisconnect, RuntimeError):
+                break
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("type") == "ping":
+                registry.touch(decider_id)
+                # NOTE(#2244): when this endpoint fans out held requests, route
+                # outbound writes through SafeWebSocket (bounded queue +
+                # SlowClientError) like the main /ws handler; raw send_text is
+                # fine while pong is the only outbound message.
+                await websocket.send_text(json.dumps({"type": "pong"}))
+    finally:
+        # Connection gone (clean disconnect, error, or crash) -> drop the
+        # registration so the workspace reverts to static (#2308).
+        registry.deregister(decider_id)

--- a/src/klangk/klangkd-tests/tests/test_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_consent.py
@@ -29,6 +29,7 @@ def _app(
     static_denial=None,
     egress_mode: str = "static",
     workspace_exists: bool = True,
+    has_decider: bool = True,
 ):
     app = types.SimpleNamespace()
     app.state = types.SimpleNamespace()
@@ -47,6 +48,9 @@ def _app(
     )
     app.state.model = types.SimpleNamespace(
         egress_consent=egress_consent, workspaces=workspaces
+    )
+    app.state.consent_deciders = types.SimpleNamespace(
+        has_decider=lambda workspace_id: has_decider
     )
     return app
 
@@ -89,6 +93,22 @@ class TestEgressConsentMonitor:
         mon = consent.EgressConsentMonitor(app)
         await mon._handle_event(FULL_WS, "1.2.3.4", 80)
         app.state.model.egress_consent.record_static_denial.assert_awaited_once()
+
+    async def test_interactive_without_decider_falls_to_static(self):
+        # #2308: interactive mode is runtime state -- with no live decider
+        # registered, a blocked destination is recorded as a static denial,
+        # not queued as pending (no hanging connection).
+        app = _app(
+            egress_mode="interactive",
+            has_decider=False,
+            static_denial=_denial(),
+        )
+        mon = consent.EgressConsentMonitor(app)
+        await mon._handle_event(FULL_WS, "1.2.3.4", 80)
+        app.state.model.egress_consent.record_static_denial.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 80
+        )
+        app.state.model.egress_consent.create_request.assert_not_called()
 
     async def test_interactive_creates_pending_and_schedules_timeout(self):
         req = {

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -1,0 +1,277 @@
+"""Tests for :mod:`klangk.consent_deciders` -- the live-decider registry (#2308)."""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+from klangk.consent_deciders import ConsentDeciderRegistry
+
+WS = "ws-aaaa1111-2222-3333-4444-555566667777"
+WS2 = "ws-bbbb2222-3333-4444-5555-666677778888"
+
+
+def _app(timeout: float = 45.0):
+    app = types.SimpleNamespace()
+    app.state = types.SimpleNamespace()
+    app.state.settings = types.SimpleNamespace(consent_decider_timeout=timeout)
+    return app
+
+
+class TestConsentDeciderRegistry:
+    async def test_no_decider_is_not_interactive(self):
+        reg = ConsentDeciderRegistry(_app())
+        assert reg.has_decider(WS) is False
+
+    async def test_register_then_deregister(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "admin@example.com")
+        assert reg.has_decider(WS) is True
+        reg.deregister("d1")
+        assert reg.has_decider(WS) is False
+        # deregister of unknown id is a no-op
+        reg.deregister("nope")
+
+    async def test_multiple_deciders_same_workspace(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x")
+        reg.register("d2", WS, "b@x")
+        reg.register("d3", WS, "c@x")
+        assert reg.has_decider(WS) is True
+        # N concurrent deciders; removing one leaves the rest
+        reg.deregister("d1")
+        assert reg.has_decider(WS) is True
+        assert reg.deciders_for(WS) == ["d2", "d3"]
+        reg.deregister("d2")
+        reg.deregister("d3")
+        assert reg.has_decider(WS) is False
+
+    async def test_decider_scoped_to_one_workspace(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x")
+        assert reg.has_decider(WS) is True
+        # not visible to a different workspace
+        assert reg.has_decider(WS2) is False
+        assert reg.deciders_for(WS2) == []
+
+    async def test_deploy_wide_decider_covers_every_workspace(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("admin", None, "admin@example.com")
+        assert reg.has_decider(WS) is True
+        assert reg.has_decider(WS2) is True
+        assert set(reg.deciders_for(WS)) == {"admin"}
+
+    async def test_register_is_idempotent_on_decider_id(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x")
+        reg.register(
+            "d1", WS, "a@x"
+        )  # reconnect with same id -> refresh, not dup
+        assert reg.deciders_for(WS) == ["d1"]
+
+    async def test_touch_extends_liveness(self):
+        reg = ConsentDeciderRegistry(_app(timeout=0.05))
+        reg.register("d1", WS, "a@x")
+        # age it past the timeout, then ping to refresh
+        reg._deciders["d1"]["seen"] -= 1.0
+        assert reg.has_decider(WS) is False
+        reg.touch("d1")
+        assert reg.has_decider(WS) is True
+        # touch of unknown id is a no-op
+        reg.touch("nope")
+
+    async def test_reaper_drops_stale_deciders(self):
+        reg = ConsentDeciderRegistry(_app(timeout=0.02))
+        reg.register("d1", WS, "a@x")
+        reg.start()
+        try:
+            # mark stale; the reaper ticks at >= timeout
+            reg._deciders["d1"]["seen"] -= 1.0
+            await asyncio.sleep(0.08)
+            assert reg.has_decider(WS) is False
+            assert reg._deciders == {}
+        finally:
+            await reg.stop()
+
+    async def test_reaper_keeps_fresh_deciders(self):
+        reg = ConsentDeciderRegistry(_app(timeout=0.05))
+        reg.register("d1", WS, "a@x")
+        reg.start()
+        try:
+            await asyncio.sleep(0.04)
+            reg.touch("d1")  # keep it alive across reaper ticks
+            await asyncio.sleep(0.04)
+            assert reg.has_decider(WS) is True
+        finally:
+            await reg.stop()
+
+    async def test_stop_clears_all_and_is_idempotent(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x")
+        reg.register("d2", None, "b@x")
+        await reg.stop()
+        assert reg._deciders == {}
+        assert reg._reaper is None
+        await reg.stop()  # idempotent
+
+
+class _FakeWS:
+    """Minimal stand-in for a fastapi WebSocket for handler-level tests."""
+
+    def __init__(self, params: dict, incoming: list):
+        self.query_params = params
+        self._incoming = iter(incoming)
+        self.sent: list[str] = []
+        self.accepted = False
+        self.closed: tuple | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = (code, reason)
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def receive_text(self) -> str:
+        item = next(self._incoming)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+def _ws_app(token_result):
+    """App with mocked auth + a real ConsentDeciderRegistry."""
+    from unittest.mock import AsyncMock
+
+    app = types.SimpleNamespace()
+    app.state = types.SimpleNamespace()
+    app.state.settings = types.SimpleNamespace(consent_decider_timeout=45.0)
+    app.state.consent_deciders = ConsentDeciderRegistry(app)
+    app.state.auth = types.SimpleNamespace(
+        get_user_from_token=AsyncMock(return_value=token_result)
+    )
+    return app
+
+
+class TestConsentDeciderWS:
+    async def test_connect_registers_disconnect_deregisters(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"email": "admin@example.com"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [WebSocketDisconnect()],  # connect, then immediately disconnect
+        )
+        await handle_consent_decider(ws, app)
+        assert ws.accepted
+        assert (
+            app.state.consent_deciders.has_decider(WS) is False
+        )  # deregistered
+
+    async def test_missing_token_is_rejected(self):
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"email": "a@x"})
+        ws = _FakeWS({"workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4001, "Missing token")
+        assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_invalid_token_is_rejected(self):
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app(None)
+        ws = _FakeWS({"token": "bad"}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4001, "Invalid token")
+
+    async def test_expired_token_is_rejected(self):
+        from klangk import auth
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app(auth.Auth.TOKEN_EXPIRED)
+        ws = _FakeWS({"token": "stale"}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4002, "Token expired")
+
+    async def test_ping_touches_and_pongs(self):
+        import json
+
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"ping"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        assert any(json.loads(m).get("type") == "pong" for m in ws.sent)
+
+    async def test_deploy_wide_when_no_workspace_param(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"email": "admin@example.com"})
+        ws = _FakeWS({"token": "tok"}, [WebSocketDisconnect()])
+        # While connected it would cover every workspace; after disconnect,
+        # nothing remains.
+        await handle_consent_decider(ws, app)
+        assert app.state.consent_deciders.has_decider(WS) is False
+        assert app.state.consent_deciders.has_decider(WS2) is False
+
+    async def test_non_ping_and_invalid_json_are_ignored(self):
+        import json
+
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                "not-json",  # invalid JSON -> continue
+                '{"type":"hello"}',  # valid JSON, not a ping -> ignored
+                '{"type":"ping"}',  # ping -> pong
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        assert any(json.loads(m).get("type") == "pong" for m in ws.sent)
+        assert (
+            app.state.consent_deciders.has_decider(WS) is False
+        )  # deregistered
+
+    async def test_runtime_error_disconnect_breaks_cleanly(self):
+        # Starlette raises RuntimeError on a mid-receive disconnect; the
+        # handler treats it as a disconnect and still deregisters.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS}, [RuntimeError("disconnected")]
+        )
+        await handle_consent_decider(ws, app)
+        assert app.state.consent_deciders.has_decider(WS) is False
+
+
+class TestConsentDeciderRegistryReconfigure:
+    async def test_reconfigure_swaps_app(self):
+        import types as _types
+
+        reg = ConsentDeciderRegistry(_app(timeout=10.0))
+        new_app = _types.SimpleNamespace(
+            state=_types.SimpleNamespace(
+                settings=_types.SimpleNamespace(consent_decider_timeout=99.0)
+            )
+        )
+        reg.reconfigure(new_app)
+        assert reg.timeout == 99.0

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -20,6 +20,7 @@ from klangk import (
     auth as auth_mod,
     caddy as caddy_mod,
     consent,
+    consent_deciders,
     emailsvc as emailsvc_mod,
     files as files_mod,
     ssl_trust as ssl_trust_mod,
@@ -807,6 +808,9 @@ class TestLifespan:
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
+        app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
+            app
+        )
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -856,6 +860,9 @@ class TestLifespan:
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
+        app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
+            app
+        )
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -1385,6 +1392,9 @@ class TestStartupShutdownRestart:
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
+        app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
+            app
+        )
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)


### PR DESCRIPTION
## Summary

Closes #2308. Makes interactive egress consent **runtime state**: a workspace's blocked egress is held for a decision only while ≥1 consent decider is registered for it (or deploy-wide), instead of merely because `egress_mode='interactive'`.

- **`ConsentDeciderRegistry`** (`consent_deciders.py`) — N concurrent deciders per workspace (or deploy-wide); `has_decider` is the gate; ping-driven liveness + a reaper (`consent_decider_timeout`, default 45s) drops silent deciders so a crashed/half-open client can't strand a workspace in interactive mode.
- **`/ws/consent-decider`** endpoint (`wshandler/decider.py`) — user-JWT auth, optional `?workspace=<id>` scope (deploy-wide if omitted); connect→register, `ping`→touch/pong, disconnect→deregister. Idempotent registration; `WebSocketDisconnect` and Starlette's `RuntimeError` both treated as disconnect, with `finally` always deregistering.
- **The gate** — the monitor's `_is_interactive` now ANDs `egress_mode==interactive` with `has_decider`, so an interactive workspace with **no decider registered** records blocked egress as a static denial instead of queuing a pending request (clean deny, no hanging connection — the #2308 model).
- Wired into `build_app` / lifespan / SIGHUP; new `consent_decider_timeout` setting; changelog entry.

Event content (pushing held requests) lands with #2244; the synchronous hold + sidecar-role WS with #2311; the `consent-decide` client with #2310. This PR is the foundation: the runtime gate + the decider-presence registry + the WS endpoint that drives it.

The agreed end-to-end data-flow contract (`sidecar ←WS→ klangkd ←{SQLite + in-process event}→ klangkd ←WS→ decider`) is recorded on #2311 / #2244 / #2308.

## Test coverage

4433 passed, 100%. New `test_consent_deciders.py` (registry: N deciders, deploy-wide, touch, reap, reconfigure; WS endpoint: register/deregister, ping/pong, the three reject paths, invalid-JSON + non-ping ignore, RuntimeError disconnect). Updated `test_consent.py` (the no-decider→static gate) and `test_main.py` (consent_deciders across the lifespan/SIGHUP tests).
