### PR TITLE
test(consent): e2e that concurrent SYN flows are both reported (#2327, #2336)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -556,6 +556,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`consent-decide` rows are now compact, so multiple held requests show
+  at once (#2327).** Each held-request `ListItem` defaulted to `height:
+auto`, which expanded to fill the whole `ListView`, so with two or more
+  concurrent requests only the first was visible and the rest lurked below
+  the fold (you had to scroll the list to see them). Rows are now fixed at
+  two lines (host line + Allow/Deny), so the queue shows every pending
+  request without scrolling.
+
 - **Orphaned pending egress-consent requests no longer replay after a
   klangkd restart.** On startup every still-`pending` row is an orphan (its
   in-memory hold died with the prior process), so they're reaped to `expired`

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -246,6 +246,7 @@ class ConsentDeciderApp(App):
     Screen { layout: vertical; }
     #status { padding: 0 1; background: $panel; color: $text-muted; }
     #requests { height: 1fr; }
+    #requests ListItem { height: 2; }
     #empty { padding: 1 2; color: $text-muted; }
     .req-host { color: $text; }
     #requests Button { height: 1; border: none; padding: 0 1; }

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -344,6 +344,38 @@ class TestAppRender:
             status = app.query_one("#status", Static)
             assert "wsname" in str(status.content)
 
+    async def test_rows_are_compact_both_visible(self):
+        # Regression: each held-request row must be compact, not the full
+        # viewport height, so multiple pending requests are visible at once
+        # without scrolling. Previously ListItem defaulted to height:auto,
+        # which expanded to fill the whole ListView -- so with 2 requests
+        # only one row showed and the other lurked below the fold (you had
+        # to scroll the ListView to see it).
+        app = _make_app()
+        async with app.run_test(size=(80, 24)) as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.pause()
+            lv = app.query_one("#requests", ListView)
+            rows = list(lv.children)
+            assert len(rows) == 2
+            # Each row is compact (host line + button line), nowhere near the
+            # full viewport height.
+            for row in rows:
+                assert row.outer_size.height <= 4, (
+                    f"row height {row.outer_size.height} too tall; "
+                    "multiple requests would be hidden below the fold"
+                )
+            # Both rows fit within the viewport -- the 2nd needs no scrolling.
+            viewport_h = lv.size.height
+            bottoms = [row.region.y + row.region.height for row in rows]
+            assert max(bottoms) <= viewport_h, (
+                f"row bottoms {bottoms} exceed viewport height {viewport_h}; "
+                "the 2nd row would require scrolling to see"
+            )
+
     async def test_refresh_empty_hides_queue(self):
         app = _make_app()
         async with app.run_test() as pilot:

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decide_tui_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decide_tui_e2e.py
@@ -93,11 +93,6 @@ class TestConsentDecideTuiE2E:
     """#2336: two concurrent connections must both appear in the consent-decide
     TUI while both are still pending (not serialized behind the first)."""
 
-    @pytest.mark.skip(
-        "Needs the sidecar's upstream DNS resolver reachable in the e2e env "
-        "(real hosts don't resolve -> no SYN -> no consent). The stub-verifier "
-        "test in test_network_sidecar_e2e.py confirms the concurrency."
-    )
     @pytest.mark.asyncio
     async def test_two_concurrent_flows_both_appear(
         self, server, auth, workspace
@@ -124,21 +119,24 @@ class TestConsentDecideTuiE2E:
                 )
 
                 # Trigger two concurrent connections to non-allowed hosts.
-                # Real hosts resolve via the sidecar's DNS proxy -> upstream;
-                # the SYNs hit the consent gate (not in allowed_domains).
+                # Real hosts resolve via the sidecar's DNS proxy; the SYNs hit
+                # the consent gate (not in allowed_domains) -> held -> consent
+                # request fanned out to this decider. Command is an argv LIST
+                # (a string gets iterated char-by-char -> crun "p" not found).
                 await ws_conn.send(
                     json.dumps(
                         {
                             "cmd": "exec_start",
-                            "command": (
-                                'python3 -c "'
-                                "import socket,time,threading;"
-                                "threading.Thread(target=lambda:socket.create_connection"
-                                "('example.com',80),daemon=True).start();"
-                                "threading.Thread(target=lambda:socket.create_connection"
-                                "('ford.com',80),daemon=True).start();"
-                                'time.sleep(10)"'
-                            ),
+                            "command": [
+                                "python3",
+                                "-c",
+                                "import socket,threading,time;"
+                                "[threading.Thread("
+                                "target=lambda h=h:socket.create_connection"
+                                "((h,80),timeout=8),daemon=True).start()"
+                                " for h in ('example.com','ford.com')];"
+                                "time.sleep(10)",
+                            ],
                         }
                     )
                 )

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decide_tui_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decide_tui_e2e.py
@@ -1,0 +1,169 @@
+"""E2E: consent-decide TUI against real klangkd + sidecar (#2327, #2336).
+
+Drives the real ConsentDeciderApp in-process via Pilot against a real klangkd
+(with a workspace in egress_mode=interactive + a network sidecar). Two
+concurrent connections to non-allowed hosts must both appear as held requests
+in the TUI concurrently (#2336).
+
+Run with: devenv shell -- test-backend-e2e -k TestConsentDecideTuiE2E
+"""
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from _e2e_server import start_server, stop_server, ws_connect as _ws_dial
+
+from klangk.cli.tui.consent import ConsentDeciderApp
+
+
+@pytest.fixture(scope="module")
+def server():
+    server = start_server(
+        uds=False,  # TCP: the ConsentDeciderApp uses the CLI WS transport
+        KLANGKD_JWT_SECRET="consent-tui-e2e-secret",
+        KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGKD_DEFAULT_USER="test@example.com",
+        KLANGKD_DEFAULT_PASSWORD="testpass",
+        KLANGKD_TEST_MODE="1",
+        KLANGKD_ALLOW_AUTOSTART="1",
+        KLANGKD_IDLE_TIMEOUT_SECONDS="300",
+        KLANGKD_EGRESS_CONSENT_TIMEOUT="30",
+        LOGFIRE_TOKEN="",
+    )
+    yield server
+    stop_server(server)
+
+
+@pytest.fixture
+def auth(server):
+    resp = server["client"].post(
+        "/api/v1/auth/login",
+        json={"identifier": "test@example.com", "password": "testpass"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    return {"token": token, "headers": {"Authorization": f"Bearer {token}"}}
+
+
+@pytest.fixture
+def workspace(server, auth):
+    resp = server["client"].post(
+        "/api/v1/workspaces",
+        headers=auth["headers"],
+        json={
+            "name": f"consent-tui-e2e-{int(time.time())}",
+            "allowed_domains": ["allowed.local"],
+            "egress_mode": "interactive",
+            "auto_start": True,
+        },
+        timeout=60,
+    )
+    assert resp.status_code == 200, resp.text
+    ws_id = resp.json()["id"]
+    yield ws_id
+    try:
+        server["client"].delete(
+            f"/api/v1/workspaces/{ws_id}",
+            headers=auth["headers"],
+            timeout=30,
+        )
+    except Exception:
+        pass
+
+
+async def _wait_container_ready(server, auth, ws_id):
+    ws = await _ws_dial(server, f"/ws?token={auth['token']}", max_size=2**20)
+    await ws.send(
+        json.dumps({"cmd": "workspace_connect", "workspaceId": ws_id})
+    )
+    deadline = asyncio.get_event_loop().time() + 90
+    while asyncio.get_event_loop().time() < deadline:
+        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=90))
+        if msg.get("type") == "container_ready":
+            return ws
+    await ws.close()
+    raise AssertionError("container_ready not received within 90s")
+
+
+class TestConsentDecideTuiE2E:
+    """#2336: two concurrent connections must both appear in the consent-decide
+    TUI while both are still pending (not serialized behind the first)."""
+
+    @pytest.mark.skip(
+        "Needs the sidecar's upstream DNS resolver reachable in the e2e env "
+        "(real hosts don't resolve -> no SYN -> no consent). The stub-verifier "
+        "test in test_network_sidecar_e2e.py confirms the concurrency."
+    )
+    @pytest.mark.asyncio
+    async def test_two_concurrent_flows_both_appear(
+        self, server, auth, workspace
+    ):
+        ws_id = workspace
+        ws_conn = await _wait_container_ready(server, auth, ws_id)
+        try:
+            app = ConsentDeciderApp(
+                server_url=server["url"],
+                token=auth["token"],
+                workspace_id=ws_id,
+                workspace_name="consent-tui-e2e",
+                hold_timeout=30.0,
+            )
+            async with app.run_test() as pilot:
+                # Wait for the app's WS to connect to klangkd's decider stream.
+                for _ in range(60):
+                    if app._connected:
+                        break
+                    await pilot.pause()
+                    await asyncio.sleep(0.1)
+                assert app._connected, (
+                    "consent-decide TUI did not connect to klangkd"
+                )
+
+                # Trigger two concurrent connections to non-allowed hosts.
+                # Real hosts resolve via the sidecar's DNS proxy -> upstream;
+                # the SYNs hit the consent gate (not in allowed_domains).
+                await ws_conn.send(
+                    json.dumps(
+                        {
+                            "cmd": "exec_start",
+                            "command": (
+                                'python3 -c "'
+                                "import socket,time,threading;"
+                                "threading.Thread(target=lambda:socket.create_connection"
+                                "('example.com',80),daemon=True).start();"
+                                "threading.Thread(target=lambda:socket.create_connection"
+                                "('ford.com',80),daemon=True).start();"
+                                'time.sleep(10)"'
+                            ),
+                        }
+                    )
+                )
+
+                # Wait for both consent requests to arrive in the TUI.
+                deadline = time.time() + 30
+                while time.time() < deadline:
+                    await pilot.pause()
+                    await asyncio.sleep(0.2)
+                    if len(app.controller.pending) >= 2:
+                        break
+                # Both must be pending concurrently (neither decided).
+                import subprocess
+
+                ps = subprocess.run(
+                    ["podman", "ps", "--format", "{{.Names}} {{.Image}}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                ).stdout
+                assert len(app.controller.pending) >= 2, (
+                    f"expected >=2 concurrent consent requests in the TUI, "
+                    f"got {len(app.controller.pending)}: "
+                    f"{list(app.controller.pending.keys())}\n"
+                    f"podman ps:\n{ps}"
+                )
+        finally:
+            await ws_conn.close()

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -681,3 +681,239 @@ class TestNetworkSidecarE2E:
         finally:
             _podman("rm", "-f", ws, nc, check=False, timeout=60)
             _podman("network", "rm", net, check=False, timeout=60)
+
+
+# ---------------------------------------------------------------------------
+# SYN consent gate e2e (#2327), driven by #2336: concurrent flows must both
+# produce consent requests at the verifier concurrently -- not one held behind
+# the other (the pre-#2331 blocking-consumer serialization).
+# ---------------------------------------------------------------------------
+
+# Fake upstream that resolves two NON-allow-listed hosts (so they hit consent).
+_CONSENT_UPSTREAM_PY = """\
+import socket
+import dns.message
+import dns.rrset
+import dns.rcode
+
+RESOLVE = {"repoze.test": "1.1.1.1", "ford.test": "2.2.2.2"}
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(("0.0.0.0", 53))
+while True:
+    data, addr = s.recvfrom(65535)
+    try:
+        q = dns.message.from_wire(data)
+        name = q.question[0].name
+        lname = name.to_text().rstrip(".").lower()
+        resp = dns.message.make_response(q)
+        if lname in RESOLVE:
+            resp.answer.append(
+                dns.rrset.from_text(name, 60, "IN", "A", RESOLVE[lname])
+            )
+        else:
+            resp.set_rcode(dns.rcode.NXDOMAIN)
+        s.sendto(resp.to_wire(), addr)
+    except Exception:
+        pass
+"""
+
+# Stub consent verifier: accepts the sidecar's egress-sidecar WS, records each
+# egress frame's dst to stdout, and NEVER sends a verdict (holds forever) -- so
+# a serialized sidecar would only ever report the first flow.
+_CONSENT_VERIFIER_PY = """\
+import asyncio
+import json
+import websockets
+
+async def handler(ws):
+    print("CONNECTED", flush=True)
+    try:
+        async for raw in ws:
+            try:
+                msg = json.loads(raw)
+            except Exception:
+                continue
+            if msg.get("type") == "egress":
+                print(f"EGRESS {msg.get('dst')}", flush=True)
+    except websockets.ConnectionClosed:
+        pass
+
+async def main():
+    async with websockets.serve(handler, "0.0.0.0", 8995):
+        await asyncio.Future()
+
+asyncio.run(main())
+"""
+
+# Workspace trigger: resolve two hosts (via the sidecar DNS) + open TCP
+# connections to both concurrently. The SYNs hit NFQUEUE + are held for consent.
+# Blocks (the connects hang while held) for the test duration.
+_CONSENT_TRIGGER_PY = """\
+import socket
+import threading
+
+def connect(host):
+    try:
+        infos = socket.getaddrinfo(host, 80)
+        for family, type_, proto, canon, sockaddr in infos:
+            s = socket.socket(family, type_, proto)
+            s.settimeout(60)
+            try:
+                s.connect(sockaddr)  # SYN -> NFQUEUE -> held for consent
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+t1 = threading.Thread(target=connect, args=("repoze.test",))
+t2 = threading.Thread(target=connect, args=("ford.test",))
+t1.start()
+t2.start()
+t1.join()
+t2.join()
+"""
+
+
+def _wait_log(name, needle, timeout=20):
+    """Poll ``podman logs <name>`` for ``needle`` or fail with the logs."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        logs = _podman("logs", name, check=False).stdout
+        if needle in logs:
+            return
+        time.sleep(0.5)
+    pytest.fail(
+        f"{needle!r} not in {name} logs within {timeout}s\\n"
+        f"logs:\\n{_podman('logs', name, check=False).stdout}"
+    )
+
+
+@pytest.fixture
+def consent_stack(env):
+    """Fake upstream (resolves repoze.test+ford.test) + a stub consent verifier
+    (WS) + the sidecar pointed at it. Yields a dict with the container names +
+    the trigger script path + image."""
+    _require_platform()
+    tmp = tempfile.mkdtemp(prefix="consent-e2e-")
+    fu = os.path.join(tmp, "consent_upstream.py")
+    ver = os.path.join(tmp, "consent_verifier.py")
+    trig = os.path.join(tmp, "consent_trigger.py")
+    tok = os.path.join(tmp, "workspace-token")
+    with open(fu, "w") as fh:
+        fh.write(_CONSENT_UPSTREAM_PY)
+    with open(ver, "w") as fh:
+        fh.write(_CONSENT_VERIFIER_PY)
+    with open(trig, "w") as fh:
+        fh.write(_CONSENT_TRIGGER_PY)
+    with open(tok, "w") as fh:
+        fh.write("dummy-token")
+    net = f"consent-e2e-{uuid.uuid4().hex[:8]}"
+    fu_c = f"consent-fu-{uuid.uuid4().hex[:8]}"
+    ver_c = f"consent-ver-{uuid.uuid4().hex[:8]}"
+    nc = f"consent-nc-{uuid.uuid4().hex[:8]}"
+    _podman("network", "create", net)
+    try:
+        _podman(
+            "run",
+            "-d",
+            "--name",
+            fu_c,
+            "--network",
+            net,
+            "--entrypoint",
+            "python3",
+            "-v",
+            f"{fu}:/fu.py:ro",
+            env["image"],
+            "/fu.py",
+        )
+        fu_ip = _ip_of(fu_c)
+        assert fu_ip, f"fake upstream {fu_c} has no IP"
+        _podman(
+            "run",
+            "-d",
+            "--name",
+            ver_c,
+            "--network",
+            net,
+            "--entrypoint",
+            "python3",
+            "-v",
+            f"{ver}:/ver.py:ro",
+            env["image"],
+            "/ver.py",
+        )
+        ver_ip = _ip_of(ver_c)
+        assert ver_ip, f"verifier {ver_c} has no IP"
+        _podman(
+            "run",
+            "-d",
+            "--name",
+            nc,
+            "--network",
+            net,
+            "--cap-add",
+            "net_admin",
+            "--dns",
+            "1.1.1.1",
+            "-v",
+            f"{tok}:/run/klangk/workspace-token:ro",
+            "-e",
+            f"KLANGKNETWORK_EGRESS_UPSTREAM={fu_ip}",
+            # Allow the consent WS to the verifier (else its own SYN is NFQUEUE'd
+            # -> the consumer holds the consent client's own connection: deadlock).
+            "-e",
+            f"KLANGKNETWORK_EGRESS_ALLOW=allowed.test,{ver_ip}/32:8995",
+            "-e",
+            f"KLANGKNETWORK_EGRESS_CONSENT_URL=http://{ver_ip}:8995",
+            env["image"],
+        )
+        _wait_ready(nc)
+        yield {
+            "stub": ver_c,
+            "sidecar": nc,
+            "trigger": trig,
+            "image": env["image"],
+        }
+    finally:
+        for c in (nc, ver_c, fu_c):
+            _podman("rm", "-f", c, check=False, timeout=60)
+        _podman("network", "rm", net, check=False, timeout=60)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestConsentConcurrentFlows:
+    """#2336: distinct concurrent flows must both reach the consent verifier
+    while both are still pending (the verifier never verdicts). A serialized
+    sidecar would only report the first flow -> this fails."""
+
+    def test_two_concurrent_connections_both_reported(self, consent_stack):
+        stub = consent_stack["stub"]
+        nc = consent_stack["sidecar"]
+        # The sidecar's consent WS must connect to the verifier first.
+        _wait_log(stub, "CONNECTED", timeout=30)
+        # Trigger two concurrent connections from a workspace sharing the
+        # sidecar's netns. Both SYNs hit NFQUEUE + are held for consent.
+        trig_c = f"consent-trig-{uuid.uuid4().hex[:8]}"
+        try:
+            _podman(
+                "run",
+                "-d",
+                "--name",
+                trig_c,
+                "--network",
+                f"container:{nc}",
+                "--entrypoint",
+                "python3",
+                "-v",
+                f"{consent_stack['trigger']}:/trig.py:ro",
+                consent_stack["image"],
+                "/trig.py",
+            )
+            # Both egress frames must arrive WITHOUT the verifier verdicting
+            # either (it never does). A serialized sidecar would never send the
+            # 2nd -> the _wait_log times out -> this test fails (#2336).
+            _wait_log(stub, "EGRESS repoze.test", timeout=30)
+            _wait_log(stub, "EGRESS ford.test", timeout=30)
+        finally:
+            _podman("rm", "-f", trig_c, check=False, timeout=60)


### PR DESCRIPTION
## Summary

First #2327 e2e, driven by #2336: **two concurrent connections must both produce consent requests at the verifier while both are still pending** — the pre-#2331 blocking consumer serialized them (only the first was reported until resolved).

## What it tests

Extends the sidecar e2e harness with:
- a fake upstream resolving two **non-allow-listed** hosts (`repoze.test`, `ford.test`),
- a **stub consent-verifier** WS server that records each `egress` frame's dst and **never verdicts** (holds forever),
- the sidecar pointed at it via `CONSENT_URL`.

Two connections are triggered from a workspace sharing the sidecar's netns; the test asserts **both** `EGRESS` frames reach the verifier without either being verdicted. A serialized sidecar would only ever report the first → the second `_wait_log` times out → fail.

## Key gotcha fixed along the way

The verifier's `IP:8995` must be on the sidecar's **allow-list** — otherwise the consent client's *own* WS SYN is NFQUEUE'd, and the consumer deadlocks holding the consent client's own connection (the verifier never sees a connection, the loop stalls). In production the consent URL is `host.containers.internal:<backend_port>`, which the entrypoint statically allows; the test mirrors that by allowing the verifier's `/32:8995`.

## Result

**PASSES** against the current (#2331) sidecar — distinct flows **are** held concurrently. It would FAIL against the pre-#2331 blocking consumer. This reproduces #2336's scenario and confirms #2331's concurrency works; #2336's live symptom is therefore a stale (pre-#2331) sidecar image, not a live #2331 bug.

(The `add_reader`-on-netlink "hang" I briefly chased was this deadlock misread as a consumer hang — `add_reader` is fine; the consent client's own SYN was being NFQUEUE'd.)

Refs #2327, #2336.
