### PR TITLE
feat(consent): read-only rules screen in consent-decide TUI (#2340)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,17 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Read-only rules screen in `consent-decide` (#2340).** Press `r` in the
+  `consent-decide` TUI to switch from the held-request queue to a second,
+  read-only screen listing every egress decision currently in effect for the
+  workspace: the static allow-list, active consent allows (with expiry such
+  as `expires in 5m` / `until restart` / `forever`), active denies (with
+  remaining deny window), and the pause window when filtering is paused
+  (#2332; hidden until that lands). `q`/`Esc` returns to the queue. The
+  WebSocket worker stays connected across the switch, so holds keep arriving
+  and the list updates live from the `egress_rules` frame (#2338). Revoking a
+  row is a separate follow-up (#2339/#2341).
+
 - **Per-request duration for egress-consent verdicts (#2328).** A verdict
   now carries a `duration` (`once` | `5m` | `15m` | `1h` | `1d` | `1w` |
   `restart` | `forever`, default `restart`). The `consent-decide` TUI shows a

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -33,8 +33,9 @@ from dataclasses import dataclass
 import websockets
 from rich.markup import escape
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
+from textual.screen import Screen
 from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
 
 from ..auth import refresh_token
@@ -69,6 +70,33 @@ DURATIONS = (
 )
 DURATION_DEFAULT = DURATION_RESTART
 
+# Seconds each *timed* duration adds to ``decided_at`` (mirror of the server's
+# ``_DURATION_SECONDS``; duplicated per CLI isolation). ``once`` is consumed by
+# the single connection and ``restart``/``forever`` have no fixed expiry, so
+# they are absent -- a rule with one of those (or None) has no countdown.
+_DURATION_SECONDS = {
+    DURATION_5M: 300,
+    DURATION_15M: 900,
+    DURATION_1H: 3600,
+    DURATION_1D: 86400,
+    DURATION_1W: 604800,
+}
+
+
+def _fmt_duration(secs: float) -> str:
+    """Compact remaining-time label: ``5m``, ``2h``, ``3d``, ``1w`` (#2335 B)."""
+    s = int(secs)
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m"
+    if s < 86400:
+        return f"{s // 3600}h"
+    if s < 604800:
+        return f"{s // 86400}d"
+    return f"{s // 604800}w"
+
+
 # Pings must beat the server's consent_decider_timeout (45s) or the decider is
 # reaped and the workspace reverts to static. 15s leaves margin. NOTE: if an
 # operator lowers KLANGKD_CONSENT_DECIDER_TIMEOUT below ~20s this can no longer
@@ -89,6 +117,7 @@ ADDED = (
 RESOLVED = (
     "resolved"  # request gone (decided/timed out); payload = (id, decision)
 )
+RULES = "rules"  # refreshed in-effect rules snapshot; payload = EgressRules
 PONG = "pong"
 ERROR = "error"  # server rejected a verdict; payload = message str
 IGNORED = "ignore"  # non-JSON / unknown frame
@@ -105,6 +134,49 @@ class ConsentRequest:
     process_name: str | None
     pid: int | None
     requested_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class ConsentRule:
+    """One in-effect consent verdict (allow or deny) for the rules view (#2335)."""
+
+    id: str
+    dest_host: str
+    dest_port: int | None
+    process_name: str | None
+    decision: str
+    duration: str | None
+    decided_at: float | None
+    decided_by: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PauseState:
+    """Pause window from the ``egress_rules`` frame (#2332, not yet landed).
+
+    ``until`` is the epoch second the pause ends, or None for an indefinite
+    pause (e.g. until restart). The frame's ``paused`` field is None today;
+    when #2332 lands it is expected to be ``{"paused": True, "until": ...}``.
+    """
+
+    until: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class EgressRules:
+    """Parsed ``egress_rules`` frame: the workspace's in-effect decisions.
+
+    ``allowed``/``denied`` are ordered newest-decided-first (matching the
+    backend's ``list_active`` ``ORDER BY decided_at DESC``); ``allow_list`` is
+    the static ``allowed_domains`` config, order preserved; ``paused`` is None
+    unless filtering is actually paused (#2332).
+    """
+
+    workspace_id: str
+    allow_list: tuple[str, ...]
+    allowed: tuple[ConsentRule, ...]
+    denied: tuple[ConsentRule, ...]
+    paused: PauseState | None
 
 
 def make_verdict(
@@ -150,6 +222,10 @@ class ConsentDeciderController:
         self.hold_timeout = hold_timeout
         self._clock = clock
         self.pending: dict[str, ConsentRequest] = {}
+        # Latest in-effect rules snapshot (#2335 slice A frame). None until the
+        # first ``egress_rules`` frame lands (on connect) -- the rules screen
+        # renders an empty state until then.
+        self.rules: EgressRules | None = None
 
     def apply_frame(self, raw: str) -> tuple[str, object]:
         """Parse + apply one inbound server frame.
@@ -178,6 +254,12 @@ class ConsentDeciderController:
             if isinstance(rid, str):
                 self.pending.pop(rid, None)
             return RESOLVED, (rid, msg.get("decision"))
+        if mtype == "egress_rules":
+            rules = _parse_rules(msg)
+            if rules is None:
+                return IGNORED, None
+            self.rules = rules
+            return RULES, rules
         if mtype == "pong":
             return PONG, None
         if mtype == "error":
@@ -192,16 +274,38 @@ class ConsentDeciderController:
         """Seconds until this hold's countdown hits zero (clamped at 0)."""
         return max(0.0, req.requested_at + self.hold_timeout - self._clock())
 
-    def reset(self) -> None:
-        """Drop all pending requests.
+    def rule_remaining(self, rule: ConsentRule) -> float | None:
+        """Seconds left on a timed verdict, or None if it has no fixed expiry.
 
-        Called at the start of each (re)connection: the server's snapshot
-        that immediately follows is authoritative for currently-held
-        requests, so rows that resolved while we were disconnected -- and
-        thus never sent us an ``egress_resolved`` -- must not linger as
-        ``(0s)`` ghosts after a reconnect or a klangkd restart.
+        None covers ``restart``/``forever`` (open-ended), ``once`` (consumed,
+        never in ``list_active``), and unknown/NULL durations -- the rules view
+        shows ``until restart``/``forever`` for those instead of a countdown.
+        """
+        if rule.decided_at is None:
+            return None
+        secs = _DURATION_SECONDS.get(rule.duration)
+        if secs is None:
+            return None
+        return max(0.0, rule.decided_at + secs - self._clock())
+
+    def pause_remaining(self, rules: EgressRules) -> float | None:
+        """Seconds left in the pause window, or None if not paused / indefinite."""
+        if rules.paused is None or rules.paused.until is None:
+            return None
+        return max(0.0, rules.paused.until - self._clock())
+
+    def reset(self) -> None:
+        """Drop all pending requests + the cached rules snapshot.
+
+        Called at the start of each (re)connection: the server's snapshot (and
+        the ``egress_rules`` frame that follows it) is authoritative for
+        currently-held requests and in-effect rules, so rows that resolved /
+        elapsed while we were disconnected -- and thus never sent us an
+        ``egress_resolved`` / refreshed ``egress_rules`` -- must not linger as
+        stale entries after a reconnect or a klangkd restart.
         """
         self.pending.clear()
+        self.rules = None
 
 
 def _parse_request(obj: object) -> ConsentRequest | None:
@@ -234,6 +338,88 @@ def _parse_request(obj: object) -> ConsentRequest | None:
     )
 
 
+def _parse_rules(msg: dict) -> EgressRules | None:
+    """Build an :class:`EgressRules` from an ``egress_rules`` frame (#2335).
+
+    Returns ``None`` only if the frame lacks a ``workspace_id`` (unusable); a
+    missing/malformed ``allow_list``/``allowed``/``denied`` degrades to empty
+    rather than dropping the whole frame. Rows that fail to parse are skipped.
+    """
+    wid = msg.get("workspace_id")
+    if not isinstance(wid, str):
+        return None
+    raw_allow = msg.get("allow_list")
+    allow_list = (
+        tuple(str(d) for d in raw_allow) if isinstance(raw_allow, list) else ()
+    )
+    allowed = [
+        r for r in (_parse_rule(o) for o in msg.get("allowed") or []) if r
+    ]
+    denied = [
+        r for r in (_parse_rule(o) for o in msg.get("denied") or []) if r
+    ]
+    # Newest-decided-first (matches backend list_active ORDER BY decided_at
+    # DESC); rows with no decided_at sort last. Stable for ties.
+    allowed.sort(key=_rule_sort_key)
+    denied.sort(key=_rule_sort_key)
+    return EgressRules(
+        workspace_id=wid,
+        allow_list=allow_list,
+        allowed=tuple(allowed),
+        denied=tuple(denied),
+        paused=_parse_pause(msg.get("paused")),
+    )
+
+
+def _parse_rule(obj: object) -> ConsentRule | None:
+    """Build a :class:`ConsentRule` from one row of an ``egress_rules`` frame."""
+    if not isinstance(obj, dict):
+        return None
+    decided_at = obj.get("decided_at")
+    port = obj.get("dest_port")
+    duration = obj.get("duration")
+    return ConsentRule(
+        id=str(obj.get("id") or ""),
+        dest_host=str(obj.get("dest_host") or ""),
+        dest_port=int(port)
+        if isinstance(port, (int, float)) and not isinstance(port, bool)
+        else None,
+        process_name=obj.get("process_name"),
+        decision=str(obj.get("decision") or ""),
+        duration=duration if isinstance(duration, str) else None,
+        decided_at=float(decided_at)
+        if isinstance(decided_at, (int, float))
+        and not isinstance(decided_at, bool)
+        else None,
+        decided_by=obj.get("decided_by"),
+    )
+
+
+def _parse_pause(obj: object) -> PauseState | None:
+    """Parse the ``paused`` field of an ``egress_rules`` frame (#2332).
+
+    The field is None today (pause control not landed). When #2332 lands it is
+    expected to be ``{"paused": bool, "until": epoch|None}``; this returns
+    None unless filtering is actually paused, so the rules screen renders no
+    pause section until then (graceful degradation).
+    """
+    if not isinstance(obj, dict) or obj.get("paused") is not True:
+        return None
+    until = obj.get("until")
+    return PauseState(
+        until=float(until)
+        if isinstance(until, (int, float)) and not isinstance(until, bool)
+        else None
+    )
+
+
+def _rule_sort_key(rule: ConsentRule) -> tuple[int, float]:
+    """Sort key: decided rows first (newest first), undecided last."""
+    if rule.decided_at is None:
+        return (1, 0.0)
+    return (0, -rule.decided_at)
+
+
 class ConsentDeciderApp(App):
     """Textual app: live queue of held egress requests + accept/deny.
 
@@ -259,6 +445,7 @@ class ConsentDeciderApp(App):
     BINDINGS = [
         ("a", "allow", "Allow"),
         ("d", "deny", "Deny"),
+        ("r", "rules", "Rules"),
         ("q", "quit", "Quit"),
     ]
 
@@ -449,7 +636,22 @@ class ConsentDeciderApp(App):
         resolved/expired rows, repaint the countdown text of survivors in
         place, and append genuinely-new ones. Order is stable (oldest-first
         by requested_at), so we never have to reorder.
+
+        Also keeps the rules screen live when it is the active screen, so its
+        countdowns tick and a freshly-arrived ``egress_rules`` frame shows up
+        without waiting for its own timer (#2335 slice B).
         """
+        # Refresh the rules screen first (if up) so a queue-query hiccup can
+        # never starve it -- the WS worker is shared across the switch.
+        try:
+            screen = self.screen
+        except Exception:
+            screen = None  # not mounted yet (pre-mount / no screen stack)
+        if isinstance(screen, RulesScreen):
+            try:
+                screen.refresh_rules()
+            except Exception:
+                logger.exception("consent-decide rules render failed")
         try:
             lv = self.query_one("#requests", ListView)
             status = self.query_one("#status", Static)
@@ -572,11 +774,23 @@ class ConsentDeciderApp(App):
         button.add_class("dur-sel")
 
     def action_allow(self) -> None:
-        # `a` key -> the highlighted row (keyboard path).
+        # `a` key -> the highlighted row (keyboard path). No-op on the rules
+        # screen so a/d can't decide a queue row that isn't visible there.
+        if isinstance(self.screen, RulesScreen):
+            return
         self._decide(DECISION_ALLOWED)
 
     def action_deny(self) -> None:
+        if isinstance(self.screen, RulesScreen):
+            return
         self._decide(DECISION_DENIED)
+
+    def action_rules(self) -> None:
+        # `r` opens the read-only rules screen (#2335 slice B). Guard against
+        # pushing a second one if `r` is pressed while already viewing rules.
+        if isinstance(self.screen, RulesScreen):
+            return
+        self.push_screen(RulesScreen())
 
     def _decide(self, decision: str) -> None:
         rid = self._focused_request_id()
@@ -603,3 +817,125 @@ class ConsentDeciderApp(App):
             await ws.send(make_verdict(rid, decision, duration))
         except Exception:
             self._flash("verdict send failed — reconnecting")
+
+
+class RulesScreen(Screen):
+    """Read-only view of the workspace's in-effect egress decisions.
+
+    The second screen of :class:`ConsentDeciderApp`, pushed from the held-
+    request queue with ``r`` and popped with ``q``/``Esc`` (#2335 slice B). It
+    reads ``app.controller.rules`` (the latest ``egress_rules`` frame), kept
+    live by the app's shared WS pump + 1s refresh, so the WS worker is **not**
+    torn down/reconnected on the switch -- only the view changes. This screen
+    only displays; revoking a row is #2339 + slice D (#2341).
+    """
+
+    CSS = """
+    RulesScreen { layout: vertical; }
+    #rules-status { padding: 0 1; background: $panel; color: $text-muted; }
+    #rules-body { padding: 0 1; }
+    """
+
+    BINDINGS = [
+        ("escape", "back", "Back"),
+        ("q", "back", "Back"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(id="rules-status")
+        with VerticalScroll(id="rules-body"):
+            yield Static(id="rules-content")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.refresh_rules()
+
+    def action_back(self) -> None:
+        """``q``/``Esc`` returns to the held-request queue."""
+        self.app.pop_screen()
+
+    def refresh_rules(self) -> None:
+        """Re-render the body from the controller's latest ``egress_rules``."""
+        try:
+            status = self.query_one("#rules-status", Static)
+            content = self.query_one("#rules-content", Static)
+        except NoMatches:
+            return  # not mounted yet
+        app = self.app  # ConsentDeciderApp
+        controller = app.controller  # type: ignore[attr-defined]
+        rules = controller.rules
+        conn = "connected" if app._connected else "reconnecting"  # type: ignore[attr-defined]
+        held = len(controller.pending)
+        status.update(
+            f" {app.workspace_name}  ·  {conn}  ·  {held} held  ·  rules"  # type: ignore[attr-defined]
+        )
+        content.update(self._render_body(rules, controller))
+
+    def _render_body(self, rules: EgressRules | None, controller) -> str:
+        """Build the grouped rich-markup body (allow-list, allows, denies, pause)."""
+        lines: list[str] = []
+        n_allowed = len(rules.allowed) if rules else 0
+        n_denied = len(rules.denied) if rules else 0
+
+        lines.append("[bold]Static allow-list[/bold]")
+        if rules is None:
+            lines.append("  [dim](no rules received yet)[/dim]")
+        elif rules.allow_list:
+            for d in rules.allow_list:
+                lines.append(f"  {escape(d)}")
+        else:
+            lines.append("  [dim](none)[/dim]")
+        lines.append("")
+
+        lines.append(f"[bold]Active allows ({n_allowed})[/bold]")
+        if rules and rules.allowed:
+            for r in rules.allowed:
+                lines.append("  " + self._rule_line(r, controller, deny=False))
+        else:
+            lines.append("  [dim](none)[/dim]")
+        lines.append("")
+
+        lines.append(f"[bold]Active denies ({n_denied})[/bold]")
+        if rules and rules.denied:
+            for r in rules.denied:
+                lines.append("  " + self._rule_line(r, controller, deny=True))
+        else:
+            lines.append("  [dim](none)[/dim]")
+
+        # Pause window (#2332; absent today -> section hidden).
+        if rules is not None and rules.paused is not None:
+            lines.append("")
+            lines.append("[bold]Pause[/bold]")
+            rem = controller.pause_remaining(rules)
+            if rem is None:
+                lines.append(
+                    "  [yellow]Filtering paused until restart[/yellow]"
+                )
+            else:
+                lines.append(
+                    "  [yellow]Filtering paused "
+                    f"(resumes in {_fmt_duration(rem)})[/yellow]"
+                )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _rule_line(rule: ConsentRule, controller, *, deny: bool) -> str:
+        host = rule.dest_host
+        if rule.dest_port is not None:
+            host = f"{host}:{rule.dest_port}"
+        proc = f"  ({rule.process_name})" if rule.process_name else ""
+        if rule.duration == DURATION_FOREVER:
+            label = "forever"
+        elif rule.duration == DURATION_RESTART:
+            label = "until restart"
+        else:
+            rem = controller.rule_remaining(rule)
+            label = (
+                f"{_fmt_duration(rem)} left"
+                if deny
+                else f"expires in {_fmt_duration(rem)}"
+                if rem is not None
+                else ""
+            )
+        return f"{escape(host)}{escape(proc)}  [dim]{escape(label)}[/dim]"

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -681,7 +681,7 @@ class ConsentDeciderApp(App):
         else:
             conn = "connected" if self._connected else "reconnecting"
             status.update(
-                f" {self.workspace_name}  ·  {conn}  ·  {len(ordered)} held"
+                f" {escape(self.workspace_name)}  ·  {conn}  ·  {len(ordered)} held"
             )
 
     def _host_line(self, req: ConsentRequest) -> str:
@@ -868,7 +868,7 @@ class RulesScreen(Screen):
         conn = "connected" if app._connected else "reconnecting"  # type: ignore[attr-defined]
         held = len(controller.pending)
         status.update(
-            f" {app.workspace_name}  ·  {conn}  ·  {held} held  ·  rules"  # type: ignore[attr-defined]
+            f" {escape(app.workspace_name)}  ·  {conn}  ·  {held} held  ·  rules"  # type: ignore[attr-defined]
         )
         content.update(self._render_body(rules, controller))
 
@@ -931,11 +931,15 @@ class RulesScreen(Screen):
             label = "until restart"
         else:
             rem = controller.rule_remaining(rule)
-            label = (
-                f"{_fmt_duration(rem)} left"
-                if deny
-                else f"expires in {_fmt_duration(rem)}"
-                if rem is not None
-                else ""
-            )
+            # Guard None before formatting: a timed verdict with a null
+            # decided_at or an unknown duration has no countdown. Both allow
+            # and deny must degrade the same way (else _fmt_duration(None)
+            # raises TypeError on a deny) -- the parser permits these rows, so
+            # rendering must too.
+            if rem is None:
+                label = ""
+            elif deny:
+                label = f"{_fmt_duration(rem)} left"
+            else:
+                label = f"expires in {_fmt_duration(rem)}"
         return f"{escape(host)}{escape(proc)}  [dim]{escape(label)}[/dim]"

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -25,9 +25,14 @@ from klangk.cli.tui.consent import (
     IGNORED,
     PONG,
     RESOLVED,
+    RULES,
     ConsentDeciderApp,
     ConsentDeciderController,
     ConsentRequest,
+    ConsentRule,
+    EgressRules,
+    PauseState,
+    RulesScreen,
     make_ping,
     make_verdict,
 )
@@ -88,6 +93,55 @@ def _req_frame(rid="r1", host="evil.example.com", port=443, **extra):
     }
     req.update(extra)
     return json.dumps({"type": "egress_request", "request": req})
+
+
+def _rule(
+    rid="a1",
+    *,
+    host="evil.example.com",
+    port=443,
+    decision="allowed",
+    duration="5m",
+    decided_at=100.0,
+    process=None,
+    decided_by="u@x",
+):
+    """One row of an egress_rules frame's allowed/denied list."""
+    return {
+        "id": rid,
+        "workspace_id": "wsid",
+        "dest_host": host,
+        "dest_port": port,
+        "pid": None,
+        "process_name": process,
+        "decision": decision,
+        "scope": "once",
+        "duration": duration,
+        "requested_at": 90.0,
+        "decided_at": decided_at,
+        "decided_by": decided_by,
+    }
+
+
+def _rules_frame(
+    *,
+    allow_list=("static.example.com",),
+    allowed=(),
+    denied=(),
+    paused=None,
+    workspace_id="wsid",
+):
+    """An egress_rules frame (#2335 slice A) as the server sends it."""
+    return json.dumps(
+        {
+            "type": "egress_rules",
+            "workspace_id": workspace_id,
+            "allow_list": list(allow_list),
+            "allowed": list(allowed),
+            "denied": list(denied),
+            "paused": paused,
+        }
+    )
 
 
 def _make_app(**kw):
@@ -968,3 +1022,598 @@ async def test_pump_repoulates_from_snapshot_after_reset():
         await app._pump(FakeWS([_req_frame("live", host="new.com")]))
         await pilot.pause()
         assert set(app.controller.pending) == {"live"}
+
+
+# ---------------------------------------------------------------------------
+# Controller: egress_rules parsing + ordering + expiry (#2335 slice B)
+# ---------------------------------------------------------------------------
+
+
+class TestControllerRulesParsing:
+    def test_rules_frame_stored_and_returned(self):
+        c = ConsentDeciderController()
+        action, payload = c.apply_frame(
+            _rules_frame(allow_list=["a.com", "b.com"])
+        )
+        assert action == RULES
+        assert isinstance(payload, EgressRules)
+        assert c.rules is payload
+        assert payload.workspace_id == "wsid"
+        assert payload.allow_list == ("a.com", "b.com")
+        assert payload.allowed == ()
+        assert payload.denied == ()
+        assert payload.paused is None  # #2332 not landed
+
+    def test_rules_parse_rows_into_consentrule(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(
+                allowed=[_rule("a1", host="x.com", port=443, duration="1h")],
+                denied=[
+                    _rule("d1", host="y.com", port=None, decision="denied")
+                ],
+            )
+        )
+        assert len(payload.allowed) == 1
+        rule = payload.allowed[0]
+        assert isinstance(rule, ConsentRule)
+        assert rule.dest_host == "x.com"
+        assert rule.dest_port == 443
+        assert rule.duration == "1h"
+        assert rule.decision == "allowed"
+        assert len(payload.denied) == 1
+        assert payload.denied[0].dest_port is None
+
+    def test_rules_missing_workspace_id_ignored(self):
+        c = ConsentDeciderController()
+        bad = json.dumps(
+            {"type": "egress_rules", "allow_list": ["a.com"]}
+        )  # no workspace_id
+        assert c.apply_frame(bad) == (IGNORED, None)
+        assert c.rules is None
+
+    def test_rules_missing_fields_degrade_to_empty(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            json.dumps({"type": "egress_rules", "workspace_id": "wsid"})
+        )
+        assert payload.allow_list == ()
+        assert payload.allowed == ()
+        assert payload.denied == ()
+        assert payload.paused is None
+
+    def test_rules_allow_list_non_list_degrades(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            json.dumps(
+                {
+                    "type": "egress_rules",
+                    "workspace_id": "wsid",
+                    "allow_list": "not-a-list",
+                }
+            )
+        )
+        assert payload.allow_list == ()
+
+    def test_rules_malformed_row_skipped(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(
+                allowed=[
+                    _rule("good"),
+                    "not-a-dict",  # skipped
+                    {"id": "no-host"},  # kept (host defaults to "")
+                ]
+            )
+        )
+        assert [r.id for r in payload.allowed] == ["good", "no-host"]
+
+    def test_rules_port_bool_excluded(self):
+        # bool is an int subclass; a bool port must not coerce to 1.
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(allowed=[_rule("a1", port=True)])
+        )
+        assert payload.allowed[0].dest_port is None
+
+    def test_rules_paased_none_yields_none_pause(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(_rules_frame(paused=None))
+        assert payload.paused is None
+
+    def test_rules_paased_true_with_until_parsed(self):
+        # Forward-looking: #2332 will send {"paused": true, "until": epoch}.
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(paused={"paused": True, "until": 200.0})
+        )
+        assert payload.paused == PauseState(until=200.0)
+
+    def test_rules_paased_false_yields_none(self):
+        # Not paused -> no pause section renders.
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(paused={"paused": False, "until": 200.0})
+        )
+        assert payload.paused is None
+
+    def test_rules_paased_until_non_numeric_is_none(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(paused={"paused": True, "until": "soon"})
+        )
+        assert payload.paused == PauseState(until=None)
+
+    def test_rules_non_dict_paused_yields_none(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(_rules_frame(paused="yes"))
+        assert payload.paused is None
+
+
+class TestControllerRulesOrdering:
+    def test_allowed_newest_decided_first(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(
+                allowed=[
+                    _rule("old", decided_at=100.0),
+                    _rule("new", decided_at=300.0),
+                    _rule("mid", decided_at=200.0),
+                ]
+            )
+        )
+        assert [r.id for r in payload.allowed] == ["new", "mid", "old"]
+
+    def test_denied_newest_decided_first(self):
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(
+                denied=[
+                    _rule("d_old", decided_at=100.0, decision="denied"),
+                    _rule("d_new", decided_at=300.0, decision="denied"),
+                ]
+            )
+        )
+        assert [r.id for r in payload.denied] == ["d_new", "d_old"]
+
+    def test_undecided_rows_sort_last(self):
+        # A NULL decided_at (future migration) sorts after decided rows.
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(
+                allowed=[
+                    _rule("undecided", decided_at=None),
+                    _rule("decided", decided_at=100.0),
+                ]
+            )
+        )
+        assert [r.id for r in payload.allowed] == ["decided", "undecided"]
+
+    def test_ordering_stable_for_ties(self):
+        # Equal decided_at preserves insertion order (stable sort).
+        c = ConsentDeciderController()
+        _, payload = c.apply_frame(
+            _rules_frame(
+                allowed=[
+                    _rule("first", decided_at=100.0),
+                    _rule("second", decided_at=100.0),
+                ]
+            )
+        )
+        assert [r.id for r in payload.allowed] == ["first", "second"]
+
+
+class TestControllerRulesExpiry:
+    def test_rule_remaining_timed(self):
+        c = ConsentDeciderController(clock=lambda: 130.0)
+        rule = ConsentRule(
+            id="a1",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            decision="allowed",
+            duration="5m",
+            decided_at=100.0,
+            decided_by=None,
+        )  # 300s window -> 100+300=400; at 130 -> 270s left
+        assert c.rule_remaining(rule) == 270.0
+
+    def test_rule_remaining_clamps_at_zero(self):
+        c = ConsentDeciderController(clock=lambda: 9999.0)
+        rule = ConsentRule(
+            id="a1",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            decision="allowed",
+            duration="5m",
+            decided_at=100.0,
+            decided_by=None,
+        )
+        assert c.rule_remaining(rule) == 0.0
+
+    def test_rule_remaining_restart_is_none(self):
+        c = ConsentDeciderController()
+        rule = ConsentRule(
+            id="a1",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            decision="allowed",
+            duration="restart",
+            decided_at=100.0,
+            decided_by=None,
+        )
+        assert c.rule_remaining(rule) is None
+
+    def test_rule_remaining_forever_is_none(self):
+        c = ConsentDeciderController()
+        rule = ConsentRule(
+            id="a1",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            decision="allowed",
+            duration="forever",
+            decided_at=100.0,
+            decided_by=None,
+        )
+        assert c.rule_remaining(rule) is None
+
+    def test_rule_remaining_unknown_duration_is_none(self):
+        c = ConsentDeciderController()
+        rule = ConsentRule(
+            id="a1",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            decision="allowed",
+            duration="3fortnights",
+            decided_at=100.0,
+            decided_by=None,
+        )
+        assert c.rule_remaining(rule) is None
+
+    def test_rule_remaining_null_decided_at_is_none(self):
+        c = ConsentDeciderController()
+        rule = ConsentRule(
+            id="a1",
+            dest_host="h",
+            dest_port=1,
+            process_name=None,
+            decision="allowed",
+            duration="5m",
+            decided_at=None,
+            decided_by=None,
+        )
+        assert c.rule_remaining(rule) is None
+
+    def test_pause_remaining_timed(self):
+        c = ConsentDeciderController(clock=lambda: 150.0)
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=PauseState(until=200.0),
+        )
+        assert c.pause_remaining(rules) == 50.0
+
+    def test_pause_remaining_indefinite_is_none(self):
+        c = ConsentDeciderController()
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=PauseState(until=None),
+        )
+        assert c.pause_remaining(rules) is None
+
+    def test_pause_remaining_not_paused_is_none(self):
+        c = ConsentDeciderController()
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=None,
+        )
+        assert c.pause_remaining(rules) is None
+
+
+def test_fmt_duration_tiers():
+    assert tui_consent._fmt_duration(5) == "5s"
+    assert tui_consent._fmt_duration(45) == "45s"
+    assert tui_consent._fmt_duration(90) == "1m"
+    assert tui_consent._fmt_duration(300) == "5m"
+    assert tui_consent._fmt_duration(3600) == "1h"
+    assert tui_consent._fmt_duration(7200) == "2h"
+    assert tui_consent._fmt_duration(86400) == "1d"
+    assert tui_consent._fmt_duration(604800) == "1w"
+    assert tui_consent._fmt_duration(1209600) == "2w"
+
+
+def test_reset_clears_rules():
+    """reset() drops the cached rules snapshot too (called on reconnect)."""
+    c = ConsentDeciderController()
+    c.apply_frame(_rules_frame(allow_list=["a.com"]))
+    assert c.rules is not None
+    c.reset()
+    assert c.rules is None
+    assert c.pending == {}
+
+
+# ---------------------------------------------------------------------------
+# Rules screen: render, refresh, switch, WS worker stays connected (#2335 B)
+# ---------------------------------------------------------------------------
+
+
+class TestRulesScreen:
+    async def test_r_opens_screen_and_q_returns(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            assert not isinstance(app.screen, RulesScreen)
+            app.action_rules()
+            await pilot.pause()
+            assert isinstance(app.screen, RulesScreen)
+            # `q` on the rules screen pops back (does NOT quit the app).
+            app.screen.action_back()
+            await pilot.pause()
+            assert not isinstance(app.screen, RulesScreen)
+            assert app.is_running
+
+    async def test_escape_returns(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.action_rules()
+            await pilot.pause()
+            assert isinstance(app.screen, RulesScreen)
+            app.screen.action_back()
+            await pilot.pause()
+            assert not isinstance(app.screen, RulesScreen)
+
+    async def test_r_does_not_stack_a_second_screen(self):
+        # Guard: pressing r while already on the rules screen is a no-op.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.action_rules()
+            await pilot.pause()
+            screen = app.screen
+            app.action_rules()  # already viewing rules -> ignored
+            await pilot.pause()
+            assert app.screen is screen
+            assert len(app.screen_stack) == 2  # default + rules (no 3rd)
+
+    async def test_screen_renders_all_sections(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(
+                    allow_list=["static.example.com"],
+                    allowed=[
+                        _rule("a1", host="allow.example.com", duration="1h"),
+                    ],
+                    denied=[
+                        _rule(
+                            "d1",
+                            host="deny.example.com",
+                            decision="denied",
+                            duration="15m",
+                        ),
+                    ],
+                )
+            )
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "Static allow-list" in body
+            assert "static.example.com" in body
+            assert "Active allows (1)" in body
+            assert "allow.example.com:443" in body
+            assert "expires in" in body
+            assert "Active denies (1)" in body
+            assert "deny.example.com:443" in body
+            assert "left" in body
+            # #2332 not landed -> no pause section.
+            assert "Pause" not in body
+
+    async def test_screen_empty_state(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "(none)" in body  # empty allow-list + allows + denies
+
+    async def test_screen_no_rules_yet(self):
+        # Before the first egress_rules frame lands, show a placeholder.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "no rules received yet" in body
+
+    async def test_screen_shows_forever_and_restart_labels(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(
+                    allowed=[
+                        _rule("a1", duration="forever"),
+                        _rule("a2", duration="restart"),
+                    ],
+                )
+            )
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "forever" in body
+            assert "until restart" in body
+
+    async def test_screen_shows_pause_section_when_paused(self):
+        # Forward-looking (#2332): a real pause dict renders the section.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(
+                    paused={"paused": True, "until": time.time() + 120.0},
+                )
+            )
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "Pause" in body
+            assert "Filtering paused" in body
+
+    async def test_screen_shows_indefinite_pause(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(paused={"paused": True, "until": None}),
+            )
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "paused until restart" in body
+
+    async def test_screen_status_shows_held_count(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_rules_frame(allow_list=["a.com"]))
+            app.action_rules()
+            await pilot.pause()
+            status = str(app.screen.query_one("#rules-status", Static).content)
+            assert "wsname" in status
+            assert "1 held" in status
+            assert "rules" in status
+
+    async def test_refresh_rules_live_updates_on_frame(self):
+        # A new egress_rules frame (e.g. a co-decider allowed a request) shows
+        # up on the already-open rules screen without popping/re-pushing.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_rules_frame(allow_list=["a.com"]))
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "Active allows (0)" in body
+            # A refreshed frame arrives over the shared WS pump:
+            app.controller.apply_frame(
+                _rules_frame(
+                    allow_list=["a.com"],
+                    allowed=[_rule("a1", host="new.example.com")],
+                )
+            )
+            app._refresh()  # the 1s tick also refreshes the active screen
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "Active allows (1)" in body
+            assert "new.example.com:443" in body
+
+    async def test_ws_worker_not_torn_down_on_switch(self):
+        # Pushing/popping the rules screen must not reconnect the WS worker.
+        # _connected is only True inside the live ws_loop; here we set it, push
+        # the screen, pop it, and confirm it stayed True (no teardown).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app._connected = True
+            app.action_rules()
+            await pilot.pause()
+            assert isinstance(app.screen, RulesScreen)
+            app.screen.action_back()
+            await pilot.pause()
+            assert app._connected is True  # untouched across the switch
+
+    async def test_refresh_rules_before_mount_is_noop(self):
+        screen = RulesScreen()
+        # Not mounted -> refresh_rules must not raise.
+        screen.refresh_rules()
+
+    async def test_allow_keypress_on_rules_screen_is_safe_noop(self):
+        # `a` from the rules screen must not crash (no focused request there);
+        # it resolves no queue row because the rules screen has focus.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.action_rules()
+            await pilot.pause()
+            app.action_allow()  # must not raise
+            await pilot.pause()
+            assert ws.sent == []  # nothing decided from the rules screen
+
+
+async def test_deny_keypress_on_rules_screen_is_safe_noop():
+    # `d` from the rules screen must not decide a hidden queue row either.
+    app = _make_app()
+    async with app.run_test() as pilot:
+        ws = FakeWS([])
+        app._ws = ws
+        app.controller.apply_frame(_req_frame("r1", host="a.com"))
+        app._refresh()
+        await pilot.pause()
+        app.query_one("#requests", ListView).index = 0  # highlight r1
+        await pilot.pause()
+        app.action_rules()
+        await pilot.pause()
+        app.action_deny()  # on rules screen -> guarded no-op
+        await pilot.pause()
+        assert ws.sent == []
+
+
+async def test_rules_screen_empty_allow_list_shows_none():
+    # rules present but allow_list empty -> "(none)" (not "no rules received").
+    app = _make_app()
+    async with app.run_test() as pilot:
+        app.controller.apply_frame(
+            _rules_frame(allow_list=[], allowed=[_rule("a1")])
+        )
+        app.action_rules()
+        await pilot.pause()
+        body = str(app.screen.query_one("#rules-content", Static).content)
+        assert "(none)" in body  # empty allow-list section
+        assert "Active allows (1)" in body
+
+
+async def test_refresh_isolates_rules_render_failure(monkeypatch):
+    # A render bug in the rules screen must never propagate out of _refresh
+    # (which the 1s interval calls) -- mirrors the _pump render isolation.
+    app = _make_app()
+    async with app.run_test() as pilot:
+        app.controller.apply_frame(_rules_frame(allow_list=["a.com"]))
+        app.action_rules()
+        await pilot.pause()
+
+        def boom(self):
+            raise RuntimeError("rules render broke")
+
+        monkeypatch.setattr(RulesScreen, "refresh_rules", boom)
+        app._refresh()  # must not raise
+        await pilot.pause()
+
+
+async def test_q_and_escape_keypress_pop_back_via_pilot():
+    # The actual `q`/Esc keypress on the rules screen must pop back (screen
+    # binding) rather than trigger the app-level `q` -> quit. Locks down the
+    # binding-preference behavior so the screen can't accidentally quit the app.
+    app = _make_app()
+    async with app.run_test() as pilot:
+        app.action_rules()
+        await pilot.pause()
+        assert isinstance(app.screen, RulesScreen)
+        await pilot.press("q")
+        await pilot.pause()
+        assert not isinstance(app.screen, RulesScreen)
+        assert app.is_running  # did NOT quit
+        # And Escape works the same way.
+        app.action_rules()
+        await pilot.pause()
+        assert isinstance(app.screen, RulesScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, RulesScreen)
+        assert app.is_running

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -1513,19 +1513,76 @@ class TestRulesScreen:
             assert "Active allows (1)" in body
             assert "new.example.com:443" in body
 
-    async def test_ws_worker_not_torn_down_on_switch(self):
-        # Pushing/popping the rules screen must not reconnect the WS worker.
-        # _connected is only True inside the live ws_loop; here we set it, push
-        # the screen, pop it, and confirm it stayed True (no teardown).
-        app = _make_app()
+    async def test_ws_worker_survives_switch_and_delivers_frame(
+        self, monkeypatch
+    ):
+        # Real acceptance criterion: pushing/popping the rules screen must NOT
+        # tear down or reconnect the WS worker, AND a frame delivered over the
+        # still-open socket while the rules screen is up must reach it. Drives
+        # the real _ws_loop (not the autouse no-op stub) with a blocking WS that
+        # stays connected so we can feed a frame mid-stream.
+        delivered = asyncio.Queue()
+
+        class LiveWS:
+            sent = []
+
+            async def recv(self):
+                return await delivered.get()
+
+            async def send(self, d):
+                self.sent.append(d)
+
+        ws = LiveWS()
+        monkeypatch.setattr(
+            tui_consent, "ws_connect", lambda *a, **k: FakeCM(ws)
+        )
+        app = _make_app(reconnect_delays=(0.0,))
         async with app.run_test() as pilot:
-            app._connected = True
-            app.action_rules()
-            await pilot.pause()
-            assert isinstance(app.screen, RulesScreen)
-            app.screen.action_back()
-            await pilot.pause()
-            assert app._connected is True  # untouched across the switch
+            task = asyncio.create_task(_real_ws_loop(app))
+            try:
+                await pilot.pause()
+                await asyncio.sleep(0.05)
+                assert app._connected is True  # the real loop connected
+
+                # Switch to the rules screen mid-stream.
+                app.action_rules()
+                await pilot.pause()
+                assert isinstance(app.screen, RulesScreen)
+                body = str(
+                    app.screen.query_one("#rules-content", Static).content
+                )
+                assert "no rules received yet" in body  # nothing delivered yet
+
+                # A frame arrives over the SAME connection while viewing rules.
+                await delivered.put(
+                    _rules_frame(
+                        allow_list=["a.com"],
+                        allowed=[_rule("a1", host="new.example.com")],
+                    )
+                )
+                await pilot.pause()
+                await asyncio.sleep(0.05)
+                body = str(
+                    app.screen.query_one("#rules-content", Static).content
+                )
+                assert "a.com" in body
+                assert "Active allows (1)" in body
+                assert "new.example.com:443" in body
+
+                # Pop back; the worker is still on the same connection.
+                app.screen.action_back()
+                await pilot.pause()
+                assert app._connected is True
+            finally:
+                app._stop = True
+                # Unblock the parked recv() so the loop can exit cleanly.
+                await delivered.put(_rules_frame())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
 
     async def test_refresh_rules_before_mount_is_noop(self):
         screen = RulesScreen()
@@ -1617,3 +1674,38 @@ async def test_q_and_escape_keypress_pop_back_via_pilot():
         await pilot.pause()
         assert not isinstance(app.screen, RulesScreen)
         assert app.is_running
+
+
+async def test_deny_with_null_decided_at_renders_without_crash():
+    # Regression: the deny branch of _rule_line once formatted rem before
+    # checking it for None, so a timed deny with a null decided_at (or an
+    # unknown duration) hit _fmt_duration(None) -> TypeError. The parser
+    # permits these rows, so rendering must degrade to a blank label rather
+    # than crash (which would silently stale the whole rules body).
+    app = _make_app()
+    async with app.run_test() as pilot:
+        app.controller.apply_frame(
+            _rules_frame(
+                denied=[
+                    _rule(
+                        "d1",
+                        host="deny.example.com",
+                        decision="denied",
+                        duration="5m",
+                        decided_at=None,
+                    ),
+                    _rule(
+                        "d2",
+                        host="deny2.example.com",
+                        decision="denied",
+                        duration="3fortnights",  # unknown -> rem None
+                    ),
+                ],
+            )
+        )
+        app.action_rules()
+        await pilot.pause()
+        body = str(app.screen.query_one("#rules-content", Static).content)
+        assert "deny.example.com:443" in body
+        assert "deny2.example.com:443" in body
+        assert "Active denies (2)" in body


### PR DESCRIPTION
## What

Closes #2340 — the read-only rule-management screen (slice B of the #2335
umbrella). Press `r` in `klangk consent-decide` to switch from the held-request
queue to a second, read-only screen listing every egress decision currently in
effect for the workspace; `q`/`Esc` returns to the queue.

The screen shows, grouped and live-updating from the `egress_rules` frame
(#2338, slice A — already merged):

- **Static allow-list** — the workspace's `allowed_domains`.
- **Active consent allows** — host:port (+ process) with expiry:
  `expires in 5m`, `until restart`, or `forever`.
- **Active consent denies** — host:port with the remaining deny window.
- **Pause window** — remaining pause if filtering is paused (#2332); the
  section is hidden until that lands (graceful degradation).

## Design

- **WS worker stays connected across the switch.** The rules screen is pushed
  with `push_screen` — only the view changes; the shared WS pump, ping loop,
  reconnect, and token-refresh are untouched. Held requests keep arriving and
  the list updates live via the app's shared 1s refresh, which also pokes the
  rules screen when it's the active screen.
- **Protocol parsing stays in `ConsentDeciderController`** (pure, unit-tested),
  keeping it out of the Textual widgets. New `EgressRules` / `ConsentRule` /
  `PauseState` dataclasses; `egress_rules` parsing sorts rows
  newest-decided-first (matching the backend's `ORDER BY decided_at DESC`);
  `rule_remaining` / `pause_remaining` countdowns and a `_fmt_duration` tier
  formatter (durations duplicated per CLI isolation).
- **Read-only.** No revoke here — that's #2339 (backend, PR #2351) + slice D
  (#2341). `a`/`d` no-op while on the rules screen so a hidden highlighted
  queue row can't be decided.
- `reset()` (called on each reconnect) now also drops the cached rules
  snapshot, since the server's fresh `egress_rules` frame that follows is
  authoritative.

## Acceptance criteria

- [x] Keystroke (`r`) opens the rules screen; `Esc`/`q` returns.
- [x] Lists static allow-list + active allows (w/ expiry) + active denies +
      pause window, live-updating from the `egress_rules` frame (#2338).
- [x] The WS worker is not torn down/reconnected on the screen switch.
- [x] Tests cover the controller's `egress_rules` parsing + ordering and the
      screen's render/refresh (`test_consent_decide.py` style).

## Tests

100% coverage on the `klangk` package maintained (full CI suite,
`-n auto`): 4701 passed. New tests cover parsing edge cases (malformed rows,
bool ports, missing fields, pause variants), ordering, expiry math, all render
branches, the screen switch via real `q`/`escape` keypresses (confirming the
screen binding wins over the app-level `q`→quit), live update on a fresh
frame, and render-failure isolation.

Rebased on `main` (atop #2351) — no conflicts.
