### PR TITLE
fix(consent): proxy egress-sidecar WS on the egress site (#2319 regression)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -518,6 +518,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Egress-sidecar WebSocket on the egress port (#2319).** The network
+  sidecar's held-egress WS (`/ws/egress-sidecar`) was never added as an
+  explicit handle on the container-egress Caddy site, so every sidecar WS
+  upgrade fell through to the catch-all `StaticFiles` (which asserts
+  `scope["type"] == "http"`) and failed with HTTP 500. The egress site now
+  reverse-proxies that WS to the app, and the sidecar sends its workspace JWT
+  as an `Authorization: Bearer` header (matching the site's `forward_auth`
+  and the legacy consent POST) instead of a `?token=` query param.
+
 - **Sidecar token file retention (#2309).** A periodic sweep now removes
   leftover per-workspace token files under `data_dir/ws-tokens/` once the
   workspace row is gone, so they no longer accumulate one file per workspace

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -556,10 +556,13 @@ class SidecarConsentClient:
                     self._no_token_warned = True
                 await asyncio.sleep(1.0)
                 continue
-            url = f"{self._url}?token={token}"
             try:
                 async with websockets.connect(
-                    url, ping_interval=20, ping_timeout=10, close_timeout=5
+                    self._url,
+                    ping_interval=20,
+                    ping_timeout=10,
+                    close_timeout=5,
+                    additional_headers={"Authorization": "Bearer " + token},
                 ) as ws:
                     self._ws = ws
                     self._connected.set()
@@ -570,10 +573,11 @@ class SidecarConsentClient:
                     async for raw in ws:
                         self._dispatch(raw)
             except Exception as exc:
-                # Log the exception TYPE only -- the URL carries the workspace
-                # JWT as ?token=, and a websockets exception could embed it
-                # (#2309). The websockets package logger is capped at WARNING
-                # on import so its DEBUG request-line can't leak either.
+                # Log the exception TYPE only -- the connection carries the
+                # workspace JWT (Authorization header), and a websockets
+                # exception could embed request details (#2309). The websockets
+                # package logger is capped at WARNING on import so its DEBUG
+                # request-line can't leak either.
                 if DEBUG:
                     print(
                         f"consent: connection error: {type(exc).__name__}",

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -540,7 +540,25 @@ class CaddyRenderer:
             f"		reverse_proxy {upstream}\n"
             "	}\n"
         )
-        return not_src_matcher + consent + llm + delegate + post_chat
+        # #2319: the sidecar's egress-sidecar WebSocket (held-egress verdicts).
+        # Same protection as the consent POST above: the site-level
+        # forward_auth validates the sidecar's workspace JWT, then this handle
+        # proxies the WS upgrade to the app. The sidecar sends the JWT as an
+        # ``Authorization: Bearer`` header (not a query param) so forward_auth
+        # sees it; ``flush_interval -1`` avoids buffering the bidirectional
+        # verdict stream.
+        egress_ws = (
+            "	handle /ws/egress-sidecar {\n"
+            f"{guard}"
+            f"		reverse_proxy {upstream} {{\n"
+            f"{self._common_rp_headers()}\n"
+            "			flush_interval -1\n"
+            "		}\n"
+            "	}\n"
+        )
+        return (
+            not_src_matcher + consent + egress_ws + llm + delegate + post_chat
+        )
 
     def _egress_site(self, upstream: str, container_srcs: str) -> str:
         """The full container-egress site block (headless + full both render it)."""

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -36,7 +36,13 @@ logger = logging.getLogger(__name__)
 
 async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
     """Receive blocked-egress events from the sidecar; relay verdicts back."""
-    token = websocket.query_params.get("token")
+    # forward_auth validated the workspace JWT from the Authorization header
+    # on the egress site; re-read it here for the workspace id. The ?token=
+    # query-param fallback covers the ingress path and handler-level tests.
+    authorization = websocket.headers.get("authorization", "")
+    token = authorization[7:] if authorization.startswith("Bearer ") else None
+    if not token:
+        token = websocket.query_params.get("token")
     if not token:
         await websocket.close(code=4001, reason="Missing token")
         return

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -523,6 +523,19 @@ class TestRenderConfig:
         assert "respond @notContainerSrc 403" in locs
         assert "reverse_proxy upstream" in locs
 
+    def test_egress_proxies_sidecar_ws(self):
+        # #2319: the sidecar's egress-sidecar WebSocket has an explicit handle
+        # on the egress site so its WS upgrade is reverse-proxied to the app
+        # (+ container-src-guarded) instead of falling through to the catch-all
+        # StaticFiles (which asserts scope["type"]=="http" -> 500).
+        s = make_settings(env={"KLANGKD_EGRESS_PORT": "8995"})
+        locs = _renderer(s)._egress_locations("upstream", "10.0.0.0/8")
+        assert "handle /ws/egress-sidecar" in locs
+        assert (
+            "flush_interval -1" in locs
+        )  # unbuffered bidirectional verdict stream
+        assert "reverse_proxy upstream" in locs
+
     def test_headless_has_only_egress(self):
         s = make_settings(env={"KLANGKD_EGRESS_PORT": "8995"})
         cf = _renderer(s).render_config("unix//sock", self.ADMIN)

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -399,8 +399,9 @@ class _FakeWS:
     mirroring the real sidecar's send-then-wait-for-verdict ordering.
     """
 
-    def __init__(self, params: dict):
+    def __init__(self, params: dict, headers: dict | None = None):
         self.query_params = params
+        self.headers = headers or {}
         self._incoming: asyncio.Queue = asyncio.Queue()
         self.sent: list[str] = []
         self.accepted = False
@@ -451,6 +452,33 @@ class TestEgressSidecarWS:
         await handle_egress_sidecar(ws, app)
         assert ws.closed == (4001, "Missing token")
         assert ws.accepted is False
+
+    async def test_authorization_header_token_accepted(self):
+        # egress path (#2319): the JWT rides in the Authorization header (the
+        # sidecar sends `Bearer <jwt>` so the egress site's forward_auth sees
+        # it), not the ?token= query param. Both paths must authenticate.
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, coord = _sidecar_app()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        fut.set_result({"decision": "deny", "reason": "static"})
+        coord.hold = AsyncMock(return_value=fut)
+        ws = _FakeWS({}, headers={"authorization": "Bearer hdr-tok"})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(
+            json.dumps(
+                {
+                    "type": "egress",
+                    "id": "loc1",
+                    "dst": "1.2.3.4",
+                    "dport": 443,
+                }
+            )
+        )
+        await asyncio.sleep(0.05)
+        coord.hold.assert_awaited_once_with(FULL_WS, "1.2.3.4", 443)
+        await ws.feed(WebSocketDisconnect())
+        await handler
 
     async def test_invalid_token_rejected(self):
         from klangk.wshandler.sidecar import handle_egress_sidecar


### PR DESCRIPTION
## What

Fixes the storm of `Exception in ASGI application / staticfiles.py: assert
scope["type"] == "http"` errors seen whenever a consent-filtered workspace
(and its network sidecar) is running. **A #2319 regression.**

## Root cause

#2319 moved the sidecar from a fire-and-forget HTTP POST to a synchronous
WebSocket on `/ws/egress-sidecar`. But the container-**egress** Caddy site
"only reverse-proxies its explicit handles" — it had the legacy
`/internal/egress-consent/events` POST handle but **no `handle /ws/egress-sidecar`**.
So every sidecar WS upgrade fell through to the catch-all `StaticFiles`,
which asserts `scope["type"] == "http"` → HTTP 500. (The browser terminal
`/ws` on ingress was never affected — only the sidecar on the egress port.)

Confirmed empirically: `/ws/egress-sidecar` on `:8995` → 500 (StaticFiles),
on `:8997` → 403 (route). The reconnect loop turned it into a continuous
storm.

A second gap, found while fixing it: the egress site's `forward_auth`
validates the workspace JWT from the **`Authorization` header** (like the
legacy consent POST), but #2319's sidecar sent it as a `?token=` query param
— so even with the handle added, `forward_auth` would have rejected it.

## Fix

- **`caddy.py`** — add `handle /ws/egress-sidecar` to `_egress_locations`
  (reverse_proxy to the app + the `@notContainerSrc` guard,
  `flush_interval -1` for the unbuffered verdict stream), mirroring the
  existing consent-POST handle.
- **`proxy.py`** — send the workspace JWT as an `Authorization: Bearer` header
  (`additional_headers`), not `?token=`, so the egress `forward_auth` sees it.
- **`wshandler/sidecar.py`** — read the `Authorization` header (fallback to
  `?token=` for the ingress path / handler tests).

## Test plan

- [x] `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 4521 passed, 100%.
- [x] `test_caddy.py::test_egress_proxies_sidecar_ws` — asserts the new handle
      + `flush_interval -1` render in the egress locations.
- [x] `test_consent_coordinator.py::test_authorization_header_token_accepted`
      — the handler authenticates a header-only (`Bearer`) token.
- [ ] Manual: a consent-filtered workspace's sidecar connects without the
      staticfiles 500s (the storm stops); a held request reaches a decider.
