### PR TITLE
feat(consent): revoke an active verdict — drop sidecar rule + mark revoked (#2339)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -52,6 +52,16 @@ operators or integrators to act when upgrading.
   `egress_consent.duration` column is now read back and constrained by a DB
   `CHECK` to the documented duration values (mirroring `DURATIONS`).
 
+- **Revoking a consent verdict (#2339).** A decider can revoke an active
+  allow/deny so its effect is immediate (not waiting for the duration/restart):
+  klangkd pushes a `drop_rule` to the workspace's network sidecar, which drops
+  the learned ACCEPT/REJECT rule for the host and acks back, and only then is
+  the `egress_consent` row flipped to `revoked` (fail-closed -- a connected
+  but unresponsive sidecar leaves the row enforced rather than falsely marking
+  it revoked). A `revoke` decision + `revoked_at`/`revoked_by` audit columns are
+  added (the `decision` `CHECK` is now generated from `DECISIONS`, like
+  `duration`).
+
 - **`klangk consent-decide <workspace>` (#2310).** A live Textual client that
   connects to a workspace's consent-decider stream and shows its held egress
   requests (blocked destinations the network sidecar is holding for a

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -433,9 +433,15 @@ def drop_for_host(host: str, decision: str) -> None:
     Host->IP comes from ``_LEARNED[ip]["host"]`` (set by ``_record_hosts`` for
     every resolved name, allow-listed or not), so a deny's IPs are found too;
     the host string itself is also a candidate IP (a direct-IP connect that
-    never went through DNS). Best-effort: a failed delete drops one rule, not
-    the whole revoke. Sync (forks iptables) — run off the loop; under ``_LOCK``
-    like allow/sweep.
+    never went through DNS, and a direct-IP allow whose ``host`` is ``None``).
+    Best-effort: a failed delete drops one rule, not the whole revoke. Sync
+    (forks iptables) — run off the loop; under ``_LOCK`` like allow/sweep.
+
+    L3/L4 limit (co-resident hosts): the egress rules are per IP+port, so two
+    DNS names that resolve to the SAME IP share one rule and cannot be revoked
+    individually — revoking one name removes the shared rule, affecting the
+    other too. A correct per-host revoke for co-resident hosts (CDN/S3/Cloudflare
+    fronted sites) needs L7/SNI filtering, which is a separate feature (#2352).
     """
     host_l = host.lower()
     with _LOCK:
@@ -445,7 +451,13 @@ def drop_for_host(host: str, decision: str) -> None:
             if (rec.get("host") or "").lower() == host_l
         ]
         if decision == "allowed":
-            for ip in ips:
+            # IPs that resolved to this host, plus the host itself if it's a
+            # direct-IP allow (allow() records host=None, so the scan above
+            # misses it).
+            targets = {ip for ip in ips}
+            targets.add(host_l)
+            targets.add(host)
+            for ip in [i for i in targets if i in _LEARNED]:
                 for port in list(_LEARNED[ip]["ports"]):
                     try:
                         _remove(ip, port)

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -422,6 +422,50 @@ def reject(ip: str, port: int, ttl: float) -> None:
         _REJECTED[(ip, port)] = max(_REJECTED.get((ip, port), 0.0), expire)
 
 
+def drop_for_host(host: str, decision: str) -> None:
+    """Drop the sidecar's rules for a host (revocation, #2339).
+
+    ``allowed``: remove the learned ACCEPT rules (+ ``_LEARNED`` records) for
+    the host's IPs (revert to default/allow-list filtering).
+    ``denied``: remove the temporary REJECT rules for the host's IPs (stop
+    force-rejecting; the host is again subject to the allow-list).
+
+    Host->IP comes from ``_LEARNED[ip]["host"]`` (set by ``_record_hosts`` for
+    every resolved name, allow-listed or not), so a deny's IPs are found too;
+    the host string itself is also a candidate IP (a direct-IP connect that
+    never went through DNS). Best-effort: a failed delete drops one rule, not
+    the whole revoke. Sync (forks iptables) — run off the loop; under ``_LOCK``
+    like allow/sweep.
+    """
+    host_l = host.lower()
+    with _LOCK:
+        ips = [
+            ip
+            for ip, rec in _LEARNED.items()
+            if (rec.get("host") or "").lower() == host_l
+        ]
+        if decision == "allowed":
+            for ip in ips:
+                for port in list(_LEARNED[ip]["ports"]):
+                    try:
+                        _remove(ip, port)
+                    except Exception:
+                        pass
+                del _LEARNED[ip]
+        elif decision == "denied":
+            # IPs that resolved to this host, plus the host itself if it's a
+            # direct-IP connect (never DNS host-recorded).
+            targets = {ip for ip in ips}
+            targets.add(host_l)
+            targets.add(host)
+            for key in [k for k in _REJECTED if k[0] in targets]:
+                try:
+                    _remove_reject(*key)
+                except Exception:
+                    pass
+                del _REJECTED[key]
+
+
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
     """Remove learned IPs whose TTL has elapsed; return ``(ip, ports)`` removed.
 
@@ -707,7 +751,7 @@ class SidecarConsentClient:
                     if DEBUG:
                         print(f"consent: connected to {self._url}", flush=True)
                     async for raw in ws:
-                        self._dispatch(raw)
+                        await self._dispatch(raw)
             except Exception as exc:
                 # Log the exception TYPE only -- the connection carries the
                 # workspace JWT (Authorization header), and a websockets
@@ -731,13 +775,20 @@ class SidecarConsentClient:
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 15.0)  # capped exponential backoff
 
-    def _dispatch(self, raw: str | bytes) -> None:
+    async def _dispatch(self, raw: str | bytes) -> None:
         try:
             msg = json.loads(raw)
         except Exception:
             return
-        if not isinstance(msg, dict) or msg.get("type") != "verdict":
+        if not isinstance(msg, dict):
             return
+        mtype = msg.get("type")
+        if mtype == "verdict":
+            self._apply_verdict(msg)
+        elif mtype == "drop_rule":
+            await self._handle_drop_rule(msg)
+
+    def _apply_verdict(self, msg: dict) -> None:
         vid = msg.get("id")
         decision = msg.get("decision")
         if not isinstance(vid, str):
@@ -748,6 +799,32 @@ class SidecarConsentClient:
             token = decision if decision == "allow" else "deny"
             duration = msg.get("duration") or "once"
             fut.set_result((token, duration))
+
+    async def _handle_drop_rule(self, msg: dict) -> None:
+        """klangkd asked us to drop a host's rules (revocation, #2339).
+
+        Runs :func:`drop_for_host` off the loop (it forks iptables) and acks
+        back so klangkd marks the verdict revoked only once the rule is gone.
+        """
+        ack_id = msg.get("id")
+        host = msg.get("host")
+        decision = msg.get("decision")
+        ok = False
+        if isinstance(host, str) and decision in ("allowed", "denied"):
+            try:
+                await asyncio.get_running_loop().run_in_executor(
+                    None, drop_for_host, host, decision
+                )
+                ok = True
+            except Exception:
+                ok = False
+        if isinstance(ack_id, str) and self._ws is not None:
+            try:
+                await self._ws.send(
+                    json.dumps({"type": "drop_ack", "id": ack_id, "ok": ok})
+                )
+            except Exception:
+                pass
 
     async def request(self, dst: str, dport: int | None) -> tuple[str, str]:
         """Send an egress frame + await the verdict. Fail-close -> ``("deny",

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -49,6 +49,11 @@ logger = logging.getLogger(__name__)
 VERDICT_ALLOW = "allow"
 VERDICT_DENY = "deny"
 
+# How long revoke() waits for the sidecar's drop-rule ack before giving up
+# (fail-closed: leave the row enforced). The sidecar's rule-drop is a single
+# iptables delete, so this is generous.
+_REVOKE_ACK_TIMEOUT = 5.0
+
 
 class ConsentCoordinator:
     """In-process holds for egress requests awaiting a verdict (#2311).
@@ -228,6 +233,60 @@ class ConsentCoordinator:
             # rule-management view (#2335 slice A) without a reconnect.
             await self._broadcast_rules(hold["workspace_id"])
         return verdict
+
+    async def revoke(
+        self,
+        request_id: str,
+        revoked_by: str,
+        *,
+        decider_workspace: str | None = None,
+    ) -> bool:
+        """Revoke an active consent verdict (#2339).
+
+        Drops the sidecar's learned rule for the verdict's host (immediate,
+        not waiting for the duration/restart) and marks the row ``revoked``.
+        Returns True if revoked; False if the request isn't an active verdict,
+        is outside the decider's workspace (``decider_workspace``), or the
+        sidecar never acked the drop. Fail-closed: a connected-but-
+        unresponsive sidecar leaves the row enforced rather than falsely
+        marking it revoked (the view must not claim "not in effect" while the
+        rule still fires).
+        """
+        row = await self.app.state.model.egress_consent.get_request(request_id)
+        if row is None or row["decision"] not in (
+            DECISION_ALLOWED,
+            DECISION_DENIED,
+        ):
+            return False
+        workspace_id = row["workspace_id"]
+        if decider_workspace is not None and workspace_id != decider_workspace:
+            return False
+        host = row["dest_host"]
+        decision = row["decision"]
+        # Ask the sidecar to drop its rule for this host+decision. No live
+        # sidecar -> nothing is enforced (its in-memory rules die with it), so
+        # proceed to mark revoked. A live sidecar must ack first: else a
+        # connected-but-unresponsive sidecar could keep enforcing after the
+        # view says "revoked".
+        fut = self.app.state.sidecar_connections.send_drop(
+            workspace_id, host, decision
+        )
+        if fut is not None:
+            try:
+                ok = await asyncio.wait_for(fut, _REVOKE_ACK_TIMEOUT)
+            except asyncio.TimeoutError:
+                ok = False
+            if not ok:
+                return False
+        if (
+            await self.app.state.model.egress_consent.revoke(
+                request_id, revoked_by
+            )
+            is None
+        ):
+            return False
+        await self._broadcast_rules(workspace_id)
+        return True
 
     async def _timeout(self, request_id: str) -> None:
         """Auto-expire a held request after the timeout; fail-close on wake.

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -31,6 +31,7 @@ from . import (
     nix,
     podman,
     netfilter,
+    sidecar_connections,
     ssl_trust,
     terminal,
     util as util_mod,
@@ -477,6 +478,7 @@ class Lifecycle:
             "consent_monitor",
             "consent_coordinator",
             "consent_deciders",
+            "sidecar_connections",
             "proxy_watchdog",
             "llm_router",
             "terminal",
@@ -709,6 +711,7 @@ async def lifespan(app: FastAPI):
     app.state.consent_monitor.start()
     app.state.consent_coordinator.start()
     app.state.consent_deciders.start()
+    app.state.sidecar_connections.start()
     # Start the proxy (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.proxy_watchdog.start()
@@ -730,6 +733,7 @@ async def lifespan(app: FastAPI):
         await app.state.consent_monitor.stop()
         await app.state.consent_coordinator.stop()
         await app.state.consent_deciders.stop()
+        await app.state.sidecar_connections.stop()
         await app.state.proxy_watchdog.stop()
         await app.state.lifecycle.runtime_shutdown()
         await app.state.lifecycle.process_shutdown()
@@ -912,6 +916,9 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     app.state.consent_monitor = consent.EgressConsentMonitor(app)
     app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(app)
     app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(app)
+    # #2339: live network-sidecar sockets by workspace, so a revoke can push a
+    # rule-drop to a workspace's sidecar + correlate the ack.
+    app.state.sidecar_connections = sidecar_connections.SidecarConnections(app)
     # #2201: per-workspace nix store via a btrfs snapshot or fuse overlay
     # (off unless KLANGKD_NIX_SEED__PATH names a seed; see nix.Nix).
     app.state.nix = nix.Nix(app)

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -15,8 +15,15 @@ DECISION_PENDING = "pending"
 DECISION_ALLOWED = "allowed"
 DECISION_DENIED = "denied"
 DECISION_EXPIRED = "expired"  # auto-denied on timeout, distinct from user deny
+DECISION_REVOKED = "revoked"  # a prior allow/deny undone by a decider (#2339)
 DECISIONS = frozenset(
-    {DECISION_PENDING, DECISION_ALLOWED, DECISION_DENIED, DECISION_EXPIRED}
+    {
+        DECISION_PENDING,
+        DECISION_ALLOWED,
+        DECISION_DENIED,
+        DECISION_EXPIRED,
+        DECISION_REVOKED,
+    }
 )
 
 # Scope values for an allow/deny decision.
@@ -53,6 +60,14 @@ DURATIONS = frozenset(
     }
 )
 DURATION_DEFAULT = DURATION_RESTART
+
+# Canonical column list for SELECTs + _row_to_dict, so the read shape cannot
+# drift from the schema (a column added to the table is added here once).
+_EC_COLUMNS = (
+    "id, workspace_id, dest_host, dest_port, pid, process_name,"
+    " decision, scope, duration, requested_at, decided_at, decided_by,"
+    " revoked_at, revoked_by"
+)
 
 
 class EgressConsentModel:
@@ -168,10 +183,7 @@ class EgressConsentModel:
     async def get_request(self, request_id: str) -> dict | None:
         """Get a single consent request by ID."""
         row = await self.app.state.db.fetchone(
-            "SELECT id, workspace_id, dest_host, dest_port,"
-            " pid, process_name,"
-            " decision, scope, duration, requested_at, decided_at, decided_by"
-            " FROM egress_consent WHERE id = ?",
+            f"SELECT {_EC_COLUMNS} FROM egress_consent WHERE id = ?",
             (request_id,),
         )
         if row is None:
@@ -188,22 +200,14 @@ class EgressConsentModel:
         async with self.app.state.db.transaction() as db:
             if decision is not None:
                 cursor = await db.execute(
-                    "SELECT id, workspace_id, dest_host, dest_port,"
-                    " pid, process_name,"
-                    " decision, scope, duration, requested_at, decided_at,"
-                    " decided_by"
-                    " FROM egress_consent"
+                    f"SELECT {_EC_COLUMNS} FROM egress_consent"
                     " WHERE workspace_id = ? AND decision = ?"
                     " ORDER BY requested_at DESC LIMIT ?",
                     (workspace_id, decision, limit),
                 )
             else:
                 cursor = await db.execute(
-                    "SELECT id, workspace_id, dest_host, dest_port,"
-                    " pid, process_name,"
-                    " decision, scope, duration, requested_at, decided_at,"
-                    " decided_by"
-                    " FROM egress_consent"
+                    f"SELECT {_EC_COLUMNS} FROM egress_consent"
                     " WHERE workspace_id = ?"
                     " ORDER BY requested_at DESC LIMIT ?",
                     (workspace_id, limit),
@@ -250,11 +254,7 @@ class EgressConsentModel:
         now = time.time()
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
-                "SELECT id, workspace_id, dest_host, dest_port,"
-                " pid, process_name,"
-                " decision, scope, duration, requested_at, decided_at,"
-                " decided_by"
-                " FROM egress_consent"
+                f"SELECT {_EC_COLUMNS} FROM egress_consent"
                 " WHERE workspace_id = ? AND decision IN (?, ?)"
                 " AND decided_by IS NOT NULL"
                 " ORDER BY decided_at DESC",
@@ -371,10 +371,40 @@ class EgressConsentModel:
             # Re-read inside the same transaction so the result is
             # consistent even if the row is deleted concurrently.
             cursor = await db.execute(
-                "SELECT id, workspace_id, dest_host, dest_port,"
-                " pid, process_name,"
-                " decision, scope, duration, requested_at, decided_at, decided_by"
-                " FROM egress_consent WHERE id = ?",
+                f"SELECT {_EC_COLUMNS} FROM egress_consent WHERE id = ?",
+                (request_id,),
+            )
+            row = await cursor.fetchone()
+            return _row_to_dict(row) if row else None
+
+    async def revoke(self, request_id: str, revoked_by: str) -> dict | None:
+        """Mark a prior allow/deny verdict revoked (#2339).
+
+        Only flips a row that is currently an active verdict (``allowed`` or
+        ``denied``); pending/expired/already-revoked rows are untouched
+        (returns None). Stamps ``revoked_at`` + ``revoked_by`` for audit (the
+        original ``decided_*`` is preserved as the verdict's provenance).
+        Returns the updated row, or None.
+        """
+        now = time.time()
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "UPDATE egress_consent"
+                " SET decision = ?, revoked_at = ?, revoked_by = ?"
+                " WHERE id = ? AND decision IN (?, ?)",
+                (
+                    DECISION_REVOKED,
+                    now,
+                    revoked_by,
+                    request_id,
+                    DECISION_ALLOWED,
+                    DECISION_DENIED,
+                ),
+            )
+            if cursor.rowcount == 0:
+                return None
+            cursor = await db.execute(
+                f"SELECT {_EC_COLUMNS} FROM egress_consent WHERE id = ?",
                 (request_id,),
             )
             row = await cursor.fetchone()
@@ -482,4 +512,6 @@ def _row_to_dict(row) -> dict:
         "requested_at": row["requested_at"],
         "decided_at": row["decided_at"],
         "decided_by": row["decided_by"],
+        "revoked_at": row["revoked_at"],
+        "revoked_by": row["revoked_by"],
     }

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -1,12 +1,14 @@
 """Database schema creation and in-place migrations (``init_db``)."""
 
 from .acl import PRINCIPAL_USER
-from .egress_consent import DURATIONS
+from .egress_consent import DECISIONS, DURATIONS
 from .users import AGENT_USER_ID, backfill_handles
 
-# The duration CHECK value list is generated from the single source of truth
-# (DURATIONS) so the DB constraint cannot drift from the Python enum (#2338).
+# The duration + decision CHECK value lists are generated from the single
+# sources of truth (DURATIONS / DECISIONS) so the DB constraints cannot drift
+# from the Python enums (#2338, #2339).
 _DURATION_CHECK_VALUES = ", ".join(f"'{d}'" for d in sorted(DURATIONS))
+_DECISION_CHECK_VALUES = ", ".join(f"'{d}'" for d in sorted(DECISIONS))
 
 
 async def init_db(db) -> None:
@@ -353,7 +355,7 @@ async def init_db(db) -> None:
                 pid INTEGER,
                 process_name TEXT,
                 decision TEXT NOT NULL DEFAULT 'pending'
-                    CHECK (decision IN ('pending', 'allowed', 'denied', 'expired')),
+                    CHECK (decision IN ({_DECISION_CHECK_VALUES})),
                 scope TEXT
                     CHECK (scope IS NULL OR scope IN ('once', 'workspace', 'deploy')),
                 duration TEXT
@@ -361,25 +363,24 @@ async def init_db(db) -> None:
                         ({_DURATION_CHECK_VALUES})),
                 requested_at REAL NOT NULL,
                 decided_at REAL,
-                decided_by TEXT REFERENCES users(id) ON DELETE SET NULL
+                decided_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+                revoked_at REAL,
+                revoked_by TEXT REFERENCES users(id) ON DELETE SET NULL
             )
         """)
-        # egress_consent: attach a CHECK on `duration` (#2338). The column may
-        # already exist from an earlier ALTER (without the constraint) or be
-        # absent in an older dev DB; rebuild the table either way so the
-        # constraint is universal. Detected via sqlite_master (PRAGMA
-        # table_info doesn't expose CHECK). Data is copied across (mirrors the
-        # users rebuild above); the partial unique indexes are recreated by
-        # the CREATE INDEX statements below. No deployments to preserve.
+        # egress_consent: add the `revoked` decision (#2339) + the
+        # `revoked_at`/`revoked_by` audit columns (and attach the CHECKs). The
+        # table may already exist from #2338 (has the duration CHECK but not
+        # `revoked`); rebuild it either way so the shape is universal. Detected
+        # via sqlite_master (PRAGMA table_info doesn't expose CHECK/columns).
+        # Data is copied across (mirrors the users rebuild above); the partial
+        # unique indexes are recreated by the CREATE INDEX statements below.
         ec_sql_cur = await db.execute(
             "SELECT sql FROM sqlite_master"
             " WHERE type='table' AND name='egress_consent'"
         )
         ec_sql_row = await ec_sql_cur.fetchone()
-        if (
-            ec_sql_row
-            and "duration IS NULL OR duration IN" not in ec_sql_row[0]
-        ):
+        if ec_sql_row and "revoked_at" not in ec_sql_row[0]:
             await db.execute(f"""
                 CREATE TABLE egress_consent_new (
                     id TEXT PRIMARY KEY,
@@ -389,7 +390,7 @@ async def init_db(db) -> None:
                     pid INTEGER,
                     process_name TEXT,
                     decision TEXT NOT NULL DEFAULT 'pending'
-                        CHECK (decision IN ('pending', 'allowed', 'denied', 'expired')),
+                        CHECK (decision IN ({_DECISION_CHECK_VALUES})),
                     scope TEXT
                         CHECK (scope IS NULL OR scope IN ('once', 'workspace', 'deploy')),
                     duration TEXT
@@ -397,7 +398,9 @@ async def init_db(db) -> None:
                             ({_DURATION_CHECK_VALUES})),
                     requested_at REAL NOT NULL,
                     decided_at REAL,
-                    decided_by TEXT REFERENCES users(id) ON DELETE SET NULL
+                    decided_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+                    revoked_at REAL,
+                    revoked_by TEXT REFERENCES users(id) ON DELETE SET NULL
                 )
             """)
             ec_info = await db.execute("PRAGMA table_info(egress_consent)")
@@ -417,6 +420,8 @@ async def init_db(db) -> None:
                     "requested_at",
                     "decided_at",
                     "decided_by",
+                    "revoked_at",
+                    "revoked_by",
                 )
                 if c in ec_old_cols
             ]

--- a/src/klangk/klangk/sidecar_connections.py
+++ b/src/klangk/klangk/sidecar_connections.py
@@ -1,0 +1,126 @@
+"""Live network-sidecar WebSocket connections, keyed by workspace (#2339).
+
+The network sidecar opens one socket per workspace to ``/ws/egress-sidecar``
+(``wshandler/sidecar.py``). That channel carries blocked-egress events
+(sidecar -> klangkd) and verdict relays (klangkd -> sidecar). Revocation
+(#2339) needs the *reverse*: klangkd PUSHING a rule-drop command to a specific
+workspace's sidecar and correlating the sidecar's ack back to the awaiting
+``revoke``. This registry holds those live connections (so a revoke can find
+the right socket) plus the pending ack map.
+
+Owns only ``app`` (the app-ownership rule); no background task, so
+:meth:`start` is lifespan-symmetry only and :meth:`stop` clears state on
+shutdown (failing any in-flight revoke acks).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from .wshandler.safe_websocket import WS_ERRORS
+
+logger = logging.getLogger(__name__)
+
+
+class SidecarConnections:
+    """Tracks live sidecar sockets by workspace + pending drop-rule acks (#2339)."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+        # workspace_id -> SafeWebSocket
+        self._conns: dict[str, object] = {}
+        # ack_id -> {"future": Future, "ws": workspace_id}
+        self._pending: dict[str, dict] = {}
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    def start(self) -> None:
+        """Lifespan symmetry only -- connections register on demand."""
+
+    def register(self, workspace_id: str, sock) -> None:
+        """Record a sidecar's live socket (on /ws/egress-sidecar connect).
+
+        Re-registers if the sidecar reconnects (drops the stale socket).
+        """
+        self._conns[workspace_id] = sock
+        logger.info(
+            "sidecar connection registered: ws=%s", str(workspace_id)[:8]
+        )
+
+    def deregister(self, workspace_id: str) -> None:
+        """Drop a sidecar socket (disconnect) + fail its pending drop-acks.
+
+        Failing the acks (rather than leaving them to time out) lets an
+        in-flight ``revoke`` learn at once that the sidecar is gone.
+        """
+        self._conns.pop(workspace_id, None)
+        stale = [
+            aid
+            for aid, entry in self._pending.items()
+            if entry["ws"] == workspace_id
+        ]
+        for aid in stale:
+            entry = self._pending.pop(aid, None)
+            if entry is not None and not entry["future"].done():
+                entry["future"].set_result(False)
+        if stale or workspace_id in self._conns:
+            logger.info(
+                "sidecar connection deregistered: ws=%s", str(workspace_id)[:8]
+            )
+
+    def get(self, workspace_id: str):
+        """The live socket for a workspace, or None."""
+        return self._conns.get(workspace_id)
+
+    def send_drop(
+        self, workspace_id: str, host: str, decision: str
+    ) -> asyncio.Future | None:
+        """Push a ``drop_rule`` frame to the workspace's sidecar (#2339).
+
+        Returns a Future that resolves ``True`` on a matching ``drop_ack``,
+        ``False`` on disconnect; or ``None`` if there is no live sidecar (or
+        the send failed) -- in the None case the caller proceeds (the rule
+        isn't enforced while the sidecar is down, so there's nothing to drop).
+        """
+        sock = self._conns.get(workspace_id)
+        if sock is None:
+            return None
+        ack_id = uuid.uuid4().hex
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future = loop.create_future()
+        self._pending[ack_id] = {"future": fut, "ws": workspace_id}
+        try:
+            sock.send_json(
+                {
+                    "type": "drop_rule",
+                    "id": ack_id,
+                    "host": host,
+                    "decision": decision,
+                }
+            )
+        except WS_ERRORS:
+            # Socket died between the get() and the send -- treat as "no
+            # sidecar": nothing to drop, caller proceeds.
+            self._pending.pop(ack_id, None)
+            return None
+        return fut
+
+    def resolve_ack(self, ack_id: str, ok: bool) -> None:
+        """Resolve a pending drop-rule ack (the sidecar handled drop_rule).
+
+        No-op if unknown (a late ack after deregister/timeout).
+        """
+        entry = self._pending.pop(ack_id, None)
+        if entry is not None and not entry["future"].done():
+            entry["future"].set_result(bool(ok))
+
+    async def stop(self) -> None:
+        """Clear connections + fail every pending drop-ack (shutdown)."""
+        for entry in list(self._pending.values()):
+            if not entry["future"].done():
+                entry["future"].set_result(False)
+        self._pending.clear()
+        self._conns.clear()

--- a/src/klangk/klangk/sidecar_connections.py
+++ b/src/klangk/klangk/sidecar_connections.py
@@ -81,9 +81,19 @@ class SidecarConnections:
         """Push a ``drop_rule`` frame to the workspace's sidecar (#2339).
 
         Returns a Future that resolves ``True`` on a matching ``drop_ack``,
-        ``False`` on disconnect; or ``None`` if there is no live sidecar (or
-        the send failed) -- in the None case the caller proceeds (the rule
-        isn't enforced while the sidecar is down, so there's nothing to drop).
+        ``False`` on disconnect/shutdown; or ``None`` if there is no live
+        sidecar or the enqueue failed -- in the ``None`` case the caller
+        proceeds (the rule isn't enforced while the sidecar is down, so
+        there's nothing to drop).
+
+        The registered socket is a :class:`SafeWebSocket`, whose ``send_json``
+        is a non-blocking queue enqueue that raises only ``SlowClientError``
+        (queue full / sender stopped). So a dead-but-not-yet-stopped socket
+        accepts the enqueue and the Future stays pending; the caller's
+        ``wait_for`` timeout (in ``ConsentCoordinator.revoke``) is the backstop
+        and resolves fail-closed. The done-callback below pops the pending
+        entry on resolve OR cancel (the timeout cancels the Future), so a
+        timed-out revoke against a hung-but-connected sidecar does not leak.
         """
         sock = self._conns.get(workspace_id)
         if sock is None:
@@ -92,6 +102,9 @@ class SidecarConnections:
         loop = asyncio.get_running_loop()
         fut: asyncio.Future = loop.create_future()
         self._pending[ack_id] = {"future": fut, "ws": workspace_id}
+        fut.add_done_callback(
+            lambda _f, aid=ack_id: self._pending.pop(aid, None)
+        )
         try:
             sock.send_json(
                 {
@@ -102,8 +115,8 @@ class SidecarConnections:
                 }
             )
         except WS_ERRORS:
-            # Socket died between the get() and the send -- treat as "no
-            # sidecar": nothing to drop, caller proceeds.
+            # Queue full / sender stopped -- treat as "no sidecar": nothing
+            # to drop, caller proceeds.
             self._pending.pop(ack_id, None)
             return None
         return fut

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -130,6 +130,22 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
                     await _handle_verdict(
                         app, safe_ws, msg, workspace, user["id"]
                     )
+                elif mtype == "revoke":
+                    # #2339: drop the sidecar rule + mark the verdict revoked.
+                    # ok=False if it's not an active verdict, is outside this
+                    # decider's workspace, or the sidecar never acked the drop.
+                    ok = await app.state.consent_coordinator.revoke(
+                        msg.get("request_id"),
+                        user["id"],
+                        decider_workspace=workspace,
+                    )
+                    safe_ws.send_json(
+                        {
+                            "type": "revoke_ack",
+                            "request_id": msg.get("request_id"),
+                            "ok": ok,
+                        }
+                    )
                 # unknown types are ignored
             except SlowClientError:
                 # Outbound queue full -- the client can't keep up. Drop it

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -59,6 +59,9 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
     coordinator = app.state.consent_coordinator
     safe = SafeWebSocket(websocket)
     safe.start_sender()
+    # #2339: record this workspace's live sidecar socket so a revoke can push
+    # a drop-rule to it + correlate the ack.
+    app.state.sidecar_connections.register(workspace_id, safe)
     relay_tasks: set[asyncio.Task] = set()
     try:
         while True:
@@ -75,7 +78,15 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
                 continue
             if not isinstance(msg, dict):
                 continue
-            if msg.get("type") != "egress":
+            mtype = msg.get("type")
+            if mtype == "drop_ack":
+                # Sidecar confirmed a rule-drop (revocation, #2339): resolve
+                # the awaiting revoke's ack Future.
+                app.state.sidecar_connections.resolve_ack(
+                    msg.get("id"), bool(msg.get("ok", False))
+                )
+                continue
+            if mtype != "egress":
                 continue
             local_id = msg.get("id")
             dst = msg.get("dst")
@@ -97,9 +108,9 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
             relay_tasks.add(task)
             task.add_done_callback(relay_tasks.discard)
     finally:
-        # Sidecar gone (disconnect/restart/crash): cancel in-flight relays.
-        # The sidecar's own held connections die with it (fail-close); the
-        # coordinator's per-hold timeout expires the orphaned pending rows.
+        # Sidecar gone (disconnect/restart/crash): drop its registration (any
+        # in-flight revoke ack fails at once) + cancel in-flight relays.
+        app.state.sidecar_connections.deregister(workspace_id)
         for task in list(relay_tasks):
             task.cancel()
         await safe.stop_sender()

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -74,6 +74,11 @@ def _app(
         has_decider=lambda workspace_id: has_decider,
         broadcast=Mock(return_value=0),
     )
+    # #2339: the revoke path pushes a drop-rule to a workspace's sidecar via
+    # this registry. Default send_drop -> None (no live sidecar).
+    app.state.sidecar_connections = types.SimpleNamespace(
+        send_drop=Mock(return_value=None)
+    )
     return app
 
 
@@ -86,6 +91,122 @@ def _denial():
         "decision": "denied",
         "decided_by": None,
     }
+
+
+def _active_row(req_id="rid-1", decision="allowed", host="1.2.3.4"):
+    """An in-effect verdict row for revoke tests (#2339)."""
+    return {
+        "id": req_id,
+        "workspace_id": FULL_WS,
+        "dest_host": host,
+        "dest_port": 443,
+        "decision": decision,
+        "duration": "restart",
+    }
+
+
+class TestConsentCoordinatorRevoke:
+    async def test_revoke_no_sidecar_marks_revoked(self):
+        # No live sidecar -> nothing to drop -> mark revoked + refresh the view.
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row()
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.egress_consent.revoke.assert_awaited_once_with(
+            "rid-1", "a@x"
+        )
+        app.state.sidecar_connections.send_drop.assert_called_once_with(
+            FULL_WS, "1.2.3.4", "allowed"
+        )
+
+    async def test_revoke_sidecar_acked_marks_revoked(self):
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row()
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(True)
+        app.state.sidecar_connections.send_drop = Mock(return_value=fut)
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+
+    async def test_revoke_sidecar_no_ack_returns_false(self):
+        # A connected sidecar that doesn't ack ok -> leave enforced (fail-closed).
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row()
+        )
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(False)
+        app.state.sidecar_connections.send_drop = Mock(return_value=fut)
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is False
+        app.state.model.egress_consent.revoke.assert_not_awaited()
+
+    async def test_revoke_sidecar_ack_timeout_returns_false(self, monkeypatch):
+        # A sidecar that never acks -> wait_for times out -> leave enforced.
+        import klangk.consent_coordinator as cc
+
+        monkeypatch.setattr(cc, "_REVOKE_ACK_TIMEOUT", 0.05)
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row()
+        )
+        # a Future that never resolves
+        app.state.sidecar_connections.send_drop = Mock(
+            return_value=asyncio.get_running_loop().create_future()
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is False
+        app.state.model.egress_consent.revoke.assert_not_awaited()
+
+    async def test_revoke_unknown_request_returns_false(self):
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=None
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("nope", "a@x") is False
+        app.state.sidecar_connections.send_drop.assert_not_called()
+
+    async def test_revoke_not_active_verdict_returns_false(self):
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row(decision="pending")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is False
+        app.state.sidecar_connections.send_drop.assert_not_called()
+
+    async def test_revoke_outside_decider_workspace_returns_false(self):
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row()
+        )
+        coord = ConsentCoordinator(app)
+        assert (
+            await coord.revoke("rid-1", "a@x", decider_workspace="other")
+            is False
+        )
+        app.state.sidecar_connections.send_drop.assert_not_called()
+
+    async def test_revoke_model_returns_none_returns_false(self):
+        # race: the row changed under us -> model.revoke returns None
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row()
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(return_value=None)
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is False
 
 
 class TestConsentCoordinatorGate:
@@ -575,6 +696,9 @@ def _sidecar_app(token_result=FULL_WS):
     app.state.auth = types.SimpleNamespace(decode_workspace_token=_decode)
     coord = AsyncMock()
     app.state.consent_coordinator = coord
+    # #2339: the handler registers/deregisters the sidecar socket + resolves
+    # drop-acks via this registry.
+    app.state.sidecar_connections = Mock()
     return app, coord
 
 
@@ -612,6 +736,25 @@ class TestEgressSidecarWS:
         )
         await asyncio.sleep(0.05)
         coord.hold.assert_awaited_once_with(FULL_WS, "1.2.3.4", 443)
+        await ws.feed(WebSocketDisconnect())
+        await handler
+
+    async def test_drop_ack_resolves_pending(self):
+        # a drop_ack frame from the sidecar -> resolve_ack on the registry (#2339)
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, _ = _sidecar_app()
+        ws = _FakeWS({"token": FULL_WS})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(
+            json.dumps({"type": "drop_ack", "id": "ack-1", "ok": True})
+        )
+        await asyncio.sleep(0.02)
+        app.state.sidecar_connections.resolve_ack.assert_called_once_with(
+            "ack-1", True
+        )
         await ws.feed(WebSocketDisconnect())
         await handler
 

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -232,6 +232,7 @@ def _ws_app(
         snapshot=AsyncMock(return_value=snapshot or []),
         resolve=AsyncMock(return_value=None),
         rules_frame=AsyncMock(return_value=rules_frame),
+        revoke=AsyncMock(return_value=True),
     )
     return app
 
@@ -382,6 +383,32 @@ class TestConsentDeciderWS:
         app.state.consent_coordinator.resolve.assert_awaited_once_with(
             "rid", "allowed", "once", "u1", duration="1w", decider_workspace=WS
         )
+
+    async def test_revoke_frame_calls_coordinator_and_acks(self):
+        # #2339: a revoke frame -> coordinator.revoke(decider_workspace guard)
+        # + a revoke_ack back to the decider.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        app.state.consent_coordinator.revoke = AsyncMock(return_value=True)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"revoke","request_id":"r1"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.revoke.assert_awaited_once()
+        args, kwargs = app.state.consent_coordinator.revoke.call_args
+        assert args[0] == "r1"  # request_id
+        assert kwargs["decider_workspace"] == WS  # defense-in-depth scope
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "revoke_ack"
+        ]
+        assert acks and acks[0]["ok"] is True
+        assert acks[0]["request_id"] == "r1"
 
     async def test_verdict_invalid_decision_sends_error(self):
         from fastapi import WebSocketDisconnect

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -22,6 +22,7 @@ from klangk import (
     consent,
     consent_coordinator,
     consent_deciders,
+    sidecar_connections,
     emailsvc as emailsvc_mod,
     files as files_mod,
     ssl_trust as ssl_trust_mod,
@@ -815,6 +816,9 @@ class TestLifespan:
         app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
             app
         )
+        app.state.sidecar_connections = sidecar_connections.SidecarConnections(
+            app
+        )
         app.state.oidc = oidc.OIDC(app)
         app.state.features = features.Features(app)
         app.state.workspaces = workspaces.Workspaces(app)
@@ -868,6 +872,9 @@ class TestLifespan:
             app
         )
         app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
+            app
+        )
+        app.state.sidecar_connections = sidecar_connections.SidecarConnections(
             app
         )
         app.state.oidc = oidc.OIDC(app)
@@ -1403,6 +1410,9 @@ class TestStartupShutdownRestart:
             app
         )
         app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
+            app
+        )
+        app.state.sidecar_connections = sidecar_connections.SidecarConnections(
             app
         )
         app.state.oidc = oidc.OIDC(app)

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -10,6 +10,7 @@ from klangk.model.egress_consent import (
     DECISION_DENIED,
     DECISION_EXPIRED,
     DECISION_PENDING,
+    DECISION_REVOKED,
     DURATIONS,
     SCOPE_ONCE,
     SCOPE_WORKSPACE,
@@ -578,6 +579,69 @@ async def test_clear_restart_duration_no_rows_is_zero(ec, ws, user):
     # First-ever start: no restart rows -> no-op, returns 0.
     w = await ws.create_workspace(user["id"], "clr-empty")
     assert await ec.clear_restart_duration(w["id"]) == 0
+
+
+# -- revoke (#2339) --
+
+
+async def test_revoke_flips_active_allow(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "revoke-allow")
+    req = await ec.create_request(w["id"], "allow.com", 443)
+    await ec.decide(
+        req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+    row = await ec.revoke(req["id"], user["id"])
+    assert row["decision"] == DECISION_REVOKED
+    assert row["revoked_at"] is not None
+    assert row["revoked_by"] == user["id"]
+    # original verdict provenance preserved
+    assert row["decided_by"] == user["id"]
+    assert (await ec.get_request(req["id"]))["decision"] == DECISION_REVOKED
+
+
+async def test_revoke_flips_active_deny(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "revoke-deny")
+    req = await ec.create_request(w["id"], "deny.com")
+    await ec.decide(req["id"], DECISION_DENIED, None, user["id"], "forever")
+    assert (await ec.revoke(req["id"], user["id"]))[
+        "decision"
+    ] == DECISION_REVOKED
+
+
+async def test_revoke_returns_none_for_non_verdict(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "revoke-pending")
+    req = await ec.create_request(w["id"], "pending.com")  # still pending
+    to_expire = await ec.create_request(w["id"], "expired.com")
+    await ec.expire_pending(to_expire["id"])
+    assert await ec.revoke(req["id"], user["id"]) is None  # pending
+    assert await ec.revoke(to_expire["id"], user["id"]) is None  # expired
+    assert (await ec.get_request(req["id"]))["decision"] == DECISION_PENDING
+
+
+async def test_revoke_unknown_returns_none(ec, ws, user):
+    await ws.create_workspace(user["id"], "revoke-unknown")  # schema setup
+    assert await ec.revoke("nope", user["id"]) is None
+
+
+async def test_revoke_idempotent_second_call_returns_none(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "revoke-idem")
+    req = await ec.create_request(w["id"], "idem.com")
+    await ec.decide(
+        req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+    assert await ec.revoke(req["id"], user["id"]) is not None
+    assert await ec.revoke(req["id"], user["id"]) is None  # already revoked
+
+
+async def test_list_active_excludes_revoked(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "revoke-excluded")
+    req = await ec.create_request(w["id"], "rev.com")
+    await ec.decide(
+        req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
+    )
+    assert len(await ec.list_active(w["id"])) == 1
+    await ec.revoke(req["id"], user["id"])
+    assert await ec.list_active(w["id"]) == []
 
 
 # -- DB-level integrity (CHECK constraints + partial unique index) --

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -701,7 +701,7 @@ class TestConsentForward:
         assert frame["type"] == "egress"
         assert frame["dst"] == "evil.test"
         assert frame["dport"] == 443
-        c._dispatch(
+        await c._dispatch(
             json.dumps(
                 {"type": "verdict", "id": frame["id"], "decision": "allow"}
             )
@@ -722,7 +722,7 @@ class TestConsentForward:
         task = asyncio.create_task(c.request("evil.test", None))
         await asyncio.sleep(0)
         frame = json.loads(sent[0])
-        c._dispatch(
+        await c._dispatch(
             json.dumps(
                 {"type": "verdict", "id": frame["id"], "decision": "deny"}
             )
@@ -743,7 +743,7 @@ class TestConsentForward:
         task = asyncio.create_task(c.request("evil.test", None))
         await asyncio.sleep(0)
         frame = json.loads(sent[0])
-        c._dispatch(
+        await c._dispatch(
             json.dumps(
                 {"type": "verdict", "id": frame["id"], "decision": "expired"}
             )
@@ -778,18 +778,20 @@ class TestConsentForward:
         assert await c.request("evil.test", None) == ("deny", "once")
         assert c._pending == {}
 
-    def test_dispatch_ignores_non_verdict_and_bad_id(self, proxy, tmp_path):
+    async def test_dispatch_ignores_non_verdict_and_bad_id(
+        self, proxy, tmp_path
+    ):
         c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
-        c._dispatch("not-json")
-        c._dispatch(json.dumps({"type": "egress"}))  # wrong type
-        c._dispatch(
+        await c._dispatch("not-json")
+        await c._dispatch(json.dumps({"type": "egress"}))  # wrong type
+        await c._dispatch(
             json.dumps({"type": "verdict", "decision": "allow"})
         )  # no id
-        c._dispatch(
+        await c._dispatch(
             json.dumps({"type": "verdict", "id": 123, "decision": "allow"})
         )  # non-str id
         # a verdict for an unknown id is a no-op (already popped/timed out)
-        c._dispatch(
+        await c._dispatch(
             json.dumps({"type": "verdict", "id": "nope", "decision": "allow"})
         )
 
@@ -797,7 +799,7 @@ class TestConsentForward:
         c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
         fut = asyncio.get_running_loop().create_future()
         c._pending["abc"] = fut
-        c._dispatch(
+        await c._dispatch(
             json.dumps({"type": "verdict", "id": "abc", "decision": "allow"})
         )
         assert fut.result() == ("allow", "once")
@@ -1226,3 +1228,152 @@ class TestHandlePacket:
         await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
         s.sendto.assert_not_called()  # dropped, no response
         fwd.assert_not_awaited()
+
+
+class TestDropForHost:
+    """Revoke rule-drop (#2339): drop_for_host + the drop_rule dispatch/ack."""
+
+    def test_allowed_removes_learned_accept(self, proxy, monkeypatch):
+        proxy._LEARNED.clear()
+        proxy._REJECTED.clear()
+        runs = []
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: (
+                runs.append(a[0]) or types.SimpleNamespace(returncode=0)
+            ),
+        )
+        proxy._LEARNED["1.2.3.4"] = {
+            "expire": 9999.0,
+            "ports": {443, None},
+            "host": "evil.test",
+        }
+        proxy.drop_for_host("evil.test", "allowed")
+        assert "1.2.3.4" not in proxy._LEARNED
+        # an ACCEPT rule delete per port
+        assert sum(1 for r in runs if "-D" in r and "ACCEPT" in r) == 2
+
+    def test_denied_removes_rejects(self, proxy, monkeypatch):
+        proxy._LEARNED.clear()
+        proxy._REJECTED.clear()
+        runs = []
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: (
+                runs.append(a[0]) or types.SimpleNamespace(returncode=0)
+            ),
+        )
+        # the denied IP was DNS-recorded (host set) + has a REJECT rule
+        proxy._LEARNED["5.6.7.8"] = {
+            "expire": 9999.0,
+            "ports": set(),
+            "host": "bad.test",
+        }
+        proxy._REJECTED[("5.6.7.8", 443)] = 9999.0
+        proxy.drop_for_host("bad.test", "denied")
+        assert ("5.6.7.8", 443) not in proxy._REJECTED
+        assert any("-D" in r and "REJECT" in r for r in runs)
+
+    def test_denied_direct_ip_match(self, proxy, monkeypatch):
+        # a direct-IP deny (host == ip, never DNS host-recorded) is still dropped
+        proxy._LEARNED.clear()
+        proxy._REJECTED.clear()
+        runs = []
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: (
+                runs.append(a[0]) or types.SimpleNamespace(returncode=0)
+            ),
+        )
+        proxy._REJECTED[("9.9.9.9", 80)] = 9999.0
+        proxy.drop_for_host("9.9.9.9", "denied")
+        assert ("9.9.9.9", 80) not in proxy._REJECTED
+
+    def test_no_match_is_noop(self, proxy, monkeypatch):
+        proxy._LEARNED.clear()
+        proxy._REJECTED.clear()
+        ran = []
+        monkeypatch.setattr(
+            proxy.subprocess, "run", lambda *a, **k: ran.append(a[0])
+        )
+        proxy._LEARNED["1.2.3.4"] = {
+            "expire": 9.0,
+            "ports": {443},
+            "host": "other.test",
+        }
+        proxy.drop_for_host("evil.test", "allowed")
+        assert "1.2.3.4" in proxy._LEARNED  # untouched
+        assert ran == []
+
+    def test_unknown_decision_is_noop(self, proxy, monkeypatch):
+        proxy._LEARNED.clear()
+        proxy._REJECTED.clear()
+        ran = []
+        monkeypatch.setattr(
+            proxy.subprocess, "run", lambda *a, **k: ran.append(a[0])
+        )
+        proxy._LEARNED["1.2.3.4"] = {
+            "expire": 9.0,
+            "ports": {443},
+            "host": "h.test",
+        }
+        proxy.drop_for_host("h.test", "bogus")
+        assert "1.2.3.4" in proxy._LEARNED
+        assert ran == []
+
+    async def test_dispatch_drop_rule_acks_ok(
+        self, proxy, tmp_path, monkeypatch
+    ):
+        proxy._LEARNED.clear()
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=0),
+        )
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        await c._dispatch(
+            json.dumps(
+                {
+                    "type": "drop_rule",
+                    "id": "ack-1",
+                    "host": "h.test",
+                    "decision": "allowed",
+                }
+            )
+        )
+        ack = json.loads(sent[0])
+        assert ack["type"] == "drop_ack"
+        assert ack["id"] == "ack-1"
+        assert ack["ok"] is True
+
+    async def test_dispatch_drop_rule_bad_payload_acks_false(
+        self, proxy, tmp_path
+    ):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        # missing host + bogus decision -> drop skipped, ack ok=False
+        await c._dispatch(
+            json.dumps(
+                {"type": "drop_rule", "id": "ack-2", "decision": "bogus"}
+            )
+        )
+        ack = json.loads(sent[0])
+        assert ack["ok"] is False

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1254,6 +1254,28 @@ class TestDropForHost:
         # an ACCEPT rule delete per port
         assert sum(1 for r in runs if "-D" in r and "ACCEPT" in r) == 2
 
+    def test_allowed_direct_ip_removes_learned(self, proxy, monkeypatch):
+        # #2339 review #1: a direct-IP allow records host=None (no DNS), so the
+        # allow branch must also admit the host string itself as a candidate IP.
+        proxy._LEARNED.clear()
+        proxy._REJECTED.clear()
+        runs = []
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: (
+                runs.append(a[0]) or types.SimpleNamespace(returncode=0)
+            ),
+        )
+        monkeypatch.setattr(proxy.time, "time", lambda: 0.0)
+        proxy.allow(
+            "203.0.113.9", None, 3600
+        )  # direct-IP allow, host stays None
+        assert proxy._LEARNED["203.0.113.9"]["host"] is None
+        proxy.drop_for_host("203.0.113.9", "allowed")
+        assert "203.0.113.9" not in proxy._LEARNED  # rule + record removed
+        assert any("-D" in r and "ACCEPT" in r for r in runs)
+
     def test_denied_removes_rejects(self, proxy, monkeypatch):
         proxy._LEARNED.clear()
         proxy._REJECTED.clear()

--- a/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
+++ b/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import types
 
 from klangk.sidecar_connections import SidecarConnections
+from klangk.wshandler.safe_websocket import SlowClientError
 
 
 def _app():
@@ -21,9 +23,16 @@ class _Sock:
         self.sent.append(msg)
 
 
-class _DeadSock:
+class _FullSock:
+    """Mimics a SafeWebSocket whose send queue is full / sender stopped.
+
+    ``SafeWebSocket.send_json`` only ever raises ``SlowClientError`` (queue
+    full / ``_closed``) -- never ``ConnectionError``/``OSError`` -- so this is
+    the realistic production failure shape for the send_drop None path.
+    """
+
     def send_json(self, msg: dict) -> None:
-        raise ConnectionError("socket gone")
+        raise SlowClientError("outbound queue full")
 
 
 class TestSidecarConnections:
@@ -53,10 +62,27 @@ class TestSidecarConnections:
         assert fut.result() is True
 
     async def test_send_drop_send_failure_returns_none(self):
-        # socket died between get() and send() -> treat as "no sidecar"
+        # SafeWebSocket.send_json raises only SlowClientError (queue full /
+        # sender stopped) -> treat as "no sidecar" (the only realistic send
+        # failure; a dead-but-not-stopped socket accepts the enqueue and the
+        # caller's wait_for timeout is the backstop).
         reg = SidecarConnections(_app())
-        reg.register("ws-1", _DeadSock())
+        reg.register("ws-1", _FullSock())
         assert reg.send_drop("ws-1", "h", "allowed") is None
+        assert reg._pending == {}  # nothing leaked
+
+    async def test_send_drop_timeout_pops_pending(self):
+        # A hung-but-connected sidecar: the caller's wait_for cancels the
+        # Future on timeout -> the done-callback must pop the pending entry
+        # (no process-lifetime leak, #2339 review #3).
+        reg = SidecarConnections(_app())
+        reg.register("ws-1", _Sock())
+        fut = reg.send_drop("ws-1", "h", "allowed")
+        assert fut is not None
+        assert len(reg._pending) == 1
+        fut.cancel()  # simulate asyncio.wait_for timeout cancel
+        await asyncio.sleep(0)  # done-callback fires on the next loop tick
+        assert reg._pending == {}
 
     async def test_resolve_ack_unknown_is_noop(self):
         reg = SidecarConnections(_app())

--- a/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
+++ b/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
@@ -1,0 +1,89 @@
+"""Tests for :mod:`klangk.sidecar_connections` (#2339)."""
+
+from __future__ import annotations
+
+import types
+
+from klangk.sidecar_connections import SidecarConnections
+
+
+def _app():
+    app = types.SimpleNamespace()
+    app.state = types.SimpleNamespace()
+    return app
+
+
+class _Sock:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    def send_json(self, msg: dict) -> None:
+        self.sent.append(msg)
+
+
+class _DeadSock:
+    def send_json(self, msg: dict) -> None:
+        raise ConnectionError("socket gone")
+
+
+class TestSidecarConnections:
+    async def test_register_get_deregister(self):
+        reg = SidecarConnections(_app())
+        sock = _Sock()
+        reg.register("ws-1", sock)
+        assert reg.get("ws-1") is sock
+        reg.deregister("ws-1")
+        assert reg.get("ws-1") is None
+
+    async def test_send_drop_no_connection_returns_none(self):
+        reg = SidecarConnections(_app())
+        assert reg.send_drop("ws-1", "h", "allowed") is None
+
+    async def test_send_drop_sends_frame_and_resolve_ack(self):
+        reg = SidecarConnections(_app())
+        sock = _Sock()
+        reg.register("ws-1", sock)
+        fut = reg.send_drop("ws-1", "host.com", "allowed")
+        assert fut is not None and not fut.done()
+        frame = sock.sent[0]
+        assert frame["type"] == "drop_rule"
+        assert frame["host"] == "host.com"
+        assert frame["decision"] == "allowed"
+        reg.resolve_ack(frame["id"], True)
+        assert fut.result() is True
+
+    async def test_send_drop_send_failure_returns_none(self):
+        # socket died between get() and send() -> treat as "no sidecar"
+        reg = SidecarConnections(_app())
+        reg.register("ws-1", _DeadSock())
+        assert reg.send_drop("ws-1", "h", "allowed") is None
+
+    async def test_resolve_ack_unknown_is_noop(self):
+        reg = SidecarConnections(_app())
+        reg.resolve_ack("nope", True)  # late/unknown ack -> no error
+
+    async def test_deregister_fails_pending_ack(self):
+        reg = SidecarConnections(_app())
+        reg.register("ws-1", _Sock())
+        fut = reg.send_drop("ws-1", "h", "denied")
+        reg.deregister("ws-1")  # sidecar gone -> its ack fails
+        assert fut.result() is False
+
+    async def test_stop_clears_and_fails_pending(self):
+        reg = SidecarConnections(_app())
+        reg.register("ws-1", _Sock())
+        fut = reg.send_drop("ws-1", "h", "allowed")
+        await reg.stop()
+        assert fut.result() is False
+        assert reg.get("ws-1") is None
+
+    async def test_start_is_noop(self):
+        # lifespan symmetry: start() must not blow up
+        SidecarConnections(_app()).start()
+
+    async def test_reconfigure_swaps_app(self):
+        app1 = _app()
+        reg = SidecarConnections(app1)
+        app2 = _app()
+        reg.reconfigure(app2)
+        assert reg.app is app2


### PR DESCRIPTION
Closes #2339 (slice C of the #2335 rule-management view umbrella).

## What

The backend half of revoking a prior consent verdict so its effect is
**immediate** (not waiting for the duration or a container restart): klangkd
drops the network sidecar's learned rule for the host and marks the row
`revoked`. The TUI action that sends the revoke frame is slice D (#2341).

```
decider ──{type:revoke, request_id}──▶ klangkd decider handler
  └─ ConsentCoordinator.revoke(request_id, by, decider_workspace=…)
       ├─ read row (host, decision, workspace); decider_workspace guard
       ├─ SidecarConnections.send_drop(ws, host, decision) -> await drop_ack (timeout)
       │   (no live sidecar -> nothing enforced -> mark revoked outright)
       ├─ EgressConsentModel.revoke() -> decision='revoked', revoked_at, revoked_by
       └─ broadcast refreshed egress_rules (reuse slice A's #2338 path)
```
The sidecar (`proxy.py`) `_dispatch` gets a `drop_rule` branch → `drop_for_host`
(drops ACCEPT rules for an allow, REJECT rules for a deny, for the host's IPs)
→ `drop_ack` back.

## Changes

- **`EgressConsentModel.revoke(request_id, by)`** — flips an active
  (allowed/denied) row to `revoked`, stamping `revoked_at`/`revoked_by`
  (original `decided_*` kept as the verdict's provenance); idempotent (None for
  non-verdict/unknown). `list_active` already excludes `revoked` (its
  `decision IN (allowed,denied)` filter).
- **Schema** — add the `revoked` decision + `revoked_at`/`revoked_by` columns,
  via a one-shot rebuild (data copied). The **decision** `CHECK` is now
  generated from `DECISIONS`, mirroring the duration `CHECK` from #2338 — so
  neither can drift from the Python enums.
- **`SidecarConnections` (new)** — live sidecar sockets by workspace (registered
  in the egress-sidecar handler; deregistered on disconnect, failing any pending
  ack), so a revoke can push a `drop_rule` + correlate the ack.
- **`ConsentCoordinator.revoke`** — orchestrates drop→ack→mark→broadcast;
  **fail-closed**: a connected-but-unresponsive sidecar (no ack within
  `_REVOKE_ACK_TIMEOUT`) leaves the row enforced rather than falsely marking it
  revoked.
- **`proxy.py` `drop_for_host`** — removes the learned ACCEPT rules (allow) or
  REJECT rules (deny) for a host's IPs (host→IP via `_LEARNED["host"]`, which is
  set for every resolved name incl. denied ones; direct-IP covered too).
- **Decider handler** — a `revoke` frame → `coordinator.revoke` (with the
  `decider_workspace` defense-in-depth guard) + a `revoke_ack` back.

## Verification

Full suite (both packages, `-n auto`): **4662 passed, 100% coverage**.

New tests: model `revoke` (allow/deny/non-verdict/unknown/idempotent +
`list_active` excludes revoked); coordinator `revoke` (no-sidecar / ack-ok /
ack-false / ack-timeout / unknown / non-active / wrong-workspace / model-None);
`SidecarConnections` (register/get/deregister/send-drop/resolve-ack/send-failure/
deregister-fails-pending/stop/start/reconfigure); decider `revoke` frame → ack;
sidecar `drop_ack` resolution; `proxy.drop_for_host` (allow/deny/direct-IP/
no-match/unknown-decision) + the `drop_rule` dispatch→ack.

## Parent / siblings

#2335 (umbrella). Slice A (#2338) is on main; B (#2340) is the read-only view
that surfaces the revoke action (slice D, #2341).
