### PR TITLE
feat(frontend): egress-consent verdict overlay on workspace page

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,17 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Flutter egress-consent verdict overlay (#2333).** The workspace page
+  now shows a live consent overlay (anchored in the page `Stack`, so it appears
+  on every tab, not just the terminal) that mirrors the `consent-decide` TUI.
+  It connects to `/ws/consent-decider` for its own workspace, pings to stay
+  registered, shows held egress requests with destination host:port, process,
+  and auto-deny countdown, and sends Allow/Deny verdicts (`scope=once`) over the
+  held connection. A compact collapsed chip is shown when idle; the panel
+  auto-expands when a decision is pending and collapses when none remain. While
+  disconnected the overlay warns that holds auto-deny (fail-closed). No backend
+  protocol change.
+
 - **Per-request duration for egress-consent verdicts (#2328).** A verdict
   now carries a `duration` (`once` | `5m` | `15m` | `1h` | `1d` | `1w` |
   `restart` | `forever`, default `restart`). The `consent-decide` TUI shows a

--- a/src/frontend/lib/consent/consent_decider_client.dart
+++ b/src/frontend/lib/consent/consent_decider_client.dart
@@ -1,0 +1,381 @@
+/// Egress-consent decider client for the Flutter workspace page (#2333).
+///
+/// The in-app mirror of the TUI `consent-decide` client
+/// (`src/klangk/klangk/cli/tui/consent.py`, PR #2320). Opens its own WebSocket
+/// to the server's `/ws/consent-decider?token=<JWT>&workspace=<id>` endpoint
+/// (#2244), stays registered via pings (must beat `consent_decider_timeout`,
+/// 45s), surfaces held egress requests, and sends allow/deny verdicts that the
+/// coordinator applies to the held sidecar connection (#2311).
+///
+/// This is a **separate** WebSocket from the main [WsClient] (which speaks
+/// `/ws` for terminal/chat/etc). The decider stream is its own endpoint with
+/// its own authz + frame protocol, so — like the TUI — it gets its own
+/// connection. We reuse the WsClient *patterns* (JWT from AuthService,
+/// reconnect with backoff, auth-failure close-code handling, test channel
+/// factory) rather than a bespoke transport.
+///
+/// Fail-closed: while disconnected the decider is deregistered server-side,
+/// so in-flight holds auto-deny on their own timeout — never silently
+/// allowed. The UI reflects this by showing a disconnected/warning state.
+///
+/// The client is a [ChangeNotifier]; the overlay widget listens and rebuilds
+/// on connection/data changes. A 1s tick (active only while requests are
+/// pending) drives the auto-deny countdown display.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../auth/auth_service.dart';
+import 'consent_request.dart';
+
+/// Verdict decision values (mirror the server's
+/// `model/egress_consent.py`). v1 sends `scope=once` only (#2333 non-goal:
+/// richer scope/duration is tracked in #2328 for the TUI; the Flutter client
+/// can follow once that lands).
+const _kDecisionAllowed = 'allowed';
+const _kDecisionDenied = 'denied';
+const _kScopeOnce = 'once';
+
+/// Server default `egress_consent_timeout` (settings.py), in seconds. The
+/// client cannot learn the server's value, so it defaults to the server
+/// default for the countdown display. The server is the source of truth —
+/// it auto-denies at the real timeout regardless of what this shows.
+const double kDefaultHoldTimeoutSeconds = 120.0;
+
+/// Pings must beat the server's `consent_decider_timeout` (45s) or the
+/// decider is reaped and the workspace reverts to static. 15s leaves margin,
+/// matching the TUI client's interval.
+const Duration _kPingInterval = Duration(seconds: 15);
+
+/// Reconnect backoff caps (seconds), matching the TUI. Caps the spin on a
+/// repeatedly-dropping server.
+const List<double> _kReconnectDelays = [1.0, 2.0, 5.0];
+
+/// A live consent decider for one workspace, owning its WS lifecycle.
+///
+/// Construct with the workspace id + an [AuthService] (read live for the
+/// token so reconnects pick up a refreshed JWT). Call [connect] to open the
+/// socket, [dispose] to tear it down. Listen via [addListener].
+class ConsentDeciderClient extends ChangeNotifier {
+  ConsentDeciderClient({
+    required this.workspaceId,
+    required AuthService auth,
+    double holdTimeoutSeconds = kDefaultHoldTimeoutSeconds,
+    Duration pingInterval = _kPingInterval,
+    Duration countdownInterval = const Duration(seconds: 1),
+    List<double> reconnectDelays = _kReconnectDelays,
+  })  : _auth = auth,
+        _holdTimeoutSeconds = holdTimeoutSeconds,
+        _pingInterval = pingInterval,
+        _countdownInterval = countdownInterval,
+        _reconnectDelays = reconnectDelays;
+
+  final String workspaceId;
+  final AuthService _auth;
+  final double _holdTimeoutSeconds;
+  final Duration _pingInterval;
+  final Duration _countdownInterval;
+  final List<double> _reconnectDelays;
+
+  WebSocketChannel? _channel;
+  bool _connected = false;
+  bool _connecting = false;
+  bool _manualDisconnect = false;
+  bool _authFailed = false;
+  bool _disposed = false;
+  Timer? _pingTimer;
+  Timer? _reconnectTimer;
+  Timer? _countdownTimer;
+  int _reconnectAttempt = 0;
+  StreamSubscription? _sub;
+
+  /// Override for testing to inject a fake channel factory (mirrors
+  /// [WsClient.testChannelFactory]).
+  @visibleForTesting
+  static WebSocketChannel Function(Uri uri)? testChannelFactory;
+
+  /// Override for testing to control reconnect backoff (mirrors
+  /// [WsClient.testBackoffOverride]).
+  @visibleForTesting
+  static Duration Function(int attempt)? testBackoffOverride;
+
+  /// Pending held requests keyed by id.
+  final Map<String, ConsentRequest> _pending = {};
+
+  /// Whether egress filtering is paused for the workspace, from the
+  /// `egress_rules` frame's `paused` field. `null` = not yet received (or the
+  /// server sent `null`, which it always does today — #2332 pause control is
+  /// not yet landed).
+  bool? _paused;
+
+  // -- public read-only state ------------------------------------------------
+
+  bool get connected => _connected;
+  bool get connecting => _connecting;
+  bool get authFailed => _authFailed;
+
+  /// Pending held requests, oldest-first.
+  List<ConsentRequest> get pending => _pending.values.toList()
+    ..sort((a, b) => a.requestedAt.compareTo(b.requestedAt));
+
+  /// Whether at least one held request is awaiting a verdict.
+  bool get hasPending => _pending.isNotEmpty;
+
+  /// Paused state from the last `egress_rules` frame (null = unknown).
+  bool? get paused => _paused;
+
+  /// Seconds until a hold's countdown hits zero (clamped at 0). UX hint only
+  /// — the server auto-denies at the real timeout regardless.
+  double remaining(ConsentRequest req) {
+    final now = DateTime.now().millisecondsSinceEpoch / 1000.0;
+    final left = req.requestedAt + _holdTimeoutSeconds - now;
+    return left < 0 ? 0.0 : left;
+  }
+
+  // -- lifecycle -------------------------------------------------------------
+
+  /// Open the decider socket. Safe to call once (the overlay calls it on
+  /// mount). Reconnects are handled internally on drop.
+  Future<void> connect() async {
+    if (_disposed || _connecting || _connected) return;
+    final token = _auth.token;
+    if (token == null) return;
+    _connecting = true;
+    notifyListeners();
+    try {
+      await _openSocket(token);
+    } finally {
+      _connecting = false;
+    }
+    if (!_disposed) notifyListeners();
+  }
+
+  Future<void> _openSocket(String token) async {
+    final channel = testChannelFactory != null
+        ? testChannelFactory!(Uri())
+        // coverage:ignore-start
+        : WebSocketChannel.connect(_deciderUri(token));
+    // coverage:ignore-end
+    _channel = channel;
+    try {
+      await channel.ready;
+    } catch (_) {
+      // Ready failed (connect refused / auth close). Inspect the close code
+      // to decide between auth-failure (stop) and transient (reconnect).
+      _handleClose(channel.closeCode);
+      if (!_authFailed && !_disposed) {
+        // A connect-time failure never opened the stream, so its onDone won't
+        // fire — schedule the reconnect ourselves.
+        _scheduleReconnect();
+      }
+      return;
+    }
+    _authFailed = false;
+    _connected = true;
+    _reconnectAttempt = 0;
+    // The server's snapshot (sent immediately on connect) is authoritative
+    // for currently-held requests: drop anything stale from a prior session
+    // so rows that resolved while we were disconnected — and thus never sent
+    // us an egress_resolved — don't linger as ghosts. Matches the TUI's
+    // reset() on each pump start.
+    _pending.clear();
+    _paused = null;
+    _startPing();
+    _sub = channel.stream.listen(
+      _onData,
+      onError: (Object e) {
+        debugPrint('[ConsentDecider] stream error: $e');
+      },
+      onDone: () {
+        _teardownConnection();
+        _handleClose(channel.closeCode);
+        if (!_manualDisconnect && !_authFailed && !_disposed) {
+          _scheduleReconnect();
+        }
+      },
+    );
+  }
+
+  // coverage:ignore-start
+  Uri _deciderUri(String token) {
+    final loc = Uri.base;
+    final wsScheme = loc.scheme == 'https' ? 'wss' : 'ws';
+    final base = baseUrl; // from klangk_plugin_api ('' or '/klangk')
+    return Uri.parse(
+      '$wsScheme://${loc.host}:${loc.port}$base/ws/consent-decider'
+      '?token=${Uri.encodeQueryComponent(token)}'
+      '&workspace=${Uri.encodeQueryComponent(workspaceId)}',
+    );
+    // coverage:ignore-end
+  }
+
+  void _onData(dynamic data) {
+    if (data is! String) return;
+    Map<String, dynamic> msg;
+    try {
+      final decoded = jsonDecode(data);
+      if (decoded is! Map<String, dynamic>) return;
+      msg = decoded;
+    } catch (_) {
+      return; // malformed frame — ignore
+    }
+    final type = msg['type'];
+    var changed = false;
+    switch (type) {
+      case 'egress_request':
+        final req = parseConsentRequest(msg['request']);
+        if (req != null) {
+          _pending[req.id] = req;
+          _ensureCountdownTimer();
+          changed = true;
+        }
+        break;
+      case 'egress_resolved':
+        final rid = msg['request_id'];
+        if (rid is String) {
+          _pending.remove(rid);
+          changed = true;
+        }
+        break;
+      case 'egress_rules':
+        // paused is always null today (#2332 not landed); track anyway for
+        // forward-compat with a future pause-control backend.
+        _paused = msg['paused'] as bool?;
+        changed = true;
+        break;
+      case 'pong':
+      case 'error':
+        // pong confirms liveness (no state change); error is a rejected
+        // verdict (server already logged it). Neither needs UI action.
+        break;
+      default:
+        break; // unknown frame — ignore
+    }
+    if (changed && !_disposed) notifyListeners();
+  }
+
+  // -- verdicts --------------------------------------------------------------
+
+  /// Send an allow verdict for [requestId] (scope=once). No-op if not
+  /// connected; the UI shows a disconnected warning in that case.
+  void allow(String requestId) => _sendVerdict(requestId, _kDecisionAllowed);
+
+  /// Send a deny verdict for [requestId] (scope=once).
+  void deny(String requestId) => _sendVerdict(requestId, _kDecisionDenied);
+
+  void _sendVerdict(String requestId, String decision) {
+    final channel = _channel;
+    if (channel == null) return;
+    try {
+      channel.sink.add(jsonEncode({
+        'type': 'verdict',
+        'request_id': requestId,
+        'decision': decision,
+        'scope': _kScopeOnce,
+      }));
+    } catch (e) {
+      debugPrint('[ConsentDecider] verdict send failed: $e');
+    }
+  }
+
+  // -- liveness / reconnect --------------------------------------------------
+
+  void _startPing() {
+    _pingTimer?.cancel();
+    _pingTimer = Timer.periodic(_pingInterval, (_) {
+      final channel = _channel;
+      if (channel == null) return;
+      try {
+        channel.sink.add(jsonEncode({'type': 'ping'}));
+      } catch (e) {
+        debugPrint('[ConsentDecider] ping send failed: $e');
+      }
+    });
+  }
+
+  void _ensureCountdownTimer() {
+    // Only run the 1s countdown tick while there are holds to count down;
+    // idle workspaces pay nothing. The tick just refreshes the display —
+    // the server's egress_resolved frame (or the next snapshot) removes
+    // rows; we don't prune locally, matching the TUI.
+    if (_countdownTimer != null) return;
+    _countdownTimer = Timer.periodic(_countdownInterval, (_) {
+      if (_disposed) return;
+      if (_pending.isEmpty) {
+        _countdownTimer?.cancel();
+        _countdownTimer = null;
+        return;
+      }
+      notifyListeners();
+    });
+  }
+
+  void _handleClose(int? code) {
+    if (code == 4001 || code == 4002) {
+      // Auth-related close (missing/expired token). Stop reconnecting — the
+      // app's auth guard redirects to login via the main WsClient's logout.
+      _authFailed = true;
+    }
+  }
+
+  void _scheduleReconnect() {
+    if (_disposed || _authFailed) return;
+    _reconnectAttempt++;
+    final delay = testBackoffOverride != null
+        ? testBackoffOverride!(_reconnectAttempt)
+        : _backoffDelay(_reconnectAttempt);
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer(delay, () {
+      _reconnectTimer = null;
+      if (_disposed) return;
+      // Re-read the token: it may have refreshed while we were backed off.
+      if (_auth.token == null) return;
+      connect();
+    });
+  }
+
+  Duration _backoffDelay(int attempt) {
+    // coverage:ignore-start
+    final idx = min(attempt - 1, _reconnectDelays.length - 1);
+    final base = _reconnectDelays[idx < 0 ? 0 : idx];
+    return Duration(milliseconds: (base * 1000).round());
+    // coverage:ignore-end
+  }
+
+  void _teardownConnection() {
+    _pingTimer?.cancel();
+    _pingTimer = null;
+    _sub?.cancel();
+    _sub = null;
+    _channel?.sink.close();
+    _channel = null;
+    final wasConnected = _connected;
+    _connected = false;
+    // While disconnected the server has deregistered us, so any holds we
+    // still show will auto-deny on their own timeout. Keep them visible
+    // (with a disconnected warning) rather than clearing — the user can see
+    // what's pending. They clear on reconnect snapshot or via egress_resolved.
+    if (wasConnected && !_disposed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _manualDisconnect = true;
+    _connected = false;
+    _pingTimer?.cancel();
+    _reconnectTimer?.cancel();
+    _countdownTimer?.cancel();
+    _sub?.cancel();
+    _channel?.sink.close(1000, 'client dispose');
+    _channel = null;
+    _pending.clear();
+    super.dispose();
+  }
+}

--- a/src/frontend/lib/consent/consent_overlay.dart
+++ b/src/frontend/lib/consent/consent_overlay.dart
@@ -1,0 +1,401 @@
+/// Egress-consent verdict overlay for the workspace page (#2333).
+///
+/// The in-app mirror of the TUI `consent-decide` client. Anchored in
+/// [WorkspacePage]'s body `Stack` (not the terminal view), so it surfaces
+/// held egress requests across **every** workspace-page tab — terminal,
+/// files, settings, sharing, debug, and any feature tab.
+///
+/// Behavior (matches the issue's acceptance criteria):
+///
+/// - **Collapsed by default**: a compact bottom-corner chip showing the
+///   held-request count (or an idle indicator) plus a pause-state button.
+///   Obscures minimal screen area.
+/// - **Auto-expands** when a held request needs a decision: shows each
+///   request's destination host:port, process, and auto-deny countdown with
+///   Allow / Deny actions. Collapses back when no requests are pending.
+/// - **Fail-closed**: while the decider socket is disconnected the chip shows
+///   a warning — in-flight holds auto-deny on their own server timeout
+///   (mirrors the TUI, #2320).
+///
+/// The widget owns a [ConsentDeciderClient] (its own `/ws/consent-decider`
+/// socket); pass `client` to inject a fake for tests.
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../auth/auth_service.dart';
+import '../theme/colors.dart';
+import 'consent_decider_client.dart';
+import 'consent_request.dart';
+
+/// A self-contained overlay that connects to the consent-decider stream for
+/// [workspaceId] and renders the verdict UI.
+class ConsentOverlay extends StatefulWidget {
+  const ConsentOverlay({
+    super.key,
+    required this.workspaceId,
+    this.client,
+  });
+
+  final String workspaceId;
+
+  /// Optional injected client (tests). When null the widget constructs one
+  /// from the ambient [AuthService] (via Provider) on mount.
+  final ConsentDeciderClient? client;
+
+  @override
+  State<ConsentOverlay> createState() => _ConsentOverlayState();
+}
+
+class _ConsentOverlayState extends State<ConsentOverlay> {
+  ConsentDeciderClient? _client;
+  bool _ownsClient = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _client ??= () {
+      if (widget.client != null) return widget.client;
+      final c = ConsentDeciderClient(
+        workspaceId: widget.workspaceId,
+        auth: context.read<AuthService>(),
+      );
+      _ownsClient = true;
+      // Fire-and-forget: the connection completes asynchronously; the widget
+      // rebuilds via ChangeNotifier when state changes.
+      c.connect();
+      return c;
+    }();
+  }
+
+  @override
+  void dispose() {
+    if (_ownsClient) {
+      _client?.dispose();
+    }
+    super.dispose();
+  }
+
+  void _showPauseUnavailable() {
+    // #2332: pause control has no backend today (the coordinator's
+    // egress_rules frame always reports paused=null). The button is present
+    // for UI completeness (#2333 acceptance criterion) but signals it isn't
+    // wired rather than silently no-op-ing.
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        const SnackBar(
+          content: Text('Egress pause control is not yet available.'),
+          duration: Duration(seconds: 3),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final client = _client;
+    if (client == null) return const SizedBox.shrink();
+    return Positioned(
+      bottom: 16,
+      right: 16,
+      child: ListenableBuilder(
+        listenable: client,
+        builder: (context, _) {
+          return client.hasPending
+              ? _VerdictPanel(
+                  client: client,
+                  onPause: _showPauseUnavailable,
+                )
+              : _CollapsedChip(
+                  heldCount: 0,
+                  connected: client.connected,
+                  connecting: client.connecting,
+                  onPause: _showPauseUnavailable,
+                );
+        },
+      ),
+    );
+  }
+}
+
+/// The compact collapsed chip: held count + pause button. Shown when no
+/// request is pending. Tints to a warning style while disconnected to convey
+/// that any in-flight holds auto-deny (fail-closed).
+class _CollapsedChip extends StatelessWidget {
+  const _CollapsedChip({
+    required this.heldCount,
+    required this.connected,
+    required this.connecting,
+    required this.onPause,
+  });
+
+  final int heldCount;
+  final bool connected;
+  final bool connecting;
+  final VoidCallback onPause;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isWarning = !connected && !connecting;
+    return Material(
+      elevation: 6,
+      borderRadius: BorderRadius.circular(24),
+      color: isWarning
+          ? Colors.orange.shade900
+          : theme.colorScheme.surfaceContainerHighest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              isWarning ? Icons.warning_amber_rounded : Icons.shield_outlined,
+              size: 18,
+              color: isWarning ? Colors.white : theme.colorScheme.onSurface,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              _label(),
+              style: TextStyle(
+                color: isWarning ? Colors.white : theme.colorScheme.onSurface,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(width: 4),
+            _PauseButton(onPause: onPause, light: isWarning),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _label() {
+    if (connecting) return 'Consent…';
+    if (!connected) return 'Auto-deny';
+    return 'Egress: $heldCount held';
+  }
+}
+
+/// The expanded verdict panel: a header (count + pause + collapse hint) and a
+/// scrollable list of held requests, each with host:port, process, countdown,
+/// and Allow / Deny actions.
+class _VerdictPanel extends StatelessWidget {
+  const _VerdictPanel({required this.client, required this.onPause});
+
+  final ConsentDeciderClient client;
+  final VoidCallback onPause;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final pending = client.pending;
+    return Material(
+      elevation: 8,
+      borderRadius: BorderRadius.circular(12),
+      color: theme.colorScheme.surface,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 380, maxHeight: 400),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.shield,
+                    size: 18,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '${pending.length} egress request'
+                      '${pending.length == 1 ? '' : 's'} held',
+                      style: theme.textTheme.titleSmall,
+                    ),
+                  ),
+                  if (!client.connected)
+                    Tooltip(
+                      message: 'Disconnected — held requests auto-deny',
+                      child: Icon(
+                        Icons.warning_amber_rounded,
+                        size: 18,
+                        color: Colors.orange.shade700,
+                      ),
+                    ),
+                  _PauseButton(onPause: onPause, light: false),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Flexible(
+              child: ListView.separated(
+                shrinkWrap: true,
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                itemCount: pending.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (context, i) =>
+                    _RequestRow(client: client, req: pending[i]),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RequestRow extends StatelessWidget {
+  const _RequestRow({required this.client, required this.req});
+
+  final ConsentDeciderClient client;
+  final ConsentRequest req;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final secs = client.remaining(req).ceil();
+    final host =
+        req.destPort != null ? '${req.destHost}:${req.destPort}' : req.destHost;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  host,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (req.processName != null && req.processName!.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      req.processName!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          _CountdownBadge(seconds: secs),
+          const SizedBox(width: 8),
+          _VerdictButtons(client: client, requestId: req.id),
+        ],
+      ),
+    );
+  }
+}
+
+class _CountdownBadge extends StatelessWidget {
+  const _CountdownBadge({required this.seconds});
+  final int seconds;
+
+  @override
+  Widget build(BuildContext context) {
+    final urgent = seconds <= 10;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: urgent ? Colors.red.shade700 : Colors.grey.shade300,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        '${seconds}s',
+        style: TextStyle(
+          color: urgent ? Colors.white : Colors.black87,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _VerdictButtons extends StatelessWidget {
+  const _VerdictButtons({required this.client, required this.requestId});
+  final ConsentDeciderClient client;
+  final String requestId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _CompactButton(
+          label: 'Allow',
+          color: KColors.accentGreen,
+          onPressed: () => client.allow(requestId),
+        ),
+        const SizedBox(width: 4),
+        _CompactButton(
+          label: 'Deny',
+          color: Colors.red.shade700,
+          onPressed: () => client.deny(requestId),
+        ),
+      ],
+    );
+  }
+}
+
+class _CompactButton extends StatelessWidget {
+  const _CompactButton({
+    required this.label,
+    required this.color,
+    required this.onPressed,
+  });
+
+  final String label;
+  final Color color;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 32,
+      child: FilledButton(
+        onPressed: onPressed,
+        style: FilledButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          textStyle: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+        ),
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _PauseButton extends StatelessWidget {
+  const _PauseButton({required this.onPause, required this.light});
+  final VoidCallback onPause;
+  final bool light;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onPause,
+      icon: const Icon(Icons.pause_circle_outline, size: 20),
+      tooltip: 'Pause egress filtering (unavailable)',
+      visualDensity: VisualDensity.compact,
+      color: light ? Colors.white : null,
+      constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+      padding: EdgeInsets.zero,
+    );
+  }
+}

--- a/src/frontend/lib/consent/consent_request.dart
+++ b/src/frontend/lib/consent/consent_request.dart
@@ -1,0 +1,69 @@
+/// One held egress request awaiting an allow/deny verdict.
+///
+/// Mirrors the TUI decider client's `ConsentRequest`
+/// (`src/klangk/klangk/cli/tui/consent.py`) so both deciders speak the same
+/// server frame protocol (`/ws/consent-decider`, #2244). Flutter-side pure
+/// model; parsing lives in [parseConsentRequest] so the client stays focused
+/// on transport.
+class ConsentRequest {
+  ConsentRequest({
+    required this.id,
+    required this.workspaceId,
+    required this.destHost,
+    required this.destPort,
+    required this.processName,
+    required this.pid,
+    required this.requestedAt,
+  });
+
+  /// Server-assigned request id (used as the `verdict.request_id`).
+  final String id;
+
+  /// Workspace the held connection originated in.
+  final String workspaceId;
+
+  /// Destination host the workspace process tried to reach (server-observed
+  /// DNS). Rendered literally — never styled from it.
+  final String destHost;
+
+  /// Destination port, or null when the server didn't record one.
+  final int? destPort;
+
+  /// Originating process name (e.g. "curl"), or null.
+  final String? processName;
+
+  /// Originating PID inside the workspace, or null.
+  final int? pid;
+
+  /// Epoch seconds (wall-clock) the server stamped the hold. Shares the
+  /// `time.time()` domain the server uses, so the auto-deny countdown math
+  /// (`requestedAt + holdTimeout - now`) is meaningful.
+  final double requestedAt;
+}
+
+/// Build a [ConsentRequest] from an inbound frame's `request` object.
+///
+/// Returns `null` on a shape that can't be acted on (missing id/workspace),
+/// mirroring the TUI's `_parse_request`. Defensive about types: the frame
+/// comes off the wire untyped.
+ConsentRequest? parseConsentRequest(Object? obj) {
+  if (obj is! Map<String, dynamic>) return null;
+  final id = obj['id'];
+  final wid = obj['workspace_id'];
+  if (id is! String || wid is! String) return null;
+  final requestedAtRaw = obj['requested_at'];
+  final requestedAt = requestedAtRaw is num ? requestedAtRaw.toDouble() : 0.0;
+  final port = obj['dest_port'];
+  final pid = obj['pid'];
+  return ConsentRequest(
+    id: id,
+    workspaceId: wid,
+    destHost: (obj['dest_host'] ?? '').toString(),
+    destPort: port is num ? port.toInt() : null,
+    processName: obj['process_name']?.toString(),
+    // int and bool are disjoint types in Dart, so `pid is int` already
+    // excludes a JSON true/false (no Python-style bool-is-int gotcha here).
+    pid: pid is int ? pid : null,
+    requestedAt: requestedAt,
+  );
+}

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -22,6 +22,7 @@ import 'package:http/http.dart' as http;
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../debug/debug_panel.dart';
+import '../consent/consent_overlay.dart';
 import 'workspace_settings_panel.dart';
 import 'workspace_sharing_panel.dart';
 import 'terminal_tabs_view.dart';
@@ -442,6 +443,11 @@ class _WorkspacePageState extends State<WorkspacePage> {
           for (final feature in _features)
             if (feature.buildOverlay(context) != null)
               feature.buildOverlay(context)!,
+          // Egress-consent verdict overlay (#2333): anchored in the page Stack
+          // (not the terminal view) so it surfaces held requests on every
+          // workspace-page tab. Sits below the full-screen status overlays so
+          // those cover it when active.
+          ConsentOverlay(workspaceId: widget.workspaceId),
           if (_containerStopped)
             buildContainerStoppedOverlay(
               restarting: _restarting,

--- a/src/frontend/test/consent_decider_client_test.dart
+++ b/src/frontend/test/consent_decider_client_test.dart
@@ -1,0 +1,596 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/consent/consent_decider_client.dart';
+import 'package:klangk_frontend/consent/consent_request.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Minimal fake WebSocketChannel mirroring ws_client_test.dart's fake.
+class _FakeChannel extends Fake implements WebSocketChannel {
+  final _incoming = StreamController<dynamic>.broadcast();
+  final _sink = _FakeSink();
+  final Completer<void>? _readyCompleter;
+  final bool _failReady;
+  int? _closeCode;
+
+  _FakeChannel({bool failReady = false, Completer<void>? readyCompleter})
+      : _failReady = failReady,
+        _readyCompleter = readyCompleter;
+
+  @override
+  Stream<dynamic> get stream => _incoming.stream;
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  int? get closeCode => _closeCode;
+
+  @override
+  Future<void> get ready {
+    if (_failReady) return Future.error('Connection refused');
+    if (_readyCompleter != null) return _readyCompleter.future;
+    return Future.value();
+  }
+
+  void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
+  void serverSendRaw(String raw) => _incoming.add(raw);
+
+  /// Close the inbound stream, simulating a server-side disconnect. Sets the
+  /// reported [closeCode] so tests can drive the auth-close path.
+  void serverClose([int? code]) {
+    _closeCode = code;
+    _incoming.close();
+  }
+
+  /// Inject a stream error (transient decode glitch) without closing.
+  void serverError(Object error) => _incoming.addError(error);
+
+  List<dynamic> get sent => _sink.sent;
+
+  void dispose() => _incoming.close();
+}
+
+class _FakeSink extends Fake implements WebSocketSink {
+  final List<dynamic> sent = [];
+  bool closeCalled = false;
+
+  @override
+  void add(dynamic data) => sent.add(data);
+
+  @override
+  Future close([int? closeCode, String? closeReason]) async {
+    closeCalled = true;
+  }
+}
+
+/// A channel whose sink.add always throws — exercises the verdict/ping
+/// send-failure defensive catches.
+class _ThrowingSinkChannel extends _FakeChannel {
+  @override
+  WebSocketSink get sink => _ThrowingSink();
+}
+
+class _ThrowingSink extends Fake implements WebSocketSink {
+  @override
+  void add(dynamic data) => throw StateError('sink closed');
+
+  @override
+  Future close([int? closeCode, String? closeReason]) async {}
+}
+
+/// Builds an AuthService whose token is already loaded (ready to connect).
+Future<AuthService> _authedAuthService({String token = 'test-token'}) async {
+  SharedPreferences.setMockInitialValues({'klangk_jwt': token});
+  final auth = AuthService();
+  await Future.delayed(Duration.zero);
+  return auth;
+}
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({});
+    ConsentDeciderClient.testChannelFactory = null;
+    ConsentDeciderClient.testBackoffOverride = null;
+  });
+
+  tearDown(() {
+    ConsentDeciderClient.testChannelFactory = null;
+    ConsentDeciderClient.testBackoffOverride = null;
+    testBaseUrlOverride = null;
+  });
+
+  ConsentDeciderClient _client(
+    _FakeChannel channel, {
+    required AuthService auth,
+    Duration pingInterval = const Duration(minutes: 1),
+    Duration countdownInterval = const Duration(seconds: 1),
+  }) {
+    ConsentDeciderClient.testChannelFactory = (_) => channel;
+    return ConsentDeciderClient(
+      workspaceId: 'ws-1',
+      auth: auth,
+      pingInterval: pingInterval,
+      countdownInterval: countdownInterval,
+    );
+  }
+
+  group('initial state', () {
+    test('not connected, no pending', () {
+      final auth = AuthService();
+      final c = ConsentDeciderClient(workspaceId: 'ws-1', auth: auth);
+      expect(c.connected, isFalse);
+      expect(c.connecting, isFalse);
+      expect(c.hasPending, isFalse);
+      expect(c.pending, isEmpty);
+      expect(c.paused, isNull);
+      expect(c.authFailed, isFalse);
+      c.dispose();
+    });
+  });
+
+  group('connect', () {
+    test('connects when a token is available', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      expect(c.connected, isTrue);
+      expect(c.connecting, isFalse);
+      c.dispose();
+    });
+
+    test('no-ops when there is no token', () async {
+      final auth = AuthService(); // not logged in
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      expect(c.connected, isFalse);
+      expect(channel.sent, isEmpty);
+      c.dispose();
+    });
+
+    test('idempotent: second connect is a no-op', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      await c.connect();
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+  });
+
+  group('inbound frames', () {
+    test('egress_request adds a held request', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'r1',
+          'workspace_id': 'ws-1',
+          'dest_host': 'example.com',
+          'dest_port': 443,
+          'process_name': 'curl',
+          'requested_at': DateTime.now().millisecondsSinceEpoch / 1000.0,
+        },
+      });
+      await Future.delayed(Duration.zero);
+      expect(c.hasPending, isTrue);
+      expect(c.pending.single.id, 'r1');
+      c.dispose();
+    });
+
+    test('egress_request with a bad payload is ignored', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {'workspace_id': 'ws-1'}, // missing id
+      });
+      await Future.delayed(Duration.zero);
+      expect(c.hasPending, isFalse);
+      c.dispose();
+    });
+
+    test('egress_resolved removes the request', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'r1',
+          'workspace_id': 'ws-1',
+          'dest_host': 'h',
+          'requested_at': 0,
+        },
+      });
+      await Future.delayed(Duration.zero);
+      expect(c.hasPending, isTrue);
+      channel.serverSend({
+        'type': 'egress_resolved',
+        'request_id': 'r1',
+        'decision': 'allowed',
+      });
+      await Future.delayed(Duration.zero);
+      expect(c.hasPending, isFalse);
+      c.dispose();
+    });
+
+    test('egress_rules sets paused', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel.serverSend({
+        'type': 'egress_rules',
+        'workspace_id': 'ws-1',
+        'allow_list': [],
+        'allowed': [],
+        'denied': [],
+        'paused': null,
+      });
+      await Future.delayed(Duration.zero);
+      expect(c.paused, isNull);
+      // Forward-compat: a future server that reports paused=true is tracked.
+      channel.serverSend({
+        'type': 'egress_rules',
+        'paused': true,
+      });
+      await Future.delayed(Duration.zero);
+      expect(c.paused, isTrue);
+      c.dispose();
+    });
+
+    test('pong and error frames do not change pending state', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel.serverSend({'type': 'pong'});
+      channel.serverSend({'type': 'error', 'message': 'bad verdict'});
+      await Future.delayed(Duration.zero);
+      expect(c.hasPending, isFalse);
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+
+    test('malformed and unknown frames are ignored', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel.serverSendRaw('not json');
+      channel.serverSendRaw('[]'); // a list, not an object
+      channel.serverSend({'type': 'something_new', 'foo': 1});
+      await Future.delayed(Duration.zero);
+      expect(c.hasPending, isFalse);
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+
+    test('non-string stream events are ignored', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel._incoming.add(12345); // bytes, not string
+      await Future.delayed(Duration.zero);
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+  });
+
+  group('reconnect resets stale state', () {
+    test('pending rows clear before the new snapshot arrives', () async {
+      final auth = await _authedAuthService();
+      final channels = <_FakeChannel>[];
+      ConsentDeciderClient.testChannelFactory = (_) {
+        final ch = _FakeChannel();
+        channels.add(ch);
+        return ch;
+      };
+      ConsentDeciderClient.testBackoffOverride = (_) => Duration.zero;
+      final c = ConsentDeciderClient(workspaceId: 'ws-1', auth: auth);
+      await c.connect();
+      channels.first.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'stale',
+          'workspace_id': 'ws-1',
+          'dest_host': 'h',
+          'requested_at': 0,
+        },
+      });
+      await Future.delayed(Duration.zero);
+      expect(c.pending.any((r) => r.id == 'stale'), isTrue);
+
+      // Drop then reconnect (fresh channel). The reconnect clears pending
+      // before the new snapshot arrives.
+      channels.first.serverClose();
+      await Future.delayed(const Duration(milliseconds: 30));
+      expect(c.pending.any((r) => r.id == 'stale'), isFalse);
+      c.dispose();
+    });
+  });
+
+  group('verdicts', () {
+    test('allow sends an allow/once verdict frame', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      c.allow('r1');
+      expect(channel.sent, hasLength(1));
+      final msg = jsonDecode(channel.sent.single as String) as Map;
+      expect(msg['type'], 'verdict');
+      expect(msg['request_id'], 'r1');
+      expect(msg['decision'], 'allowed');
+      expect(msg['scope'], 'once');
+      c.dispose();
+    });
+
+    test('deny sends a deny/once verdict frame', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      c.deny('r9');
+      final msg = jsonDecode(channel.sent.single as String) as Map;
+      expect(msg['decision'], 'denied');
+      expect(msg['scope'], 'once');
+      c.dispose();
+    });
+
+    test('verdict is a no-op when not connected', () async {
+      final auth = AuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      c.allow('r1'); // never connected
+      expect(channel.sent, isEmpty);
+      c.dispose();
+    });
+  });
+
+  group('liveness ping', () {
+    test('sends ping frames at the ping interval', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(
+        channel,
+        auth: auth,
+        pingInterval: const Duration(milliseconds: 20),
+      );
+      await c.connect();
+      // Wait for >=2 ping ticks.
+      await Future.delayed(const Duration(milliseconds: 70));
+      final pings = channel.sent
+          .map((s) => jsonDecode(s as String))
+          .where((m) => m['type'] == 'ping')
+          .toList();
+      expect(pings.length, greaterThanOrEqualTo(2));
+      c.dispose();
+    });
+  });
+
+  group('reconnect', () {
+    test('reconnects with backoff after a transient drop', () async {
+      final auth = await _authedAuthService();
+      final channels = <_FakeChannel>[];
+      ConsentDeciderClient.testChannelFactory = (_) {
+        final ch = _FakeChannel();
+        channels.add(ch);
+        return ch;
+      };
+      ConsentDeciderClient.testBackoffOverride = (_) => Duration.zero;
+      final c = ConsentDeciderClient(workspaceId: 'ws-1', auth: auth);
+      await c.connect();
+      expect(channels, hasLength(1));
+      expect(c.connected, isTrue);
+      channels.first.serverClose(); // transient close (no 4001/4002)
+      await Future.delayed(const Duration(milliseconds: 30));
+      // A fresh channel was created for the reconnect and we connected again.
+      expect(channels.length, greaterThanOrEqualTo(2));
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+
+    test('does NOT reconnect after an auth-failure close', () async {
+      final auth = await _authedAuthService();
+      final channels = <_FakeChannel>[];
+      ConsentDeciderClient.testChannelFactory = (_) {
+        final ch = _FakeChannel();
+        channels.add(ch);
+        return ch;
+      };
+      ConsentDeciderClient.testBackoffOverride = (_) => Duration.zero;
+      final c = ConsentDeciderClient(workspaceId: 'ws-1', auth: auth);
+      await c.connect();
+      expect(c.authFailed, isFalse);
+      channels.first.serverClose(4001); // auth failure
+      await Future.delayed(const Duration(milliseconds: 30));
+      expect(c.authFailed, isTrue);
+      expect(c.connected, isFalse);
+      expect(channels, hasLength(1)); // no second connect attempt
+      c.dispose();
+    });
+
+    test('reconnects to a healthy server after initial connect failures',
+        () async {
+      final auth = await _authedAuthService();
+      var failsRemaining = 2;
+      ConsentDeciderClient.testChannelFactory = (_) {
+        if (failsRemaining > 0) {
+          failsRemaining--;
+          return _FakeChannel(failReady: true);
+        }
+        return _FakeChannel();
+      };
+      ConsentDeciderClient.testBackoffOverride = (_) => Duration.zero;
+      final c = ConsentDeciderClient(workspaceId: 'ws-1', auth: auth);
+      await c.connect();
+      expect(c.connected, isFalse);
+      // The failed connects reschedule via backoff; once the factory returns a
+      // healthy channel the client connects.
+      await Future.delayed(const Duration(milliseconds: 40));
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+  });
+
+  group('remaining countdown', () {
+    test('clamps at zero for an expired hold', () {
+      final auth = AuthService();
+      final c = ConsentDeciderClient(workspaceId: 'ws-1', auth: auth);
+      final req = parseConsentRequest({
+        'id': 'old',
+        'workspace_id': 'ws-1',
+        'dest_host': 'h',
+        'requested_at': 0,
+      })!;
+      expect(c.remaining(req), 0.0);
+      c.dispose();
+    });
+
+    test('is positive for a fresh hold', () {
+      final auth = AuthService();
+      final c = ConsentDeciderClient(workspaceId: 'ws-1', auth: auth);
+      final now = DateTime.now().millisecondsSinceEpoch / 1000.0;
+      final req = parseConsentRequest({
+        'id': 'fresh',
+        'workspace_id': 'ws-1',
+        'dest_host': 'h',
+        'requested_at': now,
+      })!;
+      expect(c.remaining(req), greaterThan(100.0));
+      c.dispose();
+    });
+  });
+
+  group('countdown tick', () {
+    test('fires notifyListeners while pending and self-cancels when empty',
+        () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(
+        channel,
+        auth: auth,
+        countdownInterval: const Duration(milliseconds: 20),
+      );
+      await c.connect();
+      var notifications = 0;
+      c.addListener(() => notifications++);
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'r1',
+          'workspace_id': 'ws-1',
+          'dest_host': 'h',
+          'requested_at': 0,
+        },
+      });
+      await Future.delayed(Duration.zero);
+      // The 20ms countdown tick should fire at least once while pending.
+      await Future.delayed(const Duration(milliseconds: 60));
+      expect(notifications, greaterThan(0));
+      // Clearing pending makes the next tick self-cancel.
+      channel.serverSend({'type': 'egress_resolved', 'request_id': 'r1'});
+      await Future.delayed(const Duration(milliseconds: 60));
+      c.dispose();
+    });
+  });
+
+  group('defensive send failures', () {
+    test('verdict send failure is swallowed (no throw)', () async {
+      final auth = await _authedAuthService();
+      final channel = _ThrowingSinkChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      // Must not throw.
+      c.allow('r1');
+      c.deny('r2');
+      c.dispose();
+    });
+
+    test('ping send failure is swallowed (no throw)', () async {
+      final auth = await _authedAuthService();
+      final channel = _ThrowingSinkChannel();
+      final c = _client(
+        channel,
+        auth: auth,
+        pingInterval: const Duration(milliseconds: 20),
+      );
+      await c.connect();
+      await Future.delayed(const Duration(milliseconds: 60));
+      c.dispose();
+    });
+  });
+
+  group('stream errors', () {
+    test('stream onError is handled without disconnecting', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(channel, auth: auth);
+      await c.connect();
+      channel.serverError(Exception('transient decode glitch'));
+      await Future.delayed(Duration.zero);
+      // Still connected (onError doesn't close the stream).
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+  });
+
+  group('real backoff (no override)', () {
+    test('uses the constructor reconnectDelays', () async {
+      final auth = await _authedAuthService();
+      final channels = <_FakeChannel>[];
+      ConsentDeciderClient.testChannelFactory = (_) {
+        final ch = _FakeChannel();
+        channels.add(ch);
+        return ch;
+      };
+      // No testBackoffOverride: exercises the real _backoffDelay path.
+      // reconnectDelays=[0] -> Duration.zero backoff -> fast reconnect.
+      final c = ConsentDeciderClient(
+        workspaceId: 'ws-1',
+        auth: auth,
+        reconnectDelays: const [0.0],
+      );
+      await c.connect();
+      expect(channels, hasLength(1));
+      channels.first.serverClose();
+      await Future.delayed(const Duration(milliseconds: 40));
+      expect(channels.length, greaterThanOrEqualTo(2));
+      expect(c.connected, isTrue);
+      c.dispose();
+    });
+  });
+
+  group('dispose', () {
+    test('closes the channel and stops timers', () async {
+      final auth = await _authedAuthService();
+      final channel = _FakeChannel();
+      final c = _client(
+        channel,
+        auth: auth,
+        pingInterval: const Duration(milliseconds: 20),
+      );
+      await c.connect();
+      c.dispose();
+      expect(channel._sink.closeCalled, isTrue);
+      expect(c.connected, isFalse);
+    });
+  });
+}

--- a/src/frontend/test/consent_overlay_test.dart
+++ b/src/frontend/test/consent_overlay_test.dart
@@ -1,0 +1,363 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/consent/consent_decider_client.dart';
+import 'package:klangk_frontend/consent/consent_overlay.dart';
+import 'package:klangk_frontend/consent/consent_request.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// A controllable fake client: lets tests set state directly and capture
+/// verdict calls without a real socket.
+class _FakeClient extends ConsentDeciderClient {
+  _FakeClient(AuthService auth) : super(workspaceId: 'ws-1', auth: auth);
+
+  final List<Map<String, String>> verdicts = [];
+
+  @override
+  bool connected = false;
+
+  @override
+  bool get connecting => false;
+
+  @override
+  bool get authFailed => false;
+
+  final Map<String, ConsentRequest> _pending = {};
+
+  void addRequest(ConsentRequest req) {
+    _pending[req.id] = req;
+    notifyListeners();
+  }
+
+  void clearPending() {
+    _pending.clear();
+    notifyListeners();
+  }
+
+  @override
+  List<ConsentRequest> get pending => _pending.values.toList()
+    ..sort((a, b) => a.requestedAt.compareTo(b.requestedAt));
+
+  @override
+  bool get hasPending => _pending.isNotEmpty;
+
+  @override
+  double remaining(ConsentRequest req) => 42.0;
+
+  @override
+  void allow(String requestId) =>
+      verdicts.add({'request_id': requestId, 'decision': 'allowed'});
+
+  @override
+  void deny(String requestId) =>
+      verdicts.add({'request_id': requestId, 'decision': 'denied'});
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+}
+
+/// Minimal fake WebSocketChannel for the production-path test (the widget's
+/// own client connects through this).
+class _OverlayFakeChannel extends Fake implements WebSocketChannel {
+  final _incoming = StreamController<dynamic>.broadcast();
+
+  @override
+  Stream<dynamic> get stream => _incoming.stream;
+
+  @override
+  WebSocketSink get sink => _OverlaySink();
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  Future<void> get ready => Future.value();
+}
+
+class _OverlaySink extends Fake implements WebSocketSink {
+  @override
+  void add(dynamic data) {}
+
+  @override
+  Future close([int? closeCode, String? closeReason]) async {}
+}
+
+void main() {
+  late AuthService auth;
+
+  setUp(() async {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+    auth = AuthService();
+    await Future.delayed(Duration.zero);
+    // Don't trip the real channel factory in any overlay created without an
+    // injected client.
+    ConsentDeciderClient.testChannelFactory = null;
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    ConsentDeciderClient.testChannelFactory = null;
+  });
+
+  Widget _wrap(Widget child) =>
+      MaterialApp(home: Scaffold(body: Stack(children: [child])));
+
+  testWidgets('collapsed chip shows idle egress label when connected',
+      (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    // Idle: shows "Egress: 0 held".
+    expect(find.textContaining('Egress'), findsOneWidget);
+    expect(find.byIcon(Icons.shield_outlined), findsOneWidget);
+    // Pause button present.
+    expect(
+        find.byTooltip('Pause egress filtering (unavailable)'), findsOneWidget);
+  });
+
+  testWidgets('collapsed chip shows auto-deny warning when disconnected',
+      (tester) async {
+    final client = _FakeClient(auth)..connected = false;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    expect(find.textContaining('Auto-deny'), findsOneWidget);
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+  });
+
+  testWidgets('pause button shows unavailable snackbar', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    await tester.tap(find.byTooltip('Pause egress filtering (unavailable)'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('not yet available'), findsOneWidget);
+  });
+
+  testWidgets('expands when a held request arrives', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r1',
+      workspaceId: 'ws-1',
+      destHost: 'example.com',
+      destPort: 443,
+      processName: 'curl',
+      pid: 7,
+      requestedAt: 0,
+    ));
+    await tester.pump();
+    expect(find.text('example.com:443'), findsOneWidget);
+    expect(find.text('curl'), findsOneWidget);
+    expect(find.text('Allow'), findsOneWidget);
+    expect(find.text('Deny'), findsOneWidget);
+    expect(find.textContaining('1 egress request held'), findsOneWidget);
+  });
+
+  testWidgets('collapses back when no requests are pending', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r1',
+      workspaceId: 'ws-1',
+      destHost: 'h',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 0,
+    ));
+    await tester.pump();
+    expect(find.text('Allow'), findsOneWidget);
+    client.clearPending();
+    await tester.pump();
+    expect(find.text('Allow'), findsNothing);
+    expect(find.textContaining('Egress'), findsOneWidget);
+  });
+
+  testWidgets('Allow button sends an allow verdict', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r1',
+      workspaceId: 'ws-1',
+      destHost: 'h',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 0,
+    ));
+    await tester.pump();
+    await tester.tap(find.text('Allow'));
+    expect(client.verdicts, [
+      {'request_id': 'r1', 'decision': 'allowed'},
+    ]);
+  });
+
+  testWidgets('Deny button sends a deny verdict', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r2',
+      workspaceId: 'ws-1',
+      destHost: 'h',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 0,
+    ));
+    await tester.pump();
+    await tester.tap(find.text('Deny'));
+    expect(client.verdicts, [
+      {'request_id': 'r2', 'decision': 'denied'},
+    ]);
+  });
+
+  testWidgets('renders host without port when port is null', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r1',
+      workspaceId: 'ws-1',
+      destHost: 'noport.example',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 0,
+    ));
+    await tester.pump();
+    expect(find.text('noport.example'), findsOneWidget);
+  });
+
+  testWidgets('shows countdown seconds', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r1',
+      workspaceId: 'ws-1',
+      destHost: 'h',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 0,
+    ));
+    await tester.pump();
+    // remaining() is stubbed to 42.0 -> ceil -> "42s".
+    expect(find.text('42s'), findsOneWidget);
+  });
+
+  testWidgets('pluralizes header for multiple held requests', (tester) async {
+    final client = _FakeClient(auth)..connected = true;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r1',
+      workspaceId: 'ws-1',
+      destHost: 'a',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 1,
+    ));
+    client.addRequest(ConsentRequest(
+      id: 'r2',
+      workspaceId: 'ws-1',
+      destHost: 'b',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 2,
+    ));
+    await tester.pump();
+    expect(find.textContaining('2 egress requests held'), findsOneWidget);
+  });
+
+  testWidgets('expanded panel shows disconnected warning in header',
+      (tester) async {
+    final client = _FakeClient(auth)..connected = false;
+    await tester.pumpWidget(_wrap(ConsentOverlay(
+      workspaceId: 'ws-1',
+      client: client,
+    )));
+    await tester.pump();
+    client.addRequest(ConsentRequest(
+      id: 'r1',
+      workspaceId: 'ws-1',
+      destHost: 'h',
+      destPort: null,
+      processName: null,
+      pid: null,
+      requestedAt: 0,
+    ));
+    await tester.pump();
+    expect(find.byTooltip('Disconnected — held requests auto-deny'),
+        findsOneWidget);
+  });
+
+  testWidgets('production path: creates its own client from AuthService',
+      (tester) async {
+    // A fake channel the widget's own client connects through.
+    final channel = _OverlayFakeChannel();
+    ConsentDeciderClient.testChannelFactory = (_) => channel;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider<AuthService>.value(
+          value: auth,
+          child: const Scaffold(
+            body: Stack(children: [ConsentOverlay(workspaceId: 'ws-1')]),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    // The widget connected through the fake factory and renders the
+    // collapsed idle chip.
+    expect(find.textContaining('Egress'), findsOneWidget);
+    ConsentDeciderClient.testChannelFactory = null;
+  });
+}

--- a/src/frontend/test/consent_request_test.dart
+++ b/src/frontend/test/consent_request_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/consent/consent_request.dart';
+
+void main() {
+  group('parseConsentRequest', () {
+    test('returns null for non-map input', () {
+      expect(parseConsentRequest(null), isNull);
+      expect(parseConsentRequest('nope'), isNull);
+      expect(parseConsentRequest(42), isNull);
+      expect(parseConsentRequest(<String, dynamic>{}), isNull);
+    });
+
+    test('returns null when id or workspace_id missing', () {
+      expect(parseConsentRequest({'workspace_id': 'w1'}), isNull);
+      expect(parseConsentRequest({'id': 'r1'}), isNull);
+      expect(
+        parseConsentRequest({'id': 5, 'workspace_id': 'w1'}),
+        isNull,
+      );
+    });
+
+    test('parses a full request row', () {
+      final req = parseConsentRequest({
+        'id': 'r1',
+        'workspace_id': 'w1',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'process_name': 'curl',
+        'pid': 1234,
+        'requested_at': 1000.5,
+      });
+      expect(req, isNotNull);
+      expect(req!.id, 'r1');
+      expect(req.workspaceId, 'w1');
+      expect(req.destHost, 'example.com');
+      expect(req.destPort, 443);
+      expect(req.processName, 'curl');
+      expect(req.pid, 1234);
+      expect(req.requestedAt, 1000.5);
+    });
+
+    test('handles missing optional fields', () {
+      final req = parseConsentRequest({
+        'id': 'r2',
+        'workspace_id': 'w1',
+        'dest_host': 'host',
+      });
+      expect(req, isNotNull);
+      expect(req!.destPort, isNull);
+      expect(req.processName, isNull);
+      expect(req.pid, isNull);
+      // requested_at defaults to 0 when absent/invalid.
+      expect(req.requestedAt, 0);
+    });
+
+    test('coerces numeric requested_at from int', () {
+      final req = parseConsentRequest({
+        'id': 'r3',
+        'workspace_id': 'w1',
+        'requested_at': 5,
+      });
+      expect(req!.requestedAt, 5.0);
+    });
+
+    test('coerces dest_port from double', () {
+      final req = parseConsentRequest({
+        'id': 'r4',
+        'workspace_id': 'w1',
+        'dest_port': 80.0,
+      });
+      expect(req!.destPort, 80);
+    });
+
+    test('rejects a bool pid (does not coerce to 1)', () {
+      final req = parseConsentRequest({
+        'id': 'r5',
+        'workspace_id': 'w1',
+        'pid': true,
+      });
+      expect(req!.pid, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #2333.

Adds a Flutter overlay widget on the workspace page that surfaces live
egress-consent verdicts (held egress requests awaiting allow/deny), mirroring
the TUI `consent-decide` client (#2320 / #2310). The widget is collapsed by
default (a compact chip that obscures almost nothing) and auto-expands into its
full verdict UI only when a decision is pending. It is present as an overlay
across **every** workspace-page tab, not just the terminal.

## Behavior

- **Collapsed by default** — a small bottom-corner chip showing the held-request
  count (or an idle indicator) plus a pause-state selector button.
- **Auto-expand on a pending decision** — when a held request arrives over the
  consent stream and needs a verdict, the widget expands into its full verdict
  UI (destination host:port, process, and auto-deny countdown) with Allow / Deny
  actions. Collapses back when no requests are pending.
- **Active on all tabs** — anchored in `WorkspacePage`'s body `Stack` (above
  `IdeLayout`), so it pops up whether the terminal, files, settings, sharing,
  debug, or a feature tab is foregrounded.
- **Fail-closed + liveness, same as the TUI** — pings on the consent stream to
  stay registered (must beat `consent_decider_timeout`); while disconnected it
  is deregistered so in-flight holds auto-deny on their own timeout rather than
  being silently allowed. The overlay shows a warning while disconnected.

## Protocol / data source

Connects to the existing decider WebSocket
`/ws/consent-decider?token=<JWT>&workspace=<id>` (the same endpoint and frame
protocol the TUI client uses). It is a **separate** connection from the main
`WsClient` (which speaks `/ws`), since the decider stream is its own endpoint
with its own authz + frame protocol — matching how the TUI works — but reuses
the `WsClient` patterns (JWT from `AuthService`, reconnect with backoff,
auth-failure close-code handling, test channel factory). **No backend protocol
change** for the verdict surface itself.

v1 sends `scope=once` only (no richer scope/duration selector); the server
defaults the verdict duration.

## Files

- `lib/consent/consent_request.dart` — pure model + frame parser (mirrors the
  TUI's `ConsentRequest`).
- `lib/consent/consent_decider_client.dart` — a `ChangeNotifier` WS client
  (ping, reconnect, fail-closed) speaking the decider protocol.
- `lib/consent/consent_overlay.dart` — the collapsed chip + auto-expanding
  verdict panel.
- `lib/workspace/workspace_page.dart` — mount the overlay in the page `Stack`.

## Open questions / non-goals

- **Pause state has no backend today** (the issue's "Dependencies" section).
  The collapsed chip's pause button is present (acceptance criterion) but
  signals "not yet available" via snackbar, since `egress_rules` always reports
  `paused=null` until #2332 lands. This may split into a backend prerequisite
  issue.
- Richer verdict scope/duration is a non-goal for v1 (tracked in #2328 for the
  TUI; the Flutter equivalent can follow).

## Tests

New files at **100% coverage**; full frontend suite (**891 tests**) green with
no regression.

`flutter test --coverage` passes; `flutter analyze` clean.
