### PR TITLE
feat(consent): revoke action on the consent-decide rules screen (#2341)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -38,8 +38,7 @@ operators or integrators to act when upgrading.
   leaves the list immediately. A failed revoke (sidecar unreachable / no ack)
   flashes `revoke failed — still in effect` and leaves the row enforced — a
   still-active rule is never silently hidden. Static allow-list rows are not
-  revocable from this screen (edit them in workspace settings). Closes the
-  #2335 rule-management view.
+  revocable from this screen (edit them in workspace settings).
 
 - **Read-only rules screen in `consent-decide` (#2340).** Press `r` in the
   `consent-decide` TUI to switch from the held-request queue to a second,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,15 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Revoke action in `consent-decide` (#2341).** On the rules screen
+  (`r`), focus an active consent allow/deny row and press `x` to revoke it:
+  klangkd drops the sidecar rule and marks the verdict spent, so the row
+  leaves the list immediately. A failed revoke (sidecar unreachable / no ack)
+  flashes `revoke failed — still in effect` and leaves the row enforced — a
+  still-active rule is never silently hidden. Static allow-list rows are not
+  revocable from this screen (edit them in workspace settings). Closes the
+  #2335 rule-management view.
+
 - **Read-only rules screen in `consent-decide` (#2340).** Press `r` in the
   `consent-decide` TUI to switch from the held-request queue to a second,
   read-only screen listing every egress decision currently in effect for the

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -28,7 +28,7 @@ import asyncio
 import json
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import websockets
 from rich.markup import escape
@@ -121,6 +121,9 @@ RULES = "rules"  # refreshed in-effect rules snapshot; payload = EgressRules
 PONG = "pong"
 ERROR = "error"  # server rejected a verdict; payload = message str
 IGNORED = "ignore"  # non-JSON / unknown frame
+REVOKE_ACK = (  # server replied to a revoke (#2339/#2341); payload=(id, ok)
+    "revoke_ack"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -199,6 +202,17 @@ def make_ping() -> str:
     return json.dumps({"type": "ping"})
 
 
+def make_revoke(request_id: str) -> str:
+    """Build an outbound revoke frame (JSON string) for an active verdict (#2341).
+
+    Asks the server (#2339) to drop the verdict's sidecar rule and mark the row
+    ``revoked``. The row leaves the list only once the server's ``revoke_ack``
+    confirms success -- never optimistically, so a still-enforced rule is never
+    hidden from the decider.
+    """
+    return json.dumps({"type": "revoke", "request_id": request_id})
+
+
 class ConsentDeciderController:
     """Pure state machine over the consent-decider WS protocol (#2310).
 
@@ -260,6 +274,25 @@ class ConsentDeciderController:
                 return IGNORED, None
             self.rules = rules
             return RULES, rules
+        if mtype == "revoke_ack":
+            # #2341: server confirmed a revoke. On success drop the row from the
+            # cached snapshot (idempotent -- the server also pushes a refreshed
+            # ``egress_rules``); on failure leave it enforced. ``request_id`` may
+            # be absent on a malformed frame -> rid None, no mutation.
+            rid = msg.get("request_id")
+            ok = bool(msg.get("ok"))
+            if ok and isinstance(rid, str) and self.rules is not None:
+                self.rules = replace(
+                    self.rules,
+                    allowed=tuple(
+                        r for r in self.rules.allowed if r.id != rid
+                    ),
+                    denied=tuple(r for r in self.rules.denied if r.id != rid),
+                )
+            return REVOKE_ACK, (
+                rid if isinstance(rid, str) else None,
+                ok,
+            )
         if mtype == "pong":
             return PONG, None
         if mtype == "error":
@@ -599,6 +632,17 @@ class ConsentDeciderApp(App):
                 try:
                     if action == ERROR:
                         self._flash(str(payload))
+                    elif action == REVOKE_ACK:
+                        # payload = (request_id, ok). A failed revoke (not an
+                        # active verdict, wrong workspace, or the sidecar never
+                        # acked the drop) leaves the row enforced -- flash so
+                        # the decider knows it is still in effect, never silent.
+                        # Success needs no flash; the controller already dropped
+                        # the row and the refresh re-renders the list without it.
+                        _rid, ok = payload  # type: ignore[misc]
+                        if not ok:
+                            self._flash("revoke failed — still in effect")
+                        self._refresh()
                     else:
                         self._refresh()
                 except Exception:
@@ -744,7 +788,15 @@ class ConsentDeciderApp(App):
         """
         self._flash_msg = f" [red]![/red] {escape(message)}"
         self._flash_until = time.time() + ttl
-        self.query_one("#status", Static).update(self._flash_msg)
+        # Query the ACTIVE screen (App.query_one searches the app's default
+        # screen, not a pushed one): the main queue's ``#status`` or the rules
+        # screen's ``#rules-status`` (a revoke can be issued / its ack can
+        # arrive while either is up).
+        screen = self.screen
+        target = (
+            "#rules-status" if isinstance(screen, RulesScreen) else "#status"
+        )
+        screen.query_one(target, Static).update(self._flash_msg)
 
     # -- actions -----------------------------------------------------------
 
@@ -833,12 +885,17 @@ class RulesScreen(Screen):
     CSS = """
     RulesScreen { layout: vertical; }
     #rules-status { padding: 0 1; background: $panel; color: $text-muted; }
-    #rules-body { padding: 0 1; }
+    #rules-body { padding: 0 1; height: 1fr; }
+    #rules-list-label { padding: 0 1; background: $panel; color: $text-muted; }
+    #rules-list { min-height: 3; height: auto; max-height: 12; border: round $primary; }
+    #rules-list:focus-within { border: round $accent; }
+    #rules-list ListItem { height: 1; }
     """
 
     BINDINGS = [
         ("escape", "back", "Back"),
         ("q", "back", "Back"),
+        ("x", "revoke", "Revoke"),
     ]
 
     def compose(self) -> ComposeResult:
@@ -846,14 +903,56 @@ class RulesScreen(Screen):
         yield Static(id="rules-status")
         with VerticalScroll(id="rules-body"):
             yield Static(id="rules-content")
+        # #2341 slice D: a compact, selectable list of the revocable verdicts
+        # (allows + denies). The static allow-list is NOT here (it lives in the
+        # read-only #rules-content above), so it can never be the focused
+        # revoke target -- the scope guard is structural, not a runtime check.
+        yield Static(
+            "Revoke: focus a rule, press [bold]x[/bold]",
+            id="rules-list-label",
+        )
+        yield ListView(id="rules-list")
         yield Footer()
 
     def on_mount(self) -> None:
         self.refresh_rules()
+        # Focus the revoke selector so arrow keys + `x` work immediately.
+        self.query_one("#rules-list", ListView).focus()
 
     def action_back(self) -> None:
         """``q``/``Esc`` returns to the held-request queue."""
         self.app.pop_screen()
+
+    def action_revoke(self) -> None:
+        """``x`` revokes the focused revocable rule (#2341 slice D).
+
+        Sends the ``revoke`` frame; the row stays in the list until the
+        server's ``revoke_ack`` confirms it (never optimistically -- a still-
+        enforced rule must not be hidden). A failed ack flashes and leaves the
+        row; the removal-on-success is driven by the ack in :meth:`_pump`.
+        """
+        app = self.app
+        rid = self._focused_rule_id()
+        if rid is None:
+            return
+        ws = app._ws  # type: ignore[attr-defined]
+        if ws is None:
+            app._flash("disconnected — reconnecting")  # type: ignore[attr-defined]
+            return
+        asyncio.create_task(self._send_revoke(app, ws, rid))
+
+    async def _send_revoke(self, app, ws, rid: str) -> None:
+        try:
+            await ws.send(make_revoke(rid))
+        except Exception:
+            app._flash("revoke send failed — reconnecting")  # type: ignore[attr-defined]
+
+    def _focused_rule_id(self) -> str | None:
+        lv = self.query_one("#rules-list", ListView)
+        child = lv.highlighted_child
+        if child is None:
+            return None
+        return getattr(child, "rule_id", None)
 
     def refresh_rules(self) -> None:
         """Re-render the body from the controller's latest ``egress_rules``."""
@@ -865,12 +964,70 @@ class RulesScreen(Screen):
         app = self.app  # ConsentDeciderApp
         controller = app.controller  # type: ignore[attr-defined]
         rules = controller.rules
-        conn = "connected" if app._connected else "reconnecting"  # type: ignore[attr-defined]
-        held = len(controller.pending)
-        status.update(
-            f" {escape(app.workspace_name)}  ·  {conn}  ·  {held} held  ·  rules"  # type: ignore[attr-defined]
-        )
+        # Respect an active flash (e.g. a failed revoke) so the 1s refresh
+        # does not clobber it -- mirrors the main screen's status behavior.
+        if app._flash_until > time.time():  # type: ignore[attr-defined]
+            status.update(app._flash_msg)  # type: ignore[attr-defined]
+        else:
+            conn = "connected" if app._connected else "reconnecting"  # type: ignore[attr-defined]
+            held = len(controller.pending)
+            status.update(
+                f" {escape(app.workspace_name)}  ·  {conn}  ·  {held} held  ·  rules"  # type: ignore[attr-defined]
+            )
         content.update(self._render_body(rules, controller))
+        self._rebuild_rule_list(rules)
+
+    def _rebuild_rule_list(self, rules: EgressRules | None) -> None:
+        """Rebuild the revoke selector from the controller's rules (#2341).
+
+        Compact rows (no countdown -- the detail body above ticks that). Only
+        rebuilt when the set of revocable rule ids changes, so the 1s refresh
+        never flickers it. The static allow-list is intentionally absent -> it
+        is never a revoke target.
+        """
+        lv = self.query_one("#rules-list", ListView)
+        desired: list[str] = []
+        if rules is not None:
+            desired += [r.id for r in rules.allowed]
+            desired += [r.id for r in rules.denied]
+        current = [getattr(c, "rule_id", None) for c in lv.children]
+        if current == desired:
+            return  # unchanged -> no flicker
+        focused = (
+            getattr(lv.highlighted_child, "rule_id", None)
+            if lv.highlighted_child is not None
+            else None
+        )
+        lv.clear()
+        if rules is not None:
+            for r in rules.allowed:
+                lv.append(self._rule_item(r, DECISION_ALLOWED))
+            for r in rules.denied:
+                lv.append(self._rule_item(r, DECISION_DENIED))
+        if focused is not None:
+            # Restore focus to the surviving rule. ``lv.clear()`` schedules an
+            # index reset that would clobber a synchronous set, so defer the
+            # restore to after the refresh pass lands it.
+            def _restore_focus(_lv=lv, _focused=focused) -> None:
+                for index, child in enumerate(_lv.children):
+                    if getattr(child, "rule_id", None) == _focused:
+                        _lv.index = index
+                        break
+
+            lv.call_after_refresh(_restore_focus)
+
+    @staticmethod
+    def _rule_item(rule: ConsentRule, decision: str) -> ListItem:
+        host = rule.dest_host
+        if rule.dest_port is not None:
+            host = f"{host}:{rule.dest_port}"
+        proc = f"  ({rule.process_name})" if rule.process_name else ""
+        mark = "allow" if decision == DECISION_ALLOWED else "deny"
+        item = ListItem(
+            Static(f"{escape(mark)}  {escape(host)}{escape(proc)}")
+        )
+        item.rule_id = rule.id  # type: ignore[attr-defined]
+        return item
 
     def _render_body(self, rules: EgressRules | None, controller) -> str:
         """Build the grouped rich-markup body (allow-list, allows, denies, pause)."""

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -25,6 +25,7 @@ from klangk.cli.tui.consent import (
     IGNORED,
     PONG,
     RESOLVED,
+    REVOKE_ACK,
     RULES,
     ConsentDeciderApp,
     ConsentDeciderController,
@@ -34,6 +35,7 @@ from klangk.cli.tui.consent import (
     PauseState,
     RulesScreen,
     make_ping,
+    make_revoke,
     make_verdict,
 )
 
@@ -371,6 +373,13 @@ class TestFrameBuilders:
 
     def test_make_ping(self):
         assert json.loads(make_ping()) == {"type": "ping"}
+
+    def test_make_revoke(self):
+        # #2341: revoke frame carries only the request id.
+        assert json.loads(make_revoke("r9")) == {
+            "type": "revoke",
+            "request_id": "r9",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1349,6 +1358,73 @@ def test_reset_clears_rules():
 # ---------------------------------------------------------------------------
 
 
+class TestControllerRevokeAck:
+    """``revoke_ack`` frame handling (#2341 slice D)."""
+
+    @staticmethod
+    def _controller_with(allowed=(), denied=()) -> ConsentDeciderController:
+        c = ConsentDeciderController()
+        c.apply_frame(
+            _rules_frame(allow_list=(), allowed=allowed, denied=denied)
+        )
+        return c
+
+    def test_ok_removes_from_allowed(self):
+        c = self._controller_with(
+            allowed=[_rule("a1", host="x.com"), _rule("a2", host="y.com")]
+        )
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "revoke_ack", "request_id": "a1", "ok": True})
+        )
+        assert outcome == REVOKE_ACK
+        assert payload == ("a1", True)
+        assert [r.id for r in c.rules.allowed] == ["a2"]
+
+    def test_ok_removes_from_denied(self):
+        c = self._controller_with(
+            denied=[_rule("d1", decision="denied", host="x.com")]
+        )
+        c.apply_frame(
+            json.dumps({"type": "revoke_ack", "request_id": "d1", "ok": True})
+        )
+        assert c.rules.denied == ()
+
+    def test_fail_leaves_rules_intact(self):
+        c = self._controller_with(allowed=[_rule("a1", host="x.com")])
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "revoke_ack", "request_id": "a1", "ok": False})
+        )
+        assert payload == ("a1", False)
+        assert [r.id for r in c.rules.allowed] == ["a1"]
+
+    def test_ok_unknown_id_is_noop(self):
+        c = self._controller_with(allowed=[_rule("a1", host="x.com")])
+        c.apply_frame(
+            json.dumps({"type": "revoke_ack", "request_id": "zzz", "ok": True})
+        )
+        assert [r.id for r in c.rules.allowed] == ["a1"]
+
+    def test_ok_when_no_rules_is_safe(self):
+        # No egress_rules frame yet -> rules is None; a success ack must not
+        # crash (nothing to remove).
+        c = ConsentDeciderController()
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "revoke_ack", "request_id": "a1", "ok": True})
+        )
+        assert outcome == REVOKE_ACK
+        assert payload == ("a1", True)
+        assert c.rules is None
+
+    def test_missing_request_id_returns_none_rid(self):
+        c = self._controller_with(allowed=[_rule("a1")])
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "revoke_ack", "ok": True})
+        )
+        assert outcome == REVOKE_ACK
+        assert payload == (None, True)
+        assert [r.id for r in c.rules.allowed] == ["a1"]  # not removed
+
+
 class TestRulesScreen:
     async def test_r_opens_screen_and_q_returns(self):
         app = _make_app()
@@ -1709,3 +1785,190 @@ async def test_deny_with_null_decided_at_renders_without_crash():
         assert "deny.example.com:443" in body
         assert "deny2.example.com:443" in body
         assert "Active denies (2)" in body
+
+
+class TestRulesRevoke:
+    """The revoke action on the rules screen (#2341 slice D)."""
+
+    @staticmethod
+    def _list_ids(app) -> list:
+        return [
+            getattr(c, "rule_id", None)
+            for c in app.screen.query_one("#rules-list", ListView).children
+        ]
+
+    async def test_x_sends_revoke_for_focused_rule(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("a1", host="allow.com")])
+            )
+            app.action_rules()
+            await pilot.pause()
+            app.screen.query_one("#rules-list", ListView).index = 0
+            await pilot.pause()
+            app.screen.action_revoke()
+            await pilot.pause()
+            assert any('"revoke"' in s and '"a1"' in s for s in ws.sent), (
+                ws.sent
+            )
+
+    async def test_x_key_binding_sends_revoke(self):
+        # The `x` binding (not just the method) routes to action_revoke.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("a1", host="x.com")])
+            )
+            app.action_rules()
+            await pilot.pause()
+            app.screen.query_one("#rules-list", ListView).index = 0
+            await pilot.pause()
+            await pilot.press("x")
+            await pilot.pause()
+            assert any('"revoke"' in s and '"a1"' in s for s in ws.sent), (
+                ws.sent
+            )
+
+    async def test_revoke_with_no_focus_sends_nothing(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_rules_frame(allowed=[_rule("a1")]))
+            app.action_rules()
+            await pilot.pause()
+            app.screen.action_revoke()  # nothing highlighted
+            await pilot.pause()
+            assert ws.sent == []
+
+    async def test_revoke_while_disconnected_flashes(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_rules_frame(allowed=[_rule("a1")]))
+            app.action_rules()
+            await pilot.pause()
+            app.screen.query_one("#rules-list", ListView).index = 0
+            await pilot.pause()
+            app.screen.action_revoke()  # app._ws is None
+            await pilot.pause()
+            status = app.screen.query_one("#rules-status", Static)
+            assert "disconnected" in str(status.content)
+
+    async def test_revoke_send_failure_flashes(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([], send_fail=True)
+            app._ws = ws
+            app.controller.apply_frame(_rules_frame(allowed=[_rule("a1")]))
+            app.action_rules()
+            await pilot.pause()
+            app.screen.query_one("#rules-list", ListView).index = 0
+            await pilot.pause()
+            app.screen.action_revoke()
+            await pilot.pause()
+            status = app.screen.query_one("#rules-status", Static)
+            assert "revoke send failed" in str(status.content)
+
+    async def test_static_allowlist_not_in_revoke_list(self):
+        # Scope guard: the static allow-list is NOT a revoke target -- only
+        # consent allows/denies appear in #rules-list.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(
+                    allow_list=["static.example.com"],
+                    allowed=[_rule("a1", host="allow.com")],
+                    denied=[_rule("d1", host="deny.com", decision="denied")],
+                )
+            )
+            app.action_rules()
+            await pilot.pause()
+            assert self._list_ids(app) == ["a1", "d1"]
+
+    async def test_revoke_ack_success_removes_row_from_list(self):
+        # On confirmation the row leaves the list (and the cached rules).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.action_rules()
+            await pilot.pause()
+            ws = FakeWS(
+                [
+                    _rules_frame(allowed=[_rule("a1", host="x.com")]),
+                    json.dumps(
+                        {
+                            "type": "revoke_ack",
+                            "request_id": "a1",
+                            "ok": True,
+                        }
+                    ),
+                ]
+            )
+            await app._pump(ws)
+            await pilot.pause()
+            assert [r.id for r in app.controller.rules.allowed] == []
+            assert self._list_ids(app) == []
+
+    async def test_revoke_ack_failure_flashes_and_keeps_row(self):
+        # A failed ack flashes + leaves the row enforced.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.action_rules()
+            await pilot.pause()
+            ws = FakeWS(
+                [
+                    _rules_frame(allowed=[_rule("a1", host="x.com")]),
+                    json.dumps(
+                        {
+                            "type": "revoke_ack",
+                            "request_id": "a1",
+                            "ok": False,
+                        }
+                    ),
+                ]
+            )
+            await app._pump(ws)
+            await pilot.pause()
+            status = app.screen.query_one("#rules-status", Static)
+            assert "revoke failed" in str(status.content)
+            assert [r.id for r in app.controller.rules.allowed] == ["a1"]
+            assert self._list_ids(app) == ["a1"]
+
+    async def test_refresh_rebuilds_list_only_on_change(self):
+        # A second refresh with unchanged rules hits the no-op early return
+        # (no flicker) and leaves the list intact.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_rules_frame(allowed=[_rule("a1")]))
+            app.action_rules()
+            await pilot.pause()
+            screen = app.screen
+            screen.refresh_rules()  # unchanged -> early return
+            await pilot.pause()
+            assert self._list_ids(app) == ["a1"]
+
+    async def test_rebuild_restores_focus_to_surviving_rule(self):
+        # When the rule set changes but the focused rule survives, focus is
+        # restored to it (covers the focus-restore loop in _rebuild_rule_list).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("a1"), _rule("a2")])
+            )
+            app.action_rules()
+            await pilot.pause()
+            lv = app.screen.query_one("#rules-list", ListView)
+            lv.index = 1  # focus a2
+            await pilot.pause()
+            # a1 revoked elsewhere -> rules refresh drops a1; a2 survives.
+            app.controller.apply_frame(_rules_frame(allowed=[_rule("a2")]))
+            app.screen.refresh_rules()
+            await pilot.pause()
+            await pilot.pause()  # let call_after_refresh land the restore
+            lv = app.screen.query_one("#rules-list", ListView)
+            assert lv.highlighted_child is not None
+            assert getattr(lv.highlighted_child, "rule_id", None) == "a2"


### PR DESCRIPTION
## What

Slice D of the #2335 rule-management view: the TUI **revoke action**. On the rules screen (`r`), focus an active consent allow/deny row and press `x` — klangkd (#2339, merged in #2351) drops the sidecar rule and marks the verdict spent, so the row leaves the list immediately. This closes the umbrella (#2335).

The backend half (drop sidecar rule + mark revoked + `revoke_ack`) landed in #2351; this PR is the client action + confirmation handling.

## Changes

**Controller** (`cli/tui/consent.py`, pure / unit-tested):
- `make_revoke(request_id)` — outbound `revoke` frame.
- `apply_frame` handles `revoke_ack {request_id, ok}`: on success the row is dropped from the cached `egress_rules` (idempotent — the server also pushes a refreshed `egress_rules`); on failure it is left enforced.

**App** (`_pump`): a `REVOKE_ACK` with `ok=False` flashes `revoke failed — still in effect` and leaves the row; success needs no flash. `_flash` now targets the *active* screen's status line — `App.query_one` searches the app's default screen, not a pushed one, so the rules screen's `#rules-status` had to be reached via `self.screen`.

**View** (`RulesScreen`): a compact selectable `#rules-list` of the revocable allows/denies. The static allow-list stays in the read-only `#rules-content` above, so it is **structurally never a revoke target** (scope guard). `x` on the focused row sends the frame; the row stays until the ack confirms (no optimistic removal — a still-enforced rule is never hidden). `_rebuild_rule_list` only rebuilds when the id set changes (no 1s-refresh flicker) and restores focus to a surviving rule.

Static allow-list rows are not revocable from this screen (edit them in workspace settings).

## Behavior

- **Focused-row `x`** → sends `revoke {request_id}`.
- **Success** (`revoke_ack ok=True`) → row leaves the list (and the cached rules).
- **Failure** (`ok=False`) → flash `revoke failed — still in effect`, row stays.
- **Disconnected / send failure** → flash, no silent loss.
- **Static allow-list** → never in the revoke list.

## Tests

128 in `test_consent_decide.py`: `make_revoke` builder; controller `revoke_ack` (allow/deny removal, fail-leaves-intact, unknown id, no-rules, missing id); the `x` keybinding + the action (focused send, no-focus no-op, disconnected flash, send-failure flash); static-allow-list scope guard; ack-success removes the row / ack-failure flashes + keeps it; no-flicker rebuild + focus restore.

Full suite (both packages, `-n auto`): **4730 passed, 100% coverage**.

Closes #2341. Parent: #2335.
