### PR TITLE
feat(consent): forever allow persists via allowed_domains mutation (#2368)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,15 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`forever` egress-consent allow persists across container restarts (#2368).**
+  An allow with `duration=forever` now appends the consented `host:port` to
+  the workspace's `allowed_domains`, which the network sidecar re-reads on
+  (re)start, so the allow survives a workspace container restart without
+  re-prompting. The deciding connection still gets its in-memory ACCEPT
+  immediately; the persisted entry is port-scoped (the port the decider was
+  shown) and de-duplicated. The `forever` deny counterpart is a follow-up
+  (#2369).
+
 - **Revoke action in `consent-decide` (#2341).** On the rules screen
   (`r`), focus an active consent allow/deny row and press `x` to revoke it:
   klangkd drops the sidecar rule and marks the verdict spent, so the row
@@ -160,7 +169,7 @@ operators or integrators to act when upgrading.
   consumer is the `consent-decide` client (#2310).
 - **Sidecar consent gates the connection SYN (#2311, #2324).** The network
   sidecar holds a non-allow-listed connection's SYN (NFQUEUE) pending the
-  consent verdict instead of the DNS query: a denied name now _resolves_ (the
+  consent verdict instead of the DNS query: a denied name now resolves (the
   workspace gets the IP) and the first packet to that IP is queued -- `allow`
   learns the IP + lets it proceed, `deny`/timeout/WS-down fail-closes -- a
   denied connection gets a RST via a temporary REJECT (tcp-reset) rule so it
@@ -695,7 +704,7 @@ users(id)`, so the decider handler passing the decider's email violated the
 - **Egress-site `forward_auth` no longer breaks WebSocket upgrades
   (#2319, #2322).** Caddy's site-level `forward_auth` copied the WS
   `Upgrade` headers onto its auth subrequest, so uvicorn treated the
-  (HTTP) `verify-workspace-token` check _itself_ as a websocket — no ws
+  (HTTP) `verify-workspace-token` check itself as a websocket — no ws
   route at that path → the catch-all `StaticFiles` asserted
   `scope["type"] == "http"` → HTTP 500. Every WS through the container-egress
   port (the sidecar's `/ws/egress-sidecar`) failed this way even after #2321

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -143,8 +143,11 @@ CONSENT_REJECT_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_REJECT_TTL", "10
 # learn; a short deny). `restart` = the container's lifetime (the sidecar's
 # in-memory rules); `forever` = the workspace's lifetime -- at the sidecar level
 # both map to a long in-memory TTL, but `forever`'s real distinction is that
-# klangkd persists it across sidecar restarts (re-applied on reconnect). That
-# cross-restart persistence is #2328's `forever` sub-piece (not yet wired).
+# klangkd persists it across sidecar restarts: an allow is appended to the
+# workspace's `allowed_domains`, which this sidecar re-reads on start
+# (#2368), so the allow survives a container restart. (That cross-restart
+# persistence is #2368's `forever`-allow sub-piece; the deny counterpart is
+# #2369.)
 _DURATION_SECONDS = {
     "5m": 300,
     "15m": 900,

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1357,13 +1357,19 @@ test.describe("Klangk E2E", () => {
       data: { email: memberEmail },
     });
 
-    // Inject a WebSocket capture script that stores a reference to
-    // the WS so we can send chat commands from page.evaluate.
+    // Inject a WebSocket capture script that stores a reference to the
+    // main /ws socket so we can send chat commands from page.evaluate.
+    // The Flutter app also opens a /ws/consent-decider socket per workspace
+    // (#2244); capture only the main socket, or chat_send lands on a socket
+    // that ignores it (the order the two connect is racy -> intermittent).
     const wsCaptureScript = `(() => {
       const Orig = window.WebSocket;
       window.WebSocket = function(...args) {
         const ws = new Orig(...args);
-        window.__klangkWs = ws;
+        const url = String(args[0] || '');
+        if (!url.includes('consent-decider')) {
+          window.__klangkWs = ws;
+        }
         return ws;
       };
       window.WebSocket.prototype = Orig.prototype;
@@ -1397,23 +1403,38 @@ test.describe("Klangk E2E", () => {
       waitForTerminal: true,
     });
 
-    // Send chat message from page1 via the captured WebSocket
+    // Wait for the chat (main /ws) socket to be open, then send -- avoids
+    // silently dropping the send if the socket isn't ready yet.
+    await page1.waitForFunction(
+      () => {
+        const ws = (window as any).__klangkWs;
+        return !!ws && ws.readyState === 1; // WebSocket.OPEN
+      },
+      { timeout: 10_000 },
+    );
     await page1.evaluate(() => {
       const ws = (window as any).__klangkWs;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(
-          JSON.stringify({ cmd: "chat_send", message: "hello from e2e" }),
-        );
-      }
+      ws.send(JSON.stringify({ cmd: "chat_send", message: "hello from e2e" }));
     });
 
-    await page2.waitForTimeout(2000);
+    // Wait for the broadcast to reach page2 (async); poll instead of a fixed
+    // timeout so a slow CI runner doesn't flake.
+    await expect
+      .poll(
+        async () =>
+          memberChatMessages
+            .map((s) => JSON.parse(s))
+            .filter(
+              (m: any) => m.type === "chat_message" && m.message_type !== 2,
+            ).length,
+        { timeout: 10_000, intervals: [100, 250, 500] },
+      )
+      .toBeGreaterThan(0);
 
     // Filter out system messages (message_type 2 = join/leave)
     const userMessages = memberChatMessages
       .map((s) => JSON.parse(s))
       .filter((m: any) => m.type === "chat_message" && m.message_type !== 2);
-    expect(userMessages.length).toBeGreaterThan(0);
     const received = userMessages[0];
     expect(received.type).toBe("chat_message");
     expect(received.message).toBe("hello from e2e");
@@ -1540,12 +1561,17 @@ test.describe("Klangk E2E", () => {
     );
     expect(initialEmails).toContain(memberEmail);
 
-    // Capture WS on owner page to send commands
+    // Capture the main /ws socket on the owner page to send commands. Skip the
+    // /ws/consent-decider socket (#2244) so chat_send targets the chat socket
+    // regardless of which connects last.
     const wsCaptureScript = `(() => {
       const Orig = window.WebSocket;
       window.WebSocket = function(...args) {
         const ws = new Orig(...args);
-        window.__klangkWs = ws;
+        const url = String(args[0] || '');
+        if (!url.includes('consent-decider')) {
+          window.__klangkWs = ws;
+        }
         return ws;
       };
       window.WebSocket.prototype = Orig.prototype;
@@ -1588,26 +1614,42 @@ test.describe("Klangk E2E", () => {
     );
     expect(updatedEmails).toContain(lateEmail);
 
-    // Send a chat message with @mention and verify mentions field
+    // Wait for the chat (main /ws) socket to be open, then send.
+    await page1.waitForFunction(
+      () => {
+        const ws = (window as any).__klangkWs;
+        return !!ws && ws.readyState === 1; // WebSocket.OPEN
+      },
+      { timeout: 10_000 },
+    );
     await page1.evaluate((email: string) => {
       const ws = (window as any).__klangkWs;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(
-          JSON.stringify({
-            cmd: "chat_send",
-            message: `hey @${email} check this`,
-          }),
-        );
-      }
+      ws.send(
+        JSON.stringify({
+          cmd: "chat_send",
+          message: `hey @${email} check this`,
+        }),
+      );
     }, memberEmail);
 
-    await page1.waitForTimeout(2000);
+    // Wait for the broadcast to echo back on the owner page (async); poll
+    // instead of a fixed timeout so a slow CI runner doesn't flake.
+    await expect
+      .poll(
+        async () =>
+          ownerChatMessages
+            .map((s) => JSON.parse(s))
+            .filter(
+              (m: any) => m.type === "chat_message" && m.message_type !== 2,
+            ).length,
+        { timeout: 10_000, intervals: [100, 250, 500] },
+      )
+      .toBeGreaterThan(0);
 
     // Filter out system messages (message_type 2 = join/leave)
     const userChatMsgs = ownerChatMessages
       .map((s) => JSON.parse(s))
       .filter((m: any) => m.type === "chat_message" && m.message_type !== 2);
-    expect(userChatMsgs.length).toBeGreaterThan(0);
     const chatMsg = userChatMsgs[0];
     expect(chatMsg.type).toBe("chat_message");
     expect(chatMsg.message).toContain(`@${memberEmail}`);

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -258,13 +258,37 @@ class ConsentCoordinator:
         Best-effort: any failure is logged + swallowed so it can never break
         the verdict path or the post-verdict rules refresh -- the session
         still works; only the cross-restart durability is at risk.
+
+        Port-less verdicts (``dest_port`` falsy, e.g. an ICMP ping) are NOT
+        persisted -- a bare host would broaden to all-ports + subdomains.
+        Direct-IP ``dest_host`` values are likewise poor candidates (the
+        DNS-based allow-list never re-matches an IP literal after restart),
+        but are left as-is here rather than special-cased.
+
+        A ``forever`` allow now lives in BOTH ``allowed_domains`` and an
+        ``egress_consent`` audit row; revoking it must remove both (#2370).
         """
         host = row.get("dest_host")
         port = row.get("dest_port")
         workspace_id = row.get("workspace_id")
         if not host or not workspace_id:
             return
-        entry = f"{host}:{port}" if port else str(host)
+        if not port:
+            # Port-scoped only (#2368): a port-less verdict (e.g. an ICMP
+            # ping, dest_port 0) must not be persisted as a bare host -- the
+            # sidecar treats a port-less spec as all-ports + apex/subdomains,
+            # durably broadening one connection's consent to everything on
+            # that name. The deciding connection still gets its in-memory
+            # ACCEPT for this session; durability is simply withheld.
+            logger.info(
+                "consent: forever allow of port-less dest %s ws=%s not "
+                "persisted (a bare host would broaden to all-ports); "
+                "session still works",
+                host,
+                str(workspace_id)[:8],
+            )
+            return
+        entry = f"{host}:{port}"
         try:
             added = await self.app.state.model.workspaces.add_allowed_domain(
                 workspace_id, entry
@@ -319,6 +343,11 @@ class ConsentCoordinator:
             return False
         host = row["dest_host"]
         decision = row["decision"]
+        # NOTE (#2370): a `forever` allow also lives in the workspace's
+        # allowed_domains (added in resolve, #2368), which the sidecar re-reads
+        # on restart. Dropping only the in-memory rule + marking the row
+        # revoked does NOT remove that durable entry, so the allow would
+        # re-apply on the next container restart. Removing it is #2370.
         # Ask the sidecar to drop its rule for this host+decision. No live
         # sidecar -> nothing is enforced (its in-memory rules die with it), so
         # proceed to mark revoked. A live sidecar must ack first: else a

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -40,6 +40,7 @@ from .model.egress_consent import (
     DECISION_DENIED,
     DECISION_PENDING,
     DURATION_DEFAULT,
+    DURATION_FOREVER,
     DURATION_ONCE,
 )
 
@@ -193,6 +194,7 @@ class ConsentCoordinator:
             return None
         hold = self._holds.pop(request_id)
         hold["task"].cancel()
+        forever_allow_row: dict | None = None
         try:
             row = await self.app.state.model.egress_consent.decide(
                 request_id, decision, decided_by, duration
@@ -217,6 +219,14 @@ class ConsentCoordinator:
                     "duration": duration,
                 }
                 resolved = "allowed"
+                # A `forever` allow persists by mutating the workspace's
+                # allow-list (#2368) so it survives a container/sidecar
+                # restart. Captured here, persisted after the Future is
+                # resolved (the deciding connection gets its in-memory ACCEPT
+                # first) and before the rules refresh (so the view reflects
+                # the new entry).
+                if duration == DURATION_FOREVER:
+                    forever_allow_row = row
             else:
                 verdict = {
                     "decision": VERDICT_DENY,
@@ -227,11 +237,58 @@ class ConsentCoordinator:
         if not hold["future"].done():
             hold["future"].set_result(verdict)
         self._broadcast_resolved(request_id, hold["workspace_id"], resolved)
+        if forever_allow_row is not None:
+            await self._persist_forever_allow(forever_allow_row)
         if resolved in ("allowed", "denied"):
             # A new verdict entered the in-effect set: refresh the deciders'
             # rule-management view (#2335 slice A) without a reconnect.
             await self._broadcast_rules(hold["workspace_id"])
         return verdict
+
+    async def _persist_forever_allow(self, row: dict) -> None:
+        """Persist a ``forever`` allow by appending ``host:port`` to the
+        workspace's ``allowed_domains`` (#2368).
+
+        The network sidecar re-reads ``allowed_domains`` on (re)start, so a
+        forever allow survives a container/sidecar restart (the deciding
+        connection already got its in-memory ACCEPT from the verdict). The
+        entry is the consented ``host:port`` (the port the decider was shown;
+        least-privilege -- a durable record is not broadened to all-ports).
+
+        Best-effort: any failure is logged + swallowed so it can never break
+        the verdict path or the post-verdict rules refresh -- the session
+        still works; only the cross-restart durability is at risk.
+        """
+        host = row.get("dest_host")
+        port = row.get("dest_port")
+        workspace_id = row.get("workspace_id")
+        if not host or not workspace_id:
+            return
+        entry = f"{host}:{port}" if port else str(host)
+        try:
+            added = await self.app.state.model.workspaces.add_allowed_domain(
+                workspace_id, entry
+            )
+        except Exception:
+            logger.exception(
+                "consent: forever-allow persist failed (%s) ws=%s",
+                entry,
+                str(workspace_id)[:8],
+            )
+            return
+        if added:
+            logger.info(
+                "consent: forever allow -> allowed_domains %s ws=%s",
+                entry,
+                str(workspace_id)[:8],
+            )
+        else:
+            logger.warning(
+                "consent: forever allow not persisted (%s) ws=%s "
+                "(workspace missing or malformed); session unaffected",
+                entry,
+                str(workspace_id)[:8],
+            )
 
     async def revoke(
         self,

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -31,8 +31,9 @@ DECISIONS = frozenset(
 # connection only; `restart` = the workspace container's lifetime (the sidecar's
 # in-memory rules); `forever` = the workspace's lifetime -- persists across
 # container/sidecar restarts: an allow persists via an `allowed_domains`
-# mutation the sidecar re-reads on start (#2368); the deny counterpart
-# (`rejected_domains`) is #2369.
+# mutation the sidecar re-reads on start (#2368) -- best-effort, so a failed
+# mutation means the allow won't survive restart despite the audit row here;
+# the deny counterpart (`rejected_domains`) is #2369.
 DURATION_ONCE = "once"
 DURATION_5M = "5m"
 DURATION_15M = "15m"

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -30,7 +30,9 @@ DECISIONS = frozenset(
 # honors it (allow learns the IP for T; deny REJECTs for T). `once` = this
 # connection only; `restart` = the workspace container's lifetime (the sidecar's
 # in-memory rules); `forever` = the workspace's lifetime -- persists across
-# container/sidecar restarts (klangkd stores + re-applies it on reconnect).
+# container/sidecar restarts: an allow persists via an `allowed_domains`
+# mutation the sidecar re-reads on start (#2368); the deny counterpart
+# (`rejected_domains`) is #2369.
 DURATION_ONCE = "once"
 DURATION_5M = "5m"
 DURATION_15M = "15m"
@@ -232,8 +234,9 @@ class EgressConsentModel:
           #2346), so the recorded set matches what the sidecar enforces across
           container restarts; a sidecar-only restart (no container restart)
           is the one residual gap.
-        - ``forever`` -> in effect (workspace lifetime; cross-restart
-          persistence lands with #2328).
+        - ``forever`` -> in effect (workspace lifetime). An allow's
+          cross-restart enforcement is via ``allowed_domains`` (#2368); the
+          row itself is the audit record.
 
         Only **verdict** decisions are returned (``decided_by`` not NULL):
         static policy denials (``record_static_denial``, ``decided_by`` NULL)
@@ -464,8 +467,9 @@ class EgressConsentModel:
 
         - Clears **both** allows and denies (a ``restart`` deny's REJECT dies
           with the container too).
-        - Leaves ``forever`` (intended to survive restarts -- re-applied by
-          klangkd once #2328 lands), time-bounded (``5m``..``1w``) and ``once``
+        - Leaves ``forever`` (intended to survive restarts -- an allow
+          persists via ``allowed_domains`` which the sidecar re-reads on
+          start, #2368), time-bounded (``5m``..``1w``) and ``once"
           rows (governed by their own expiry), ``pending`` rows, and static
           policy denials (``decided_by`` NULL, duration NULL). Returns count.
         """

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -4,6 +4,7 @@ import json
 import uuid
 from datetime import datetime, timezone
 
+from ..netfilter import parse_allowed_domains
 from .acl import ACTION_ALLOW, PRINCIPAL_GROUP, PRINCIPAL_USER
 from .users import AGENT_USER_ID, AgentPrincipalError
 
@@ -779,6 +780,56 @@ class WorkspacesModel:
                 values,
             )
             return cursor.rowcount > 0
+
+    async def add_allowed_domain(self, workspace_id: str, entry: str) -> bool:
+        """Append ``entry`` (``host[:port]``) to a workspace's
+        ``allowed_domains`` (#2368).
+
+        A ``forever`` egress-consent allow persists by mutating the workspace's
+        allow-list, which the network sidecar re-reads on (re)start -- so the
+        allow survives a container/sidecar restart (the deciding connection
+        already got its in-memory ACCEPT from the verdict). Unlike
+        :meth:`update_workspace` this is a server-internal mutation with no
+        owner-user gate: the consent verdict already authorized it.
+
+        Compare-and-swap on the JSON blob (like
+        :meth:`update_workspace_settings`) so two concurrent appends can't lose
+        one. Normalizes ``entry`` to lowercase and de-duplicates
+        case-insensitively. Returns True if the workspace exists and ``entry``
+        is in the list afterwards (added or already present); False if the
+        workspace is missing or ``entry`` is malformed (the caller -- the
+        verdict path -- must not break on a persistence failure).
+        """
+        try:
+            normalized = parse_allowed_domains([entry])
+        except ValueError:
+            return False
+        if not normalized:
+            return False
+        spec = normalized[0].lower()
+        for _ in range(_SETTINGS_CAS_RETRIES):
+            async with self.app.state.db.transaction() as db:
+                cursor = await db.execute(
+                    "SELECT allowed_domains FROM workspaces WHERE id = ?",
+                    (workspace_id,),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    return False
+                old_blob = row["allowed_domains"]
+                current = json.loads(old_blob) if old_blob else []
+                if spec in (s.lower() for s in current):
+                    return True  # already present (idempotent)
+                current.append(spec)
+                new_blob = json.dumps(current)
+                cursor = await db.execute(
+                    "UPDATE workspaces SET allowed_domains = ?"
+                    " WHERE id = ? AND allowed_domains IS ?",
+                    (new_blob, workspace_id, old_blob),
+                )
+                if cursor.rowcount == 1:
+                    return True
+        return False  # pragma: no cover - CAS exhausted under contention
 
     async def transfer_workspace(
         self,

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -650,6 +650,53 @@ class TestConsentCoordinatorResolve:
         assert verdict["decision"] == "allow"
         app.state.model.workspaces.add_allowed_domain.assert_awaited_once()
 
+    async def test_forever_deny_does_not_mutate_allowed_domains(self):
+        # `forever` mutates allowed_domains only for an ALLOW; a deny never
+        # touches the list (deny-forever is #2369, via rejected_domains).
+        row = _request()
+        row["decision"] = "denied"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        await coord.resolve("rid-1", "denied", "a@x", duration="forever")
+        app.state.model.workspaces.add_allowed_domain.assert_not_awaited()
+
+    async def test_forever_allow_portless_not_persisted(self):
+        # A port-less verdict (e.g. ICMP, dest_port 0) is NOT persisted -- a
+        # bare host would broaden to all-ports + subdomains (#2371 review).
+        # The deciding connection still gets its in-memory ACCEPT (verdict
+        # allow); only durability is withheld.
+        row = _request()
+        row["decision"] = "allowed"
+        row["dest_port"] = 0
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "allowed", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "allow"
+        app.state.model.workspaces.add_allowed_domain.assert_not_awaited()
+
+    async def test_forever_allow_blocked_outside_decider_workspace(self):
+        # defense-in-depth: a workspace-scoped decider may not decide another
+        # workspace's request -> no verdict, no allowed_domains mutation.
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1",
+            "allowed",
+            "a@x",
+            duration="forever",
+            decider_workspace="other",
+        )
+        assert verdict is None
+        app.state.model.egress_consent.decide.assert_not_awaited()
+        app.state.model.workspaces.add_allowed_domain.assert_not_awaited()
+
 
 class TestConsentCoordinatorTimeout:
     async def test_timeout_expires_and_denies(self):

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -67,6 +67,7 @@ def _app(
             else None
         )
     )
+    workspaces.add_allowed_domain = AsyncMock(return_value=True)
     app.state.model = types.SimpleNamespace(
         egress_consent=egress_consent, workspaces=workspaces
     )
@@ -565,6 +566,89 @@ class TestConsentCoordinatorResolve:
         assert (
             app.state.model.egress_consent.decide.await_count == 1
         )  # one DB write
+
+    async def test_forever_allow_appends_host_port_to_allowed_domains(self):
+        # A `forever` allow persists by appending the consented host:port to
+        # the workspace's allowed_domains (#2368) -- least-privilege (the port
+        # the decider was shown), lowercased + deduped by the model.
+        row = _request()  # host 1.2.3.4, port 443
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "allowed", "a@x", duration="forever"
+        )
+        assert verdict == {
+            "decision": "allow",
+            "reason": "decided",
+            "duration": "forever",
+        }
+        assert fut.result()["decision"] == "allow"
+        app.state.model.workspaces.add_allowed_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+
+    async def test_timed_allow_does_not_mutate_allowed_domains(self):
+        # Only `forever` mutates allowed_domains; a timed allow ("1d") is a
+        # plain in-memory learn (no list mutation).
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        await coord.resolve("rid-1", "allowed", "a@x", duration="1d")
+        app.state.model.workspaces.add_allowed_domain.assert_not_awaited()
+
+    async def test_forever_allow_persist_failure_does_not_break_verdict(self):
+        # A persistence failure (model raises) is swallowed: the verdict is
+        # still allow and the rules refresh still fires (best-effort
+        # durability; the session's in-memory ACCEPT already covers it).
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        app.state.model.workspaces.add_allowed_domain = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "allowed", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "allow"
+        app.state.model.workspaces.add_allowed_domain.assert_awaited_once()
+
+    async def test_forever_allow_missing_host_skips_persist(self):
+        # No host in the row -> nothing to persist; the verdict still lands
+        # (best-effort durability; the session's in-memory ACCEPT covers it).
+        row = _request()
+        row["decision"] = "allowed"
+        row["dest_host"] = None
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "allowed", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "allow"
+        app.state.model.workspaces.add_allowed_domain.assert_not_awaited()
+
+    async def test_forever_allow_not_persisted_still_succeeds(self):
+        # add_allowed_domain returns False (workspace missing / malformed):
+        # logged as a warning, but the verdict still lands.
+        row = _request()
+        row["decision"] = "allowed"
+        app = _app(request=_request(), decide_row=row)
+        app.state.model.workspaces.add_allowed_domain = AsyncMock(
+            return_value=False
+        )
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "allowed", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "allow"
+        app.state.model.workspaces.add_allowed_domain.assert_awaited_once()
 
 
 class TestConsentCoordinatorTimeout:

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -241,6 +241,55 @@ async def test_allowed_domains_updateable(ws, user):
     assert got["allowed_domains"] is None
 
 
+async def test_add_allowed_domain_appends_lowercased_deduped(ws, user):
+    # A forever consent allow persists by mutating allowed_domains (#2368).
+    # New entries are lowercased + de-duplicated; an existing entry (even with
+    # different case) is a no-op (idempotent).
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "forever", allowed_domains=["PyPI.org:443"]
+    )
+    assert await ws.add_allowed_domain(ws_row["id"], "github.com:443") is True
+    assert (
+        await ws.add_allowed_domain(ws_row["id"], "GITHUB.COM:443") is True
+    )  # case-insensitive dedup -> no duplicate
+    assert (
+        await ws.add_allowed_domain(ws_row["id"], "github.com:443") is True
+    )  # exact dup -> still True (idempotent)
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    # Original entry preserved as-typed; new entry lowercased; no dup.
+    assert got["allowed_domains"] == ["PyPI.org:443", "github.com:443"]
+
+
+async def test_add_allowed_domain_from_empty(ws, user):
+    # No allowed_domains yet (NULL) -> a single-element list.
+    ws_row = await ws.create_workspace(user["id"], "fresh")
+    assert await ws.add_allowed_domain(ws_row["id"], "example.com:443") is True
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["allowed_domains"] == ["example.com:443"]
+
+
+async def test_add_allowed_domain_missing_workspace(ws):
+    assert await ws.add_allowed_domain("nope", "example.com:443") is False
+
+
+async def test_add_allowed_domain_rejects_malformed(ws, user):
+    # A malformed entry is skipped (returns False), never raises -- the
+    # verdict path must not break on persistence.
+    ws_row = await ws.create_workspace(user["id"], "strict")
+    assert await ws.add_allowed_domain(ws_row["id"], "not a domain!") is False
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["allowed_domains"] is None
+
+
+async def test_add_allowed_domain_ignores_blank(ws, user):
+    # A blank entry normalizes to nothing (parse_allowed_domains drops it) ->
+    # no append, returns False, never raises.
+    ws_row = await ws.create_workspace(user["id"], "blank")
+    assert await ws.add_allowed_domain(ws_row["id"], "   ") is False
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["allowed_domains"] is None
+
+
 async def test_transfer_workspace(ws, app_state, user):
     new_owner = await app_state.state.model.users.create_user("new@x.com", "h")
     ws_row = await ws.create_workspace_with_acl(user["id"], "transfer-me")


### PR DESCRIPTION
## Summary

Closes the `forever`-allow cross-restart persistence sub-piece of #2328 (issue: #2368). A decider's **allow** with `duration=forever` now appends the consented `host:port` to the workspace's `allowed_domains`; the network sidecar re-reads `allowed_domains` on (re)start, so the allow survives a workspace container restart without re-prompting.

This replaces the earlier "replay forever allows to the sidecar on reconnect" design (which was never wired). `forever` stays a duration token — only its *enforcement* flips from an in-memory rule to a persisted-setting mutation.

## Behavior

- The deciding connection still gets its immediate in-memory ACCEPT from the verdict path (works in-session) — no dead zone before restart.
- The `allowed_domains` entry is **port-scoped** (`host:port` — the port the decider was shown; least-privilege: a durable record is not broadened to all-ports), lowercased + de-duplicated (case-insensitive).
- The list mutation is **best-effort**: any persistence failure is logged + swallowed so it can never break the verdict path; the session's in-memory ACCEPT already covers it.
- `forever` *deny* counterpart (`rejected_domains`) is a follow-up (#2369).

## Changes

- `WorkspacesModel.add_allowed_domain` — CAS append on the `allowed_domains` blob (no owner-user gate; the verdict authorized it), reusing `netfilter.parse_allowed_domains` for validation. Idempotent + concurrent-safe.
- `ConsentCoordinator.resolve` — captures a `forever`-allow row and persists it after the Future is resolved (verdict first) and before the rules broadcast (so the decider's refreshed view reflects the new entry).
- Stale "not yet wired / replay" docstrings updated (`model/egress_consent.py`, `containers/network/proxy.py`).
- 10 new tests (5 coordinator, 5 model); full backend suite green at 100%.

The e2e test (#2364) lands separately once this is in — it's blocked on this PR.

## Notes

- The changelog edit exposed a latent prettier/markdownlint conflict (prettier normalizes emphasis to `_`, MD049 demands `*`), so emphasis was removed from the new entry and two pre-existing underscore instances elsewhere in `docs/changes.md` rather than disabling MD049.
