### PR TITLE
feat(consent): per-request verdict duration (#2328, Slice A)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,18 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Per-request duration for egress-consent verdicts (#2328).** A verdict
+  now carries a `duration` (`once` | `5m` | `15m` | `1h` | `1d` | `1w` |
+  `restart` | `forever`, default `restart`). The `consent-decide` TUI shows a
+  per-row duration selector (click to choose; selecting does NOT submit -- only
+  Allow/Deny submit with the chosen duration). The sidecar honors it: an allow
+  learns the IP for that long (`once` = this connection only, no learn); a deny
+  REJECTs (tcp-reset) for that long. `restart` = the workspace container's
+  lifetime; `forever` = the workspace's lifetime (persists across container
+  restarts via klangkd -- the cross-restart persistence is a follow-up; at the
+  sidecar level it maps to a long in-memory TTL). Recorded on the
+  `egress_consent` row.
+
 - **`klangk consent-decide <workspace>` (#2310).** A live Textual client that
   connects to a workspace's consent-decider stream and shows its held egress
   requests (blocked destinations the network sidecar is holding for a

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -137,6 +137,32 @@ VERDICT_CACHE_TTL = float(
 # Only needs to catch the SYN retransmit (~1 RTO); the verdict cache separately
 # keeps the deny from re-prompting for VERDICT_CACHE_TTL.
 CONSENT_REJECT_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_REJECT_TTL", "10"))
+# Duration token -> seconds the sidecar honors a verdict (#2328): an allow
+# learns the IP for T; a deny REJECTs for T. `once` = this connection only (no
+# learn; a short deny). `restart` = the container's lifetime (the sidecar's
+# in-memory rules); `forever` = the workspace's lifetime -- at the sidecar level
+# both map to a long in-memory TTL, but `forever`'s real distinction is that
+# klangkd persists it across sidecar restarts (re-applied on reconnect). That
+# cross-restart persistence is #2328's `forever` sub-piece (not yet wired).
+_DURATION_SECONDS = {
+    "5m": 300,
+    "15m": 900,
+    "1h": 3600,
+    "1d": 86400,
+    "1w": 604800,
+}
+_DURATION_FOREVER = 365 * 86400  # ~a year; practically until restart
+
+
+def _duration_ttl(duration: str) -> float | None:
+    """Seconds for a timed/restart/forever duration, or None for ``once``."""
+    if duration in _DURATION_SECONDS:
+        return _DURATION_SECONDS[duration]
+    if duration in ("restart", "forever"):
+        return _DURATION_FOREVER
+    return None  # "once" or unknown -> caller handles (no learn / short reject)
+
+
 # The workspace JWT (rotated) is bind-mounted here read-only; read fresh on each
 # (re)connect so rotation is picked up (#2242, #2311). Not baked in env because
 # the workspace token expires and rotates.
@@ -719,17 +745,21 @@ class SidecarConsentClient:
         fut = self._pending.pop(vid, None)
         if fut is not None and not fut.done():
             # Any non-"allow" verdict (deny, expired, malformed) -> deny.
-            fut.set_result(decision if decision == "allow" else "deny")
+            token = decision if decision == "allow" else "deny"
+            duration = msg.get("duration") or "once"
+            fut.set_result((token, duration))
 
-    async def request(self, dst: str, dport: int | None) -> str:
-        """Send an egress frame + await the verdict. Fail-close -> ``"deny"``.
+    async def request(self, dst: str, dport: int | None) -> tuple[str, str]:
+        """Send an egress frame + await the verdict. Fail-close -> ``("deny",
+        "once")``.
 
-        Returns ``"allow"`` or ``"deny"``. A down connection returns ``"deny"``
-        at once (no frame sent); a timed-out or disconnected-in-flight request
-        resolves to ``"deny"`` so the caller fail-closes.
+        Returns ``(decision, duration)`` where decision is ``"allow"`` or
+        ``"deny"`` and duration is the verdict's duration token (#2328). A
+        down connection returns the fail-close pair at once (no frame sent); a
+        timed-out or disconnected-in-flight request resolves the same way.
         """
         if not self._connected.is_set() or self._ws is None:
-            return "deny"
+            return "deny", "once"
         lid = uuid.uuid4().hex
         fut = asyncio.get_running_loop().create_future()
         self._pending[lid] = fut
@@ -738,12 +768,12 @@ class SidecarConsentClient:
             await self._ws.send(frame)
         except Exception:
             self._pending.pop(lid, None)
-            return "deny"
+            return "deny", "once"
         try:
             return await asyncio.wait_for(fut, self._hold_timeout)
         except asyncio.TimeoutError:
             self._pending.pop(lid, None)
-            return "deny"
+            return "deny", "once"
 
     def _fail_close_pending(self) -> None:
         # A lost connection is a fresh session against a (possibly restarted)
@@ -754,7 +784,7 @@ class SidecarConsentClient:
         for lid in list(self._pending):
             fut = self._pending.pop(lid, None)
             if fut is not None and not fut.done():
-                fut.set_result("deny")
+                fut.set_result(("deny", "once"))
 
     def _read_token(self) -> str:
         try:
@@ -950,9 +980,9 @@ async def _decide_and_verdict(
     this flow reuse it.
     """
     try:
-        decision = await client.request(host, port)
+        decision, duration = await client.request(host, port)
     except Exception:
-        decision = "deny"  # timeout / loop dead -> fail-close
+        decision, duration = "deny", "once"  # timeout / loop dead -> fail-close
     now = time.time()
     # Bound memory under a denied-flow flood (allowed flows get learned +
     # stop hitting NFQUEUE; only denied flows accumulate in the cache).
@@ -964,19 +994,25 @@ async def _decide_and_verdict(
     # off the loop. The packet is retained, so verdicting after the await is
     # safe; the rule is installed before the SYN is released.
     loop = asyncio.get_running_loop()
+    ttl = _duration_ttl(duration)
     if decision == "allow":
-        try:
-            await loop.run_in_executor(None, allow, dst, None, MIN_TTL)
-        except Exception:
-            pass
+        # `once` (ttl None) -> no learn, just this connection (reconnect
+        # re-prompts); a timed duration -> learn all-ports for it.
+        if ttl is not None:
+            try:
+                await loop.run_in_executor(None, allow, dst, None, ttl)
+            except Exception:
+                pass
         pkt.accept()
     else:
         # Dropping a SYN doesn't fail connect() -- the kernel retransmits for
         # tcp_syn_retries (~127s). Install a temporary REJECT (tcp-reset) so the
-        # next retransmit gets a RST -> ECONNREFUSED (eager deny).
+        # next retransmit gets a RST -> ECONNREFUSED (eager deny). `once` ->
+        # the short fail-close window; a timed duration -> that long.
+        reject_ttl = ttl if ttl is not None else CONSENT_REJECT_TTL
         if port:
             try:
-                await loop.run_in_executor(None, reject, dst, port, CONSENT_REJECT_TTL)
+                await loop.run_in_executor(None, reject, dst, port, reject_ttl)
             except Exception:
                 pass
         pkt.drop()

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -249,7 +249,9 @@ class ConsentDeciderApp(App):
     #empty { padding: 1 2; color: $text-muted; }
     .req-host { color: $text; }
     #requests Button { height: 1; border: none; padding: 0 1; }
-    #requests .dur-sel { background: $accent; color: $background; }
+    #duration-selector { width: auto; height: 1; }
+    #duration-selector Button { width: auto; min-width: 0; height: 1; border: none; padding: 0 1; }
+    .dur-sel { background: $accent; color: $background; }
     """
 
     BINDINGS = [
@@ -284,14 +286,30 @@ class ConsentDeciderApp(App):
         self._stop = False
         self._flash_msg = ""
         self._flash_until = 0.0
+        self._duration = DURATION_DEFAULT
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static(id="status")
+        # Global duration selector (default `restart`): click to choose; selecting
+        # does NOT submit -- only a row's Allow/Deny submits with this duration.
+        yield Horizontal(*self._duration_buttons(), id="duration-selector")
         with Vertical():
             yield ListView(id="requests")
             yield Static("No held requests — connected, waiting.", id="empty")
         yield Footer()
+
+    def _duration_buttons(self) -> list[Button]:
+        btns = []
+        for d in DURATIONS:
+            b = Button(
+                d,
+                id=f"dur-{d}",
+                classes=("dur-sel" if d == self._duration else ""),
+            )
+            b.duration = d  # type: ignore[attr-defined]
+            btns.append(b)
+        return btns
 
     def on_mount(self) -> None:
         self.title = f"consent-decide · {self.workspace_name}"
@@ -473,28 +491,17 @@ class ConsentDeciderApp(App):
         return escape(f"{host}{proc}  ({secs}s)")
 
     def _render_item(self, req: ConsentRequest) -> ListItem:
-        # Host line; a row of duration toggle-buttons (default `restart`, click to
-        # select -- selecting does NOT submit); Allow/Deny are the only submit
-        # actions, decided with the row's selected duration (#2328).
-        dur_btns = []
-        for d in DURATIONS:
-            b = Button(
-                d,
-                id=f"dur-{d}-{req.id}",
-                classes=("dur-sel" if d == DURATION_DEFAULT else ""),
-            )
-            b.duration = d  # type: ignore[attr-defined]
-            dur_btns.append(b)
+        # Host line + per-row Allow/Deny (the only submit actions). The duration
+        # is chosen once via the global selector above the list (#2328), so the
+        # row stays compact.
         item = ListItem(
             Static(self._host_line(req), classes="req-host"),
-            Horizontal(*dur_btns, classes="req-durations"),
             Horizontal(
                 Button("Allow", id=f"allow-{req.id}", variant="success"),
                 Button("Deny", id=f"deny-{req.id}", variant="error"),
             ),
         )
         item.request_id = req.id  # type: ignore[attr-defined]
-        item.selected_duration = DURATION_DEFAULT  # type: ignore[attr-defined]
         return item
 
     def _update_item(self, item: ListItem, req: ConsentRequest) -> None:
@@ -532,37 +539,27 @@ class ConsentDeciderApp(App):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         bid = event.button.id or ""
         if bid.startswith("dur-"):
-            # Selecting a duration does NOT submit -- it only sets the row's
-            # pending choice (Allow/Deny submit with it).
+            # Selecting a duration does NOT submit -- it only sets the global
+            # choice (Allow/Deny submit with it).
             self._select_duration(event.button)
         elif bid.startswith("allow-"):
-            rid = bid.removeprefix("allow-")
-            self._decide_id(rid, DECISION_ALLOWED, self._row_duration(rid))
+            self._decide_id(
+                bid.removeprefix("allow-"), DECISION_ALLOWED, self._duration
+            )
         elif bid.startswith("deny-"):
-            rid = bid.removeprefix("deny-")
-            self._decide_id(rid, DECISION_DENIED, self._row_duration(rid))
+            self._decide_id(
+                bid.removeprefix("deny-"), DECISION_DENIED, self._duration
+            )
 
     def _select_duration(self, button: Button) -> None:
-        """Set a row's selected duration + highlight it (no submit)."""
+        """Set the global selected duration + highlight it (no submit)."""
         d = getattr(button, "duration", None)
         if d is None:
             return
-        item = button.parent
-        while item is not None and not isinstance(item, ListItem):
-            item = item.parent
-        if item is None:
-            return
-        item.selected_duration = d  # type: ignore[attr-defined]
-        for b in item.query(".dur-sel"):
+        self._duration = d
+        for b in self.query(".dur-sel"):
             b.remove_class("dur-sel")
         button.add_class("dur-sel")
-
-    def _row_duration(self, rid: str) -> str:
-        """The selected duration for a request's row (default if not found)."""
-        for child in self.query_one("#requests", ListView).children:
-            if getattr(child, "request_id", None) == rid:
-                return getattr(child, "selected_duration", DURATION_DEFAULT)
-        return DURATION_DEFAULT
 
     def action_allow(self) -> None:
         # `a` key -> the highlighted row (keyboard path).
@@ -575,7 +572,7 @@ class ConsentDeciderApp(App):
         rid = self._focused_request_id()
         if rid is None:
             return
-        self._decide_id(rid, decision, self._row_duration(rid))
+        self._decide_id(rid, decision, self._duration)
 
     def _decide_id(self, rid: str, decision: str, duration: str) -> None:
         ws = self._ws

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -46,6 +46,27 @@ logger = logging.getLogger(__name__)
 DECISION_ALLOWED = "allowed"
 DECISION_DENIED = "denied"
 SCOPE_ONCE = "once"
+# Duration tokens mirror the server (model/egress_consent.py); duplicated here
+# per CLI isolation. Ordered for the TUI selector; default is `restart` (#2328).
+DURATION_ONCE = "once"
+DURATION_5M = "5m"
+DURATION_15M = "15m"
+DURATION_1H = "1h"
+DURATION_1D = "1d"
+DURATION_1W = "1w"
+DURATION_RESTART = "restart"
+DURATION_FOREVER = "forever"
+DURATIONS = (
+    DURATION_ONCE,
+    DURATION_5M,
+    DURATION_15M,
+    DURATION_1H,
+    DURATION_1D,
+    DURATION_1W,
+    DURATION_RESTART,
+    DURATION_FOREVER,
+)
+DURATION_DEFAULT = DURATION_RESTART
 
 # Pings must beat the server's consent_decider_timeout (45s) or the decider is
 # reaped and the workspace reverts to static. 15s leaves margin. NOTE: if an
@@ -86,7 +107,7 @@ class ConsentRequest:
 
 
 def make_verdict(
-    request_id: str, decision: str, scope: str = SCOPE_ONCE
+    request_id: str, decision: str, duration: str = DURATION_DEFAULT
 ) -> str:
     """Build an outbound verdict frame (JSON string) for a held request."""
     return json.dumps(
@@ -94,7 +115,8 @@ def make_verdict(
             "type": "verdict",
             "request_id": request_id,
             "decision": decision,
-            "scope": scope,
+            "scope": SCOPE_ONCE,
+            "duration": duration,
         }
     )
 
@@ -227,6 +249,7 @@ class ConsentDeciderApp(App):
     #empty { padding: 1 2; color: $text-muted; }
     .req-host { color: $text; }
     #requests Button { height: 1; border: none; padding: 0 1; }
+    #requests .dur-sel { background: $accent; color: $background; }
     """
 
     BINDINGS = [
@@ -450,17 +473,28 @@ class ConsentDeciderApp(App):
         return escape(f"{host}{proc}  ({secs}s)")
 
     def _render_item(self, req: ConsentRequest) -> ListItem:
-        # Host+time is a direct child of the ListItem (renders horizontally);
-        # the per-row Allow/Deny buttons sit in a Horizontal below it so they
-        # never fight the host for width. Each button id encodes the request id.
+        # Host line; a row of duration toggle-buttons (default `restart`, click to
+        # select -- selecting does NOT submit); Allow/Deny are the only submit
+        # actions, decided with the row's selected duration (#2328).
+        dur_btns = []
+        for d in DURATIONS:
+            b = Button(
+                d,
+                id=f"dur-{d}-{req.id}",
+                classes=("dur-sel" if d == DURATION_DEFAULT else ""),
+            )
+            b.duration = d  # type: ignore[attr-defined]
+            dur_btns.append(b)
         item = ListItem(
             Static(self._host_line(req), classes="req-host"),
+            Horizontal(*dur_btns, classes="req-durations"),
             Horizontal(
                 Button("Allow", id=f"allow-{req.id}", variant="success"),
                 Button("Deny", id=f"deny-{req.id}", variant="error"),
             ),
         )
         item.request_id = req.id  # type: ignore[attr-defined]
+        item.selected_duration = DURATION_DEFAULT  # type: ignore[attr-defined]
         return item
 
     def _update_item(self, item: ListItem, req: ConsentRequest) -> None:
@@ -496,14 +530,39 @@ class ConsentDeciderApp(App):
     # -- actions -----------------------------------------------------------
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        # Each row carries its own Allow/Deny button whose id encodes the
-        # request id (``allow-<rid>`` / ``deny-<rid>``), so a click decides
-        # THAT request unambiguously -- not a separate "focused" one.
         bid = event.button.id or ""
-        if bid.startswith("allow-"):
-            self._decide_id(bid.removeprefix("allow-"), DECISION_ALLOWED)
+        if bid.startswith("dur-"):
+            # Selecting a duration does NOT submit -- it only sets the row's
+            # pending choice (Allow/Deny submit with it).
+            self._select_duration(event.button)
+        elif bid.startswith("allow-"):
+            rid = bid.removeprefix("allow-")
+            self._decide_id(rid, DECISION_ALLOWED, self._row_duration(rid))
         elif bid.startswith("deny-"):
-            self._decide_id(bid.removeprefix("deny-"), DECISION_DENIED)
+            rid = bid.removeprefix("deny-")
+            self._decide_id(rid, DECISION_DENIED, self._row_duration(rid))
+
+    def _select_duration(self, button: Button) -> None:
+        """Set a row's selected duration + highlight it (no submit)."""
+        d = getattr(button, "duration", None)
+        if d is None:
+            return
+        item = button.parent
+        while item is not None and not isinstance(item, ListItem):
+            item = item.parent
+        if item is None:
+            return
+        item.selected_duration = d  # type: ignore[attr-defined]
+        for b in item.query(".dur-sel"):
+            b.remove_class("dur-sel")
+        button.add_class("dur-sel")
+
+    def _row_duration(self, rid: str) -> str:
+        """The selected duration for a request's row (default if not found)."""
+        for child in self.query_one("#requests", ListView).children:
+            if getattr(child, "request_id", None) == rid:
+                return getattr(child, "selected_duration", DURATION_DEFAULT)
+        return DURATION_DEFAULT
 
     def action_allow(self) -> None:
         # `a` key -> the highlighted row (keyboard path).
@@ -516,9 +575,9 @@ class ConsentDeciderApp(App):
         rid = self._focused_request_id()
         if rid is None:
             return
-        self._decide_id(rid, decision)
+        self._decide_id(rid, decision, self._row_duration(rid))
 
-    def _decide_id(self, rid: str, decision: str) -> None:
+    def _decide_id(self, rid: str, decision: str, duration: str) -> None:
         ws = self._ws
         if ws is None:
             self._flash("disconnected — reconnecting")
@@ -528,10 +587,12 @@ class ConsentDeciderApp(App):
         # would otherwise silently lose the verdict). Do not optimistically
         # drop the row: a duplicate/no-op verdict must not hide a still-held
         # request (the server's egress_resolved frame removes it).
-        asyncio.create_task(self._send_verdict(ws, rid, decision))
+        asyncio.create_task(self._send_verdict(ws, rid, decision, duration))
 
-    async def _send_verdict(self, ws, rid: str, decision: str) -> None:
+    async def _send_verdict(
+        self, ws, rid: str, decision: str, duration: str
+    ) -> None:
         try:
-            await ws.send(make_verdict(rid, decision))
+            await ws.send(make_verdict(rid, decision, duration))
         except Exception:
             self._flash("verdict send failed — reconnecting")

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -35,7 +35,11 @@ import asyncio
 import logging
 
 from .consent import workspace_is_interactive
-from .model.egress_consent import DECISION_PENDING, DURATION_DEFAULT
+from .model.egress_consent import (
+    DECISION_PENDING,
+    DURATION_DEFAULT,
+    DURATION_ONCE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -257,7 +261,11 @@ class ConsentCoordinator:
             )
         if not hold["future"].done():
             hold["future"].set_result(
-                {"decision": VERDICT_DENY, "reason": reason}
+                {
+                    "decision": VERDICT_DENY,
+                    "reason": reason,
+                    "duration": DURATION_ONCE,
+                }
             )
         self._broadcast_resolved(request_id, hold["workspace_id"], "expired")
 

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -35,7 +35,7 @@ import asyncio
 import logging
 
 from .consent import workspace_is_interactive
-from .model.egress_consent import DECISION_PENDING
+from .model.egress_consent import DECISION_PENDING, DURATION_DEFAULT
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +157,7 @@ class ConsentCoordinator:
         decision: str,
         scope: str | None,
         decided_by: str,
+        duration: str = DURATION_DEFAULT,
         *,
         decider_workspace: str | None = None,
     ) -> dict | None:
@@ -184,7 +185,7 @@ class ConsentCoordinator:
         hold["task"].cancel()
         try:
             row = await self.app.state.model.egress_consent.decide(
-                request_id, decision, scope, decided_by
+                request_id, decision, scope, decided_by, duration
             )
         except Exception:
             # decide() failed (DB error). The hold's own timeout is already
@@ -200,10 +201,18 @@ class ConsentCoordinator:
                 verdict = {"decision": VERDICT_DENY, "reason": "gone"}
                 resolved = "expired"
             elif decision == "allowed":
-                verdict = {"decision": VERDICT_ALLOW, "reason": "decided"}
+                verdict = {
+                    "decision": VERDICT_ALLOW,
+                    "reason": "decided",
+                    "duration": duration,
+                }
                 resolved = "allowed"
             else:
-                verdict = {"decision": VERDICT_DENY, "reason": "decided"}
+                verdict = {
+                    "decision": VERDICT_DENY,
+                    "reason": "decided",
+                    "duration": duration,
+                }
                 resolved = "denied"
         if not hold["future"].done():
             hold["future"].set_result(verdict)

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -308,15 +308,23 @@ class EgressConsentModel:
         """Auto-expire a pending request (timeout). Returns True if updated.
 
         Uses ``DECISION_EXPIRED`` so the audit trail distinguishes a
-        human deny from an unattended timeout.
+        human deny from an unattended timeout. The duration is ``once`` -- a
+        timeout is a non-persistent deny (just this connection), distinct from
+        an active deny (which defaults to `restart`).
         """
         decided_at = time.time()
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
                 "UPDATE egress_consent"
-                " SET decision = ?, decided_at = ?"
+                " SET decision = ?, duration = ?, decided_at = ?"
                 " WHERE id = ? AND decision = ?",
-                (DECISION_EXPIRED, decided_at, request_id, DECISION_PENDING),
+                (
+                    DECISION_EXPIRED,
+                    DURATION_ONCE,
+                    decided_at,
+                    request_id,
+                    DECISION_PENDING,
+                ),
             )
             return cursor.rowcount > 0
 

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -27,6 +27,33 @@ SCOPE_WORKSPACE = "workspace"  # persisted to workspace's allowed_domains
 SCOPE_DEPLOY = "deploy"  # promoted to deploy-wide default
 SCOPES = frozenset({SCOPE_ONCE, SCOPE_WORKSPACE, SCOPE_DEPLOY})
 
+# Duration values for an allow/deny decision (#2328): how long the sidecar
+# honors it (allow learns the IP for T; deny REJECTs for T). `once` = this
+# connection only; `restart` = the workspace container's lifetime (the sidecar's
+# in-memory rules); `forever` = the workspace's lifetime -- persists across
+# container/sidecar restarts (klangkd stores + re-applies it on reconnect).
+DURATION_ONCE = "once"
+DURATION_5M = "5m"
+DURATION_15M = "15m"
+DURATION_1H = "1h"
+DURATION_1D = "1d"
+DURATION_1W = "1w"
+DURATION_RESTART = "restart"
+DURATION_FOREVER = "forever"
+DURATIONS = frozenset(
+    {
+        DURATION_ONCE,
+        DURATION_5M,
+        DURATION_15M,
+        DURATION_1H,
+        DURATION_1D,
+        DURATION_1W,
+        DURATION_RESTART,
+        DURATION_FOREVER,
+    }
+)
+DURATION_DEFAULT = DURATION_RESTART
+
 
 class EgressConsentModel:
     """CRUD for the ``egress_consent`` table."""
@@ -226,12 +253,13 @@ class EgressConsentModel:
         decision: str,
         scope: str | None,
         decided_by: str,
+        duration: str = DURATION_DEFAULT,
     ) -> dict | None:
         """Record a decision on a pending request.
 
         Returns the updated row dict, or ``None`` if the request doesn't
         exist or is no longer pending. Raises ``ValueError`` for invalid
-        decision/scope values.
+        decision/scope/duration values.
         """
         if decision not in (DECISION_ALLOWED, DECISION_DENIED):
             raise ValueError(
@@ -240,15 +268,19 @@ class EgressConsentModel:
             )
         if scope is not None and scope not in SCOPES:
             raise ValueError(f"Invalid scope: {scope!r}")
+        if duration not in DURATIONS:
+            raise ValueError(f"Invalid duration: {duration!r}")
         decided_at = time.time()
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
                 "UPDATE egress_consent"
-                " SET decision = ?, scope = ?, decided_at = ?, decided_by = ?"
+                " SET decision = ?, scope = ?, duration = ?,"
+                " decided_at = ?, decided_by = ?"
                 " WHERE id = ? AND decision = ?",
                 (
                     decision,
                     scope,
+                    duration,
                     decided_at,
                     decided_by,
                     request_id,

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -351,6 +351,7 @@ async def init_db(db) -> None:
                     CHECK (decision IN ('pending', 'allowed', 'denied', 'expired')),
                 scope TEXT
                     CHECK (scope IS NULL OR scope IN ('once', 'workspace', 'deploy')),
+                duration TEXT,
                 requested_at REAL NOT NULL,
                 decided_at REAL,
                 decided_by TEXT REFERENCES users(id) ON DELETE SET NULL
@@ -378,6 +379,14 @@ async def init_db(db) -> None:
             ON egress_consent(workspace_id, dest_host, COALESCE(dest_port, -1))
             WHERE decision = 'denied' AND decided_by IS NULL
         """)
+        # Migration: add duration column (#2328). NULL until a decider records
+        # a decision; the sidecar honors it (allow-learn / deny-REJECT for T).
+        cursor = await db.execute("PRAGMA table_info(egress_consent)")
+        ec_cols = {row[1] for row in await cursor.fetchall()}
+        if "duration" not in ec_cols:
+            await db.execute(
+                "ALTER TABLE egress_consent ADD COLUMN duration TEXT"
+            )
         # Migration: drop legacy role and workspace_access tables
         for table in ("user_roles", "roles", "workspace_access"):
             await db.execute(f"DROP TABLE IF EXISTS {table}")  # noqa: S608

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -45,6 +45,8 @@ from .safe_websocket import SafeWebSocket, SlowClientError
 from ..model.egress_consent import (
     DECISION_ALLOWED,
     DECISION_DENIED,
+    DURATIONS,
+    DURATION_DEFAULT,
     SCOPES,
 )
 
@@ -155,6 +157,12 @@ async def _handle_verdict(app, safe_ws, msg, workspace, user_id) -> None:
             {"type": "error", "message": f"invalid scope: {scope!r}"}
         )
         return
+    duration = msg.get("duration") or DURATION_DEFAULT
+    if duration not in DURATIONS:
+        safe_ws.send_json(
+            {"type": "error", "message": f"invalid duration: {duration!r}"}
+        )
+        return
     request_id = msg.get("request_id")
     if not isinstance(request_id, str):
         safe_ws.send_json(
@@ -169,5 +177,6 @@ async def _handle_verdict(app, safe_ws, msg, workspace, user_id) -> None:
         # users(id); the email is volatile + not a key). Never NULL for a human
         # decision -- NULL means "no human" (the static/expired case).
         user_id,
+        duration=duration,
         decider_workspace=workspace,
     )

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -125,6 +125,7 @@ async def _relay_verdict(
                 "type": "verdict",
                 "id": local_id,
                 "decision": verdict["decision"],
+                "duration": verdict.get("duration", "once"),
             }
         )
     except (asyncio.CancelledError, SlowClientError, *WS_ERRORS):

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -606,8 +606,8 @@ class TestAppActions:
             assert any('"denied"' in s and '"r1"' in s for s in ws.sent)
 
     async def test_duration_selection_does_not_submit(self):
-        # Clicking a duration button selects it (highlights + stores) but sends
-        # NO verdict -- only Allow/Deny submit (#2328).
+        # Clicking a global duration button selects it (highlights + stores) but
+        # sends NO verdict -- only Allow/Deny submit (#2328).
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -615,20 +615,15 @@ class TestAppActions:
             app.controller.apply_frame(_req_frame("r1", host="a.com"))
             app._refresh()
             await pilot.pause()
-            btn = app.query_one("#dur-1d-r1", Button)
+            btn = app.query_one("#dur-1d", Button)
             app.on_button_pressed(types.SimpleNamespace(button=btn))
             await pilot.pause()
             assert ws.sent == []  # selecting a duration does NOT submit
-            row = next(
-                c
-                for c in app.query_one("#requests", ListView).children
-                if getattr(c, "request_id", None) == "r1"
-            )
-            assert row.selected_duration == "1d"
+            assert app._duration == "1d"
             assert btn.has_class("dur-sel")
 
     async def test_allow_submits_with_selected_duration(self):
-        # Allow sends the verdict carrying the row's selected duration.
+        # Allow sends the verdict carrying the global selected duration.
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -637,9 +632,7 @@ class TestAppActions:
             app._refresh()
             await pilot.pause()
             app.on_button_pressed(
-                types.SimpleNamespace(
-                    button=app.query_one("#dur-1h-r1", Button)
-                )
+                types.SimpleNamespace(button=app.query_one("#dur-1h", Button))
             )
             app.on_button_pressed(
                 types.SimpleNamespace(
@@ -671,23 +664,14 @@ class TestAppActions:
             assert any('"restart"' in s for s in ws.sent), ws.sent
 
     async def test_duration_selector_guards(self):
-        # Defensive guards: a button without a duration / without a ListItem
-        # ancestor is a no-op; an unknown rid yields the default duration.
+        # Defensive guard: a button without a duration attr is a no-op.
         app = _make_app()
         async with app.run_test() as pilot:
             app.controller.apply_frame(_req_frame("r1", host="a.com"))
             app._refresh()
             await pilot.pause()
-            # button without a duration attr -> no-op
-            app._select_duration(
-                types.SimpleNamespace(duration=None, parent=None)
-            )
-            # button with a duration but no ListItem ancestor -> no-op
-            app._select_duration(
-                types.SimpleNamespace(duration="1h", parent=None)
-            )
-            # unknown rid -> default duration
-            assert app._row_duration("does-not-exist") == "restart"
+            app._select_duration(types.SimpleNamespace(duration=None))
+            assert app._duration == "restart"  # unchanged (default)
 
 
 class TestWsLoop:

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -303,11 +303,17 @@ class TestFrameBuilders:
             "request_id": "r1",
             "decision": "allowed",
             "scope": "once",
+            "duration": "restart",
         }
+
+    def test_make_verdict_carries_duration(self):
+        msg = json.loads(make_verdict("r1", "allowed", "1d"))
+        assert msg["duration"] == "1d"
 
     def test_make_verdict_denied(self):
         msg = json.loads(make_verdict("r1", "denied"))
         assert msg["decision"] == "denied"
+        assert msg["duration"] == "restart"
 
     def test_make_ping(self):
         assert json.loads(make_ping()) == {"type": "ping"}
@@ -598,6 +604,90 @@ class TestAppActions:
             )
             await pilot.pause()
             assert any('"denied"' in s and '"r1"' in s for s in ws.sent)
+
+    async def test_duration_selection_does_not_submit(self):
+        # Clicking a duration button selects it (highlights + stores) but sends
+        # NO verdict -- only Allow/Deny submit (#2328).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            btn = app.query_one("#dur-1d-r1", Button)
+            app.on_button_pressed(types.SimpleNamespace(button=btn))
+            await pilot.pause()
+            assert ws.sent == []  # selecting a duration does NOT submit
+            row = next(
+                c
+                for c in app.query_one("#requests", ListView).children
+                if getattr(c, "request_id", None) == "r1"
+            )
+            assert row.selected_duration == "1d"
+            assert btn.has_class("dur-sel")
+
+    async def test_allow_submits_with_selected_duration(self):
+        # Allow sends the verdict carrying the row's selected duration.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.on_button_pressed(
+                types.SimpleNamespace(
+                    button=app.query_one("#dur-1h-r1", Button)
+                )
+            )
+            app.on_button_pressed(
+                types.SimpleNamespace(
+                    button=types.SimpleNamespace(id="allow-r1")
+                )
+            )
+            await pilot.pause()
+            assert any(
+                '"allowed"' in s and '"r1"' in s and '"1h"' in s
+                for s in ws.sent
+            ), ws.sent
+
+    async def test_duration_defaults_to_restart(self):
+        # A fresh row defaults to `restart`; Allow without changing it sends
+        # `restart`.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.on_button_pressed(
+                types.SimpleNamespace(
+                    button=types.SimpleNamespace(id="allow-r1")
+                )
+            )
+            await pilot.pause()
+            assert any('"restart"' in s for s in ws.sent), ws.sent
+
+    async def test_duration_selector_guards(self):
+        # Defensive guards: a button without a duration / without a ListItem
+        # ancestor is a no-op; an unknown rid yields the default duration.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            # button without a duration attr -> no-op
+            app._select_duration(
+                types.SimpleNamespace(duration=None, parent=None)
+            )
+            # button with a duration but no ListItem ancestor -> no-op
+            app._select_duration(
+                types.SimpleNamespace(duration="1h", parent=None)
+            )
+            # unknown rid -> default duration
+            assert app._row_duration("does-not-exist") == "restart"
 
 
 class TestWsLoop:

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -226,11 +226,21 @@ class TestConsentCoordinatorResolve:
         app = _app(request=_request(), decide_row=row)
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
-        verdict = await coord.resolve("rid-1", "allowed", "workspace", "a@x")
-        assert verdict == {"decision": "allow", "reason": "decided"}
-        assert fut.result() == {"decision": "allow", "reason": "decided"}
+        verdict = await coord.resolve(
+            "rid-1", "allowed", "workspace", "a@x", duration="1d"
+        )
+        assert verdict == {
+            "decision": "allow",
+            "reason": "decided",
+            "duration": "1d",
+        }
+        assert fut.result() == {
+            "decision": "allow",
+            "reason": "decided",
+            "duration": "1d",
+        }
         app.state.model.egress_consent.decide.assert_awaited_once_with(
-            "rid-1", "allowed", "workspace", "a@x"
+            "rid-1", "allowed", "workspace", "a@x", "1d"
         )
         assert coord._holds == {}
 
@@ -240,8 +250,14 @@ class TestConsentCoordinatorResolve:
         app = _app(request=_request(), decide_row=row)
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
-        verdict = await coord.resolve("rid-1", "denied", "once", "a@x")
-        assert verdict == {"decision": "deny", "reason": "decided"}
+        verdict = await coord.resolve(
+            "rid-1", "denied", "once", "a@x", duration="15m"
+        )
+        assert verdict == {
+            "decision": "deny",
+            "reason": "decided",
+            "duration": "15m",
+        }
         assert fut.result()["decision"] == "deny"
 
     async def test_resolve_unknown_returns_none(self):
@@ -521,7 +537,12 @@ class TestEgressSidecarWS:
         )  # let the relay call hold + flush the verdict
         coord.hold.assert_awaited_once_with(FULL_WS, "1.2.3.4", 443)
         assert [json.loads(m) for m in ws.sent] == [
-            {"type": "verdict", "id": "loc1", "decision": "deny"}
+            {
+                "type": "verdict",
+                "id": "loc1",
+                "decision": "deny",
+                "duration": "once",
+            }
         ]
         await ws.feed(WebSocketDisconnect())
         await handler
@@ -541,10 +562,17 @@ class TestEgressSidecarWS:
             )
         )
         await asyncio.sleep(0.05)  # relay is now awaiting the verdict Future
-        fut.set_result({"decision": "allow", "reason": "decided"})
+        fut.set_result(
+            {"decision": "allow", "reason": "decided", "duration": "1d"}
+        )
         await asyncio.sleep(0.05)  # relay sends the verdict
         assert [json.loads(m) for m in ws.sent] == [
-            {"type": "verdict", "id": "loc1", "decision": "allow"}
+            {
+                "type": "verdict",
+                "id": "loc1",
+                "decision": "allow",
+                "duration": "1d",
+            }
         ]
         await ws.feed(WebSocketDisconnect())
         await handler

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -328,7 +328,11 @@ class TestConsentCoordinatorTimeout:
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
         verdict = await fut
-        assert verdict == {"decision": "deny", "reason": "timeout"}
+        assert verdict == {
+            "decision": "deny",
+            "reason": "timeout",
+            "duration": "once",
+        }
         app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
             "rid-1"
         )
@@ -361,7 +365,11 @@ class TestConsentCoordinatorTimeout:
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
         verdict = await fut
-        assert verdict == {"decision": "deny", "reason": "timeout"}
+        assert verdict == {
+            "decision": "deny",
+            "reason": "timeout",
+            "duration": "once",
+        }
         app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
             "rid-1"
         )

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -345,6 +345,7 @@ class TestConsentDeciderWS:
                         "request_id": "rid",
                         "decision": "allowed",
                         "scope": "once",
+                        "duration": "1w",
                     }
                 ),
                 WebSocketDisconnect(),
@@ -352,7 +353,7 @@ class TestConsentDeciderWS:
         )
         await handle_consent_decider(ws, app)
         app.state.consent_coordinator.resolve.assert_awaited_once_with(
-            "rid", "allowed", "once", "u1", decider_workspace=WS
+            "rid", "allowed", "once", "u1", duration="1w", decider_workspace=WS
         )
 
     async def test_verdict_invalid_decision_sends_error(self):
@@ -393,6 +394,30 @@ class TestConsentDeciderWS:
                         "request_id": "rid",
                         "decision": "denied",
                         "scope": "bogus",
+                    }
+                ),
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.resolve.assert_not_awaited()
+        assert any(json.loads(m).get("type") == "error" for m in ws.sent)
+
+    async def test_verdict_invalid_duration_sends_error(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                json.dumps(
+                    {
+                        "type": "verdict",
+                        "request_id": "rid",
+                        "decision": "allowed",
+                        "duration": "2d",
                     }
                 ),
                 WebSocketDisconnect(),

--- a/src/klangk/klangkd-tests/tests/test_model.py
+++ b/src/klangk/klangkd-tests/tests/test_model.py
@@ -259,6 +259,42 @@ class TestMigration:
             assert mounts is None
             assert env is None
 
+    async def test_migrate_egress_consent_adds_duration(
+        self, temp_data_dir, app_state
+    ):
+        """init_db adds the duration column to egress_consent tables that
+        predate #2328 (NULL until a decider records a decision)."""
+        db_path = get_test_db().db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = await aiosqlite.connect(str(db_path))
+        try:
+            # Old egress_consent WITHOUT the duration column.
+            await db.execute("""
+                CREATE TABLE egress_consent (
+                    id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    dest_host TEXT NOT NULL,
+                    dest_port INTEGER,
+                    pid INTEGER,
+                    process_name TEXT,
+                    decision TEXT NOT NULL DEFAULT 'pending',
+                    scope TEXT,
+                    requested_at REAL NOT NULL,
+                    decided_at REAL,
+                    decided_by TEXT
+                )
+            """)
+            await db.commit()
+        finally:
+            await db.close()
+
+        await app_state.state.model.init_db()
+
+        async with app_state.state.db.transaction() as conn:
+            cursor = await conn.execute("PRAGMA table_info(egress_consent)")
+            cols = {row[1] for row in await cursor.fetchall()}
+            assert "duration" in cols
+
     async def test_migrate_workspaces_adds_settings(
         self, temp_data_dir, app_state
     ):

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -266,6 +266,35 @@ async def test_decide_invalid_decision_raises(ec, ws, user):
         await ec.decide(req["id"], "bogus", SCOPE_ONCE, user["id"])
 
 
+async def test_decide_records_duration(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "dur-ws")
+    req = await ec.create_request(w["id"], "a.com", 443)
+    await ec.decide(req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "1d")
+    row = await ec.app.state.db.fetchone(
+        "SELECT duration FROM egress_consent WHERE id = ?", (req["id"],)
+    )
+    assert row["duration"] == "1d"
+
+
+async def test_decide_default_duration_is_restart(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "dur-default")
+    req = await ec.create_request(w["id"], "a.com", 443)
+    await ec.decide(req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"])
+    row = await ec.app.state.db.fetchone(
+        "SELECT duration FROM egress_consent WHERE id = ?", (req["id"],)
+    )
+    assert row["duration"] == "restart"
+
+
+async def test_decide_invalid_duration_raises(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "bad-dur")
+    req = await ec.create_request(w["id"], "a.com", 443)
+    with pytest.raises(ValueError, match="Invalid duration"):
+        await ec.decide(
+            req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "2d"
+        )
+
+
 async def test_decide_pending_not_allowed_as_decision(ec, ws, user):
     """Can't 'decide' to set decision back to pending."""
     w = await ws.create_workspace(user["id"], "pend-decide")

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -341,6 +341,11 @@ async def test_expire_pending(ec, ws, user):
     got = await ec.get_request(req["id"])
     assert got["decision"] == DECISION_EXPIRED
     assert got["decided_by"] is None  # auto-expired, no user
+    # a timeout is a non-persistent deny: duration=once (#2328)
+    row = await ec.app.state.db.fetchone(
+        "SELECT duration FROM egress_consent WHERE id = ?", (req["id"],)
+    )
+    assert row["duration"] == "once"
 
 
 async def test_expire_all_pending_reaps_only_pending(ec, ws, user):

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -681,7 +681,7 @@ class TestConsentForward:
         # WS down -> "deny" at once, no frame sent (today's static behavior).
         c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
         assert c.connected is False
-        assert await c.request("evil.test", None) == "deny"
+        assert await c.request("evil.test", None) == ("deny", "once")
 
     async def test_request_sends_frame_and_resolves_on_verdict(
         self, proxy, tmp_path
@@ -706,7 +706,7 @@ class TestConsentForward:
                 {"type": "verdict", "id": frame["id"], "decision": "allow"}
             )
         )
-        assert await task == "allow"
+        assert await task == ("allow", "once")
         assert c._pending == {}  # cleaned up
 
     async def test_request_deny_verdict(self, proxy, tmp_path):
@@ -727,7 +727,7 @@ class TestConsentForward:
                 {"type": "verdict", "id": frame["id"], "decision": "deny"}
             )
         )
-        assert await task == "deny"
+        assert await task == ("deny", "once")
 
     async def test_request_non_allow_verdict_is_deny(self, proxy, tmp_path):
         # expired/malformed decision -> deny (fail-close)
@@ -748,7 +748,7 @@ class TestConsentForward:
                 {"type": "verdict", "id": frame["id"], "decision": "expired"}
             )
         )
-        assert await task == "deny"
+        assert await task == ("deny", "once")
 
     async def test_request_timeout_fail_close(self, proxy, tmp_path):
         # no verdict within HOLD_TIMEOUT -> "deny"; slot cleaned up
@@ -762,7 +762,7 @@ class TestConsentForward:
                 pass
 
         c._ws = _FakeWS()
-        assert await c.request("evil.test", None) == "deny"
+        assert await c.request("evil.test", None) == ("deny", "once")
         assert c._pending == {}
 
     async def test_request_send_error_fail_close(self, proxy, tmp_path):
@@ -775,7 +775,7 @@ class TestConsentForward:
                 raise OSError("connection gone")
 
         c._ws = _FakeWS()
-        assert await c.request("evil.test", None) == "deny"
+        assert await c.request("evil.test", None) == ("deny", "once")
         assert c._pending == {}
 
     def test_dispatch_ignores_non_verdict_and_bad_id(self, proxy, tmp_path):
@@ -800,7 +800,7 @@ class TestConsentForward:
         c._dispatch(
             json.dumps({"type": "verdict", "id": "abc", "decision": "allow"})
         )
-        assert fut.result() == "allow"
+        assert fut.result() == ("allow", "once")
         assert "abc" not in c._pending
 
     async def test_fail_close_pending_resolves_deny_and_clears_cache(
@@ -813,7 +813,7 @@ class TestConsentForward:
         proxy._VERDICT_CACHE.clear()
         proxy._VERDICT_CACHE[("1.2.3.4", 443)] = ("allow", 9999999.0)
         c._fail_close_pending()
-        assert fut.result() == "deny"
+        assert fut.result() == ("deny", "once")
         assert c._pending == {}
         assert (
             proxy._VERDICT_CACHE == {}
@@ -952,7 +952,7 @@ class TestNfqueueCallback:
     ):
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value="allow")
+        client.request = AsyncMock(return_value=("allow", "restart"))
         learned = []
         monkeypatch.setattr(
             proxy,
@@ -967,13 +967,13 @@ class TestNfqueueCallback:
             "1.2.3.4", 443
         )  # host=IP (no record)
         assert learned == [
-            ("1.2.3.4", None, proxy.MIN_TTL)
+            ("1.2.3.4", None, proxy._DURATION_FOREVER)
         ]  # learned all-ports
 
     async def test_allow_names_host_from_ip_map(self, proxy, monkeypatch):
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value="allow")
+        client.request = AsyncMock(return_value=("allow", "restart"))
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
         self._bind(proxy, monkeypatch, client)
         proxy._record_hosts(
@@ -991,7 +991,7 @@ class TestNfqueueCallback:
         # gets RST'd (ECONNREFUSED), not a ~127s tcp_syn_retries wait.
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value="deny")
+        client.request = AsyncMock(return_value=("deny", "once"))
         rejected = []
         monkeypatch.setattr(
             proxy,
@@ -1039,7 +1039,7 @@ class TestNfqueueCallback:
     async def test_unparseable_dest_drops(self, proxy, monkeypatch):
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value="allow")
+        client.request = AsyncMock(return_value=("allow", "restart"))
         self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(b"\x00" * 24)  # version nibble 0 -> parse_dest ("", 0)
         await self._decide(proxy, pkt, client)
@@ -1053,7 +1053,7 @@ class TestNfqueueCallback:
         # cached verdict so it doesn't re-prompt the decider.
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value="allow")
+        client.request = AsyncMock(return_value=("allow", "restart"))
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
         self._bind(proxy, monkeypatch, client)
         pkt1 = _FakePkt(_ip_payload("1.2.3.4", 443))
@@ -1094,6 +1094,83 @@ class TestNfqueueCallback:
         assert set(started) == {("1.2.3.4", 443), ("5.6.7.8", 80)}
         gate.set()  # release both
         await asyncio.gather(*proxy._BG_TASKS)
+
+    async def test_allow_once_does_not_learn(self, proxy, monkeypatch):
+        # `once` allow -> no ACCEPT rule (just this connection; reconnect
+        # re-prompts).
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "once"))
+        learned = []
+        monkeypatch.setattr(proxy, "allow", lambda *a: learned.append(a))
+        self._bind(proxy, monkeypatch, client)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await self._decide(proxy, pkt, client)
+        assert pkt.verdict == "accept"
+        assert learned == []  # no learn for `once`
+
+    async def test_allow_timed_duration_learns_for_ttl(
+        self, proxy, monkeypatch
+    ):
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "1h"))
+        learned = []
+        monkeypatch.setattr(
+            proxy,
+            "allow",
+            lambda ip, port, ttl: learned.append((ip, port, ttl)),
+        )
+        self._bind(proxy, monkeypatch, client)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await self._decide(proxy, pkt, client)
+        assert pkt.verdict == "accept"
+        assert learned == [("1.2.3.4", None, 3600)]  # 1h -> 3600s
+
+    async def test_deny_timed_duration_rejects_for_ttl(
+        self, proxy, monkeypatch
+    ):
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("deny", "15m"))
+        rejected = []
+        monkeypatch.setattr(
+            proxy,
+            "reject",
+            lambda ip, port, ttl: rejected.append((ip, port, ttl)),
+        )
+        self._bind(proxy, monkeypatch, client)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await self._decide(proxy, pkt, client)
+        assert pkt.verdict == "drop"
+        assert rejected == [("1.2.3.4", 443, 900)]  # 15m -> 900s
+
+    async def test_deny_once_uses_short_fail_close_ttl(
+        self, proxy, monkeypatch
+    ):
+        # `once` deny -> the short CONSENT_REJECT_TTL (fail-close this conn).
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("deny", "once"))
+        rejected = []
+        monkeypatch.setattr(
+            proxy, "reject", lambda ip, port, ttl: rejected.append(ttl)
+        )
+        self._bind(proxy, monkeypatch, client)
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await self._decide(proxy, pkt, client)
+        assert pkt.verdict == "drop"
+        assert rejected == [proxy.CONSENT_REJECT_TTL]
+
+
+def test_duration_ttl_mapping(proxy):
+    assert proxy._duration_ttl("once") is None
+    assert proxy._duration_ttl("5m") == 300
+    assert proxy._duration_ttl("1h") == 3600
+    assert proxy._duration_ttl("1w") == 604800
+    assert proxy._duration_ttl("restart") == proxy._DURATION_FOREVER
+    assert proxy._duration_ttl("forever") == proxy._DURATION_FOREVER
+    assert proxy._duration_ttl("bogus") is None  # unknown -> None
 
 
 class TestHandlePacket:


### PR DESCRIPTION
## Summary

Implements **Slice A of #2328** — per-request verdict `duration`. A consent verdict now carries a duration (`once` | `5m` | `15m` | `1h` | `1d` | `1w` | `restart` | `forever`, default `restart`), threaded end-to-end and honored by the sidecar. The blanket "pause consent filtering" control (workspace-level, top-bar) is **Slice B, split to #2332**.

> Builds on the merged SYN consent gate (#2324/#2326/#2329).

## What changed

- **TUI (`consent-decide`)**: each request row has a duration selector (a row of toggle-buttons, default `restart`). Selecting a duration does **not** submit — it only sets the row's pending choice (highlighted). Only **Allow / Deny** submit, with the currently-selected duration. `make_verdict` carries `duration`.
- **Decider handler**: validates the duration (error frame on invalid) → `coordinator.resolve`.
- **Coordinator `resolve`**: records the duration (`egress_consent.decide`) + adds it to the verdict dict relayed to the sidecar.
- **Sidecar (`proxy.py`)**: honors the duration — an allow learns the IP for that long (`once` = this connection only, **no learn**); a deny REJECTs (tcp-reset) for that long. `_duration_ttl` maps the token → seconds.
- **Model**: new `duration` column on `egress_consent` (CREATE TABLE + ALTER migration for existing DBs); `decide()` records + validates it.

## Duration semantics

- `once` — this connection only (allow: no learn, just accept; deny: short fail-close REJECT).
- `5m` / `15m` / `1h` / `1d` / `1w` — learn/REJECT for that TTL.
- `restart` — the workspace **container's** lifetime (the sidecar's in-memory rules).
- `forever` — the **workspace's** lifetime (persists across container/sidecar restarts via klangkd). **Cross-restart persistence is a follow-up within #2328** — at the sidecar level it currently maps to a long in-memory TTL like `restart`; the klangkd-side persistence + re-apply on sidecar reconnect is the remaining `forever` work.

## Verification

4606 passed, 100% coverage. New tests cover: the duration validation (model + decider handler), the DB write + migration, the sidecar's `_duration_ttl` + the once/timed/deny paths, and the TUI selector (selection doesn't submit; Allow/Deny submit with the chosen duration; default `restart`; the defensive guards).

The loop-native sidecar plumbing (`get_fd`/`add_reader`) is exercised by the e2e suite (#2327); unit tests cover `_decide_and_verdict` + the duration logic.

Refs #2328 (Slice A; Slice B = #2332).
