### PR TITLE
feat(consent): gate egress consent at the connection SYN, not DNS (#2324)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -105,9 +105,11 @@ operators or integrators to act when upgrading.
   sidecar holds a non-allow-listed connection's SYN (NFQUEUE) pending the
   consent verdict instead of the DNS query: a denied name now _resolves_ (the
   workspace gets the IP) and the first packet to that IP is queued -- `allow`
-  learns the IP + lets it proceed, `deny`/timeout/WS-down fail-closes (a static
-  workspace or an unreachable klangkd behaves exactly as before; no new latency,
-  no hang). Gating the SYN gives the human the kernel's connect timeout
+  learns the IP + lets it proceed, `deny`/timeout/WS-down fail-closes -- a
+  denied connection gets a RST via a temporary REJECT (tcp-reset) rule so it
+  fails at once (ECONNREFUSED), not after tcp_syn_retries ~127s (a static
+  workspace or an unreachable klangkd behaves exactly as before; no hang).
+  Gating the SYN gives the human the kernel's connect timeout
   (`tcp_syn_retries` ~127s) instead of a DNS resolver's <=30s `getaddrinfo`
   cap. `KLANGKD_EGRESS_CONSENT_TIMEOUT` and `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT`
   defaults rise 30 -> 120s to use that window; SYN retransmits reuse the cached

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -101,18 +101,21 @@ operators or integrators to act when upgrading.
   deploy-wide decider needs admin (else the socket is closed `4003 Forbidden`),
   and a verdict is honored only for the decider's own workspace. The first
   consumer is the `consent-decide` client (#2310).
-- **Sidecar kernel-level egress hold (#2311).** The network sidecar now
-  _holds_ a denied connection in-flight pending the consent verdict (DNS:
-  suspends the query; NFQUEUE: defers the packet) instead of NXDOMAIN/DROP-ing
-  at once -- `allow` lets it proceed, `deny`/timeout/WS-down fail-closes
-  (a static workspace or an unreachable klangkd behaves exactly as before; no
-  new latency, no hang). New sidecar config: `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT`
-  (default 30s), `KLANGKNETWORK_EGRESS_HOLD_LIMIT` (default 32 concurrent
-  holds; a flood past it fail-closes to NXDOMAIN). The proxy is now asyncio
-  (one task per denied query so holds never block the receive loop) and the
-  sidecar image gains the `websockets` dependency; the legacy fire-and-forget
-  POST endpoint is superseded (recording now happens on the WS hold path,
-  removal tracked in #2318).
+- **Sidecar consent gates the connection SYN (#2311, #2324).** The network
+  sidecar holds a non-allow-listed connection's SYN (NFQUEUE) pending the
+  consent verdict instead of the DNS query: a denied name now _resolves_ (the
+  workspace gets the IP) and the first packet to that IP is queued -- `allow`
+  learns the IP + lets it proceed, `deny`/timeout/WS-down fail-closes (a static
+  workspace or an unreachable klangkd behaves exactly as before; no new latency,
+  no hang). Gating the SYN gives the human the kernel's connect timeout
+  (`tcp_syn_retries` ~127s) instead of a DNS resolver's <=30s `getaddrinfo`
+  cap. `KLANGKD_EGRESS_CONSENT_TIMEOUT` and `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT`
+  defaults rise 30 -> 120s to use that window; SYN retransmits reuse the cached
+  verdict so they don't each re-prompt. `KLANGKNETWORK_EGRESS_HOLD_LIMIT` is
+  removed (the DNS-path hold bound; the SYN path is bounded by the iptables
+  rate-limit). The proxy is asyncio + the sidecar image gains the `websockets`
+  dependency; the legacy fire-and-forget POST endpoint is superseded (recording
+  happens on the WS path, removal tracked in #2318).
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -113,9 +113,12 @@ operators or integrators to act when upgrading.
   (`tcp_syn_retries` ~127s) instead of a DNS resolver's <=30s `getaddrinfo`
   cap. `KLANGKD_EGRESS_CONSENT_TIMEOUT` and `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT`
   defaults rise 30 -> 120s to use that window; SYN retransmits reuse the cached
-  verdict so they don't each re-prompt. `KLANGKNETWORK_EGRESS_HOLD_LIMIT` is
-  removed (the DNS-path hold bound; the SYN path is bounded by the iptables
-  rate-limit). The proxy is asyncio + the sidecar image gains the `websockets`
+  verdict so they don't each re-prompt. New sidecar config:
+  `KLANGKNETWORK_EGRESS_VERDICT_CACHE_TTL` (how long to reuse a SYN verdict,
+  default 120s) and `KLANGKNETWORK_EGRESS_REJECT_TTL` (how long a deny keeps its
+  REJECT tcp-reset rule so the connection fails fast, default 10s).
+  `KLANGKNETWORK_EGRESS_HOLD_LIMIT` is removed (the DNS-path hold bound; the SYN
+  path is bounded by the iptables rate-limit). The proxy is asyncio + the sidecar image gains the `websockets`
   dependency; the legacy fire-and-forget POST endpoint is superseded (recording
   happens on the WS path, removal tracked in #2318).
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -88,7 +88,9 @@ esac
 # not the DNS query: non-allow-listed names resolve (the workspace gets the IP),
 # and the first packet to that IP is queued here pending a verdict (allow ->
 # pkt.accept() + learn the IP, then conntrack's ESTABLISHED,RELATED rule passes
-# the rest; deny/timeout/WS-down -> pkt.drop()); klangkd records the decision.
+# the rest; deny/timeout/WS-down -> pkt.drop() + a temporary REJECT
+# (tcp-reset) rule so the retransmit fails connect() at once (ECONNREFUSED), not
+# after tcp_syn_retries ~127s); klangkd records the decision.
 # Gating the SYN (not the DNS query) gives the human the kernel's connect
 # timeout (~127s) instead of a DNS resolver's <=30s getaddrinfo cap. The sidecar
 # is the netns owner with NET_ADMIN, so it reads its own NFQUEUE -- no host-side

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -82,18 +82,20 @@ case "${KLANGKNETWORK_EGRESS_BACKEND_PORT:-}" in
   ;;
 esac
 
-# --- egress consent hold (#2242 recording -> #2311 half B hold): queue
-# blocked packets to the sidecar's own NFQUEUE consumer (proxy.py) whenever a
-# consent endpoint is configured. The consumer holds each packet pending a
-# verdict (allow -> pkt.accept(), then conntrack's ESTABLISHED,RELATED rule
-# passes the rest of the connection; deny/timeout/WS-down -> pkt.drop());
-# klangkd records the decision. The sidecar is the netns owner with NET_ADMIN,
-# so it reads its own NFQUEUE -- no host-side /dev/kmsg access or new privilege.
-# Fail-closed: a down consumer means the kernel drops queued packets; unmatched
-# traffic hits the OUTPUT DROP policy. Rate-limited so a flooding workspace can't
-# overwhelm the consumer; packets past the limit miss the match and fall through
-# to DROP (denied). Denied DNS queries are also held by the proxy (by domain) --
-# NFQUEUE only carries raw IPs.
+# --- egress consent gate (#2242 recording -> #2311 half B -> #2324 SYN gate):
+# queue blocked packets to the sidecar's own NFQUEUE consumer (proxy.py)
+# whenever a consent endpoint is configured. Consent gates the connection SYN,
+# not the DNS query: non-allow-listed names resolve (the workspace gets the IP),
+# and the first packet to that IP is queued here pending a verdict (allow ->
+# pkt.accept() + learn the IP, then conntrack's ESTABLISHED,RELATED rule passes
+# the rest; deny/timeout/WS-down -> pkt.drop()); klangkd records the decision.
+# Gating the SYN (not the DNS query) gives the human the kernel's connect
+# timeout (~127s) instead of a DNS resolver's <=30s getaddrinfo cap. The sidecar
+# is the netns owner with NET_ADMIN, so it reads its own NFQUEUE -- no host-side
+# /dev/kmsg access or new privilege. Fail-closed: a down consumer means the
+# kernel drops queued packets; unmatched traffic hits the OUTPUT DROP policy.
+# Rate-limited so a flooding workspace can't overwhelm the consumer; packets
+# past the limit miss the match and fall through to DROP (denied).
 if [ -n "${KLANGKNETWORK_EGRESS_CONSENT_URL:-}" ]; then
   $IPT -A OUTPUT -m limit --limit 5/sec --limit-burst 20 \
     -j NFQUEUE --queue-num "${KLANGKNETWORK_EGRESS_NFQUEUE_NUM:-5139}"

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -182,8 +182,8 @@ SPECS = parse_specs()
 # NFQUEUE (#2324). Guarded by _LOCK: the asyncio loop runs the iptables installs
 # + sweeps in the default thread-pool executor (see _learn_all / _async_sweeper),
 # so two worker threads can touch _LEARNED at once; the lock serializes the
-# rule+record mutations. The NFQUEUE consumer reads ``host`` without the lock
-# (GIL-atomic; set by the DNS loop before the SYN arrives).
+# rule+record mutations. The NFQUEUE consumer reads ``host`` via _host_for
+# (under the lock; the host is set by the DNS loop before the SYN arrives).
 _LEARNED: dict[str, dict] = {}
 _LOCK = threading.Lock()
 # Reused SYN verdicts: {(ip, port): (verdict, expire)} so the kernel's SYN
@@ -324,6 +324,17 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
             rec["expire"] = max(rec["expire"], expire)
             rec["ports"].add(port)
             # ``host`` (set by _record_hosts) is preserved across re-learn.
+        # An all-ports allow (the consent path) supersedes any prior per-port
+        # denies for this IP -- otherwise the all-ports ACCEPT at the top of
+        # OUTPUT would silently shadow a lingering REJECT (the decider allowed
+        # the host, so a prior port-specific deny no longer applies).
+        if port is None:
+            for key in [k for k in _REJECTED if k[0] == ip]:
+                try:
+                    _remove_reject(*key)
+                except Exception:
+                    pass
+                del _REJECTED[key]
 
 
 def _reject_rule_args(ip: str, port: int) -> list[str]:

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -74,6 +74,10 @@ Configuration (env):
   KLANGKNETWORK_EGRESS_VERDICT_CACHE_TTL  seconds to reuse a SYN verdict for an
                             (ip, port) flow so the kernel's SYN retransmits
                             (tcp_syn_retries) don't each re-prompt (default 120).
+  KLANGKNETWORK_EGRESS_REJECT_TTL   seconds a deny keeps its REJECT (tcp-reset)
+                            rule so the denied connection fails fast
+                            (ECONNREFUSED) instead of waiting for tcp_syn_retries
+                            (~127s) (default 10).
 
 Limitations: transport is UDP only (TCP fallback is a future addition).
 """
@@ -128,6 +132,11 @@ HOLD_TIMEOUT = float(os.environ.get("KLANGKNETWORK_EGRESS_HOLD_TIMEOUT", "120"))
 VERDICT_CACHE_TTL = float(
     os.environ.get("KLANGKNETWORK_EGRESS_VERDICT_CACHE_TTL", "120")
 )
+# How long a deny keeps its REJECT (tcp-reset) rule so the denied connection
+# fails fast (ECONNREFUSED) instead of waiting for tcp_syn_retries (~127s).
+# Only needs to catch the SYN retransmit (~1 RTO); the verdict cache separately
+# keeps the deny from re-prompting for VERDICT_CACHE_TTL.
+CONSENT_REJECT_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_REJECT_TTL", "10"))
 # The workspace JWT (rotated) is bind-mounted here read-only; read fresh on each
 # (re)connect so rotation is picked up (#2242, #2311). Not baked in env because
 # the workspace token expires and rotates.
@@ -181,6 +190,11 @@ _LOCK = threading.Lock()
 # retransmits (tcp_syn_retries) don't each re-prompt. Single-threaded NFQUEUE
 # consumer -- no lock. Lazy-evicted on read.
 _VERDICT_CACHE: dict[tuple[str, int], tuple[str, float]] = {}
+# Temporary REJECT (tcp-reset) rules for denied connections: {(ip, port): expire}.
+# Swept by sweep_once alongside _LEARNED. Makes a deny fail-fast (ECONNREFUSED)
+# instead of waiting for tcp_syn_retries (~127s) -- dropping a SYN alone doesn't
+# fail connect(); the kernel just retransmits until its own timeout.
+_REJECTED: dict[tuple[str, int], float] = {}
 # Strong refs to background asyncio tasks (the TTL sweeper) so CPython doesn't
 # GC a sleeping task. A done-callback discards each entry on completion.
 _BG_TASKS: set[asyncio.Task] = set()
@@ -312,6 +326,65 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
             # ``host`` (set by _record_hosts) is preserved across re-learn.
 
 
+def _reject_rule_args(ip: str, port: int) -> list[str]:
+    """iptables OUTPUT rule args for REJECT (tcp-reset) to ``ip:port``."""
+    return [
+        "-d",
+        ip,
+        "-p",
+        "tcp",
+        "--dport",
+        str(port),
+        "-j",
+        "REJECT",
+        "--reject-with",
+        "tcp-reset",
+    ]
+
+
+def _reject_rule_exists(ip: str, port: int) -> bool:
+    return (
+        subprocess.run(
+            [IPT, "-C", "OUTPUT", *_reject_rule_args(ip, port)],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def _install_reject(ip: str, port: int) -> None:
+    """Insert the REJECT (tcp-reset) rule at the top of OUTPUT if not present."""
+    if _reject_rule_exists(ip, port):
+        return
+    subprocess.run(
+        [IPT, "-I", "OUTPUT", "1", *_reject_rule_args(ip, port)],
+        capture_output=True,
+    )
+
+
+def _remove_reject(ip: str, port: int) -> None:
+    """Delete the REJECT rule; swallow failure if it's already gone."""
+    subprocess.run(
+        [IPT, "-D", "OUTPUT", *_reject_rule_args(ip, port)],
+        capture_output=True,
+    )
+
+
+def reject(ip: str, port: int, ttl: float) -> None:
+    """Install a temporary REJECT (tcp-reset) for ``ip:port`` + set its TTL.
+
+    A denied SYN is dropped, but dropping a SYN doesn't fail ``connect()`` --
+    the kernel retransmits (tcp_syn_retries, ~127s) before timing out. The
+    REJECT rule makes the next retransmit get a RST, so ``connect()`` returns
+    ECONNREFUSED at once (eager deny). Like :func:`allow`, the install + the
+    ``_REJECTED`` record are atomic under :data:`_LOCK` w.r.t. :func:`sweep_once`.
+    """
+    expire = time.time() + ttl
+    with _LOCK:
+        _install_reject(ip, port)
+        _REJECTED[(ip, port)] = max(_REJECTED.get((ip, port), 0.0), expire)
+
+
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
     """Remove learned IPs whose TTL has elapsed; return ``(ip, ports)`` removed.
 
@@ -336,6 +409,13 @@ def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
                     pass  # a transient failure drops one rule, not the sweep
             del _LEARNED[ip]
             expired.append((ip, ports))
+        # also sweep temporary REJECT (tcp-reset) rules for denied connections
+        for key in [k for k, exp in _REJECTED.items() if exp <= now]:
+            try:
+                _remove_reject(*key)
+            except Exception:
+                pass
+            del _REJECTED[key]
     return expired
 
 
@@ -780,7 +860,9 @@ def _run_nfq_consumer(
     all-ports (reconnects + the rest of this connection's SYN retransmits pass
     without re-prompting) + ``pkt.accept()`` (conntrack ESTABLISHED,RELATED
     carries the in-flight connection); ``deny``/timeout/WS-down -> ``pkt.drop``
-    (fail-close). SYN retransmits (tcp_syn_retries) of a flow already decided
+    + a temporary REJECT (tcp-reset) rule so the next retransmit gets RST'd
+    (ECONNREFUSED) instead of the kernel retransmitting for ~127s. SYN retransmits
+    (tcp_syn_retries) of a flow already decided
     reuse the cached verdict so they don't each re-prompt. Blocking the callback
     serializes NFQUEUE; the kernel queue length + the iptables rate-limit in
     entrypoint.sh absorb bursts (overflows DROP). netfilterqueue is a sidecar-
@@ -825,6 +907,14 @@ def _run_nfq_consumer(
                 pass
             pkt.accept()
         else:
+            # Dropping a SYN doesn't fail connect() -- the kernel retransmits
+            # for tcp_syn_retries (~127s). Install a temporary REJECT (tcp-reset)
+            # so the next retransmit gets a RST -> ECONNREFUSED (eager deny).
+            if port:
+                try:
+                    reject(dst, port, CONSENT_REJECT_TTL)
+                except Exception:
+                    pass
             pkt.drop()
 
     try:

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -62,17 +62,18 @@ Configuration (env):
                             workspace needs to reach the IP it just resolved
                             (default 30).
   KLANGKNETWORK_EGRESS_CONSENT_URL  klangkd consent endpoint (HTTP). When set,
-                            the proxy opens the egress-sidecar WS + holds denied
-                            egress pending a verdict. Empty -> static
-                            NXDOMAIN/DROP (today's behavior; consent disabled).
+                            the proxy opens the egress-sidecar WS + gates
+                            non-allow-listed egress at the connection SYN
+                            (NFQUEUE) pending a verdict. Empty -> static
+                            NXDOMAIN/DROP (consent disabled).
   KLANGKNETWORK_EGRESS_HOLD_TIMEOUT  seconds to await a verdict before
-                            fail-closing to deny (default 30). Should be >=
-                            klangkd's consent hold timeout; a DNS resolver may
-                            give up first (~10s), in which case a slower verdict
-                            effectively denies the query.
-  KLANGKNETWORK_EGRESS_HOLD_LIMIT    max concurrent DNS-path holds in flight
-                            (default 32); a flood past this fail-closes to
-                            NXDOMAIN.
+                            fail-closing to deny (default 120). The gate is the
+                            connection SYN, so this can match the kernel's
+                            connect timeout (tcp_syn_retries ~= 127s), not a
+                            DNS resolver's <=30s getaddrinfo cap (#2324).
+  KLANGKNETWORK_EGRESS_VERDICT_CACHE_TTL  seconds to reuse a SYN verdict for an
+                            (ip, port) flow so the kernel's SYN retransmits
+                            (tcp_syn_retries) don't each re-prompt (default 120).
 
 Limitations: transport is UDP only (TCP fallback is a future addition).
 """
@@ -114,15 +115,19 @@ MIN_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_MIN_TTL", "30"))
 # the proxy holds denied egress pending a verdict over the egress-sidecar WS.
 QUEUE_NUM = int(os.environ.get("KLANGKNETWORK_EGRESS_NFQUEUE_NUM", "5139"))
 CONSENT_URL = os.environ.get("KLANGKNETWORK_EGRESS_CONSENT_URL", "")
-# How long to await a verdict before fail-closing to deny. Should be >= klangkd's
-# consent hold timeout so the sidecar is still waiting when the coordinator
-# expires the hold (and returns deny/expired).
-HOLD_TIMEOUT = float(os.environ.get("KLANGKNETWORK_EGRESS_HOLD_TIMEOUT", "30"))
-# Bounds concurrent DNS-path holds so a flooding workspace can't exhaust the
-# proxy (each hold occupies a task + a slot for up to HOLD_TIMEOUT). The NFQUEUE
-# path is bounded separately by the kernel queue length + the iptables
-# rate-limit in entrypoint.sh; overflows DROP (fail-close).
-HOLD_LIMIT = int(os.environ.get("KLANGKNETWORK_EGRESS_HOLD_LIMIT", "32"))
+# How long to await a verdict before fail-closing to deny. The consent gate is
+# the connection SYN (NFQUEUE), so this can match the kernel's connect timeout
+# (tcp_syn_retries ~= 127s) -- far longer than a DNS resolver's <=30s getaddrinfo
+# cap (#2324). Should be >= klangkd's consent hold timeout so the sidecar is
+# still waiting when the coordinator expires the hold (and returns deny/expired).
+HOLD_TIMEOUT = float(os.environ.get("KLANGKNETWORK_EGRESS_HOLD_TIMEOUT", "120"))
+# How long to reuse a SYN verdict for a (ip, port) flow. The kernel retransmits
+# a held SYN (tcp_syn_retries); without reuse each retransmit would re-prompt.
+# After an allow the IP is also learned (ACCEPT), so new SYNs stop hitting
+# NFQUEUE -- this only covers retransmits that queued during the hold.
+VERDICT_CACHE_TTL = float(
+    os.environ.get("KLANGKNETWORK_EGRESS_VERDICT_CACHE_TTL", "120")
+)
 # The workspace JWT (rotated) is bind-mounted here read-only; read fresh on each
 # (re)connect so rotation is picked up (#2242, #2311). Not baked in env because
 # the workspace token expires and rotates.
@@ -160,16 +165,24 @@ def parse_specs() -> list[tuple[str, int | None, bool]]:
 
 SPECS = parse_specs()
 
-# Learned IPs: {ip: {"expire": epoch, "ports": set[int | None]}}. A ``None``
-# in ``ports`` is the all-ports ACCEPT rule. Guarded by _LOCK because the
-# asyncio loop runs the iptables installs + sweeps in the default thread-pool
-# executor (see _learn_all / _async_sweeper), so two worker threads can touch
-# _LEARNED at once; the lock serializes the rule+record mutations.
+# Learned IPs: {ip: {"expire": epoch, "ports": set[int | None], "host": str}}.
+# ``ports`` holds the ACCEPT rule ports (a ``None`` is all-ports); ``host`` is
+# the DNS name that resolved to this IP (named in the consent request). An
+# entry can be host-only (ports empty, no ACCEPT) -- recorded when a
+# non-allow-listed name resolves so its connection SYN is consent-gated at
+# NFQUEUE (#2324). Guarded by _LOCK: the asyncio loop runs the iptables installs
+# + sweeps in the default thread-pool executor (see _learn_all / _async_sweeper),
+# so two worker threads can touch _LEARNED at once; the lock serializes the
+# rule+record mutations. The NFQUEUE consumer reads ``host`` without the lock
+# (GIL-atomic; set by the DNS loop before the SYN arrives).
 _LEARNED: dict[str, dict] = {}
 _LOCK = threading.Lock()
-# Strong refs to background asyncio tasks (DNS holds + the TTL sweeper) so
-# CPython doesn't GC a task that's awaiting a verdict / sleeping. A done-callback
-# discards each entry when its task completes.
+# Reused SYN verdicts: {(ip, port): (verdict, expire)} so the kernel's SYN
+# retransmits (tcp_syn_retries) don't each re-prompt. Single-threaded NFQUEUE
+# consumer -- no lock. Lazy-evicted on read.
+_VERDICT_CACHE: dict[tuple[str, int], tuple[str, float]] = {}
+# Strong refs to background asyncio tasks (the TTL sweeper) so CPython doesn't
+# GC a sleeping task. A done-callback discards each entry on completion.
 _BG_TASKS: set[asyncio.Task] = set()
 
 
@@ -292,10 +305,11 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
         _install(ip, port)
         rec = _LEARNED.get(ip)
         if rec is None:
-            _LEARNED[ip] = {"expire": expire, "ports": {port}}
+            _LEARNED[ip] = {"expire": expire, "ports": {port}, "host": None}
         else:
             rec["expire"] = max(rec["expire"], expire)
             rec["ports"].add(port)
+            # ``host`` (set by _record_hosts) is preserved across re-learn.
 
 
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
@@ -368,6 +382,34 @@ def _learn_all(recs: list[tuple[str, int]], ports: set[int | None]) -> None:
     for ip, ttl in recs:
         for port in ports:
             allow(ip, port, ttl)
+
+
+def _record_hosts(recs: list[tuple[str, int]], host: str) -> None:
+    """Record IP->host in _LEARNED WITHOUT installing an ACCEPT rule (#2324).
+
+    A non-allow-listed name resolves (the workspace gets the IP + can SYN) but
+    its connection is consent-gated at the SYN (NFQUEUE), so the IP must NOT be
+    allow-learned here. Recording host lets the NFQUEUE consumer name the host
+    in the consent request. Sync; runs in the executor alongside allow/sweep
+    (under _LOCK). The TTL refreshes on each resolve so a re-resolution extends
+    the window in which a SYN names the right host.
+    """
+    now = time.time()
+    with _LOCK:
+        for ip, ttl in recs:
+            expire = now + max(ttl, MIN_TTL)
+            rec = _LEARNED.get(ip)
+            if rec is None:
+                _LEARNED[ip] = {"expire": expire, "ports": set(), "host": host}
+            else:
+                rec["expire"] = max(rec["expire"], expire)
+                rec["host"] = host  # latest name that resolved to this IP
+
+
+def _host_for(ip: str) -> str:
+    """The DNS name that resolved to ``ip``, or ``ip`` itself (direct-IP connect)."""
+    with _LOCK:
+        return _LEARNED.get(ip, {}).get("host") or ip
 
 
 async def _respond_allowed(
@@ -464,29 +506,6 @@ def _ws_url(consent_url: str) -> str:
         host = consent_url[len("http://") :].split("/", 1)[0]
         return f"ws://{host}/ws/egress-sidecar"
     return consent_url  # already ws(s)://, or an exotic scheme used verbatim
-
-
-class _HoldLimiter:
-    """Bounded in-flight DNS holds (single-threaded asyncio: no lock needed).
-
-    A flood of denied queries past :data:`HOLD_LIMIT` fail-closes to NXDOMAIN
-    rather than queuing unbounded hold tasks. ``try_acquire`` / ``release``
-    run between await points on the loop thread, so they are atomic.
-    """
-
-    def __init__(self, limit: int) -> None:
-        self._limit = limit
-        self._in_flight = 0
-
-    def try_acquire(self) -> bool:
-        if self._in_flight >= self._limit:
-            return False
-        self._in_flight += 1
-        return True
-
-    def release(self) -> None:
-        if self._in_flight > 0:
-            self._in_flight -= 1
 
 
 class SidecarConsentClient:
@@ -677,6 +696,66 @@ async def _forward_and_learn(
     await _respond_allowed(s, resp, addr, qname, port_set)
 
 
+async def _respond_recorded(
+    s: socket.socket,
+    resp: bytes,
+    addr: tuple[str, int],
+    qname: str,
+) -> None:
+    """Record the response's IP->host (NO ACCEPT install) + send it (#2324).
+
+    The workspace gets the IP (can SYN) but the connection is consent-gated at
+    the SYN (NFQUEUE), so the IP is NOT allow-learned here -- only the IP->host
+    mapping is recorded so the NFQUEUE consumer can name the host. Mirrors
+    :func:`_respond_allowed` minus the ACCEPT install.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        recs = a_records_with_ttl(resp)
+    except Exception:
+        recs = []
+    try:
+        if recs:
+            await loop.run_in_executor(None, _record_hosts, recs, qname)
+        if DEBUG:
+            print(
+                f"resolve {qname} -> {[ip for ip, _ in recs]} (consent at SYN)",
+                flush=True,
+            )
+        s.sendto(resp, addr)
+    except Exception:
+        pass
+
+
+async def _forward_and_record(
+    s: socket.socket,
+    data: bytes,
+    addr: tuple[str, int],
+    qname: str,
+) -> None:
+    """Forward a non-allow-listed query upstream + respond, recording IP->host
+    but NOT learning an ACCEPT (#2324).
+
+    The workspace resolves the name (gets the IP, can SYN); the connection is
+    consent-gated at the SYN (NFQUEUE) rather than held at the DNS query, so the
+    human decision window is the kernel's connect timeout (~127s), not the
+    resolver's <=30s getaddrinfo cap. Uses a non-blocking socket + the loop's
+    sock_* helpers like :func:`_forward_and_learn`.
+    """
+    loop = asyncio.get_running_loop()
+    us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
+    us.setblocking(False)
+    try:
+        await asyncio.wait_for(loop.sock_sendto(us, data, UPSTREAM), 3)
+        resp, _ = await asyncio.wait_for(loop.sock_recvfrom(us, 65535), 3)
+    except Exception:
+        return
+    finally:
+        us.close()
+    await _respond_recorded(s, resp, addr, qname)
+
+
 def _send_nxdomain(s: socket.socket, data: bytes, addr: tuple[str, int]) -> None:
     try:
         s.sendto(nxdomain_for(data), addr)
@@ -684,66 +763,28 @@ def _send_nxdomain(s: socket.socket, data: bytes, addr: tuple[str, int]) -> None
         pass
 
 
-def _gate_deny(client: SidecarConsentClient | None, limiter: _HoldLimiter) -> bool:
-    """True if a denied query should be held (ask the coordinator); False if it
-    should fail-close NXDOMAIN inline -- no client, WS down, or the flood bound
-    is exhausted. On True the limiter slot is acquired (released by the hold).
-    Pure + inline so a flood of fail-close denies never spawns a task per query
-    (only real holds do, bounded by :data:`HOLD_LIMIT`).
-    """
-    if client is None or not client.connected:
-        return False
-    return limiter.try_acquire()
-
-
-async def _handle_hold(
-    s: socket.socket,
-    data: bytes,
-    addr: tuple[str, int],
-    qname: str,
-    client: SidecarConsentClient,
-    limiter: _HoldLimiter,
-) -> None:
-    """Hold a denied DNS query pending the consent verdict (#2311 half B).
-
-    The caller has already gate-checked + acquired the limiter slot (see
-    :func:`_gate_deny`): ``allow`` resolves upstream + learns the IPs
-    (all-ports, TTL-tracked); ``deny``/timeout -> NXDOMAIN. Runs as a task so
-    the hold never blocks the receive loop.
-    """
-    try:
-        decision = await client.request(qname, None)
-    except Exception:
-        decision = "deny"
-    finally:
-        limiter.release()
-    if decision == "allow":
-        if DEBUG:
-            print(f"consent-allow {qname}", flush=True)
-        # all-ports {None}: a human consenting to a domain opens every port to
-        # its resolved IPs for the TTL (like a port-less allow spec) -- consent
-        # is per-domain, not per-port (#2311 half B).
-        await _forward_and_learn(s, data, addr, qname, {None})
-    else:
-        if DEBUG:
-            print(f"consent-deny  {qname}", flush=True)
-        _send_nxdomain(s, data, addr)
-
-
 def _run_nfq_consumer(
     client: SidecarConsentClient | None, loop: asyncio.AbstractEventLoop
 ) -> None:
-    """Bind the sidecar's NFQUEUE and consent-gate blocked IP egress (#2311).
+    """Bind the sidecar's NFQUEUE and consent-gate the connection SYN (#2324).
 
-    Runs ``nfq.run()`` in a thread (netfilterqueue is synchronous). The
-    callback holds the packet pending the verdict by crossing into the loop
-    via ``run_coroutine_threadsafe`` (blocking): ``allow`` -> ``pkt.accept()``
-    (conntrack's ``ESTABLISHED,RELATED`` rule passes the rest of the
-    connection); ``deny``/timeout/WS-down -> ``pkt.drop()`` (fail-close).
-    Blocking the callback serializes NFQUEUE; the kernel queue length + the
-    iptables rate-limit in entrypoint.sh absorb bursts (overflows DROP).
-    netfilterqueue is a sidecar-only dep, imported lazily so the module loads
-    without it.
+    Consent gates the SYN, not the DNS query: a non-allow-listed name resolves
+    (the workspace gets the IP) and the first packet to that IP is queued here
+    pending a verdict -- so the human decision window is the kernel's connect
+    timeout (tcp_syn_retries ~= 127s), not the resolver's <=30s getaddrinfo
+    cap. Runs ``nfq.run()`` in a thread (netfilterqueue is synchronous); the
+    callback crosses into the loop via ``run_coroutine_threadsafe`` (blocking).
+
+    Per packet: name the host from the IP->host map (the IP itself for a
+    direct-IP connect), ask the coordinator, then ``allow`` -> learn the IP
+    all-ports (reconnects + the rest of this connection's SYN retransmits pass
+    without re-prompting) + ``pkt.accept()`` (conntrack ESTABLISHED,RELATED
+    carries the in-flight connection); ``deny``/timeout/WS-down -> ``pkt.drop``
+    (fail-close). SYN retransmits (tcp_syn_retries) of a flow already decided
+    reuse the cached verdict so they don't each re-prompt. Blocking the callback
+    serializes NFQUEUE; the kernel queue length + the iptables rate-limit in
+    entrypoint.sh absorb bursts (overflows DROP). netfilterqueue is a sidecar-
+    only dep, imported lazily so the module loads without it.
     """
     try:
         from netfilterqueue import NetfilterQueue
@@ -756,12 +797,32 @@ def _run_nfq_consumer(
         if not dst or client is None or not client.connected:
             pkt.drop()  # unparseable / no consent / WS down -> fail-close
             return
+        now = time.time()
+        # SYN retransmit of an already-decided flow -> reuse the verdict so the
+        # kernel's retransmits (tcp_syn_retries) don't each re-prompt.
+        cached = _VERDICT_CACHE.get((dst, port))
+        if cached is not None and cached[1] > now:
+            if cached[0] == "allow":
+                pkt.accept()
+            else:
+                pkt.drop()
+            return
+        host = _host_for(dst)  # DNS name if resolved here, else the IP
         try:
-            fut = asyncio.run_coroutine_threadsafe(client.request(dst, port), loop)
+            fut = asyncio.run_coroutine_threadsafe(client.request(host, port), loop)
             decision = fut.result(HOLD_TIMEOUT)
         except Exception:
             decision = "deny"  # timeout / loop dead -> fail-close
+        # Bound memory under a denied-flow flood (allowed flows get learned +
+        # stop hitting NFQUEUE; only denied flows accumulate in the cache).
+        if len(_VERDICT_CACHE) > 4096:
+            _VERDICT_CACHE.clear()
+        _VERDICT_CACHE[(dst, port)] = (decision, now + VERDICT_CACHE_TTL)
         if decision == "allow":
+            try:
+                allow(dst, None, MIN_TTL)
+            except Exception:
+                pass
             pkt.accept()
         else:
             pkt.drop()
@@ -780,14 +841,14 @@ async def _handle_packet(
     data: bytes,
     addr: tuple[str, int],
     client: SidecarConsentClient | None,
-    limiter: _HoldLimiter,
 ) -> None:
     """Classify + route one DNS query (the per-packet body of :func:`_async_main`).
 
-    Factored out of the receive loop so the routing -- classify -> gate ->
-    hold / NXDOMAIN / forward -- is unit-testable without running the infinite
-    ``recvfrom`` loop. A statically-allow-listed name goes straight to the
-    forward path (never held); only denied names hit the consent gate.
+    Allow-listed names forward + learn (ACCEPT). A denied name in interactive
+    mode (a consent client) resolves + responds + records IP->host but installs
+    NO ACCEPT -- its connection SYN is consent-gated at NFQUEUE (#2324), so the
+    human decision window is the kernel's connect timeout (~127s), not the
+    resolver's <=30s getaddrinfo cap. Static mode (no client) -> NXDOMAIN.
     """
     try:
         qname = query_name(data)
@@ -798,10 +859,10 @@ async def _handle_packet(
     if deny:
         if DEBUG:
             print(f"deny  {qname}", flush=True)
-        if _gate_deny(client, limiter):
-            t = asyncio.create_task(_handle_hold(s, data, addr, qname, client, limiter))
-            _BG_TASKS.add(t)  # strong ref so the hold task isn't GC'd
-            t.add_done_callback(_BG_TASKS.discard)
+        if client is not None:
+            # Interactive: resolve + respond + record IP->host; the SYN is
+            # consent-gated at NFQUEUE (not held here at the DNS query).
+            await _forward_and_record(s, data, addr, qname)
         else:
             _send_nxdomain(s, data, addr)
         return
@@ -809,10 +870,9 @@ async def _handle_packet(
 
 
 async def _async_main() -> None:
-    """The asyncio DNS loop (#2311 half B): holds denied queries pending verdicts.
-
-    Allowed queries forward inline (serial, like the pre-consent proxy); denied
-    queries run as bounded tasks so a hold never blocks the receive loop.
+    """The asyncio DNS loop (#2311 half B, #2324): allow-listed + denied names
+    resolve inline; a denied name in interactive mode records IP->host so its
+    connection SYN is consent-gated at NFQUEUE (a separate thread).
     """
     loop = asyncio.get_running_loop()
     client: SidecarConsentClient | None = None
@@ -832,18 +892,17 @@ async def _async_main() -> None:
     _BG_TASKS.add(_sweep)  # strong ref for the loop's lifetime
     _sweep.add_done_callback(_BG_TASKS.discard)
     # NFQUEUE consumer runs nfq.run() in a thread (blocking); its callback
-    # crosses into this loop to await the consent verdict (#2311 half B).
+    # crosses into this loop to await the consent verdict (#2311 half B, #2324).
     if CONSENT_URL:
         threading.Thread(
             target=_run_nfq_consumer, args=(client, loop), daemon=True
         ).start()
-    limiter = _HoldLimiter(HOLD_LIMIT)
     while True:
         try:
             data, addr = await loop.sock_recvfrom(s, 65535)
         except Exception:
             continue
-        await _handle_packet(s, data, addr, client, limiter)
+        await _handle_packet(s, data, addr, client)
 
 
 def main() -> None:

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -2671,7 +2671,7 @@ def consent_decide(
         help="Workspace name or id whose held egress requests to decide"
     ),
     hold_timeout: float = typer.Option(
-        30.0,
+        120.0,
         "--hold-timeout",
         help=(
             "Seconds a held request counts down before auto-deny "

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -120,7 +120,7 @@ class ConsentDeciderController:
 
     def __init__(
         self,
-        hold_timeout: float = 30.0,
+        hold_timeout: float = 120.0,
         *,
         clock=time.time,
     ) -> None:
@@ -242,7 +242,7 @@ class ConsentDeciderApp(App):
         workspace_id: str,
         workspace_name: str,
         *,
-        hold_timeout: float = 30.0,
+        hold_timeout: float = 120.0,
         max_size: int | None = None,
         ping_interval: float = _PING_INTERVAL,
         reconnect_delays: tuple[float, ...] = _RECONNECT_DELAYS,

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -727,10 +727,12 @@ class KlangkSettings(BaseSettings):
     # consent monitor (#2242) tuning. rate_limit caps pending requests per
     # workspace (anti attention-flood from adversarial containers); timeout
     # is how long a request stays pending before the monitor auto-expires it
-    # (DECISION_EXPIRED). The human decide/notify UI lands with #2244; until
-    # then requests simply expire. Read live (SIGHUP reload-safe).
+    # (DECISION_EXPIRED). Now that consent gates the connection SYN (#2324)
+    # the human window is the kernel's connect timeout (~127s), so the default
+    # matches it (was 30s when the gate was the DNS query, bounded by
+    # getaddrinfo). Read live (SIGHUP reload-safe).
     egress_consent_rate_limit: int = 50
-    egress_consent_timeout: float = 30.0
+    egress_consent_timeout: float = 120.0
     # consent_decider_timeout (#2308): a consent decider (a live client that
     # can approve/deny held egress) is registered while its WebSocket is
     # connected and pinging. This is the liveness window -- a decider whose

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -407,6 +407,30 @@ class TestTTLAndSweep:
         assert ("1.2.3.4", 80) not in learned._REJECTED
         assert ("5.6.7.8", 443) in learned._REJECTED  # live one kept
 
+    def test_all_ports_allow_supersedes_prior_port_denies(
+        self, learned, monkeypatch
+    ):
+        # An all-ports allow must clear per-port REJECTs for that IP, else the
+        # ACCEPT at the top of OUTPUT silently shadows a lingering REJECT (the
+        # decider allowed the host -> a prior port-specific deny no longer applies).
+        removed = []
+        monkeypatch.setattr(
+            learned,
+            "_remove_reject",
+            lambda ip, port: removed.append((ip, port)),
+        )
+        monkeypatch.setattr(learned, "_install", lambda *a: None)
+        learned._REJECTED.clear()
+        learned._REJECTED[("1.2.3.4", 443)] = 9999.0
+        learned._REJECTED[("1.2.3.4", 80)] = 9999.0
+        learned._REJECTED[("5.6.7.8", 443)] = 9999.0  # different IP, untouched
+        learned.allow("1.2.3.4", None, 60)  # all-ports (consent path)
+        assert ("1.2.3.4", 443) in removed
+        assert ("1.2.3.4", 80) in removed
+        assert ("5.6.7.8", 443) not in removed  # different IP kept
+        assert ("1.2.3.4", 443) not in learned._REJECTED
+        assert ("5.6.7.8", 443) in learned._REJECTED
+
 
 class TestARecordsWithTtl:
     """``a_records_with_ttl`` extracts every A record from a DNS response's

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -368,6 +368,45 @@ class TestTTLAndSweep:
         assert [ip for ip, _ in gone] == ["dead"]
         assert "live" in learned._LEARNED
 
+    def test_reject_installs_reject_rule_and_records(
+        self, learned, monkeypatch
+    ):
+        runs = []
+
+        def fake_run(args, **kw):
+            runs.append(args)
+            return types.SimpleNamespace(returncode=1)  # rule absent -> -I
+
+        monkeypatch.setattr(learned.subprocess, "run", fake_run)
+        monkeypatch.setattr(learned.time, "time", lambda: 1000.0)
+        learned._REJECTED.clear()
+        learned.reject("1.2.3.4", 80, 10)
+        assert any(
+            "-I" in a and "REJECT" in a and "tcp-reset" in a for a in runs
+        )
+        assert learned._REJECTED[("1.2.3.4", 80)] == 1010.0
+
+    def test_sweep_removes_expired_reject_rules(self, learned, monkeypatch):
+        removed = []
+
+        def fake_run(args, **kw):
+            if "-D" in args:
+                removed.append(args)
+            return types.SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(learned.subprocess, "run", fake_run)
+        learned._LEARNED.clear()
+        learned._REJECTED.clear()
+        learned._REJECTED[("1.2.3.4", 80)] = 100.0  # expired
+        learned._REJECTED[("5.6.7.8", 443)] = 9999.0  # live
+        learned.sweep_once(now=500.0)
+        assert any(
+            "1.2.3.4" in a and "REJECT" in a and "tcp-reset" in a
+            for a in removed
+        )
+        assert ("1.2.3.4", 80) not in learned._REJECTED
+        assert ("5.6.7.8", 443) in learned._REJECTED  # live one kept
+
 
 class TestARecordsWithTtl:
     """``a_records_with_ttl`` extracts every A record from a DNS response's
@@ -930,14 +969,25 @@ class TestNfqueueCallback:
             "evil.test", 443
         )  # host, not IP
 
-    async def test_deny_verdict_drops(self, proxy, monkeypatch):
+    async def test_deny_verdict_drops_and_rejects(self, proxy, monkeypatch):
+        # deny -> drop the SYN + install a REJECT (tcp-reset) so the retransmit
+        # gets RST'd (ECONNREFUSED), not a ~127s tcp_syn_retries wait.
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value="deny")
+        rejected = []
+        monkeypatch.setattr(
+            proxy,
+            "reject",
+            lambda ip, port, ttl: rejected.append((ip, port, ttl)),
+        )
         nfq = self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await asyncio.to_thread(nfq.cb, pkt)
         assert pkt.verdict == "drop"
+        assert rejected == [
+            ("1.2.3.4", 443, proxy.CONSENT_REJECT_TTL)
+        ]  # eager deny
 
     async def test_request_error_drops(self, proxy, monkeypatch):
         client = MagicMock()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -579,20 +579,38 @@ class TestConsentForward:
             == "ws://x/ws/egress-sidecar"
         )
 
-    # --- _HoldLimiter: bounded in-flight DNS holds ---
+    # --- _record_hosts / _host_for: IP->host map for the SYN consent gate (#2324) ---
 
-    def test_hold_limiter_bounds_and_releases(self, proxy):
-        lim = proxy._HoldLimiter(2)
-        assert lim.try_acquire() is True
-        assert lim.try_acquire() is True
-        assert lim.try_acquire() is False  # exhausted
-        lim.release()
-        assert lim.try_acquire() is True  # freed
+    def test_record_hosts_records_ip_to_host_without_accept(self, proxy):
+        proxy._LEARNED.clear()
+        proxy._record_hosts([("1.2.3.4", 60)], "evil.test")
+        rec = proxy._LEARNED["1.2.3.4"]
+        assert rec["host"] == "evil.test"
+        assert rec["ports"] == set()  # NO ACCEPT rule installed
 
-    def test_hold_limiter_release_floor(self, proxy):
-        lim = proxy._HoldLimiter(1)
-        lim.release()  # must not go negative
-        assert lim.try_acquire() is True
+    def test_record_hosts_preserves_prior_learn_ports(self, learned):
+        import time
+
+        # a prior consent-allow learned the IP (ports={None}); a re-resolve
+        # refreshes host + expire without dropping the ports.
+        learned._LEARNED["1.2.3.4"] = {
+            "expire": time.time() + 10,
+            "ports": {None},
+            "host": None,
+        }
+        learned._record_hosts([("1.2.3.4", 300)], "evil.test")
+        rec = learned._LEARNED["1.2.3.4"]
+        assert rec["host"] == "evil.test"
+        assert rec["ports"] == {None}  # preserved
+
+    def test_host_for_returns_host_when_recorded(self, proxy):
+        proxy._LEARNED.clear()
+        proxy._record_hosts([("1.2.3.4", 60)], "evil.test")
+        assert proxy._host_for("1.2.3.4") == "evil.test"
+
+    def test_host_for_falls_back_to_ip_for_direct_connect(self, proxy):
+        proxy._LEARNED.clear()
+        assert proxy._host_for("5.6.7.8") == "5.6.7.8"  # no DNS record -> IP
 
     # --- SidecarConsentClient.request: fail-close contract ---
 
@@ -742,86 +760,59 @@ class TestConsentForward:
         c = proxy.SidecarConsentClient("http://h/ev", str(f), 5)
         assert c._read_token() == "abc-xyz"
 
-    # --- _gate_deny: should this denied query be held or fail-close NXDOMAIN? ---
+    # --- _respond_recorded: resolve + record IP->host + respond (no ACCEPT) (#2324) ---
 
-    def test_gate_deny_false_when_no_client(self, proxy):
-        # consent disabled -> never hold, always NXDOMAIN (today's behavior)
-        assert proxy._gate_deny(None, proxy._HoldLimiter(8)) is False
-
-    def test_gate_deny_false_when_disconnected(self, proxy):
-        client = MagicMock()
-        client.connected = False
-        assert proxy._gate_deny(client, proxy._HoldLimiter(8)) is False
-
-    def test_gate_deny_false_when_flood_bound(self, proxy):
-        client = MagicMock()
-        client.connected = True
-        lim = proxy._HoldLimiter(1)
-        assert lim.try_acquire()  # fill the only slot
-        assert (
-            proxy._gate_deny(client, lim) is False
-        )  # exhausted -> fail-close
-
-    def test_gate_deny_true_acquires_slot(self, proxy):
-        client = MagicMock()
-        client.connected = True
-        lim = proxy._HoldLimiter(2)
-        assert proxy._gate_deny(client, lim) is True
-        assert lim.try_acquire() is True  # one slot now in use -> one left
-        assert lim.try_acquire() is False  # both taken
-
-    # --- _handle_hold: the DNS hold task (gate already passed) ---
-
-    async def test_handle_hold_allow_forwards_upstream(
+    async def test_respond_recorded_records_host_and_sends(
         self, proxy, monkeypatch
     ):
-        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
-        fwd = AsyncMock()
-        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
-        client = MagicMock()
-        client.connected = True
-        client.request = AsyncMock(return_value="allow")
-        s = MagicMock()
-        lim = proxy._HoldLimiter(8)
-        await proxy._handle_hold(
-            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
+        proxy._LEARNED.clear()
+        recorded = []
+        monkeypatch.setattr(
+            proxy,
+            "_record_hosts",
+            lambda recs, host: recorded.append((recs, host)),
         )
-        s.sendto.assert_not_called()  # not denied
-        client.request.assert_awaited_once_with("evil.test", None)
-        fwd.assert_awaited_once()  # forwarded upstream (all-ports)
-        assert lim._in_flight == 0  # slot released
-
-    async def test_handle_hold_deny_sends_nxdomain(self, proxy, monkeypatch):
-        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
-        fwd = AsyncMock()
-        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
-        client = MagicMock()
-        client.connected = True
-        client.request = AsyncMock(return_value="deny")
-        s = MagicMock()
-        lim = proxy._HoldLimiter(8)
-        await proxy._handle_hold(
-            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
+        monkeypatch.setattr(
+            proxy, "a_records_with_ttl", lambda wire: [("1.2.3.4", 60)]
         )
-        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
-        fwd.assert_not_awaited()
-        assert lim._in_flight == 0  # slot released
+        s = MagicMock()
+        await proxy._respond_recorded(s, b"resp", ("1.2.3.4", 53), "evil.test")
+        assert recorded == [([("1.2.3.4", 60)], "evil.test")]
+        s.sendto.assert_called_once_with(b"resp", ("1.2.3.4", 53))
 
-    async def test_handle_hold_request_error_fail_closes(
+    async def test_respond_recorded_no_records_skips_record(
         self, proxy, monkeypatch
     ):
-        # request() raising -> deny + NXDOMAIN + slot still released
-        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
-        client = MagicMock()
-        client.connected = True
-        client.request = AsyncMock(side_effect=RuntimeError("boom"))
-        s = MagicMock()
-        lim = proxy._HoldLimiter(8)
-        await proxy._handle_hold(
-            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
+        proxy._LEARNED.clear()
+        recorded = []
+        monkeypatch.setattr(
+            proxy,
+            "_record_hosts",
+            lambda recs, host: recorded.append((recs, host)),
         )
-        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
-        assert lim._in_flight == 0  # released despite the error
+        monkeypatch.setattr(
+            proxy, "a_records_with_ttl", lambda wire: []
+        )  # upstream NXDOMAIN
+        s = MagicMock()
+        await proxy._respond_recorded(s, b"resp", ("1.2.3.4", 53), "evil.test")
+        assert recorded == []  # nothing to record
+        s.sendto.assert_called_once_with(
+            b"resp", ("1.2.3.4", 53)
+        )  # still forwarded
+
+    async def test_respond_recorded_swallows_sendto_failure(
+        self, proxy, monkeypatch
+    ):
+        proxy._LEARNED.clear()
+        monkeypatch.setattr(proxy, "_record_hosts", lambda recs, host: None)
+        monkeypatch.setattr(
+            proxy, "a_records_with_ttl", lambda wire: [("1.2.3.4", 60)]
+        )
+        s = MagicMock()
+        s.sendto.side_effect = OSError("gone")
+        await proxy._respond_recorded(  # must not raise
+            s, b"resp", ("1.2.3.4", 53), "evil.test"
+        )
 
     # --- _run_nfq_consumer: graceful no-op without netfilterqueue ---
 
@@ -885,157 +876,172 @@ def _install_fake_nfq(monkeypatch, nfq: _FakeNFQ) -> None:
 
 
 class TestNfqueueCallback:
-    """The NFQUEUE verdict->accept/drop path (#2311 half B review #1): the
-    ``_cb`` body is otherwise untested (only the import-failure early-return
-    was). Drive it with a stubbed netfilterqueue + a fake packet."""
+    """The SYN consent gate (#2324): the NFQUEUE ``_cb`` names the host from the
+    IP->host map, holds the packet pending the verdict, learns the IP on allow,
+    and reuses the verdict for SYN retransmits. Driven with a stubbed
+    netfilterqueue + a fake packet."""
 
-    async def test_allow_verdict_accepts(self, proxy, monkeypatch):
-        loop = asyncio.get_running_loop()
+    def _bind(self, proxy, monkeypatch, client):
+        """Clear module state + bind the fake NFQUEUE consumer; return its cb."""
+        proxy._VERDICT_CACHE.clear()
+        proxy._LEARNED.clear()
+        proxy._BG_TASKS.clear()
         nfq = _FakeNFQ()
         _install_fake_nfq(monkeypatch, nfq)
+        proxy._run_nfq_consumer(client, asyncio.get_running_loop())  # binds cb
+        return nfq
+
+    async def test_allow_verdict_accepts_and_learns_ip(
+        self, proxy, monkeypatch
+    ):
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value="allow")
-        proxy._run_nfq_consumer(client, loop)  # binds cb; run() returns
+        learned = []
+        monkeypatch.setattr(
+            proxy,
+            "allow",
+            lambda ip, port, ttl: learned.append((ip, port, ttl)),
+        )
+        nfq = self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        # _cb blocks on the verdict (run_coroutine_threadsafe); run it in a
-        # worker thread so the loop is free to resolve client.request.
         await asyncio.to_thread(nfq.cb, pkt)
         assert pkt.verdict == "accept"
-        client.request.assert_awaited_once_with("1.2.3.4", 443)
+        client.request.assert_awaited_once_with(
+            "1.2.3.4", 443
+        )  # host=IP (no record)
+        assert learned == [
+            ("1.2.3.4", None, proxy.MIN_TTL)
+        ]  # learned all-ports
+
+    async def test_allow_names_host_from_ip_map(self, proxy, monkeypatch):
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value="allow")
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        nfq = self._bind(proxy, monkeypatch, client)
+        proxy._record_hosts(
+            [("1.2.3.4", 60)], "evil.test"
+        )  # DNS resolved this IP
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await asyncio.to_thread(nfq.cb, pkt)
+        assert pkt.verdict == "accept"
+        client.request.assert_awaited_once_with(
+            "evil.test", 443
+        )  # host, not IP
 
     async def test_deny_verdict_drops(self, proxy, monkeypatch):
-        loop = asyncio.get_running_loop()
-        nfq = _FakeNFQ()
-        _install_fake_nfq(monkeypatch, nfq)
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value="deny")
-        proxy._run_nfq_consumer(client, loop)
+        nfq = self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await asyncio.to_thread(nfq.cb, pkt)
         assert pkt.verdict == "drop"
 
     async def test_request_error_drops(self, proxy, monkeypatch):
-        loop = asyncio.get_running_loop()
-        nfq = _FakeNFQ()
-        _install_fake_nfq(monkeypatch, nfq)
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(side_effect=RuntimeError("boom"))
-        proxy._run_nfq_consumer(client, loop)
+        nfq = self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await asyncio.to_thread(nfq.cb, pkt)
         assert pkt.verdict == "drop"  # except -> deny -> drop
 
     async def test_verdict_timeout_drops(self, proxy, monkeypatch):
-        loop = asyncio.get_running_loop()
         monkeypatch.setattr(proxy, "HOLD_TIMEOUT", 0.05)
-        nfq = _FakeNFQ()
-        _install_fake_nfq(monkeypatch, nfq)
         client = MagicMock()
         client.connected = True
         # request outlasts HOLD_TIMEOUT -> fut.result() times out -> drop
         client.request = AsyncMock(side_effect=lambda *a: asyncio.sleep(0.5))
-        proxy._run_nfq_consumer(client, loop)
+        nfq = self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await asyncio.to_thread(nfq.cb, pkt)
         assert pkt.verdict == "drop"
         await asyncio.sleep(0.6)  # let the abandoned sleep(0.5) finish cleanly
 
     async def test_ws_down_drops_without_request(self, proxy, monkeypatch):
-        loop = asyncio.get_running_loop()
-        nfq = _FakeNFQ()
-        _install_fake_nfq(monkeypatch, nfq)
         client = MagicMock()
         client.connected = False
         client.request = AsyncMock()
-        proxy._run_nfq_consumer(client, loop)
+        nfq = self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await asyncio.to_thread(nfq.cb, pkt)
         assert pkt.verdict == "drop"
         client.request.assert_not_awaited()
 
     async def test_unparseable_dest_drops(self, proxy, monkeypatch):
-        loop = asyncio.get_running_loop()
-        nfq = _FakeNFQ()
-        _install_fake_nfq(monkeypatch, nfq)
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value="allow")
-        proxy._run_nfq_consumer(client, loop)
+        nfq = self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(b"\x00" * 24)  # version nibble 0 -> parse_dest ("", 0)
         await asyncio.to_thread(nfq.cb, pkt)
         assert pkt.verdict == "drop"
         client.request.assert_not_awaited()
 
+    async def test_retransmit_reuses_verdict_without_re_request(
+        self, proxy, monkeypatch
+    ):
+        # A SYN retransmit (tcp_syn_retries) of an already-decided flow reuses the
+        # cached verdict so it doesn't re-prompt the decider.
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value="allow")
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        nfq = self._bind(proxy, monkeypatch, client)
+        pkt1 = _FakePkt(_ip_payload("1.2.3.4", 443))
+        pkt2 = _FakePkt(_ip_payload("1.2.3.4", 443))  # retransmit
+        await asyncio.to_thread(nfq.cb, pkt1)
+        await asyncio.to_thread(nfq.cb, pkt2)
+        assert pkt1.verdict == "accept"
+        assert pkt2.verdict == "accept"  # reused the cached allow
+        client.request.assert_awaited_once()  # NOT twice
+
 
 class TestHandlePacket:
-    """The per-packet routing extracted from _async_main (#2311 half B review #2):
-    classify -> gate -> hold / NXDOMAIN / forward, incl. the property that a
-    statically-allow-listed name is never held."""
+    """The per-packet DNS routing (#2311 half B, #2324): classify -> forward /
+    resolve+record / NXDOMAIN. A statically-allow-listed name forwards + learns;
+    a denied name in interactive mode resolves + records IP->host (its SYN is
+    consent-gated at NFQUEUE); static mode (no client) -> NXDOMAIN."""
 
-    async def test_allowed_name_forwards_not_held(self, proxy, monkeypatch):
-        proxy._BG_TASKS.clear()
+    async def test_allowed_name_forwards_and_learns(self, proxy, monkeypatch):
         monkeypatch.setattr(proxy, "query_name", lambda wire: "allowed.test")
         monkeypatch.setattr(proxy, "SPECS", [("allowed.test", None, False)])
         fwd = AsyncMock()
         monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
         s = MagicMock()
-        await proxy._handle_packet(
-            s, b"q", ("1.2.3.4", 53), None, proxy._HoldLimiter(8)
-        )
-        fwd.assert_awaited_once()  # forwarded, not held/denied
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
+        fwd.assert_awaited_once()  # forwarded + learned, not denied
         s.sendto.assert_not_called()  # no NXDOMAIN
 
     async def test_denied_no_client_sends_nxdomain(self, proxy, monkeypatch):
-        proxy._BG_TASKS.clear()
         monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
         monkeypatch.setattr(proxy, "SPECS", [])
         monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
         s = MagicMock()
-        await proxy._handle_packet(
-            s, b"q", ("1.2.3.4", 53), None, proxy._HoldLimiter(8)
-        )
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
         s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
 
-    async def test_denied_connected_spawns_hold(self, proxy, monkeypatch):
-        proxy._BG_TASKS.clear()
+    async def test_denied_with_client_resolves_and_records(
+        self, proxy, monkeypatch
+    ):
+        # Interactive: a denied name resolves + records IP->host (NO ACCEPT) so
+        # its SYN is consent-gated at NFQUEUE -- it is NOT held at the DNS query.
         monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
         monkeypatch.setattr(proxy, "SPECS", [])
-        hold = AsyncMock()
-        monkeypatch.setattr(proxy, "_handle_hold", hold)
+        rec = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_record", rec)
+        nxd = MagicMock()
+        monkeypatch.setattr(proxy, "_send_nxdomain", nxd)
         client = MagicMock()
         client.connected = True
-        lim = proxy._HoldLimiter(8)
         s = MagicMock()
-        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client, lim)
-        tasks = list(proxy._BG_TASKS)
-        await asyncio.gather(*tasks)  # run the spawned hold task(s)
-        hold.assert_awaited_once_with(
-            s, b"q", ("1.2.3.4", 53), "evil.test", client, lim
-        )
-        assert proxy._BG_TASKS == set()  # done-callback discarded the entry
-
-    async def test_denied_flood_bound_sends_nxdomain(self, proxy, monkeypatch):
-        proxy._BG_TASKS.clear()
-        monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
-        monkeypatch.setattr(proxy, "SPECS", [])
-        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
-        hold = AsyncMock()
-        monkeypatch.setattr(proxy, "_handle_hold", hold)
-        client = MagicMock()
-        client.connected = True
-        lim = proxy._HoldLimiter(1)
-        assert lim.try_acquire()  # fill the only slot
-        s = MagicMock()
-        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client, lim)
-        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))  # fail-close
-        hold.assert_not_awaited()
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        rec.assert_awaited_once_with(s, b"q", ("1.2.3.4", 53), "evil.test")
+        nxd.assert_not_called()  # not NXDOMAIN -- resolves for the SYN gate
 
     async def test_malformed_query_is_dropped(self, proxy, monkeypatch):
-        proxy._BG_TASKS.clear()
-
         def _boom(wire):
             raise RuntimeError("bad wire")
 
@@ -1043,8 +1049,6 @@ class TestHandlePacket:
         fwd = AsyncMock()
         monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
         s = MagicMock()
-        await proxy._handle_packet(
-            s, b"q", ("1.2.3.4", 53), None, proxy._HoldLimiter(8)
-        )
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
         s.sendto.assert_not_called()  # dropped, no response
         fwd.assert_not_awaited()


### PR DESCRIPTION
## Summary

Implements **#2324** — moves interactive egress consent from the **DNS query** to the **connection SYN** so the human decision window is the kernel's connect timeout (`tcp_syn_retries` ~127s) instead of a DNS resolver's ≤30s `getaddrinfo` cap. Previously `curl` (and most apps) reported "could not resolve" before a human could click Allow.

The NFQUEUE consumer already held the SYN for raw-IP egress; this makes it the **primary** consent gate and drops the DNS-hold.

## What changed (all sidecar-side; klangkd's coordinator/decider/model are unchanged)

**`proxy.py`**
- A non-allow-listed name now **resolves + responds + records IP→host** but installs **no ACCEPT** rule (new `_forward_and_record` / `_respond_recorded`). The workspace gets the IP (can SYN); the connection is consent-gated at NFQUEUE. Static mode (no consent client) is unchanged → NXDOMAIN.
- The NFQUEUE consumer (`_cb`) is the consent gate: name the host from the IP→host map (the IP itself for a direct-IP connect), hold the SYN pending the verdict, then **allow** → learn the IP all-ports (reconnects + this connection's SYN retransmits pass) + `accept`; **deny**/timeout/WS-down → `drop`.
- **Verdict cache** `{(ip,port): verdict}` so the kernel's SYN retransmits (`tcp_syn_retries`) reuse a flow's verdict instead of each re-prompting (without this a slow verdict → re-prompt storm).
- Removed the DNS-hold path (`_handle_hold` / `_gate_deny` / `_HoldLimiter` / `HOLD_LIMIT`); the SYN path is bounded by the iptables rate-limit.

**Timeouts** — `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT` (sidecar), `KLANGKD_EGRESS_CONSENT_TIMEOUT` (klangkd), and the `consent-decide` client's countdown default all rise **30 → 120s** to use the new window.

## The one behavior change (confirmed in the issue)

In interactive mode, non-allow-listed hostnames now **resolve** (the workspace learns the public IP); the actual connection is still fail-closed at the SYN. Previously those names were NXDOMAIN-held at DNS. IPs aren't secret; data exfil is what's gated. Static mode is unchanged.

**Bonus:** this naturally dedups the 3-requests-per-curl search-domain expansion — only the real connection's SYN triggers one consent request, not each DNS variant.

## Verification

- 4587 passed, 100% coverage on the `klangk` package (`proxy.py` is a container script, not coverage-gated, but its hold paths are unit-tested: `_record_hosts`/`_host_for`, `_respond_recorded`, the new NFQUEUE `_cb` incl. host-from-map, learn-on-allow, and retransmit-reuses-verdict).
- Follow-ups filed: #2325 (interactive shouldn't be gated on `allowed_domains`).

Closes #2324.
