### PR TITLE
fix(egress): key the consent verdict cache on the connection, not the destination (#2361)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -624,6 +624,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   focused, leaving the selected (`dur-sel`) button as the only one with a
   background.
 
+- **`duration=once` consent verdicts now re-prompt every subsequent
+  connection (#2361).** The sidecar's SYN verdict cache was keyed on
+  (destination, port), so an allow-once was reused for a later connection to
+  the same destination (the 2nd+ `curl` passed without re-prompting). The cache
+  - in-flight set are now keyed on the connection (source IP+port + dest), so a
+    SYN retransmit still reuses the verdict but a new connection (new source
+    port) is a cache miss and re-prompts. Non-`once` persistence is unchanged
+    (an allow learns the IP; a deny installs a REJECT rule -- both per-destination
+    rules ahead of NFQUEUE).
+
 - **A reconnecting consent decider no longer re-shows an already-resolved
   request (#2345).** The decider (re)connect snapshot read pending requests
   from the DB, so a request whose `egress_resolved` broadcast was lost on

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -213,18 +213,23 @@ SPECS = parse_specs()
 # (under the lock; the host is set by the DNS loop before the SYN arrives).
 _LEARNED: dict[str, dict] = {}
 _LOCK = threading.Lock()
-# Reused SYN verdicts: {(ip, port): (verdict, expire)} so the kernel's SYN
-# retransmits (tcp_syn_retries) don't each re-prompt. Touched only on the
-# event-loop thread (the NFQUEUE consumer is loop-driven) -- no lock.
-_VERDICT_CACHE: dict[tuple[str, int], tuple[str, float]] = {}
-# Flows with a verdict task still in flight (held, no verdict yet): prevents a
-# SYN retransmit during the hold from spawning a SECOND consent request. The
-# post-verdict :data:`_VERDICT_CACHE` covers retransmits after a decision; this
-# covers the window before it (#2345 e2e: retransmit-pileup left duplicate
-# pending requests lingering past the first's resolution). Touched only on the
+# Reused SYN verdicts, keyed by connection (src IP+port, dst IP+port):
+# {(src_ip, src_port, dst, port): (verdict, expire)} so the kernel's SYN
+# retransmits (tcp_syn_retries) of an already-decided connection reuse the
+# verdict without re-prompting. The connection key (not just dst) is what makes
+# a NEW connection -- new source port -- re-prompt, so duration=once is truly
+# per-connection (#2361). Touched only on the event-loop thread (the NFQUEUE
+# consumer is loop-driven) -- no lock.
+_VERDICT_CACHE: dict[tuple[str, int, str, int], tuple[str, float]] = {}
+# Connections with a verdict task still in flight (held, no verdict yet):
+# keyed by the same connection tuple, prevents a SYN retransmit during the
+# hold from spawning a SECOND consent request. The post-verdict
+# :data:`_VERDICT_CACHE` covers retransmits after a decision; this covers the
+# window before it (#2345 e2e: retransmit-pileup left duplicate pending
+# requests lingering past the first's resolution). Touched only on the
 # event-loop thread -- no lock. Added in :func:`_cb`, discarded in
 # :func:`_decide_and_verdict` once the verdict is cached.
-_INFLIGHT: set[tuple[str, int]] = set()
+_INFLIGHT: set[tuple[str, int, str, int]] = set()
 # Temporary REJECT (tcp-reset) rules for denied connections: {(ip, port): expire}.
 # Swept by sweep_once alongside _LEARNED. Makes a deny fail-fast (ECONNREFUSED)
 # instead of waiting for tcp_syn_retries (~127s) -- dropping a SYN alone doesn't
@@ -1186,19 +1191,31 @@ def _drain(nfq) -> None:
 def _cb(pkt, client: SidecarConsentClient | None) -> None:
     """Classify + route one queued SYN -- non-blocking (#2324, #2329).
 
-    A retransmit of an already-decided flow reuses the cached verdict inline
-    (fast path). A new flow is retained + handed to :func:`_decide_and_verdict`
-    so the verdict wait doesn't block the queue's drain (distinct flows are held
-    concurrently, not serialized behind the first).
+    A retransmit of an already-decided connection reuses the cached verdict
+    inline (fast path). A new connection is retained + handed to
+    :func:`_decide_and_verdict` so the verdict wait doesn't block the queue's
+    drain (distinct connections are held concurrently, not serialized behind
+    the first).
     """
-    dst, port = parse_dest(pkt.get_payload())
+    payload = pkt.get_payload()
+    # Connection-level key (src IP+port + dst IP+port): a SYN retransmit shares
+    # its connection's tuple, a NEW connection has a new source port. Keying the
+    # verdict cache + in-flight set on the connection -- not just (dst, port) --
+    # is what makes duration=once re-prompt every subsequent connection instead
+    # of reusing a prior allow for the same destination (#2361).
+    src_ip, src_port, tdst, tport, _ = parse_syn_tuple(payload)
+    if tport:  # TCP: full connection tuple
+        dst, port = tdst, tport
+    else:  # non-TCP (UDP/other): no source port -> destination granularity
+        dst, port = parse_dest(payload)
     if not dst or client is None or not client.connected:
         pkt.drop()  # unparseable / no consent / WS down -> fail-close
         return
+    flow = (src_ip, src_port, dst, port)
     now = time.time()
-    # SYN retransmit of an already-decided flow -> reuse the verdict so the
-    # kernel's retransmits (tcp_syn_retries) don't each re-prompt.
-    cached = _VERDICT_CACHE.get((dst, port))
+    # SYN retransmit of an already-decided connection -> reuse the verdict so
+    # the kernel's retransmits (tcp_syn_retries) don't each re-prompt.
+    cached = _VERDICT_CACHE.get(flow)
     if cached is not None and cached[1] > now:
         if cached[0] == "allow":
             pkt.accept()
@@ -1206,27 +1223,28 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
             # Forge the eager-deny RST (a retried connect() to a denied flow
             # fails fast too), then drop. TCP only (port 0 is non-TCP).
             if port:
-                _send_rst(pkt.get_payload())
+                _send_rst(payload)
             pkt.drop()
         return
-    # A SYN retransmit that arrives WHILE this flow is still held (no verdict
-    # yet) must not spawn a second consent request: the in-flight task resolves
-    # the flow, and a request per retransmit piles up duplicates that linger
+    # A SYN retransmit that arrives WHILE this connection is still held (no
+    # verdict yet) must not spawn a second consent request: the in-flight task
+    # resolves it, and a request per retransmit piles up duplicates that linger
     # past the first's resolution (#2345 e2e flake). Drop it -- the kernel sends
     # another retransmit once the verdict lands, and that one hits the cache.
-    if (dst, port) in _INFLIGHT:
+    if flow in _INFLIGHT:
         pkt.drop()
         return
     host = _host_for(dst)  # DNS name if resolved here, else the IP
     pkt.retain()  # keep the payload valid past this callback (deferred verdict)
-    _INFLIGHT.add((dst, port))
-    t = asyncio.create_task(_decide_and_verdict(pkt, dst, port, host, client))
+    _INFLIGHT.add(flow)
+    t = asyncio.create_task(_decide_and_verdict(pkt, flow, dst, port, host, client))
     _BG_TASKS.add(t)  # strong ref so the verdict task isn't GC'd
     t.add_done_callback(_BG_TASKS.discard)
 
 
 async def _decide_and_verdict(
     pkt,
+    flow: tuple[str, int, str, int],
     dst: str,
     port: int,
     host: str,
@@ -1239,8 +1257,10 @@ async def _decide_and_verdict(
     ESTABLISHED,RELATED carries the in-flight connection); ``deny``/timeout/
     WS-down -> ``pkt.drop`` + a temporary REJECT (tcp-reset) rule so the next
     retransmit gets RST'd (ECONNREFUSED) instead of the kernel retransmitting
-    for ~127s. The verdict is cached so SYN retransmits (tcp_syn_retries) of
-    this flow reuse it.
+    for ~127s. The verdict is cached against ``flow`` (the connection tuple) so
+    SYN retransmits (tcp_syn_retries) of THIS connection reuse it -- a new
+    connection (new source port) is a cache miss and re-prompts, which is what
+    makes duration=once per-connection (#2361).
     """
     try:
         decision, duration = await client.request(host, port)
@@ -1251,7 +1271,7 @@ async def _decide_and_verdict(
     # stop hitting NFQUEUE; only denied flows accumulate in the cache).
     if len(_VERDICT_CACHE) > 4096:
         _VERDICT_CACHE.clear()
-    _VERDICT_CACHE[(dst, port)] = (decision, now + VERDICT_CACHE_TTL)
+    _VERDICT_CACHE[flow] = (decision, now + VERDICT_CACHE_TTL)
     # Run the iptables fork (allow/reject) in the executor so it doesn't block
     # the loop thread -- matches the DNS path's _learn_all, which also runs
     # off the loop. The packet is retained, so verdicting after the await is
@@ -1286,10 +1306,10 @@ async def _decide_and_verdict(
                     pass
             pkt.drop()
     finally:
-        # Flow resolved (verdict cached) -> retransmits now hit the cache, not
-        # the in-flight check. Always discard, even if the verdict raised, so a
-        # stuck flow can't block the tuple forever.
-        _INFLIGHT.discard((dst, port))
+        # Connection resolved (verdict cached) -> retransmits now hit the cache,
+        # not the in-flight check. Always discard, even if the verdict raised,
+        # so a stuck connection can't block the tuple forever.
+        _INFLIGHT.discard(flow)
 
 
 async def _handle_packet(

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
@@ -35,6 +35,8 @@ from klangk.cli.tui.consent import (
     ConsentDeciderApp,
     DECISION_ALLOWED,
     DECISION_DENIED,
+    DURATION_FOREVER,
+    DURATION_ONCE,
     DURATION_RESTART,
 )
 
@@ -474,5 +476,214 @@ class TestConsentDecisionEndStates:
                 f"the denied host (cloudflare.com) should not succeed, got: "
                 f"{res_deny!r}"
             )
+        finally:
+            await ws_conn.close()
+
+    @pytest.mark.asyncio
+    async def test_once_reprompts_each_subsequent_connection(
+        self, server, auth, workspace
+    ):
+        # #2361: an allow with duration=once must re-prompt EVERY subsequent
+        # connection to the same host. The sidecar's verdict cache is keyed on
+        # the connection (source port), so a new connection (new source port)
+        # is a cache miss and re-prompts -- a prior allow-once never carries
+        # over to a later connection.
+        ws_id = workspace
+        ws_conn = await ws_connect(server, auth, ws_id)
+        try:
+            container = _container_for_workspace(ws_id)
+            app = ConsentDeciderApp(
+                server_url=server["url"],
+                token=auth["token"],
+                workspace_id=ws_id,
+                workspace_name="once-test",
+                hold_timeout=_CONSENT_TIMEOUT,
+            )
+            async with app.run_test() as pilot:
+                await _wait_connected(app)
+                seen_rids = []
+                for i in range(3):
+                    outfile = f"/tmp/r_once_{i}.out"
+                    _trigger(container, "example.com", outfile)
+                    rid = await _wait_for_request(app, "example.com")
+                    # Each new connection produces a DISTINCT prompt -- a
+                    # prior allow-once must not be reused for a later curl.
+                    assert rid not in seen_rids, (
+                        f"iteration {i} reused prior request {rid}; "
+                        "once must re-prompt each new connection"
+                    )
+                    seen_rids.append(rid)
+                    app._decide_id(rid, DECISION_ALLOWED, DURATION_ONCE)
+                    await _wait_resolved(app, rid)
+                    await pilot.pause()
+                results = [
+                    await _wait_result(container, f"/tmp/r_once_{i}.out")
+                    for i in range(3)
+                ]
+            # Every allow-once connection was released and succeeded.
+            assert all("EXIT:0" in r for r in results), (
+                f"each allow-once connection should succeed; got: {results!r}"
+            )
+        finally:
+            await ws_conn.close()
+
+    @pytest.mark.asyncio
+    async def test_forever_deny_persists_without_reprompting(
+        self, server, auth, workspace
+    ):
+        # Inverse of test_once_reprompts_each_subsequent_connection: a deny
+        # with duration=forever PERSISTS across connections. A later curl to
+        # the same host is refused fast (ECONNREFUSED, exit 7) WITHOUT a new
+        # consent prompt -- the sidecar's long-lived REJECT rule (top of
+        # OUTPUT, ahead of NFQUEUE) catches the new SYN. This pins that
+        # connection-keying the verdict cache (#2361) did not break
+        # duration-bounded persistence: "forever" still holds across
+        # connections via the rule, even though the per-connection cache no
+        # longer reuses the verdict for a new source port.
+        ws_id = workspace
+        ws_conn = await ws_connect(server, auth, ws_id)
+        try:
+            container = _container_for_workspace(ws_id)
+            app = ConsentDeciderApp(
+                server_url=server["url"],
+                token=auth["token"],
+                workspace_id=ws_id,
+                workspace_name="forever-deny-test",
+                hold_timeout=_CONSENT_TIMEOUT,
+            )
+            async with app.run_test() as pilot:
+                await _wait_connected(app)
+                # 1st connection: held, then denied forever.
+                _trigger(container, "example.com", "/tmp/r_forever_0.out")
+                rid = await _wait_for_request(app, "example.com")
+                app._decide_id(rid, DECISION_DENIED, DURATION_FOREVER)
+                await _wait_resolved(app, rid)
+                await pilot.pause()
+                # Wait for the 1st curl to fail fast (ECONNREFUSED via the forged
+                # RST -- confirms the sidecar processed the verdict) and let the
+                # forever-REJECT rule settle into OUTPUT before the 2nd curl: the
+                # rule installs in a worker thread that lags the decider's
+                # egress_resolved broadcast, so an instant 2nd SYN would race it.
+                res0 = await _wait_result(container, "/tmp/r_forever_0.out")
+                assert "EXIT:7" in res0, (
+                    f"the denied connection should be refused fast, got: {res0!r}"
+                )
+                await asyncio.sleep(2)
+                # 2nd connection: the forever-deny REJECT rule must refuse it
+                # fast with NO new prompt. Watch the decider's in-memory
+                # pending set for a short window (no blocking subprocess in the
+                # loop, so the decider WS stays alive); a prompt here is the
+                # regression. The new SYN never reaches NFQUEUE (the REJECT
+                # rule, top of OUTPUT, RSTs it first), so no prompt arrives.
+                _trigger(container, "example.com", "/tmp/r_forever_1.out")
+                prompted = False
+                deadline = time.time() + 8
+                while time.time() < deadline:
+                    if any(
+                        "example.com" in (r.dest_host or "")
+                        for r in app.controller.pending.values()
+                    ):
+                        prompted = True
+                        break
+                    await asyncio.sleep(0.3)
+                res1 = await _wait_result(container, "/tmp/r_forever_1.out")
+            assert not prompted, (
+                "forever-deny must not re-prompt a later connection "
+                "(persistence is via the REJECT rule, not the verdict cache)"
+            )
+            assert "EXIT:7" in res1, (
+                f"the later connection should be refused fast (ECONNREFUSED) "
+                f"by the forever-deny REJECT rule, got: {res1!r}"
+            )
+        finally:
+            await ws_conn.close()
+
+    @pytest.mark.asyncio
+    async def test_restart_deny_persists_then_clears_on_container_restart(
+        self, server, auth, workspace
+    ):
+        # A deny with duration=restart is bounded to the workspace container's
+        # lifetime: it persists while the container runs (a later curl is
+        # auto-rejected, no re-prompt) but does NOT survive a container
+        # restart -- the sidecar's in-memory REJECT rule dies with the old
+        # container and klangkd reaps the row (clear_restart_duration, #2346).
+        # After a restart, a curl re-prompts.
+        ws_id = workspace
+        ws_conn = await ws_connect(server, auth, ws_id)
+        try:
+            container = _container_for_workspace(ws_id)
+            app = ConsentDeciderApp(
+                server_url=server["url"],
+                token=auth["token"],
+                workspace_id=ws_id,
+                workspace_name="restart-deny-test",
+                hold_timeout=_CONSENT_TIMEOUT,
+            )
+            async with app.run_test() as pilot:
+                await _wait_connected(app)
+                # 1st connection: held, then denied until restart.
+                _trigger(container, "example.com", "/tmp/r_restart_0.out")
+                rid = await _wait_for_request(app, "example.com")
+                app._decide_id(rid, DECISION_DENIED, DURATION_RESTART)
+                await _wait_resolved(app, rid)
+                await pilot.pause()
+                res0 = await _wait_result(container, "/tmp/r_restart_0.out")
+                assert "EXIT:7" in res0, (
+                    f"the denied connection should be refused fast, "
+                    f"got: {res0!r}"
+                )
+                await asyncio.sleep(2)
+                # 2nd connection: the restart-deny REJECT rule persists for
+                # the container's lifetime -> refused fast, NO new prompt.
+                _trigger(container, "example.com", "/tmp/r_restart_1.out")
+                prompted = False
+                deadline = time.time() + 8
+                while time.time() < deadline:
+                    if any(
+                        "example.com" in (r.dest_host or "")
+                        for r in app.controller.pending.values()
+                    ):
+                        prompted = True
+                        break
+                    await asyncio.sleep(0.3)
+                res1 = await _wait_result(container, "/tmp/r_restart_1.out")
+                assert not prompted, (
+                    "restart-deny must not re-prompt while the container runs"
+                )
+                assert "EXIT:7" in res1, (
+                    f"2nd connection should be refused by the persisted "
+                    f"REJECT rule, got: {res1!r}"
+                )
+                # Restart the workspace container. stop_and_remove tears down
+                # the sidecar (its in-memory REJECT rule dies); start_container
+                # starts a fresh sidecar + reaps restart-duration rows (#2346).
+                # Run the blocking POST in a thread so the decider's WS loop
+                # stays alive (a ~30s blocking call would trip its keepalive).
+                restart = await asyncio.to_thread(
+                    server["client"].post,
+                    f"/api/v1/workspaces/{ws_id}/restart",
+                    headers=auth["headers"],
+                    timeout=120,
+                )
+                assert restart.status_code == 200, restart.text
+                # The pre-restart workspace WS is stale; wait on a fresh one
+                # for the new container + sidecar to come back.
+                await ws_conn.close()
+                ws_conn = await ws_connect(server, auth, ws_id)
+                await asyncio.sleep(
+                    2
+                )  # let the fresh sidecar's dns-proxy settle
+                container = _container_for_workspace(ws_id)
+                # 3rd connection: the restart-deny did NOT survive the restart
+                # -> a fresh egress request is held for a decision.
+                _trigger(container, "example.com", "/tmp/r_restart_2.out")
+                rid2 = await _wait_for_request(app, "example.com")
+                assert rid2 != rid, (
+                    "a connection after restart must produce a fresh prompt, "
+                    "not reuse the reaped request"
+                )
+                # Clean up: deny so the held connection doesn't outlive the test.
+                app._decide_id(rid2, DECISION_DENIED, DURATION_RESTART)
+                await _wait_resolved(app, rid2)
         finally:
             await ws_conn.close()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1323,17 +1323,58 @@ class TestNfqueueCallback:
         monkeypatch.setattr(proxy, "reject", lambda *a: None)
         monkeypatch.setattr(proxy, "_RST_SOCK", None)
         self._bind(proxy, monkeypatch, client)
-        pkt1 = _FakePkt(_ip_payload("1.2.3.4", 443))
-        pkt2 = _FakePkt(_ip_payload("1.2.3.4", 443))  # retransmit during hold
-        proxy._cb(pkt1, client)  # spawns the task; flow is now in-flight
+        pkt1 = _FakePkt(_syn_payload("10.0.0.5", 50000, "1.2.3.4", 443, 1))
+        pkt2 = _FakePkt(
+            _syn_payload("10.0.0.5", 50000, "1.2.3.4", 443, 1)
+        )  # retransmit during hold
+        flow = ("10.0.0.5", 50000, "1.2.3.4", 443)
+        proxy._cb(pkt1, client)  # spawns the task; connection is now in-flight
         proxy._cb(pkt2, client)  # in-flight -> drop, no new task
         assert pkt2.verdict == "drop"  # the retransmit is dropped
         assert len(proxy._BG_TASKS) == 1  # only ONE verdict task
-        assert ("1.2.3.4", 443) in proxy._INFLIGHT  # still held
+        assert flow in proxy._INFLIGHT  # still held (connection-level key)
         gate.set()  # release the verdict
         await asyncio.gather(*proxy._BG_TASKS)
         assert len(started) == 1  # only ONE request to the decider
-        assert ("1.2.3.4", 443) not in proxy._INFLIGHT  # cleared after verdict
+        assert flow not in proxy._INFLIGHT  # cleared after verdict
+
+    async def test_distinct_source_port_re_prompts_after_allow_once(
+        self, proxy, monkeypatch
+    ):
+        # #2361: a NEW connection (new source port) to the same (dst, port) is a
+        # distinct flow, so an allow-once does NOT carry over -- the 2nd SYN is
+        # a cache miss and re-prompts. (A retransmit -- same source port -- DOES
+        # reuse the verdict; that's test_retransmit_during_hold_* above and the
+        # cache-reuse tests.) This is the unit-level grounding of the
+        # connection-keyed verdict cache.
+        requests = []
+
+        async def fast_request(host, port):
+            requests.append((host, port))
+            return ("allow", "once")
+
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(side_effect=fast_request)
+        monkeypatch.setattr(proxy, "_RST_SOCK", None)
+        self._bind(proxy, monkeypatch, client)
+        # Connection A (sport 50000) -> allow/once -> cached for flow A only.
+        proxy._cb(
+            _FakePkt(_syn_payload("10.0.0.5", 50000, "1.2.3.4", 443, 1)),
+            client,
+        )
+        await asyncio.gather(*proxy._BG_TASKS)
+        # Connection B (sport 50001, same dst) -> DISTINCT flow -> cache MISS
+        # -> re-prompts (a 2nd request), NOT a silent reuse of A's allow.
+        proxy._cb(
+            _FakePkt(_syn_payload("10.0.0.5", 50001, "1.2.3.4", 443, 1)),
+            client,
+        )
+        await asyncio.gather(*proxy._BG_TASKS)
+        assert len(requests) == 2, (
+            "a new connection (new source port) must re-prompt after an "
+            "allow-once, not reuse the prior verdict"
+        )
 
 
 def test_duration_ttl_mapping(proxy):


### PR DESCRIPTION
## Summary

Closes #2361.

A `duration=once` consent allow was reused for later connections to the same
destination (the 2nd+ `curl` passed without re-prompting) because the sidecar's
SYN verdict cache + in-flight set were keyed on `(dst, port)`. This re-keys
them on the **connection** `(src IP, src_port, dst, dst_port)` so a SYN
retransmit still reuses the verdict, but a new connection (new source port) is
a cache miss and re-prompts.

## Root cause

`src/containers/network/proxy.py`:

- `_decide_and_verdict` cached every verdict at `(dst, port)` for
  `VERDICT_CACHE_TTL` (120s), and `_cb` reused it for any SYN to that
  `(dst, port)`.
- The `once` path correctly skips the IP-learn (so new SYNs reach NFQUEUE) but
  still wrote the 120s cache entry, which then admitted them. The cache could
  not distinguish a retransmit of the held connection from a genuinely-new
  connection.

Non-`once` durations were unaffected (an allow learns the IP → new SYNs bypass
NFQUEUE; a deny installs a REJECT rule) — so this only mis-fired for `once`.

## Fix

Key `_VERDICT_CACHE` and `_INFLIGHT` on the connection 4-tuple. `_cb` now parses
`parse_syn_tuple` (already present for the RST path) for the source end; for
non-TCP it falls back to `parse_dest` (destination granularity, unchanged).
Retransmits (same tuple) reuse; a new connection (new source port) misses →
re-prompts. `allow`/`reject` rules stay per-destination (ordered ahead of
NFQUEUE), so `restart`/`forever`/timed persistence is unchanged.

## Tests (grounded end-to-end + a unit test)

New tests in `test_consent_decisions_e2e.py` (real klangkd + workspace
container + network sidecar, piloting the real `ConsentDeciderApp`):

- `once` re-prompts **every** subsequent `curl` (3 distinct prompts). Confirmed
  **failing pre-fix** (2nd curl produced no request) and passing post-fix.
- `forever` **deny** persists across connections — a later curl is refused fast
  (ECONNREFUSED, exit 7) with **no** re-prompt (the REJECT rule).
- `restart` **deny** persists for the container's lifetime (2nd curl
  auto-rejected) and is **cleared on a container restart** (3rd curl re-prompts
  via `clear_restart_duration`, #2346).

Plus a `test_proxy.py` unit test: two SYNs with different source ports to the
same `(dst, port)` produce two distinct verdict requests (the connection-keyed
cache), while a retransmit (same source port) still reuses.

## Verification

- Proxy unit tests: 105 passed.
- Full unit suite (`klangkd-tests/tests` + `klangkc-tests/tests`): **4710
  passed at 100% coverage**.
- Consent e2e class (`TestConsentDecisionEndStates`): **8 passed** — the 3 new
  + the 5 pre-existing.

## Related

- #2363 — a `5s` duration to test timed-expiry the same way.
- #2364 — the `forever` *allow* survives-restart test (blocked on #2328's
  cross-restart re-apply, not yet wired).
- #2357 — the `restart` → `tilrestart` rename.
