### PR TITLE
feat(consent): synchronous hold/resolve coordinator + egress-sidecar WS (#2311)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -61,6 +61,17 @@ operators or integrators to act when upgrading.
   workspace with no decider registered now records blocked egress as a
   static denial instead of queuing it — it needs a live decider to queue.
   The decider client itself lands with #2310.
+- **`/ws/egress-sidecar` + consent hold/resolve coordinator (#2311).** The
+  network sidecar's blocked-egress path gains a synchronous hold: a
+  workspace's blocked egress is held in-flight (pending a human verdict) only
+  while a consent decider is registered (#2308); with no decider it is denied
+  at once as a static denial (no hold, no queued row). The sidecar connects
+  over a new `/ws/egress-sidecar` WebSocket (workspace-JWT auth) and receives
+  a verdict per blocked destination; the in-process coordinator fail-closes
+  on timeout or shutdown (no leaked allow, no hung connection). **Scope: this
+  is the klangkd coordination half** — the sidecar's kernel-level hold
+  (suspending DNS queries, deferring NFQUEUE verdicts) + its WS client land in
+  a follow-up, and decider fanout/verdict reception with #2244.
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the

--- a/src/klangk/klangk/consent.py
+++ b/src/klangk/klangk/consent.py
@@ -27,6 +27,17 @@ from .model.workspaces import EGRESS_MODE_INTERACTIVE
 logger = logging.getLogger(__name__)
 
 
+async def workspace_is_interactive(app, workspace_id: str) -> bool:
+    # #2308: interactivity is runtime state -- a workspace is interactive
+    # only while a live consent decider is registered for it (or
+    # deploy-wide), AND the workspace has opted in (egress_mode). No
+    # decider -> static behavior (clean denial, no held connection).
+    ws = await app.state.model.workspaces.get_workspace(workspace_id)
+    if not ws or ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
+        return False
+    return app.state.consent_deciders.has_decider(workspace_id)
+
+
 class EgressConsentMonitor:
     """Receive sidecar egress events and persist consent requests.
 
@@ -112,14 +123,7 @@ class EgressConsentMonitor:
                 self._notify(request)
 
     async def _is_interactive(self, workspace_id: str) -> bool:
-        # #2308: interactivity is runtime state -- a workspace is interactive
-        # only while a live consent decider is registered for it (or
-        # deploy-wide), AND the workspace has opted in (egress_mode). No
-        # decider -> static behavior (clean denial, no held connection).
-        ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
-        if not ws or ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
-            return False
-        return self.app.state.consent_deciders.has_decider(workspace_id)
+        return await workspace_is_interactive(self.app, workspace_id)
 
     async def _handle_interactive(
         self, workspace_id: str, dst_ip: str, dst_port: int | None

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -1,0 +1,242 @@
+"""Synchronous egress-consent hold/resolve coordinator (#2311).
+
+#2308 makes "interactive" runtime state -- a workspace is interactive only
+while >= 1 consent decider is registered. THIS module is what actually *holds*
+a blocked egress connection in-flight for that decision: the sidecar's
+egress-sidecar WebSocket calls :meth:`ConsentCoordinator.hold` per blocked
+destination, and the coordinator returns a :class:`~asyncio.Future` that
+resolves to the verdict once a decider decides (#2244 calls :meth:`resolve`),
+the hold times out, or the coordinator shuts down. The sidecar relay task
+awaits that Future and sends the verdict back over its socket (#2311).
+
+Fail-closed throughout:
+
+- no decider registered (or workspace not opted in) -> immediate static
+  denial (no hold, no pending row, deny verdict at once);
+- decider too slow -> the per-hold timeout expires the row + denies;
+- coordinator shutdown -> every in-flight hold is denied (a sidecar restart's
+  in-process holds die with the process, and the orphaned pending rows are
+  expired here).
+
+No hold is ever left pending forever.
+
+Owns only ``app`` (the app-ownership rule); timeout / rate-limit are read
+live via property so a SIGHUP reload propagates.
+
+Scope note: this is the klangkd coordination half of #2311. The sidecar's
+kernel-level hold (suspending DNS queries, deferring NFQUEUE verdicts) + its
+WS client land in a stacked follow-up; #2244 wires the decider fanout and
+verdict reception to :meth:`resolve`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from .consent import workspace_is_interactive
+
+logger = logging.getLogger(__name__)
+
+# Verdicts sent back to the sidecar over its WS relay (#2311).
+VERDICT_ALLOW = "allow"
+VERDICT_DENY = "deny"
+
+
+class ConsentCoordinator:
+    """In-process holds for egress requests awaiting a verdict (#2311).
+
+    Constructed once in :func:`build_app` and stored on ``app.state``; holds
+    are created on demand by :meth:`hold` (called by the sidecar WS endpoint)
+    and resolved by :meth:`resolve` (the #2244 decider hook), a timeout, or
+    :meth:`stop` (fail-close on shutdown).
+    """
+
+    def __init__(self, app) -> None:
+        self.app = app
+        # request_id -> {"future": Future, "workspace_id": str, "task": Task}
+        self._holds: dict[str, dict] = {}
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    @property
+    def timeout(self) -> float:
+        return self.app.state.settings.egress_consent_timeout
+
+    @property
+    def rate_limit(self) -> int:
+        return self.app.state.settings.egress_consent_rate_limit
+
+    def start(self) -> None:
+        """Lifespan symmetry only -- holds are created on demand by :meth:`hold`.
+
+        Kept so every ``app.state`` subsystem has a uniform start/stop pair.
+        """
+
+    async def stop(self) -> None:
+        """Fail-close every in-flight hold (coordinator shutdown / sidecar gone).
+
+        Each orphaned pending row is expired (audit) and its Future resolved
+        deny, so a sidecar restart leaves no leaked allow and no hung relay.
+        """
+        for request_id in list(self._holds):
+            hold = self._holds.get(request_id)
+            if hold is not None:
+                hold["task"].cancel()
+            await self._fail_close(request_id, reason="shutdown")
+
+    async def hold(
+        self, workspace_id: str, dst: str, dport: int | None
+    ) -> asyncio.Future:
+        """Gate-check a blocked egress and create a hold; return its verdict Future.
+
+        - not interactive (no decider, or workspace not opted in) -> record a
+          static denial and resolve the Future deny at once (no pending row,
+          no hold, no timeout) -- the sidecar denies immediately.
+        - interactive + decider, but the per-workspace pending cap is reached
+          -> deny at once (flood bound; the hold is refused, not held).
+        - a pending request for this (workspace, dst, dport) already exists
+          (create_request dedup) -> deny the duplicate.
+        - otherwise -> create the pending request, register the hold, arm its
+          timeout, and fan out to the workspace's deciders (#2244 stub).
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            if not await self._is_interactive(workspace_id):
+                await self.app.state.model.egress_consent.record_static_denial(
+                    workspace_id, dst, dport
+                )
+                fut: asyncio.Future = loop.create_future()
+                fut.set_result({"decision": VERDICT_DENY, "reason": "static"})
+                return fut
+            consent = self.app.state.model.egress_consent
+            if await consent.count_pending(workspace_id) >= self.rate_limit:
+                fut = loop.create_future()
+                fut.set_result(
+                    {"decision": VERDICT_DENY, "reason": "rate_limited"}
+                )
+                return fut
+            request = await consent.create_request(workspace_id, dst, dport)
+            if request is None:
+                fut = loop.create_future()
+                fut.set_result(
+                    {"decision": VERDICT_DENY, "reason": "duplicate"}
+                )
+                return fut
+            return self._register_hold(request)
+        except Exception:
+            # A model/DB failure must not crash the relay or strand the hold:
+            # fail-close to a deny verdict so the sidecar NXDOMAIN/DROPs. The
+            # kernel keeps the connection blocked either way (fail-closed), but
+            # this gives the sidecar a definitive deny instead of silence.
+            logger.exception("consent: hold failed; fail-closing to deny")
+            fut = loop.create_future()
+            fut.set_result({"decision": VERDICT_DENY, "reason": "error"})
+            return fut
+
+    def _register_hold(self, request: dict) -> asyncio.Future:
+        """Register a held request + arm its timeout + fan out (interactive path)."""
+        request_id = request["id"]
+        workspace_id = request["workspace_id"]
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        task = asyncio.create_task(self._timeout(request_id))
+        self._holds[request_id] = {
+            "future": fut,
+            "workspace_id": workspace_id,
+            "task": task,
+        }
+        self._fanout(request)
+        return fut
+
+    async def resolve(
+        self,
+        request_id: str,
+        decision: str,
+        scope: str | None,
+        decided_by: str,
+    ) -> dict | None:
+        """Apply a decider verdict to a held request (the #2244 hook).
+
+        Records the decision in SQLite (allowed/denied), cancels the hold's
+        timeout, and resolves its Future. Returns the verdict dict relayed to
+        the sidecar, or ``None`` if the request is not currently held (already
+        resolved, timed out, or never held).
+        """
+        hold = self._holds.pop(request_id, None)
+        if hold is None:
+            return None
+        hold["task"].cancel()
+        row = await self.app.state.model.egress_consent.decide(
+            request_id, decision, scope, decided_by
+        )
+        if row is None:
+            verdict = {"decision": VERDICT_DENY, "reason": "gone"}
+        elif decision == "allowed":
+            verdict = {"decision": VERDICT_ALLOW, "reason": "decided"}
+        else:
+            verdict = {"decision": VERDICT_DENY, "reason": "decided"}
+        if not hold["future"].done():
+            hold["future"].set_result(verdict)
+        return verdict
+
+    async def _timeout(self, request_id: str) -> None:
+        """Auto-expire a held request after the timeout; fail-close on wake.
+
+        ``resolve``/``stop`` **pop the hold before cancelling this task**, with
+        no ``await`` between the pop and the cancel -- so a not-yet-woken
+        timeout is cancelled (the ``except CancelledError`` returns) and never
+        reaches ``_fail_close``. If this coroutine *does* wake past the sleep,
+        no one popped in the meantime, so the hold is still present.
+        ``_fail_close`` nonetheless pops first and no-ops if the hold is already
+        gone (e.g. a ``stop`` racing this wake) -- that pop-``None`` guard is
+        load-bearing; do not remove it.
+        """
+        try:
+            await asyncio.sleep(self.timeout)
+        except asyncio.CancelledError:
+            return
+        await self._fail_close(request_id, reason="timeout")
+
+    async def _fail_close(self, request_id: str, *, reason: str) -> None:
+        """Expire the pending row and resolve the Future deny (timeout/shutdown).
+
+        Does NOT cancel the hold's own task -- the caller owns that (``_timeout``
+        is the task itself; ``stop`` cancels before calling). Pop-first: if
+        :meth:`resolve` already popped, this is a no-op.
+        """
+        hold = self._holds.pop(request_id, None)
+        if hold is None:
+            return
+        try:
+            await self.app.state.model.egress_consent.expire_pending(
+                request_id
+            )
+        except Exception:
+            logger.exception(
+                "consent: failed to expire held request %s", request_id[:8]
+            )
+        if not hold["future"].done():
+            hold["future"].set_result(
+                {"decision": VERDICT_DENY, "reason": reason}
+            )
+
+    def _fanout(self, request: dict) -> None:
+        """Broadcast the pending request to the workspace's deciders (#2244).
+
+        Stub: until #2244 wires the decider WebSocket fanout, a hold simply
+        waits for its timeout (or a ``resolve`` call). The hold is correct
+        end-to-end without the fanout -- it fail-closes on timeout.
+        """
+        logger.info(
+            "consent hold created: ws=%s %s:%s id=%s (fanout via #2244)",
+            str(request.get("workspace_id"))[:8],
+            request.get("dest_host"),
+            request.get("dest_port"),
+            str(request.get("id"))[:8],
+        )
+
+    async def _is_interactive(self, workspace_id: str) -> bool:
+        """Interactive iff the workspace opted in AND a live decider exists (#2308)."""
+        return await workspace_is_interactive(self.app, workspace_id)

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -20,6 +20,7 @@ from . import (
     auth,
     container,
     consent,
+    consent_coordinator,
     consent_deciders,
     emailsvc,
     files,
@@ -50,7 +51,11 @@ from .model import (
     SYSTEM_EVERYONE,
 )
 from .model import AGENT_USER_ID
-from .wshandler import handle_consent_decider, handle_websocket
+from .wshandler import (
+    handle_consent_decider,
+    handle_egress_sidecar,
+    handle_websocket,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -470,6 +475,7 @@ class Lifecycle:
             "sockets",
             "container_registry",
             "consent_monitor",
+            "consent_coordinator",
             "consent_deciders",
             "proxy_watchdog",
             "llm_router",
@@ -693,6 +699,7 @@ async def lifespan(app: FastAPI):
     )
     await app.state.lifecycle.startup()
     app.state.consent_monitor.start()
+    app.state.consent_coordinator.start()
     app.state.consent_deciders.start()
     # Start the proxy (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
@@ -713,6 +720,7 @@ async def lifespan(app: FastAPI):
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
         await app.state.consent_monitor.stop()
+        await app.state.consent_coordinator.stop()
         await app.state.consent_deciders.stop()
         await app.state.proxy_watchdog.stop()
         await app.state.lifecycle.runtime_shutdown()
@@ -894,6 +902,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # sidecar's interactive-mode LOG lines and persists pending consent
     # requests (started/stopped in the lifespan; WS notify lands with #2244).
     app.state.consent_monitor = consent.EgressConsentMonitor(app)
+    app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(app)
     app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(app)
     # #2201: per-workspace nix store via a btrfs snapshot or fuse overlay
     # (off unless KLANGKD_NIX_SEED__PATH names a seed; see nix.Nix).
@@ -976,6 +985,14 @@ def build_app(settings: KlangkSettings) -> FastAPI:
         # lifecycle drives the ConsentDeciderRegistry (the interactive-mode
         # gate). Event content lands with #2244.
         await handle_consent_decider(ws, app)
+
+    @app.websocket("/ws/egress-sidecar")
+    async def egress_sidecar_endpoint(ws: WebSocket):  # pragma: no cover
+        # #2311: the network sidecar sends blocked-egress events here and
+        # receives verdicts (hold-and-prompt). The coordinator gate-checks
+        # (hold iff a decider is registered, else static deny); the decider
+        # fanout lands with #2244, the sidecar kernel hold in a follow-up.
+        await handle_egress_sidecar(ws, app)
 
     # Frontend UI dir, resolved from settings (#1456, #1600). Mounted only
     # when it exists; a packaged/installed klangkd ships the UI inside the

--- a/src/klangk/klangk/wshandler/__init__.py
+++ b/src/klangk/klangk/wshandler/__init__.py
@@ -59,6 +59,7 @@ from .agent_mention import (
     mentions_agent as mentions_agent,
 )
 from .decider import handle_consent_decider as handle_consent_decider
+from .sidecar import handle_egress_sidecar as handle_egress_sidecar
 from .dispatch import (
     _WS_CONNECTION_COMMANDS as _WS_CONNECTION_COMMANDS,
     _WS_STATE_COMMANDS as _WS_STATE_COMMANDS,

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -68,6 +68,8 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
                 msg = json.loads(raw)
             except json.JSONDecodeError:
                 continue
+            if not isinstance(msg, dict):
+                continue
             if msg.get("type") == "ping":
                 registry.touch(decider_id)
                 # NOTE(#2244): when this endpoint fans out held requests, route

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -1,0 +1,127 @@
+"""Egress-sidecar WebSocket endpoint (#2311).
+
+The network sidecar connects here -- one socket per workspace, at startup --
+and sends each blocked egress destination as ``{type:egress, id, dst, dport}``.
+For each, the coordinator gate-checks: interactive + a live decider -> the
+request is *held* (the sidecar keeps the connection in-flight) and this
+endpoint relays the eventual verdict back as ``{type:verdict, id, decision}``;
+otherwise the coordinator records a static denial and returns deny at once,
+and the sidecar NXDOMAIN/DROPs immediately (no hold).
+
+Auth is the workspace's own JWT (the sidecar shares it, validated by Caddy's
+``forward_auth`` and re-decoded here for the workspace id) -- the same
+credential the fire-and-forget POST endpoint uses, now over the sidecar leg of
+the consent WS contract (``sidecar <-WS-> klangkd <-WS-> decider``). No bespoke
+credential; the workspace id comes straight from the token.
+
+This is the klangkd half of #2311. The sidecar's kernel-level hold (suspending
+DNS queries, deferring NFQUEUE verdicts) + its WS client land in a stacked
+follow-up; #2244 wires the decider fanout to
+:meth:`klangk.consent_coordinator.ConsentCoordinator.resolve`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+from .. import auth
+from .safe_websocket import WS_ERRORS, SlowClientError, SafeWebSocket
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
+    """Receive blocked-egress events from the sidecar; relay verdicts back."""
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=4001, reason="Missing token")
+        return
+    result = app.state.auth.decode_workspace_token(token)
+    if result is auth.Auth.WORKSPACE_TOKEN_EXPIRED:
+        await websocket.close(code=4002, reason="Token expired")
+        return
+    if result is None:
+        await websocket.close(code=4001, reason="Invalid token")
+        return
+    workspace_id = result
+
+    await websocket.accept()
+    coordinator = app.state.consent_coordinator
+    safe = SafeWebSocket(websocket)
+    safe.start_sender()
+    relay_tasks: set[asyncio.Task] = set()
+    try:
+        while True:
+            # Starlette raises RuntimeError ("WebSocket is not connected...")
+            # on a client disconnect during receive_text(); treat it the same
+            # as WebSocketDisconnect.
+            try:
+                raw = await websocket.receive_text()
+            except (WebSocketDisconnect, RuntimeError):
+                break
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("type") != "egress":
+                continue
+            local_id = msg.get("id")
+            dst = msg.get("dst")
+            dport = msg.get("dport")
+            if not isinstance(local_id, str) or not isinstance(dst, str):
+                continue
+            if dport is not None and (
+                not isinstance(dport, int) or isinstance(dport, bool)
+            ):
+                continue
+            # One relay task per egress event: it holds via the coordinator
+            # (awaiting the verdict Future) and sends the verdict when ready,
+            # without blocking the receive loop (other events stream through).
+            task = asyncio.create_task(
+                _relay_verdict(
+                    safe, coordinator, workspace_id, local_id, dst, dport
+                )
+            )
+            relay_tasks.add(task)
+            task.add_done_callback(relay_tasks.discard)
+    finally:
+        # Sidecar gone (disconnect/restart/crash): cancel in-flight relays.
+        # The sidecar's own held connections die with it (fail-close); the
+        # coordinator's per-hold timeout expires the orphaned pending rows.
+        for task in list(relay_tasks):
+            task.cancel()
+        await safe.stop_sender()
+
+
+async def _relay_verdict(
+    safe: SafeWebSocket,
+    coordinator,
+    workspace_id: str,
+    local_id: str,
+    dst: str,
+    dport: int | None,
+) -> None:
+    """Hold the egress via the coordinator and send the verdict when resolved."""
+    try:
+        future = await coordinator.hold(workspace_id, dst, dport)
+        # shield: if the sidecar disconnects and this relay is cancelled, the
+        # coordinator's owned Future must NOT be cancelled with it -- the hold
+        # is cleaned by its own timeout (expire), not by the relay dying.
+        verdict = await asyncio.shield(future)
+        safe.send_json(
+            {
+                "type": "verdict",
+                "id": local_id,
+                "decision": verdict["decision"],
+            }
+        )
+    except (asyncio.CancelledError, SlowClientError, *WS_ERRORS):
+        # Cancelled: the sidecar socket closed (the relay is moot). SlowClient
+        # / WS_ERRORS: the outbound socket is gone. Nothing more to do.
+        pass

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1,0 +1,476 @@
+"""Tests for :mod:`klangk.consent_coordinator` -- the synchronous hold/resolve
+coordinator (#2311) -- and the egress-sidecar WebSocket endpoint that drives it.
+
+The coordinator gate-checks each blocked egress (hold iff interactive + a live
+decider, else static deny), holds the request in-process (a Future) until a
+verdict (#2244 ``resolve``), a timeout, or shutdown, and fail-closes throughout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+from unittest.mock import AsyncMock
+
+from fastapi import WebSocketDisconnect
+
+from klangk import auth
+from klangk.consent_coordinator import ConsentCoordinator
+
+FULL_WS = "aaaa1111bbbb-cccc-dddd-eeee-ffffffffffff"
+
+
+def _request(req_id="rid-1", host="1.2.3.4", port=443):
+    return {
+        "id": req_id,
+        "workspace_id": FULL_WS,
+        "dest_host": host,
+        "dest_port": port,
+        "decision": "pending",
+    }
+
+
+def _app(
+    *,
+    timeout: float = 30.0,
+    rate_limit: int = 50,
+    count_pending: int = 0,
+    request=None,
+    egress_mode: str = "interactive",
+    workspace_exists: bool = True,
+    has_decider: bool = True,
+    decide_row=None,
+):
+    app = types.SimpleNamespace()
+    app.state = types.SimpleNamespace()
+    app.state.settings = types.SimpleNamespace(
+        egress_consent_timeout=timeout,
+        egress_consent_rate_limit=rate_limit,
+    )
+    egress_consent = AsyncMock()
+    egress_consent.count_pending = AsyncMock(return_value=count_pending)
+    egress_consent.create_request = AsyncMock(return_value=request)
+    egress_consent.record_static_denial = AsyncMock(return_value=_denial())
+    egress_consent.decide = AsyncMock(return_value=decide_row)
+    egress_consent.expire_pending = AsyncMock(return_value=True)
+    workspaces = AsyncMock()
+    workspaces.get_workspace = AsyncMock(
+        return_value={"egress_mode": egress_mode} if workspace_exists else None
+    )
+    app.state.model = types.SimpleNamespace(
+        egress_consent=egress_consent, workspaces=workspaces
+    )
+    app.state.consent_deciders = types.SimpleNamespace(
+        has_decider=lambda workspace_id: has_decider
+    )
+    return app
+
+
+def _denial():
+    return {
+        "id": "sid",
+        "workspace_id": FULL_WS,
+        "dest_host": "1.2.3.4",
+        "dest_port": 443,
+        "decision": "denied",
+        "decided_by": None,
+    }
+
+
+class TestConsentCoordinatorGate:
+    async def test_no_decider_records_static_and_denies_at_once(self):
+        app = _app(has_decider=False)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = fut.result()
+        assert verdict == {"decision": "deny", "reason": "static"}
+        app.state.model.egress_consent.record_static_denial.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 443
+        )
+        app.state.model.egress_consent.create_request.assert_not_awaited()
+        assert coord._holds == {}
+
+    async def test_not_opted_in_denies_as_static(self):
+        app = _app(egress_mode="static", has_decider=True)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result()["reason"] == "static"
+
+    async def test_rate_limited_denies_without_hold(self):
+        app = _app(count_pending=50, rate_limit=50, request=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result() == {"decision": "deny", "reason": "rate_limited"}
+        app.state.model.egress_consent.create_request.assert_not_awaited()
+        assert coord._holds == {}
+
+    async def test_duplicate_pending_denies(self):
+        app = _app(request=None)  # create_request dedup -> None
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result() == {"decision": "deny", "reason": "duplicate"}
+        assert coord._holds == {}
+
+    async def test_interactive_with_decider_creates_hold(self):
+        app = _app(request=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert not fut.done()  # held, awaiting verdict
+        assert "rid-1" in coord._holds
+        app.state.model.egress_consent.create_request.assert_awaited_once()
+
+    async def test_hold_db_error_fail_closes_to_deny(self):
+        # a DB/model failure during the static-deny recording must not crash the
+        # caller or strand the hold -- hold() returns a resolved deny verdict.
+        app = _app(egress_mode="static", has_decider=True)
+        app.state.model.egress_consent.record_static_denial = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result() == {"decision": "deny", "reason": "error"}
+        assert coord._holds == {}
+
+    async def test_hold_interactive_db_error_fail_closes_to_deny(self):
+        # same resilience on the interactive path (create_request raises).
+        app = _app(request=_request())
+        app.state.model.egress_consent.create_request = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result() == {"decision": "deny", "reason": "error"}
+        assert coord._holds == {}
+
+
+class TestConsentCoordinatorResolve:
+    async def test_resolve_allow_records_and_releases(self):
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve("rid-1", "allowed", "workspace", "a@x")
+        assert verdict == {"decision": "allow", "reason": "decided"}
+        assert fut.result() == {"decision": "allow", "reason": "decided"}
+        app.state.model.egress_consent.decide.assert_awaited_once_with(
+            "rid-1", "allowed", "workspace", "a@x"
+        )
+        assert coord._holds == {}
+
+    async def test_resolve_deny_releases_deny(self):
+        row = _request()
+        row["decision"] = "denied"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve("rid-1", "denied", "once", "a@x")
+        assert verdict == {"decision": "deny", "reason": "decided"}
+        assert fut.result()["decision"] == "deny"
+
+    async def test_resolve_unknown_returns_none(self):
+        app = _app(request=_request())
+        coord = ConsentCoordinator(app)
+        assert await coord.resolve("nope", "allowed", "once", "a@x") is None
+
+    async def test_resolve_after_decide_returns_none_fail_closes(self):
+        # decide() returns None (row no longer pending -- concurrent expiry):
+        # the hold fail-closes to deny.
+        app = _app(request=_request(), decide_row=None)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve("rid-1", "allowed", "once", "a@x")
+        assert verdict == {"decision": "deny", "reason": "gone"}
+        assert fut.result()["decision"] == "deny"
+
+    async def test_resolve_cancels_the_timeout(self):
+        app = _app(timeout=0.05, request=_request(), decide_row=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        await asyncio.sleep(0.12)  # past the would-be timeout
+        # timeout cancelled -> the row was NOT expired
+        app.state.model.egress_consent.expire_pending.assert_not_awaited()
+        assert fut.result()["decision"] == "allow"
+
+
+class TestConsentCoordinatorTimeout:
+    async def test_timeout_expires_and_denies(self):
+        app = _app(timeout=0.05, request=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await fut
+        assert verdict == {"decision": "deny", "reason": "timeout"}
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+        assert coord._holds == {}
+
+    async def test_timeout_noops_if_resolved_first(self):
+        # resolve wins the race -> the timeout task is cancelled before wake.
+        app = _app(timeout=0.05, request=_request(), decide_row=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        await asyncio.sleep(0.12)
+        app.state.model.egress_consent.expire_pending.assert_not_awaited()
+        assert fut.result()["decision"] == "allow"
+
+    async def test_fail_close_on_unknown_id_is_noop(self):
+        app = _app()
+        coord = ConsentCoordinator(app)
+        # defensive: fail-closing a hold that is already gone does nothing.
+        await coord._fail_close("never-held", reason="timeout")
+        app.state.model.egress_consent.expire_pending.assert_not_awaited()
+
+    async def test_timeout_still_denies_when_expire_raises(self):
+        # expire_pending failing must not strand the hold -- it logs + still
+        # resolves the Future deny.
+        app = _app(timeout=0.05, request=_request())
+        app.state.model.egress_consent.expire_pending = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await fut
+        assert verdict == {"decision": "deny", "reason": "timeout"}
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+
+
+class TestConsentCoordinatorStop:
+    async def test_stop_fail_closes_all_holds(self):
+        app = _app(request=_request("r1"))
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        # second hold with a distinct request id
+        app.state.model.egress_consent.create_request = AsyncMock(
+            return_value=_request("r2")
+        )
+        await coord.hold(FULL_WS, "5.6.7.8", 80)
+        assert len(coord._holds) == 2
+        await coord.stop()
+        assert coord._holds == {}
+        expired = {
+            call.args[0]
+            for call in app.state.model.egress_consent.expire_pending.await_args_list
+        }
+        assert expired == {"r1", "r2"}
+
+    async def test_stop_is_idempotent(self):
+        app = _app(request=_request())
+        coord = ConsentCoordinator(app)
+        await coord.stop()
+        await coord.stop()
+        assert coord._holds == {}
+
+
+class TestConsentCoordinatorReconfigure:
+    async def test_reconfigure_swaps_app(self):
+        app = _app(request=_request())
+        coord = ConsentCoordinator(app)
+        new_app = _app(timeout=1.0, request=_request())
+        coord.reconfigure(new_app)
+        assert coord.app is new_app
+        assert coord.timeout == 1.0
+
+
+# --- egress-sidecar WebSocket endpoint --------------------------------------
+
+
+class _FakeWS:
+    """Minimal stand-in for a fastapi WebSocket for handler-level tests.
+
+    Incoming messages come from an asyncio.Queue (``feed``), so a test can
+    push an egress event, let the relay task run, then push a disconnect --
+    mirroring the real sidecar's send-then-wait-for-verdict ordering.
+    """
+
+    def __init__(self, params: dict):
+        self.query_params = params
+        self._incoming: asyncio.Queue = asyncio.Queue()
+        self.sent: list[str] = []
+        self.accepted = False
+        self.closed: tuple | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = (code, reason)
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(json.dumps(data))
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def receive_text(self) -> str:
+        item = await self._incoming.get()
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def feed(self, item) -> None:
+        await self._incoming.put(item)
+
+
+def _sidecar_app(token_result=FULL_WS):
+    """App with mocked workspace-token decode + a mock coordinator."""
+    app = types.SimpleNamespace()
+    app.state = types.SimpleNamespace()
+
+    def _decode(token):
+        return token_result
+
+    app.state.auth = types.SimpleNamespace(decode_workspace_token=_decode)
+    coord = AsyncMock()
+    app.state.consent_coordinator = coord
+    return app, coord
+
+
+class TestEgressSidecarWS:
+    async def test_missing_token_rejected(self):
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, _ = _sidecar_app()
+        ws = _FakeWS({})
+        await handle_egress_sidecar(ws, app)
+        assert ws.closed == (4001, "Missing token")
+        assert ws.accepted is False
+
+    async def test_invalid_token_rejected(self):
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, _ = _sidecar_app(token_result=None)
+        ws = _FakeWS({"token": "bad"})
+        await handle_egress_sidecar(ws, app)
+        assert ws.closed == (4001, "Invalid token")
+
+    async def test_expired_token_rejected(self):
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, _ = _sidecar_app(token_result=auth.Auth.WORKSPACE_TOKEN_EXPIRED)
+        ws = _FakeWS({"token": "stale"})
+        await handle_egress_sidecar(ws, app)
+        assert ws.closed == (4002, "Token expired")
+
+    async def test_static_egress_relays_deny_immediately(self):
+        # coordinator returns an already-resolved deny Future (static path)
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, coord = _sidecar_app()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        fut.set_result({"decision": "deny", "reason": "static"})
+        coord.hold = AsyncMock(return_value=fut)
+        ws = _FakeWS({"token": "tok"})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(
+            json.dumps(
+                {
+                    "type": "egress",
+                    "id": "loc1",
+                    "dst": "1.2.3.4",
+                    "dport": 443,
+                }
+            )
+        )
+        await asyncio.sleep(
+            0.05
+        )  # let the relay call hold + flush the verdict
+        coord.hold.assert_awaited_once_with(FULL_WS, "1.2.3.4", 443)
+        assert [json.loads(m) for m in ws.sent] == [
+            {"type": "verdict", "id": "loc1", "decision": "deny"}
+        ]
+        await ws.feed(WebSocketDisconnect())
+        await handler
+
+    async def test_held_egress_relays_verdict_when_resolved(self):
+        # coordinator returns a pending Future the test resolves -> allow
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, coord = _sidecar_app()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        coord.hold = AsyncMock(return_value=fut)
+        ws = _FakeWS({"token": "tok"})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(
+            json.dumps(
+                {"type": "egress", "id": "loc1", "dst": "9.9.9.9", "dport": 53}
+            )
+        )
+        await asyncio.sleep(0.05)  # relay is now awaiting the verdict Future
+        fut.set_result({"decision": "allow", "reason": "decided"})
+        await asyncio.sleep(0.05)  # relay sends the verdict
+        assert [json.loads(m) for m in ws.sent] == [
+            {"type": "verdict", "id": "loc1", "decision": "allow"}
+        ]
+        await ws.feed(WebSocketDisconnect())
+        await handler
+
+    async def test_non_egress_and_invalid_json_ignored(self):
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, coord = _sidecar_app()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        fut.set_result({"decision": "deny", "reason": "static"})
+        coord.hold = AsyncMock(return_value=fut)
+        ws = _FakeWS({"token": "tok"})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed("not-json")
+        await ws.feed(json.dumps({"type": "ping"}))
+        # valid JSON but not a dict (string / int / list / bool) must be
+        # ignored, not crash the handler with AttributeError on .get().
+        await ws.feed(json.dumps("hello"))
+        await ws.feed(json.dumps(123))
+        await ws.feed(json.dumps([1, 2]))
+        await ws.feed(json.dumps(True))
+        await ws.feed(
+            json.dumps({"type": "egress", "id": 5, "dst": "1.2.3.4"})
+        )  # bad id (not a str)
+        await ws.feed(
+            json.dumps(
+                {"type": "egress", "id": "ok", "dst": "1.2.3.4", "dport": "x"}
+            )
+        )  # bad dport (not an int)
+        await ws.feed(
+            json.dumps(
+                {"type": "egress", "id": "ok", "dst": "1.2.3.4", "dport": True}
+            )
+        )  # bad dport (bool, not an int -- isinstance(True, int) is True)
+        await ws.feed(
+            json.dumps({"type": "egress", "id": "ok", "dst": "1.2.3.4"})
+        )
+        await asyncio.sleep(0.05)
+        await ws.feed(WebSocketDisconnect())
+        await handler
+        # only the well-formed egress event reached the coordinator
+        coord.hold.assert_awaited_once_with(FULL_WS, "1.2.3.4", None)
+
+    async def test_disconnect_cancels_in_flight_relay(self):
+        # a held egress whose relay never resolves: disconnect cancels it,
+        # and no verdict is sent.
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, coord = _sidecar_app()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        coord.hold = AsyncMock(return_value=fut)
+        ws = _FakeWS({"token": "tok"})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(
+            json.dumps(
+                {
+                    "type": "egress",
+                    "id": "loc1",
+                    "dst": "1.2.3.4",
+                    "dport": 443,
+                }
+            )
+        )
+        await asyncio.sleep(0.05)  # relay is now awaiting the Future
+        await ws.feed(RuntimeError())  # disconnect mid-hold
+        await handler
+        assert ws.sent == []  # relay cancelled before it could send
+        assert not fut.done()  # the coordinator's hold Future is untouched

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -239,6 +239,9 @@ class TestConsentDeciderWS:
             {"token": "tok", "workspace": WS},
             [
                 "not-json",  # invalid JSON -> continue
+                '"hello"',  # valid JSON but not a dict -> continue
+                "123",  # valid JSON int, not a dict -> continue
+                "[1, 2]",  # valid JSON list, not a dict -> continue
                 '{"type":"hello"}',  # valid JSON, not a ping -> ignored
                 '{"type":"ping"}',  # ping -> pong
                 WebSocketDisconnect(),

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -20,6 +20,7 @@ from klangk import (
     auth as auth_mod,
     caddy as caddy_mod,
     consent,
+    consent_coordinator,
     consent_deciders,
     emailsvc as emailsvc_mod,
     files as files_mod,
@@ -811,6 +812,9 @@ class TestLifespan:
         app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
             app
         )
+        app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
+            app
+        )
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -861,6 +865,9 @@ class TestLifespan:
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
         app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
+            app
+        )
+        app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
             app
         )
         app.state.oidc = oidc.OIDC(app)
@@ -1393,6 +1400,9 @@ class TestStartupShutdownRestart:
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
         app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
+            app
+        )
+        app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
             app
         )
         app.state.oidc = oidc.OIDC(app)


### PR DESCRIPTION
## Summary

The **klangkd coordination half** of #2311: a blocked egress connection is now **held** in-flight for a human verdict (instead of denied at once) while a consent decider is registered for the workspace (#2308); with no decider it is denied immediately as a static denial (no hold, no queued row, no hung connection). This is the foundation the sidecar kernel hold (follow-up) and the decider fanout (#2244) plug into.

- **`ConsentCoordinator`** (`consent_coordinator.py`) — owns in-process holds (`asyncio.Future`s keyed by request id):
  - `hold(ws, dst, dport)→Future` gate-checks each blocked egress: interactive + `has_decider` → create the pending request, register the hold, arm its timeout, fan out to deciders (#2244 stub); **else** → `record_static_denial` + resolve the Future deny **at once** (no hold). Rate-limited / duplicate-destination holds are refused (deny), not held.
  - `resolve(request_id, decision, scope, decided_by)` is the **#2244 decider hook**: records the decision in SQLite, cancels the timeout, releases the hold.
  - **Fail-closed throughout**: per-hold timeout expires the row + denies; `stop()` fail-closes every in-flight hold on shutdown (a sidecar restart leaves no leaked allow); the timeout-vs-resolve race is resolved pop-first (resolve cancels the timeout task; `_fail_close` no-ops if the hold is gone).
- **`/ws/egress-sidecar`** (`wshandler/sidecar.py`) — the sidecar connects here (workspace-JWT auth, decoded for the workspace id), sends `{type:egress,id,dst,dport}` per blocked destination; a per-event **relay task** awaits the coordinator's verdict Future and sends `{type:verdict,id,decision}` back — never blocking the receive loop. Relay tasks are `asyncio.shield`-ed so a sidecar disconnect cancels the relay **without** cancelling the coordinator's owned Future (the orphaned hold still expires via its own timeout → audit row). `SafeWebSocket` for bounded outbound writes.

Wired into `build_app` / lifespan / SIGHUP; exported from `wshandler`. The fire-and-forget POST recording path (#2298) is untouched and coexists until the sidecar migrates to the WS.

## Scope (what's NOT here)

This is the klangkd coordination half only. Landing separately:
- **Sidecar kernel hold** (stacked follow-up) — `proxy.py` WS client, suspending DNS queries without blocking the UDP loop, deferring NFQUEUE verdicts, fail-close on sidecar restart, flood bounds.
- **Decider fanout + verdict reception** (#2244) — wires the decider WebSocket to `ConsentCoordinator.resolve`.
- **Decider client** (#2310).

## Test coverage

4457 passed, 100%. New `test_consent_coordinator.py` (24 tests): coordinator gate (static/rate-limited/duplicate/not-opted-in all deny without a hold; interactive+decider holds), resolve (allow/deny/unknown/concurrent-expiry, timeout-cancelled), timeout (expire+deny, expire-fails-still-denies, fail-close-on-unknown), stop (fail-close-all + idempotent), reconfigure, and the WS endpoint (the three auth rejects, static-relays-deny-at-once, held-relays-verdict-when-resolved, invalid-JSON/non-egress/bad-id/bad-dport ignored, disconnect-cancels-relay-without-touching-the-Future). `test_main.py` updated for the new `consent_coordinator` state object across its lifespan/SIGHUP fixtures.
