### PR TITLE
fix(consent-decide): only the selected duration button carries a background (#2360)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -608,6 +608,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`consent-decide` duration selector no longer shows two highlighted
+  buttons at first render (#2360).** The first duration button ("once")
+  grabbed initial focus on mount and rendered with the default focus
+  background, so it read as "selected" alongside the real default
+  (`restart`). Non-selected duration buttons are now transparent even when
+  focused, leaving the selected (`dur-sel`) button as the only one with a
+  background.
+
 - **A reconnecting consent decider no longer re-shows an already-resolved
   request (#2345).** The decider (re)connect snapshot read pending requests
   from the DB, so a request whose `egress_resolved` broadcast was lost on

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -469,8 +469,17 @@ class ConsentDeciderApp(App):
     .req-host { color: $text; }
     #requests Button { height: 1; border: none; padding: 0 1; }
     #duration-selector { width: auto; height: 1; }
-    #duration-selector Button { width: auto; min-width: 0; height: 1; border: none; padding: 0 1; }
-    .dur-sel { background: $accent; color: $background; }
+    /* Non-selected duration buttons carry no background -- not even when focused
+    (#2360). The first button grabs initial focus on mount; without an explicit
+    transparent :focus it rendered with the white focus background, so it read
+    as "selected" alongside the real ``dur-sel`` default (``restart``). The
+    ``dur-sel`` rules are qualified under ``#duration-selector`` so they outrank
+    these ID-based transparent rules on specificity (an unqualified ``.dur-sel``
+    loses to ``#duration-selector Button:focus`` and the accent vanishes). */
+    #duration-selector Button { width: auto; min-width: 0; height: 1; border: none; padding: 0 1; background: transparent; }
+    #duration-selector Button:focus { background: transparent; }
+    #duration-selector .dur-sel { background: $accent; color: $background; }
+    #duration-selector .dur-sel:focus { background: $accent; color: $background; }
     """
 
     BINDINGS = [

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -786,6 +786,54 @@ class TestAppActions:
             app._select_duration(types.SimpleNamespace(duration=None))
             assert app._duration == "restart"  # unchanged (default)
 
+    async def test_only_selected_duration_has_background_at_first_render(self):
+        # Regression (#2360): the first duration button ("once") grabbed
+        # initial focus on mount and, with no explicit transparent :focus,
+        # rendered the white focus background -- so it read as "selected"
+        # alongside the real ``dur-sel`` default (``restart``). Only the
+        # selected button may carry a background; every other (focused or
+        # not) must be transparent at first render. Asserted opacity-only so
+        # it holds across light/dark themes (the exact accent hue is the
+        # theme's business; the bug was a *second* visible background).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            opaque = [
+                d
+                for d in tui_consent.DURATIONS
+                if app.query_one(f"#dur-{d}", Button).styles.background.a != 0
+            ]
+            assert opaque == [tui_consent.DURATION_DEFAULT], (
+                f"expected only {tui_consent.DURATION_DEFAULT!r} to carry a "
+                f"background at first render, got {opaque!r}"
+            )
+
+    async def test_selected_duration_keeps_accent_when_focused(self):
+        # The ``.dur-sel`` rules must be specific enough to outrank the
+        # transparent ``#duration-selector Button:focus`` (#2360): selecting a
+        # duration both adds ``dur-sel`` and focuses the button, and the
+        # accent must survive focus -- else the just-selected button goes
+        # transparent and looks unselected. The previously-selected default
+        # drops to transparent.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one(f"#dur-{tui_consent.DURATION_5M}", Button)
+            app.on_button_pressed(types.SimpleNamespace(button=btn))
+            btn.focus()
+            await pilot.pause()
+            assert app.focused is btn  # focus really landed on it
+            assert btn.has_class("dur-sel")
+            assert btn.styles.background.a != 0, (
+                f"selected+focused button lost its background "
+                f"(got {btn.styles.background!r})"
+            )
+            restart = app.query_one(
+                f"#dur-{tui_consent.DURATION_DEFAULT}", Button
+            )
+            assert not restart.has_class("dur-sel")
+            assert restart.styles.background.a == 0
+
 
 class TestWsLoop:
     async def test_reconnect_after_drop(self, monkeypatch):


### PR DESCRIPTION
## What

Fixes #2360.

In the `consent-decide` TUI's duration selector, the first button (`once`) grabbed initial focus on mount and rendered with Textual's default **white focus background**, so it read as "selected" alongside the real default (`restart`, orange `$accent`). Two buttons read as "active" at first render, so it was ambiguous which duration an Allow/Deny would use. The spurious background cleared once the user selected any duration (focus moved off `once`).

## Root

`src/klangk/klangk/cli/tui/consent.py` — the selector's button CSS only sized the buttons and added the selected fill; it did not normalize their backgrounds:

```css
#duration-selector Button { width: auto; min-width: 0; height: 1; border: none; padding: 0 1; }
.dur-sel { background: $accent; color: $background; }
```

Non-selected buttons kept Textual's default/focus background, and `once` (first in the `Horizontal`) grabbed focus on mount.

## Fix

Only the `dur-sel` (selected) button carries a background. Strip the default **and** focus backgrounds from the rest of the selector buttons:

```css
#duration-selector Button { ...; background: transparent; }
#duration-selector Button:focus { background: transparent; }
#duration-selector .dur-sel { background: $accent; color: $background; }
#duration-selector .dur-sel:focus { background: $accent; color: $background; }
```

The `dur-sel` rules are **qualified under `#duration-selector`** so they outrank the ID-based transparent rules on CSS specificity. I verified empirically that the issue's literal proposal (unqualified `.dur-sel`) breaks the accent: `#duration-selector Button:focus` (id + type + pseudo) beats a bare `.dur-sel` (class), so `restart` goes transparent too. Qualifying restores the selected highlight (focused or not).

Now only the selected button has a background at first render, so the default (`restart`) is unambiguous.

## Tests

Two regression guards in `test_consent_decide.py` (both confirmed to fail without the fix, pass with it):

- `test_only_selected_duration_has_background_at_first_render` — at first render, only `restart` is opaque; every other duration is transparent. Assertions are opacity-only so they hold across light/dark themes (the bug was a *second* visible background, not a wrong hue).
- `test_selected_duration_keeps_accent_when_focused` — selecting `5m` keeps its accent under focus (the `.dur-sel:focus` rule outranks the transparent `Button:focus`); `restart` drops to transparent.

Full suite: **4728 passed, 100% coverage** (`-n auto`, the CI invocation).
