### PR TITLE
feat(host): embed the network sidecar image in the host image

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,13 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Embedded network sidecar image (#2301).** The all-in-one host image
+  (`scripts/build-host-image.sh`) now embeds the network sidecar image as a
+  tarball and `podman load`s it on first startup, mirroring the workspace
+  image. A default host-image deployment with FQDN egress enabled can start
+  a workspace with `allowed_domains` without separately building or pulling
+  the sidecar.
+
 - **Egress consent recording (#2242).** The network sidecar records every
   blocked destination to the `egress_consent` table: for **static**
   workspaces (the default) as `denied` with no human (`decided_by` NULL),

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -92,11 +92,14 @@ ships with a default (`klangk-network-sidecar`), so a workspace that
 declares `allowed_domains` is filtered out of the box — no configuration
 is required for the common case.
 
-1. Build (or pull) the sidecar image so it's available to podman. In dev,
-   the `klangk:build-network-sidecar` devenv task builds it from
-   `src/containers/network/`. For a deploy, publish the image to your
-   registry and point `KLANGKD_NETWORK_SIDECAR_IMAGE` at it if you don't
-   use the default name.
+1. Make the sidecar image available to podman:
+   - **All-in-one host image** (`scripts/build-host-image.sh`): nothing to
+     do — the sidecar image is embedded as a tarball in the host image and
+     `podman load`ed on first startup (#2301).
+   - **Dev**: the `klangk:build-network-sidecar` devenv task builds it from
+     `src/containers/network/`.
+   - **Other deploys**: publish the image to your registry and point
+     `KLANGKD_NETWORK_SIDECAR_IMAGE` at it if you don't use the default name.
 2. Restart klangkd. A workspace that declares `allowed_domains` now starts
    behind the sidecar.
 

--- a/scripts/build-host-image.sh
+++ b/scripts/build-host-image.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Build the klangk-host container image via Dockerfile.
 #
-# Builds all prerequisites (flutter web, workspace image) then embeds
-# the workspace image tarball in the host image.
+# Builds all prerequisites (flutter web, workspace image, network sidecar
+# image) then embeds both image tarballs in the host image.
 #
 # Usage:
 #   bash scripts/build-host-image.sh
@@ -22,6 +22,7 @@ rm -rf src/klangk/dist
 bash "$SCRIPT_DIR/build_wheel.sh"
 
 bash "$SCRIPT_DIR/build-workspace-image.sh"
+bash "$SCRIPT_DIR/build-network-sidecar.sh"
 
 VERSION="$(jq -r .version "$KLANGKD_VERSION_FILE")"
 IMAGE="${KLANGKBUILD_HOST_IMAGE:-klangk-host}"
@@ -30,6 +31,10 @@ IMAGE="${KLANGKBUILD_HOST_IMAGE:-klangk-host}"
 cp "$KLANGKD_VERSION_FILE" version.json
 
 WORKSPACE_IMAGE="${KLANGKD_IMAGE_NAME:-klangk-workspace}"
+# Must match the tag in scripts/build-network-sidecar.sh and the default of
+# the network_sidecar_image setting (settings.py) so all three agree on the
+# name the embedded tar provides.
+SIDECAR_IMAGE="klangk-network-sidecar"
 PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
 # Export workspace image so it can be embedded in the host image. The host
 # image no longer stages feature trees (#1660/#1665) — the runtime reads
@@ -37,9 +42,12 @@ PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
 # above) already bakes feature trees in for Pi — so there's no separate
 # staging tempdir here anymore, just the workspace tarball.
 WORKSPACE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/klangk-workspace-XXXXXX")
-trap 'rm -rf "$WORKSPACE_DIR"' EXIT
+SIDECAR_DIR=$(mktemp -d "${TMPDIR:-/tmp}/klangk-sidecar-XXXXXX")
+trap 'rm -rf "$WORKSPACE_DIR" "$SIDECAR_DIR"' EXIT
 echo "Exporting workspace image $WORKSPACE_IMAGE from podman ..."
 "$PODMAN" save -o "$WORKSPACE_DIR/workspace.tar" "$WORKSPACE_IMAGE"
+echo "Exporting network sidecar image $SIDECAR_IMAGE from podman ..."
+"$PODMAN" save -o "$SIDECAR_DIR/network-sidecar.tar" "$SIDECAR_IMAGE"
 
 echo "Building $IMAGE $VERSION ..."
 
@@ -47,6 +55,7 @@ docker build \
   --platform "${KLANGKBUILD_PLATFORM:-linux/amd64}" \
   -f src/containers/host/Dockerfile \
   --build-context "workspace-image=$WORKSPACE_DIR" \
+  --build-context "network-sidecar-image=$SIDECAR_DIR" \
   -t "$IMAGE:latest" \
   -t "$IMAGE:$VERSION" \
   "$@" \

--- a/src/containers/host/Dockerfile
+++ b/src/containers/host/Dockerfile
@@ -79,6 +79,8 @@ COPY --chown=klangk:klangk src/containers/host/storage.conf /home/klangk/.config
 
 # Embedded workspace image — loaded into podman on first startup
 COPY --from=workspace-image --chown=klangk:klangk workspace.tar /home/klangk/workspace.tar
+# Embedded network sidecar image — loaded into podman on first startup (#2301)
+COPY --from=network-sidecar-image --chown=klangk:klangk network-sidecar.tar /home/klangk/network-sidecar.tar
 
 
 ENV HOME=/home/klangk

--- a/src/containers/host/entrypoint.sh
+++ b/src/containers/host/entrypoint.sh
@@ -22,6 +22,25 @@ print(d.get('image_name') or d.get('image-name') or 'klangk-workspace')
   fi
 fi
 
+# Load the embedded network sidecar image into podman on first startup (#2301).
+# Same pattern as the workspace image above: the image name comes from
+# klangkd.yaml (network_sidecar_image), read here so the entrypoint and klangkd
+# agree on which image the sidecar tar provides. The python fallback matches
+# klangkd's own field default ("klangk-network-sidecar"), which is what the
+# generated klangkd.yaml falls back to when the key is absent.
+SIDECAR_TAR="$HOME/network-sidecar.tar"
+if [ -f "$SIDECAR_TAR" ]; then
+  SIDECAR_IMAGE=$(python3 -c "
+import yaml
+d = yaml.safe_load(open('$CONFIG')) or {}
+print(d.get('network_sidecar_image') or d.get('network-sidecar-image') or 'klangk-network-sidecar')
+" 2>/dev/null || echo klangk-network-sidecar)
+  if ! podman image exists "$SIDECAR_IMAGE" 2>/dev/null; then
+    echo "Loading network sidecar image $SIDECAR_IMAGE ..."
+    podman load -i "$SIDECAR_TAR"
+  fi
+fi
+
 case "${1:-start}" in
 start)
   exec supervisord -c "$HOME/etc/supervisord.conf"


### PR DESCRIPTION
## Summary

Closes #2301. Mirrors the existing **workspace-image embedding** for the **network sidecar image**, so an all-in-one host-image deployment (`scripts/build-host-image.sh`) ships with the sidecar baked in. A default deployment with FQDN egress enabled (the default) can now start a workspace with `allowed_domains` without separately building or pulling the sidecar — previously it **failed fail-closed** at start (`_start_network_sidecar` raises when the image is absent).

## Changes

Three direct parallels to the workspace image, plus docs/changelog.

**1. `scripts/build-host-image.sh`** — build the sidecar (`build-network-sidecar.sh`, after the existing workspace build), `podman save` its tar, and pass it as a second named build context:
```bash
bash "$SCRIPT_DIR/build-network-sidecar.sh"
...
SIDECAR_IMAGE="klangk-network-sidecar"
SIDECAR_DIR=$(mktemp -d ...)
"$PODMAN" save -o "$SIDECAR_DIR/network-sidecar.tar" "$SIDECAR_IMAGE"
...
docker build ... --build-context "workspace-image=$WORKSPACE_DIR" \
                 --build-context "network-sidecar-image=$SIDECAR_DIR" ...
```
The `SIDECAR_IMAGE` name is hardcoded to `klangk-network-sidecar` with a comment pointing at the two other places it must agree with (`build-network-sidecar.sh`'s tag and the `network_sidecar_image` setting default).

**2. `src/containers/host/Dockerfile`** — COPY the sidecar tar next to the workspace tar:
```dockerfile
# Embedded network sidecar image — loaded into podman on first startup (#2301)
COPY --from=network-sidecar-image --chown=klangk:klangk network-sidecar.tar /home/klangk/network-sidecar.tar
```

**3. `src/containers/host/entrypoint.sh`** — `podman load` the sidecar tar on first startup when the image isn't already present, reading the name from `klangkd.yaml` `network_sidecar_image` (python fallback to the `klangk-network-sidecar` default, matching the workspace-image block):
```bash
SIDECAR_TAR="$HOME/network-sidecar.tar"
if [ -f "$SIDECAR_TAR" ]; then
  SIDECAR_IMAGE=$(python3 -c "
import yaml
d = yaml.safe_load(open('$CONFIG')) or {}
print(d.get('network_sidecar_image') or d.get('network-sidecar-image') or 'klangk-network-sidecar')
" 2>/dev/null || echo klangk-network-sidecar)
  if ! podman image exists "$SIDECAR_IMAGE" 2>/dev/null; then
    echo "Loading network sidecar image $SIDECAR_IMAGE ..."
    podman load -i "$SIDECAR_TAR"
  fi
fi
```

**Docs** — `docs/features/egress-filtering.md` now lists the all-in-one host image as the zero-config path for making the sidecar available (first, before the dev-build and pull options). Changelog entry under `## [Unreleased]` → Added.

## Design notes

- **The generated `klangkd.yaml` (Dockerfile) does not set `network_sidecar_image`**, so the default `klangk-network-sidecar` applies in klangkd (settings default) **and** the entrypoint's python fallback applies — they agree, exactly as the workspace image does (its `image_name` fallback mirrors this).
- **Override edge case**: if an operator overrides `network_sidecar_image` in `klangkd.yaml`, the embedded tar (which contains the `klangk-network-sidecar` tag) won't match the custom name. This is the same edge case the workspace image has, and in both cases an operator overriding the image name is not using the embedded tar — so it's out of scope for this issue.
- **Unconditional embed**: the sidecar is small (dnspython + iptables + a Python proxy); building it adds negligible time to every host-image build, mirroring the unconditional workspace-image build. The default deployment has egress enabled, so this is the right default.

## Verification

- `pre-commit run` clean on all five files: `shfmt`, `shellcheck`, `prettier`, `markdownlint`, `trufflehog`, `binary-integrity` all Passed.
- No Python or Dart files changed; the two tests that mention "entrypoint.sh" (`test_container.py:1265`, `test_network_sidecar_e2e.py:48`) reference the **sidecar's** `src/containers/network/entrypoint.sh`, not the host's — a different, untouched file. The coverage gate and unit suite are not load-bearing for this PR (shell/Dockerfile/docs only, none imported by the test suite).
