### PR TITLE
feat(consent): expose active egress decisions + egress_rules frame (#2338)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -44,6 +44,14 @@ operators or integrators to act when upgrading.
   sidecar level it maps to a long in-memory TTL). Recorded on the
   `egress_consent` row.
 
+- **Active-egress-decisions snapshot (`egress_rules` frame) (#2338).** The
+  consent-decider WebSocket now pushes an `egress_rules` snapshot on connect
+  (and refreshes it after each verdict): the workspace's in-effect consent
+  verdicts (allows and denies still within their duration) plus its static
+  allow-list, for the upcoming rule-management view (#2335). The
+  `egress_consent.duration` column is now read back and constrained by a DB
+  `CHECK` to the documented duration values (mirroring `DURATIONS`).
+
 - **`klangk consent-decide <workspace>` (#2310).** A live Textual client that
   connects to a workspace's consent-decider stream and shows its held egress
   requests (blocked destinations the network sidecar is holding for a

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -36,6 +36,8 @@ import logging
 
 from .consent import workspace_is_interactive
 from .model.egress_consent import (
+    DECISION_ALLOWED,
+    DECISION_DENIED,
     DECISION_PENDING,
     DURATION_DEFAULT,
     DURATION_ONCE,
@@ -221,6 +223,10 @@ class ConsentCoordinator:
         if not hold["future"].done():
             hold["future"].set_result(verdict)
         self._broadcast_resolved(request_id, hold["workspace_id"], resolved)
+        if resolved in ("allowed", "denied"):
+            # A new verdict entered the in-effect set: refresh the deciders'
+            # rule-management view (#2335 slice A) without a reconnect.
+            await self._broadcast_rules(hold["workspace_id"])
         return verdict
 
     async def _timeout(self, request_id: str) -> None:
@@ -307,6 +313,34 @@ class ConsentCoordinator:
         )
         return [self._request_frame(row) for row in rows]
 
+    async def rules_frame(self, workspace_id: str | None) -> dict | None:
+        """Build an ``egress_rules`` snapshot for a workspace (#2335 slice A).
+
+        The in-effect consent verdicts (grouped allow/deny) + the static
+        allow-list, for the decider's rule-management view. Returns None for a
+        missing/deleted workspace (the caller skips the frame); deploy-wide
+        deciders (workspace None) get no frame for now (a cross-workspace view
+        is a follow-up, matching :meth:`snapshot`).
+        """
+        if workspace_id is None:
+            return None
+        ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
+        if ws is None:
+            return None
+        rows = await self.app.state.model.egress_consent.list_active(
+            workspace_id
+        )
+        return {
+            "type": "egress_rules",
+            "workspace_id": workspace_id,
+            "allow_list": ws.get("allowed_domains") or [],
+            "allowed": [r for r in rows if r["decision"] == DECISION_ALLOWED],
+            "denied": [r for r in rows if r["decision"] == DECISION_DENIED],
+            # #2332 (pause control) not yet landed: no transient pause state
+            # exists, so this is always None until that work adds it.
+            "paused": None,
+        }
+
     @staticmethod
     def _request_frame(request: dict) -> dict:
         """Build an ``egress_request`` frame from a consent-request row."""
@@ -333,6 +367,23 @@ class ConsentCoordinator:
                 "decision": decision,
             },
         )
+
+    async def _broadcast_rules(self, workspace_id: str) -> None:
+        """Push a refreshed ``egress_rules`` frame to the workspace's deciders.
+
+        Called after a verdict lands (and, in slice C, after a revoke) so the
+        deciders' rule-management view reflects the new in-effect set without a
+        reconnect. Best-effort: a refresh failure (DB read) is logged +
+        swallowed so it can never break the verdict path that called this --
+        the sidecar already has its verdict.
+        """
+        try:
+            frame = await self.rules_frame(workspace_id)
+        except Exception:
+            logger.exception("consent: rules refresh broadcast failed")
+            return
+        if frame is not None:
+            self.app.state.consent_deciders.broadcast(workspace_id, frame)
 
     async def _is_interactive(self, workspace_id: str) -> bool:
         """Interactive iff the workspace opted in AND a live decider exists (#2308)."""

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -170,7 +170,7 @@ class EgressConsentModel:
         row = await self.app.state.db.fetchone(
             "SELECT id, workspace_id, dest_host, dest_port,"
             " pid, process_name,"
-            " decision, scope, requested_at, decided_at, decided_by"
+            " decision, scope, duration, requested_at, decided_at, decided_by"
             " FROM egress_consent WHERE id = ?",
             (request_id,),
         )
@@ -190,7 +190,8 @@ class EgressConsentModel:
                 cursor = await db.execute(
                     "SELECT id, workspace_id, dest_host, dest_port,"
                     " pid, process_name,"
-                    " decision, scope, requested_at, decided_at, decided_by"
+                    " decision, scope, duration, requested_at, decided_at,"
+                    " decided_by"
                     " FROM egress_consent"
                     " WHERE workspace_id = ? AND decision = ?"
                     " ORDER BY requested_at DESC LIMIT ?",
@@ -200,7 +201,8 @@ class EgressConsentModel:
                 cursor = await db.execute(
                     "SELECT id, workspace_id, dest_host, dest_port,"
                     " pid, process_name,"
-                    " decision, scope, requested_at, decided_at, decided_by"
+                    " decision, scope, duration, requested_at, decided_at,"
+                    " decided_by"
                     " FROM egress_consent"
                     " WHERE workspace_id = ?"
                     " ORDER BY requested_at DESC LIMIT ?",
@@ -208,6 +210,85 @@ class EgressConsentModel:
                 )
             rows = await cursor.fetchall()
             return [_row_to_dict(row) for row in rows]
+
+    # Duration string -> seconds, for the time-bounded in-effect window
+    # (#2328). `once`/`restart`/`forever` are not time-bounded (handled
+    # separately in :meth:`_duration_in_effect`), so they're absent here.
+    _DURATION_SECONDS = {
+        DURATION_5M: 300,
+        DURATION_15M: 900,
+        DURATION_1H: 3600,
+        DURATION_1D: 86400,
+        DURATION_1W: 604800,
+    }
+
+    async def list_active(self, workspace_id: str) -> list[dict]:
+        """Consent verdicts still in effect for a workspace (#2335 slice A).
+
+        Returns allowed/denied rows whose duration hasn't elapsed, so a
+        rule-management view can show "what's currently affecting networking".
+        Each row carries its ``decision`` so the caller can group allows vs
+        denies.
+
+        - ``once`` -> excluded (consumed by the single connection).
+        - ``5m``/``15m``/``1h``/``1d``/``1w`` -> in effect iff
+          ``decided_at + duration`` > now.
+        - ``restart`` -> recorded in effect (container lifetime). CAVEAT: the
+          sidecar's in-memory rule does NOT survive a sidecar/container
+          restart, but this row does, so a recorded ``restart`` allow may be
+          not-enforced after a restart until re-triggered. Reaping ``restart``
+          rows on container restart is a follow-up (out of scope for slice A);
+          until then this view reports the *recorded* set, not the live-enforced
+          one.
+        - ``forever`` -> in effect (workspace lifetime; cross-restart
+          persistence lands with #2328).
+
+        Only **verdict** decisions are returned (``decided_by`` not NULL):
+        static policy denials (``record_static_denial``, ``decided_by`` NULL)
+        are the complement of the allow-list, infinite in number, and not
+        actionable in the rules view. Expired / pending / revoked rows are
+        never in effect.
+        """
+        now = time.time()
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, workspace_id, dest_host, dest_port,"
+                " pid, process_name,"
+                " decision, scope, duration, requested_at, decided_at,"
+                " decided_by"
+                " FROM egress_consent"
+                " WHERE workspace_id = ? AND decision IN (?, ?)"
+                " AND decided_by IS NOT NULL"
+                " ORDER BY decided_at DESC",
+                (workspace_id, DECISION_ALLOWED, DECISION_DENIED),
+            )
+            rows = await cursor.fetchall()
+        out = []
+        for row in rows:
+            if self._duration_in_effect(
+                row["duration"], row["decided_at"], now
+            ):
+                out.append(_row_to_dict(row))
+        return out
+
+    @classmethod
+    def _duration_in_effect(
+        cls, duration: str | None, decided_at: float | None, now: float
+    ) -> bool:
+        """Whether a decision is still in effect at ``now`` (#2335 slice A)."""
+        if decided_at is None:
+            return False
+        if duration in (DURATION_RESTART, DURATION_FOREVER):
+            return True
+        if duration == DURATION_ONCE:
+            return False
+        secs = cls._DURATION_SECONDS.get(duration)
+        if secs is None:
+            # Unknown / NULL duration: a verdict always sets one, so this only
+            # hits a NULL (e.g. a future migration). Treat as not in effect
+            # (fail-safe: don't claim an effect we can't bound).
+            return False
+        return decided_at + secs > now
 
     async def count_pending(self, workspace_id: str) -> int:
         """Count pending requests for a workspace.
@@ -294,7 +375,7 @@ class EgressConsentModel:
             cursor = await db.execute(
                 "SELECT id, workspace_id, dest_host, dest_port,"
                 " pid, process_name,"
-                " decision, scope, requested_at, decided_at, decided_by"
+                " decision, scope, duration, requested_at, decided_at, decided_by"
                 " FROM egress_consent WHERE id = ?",
                 (request_id,),
             )
@@ -367,6 +448,7 @@ def _row_to_dict(row) -> dict:
         "process_name": row["process_name"],
         "decision": row["decision"],
         "scope": row["scope"],
+        "duration": row["duration"],
         "requested_at": row["requested_at"],
         "decided_at": row["decided_at"],
         "decided_by": row["decided_by"],

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -1,7 +1,12 @@
 """Database schema creation and in-place migrations (``init_db``)."""
 
 from .acl import PRINCIPAL_USER
+from .egress_consent import DURATIONS
 from .users import AGENT_USER_ID, backfill_handles
+
+# The duration CHECK value list is generated from the single source of truth
+# (DURATIONS) so the DB constraint cannot drift from the Python enum (#2338).
+_DURATION_CHECK_VALUES = ", ".join(f"'{d}'" for d in sorted(DURATIONS))
 
 
 async def init_db(db) -> None:
@@ -339,7 +344,7 @@ async def init_db(db) -> None:
         # connections that need human approval. CHECK constraints enforce
         # the decision/scope state machine at the storage layer — the same
         # DB-backstop philosophy as the agent-user triggers above.
-        await db.execute("""
+        await db.execute(f"""
             CREATE TABLE IF NOT EXISTS egress_consent (
                 id TEXT PRIMARY KEY,
                 workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
@@ -351,12 +356,79 @@ async def init_db(db) -> None:
                     CHECK (decision IN ('pending', 'allowed', 'denied', 'expired')),
                 scope TEXT
                     CHECK (scope IS NULL OR scope IN ('once', 'workspace', 'deploy')),
-                duration TEXT,
+                duration TEXT
+                    CHECK (duration IS NULL OR duration IN
+                        ({_DURATION_CHECK_VALUES})),
                 requested_at REAL NOT NULL,
                 decided_at REAL,
                 decided_by TEXT REFERENCES users(id) ON DELETE SET NULL
             )
         """)
+        # egress_consent: attach a CHECK on `duration` (#2338). The column may
+        # already exist from an earlier ALTER (without the constraint) or be
+        # absent in an older dev DB; rebuild the table either way so the
+        # constraint is universal. Detected via sqlite_master (PRAGMA
+        # table_info doesn't expose CHECK). Data is copied across (mirrors the
+        # users rebuild above); the partial unique indexes are recreated by
+        # the CREATE INDEX statements below. No deployments to preserve.
+        ec_sql_cur = await db.execute(
+            "SELECT sql FROM sqlite_master"
+            " WHERE type='table' AND name='egress_consent'"
+        )
+        ec_sql_row = await ec_sql_cur.fetchone()
+        if (
+            ec_sql_row
+            and "duration IS NULL OR duration IN" not in ec_sql_row[0]
+        ):
+            await db.execute(f"""
+                CREATE TABLE egress_consent_new (
+                    id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                    dest_host TEXT NOT NULL,
+                    dest_port INTEGER,
+                    pid INTEGER,
+                    process_name TEXT,
+                    decision TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (decision IN ('pending', 'allowed', 'denied', 'expired')),
+                    scope TEXT
+                        CHECK (scope IS NULL OR scope IN ('once', 'workspace', 'deploy')),
+                    duration TEXT
+                        CHECK (duration IS NULL OR duration IN
+                            ({_DURATION_CHECK_VALUES})),
+                    requested_at REAL NOT NULL,
+                    decided_at REAL,
+                    decided_by TEXT REFERENCES users(id) ON DELETE SET NULL
+                )
+            """)
+            ec_info = await db.execute("PRAGMA table_info(egress_consent)")
+            ec_old_cols = {r[1] for r in await ec_info.fetchall()}
+            ec_shared = [
+                c
+                for c in (
+                    "id",
+                    "workspace_id",
+                    "dest_host",
+                    "dest_port",
+                    "pid",
+                    "process_name",
+                    "decision",
+                    "scope",
+                    "duration",
+                    "requested_at",
+                    "decided_at",
+                    "decided_by",
+                )
+                if c in ec_old_cols
+            ]
+            ec_cols_str = ", ".join(ec_shared)
+            await db.execute(
+                f"INSERT INTO egress_consent_new ({ec_cols_str})"  # noqa: S608
+                f" SELECT {ec_cols_str} FROM egress_consent"
+            )
+            await db.execute("DROP TABLE egress_consent")
+            await db.execute(
+                "ALTER TABLE egress_consent_new RENAME TO egress_consent"
+            )
         await db.execute("""
             CREATE INDEX IF NOT EXISTS idx_egress_consent_workspace
             ON egress_consent(workspace_id, decision)
@@ -379,14 +451,6 @@ async def init_db(db) -> None:
             ON egress_consent(workspace_id, dest_host, COALESCE(dest_port, -1))
             WHERE decision = 'denied' AND decided_by IS NULL
         """)
-        # Migration: add duration column (#2328). NULL until a decider records
-        # a decision; the sidecar honors it (allow-learn / deny-REJECT for T).
-        cursor = await db.execute("PRAGMA table_info(egress_consent)")
-        ec_cols = {row[1] for row in await cursor.fetchall()}
-        if "duration" not in ec_cols:
-            await db.execute(
-                "ALTER TABLE egress_consent ADD COLUMN duration TEXT"
-            )
         # Migration: drop legacy role and workspace_access tables
         for table in ("user_roles", "roles", "workspace_access"):
             await db.execute(f"DROP TABLE IF EXISTS {table}")  # noqa: S608

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -101,6 +101,12 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         # to never miss.
         for frame in await app.state.consent_coordinator.snapshot(workspace):
             safe_ws.send_json(frame)
+        # The in-effect rules snapshot (#2335 slice A): lets a decider joining
+        # mid-flight see what's currently allowed/denied, not just holds. None
+        # for a deploy-wide decider (no single workspace) — matches snapshot().
+        rules = await app.state.consent_coordinator.rules_frame(workspace)
+        if rules is not None:
+            safe_ws.send_json(rules)
         while True:
             # Starlette raises RuntimeError ("WebSocket is not connected...")
             # on a client disconnect during receive_text(); treat it the same

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -42,6 +42,8 @@ def _app(
     has_decider: bool = True,
     decide_row=None,
     pending_rows=None,
+    active_rows=None,
+    allowed_domains=None,
 ):
     app = types.SimpleNamespace()
     app.state = types.SimpleNamespace()
@@ -56,9 +58,14 @@ def _app(
     egress_consent.decide = AsyncMock(return_value=decide_row)
     egress_consent.expire_pending = AsyncMock(return_value=True)
     egress_consent.list_requests = AsyncMock(return_value=pending_rows or [])
+    egress_consent.list_active = AsyncMock(return_value=active_rows or [])
     workspaces = AsyncMock()
     workspaces.get_workspace = AsyncMock(
-        return_value={"egress_mode": egress_mode} if workspace_exists else None
+        return_value=(
+            {"egress_mode": egress_mode, "allowed_domains": allowed_domains}
+            if workspace_exists
+            else None
+        )
     )
     app.state.model = types.SimpleNamespace(
         egress_consent=egress_consent, workspaces=workspaces
@@ -167,14 +174,51 @@ class TestConsentCoordinatorFanout:
         await coord.hold(FULL_WS, "1.2.3.4", 443)
         app.state.consent_deciders.broadcast.reset_mock()
         await coord.resolve("rid-1", "allowed", "once", "a@x")
-        # second broadcast is the resolved frame (first was the egress_request)
-        ws_arg, frame = app.state.consent_deciders.broadcast.call_args.args
-        assert frame == {
+        # the egress_resolved frame is among the broadcasts (resolve also pushes
+        # a refreshed egress_rules frame, #2335 slice A)
+        frames = [
+            c.args[1]
+            for c in app.state.consent_deciders.broadcast.call_args_list
+        ]
+        assert {
             "type": "egress_resolved",
             "workspace_id": FULL_WS,
             "request_id": "rid-1",
             "decision": "allowed",
-        }
+        } in frames
+
+    async def test_resolve_broadcasts_rules_after_verdict(self):
+        # A verdict landing refreshes the deciders' in-effect rules view
+        # (#2335 slice A).
+        row = _request()
+        row["decision"] = "allowed"
+        row["duration"] = (
+            "restart"  # a real in-effect duration (once would be excluded)
+        )
+        app = _app(
+            request=_request(),
+            decide_row=row,
+            active_rows=[row],
+            allowed_domains=["static.example.com"],
+        )
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.consent_deciders.broadcast.reset_mock()
+        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        app.state.model.egress_consent.list_active.assert_awaited_once_with(
+            FULL_WS
+        )
+        frames = [
+            c.args[1]
+            for c in app.state.consent_deciders.broadcast.call_args_list
+        ]
+        rules = [f for f in frames if f["type"] == "egress_rules"]
+        assert len(rules) == 1
+        assert rules[0]["workspace_id"] == FULL_WS
+        assert rules[0]["allow_list"] == ["static.example.com"]
+        assert [r["dest_host"] for r in rules[0]["allowed"]] == ["1.2.3.4"]
+        assert rules[0]["denied"] == []
+        assert rules[0]["paused"] is None
 
     async def test_resolve_rejects_verdict_outside_decider_workspace(self):
         # defense-in-depth: a workspace-scoped decider may not decide another
@@ -201,6 +245,21 @@ class TestConsentCoordinatorFanout:
         assert frame["type"] == "egress_resolved"
         assert frame["decision"] == "expired"
 
+    async def test_broadcast_rules_swallows_refresh_failure(self):
+        # A rules-frame DB failure during the post-verdict refresh must not
+        # break resolve (best-effort: the sidecar already has its verdict).
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.model.workspaces.get_workspace = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        # must not raise -- the verdict path is unaffected by the refresh
+        verdict = await coord.resolve("rid-1", "allowed", "once", "a@x")
+        assert verdict["decision"] == "allow"
+
     async def test_snapshot_replays_pending_requests(self):
         rows = [_request("a"), _request("b")]
         app = _app(pending_rows=rows)
@@ -217,6 +276,58 @@ class TestConsentCoordinatorFanout:
         coord = ConsentCoordinator(app)
         assert await coord.snapshot(None) == []
         app.state.model.egress_consent.list_requests.assert_not_awaited()
+
+
+class TestConsentCoordinatorRules:
+    async def test_rules_frame_groups_active_and_allow_list(self):
+        allowed = {
+            "id": "a1",
+            "workspace_id": FULL_WS,
+            "dest_host": "allow.com",
+            "dest_port": 443,
+            "decision": "allowed",
+            "duration": "restart",
+        }
+        denied = {
+            "id": "d1",
+            "workspace_id": FULL_WS,
+            "dest_host": "deny.com",
+            "dest_port": 443,
+            "decision": "denied",
+            "duration": "forever",
+        }
+        app = _app(
+            active_rows=[allowed, denied],
+            allowed_domains=["static.example.com"],
+        )
+        coord = ConsentCoordinator(app)
+        frame = await coord.rules_frame(FULL_WS)
+        assert frame == {
+            "type": "egress_rules",
+            "workspace_id": FULL_WS,
+            "allow_list": ["static.example.com"],
+            "allowed": [allowed],
+            "denied": [denied],
+            "paused": None,
+        }
+        app.state.model.egress_consent.list_active.assert_awaited_once_with(
+            FULL_WS
+        )
+
+    async def test_rules_frame_none_for_missing_workspace(self):
+        app = _app(workspace_exists=False)
+        coord = ConsentCoordinator(app)
+        assert await coord.rules_frame(FULL_WS) is None
+        app.state.model.egress_consent.list_active.assert_not_awaited()
+
+    async def test_rules_frame_none_for_deploy_wide(self):
+        app = _app()
+        coord = ConsentCoordinator(app)
+        assert await coord.rules_frame(None) is None
+        # deploy-wide deciders get no rules frame (no single workspace),
+        # matching snapshot().
+        app.state.model.workspaces.get_workspace.assert_not_awaited()
+        app.state.model.egress_consent.list_active.assert_not_awaited()
 
 
 class TestConsentCoordinatorResolve:

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -208,6 +208,7 @@ def _ws_app(
     *,
     allowed: bool = True,
     snapshot=None,
+    rules_frame=None,
 ):
     """App with mocked auth + acl + coordinator, and a real registry."""
     app = types.SimpleNamespace()
@@ -230,6 +231,7 @@ def _ws_app(
     app.state.consent_coordinator = types.SimpleNamespace(
         snapshot=AsyncMock(return_value=snapshot or []),
         resolve=AsyncMock(return_value=None),
+        rules_frame=AsyncMock(return_value=rules_frame),
     )
     return app
 
@@ -329,6 +331,31 @@ class TestConsentDeciderWS:
             json.loads(m).get("type") == "egress_request" for m in ws.sent
         )
         app.state.consent_coordinator.snapshot.assert_awaited_once_with(WS)
+
+    async def test_rules_frame_pushed_on_connect(self):
+        # On connect the in-effect rules snapshot is pushed too (#2335 slice
+        # A), right after the pending-request snapshot.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        rules = {
+            "type": "egress_rules",
+            "workspace_id": WS,
+            "allow_list": ["static.example.com"],
+            "allowed": [],
+            "denied": [],
+            "paused": None,
+        }
+        app = _ws_app({"id": "u1", "email": "a@x"}, rules_frame=rules)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS}, [WebSocketDisconnect()]
+        )
+        await handle_consent_decider(ws, app)
+        assert any(
+            json.loads(m).get("type") == "egress_rules" for m in ws.sent
+        )
+        app.state.consent_coordinator.rules_frame.assert_awaited_once_with(WS)
 
     async def test_verdict_resolves_the_hold(self):
         from fastapi import WebSocketDisconnect

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -10,6 +10,7 @@ from klangk.model.egress_consent import (
     DECISION_DENIED,
     DECISION_EXPIRED,
     DECISION_PENDING,
+    DURATIONS,
     SCOPE_ONCE,
     SCOPE_WORKSPACE,
 )
@@ -404,6 +405,95 @@ async def test_cascade_delete_on_workspace_delete(ec, ws, user):
     assert await ec.list_requests(w["id"]) == []
 
 
+# -- list_active (in-effect computation, #2335 slice A) --
+
+
+async def test_list_active_groups_allowed_and_denied(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "active-grp")
+    a = await ec.create_request(w["id"], "allow.com", 443)
+    await ec.decide(
+        a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+    d = await ec.create_request(w["id"], "deny.com", 443)
+    await ec.decide(d["id"], DECISION_DENIED, None, user["id"], "forever")
+    rows = await ec.list_active(w["id"])
+    decisions = {r["dest_host"]: r["decision"] for r in rows}
+    assert decisions == {
+        "allow.com": DECISION_ALLOWED,
+        "deny.com": DECISION_DENIED,
+    }
+    # each row carries its duration (the read fix, #2338)
+    by_host = {r["dest_host"]: r for r in rows}
+    assert by_host["allow.com"]["duration"] == "restart"
+    assert by_host["deny.com"]["duration"] == "forever"
+
+
+async def test_list_active_excludes_once(ec, ws, user):
+    # `once` is consumed by the single connection — never in effect.
+    w = await ws.create_workspace(user["id"], "active-once")
+    a = await ec.create_request(w["id"], "once.com")
+    await ec.decide(a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "once")
+    assert await ec.list_active(w["id"]) == []
+
+
+async def test_list_active_time_bounded_within_and_past_window(
+    ec, ws, user, app_state
+):
+    w = await ws.create_workspace(user["id"], "active-timed")
+    fresh = await ec.create_request(w["id"], "fresh.com")
+    await ec.decide(
+        fresh["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "5m"
+    )
+    stale = await ec.create_request(w["id"], "stale.com")
+    await ec.decide(
+        stale["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "5m"
+    )
+    # Backdate the stale row past its 5m window.
+    async with app_state.state.db.transaction() as conn:
+        await conn.execute(
+            "UPDATE egress_consent SET decided_at = ? WHERE id = ?",
+            (0.0, stale["id"]),
+        )
+    hosts = {r["dest_host"] for r in await ec.list_active(w["id"])}
+    assert hosts == {"fresh.com"}
+
+
+async def test_list_active_excludes_static_denial(ec, ws, user):
+    # Static policy denials (decided_by NULL) are the allow-list's complement,
+    # not actionable verdicts — excluded from the in-effect view.
+    w = await ws.create_workspace(user["id"], "active-static")
+    await ec.record_static_denial(w["id"], "evil.com", 443)
+    assert await ec.list_active(w["id"]) == []
+
+
+async def test_list_active_excludes_pending_and_expired(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "active-other")
+    pending = await ec.create_request(w["id"], "pending.com")  # stays pending
+    to_expire = await ec.create_request(w["id"], "expired.com")
+    await ec.expire_pending(to_expire["id"])  # pending -> expired (no verdict)
+    assert pending is not None
+    # neither pending nor expired rows are in-effect verdicts
+    assert await ec.list_active(w["id"]) == []
+
+
+def test_duration_in_effect_unknown_and_null_duration():
+    # Unknown / NULL duration: a verdict always sets one, so this only hits a
+    # NULL (future migration) — fail-safe to not-in-effect.
+    from klangk.model.egress_consent import EgressConsentModel
+
+    assert EgressConsentModel._duration_in_effect(None, 1.0, 2.0) is False
+    assert EgressConsentModel._duration_in_effect("bogus", 1.0, 2.0) is False
+    # decided_at None (no decision recorded) -> not in effect.
+    assert EgressConsentModel._duration_in_effect("5m", None, 2.0) is False
+    # restart/forever are event-bounded, not time-bounded -> always in effect.
+    assert (
+        EgressConsentModel._duration_in_effect("restart", 0.0, 999.0) is True
+    )
+    assert (
+        EgressConsentModel._duration_in_effect("forever", 0.0, 999.0) is True
+    )
+
+
 # -- DB-level integrity (CHECK constraints + partial unique index) --
 #
 # The CHECK constraints + partial unique index are the structural backstop:
@@ -479,6 +569,41 @@ async def test_db_check_accepts_null_and_legal_scopes(ws, user, db, app_state):
             )
 
 
+async def test_db_check_accepts_null_and_legal_durations(
+    ws, user, db, app_state
+):
+    """duration NULL (pending/static rows) + each legal value pass the CHECK."""
+    w = await ws.create_workspace(user["id"], "chk-dur-ok")
+    # iterate the single source of truth so the test cannot drift from the
+    # CHECK (which is itself generated from DURATIONS, #2338)
+    legal = [None, *DURATIONS]
+    async with app_state.state.db.transaction() as conn:
+        for i, duration in enumerate(legal):
+            await conn.execute(
+                "INSERT INTO egress_consent"
+                " (id, workspace_id, dest_host, duration, requested_at)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (f"ok-d-{i}", w["id"], f"h{i}.com", duration, 0.0),
+            )
+
+
+async def test_db_check_rejects_invalid_duration(ws, user, db, app_state):
+    w = await ws.create_workspace(user["id"], "chk-dur-ws")
+    async with app_state.state.db.transaction() as conn:
+        await conn.execute(
+            "INSERT INTO egress_consent"
+            " (id, workspace_id, dest_host, requested_at)"
+            " VALUES (?, ?, ?, ?)",
+            ("rd1", w["id"], "a.com", 0.0),
+        )
+        with pytest.raises(SAIntegrityError) as exc_info:
+            await conn.execute(
+                "UPDATE egress_consent SET duration = '99d' WHERE id = ?",
+                ("rd1",),
+            )
+    assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
+
+
 async def test_db_partial_unique_index_rejects_duplicate_pending(
     ws, user, db, app_state
 ):
@@ -499,5 +624,68 @@ async def test_db_partial_unique_index_rejects_duplicate_pending(
                 " (id, workspace_id, dest_host, dest_port, requested_at)"
                 " VALUES (?, ?, ?, ?, ?)",
                 ("u2", w["id"], "a.com", 443, 0.0),
+            )
+    assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
+
+
+async def test_init_db_rebuilds_egress_consent_to_add_duration_check(
+    ws, user, app_state
+):
+    """A pre-existing egress_consent lacking the duration CHECK is rebuilt
+    in place (#2338) — data preserved, constraint attached.
+
+    Simulates the stale shape (duration column from an earlier ALTER, no
+    CHECK) by dropping the well-formed table and recreating it without the
+    constraint, then re-running init_db. The rebuild path copies the row
+    across and attaches the CHECK; a bad duration is then rejected at the DB.
+    """
+    w = await ws.create_workspace(user["id"], "rebuild-ws")
+    db = app_state.state.db
+    # Replace the well-formed table with a stale shape (no duration CHECK),
+    # keeping one real row referencing the real workspace + user (so the
+    # rebuild's FK copy satisfies foreign_keys if enforced).
+    async with db.transaction() as conn:
+        await conn.execute("DROP TABLE egress_consent")
+        await conn.execute(
+            "CREATE TABLE egress_consent ("
+            " id TEXT PRIMARY KEY, workspace_id TEXT, dest_host TEXT,"
+            " dest_port INTEGER, pid INTEGER, process_name TEXT,"
+            " decision TEXT, scope TEXT, duration TEXT,"
+            " requested_at REAL, decided_at REAL, decided_by TEXT)"
+        )
+        await conn.execute(
+            "INSERT INTO egress_consent"
+            " (id, workspace_id, dest_host, decision, duration,"
+            "  requested_at, decided_at, decided_by)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "keep-1",
+                w["id"],
+                "preserved.com",
+                "allowed",
+                "1d",
+                1.0,
+                2.0,
+                user["id"],
+            ),
+        )
+    # Re-run init_db: the rebuild fires (no CHECK in sqlite_master), attaches
+    # the CHECK, and copies the row across.
+    await app_state.state.model.init_db()
+    async with db.transaction() as conn:
+        cur = await conn.execute(
+            "SELECT dest_host, duration FROM egress_consent WHERE id = ?",
+            ("keep-1",),
+        )
+        row = await cur.fetchone()
+    assert row is not None
+    assert row["dest_host"] == "preserved.com"
+    assert row["duration"] == "1d"
+    # The CHECK is now enforced.
+    async with db.transaction() as conn:
+        with pytest.raises(SAIntegrityError) as exc_info:
+            await conn.execute(
+                "UPDATE egress_consent SET duration = '99d' WHERE id = ?",
+                ("keep-1",),
             )
     assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)


### PR DESCRIPTION
Closes #2338 (slice A of the #2335 rule-management view umbrella).

## What

The backend data foundation for the upcoming rule-management view (#2335):
klangkd now computes and exposes, per workspace, the egress decisions
**currently in effect** — past consent verdicts still within their duration,
plus the static allow-list — over the consent-decider WebSocket. No UI here
(that's slice B / #2340); this ships the data.

## Changes

- **`EgressConsentModel.list_active(workspace_id)`** — consent verdicts still
  in effect per their duration (`once` excluded; `5m`..`1w` within window;
  `restart`/`forever` kept), excluding static policy denials (`decided_by` NULL
  — those are the allow-list's complement, not actionable verdicts).
- **`duration` read fix** — `_row_to_dict` + the `SELECT`s now read the
  `duration` column (it was written by `decide()` but never selected, so expiry
  couldn't be computed).
- **DB `CHECK` on `egress_consent.duration`** — constrains it to the documented
  `DURATIONS` set (NULL allowed for pre-verdict rows), mirroring the existing
  `decision`/`scope` CHECKs. A one-shot table rebuild (data copied across)
  brings the existing dev DB up to shape — no deployments to preserve.
- **`ConsentCoordinator.rules_frame(workspace_id)`** — builds
  `{allow_list, allowed, denied, paused: None}` (`paused` awaits #2332) from
  `list_active` + the workspace's `allowed_domains`.
- **Decider stream (`wshandler/decider.py`)** — pushes the `egress_rules`
  snapshot on connect (after the pending-request snapshot); the coordinator
  re-broadcasts it after each verdict lands (`resolve`).

The in-effect computation is view-only (reads stored `duration`/`decided_at`);
whether the sidecar *enforces* durations is #2328's job.

## Verification

Full suite (both packages, `-n auto`): **4621 passed, 100% coverage**.

New tests: `list_active` duration matrix (once / 5m-within / past-window /
restart / forever / static-denial / pending+expired / grouping), the
`_duration_in_effect` branches, the DB duration `CHECK` (accepts NULL+legal,
rejects invalid), the schema rebuild migration (stale table rebuilt + data
preserved + CHECK attached), `rules_frame` (grouping / missing-workspace /
deploy-wide), the resolve rules re-broadcast, and the decider connect-push.

## Parent

#2335 (umbrella). Slices B (#2340) and D (#2341) build on this; C (#2339) is
independent.
