### PR TITLE
fix(consent): reap restart-duration verdicts on container restart (#2346)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -564,6 +564,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`restart`-duration consent verdicts are now reaped when a workspace
+  container (re)starts (#2346).** A `restart` verdict means "for the
+  container's lifetime" -- the sidecar honors it via an in-memory rule that
+  dies on restart, but the `egress_consent` row persisted, so the
+  in-effect view (`list_active`) reported stale `restart` allows/denies after
+  a restart. They are now deleted on container (re)start (the create path,
+  not the already-running reconnect), so the recorded set matches what the
+  sidecar actually enforces. `forever`/time-bounded/`once`/pending/static
+  rows are left untouched.
+
 - **`consent-decide` no longer crashes when a held request arrives while a
   row is mid-mount (#2327).** `_refresh`'s in-place diff treats a just-appended
   row (its `request_id` is set synchronously) as "existing" on the very next

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -2009,6 +2009,16 @@ class ContainerRegistry:
                     self._ws_with_network_sidecar.add(workspace_id)
                 return result
 
+        # A fresh container (re)start means no `restart`-duration consent
+        # verdict can still be in effect -- the sidecar's in-memory rules
+        # (learned ACCEPT for an allow, REJECT for a deny) died with the
+        # previous container. Reap those rows so list_active (#2335) matches
+        # the enforced set (#2346). Safe on a first-ever start (no rows yet);
+        # `forever`/time-bounded/`once`/pending/static rows are left alone.
+        await self.app.state.model.egress_consent.clear_restart_duration(
+            workspace_id
+        )
+
         # Allocate host ports.
         t_ports = time.monotonic()
         host_ports = await self._reconcile_ports(workspace_id, num_ports)

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -233,13 +233,11 @@ class EgressConsentModel:
         - ``once`` -> excluded (consumed by the single connection).
         - ``5m``/``15m``/``1h``/``1d``/``1w`` -> in effect iff
           ``decided_at + duration`` > now.
-        - ``restart`` -> recorded in effect (container lifetime). CAVEAT: the
-          sidecar's in-memory rule does NOT survive a sidecar/container
-          restart, but this row does, so a recorded ``restart`` allow may be
-          not-enforced after a restart until re-triggered. Reaping ``restart``
-          rows on container restart is a follow-up (out of scope for slice A);
-          until then this view reports the *recorded* set, not the live-enforced
-          one.
+        - ``restart`` -> in effect (container lifetime). Reaped when the
+          workspace container (re)starts (:meth:`clear_restart_duration`,
+          #2346), so the recorded set matches what the sidecar enforces across
+          container restarts; a sidecar-only restart (no container restart)
+          is the one residual gap.
         - ``forever`` -> in effect (workspace lifetime; cross-restart
           persistence lands with #2328).
 
@@ -434,6 +432,38 @@ class EgressConsentModel:
             cursor = await db.execute(
                 "DELETE FROM egress_consent WHERE workspace_id = ?",
                 (workspace_id,),
+            )
+            return cursor.rowcount
+
+    async def clear_restart_duration(self, workspace_id: str) -> int:
+        """Delete decided ``restart``-duration verdicts for a workspace (#2346).
+
+        A ``restart`` verdict means "for the workspace container's lifetime" --
+        the sidecar honors it via an in-memory rule (a learned ACCEPT for an
+        allow, a REJECT for a deny) that dies when the sidecar/container
+        restarts. But this row persists, so without reaping :meth:`list_active`
+        would keep returning stale ``restart`` verdicts as in effect after a
+        restart (the rule-management view would show rules no longer enforced).
+        Called from the container (re)start path.
+
+        - Clears **both** allows and denies (a ``restart`` deny's REJECT dies
+          with the container too).
+        - Leaves ``forever`` (intended to survive restarts -- re-applied by
+          klangkd once #2328 lands), time-bounded (``5m``..``1w``) and ``once``
+          rows (governed by their own expiry), ``pending`` rows, and static
+          policy denials (``decided_by`` NULL, duration NULL). Returns count.
+        """
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "DELETE FROM egress_consent"
+                " WHERE workspace_id = ? AND duration = ?"
+                " AND decision IN (?, ?)",
+                (
+                    workspace_id,
+                    DURATION_RESTART,
+                    DECISION_ALLOWED,
+                    DECISION_DENIED,
+                ),
             )
             return cursor.rowcount
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -2048,6 +2048,45 @@ class TestStartContainer:
         assert status == "created"
         p.remove_container.assert_not_awaited()
 
+    async def test_create_clears_restart_duration_verdicts(
+        self, workspace, user
+    ):
+        # #2346: a fresh container (re)start reaps the workspace's
+        # restart-duration verdicts -- the sidecar's in-memory rules died
+        # with the previous container, so list_active must not report them.
+        ec = self.registry.app.state.model.egress_consent
+        a = await ec.create_request(workspace["id"], "stale.com", 443)
+        await ec.decide(a["id"], "allowed", "once", user["id"], "restart")
+        # sanity: in effect before the start
+        assert {
+            r["dest_host"] for r in await ec.list_active(workspace["id"])
+        } == {"stale.com"}
+        with patch_podman(self.registry):
+            await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert await ec.list_active(workspace["id"]) == []
+
+    async def test_reuse_running_container_keeps_restart_verdicts(
+        self, workspace, user
+    ):
+        # #2346: the "connected" path (already running) must NOT reap -- the
+        # container didn't restart, so its in-memory rules are still alive.
+        ec = self.registry.app.state.model.egress_consent
+        a = await ec.create_request(workspace["id"], "live.com", 443)
+        await ec.decide(a["id"], "allowed", "once", user["id"], "restart")
+        with patch_podman(self.registry, inspect_container=_running(True)):
+            cid, status = await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                existing_container_id="existing-cid",
+            )
+        assert status == "connected"
+        assert {
+            r["dest_host"] for r in await ec.list_active(workspace["id"])
+        } == {"live.com"}
+
     async def test_disallowed_image_raises(self, workspace):
         with pytest.raises(ValueError, match="not in the allowed list"):
             await self.registry.start_container(

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -494,6 +494,92 @@ def test_duration_in_effect_unknown_and_null_duration():
     )
 
 
+# -- clear_restart_duration (container-restart reaping, #2346) --
+
+
+async def test_clear_restart_duration_clears_allow_and_deny(ec, ws, user):
+    # A restart allow AND a restart deny both die with the container.
+    w = await ws.create_workspace(user["id"], "clr-rst")
+    a = await ec.create_request(w["id"], "allow.com", 443)
+    await ec.decide(
+        a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+    d = await ec.create_request(w["id"], "deny.com", 443)
+    await ec.decide(d["id"], DECISION_DENIED, None, user["id"], "restart")
+    count = await ec.clear_restart_duration(w["id"])
+    assert count == 2
+    # Neither survives in list_active (the rule-management view).
+    assert await ec.list_active(w["id"]) == []
+
+
+async def test_clear_restart_duration_leaves_other_durations(ec, ws, user):
+    # forever / time-bounded (5m) / once are governed by their own lifetime,
+    # not the container's -- left untouched.
+    w = await ws.create_workspace(user["id"], "clr-keep")
+    fa = await ec.create_request(w["id"], "forever-allow.com")
+    await ec.decide(
+        fa["id"], DECISION_ALLOWED, SCOPE_WORKSPACE, user["id"], "forever"
+    )
+    fd = await ec.create_request(w["id"], "forever-deny.com")
+    await ec.decide(fd["id"], DECISION_DENIED, None, user["id"], "forever")
+    tb = await ec.create_request(w["id"], "timed.com")
+    await ec.decide(tb["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "5m")
+    once = await ec.create_request(w["id"], "once.com")
+    await ec.decide(
+        once["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "once"
+    )
+    # one restart row to clear, to confirm only it is reaped.
+    ra = await ec.create_request(w["id"], "restart.com")
+    await ec.decide(
+        ra["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+
+    count = await ec.clear_restart_duration(w["id"])
+    assert count == 1
+    # forever (allow + deny) + the fresh 5m are still in effect; once excluded.
+    hosts = {r["dest_host"] for r in await ec.list_active(w["id"])}
+    assert hosts == {"forever-allow.com", "forever-deny.com", "timed.com"}
+
+
+async def test_clear_restart_duration_leaves_pending_and_static(ec, ws, user):
+    # Pending requests + static policy denials are not restart verdicts.
+    w = await ws.create_workspace(user["id"], "clr-pend")
+    await ec.create_request(w["id"], "pending.com", 443)  # stays pending
+    await ec.record_static_denial(w["id"], "static.com", 443)
+    count = await ec.clear_restart_duration(w["id"])
+    assert count == 0
+    # Both rows still present (list_active excludes them, so check list_requests).
+    hosts = {r["dest_host"] for r in await ec.list_requests(w["id"])}
+    assert hosts == {"pending.com", "static.com"}
+
+
+async def test_clear_restart_duration_is_scoped_to_workspace(ec, ws, user):
+    # Only the named workspace's restart rows are reaped.
+    w1 = await ws.create_workspace(user["id"], "clr-a")
+    w2 = await ws.create_workspace(user["id"], "clr-b")
+    a = await ec.create_request(w1["id"], "a.com", 443)
+    await ec.decide(
+        a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+    b = await ec.create_request(w2["id"], "b.com", 443)
+    await ec.decide(
+        b["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+    count = await ec.clear_restart_duration(w1["id"])
+    assert count == 1
+    # w2's restart row survives.
+    assert {r["dest_host"] for r in await ec.list_active(w2["id"])} == {
+        "b.com"
+    }
+    assert await ec.list_active(w1["id"]) == []
+
+
+async def test_clear_restart_duration_no_rows_is_zero(ec, ws, user):
+    # First-ever start: no restart rows -> no-op, returns 0.
+    w = await ws.create_workspace(user["id"], "clr-empty")
+    assert await ec.clear_restart_duration(w["id"]) == 0
+
+
 # -- DB-level integrity (CHECK constraints + partial unique index) --
 #
 # The CHECK constraints + partial unique index are the structural backstop:


### PR DESCRIPTION
## What

Closes #2346. Reap a workspace's `restart`-duration consent verdicts when its
container (re)starts, so the rule-management view's "in-effect" set
(`list_active`) matches what the network sidecar is actually enforcing.

A `restart` verdict means "for the container's lifetime" — the sidecar honors
it via an **in-memory** rule (a learned ACCEPT for an allow, a REJECT for a
deny) that dies when the sidecar/container restarts. But the `egress_consent`
row persisted, so `list_active` (#2338) kept returning stale `restart` verdicts
as in-effect after a restart. The rule-management view (#2340 / slice B) would
then show rules that no longer affect networking. This closes that gap.

## Changes

- **`EgressConsentModel.clear_restart_duration(workspace_id)`** — scoped
  delete on `delete_for_workspace`, restricted to decided `restart` rows
  (`duration = 'restart' AND decision IN ('allowed','denied')`); returns count.
  - Clears **both** allows and denies (a `restart` deny's REJECT dies with the
    container too).
  - Leaves `forever` (intended to survive restarts — re-applied by klangkd once
    #2328 lands), time-bounded (`5m`..`1w`), `once`, `pending`, and static
    policy denials (`decided_by` NULL, duration NULL) untouched.
- **Wired into `_start_container_inner`'s create path** — called right after the
  reconnect shortcut (the `return result` for an already-running container),
  so it only fires on an actual (re)start, **not** on a `connected` reconnect.
  Safe on a first-ever start (no rows → no-op).
- **`list_active` CAVEAT docstring** (added in #2338) updated — the forward
  reference to "reaping `restart` rows on container restart is a follow-up" is
  now resolved (the recorded set matches the enforced set across container
  restarts; a sidecar-only restart without a container restart is the one
  residual gap, noted).

## Tests (100% coverage held)

- **Model layer** (`test_model_egress_consent.py`): `clear_restart_duration`
  scoping — clears allow+deny restart rows (count 2); leaves
  forever/time-bounded/once rows; leaves pending + static; scoped to the named
  workspace (cross-workspace isolation); no-op (0) on an empty workspace.
- **Container layer** (`test_container.py`): the create path reaps a seeded
  `restart` allow (gone from `list_active` after start); the `connected`
  reconnect path leaves it in place (the container didn't restart).

`4630 passed, 100% coverage` (the full backend + CLI suites, `-n auto`).
