### PR TITLE
feat(consent): decider WebSocket fanout + verdict reception (#2244)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -79,6 +79,18 @@ operators or integrators to act when upgrading.
   is the klangkd coordination half** — the sidecar's kernel-level hold
   (suspending DNS queries, deferring NFQUEUE verdicts) + its WS client land in
   a follow-up, and decider fanout/verdict reception with #2244.
+- **Decider WebSocket fanout + verdict reception (#2244).** Held egress
+  requests now reach a human: when the coordinator creates a hold it broadcasts
+  an `egress_request` frame to every live decider for the workspace (and
+  deploy-wide) over the `/ws/consent-decider` socket; a decider's `verdict`
+  message is fed to `resolve()`, which records the decision, releases the held
+  sidecar connection, and broadcasts `egress_resolved` so co-deciders drop it
+  (first-decision-wins). A decider connecting mid-flight gets a snapshot of the
+  workspace's current pending requests. The #2308 authz gap is closed: a
+  workspace-scoped decider now needs `terminal` access to that workspace, a
+  deploy-wide decider needs admin (else the socket is closed `4003 Forbidden`),
+  and a verdict is honored only for the decider's own workspace. The first
+  consumer is the `consent-decide` client (#2310).
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -35,6 +35,7 @@ import asyncio
 import logging
 
 from .consent import workspace_is_interactive
+from .model.egress_consent import DECISION_PENDING
 
 logger = logging.getLogger(__name__)
 
@@ -156,29 +157,57 @@ class ConsentCoordinator:
         decision: str,
         scope: str | None,
         decided_by: str,
+        *,
+        decider_workspace: str | None = None,
     ) -> dict | None:
         """Apply a decider verdict to a held request (the #2244 hook).
 
         Records the decision in SQLite (allowed/denied), cancels the hold's
-        timeout, and resolves its Future. Returns the verdict dict relayed to
-        the sidecar, or ``None`` if the request is not currently held (already
-        resolved, timed out, or never held).
+        timeout, resolves its Future, and broadcasts an ``egress_resolved``
+        frame so co-deciders drop it (first-decision-wins across N deciders).
+        Returns the verdict dict relayed to the sidecar, or ``None`` if the
+        request is not currently held (already resolved, timed out, never
+        held) or -- defense-in-depth -- if a workspace-scoped decider tries to
+        decide a request outside its workspace (``decider_workspace``).
         """
-        hold = self._holds.pop(request_id, None)
+        hold = self._holds.get(request_id)
         if hold is None:
             return None
+        if (
+            decider_workspace is not None
+            and hold["workspace_id"] != decider_workspace
+        ):
+            # Restore nothing (we only peeked); the hold stays for a decider
+            # actually scoped to it.
+            return None
+        hold = self._holds.pop(request_id)
         hold["task"].cancel()
-        row = await self.app.state.model.egress_consent.decide(
-            request_id, decision, scope, decided_by
-        )
-        if row is None:
-            verdict = {"decision": VERDICT_DENY, "reason": "gone"}
-        elif decision == "allowed":
-            verdict = {"decision": VERDICT_ALLOW, "reason": "decided"}
+        try:
+            row = await self.app.state.model.egress_consent.decide(
+                request_id, decision, scope, decided_by
+            )
+        except Exception:
+            # decide() failed (DB error). The hold's own timeout is already
+            # cancelled, so we MUST resolve the Future ourselves -- otherwise
+            # the sidecar relay awaits it forever ("no hold pending forever").
+            # Fail-close to deny + broadcast so co-deciders drop it; the
+            # pending row is left for GC.
+            logger.exception("consent: resolve failed; fail-closing to deny")
+            verdict = {"decision": VERDICT_DENY, "reason": "error"}
+            resolved = "expired"
         else:
-            verdict = {"decision": VERDICT_DENY, "reason": "decided"}
+            if row is None:
+                verdict = {"decision": VERDICT_DENY, "reason": "gone"}
+                resolved = "expired"
+            elif decision == "allowed":
+                verdict = {"decision": VERDICT_ALLOW, "reason": "decided"}
+                resolved = "allowed"
+            else:
+                verdict = {"decision": VERDICT_DENY, "reason": "decided"}
+                resolved = "denied"
         if not hold["future"].done():
             hold["future"].set_result(verdict)
+        self._broadcast_resolved(request_id, hold["workspace_id"], resolved)
         return verdict
 
     async def _timeout(self, request_id: str) -> None:
@@ -221,20 +250,71 @@ class ConsentCoordinator:
             hold["future"].set_result(
                 {"decision": VERDICT_DENY, "reason": reason}
             )
+        self._broadcast_resolved(request_id, hold["workspace_id"], "expired")
 
     def _fanout(self, request: dict) -> None:
         """Broadcast the pending request to the workspace's deciders (#2244).
 
-        Stub: until #2244 wires the decider WebSocket fanout, a hold simply
-        waits for its timeout (or a ``resolve`` call). The hold is correct
-        end-to-end without the fanout -- it fail-closes on timeout.
+        Pushes an ``egress_request`` frame to every live decider for the
+        workspace (and deploy-wide). Until a decider responds with a verdict,
+        the hold simply waits for its timeout (or a ``resolve`` call) -- the
+        hold is correct end-to-end regardless: it fail-closes on timeout.
         """
+        workspace_id = request["workspace_id"]
+        self.app.state.consent_deciders.broadcast(
+            workspace_id, self._request_frame(request)
+        )
         logger.info(
-            "consent hold created: ws=%s %s:%s id=%s (fanout via #2244)",
-            str(request.get("workspace_id"))[:8],
+            "consent hold created: ws=%s %s:%s id=%s",
+            str(workspace_id)[:8],
             request.get("dest_host"),
             request.get("dest_port"),
             str(request.get("id"))[:8],
+        )
+
+    async def snapshot(self, workspace_id: str | None) -> list[dict]:
+        """Pending-request frames for a newly-connected decider (replay).
+
+        A decider that connects mid-flight sees the workspace's current holds
+        so it can act on in-flight requests, not just ones created after it
+        joined. Deploy-wide deciders (``workspace_id`` None) get no snapshot
+        for now -- a cross-workspace pending list is a follow-up. Caveat: a
+        deploy-only decider connecting after holds exist will not see them, so
+        those holds time out fail-closed; they still receive NEW holds live via
+        :meth:`_fanout`.
+        """
+        if workspace_id is None:
+            return []
+        rows = await self.app.state.model.egress_consent.list_requests(
+            workspace_id, decision=DECISION_PENDING
+        )
+        return [self._request_frame(row) for row in rows]
+
+    @staticmethod
+    def _request_frame(request: dict) -> dict:
+        """Build an ``egress_request`` frame from a consent-request row."""
+        return {
+            "type": "egress_request",
+            "workspace_id": request["workspace_id"],
+            "request": request,
+        }
+
+    def _broadcast_resolved(
+        self, request_id: str, workspace_id: str, decision: str
+    ) -> None:
+        """Tell the workspace's deciders a request is no longer pending.
+
+        Sent on verdict (``resolve``) and timeout/shutdown (``_fail_close``)
+        so co-deciders drop it from their queue (first-decision-wins).
+        """
+        self.app.state.consent_deciders.broadcast(
+            workspace_id,
+            {
+                "type": "egress_resolved",
+                "workspace_id": workspace_id,
+                "request_id": request_id,
+                "decision": decision,
+            },
         )
 
     async def _is_interactive(self, workspace_id: str) -> bool:

--- a/src/klangk/klangk/consent_deciders.py
+++ b/src/klangk/klangk/consent_deciders.py
@@ -31,6 +31,8 @@ import asyncio
 import logging
 import time
 
+from .wshandler.safe_websocket import WS_ERRORS
+
 logger = logging.getLogger(__name__)
 
 
@@ -43,7 +45,8 @@ class ConsentDeciderRegistry:
 
     def __init__(self, app) -> None:
         self.app = app
-        # decider_id -> {"ws": workspace_id | None, "seen": monotonic, "email"}
+        # decider_id -> {"ws": workspace_id | None, "seen": monotonic,
+        #                 "email": str, "sock": SafeWebSocket}
         # workspace_id None = deploy-wide (decides for every workspace).
         self._deciders: dict[str, dict] = {}
         self._reaper: asyncio.Task | None = None
@@ -56,13 +59,23 @@ class ConsentDeciderRegistry:
         return self.app.state.settings.consent_decider_timeout
 
     def register(
-        self, decider_id: str, workspace_id: str | None, email: str | None
+        self,
+        decider_id: str,
+        workspace_id: str | None,
+        email: str | None,
+        sock,
     ) -> None:
-        """Register a live decider (connect). Idempotent on decider_id."""
+        """Register a live decider (connect). Idempotent on decider_id.
+
+        ``sock`` is the decider's :class:`SafeWebSocket`; the endpoint owns its
+        lifecycle (start/stop sender) -- the registry holds only a reference for
+        :meth:`broadcast` fanout.
+        """
         self._deciders[decider_id] = {
             "ws": workspace_id,
             "seen": time.monotonic(),
             "email": email,
+            "sock": sock,
         }
         logger.info(
             "consent decider registered: scope=%s decider=%s",
@@ -105,6 +118,35 @@ class ConsentDeciderRegistry:
             if (entry["ws"] is None or entry["ws"] == workspace_id)
             and (now - entry["seen"] <= cutoff)
         ]
+
+    def broadcast(self, workspace_id: str, message: dict) -> int:
+        """Send *message* to every live decider for this workspace or deploy-wide.
+
+        Used by the coordinator to fan out ``egress_request`` (new hold) and
+        ``egress_resolved`` (verdict/timeout) frames. A decider whose socket is
+        dead/slow is pruned immediately (its endpoint's ``finally`` deregister
+        is then a no-op). Returns the number of deciders delivered to.
+        Non-blocking: ``SafeWebSocket.send_json`` enqueues on a bounded queue.
+        """
+        now = time.monotonic()
+        cutoff = self.timeout
+        dead: list[str] = []
+        delivered = 0
+        for did, entry in self._deciders.items():
+            scope = entry["ws"]
+            if (
+                not (scope is None or scope == workspace_id)
+                or now - entry["seen"] > cutoff
+            ):
+                continue
+            try:
+                entry["sock"].send_json(message)
+                delivered += 1
+            except WS_ERRORS:
+                dead.append(did)
+        for did in dead:
+            self._deciders.pop(did, None)
+        return delivered
 
     def start(self) -> None:
         """Start the liveness reaper (idempotent). Runs until :meth:`stop`."""

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -1,35 +1,58 @@
-"""Consent-decider WebSocket endpoint (#2308).
+"""Consent-decider WebSocket endpoint (#2308, #2244).
 
 A decider (a live client that can approve/deny held egress -- the ``klangk``
 CLI in #2310, or a Flutter client) connects here to register its live presence
-for a workspace (or deploy-wide). The connection lifecycle drives the
-:class:`~klangk.consent_deciders.ConsentDeciderRegistry`: connect -> register,
-client ``ping`` -> touch (liveness), disconnect -> deregister. While at least
-one decider is registered the workspace is "interactive" (its blocked egress is
-held for a decision, #2311); with none, it reverts to static allow-list.
+for a workspace (or deploy-wide) AND to act on held requests. The connection
+lifecycle drives the :class:`~klangk.consent_deciders.ConsentDeciderRegistry`:
+connect -> register, client ``ping`` -> touch (liveness), disconnect ->
+deregister. While at least one decider is registered the workspace is
+"interactive" (its blocked egress is held for a decision, #2311); with none,
+it reverts to static allow-list.
 
-This endpoint owns **registration + liveness only**. The event content --
-pushing held requests down and receiving verdicts -- lands with #2244 and is
-carried over this same socket; until then the only client message is ``ping``.
+#2244 adds the decision half on top of #2308's registration/liveness:
 
-Auth mirrors the main ``/ws`` handler: a user JWT in the ``token`` query param.
-Scope is ``?workspace=<id>`` (workspace-scoped); omit it for a deploy-wide
-decider. Authorization to decide for a workspace is enforced when decision
-power arrives (#2244); presence registration itself grants no decision power.
+- **fan-in**: on connect, the workspace's currently-pending requests are
+  replayed (snapshot) so a decider joining mid-flight sees in-flight holds; new
+  holds are pushed live as ``egress_request`` frames by the coordinator's
+  fanout (over this same socket).
+- **fan-out**: a ``verdict`` message from the decider is fed to
+  :meth:`ConsentCoordinator.resolve`, which records the decision, releases the
+  held sidecar connection, and broadcasts ``egress_resolved`` so co-deciders
+  drop it (first-decision-wins).
+
+Authorization (#2244 closes the #2308 authz gap): a workspace-scoped decider
+(``?workspace=<id>``) must have ``terminal`` access to that workspace (owner,
+member, or spectator -- anyone who can open a terminal there); a deploy-wide
+decider (no ``workspace``) must be an admin. A verdict is honored only if it
+targets the decider's own workspace (defense-in-depth), enforced in ``resolve``
+via ``decider_workspace``. Auth mirrors the main ``/ws`` handler: a user JWT in
+the ``token`` query param.
+
+Outbound writes go through :class:`SafeWebSocket` (bounded queue +
+``SlowClientError``) like the main ``/ws`` handler.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 
 from fastapi import WebSocket, WebSocketDisconnect
 
 from .. import auth
+from .safe_websocket import SafeWebSocket, SlowClientError
+from ..model.egress_consent import (
+    DECISION_ALLOWED,
+    DECISION_DENIED,
+    SCOPES,
+)
+
+logger = logging.getLogger(__name__)
 
 
 async def handle_consent_decider(websocket: WebSocket, app) -> None:
-    """Register a consent decider for its connection lifetime."""
+    """Register a consent decider for its connection lifetime + act on holds."""
     token = websocket.query_params.get("token")
     if not token:
         await websocket.close(code=4001, reason="Missing token")
@@ -43,25 +66,45 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         return
     user = result
     workspace = websocket.query_params.get("workspace")  # None = deploy-wide
-    # TODO(#2244): authorize workspace membership here. Today any authenticated
-    # user can register a decider for any workspace (or deploy-wide); presence
-    # alone grants no decision power, but it flips an interactive workspace
-    # from static-deny to held-pending. #2244 must enforce membership before
-    # granting any decision power.
+
+    # Authorization: workspace-scoped deciders need terminal access to the
+    # workspace (owner or member); deploy-wide deciders need admin. Mirrors the
+    # main /ws handler's workspace gate (wshandler/connection.py).
+    principals = await app.state.acl.get_principals(user["id"])
+    if workspace is not None:
+        allowed = await app.state.acl.check_permission(
+            f"/workspaces/{workspace}", principals, "terminal"
+        )
+    else:
+        allowed = await app.state.acl.check_permission(
+            "/admin", principals, "admin"
+        )
+    if not allowed:
+        await websocket.close(code=4003, reason="Forbidden")
+        return
 
     await websocket.accept()
-    decider_id = str(uuid.uuid4())
+    safe_ws = SafeWebSocket(websocket)
+    safe_ws.start_sender()
     registry = app.state.consent_deciders
+    decider_id = str(uuid.uuid4())
+    email = user.get("email")
     try:
-        # register inside the try so the finally-deregister invariant holds
-        # structurally rather than relying on register() not raising.
-        registry.register(decider_id, workspace, user.get("email"))
+        registry.register(decider_id, workspace, email, safe_ws)
+        # Register BEFORE reading the snapshot: a hold created between the two
+        # is then delivered twice (once live via fanout, once from the
+        # snapshot). That duplicate is benign -- the second verdict no-ops
+        # (resolve pops first) -- whereas snapshot-then-register would MISS
+        # holds created in the gap (silent fail-close). Tolerate the duplicate
+        # to never miss.
+        for frame in await app.state.consent_coordinator.snapshot(workspace):
+            safe_ws.send_json(frame)
         while True:
             # Starlette raises RuntimeError ("WebSocket is not connected...")
             # on a client disconnect during receive_text(); treat it the same
             # as WebSocketDisconnect.
             try:
-                raw = await websocket.receive_text()
+                raw = await safe_ws.receive_text()
             except (WebSocketDisconnect, RuntimeError):
                 break
             try:
@@ -70,14 +113,63 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
                 continue
             if not isinstance(msg, dict):
                 continue
-            if msg.get("type") == "ping":
-                registry.touch(decider_id)
-                # NOTE(#2244): when this endpoint fans out held requests, route
-                # outbound writes through SafeWebSocket (bounded queue +
-                # SlowClientError) like the main /ws handler; raw send_text is
-                # fine while pong is the only outbound message.
-                await websocket.send_text(json.dumps({"type": "pong"}))
+            mtype = msg.get("type")
+            try:
+                if mtype == "ping":
+                    registry.touch(decider_id)
+                    safe_ws.send_json({"type": "pong"})
+                elif mtype == "verdict":
+                    await _handle_verdict(
+                        app, safe_ws, msg, workspace, email, user["id"]
+                    )
+                # unknown types are ignored
+            except SlowClientError:
+                # Outbound queue full -- the client can't keep up. Drop it
+                # (matches the main /ws handler's slow-client handling).
+                break
+            except Exception:
+                # A single bad verdict or transient send error must not tear
+                # down the whole connection (and every other in-flight prompt
+                # on it). Log + keep going.
+                logger.exception(
+                    "consent decider: error handling %r message", mtype
+                )
     finally:
         # Connection gone (clean disconnect, error, or crash) -> drop the
         # registration so the workspace reverts to static (#2308).
         registry.deregister(decider_id)
+        await safe_ws.stop_sender()
+
+
+async def _handle_verdict(
+    app, safe_ws, msg, workspace, email, user_id
+) -> None:
+    """Validate + apply a decider's verdict to a held request (#2244)."""
+    decision = msg.get("decision")
+    if decision not in (DECISION_ALLOWED, DECISION_DENIED):
+        safe_ws.send_json(
+            {"type": "error", "message": f"invalid decision: {decision!r}"}
+        )
+        return
+    scope = msg.get("scope")
+    if scope is not None and scope not in SCOPES:
+        safe_ws.send_json(
+            {"type": "error", "message": f"invalid scope: {scope!r}"}
+        )
+        return
+    request_id = msg.get("request_id")
+    if not isinstance(request_id, str):
+        safe_ws.send_json(
+            {"type": "error", "message": "verdict requires a request_id"}
+        )
+        return
+    await app.state.consent_coordinator.resolve(
+        request_id,
+        decision,
+        scope,
+        # A human decision is always attributable; fall back to the stable
+        # user id if the row lacks an email (never NULL -- NULL means "no
+        # human", the static/expired case).
+        email or user_id or "",
+        decider_workspace=workspace,
+    )

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import types
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from fastapi import WebSocketDisconnect
 
@@ -41,6 +41,7 @@ def _app(
     workspace_exists: bool = True,
     has_decider: bool = True,
     decide_row=None,
+    pending_rows=None,
 ):
     app = types.SimpleNamespace()
     app.state = types.SimpleNamespace()
@@ -54,6 +55,7 @@ def _app(
     egress_consent.record_static_denial = AsyncMock(return_value=_denial())
     egress_consent.decide = AsyncMock(return_value=decide_row)
     egress_consent.expire_pending = AsyncMock(return_value=True)
+    egress_consent.list_requests = AsyncMock(return_value=pending_rows or [])
     workspaces = AsyncMock()
     workspaces.get_workspace = AsyncMock(
         return_value={"egress_mode": egress_mode} if workspace_exists else None
@@ -62,7 +64,8 @@ def _app(
         egress_consent=egress_consent, workspaces=workspaces
     )
     app.state.consent_deciders = types.SimpleNamespace(
-        has_decider=lambda workspace_id: has_decider
+        has_decider=lambda workspace_id: has_decider,
+        broadcast=Mock(return_value=0),
     )
     return app
 
@@ -144,6 +147,78 @@ class TestConsentCoordinatorGate:
         assert coord._holds == {}
 
 
+class TestConsentCoordinatorFanout:
+    async def test_hold_broadcasts_egress_request_to_deciders(self):
+        app = _app(request=_request())
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.consent_deciders.broadcast.assert_called_once()
+        ws_arg, frame = app.state.consent_deciders.broadcast.call_args.args
+        assert ws_arg == FULL_WS
+        assert frame["type"] == "egress_request"
+        assert frame["workspace_id"] == FULL_WS
+        assert frame["request"]["id"] == "rid-1"
+
+    async def test_resolve_broadcasts_egress_resolved(self):
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.consent_deciders.broadcast.reset_mock()
+        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        # second broadcast is the resolved frame (first was the egress_request)
+        ws_arg, frame = app.state.consent_deciders.broadcast.call_args.args
+        assert frame == {
+            "type": "egress_resolved",
+            "workspace_id": FULL_WS,
+            "request_id": "rid-1",
+            "decision": "allowed",
+        }
+
+    async def test_resolve_rejects_verdict_outside_decider_workspace(self):
+        # defense-in-depth: a workspace-scoped decider may not decide another
+        # workspace's request; the hold stays for a scoped decider.
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "allowed", "once", "a@x", decider_workspace="other-ws"
+        )
+        assert verdict is None
+        assert "rid-1" in coord._holds  # hold untouched
+        app.state.model.egress_consent.decide.assert_not_awaited()
+
+    async def test_timeout_broadcasts_expired(self):
+        app = _app(timeout=0.05, request=_request())
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.consent_deciders.broadcast.reset_mock()
+        await asyncio.sleep(0.12)
+        ws_arg, frame = app.state.consent_deciders.broadcast.call_args.args
+        assert frame["type"] == "egress_resolved"
+        assert frame["decision"] == "expired"
+
+    async def test_snapshot_replays_pending_requests(self):
+        rows = [_request("a"), _request("b")]
+        app = _app(pending_rows=rows)
+        coord = ConsentCoordinator(app)
+        frames = await coord.snapshot(FULL_WS)
+        assert [f["request"]["id"] for f in frames] == ["a", "b"]
+        assert all(f["type"] == "egress_request" for f in frames)
+        app.state.model.egress_consent.list_requests.assert_awaited_once_with(
+            FULL_WS, decision="pending"
+        )
+
+    async def test_snapshot_deploy_wide_is_empty(self):
+        app = _app()
+        coord = ConsentCoordinator(app)
+        assert await coord.snapshot(None) == []
+        app.state.model.egress_consent.list_requests.assert_not_awaited()
+
+
 class TestConsentCoordinatorResolve:
     async def test_resolve_allow_records_and_releases(self):
         row = _request()
@@ -193,6 +268,42 @@ class TestConsentCoordinatorResolve:
         # timeout cancelled -> the row was NOT expired
         app.state.model.egress_consent.expire_pending.assert_not_awaited()
         assert fut.result()["decision"] == "allow"
+
+    async def test_resolve_fail_closes_when_decide_raises(self):
+        # decide() raising (DB error) must not orphan the Future -- the hold's
+        # timeout is already cancelled, so resolve fail-closes to deny itself.
+        app = _app(request=_request())
+        app.state.model.egress_consent.decide = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.consent_deciders.broadcast.reset_mock()
+        verdict = await coord.resolve("rid-1", "allowed", "once", "a@x")
+        assert verdict == {"decision": "deny", "reason": "error"}
+        assert fut.done() and fut.result()["decision"] == "deny"
+        ws_arg, frame = app.state.consent_deciders.broadcast.call_args.args
+        assert frame["type"] == "egress_resolved"
+        assert frame["decision"] == "expired"
+        assert coord._holds == {}  # hold gone, no orphan
+
+    async def test_concurrent_resolves_first_decision_wins(self):
+        # two deciders resolve the same hold concurrently: exactly one wins
+        # (one decide() write), the other is a no-op (returns None).
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        v1, v2 = await asyncio.gather(
+            coord.resolve("rid-1", "allowed", "once", "a@x"),
+            coord.resolve("rid-1", "denied", "once", "b@x"),
+        )
+        winners = [v for v in (v1, v2) if v is not None]
+        assert len(winners) == 1  # exactly one winner
+        assert (
+            app.state.model.egress_consent.decide.await_count == 1
+        )  # one DB write
 
 
 class TestConsentCoordinatorTimeout:

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import types
+from unittest.mock import AsyncMock
 
 from klangk.consent_deciders import ConsentDeciderRegistry
 
@@ -18,6 +20,19 @@ def _app(timeout: float = 45.0):
     return app
 
 
+class _FakeSock:
+    """Stand-in for a SafeWebSocket's outbound channel (registry broadcast)."""
+
+    def __init__(self, *, raising: bool = False) -> None:
+        self.sent: list[dict] = []
+        self._raising = raising
+
+    def send_json(self, msg: dict) -> None:
+        if self._raising:
+            raise RuntimeError("dead socket")
+        self.sent.append(msg)
+
+
 class TestConsentDeciderRegistry:
     async def test_no_decider_is_not_interactive(self):
         reg = ConsentDeciderRegistry(_app())
@@ -25,7 +40,7 @@ class TestConsentDeciderRegistry:
 
     async def test_register_then_deregister(self):
         reg = ConsentDeciderRegistry(_app())
-        reg.register("d1", WS, "admin@example.com")
+        reg.register("d1", WS, "admin@example.com", _FakeSock())
         assert reg.has_decider(WS) is True
         reg.deregister("d1")
         assert reg.has_decider(WS) is False
@@ -34,9 +49,9 @@ class TestConsentDeciderRegistry:
 
     async def test_multiple_deciders_same_workspace(self):
         reg = ConsentDeciderRegistry(_app())
-        reg.register("d1", WS, "a@x")
-        reg.register("d2", WS, "b@x")
-        reg.register("d3", WS, "c@x")
+        reg.register("d1", WS, "a@x", _FakeSock())
+        reg.register("d2", WS, "b@x", _FakeSock())
+        reg.register("d3", WS, "c@x", _FakeSock())
         assert reg.has_decider(WS) is True
         # N concurrent deciders; removing one leaves the rest
         reg.deregister("d1")
@@ -48,7 +63,7 @@ class TestConsentDeciderRegistry:
 
     async def test_decider_scoped_to_one_workspace(self):
         reg = ConsentDeciderRegistry(_app())
-        reg.register("d1", WS, "a@x")
+        reg.register("d1", WS, "a@x", _FakeSock())
         assert reg.has_decider(WS) is True
         # not visible to a different workspace
         assert reg.has_decider(WS2) is False
@@ -56,22 +71,22 @@ class TestConsentDeciderRegistry:
 
     async def test_deploy_wide_decider_covers_every_workspace(self):
         reg = ConsentDeciderRegistry(_app())
-        reg.register("admin", None, "admin@example.com")
+        reg.register("admin", None, "admin@example.com", _FakeSock())
         assert reg.has_decider(WS) is True
         assert reg.has_decider(WS2) is True
         assert set(reg.deciders_for(WS)) == {"admin"}
 
     async def test_register_is_idempotent_on_decider_id(self):
         reg = ConsentDeciderRegistry(_app())
-        reg.register("d1", WS, "a@x")
+        reg.register("d1", WS, "a@x", _FakeSock())
         reg.register(
-            "d1", WS, "a@x"
+            "d1", WS, "a@x", _FakeSock()
         )  # reconnect with same id -> refresh, not dup
         assert reg.deciders_for(WS) == ["d1"]
 
     async def test_touch_extends_liveness(self):
         reg = ConsentDeciderRegistry(_app(timeout=0.05))
-        reg.register("d1", WS, "a@x")
+        reg.register("d1", WS, "a@x", _FakeSock())
         # age it past the timeout, then ping to refresh
         reg._deciders["d1"]["seen"] -= 1.0
         assert reg.has_decider(WS) is False
@@ -82,7 +97,7 @@ class TestConsentDeciderRegistry:
 
     async def test_reaper_drops_stale_deciders(self):
         reg = ConsentDeciderRegistry(_app(timeout=0.02))
-        reg.register("d1", WS, "a@x")
+        reg.register("d1", WS, "a@x", _FakeSock())
         reg.start()
         try:
             # mark stale; the reaper ticks at >= timeout
@@ -95,7 +110,7 @@ class TestConsentDeciderRegistry:
 
     async def test_reaper_keeps_fresh_deciders(self):
         reg = ConsentDeciderRegistry(_app(timeout=0.05))
-        reg.register("d1", WS, "a@x")
+        reg.register("d1", WS, "a@x", _FakeSock())
         reg.start()
         try:
             await asyncio.sleep(0.04)
@@ -107,12 +122,55 @@ class TestConsentDeciderRegistry:
 
     async def test_stop_clears_all_and_is_idempotent(self):
         reg = ConsentDeciderRegistry(_app())
-        reg.register("d1", WS, "a@x")
-        reg.register("d2", None, "b@x")
+        reg.register("d1", WS, "a@x", _FakeSock())
+        reg.register("d2", None, "b@x", _FakeSock())
         await reg.stop()
         assert reg._deciders == {}
         assert reg._reaper is None
         await reg.stop()  # idempotent
+
+
+class TestConsentDeciderRegistryBroadcast:
+    async def test_broadcast_sends_to_matching_deciders_only(self):
+        reg = ConsentDeciderRegistry(_app())
+        s1, s2, s3 = _FakeSock(), _FakeSock(), _FakeSock()
+        reg.register("d1", WS, "a@x", s1)  # scoped to WS
+        reg.register("d2", WS, "b@x", s2)  # scoped to WS
+        reg.register("d3", WS2, "c@x", s3)  # different workspace
+        delivered = reg.broadcast(WS, {"type": "egress_request"})
+        assert delivered == 2
+        assert len(s1.sent) == 1
+        assert len(s2.sent) == 1
+        assert s3.sent == []  # different workspace, not delivered
+
+    async def test_broadcast_includes_deploy_wide_deciders(self):
+        reg = ConsentDeciderRegistry(_app())
+        deploy, scoped = _FakeSock(), _FakeSock()
+        reg.register("admin", None, "admin@x", deploy)  # deploy-wide
+        reg.register("d2", WS, "a@x", scoped)  # scoped to WS
+        delivered = reg.broadcast(WS, {"type": "egress_request"})
+        assert delivered == 2
+        assert len(deploy.sent) == 1
+        assert len(scoped.sent) == 1
+
+    async def test_broadcast_prunes_dead_deciders(self):
+        reg = ConsentDeciderRegistry(_app())
+        live = _FakeSock()
+        dead = _FakeSock(raising=True)  # send_json raises -> dead socket
+        reg.register("d1", WS, "a@x", live)
+        reg.register("d2", WS, "b@x", dead)
+        delivered = reg.broadcast(WS, {"type": "egress_resolved"})
+        assert delivered == 1
+        assert reg.has_decider(WS) is True  # d1 still live
+        assert "d2" not in reg._deciders  # pruned on socket error
+
+    async def test_broadcast_skips_stale_deciders(self):
+        reg = ConsentDeciderRegistry(_app(timeout=0.05))
+        s = _FakeSock()
+        reg.register("d1", WS, "a@x", s)
+        reg._deciders["d1"]["seen"] -= 1.0  # age past timeout
+        assert reg.broadcast(WS, {"type": "x"}) == 0
+        assert s.sent == []
 
 
 class _FakeWS:
@@ -134,6 +192,10 @@ class _FakeWS:
     async def send_text(self, data: str) -> None:
         self.sent.append(data)
 
+    async def send_json(self, data) -> None:
+        # SafeWebSocket's sender task writes each enqueued frame here.
+        self.sent.append(json.dumps(data))
+
     async def receive_text(self) -> str:
         item = next(self._incoming)
         if isinstance(item, BaseException):
@@ -141,16 +203,33 @@ class _FakeWS:
         return item
 
 
-def _ws_app(token_result):
-    """App with mocked auth + a real ConsentDeciderRegistry."""
-    from unittest.mock import AsyncMock
-
+def _ws_app(
+    token_result,
+    *,
+    allowed: bool = True,
+    snapshot=None,
+):
+    """App with mocked auth + acl + coordinator, and a real registry."""
     app = types.SimpleNamespace()
     app.state = types.SimpleNamespace()
     app.state.settings = types.SimpleNamespace(consent_decider_timeout=45.0)
     app.state.consent_deciders = ConsentDeciderRegistry(app)
     app.state.auth = types.SimpleNamespace(
         get_user_from_token=AsyncMock(return_value=token_result)
+    )
+    app.state.acl = types.SimpleNamespace(
+        get_principals=AsyncMock(
+            return_value={
+                "user_id": "u1",
+                "group_ids": [],
+                "authenticated": True,
+            }
+        ),
+        check_permission=AsyncMock(return_value=allowed),
+    )
+    app.state.consent_coordinator = types.SimpleNamespace(
+        snapshot=AsyncMock(return_value=snapshot or []),
+        resolve=AsyncMock(return_value=None),
     )
     return app
 
@@ -161,7 +240,7 @@ class TestConsentDeciderWS:
 
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"email": "admin@example.com"})
+        app = _ws_app({"id": "u1", "email": "admin@example.com"})
         ws = _FakeWS(
             {"token": "tok", "workspace": WS},
             [WebSocketDisconnect()],  # connect, then immediately disconnect
@@ -175,7 +254,7 @@ class TestConsentDeciderWS:
     async def test_missing_token_is_rejected(self):
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"email": "a@x"})
+        app = _ws_app({"id": "u1", "email": "a@x"})
         ws = _FakeWS({"workspace": WS}, [])
         await handle_consent_decider(ws, app)
         assert ws.closed == (4001, "Missing token")
@@ -199,14 +278,31 @@ class TestConsentDeciderWS:
         await handle_consent_decider(ws, app)
         assert ws.closed == (4002, "Token expired")
 
-    async def test_ping_touches_and_pongs(self):
-        import json
+    async def test_non_member_workspace_scoped_is_forbidden(self):
+        from klangk.wshandler.decider import handle_consent_decider
 
+        app = _ws_app({"id": "u1", "email": "a@x"}, allowed=False)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4003, "Forbidden")
+        assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_non_admin_deploy_wide_is_forbidden(self):
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"}, allowed=False)
+        ws = _FakeWS({"token": "tok"}, [])  # no workspace -> deploy-wide
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4003, "Forbidden")
+        assert ws.accepted is False
+
+    async def test_ping_touches_and_pongs(self):
         from fastapi import WebSocketDisconnect
 
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"email": "a@x"})
+        app = _ws_app({"id": "u1", "email": "a@x"})
         ws = _FakeWS(
             {"token": "tok", "workspace": WS},
             ['{"type":"ping"}', WebSocketDisconnect()],
@@ -214,12 +310,123 @@ class TestConsentDeciderWS:
         await handle_consent_decider(ws, app)
         assert any(json.loads(m).get("type") == "pong" for m in ws.sent)
 
+    async def test_snapshot_replayed_on_connect(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        frame = {
+            "type": "egress_request",
+            "workspace_id": WS,
+            "request": {"id": "r1"},
+        }
+        app = _ws_app({"id": "u1", "email": "a@x"}, snapshot=[frame])
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS}, [WebSocketDisconnect()]
+        )
+        await handle_consent_decider(ws, app)
+        assert any(
+            json.loads(m).get("type") == "egress_request" for m in ws.sent
+        )
+        app.state.consent_coordinator.snapshot.assert_awaited_once_with(WS)
+
+    async def test_verdict_resolves_the_hold(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "decider@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                json.dumps(
+                    {
+                        "type": "verdict",
+                        "request_id": "rid",
+                        "decision": "allowed",
+                        "scope": "once",
+                    }
+                ),
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.resolve.assert_awaited_once_with(
+            "rid", "allowed", "once", "decider@x", decider_workspace=WS
+        )
+
+    async def test_verdict_invalid_decision_sends_error(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                json.dumps(
+                    {
+                        "type": "verdict",
+                        "request_id": "rid",
+                        "decision": "maybe",
+                    }
+                ),
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.resolve.assert_not_awaited()
+        assert any(json.loads(m).get("type") == "error" for m in ws.sent)
+
+    async def test_verdict_invalid_scope_sends_error(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                json.dumps(
+                    {
+                        "type": "verdict",
+                        "request_id": "rid",
+                        "decision": "denied",
+                        "scope": "bogus",
+                    }
+                ),
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.resolve.assert_not_awaited()
+        assert any(json.loads(m).get("type") == "error" for m in ws.sent)
+
+    async def test_verdict_missing_request_id_sends_error(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                json.dumps(
+                    {"type": "verdict", "decision": "denied"}  # no request_id
+                ),
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.resolve.assert_not_awaited()
+        assert any(json.loads(m).get("type") == "error" for m in ws.sent)
+
     async def test_deploy_wide_when_no_workspace_param(self):
         from fastapi import WebSocketDisconnect
 
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"email": "admin@example.com"})
+        app = _ws_app({"id": "u1", "email": "admin@example.com"})
         ws = _FakeWS({"token": "tok"}, [WebSocketDisconnect()])
         # While connected it would cover every workspace; after disconnect,
         # nothing remains.
@@ -227,14 +434,66 @@ class TestConsentDeciderWS:
         assert app.state.consent_deciders.has_decider(WS) is False
         assert app.state.consent_deciders.has_decider(WS2) is False
 
-    async def test_non_ping_and_invalid_json_are_ignored(self):
-        import json
-
+    async def test_verdict_resolve_error_does_not_tear_down_connection(self):
+        # a verdict whose resolve() raises is logged + swallowed -- the
+        # connection survives to handle later messages (no whole-connection
+        # teardown for one bad verdict).
         from fastapi import WebSocketDisconnect
 
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"email": "a@x"})
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        app.state.consent_coordinator.resolve = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                json.dumps(
+                    {
+                        "type": "verdict",
+                        "request_id": "rid",
+                        "decision": "allowed",
+                    }
+                ),
+                '{"type":"ping"}',  # must still be handled after the error
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        assert any(
+            json.loads(m).get("type") == "pong" for m in ws.sent
+        )  # connection survived
+        app.state.consent_coordinator.resolve.assert_awaited_once()
+
+    async def test_slow_client_is_dropped(self):
+        # a full outbound queue (SlowClientError) drops the connection, like
+        # the main /ws handler.
+        from unittest.mock import patch
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler import safe_websocket as sw_mod
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"ping"}', WebSocketDisconnect()],
+        )
+        with patch.object(
+            sw_mod.SafeWebSocket,
+            "send_json",
+            side_effect=sw_mod.SlowClientError("full"),
+        ):
+            await handle_consent_decider(ws, app)
+        assert app.state.consent_deciders.has_decider(WS) is False  # dropped
+
+    async def test_non_ping_and_invalid_json_are_ignored(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
         ws = _FakeWS(
             {"token": "tok", "workspace": WS},
             [
@@ -242,7 +501,7 @@ class TestConsentDeciderWS:
                 '"hello"',  # valid JSON but not a dict -> continue
                 "123",  # valid JSON int, not a dict -> continue
                 "[1, 2]",  # valid JSON list, not a dict -> continue
-                '{"type":"hello"}',  # valid JSON, not a ping -> ignored
+                '{"type":"hello"}',  # valid JSON, unknown type -> ignored
                 '{"type":"ping"}',  # ping -> pong
                 WebSocketDisconnect(),
             ],
@@ -258,7 +517,7 @@ class TestConsentDeciderWS:
         # handler treats it as a disconnect and still deregisters.
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"email": "a@x"})
+        app = _ws_app({"id": "u1", "email": "a@x"})
         ws = _FakeWS(
             {"token": "tok", "workspace": WS}, [RuntimeError("disconnected")]
         )


### PR DESCRIPTION
## Summary

Held egress requests now **reach a human**. Building on #2315's `ConsentCoordinator` (the synchronous hold) + #2308's decider registry/WS, this wires the two halves together: when the coordinator creates a hold it pushes an `egress_request` to the workspace's deciders; a decider's `verdict` releases the hold; co-deciders learn it's resolved (first-decision-wins).

### What changed

- **`consent_deciders.py`** — `register()` now stores the decider's `SafeWebSocket`. New `broadcast(workspace_id, msg)` sends to every live decider matching the workspace (or deploy-wide), pruning any whose socket is dead/slow (`WS_ERRORS`). Non-blocking (`SafeWebSocket.send_json` enqueues on a bounded queue).
- **`consent_coordinator.py`** —
  - `_fanout(request)` is real: builds + broadcasts an `egress_request` frame (was a `#2244` stub).
  - `resolve(..., *, decider_workspace=None)` adds defense-in-depth scope enforcement (a workspace-scoped decider may only decide its own workspace) and broadcasts `egress_resolved` (allow/deny/expired) so co-deciders drop the request.
  - `_fail_close()` broadcasts `egress_resolved` (decision `expired`) on timeout/shutdown.
  - new `snapshot(workspace_id)` replays the workspace's pending requests for a decider connecting mid-flight (deploy-wide deciders get no snapshot for now — cross-workspace list is a follow-up).
- **`wshandler/decider.py`** — outbound writes now go through `SafeWebSocket` (bounded queue, like the main `/ws`); on connect it replays the snapshot; a `verdict` message (validated decision/scope/request_id) is fed to `coordinator.resolve(..., decider_workspace=...)`. **Closes the #2308 authz gap**: a workspace-scoped decider (`?workspace=`) needs `terminal` access to that workspace; a deploy-wide decider needs admin; otherwise the socket is closed `4003 Forbidden` (mirrors the main handler's workspace gate).

### Scope note (issue reconciliation)

The #2244 body said "broadcast to frontends" but named the **decider client (#2310)** as first consumer — internally inconsistent (#2310 connects to `/ws/consent-decider`, not the browser session WS). The evolved design (#2315's `_fanout` stub + the data-flow contract `sidecar ←WS→ klangkd ←WS→ decider`) makes the **decider fanout** the right scope; all four acceptance criteria map onto it. The browser "pending requests" UI panel is intentionally omitted (informational, not on the consent-critical path) — a separate follow-up if wanted.

### Frames

- `{type: "egress_request", workspace_id, request: <row>}` — new hold (from `_fanout`) or snapshot replay.
- `{type: "egress_resolved", workspace_id, request_id, decision: allowed|denied|expired}` — terminal state change (first-decision-wins).
- `{type: "verdict", request_id, decision: allowed|denied, scope?: once|workspace|deploy}` — decider → klangkd.

## Test coverage

4485 passed, 100%. New/extended: registry `broadcast` (matching-only, deploy-wide inclusion, dead-socket pruning, stale-skip); coordinator fanout (`_fanout` broadcasts, `resolve` broadcasts resolved + rejects out-of-workspace verdicts, timeout broadcasts expired, snapshot replay, deploy-wide snapshot empty); decider endpoint (non-member/non-admin → 4003, snapshot replayed, verdict → resolve with correct `decider_workspace`, invalid decision/scope/missing request_id → error + no resolve, ping/snapshot/disconnect lifecycle).
