### PR TITLE
feat(consent): drop the inert `scope` field from egress-consent verdicts

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -523,6 +523,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Removed
 
+- **`scope` removed from egress-consent verdicts (#2356).** The `scope`
+  field is gone from the decider WebSocket protocol, the `consent-decide` TUI,
+  and the `egress_consent` DB column + CHECK constraint. `duration` is now the
+  sole axis for how long a verdict holds (default unchanged: `restart`; `once`
+  is a one-connection duration). Operators with an existing DB keep a dead
+  `scope` column (harmless, unreferenced); no migration action.
+
 - **`POST /internal/egress-consent/events` (#2318).** The sidecar's
   fire-and-forget consent-event endpoint is gone, superseded by the
   synchronous `/ws/egress-sidecar` hold path (#2311): recording now happens

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -43,11 +43,10 @@ from ..transport import ws_connect
 
 logger = logging.getLogger(__name__)
 
-# Decision/scope values mirror the server (model/egress_consent.py); the CLI
+# Decision values mirror the server (model/egress_consent.py); the CLI
 # is isolated from the server package, so they are duplicated here (#2309 rule).
 DECISION_ALLOWED = "allowed"
 DECISION_DENIED = "denied"
-SCOPE_ONCE = "once"
 # Duration tokens mirror the server (model/egress_consent.py); duplicated here
 # per CLI isolation. Ordered for the TUI selector; default is `restart` (#2328).
 DURATION_ONCE = "once"
@@ -188,7 +187,6 @@ def make_verdict(
             "type": "verdict",
             "request_id": request_id,
             "decision": decision,
-            "scope": SCOPE_ONCE,
             "duration": duration,
         }
     )

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -166,7 +166,6 @@ class ConsentCoordinator:
         self,
         request_id: str,
         decision: str,
-        scope: str | None,
         decided_by: str,
         duration: str = DURATION_DEFAULT,
         *,
@@ -196,7 +195,7 @@ class ConsentCoordinator:
         hold["task"].cancel()
         try:
             row = await self.app.state.model.egress_consent.decide(
-                request_id, decision, scope, decided_by, duration
+                request_id, decision, decided_by, duration
             )
         except Exception:
             # decide() failed (DB error). The hold's own timeout is already

--- a/src/klangk/klangk/model/__init__.py
+++ b/src/klangk/klangk/model/__init__.py
@@ -84,10 +84,6 @@ from .egress_consent import (
     DECISION_EXPIRED,
     DECISION_PENDING,
     DECISIONS,
-    SCOPE_DEPLOY,
-    SCOPE_ONCE,
-    SCOPE_WORKSPACE,
-    SCOPES,
 )
 from .invitations import ADMIN_INVITATION_SORT_COLUMNS
 
@@ -147,16 +143,12 @@ __all__ = (
     "MSG_SYSTEM",
     "MSG_USER",
     "MENTION_RE",
-    # egress consent — decision/scope constants
+    # egress consent — decision constants
     "DECISION_ALLOWED",
     "DECISION_DENIED",
     "DECISION_EXPIRED",
     "DECISION_PENDING",
     "DECISIONS",
-    "SCOPE_DEPLOY",
-    "SCOPE_ONCE",
-    "SCOPE_WORKSPACE",
-    "SCOPES",
     # invitations — sort columns
     "ADMIN_INVITATION_SORT_COLUMNS",
 )

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -26,14 +26,6 @@ DECISIONS = frozenset(
     }
 )
 
-# Scope values for an allow/deny decision.
-SCOPE_ONCE = (
-    "once"  # container lifetime only, not persisted to allowed_domains
-)
-SCOPE_WORKSPACE = "workspace"  # persisted to workspace's allowed_domains
-SCOPE_DEPLOY = "deploy"  # promoted to deploy-wide default
-SCOPES = frozenset({SCOPE_ONCE, SCOPE_WORKSPACE, SCOPE_DEPLOY})
-
 # Duration values for an allow/deny decision (#2328): how long the sidecar
 # honors it (allow learns the IP for T; deny REJECTs for T). `once` = this
 # connection only; `restart` = the workspace container's lifetime (the sidecar's
@@ -65,7 +57,7 @@ DURATION_DEFAULT = DURATION_RESTART
 # drift from the schema (a column added to the table is added here once).
 _EC_COLUMNS = (
     "id, workspace_id, dest_host, dest_port, pid, process_name,"
-    " decision, scope, duration, requested_at, decided_at, decided_by,"
+    " decision, duration, requested_at, decided_at, decided_by,"
     " revoked_at, revoked_by"
 )
 
@@ -123,7 +115,6 @@ class EgressConsentModel:
             "pid": pid,
             "process_name": process_name,
             "decision": DECISION_PENDING,
-            "scope": None,
             "requested_at": requested_at,
             "decided_at": None,
             "decided_by": None,
@@ -174,7 +165,6 @@ class EgressConsentModel:
             "pid": None,
             "process_name": None,
             "decision": DECISION_DENIED,
-            "scope": None,
             "requested_at": now,
             "decided_at": now,
             "decided_by": None,
@@ -330,7 +320,6 @@ class EgressConsentModel:
         self,
         request_id: str,
         decision: str,
-        scope: str | None,
         decided_by: str,
         duration: str = DURATION_DEFAULT,
     ) -> dict | None:
@@ -338,27 +327,24 @@ class EgressConsentModel:
 
         Returns the updated row dict, or ``None`` if the request doesn't
         exist or is no longer pending. Raises ``ValueError`` for invalid
-        decision/scope/duration values.
+        decision/duration values.
         """
         if decision not in (DECISION_ALLOWED, DECISION_DENIED):
             raise ValueError(
                 f"Invalid decision: {decision!r}"
                 f" (must be {DECISION_ALLOWED!r} or {DECISION_DENIED!r})"
             )
-        if scope is not None and scope not in SCOPES:
-            raise ValueError(f"Invalid scope: {scope!r}")
         if duration not in DURATIONS:
             raise ValueError(f"Invalid duration: {duration!r}")
         decided_at = time.time()
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
                 "UPDATE egress_consent"
-                " SET decision = ?, scope = ?, duration = ?,"
+                " SET decision = ?, duration = ?,"
                 " decided_at = ?, decided_by = ?"
                 " WHERE id = ? AND decision = ?",
                 (
                     decision,
-                    scope,
                     duration,
                     decided_at,
                     decided_by,
@@ -507,7 +493,6 @@ def _row_to_dict(row) -> dict:
         "pid": row["pid"],
         "process_name": row["process_name"],
         "decision": row["decision"],
-        "scope": row["scope"],
         "duration": row["duration"],
         "requested_at": row["requested_at"],
         "decided_at": row["decided_at"],

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -344,7 +344,7 @@ async def init_db(db) -> None:
         """)
         # Interactive egress consent (#2239). Tracks blocked outbound
         # connections that need human approval. CHECK constraints enforce
-        # the decision/scope state machine at the storage layer — the same
+        # the decision state machine at the storage layer — the same
         # DB-backstop philosophy as the agent-user triggers above.
         await db.execute(f"""
             CREATE TABLE IF NOT EXISTS egress_consent (
@@ -356,8 +356,6 @@ async def init_db(db) -> None:
                 process_name TEXT,
                 decision TEXT NOT NULL DEFAULT 'pending'
                     CHECK (decision IN ({_DECISION_CHECK_VALUES})),
-                scope TEXT
-                    CHECK (scope IS NULL OR scope IN ('once', 'workspace', 'deploy')),
                 duration TEXT
                     CHECK (duration IS NULL OR duration IN
                         ({_DURATION_CHECK_VALUES})),
@@ -391,8 +389,6 @@ async def init_db(db) -> None:
                     process_name TEXT,
                     decision TEXT NOT NULL DEFAULT 'pending'
                         CHECK (decision IN ({_DECISION_CHECK_VALUES})),
-                    scope TEXT
-                        CHECK (scope IS NULL OR scope IN ('once', 'workspace', 'deploy')),
                     duration TEXT
                         CHECK (duration IS NULL OR duration IN
                             ({_DURATION_CHECK_VALUES})),
@@ -415,7 +411,6 @@ async def init_db(db) -> None:
                     "pid",
                     "process_name",
                     "decision",
-                    "scope",
                     "duration",
                     "requested_at",
                     "decided_at",

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -47,7 +47,6 @@ from ..model.egress_consent import (
     DECISION_DENIED,
     DURATIONS,
     DURATION_DEFAULT,
-    SCOPES,
 )
 
 logger = logging.getLogger(__name__)
@@ -173,12 +172,6 @@ async def _handle_verdict(app, safe_ws, msg, workspace, user_id) -> None:
             {"type": "error", "message": f"invalid decision: {decision!r}"}
         )
         return
-    scope = msg.get("scope")
-    if scope is not None and scope not in SCOPES:
-        safe_ws.send_json(
-            {"type": "error", "message": f"invalid scope: {scope!r}"}
-        )
-        return
     duration = msg.get("duration") or DURATION_DEFAULT
     if duration not in DURATIONS:
         safe_ws.send_json(
@@ -194,7 +187,6 @@ async def _handle_verdict(app, safe_ws, msg, workspace, user_id) -> None:
     await app.state.consent_coordinator.resolve(
         request_id,
         decision,
-        scope,
         # decided_by is the stable user id (egress_consent.decided_by REFERENCES
         # users(id); the email is volatile + not a key). Never NULL for a human
         # decision -- NULL means "no human" (the static/expired case).

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -115,7 +115,6 @@ def _rule(
         "pid": None,
         "process_name": process,
         "decision": decision,
-        "scope": "once",
         "duration": duration,
         "requested_at": 90.0,
         "decided_at": decided_at,
@@ -356,7 +355,6 @@ class TestFrameBuilders:
             "type": "verdict",
             "request_id": "r1",
             "decision": "allowed",
-            "scope": "once",
             "duration": "restart",
         }
 

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -294,7 +294,7 @@ class TestConsentCoordinatorFanout:
         coord = ConsentCoordinator(app)
         await coord.hold(FULL_WS, "1.2.3.4", 443)
         app.state.consent_deciders.broadcast.reset_mock()
-        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        await coord.resolve("rid-1", "allowed", "a@x")
         # the egress_resolved frame is among the broadcasts (resolve also pushes
         # a refreshed egress_rules frame, #2335 slice A)
         frames = [
@@ -325,7 +325,7 @@ class TestConsentCoordinatorFanout:
         coord = ConsentCoordinator(app)
         await coord.hold(FULL_WS, "1.2.3.4", 443)
         app.state.consent_deciders.broadcast.reset_mock()
-        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        await coord.resolve("rid-1", "allowed", "a@x")
         app.state.model.egress_consent.list_active.assert_awaited_once_with(
             FULL_WS
         )
@@ -350,7 +350,7 @@ class TestConsentCoordinatorFanout:
         coord = ConsentCoordinator(app)
         await coord.hold(FULL_WS, "1.2.3.4", 443)
         verdict = await coord.resolve(
-            "rid-1", "allowed", "once", "a@x", decider_workspace="other-ws"
+            "rid-1", "allowed", "a@x", decider_workspace="other-ws"
         )
         assert verdict is None
         assert "rid-1" in coord._holds  # hold untouched
@@ -378,7 +378,7 @@ class TestConsentCoordinatorFanout:
             side_effect=RuntimeError("db gone")
         )
         # must not raise -- the verdict path is unaffected by the refresh
-        verdict = await coord.resolve("rid-1", "allowed", "once", "a@x")
+        verdict = await coord.resolve("rid-1", "allowed", "a@x")
         assert verdict["decision"] == "allow"
 
     async def test_snapshot_replays_pending_requests(self):
@@ -475,9 +475,7 @@ class TestConsentCoordinatorResolve:
         app = _app(request=_request(), decide_row=row)
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
-        verdict = await coord.resolve(
-            "rid-1", "allowed", "workspace", "a@x", duration="1d"
-        )
+        verdict = await coord.resolve("rid-1", "allowed", "a@x", duration="1d")
         assert verdict == {
             "decision": "allow",
             "reason": "decided",
@@ -489,7 +487,7 @@ class TestConsentCoordinatorResolve:
             "duration": "1d",
         }
         app.state.model.egress_consent.decide.assert_awaited_once_with(
-            "rid-1", "allowed", "workspace", "a@x", "1d"
+            "rid-1", "allowed", "a@x", "1d"
         )
         assert coord._holds == {}
 
@@ -499,9 +497,7 @@ class TestConsentCoordinatorResolve:
         app = _app(request=_request(), decide_row=row)
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
-        verdict = await coord.resolve(
-            "rid-1", "denied", "once", "a@x", duration="15m"
-        )
+        verdict = await coord.resolve("rid-1", "denied", "a@x", duration="15m")
         assert verdict == {
             "decision": "deny",
             "reason": "decided",
@@ -512,7 +508,7 @@ class TestConsentCoordinatorResolve:
     async def test_resolve_unknown_returns_none(self):
         app = _app(request=_request())
         coord = ConsentCoordinator(app)
-        assert await coord.resolve("nope", "allowed", "once", "a@x") is None
+        assert await coord.resolve("nope", "allowed", "a@x") is None
 
     async def test_resolve_after_decide_returns_none_fail_closes(self):
         # decide() returns None (row no longer pending -- concurrent expiry):
@@ -520,7 +516,7 @@ class TestConsentCoordinatorResolve:
         app = _app(request=_request(), decide_row=None)
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
-        verdict = await coord.resolve("rid-1", "allowed", "once", "a@x")
+        verdict = await coord.resolve("rid-1", "allowed", "a@x")
         assert verdict == {"decision": "deny", "reason": "gone"}
         assert fut.result()["decision"] == "deny"
 
@@ -528,7 +524,7 @@ class TestConsentCoordinatorResolve:
         app = _app(timeout=0.05, request=_request(), decide_row=_request())
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
-        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        await coord.resolve("rid-1", "allowed", "a@x")
         await asyncio.sleep(0.12)  # past the would-be timeout
         # timeout cancelled -> the row was NOT expired
         app.state.model.egress_consent.expire_pending.assert_not_awaited()
@@ -544,7 +540,7 @@ class TestConsentCoordinatorResolve:
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
         app.state.consent_deciders.broadcast.reset_mock()
-        verdict = await coord.resolve("rid-1", "allowed", "once", "a@x")
+        verdict = await coord.resolve("rid-1", "allowed", "a@x")
         assert verdict == {"decision": "deny", "reason": "error"}
         assert fut.done() and fut.result()["decision"] == "deny"
         ws_arg, frame = app.state.consent_deciders.broadcast.call_args.args
@@ -561,8 +557,8 @@ class TestConsentCoordinatorResolve:
         coord = ConsentCoordinator(app)
         await coord.hold(FULL_WS, "1.2.3.4", 443)
         v1, v2 = await asyncio.gather(
-            coord.resolve("rid-1", "allowed", "once", "a@x"),
-            coord.resolve("rid-1", "denied", "once", "b@x"),
+            coord.resolve("rid-1", "allowed", "a@x"),
+            coord.resolve("rid-1", "denied", "b@x"),
         )
         winners = [v for v in (v1, v2) if v is not None]
         assert len(winners) == 1  # exactly one winner
@@ -592,7 +588,7 @@ class TestConsentCoordinatorTimeout:
         app = _app(timeout=0.05, request=_request(), decide_row=_request())
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
-        await coord.resolve("rid-1", "allowed", "once", "a@x")
+        await coord.resolve("rid-1", "allowed", "a@x")
         await asyncio.sleep(0.12)
         app.state.model.egress_consent.expire_pending.assert_not_awaited()
         assert fut.result()["decision"] == "allow"

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -372,7 +372,6 @@ class TestConsentDeciderWS:
                         "type": "verdict",
                         "request_id": "rid",
                         "decision": "allowed",
-                        "scope": "once",
                         "duration": "1w",
                     }
                 ),
@@ -381,7 +380,7 @@ class TestConsentDeciderWS:
         )
         await handle_consent_decider(ws, app)
         app.state.consent_coordinator.resolve.assert_awaited_once_with(
-            "rid", "allowed", "once", "u1", duration="1w", decider_workspace=WS
+            "rid", "allowed", "u1", duration="1w", decider_workspace=WS
         )
 
     async def test_revoke_frame_calls_coordinator_and_acks(self):
@@ -424,30 +423,6 @@ class TestConsentDeciderWS:
                         "type": "verdict",
                         "request_id": "rid",
                         "decision": "maybe",
-                    }
-                ),
-                WebSocketDisconnect(),
-            ],
-        )
-        await handle_consent_decider(ws, app)
-        app.state.consent_coordinator.resolve.assert_not_awaited()
-        assert any(json.loads(m).get("type") == "error" for m in ws.sent)
-
-    async def test_verdict_invalid_scope_sends_error(self):
-        from fastapi import WebSocketDisconnect
-
-        from klangk.wshandler.decider import handle_consent_decider
-
-        app = _ws_app({"id": "u1", "email": "a@x"})
-        ws = _FakeWS(
-            {"token": "tok", "workspace": WS},
-            [
-                json.dumps(
-                    {
-                        "type": "verdict",
-                        "request_id": "rid",
-                        "decision": "denied",
-                        "scope": "bogus",
                     }
                 ),
                 WebSocketDisconnect(),

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -2058,7 +2058,7 @@ class TestStartContainer:
         # with the previous container, so list_active must not report them.
         ec = self.registry.app.state.model.egress_consent
         a = await ec.create_request(workspace["id"], "stale.com", 443)
-        await ec.decide(a["id"], "allowed", "once", user["id"], "restart")
+        await ec.decide(a["id"], "allowed", user["id"], "restart")
         # sanity: in effect before the start
         assert {
             r["dest_host"] for r in await ec.list_active(workspace["id"])
@@ -2076,7 +2076,7 @@ class TestStartContainer:
         # container didn't restart, so its in-memory rules are still alive.
         ec = self.registry.app.state.model.egress_consent
         a = await ec.create_request(workspace["id"], "live.com", 443)
-        await ec.decide(a["id"], "allowed", "once", user["id"], "restart")
+        await ec.decide(a["id"], "allowed", user["id"], "restart")
         with patch_podman(self.registry, inspect_container=_running(True)):
             cid, status = await self.registry.start_container(
                 workspace["id"],

--- a/src/klangk/klangkd-tests/tests/test_model.py
+++ b/src/klangk/klangkd-tests/tests/test_model.py
@@ -263,7 +263,8 @@ class TestMigration:
         self, temp_data_dir, app_state
     ):
         """init_db adds the duration column to egress_consent tables that
-        predate #2328 (NULL until a decider records a decision)."""
+        predate #2328 (NULL until a decider records a decision), and drops the
+        legacy `scope` column (#2356)."""
         db_path = get_test_db().db_path
         db_path.parent.mkdir(parents=True, exist_ok=True)
         db = await aiosqlite.connect(str(db_path))
@@ -294,6 +295,8 @@ class TestMigration:
             cursor = await conn.execute("PRAGMA table_info(egress_consent)")
             cols = {row[1] for row in await cursor.fetchall()}
             assert "duration" in cols
+            # The rebuild drops the legacy `scope` column (#2356).
+            assert "scope" not in cols
 
     async def test_migrate_workspaces_adds_settings(
         self, temp_data_dir, app_state

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -12,8 +12,6 @@ from klangk.model.egress_consent import (
     DECISION_PENDING,
     DECISION_REVOKED,
     DURATIONS,
-    SCOPE_ONCE,
-    SCOPE_WORKSPACE,
 )
 from klangk.model.workspaces import (
     EGRESS_MODE_DEFAULT,
@@ -175,7 +173,7 @@ async def test_create_request_after_decision_allows_new_pending(ec, ws, user):
     """After a request is decided, a new pending for the same dest is allowed."""
     w = await ws.create_workspace(user["id"], "re-request")
     req = await ec.create_request(w["id"], "a.com", 443)
-    await ec.decide(req["id"], DECISION_DENIED, None, user["id"])
+    await ec.decide(req["id"], DECISION_DENIED, user["id"])
     # The old one is no longer pending, so a new one should succeed
     new = await ec.create_request(w["id"], "a.com", 443)
     assert new is not None
@@ -207,7 +205,7 @@ async def test_list_requests(ec, ws, user):
 async def test_list_requests_filtered(ec, ws, user):
     w = await ws.create_workspace(user["id"], "filter-ws")
     req = await ec.create_request(w["id"], "a.com", 443)
-    await ec.decide(req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"])
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"])
     await ec.create_request(w["id"], "b.com", 80)
 
     pending = await ec.list_requests(w["id"], decision=DECISION_PENDING)
@@ -245,11 +243,8 @@ async def test_has_pending_no_port(ec, ws, user):
 async def test_decide_allow(ec, ws, user):
     w = await ws.create_workspace(user["id"], "decide-ws")
     req = await ec.create_request(w["id"], "api.com", 443)
-    result = await ec.decide(
-        req["id"], DECISION_ALLOWED, SCOPE_WORKSPACE, user["id"]
-    )
+    result = await ec.decide(req["id"], DECISION_ALLOWED, user["id"])
     assert result["decision"] == DECISION_ALLOWED
-    assert result["scope"] == SCOPE_WORKSPACE
     assert result["decided_by"] == user["id"]
     assert result["decided_at"] is not None
 
@@ -257,7 +252,7 @@ async def test_decide_allow(ec, ws, user):
 async def test_decide_deny(ec, ws, user):
     w = await ws.create_workspace(user["id"], "deny-ws")
     req = await ec.create_request(w["id"], "bad.com", 443)
-    result = await ec.decide(req["id"], DECISION_DENIED, None, user["id"])
+    result = await ec.decide(req["id"], DECISION_DENIED, user["id"])
     assert result["decision"] == DECISION_DENIED
 
 
@@ -265,13 +260,13 @@ async def test_decide_invalid_decision_raises(ec, ws, user):
     w = await ws.create_workspace(user["id"], "bad-decision")
     req = await ec.create_request(w["id"], "a.com", 443)
     with pytest.raises(ValueError, match="Invalid decision"):
-        await ec.decide(req["id"], "bogus", SCOPE_ONCE, user["id"])
+        await ec.decide(req["id"], "bogus", user["id"])
 
 
 async def test_decide_records_duration(ec, ws, user):
     w = await ws.create_workspace(user["id"], "dur-ws")
     req = await ec.create_request(w["id"], "a.com", 443)
-    await ec.decide(req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "1d")
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "1d")
     row = await ec.app.state.db.fetchone(
         "SELECT duration FROM egress_consent WHERE id = ?", (req["id"],)
     )
@@ -281,7 +276,7 @@ async def test_decide_records_duration(ec, ws, user):
 async def test_decide_default_duration_is_restart(ec, ws, user):
     w = await ws.create_workspace(user["id"], "dur-default")
     req = await ec.create_request(w["id"], "a.com", 443)
-    await ec.decide(req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"])
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"])
     row = await ec.app.state.db.fetchone(
         "SELECT duration FROM egress_consent WHERE id = ?", (req["id"],)
     )
@@ -292,9 +287,7 @@ async def test_decide_invalid_duration_raises(ec, ws, user):
     w = await ws.create_workspace(user["id"], "bad-dur")
     req = await ec.create_request(w["id"], "a.com", 443)
     with pytest.raises(ValueError, match="Invalid duration"):
-        await ec.decide(
-            req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "2d"
-        )
+        await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "2d")
 
 
 async def test_decide_pending_not_allowed_as_decision(ec, ws, user):
@@ -302,7 +295,7 @@ async def test_decide_pending_not_allowed_as_decision(ec, ws, user):
     w = await ws.create_workspace(user["id"], "pend-decide")
     req = await ec.create_request(w["id"], "a.com", 443)
     with pytest.raises(ValueError, match="Invalid decision"):
-        await ec.decide(req["id"], DECISION_PENDING, None, user["id"])
+        await ec.decide(req["id"], DECISION_PENDING, user["id"])
 
 
 async def test_decide_expired_not_allowed_as_decision(ec, ws, user):
@@ -310,29 +303,20 @@ async def test_decide_expired_not_allowed_as_decision(ec, ws, user):
     w = await ws.create_workspace(user["id"], "exp-decide")
     req = await ec.create_request(w["id"], "a.com", 443)
     with pytest.raises(ValueError, match="Invalid decision"):
-        await ec.decide(req["id"], DECISION_EXPIRED, None, user["id"])
-
-
-async def test_decide_invalid_scope_raises(ec, ws, user):
-    w = await ws.create_workspace(user["id"], "bad-scope")
-    req = await ec.create_request(w["id"], "a.com", 443)
-    with pytest.raises(ValueError, match="Invalid scope"):
-        await ec.decide(req["id"], DECISION_ALLOWED, "nonsense", user["id"])
+        await ec.decide(req["id"], DECISION_EXPIRED, user["id"])
 
 
 async def test_decide_already_decided(ec, ws, user):
     w = await ws.create_workspace(user["id"], "double-ws")
     req = await ec.create_request(w["id"], "api.com", 443)
-    await ec.decide(req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"])
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"])
     # Second decide on same request returns None (no longer pending)
-    result = await ec.decide(req["id"], DECISION_DENIED, None, user["id"])
+    result = await ec.decide(req["id"], DECISION_DENIED, user["id"])
     assert result is None
 
 
 async def test_decide_missing(ec, user):
-    result = await ec.decide(
-        "no-such-id", DECISION_ALLOWED, SCOPE_ONCE, user["id"]
-    )
+    result = await ec.decide("no-such-id", DECISION_ALLOWED, user["id"])
     assert result is None
 
 
@@ -360,7 +344,7 @@ async def test_expire_all_pending_reaps_only_pending(ec, ws, user):
     p1 = await ec.create_request(w1["id"], "a.com", 443)
     p2 = await ec.create_request(w2["id"], "b.com", 80)
     decided = await ec.create_request(w1["id"], "c.com", 443)
-    await ec.decide(decided["id"], DECISION_DENIED, SCOPE_ONCE, user["id"])
+    await ec.decide(decided["id"], DECISION_DENIED, user["id"])
     assert await ec.expire_all_pending() == 2
     assert (await ec.get_request(p1["id"]))["decision"] == DECISION_EXPIRED
     assert (await ec.get_request(p2["id"]))["decision"] == DECISION_EXPIRED
@@ -373,7 +357,7 @@ async def test_expire_distinct_from_deny(ec, ws, user):
     r1 = await ec.create_request(w["id"], "a.com", 443)
     r2 = await ec.create_request(w["id"], "b.com", 80)
     await ec.expire_pending(r1["id"])
-    await ec.decide(r2["id"], DECISION_DENIED, None, user["id"])
+    await ec.decide(r2["id"], DECISION_DENIED, user["id"])
 
     g1 = await ec.get_request(r1["id"])
     g2 = await ec.get_request(r2["id"])
@@ -386,7 +370,7 @@ async def test_expire_distinct_from_deny(ec, ws, user):
 async def test_expire_already_decided(ec, ws, user):
     w = await ws.create_workspace(user["id"], "expire2-ws")
     req = await ec.create_request(w["id"], "fast.com", 443)
-    await ec.decide(req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"])
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"])
     assert not await ec.expire_pending(req["id"])
 
 
@@ -412,11 +396,9 @@ async def test_cascade_delete_on_workspace_delete(ec, ws, user):
 async def test_list_active_groups_allowed_and_denied(ec, ws, user):
     w = await ws.create_workspace(user["id"], "active-grp")
     a = await ec.create_request(w["id"], "allow.com", 443)
-    await ec.decide(
-        a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "restart")
     d = await ec.create_request(w["id"], "deny.com", 443)
-    await ec.decide(d["id"], DECISION_DENIED, None, user["id"], "forever")
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], "forever")
     rows = await ec.list_active(w["id"])
     decisions = {r["dest_host"]: r["decision"] for r in rows}
     assert decisions == {
@@ -433,7 +415,7 @@ async def test_list_active_excludes_once(ec, ws, user):
     # `once` is consumed by the single connection — never in effect.
     w = await ws.create_workspace(user["id"], "active-once")
     a = await ec.create_request(w["id"], "once.com")
-    await ec.decide(a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "once")
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "once")
     assert await ec.list_active(w["id"]) == []
 
 
@@ -442,13 +424,9 @@ async def test_list_active_time_bounded_within_and_past_window(
 ):
     w = await ws.create_workspace(user["id"], "active-timed")
     fresh = await ec.create_request(w["id"], "fresh.com")
-    await ec.decide(
-        fresh["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "5m"
-    )
+    await ec.decide(fresh["id"], DECISION_ALLOWED, user["id"], "5m")
     stale = await ec.create_request(w["id"], "stale.com")
-    await ec.decide(
-        stale["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "5m"
-    )
+    await ec.decide(stale["id"], DECISION_ALLOWED, user["id"], "5m")
     # Backdate the stale row past its 5m window.
     async with app_state.state.db.transaction() as conn:
         await conn.execute(
@@ -502,11 +480,9 @@ async def test_clear_restart_duration_clears_allow_and_deny(ec, ws, user):
     # A restart allow AND a restart deny both die with the container.
     w = await ws.create_workspace(user["id"], "clr-rst")
     a = await ec.create_request(w["id"], "allow.com", 443)
-    await ec.decide(
-        a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "restart")
     d = await ec.create_request(w["id"], "deny.com", 443)
-    await ec.decide(d["id"], DECISION_DENIED, None, user["id"], "restart")
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], "restart")
     count = await ec.clear_restart_duration(w["id"])
     assert count == 2
     # Neither survives in list_active (the rule-management view).
@@ -518,22 +494,16 @@ async def test_clear_restart_duration_leaves_other_durations(ec, ws, user):
     # not the container's -- left untouched.
     w = await ws.create_workspace(user["id"], "clr-keep")
     fa = await ec.create_request(w["id"], "forever-allow.com")
-    await ec.decide(
-        fa["id"], DECISION_ALLOWED, SCOPE_WORKSPACE, user["id"], "forever"
-    )
+    await ec.decide(fa["id"], DECISION_ALLOWED, user["id"], "forever")
     fd = await ec.create_request(w["id"], "forever-deny.com")
-    await ec.decide(fd["id"], DECISION_DENIED, None, user["id"], "forever")
+    await ec.decide(fd["id"], DECISION_DENIED, user["id"], "forever")
     tb = await ec.create_request(w["id"], "timed.com")
-    await ec.decide(tb["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "5m")
+    await ec.decide(tb["id"], DECISION_ALLOWED, user["id"], "5m")
     once = await ec.create_request(w["id"], "once.com")
-    await ec.decide(
-        once["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "once"
-    )
+    await ec.decide(once["id"], DECISION_ALLOWED, user["id"], "once")
     # one restart row to clear, to confirm only it is reaped.
     ra = await ec.create_request(w["id"], "restart.com")
-    await ec.decide(
-        ra["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(ra["id"], DECISION_ALLOWED, user["id"], "restart")
 
     count = await ec.clear_restart_duration(w["id"])
     assert count == 1
@@ -559,13 +529,9 @@ async def test_clear_restart_duration_is_scoped_to_workspace(ec, ws, user):
     w1 = await ws.create_workspace(user["id"], "clr-a")
     w2 = await ws.create_workspace(user["id"], "clr-b")
     a = await ec.create_request(w1["id"], "a.com", 443)
-    await ec.decide(
-        a["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "restart")
     b = await ec.create_request(w2["id"], "b.com", 443)
-    await ec.decide(
-        b["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(b["id"], DECISION_ALLOWED, user["id"], "restart")
     count = await ec.clear_restart_duration(w1["id"])
     assert count == 1
     # w2's restart row survives.
@@ -587,9 +553,7 @@ async def test_clear_restart_duration_no_rows_is_zero(ec, ws, user):
 async def test_revoke_flips_active_allow(ec, ws, user):
     w = await ws.create_workspace(user["id"], "revoke-allow")
     req = await ec.create_request(w["id"], "allow.com", 443)
-    await ec.decide(
-        req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "restart")
     row = await ec.revoke(req["id"], user["id"])
     assert row["decision"] == DECISION_REVOKED
     assert row["revoked_at"] is not None
@@ -602,7 +566,7 @@ async def test_revoke_flips_active_allow(ec, ws, user):
 async def test_revoke_flips_active_deny(ec, ws, user):
     w = await ws.create_workspace(user["id"], "revoke-deny")
     req = await ec.create_request(w["id"], "deny.com")
-    await ec.decide(req["id"], DECISION_DENIED, None, user["id"], "forever")
+    await ec.decide(req["id"], DECISION_DENIED, user["id"], "forever")
     assert (await ec.revoke(req["id"], user["id"]))[
         "decision"
     ] == DECISION_REVOKED
@@ -626,9 +590,7 @@ async def test_revoke_unknown_returns_none(ec, ws, user):
 async def test_revoke_idempotent_second_call_returns_none(ec, ws, user):
     w = await ws.create_workspace(user["id"], "revoke-idem")
     req = await ec.create_request(w["id"], "idem.com")
-    await ec.decide(
-        req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "restart")
     assert await ec.revoke(req["id"], user["id"]) is not None
     assert await ec.revoke(req["id"], user["id"]) is None  # already revoked
 
@@ -636,9 +598,7 @@ async def test_revoke_idempotent_second_call_returns_none(ec, ws, user):
 async def test_list_active_excludes_revoked(ec, ws, user):
     w = await ws.create_workspace(user["id"], "revoke-excluded")
     req = await ec.create_request(w["id"], "rev.com")
-    await ec.decide(
-        req["id"], DECISION_ALLOWED, SCOPE_ONCE, user["id"], "restart"
-    )
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "restart")
     assert len(await ec.list_active(w["id"])) == 1
     await ec.revoke(req["id"], user["id"])
     assert await ec.list_active(w["id"]) == []
@@ -648,7 +608,7 @@ async def test_list_active_excludes_revoked(ec, ws, user):
 #
 # The CHECK constraints + partial unique index are the structural backstop:
 # a code path that bypasses EgressConsentModel (raw SQL) still can't land a
-# bad decision/scope or a duplicate pending prompt. These prove the
+# bad decision or a duplicate pending prompt. These prove the
 # constraints are enforced at the storage layer, independent of decide()'s
 # Python validation (#2251). They mirror the idiom in
 # test_main.test_users_handle_has_unique_constraint.
@@ -686,37 +646,6 @@ async def test_db_check_rejects_invalid_decision_on_update(
                 ("r2",),
             )
     assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
-
-
-async def test_db_check_rejects_invalid_scope(ws, user, db, app_state):
-    w = await ws.create_workspace(user["id"], "chk-scope-ws")
-    async with app_state.state.db.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO egress_consent"
-            " (id, workspace_id, dest_host, requested_at)"
-            " VALUES (?, ?, ?, ?)",
-            ("r3", w["id"], "a.com", 0.0),
-        )
-        with pytest.raises(SAIntegrityError) as exc_info:
-            await conn.execute(
-                "UPDATE egress_consent SET scope = 'nonsense' WHERE id = ?",
-                ("r3",),
-            )
-    assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
-
-
-async def test_db_check_accepts_null_and_legal_scopes(ws, user, db, app_state):
-    """scope NULL (the default) + each legal value pass the CHECK."""
-    w = await ws.create_workspace(user["id"], "chk-scope-ok")
-    legal = [None, "once", "workspace", "deploy"]
-    async with app_state.state.db.transaction() as conn:
-        for i, scope in enumerate(legal):
-            await conn.execute(
-                "INSERT INTO egress_consent"
-                " (id, workspace_id, dest_host, scope, requested_at)"
-                " VALUES (?, ?, ?, ?, ?)",
-                (f"ok-{i}", w["id"], f"h{i}.com", scope, 0.0),
-            )
 
 
 async def test_db_check_accepts_null_and_legal_durations(
@@ -800,7 +729,7 @@ async def test_init_db_rebuilds_egress_consent_to_add_duration_check(
             "CREATE TABLE egress_consent ("
             " id TEXT PRIMARY KEY, workspace_id TEXT, dest_host TEXT,"
             " dest_port INTEGER, pid INTEGER, process_name TEXT,"
-            " decision TEXT, scope TEXT, duration TEXT,"
+            " decision TEXT, duration TEXT,"
             " requested_at REAL, decided_at REAL, decided_by TEXT)"
         )
         await conn.execute(


### PR DESCRIPTION
## Summary

Closes #2356.

Drops the inert `scope` field (`once` | `workspace` | `deploy`) from
egress-consent verdicts entirely. `duration` is now the sole axis for how long
a verdict holds; the default stays `restart`. No migration (single deployment).

## Why

`scope` did nothing:

- Only `scope=once` was ever sent (TUI and Flutter both hardcode it); no client
  ever emitted `workspace` or `deploy`.
- It never reached the sidecar — `consent_coordinator.resolve()` returns a
  verdict of `{decision, reason, duration}` to the enforcer.
- The `scope=workspace` ("persist to `allowed_domains`") and `scope=deploy`
  ("promote deploy-wide") behaviors described in the comments were **never
  implemented**.
- It overlapped with `duration` (`scope=workspace` ≈ `duration=forever`), and
  its only non-`once` behaviors would bleed interactive decisions into the
  operator-managed `allowed_domains` — exactly the non-overlap we want.

See the analysis folded into #2356.

## Changes

- **`model/egress_consent.py`** — removed `SCOPE_*` / `SCOPES`, the `scope`
  param of `decide()`, the `scope` column from `_EC_COLUMNS` / `_row_to_dict` /
  the two insert-return dicts, and the scope validation.
- **`model/schema.py`** — dropped the `scope` column + CHECK from the
  `egress_consent` table def and the rebuild-migration's new table + column
  list.
- **`model/__init__.py`** — dropped the `SCOPE_*` / `SCOPES` re-exports.
- **`consent_coordinator.py`** — dropped `scope` from `resolve()` and its
  `decide()` call.
- **`wshandler/decider.py`** — dropped the `SCOPES` import, the scope
  validation, and the `scope` arg to `resolve()`.
- **`cli/tui/consent.py`** — dropped `SCOPE_ONCE` and the `scope` field from
  `make_verdict()`.
- Tests updated across `test_model_egress_consent`, `test_consent_coordinator`,
  `test_consent_deciders`, `test_container`, and `test_consent_decide` (CLI);
  removed the now-dead `test_*_invalid_scope*` cases.

`once` is already a `duration` value (`DURATION_ONCE`, "this connection only")
— it becomes the sole way to get one-connection behavior. `DURATION_DEFAULT`
stays `restart`.

## Coordination

The Flutter consent overlay in #2355 still sends `scope: once` in its verdict
frame. That's harmless (the server now ignores the field), but for cleanliness
that branch should drop it too when it rebases.

## Tests

Full backend suite green at **100% coverage** (4709 tests). No frontend change
in this PR (the Flutter client lives on #2355's branch, off `main`).
