### PR TITLE
feat(ui): Flutter consent banner for interactive egress consent (#2246)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -51,6 +51,14 @@ operators or integrators to act when upgrading.
   and the list updates live from the `egress_rules` frame (#2338). Revoking a
   row is a separate follow-up (#2339/#2341).
 
+- **Interactive egress-consent banner in the web UI (#2246).** Workspaces
+  in `interactive` egress mode now show a banner on the workspace page listing
+  pending held egress requests (host:port, process, countdown) with a global
+  duration selector + per-row Allow/Deny, mirroring the `consent-decide`
+  TUI; verdicts go live over the `/ws/consent-decider` stream. Server error
+  frames, verdict send failures, and verdicts attempted while disconnected
+  surface as a transient flash so a rejected/lost verdict is never silent.
+
 - **Per-request duration for egress-consent verdicts (#2328).** A verdict
   now carries a `duration` (`once` | `5m` | `15m` | `1h` | `1d` | `1w` |
   `restart` | `forever`, default `restart`). The `consent-decide` TUI shows a

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -1,0 +1,246 @@
+/// Interactive egress-consent banner for the workspace page (#2246).
+///
+/// A compact banner shown above the workspace body when [ConsentDeciderService]
+/// has pending held requests (interactive `egress_mode` only). The header
+/// carries a single *global* duration selector (default `restart`); each row
+/// shows the destination host:port (+ process + a countdown) and Allow/Deny
+/// buttons that send a `verdict` frame carrying the selected duration. Mirrors
+/// the standalone `klangk consent-decide` TUI (one `#duration-selector` for the
+/// whole list, applied at allow/deny time -- not per row), adapted to an inline
+/// Flutter banner.
+///
+/// Server error frames, verdict send failures, and verdicts attempted while
+/// disconnected surface as a transient flash row (the service's
+/// [ConsentDeciderService.flashMessage]) -- matching the TUI's status-line
+/// flash, so a rejected/lost verdict is never silent.
+///
+/// The row is NOT optimistically removed on a click: the server's
+/// `egress_resolved` frame removes it once the verdict is actually applied to
+/// the held connection (a duplicate/no-op verdict must not hide a still-held
+/// request) -- matching the TUI.
+
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'consent_decider_service.dart';
+
+/// A banner over the workspace body showing held egress requests + actions.
+///
+/// Renders nothing when there are no pending requests (and the service isn't
+/// in an auth-failed state), so a static-mode or idle workspace sees no UI.
+class ConsentBanner extends StatefulWidget {
+  const ConsentBanner({super.key, required this.service});
+
+  final ConsentDeciderService service;
+
+  @override
+  State<ConsentBanner> createState() => _ConsentBannerState();
+}
+
+class _ConsentBannerState extends State<ConsentBanner> {
+  /// The chosen verdict duration, applied to whichever row's Allow/Deny is
+  /// tapped. One selector for the whole banner (default `restart`), mirroring
+  /// the TUI's single global `#duration-selector` -- not a per-row choice.
+  String _duration = kConsentDurationDefault;
+  Timer? _tick;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.service.addListener(_onChange);
+    // 1s countdown refresh while requests are held (the server is the source
+    // of truth; this only repaints the remaining-seconds hint).
+    _tick = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted && widget.service.pending.isNotEmpty) _onChange();
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.service.removeListener(_onChange);
+    _tick?.cancel();
+    super.dispose();
+  }
+
+  void _onChange() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = widget.service;
+    if (service.authFailed) {
+      return const _BannerSurface(
+        child: ListTile(
+          dense: true,
+          leading: Icon(Icons.lock_outline, size: 20),
+          title: Text('Consent session expired — please log in again'),
+        ),
+      );
+    }
+    final pending = service.pending;
+    if (pending.isEmpty) {
+      return const SizedBox.shrink(); // nothing held -> no banner
+    }
+    final flash = service.flashMessage;
+    return _BannerSurface(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+            child: Row(
+              children: [
+                const Icon(Icons.shield_outlined, size: 18),
+                const SizedBox(width: 8),
+                Text(
+                  'Pending egress consent',
+                  style: Theme.of(context).textTheme.labelLarge,
+                ),
+                const SizedBox(width: 12),
+                // One global duration selector (TUI parity): applies to the
+                // next Allow/Deny tapped on any row. Not per row.
+                _DurationMenu(
+                  value: _duration,
+                  onChanged: (v) => setState(() => _duration = v),
+                ),
+                const Spacer(),
+                if (!service.connected)
+                  const Text('reconnecting…',
+                      style: TextStyle(fontStyle: FontStyle.italic)),
+              ],
+            ),
+          ),
+          if (flash != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 2),
+              child: Row(
+                children: [
+                  const Icon(Icons.error_outline,
+                      size: 16, color: Colors.redAccent),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      flash,
+                      style: const TextStyle(
+                          color: Colors.redAccent, fontSize: 13),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ...pending.map(_buildRow),
+          const SizedBox(height: 4),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRow(PendingRequest req) {
+    final service = widget.service;
+    final host = req.destHost;
+    final hostDisplay = req.destPort != null ? '$host:${req.destPort}' : host;
+    final proc = req.processName;
+    final secs = service.remainingSeconds(req);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              proc == null || proc.isEmpty
+                  ? '$hostDisplay  (${secs}s)'
+                  : '$hostDisplay  ·  $proc  (${secs}s)',
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          _ActionChip(
+            label: 'Allow',
+            color: Colors.green,
+            onPressed: () =>
+                service.sendVerdict(req.id, kDecisionAllowed, _duration),
+          ),
+          const SizedBox(width: 4),
+          _ActionChip(
+            label: 'Deny',
+            color: Colors.red,
+            onPressed: () =>
+                service.sendVerdict(req.id, kDecisionDenied, _duration),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The banner's surface (a flat warning-toned Material strip).
+class _BannerSurface extends StatelessWidget {
+  const _BannerSurface({required this.child});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      elevation: 0,
+      color: Theme.of(context).colorScheme.secondaryContainer,
+      child: child,
+    );
+  }
+}
+
+/// A compact duration selector for one request row.
+class _DurationMenu extends StatelessWidget {
+  const _DurationMenu({required this.value, required this.onChanged});
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<String>(
+      value: value,
+      isDense: true,
+      underline: const SizedBox.shrink(),
+      items: kConsentDurations
+          .map((d) => DropdownMenuItem(value: d, child: Text(d)))
+          .toList(),
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+}
+
+/// A small colored action button (Allow/Deny) for a request row.
+class _ActionChip extends StatelessWidget {
+  const _ActionChip({
+    required this.label,
+    required this.color,
+    required this.onPressed,
+  });
+  final String label;
+  final Color color;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 28,
+      child: FilledButton.icon(
+        onPressed: onPressed,
+        style: FilledButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          textStyle: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+        ),
+        icon: const SizedBox.shrink(),
+        label: Text(label),
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -1,0 +1,421 @@
+/// Interactive egress-consent decider service for the web UI (#2246).
+///
+/// Mirrors the standalone ``klangk consent-decide`` TUI
+/// (``cli/tui/consent.py``): connects to the server's ``/ws/consent-decider``
+/// stream for a workspace, holds the snapshot + live pending egress requests,
+/// and sends ``verdict`` frames so the deciding user can allow/deny each held
+/// connection *while the sidecar holds it* (#2311). The verdict protocol +
+/// frame shapes are duplicated from the server (``model/egress_consent.py``)
+/// per the isolation boundary the web client shares with the CLI.
+///
+/// A decider that goes silent is reaped by the server after
+/// ``consent_decider_timeout`` (45s), reverting the workspace to static
+/// allow-list (fail-closed); this client pings every [_pingInterval] to stay
+/// registered. On disconnect it reconnects with backoff; while disconnected it
+/// is deregistered server-side, so held requests auto-deny on their own
+/// timeout -- never silently allowed.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Decision + duration tokens mirror the server (``model/egress_consent.py``);
+/// duplicated here per the client isolation boundary (#2309 rule).
+const String kDecisionAllowed = 'allowed';
+const String kDecisionDenied = 'denied';
+
+/// Ordered for the duration selector; the default is `restart` (#2328).
+const List<String> kConsentDurations = [
+  'once',
+  '5m',
+  '15m',
+  '1h',
+  '1d',
+  '1w',
+  'restart',
+  'forever',
+];
+const String kConsentDurationDefault = 'restart';
+
+/// Inbound-frame application outcomes returned by [ConsentDeciderService.applyFrame].
+enum ConsentFrameOutcome {
+  /// A new held request (snapshot or live); [ConsentFrameResult.request] is set.
+  added,
+
+  /// A request resolved (decided/timed out); [ConsentFrameResult.resolvedId]
+  /// is set.
+  resolved,
+
+  /// A liveness pong (no state change).
+  pong,
+
+  /// The server rejected a verdict; [ConsentFrameResult.message] is set.
+  error,
+
+  /// Non-JSON / unknown frame (ignored).
+  ignored,
+}
+
+/// The payload of an applied frame (see [ConsentFrameOutcome] for which fields
+/// are set per outcome).
+class ConsentFrameResult {
+  final ConsentFrameOutcome outcome;
+  final PendingRequest? request;
+  final String? resolvedId;
+  final String? message;
+
+  const ConsentFrameResult(this.outcome,
+      {this.request, this.resolvedId, this.message});
+
+  static const ignored = ConsentFrameResult(ConsentFrameOutcome.ignored);
+}
+
+/// One held egress request awaiting a verdict.
+@immutable
+class PendingRequest {
+  final String id;
+  final String destHost;
+  final int? destPort;
+  final String? processName;
+  final double requestedAt;
+
+  const PendingRequest({
+    required this.id,
+    required this.destHost,
+    this.destPort,
+    this.processName,
+    required this.requestedAt,
+  });
+
+  /// Parse a frame's ``request`` object. Returns `null` on a shape that
+  /// cannot be acted on (missing id / non-numeric port handled defensively).
+  static PendingRequest? fromJson(Object? obj) {
+    if (obj is! Map<String, dynamic>) return null;
+    final id = obj['id'];
+    if (id is! String) return null;
+    final port = obj['dest_port'];
+    final requestedAt = obj['requested_at'];
+    return PendingRequest(
+      id: id,
+      destHost: obj['dest_host']?.toString() ?? '',
+      destPort: port is int ? port : (port is num ? port.toInt() : null),
+      processName: obj['process_name']?.toString(),
+      requestedAt: requestedAt is num
+          ? requestedAt.toDouble()
+          : (requestedAt is int ? requestedAt.toDouble() : 0.0),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PendingRequest &&
+          id == other.id &&
+          destHost == other.destHost &&
+          destPort == other.destPort &&
+          processName == other.processName &&
+          requestedAt == other.requestedAt;
+
+  @override
+  int get hashCode =>
+      Object.hash(id, destHost, destPort, processName, requestedAt);
+}
+
+/// Manages the WebSocket to ``/ws/consent-decider`` for one workspace.
+///
+/// The frame protocol (parse + verdict builder) lives in the pure static
+/// [applyFrame] / [buildVerdict] so it is unit-testable without a transport;
+/// this class is a thin owner of the socket + the pending-request map.
+class ConsentDeciderService extends ChangeNotifier {
+  ConsentDeciderService({
+    required this.workspaceId,
+    required this.token,
+    this.holdTimeout = const Duration(seconds: 120),
+    this.pingInterval = const Duration(seconds: 15),
+    this.reconnectDelays = const [
+      Duration(seconds: 1),
+      Duration(seconds: 2),
+      Duration(seconds: 5),
+    ],
+    this.clock = _wallClock,
+  });
+
+  final String workspaceId;
+  String token;
+  final Duration holdTimeout;
+  final Duration pingInterval;
+  final List<Duration> reconnectDelays;
+  final DateTime Function() clock;
+
+  WebSocketChannel? _channel;
+  StreamSubscription? _sub;
+  Timer? _pingTimer;
+  Timer? _reconnectTimer;
+  bool _connected = false;
+  bool _stopped = false;
+  int _attempt = 0;
+
+  /// Whether the last disconnect was an auth failure (close codes 4001/4002).
+  /// While true the service stops reconnecting -- the app surfaces re-login.
+  bool _authFailed = false;
+  bool get authFailed => _authFailed;
+
+  /// Transient status flash (server `error` frame / verdict send failure /
+  /// verdict attempted while disconnected), shown by the banner until
+  /// [_flashUntil]. Mirrors the TUI's status-line flash (cli/tui/consent.py
+  /// `_flash`) so the user is never left wondering whether a verdict landed.
+  String? _flashMessage;
+  DateTime? _flashUntil;
+
+  /// The active flash message, or null once it has expired. Clock-based (not a
+  /// real timer) so it is unit-testable by advancing the injected [clock]; the
+  /// banner's 1s tick repaint re-reads this and the flash visually clears.
+  String? get flashMessage {
+    final msg = _flashMessage;
+    final until = _flashUntil;
+    if (msg == null || until == null) return null;
+    return clock().isBefore(until) ? msg : null;
+  }
+
+  /// Surface a transient message to the user. Used for server error frames,
+  /// verdict send failures, and verdicts attempted while disconnected --
+  /// cases the TUI flashes to its status line rather than failing silently.
+  void _flash(String message, {Duration ttl = const Duration(seconds: 5)}) {
+    _flashMessage = message;
+    _flashUntil = clock().add(ttl);
+    notifyListeners();
+  }
+
+  final Map<String, PendingRequest> _pending = {};
+
+  /// Pending requests, oldest-first (stable UI ordering by requested_at).
+  List<PendingRequest> get pending => _pending.values.toList()
+    ..sort((a, b) => a.requestedAt.compareTo(b.requestedAt));
+
+  bool get connected => _connected;
+
+  /// Override for testing to inject a fake channel factory.
+  @visibleForTesting
+  static WebSocketChannel Function(Uri uri)? testChannelFactory;
+
+  /// The consent-decider WS URL for this workspace (token as a query param,
+  /// mirroring [WsClient]).
+  String get wsUrl {
+    final loc = Uri.base;
+    final wsScheme = loc.scheme == 'https' ? 'wss' : 'ws';
+    final base =
+        '$wsScheme://${loc.host}:${loc.port}$baseUrl/ws/consent-decider';
+    return '$base?workspace=$workspaceId&token=$token';
+  }
+
+  /// Open the connection (idempotent: a no-op if already connected/connecting).
+  void connect() {
+    if (_channel != null || _stopped) return;
+    final factory = testChannelFactory;
+    WebSocketChannel ch;
+    if (factory != null) {
+      ch = factory(Uri.parse(wsUrl));
+    } else {
+      // coverage:ignore-start
+      ch = WebSocketChannel.connect(Uri.parse(wsUrl));
+      // coverage:ignore-end
+    }
+    _channel = ch;
+    // The server's snapshot (sent immediately on connect) is authoritative
+    // for currently-held requests, so rows that resolved while we were
+    // disconnected -- and thus never sent us an `egress_resolved` -- must not
+    // linger. The snapshot `egress_request` frames that follow repopulate.
+    _pending.clear();
+    _connected = true;
+    _attempt = 0;
+    _authFailed = false;
+    _flashMessage = null;
+    _flashUntil = null;
+    _startPing();
+    notifyListeners();
+    _sub = ch.stream.listen(
+      (raw) {
+        if (raw is String) _onMessage(raw);
+      },
+      onError: (Object e) => debugPrint('[ConsentDecider] stream error: $e'),
+      onDone: () => _onClosed(ch),
+      cancelOnError: true,
+    );
+  }
+
+  void _onMessage(String raw) {
+    final res = applyFrame(_pending, raw);
+    switch (res.outcome) {
+      case ConsentFrameOutcome.added:
+      case ConsentFrameOutcome.resolved:
+        notifyListeners();
+        break;
+      case ConsentFrameOutcome.error:
+        // Surface the rejection to the user (the TUI flashes it); a verdict
+        // the server refused must not vanish silently.
+        final m = res.message;
+        _flash(m != null && m.isNotEmpty ? m : 'server error');
+        break;
+      case ConsentFrameOutcome.pong:
+      case ConsentFrameOutcome.ignored:
+        break;
+    }
+  }
+
+  void _onClosed(WebSocketChannel ch) {
+    if (!identical(ch, _channel))
+      return; // a stale callback from a prior socket
+    _stopPing();
+    _connected = false;
+    final code = ch.closeCode;
+    if (code == 4001 || code == 4002) {
+      _authFailed = true;
+      notifyListeners();
+      return; // stop reconnecting; the app surfaces re-login
+    }
+    notifyListeners();
+    if (!_stopped) _scheduleReconnect();
+  }
+
+  void _scheduleReconnect() {
+    if (_stopped || reconnectDelays.isEmpty) return;
+    _attempt += 1;
+    final delay =
+        reconnectDelays[(_attempt - 1).clamp(0, reconnectDelays.length - 1)];
+    _reconnectTimer?.cancel();
+    // coverage:ignore-start
+    _reconnectTimer = Timer(delay, () {
+      _channel = null;
+      _sub?.cancel();
+      _sub = null;
+      connect();
+    });
+    // coverage:ignore-end
+  }
+
+  void _startPing() {
+    _stopPing();
+    // coverage:ignore-start
+    _pingTimer = Timer.periodic(pingInterval, (_) {
+      final ch = _channel;
+      if (ch == null) return;
+      try {
+        ch.sink.add(jsonEncode({'type': 'ping'}));
+      } catch (e) {
+        debugPrint('[ConsentDecider] ping failed: $e');
+      }
+    });
+    // coverage:ignore-end
+  }
+
+  void _stopPing() {
+    _pingTimer?.cancel();
+    _pingTimer = null;
+  }
+
+  /// Send a verdict for a held request. No-op if disconnected (the caller's
+  /// UI should reflect the disconnected state; the server auto-denies on the
+  /// hold timeout, fail-closed).
+  void sendVerdict(String requestId, String decision, String duration) {
+    final ch = _channel;
+    if (ch == null || !_connected) {
+      // A verdict attempted while disconnected flashes (mirrors the TUI)
+      // instead of failing silently; the server auto-denies on the hold
+      // timeout -- fail-closed.
+      _flash('disconnected — reconnecting');
+      return;
+    }
+    try {
+      ch.sink.add(buildVerdict(requestId, decision, duration));
+    } catch (e) {
+      debugPrint('[ConsentDecider] verdict send failed: $e');
+      _flash('verdict send failed — reconnecting');
+    }
+  }
+
+  @override
+  void dispose() {
+    _stopped = true;
+    _stopPing();
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _sub?.cancel();
+    _sub = null;
+    // coverage:ignore-start
+    _channel?.sink.close(1000, 'dispose');
+    // coverage:ignore-end
+    _channel = null;
+    _pending.clear();
+    super.dispose();
+  }
+
+  // -- pure protocol logic (unit-testable without a transport) ----------------
+
+  /// Parse + apply one inbound server frame to [pending] (mutating).
+  ///
+  /// Mirrors `cli/tui/consent.py`'s `ConsentDeciderController.apply_frame`:
+  /// `egress_request` adds the request, `egress_resolved` removes it, `pong`
+  /// and `error` are non-mutating signals, anything else is ignored. Malformed
+  /// / non-JSON / unknown frames leave [pending] untouched.
+  @visibleForTesting
+  static ConsentFrameResult applyFrame(
+      Map<String, PendingRequest> pending, String raw) {
+    Map<String, dynamic> msg;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return ConsentFrameResult.ignored;
+      msg = decoded;
+    } catch (e) {
+      return ConsentFrameResult.ignored;
+    }
+    final mtype = msg['type'];
+    if (mtype == 'egress_request') {
+      final req = PendingRequest.fromJson(msg['request']);
+      if (req == null) return ConsentFrameResult.ignored;
+      pending[req.id] = req;
+      return ConsentFrameResult(ConsentFrameOutcome.added, request: req);
+    }
+    if (mtype == 'egress_resolved') {
+      final rid = msg['request_id'];
+      if (rid is String) pending.remove(rid);
+      return ConsentFrameResult(ConsentFrameOutcome.resolved, resolvedId: rid);
+    }
+    if (mtype == 'pong') {
+      return const ConsentFrameResult(ConsentFrameOutcome.pong);
+    }
+    if (mtype == 'error') {
+      return ConsentFrameResult(ConsentFrameOutcome.error,
+          message: msg['message']?.toString() ?? '');
+    }
+    return ConsentFrameResult.ignored;
+  }
+
+  /// Build an outbound verdict frame (JSON string) for a held request.
+  @visibleForTesting
+  static String buildVerdict(
+      String requestId, String decision, String duration) {
+    return jsonEncode({
+      'type': 'verdict',
+      'request_id': requestId,
+      'decision': decision,
+      'scope': 'once',
+      'duration': duration,
+    });
+  }
+
+  /// Seconds until this hold's countdown hits zero (clamped at 0). The server
+  /// is the source of truth (it auto-denies at the real timeout); this is only
+  /// a UX hint.
+  int remainingSeconds(PendingRequest req) {
+    final expire = req.requestedAt + holdTimeout.inSeconds;
+    final now = clock().millisecondsSinceEpoch / 1000.0;
+    final left = expire - now;
+    return left < 0 ? 0 : left.round();
+  }
+}
+
+DateTime _wallClock() => DateTime.now();

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -18,6 +18,8 @@ import '../terminal/ghostty_terminal.dart';
 import '../terminal/terminal_link.dart';
 import 'workspace_file_api.dart';
 import 'workspace_overlays.dart';
+import 'consent_banner.dart';
+import 'consent_decider_service.dart';
 import 'package:http/http.dart' as http;
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
@@ -70,6 +72,12 @@ class _WorkspacePageState extends State<WorkspacePage> {
   String? _selectedOwnWindowId;
   String _stopReason = '';
   List<String> _workspacePermissions = [];
+
+  /// The workspace's egress_mode ('static' or 'interactive'), captured on
+  /// load. When interactive, a [ConsentDeciderService] + [ConsentBanner] let
+  /// the deciding user allow/deny held egress requests inline (#2246).
+  String _egressMode = 'interactive';
+  ConsentDeciderService? _consent;
   late final ToolPluginRegistry _featureRegistry;
   late final List<ToolPlugin> _features;
   late final List<WorkspaceTabPlugin> _featureTabs;
@@ -134,11 +142,16 @@ class _WorkspacePageState extends State<WorkspacePage> {
   Future<void> _fetchWorkspaceName() async {
     final auth = context.read<AuthService>();
     try {
-      final name = await _findWorkspaceName(auth, '/api/v1/workspaces') ??
-          await _findWorkspaceName(auth, '/api/v1/workspaces/shared');
-      if (name != null && mounted) {
-        setState(() => _workspaceName = name);
-        setPageTitle(_workspaceName);
+      final ws = await _findWorkspace(auth, '/api/v1/workspaces') ??
+          await _findWorkspace(auth, '/api/v1/workspaces/shared');
+      if (ws != null && mounted) {
+        final name = ws['name'] as String?;
+        setState(() {
+          if (name != null) _workspaceName = name;
+          _egressMode = ws['egress_mode']?.toString() ?? 'interactive';
+        });
+        if (name != null) setPageTitle(_workspaceName);
+        _maybeInitConsent(auth.token);
       }
     } catch (e) {
       debugPrint('[WorkspacePage] fetch workspace name failed: $e');
@@ -163,17 +176,28 @@ class _WorkspacePageState extends State<WorkspacePage> {
     }
   }
 
-  Future<String?> _findWorkspaceName(AuthService auth, String url) async {
+  Future<Map<String, dynamic>?> _findWorkspace(
+      AuthService auth, String url) async {
     final response = await auth.authGet(url);
     if (response.statusCode == 200) {
       final workspaces = jsonDecode(response.body) as List;
       for (final ws in workspaces) {
         if (ws['id'] == widget.workspaceId) {
-          return ws['name'] as String;
+          return ws as Map<String, dynamic>;
         }
       }
     }
     return null;
+  }
+
+  /// Create + connect the consent-decider service for an interactive-mode
+  /// workspace (#2246). Static (or unknown) mode mounts no banner.
+  void _maybeInitConsent(String? token) {
+    if (_egressMode != 'interactive' || token == null) return;
+    _consent ??= ConsentDeciderService(
+      workspaceId: widget.workspaceId,
+      token: token,
+    )..connect();
   }
 
   bool _hasPerm(String perm) =>
@@ -401,6 +425,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
 
   @override
   void dispose() {
+    _consent?.dispose();
     for (final feature in _features) {
       feature.dispose();
     }
@@ -436,26 +461,34 @@ class _WorkspacePageState extends State<WorkspacePage> {
           const AppBarActions(),
         ],
       ),
-      body: Stack(
+      body: Column(
         children: [
-          _buildIdeLayout(wsClient, authToken),
-          for (final feature in _features)
-            if (feature.buildOverlay(context) != null)
-              feature.buildOverlay(context)!,
-          if (_containerStopped)
-            buildContainerStoppedOverlay(
-              restarting: _restarting,
-              stopReason: _stopReason,
-              onRestart: _restartContainer,
-              onBack: () => context.go('/workspaces'),
+          if (_egressMode == 'interactive' && _consent != null)
+            ConsentBanner(service: _consent!),
+          Expanded(
+            child: Stack(
+              children: [
+                _buildIdeLayout(wsClient, authToken),
+                for (final feature in _features)
+                  if (feature.buildOverlay(context) != null)
+                    feature.buildOverlay(context)!,
+                if (_containerStopped)
+                  buildContainerStoppedOverlay(
+                    restarting: _restarting,
+                    stopReason: _stopReason,
+                    onRestart: _restartContainer,
+                    onBack: () => context.go('/workspaces'),
+                  ),
+                if (_disconnected && !_containerStopped && !wsClient.authFailed)
+                  buildDisconnectedOverlay(
+                    reconnecting: wsClient.reconnecting,
+                    reconnectAttempt: wsClient.reconnectAttempt,
+                    onReconnect: _reconnect,
+                    onBack: () => context.go('/workspaces'),
+                  ),
+              ],
             ),
-          if (_disconnected && !_containerStopped && !wsClient.authFailed)
-            buildDisconnectedOverlay(
-              reconnecting: wsClient.reconnecting,
-              reconnectAttempt: wsClient.reconnectAttempt,
-              onReconnect: _reconnect,
-              onBack: () => context.go('/workspaces'),
-            ),
+          ),
         ],
       ),
     );

--- a/src/frontend/test/consent_banner_test.dart
+++ b/src/frontend/test/consent_banner_test.dart
@@ -1,0 +1,263 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/workspace/consent_banner.dart';
+import 'package:klangk_frontend/workspace/consent_decider_service.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class _FakeChannel extends Fake implements WebSocketChannel {
+  final _incoming = StreamController<dynamic>.broadcast();
+  final _sinkImpl = _FakeSink();
+  int? _closeCode;
+
+  @override
+  Stream<dynamic> get stream => _incoming.stream;
+
+  @override
+  WebSocketSink get sink => _sinkImpl;
+
+  @override
+  int? get closeCode => _closeCode;
+
+  @override
+  Future<void> get ready => Future.value();
+
+  void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
+
+  void serverClose([int? code]) {
+    _closeCode = code;
+    _incoming.close();
+  }
+
+  List<dynamic> get sent => _sinkImpl.sent;
+}
+
+class _FakeSink extends Fake implements WebSocketSink {
+  final List<dynamic> sent = [];
+
+  @override
+  void add(dynamic data) => sent.add(data);
+
+  @override
+  Future close([int? code, String? reason]) async {}
+}
+
+ConsentDeciderService _serviceWithChannel(_FakeChannel channel) {
+  ConsentDeciderService.testChannelFactory = (_) => channel;
+  return ConsentDeciderService(
+    workspaceId: 'ws',
+    token: 't',
+    // Fixed clock so the countdown is deterministic.
+    clock: () => DateTime.fromMillisecondsSinceEpoch(2000 * 1000, isUtc: true),
+  );
+}
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  tearDown(() {
+    ConsentDeciderService.testChannelFactory = null;
+  });
+
+  testWidgets('renders nothing when there are no pending requests',
+      (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Pending egress consent'), findsNothing);
+    svc.dispose();
+  });
+
+  testWidgets('shows the host + Allow/Deny for a pending request',
+      (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r1',
+        'workspace_id': 'ws',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'process_name': 'curl',
+        // requested 0s ago at the fixed clock (epoch 2000s).
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    expect(find.textContaining('example.com:443'), findsOneWidget);
+    expect(find.text('Allow'), findsOneWidget);
+    expect(find.text('Deny'), findsOneWidget);
+    svc.dispose();
+  });
+
+  testWidgets('tapping Allow sends an allow verdict on the socket',
+      (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r1',
+        'workspace_id': 'ws',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    await tester.tap(find.text('Allow'));
+    await tester.pump();
+    expect(channel.sent, isNotEmpty);
+    final out = jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+    expect(out['type'], 'verdict');
+    expect(out['request_id'], 'r1');
+    expect(out['decision'], 'allowed');
+    svc.dispose();
+  });
+
+  testWidgets('tapping Deny sends a deny verdict on the socket',
+      (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r2',
+        'workspace_id': 'ws',
+        'dest_host': 'bad.io',
+        'dest_port': 22,
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    await tester.tap(find.text('Deny'));
+    await tester.pump();
+    final out = jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+    expect(out['decision'], 'denied');
+    expect(out['request_id'], 'r2');
+    svc.dispose();
+  });
+
+  testWidgets('Allow carries the default duration (restart)', (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r1',
+        'workspace_id': 'ws',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    await tester.tap(find.text('Allow'));
+    await tester.pump();
+    final out = jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+    expect(out['duration'], 'restart');
+    svc.dispose();
+  });
+
+  testWidgets('the global duration selector is a single dropdown',
+      (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r1',
+        'workspace_id': 'ws',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    // Exactly one duration selector (global, in the header) -- not one per row.
+    expect(find.byType(DropdownButton<String>), findsOneWidget);
+    expect(find.text('restart'), findsOneWidget);
+    svc.dispose();
+  });
+
+  testWidgets('selecting a duration applies it to the next Allow',
+      (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r1',
+        'workspace_id': 'ws',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    // Open the single global duration selector and pick '1d'.
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(find.text('1d').last);
+    await tester.pump();
+    // The chosen duration now rides on the verdict.
+    await tester.tap(find.text('Allow'));
+    await tester.pump();
+    final out = jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+    expect(out['duration'], '1d');
+    svc.dispose();
+  });
+
+  testWidgets('shows a flash for a server error frame', (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r1',
+        'workspace_id': 'ws',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    channel.serverSend({'type': 'error', 'message': 'verdict rejected'});
+    await tester.pump();
+    await tester.pump();
+    expect(find.textContaining('verdict rejected'), findsOneWidget);
+    svc.dispose();
+  });
+
+  testWidgets('shows a re-login notice when the session auth-failed',
+      (tester) async {
+    final channel = _FakeChannel();
+    final svc = _serviceWithChannel(channel);
+    svc.connect();
+    channel.serverClose(4001);
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('please log in again'), findsOneWidget);
+    svc.dispose();
+  });
+}

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -1,0 +1,327 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/workspace/consent_decider_service.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Minimal fake WebSocketChannel mirroring ws_client_test's helper.
+class _FakeChannel extends Fake implements WebSocketChannel {
+  final _incoming = StreamController<dynamic>.broadcast();
+  final _sinkImpl = _FakeSink();
+  int? _closeCode;
+
+  @override
+  Stream<dynamic> get stream => _incoming.stream;
+
+  @override
+  WebSocketSink get sink => _sinkImpl;
+
+  @override
+  int? get closeCode => _closeCode;
+
+  @override
+  Future<void> get ready => Future.value();
+
+  void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
+
+  void serverClose([int? code]) {
+    _closeCode = code;
+    _incoming.close();
+  }
+
+  List<dynamic> get sent => _sinkImpl.sent;
+}
+
+class _FakeSink extends Fake implements WebSocketSink {
+  final List<dynamic> sent = [];
+
+  @override
+  void add(dynamic data) => sent.add(data);
+
+  @override
+  Future close([int? code, String? reason]) async {}
+}
+
+/// A channel whose [sink] throws on add, to exercise sendVerdict's catch
+/// path (a socket that died between the connected check and the send).
+class _ThrowingChannel extends Fake implements WebSocketChannel {
+  final _ctrl = StreamController<dynamic>.broadcast();
+
+  @override
+  Stream<dynamic> get stream => _ctrl.stream;
+
+  @override
+  WebSocketSink get sink => _ThrowingSink();
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  Future<void> get ready => Future.value();
+}
+
+class _ThrowingSink extends Fake implements WebSocketSink {
+  @override
+  void add(dynamic data) => throw Exception('socket gone');
+
+  @override
+  Future close([int? code, String? reason]) async {}
+}
+
+Map<String, dynamic> _request(
+        {String id = 'r1',
+        String host = 'example.com',
+        int port = 443,
+        String? proc = 'curl',
+        double at = 1000.0}) =>
+    {
+      'id': id,
+      'workspace_id': 'ws-1',
+      'dest_host': host,
+      'dest_port': port,
+      'process_name': proc,
+      'requested_at': at,
+    };
+
+void main() {
+  group('applyFrame', () {
+    test('egress_request adds the request', () {
+      final pending = <String, PendingRequest>{};
+      final res = ConsentDeciderService.applyFrame(
+          pending,
+          jsonEncode({
+            'type': 'egress_request',
+            'request': _request(),
+          }));
+      expect(res.outcome, ConsentFrameOutcome.added);
+      expect(res.request!.id, 'r1');
+      expect(pending, contains('r1'));
+      expect(pending['r1']!.destHost, 'example.com');
+      expect(pending['r1']!.destPort, 443);
+    });
+
+    test('egress_resolved removes the request', () {
+      final pending = <String, PendingRequest>{
+        'r1': PendingRequest(id: 'r1', destHost: 'h', requestedAt: 0)
+      };
+      final res = ConsentDeciderService.applyFrame(
+          pending, jsonEncode({'type': 'egress_resolved', 'request_id': 'r1'}));
+      expect(res.outcome, ConsentFrameOutcome.resolved);
+      expect(res.resolvedId, 'r1');
+      expect(pending, isNot(contains('r1')));
+    });
+
+    test('pong is non-mutating', () {
+      final pending = <String, PendingRequest>{};
+      final res = ConsentDeciderService.applyFrame(
+          pending, jsonEncode({'type': 'pong'}));
+      expect(res.outcome, ConsentFrameOutcome.pong);
+      expect(pending, isEmpty);
+    });
+
+    test('error surfaces the message', () {
+      final res = ConsentDeciderService.applyFrame(
+          {}, jsonEncode({'type': 'error', 'message': 'bad verdict'}));
+      expect(res.outcome, ConsentFrameOutcome.error);
+      expect(res.message, 'bad verdict');
+    });
+
+    test('malformed JSON is ignored', () {
+      final pending = <String, PendingRequest>{};
+      final res = ConsentDeciderService.applyFrame(pending, 'not json{');
+      expect(res.outcome, ConsentFrameOutcome.ignored);
+      expect(pending, isEmpty);
+    });
+
+    test('unknown type is ignored', () {
+      final res = ConsentDeciderService.applyFrame(
+          {}, jsonEncode({'type': 'egress_rules', 'rules': []}));
+      expect(res.outcome, ConsentFrameOutcome.ignored);
+    });
+
+    test('egress_request with a bad request payload is ignored', () {
+      final pending = <String, PendingRequest>{};
+      final res = ConsentDeciderService.applyFrame(
+          pending, jsonEncode({'type': 'egress_request', 'request': {}}));
+      expect(res.outcome, ConsentFrameOutcome.ignored);
+      expect(pending, isEmpty);
+    });
+  });
+
+  group('buildVerdict', () {
+    test('produces a well-formed verdict frame', () {
+      final raw = ConsentDeciderService.buildVerdict('r1', 'allowed', '5m');
+      final msg = jsonDecode(raw) as Map<String, dynamic>;
+      expect(msg, {
+        'type': 'verdict',
+        'request_id': 'r1',
+        'decision': 'allowed',
+        'scope': 'once',
+        'duration': '5m',
+      });
+    });
+  });
+
+  group('PendingRequest.fromJson', () {
+    test('parses a full payload', () {
+      final r = PendingRequest.fromJson(_request(proc: 'wget'))!;
+      expect(r.id, 'r1');
+      expect(r.destHost, 'example.com');
+      expect(r.destPort, 443);
+      expect(r.processName, 'wget');
+      expect(r.requestedAt, 1000.0);
+    });
+
+    test('missing dest_port yields null port', () {
+      final r = PendingRequest.fromJson({
+        'id': 'r2',
+        'workspace_id': 'ws',
+        'dest_host': 'h',
+      })!;
+      expect(r.destPort, isNull);
+    });
+
+    test('missing id yields null', () {
+      expect(PendingRequest.fromJson({'workspace_id': 'ws'}), isNull);
+    });
+
+    test('non-map yields null', () {
+      expect(PendingRequest.fromJson('nope'), isNull);
+      expect(PendingRequest.fromJson(null), isNull);
+    });
+  });
+
+  group('ConsentDeciderService', () {
+    late _FakeChannel channel;
+
+    setUp(() {
+      channel = _FakeChannel();
+      ConsentDeciderService.testChannelFactory = (_) => channel;
+    });
+
+    tearDown(() {
+      ConsentDeciderService.testChannelFactory = null;
+    });
+
+    test('empty pending + not auth-failed initially', () {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      expect(svc.pending, isEmpty);
+      expect(svc.authFailed, isFalse);
+      svc.dispose();
+    });
+
+    test('connect + snapshot populates pending + sends verdict on the socket',
+        () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      expect(svc.connected, isTrue);
+      // Server's connect snapshot. (Broadcast streams deliver on a microtask,
+      // so flush before asserting.)
+      channel.serverSend(
+          {'type': 'egress_request', 'request': _request(host: 'a.io')});
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': _request(id: 'r2', host: 'b.io', at: 999)
+      });
+      await Future.delayed(Duration.zero);
+      expect(
+          svc.pending.map((r) => r.destHost), ['b.io', 'a.io']); // oldest-first
+
+      // A live resolve removes it.
+      channel.serverSend({'type': 'egress_resolved', 'request_id': 'r1'});
+      await Future.delayed(Duration.zero);
+      expect(svc.pending.map((r) => r.id), ['r2']);
+
+      // Verdict goes out on the socket.
+      svc.sendVerdict('r2', 'denied', 'once');
+      expect(channel.sent, isNotEmpty);
+      final out =
+          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+      expect(out['type'], 'verdict');
+      expect(out['request_id'], 'r2');
+      expect(out['decision'], 'denied');
+      svc.dispose();
+    });
+
+    test('sendVerdict flashes (not silent) when disconnected', () {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      // Never connect -> sendVerdict flashes "disconnected" (mirrors the TUI)
+      // and drops the frame; the server auto-denies on the hold timeout.
+      svc.sendVerdict('r1', 'allowed', 'once');
+      expect(channel.sent, isEmpty);
+      expect(svc.flashMessage, contains('disconnected'));
+      svc.dispose();
+    });
+
+    test('a server error frame surfaces a flash', () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend({'type': 'error', 'message': 'verdict rejected'});
+      await Future.delayed(Duration.zero);
+      expect(svc.flashMessage, 'verdict rejected');
+      svc.dispose();
+    });
+
+    test('a server error frame with no message flashes a fallback', () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend({'type': 'error'});
+      await Future.delayed(Duration.zero);
+      expect(svc.flashMessage, 'server error');
+      svc.dispose();
+    });
+
+    test('flash clears once the ttl elapses (clock-based)', () async {
+      var now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final svc = ConsentDeciderService(
+        workspaceId: 'ws',
+        token: 't',
+        clock: () => now,
+      );
+      svc.connect();
+      channel.serverSend({'type': 'error', 'message': 'boom'});
+      await Future.delayed(Duration.zero);
+      expect(svc.flashMessage, 'boom');
+      now = now.add(const Duration(seconds: 6)); // past the 5s ttl
+      expect(svc.flashMessage, isNull);
+      svc.dispose();
+    });
+
+    test('sendVerdict flashes when the socket send throws', () {
+      ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      svc.sendVerdict('r1', 'allowed', 'once'); // sink.add throws
+      expect(svc.flashMessage, contains('verdict send failed'));
+      svc.dispose();
+    });
+
+    test('auth-fail close (4001) sets authFailed and stops reconnecting',
+        () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend({'type': 'egress_request', 'request': _request()});
+      await Future.delayed(Duration.zero);
+      expect(svc.pending, isNotEmpty);
+      channel.serverClose(4001);
+      await Future.delayed(Duration.zero);
+      expect(svc.authFailed, isTrue);
+      svc.dispose();
+    });
+
+    test('remainingSeconds counts down from requested_at + holdTimeout', () {
+      // Fixed clock at epoch-second 1000; requested at 1000, hold 120s.
+      final svc = ConsentDeciderService(
+        workspaceId: 'ws',
+        token: 't',
+        holdTimeout: const Duration(seconds: 120),
+        clock: () =>
+            DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true),
+      );
+      final req = PendingRequest(id: 'r', destHost: 'h', requestedAt: 1000.0);
+      expect(svc.remainingSeconds(req), 120);
+      svc.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What

Closes #2246. Flutter UI for the interactive egress-consent flow, modeled on the standalone `klangk consent-decide` TUI (`cli/tui/consent.py`).

**Workspace page — consent banner.** A workspace in `interactive` egress mode shows a banner over the workspace body listing pending held egress requests (host:port, process, countdown) with a per-request duration selector + Allow/Deny. Verdicts go out live over the existing `/ws/consent-decider` stream; the banner is hidden when nothing is pending, and a re-login notice shows if the consent session's token expired (close 4001/4002). Requests arrive via the connect snapshot (replayed on page load) and live `egress_request`/`egress_resolved` frames.

## How

- `consent_decider_service.dart` (new) — a `ChangeNotifier` owning the `/ws/consent-decider` socket: snapshot + live frame handling, outbound verdict frames, a 15 s liveness ping (beats the server's 45 s `consent_decider_timeout`), and backoff reconnect. The frame protocol (`applyFrame` / `buildVerdict` / `PendingRequest.fromJson`) is pure static logic so it's unit-tested without a transport — the same controller/view split as the TUI.
- `consent_banner.dart` (new) — a thin view over the service; a 1 s countdown tick refreshes the remaining-seconds hint (the server is the source of truth for the real timeout).
- `workspace_page.dart` — fetches the workspace `egress_mode` and mounts the banner only for interactive workspaces; creates + disposes the service with the page.

The web client duplicates the verdict/duration tokens from the server (`model/egress_consent.py`) per the same isolation boundary the CLI shares (it cannot import the server package).

## Testing

- `consent_decider_service_test.dart` — frame parsing (add/resolve/pong/error/ignored/malformed), verdict shape, `PendingRequest` parsing, service connect+snapshot+verdict, auth-fail, countdown.
- `consent_banner_test.dart` — hidden when empty, shows host + actions, Allow/Deny send the right verdict, re-login notice.

Full frontend suite: **867 passed**. `dart format` / `flutter analyze` clean (the 6 pre-existing `klangk_features`/PLACEHOLDER analyzer issues are unrelated to this change).

## Notes

- No backend changes — `egress_mode` already exists (#2239); decisions are WS verdict frames (#2244), not REST.
- The banner uses the same duration set as the TUI (`once`/`5m`/…/`forever`, default `restart`), not the issue's original scope-based buttons — the duration system (#2328) superseded them, and the user asked to follow the TUI as the template.
