### PR TITLE
fix(egress): auto-allow forever-host SYNs at the NFQUEUE gate (#2372)

### DIFF
--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -287,6 +287,20 @@ def nxdomain_for(wire: bytes) -> bytes:
     return resp.to_wire()
 
 
+def _host_matches(qname: str, host: str, is_wildcard: bool) -> bool:
+    """Apex+subdomain (bare host) vs subdomain-only (``*.host`` wildcard) match.
+
+    Shared by :func:`ports_for` (the DNS gate) and :func:`_forever_host_allows`
+    (the NFQUEUE gate) so the rule can't drift between them (#2256, #2372). A
+    bare host matches the apex + subdomains; a ``*.host`` wildcard matches
+    subdomains only (apex excluded). The suffix check requires a leading dot,
+    so ``evilexample.com`` does NOT match ``example.com``.
+    """
+    if is_wildcard:
+        return qname.endswith("." + host)
+    return qname == host or qname.endswith("." + host)
+
+
 def ports_for(qname: str) -> set[int] | None:
     """The ports a queried name is allowed on under :data:`SPECS`.
 
@@ -300,11 +314,7 @@ def ports_for(qname: str) -> set[int] | None:
     """
     ports: set[int] = set()
     for host, port, is_wildcard in (*SPECS, *_FOREVER_HOSTS):
-        if is_wildcard:
-            matched = qname.endswith("." + host)
-        else:
-            matched = qname == host or qname.endswith("." + host)
-        if not matched:
+        if not _host_matches(qname, host, is_wildcard):
             continue
         if port is None:
             return None  # an all-ports spec dominates
@@ -338,11 +348,7 @@ def _forever_host_allows(host: str, port: int) -> bool:
     if not host:
         return False
     for h, p, is_wildcard in _FOREVER_HOSTS:
-        if is_wildcard:
-            matched = host.endswith("." + h)
-        else:
-            matched = host == h or host.endswith("." + h)
-        if matched and (p == port or p is None):
+        if _host_matches(host, h, is_wildcard) and (p == port or p is None):
             return True
     return False
 
@@ -1290,12 +1296,22 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
     # auto-allowed here, the last gate before prompting, so the user isn't
     # re-asked for a domain they allowed forever.
     if port and _forever_host_allows(host, port):
-        try:
-            allow(dst, port, _DURATION_FOREVER)
-        except Exception:
-            pass
+        # allow() forks iptables under _LOCK -- run it off the loop thread (the
+        # file's invariant; every other allow/learn/reject call is in the
+        # executor). Fire-and-forget: conntrack ESTABLISHED,RELATED carries THIS
+        # connection after pkt.accept(); the ACCEPT rule only helps FUTURE
+        # connections, and the _VERDICT_CACHE write below covers retransmits.
+        # Port-scoped (the consented port) -- deliberately stricter than the
+        # consent-allow path's all-ports learn (allow(dst, None, ...)).
+        asyncio.get_running_loop().run_in_executor(
+            None, allow, dst, port, _DURATION_FOREVER
+        )
         pkt.accept()
         _VERDICT_CACHE[flow] = ("allow", now + VERDICT_CACHE_TTL)
+        # NOTE (#2370): revoking a forever verdict must also drop this host
+        # from _FOREVER_HOSTS and clear _VERDICT_CACHE, or a revoked
+        # forever-allow keeps passing (ports_for re-allow-lists it + this
+        # cache reuses the verdict). Wired with the revoke path in #2370.
         return
     pkt.retain()  # keep the payload valid past this callback (deferred verdict)
     _INFLIGHT.add(flow)
@@ -1334,6 +1350,12 @@ async def _decide_and_verdict(
     if len(_VERDICT_CACHE) > 4096:
         _VERDICT_CACHE.clear()
     _VERDICT_CACHE[flow] = (decision, now + VERDICT_CACHE_TTL)
+    # Populate the in-session allow-list BEFORE the iptables fork below (which
+    # yields to the executor): a SYN to a different IP of this host arriving
+    # during that yield would otherwise miss _FOREVER_HOSTS and re-prompt. Both
+    # gates (ports_for + _cb) read it (#2372).
+    if decision == "allow" and duration == "forever" and port:
+        _add_forever_host(host, port)
     # Run the iptables fork (allow/reject) in the executor so it doesn't block
     # the loop thread -- matches the DNS path's _learn_all, which also runs
     # off the loop. The packet is retained, so verdicting after the await is
@@ -1350,13 +1372,6 @@ async def _decide_and_verdict(
                 except Exception:
                     pass
             pkt.accept()
-            if duration == "forever" and port:
-                # In-session domain coverage (#2372): a forever allow approves
-                # the host, so any later resolution of it (including a
-                # CDN-rotated IP) is allow-listed and passes without
-                # re-prompting. _FOREVER_HOSTS is read by ports_for alongside
-                # the static allow-list.
-                _add_forever_host(host, port)
         else:
             # Forge a RST directly so connect() fails fast (ECONNREFUSED) at once,
             # independent of the conntrack/retransmit race that made the REJECT

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -327,6 +327,26 @@ def _add_forever_host(host: str, port: int) -> None:
         _FOREVER_HOSTS.append(spec)
 
 
+def _forever_host_allows(host: str, port: int) -> bool:
+    """Does a `forever` verdict allow-list ``host`` on ``port`` (#2372)?
+
+    Used by :func:`_cb` as the last-chance gate before prompting: a SYN to a
+    host:port the user allowed forever is auto-allowed even when no fresh DNS
+    resolution re-ACCEPTed the (CDN-rotated or resolver-cached) IP. Mirrors
+    :func:`ports_for`'s apex+subdomain matching but tests a specific port.
+    """
+    if not host:
+        return False
+    for h, p, is_wildcard in _FOREVER_HOSTS:
+        if is_wildcard:
+            matched = host.endswith("." + h)
+        else:
+            matched = host == h or host.endswith("." + h)
+        if matched and (p == port or p is None):
+            return True
+    return False
+
+
 def _rule_args(ip: str, port: int | None) -> list[str]:
     """iptables OUTPUT rule args for ``ACCEPT`` to ``ip`` (optionally scoped)."""
     args = ["-d", ip]
@@ -1264,6 +1284,19 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
         pkt.drop()
         return
     host = _host_for(dst)  # DNS name if resolved here, else the IP
+    # A `forever` allow covers the whole domain (#2372): a SYN to a host:port
+    # the user already allowed forever -- including a CDN-rotated or
+    # resolver-cached IP that no fresh DNS resolution re-ACCEPTed -- is
+    # auto-allowed here, the last gate before prompting, so the user isn't
+    # re-asked for a domain they allowed forever.
+    if port and _forever_host_allows(host, port):
+        try:
+            allow(dst, port, _DURATION_FOREVER)
+        except Exception:
+            pass
+        pkt.accept()
+        _VERDICT_CACHE[flow] = ("allow", now + VERDICT_CACHE_TTL)
+        return
     pkt.retain()  # keep the payload valid past this callback (deferred verdict)
     _INFLIGHT.add(flow)
     t = asyncio.create_task(_decide_and_verdict(pkt, flow, dst, port, host, client))

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -207,7 +207,8 @@ class TestPortsFor:
 
     def test_forever_host_allows(self, proxy, monkeypatch):
         # The NFQUEUE-gate predicate (#2372): apex + subdomain match, port must
-        # match, wrong host/port denied.
+        # match, wrong host/port denied. Mirrors ports_for's matching (shared
+        # via _host_matches) -- pin the boundary cases ports_for is pinned on.
         monkeypatch.setattr(
             proxy, "_FOREVER_HOSTS", [("example.com", 443, False)]
         )
@@ -215,7 +216,22 @@ class TestPortsFor:
         assert proxy._forever_host_allows("api.example.com", 443)  # subdomain
         assert not proxy._forever_host_allows("example.com", 80)  # wrong port
         assert not proxy._forever_host_allows("other.com", 443)  # wrong host
+        assert not proxy._forever_host_allows("evilexample.com", 443)  # suffix
         assert not proxy._forever_host_allows("", 443)  # no host
+        # wildcard: subdomains only, NOT the apex.
+        monkeypatch.setattr(
+            proxy, "_FOREVER_HOSTS", [("example.com", 443, True)]
+        )
+        assert proxy._forever_host_allows("a.example.com", 443)
+        assert not proxy._forever_host_allows(
+            "example.com", 443
+        )  # apex excluded
+        # all-ports entry (p is None) matches any port -- defensive (forever
+        # entries are added port-scoped, but the predicate tolerates None).
+        monkeypatch.setattr(
+            proxy, "_FOREVER_HOSTS", [("example.com", None, False)]
+        )
+        assert proxy._forever_host_allows("example.com", 8080)
 
 
 class TestRuleArgs:
@@ -1132,22 +1148,44 @@ class TestNfqueueCallback:
     ):
         # A SYN to an IP whose host was allowed forever is auto-allowed at the
         # NFQUEUE gate (no consent prompt), even though no ACCEPT rule covered
-        # it -- covers a CDN-rotated / resolver-cached IP that no fresh DNS
-        # resolution re-learned (#2372). _decide_and_verdict populated
-        # _FOREVER_HOSTS on the deciding connection; this LATER SYN to a
-        # different recorded IP of the same host is auto-allowed here.
+        # it -- covers a CDN-rotated / cached IP that no fresh DNS resolution
+        # re-learned (#2372). allow() runs off the loop in the executor; the
+        # verdict is cached for retransmits.
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value=("allow", "forever"))
-        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        allowed = []
+        monkeypatch.setattr(proxy, "allow", lambda *a: allowed.append(a))
         self._bind(proxy, monkeypatch, client)
         proxy._add_forever_host("example.com", 443)
         proxy._record_hosts([("2.2.2.2", 60)], "example.com")
         pkt = _FakePkt(_ip_payload("2.2.2.2", 443))
         proxy._cb(pkt, client)  # sync: auto-allows inline, no task
+        await asyncio.sleep(0.1)  # let the executor run allow()
         assert pkt.verdict == "accept"
         client.request.assert_not_awaited()  # no consent prompt
         assert not proxy._BG_TASKS  # no verdict task spawned
+        # allow() called port-scoped, in the executor, with the forever TTL.
+        assert allowed == [("2.2.2.2", 443, proxy._DURATION_FOREVER)]
+        # Verdict cached so a retransmit reuses it without re-prompting.
+        assert any(v[0] == "allow" for v in proxy._VERDICT_CACHE.values())
+
+    async def test_cb_does_not_auto_allow_wrong_port(self, proxy, monkeypatch):
+        # The gate is host+port scoped end-to-end: a SYN to a forever host on a
+        # DIFFERENT port (the allow was :443; this SYN is :80) is NOT
+        # auto-allowed -- it reaches the consent prompt (the security property,
+        # exercised through _cb, not just the predicate).
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "once"))
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        monkeypatch.setattr(proxy, "reject", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._add_forever_host("example.com", 443)
+        proxy._record_hosts([("2.2.2.2", 60)], "example.com")
+        proxy._cb(_FakePkt(_ip_payload("2.2.2.2", 80)), client)
+        await asyncio.gather(*proxy._BG_TASKS)  # the prompt task ran
+        client.request.assert_awaited_once_with("example.com", 80)
 
     async def test_restart_allow_does_not_add_session_allowlist(
         self, proxy, monkeypatch

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -205,6 +205,18 @@ class TestPortsFor:
             ("example.com", 8443, False),
         ]
 
+    def test_forever_host_allows(self, proxy, monkeypatch):
+        # The NFQUEUE-gate predicate (#2372): apex + subdomain match, port must
+        # match, wrong host/port denied.
+        monkeypatch.setattr(
+            proxy, "_FOREVER_HOSTS", [("example.com", 443, False)]
+        )
+        assert proxy._forever_host_allows("example.com", 443)
+        assert proxy._forever_host_allows("api.example.com", 443)  # subdomain
+        assert not proxy._forever_host_allows("example.com", 80)  # wrong port
+        assert not proxy._forever_host_allows("other.com", 443)  # wrong host
+        assert not proxy._forever_host_allows("", 443)  # no host
+
 
 class TestRuleArgs:
     """The iptables rule shape: port-scoped vs all-ports (#2256)."""
@@ -1114,6 +1126,28 @@ class TestNfqueueCallback:
         monkeypatch.setattr(proxy, "SPECS", [])
         assert proxy.ports_for("example.com") == {443}
         assert proxy.ports_for("api.example.com") == {443}
+
+    async def test_cb_auto_allows_syn_to_forever_host_ip(
+        self, proxy, monkeypatch
+    ):
+        # A SYN to an IP whose host was allowed forever is auto-allowed at the
+        # NFQUEUE gate (no consent prompt), even though no ACCEPT rule covered
+        # it -- covers a CDN-rotated / resolver-cached IP that no fresh DNS
+        # resolution re-learned (#2372). _decide_and_verdict populated
+        # _FOREVER_HOSTS on the deciding connection; this LATER SYN to a
+        # different recorded IP of the same host is auto-allowed here.
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "forever"))
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._add_forever_host("example.com", 443)
+        proxy._record_hosts([("2.2.2.2", 60)], "example.com")
+        pkt = _FakePkt(_ip_payload("2.2.2.2", 443))
+        proxy._cb(pkt, client)  # sync: auto-allows inline, no task
+        assert pkt.verdict == "accept"
+        client.request.assert_not_awaited()  # no consent prompt
+        assert not proxy._BG_TASKS  # no verdict task spawned
 
     async def test_restart_allow_does_not_add_session_allowlist(
         self, proxy, monkeypatch


### PR DESCRIPTION
## Summary

Closes #2372 (reopened). Follow-up to #2373: a `forever` allow must cover the **whole domain** in-session, including a later connection that lands on a **CDN-rotated or resolver-cached IP**.

#2373 made `ports_for` consult `_FOREVER_HOSTS`, so a connection that does a *fresh DNS resolution* of a forever-allowed host is allow-listed (no NFQUEUE). But a later connection can land on an IP that no fresh resolution re-ACCEPTed — its SYN reaches NFQUEUE and re-prompts, seconds after the user said "allow forever." example.com round-robins across `172.66.x` / `104.20.x` and curl's Happy Eyeballs retries them, so this presented as ~50% flakiness.

## Fix

The NFQUEUE callback (`_cb`) is the **last gate before prompting**. When a SYN arrives whose dst IP maps (via `_host_for`) to a host:port the user allowed forever, auto-allow it (install the ACCEPT + accept the packet, no prompt) and cache the verdict for retransmits. Robust to any CDN rotation / caching: every SYN to a forever-host is allowed at the final gate. The DNS-level check (#2373) stays as a fast path (avoids NFQUEUE for fresh resolutions); this is the correctness backstop.

## Verification

- Unit: `_cb` auto-allows a SYN to a forever-host IP (no prompt, no verdict task); `_forever_host_allows` apex/subdomain/port matching. `test_proxy.py` 111 passed.
- **End-to-end (rebuilt sidecar): 4/4 runs where the 2nd curl hit a DIFFERENT CDN-rotated IP than the deciding connection all passed with no re-prompt** — was ~50% flaky before the gate.

  Note: the earlier local flakiness was a **stale sidecar image** — `proxy.py` is baked into the sidecar image and `test-backend-e2e` does not rebuild it. CI's e2e job rebuilds the sidecar in setup, so it has the fix. (Worth a separate look: should the e2e task rebuild the sidecar if `src/containers/network/**` changed? Out of scope here.)

## Files

- `proxy.py`: `_forever_host_allows` predicate; `_cb` auto-allows + caches.
- `test_proxy.py`: `_cb` auto-allow test + `_forever_host_allows` matching test.

Once this merges, #2364's e2e (in-session no-re-prompt **and** cross-restart) becomes deterministic.
