### PR TITLE
fix(container): sweep orphaned sidecar token files (#2309)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -476,6 +476,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Sidecar token file retention (#2309).** A periodic sweep now removes
+  leftover per-workspace token files under `data_dir/ws-tokens/` once the
+  workspace row is gone, so they no longer accumulate one file per workspace
+  ever started. The sweep piggybacks on the idle container cleanup loop (at
+  most every 5 minutes) and leaves the token in place for any workspace that
+  still exists, including stopped ones awaiting a restart.
+
 - **Starting/restarting a workspace with a bad bind mount returns a 400, not
   a 500 (#2157).** A workspace whose extra mount points at a nonexistent host
   path previously raised an unhandled `ValueError` from the volume pre-check,

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -46,6 +46,10 @@ _NETWORK_SIDECAR_MARK = 75
 # Matches the old NFLOG group for familiarity; single source of truth passed to
 # both the entrypoint (iptables -j NFQUEUE) and the consumer via env.
 _NETWORK_SIDECAR_NFQUEUE = 5139
+# How often the idle cleanup loop scans data_dir/ws-tokens/ for orphaned
+# sidecar-token files (workspaces whose DB row is gone). Self-throttled so
+# the directory + workspace table are not hit on every idle tick (#2309).
+ORPHAN_TOKEN_SWEEP_INTERVAL = 300
 
 
 def _workspace_name_slug(name: str, *, limit: int = 24) -> str:
@@ -291,6 +295,7 @@ class IdleMonitor:
 
     async def cleanup_idle_containers(self) -> None:
         registry = self.app.state.container_registry
+        last_token_sweep = 0.0
         while True:
             timeouts = [
                 s.idle_timeout
@@ -336,6 +341,17 @@ class IdleMonitor:
                             logger.error("Idle callback error: %s", e)
                 await registry.notify_workspace_killed(wid)
                 await registry.stop_and_remove_container(cid)
+
+            # Periodic orphan sidecar-token sweep (#2309): reclaim
+            # ws-tokens/<id> files whose workspace row is gone. Piggybacks
+            # on this loop (no separate task); self-throttled to scan at
+            # most every ORPHAN_TOKEN_SWEEP_INTERVAL.
+            if now - last_token_sweep >= ORPHAN_TOKEN_SWEEP_INTERVAL:
+                last_token_sweep = now
+                try:
+                    await registry._sweep_orphaned_sidecar_tokens()
+                except Exception as e:
+                    logger.warning("Orphan sidecar-token sweep failed: %s", e)
 
     def start_cleanup_loop(self) -> None:
         registry = self.app.state.container_registry
@@ -1176,6 +1192,53 @@ class ContainerRegistry:
         with open(tmp, "w") as f:
             f.write(token)
         os.replace(tmp, path)
+
+    async def _sweep_orphaned_sidecar_tokens(self) -> int:
+        """Remove ``ws-tokens/<id>`` files for workspaces that no longer exist.
+
+        The sidecar's workspace-token file is written on every network-sidecar
+        start (:meth:`write_sidecar_token`) and intentionally kept across
+        stop/restart -- a stopped workspace must keep its token for a later
+        restart. Only a final delete (or a crash that skips cleanup) orphans
+        the file, so this sweep reclaims them (#2309). Safe: a workspace whose
+        row still exists keeps its token; only files with no matching row are
+        removed. Returns the number of files removed.
+        """
+        token_dir = os.path.join(self.app.state.settings.data_dir, "ws-tokens")
+        if not os.path.isdir(token_dir):
+            return 0
+        try:
+            names = os.listdir(token_dir)
+        except OSError as e:
+            logger.warning(
+                "Cannot scan %s for orphaned tokens: %s", token_dir, e
+            )
+            return 0
+        try:
+            existing = await self.app.state.workspaces.existing_workspace_ids()
+        except Exception as e:
+            logger.warning("Cannot list workspace ids for token sweep: %s", e)
+            return 0
+        removed = 0
+        for name in names:
+            # Skip transient write_sidecar_token temp files: unlinking one
+            # races the writer (os.replace would then FileNotFoundError).
+            if name.endswith(".tmp"):
+                continue
+            path = os.path.join(token_dir, name)
+            if not os.path.isfile(path):
+                continue
+            if name in existing:
+                continue
+            try:
+                os.unlink(path)
+                removed += 1
+                logger.info("Removed orphaned sidecar token %s", name)
+            except OSError as e:
+                logger.warning(
+                    "Could not remove orphaned token %s: %s", name, e
+                )
+        return removed
 
     async def _start_network_sidecar(
         self,

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -572,6 +572,18 @@ class WorkspacesModel:
             "egress_mode": row["egress_mode"],
         }
 
+    async def existing_workspace_ids(self) -> set[str]:
+        """Return the IDs of every workspace row (for orphan-file sweeps).
+
+        Used by the periodic sidecar-token sweep (:meth:`ContainerRegistry.
+        _sweep_orphaned_sidecar_tokens`) to tell token files whose workspace
+        still exists from orphans left by a deleted/crashed workspace (#2309).
+        """
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute("SELECT id FROM workspaces")
+            rows = await cursor.fetchall()
+        return {row["id"] for row in rows}
+
     async def get_workspace_members(self, workspace_id: str) -> list[dict]:
         """Get users who have been granted access to a workspace via ACL.
 

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -435,6 +435,11 @@ class Workspaces:
             workspace_id, user_id
         )
 
+    async def existing_workspace_ids(self) -> set[str]:
+        # Delegates to the model; used by the periodic sidecar-token sweep
+        # (container.py) to tell orphans from live workspace tokens (#2309).
+        return await self.app.state.model.workspaces.existing_workspace_ids()
+
     async def delete_workspace(self, workspace_id: str, user_id: str) -> bool:
         workspace = await self.app.state.model.workspaces.get_workspace(
             workspace_id, user_id

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -6,7 +6,7 @@ import types
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -3858,6 +3858,144 @@ class TestCleanupIdleContainers:
             p.remove_container.assert_awaited()
         finally:
             self.registry.states.clear()
+
+    async def test_sweep_removes_orphaned_sidecar_tokens(
+        self, tmp_path, monkeypatch
+    ):
+        # Orphan ws-tokens/<id> files (workspace row gone) are unlinked;
+        # tokens for live workspaces and transient .tmp writes are kept (#2309).
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        token_dir = tmp_path / "ws-tokens"
+        token_dir.mkdir()
+        (token_dir / "live-ws").write_text("tok-live")  # row exists
+        (token_dir / "gone-ws").write_text("tok-gone")  # orphan
+        (token_dir / "gone-ws.tmp").write_text("partial")  # transient write
+        (token_dir / "subdir").mkdir()  # non-file entry: skipped, not unlinked
+        monkeypatch.setattr(
+            self.registry.app.state.workspaces,
+            "existing_workspace_ids",
+            AsyncMock(return_value={"live-ws"}),
+        )
+        removed = await self.registry._sweep_orphaned_sidecar_tokens()
+        assert removed == 1
+        assert (token_dir / "live-ws").exists()
+        assert not (token_dir / "gone-ws").exists()
+        # .tmp is never unlinked (would race write_sidecar_token's os.replace)
+        assert (token_dir / "gone-ws.tmp").exists()
+        # non-file entries (subdirs) are left untouched
+        assert (token_dir / "subdir").is_dir()
+
+    async def test_sweep_noop_without_token_dir(self, tmp_path, monkeypatch):
+        # No ws-tokens/ dir (no filtered workspace ever started) -> 0, and
+        # the workspaces table is not even queried.
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        queried = AsyncMock()
+        monkeypatch.setattr(
+            self.registry.app.state.workspaces,
+            "existing_workspace_ids",
+            queried,
+        )
+        assert await self.registry._sweep_orphaned_sidecar_tokens() == 0
+        queried.assert_not_awaited()
+
+    async def test_sweep_swallows_workspace_lookup_error(
+        self, tmp_path, monkeypatch
+    ):
+        # A DB error mid-sweep must not propagate (resilience over crash); the
+        # token file is left intact for the next sweep to retry.
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        (tmp_path / "ws-tokens").mkdir()
+        (tmp_path / "ws-tokens" / "ws-x").write_text("t")
+        monkeypatch.setattr(
+            self.registry.app.state.workspaces,
+            "existing_workspace_ids",
+            AsyncMock(side_effect=RuntimeError("db down")),
+        )
+        assert await self.registry._sweep_orphaned_sidecar_tokens() == 0
+        assert (tmp_path / "ws-tokens" / "ws-x").exists()
+
+    async def test_idle_loop_invokes_orphan_token_sweep(self):
+        # The periodic idle loop piggybacks the sweep; last_token_sweep starts
+        # at 0 so the first iteration always sweeps (#2309).
+        sweep = AsyncMock()
+        self.registry._sweep_orphaned_sidecar_tokens = sweep
+        with patch_podman(self.registry):
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
+            await asyncio.sleep(0.05)
+            self.registry.get_cleanup_wake().set()
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        sweep.assert_awaited()
+
+    async def test_sweep_swallows_listdir_error(self, tmp_path, monkeypatch):
+        # An OSError scanning ws-tokens/ must not propagate; the workspaces
+        # table is not queried (early return).
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        (tmp_path / "ws-tokens").mkdir()
+        queried = AsyncMock()
+        monkeypatch.setattr(
+            self.registry.app.state.workspaces,
+            "existing_workspace_ids",
+            queried,
+        )
+        monkeypatch.setattr(
+            "klangk.container.os.listdir",
+            MagicMock(side_effect=OSError("io")),
+        )
+        assert await self.registry._sweep_orphaned_sidecar_tokens() == 0
+        queried.assert_not_awaited()
+
+    async def test_sweep_swallows_unlink_error(self, tmp_path, monkeypatch):
+        # An OSError unlinking one orphan is logged and skipped (the file is
+        # left for the next sweep); other orphans are still processed.
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        token_dir = tmp_path / "ws-tokens"
+        token_dir.mkdir()
+        (token_dir / "gone-ws").write_text("tok")
+        monkeypatch.setattr(
+            self.registry.app.state.workspaces,
+            "existing_workspace_ids",
+            AsyncMock(return_value=set()),
+        )
+        monkeypatch.setattr(
+            "klangk.container.os.unlink",
+            MagicMock(side_effect=OSError("busy")),
+        )
+        removed = await self.registry._sweep_orphaned_sidecar_tokens()
+        assert removed == 0  # the unlink failed
+        assert (token_dir / "gone-ws").exists()  # left intact
+
+    async def test_idle_loop_swallows_sweep_error(self):
+        # A sweep failure raised inside the loop is logged, not propagated --
+        # the loop runs a full iteration and is only stopped by cancellation.
+        self.registry._sweep_orphaned_sidecar_tokens = AsyncMock(
+            side_effect=RuntimeError("sweep broke")
+        )
+        with patch_podman(self.registry):
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
+            await asyncio.sleep(0.05)
+            self.registry.get_cleanup_wake().set()
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self.registry._sweep_orphaned_sidecar_tokens.assert_awaited()
 
 
 class TestStartCleanupLoop:

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -45,6 +45,19 @@ async def test_create_workspace_row_only(ws, user):
     assert got["id"] == ws_row["id"]
 
 
+async def test_existing_workspace_ids(ws, user):
+    # Basis for the orphan sidecar-token sweep: the set reflects the live
+    # workspaces table, and a delete drops the id (#2309).
+    a = await ws.create_workspace(user["id"], "alpha")
+    b = await ws.create_workspace(user["id"], "beta")
+    ids = await ws.existing_workspace_ids()
+    assert {a["id"], b["id"]} <= ids
+    await ws.delete_workspace(a["id"], user["id"])
+    ids_after = await ws.existing_workspace_ids()
+    assert a["id"] not in ids_after
+    assert b["id"] in ids_after
+
+
 async def test_create_workspace_with_acl_rejects_agent(ws):
     with pytest.raises(AgentPrincipalError):
         await ws.create_workspace_with_acl(AGENT_USER_ID, "agent-owned")

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -48,6 +48,21 @@ class TestCreateWorkspace:
                 user["id"], "unique"
             )
 
+    async def test_existing_workspace_ids_delegates_to_model(
+        self, user, app_state
+    ):
+        # The service wrapper delegates to the model; the live id-set is the
+        # basis for the orphan sidecar-token sweep (container.py, #2309).
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "sweep-me"
+        )
+        ids = await app_state.state.workspaces.existing_workspace_ids()
+        assert ws["id"] in ids
+        await app_state.state.workspaces.delete_workspace(ws["id"], user["id"])
+        assert ws["id"] not in (
+            await app_state.state.workspaces.existing_workspace_ids()
+        )
+
     async def test_invalid_setup_state_rejected(self, user, app_state):
         """Invalid setup_state raises ValueError (#1033)."""
         # Service layer (goes through create_workspace_with_acl).


### PR DESCRIPTION
## Summary

Fixes #2309 — leftover `data_dir/ws-tokens/<workspace_id>` token files (one per workspace that ever started a network sidecar) are now reclaimed by a periodic sweep.

`write_sidecar_token` writes the sidecar's workspace JWT on every network-sidecar start and rewrites it on rotation, but nothing removed the file. Removing it on stop/recycle is the obvious-but-wrong fix: `_start_network_sidecar` writes the token and then tears down any stale sidecar, so a stop/recycle hook would delete the freshly-written token and break the sidecar's auth on the very start that wrote it. A stopped workspace must also keep its token for a later restart.

## Approach — periodic sweep (option 2 from the issue)

`ContainerRegistry._sweep_orphaned_sidecar_tokens()` scans `data_dir/ws-tokens/` and removes any entry whose workspace row no longer exists, leaving files for live (including stopped) workspaces untouched. It is **piggybacked onto the existing idle container cleanup loop** (`IdleMonitor.cleanup_idle_containers`) — no new background task — and self-throttled via a loop-local timestamp to scan at most once per `ORPHAN_TOKEN_SWEEP_INTERVAL` (300s), so the directory and the workspaces table are not hit on every idle tick.

Safety properties:
- A workspace whose row still exists keeps its token (covers stopped-but-not-deleted, and the recycle path).
- Only files with no matching row are removed.
- Transient `*.tmp` write files are skipped (unlinking one races `write_sidecar_token`'s `os.replace`).
- Non-file entries (subdirs) are skipped.
- Every failure mode (OSError scanning, DB error listing IDs, OSError unlinking, a sweep exception inside the loop) is caught and logged — the sweep never blocks the idle loop or crashes the server.

## New helper

`Workspaces.existing_workspace_ids()` — the live id-set basis for the sweep. Added on the model (`SELECT id FROM workspaces`) with a delegating method on the service wrapper (`app.state.workspaces`), matching how every other workspaces method is exposed.

## Why "low" severity is still worth fixing

The leaked file is a self-expiring JWT (`workspace_token_hours`, 24h default), so the impact is unbounded on-disk accumulation rather than credential disclosure. Noted in the issue as worth fixing alongside the broader retention work (#2303).

## Verification

- New tests (7): sweep removes orphans / keeps live + `.tmp` + non-file entries; no-op without the token dir (table not queried); swallows listdir / DB-lookup / unlink errors; the idle loop invokes the sweep (wiring) and swallows a sweep exception. Plus `existing_workspace_ids` round-trip tests at both the model and the service wrapper.
- Full suite (CI invocation): **4442 passed, 100% coverage** (`container.py`, `workspaces.py`, `model/workspaces.py` all 100%).
