### PR TITLE
feat(consent): sidecar kernel-level egress hold (#2311, half B)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -91,6 +91,18 @@ operators or integrators to act when upgrading.
   deploy-wide decider needs admin (else the socket is closed `4003 Forbidden`),
   and a verdict is honored only for the decider's own workspace. The first
   consumer is the `consent-decide` client (#2310).
+- **Sidecar kernel-level egress hold (#2311).** The network sidecar now
+  _holds_ a denied connection in-flight pending the consent verdict (DNS:
+  suspends the query; NFQUEUE: defers the packet) instead of NXDOMAIN/DROP-ing
+  at once -- `allow` lets it proceed, `deny`/timeout/WS-down fail-closes
+  (a static workspace or an unreachable klangkd behaves exactly as before; no
+  new latency, no hang). New sidecar config: `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT`
+  (default 30s), `KLANGKNETWORK_EGRESS_HOLD_LIMIT` (default 32 concurrent
+  holds; a flood past it fail-closes to NXDOMAIN). The proxy is now asyncio
+  (one task per denied query so holds never block the receive loop) and the
+  sidecar image gains the `websockets` dependency; the legacy fire-and-forget
+  POST endpoint is superseded (recording now happens on the WS hold path,
+  removal tracked in #2318).
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the

--- a/src/containers/network/Dockerfile
+++ b/src/containers/network/Dockerfile
@@ -4,15 +4,16 @@
 # Build context is this directory (proxy.py + entrypoint.sh are COPY'd in).
 FROM alpine:3.21
 # Runtime: iptables + python3 + the C libs netfilterqueue links (the
-# interactive-mode NFQUEUE consumer, #2242). Build deps are installed
-# transiently to compile the netfilterqueue C extension, then removed.
+# interactive-mode NFQUEUE consumer, #2242) + websockets (the egress-sidecar
+# WS client, #2311 half B). Build deps are installed transiently to compile
+# the netfilterqueue C extension, then removed.
 RUN apk add --no-cache \
       iptables python3 py3-pip \
       libnetfilter_queue libmnl \
     && apk add --no-cache --virtual .build-deps \
       build-base python3-dev libnetfilter_queue-dev libmnl-dev \
     && pip install --no-cache-dir --break-system-packages \
-      "dnspython>=2.7,<3" netfilterqueue \
+      "dnspython>=2.7,<3" netfilterqueue "websockets>=12,<17" \
     && apk del .build-deps
 COPY proxy.py /proxy.py
 COPY entrypoint.sh /entrypoint.sh

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -82,17 +82,18 @@ case "${KLANGKNETWORK_EGRESS_BACKEND_PORT:-}" in
   ;;
 esac
 
-# --- egress consent recording (#2242): queue blocked packets to the sidecar's
-# own NFQUEUE consumer (proxy.py) whenever a consent endpoint is configured.
-# Recording runs for every filtered workspace; egress_mode (static vs
-# interactive) only affects the recorded decision, applied by klangkd. The
-# sidecar is the netns owner with NET_ADMIN, so it reads its own NFQUEUE -- no
-# host-side /dev/kmsg access or new privilege. Fail-closed: a down consumer
-# means the kernel drops queued packets; unmatched traffic hits the OUTPUT DROP
-# policy. Rate-limited so a flooding workspace can't overwhelm the consumer;
-# packets past the limit miss the match and fall through to DROP (denied,
-# unobserved). Denied DNS queries are also forwarded by the proxy with their
-# domain names -- NFQUEUE only carries raw IPs.
+# --- egress consent hold (#2242 recording -> #2311 half B hold): queue
+# blocked packets to the sidecar's own NFQUEUE consumer (proxy.py) whenever a
+# consent endpoint is configured. The consumer holds each packet pending a
+# verdict (allow -> pkt.accept(), then conntrack's ESTABLISHED,RELATED rule
+# passes the rest of the connection; deny/timeout/WS-down -> pkt.drop());
+# klangkd records the decision. The sidecar is the netns owner with NET_ADMIN,
+# so it reads its own NFQUEUE -- no host-side /dev/kmsg access or new privilege.
+# Fail-closed: a down consumer means the kernel drops queued packets; unmatched
+# traffic hits the OUTPUT DROP policy. Rate-limited so a flooding workspace can't
+# overwhelm the consumer; packets past the limit miss the match and fall through
+# to DROP (denied). Denied DNS queries are also held by the proxy (by domain) --
+# NFQUEUE only carries raw IPs.
 if [ -n "${KLANGKNETWORK_EGRESS_CONSENT_URL:-}" ]; then
   $IPT -A OUTPUT -m limit --limit 5/sec --limit-burst 20 \
     -j NFQUEUE --queue-num "${KLANGKNETWORK_EGRESS_NFQUEUE_NUM:-5139}"

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -79,6 +79,7 @@ Limitations: transport is UDP only (TCP fallback is a future addition).
 
 import asyncio
 import json
+import logging
 import os
 import socket
 import subprocess
@@ -89,6 +90,11 @@ import uuid
 import dns.message
 import dns.rcode
 import dns.rdatatype
+
+# The `websockets` client logs the full HTTP request line (incl. any ?token=
+# query param) at DEBUG; cap it at WARNING so a workspace JWT can't leak to
+# sidecar stdout/logs even if debug logging is enabled elsewhere (#2309).
+logging.getLogger("websockets").setLevel(logging.WARNING)
 
 UPSTREAM = (os.environ.get("KLANGKNETWORK_EGRESS_UPSTREAM", "8.8.8.8"), 53)
 LISTEN_PORT = int(os.environ.get("KLANGKNETWORK_EGRESS_LISTEN_PORT", "15353"))
@@ -156,10 +162,15 @@ SPECS = parse_specs()
 
 # Learned IPs: {ip: {"expire": epoch, "ports": set[int | None]}}. A ``None``
 # in ``ports`` is the all-ports ACCEPT rule. Guarded by _LOCK because the
-# sweeper thread removes entries while the main loop adds/refreshes them
-# (only the main loop installs rules; the sweeper only removes).
+# asyncio loop runs the iptables installs + sweeps in the default thread-pool
+# executor (see _learn_all / _async_sweeper), so two worker threads can touch
+# _LEARNED at once; the lock serializes the rule+record mutations.
 _LEARNED: dict[str, dict] = {}
 _LOCK = threading.Lock()
+# Strong refs to background asyncio tasks (DNS holds + the TTL sweeper) so
+# CPython doesn't GC a task that's awaiting a verdict / sleeping. A done-callback
+# discards each entry when its task completes.
+_BG_TASKS: set[asyncio.Task] = set()
 
 
 def query_name(wire: bytes) -> str:
@@ -268,12 +279,13 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
 
     The install happens **under** :data:`_LOCK` so the kernel rule and its
     ``_LEARNED`` record are atomic w.r.t. :func:`sweep_once`'s remove+delete
-    (also under the lock). Without that, the sweeper could delete a rule
-    :func:`allow` just installed while ``_LEARNED`` still records it as
-    present — a fail-closed availability gap that only self-heals on the next
-    re-resolution (#2256 review). The main loop is single-threaded and the
-    sweeper runs every ``SWEEP_INTERVAL``, so serializing the iptables calls
-    under the lock is negligible contention.
+    (also under the lock). Without that, a concurrent sweep running in another
+    executor worker could delete a rule :func:`allow` just installed while
+    ``_LEARNED`` still records it as present -- a fail-closed availability gap
+    that only self-heals on the next re-resolution (#2256 review). ``allow`` and
+    :func:`sweep_once` both run off the event loop in the default thread-pool
+    executor (see :func:`_learn_all` / :func:`_async_sweeper`), so the lock
+    genuinely serializes them; contention is negligible.
     """
     expire = time.time() + max(ttl, MIN_TTL)
     with _LOCK:
@@ -314,11 +326,16 @@ def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
 
 
 async def _async_sweeper() -> None:
-    """Background task: periodically drop learned IPs past their TTL (#2256)."""
+    """Background task: periodically drop learned IPs past their TTL (#2256).
+
+    :func:`sweep_once` runs in the executor so its iptables ``-D`` forks don't
+    block the loop (and so it can run concurrently with :func:`_learn_all`,
+    serialized by :data:`_LOCK`).
+    """
     while True:
         await asyncio.sleep(SWEEP_INTERVAL)
         try:
-            sweep_once()
+            await asyncio.get_running_loop().run_in_executor(None, sweep_once)
         except Exception:
             pass  # a transient sweep failure defers cleanup to the next tick
 
@@ -345,7 +362,15 @@ def check_mark() -> None:
         probe.close()
 
 
-def _respond_allowed(
+def _learn_all(recs: list[tuple[str, int]], ports: set[int | None]) -> None:
+    """Install the ACCEPT rule for each learned IP/port (sync; runs in the
+    executor so the iptables forks don't block the event loop)."""
+    for ip, ttl in recs:
+        for port in ports:
+            allow(ip, port, ttl)
+
+
+async def _respond_allowed(
     s: socket.socket,
     resp: bytes,
     addr: tuple[str, int],
@@ -355,21 +380,22 @@ def _respond_allowed(
     """Learn the response's IPs (port-scoped, TTL-tracked) + send it, swallowing
     transient errors.
 
-    A failure here (a transient ``iptables`` error in :func:`allow`, or a
-    ``sendto`` to a vanished client) must drop only this one response — not
-    kill the proxy. If it escaped :func:`main` the sidecar's PID 1 would exit,
-    DNS would be dead for the workspace, and the learned ``ACCEPT`` rules would
-    persist (a partial fail-open: previously-resolved hosts stay reachable).
-    #2278.
+    The iptables installs (:func:`_learn_all`) run off the loop in the default
+    thread-pool executor so a burst of learned IPs can't stall the DNS receive
+    loop or verdict dispatch. A failure here (a transient ``iptables`` error, or
+    a ``sendto`` to a vanished client) must drop only this one response -- not
+    kill the proxy (#2278): if it escaped, the sidecar's PID 1 would exit, DNS
+    would be dead for the workspace, and the learned ``ACCEPT`` rules would
+    persist (a partial fail-open).
     """
+    loop = asyncio.get_running_loop()
     try:
         recs = a_records_with_ttl(resp)
     except Exception:
         recs = []
     try:
-        for ip, ttl in recs:
-            for port in ports:
-                allow(ip, port, ttl)
+        if recs:
+            await loop.run_in_executor(None, _learn_all, recs, ports)
         if DEBUG:
             print(
                 f"allow {qname} -> {[ip for ip, _ in recs]} ports={_fmt_ports(ports)}",
@@ -487,6 +513,7 @@ class SidecarConsentClient:
         self._connected = asyncio.Event()
         self._pending: dict[str, asyncio.Future] = {}  # id -> Future
         self._stop = False
+        self._no_token_warned = False
         self._task: asyncio.Task | None = None
 
     @property
@@ -521,6 +548,12 @@ class SidecarConsentClient:
             if not token:
                 # Token file not present yet (workspace JWT not written). Retry
                 # without escalating backoff (expected at startup).
+                if DEBUG and not self._no_token_warned:
+                    print(
+                        "consent: workspace token not yet present; retrying",
+                        flush=True,
+                    )
+                    self._no_token_warned = True
                 await asyncio.sleep(1.0)
                 continue
             url = f"{self._url}?token={token}"
@@ -530,14 +563,22 @@ class SidecarConsentClient:
                 ) as ws:
                     self._ws = ws
                     self._connected.set()
+                    self._no_token_warned = False
                     backoff = 1.0
                     if DEBUG:
                         print(f"consent: connected to {self._url}", flush=True)
                     async for raw in ws:
                         self._dispatch(raw)
             except Exception as exc:
+                # Log the exception TYPE only -- the URL carries the workspace
+                # JWT as ?token=, and a websockets exception could embed it
+                # (#2309). The websockets package logger is capped at WARNING
+                # on import so its DEBUG request-line can't leak either.
                 if DEBUG:
-                    print(f"consent: connection error: {exc}", flush=True)
+                    print(
+                        f"consent: connection error: {type(exc).__name__}",
+                        flush=True,
+                    )
             finally:
                 # Disconnected (clean close, error, or crash): the sidecar's
                 # held connections die with it (fail-close). Any in-flight
@@ -626,10 +667,10 @@ async def _forward_and_learn(
         await asyncio.wait_for(loop.sock_sendto(us, data, UPSTREAM), 3)
         resp, _ = await asyncio.wait_for(loop.sock_recvfrom(us, 65535), 3)
     except Exception:
-        us.close()
         return
-    us.close()
-    _respond_allowed(s, resp, addr, qname, port_set)
+    finally:
+        us.close()  # closed on success, error, AND cancellation
+    await _respond_allowed(s, resp, addr, qname, port_set)
 
 
 def _send_nxdomain(s: socket.socket, data: bytes, addr: tuple[str, int]) -> None:
@@ -675,6 +716,9 @@ async def _handle_hold(
     if decision == "allow":
         if DEBUG:
             print(f"consent-allow {qname}", flush=True)
+        # all-ports {None}: a human consenting to a domain opens every port to
+        # its resolved IPs for the TTL (like a port-less allow spec) -- consent
+        # is per-domain, not per-port (#2311 half B).
         await _forward_and_learn(s, data, addr, qname, {None})
     else:
         if DEBUG:
@@ -727,6 +771,39 @@ def _run_nfq_consumer(
         print(f"nfqueue consumer failed: {exc}", flush=True)
 
 
+async def _handle_packet(
+    s: socket.socket,
+    data: bytes,
+    addr: tuple[str, int],
+    client: SidecarConsentClient | None,
+    limiter: _HoldLimiter,
+) -> None:
+    """Classify + route one DNS query (the per-packet body of :func:`_async_main`).
+
+    Factored out of the receive loop so the routing -- classify -> gate ->
+    hold / NXDOMAIN / forward -- is unit-testable without running the infinite
+    ``recvfrom`` loop. A statically-allow-listed name goes straight to the
+    forward path (never held); only denied names hit the consent gate.
+    """
+    try:
+        qname = query_name(data)
+    except Exception:
+        return  # malformed/unparseable query -> drop
+    ports = ports_for(qname)
+    deny, port_set = _decision(qname, ports)
+    if deny:
+        if DEBUG:
+            print(f"deny  {qname}", flush=True)
+        if _gate_deny(client, limiter):
+            t = asyncio.create_task(_handle_hold(s, data, addr, qname, client, limiter))
+            _BG_TASKS.add(t)  # strong ref so the hold task isn't GC'd
+            t.add_done_callback(_BG_TASKS.discard)
+        else:
+            _send_nxdomain(s, data, addr)
+        return
+    await _forward_and_learn(s, data, addr, qname, port_set)
+
+
 async def _async_main() -> None:
     """The asyncio DNS loop (#2311 half B): holds denied queries pending verdicts.
 
@@ -747,7 +824,9 @@ async def _async_main() -> None:
         flush=True,
     )
     check_mark()
-    asyncio.create_task(_async_sweeper())
+    _sweep = asyncio.create_task(_async_sweeper())
+    _BG_TASKS.add(_sweep)  # strong ref for the loop's lifetime
+    _sweep.add_done_callback(_BG_TASKS.discard)
     # NFQUEUE consumer runs nfq.run() in a thread (blocking); its callback
     # crosses into this loop to await the consent verdict (#2311 half B).
     if CONSENT_URL:
@@ -760,21 +839,7 @@ async def _async_main() -> None:
             data, addr = await loop.sock_recvfrom(s, 65535)
         except Exception:
             continue
-        try:
-            qname = query_name(data)
-        except Exception:
-            continue  # malformed/unparseable query -> drop
-        ports = ports_for(qname)
-        deny, port_set = _decision(qname, ports)
-        if deny:
-            if DEBUG:
-                print(f"deny  {qname}", flush=True)
-            if _gate_deny(client, limiter):
-                asyncio.create_task(_handle_hold(s, data, addr, qname, client, limiter))
-            else:
-                _send_nxdomain(s, data, addr)
-            continue
-        await _forward_and_learn(s, data, addr, qname, port_set)
+        await _handle_packet(s, data, addr, client, limiter)
 
 
 def main() -> None:

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -28,6 +28,20 @@ Allow-list semantics (#2256):
   the DNS response that resolved it; a background sweeper removes the ACCEPT
   rule once the TTL elapses so stale IPs do not linger.
 
+Interactive consent hold (#2311 half B): when a consent endpoint is configured,
+the proxy is an **asyncio** program that keeps one persistent WebSocket to
+klangkd's ``/ws/egress-sidecar`` and, for each *denied* destination, sends an
+``{type:egress, id, dst, dport}`` frame and *suspends* the query pending the
+matching ``{type:verdict, id, decision}`` verdict instead of NXDOMAIN-ing at
+once. The coordinator (klangkd) gate-checks: a registered decider -> the request
+is held; otherwise it returns ``deny`` fast (the proxy NXDOMAIN/DROPs as before
+-- no behavior change for static workspaces). An ``allow`` verdict lets the held
+query proceed (DNS: resolve upstream + learn the IPs; NFQUEUE: ``accept`` the
+packet, and conntrack's ``ESTABLISHED,RELATED`` rule passes the rest of the
+connection). **Fail-close**: a down WebSocket or a timed-out verdict resolves to
+``deny`` immediately, so the workspace stays locked down when klangkd or the
+decider is unreachable (today's static behavior) — no new latency, no hang.
+
 Configuration (env):
   KLANGKNETWORK_EGRESS_ALLOW       comma-separated allow-list: ``host[:port]``,
                             ``*.domain[:port]``, or CIDR specs. CIDR specs are
@@ -47,17 +61,30 @@ Configuration (env):
                             response does not immediately yank the rule the
                             workspace needs to reach the IP it just resolved
                             (default 30).
+  KLANGKNETWORK_EGRESS_CONSENT_URL  klangkd consent endpoint (HTTP). When set,
+                            the proxy opens the egress-sidecar WS + holds denied
+                            egress pending a verdict. Empty -> static
+                            NXDOMAIN/DROP (today's behavior; consent disabled).
+  KLANGKNETWORK_EGRESS_HOLD_TIMEOUT  seconds to await a verdict before
+                            fail-closing to deny (default 30). Should be >=
+                            klangkd's consent hold timeout; a DNS resolver may
+                            give up first (~10s), in which case a slower verdict
+                            effectively denies the query.
+  KLANGKNETWORK_EGRESS_HOLD_LIMIT    max concurrent DNS-path holds in flight
+                            (default 32); a flood past this fail-closes to
+                            NXDOMAIN.
 
 Limitations: transport is UDP only (TCP fallback is a future addition).
 """
 
+import asyncio
+import json
 import os
 import socket
 import subprocess
-import json
 import threading
 import time
-import urllib.request
+import uuid
 
 import dns.message
 import dns.rcode
@@ -77,24 +104,23 @@ MARK = int(os.environ.get("KLANGKNETWORK_EGRESS_MARK", "75"))
 # Learned-IP housekeeping (#2256).
 SWEEP_INTERVAL = float(os.environ.get("KLANGKNETWORK_EGRESS_SWEEP_INTERVAL", "5"))
 MIN_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_MIN_TTL", "30"))
-# --- interactive consent (#2242): the NFQUEUE consumer forwards each blocked
-# destination to klangkd's consent endpoint. Only active in interactive mode
-# (main() starts the consumer thread); empty CONSENT_URL -> log only.
+# --- interactive consent hold (#2311 half B): when a consent endpoint is set,
+# the proxy holds denied egress pending a verdict over the egress-sidecar WS.
 QUEUE_NUM = int(os.environ.get("KLANGKNETWORK_EGRESS_NFQUEUE_NUM", "5139"))
-# Bounds concurrent consent POST threads from the denied-DNS path (which has no
-# iptables rate limit, unlike NFQUEUE): at most this many _post_event threads
-# run at once. A flooding workspace can't spawn unbounded threads (which would
-# hit the pids limit, raise from Thread.start(), and crash the proxy -- PID 1
-# -- stranding learned ACCEPT rules without the sweeper).
-_FORWARD_SEM = threading.Semaphore(10)
 CONSENT_URL = os.environ.get("KLANGKNETWORK_EGRESS_CONSENT_URL", "")
-# The workspace JWT (rotated) is bind-mounted here read-only; read it fresh on
-# each POST so rotation is picked up (#2242). Not baked in env because the
-# workspace token expires and rotates.
+# How long to await a verdict before fail-closing to deny. Should be >= klangkd's
+# consent hold timeout so the sidecar is still waiting when the coordinator
+# expires the hold (and returns deny/expired).
+HOLD_TIMEOUT = float(os.environ.get("KLANGKNETWORK_EGRESS_HOLD_TIMEOUT", "30"))
+# Bounds concurrent DNS-path holds so a flooding workspace can't exhaust the
+# proxy (each hold occupies a task + a slot for up to HOLD_TIMEOUT). The NFQUEUE
+# path is bounded separately by the kernel queue length + the iptables
+# rate-limit in entrypoint.sh; overflows DROP (fail-close).
+HOLD_LIMIT = int(os.environ.get("KLANGKNETWORK_EGRESS_HOLD_LIMIT", "32"))
+# The workspace JWT (rotated) is bind-mounted here read-only; read fresh on each
+# (re)connect so rotation is picked up (#2242, #2311). Not baked in env because
+# the workspace token expires and rotates.
 WORKSPACE_TOKEN_PATH = "/run/klangk/workspace-token"
-# Consent recording (#2242): forward denied DNS queries (domains) AND
-# NFQUEUE'd blocked packets (raw IPs) to klangkd whenever a consent endpoint
-# is configured (recording runs for every filtered workspace).
 
 
 def parse_specs() -> list[tuple[str, int | None, bool]]:
@@ -266,7 +292,7 @@ def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
     Removal runs **under** :data:`_LOCK` (see :func:`allow`): the rule delete
     and the ``_LEARNED`` delete are atomic, so a concurrent :func:`allow`
     can't re-record an IP whose kernel rule was just swept. Factored out of
-    :func:`_sweeper` so it is unit-testable with a mocked clock and iptables
+    :func:`_async_sweeper` so it is unit-testable with a mocked clock and iptables
     (#2256).
     """
     if now is None:
@@ -287,11 +313,14 @@ def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
     return expired
 
 
-def _sweeper() -> None:
-    """Background thread: periodically drop learned IPs past their TTL."""
+async def _async_sweeper() -> None:
+    """Background task: periodically drop learned IPs past their TTL (#2256)."""
     while True:
-        time.sleep(SWEEP_INTERVAL)
-        sweep_once()
+        await asyncio.sleep(SWEEP_INTERVAL)
+        try:
+            sweep_once()
+        except Exception:
+            pass  # a transient sweep failure defers cleanup to the next tick
 
 
 def _fmt_ports(ports: set[int | None]) -> str:
@@ -390,43 +419,283 @@ def parse_dest(payload: bytes) -> tuple[str, int]:
     return dst, port
 
 
-def _read_workspace_token() -> str:
-    """The current workspace JWT from the bind-mounted token file."""
-    try:
-        with open(WORKSPACE_TOKEN_PATH) as f:
-            return f.read().strip()
-    except OSError:
-        return ""
+# ---------------------------------------------------------------------------
+# Interactive consent: egress-sidecar WS client + hold paths (#2311 half B).
+# ---------------------------------------------------------------------------
 
 
-def _post_event(dst: str, port: int) -> None:
-    """Best-effort POST of an observed destination to klangkd (#2242)."""
-    if not CONSENT_URL:
-        return
-    token = _read_workspace_token()
-    if not token:
-        return
-    body = json.dumps({"dst": dst, "dport": port})
-    req = urllib.request.Request(
-        CONSENT_URL,
-        data=body.encode(),
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + token,
-        },
-    )
+def _ws_url(consent_url: str) -> str:
+    """Derive the ``/ws/egress-sidecar`` WS URL from the consent HTTP URL.
+
+    ``http(s)://host:port/...`` -> ``ws(s)://host:port/ws/egress-sidecar``.
+    Reuses :data:`CONSENT_URL`'s scheme+host so no new env var is needed; the
+    sidecar leg of the consent contract (``sidecar <-WS-> klangkd``).
+    """
+    if consent_url.startswith("https://"):
+        host = consent_url[len("https://") :].split("/", 1)[0]
+        return f"wss://{host}/ws/egress-sidecar"
+    if consent_url.startswith("http://"):
+        host = consent_url[len("http://") :].split("/", 1)[0]
+        return f"ws://{host}/ws/egress-sidecar"
+    return consent_url  # already ws(s)://, or an exotic scheme used verbatim
+
+
+class _HoldLimiter:
+    """Bounded in-flight DNS holds (single-threaded asyncio: no lock needed).
+
+    A flood of denied queries past :data:`HOLD_LIMIT` fail-closes to NXDOMAIN
+    rather than queuing unbounded hold tasks. ``try_acquire`` / ``release``
+    run between await points on the loop thread, so they are atomic.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._in_flight = 0
+
+    def try_acquire(self) -> bool:
+        if self._in_flight >= self._limit:
+            return False
+        self._in_flight += 1
+        return True
+
+    def release(self) -> None:
+        if self._in_flight > 0:
+            self._in_flight -= 1
+
+
+class SidecarConsentClient:
+    """Persistent WS client to klangkd's ``/ws/egress-sidecar`` (#2311 half B).
+
+    One socket per workspace, opened at startup, reconnected (exponential
+    backoff) on drop. :meth:`request` sends an egress frame and awaits the
+    matching verdict frame by id. **Fail-close**: a down connection or a
+    timed-out verdict resolves to ``"deny"`` immediately, so the proxy
+    NXDOMAIN/DROPs (today's static behavior) when klangkd or the decider is
+    unreachable -- the workspace never hangs on a pending connection.
+
+    All ``_pending`` state lives on the event-loop thread (coroutines +
+    ``_run``'s receive loop); the NFQUEUE consumer reaches the loop via
+    ``asyncio.run_coroutine_threadsafe`` (it never touches ``_pending``
+    directly).
+    """
+
+    def __init__(self, consent_url: str, token_path: str, hold_timeout: float) -> None:
+        self._url = _ws_url(consent_url)
+        self._token_path = token_path
+        self._hold_timeout = hold_timeout
+        self._ws = None  # current websockets connection, or None
+        self._connected = asyncio.Event()
+        self._pending: dict[str, asyncio.Future] = {}  # id -> Future
+        self._stop = False
+        self._task: asyncio.Task | None = None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected.is_set()
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stop = True
+        ws = self._ws
+        if ws is not None:
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except Exception:
+                pass
+        self._fail_close_pending()
+
+    async def _run(self) -> None:
+        import websockets  # sidecar-only dep; lazy so the module loads without it
+
+        backoff = 1.0
+        while not self._stop:
+            token = self._read_token()
+            if not token:
+                # Token file not present yet (workspace JWT not written). Retry
+                # without escalating backoff (expected at startup).
+                await asyncio.sleep(1.0)
+                continue
+            url = f"{self._url}?token={token}"
+            try:
+                async with websockets.connect(
+                    url, ping_interval=20, ping_timeout=10, close_timeout=5
+                ) as ws:
+                    self._ws = ws
+                    self._connected.set()
+                    backoff = 1.0
+                    if DEBUG:
+                        print(f"consent: connected to {self._url}", flush=True)
+                    async for raw in ws:
+                        self._dispatch(raw)
+            except Exception as exc:
+                if DEBUG:
+                    print(f"consent: connection error: {exc}", flush=True)
+            finally:
+                # Disconnected (clean close, error, or crash): the sidecar's
+                # held connections die with it (fail-close). Any in-flight
+                # request resolves to deny so its caller NXDOMAIN/DROPs.
+                self._ws = None
+                self._connected.clear()
+                self._fail_close_pending()
+            if self._stop:
+                break
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 15.0)  # capped exponential backoff
+
+    def _dispatch(self, raw: str | bytes) -> None:
+        try:
+            msg = json.loads(raw)
+        except Exception:
+            return
+        if not isinstance(msg, dict) or msg.get("type") != "verdict":
+            return
+        vid = msg.get("id")
+        decision = msg.get("decision")
+        if not isinstance(vid, str):
+            return
+        fut = self._pending.pop(vid, None)
+        if fut is not None and not fut.done():
+            # Any non-"allow" verdict (deny, expired, malformed) -> deny.
+            fut.set_result(decision if decision == "allow" else "deny")
+
+    async def request(self, dst: str, dport: int | None) -> str:
+        """Send an egress frame + await the verdict. Fail-close -> ``"deny"``.
+
+        Returns ``"allow"`` or ``"deny"``. A down connection returns ``"deny"``
+        at once (no frame sent); a timed-out or disconnected-in-flight request
+        resolves to ``"deny"`` so the caller fail-closes.
+        """
+        if not self._connected.is_set() or self._ws is None:
+            return "deny"
+        lid = uuid.uuid4().hex
+        fut = asyncio.get_running_loop().create_future()
+        self._pending[lid] = fut
+        frame = json.dumps({"type": "egress", "id": lid, "dst": dst, "dport": dport})
+        try:
+            await self._ws.send(frame)
+        except Exception:
+            self._pending.pop(lid, None)
+            return "deny"
+        try:
+            return await asyncio.wait_for(fut, self._hold_timeout)
+        except asyncio.TimeoutError:
+            self._pending.pop(lid, None)
+            return "deny"
+
+    def _fail_close_pending(self) -> None:
+        for lid in list(self._pending):
+            fut = self._pending.pop(lid, None)
+            if fut is not None and not fut.done():
+                fut.set_result("deny")
+
+    def _read_token(self) -> str:
+        try:
+            with open(self._token_path) as f:
+                return f.read().strip()
+        except OSError:
+            return ""
+
+
+async def _forward_and_learn(
+    s: socket.socket,
+    data: bytes,
+    addr: tuple[str, int],
+    qname: str,
+    port_set: set[int | None],
+) -> None:
+    """Forward a query wire to the upstream + learn/respond (allow path).
+
+    Shared by the static-allow path and the consent-allow path (which passes
+    ``{None}`` -- all-ports, like a port-less allow spec). Uses a non-blocking
+    socket + the loop's sock_* helpers so the await yields to other holds +
+    the WS receive loop while the upstream is pending.
+    """
+    loop = asyncio.get_running_loop()
+    us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
+    us.setblocking(False)
     try:
-        urllib.request.urlopen(req, timeout=2).close()
+        await asyncio.wait_for(loop.sock_sendto(us, data, UPSTREAM), 3)
+        resp, _ = await asyncio.wait_for(loop.sock_recvfrom(us, 65535), 3)
     except Exception:
-        pass  # best-effort; the DROP verdict carries the deny regardless
+        us.close()
+        return
+    us.close()
+    _respond_allowed(s, resp, addr, qname, port_set)
 
 
-def _start_nfq_consumer() -> None:
-    """Bind the sidecar's NFQUEUE and forward blocked destinations (#2242).
+def _send_nxdomain(s: socket.socket, data: bytes, addr: tuple[str, int]) -> None:
+    try:
+        s.sendto(nxdomain_for(data), addr)
+    except Exception:
+        pass
 
-    Verdicts DROP (fail-closed: blocked traffic stays blocked; observation is
-    best-effort via a fire-and-forget thread). netfilterqueue is a sidecar-only
-    dep, imported lazily so the module loads without it.
+
+def _gate_deny(client: SidecarConsentClient | None, limiter: _HoldLimiter) -> bool:
+    """True if a denied query should be held (ask the coordinator); False if it
+    should fail-close NXDOMAIN inline -- no client, WS down, or the flood bound
+    is exhausted. On True the limiter slot is acquired (released by the hold).
+    Pure + inline so a flood of fail-close denies never spawns a task per query
+    (only real holds do, bounded by :data:`HOLD_LIMIT`).
+    """
+    if client is None or not client.connected:
+        return False
+    return limiter.try_acquire()
+
+
+async def _handle_hold(
+    s: socket.socket,
+    data: bytes,
+    addr: tuple[str, int],
+    qname: str,
+    client: SidecarConsentClient,
+    limiter: _HoldLimiter,
+) -> None:
+    """Hold a denied DNS query pending the consent verdict (#2311 half B).
+
+    The caller has already gate-checked + acquired the limiter slot (see
+    :func:`_gate_deny`): ``allow`` resolves upstream + learns the IPs
+    (all-ports, TTL-tracked); ``deny``/timeout -> NXDOMAIN. Runs as a task so
+    the hold never blocks the receive loop.
+    """
+    try:
+        decision = await client.request(qname, None)
+    except Exception:
+        decision = "deny"
+    finally:
+        limiter.release()
+    if decision == "allow":
+        if DEBUG:
+            print(f"consent-allow {qname}", flush=True)
+        await _forward_and_learn(s, data, addr, qname, {None})
+    else:
+        if DEBUG:
+            print(f"consent-deny  {qname}", flush=True)
+        _send_nxdomain(s, data, addr)
+
+
+def _run_nfq_consumer(
+    client: SidecarConsentClient | None, loop: asyncio.AbstractEventLoop
+) -> None:
+    """Bind the sidecar's NFQUEUE and consent-gate blocked IP egress (#2311).
+
+    Runs ``nfq.run()`` in a thread (netfilterqueue is synchronous). The
+    callback holds the packet pending the verdict by crossing into the loop
+    via ``run_coroutine_threadsafe`` (blocking): ``allow`` -> ``pkt.accept()``
+    (conntrack's ``ESTABLISHED,RELATED`` rule passes the rest of the
+    connection); ``deny``/timeout/WS-down -> ``pkt.drop()`` (fail-close).
+    Blocking the callback serializes NFQUEUE; the kernel queue length + the
+    iptables rate-limit in entrypoint.sh absorb bursts (overflows DROP).
+    netfilterqueue is a sidecar-only dep, imported lazily so the module loads
+    without it.
     """
     try:
         from netfilterqueue import NetfilterQueue
@@ -436,9 +705,18 @@ def _start_nfq_consumer() -> None:
 
     def _cb(pkt) -> None:
         dst, port = parse_dest(pkt.get_payload())
-        pkt.drop()
-        if dst:
-            threading.Thread(target=_post_event, args=(dst, port), daemon=True).start()
+        if not dst or client is None or not client.connected:
+            pkt.drop()  # unparseable / no consent / WS down -> fail-close
+            return
+        try:
+            fut = asyncio.run_coroutine_threadsafe(client.request(dst, port), loop)
+            decision = fut.result(HOLD_TIMEOUT)
+        except Exception:
+            decision = "deny"  # timeout / loop dead -> fail-close
+        if decision == "allow":
+            pkt.accept()
+        else:
+            pkt.drop()
 
     try:
         nfq = NetfilterQueue()
@@ -449,23 +727,37 @@ def _start_nfq_consumer() -> None:
         print(f"nfqueue consumer failed: {exc}", flush=True)
 
 
-def main() -> None:
+async def _async_main() -> None:
+    """The asyncio DNS loop (#2311 half B): holds denied queries pending verdicts.
+
+    Allowed queries forward inline (serial, like the pre-consent proxy); denied
+    queries run as bounded tasks so a hold never blocks the receive loop.
+    """
+    loop = asyncio.get_running_loop()
+    client: SidecarConsentClient | None = None
+    if CONSENT_URL:
+        client = SidecarConsentClient(CONSENT_URL, WORKSPACE_TOKEN_PATH, HOLD_TIMEOUT)
+        await client.start()
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(("127.0.0.1", LISTEN_PORT))
+    s.setblocking(False)
     print(
         f"dns-proxy listening on 127.0.0.1:{LISTEN_PORT} "
         f"(upstream={UPSTREAM[0]}, allowed={SPECS})",
         flush=True,
     )
     check_mark()
-    threading.Thread(target=_sweeper, daemon=True).start()
-    # Consent recording (#2242): observe NFQUEUE'd blocked destinations and
-    # forward them to klangkd. Runs whenever a consent endpoint is configured.
+    asyncio.create_task(_async_sweeper())
+    # NFQUEUE consumer runs nfq.run() in a thread (blocking); its callback
+    # crosses into this loop to await the consent verdict (#2311 half B).
     if CONSENT_URL:
-        threading.Thread(target=_start_nfq_consumer, daemon=True).start()
+        threading.Thread(
+            target=_run_nfq_consumer, args=(client, loop), daemon=True
+        ).start()
+    limiter = _HoldLimiter(HOLD_LIMIT)
     while True:
         try:
-            data, addr = s.recvfrom(65535)
+            data, addr = await loop.sock_recvfrom(s, 65535)
         except Exception:
             continue
         try:
@@ -477,38 +769,19 @@ def main() -> None:
         if deny:
             if DEBUG:
                 print(f"deny  {qname}", flush=True)
-            # Consent recording (#2242): forward the denied query's domain
-            # to klangkd (best-effort). Bounded by _FORWARD_SEM so a flooding
-            # workspace can't spawn unbounded POST threads; if the semaphore is
-            # exhausted the forward is skipped (the NXDOMAIN below still fires).
-            if CONSENT_URL and _FORWARD_SEM.acquire(blocking=False):
-
-                def _forward():
-                    try:
-                        _post_event(qname, None)
-                    finally:
-                        _FORWARD_SEM.release()
-
-                try:
-                    threading.Thread(target=_forward, daemon=True).start()
-                except Exception:
-                    _FORWARD_SEM.release()  # never started; free the slot
-            try:
-                s.sendto(nxdomain_for(data), addr)
-            except Exception:
-                pass
+            if _gate_deny(client, limiter):
+                asyncio.create_task(_handle_hold(s, data, addr, qname, client, limiter))
+            else:
+                _send_nxdomain(s, data, addr)
             continue
-        us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
-        us.settimeout(3)
-        try:
-            us.sendto(data, UPSTREAM)
-            resp, _ = us.recvfrom(65535)
-        except Exception:
-            us.close()
-            continue
-        us.close()
-        _respond_allowed(s, resp, addr, qname, port_set)
+        await _forward_and_learn(s, data, addr, qname, port_set)
+
+
+def main() -> None:
+    try:
+        asyncio.run(_async_main())
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == "__main__":

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -15,9 +15,9 @@ the consent WS contract (``sidecar <-WS-> klangkd <-WS-> decider``). No bespoke
 credential; the workspace id comes straight from the token.
 
 This is the klangkd half of #2311. The sidecar's kernel-level hold (suspending
-DNS queries, deferring NFQUEUE verdicts) + its WS client land in a stacked
-follow-up; #2244 wires the decider fanout to
-:meth:`klangk.consent_coordinator.ConsentCoordinator.resolve`.
+DNS queries, deferring NFQUEUE verdicts) + its WS client are implemented in
+the sidecar (``src/containers/network/proxy.py``); #2244 wires the decider
+fanout to :meth:`klangk.consent_coordinator.ConsentCoordinator.resolve`.
 """
 
 from __future__ import annotations

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -10,12 +10,13 @@ e2e. These tests import it as a module and drive its helpers directly.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import json
 import sys
 import types
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -520,9 +521,10 @@ class TestRespondAllowedSwallowsFailures:
 
 
 class TestConsentForward:
-    """Sidecar consent forwarding (#2242): packet parsing, the best-effort
-    POST, and the NFQUEUE consumer's graceful no-op when netfilterqueue is
-    absent (the server venv doesn't ship it)."""
+    """Sidecar consent (#2242 recording -> #2311 half B hold): packet parsing,
+    the egress-sidecar WS client's fail-close contract, the DNS hold path, and
+    the NFQUEUE consumer's graceful no-op when netfilterqueue is absent (the
+    server venv doesn't ship it)."""
 
     def test_parse_dest_tcp(self, proxy):
         ip = bytearray(40)
@@ -553,75 +555,277 @@ class TestConsentForward:
         assert proxy.parse_dest(bytes(10)) == ("", 0)
         assert proxy.parse_dest(b"\xff" * 20) == ("", 0)  # not IPv4
 
-    def test_post_event_sends_bearer_json(self, proxy, monkeypatch, tmp_path):
-        monkeypatch.setattr(proxy, "CONSENT_URL", "http://klangkd/ev")
-        token_file = tmp_path / "token"
-        token_file.write_text("from-file-tok")
-        monkeypatch.setattr(proxy, "WORKSPACE_TOKEN_PATH", str(token_file))
-        captured = {}
+    # --- _ws_url: derive the WS URL from the consent HTTP URL (#2311) ---
 
-        class _Resp:
-            def close(self):
+    def test_ws_url_http_to_ws(self, proxy):
+        assert (
+            proxy._ws_url(
+                "http://host.containers.internal:9/internal/egress-consent/events"
+            )
+            == "ws://host.containers.internal:9/ws/egress-sidecar"
+        )
+
+    def test_ws_url_https_to_wss(self, proxy):
+        assert (
+            proxy._ws_url("https://klangkd.example/ev")
+            == "wss://klangkd.example/ws/egress-sidecar"
+        )
+
+    def test_ws_url_passthrough_ws(self, proxy):
+        # an already-ws(s):// URL is used verbatim
+        assert (
+            proxy._ws_url("ws://x/ws/egress-sidecar")
+            == "ws://x/ws/egress-sidecar"
+        )
+
+    # --- _HoldLimiter: bounded in-flight DNS holds ---
+
+    def test_hold_limiter_bounds_and_releases(self, proxy):
+        lim = proxy._HoldLimiter(2)
+        assert lim.try_acquire() is True
+        assert lim.try_acquire() is True
+        assert lim.try_acquire() is False  # exhausted
+        lim.release()
+        assert lim.try_acquire() is True  # freed
+
+    def test_hold_limiter_release_floor(self, proxy):
+        lim = proxy._HoldLimiter(1)
+        lim.release()  # must not go negative
+        assert lim.try_acquire() is True
+
+    # --- SidecarConsentClient.request: fail-close contract ---
+
+    async def test_request_fail_close_when_disconnected(self, proxy, tmp_path):
+        # WS down -> "deny" at once, no frame sent (today's static behavior).
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        assert c.connected is False
+        assert await c.request("evil.test", None) == "deny"
+
+    async def test_request_sends_frame_and_resolves_on_verdict(
+        self, proxy, tmp_path
+    ):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        task = asyncio.create_task(c.request("evil.test", 443))
+        await asyncio.sleep(0)  # let it send + await the verdict
+        frame = json.loads(sent[0])
+        assert frame["type"] == "egress"
+        assert frame["dst"] == "evil.test"
+        assert frame["dport"] == 443
+        c._dispatch(
+            json.dumps(
+                {"type": "verdict", "id": frame["id"], "decision": "allow"}
+            )
+        )
+        assert await task == "allow"
+        assert c._pending == {}  # cleaned up
+
+    async def test_request_deny_verdict(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        task = asyncio.create_task(c.request("evil.test", None))
+        await asyncio.sleep(0)
+        frame = json.loads(sent[0])
+        c._dispatch(
+            json.dumps(
+                {"type": "verdict", "id": frame["id"], "decision": "deny"}
+            )
+        )
+        assert await task == "deny"
+
+    async def test_request_non_allow_verdict_is_deny(self, proxy, tmp_path):
+        # expired/malformed decision -> deny (fail-close)
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        task = asyncio.create_task(c.request("evil.test", None))
+        await asyncio.sleep(0)
+        frame = json.loads(sent[0])
+        c._dispatch(
+            json.dumps(
+                {"type": "verdict", "id": frame["id"], "decision": "expired"}
+            )
+        )
+        assert await task == "deny"
+
+    async def test_request_timeout_fail_close(self, proxy, tmp_path):
+        # no verdict within HOLD_TIMEOUT -> "deny"; slot cleaned up
+        c = proxy.SidecarConsentClient(
+            "http://h/ev", str(tmp_path / "t"), 0.05
+        )
+        c._connected.set()
+
+        class _FakeWS:
+            async def send(self, frame):
                 pass
 
-        def fake_urlopen(req, timeout):
-            captured["url"] = req.full_url
-            captured["body"] = req.data.decode()
-            captured["auth"] = req.headers.get("Authorization")
-            captured["ctype"] = req.headers.get("Content-type")
-            return _Resp()
+        c._ws = _FakeWS()
+        assert await c.request("evil.test", None) == "deny"
+        assert c._pending == {}
 
-        monkeypatch.setattr(proxy.urllib.request, "urlopen", fake_urlopen)
-        proxy._post_event("1.2.3.4", 80)
-        assert captured["url"] == "http://klangkd/ev"
-        assert json.loads(captured["body"]) == {"dst": "1.2.3.4", "dport": 80}
-        assert captured["auth"] == "Bearer from-file-tok"
-        assert captured["ctype"] == "application/json"
+    async def test_request_send_error_fail_close(self, proxy, tmp_path):
+        # ws.send raises -> "deny", slot cleaned up
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
 
-    def test_post_event_noop_without_url(self, proxy, monkeypatch, tmp_path):
-        monkeypatch.setattr(proxy, "CONSENT_URL", "")
-        monkeypatch.setattr(
-            proxy, "WORKSPACE_TOKEN_PATH", str(tmp_path / "token")
-        )
-        called = []
-        monkeypatch.setattr(
-            proxy.urllib.request, "urlopen", lambda *a, **k: called.append(1)
-        )
-        proxy._post_event("1.2.3.4", 80)
-        assert called == []
+        class _FakeWS:
+            async def send(self, frame):
+                raise OSError("connection gone")
 
-    def test_post_event_noop_without_token(self, proxy, monkeypatch, tmp_path):
-        # Missing token file -> no POST (sidecar not yet provisioned, or token
-        # expired before the file refreshed).
-        monkeypatch.setattr(proxy, "CONSENT_URL", "http://klangkd/ev")
-        monkeypatch.setattr(
-            proxy, "WORKSPACE_TOKEN_PATH", str(tmp_path / "no-such-file")
-        )
-        called = []
-        monkeypatch.setattr(
-            proxy.urllib.request, "urlopen", lambda *a, **k: called.append(1)
-        )
-        proxy._post_event("1.2.3.4", 80)
-        assert called == []
+        c._ws = _FakeWS()
+        assert await c.request("evil.test", None) == "deny"
+        assert c._pending == {}
 
-    def test_post_event_swallows_errors(self, proxy, monkeypatch, tmp_path):
-        # A down/slow klangkd must not break the verdict loop (DROP carries
-        # the deny regardless).
-        monkeypatch.setattr(proxy, "CONSENT_URL", "http://klangkd/ev")
-        token_file = tmp_path / "token"
-        token_file.write_text("tok")
-        monkeypatch.setattr(proxy, "WORKSPACE_TOKEN_PATH", str(token_file))
-        monkeypatch.setattr(
-            proxy.urllib.request,
-            "urlopen",
-            lambda *a, **k: (_ for _ in ()).throw(OSError("klangkd down")),
+    def test_dispatch_ignores_non_verdict_and_bad_id(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._dispatch("not-json")
+        c._dispatch(json.dumps({"type": "egress"}))  # wrong type
+        c._dispatch(
+            json.dumps({"type": "verdict", "decision": "allow"})
+        )  # no id
+        c._dispatch(
+            json.dumps({"type": "verdict", "id": 123, "decision": "allow"})
+        )  # non-str id
+        # a verdict for an unknown id is a no-op (already popped/timed out)
+        c._dispatch(
+            json.dumps({"type": "verdict", "id": "nope", "decision": "allow"})
         )
-        proxy._post_event("1.2.3.4", 80)  # must not raise
 
-    def test_start_nfq_consumer_noop_without_netfilterqueue(
-        self, proxy, capsys
+    async def test_dispatch_resolves_pending_future(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        fut = asyncio.get_running_loop().create_future()
+        c._pending["abc"] = fut
+        c._dispatch(
+            json.dumps({"type": "verdict", "id": "abc", "decision": "allow"})
+        )
+        assert fut.result() == "allow"
+        assert "abc" not in c._pending
+
+    async def test_fail_close_pending_resolves_deny(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        fut = asyncio.get_running_loop().create_future()
+        c._pending["x"] = fut
+        c._fail_close_pending()
+        assert fut.result() == "deny"
+        assert c._pending == {}
+
+    def test_read_token_missing_file(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient(
+            "http://h/ev", str(tmp_path / "no-such"), 5
+        )
+        assert c._read_token() == ""
+
+    def test_read_token_reads_file(self, proxy, tmp_path):
+        f = tmp_path / "tok"
+        f.write_text("abc-xyz\n")
+        c = proxy.SidecarConsentClient("http://h/ev", str(f), 5)
+        assert c._read_token() == "abc-xyz"
+
+    # --- _gate_deny: should this denied query be held or fail-close NXDOMAIN? ---
+
+    def test_gate_deny_false_when_no_client(self, proxy):
+        # consent disabled -> never hold, always NXDOMAIN (today's behavior)
+        assert proxy._gate_deny(None, proxy._HoldLimiter(8)) is False
+
+    def test_gate_deny_false_when_disconnected(self, proxy):
+        client = MagicMock()
+        client.connected = False
+        assert proxy._gate_deny(client, proxy._HoldLimiter(8)) is False
+
+    def test_gate_deny_false_when_flood_bound(self, proxy):
+        client = MagicMock()
+        client.connected = True
+        lim = proxy._HoldLimiter(1)
+        assert lim.try_acquire()  # fill the only slot
+        assert (
+            proxy._gate_deny(client, lim) is False
+        )  # exhausted -> fail-close
+
+    def test_gate_deny_true_acquires_slot(self, proxy):
+        client = MagicMock()
+        client.connected = True
+        lim = proxy._HoldLimiter(2)
+        assert proxy._gate_deny(client, lim) is True
+        assert lim.try_acquire() is True  # one slot now in use -> one left
+        assert lim.try_acquire() is False  # both taken
+
+    # --- _handle_hold: the DNS hold task (gate already passed) ---
+
+    async def test_handle_hold_allow_forwards_upstream(
+        self, proxy, monkeypatch
     ):
-        # The server venv has no netfilterqueue -> the lazy import fails and
-        # the consumer logs + returns instead of raising.
-        proxy._start_nfq_consumer()
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        fwd = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value="allow")
+        s = MagicMock()
+        lim = proxy._HoldLimiter(8)
+        await proxy._handle_hold(
+            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
+        )
+        s.sendto.assert_not_called()  # not denied
+        client.request.assert_awaited_once_with("evil.test", None)
+        fwd.assert_awaited_once()  # forwarded upstream (all-ports)
+        assert lim._in_flight == 0  # slot released
+
+    async def test_handle_hold_deny_sends_nxdomain(self, proxy, monkeypatch):
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        fwd = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value="deny")
+        s = MagicMock()
+        lim = proxy._HoldLimiter(8)
+        await proxy._handle_hold(
+            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
+        )
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+        fwd.assert_not_awaited()
+        assert lim._in_flight == 0  # slot released
+
+    async def test_handle_hold_request_error_fail_closes(
+        self, proxy, monkeypatch
+    ):
+        # request() raising -> deny + NXDOMAIN + slot still released
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(side_effect=RuntimeError("boom"))
+        s = MagicMock()
+        lim = proxy._HoldLimiter(8)
+        await proxy._handle_hold(
+            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
+        )
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+        assert lim._in_flight == 0  # released despite the error
+
+    # --- _run_nfq_consumer: graceful no-op without netfilterqueue ---
+
+    def test_run_nfq_consumer_noop_without_netfilterqueue(self, proxy, capsys):
+        # The server venv has no netfilterqueue -> lazy import fails -> logs +
+        # returns instead of raising.
+        proxy._run_nfq_consumer(None, asyncio.new_event_loop())
         assert "netfilterqueue unavailable" in capsys.readouterr().out

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -470,7 +470,7 @@ class TestRespondAllowedSwallowsFailures:
     leaving learned ACCEPT rules in place with DNS dead — a partial
     fail-open)."""
 
-    def test_allow_failure_does_not_propagate(self, proxy, monkeypatch):
+    async def test_allow_failure_does_not_propagate(self, proxy, monkeypatch):
         monkeypatch.setattr(
             proxy, "a_records_with_ttl", lambda wire: [("1.2.3.4", 100)]
         )
@@ -480,12 +480,13 @@ class TestRespondAllowedSwallowsFailures:
 
         monkeypatch.setattr(proxy, "allow", _boom)
         s = MagicMock()
-        # Must not raise.
-        proxy._respond_allowed(
+        # Must not raise (the executor propagates the iptables error, which
+        # _respond_allowed swallows).
+        await proxy._respond_allowed(
             s, b"resp", ("127.0.0.1", 1234), "allowed.test", {443}
         )
 
-    def test_sendto_failure_does_not_propagate(self, proxy, monkeypatch):
+    async def test_sendto_failure_does_not_propagate(self, proxy, monkeypatch):
         monkeypatch.setattr(
             proxy, "a_records_with_ttl", lambda wire: [("1.2.3.4", 100)]
         )
@@ -493,11 +494,11 @@ class TestRespondAllowedSwallowsFailures:
         s = MagicMock()
         s.sendto.side_effect = OSError("client gone")
         # Must not raise.
-        proxy._respond_allowed(
+        await proxy._respond_allowed(
             s, b"resp", ("127.0.0.1", 1234), "allowed.test", {443}
         )
 
-    def test_happy_path_allows_each_ip_each_port_and_sends(
+    async def test_happy_path_allows_each_ip_each_port_and_sends(
         self, proxy, monkeypatch
     ):
         monkeypatch.setattr(
@@ -510,7 +511,7 @@ class TestRespondAllowedSwallowsFailures:
             proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
         )
         s = MagicMock()
-        proxy._respond_allowed(
+        await proxy._respond_allowed(
             s, b"resp", ("127.0.0.1", 1234), "q", {443, 8443}
         )
         assert ("1.2.3.4", 443, 100) in calls
@@ -829,3 +830,221 @@ class TestConsentForward:
         # returns instead of raising.
         proxy._run_nfq_consumer(None, asyncio.new_event_loop())
         assert "netfilterqueue unavailable" in capsys.readouterr().out
+
+
+# --- helpers for the NFQUEUE callback + _handle_packet tests (#2311 half B) ---
+
+
+def _ip_payload(dst: str, dport: int, proto: int = 6) -> bytes:
+    """A minimal IPv4 packet (20-byte header + 4 bytes L4) for parse_dest."""
+    b = bytearray(24)
+    b[0] = 0x45  # version 4, IHL 5 (20-byte header)
+    b[9] = proto  # L4 protocol (6 = TCP)
+    b[16:20] = bytes(int(x) for x in dst.split("."))  # dst IP
+    b[20:22] = (12345).to_bytes(2, "big")  # source port
+    b[22:24] = dport.to_bytes(2, "big")  # destination port
+    return bytes(b)
+
+
+class _FakeNFQ:
+    """Stand-in for netfilterqueue.NetfilterQueue: captures the bound callback
+    and returns at once from run() so the test can drive _cb itself."""
+
+    def __init__(self) -> None:
+        self.cb = None
+        self.queue = None
+
+    def bind(self, queue: int, cb) -> None:
+        self.queue = queue
+        self.cb = cb
+
+    def run(self) -> None:
+        pass  # do not block -- the test invokes self.cb directly
+
+
+class _FakePkt:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self.verdict = None
+
+    def get_payload(self) -> bytes:
+        return self._payload
+
+    def accept(self) -> None:
+        self.verdict = "accept"
+
+    def drop(self) -> None:
+        self.verdict = "drop"
+
+
+def _install_fake_nfq(monkeypatch, nfq: _FakeNFQ) -> None:
+    """Make ``from netfilterqueue import NetfilterQueue`` return ``nfq``."""
+    mod = types.ModuleType("netfilterqueue")
+    mod.NetfilterQueue = lambda: nfq  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "netfilterqueue", mod)
+
+
+class TestNfqueueCallback:
+    """The NFQUEUE verdict->accept/drop path (#2311 half B review #1): the
+    ``_cb`` body is otherwise untested (only the import-failure early-return
+    was). Drive it with a stubbed netfilterqueue + a fake packet."""
+
+    async def test_allow_verdict_accepts(self, proxy, monkeypatch):
+        loop = asyncio.get_running_loop()
+        nfq = _FakeNFQ()
+        _install_fake_nfq(monkeypatch, nfq)
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value="allow")
+        proxy._run_nfq_consumer(client, loop)  # binds cb; run() returns
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        # _cb blocks on the verdict (run_coroutine_threadsafe); run it in a
+        # worker thread so the loop is free to resolve client.request.
+        await asyncio.to_thread(nfq.cb, pkt)
+        assert pkt.verdict == "accept"
+        client.request.assert_awaited_once_with("1.2.3.4", 443)
+
+    async def test_deny_verdict_drops(self, proxy, monkeypatch):
+        loop = asyncio.get_running_loop()
+        nfq = _FakeNFQ()
+        _install_fake_nfq(monkeypatch, nfq)
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value="deny")
+        proxy._run_nfq_consumer(client, loop)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await asyncio.to_thread(nfq.cb, pkt)
+        assert pkt.verdict == "drop"
+
+    async def test_request_error_drops(self, proxy, monkeypatch):
+        loop = asyncio.get_running_loop()
+        nfq = _FakeNFQ()
+        _install_fake_nfq(monkeypatch, nfq)
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(side_effect=RuntimeError("boom"))
+        proxy._run_nfq_consumer(client, loop)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await asyncio.to_thread(nfq.cb, pkt)
+        assert pkt.verdict == "drop"  # except -> deny -> drop
+
+    async def test_verdict_timeout_drops(self, proxy, monkeypatch):
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(proxy, "HOLD_TIMEOUT", 0.05)
+        nfq = _FakeNFQ()
+        _install_fake_nfq(monkeypatch, nfq)
+        client = MagicMock()
+        client.connected = True
+        # request outlasts HOLD_TIMEOUT -> fut.result() times out -> drop
+        client.request = AsyncMock(side_effect=lambda *a: asyncio.sleep(0.5))
+        proxy._run_nfq_consumer(client, loop)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await asyncio.to_thread(nfq.cb, pkt)
+        assert pkt.verdict == "drop"
+        await asyncio.sleep(0.6)  # let the abandoned sleep(0.5) finish cleanly
+
+    async def test_ws_down_drops_without_request(self, proxy, monkeypatch):
+        loop = asyncio.get_running_loop()
+        nfq = _FakeNFQ()
+        _install_fake_nfq(monkeypatch, nfq)
+        client = MagicMock()
+        client.connected = False
+        client.request = AsyncMock()
+        proxy._run_nfq_consumer(client, loop)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await asyncio.to_thread(nfq.cb, pkt)
+        assert pkt.verdict == "drop"
+        client.request.assert_not_awaited()
+
+    async def test_unparseable_dest_drops(self, proxy, monkeypatch):
+        loop = asyncio.get_running_loop()
+        nfq = _FakeNFQ()
+        _install_fake_nfq(monkeypatch, nfq)
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value="allow")
+        proxy._run_nfq_consumer(client, loop)
+        pkt = _FakePkt(b"\x00" * 24)  # version nibble 0 -> parse_dest ("", 0)
+        await asyncio.to_thread(nfq.cb, pkt)
+        assert pkt.verdict == "drop"
+        client.request.assert_not_awaited()
+
+
+class TestHandlePacket:
+    """The per-packet routing extracted from _async_main (#2311 half B review #2):
+    classify -> gate -> hold / NXDOMAIN / forward, incl. the property that a
+    statically-allow-listed name is never held."""
+
+    async def test_allowed_name_forwards_not_held(self, proxy, monkeypatch):
+        proxy._BG_TASKS.clear()
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "allowed.test")
+        monkeypatch.setattr(proxy, "SPECS", [("allowed.test", None, False)])
+        fwd = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
+        s = MagicMock()
+        await proxy._handle_packet(
+            s, b"q", ("1.2.3.4", 53), None, proxy._HoldLimiter(8)
+        )
+        fwd.assert_awaited_once()  # forwarded, not held/denied
+        s.sendto.assert_not_called()  # no NXDOMAIN
+
+    async def test_denied_no_client_sends_nxdomain(self, proxy, monkeypatch):
+        proxy._BG_TASKS.clear()
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        s = MagicMock()
+        await proxy._handle_packet(
+            s, b"q", ("1.2.3.4", 53), None, proxy._HoldLimiter(8)
+        )
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+
+    async def test_denied_connected_spawns_hold(self, proxy, monkeypatch):
+        proxy._BG_TASKS.clear()
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(proxy, "SPECS", [])
+        hold = AsyncMock()
+        monkeypatch.setattr(proxy, "_handle_hold", hold)
+        client = MagicMock()
+        client.connected = True
+        lim = proxy._HoldLimiter(8)
+        s = MagicMock()
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client, lim)
+        tasks = list(proxy._BG_TASKS)
+        await asyncio.gather(*tasks)  # run the spawned hold task(s)
+        hold.assert_awaited_once_with(
+            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
+        )
+        assert proxy._BG_TASKS == set()  # done-callback discarded the entry
+
+    async def test_denied_flood_bound_sends_nxdomain(self, proxy, monkeypatch):
+        proxy._BG_TASKS.clear()
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        hold = AsyncMock()
+        monkeypatch.setattr(proxy, "_handle_hold", hold)
+        client = MagicMock()
+        client.connected = True
+        lim = proxy._HoldLimiter(1)
+        assert lim.try_acquire()  # fill the only slot
+        s = MagicMock()
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client, lim)
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))  # fail-close
+        hold.assert_not_awaited()
+
+    async def test_malformed_query_is_dropped(self, proxy, monkeypatch):
+        proxy._BG_TASKS.clear()
+
+        def _boom(wire):
+            raise RuntimeError("bad wire")
+
+        monkeypatch.setattr(proxy, "query_name", _boom)
+        fwd = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
+        s = MagicMock()
+        await proxy._handle_packet(
+            s, b"q", ("1.2.3.4", 53), None, proxy._HoldLimiter(8)
+        )
+        s.sendto.assert_not_called()  # dropped, no response
+        fwd.assert_not_awaited()


### PR DESCRIPTION
## What

Completes **#2311 (half B)**: the network sidecar now **holds** a denied
connection in-flight pending a consent verdict over the `/ws/egress-sidecar`
WebSocket, instead of NXDOMAIN/DROP-ing at once (the #2242 fire-and-forget
POST model).

- **DNS proxy → asyncio.** One persistent WS client (`SidecarConsentClient`:
  reconnect with exponential backoff, fail-close to `deny` on disconnect /
  timeout). Denied queries run as **bounded** hold tasks; a flood of
  fail-close denies never spawns a per-query task (`_gate_deny` fails-close
  inline, so only real holds spawn tasks — bounded by `HOLD_LIMIT`).
- **NFQUEUE consumer** blocks in its callback and crosses into the loop via
  `run_coroutine_threadsafe`: `allow`→`pkt.accept()` (conntrack's
  `ESTABLISHED,RELATED` rule passes the rest of the connection — no temp
  ACCEPT rule); `deny` / timeout / WS-down → `pkt.drop()`.
- **Fail-close everywhere** — a down WS or a timed-out verdict resolves to
  `deny` immediately → NXDOMAIN/DROP (today's static behavior; no new latency,
  no hang). Static workspaces (no registered decider) are unaffected: the
  coordinator returns `deny` fast, the sidecar NXDOMAIN/DROPs as before.
- New sidecar config: `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT` (30s),
  `KLANGKNETWORK_EGRESS_HOLD_LIMIT` (32 concurrent DNS holds; a flood past it
  fail-closes). The sidecar image gains the `websockets` dependency
  (lazy-imported so unit tests need neither it nor `netfilterqueue`).

The legacy fire-and-forget POST endpoint is superseded (recording now happens
on the WS hold path); its removal is tracked in **#2318**.

Half A (klangkd coordination: the hold/resolve coordinator + the
`/ws/egress-sidecar` relay) landed in #2315; the decider fanout (#2244) in
#2316. The first consumer of the held requests is the `consent-decide` client
(#2310).

Closes #2311.

## Adversarial review

A fresh-eyes adversarial review was run on this branch. **Verdict: REQUEST
CHANGES — no allow-leak found.** Every verdict-resolution path was traced
(WS-down, timeout, send-fail, disconnect, flood, NFQUEUE WS-down/timeout,
non-`allow` verdict) and all fail-close. `entrypoint.sh` rule order was
verified correct (DROP policy → conntrack ESTABLISHED,RELATED → NFQUEUE last
→ DROP backstop; the `-m limit` overflow falls to DROP = fail-close; no
earlier permissive rule shadows the gate).

Follow-ups the review flagged — **all addressed in `dea8d00e`** (verdict was REQUEST
CHANGES, but the security invariant held; no allow-leak):

- **#1 ✅** The NFQUEUE verdict→accept/drop path (`_cb`) was untested — now
  driven with a stubbed `netfilterqueue` + fake packet (allow→`accept`,
  deny/error/timeout/WS-down/unparseable→`drop`).
- **#2 ✅** No end-to-end hold test — `_handle_packet` extracted from the
  receive loop + tested (allowed→forward not held; denied no-client/flood→
  NXDOMAIN; denied connected→hold task; malformed→drop).
- **#3 ✅** `iptables` (`allow`/`sweep_once`) forked synchronously on the
  event loop — now run in the default thread-pool executor (`_learn_all` via
  `_respond_allowed`, `sweep_once` via `_async_sweeper`); this also makes
  `_LOCK` genuinely needed (two executor workers can touch `_LEARNED`) and
  fixes the stale "sweeper thread" docstrings.
- **Nits ✅** fire-and-forget tasks kept in `_BG_TASKS` with a done-callback;
  `_forward_and_learn` now closes its socket in a `finally` (no leak on
  `CancelledError`); exception logging uses the type only + the `websockets`
  logger is capped at WARNING so the JWT-in-URL can't leak (#2309); consent-
  `allow` = all-ports confirmed in a docstring.

## Test plan

- [x] `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 4519 passed, 100% (klangk package).
- [x] `test_proxy.py`: 78 tests (WS-URL derivation, `_HoldLimiter`,
      `SidecarConsentClient` fail-close/dispatch/timeout/send-error, `_gate_deny`,
      `_handle_hold`, NFQUEUE `_cb`, `_handle_packet`). NOTE: proxy.py is sidecar
      container code, not coverage-gated.
