### PR TITLE
fix(egress): forever allow covers the whole domain in-session (#2372)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,11 +32,13 @@ operators or integrators to act when upgrading.
 
 ### Added
 
-- **`forever` egress-consent allow persists across container restarts (#2368).**
-  An allow with `duration=forever` now appends the consented `host:port` to
-  the workspace's `allowed_domains`, which the network sidecar re-reads on
-  (re)start, so the allow survives a workspace container restart without
-  re-prompting. The deciding connection still gets its in-memory ACCEPT
+- **`forever` egress-consent allow persists across connections and restarts
+  (#2368, #2372).** An allow with `duration=forever` allow-lists the host for
+  the rest of the session AND across container restarts: the sidecar treats the
+  host as live allow-listed (so a later connection that resolves to a
+  CDN-rotated IP passes without re-prompting, #2372), and klangkd appends the
+  consented `host:port` to `allowed_domains`, which the sidecar re-reads on
+  (re)start (#2368). The deciding connection still gets its in-memory ACCEPT
   immediately; the persisted entry is port-scoped (the port the decider was
   shown) and de-duplicated. The `forever` deny counterpart is a follow-up
   (#2369).

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -204,6 +204,17 @@ def parse_specs() -> list[tuple[str, int | None, bool]]:
 
 SPECS = parse_specs()
 
+# Hosts allow-listed in-session by a `forever` consent verdict (#2372): each
+# entry is (host, port, is_wildcard), mirroring SPECS. On a forever allow,
+# _decide_and_verdict adds the consented host:port here so ports_for treats it
+# as allow-listed for the rest of the session -- the DNS path then learns every
+# resolved IP and allows it without NFQUEUE, so a CDN-rotated IP does NOT
+# re-prompt seconds after the user said "allow forever." Dies with the sidecar
+# (in-memory); the persisted allowed_domains entry (#2368) covers the next
+# restart. Touched only on the event-loop thread (the NFQUEUE consumer is
+# loop-driven, and ports_for runs in the DNS loop) -- no lock, like SPECS.
+_FOREVER_HOSTS: list[tuple[str, int | None, bool]] = []
+
 # Learned IPs: {ip: {"expire": epoch, "ports": set[int | None], "host": str}}.
 # ``ports`` holds the ACCEPT rule ports (a ``None`` is all-ports); ``host`` is
 # the DNS name that resolved to this IP (named in the consent request). An
@@ -288,7 +299,7 @@ def ports_for(qname: str) -> set[int] | None:
     ``pypi.org`` are distinct, non-redundant scopes) (#2256).
     """
     ports: set[int] = set()
-    for host, port, is_wildcard in SPECS:
+    for host, port, is_wildcard in (*SPECS, *_FOREVER_HOSTS):
         if is_wildcard:
             matched = qname.endswith("." + host)
         else:
@@ -299,6 +310,21 @@ def ports_for(qname: str) -> set[int] | None:
             return None  # an all-ports spec dominates
         ports.add(port)
     return ports
+
+
+def _add_forever_host(host: str, port: int) -> None:
+    """Allow-list ``host:port`` in-session for a `forever` consent verdict (#2372).
+
+    Adds ``(host, port, False)`` to :data:`_FOREVER_HOSTS` so :func:`ports_for`
+    treats the host as allow-listed for the rest of the session -- the DNS path
+    then learns every resolved IP and allows it without NFQUEUE, so a
+    CDN-rotated IP no longer re-prompts seconds after the user allowed the
+    domain. Deduped; port-scoped (callers gate on a real port -- a port-less
+    entry would broaden to all-ports).
+    """
+    spec = (host, port, False)
+    if all(s != spec for s in _FOREVER_HOSTS):
+        _FOREVER_HOSTS.append(spec)
 
 
 def _rule_args(ip: str, port: int | None) -> list[str]:
@@ -1291,6 +1317,13 @@ async def _decide_and_verdict(
                 except Exception:
                     pass
             pkt.accept()
+            if duration == "forever" and port:
+                # In-session domain coverage (#2372): a forever allow approves
+                # the host, so any later resolution of it (including a
+                # CDN-rotated IP) is allow-listed and passes without
+                # re-prompting. _FOREVER_HOSTS is read by ports_for alongside
+                # the static allow-list.
+                _add_forever_host(host, port)
         else:
             # Forge a RST directly so connect() fails fast (ECONNREFUSED) at once,
             # independent of the conntrack/retransmit race that made the REJECT

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -182,6 +182,29 @@ class TestPortsFor:
         monkeypatch.setattr(proxy, "SPECS", [("github.com", None, False)])
         assert proxy.ports_for("GitHub.Com") == set()
 
+    def test_forever_hosts_consulted_alongside_specs(self, proxy, monkeypatch):
+        # A `forever` consent verdict adds the host to _FOREVER_HOSTS (#2372);
+        # ports_for must treat it as allow-listed (apex + subdomain, port-scoped)
+        # just like a static spec, so a later CDN-rotated IP re-resolves and is
+        # allowed without re-prompting.
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(
+            proxy, "_FOREVER_HOSTS", [("example.com", 443, False)]
+        )
+        assert proxy.ports_for("example.com") == {443}
+        assert proxy.ports_for("api.example.com") == {443}
+        assert proxy.ports_for("other.com") == set()
+
+    def test_add_forever_host_dedups(self, proxy):
+        proxy._FOREVER_HOSTS.clear()
+        proxy._add_forever_host("example.com", 443)
+        proxy._add_forever_host("example.com", 443)  # dup -> one entry
+        proxy._add_forever_host("example.com", 8443)  # different port -> added
+        assert proxy._FOREVER_HOSTS == [
+            ("example.com", 443, False),
+            ("example.com", 8443, False),
+        ]
+
 
 class TestRuleArgs:
     """The iptables rule shape: port-scoped vs all-ports (#2256)."""
@@ -1022,6 +1045,7 @@ class TestNfqueueCallback:
         proxy._VERDICT_CACHE.clear()
         proxy._INFLIGHT.clear()
         proxy._LEARNED.clear()
+        proxy._FOREVER_HOSTS.clear()
         proxy._BG_TASKS.clear()
 
     async def _decide(self, proxy, pkt, client):
@@ -1068,6 +1092,43 @@ class TestNfqueueCallback:
         client.request.assert_awaited_once_with(
             "evil.test", 443
         )  # host, not IP
+
+    async def test_forever_allow_adds_host_to_session_allowlist(
+        self, proxy, monkeypatch
+    ):
+        # A `forever` allow approves the host (not just the resolved IP): the
+        # sidecar adds it to _FOREVER_HOSTS so ports_for treats it as
+        # allow-listed for the session -- a later CDN-rotated IP re-resolves
+        # and is allowed without re-prompting (#2372).
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "forever"))
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._record_hosts([("1.2.3.4", 60)], "example.com")
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await self._decide(proxy, pkt, client)
+        assert pkt.verdict == "accept"
+        assert ("example.com", 443, False) in proxy._FOREVER_HOSTS
+        # ports_for now treats the host as allow-listed (apex + subdomain).
+        monkeypatch.setattr(proxy, "SPECS", [])
+        assert proxy.ports_for("example.com") == {443}
+        assert proxy.ports_for("api.example.com") == {443}
+
+    async def test_restart_allow_does_not_add_session_allowlist(
+        self, proxy, monkeypatch
+    ):
+        # Only `forever` mutates the in-session allow-list; a restart/timed
+        # allow is a plain in-memory IP learn (no domain-level coverage).
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "restart"))
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._record_hosts([("1.2.3.4", 60)], "example.com")
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await self._decide(proxy, pkt, client)
+        assert proxy._FOREVER_HOSTS == []
 
     async def test_deny_verdict_drops_and_rejects(self, proxy, monkeypatch):
         # deny -> drop the SYN + install a REJECT (tcp-reset) so the retransmit


### PR DESCRIPTION
## Summary

Closes #2372. A `forever` allow approves the **domain**, so once a user allows `example.com:443`, every later connection to it — including a CDN-rotated IP — should pass without re-prompting, for the rest of the session AND across restarts.

#2368 delivered only the **cross-restart** half (appends `host:port` to `allowed_domains`, which the sidecar re-reads on start). **In-session**, the sidecar only learned the single resolved IP of the deciding connection, so a 2nd curl that resolved to a different IP re-prompted seconds later — surfaced by the #2364 e2e test.

## Fix

On a `forever` allow verdict the sidecar adds the consented `host:port` to an in-memory `_FOREVER_HOSTS` set that `ports_for` consults alongside the static allow-list (`SPECS`). The DNS-resolution path (`_forward_and_learn`) then learns every resolved IP for the host and allows it without NFQUEUE — so any IP the domain resolves to in-session passes without a prompt. `_FOREVER_HOSTS` dies with the sidecar; the persisted `allowed_domains` entry (#2368) covers the next restart. Port-scoped only (a port-less verdict is not added, mirroring #2368's least-privilege decision).

## Changes

- `proxy.py`: `_FOREVER_HOSTS` global; `ports_for` iterates `(*SPECS, *_FOREVER_HOSTS)`; `_add_forever_host` helper (dedup); `_decide_and_verdict` calls it on `allow`+`forever` (port > 0).
- `test_proxy.py`: `ports_for` consults `_FOREVER_HOSTS`; `_add_forever_host` dedups; `_decide_and_verdict` populates it on forever-allow (not restart); `_bind` clears it.
- Changelog: folded the in-session coverage into the (unreleased) `forever`-allow entry.

## Verification

- Unit suite: 4746 passed, 100% on `klangk` (proxy.py is outside the package gate).
- End-to-end (temp e2e on the real stack, since removed): allow `forever` → 2nd curl to the same host (possibly a rotated IP) → **no re-prompt**, connection succeeds. Confirms the fix works through the real DNS + NFQUEUE + verdict path.

The permanent e2e (in-session no re-prompt **and** cross-restart) lands on #2364 once this merges.
