### PR TITLE
feat(consent): synchronous consent-decide client for held egress (#2310)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -348,11 +348,10 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
-- **New workspaces default to `egress_mode=interactive` (for testing).**
-  The default is `interactive` while the consent-decide end-to-end flow is
-  being exercised, so held egress requests reach a decider without a manual
-  per-workspace flip (`EGRESS_MODE_DEFAULT` in `model/workspaces.py`; move it
-  back to `static` once interactive mode is production-ready).
+- **New workspaces default to `egress_mode=interactive`.** The default is
+  `interactive`, so held egress requests reach a decider out of the box without
+  a manual per-workspace flip (`EGRESS_MODE_DEFAULT` in `model/workspaces.py`);
+  set a workspace to `static` to opt into silent deny + record instead.
 
 - **Workspace + network sidecar container names and labels (#2286).** A
   workspace and its network sidecar now share a `klangk.workspace=<id>` +

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,16 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`klangk consent-decide <workspace>` (#2310).** A live Textual client that
+  connects to a workspace's consent-decider stream and shows its held egress
+  requests (blocked destinations the network sidecar is holding for a
+  verdict), with a countdown to auto-deny. Press `a` to allow (once) or `d` to
+  deny; accepting lets that exact held connection proceed while a deny (or the
+  countdown hitting zero) fails it. It pings every 15s to stay registered as
+  the workspace's live decider and reconnects on drop; while no client is
+  attached, held requests auto-deny (fail-closed). Requires terminal access to
+  the workspace.
+
 - **Embedded network sidecar image (#2301).** The all-in-one host image
   (`scripts/build-host-image.sh`) now embeds the network sidecar image as a
   tarball and `podman load`s it on first startup, mirroring the workspace

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -534,6 +534,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Orphaned pending egress-consent requests no longer replay after a
+  klangkd restart.** On startup every still-`pending` row is an orphan (its
+  in-memory hold died with the prior process), so they're reaped to `expired`
+  up front — otherwise the decider snapshot replayed stale requests that could
+  never be resolved (the "orphans return" in `consent-decide`).
+
 - **Consent verdict `decided_by` now stores the stable user id, not the
   volatile email (#2244).** `egress_consent.decided_by` is `REFERENCES
 users(id)`, so the decider handler passing the decider's email violated the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -348,6 +348,12 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **New workspaces default to `egress_mode=interactive` (for testing).**
+  The default is `interactive` while the consent-decide end-to-end flow is
+  being exercised, so held egress requests reach a decider without a manual
+  per-workspace flip (`EGRESS_MODE_DEFAULT` in `model/workspaces.py`; move it
+  back to `static` once interactive mode is production-ready).
+
 - **Workspace + network sidecar container names and labels (#2286).** A
   workspace and its network sidecar now share a `klangk.workspace=<id>` +
   `klangk.role` label (so one `podman ps --filter label=klangk.workspace=<id>`
@@ -527,6 +533,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 - **`klangk invite` → `klangk admin invitations send` (#1374).**
 
 ### Fixed
+
+- **Consent verdict `decided_by` now stores the stable user id, not the
+  volatile email (#2244).** `egress_consent.decided_by` is `REFERENCES
+users(id)`, so the decider handler passing the decider's email violated the
+  foreign key and every verdict failed with an `IntegrityError`. It now
+  threads the user id through `_handle_verdict`.
 
 - **Egress-site `forward_auth` no longer breaks WebSocket upgrades
   (#2319, #2322).** Caddy's site-level `forward_auth` copied the WS

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -38,6 +38,7 @@ from ..workspace_settings import (
 from ._common import get_app_dep
 from ..model import (
     ACTION_ALLOW,
+    EGRESS_MODE_DEFAULT,
     PRINCIPAL_GROUP,
     PRINCIPAL_USER,
 )
@@ -203,7 +204,7 @@ class CreateWorkspaceRequest(BaseModel):
     health_check: str | None = None
     allowed_domains: list[str] | None = None
     settings: dict | None = None
-    egress_mode: Literal["static", "interactive"] = "static"
+    egress_mode: Literal["static", "interactive"] = EGRESS_MODE_DEFAULT
 
 
 @router.post("/workspaces")

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -2665,6 +2665,58 @@ def volumes_rm(
     typer.echo(f"Deleted volume {name}")
 
 
+@app.command("consent-decide")
+def consent_decide(
+    workspace: str = typer.Argument(
+        help="Workspace name or id whose held egress requests to decide"
+    ),
+    hold_timeout: float = typer.Option(
+        30.0,
+        "--hold-timeout",
+        help=(
+            "Seconds a held request counts down before auto-deny "
+            "(match the server's KLANGKD_EGRESS_CONSENT_TIMEOUT)."
+        ),
+    ),
+) -> None:
+    """Decide a workspace's held egress requests live (#2310).
+
+    Connects to the server's consent-decider stream, shows the workspace's
+    held egress requests (a blocked destination the sidecar is holding for
+    a verdict), and lets you accept (allow once) or deny each one while it
+    is held. Accepting lets that exact connection proceed; denying (or the
+    countdown hitting zero) fails it. Requires terminal access to the
+    workspace (owner/member/spectator).
+    """
+    require_auth()
+    client = _client()
+    ws = _resolve_workspace_for_consent(client, workspace)
+    token = _state().get_token(server_url())
+    # Lazy import so the textual dep only loads on this command path.
+    from .tui.consent import ConsentDeciderApp  # noqa: allow-deferred-import
+
+    ConsentDeciderApp(
+        server_url(),
+        token,
+        ws.id,
+        ws.name,
+        hold_timeout=hold_timeout,
+        max_size=ws_max_size(),
+    ).run()
+
+
+def _resolve_workspace_for_consent(client: KlangkClient, arg: str):
+    """Resolve a workspace name OR id to a Workspace (for consent-decide)."""
+    all_ws = client.list_workspaces(all_pages=True) + (
+        client.list_shared_workspaces(all_pages=True)
+    )
+    match = next((w for w in all_ws if w.id == arg or w.name == arg), None)
+    if match is None:
+        _err.print(f"[red]No such workspace:[/red] {arg}")
+        raise typer.Exit(code=1)
+    return match
+
+
 def main() -> None:  # pragma: no cover
     try:
         app()

--- a/src/klangk/klangk/cli/transport.py
+++ b/src/klangk/klangk/cli/transport.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import socket as _socket
 from dataclasses import dataclass
+from urllib.parse import urlencode
 
 import httpx
 import websockets
@@ -29,6 +30,7 @@ class ServerTransport:
     uds_path: str | None
     base_url: str  # e.g. "http://host:8995" or "http://localhost" (UDS)
     ws_uri: str  # e.g. "ws://host:8995/ws" or "ws://localhost/ws" (UDS)
+    ws_base: str  # scheme://host[:port] — ws_uri minus the path ("/ws")
     server_spec: str  # original spec for back-reference
 
 
@@ -46,14 +48,15 @@ def resolve_transport(server_spec: str) -> ServerTransport:
     if server_spec.startswith("http://") or server_spec.startswith("https://"):
         # TCP — derive WS URI from the URL.
         if server_spec.startswith("http://"):
-            ws_uri = server_spec.replace("http://", "ws://", 1) + "/ws"
+            ws_base = server_spec.replace("http://", "ws://", 1)
         else:
-            ws_uri = server_spec.replace("https://", "wss://", 1) + "/ws"
+            ws_base = server_spec.replace("https://", "wss://", 1)
         return ServerTransport(
             is_uds=False,
             uds_path=None,
             base_url=server_spec,
-            ws_uri=ws_uri,
+            ws_uri=ws_base + "/ws",
+            ws_base=ws_base,
             server_spec=server_spec,
         )
 
@@ -68,6 +71,7 @@ def resolve_transport(server_spec: str) -> ServerTransport:
         uds_path=server_spec,
         base_url="http://localhost",
         ws_uri="ws://localhost/ws",
+        ws_base="ws://localhost",
         server_spec=server_spec,
     )
 
@@ -152,6 +156,8 @@ async def ws_connect(
     *,
     token: str,
     max_size: int | None = None,
+    path: str = "/ws",
+    query: dict[str, str] | None = None,
     **kwargs,
 ):
     """Connect a WebSocket, routing through UDS or TCP.
@@ -160,10 +166,17 @@ async def ws_connect(
     module-level function tests patch).  On the UDS path it opens a
     preconnected ``AF_UNIX`` socket and passes it via ``sock=``.
 
-    Yields the open WebSocket connection.
+    ``path`` selects the server WS endpoint (default ``/ws``; the consent
+    decider client uses ``/ws/consent-decider``), and ``query`` adds extra
+    query params alongside the always-present ``token``. Yields the open
+    WebSocket connection.
     """
     transport = resolve_transport(server_spec)
-    uri = f"{transport.ws_uri}?token={token}"
+    qs = dict(query) if query else {}
+    qs["token"] = (
+        token  # token always wins -- a caller can't clobber it via query
+    )
+    uri = f"{transport.ws_base}{path}?{urlencode(qs)}"
     ws_kwargs = dict(kwargs)
     if max_size is not None:
         ws_kwargs["max_size"] = max_size

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -209,7 +209,7 @@ class ConsentDeciderApp(App):
     #status { padding: 0 1; background: $panel; color: $text-muted; }
     #requests { height: 1fr; }
     #empty { padding: 1 2; color: $text-muted; }
-    .req-host { color: $text; width: 1fr; }
+    .req-host { color: $text; }
     .req-proc { color: $text-muted; }
     .req-time { color: $warning; }
     """
@@ -402,15 +402,15 @@ class ConsentDeciderApp(App):
             host = f"{host}:{req.dest_port}"
         proc = f"  ({req.process_name})" if req.process_name else ""
         secs = int(self.controller.remaining(req))
-        # Each row carries its own Allow/Deny buttons (id encodes the request
-        # id) so a click decides THAT request, unambiguous with a queue.
+        # Host+time is a direct child of the ListItem (renders horizontally);
+        # the per-row Allow/Deny buttons sit in a Horizontal below it so they
+        # never fight the host for width. Each button id encodes the request id.
         item = ListItem(
+            Static(f"{host}{proc}  ({secs}s)", classes="req-host"),
             Horizontal(
-                Static(f"{host}{proc}", classes="req-host"),
-                Static(f"{secs}s", classes="req-time"),
                 Button("Allow", id=f"allow-{req.id}", variant="success"),
                 Button("Deny", id=f"deny-{req.id}", variant="error"),
-            )
+            ),
         )
         item.request_id = req.id  # type: ignore[attr-defined]
         return item

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -31,6 +31,7 @@ import time
 from dataclasses import dataclass
 
 import websockets
+from rich.markup import escape
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
@@ -168,6 +169,17 @@ class ConsentDeciderController:
         """Seconds until this hold's countdown hits zero (clamped at 0)."""
         return max(0.0, req.requested_at + self.hold_timeout - self._clock())
 
+    def reset(self) -> None:
+        """Drop all pending requests.
+
+        Called at the start of each (re)connection: the server's snapshot
+        that immediately follows is authoritative for currently-held
+        requests, so rows that resolved while we were disconnected -- and
+        thus never sent us an ``egress_resolved`` -- must not linger as
+        ``(0s)`` ghosts after a reconnect or a klangkd restart.
+        """
+        self.pending.clear()
+
 
 def _parse_request(obj: object) -> ConsentRequest | None:
     """Build a :class:`ConsentRequest` from a frame's ``request`` object.
@@ -184,13 +196,17 @@ def _parse_request(obj: object) -> ConsentRequest | None:
     if not isinstance(requested_at, (int, float)):
         requested_at = 0
     port = obj.get("dest_port")
+    pid = obj.get("pid")
     return ConsentRequest(
         id=rid,
         workspace_id=wid,
         dest_host=str(obj.get("dest_host") or ""),
         dest_port=int(port) if isinstance(port, (int, float)) else None,
         process_name=obj.get("process_name"),
-        pid=obj.get("pid") if isinstance(obj.get("pid"), int) else None,
+        # bool is an int subclass -- exclude it so pid=True doesn't yield 1.
+        pid=pid
+        if isinstance(pid, int) and not isinstance(pid, bool)
+        else None,
         requested_at=float(requested_at),
     )
 
@@ -329,6 +345,17 @@ class ConsentDeciderApp(App):
         and re-trigger the bug in a tight reconnect loop).
         """
         ping = asyncio.create_task(self._ping_loop(ws))
+        # The server's snapshot (sent immediately on connect) is authoritative
+        # for currently-held requests: drop anything stale from a prior session
+        # so rows that resolved while disconnected don't linger as (0s) ghosts.
+        # Refresh now too -- an EMPTY snapshot (klangkd restart + orphan reap)
+        # sends no frames, so nothing else would clear the stale UI. Isolated
+        # like every render: a UI bug must never tear down the transport.
+        self.controller.reset()
+        try:
+            self._refresh()
+        except Exception:
+            logger.exception("consent-decide render failed")
         auth_close = False
         try:
             while True:
@@ -418,7 +445,9 @@ class ConsentDeciderApp(App):
             host = f"{host}:{req.dest_port}"
         proc = f"  ({req.process_name})" if req.process_name else ""
         secs = int(self.controller.remaining(req))
-        return f"{host}{proc}  ({secs}s)"
+        # dest_host is server-observed DNS; escape it so a host containing
+        # rich markup (e.g. "[red]") renders literally, not as styling.
+        return escape(f"{host}{proc}  ({secs}s)")
 
     def _render_item(self, req: ConsentRequest) -> ListItem:
         # Host+time is a direct child of the ListItem (renders horizontally);
@@ -460,7 +489,7 @@ class ConsentDeciderApp(App):
         clobber it immediately). Used for verdict send failures and server
         error frames.
         """
-        self._flash_msg = f" [red]![/red] {message}"
+        self._flash_msg = f" [red]![/red] {escape(message)}"
         self._flash_until = time.time() + ttl
         self.query_one("#status", Static).update(self._flash_msg)
 

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -210,8 +210,7 @@ class ConsentDeciderApp(App):
     #requests { height: 1fr; }
     #empty { padding: 1 2; color: $text-muted; }
     .req-host { color: $text; }
-    .req-proc { color: $text-muted; }
-    .req-time { color: $warning; }
+    #requests Button { height: 1; border: none; padding: 0 1; }
     """
 
     BINDINGS = [
@@ -374,7 +373,13 @@ class ConsentDeciderApp(App):
     # -- rendering ---------------------------------------------------------
 
     def _refresh(self) -> None:
-        """Rebuild the request list + status line from controller state."""
+        """Sync the list to controller state WITHOUT a full rebuild.
+
+        A clear+rebuild every tick flickered badly. Instead we remove only
+        resolved/expired rows, repaint the countdown text of survivors in
+        place, and append genuinely-new ones. Order is stable (oldest-first
+        by requested_at), so we never have to reorder.
+        """
         try:
             lv = self.query_one("#requests", ListView)
             status = self.query_one("#status", Static)
@@ -382,10 +387,21 @@ class ConsentDeciderApp(App):
         except Exception:
             return  # not mounted yet (pre-mount call)
         ordered = self.controller.ordered()
+        current_ids = {req.id for req in ordered}
         focused_id = self._focused_request_id()
-        lv.clear()
+        # Drop resolved/expired rows (leave survivors untouched -> no flicker).
+        for child in list(lv.children):
+            rid = getattr(child, "request_id", None)
+            if rid is not None and rid not in current_ids:
+                child.remove()
+        # Repaint survivors' countdown in place; append only new rows.
+        existing = {getattr(c, "request_id", None): c for c in lv.children}
         for req in ordered:
-            lv.append(self._render_item(req))
+            item = existing.get(req.id)
+            if item is None:
+                lv.append(self._render_item(req))
+            else:
+                self._update_item(item, req)
         self._select_by_id(focused_id)
         empty.display = not ordered
         if self._flash_until > time.time():
@@ -396,17 +412,20 @@ class ConsentDeciderApp(App):
                 f" {self.workspace_name}  ·  {conn}  ·  {len(ordered)} held"
             )
 
-    def _render_item(self, req: ConsentRequest) -> ListItem:
+    def _host_line(self, req: ConsentRequest) -> str:
         host = req.dest_host
         if req.dest_port is not None:
             host = f"{host}:{req.dest_port}"
         proc = f"  ({req.process_name})" if req.process_name else ""
         secs = int(self.controller.remaining(req))
+        return f"{host}{proc}  ({secs}s)"
+
+    def _render_item(self, req: ConsentRequest) -> ListItem:
         # Host+time is a direct child of the ListItem (renders horizontally);
         # the per-row Allow/Deny buttons sit in a Horizontal below it so they
         # never fight the host for width. Each button id encodes the request id.
         item = ListItem(
-            Static(f"{host}{proc}  ({secs}s)", classes="req-host"),
+            Static(self._host_line(req), classes="req-host"),
             Horizontal(
                 Button("Allow", id=f"allow-{req.id}", variant="success"),
                 Button("Deny", id=f"deny-{req.id}", variant="error"),
@@ -414,6 +433,10 @@ class ConsentDeciderApp(App):
         )
         item.request_id = req.id  # type: ignore[attr-defined]
         return item
+
+    def _update_item(self, item: ListItem, req: ConsentRequest) -> None:
+        """Repaint only the host/countdown line of a surviving row."""
+        item.query_one(".req-host", Static).update(self._host_line(req))
 
     def _focused_request_id(self) -> str | None:
         child = self.query_one("#requests", ListView).highlighted_child

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -1,0 +1,465 @@
+"""Synchronous egress-consent decider TUI (#2310).
+
+A standalone Textual app launched by ``klangk consent-decide <workspace>``.
+It connects to the server's ``/ws/consent-decider`` stream (#2244), shows the
+workspace's held egress requests (a snapshot on connect, then live), and lets
+the deciding user accept/deny each one *while the sidecar holds it* (#2311).
+The verdict is sent back over the same socket and applied to that exact held
+connection (accept -> it proceeds; deny/timeout -> it fails). Stays within
+``klangk.cli`` (isolation rule): only stdlib, third-party deps, and sibling
+``cli`` modules.
+
+The protocol/state logic lives in :class:`ConsentDeciderController` (pure,
+no Textual) so it is unit-testable without the TUI harness; the
+:class:`ConsentDeciderApp` is a thin view that owns the WS worker + renders.
+
+Liveness: a decider that goes silent is reaped by the server after
+``consent_decider_timeout`` (45s), which reverts the workspace to static
+allow-list (fail-closed). This client pings every ``_PING_INTERVAL`` (well
+under that) to stay registered. If the connection drops, it reconnects with
+backoff and refreshes the JWT on an auth close (4001/4002); while disconnected
+it is deregistered, so held requests auto-deny on timeout -- never silently
+allowed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+
+import websockets
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Footer, Header, ListItem, ListView, Static
+
+from ..auth import refresh_token
+from ..transport import ws_connect
+
+logger = logging.getLogger(__name__)
+
+# Decision/scope values mirror the server (model/egress_consent.py); the CLI
+# is isolated from the server package, so they are duplicated here (#2309 rule).
+DECISION_ALLOWED = "allowed"
+DECISION_DENIED = "denied"
+SCOPE_ONCE = "once"
+
+# Pings must beat the server's consent_decider_timeout (45s) or the decider is
+# reaped and the workspace reverts to static. 15s leaves margin. NOTE: if an
+# operator lowers KLANGKD_CONSENT_DECIDER_TIMEOUT below ~20s this can no longer
+# keep up -- the client cannot learn the server's value.
+_PING_INTERVAL = 15.0
+
+# Reconnect backoff (seconds). Caps the spin on a repeatedly-dropping server.
+_RECONNECT_DELAYS = (1.0, 2.0, 5.0)
+
+# How long a flashed message (send failure, server error) stays on the status
+# line before the periodic refresh overwrites it.
+_FLASH_TTL = 5.0
+
+# Frame-application outcomes returned by ConsentDeciderController.apply_frame.
+ADDED = (
+    "added"  # new held request (snapshot or live); payload = ConsentRequest
+)
+RESOLVED = (
+    "resolved"  # request gone (decided/timed out); payload = (id, decision)
+)
+PONG = "pong"
+ERROR = "error"  # server rejected a verdict; payload = message str
+IGNORED = "ignore"  # non-JSON / unknown frame
+
+
+@dataclass(frozen=True, slots=True)
+class ConsentRequest:
+    """One held egress request awaiting a verdict."""
+
+    id: str
+    workspace_id: str
+    dest_host: str
+    dest_port: int | None
+    process_name: str | None
+    pid: int | None
+    requested_at: float
+
+
+def make_verdict(
+    request_id: str, decision: str, scope: str = SCOPE_ONCE
+) -> str:
+    """Build an outbound verdict frame (JSON string) for a held request."""
+    return json.dumps(
+        {
+            "type": "verdict",
+            "request_id": request_id,
+            "decision": decision,
+            "scope": scope,
+        }
+    )
+
+
+def make_ping() -> str:
+    """Build an outbound liveness ping frame (JSON string)."""
+    return json.dumps({"type": "ping"})
+
+
+class ConsentDeciderController:
+    """Pure state machine over the consent-decider WS protocol (#2310).
+
+    Owns the pending-request map and the frame parser/verdict builders so the
+    Textual app stays a thin view and the logic is unit-testable in isolation.
+    ``hold_timeout`` is the server's ``egress_consent_timeout`` (the countdown
+    the UI shows); the server is the source of truth (it auto-denies at the
+    real timeout) -- this is only a UX hint, defaulting to the server default.
+
+    The clock defaults to :func:`time.time` because the server stamps
+    ``requested_at`` with ``time.time()`` (epoch wall-clock); the countdown
+    math is only meaningful when both timestamps share that domain.
+    """
+
+    def __init__(
+        self,
+        hold_timeout: float = 30.0,
+        *,
+        clock=time.time,
+    ) -> None:
+        self.hold_timeout = hold_timeout
+        self._clock = clock
+        self.pending: dict[str, ConsentRequest] = {}
+
+    def apply_frame(self, raw: str) -> tuple[str, object]:
+        """Parse + apply one inbound server frame.
+
+        Returns ``(outcome, payload)``: for ``ADDED`` payload is the
+        :class:`ConsentRequest`; for ``RESOLVED`` it is ``(request_id,
+        decision)``; for ``ERROR`` a message string; otherwise ``None``.
+        Malformed / non-JSON / unknown frames yield ``(IGNORED, None)`` and
+        leave state untouched.
+        """
+        try:
+            msg = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return IGNORED, None
+        if not isinstance(msg, dict):
+            return IGNORED, None
+        mtype = msg.get("type")
+        if mtype == "egress_request":
+            req = _parse_request(msg.get("request"))
+            if req is None:
+                return IGNORED, None
+            self.pending[req.id] = req
+            return ADDED, req
+        if mtype == "egress_resolved":
+            rid = msg.get("request_id")
+            if isinstance(rid, str):
+                self.pending.pop(rid, None)
+            return RESOLVED, (rid, msg.get("decision"))
+        if mtype == "pong":
+            return PONG, None
+        if mtype == "error":
+            return ERROR, str(msg.get("message", ""))
+        return IGNORED, None
+
+    def ordered(self) -> list[ConsentRequest]:
+        """Pending requests oldest-first (stable UI ordering)."""
+        return sorted(self.pending.values(), key=lambda r: r.requested_at)
+
+    def remaining(self, req: ConsentRequest) -> float:
+        """Seconds until this hold's countdown hits zero (clamped at 0)."""
+        return max(0.0, req.requested_at + self.hold_timeout - self._clock())
+
+
+def _parse_request(obj: object) -> ConsentRequest | None:
+    """Build a :class:`ConsentRequest` from a frame's ``request`` object.
+
+    Returns ``None`` on a shape that can't be acted on (missing id/workspace).
+    """
+    if not isinstance(obj, dict):
+        return None
+    rid = obj.get("id")
+    wid = obj.get("workspace_id")
+    if not isinstance(rid, str) or not isinstance(wid, str):
+        return None
+    requested_at = obj.get("requested_at")
+    if not isinstance(requested_at, (int, float)):
+        requested_at = 0
+    port = obj.get("dest_port")
+    return ConsentRequest(
+        id=rid,
+        workspace_id=wid,
+        dest_host=str(obj.get("dest_host") or ""),
+        dest_port=int(port) if isinstance(port, (int, float)) else None,
+        process_name=obj.get("process_name"),
+        pid=obj.get("pid") if isinstance(obj.get("pid"), int) else None,
+        requested_at=float(requested_at),
+    )
+
+
+class ConsentDeciderApp(App):
+    """Textual app: live queue of held egress requests + accept/deny.
+
+    The WS worker (:meth:`_ws_loop`) connects, pings for liveness, feeds each
+    inbound frame to the controller, and sends verdicts on keypress. A 1s
+    interval refreshes the countdowns. The app is a thin view over
+    :class:`ConsentDeciderController`; all protocol logic lives there.
+    """
+
+    CSS = """
+    Screen { layout: vertical; }
+    #status { padding: 0 1; background: $panel; color: $text-muted; }
+    #requests { height: 1fr; }
+    #empty { padding: 1 2; color: $text-muted; }
+    .req-host { color: $secondary; }
+    .req-proc { color: $text-muted; }
+    .req-time { color: $warning; }
+    """
+
+    BINDINGS = [
+        ("a", "allow", "Allow"),
+        ("d", "deny", "Deny"),
+        ("q", "quit", "Quit"),
+    ]
+
+    def __init__(  # noqa: PLR0913
+        self,
+        server_url: str,
+        token: str,
+        workspace_id: str,
+        workspace_name: str,
+        *,
+        hold_timeout: float = 30.0,
+        max_size: int | None = None,
+        ping_interval: float = _PING_INTERVAL,
+        reconnect_delays: tuple[float, ...] = _RECONNECT_DELAYS,
+    ) -> None:
+        super().__init__()
+        self.server_url = server_url
+        self.token = token
+        self.workspace_id = workspace_id
+        self.workspace_name = workspace_name
+        self.max_size = max_size
+        self.ping_interval = ping_interval
+        self.reconnect_delays = reconnect_delays
+        self.controller = ConsentDeciderController(hold_timeout=hold_timeout)
+        self._ws = None
+        self._connected = False
+        self._stop = False
+        self._flash_msg = ""
+        self._flash_until = 0.0
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(id="status")
+        with Vertical():
+            yield ListView(id="requests")
+            yield Static("No held requests — connected, waiting.", id="empty")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = f"consent-decide · {self.workspace_name}"
+        self.run_worker(
+            self._ws_loop, exclusive=True, group="ws", exit_on_error=False
+        )
+        self.set_interval(1.0, self._refresh)
+
+    # -- WS worker ---------------------------------------------------------
+
+    async def _ws_loop(self) -> None:
+        """Connect -> pump -> reconnect loop, until :attr:`_stop` is set.
+
+        On any error (connect failure, mid-stream drop) the connection is
+        dropped and, after backoff, re-attempted. An auth-related close
+        (expired/invalid token, 4001/4002) refreshes the JWT first so the
+        next attempt authenticates (mirrors ``monitor``). While disconnected
+        the decider is deregistered server-side, so in-flight holds auto-deny
+        on their own timeout (fail-closed) -- never silently allowed.
+        """
+        attempt = 0
+        while not self._stop:
+            auth_close = False
+            try:
+                async with ws_connect(
+                    self.server_url,
+                    token=self.token,
+                    max_size=self.max_size,
+                    path="/ws/consent-decider",
+                    query={"workspace": self.workspace_id},
+                ) as ws:
+                    self._ws = ws
+                    self._connected = True
+                    attempt = 0
+                    self._refresh()
+                    auth_close = await self._pump(ws)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("consent-decide ws dropped: %s", e)
+            finally:
+                self._ws = None
+                self._connected = False
+            if self._stop:
+                break
+            if auth_close:
+                new = await self._refresh_token()
+                if new:
+                    self.token = new
+            attempt += 1
+            await asyncio.sleep(self._backoff(attempt))
+            self._refresh()
+
+    async def _refresh_token(self) -> str | None:
+        """Refresh the JWT off the event loop (the HTTP call is blocking)."""
+        try:
+            return await asyncio.to_thread(
+                refresh_token, self.server_url, self.token
+            )
+        except Exception:
+            logger.debug("consent-decide token refresh failed")
+            return None
+
+    def _backoff(self, attempt: int) -> float:
+        delays = self.reconnect_delays
+        if not delays:
+            return 0.0
+        return delays[min(attempt - 1, len(delays) - 1)]
+
+    async def _pump(self, ws) -> bool:
+        """Read frames until the socket closes; ping in parallel.
+
+        Returns True if the close was auth-related (token 4001/4002) so the
+        caller can refresh the JWT. Render exceptions are isolated: a UI bug
+        must never tear down the transport (which would replay the snapshot
+        and re-trigger the bug in a tight reconnect loop).
+        """
+        ping = asyncio.create_task(self._ping_loop(ws))
+        auth_close = False
+        try:
+            while True:
+                try:
+                    raw = await ws.recv()
+                except websockets.ConnectionClosed as exc:
+                    code = exc.rcvd.code if exc.rcvd else None
+                    auth_close = code in (4001, 4002)
+                    break
+                action, payload = self.controller.apply_frame(raw)
+                try:
+                    if action == ERROR:
+                        self._flash(str(payload))
+                    else:
+                        self._refresh()
+                except Exception:
+                    logger.exception("consent-decide render failed")
+        finally:
+            ping.cancel()
+            try:
+                await ping
+            except (asyncio.CancelledError, Exception):
+                pass
+        return auth_close
+
+    async def _ping_loop(self, ws) -> None:
+        """Send a liveness ping every ``ping_interval`` to stay registered."""
+        try:
+            while True:
+                await asyncio.sleep(self.ping_interval)
+                if self._stop:
+                    return
+                await ws.send(make_ping())
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            # Socket closed (ConnectionClosed, etc.); the pump's recv() loop
+            # ends at the same time. Swallowed so the task has no unobserved
+            # exception.
+            return
+
+    # -- rendering ---------------------------------------------------------
+
+    def _refresh(self) -> None:
+        """Rebuild the request list + status line from controller state."""
+        try:
+            lv = self.query_one("#requests", ListView)
+            status = self.query_one("#status", Static)
+            empty = self.query_one("#empty", Static)
+        except Exception:
+            return  # not mounted yet (pre-mount call)
+        ordered = self.controller.ordered()
+        focused_id = self._focused_request_id()
+        lv.clear()
+        for req in ordered:
+            lv.append(self._render_item(req))
+        self._select_by_id(focused_id)
+        empty.display = not ordered
+        if self._flash_until > time.time():
+            status.update(self._flash_msg)
+        else:
+            conn = "connected" if self._connected else "reconnecting"
+            status.update(
+                f" {self.workspace_name}  ·  {conn}  ·  {len(ordered)} held"
+            )
+
+    def _render_item(self, req: ConsentRequest) -> ListItem:
+        host = req.dest_host
+        if req.dest_port is not None:
+            host = f"{host}:{req.dest_port}"
+        proc = f"  ({req.process_name})" if req.process_name else ""
+        secs = int(self.controller.remaining(req))
+        item = ListItem(
+            Static(f"{host}{proc}", classes="req-host"),
+            Static(f"auto-deny in {secs}s", classes="req-time"),
+        )
+        item.request_id = req.id  # type: ignore[attr-defined]
+        return item
+
+    def _focused_request_id(self) -> str | None:
+        child = self.query_one("#requests", ListView).highlighted_child
+        if child is None:
+            return None
+        return getattr(child, "request_id", None)
+
+    def _select_by_id(self, rid: str | None) -> None:
+        if rid is None:
+            return
+        lv = self.query_one("#requests", ListView)
+        for index, child in enumerate(lv.children):
+            if getattr(child, "request_id", None) == rid:
+                lv.index = index
+                return
+
+    def _flash(self, message: str, ttl: float = _FLASH_TTL) -> None:
+        """Show a transient message in the status line for ``ttl`` seconds.
+
+        The TTL survives the 1s periodic refresh (which would otherwise
+        clobber it immediately). Used for verdict send failures and server
+        error frames.
+        """
+        self._flash_msg = f" [red]![/red] {message}"
+        self._flash_until = time.time() + ttl
+        self.query_one("#status", Static).update(self._flash_msg)
+
+    # -- actions -----------------------------------------------------------
+
+    def action_allow(self) -> None:
+        self._decide(DECISION_ALLOWED)
+
+    def action_deny(self) -> None:
+        self._decide(DECISION_DENIED)
+
+    def _decide(self, decision: str) -> None:
+        rid = self._focused_request_id()
+        if rid is None:
+            return
+        ws = self._ws
+        if ws is None:
+            self._flash("disconnected — reconnecting")
+            return
+        # Send on the shared loop via _send_verdict, which awaits the send and
+        # flashes on failure (a dropped socket between the check and the send
+        # would otherwise silently lose the verdict). Do not optimistically
+        # drop the row: a duplicate/no-op verdict must not hide a still-held
+        # request (the server's egress_resolved frame removes it).
+        asyncio.create_task(self._send_verdict(ws, rid, decision))
+
+    async def _send_verdict(self, ws, rid: str, decision: str) -> None:
+        try:
+            await ws.send(make_verdict(rid, decision))
+        except Exception:
+            self._flash("verdict send failed — reconnecting")

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -209,7 +209,7 @@ class ConsentDeciderApp(App):
     #status { padding: 0 1; background: $panel; color: $text-muted; }
     #requests { height: 1fr; }
     #empty { padding: 1 2; color: $text-muted; }
-    .req-host { color: $text; }
+    .req-host { color: $text; width: 1fr; }
     .req-proc { color: $text-muted; }
     .req-time { color: $warning; }
     """
@@ -253,9 +253,6 @@ class ConsentDeciderApp(App):
         with Vertical():
             yield ListView(id="requests")
             yield Static("No held requests — connected, waiting.", id="empty")
-        with Horizontal(id="actions"):
-            yield Button("Allow", id="allow", variant="success")
-            yield Button("Deny", id="deny", variant="error")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -405,9 +402,15 @@ class ConsentDeciderApp(App):
             host = f"{host}:{req.dest_port}"
         proc = f"  ({req.process_name})" if req.process_name else ""
         secs = int(self.controller.remaining(req))
+        # Each row carries its own Allow/Deny buttons (id encodes the request
+        # id) so a click decides THAT request, unambiguous with a queue.
         item = ListItem(
-            Static(f"{host}{proc}", classes="req-host"),
-            Static(f"auto-deny in {secs}s", classes="req-time"),
+            Horizontal(
+                Static(f"{host}{proc}", classes="req-host"),
+                Static(f"{secs}s", classes="req-time"),
+                Button("Allow", id=f"allow-{req.id}", variant="success"),
+                Button("Deny", id=f"deny-{req.id}", variant="error"),
+            )
         )
         item.request_id = req.id  # type: ignore[attr-defined]
         return item
@@ -441,14 +444,17 @@ class ConsentDeciderApp(App):
     # -- actions -----------------------------------------------------------
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        # The Allow/Deny buttons mirror the a/d keys so a click decides the
-        # currently-highlighted request (same _focused_request_id path).
-        if event.button.id == "allow":
-            self.action_allow()
-        elif event.button.id == "deny":
-            self.action_deny()
+        # Each row carries its own Allow/Deny button whose id encodes the
+        # request id (``allow-<rid>`` / ``deny-<rid>``), so a click decides
+        # THAT request unambiguously -- not a separate "focused" one.
+        bid = event.button.id or ""
+        if bid.startswith("allow-"):
+            self._decide_id(bid.removeprefix("allow-"), DECISION_ALLOWED)
+        elif bid.startswith("deny-"):
+            self._decide_id(bid.removeprefix("deny-"), DECISION_DENIED)
 
     def action_allow(self) -> None:
+        # `a` key -> the highlighted row (keyboard path).
         self._decide(DECISION_ALLOWED)
 
     def action_deny(self) -> None:
@@ -458,6 +464,9 @@ class ConsentDeciderApp(App):
         rid = self._focused_request_id()
         if rid is None:
             return
+        self._decide_id(rid, decision)
+
+    def _decide_id(self, rid: str, decision: str) -> None:
         ws = self._ws
         if ws is None:
             self._flash("disconnected — reconnecting")

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -32,8 +32,8 @@ from dataclasses import dataclass
 
 import websockets
 from textual.app import App, ComposeResult
-from textual.containers import Vertical
-from textual.widgets import Footer, Header, ListItem, ListView, Static
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
 
 from ..auth import refresh_token
 from ..transport import ws_connect
@@ -209,7 +209,7 @@ class ConsentDeciderApp(App):
     #status { padding: 0 1; background: $panel; color: $text-muted; }
     #requests { height: 1fr; }
     #empty { padding: 1 2; color: $text-muted; }
-    .req-host { color: $secondary; }
+    .req-host { color: $text; }
     .req-proc { color: $text-muted; }
     .req-time { color: $warning; }
     """
@@ -253,6 +253,9 @@ class ConsentDeciderApp(App):
         with Vertical():
             yield ListView(id="requests")
             yield Static("No held requests — connected, waiting.", id="empty")
+        with Horizontal(id="actions"):
+            yield Button("Allow", id="allow", variant="success")
+            yield Button("Deny", id="deny", variant="error")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -436,6 +439,14 @@ class ConsentDeciderApp(App):
         self.query_one("#status", Static).update(self._flash_msg)
 
     # -- actions -----------------------------------------------------------
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        # The Allow/Deny buttons mirror the a/d keys so a click decides the
+        # currently-highlighted request (same _focused_request_id path).
+        if event.button.id == "allow":
+            self.action_allow()
+        elif event.button.id == "deny":
+            self.action_deny()
 
     def action_allow(self) -> None:
         self._decide(DECISION_ALLOWED)

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -698,6 +698,14 @@ async def lifespan(app: FastAPI):
         app.state.sockets.notify_container_status
     )
     await app.state.lifecycle.startup()
+    # Reap orphaned pending consent rows from a prior run: the in-memory
+    # holds are gone on restart, so without this the decider snapshot would
+    # replay stale requests that can never be resolved (#2310).
+    reaped = await app.state.model.egress_consent.expire_all_pending()
+    logger.info(
+        "expired %d orphaned pending egress-consent request(s) on startup",
+        reaped,
+    )
     app.state.consent_monitor.start()
     app.state.consent_coordinator.start()
     app.state.consent_deciders.start()

--- a/src/klangk/klangk/model/__init__.py
+++ b/src/klangk/klangk/model/__init__.py
@@ -63,6 +63,7 @@ from .workspaces import (
     SETUP_STATES,
     EGRESS_MODE_STATIC,
     EGRESS_MODE_INTERACTIVE,
+    EGRESS_MODE_DEFAULT,
     EGRESS_MODES,
 )
 from .ports import (
@@ -134,6 +135,7 @@ __all__ = (
     "SETUP_STATES",
     "EGRESS_MODE_STATIC",
     "EGRESS_MODE_INTERACTIVE",
+    "EGRESS_MODE_DEFAULT",
     "EGRESS_MODES",
     # ports — constants + pure socket probe (re-exported via util too)
     "MAX_PORT",

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -288,6 +288,25 @@ class EgressConsentModel:
             )
             return cursor.rowcount > 0
 
+    async def expire_all_pending(self) -> int:
+        """Expire EVERY pending request (startup reaping).
+
+        On startup the in-memory holds are gone, so any row still ``pending``
+        from a prior run is an orphan with no live hold to resolve it. Mark
+        them ``expired`` so :meth:`list_requests` (the decider snapshot) does
+        not replay them to a freshly-connected decider. Returns the count
+        reaped.
+        """
+        decided_at = time.time()
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "UPDATE egress_consent"
+                " SET decision = ?, decided_at = ?"
+                " WHERE decision = ?",
+                (DECISION_EXPIRED, decided_at, DECISION_PENDING),
+            )
+            return cursor.rowcount
+
     async def delete_for_workspace(self, workspace_id: str) -> int:
         """Delete all consent records for a workspace. Returns count."""
         async with self.app.state.db.transaction() as db:

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -56,11 +56,14 @@ SETUP_STATES = frozenset(
     {SETUP_STATE_PENDING, SETUP_STATE_COMPLETE, SETUP_STATE_FAILED}
 )
 
-# egress_mode values (#2239). 'static' (the default) = deny + record
-# denied attempts (no human prompt); 'interactive' = a pending request a
-# human can allow/deny via the consent UI (#2244, not yet wired).
+# egress_mode values (#2239). 'static' = deny + record denied attempts (no
+# human prompt); 'interactive' = a pending request a human can allow/deny via
+# the consent-decide client (#2310). The default for NEW workspaces is
+# 'interactive' for now (end-to-end consent testing); flip EGRESS_MODE_DEFAULT
+# back to STATIC once it's production-ready.
 EGRESS_MODE_STATIC = "static"
 EGRESS_MODE_INTERACTIVE = "interactive"
+EGRESS_MODE_DEFAULT = EGRESS_MODE_INTERACTIVE
 EGRESS_MODES = frozenset({EGRESS_MODE_STATIC, EGRESS_MODE_INTERACTIVE})
 
 # Whitelisted sort columns for workspace list queries. Values are the
@@ -116,7 +119,7 @@ class WorkspacesModel:
         health_check: str | None,
         allowed_domains: list[str] | None = None,
         settings: dict | None = None,
-        egress_mode: str = EGRESS_MODE_STATIC,
+        egress_mode: str = EGRESS_MODE_DEFAULT,
     ) -> dict:
         """INSERT a workspace row on ``db`` and return the new workspace dict.
 
@@ -249,7 +252,7 @@ class WorkspacesModel:
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
         settings: dict | None = None,
-        egress_mode: str = EGRESS_MODE_STATIC,
+        egress_mode: str = EGRESS_MODE_DEFAULT,
     ) -> dict:
         """Create a workspace row AND seed its owner ACE + role groups.
 
@@ -303,7 +306,7 @@ class WorkspacesModel:
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
         settings: dict | None = None,
-        egress_mode: str = EGRESS_MODE_STATIC,
+        egress_mode: str = EGRESS_MODE_DEFAULT,
     ) -> dict:
         """Insert a workspace row only (no ACL seeding).
 

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -59,8 +59,8 @@ SETUP_STATES = frozenset(
 # egress_mode values (#2239). 'static' = deny + record denied attempts (no
 # human prompt); 'interactive' = a pending request a human can allow/deny via
 # the consent-decide client (#2310). The default for NEW workspaces is
-# 'interactive' for now (end-to-end consent testing); flip EGRESS_MODE_DEFAULT
-# back to STATIC once it's production-ready.
+# 'interactive' so consent-gated egress is on out of the box; set a workspace
+# to 'static' to opt back into silent deny + record.
 EGRESS_MODE_STATIC = "static"
 EGRESS_MODE_INTERACTIVE = "interactive"
 EGRESS_MODE_DEFAULT = EGRESS_MODE_INTERACTIVE

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -120,7 +120,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
                     safe_ws.send_json({"type": "pong"})
                 elif mtype == "verdict":
                     await _handle_verdict(
-                        app, safe_ws, msg, workspace, email, user["id"]
+                        app, safe_ws, msg, workspace, user["id"]
                     )
                 # unknown types are ignored
             except SlowClientError:
@@ -141,9 +141,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         await safe_ws.stop_sender()
 
 
-async def _handle_verdict(
-    app, safe_ws, msg, workspace, email, user_id
-) -> None:
+async def _handle_verdict(app, safe_ws, msg, workspace, user_id) -> None:
     """Validate + apply a decider's verdict to a held request (#2244)."""
     decision = msg.get("decision")
     if decision not in (DECISION_ALLOWED, DECISION_DENIED):
@@ -167,9 +165,9 @@ async def _handle_verdict(
         request_id,
         decision,
         scope,
-        # A human decision is always attributable; fall back to the stable
-        # user id if the row lacks an email (never NULL -- NULL means "no
-        # human", the static/expired case).
-        email or user_id or "",
+        # decided_by is the stable user id (egress_consent.decided_by REFERENCES
+        # users(id); the email is volatile + not a key). Never NULL for a human
+        # decision -- NULL means "no human" (the static/expired case).
+        user_id,
         decider_workspace=workspace,
     )

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5169,3 +5169,115 @@ class TestResolveOwnWindow:
         match, err = main._resolve_own_window([self._w("@0", "bash")], "nope")
         assert match is None
         assert "not found" in err
+
+
+class TestConsentDecideCommand:
+    """`klangk consent-decide <workspace>` wiring (#2310)."""
+
+    @staticmethod
+    def _launch_capture():
+        launched = {}
+
+        def fake_run(self):
+            launched["app"] = self
+
+        return launched, fake_run
+
+    def test_resolves_name_and_launches(self, logged_in_cfg):
+        from klangk.cli import main
+        from klangk.cli.tui import consent as tui_consent
+
+        ws = Workspace(id="wsid", name="my-ws", created_at="x")
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        client.list_shared_workspaces.return_value = []
+        launched, fake_run = self._launch_capture()
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(tui_consent.ConsentDeciderApp, "run", fake_run),
+        ):
+            from typer.testing import CliRunner
+
+            result = CliRunner().invoke(main.app, ["consent-decide", "my-ws"])
+        assert result.exit_code == 0
+        app = launched["app"]
+        assert app.workspace_id == "wsid"
+        assert app.workspace_name == "my-ws"
+        assert app.server_url == "http://localhost:8995"
+        assert app.token == "test-token"
+
+    def test_resolves_by_id(self, logged_in_cfg):
+        from klangk.cli import main
+        from klangk.cli.tui import consent as tui_consent
+
+        ws = Workspace(id="wsid", name="my-ws", created_at="x")
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        client.list_shared_workspaces.return_value = []
+        launched, fake_run = self._launch_capture()
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(tui_consent.ConsentDeciderApp, "run", fake_run),
+        ):
+            from typer.testing import CliRunner
+
+            result = CliRunner().invoke(main.app, ["consent-decide", "wsid"])
+        assert result.exit_code == 0
+        assert launched["app"].workspace_id == "wsid"
+
+    def test_shared_workspace_resolves(self, logged_in_cfg):
+        from klangk.cli import main
+        from klangk.cli.tui import consent as tui_consent
+
+        ws = Workspace(id="shared1", name="team", created_at="x")
+        client = MagicMock()
+        client.list_workspaces.return_value = []
+        client.list_shared_workspaces.return_value = [ws]
+        launched, fake_run = self._launch_capture()
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(tui_consent.ConsentDeciderApp, "run", fake_run),
+        ):
+            from typer.testing import CliRunner
+
+            result = CliRunner().invoke(main.app, ["consent-decide", "team"])
+        assert result.exit_code == 0
+        assert launched["app"].workspace_id == "shared1"
+
+    def test_hold_timeout_option_passed_through(self, logged_in_cfg):
+        from klangk.cli import main
+        from klangk.cli.tui import consent as tui_consent
+
+        ws = Workspace(id="wsid", name="my-ws", created_at="x")
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        client.list_shared_workspaces.return_value = []
+        launched, fake_run = self._launch_capture()
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(tui_consent.ConsentDeciderApp, "run", fake_run),
+        ):
+            from typer.testing import CliRunner
+
+            result = CliRunner().invoke(
+                main.app, ["consent-decide", "my-ws", "--hold-timeout", "60"]
+            )
+        assert result.exit_code == 0
+        assert launched["app"].controller.hold_timeout == 60.0
+
+    def test_not_found_exits_1(self, logged_in_cfg):
+        from klangk.cli import main
+
+        client = MagicMock()
+        client.list_workspaces.return_value = []
+        client.list_shared_workspaces.return_value = []
+
+        with patch.object(main, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            result = CliRunner().invoke(main.app, ["consent-decide", "ghost"])
+        assert result.exit_code == 1

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -801,3 +801,44 @@ async def test_refresh_appends_new_and_drops_resolved_in_place():
         app._refresh()
         await pilot.pause()
         assert {getattr(c, "request_id", None) for c in lv.children} == {"r2"}
+
+
+def test_reset_clears_pending():
+    """reset() drops all pending rows (called at the top of each connection)."""
+    c = ConsentDeciderController()
+    c.apply_frame(_req_frame("r1"))
+    c.apply_frame(_req_frame("r2"))
+    assert len(c.pending) == 2
+    c.reset()
+    assert c.pending == {}
+    assert c.ordered() == []
+
+
+async def test_pump_drops_stale_rows_on_empty_snapshot_reconnect():
+    """On (re)connect the server snapshot is authoritative. Rows that resolved
+    while disconnected (no egress_resolved ever received) must not linger as
+    (0s) ghosts -- the orphan-reap / klangkd-restart case sends an EMPTY
+    snapshot, so _pump must clear the queue even when no frames arrive."""
+    app = _make_app()
+    async with app.run_test() as pilot:
+        # stale row from a prior session (resolved server-side while offline)
+        app.controller.apply_frame(_req_frame("r1", host="a.com"))
+        await pilot.pause()
+        assert len(app.controller.pending) == 1
+        # reconnect: server reaped orphans / nothing held -> empty snapshot
+        await app._pump(FakeWS([]))
+        await pilot.pause()
+        assert app.controller.pending == {}, app.controller.pending
+
+
+async def test_pump_repoulates_from_snapshot_after_reset():
+    """reset() must not lose live rows: the snapshot that follows a reconnect
+    repopulates the queue."""
+    app = _make_app()
+    async with app.run_test() as pilot:
+        app.controller.apply_frame(_req_frame("stale", host="old.com"))
+        await pilot.pause()
+        # reconnect: snapshot carries a different, currently-held request
+        await app._pump(FakeWS([_req_frame("live", host="new.com")]))
+        await pilot.pause()
+        assert set(app.controller.pending) == {"live"}

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -16,7 +16,7 @@ import types
 
 import pytest
 import websockets
-from textual.widgets import ListView, Static
+from textual.widgets import Button, ListView, Static
 
 from klangk.cli.tui import consent as tui_consent
 from klangk.cli.tui.consent import (
@@ -713,3 +713,30 @@ class TestWsLoop:
         done.set()  # release the read -> pump ends -> early break
         await asyncio.wait_for(task, timeout=1.0)
         assert task.done()
+
+
+async def test_request_row_renders_host_horizontal_and_buttons_onscreen():
+    """Regression guard: the per-row host must render on ONE line (a width fight
+    once wrapped it one-character-per-line) and the Allow/Deny buttons must land
+    on-screen (the same fight once pushed them past the right edge)."""
+    app = _make_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.controller.apply_frame(_req_frame("r1", host="ford.com"))
+        app._refresh()
+        await pilot.pause()
+        host = app.query_one(".req-host", Static)
+        allow = app.query_one("#allow-r1", Button)
+        deny = app.query_one("#deny-r1", Button)
+        # Host text on one line, not wrapped one-character-per-line.
+        assert host.region.height == 1, (
+            f"host wrapped vertically: {host.region}"
+        )
+        assert host.region.width >= len("ford.com"), (
+            f"host too narrow: {host.region}"
+        )
+        # Both buttons fully on-screen (not pushed off the right edge).
+        screen_w = app.size.width
+        assert allow.region.right <= screen_w, (
+            f"allow off-screen: {allow.region}"
+        )
+        assert deny.region.right <= screen_w, f"deny off-screen: {deny.region}"

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -740,3 +740,64 @@ async def test_request_row_renders_host_horizontal_and_buttons_onscreen():
             f"allow off-screen: {allow.region}"
         )
         assert deny.region.right <= screen_w, f"deny off-screen: {deny.region}"
+        # Buttons flat (height 1) so a row is compact, not a 3-row bordered button.
+        assert allow.region.height == 1, f"allow not flat: {allow.region}"
+        assert deny.region.height == 1, f"deny not flat: {deny.region}"
+
+
+async def test_refresh_keeps_surviving_row_object_across_ticks():
+    """Anti-flicker: a periodic refresh updates survivors in place, never
+    clear+rebuild (which flashed the whole list every second)."""
+    app = _make_app()
+    async with app.run_test() as pilot:
+        app.controller.apply_frame(_req_frame("r1", host="a.com"))
+        app._refresh()
+        await pilot.pause()
+        before = list(app.query_one("#requests", ListView).children)
+        assert len(before) == 1
+        app._refresh()  # second tick, nothing changed
+        await pilot.pause()
+        after = list(app.query_one("#requests", ListView).children)
+        assert before[0] is after[0], "refresh rebuilt the row (flicker)"
+
+
+async def test_refresh_appends_new_and_drops_resolved_in_place():
+    """New rows append; resolved rows drop; untouched rows keep their identity."""
+    app = _make_app()
+    async with app.run_test() as pilot:
+        app.controller.apply_frame(_req_frame("r1", host="a.com"))
+        app._refresh()
+        await pilot.pause()
+        lv = app.query_one("#requests", ListView)
+        item_r1 = next(
+            c for c in lv.children if getattr(c, "request_id", None) == "r1"
+        )
+        # r2 arrives -> both present, r1 unchanged.
+        app.controller.apply_frame(_req_frame("r2", host="b.com"))
+        app._refresh()
+        await pilot.pause()
+        assert {getattr(c, "request_id", None) for c in lv.children} == {
+            "r1",
+            "r2",
+        }
+        assert (
+            next(
+                c
+                for c in lv.children
+                if getattr(c, "request_id", None) == "r1"
+            )
+            is item_r1
+        )
+        # r1 resolved -> removed; r2 survives.
+        app.controller.apply_frame(
+            json.dumps(
+                {
+                    "type": "egress_resolved",
+                    "request_id": "r1",
+                    "decision": "allowed",
+                }
+            )
+        )
+        app._refresh()
+        await pilot.pause()
+        assert {getattr(c, "request_id", None) for c in lv.children} == {"r2"}

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -565,8 +565,9 @@ class TestAppActions:
             status = app.query_one("#status", Static)
             assert "verdict send failed" in str(status.content)
 
-    async def test_allow_button_decides_focused(self):
-        # The Allow button mirrors the `a` key: a click decides the focused row.
+    async def test_allow_button_decides_that_request(self):
+        # The per-row Allow button (id "allow-<rid>") decides THAT request,
+        # independent of which row is highlighted.
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -574,15 +575,15 @@ class TestAppActions:
             app.controller.apply_frame(_req_frame("r1", host="a.com"))
             app._refresh()
             await pilot.pause()
-            app.query_one("#requests", ListView).index = 0
-            await pilot.pause()
             app.on_button_pressed(
-                types.SimpleNamespace(button=types.SimpleNamespace(id="allow"))
+                types.SimpleNamespace(
+                    button=types.SimpleNamespace(id="allow-r1")
+                )
             )
             await pilot.pause()
             assert any('"allowed"' in s and '"r1"' in s for s in ws.sent)
 
-    async def test_deny_button_decides_focused(self):
+    async def test_deny_button_decides_that_request(self):
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -590,13 +591,13 @@ class TestAppActions:
             app.controller.apply_frame(_req_frame("r1", host="a.com"))
             app._refresh()
             await pilot.pause()
-            app.query_one("#requests", ListView).index = 0
-            await pilot.pause()
             app.on_button_pressed(
-                types.SimpleNamespace(button=types.SimpleNamespace(id="deny"))
+                types.SimpleNamespace(
+                    button=types.SimpleNamespace(id="deny-r1")
+                )
             )
             await pilot.pause()
-            assert any('"denied"' in s for s in ws.sent)
+            assert any('"denied"' in s and '"r1"' in s for s in ws.sent)
 
 
 class TestWsLoop:

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -1,0 +1,680 @@
+"""Tests for the synchronous consent-decider TUI (#2310).
+
+Covers the pure :class:`ConsentDeciderController` (protocol state machine),
+the module-level frame builders, and the :class:`ConsentDeciderApp` Textual
+view (WS pump, ping loop, reconnect, key actions) under the 100% coverage
+gate. The on-mount WS worker is stubbed for view tests (it is exercised
+directly via the captured real loop).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+import websockets
+from textual.widgets import ListView, Static
+
+from klangk.cli.tui import consent as tui_consent
+from klangk.cli.tui.consent import (
+    ADDED,
+    ERROR,
+    IGNORED,
+    PONG,
+    RESOLVED,
+    ConsentDeciderApp,
+    ConsentDeciderController,
+    ConsentRequest,
+    make_ping,
+    make_verdict,
+)
+
+# Capture the real WS loop before any test stubs it, so the reconnect test can
+# invoke it directly while view tests run the app without a live worker.
+_real_ws_loop = ConsentDeciderApp._ws_loop
+
+
+class FakeWS:
+    """recv()-based WS that replays frames and records sends.
+
+    Mirrors the real ``websockets`` connection: ``recv()`` raises
+    ``ConnectionClosed`` when the (frame) stream is exhausted. ``send_fail``
+    makes ``send()`` raise, and ``close_exc`` overrides the close exception
+    (to simulate an auth 4001/4002 close).
+    """
+
+    def __init__(self, frames, *, send_fail=False, close_exc=None):
+        self._frames = list(frames)
+        self.sent = []
+        self.send_fail = send_fail
+        self.close_exc = close_exc
+
+    async def recv(self):
+        if self._frames:
+            return self._frames.pop(0)
+        raise self.close_exc or websockets.ConnectionClosed(None, None)
+
+    async def send(self, data):
+        if self.send_fail:
+            raise websockets.ConnectionClosed(None, None)
+        self.sent.append(data)
+
+
+class FakeCM:
+    """Async context manager yielding a FakeWS (stands in for ws_connect)."""
+
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self._ws
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _req_frame(rid="r1", host="evil.example.com", port=443, **extra):
+    req = {
+        "id": rid,
+        "workspace_id": "wsid",
+        "dest_host": host,
+        "dest_port": port,
+        "process_name": None,
+        "pid": None,
+        "requested_at": 100.0,
+    }
+    req.update(extra)
+    return json.dumps({"type": "egress_request", "request": req})
+
+
+def _make_app(**kw):
+    app = ConsentDeciderApp(
+        "http://server", "tok", "wsid", "wsname", hold_timeout=30.0, **kw
+    )
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _stub_ws_worker(monkeypatch):
+    """Replace the on-mount WS worker with a no-op for view tests."""
+
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(ConsentDeciderApp, "_ws_loop", _noop)
+
+
+# ---------------------------------------------------------------------------
+# Controller: frame parsing + state
+# ---------------------------------------------------------------------------
+
+
+class TestControllerFrames:
+    def test_egress_request_added(self):
+        c = ConsentDeciderController()
+        action, payload = c.apply_frame(_req_frame())
+        assert action == ADDED
+        assert isinstance(payload, ConsentRequest)
+        assert payload.id == "r1"
+        assert payload.dest_port == 443
+        assert "r1" in c.pending
+
+    def test_snapshot_and_live_both_add(self):
+        c = ConsentDeciderController()
+        c.apply_frame(_req_frame("a"))
+        c.apply_frame(_req_frame("b"))
+        assert set(c.pending) == {"a", "b"}
+
+    def test_egress_resolved_removes(self):
+        c = ConsentDeciderController()
+        c.apply_frame(_req_frame("r1"))
+        action, payload = c.apply_frame(
+            json.dumps(
+                {
+                    "type": "egress_resolved",
+                    "request_id": "r1",
+                    "decision": "allowed",
+                }
+            )
+        )
+        assert action == RESOLVED
+        assert payload == ("r1", "allowed")
+        assert "r1" not in c.pending
+
+    def test_egress_resolved_unknown_id_is_noop(self):
+        c = ConsentDeciderController()
+        action, payload = c.apply_frame(
+            json.dumps(
+                {
+                    "type": "egress_resolved",
+                    "request_id": "ghost",
+                    "decision": "expired",
+                }
+            )
+        )
+        assert action == RESOLVED
+        assert c.pending == {}
+
+    def test_pong(self):
+        c = ConsentDeciderController()
+        assert c.apply_frame(json.dumps({"type": "pong"})) == (PONG, None)
+
+    def test_error_carries_message(self):
+        c = ConsentDeciderController()
+        action, payload = c.apply_frame(
+            json.dumps({"type": "error", "message": "bad decision"})
+        )
+        assert action == ERROR
+        assert payload == "bad decision"
+
+    def test_error_missing_message(self):
+        c = ConsentDeciderController()
+        action, payload = c.apply_frame(json.dumps({"type": "error"}))
+        assert action == ERROR
+        assert payload == ""
+
+    def test_non_json_ignored(self):
+        c = ConsentDeciderController()
+        assert c.apply_frame("not json{") == (IGNORED, None)
+        assert c.apply_frame(None) == (IGNORED, None)  # type: ignore[arg-type]
+
+    def test_non_dict_ignored(self):
+        c = ConsentDeciderController()
+        assert c.apply_frame(json.dumps([1, 2, 3])) == (IGNORED, None)
+        assert c.apply_frame(json.dumps("x")) == (IGNORED, None)
+
+    def test_unknown_type_ignored(self):
+        c = ConsentDeciderController()
+        assert c.apply_frame(json.dumps({"type": "mystery"})) == (
+            IGNORED,
+            None,
+        )
+
+    def test_request_missing_id_ignored(self):
+        c = ConsentDeciderController()
+        bad = json.dumps(
+            {"type": "egress_request", "request": {"workspace_id": "wsid"}}
+        )
+        assert c.apply_frame(bad) == (IGNORED, None)
+        assert c.pending == {}
+
+    def test_request_missing_workspace_ignored(self):
+        c = ConsentDeciderController()
+        bad = json.dumps({"type": "egress_request", "request": {"id": "r1"}})
+        assert c.apply_frame(bad) == (IGNORED, None)
+
+    def test_request_missing_request_object_ignored(self):
+        c = ConsentDeciderController()
+        assert c.apply_frame(json.dumps({"type": "egress_request"})) == (
+            IGNORED,
+            None,
+        )
+
+    def test_port_none_and_garbage(self):
+        c = ConsentDeciderController()
+        _, p = c.apply_frame(_req_frame(port=None))
+        assert p.dest_port is None
+        c2 = ConsentDeciderController()
+        _, p2 = c2.apply_frame(_req_frame(port="80"))  # type: ignore[arg-type]
+        assert p2.dest_port is None  # non-numeric -> None
+
+    def test_requested_at_missing_defaults_zero(self):
+        c = ConsentDeciderController()
+        _, p = c.apply_frame(
+            json.dumps(
+                {
+                    "type": "egress_request",
+                    "request": {"id": "r1", "workspace_id": "wsid"},
+                }
+            )
+        )
+        assert p.requested_at == 0.0
+
+
+class TestControllerOrdering:
+    def test_ordered_oldest_first(self):
+        c = ConsentDeciderController()
+        c.apply_frame(_req_frame("b", requested_at=200.0))
+        c.apply_frame(_req_frame("a", requested_at=100.0))
+        ordered = c.ordered()
+        assert [r.id for r in ordered] == ["a", "b"]
+
+
+class TestControllerCountdown:
+    def test_remaining_uses_clock_and_timeout(self):
+        c = ConsentDeciderController(hold_timeout=10.0, clock=lambda: 105.0)
+        req = ConsentRequest(
+            id="r1",
+            workspace_id="wsid",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            pid=None,
+            requested_at=100.0,
+        )
+        assert c.remaining(req) == 5.0
+
+    def test_remaining_clamps_at_zero(self):
+        c = ConsentDeciderController(hold_timeout=10.0, clock=lambda: 999.0)
+        req = ConsentRequest(
+            id="r1",
+            workspace_id="wsid",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            pid=None,
+            requested_at=0.0,
+        )
+        assert c.remaining(req) == 0.0
+
+    def test_remaining_with_real_epoch_clock(self):
+        # Regression (#2320 review #1): the server stamps requested_at with
+        # time.time() (epoch wall-clock), so the controller's DEFAULT clock
+        # must be time.time -- mixing in time.monotonic made the countdown
+        # ~1.7e9s and it never visually counted down.
+        c = ConsentDeciderController(hold_timeout=10.0)  # default = time.time
+        now = time.time()
+        req = ConsentRequest(
+            id="r1",
+            workspace_id="wsid",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            pid=None,
+            requested_at=now - 4,
+        )
+        # ~6s left, allowing scheduler/clock slack on either side.
+        assert 3.0 <= c.remaining(req) <= 7.0
+
+
+# ---------------------------------------------------------------------------
+# Module-level frame builders
+# ---------------------------------------------------------------------------
+
+
+class TestFrameBuilders:
+    def test_make_verdict_allowed(self):
+        msg = json.loads(make_verdict("r1", "allowed"))
+        assert msg == {
+            "type": "verdict",
+            "request_id": "r1",
+            "decision": "allowed",
+            "scope": "once",
+        }
+
+    def test_make_verdict_denied(self):
+        msg = json.loads(make_verdict("r1", "denied"))
+        assert msg["decision"] == "denied"
+
+    def test_make_ping(self):
+        assert json.loads(make_ping()) == {"type": "ping"}
+
+
+# ---------------------------------------------------------------------------
+# App: rendering, pump, ping, reconnect, actions
+# ---------------------------------------------------------------------------
+
+
+class TestAppRender:
+    async def test_compose_mounts_widgets(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.query_one("#requests", ListView) is not None
+            assert app.query_one("#status", Static) is not None
+
+    async def test_refresh_shows_queue_and_status(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            lv = app.query_one("#requests", ListView)
+            assert len(lv.children) == 2
+            status = app.query_one("#status", Static)
+            assert "wsname" in str(status.content)
+
+    async def test_refresh_empty_hides_queue(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app._refresh()
+            await pilot.pause()
+            assert app.query_one("#empty", Static).display is True
+
+    async def test_refresh_shows_active_flash(self):
+        # While a flash is active (within TTL), _refresh renders it instead of
+        # the normal status (so flashes survive the 1s periodic refresh).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app._flash("something broke")
+            app._refresh()
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "something broke" in str(status.content)
+
+    async def test_refresh_before_mount_is_noop(self):
+        # The worker may call _refresh before mount completes; it must not blow up.
+        app = _make_app()
+        app._refresh()  # not mounted -> guards return early
+
+    async def test_refresh_preserves_focus_across_rebuild(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            lv = app.query_one("#requests", ListView)
+            lv.index = 1  # focus r2
+            await pilot.pause()
+            app._refresh()  # rebuild keeps r2 focused
+            await pilot.pause()
+            assert app._focused_request_id() == "r2"
+
+    async def test_render_item_with_process_and_port(self):
+        app = _make_app()
+        req = ConsentRequest(
+            id="r1",
+            workspace_id="wsid",
+            dest_host="h.example.com",
+            dest_port=443,
+            process_name="curl",
+            pid=42,
+            requested_at=0.0,
+        )
+        item = app._render_item(req)
+        assert item.request_id == "r1"
+
+
+class TestAppPump:
+    async def test_pump_applies_frames(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS(
+                [
+                    _req_frame("r1", host="evil.example.com"),
+                    json.dumps({"type": "pong"}),
+                    json.dumps(
+                        {
+                            "type": "egress_resolved",
+                            "request_id": "r1",
+                            "decision": "expired",
+                        }
+                    ),
+                ]
+            )
+            await app._pump(ws)
+            await pilot.pause()
+            assert app.controller.pending == {}  # added then resolved
+
+    async def test_pump_flashes_error_frame(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([json.dumps({"type": "error", "message": "nope"})])
+            await app._pump(ws)
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "nope" in str(status.content)
+
+    async def test_pump_returns_auth_close_on_4002(self):
+        app = _make_app()
+        exc = websockets.ConnectionClosed(
+            websockets.frames.Close(4002, "Token expired"), None
+        )
+        async with app.run_test():
+            ws = FakeWS([], close_exc=exc)
+            assert await app._pump(ws) is True
+
+    async def test_pump_returns_false_on_normal_close(self):
+        app = _make_app()
+        async with app.run_test():
+            ws = FakeWS([_req_frame("r1")])
+            assert await app._pump(ws) is False
+
+    async def test_pump_isolates_render_failure(self, monkeypatch):
+        # A render bug must NOT propagate out of _pump (which would tear down
+        # the transport and replay the snapshot in a tight reconnect loop).
+        app = _make_app()
+
+        def boom():
+            raise RuntimeError("render broke")
+
+        monkeypatch.setattr(app, "_refresh", boom)
+        async with app.run_test():
+            ws = FakeWS([_req_frame("r1"), json.dumps({"type": "pong"})])
+            # Must not raise; the render error is logged + swallowed.
+            assert await app._pump(ws) is False
+
+
+class TestAppPing:
+    async def test_ping_loop_sends_ping(self):
+        app = _make_app(ping_interval=0.01)
+        ws = FakeWS([])
+        task = asyncio.create_task(app._ping_loop(ws))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert any('"ping"' in s for s in ws.sent)
+
+    async def test_ping_loop_stops_when_flag_set(self):
+        app = _make_app(ping_interval=0.01)
+        app._stop = True
+        ws = FakeWS([])
+        await asyncio.wait_for(app._ping_loop(ws), timeout=0.5)
+        assert ws.sent == []  # returned before sending
+
+    async def test_ping_loop_swallows_socket_error(self):
+        # A socket close mid-send (ConnectionClosed) returns cleanly so the
+        # task has no unobserved exception (#2320 review #5).
+        app = _make_app(ping_interval=0.01)
+
+        class DeadSend:
+            sent = []
+
+            async def send(self, d):
+                raise websockets.ConnectionClosed(None, None)
+
+        await asyncio.wait_for(app._ping_loop(DeadSend()), timeout=0.5)
+
+
+class TestAppBackoff:
+    def test_backoff_progresses_then_caps(self):
+        app = _make_app(reconnect_delays=(1.0, 2.0, 5.0))
+        assert app._backoff(1) == 1.0
+        assert app._backoff(2) == 2.0
+        assert app._backoff(3) == 5.0
+        assert app._backoff(99) == 5.0  # clamped
+
+    def test_backoff_empty_delays(self):
+        app = _make_app(reconnect_delays=())
+        assert app._backoff(1) == 0.0
+
+
+class TestAppActions:
+    async def test_action_allow_sends_verdict(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            lv = app.query_one("#requests", ListView)
+            lv.index = 0
+            await pilot.pause()
+            app.action_allow()
+            await pilot.pause()
+            assert any('"allowed"' in s and '"r1"' in s for s in ws.sent)
+
+    async def test_action_deny_sends_verdict(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0
+            await pilot.pause()
+            app.action_deny()
+            await pilot.pause()
+            assert any('"denied"' in s for s in ws.sent)
+
+    async def test_action_with_no_focus_sends_nothing(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.action_allow()
+            await pilot.pause()
+            assert ws.sent == []
+
+    async def test_action_while_disconnected_sends_nothing(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0
+            await pilot.pause()
+            # app._ws is None (disconnected)
+            app.action_allow()
+            await pilot.pause()
+
+    async def test_send_failure_flashes(self):
+        # A dropped socket between the ws check and the send surfaces a flash
+        # rather than silently losing the verdict (#2320 review #2).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([], send_fail=True)
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0
+            await pilot.pause()
+            app.action_allow()
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "verdict send failed" in str(status.content)
+
+
+class TestWsLoop:
+    async def test_reconnect_after_drop(self, monkeypatch):
+        calls = {"n": 0}
+
+        def fake_connect(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionError("down")
+            return FakeCM(FakeWS([]))  # connect ok, then stream ends
+
+        monkeypatch.setattr(tui_consent, "ws_connect", fake_connect)
+        app = _make_app(reconnect_delays=(0.0,))
+        task = asyncio.create_task(_real_ws_loop(app))
+        await asyncio.sleep(0.1)
+        app._stop = True
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert calls["n"] >= 2  # failed once, then reconnected
+
+    async def test_connect_exception_logs_and_retries(self, monkeypatch):
+        # ws_connect always raises: the loop keeps retrying (never crashes).
+        def always_fail(*a, **kw):
+            raise OSError("refused")
+
+        monkeypatch.setattr(tui_consent, "ws_connect", always_fail)
+        app = _make_app(reconnect_delays=(0.0,))
+        task = asyncio.create_task(_real_ws_loop(app))
+        await asyncio.sleep(0.1)
+        app._stop = True
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert app._connected is False
+
+    async def test_refreshes_token_on_auth_close(self, monkeypatch):
+        # A 4002 (expired token) close refreshes the JWT before reconnecting
+        # (#2320 review #3), so the tool self-heals past JWT expiry instead of
+        # spinning on a dead token.
+        exc = websockets.ConnectionClosed(
+            websockets.frames.Close(4002, "Token expired"), None
+        )
+        monkeypatch.setattr(
+            tui_consent,
+            "ws_connect",
+            lambda *a, **k: FakeCM(FakeWS([], close_exc=exc)),
+        )
+        app = _make_app(reconnect_delays=(0.0,))
+
+        async def fake_refresh():
+            return "new-token"
+
+        monkeypatch.setattr(app, "_refresh_token", fake_refresh)
+        task = asyncio.create_task(_real_ws_loop(app))
+        await asyncio.sleep(0.1)
+        app._stop = True
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert app.token == "new-token"
+
+    async def test_refresh_token_success(self, monkeypatch):
+        app = _make_app()
+        monkeypatch.setattr(
+            tui_consent, "refresh_token", lambda url, tok: "fresh"
+        )
+        assert await app._refresh_token() == "fresh"
+
+    async def test_refresh_token_failure_is_swallowed(self, monkeypatch):
+        app = _make_app()
+
+        def boom(url, tok):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(tui_consent, "refresh_token", boom)
+        assert await app._refresh_token() is None
+
+    async def test_breaks_on_stop_mid_stream(self, monkeypatch):
+        # _stop set while the pump is parked in a read: the loop exits via
+        # the early `if self._stop: break` (no reconnect, no cancel needed).
+        done = asyncio.Event()
+
+        class SlowWS:
+            sent = []
+
+            async def recv(self):
+                if done.is_set():
+                    raise websockets.ConnectionClosed(None, None)
+                await asyncio.sleep(0.01)
+
+            async def send(self, d):
+                self.sent.append(d)
+
+        ws = SlowWS()
+        monkeypatch.setattr(
+            tui_consent, "ws_connect", lambda *a, **k: FakeCM(ws)
+        )
+        app = _make_app(reconnect_delays=(0.0,))
+        task = asyncio.create_task(_real_ws_loop(app))
+        await asyncio.sleep(0.05)  # connected, pumping
+        app._stop = True
+        done.set()  # release the read -> pump ends -> early break
+        await asyncio.wait_for(task, timeout=1.0)
+        assert task.done()

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+import types
 
 import pytest
 import websockets
@@ -563,6 +564,39 @@ class TestAppActions:
             await pilot.pause()
             status = app.query_one("#status", Static)
             assert "verdict send failed" in str(status.content)
+
+    async def test_allow_button_decides_focused(self):
+        # The Allow button mirrors the `a` key: a click decides the focused row.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0
+            await pilot.pause()
+            app.on_button_pressed(
+                types.SimpleNamespace(button=types.SimpleNamespace(id="allow"))
+            )
+            await pilot.pause()
+            assert any('"allowed"' in s and '"r1"' in s for s in ws.sent)
+
+    async def test_deny_button_decides_focused(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0
+            await pilot.pause()
+            app.on_button_pressed(
+                types.SimpleNamespace(button=types.SimpleNamespace(id="deny"))
+            )
+            await pilot.pause()
+            assert any('"denied"' in s for s in ws.sent)
 
 
 class TestWsLoop:

--- a/src/klangk/klangkc-tests/tests/test_transport.py
+++ b/src/klangk/klangkc-tests/tests/test_transport.py
@@ -34,6 +34,7 @@ class TestResolveTransport:
             uds_path=None,
             base_url="http://localhost:8995",
             ws_uri="ws://localhost:8995/ws",
+            ws_base="ws://localhost:8995",
             server_spec="http://localhost:8995",
         )
 
@@ -44,6 +45,7 @@ class TestResolveTransport:
             uds_path=None,
             base_url="https://example.com",
             ws_uri="wss://example.com/ws",
+            ws_base="wss://example.com",
             server_spec="https://example.com",
         )
 
@@ -54,6 +56,7 @@ class TestResolveTransport:
             uds_path="/tmp/klangk.sock",
             base_url="http://localhost",
             ws_uri="ws://localhost/ws",
+            ws_base="ws://localhost",
             server_spec="/tmp/klangk.sock",
         )
 
@@ -199,6 +202,78 @@ class TestWsConnect:
             "ws://localhost/ws?token=tok", sock=mock_sock, max_size=2048
         )
         mock_sock.close.assert_called_once()
+
+    async def test_tcp_with_path_and_query(self):
+        mock_ws = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "klangk.cli.transport.websockets.connect", return_value=mock_cm
+        ) as mock_connect:
+            async with ws_connect(
+                "http://localhost:8995",
+                token="tok",
+                path="/ws/consent-decider",
+                query={"workspace": "wsid"},
+            ) as ws:
+                assert ws is mock_ws
+
+        mock_connect.assert_called_once_with(
+            "ws://localhost:8995/ws/consent-decider?workspace=wsid&token=tok"
+        )
+
+    async def test_uds_with_path_and_query(self):
+        mock_ws = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_sock = MagicMock()
+
+        with (
+            patch(
+                "klangk.cli.transport.websockets.connect", return_value=mock_cm
+            ) as mock_connect,
+            patch(
+                "klangk.cli.transport._socket.socket", return_value=mock_sock
+            ),
+        ):
+            async with ws_connect(
+                "/tmp/klangk.sock",
+                token="tok",
+                path="/ws/consent-decider",
+                query={"workspace": "wsid"},
+            ) as ws:
+                assert ws is mock_ws
+
+        mock_connect.assert_called_once_with(
+            "ws://localhost/ws/consent-decider?workspace=wsid&token=tok",
+            sock=mock_sock,
+        )
+
+    async def test_token_wins_over_query_footgun(self):
+        # A caller passing query={"token": ...} must NOT clobber the auth token
+        # (#2320 review #6).
+        mock_ws = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "klangk.cli.transport.websockets.connect", return_value=mock_cm
+        ) as mock_connect:
+            async with ws_connect(
+                "http://localhost:8995",
+                token="real-token",
+                query={"token": "evil", "workspace": "wsid"},
+            ) as ws:
+                assert ws is mock_ws
+
+        uri = mock_connect.call_args.args[0]
+        assert "token=real-token" in uri
+        assert "token=evil" not in uri
+        assert "workspace=wsid" in uri
 
     async def test_uds_closes_socket_on_error(self):
         mock_sock = MagicMock()

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -352,7 +352,7 @@ class TestConsentDeciderWS:
         )
         await handle_consent_decider(ws, app)
         app.state.consent_coordinator.resolve.assert_awaited_once_with(
-            "rid", "allowed", "once", "decider@x", decider_workspace=WS
+            "rid", "allowed", "once", "u1", decider_workspace=WS
         )
 
     async def test_verdict_invalid_decision_sends_error(self):

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -314,6 +314,23 @@ async def test_expire_pending(ec, ws, user):
     assert got["decided_by"] is None  # auto-expired, no user
 
 
+async def test_expire_all_pending_reaps_only_pending(ec, ws, user):
+    """Startup reaping: every still-pending row is an orphan (its in-memory
+    hold died with the prior process), so expire them so the decider snapshot
+    doesn't replay stale requests. Already-decided rows are left untouched.
+    """
+    w1 = await ws.create_workspace(user["id"], "reap1")
+    w2 = await ws.create_workspace(user["id"], "reap2")
+    p1 = await ec.create_request(w1["id"], "a.com", 443)
+    p2 = await ec.create_request(w2["id"], "b.com", 80)
+    decided = await ec.create_request(w1["id"], "c.com", 443)
+    await ec.decide(decided["id"], DECISION_DENIED, SCOPE_ONCE, user["id"])
+    assert await ec.expire_all_pending() == 2
+    assert (await ec.get_request(p1["id"]))["decision"] == DECISION_EXPIRED
+    assert (await ec.get_request(p2["id"]))["decision"] == DECISION_EXPIRED
+    assert (await ec.get_request(decided["id"]))["decision"] == DECISION_DENIED
+
+
 async def test_expire_distinct_from_deny(ec, ws, user):
     """Expired and denied are distinguishable in the audit trail."""
     w = await ws.create_workspace(user["id"], "exp-vs-deny")

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -14,8 +14,8 @@ from klangk.model.egress_consent import (
     SCOPE_WORKSPACE,
 )
 from klangk.model.workspaces import (
+    EGRESS_MODE_DEFAULT,
     EGRESS_MODE_INTERACTIVE,
-    EGRESS_MODE_STATIC,
 )
 
 
@@ -35,7 +35,7 @@ async def ws(app_state, db):
 
 async def test_workspace_default_egress_mode(ws, user):
     row = await ws.create_workspace(user["id"], "default-mode")
-    assert row["egress_mode"] == EGRESS_MODE_STATIC
+    assert row["egress_mode"] == EGRESS_MODE_DEFAULT
 
 
 async def test_workspace_create_interactive_mode(ws, user):
@@ -61,7 +61,7 @@ async def test_workspace_create_with_acl_invalid_egress_mode(ws, user):
 
 async def test_workspace_update_egress_mode(ws, user):
     row = await ws.create_workspace(user["id"], "update-mode")
-    assert row["egress_mode"] == EGRESS_MODE_STATIC
+    assert row["egress_mode"] == EGRESS_MODE_DEFAULT
     updated = await ws.update_workspace(
         row["id"], user["id"], egress_mode=EGRESS_MODE_INTERACTIVE
     )


### PR DESCRIPTION
## Summary

Implements **#2310** — the live `consent-decide` client for **synchronous** egress-consent blocking. Builds on the now-merged synchronous-hold backend (#2311, #2244).

`klangk consent-decide <workspace>` connects to the workspace's consent-decider WS stream (#2244), shows its **held** egress requests (blocked destinations the network sidecar is holding for a verdict, #2311) with a live countdown to auto-deny, and lets the deciding user accept/deny each one **while it is held**. Accepting lets that exact connection proceed; denying (or the countdown hitting zero) fails it.

This is the **first consumer** of #2244's events — without it, those events are just after-the-fact notification (the DB-poll path already does that). The point is deciding a connection *while it's held*, in real time.

## Flow

1. Connects to `/ws/consent-decider?token=...&workspace=<id>`; receives the pending snapshot on connect, then live `egress_request` events.
2. Each event is a **held** connection (#2319 is holding it). The TUI shows it with a countdown to auto-expire.
3. `a` = allow (once) / `d` = deny → the verdict goes back; klangkd relays it to the sidecar → the held connection proceeds (allow) or fails (deny/timeout).

## Design

- **`ConsentDeciderController`** (pure, no Textual) owns the protocol state machine — frame parsing (`egress_request`/`egress_resolved`/`pong`/`error`), the pending-request map, the verdict/ping frame builders, and the countdown math. Fully unit-tested without the TUI harness.
- **`ConsentDeciderApp`** (Textual) is a thin view over it: a WS worker (connect → ping → read → reconnect with backoff), a 1s countdown refresh, and `a`/`d`/`q` keybindings.
- **Fail-closed throughout**: the client pings every 15s to stay registered (must beat the server's `consent_decider_timeout` = 45s, else the workspace reverts to static allow-list); on a dropped connection it deregisters and reconnects with backoff, **refreshing the JWT on an auth close (4001/4002)** so the tool self-heals past token expiry instead of spinning on a dead token; while disconnected in-flight holds auto-deny on their own timeout — never silently allowed.

## Plumbing

- **Transport** (`cli/transport.py`): `ws_connect` gains optional `path="/ws"` + `query={}` so the client can hit `/ws/consent-decider?…&workspace=`. `ServerTransport` gains a `ws_base` field (scheme://host[:port]) the URI is built from. Backward-compatible (existing `/ws` callers unaffected).
- **Command** (`consent-decide`): resolves the workspace arg by **name or id** (owned or shared) and requires login; the terminal-access check is enforced server-side by #2244's authz.
- CLI isolation respected: the decision/scope constants and frame shapes are duplicated here (the client can't import the server package).

## Verification

- New tests: controller (frame parsing, ordering, countdown, all error/ignore paths, **epoch-clock regression**), frame builders, app render/pump/ping/backoff/reconnect/key-actions, **token refresh on auth close**, **verdict send-failure feedback**, **render-error isolation**, transport path+query (TCP & UDS, **token-wins footgun**), and command wiring (name/id/shared resolution, `--hold-timeout`, not-found exit 1).
- An adversarial `/review` was run; all findings addressed: the headline bug (countdown mixed `time.monotonic` with the server's `time.time` epoch stamps, showing ~1.7e9s), silent verdict-loss on send failure, missing token refresh, render-bug triggering a reconnect loop, unobserved ping-task exceptions, and the transport `query` token-clobber footgun.
- Full suite (both packages, `-n auto`): **4577 passed, 100% coverage**.

## Scope

v1 sends `scope=once` (allow/deny this one connection). The server's verdict handler already supports `once`/`workspace`/`deploy`; a scope selector (e.g. allow workspace-wide, persisting to the allow-list) is a natural follow-up but is not in this PR.
