### PR TITLE
feat(consent): hold distinct concurrent SYN flows in parallel (#2329)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -113,14 +113,17 @@ operators or integrators to act when upgrading.
   (`tcp_syn_retries` ~127s) instead of a DNS resolver's <=30s `getaddrinfo`
   cap. `KLANGKD_EGRESS_CONSENT_TIMEOUT` and `KLANGKNETWORK_EGRESS_HOLD_TIMEOUT`
   defaults rise 30 -> 120s to use that window; SYN retransmits reuse the cached
-  verdict so they don't each re-prompt. New sidecar config:
-  `KLANGKNETWORK_EGRESS_VERDICT_CACHE_TTL` (how long to reuse a SYN verdict,
-  default 120s) and `KLANGKNETWORK_EGRESS_REJECT_TTL` (how long a deny keeps its
-  REJECT tcp-reset rule so the connection fails fast, default 10s).
-  `KLANGKNETWORK_EGRESS_HOLD_LIMIT` is removed (the DNS-path hold bound; the SYN
-  path is bounded by the iptables rate-limit). The proxy is asyncio + the sidecar image gains the `websockets`
-  dependency; the legacy fire-and-forget POST endpoint is superseded (recording
-  happens on the WS path, removal tracked in #2318).
+  verdict so they don't each re-prompt. Distinct concurrent flows are held in
+  parallel (#2329): the NFQUEUE consumer is loop-driven (`get_fd` + `add_reader`)
+  - non-blocking (each held SYN is retained + handed to a verdict task), not a
+    single blocking thread that serializes flows behind the first. New sidecar
+    config: `KLANGKNETWORK_EGRESS_VERDICT_CACHE_TTL` (how long to reuse a SYN verdict,
+    default 120s) and `KLANGKNETWORK_EGRESS_REJECT_TTL` (how long a deny keeps its
+    REJECT tcp-reset rule so the connection fails fast, default 10s).
+    `KLANGKNETWORK_EGRESS_HOLD_LIMIT` is removed (the DNS-path hold bound; the SYN
+    path is bounded by the iptables rate-limit). The proxy is asyncio + the sidecar image gains the `websockets`
+    dependency; the legacy fire-and-forget POST endpoint is superseded (recording
+    happens on the WS path, removal tracked in #2318).
 - **FQDN egress allow-list wildcards, per-domain port scoping, and learned-IP
   TTL (#2256).** `allowed_domains` now accepts `*.domain[:port]` wildcards
   (subdomains only — distinct from a bare `domain`, which also matches the

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -187,8 +187,8 @@ SPECS = parse_specs()
 _LEARNED: dict[str, dict] = {}
 _LOCK = threading.Lock()
 # Reused SYN verdicts: {(ip, port): (verdict, expire)} so the kernel's SYN
-# retransmits (tcp_syn_retries) don't each re-prompt. Single-threaded NFQUEUE
-# consumer -- no lock. Lazy-evicted on read.
+# retransmits (tcp_syn_retries) don't each re-prompt. Touched only on the
+# event-loop thread (the NFQUEUE consumer is loop-driven) -- no lock.
 _VERDICT_CACHE: dict[tuple[str, int], tuple[str, float]] = {}
 # Temporary REJECT (tcp-reset) rules for denied connections: {(ip, port): expire}.
 # Swept by sweep_once alongside _LEARNED. Makes a deny fail-fast (ECONNREFUSED)
@@ -610,9 +610,9 @@ class SidecarConsentClient:
     unreachable -- the workspace never hangs on a pending connection.
 
     All ``_pending`` state lives on the event-loop thread (coroutines +
-    ``_run``'s receive loop); the NFQUEUE consumer reaches the loop via
-    ``asyncio.run_coroutine_threadsafe`` (it never touches ``_pending``
-    directly).
+    ``_run``'s receive loop); the NFQUEUE consumer is itself loop-driven
+    (``get_fd`` + ``add_reader``) and calls :meth:`request` directly, so it
+    never crosses threads or touches ``_pending`` from outside the loop.
     """
 
     def __init__(self, consent_url: str, token_path: str, hold_timeout: float) -> None:
@@ -854,87 +854,122 @@ def _send_nxdomain(s: socket.socket, data: bytes, addr: tuple[str, int]) -> None
         pass
 
 
-def _run_nfq_consumer(
-    client: SidecarConsentClient | None, loop: asyncio.AbstractEventLoop
-) -> None:
-    """Bind the sidecar's NFQUEUE and consent-gate the connection SYN (#2324).
+def _setup_nfq_consumer(client: SidecarConsentClient | None) -> None:
+    """Bind the sidecar's NFQUEUE + drive it from the event loop (#2324, #2329).
 
-    Consent gates the SYN, not the DNS query: a non-allow-listed name resolves
-    (the workspace gets the IP) and the first packet to that IP is queued here
-    pending a verdict -- so the human decision window is the kernel's connect
-    timeout (tcp_syn_retries ~= 127s), not the resolver's <=30s getaddrinfo
-    cap. Runs ``nfq.run()`` in a thread (netfilterqueue is synchronous); the
-    callback crosses into the loop via ``run_coroutine_threadsafe`` (blocking).
+    Consent gates the connection SYN, not the DNS query: a non-allow-listed name
+    resolves (the workspace gets the IP) and the first packet to that IP is
+    queued here pending a verdict -- so the human decision window is the kernel's
+    connect timeout (tcp_syn_retries ~= 127s), not the resolver's <=30s
+    getaddrinfo cap.
 
-    Per packet: name the host from the IP->host map (the IP itself for a
-    direct-IP connect), ask the coordinator, then ``allow`` -> learn the IP
-    all-ports (reconnects + the rest of this connection's SYN retransmits pass
-    without re-prompting) + ``pkt.accept()`` (conntrack ESTABLISHED,RELATED
-    carries the in-flight connection); ``deny``/timeout/WS-down -> ``pkt.drop``
-    + a temporary REJECT (tcp-reset) rule so the next retransmit gets RST'd
-    (ECONNREFUSED) instead of the kernel retransmitting for ~127s. SYN retransmits
-    (tcp_syn_retries) of a flow already decided
-    reuse the cached verdict so they don't each re-prompt. Blocking the callback
-    serializes NFQUEUE; the kernel queue length + the iptables rate-limit in
-    entrypoint.sh absorb bursts (overflows DROP). netfilterqueue is a sidecar-
-    only dep, imported lazily so the module loads without it.
+    The queue is read on the event-loop thread via ``get_fd()`` + ``add_reader``
+    (netfilterqueue is otherwise synchronous). The per-packet callback
+    (:func:`_cb`) is **non-blocking**: it retains the packet + hands the verdict
+    wait to a task (:func:`_decide_and_verdict`), so a slow verdict on one flow
+    does NOT serialize others -- distinct flows are held concurrently
+    (netfilterqueue supports deferred verdicts; outstanding packets count
+    against the kernel queue size, and the iptables rate-limit bounds arrivals).
+    netfilterqueue is a sidecar-only dep, imported lazily so the module loads
+    without it.
     """
     try:
         from netfilterqueue import NetfilterQueue
     except Exception as exc:
         print(f"nfqueue: netfilterqueue unavailable ({exc})", flush=True)
         return
-
-    def _cb(pkt) -> None:
-        dst, port = parse_dest(pkt.get_payload())
-        if not dst or client is None or not client.connected:
-            pkt.drop()  # unparseable / no consent / WS down -> fail-close
-            return
-        now = time.time()
-        # SYN retransmit of an already-decided flow -> reuse the verdict so the
-        # kernel's retransmits (tcp_syn_retries) don't each re-prompt.
-        cached = _VERDICT_CACHE.get((dst, port))
-        if cached is not None and cached[1] > now:
-            if cached[0] == "allow":
-                pkt.accept()
-            else:
-                pkt.drop()
-            return
-        host = _host_for(dst)  # DNS name if resolved here, else the IP
-        try:
-            fut = asyncio.run_coroutine_threadsafe(client.request(host, port), loop)
-            decision = fut.result(HOLD_TIMEOUT)
-        except Exception:
-            decision = "deny"  # timeout / loop dead -> fail-close
-        # Bound memory under a denied-flow flood (allowed flows get learned +
-        # stop hitting NFQUEUE; only denied flows accumulate in the cache).
-        if len(_VERDICT_CACHE) > 4096:
-            _VERDICT_CACHE.clear()
-        _VERDICT_CACHE[(dst, port)] = (decision, now + VERDICT_CACHE_TTL)
-        if decision == "allow":
-            try:
-                allow(dst, None, MIN_TTL)
-            except Exception:
-                pass
-            pkt.accept()
-        else:
-            # Dropping a SYN doesn't fail connect() -- the kernel retransmits
-            # for tcp_syn_retries (~127s). Install a temporary REJECT (tcp-reset)
-            # so the next retransmit gets a RST -> ECONNREFUSED (eager deny).
-            if port:
-                try:
-                    reject(dst, port, CONSENT_REJECT_TTL)
-                except Exception:
-                    pass
-            pkt.drop()
-
     try:
         nfq = NetfilterQueue()
-        nfq.bind(QUEUE_NUM, _cb)
+        nfq.bind(QUEUE_NUM, lambda pkt: _cb(pkt, client))
+        loop = asyncio.get_running_loop()
+        # When the netlink socket is readable, process all pending packets on
+        # this (loop) thread; _cb then hands each off to a verdict task.
+        loop.add_reader(nfq.get_fd(), lambda: _drain(nfq))
         print(f"nfqueue consumer bound to queue {QUEUE_NUM}", flush=True)
-        nfq.run()
     except Exception as exc:
         print(f"nfqueue consumer failed: {exc}", flush=True)
+
+
+def _drain(nfq) -> None:
+    """Process pending NFQUEUE messages (called when the socket is readable)."""
+    try:
+        nfq.run(block=False)
+    except Exception:
+        pass  # a transient read failure defers to the next readability event
+
+
+def _cb(pkt, client: SidecarConsentClient | None) -> None:
+    """Classify + route one queued SYN -- non-blocking (#2324, #2329).
+
+    A retransmit of an already-decided flow reuses the cached verdict inline
+    (fast path). A new flow is retained + handed to :func:`_decide_and_verdict`
+    so the verdict wait doesn't block the queue's drain (distinct flows are held
+    concurrently, not serialized behind the first).
+    """
+    dst, port = parse_dest(pkt.get_payload())
+    if not dst or client is None or not client.connected:
+        pkt.drop()  # unparseable / no consent / WS down -> fail-close
+        return
+    now = time.time()
+    # SYN retransmit of an already-decided flow -> reuse the verdict so the
+    # kernel's retransmits (tcp_syn_retries) don't each re-prompt.
+    cached = _VERDICT_CACHE.get((dst, port))
+    if cached is not None and cached[1] > now:
+        if cached[0] == "allow":
+            pkt.accept()
+        else:
+            pkt.drop()
+        return
+    host = _host_for(dst)  # DNS name if resolved here, else the IP
+    pkt.retain()  # keep the payload valid past this callback (deferred verdict)
+    t = asyncio.create_task(_decide_and_verdict(pkt, dst, port, host, client))
+    _BG_TASKS.add(t)  # strong ref so the verdict task isn't GC'd
+    t.add_done_callback(_BG_TASKS.discard)
+
+
+async def _decide_and_verdict(
+    pkt,
+    dst: str,
+    port: int,
+    host: str,
+    client: SidecarConsentClient,
+) -> None:
+    """Await the consent verdict for a held SYN + apply it (deferred).
+
+    ``allow`` -> learn the IP all-ports (reconnects + this connection's SYN
+    retransmits pass without re-prompting) + ``pkt.accept()`` (conntrack
+    ESTABLISHED,RELATED carries the in-flight connection); ``deny``/timeout/
+    WS-down -> ``pkt.drop`` + a temporary REJECT (tcp-reset) rule so the next
+    retransmit gets RST'd (ECONNREFUSED) instead of the kernel retransmitting
+    for ~127s. The verdict is cached so SYN retransmits (tcp_syn_retries) of
+    this flow reuse it.
+    """
+    try:
+        decision = await client.request(host, port)
+    except Exception:
+        decision = "deny"  # timeout / loop dead -> fail-close
+    now = time.time()
+    # Bound memory under a denied-flow flood (allowed flows get learned +
+    # stop hitting NFQUEUE; only denied flows accumulate in the cache).
+    if len(_VERDICT_CACHE) > 4096:
+        _VERDICT_CACHE.clear()
+    _VERDICT_CACHE[(dst, port)] = (decision, now + VERDICT_CACHE_TTL)
+    if decision == "allow":
+        try:
+            allow(dst, None, MIN_TTL)
+        except Exception:
+            pass
+        pkt.accept()
+    else:
+        # Dropping a SYN doesn't fail connect() -- the kernel retransmits for
+        # tcp_syn_retries (~127s). Install a temporary REJECT (tcp-reset) so the
+        # next retransmit gets a RST -> ECONNREFUSED (eager deny).
+        if port:
+            try:
+                reject(dst, port, CONSENT_REJECT_TTL)
+            except Exception:
+                pass
+        pkt.drop()
 
 
 async def _handle_packet(
@@ -992,12 +1027,10 @@ async def _async_main() -> None:
     _sweep = asyncio.create_task(_async_sweeper())
     _BG_TASKS.add(_sweep)  # strong ref for the loop's lifetime
     _sweep.add_done_callback(_BG_TASKS.discard)
-    # NFQUEUE consumer runs nfq.run() in a thread (blocking); its callback
-    # crosses into this loop to await the consent verdict (#2311 half B, #2324).
+    # NFQUEUE consumer is driven by this event loop (get_fd + add_reader) so a
+    # slow verdict on one SYN doesn't serialize others (#2324, #2329).
     if CONSENT_URL:
-        threading.Thread(
-            target=_run_nfq_consumer, args=(client, loop), daemon=True
-        ).start()
+        _setup_nfq_consumer(client)
     while True:
         try:
             data, addr = await loop.sock_recvfrom(s, 65535)

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -746,6 +746,11 @@ class SidecarConsentClient:
             return "deny"
 
     def _fail_close_pending(self) -> None:
+        # A lost connection is a fresh session against a (possibly restarted)
+        # coordinator, so prior verdicts must not be trusted: in-flight flows
+        # re-prompt after reconnect instead of being silently re-allowed/denied
+        # by a stale cached verdict (#2326 review).
+        _VERDICT_CACHE.clear()
         for lid in list(self._pending):
             fut = self._pending.pop(lid, None)
             if fut is not None and not fut.done():

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -803,13 +803,21 @@ class TestConsentForward:
         assert fut.result() == "allow"
         assert "abc" not in c._pending
 
-    async def test_fail_close_pending_resolves_deny(self, proxy, tmp_path):
+    async def test_fail_close_pending_resolves_deny_and_clears_cache(
+        self, proxy, tmp_path
+    ):
         c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
         fut = asyncio.get_running_loop().create_future()
         c._pending["x"] = fut
+        # A lost connection is a fresh session: prior verdicts must not be trusted.
+        proxy._VERDICT_CACHE.clear()
+        proxy._VERDICT_CACHE[("1.2.3.4", 443)] = ("allow", 9999999.0)
         c._fail_close_pending()
         assert fut.result() == "deny"
         assert c._pending == {}
+        assert (
+            proxy._VERDICT_CACHE == {}
+        )  # stale verdicts dropped on disconnect
 
     def test_read_token_missing_file(self, proxy, tmp_path):
         c = proxy.SidecarConsentClient(

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -879,10 +879,12 @@ class TestConsentForward:
 
     # --- _run_nfq_consumer: graceful no-op without netfilterqueue ---
 
-    def test_run_nfq_consumer_noop_without_netfilterqueue(self, proxy, capsys):
+    def test_setup_nfq_consumer_noop_without_netfilterqueue(
+        self, proxy, capsys
+    ):
         # The server venv has no netfilterqueue -> lazy import fails -> logs +
-        # returns instead of raising.
-        proxy._run_nfq_consumer(None, asyncio.new_event_loop())
+        # returns instead of raising (before touching the event loop).
+        proxy._setup_nfq_consumer(None)
         assert "netfilterqueue unavailable" in capsys.readouterr().out
 
 
@@ -900,22 +902,6 @@ def _ip_payload(dst: str, dport: int, proto: int = 6) -> bytes:
     return bytes(b)
 
 
-class _FakeNFQ:
-    """Stand-in for netfilterqueue.NetfilterQueue: captures the bound callback
-    and returns at once from run() so the test can drive _cb itself."""
-
-    def __init__(self) -> None:
-        self.cb = None
-        self.queue = None
-
-    def bind(self, queue: int, cb) -> None:
-        self.queue = queue
-        self.cb = cb
-
-    def run(self) -> None:
-        pass  # do not block -- the test invokes self.cb directly
-
-
 class _FakePkt:
     def __init__(self, payload: bytes) -> None:
         self._payload = payload
@@ -930,29 +916,28 @@ class _FakePkt:
     def drop(self) -> None:
         self.verdict = "drop"
 
-
-def _install_fake_nfq(monkeypatch, nfq: _FakeNFQ) -> None:
-    """Make ``from netfilterqueue import NetfilterQueue`` return ``nfq``."""
-    mod = types.ModuleType("netfilterqueue")
-    mod.NetfilterQueue = lambda: nfq  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "netfilterqueue", mod)
+    def retain(self) -> None:
+        pass  # the real binding needs retain() for a deferred verdict
 
 
 class TestNfqueueCallback:
-    """The SYN consent gate (#2324): the NFQUEUE ``_cb`` names the host from the
-    IP->host map, holds the packet pending the verdict, learns the IP on allow,
-    and reuses the verdict for SYN retransmits. Driven with a stubbed
-    netfilterqueue + a fake packet."""
+    """The SYN consent gate (#2324, #2329): the non-blocking NFQUEUE ``_cb``
+    names the host, hands the verdict wait to a task, learns on allow, REJECTs
+    on deny, and reuses the verdict for retransmits. ``_cb`` +
+    ``_decide_and_verdict`` are driven directly (the loop-native get_fd /
+    add_reader plumbing is exercised by the e2e, #2327)."""
 
     def _bind(self, proxy, monkeypatch, client):
-        """Clear module state + bind the fake NFQUEUE consumer; return its cb."""
+        """Clear module state (the ``proxy`` fixture is module-scoped)."""
         proxy._VERDICT_CACHE.clear()
         proxy._LEARNED.clear()
         proxy._BG_TASKS.clear()
-        nfq = _FakeNFQ()
-        _install_fake_nfq(monkeypatch, nfq)
-        proxy._run_nfq_consumer(client, asyncio.get_running_loop())  # binds cb
-        return nfq
+
+    async def _decide(self, proxy, pkt, client):
+        """Run the non-blocking ``_cb`` to completion + await its verdict task(s)."""
+        proxy._cb(pkt, client)
+        if proxy._BG_TASKS:
+            await asyncio.gather(*proxy._BG_TASKS)
 
     async def test_allow_verdict_accepts_and_learns_ip(
         self, proxy, monkeypatch
@@ -966,9 +951,9 @@ class TestNfqueueCallback:
             "allow",
             lambda ip, port, ttl: learned.append((ip, port, ttl)),
         )
-        nfq = self._bind(proxy, monkeypatch, client)
+        self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        await asyncio.to_thread(nfq.cb, pkt)
+        await self._decide(proxy, pkt, client)
         assert pkt.verdict == "accept"
         client.request.assert_awaited_once_with(
             "1.2.3.4", 443
@@ -982,12 +967,12 @@ class TestNfqueueCallback:
         client.connected = True
         client.request = AsyncMock(return_value="allow")
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
-        nfq = self._bind(proxy, monkeypatch, client)
+        self._bind(proxy, monkeypatch, client)
         proxy._record_hosts(
             [("1.2.3.4", 60)], "evil.test"
         )  # DNS resolved this IP
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        await asyncio.to_thread(nfq.cb, pkt)
+        await self._decide(proxy, pkt, client)
         assert pkt.verdict == "accept"
         client.request.assert_awaited_once_with(
             "evil.test", 443
@@ -1005,9 +990,9 @@ class TestNfqueueCallback:
             "reject",
             lambda ip, port, ttl: rejected.append((ip, port, ttl)),
         )
-        nfq = self._bind(proxy, monkeypatch, client)
+        self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        await asyncio.to_thread(nfq.cb, pkt)
+        await self._decide(proxy, pkt, client)
         assert pkt.verdict == "drop"
         assert rejected == [
             ("1.2.3.4", 443, proxy.CONSENT_REJECT_TTL)
@@ -1017,30 +1002,29 @@ class TestNfqueueCallback:
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(side_effect=RuntimeError("boom"))
-        nfq = self._bind(proxy, monkeypatch, client)
+        self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        await asyncio.to_thread(nfq.cb, pkt)
+        await self._decide(proxy, pkt, client)
         assert pkt.verdict == "drop"  # except -> deny -> drop
 
     async def test_verdict_timeout_drops(self, proxy, monkeypatch):
-        monkeypatch.setattr(proxy, "HOLD_TIMEOUT", 0.05)
+        # client.request enforces the hold timeout (asyncio.wait_for); a timeout
+        # raises -> _decide_and_verdict fail-closes to deny -> drop.
         client = MagicMock()
         client.connected = True
-        # request outlasts HOLD_TIMEOUT -> fut.result() times out -> drop
-        client.request = AsyncMock(side_effect=lambda *a: asyncio.sleep(0.5))
-        nfq = self._bind(proxy, monkeypatch, client)
+        client.request = AsyncMock(side_effect=asyncio.TimeoutError)
+        self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        await asyncio.to_thread(nfq.cb, pkt)
+        await self._decide(proxy, pkt, client)
         assert pkt.verdict == "drop"
-        await asyncio.sleep(0.6)  # let the abandoned sleep(0.5) finish cleanly
 
     async def test_ws_down_drops_without_request(self, proxy, monkeypatch):
         client = MagicMock()
         client.connected = False
         client.request = AsyncMock()
-        nfq = self._bind(proxy, monkeypatch, client)
+        self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        await asyncio.to_thread(nfq.cb, pkt)
+        await self._decide(proxy, pkt, client)  # _cb drops inline (no task)
         assert pkt.verdict == "drop"
         client.request.assert_not_awaited()
 
@@ -1048,9 +1032,9 @@ class TestNfqueueCallback:
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value="allow")
-        nfq = self._bind(proxy, monkeypatch, client)
+        self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(b"\x00" * 24)  # version nibble 0 -> parse_dest ("", 0)
-        await asyncio.to_thread(nfq.cb, pkt)
+        await self._decide(proxy, pkt, client)
         assert pkt.verdict == "drop"
         client.request.assert_not_awaited()
 
@@ -1063,14 +1047,45 @@ class TestNfqueueCallback:
         client.connected = True
         client.request = AsyncMock(return_value="allow")
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
-        nfq = self._bind(proxy, monkeypatch, client)
+        self._bind(proxy, monkeypatch, client)
         pkt1 = _FakePkt(_ip_payload("1.2.3.4", 443))
         pkt2 = _FakePkt(_ip_payload("1.2.3.4", 443))  # retransmit
-        await asyncio.to_thread(nfq.cb, pkt1)
-        await asyncio.to_thread(nfq.cb, pkt2)
+        await self._decide(proxy, pkt1, client)
+        proxy._cb(pkt2, client)  # cache hit -> inline accept, no task
         assert pkt1.verdict == "accept"
         assert pkt2.verdict == "accept"  # reused the cached allow
         client.request.assert_awaited_once()  # NOT twice
+
+    async def test_distinct_flows_held_concurrently_not_serialized(
+        self, proxy, monkeypatch
+    ):
+        # #2329: distinct flows are held concurrently (two verdict tasks in
+        # flight), not one-behind-the-other. The pre-fix blocking _cb serialized
+        # them; this gates request() on both being started before either resolves.
+        started = []
+        gate = asyncio.Event()
+
+        async def slow_request(host, port):
+            started.append((host, port))
+            await gate.wait()
+            return "allow"
+
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(side_effect=slow_request)
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._cb(_FakePkt(_ip_payload("1.2.3.4", 443)), client)
+        proxy._cb(_FakePkt(_ip_payload("5.6.7.8", 80)), client)
+        # both verdict tasks started concurrently before either resolved
+        for _ in range(100):
+            if len(started) == 2:
+                break
+            await asyncio.sleep(0.001)
+        assert len(proxy._BG_TASKS) == 2
+        assert set(started) == {("1.2.3.4", 443), ("5.6.7.8", 80)}
+        gate.set()  # release both
+        await asyncio.gather(*proxy._BG_TASKS)
 
 
 class TestHandlePacket:


### PR DESCRIPTION
## Summary

Implements **#2329** — the SYN consent gate's NFQUEUE consumer no longer serializes distinct concurrent flows. Stacked on #2326 (the SYN gate).

## Problem

In #2326 the NFQUEUE consumer blocked per SYN: `_cb` did
`asyncio.run_coroutine_threadsafe(client.request(...), loop).result(HOLD_TIMEOUT)` — a blocking wait inside the callback that `nfq.run()` dispatches synchronously. So while one flow was held pending a verdict (up to 120s), **every other distinct flow queued behind it**; by the time the 2nd was prompted, the kernel's `tcp_syn_retries` (~127s) had often already failed it. A regression vs. the deleted concurrent DNS-hold. The verdict cache dedups retransmits *within* one flow but not *across* flows.

## Fix

Drive NFQUEUE from the asyncio loop itself + make `_cb` non-blocking.

- **`_setup_nfq_consumer`** binds the queue + registers its netlink fd with the loop (`get_fd()` + `add_reader`); `_drain` runs `nfq.run(block=False)` when readable. **No daemon thread, no cross-thread verdict.**
- **`_cb`** (loop thread): cache-check retransmits inline (fast path); for a new flow, `pkt.retain()` + `asyncio.create_task(_decide_and_verdict(...))` + return at once.
- **`_decide_and_verdict`** (loop thread): `await client.request(...)`, cache, learn/reject, verdict. N flows now hold concurrently (bounded by the kernel NFQUEUE queue size + the iptables rate-limit + klangkd's per-workspace `rate_limit`).

Verified that **netfilterqueue** (oremanj/python-netfilterqueue) supports deferred verdicts (*"you can hang onto Packet objects and resolve them later"* + `retain()`) and event-loop integration (`get_fd()` + `run(block=False)`), per its docs — so this is a supported usage, not a thread-safety gamble.

## Tests

`_cb` / `_decide_and_verdict` are now module-level + driven directly (clear state → call `_cb` → await `_BG_TASKS`). Added `test_distinct_flows_held_concurrently_not_serialized` (two flows both in-flight before either resolves — the case the old blocking design couldn't do). The verdict-timeout test now uses `side_effect=TimeoutError` (the timeout is enforced inside `client.request`, not `fut.result` in `_cb`). Removed the now-dead `_FakeNFQ`/`_install_fake_nfq` helpers.

4591 passed, 100%.

The loop-native `get_fd`/`add_reader` plumbing itself is exercised by the e2e suite (#2327); the unit tests cover `_cb`/`_decide_and_verdict` logic.

Closes #2329.
