### PR TITLE
feat(egress): exact-host-by-default matching, nginx-style (#2377)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -436,6 +436,15 @@ operators or integrators to act when upgrading.
   (valid _until_ restart vs. starting _at_ restart), `tilrestart` states the
   window directly.
 
+- **`allowed_domains` / forever-allow host matching is now exact-by-default
+  (nginx-style) (#2377).** A bare host (`example.com`) now matches the apex
+  **only**; prefix with a dot (`.example.com`) for apex + subdomains (the old
+  bare-host behavior); `*.example.com` remains subdomains only. This aligns
+  with the firewall mainstream (Cilium `matchName`, Pi-hole / hosts-file, nginx
+  `server_name`) and makes a `forever` consent allow least-privilege by default
+  — it covers exactly the host the user approved, not its subdomains. No
+  migration required (single deployment).
+
 - **New workspaces default to `egress_mode=interactive`.** The default is
   `interactive`, so held egress requests reach a decider out of the box without
   a manual per-workspace flip (`EGRESS_MODE_DEFAULT` in `model/workspaces.py`);

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -227,7 +227,7 @@ SPECS = parse_specs()
 # (in-memory); the persisted allowed_domains entry (#2368) covers the next
 # restart. Touched only on the event-loop thread (the NFQUEUE consumer is
 # loop-driven, and ports_for runs in the DNS loop) -- no lock, like SPECS.
-_FOREVER_HOSTS: list[tuple[str, int | None, bool]] = []
+_FOREVER_HOSTS: list[tuple[str, int | None, str]] = []
 
 # Learned IPs: {ip: {"expire": epoch, "ports": set[int | None], "host": str}}.
 # ``ports`` holds the ACCEPT rule ports (a ``None`` is all-ports); ``host`` is
@@ -313,9 +313,9 @@ def _host_matches(qname: str, host: str, mode: str) -> bool:
     """
     if mode == _SUBDOMAINS:
         return qname.endswith("." + host)
-    if mode == _EXACT:
-        return qname == host
-    return qname == host or qname.endswith("." + host)  # _INCLUSIVE
+    if mode == _INCLUSIVE:
+        return qname == host or qname.endswith("." + host)
+    return qname == host  # _EXACT (and the safe default for an unknown mode)
 
 
 def ports_for(qname: str) -> set[int] | None:

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -173,16 +173,26 @@ def _duration_ttl(duration: str) -> float | None:
 WORKSPACE_TOKEN_PATH = "/run/klangk/workspace-token"
 
 
-def parse_specs() -> list[tuple[str, int | None, bool]]:
-    """Structured allow-list specs from ``KLANGKNETWORK_EGRESS_ALLOW``.
+# Host-scope modes for an allow-list spec, nginx-style (#2377): a bare host is
+# EXACT (apex only); a leading-dot ``.host`` is INCLUSIVE (apex + subdomains);
+# ``*.host`` is SUBDOMAINS only. (Bare = exact is the breaking flip from the
+# old "bare = apex+subdomains" model.) One definition shared by parse_specs /
+# ports_for / _forever_host_allows.
+_EXACT = "exact"
+_INCLUSIVE = "inclusive"
+_SUBDOMAINS = "subdomains"
 
-    Each entry is ``(host, port, is_wildcard)`` where ``port`` is ``None``
-    (all ports) and ``is_wildcard`` means ``*.host`` (subdomains only). CIDR
-    specs (``10.0.0.0/8``) are excluded — the entrypoint applies those
-    statically. The grammar mirrors ``klangk.netfilter.parse_allowed_domains``
-    so the API and the sidecar agree on what a spec means (#2256).
+
+def parse_specs() -> list[tuple[str, int | None, str]]:
+    """Structured allow-list specs from ``KLANGKNETWORK_EGRESS_ALLOW`` (#2377).
+
+    Each entry is ``(host, port, mode)``: ``mode`` is :data:`_EXACT` (bare host,
+    apex only), :data:`_INCLUSIVE` (``.host``, apex + subdomains), or
+    :data:`_SUBDOMAINS` (``*.host``, subdomains only). ``port`` is ``None`` for
+    all-ports. CIDR specs (``10.0.0.0/8``) are excluded — the entrypoint applies
+    those statically. The grammar mirrors ``klangk.netfilter.parse_allowed_domains``.
     """
-    out: list[tuple[str, int | None, bool]] = []
+    out: list[tuple[str, int | None, str]] = []
     for spec in os.environ.get("KLANGKNETWORK_EGRESS_ALLOW", "").split(","):
         spec = spec.strip()
         if not spec or "/" in spec:
@@ -193,19 +203,23 @@ def parse_specs() -> list[tuple[str, int | None, bool]]:
             if port_part.isdigit():
                 port = int(port_part)
                 spec = host_part
-        host = spec.lower()
-        is_wildcard = host.startswith("*.")
-        if is_wildcard:
-            host = host[2:]
-        if host:
-            out.append((host, port, is_wildcard))
+        s = spec.lower()
+        mode = _EXACT
+        if s.startswith("*."):
+            mode = _SUBDOMAINS
+            s = s[2:]
+        elif s.startswith("."):
+            mode = _INCLUSIVE
+            s = s[1:]
+        if s:
+            out.append((s, port, mode))
     return out
 
 
 SPECS = parse_specs()
 
 # Hosts allow-listed in-session by a `forever` consent verdict (#2372): each
-# entry is (host, port, is_wildcard), mirroring SPECS. On a forever allow,
+# entry is (host, port, mode), mirroring SPECS. On a forever allow,
 # _decide_and_verdict adds the consented host:port here so ports_for treats it
 # as allow-listed for the rest of the session -- the DNS path then learns every
 # resolved IP and allows it without NFQUEUE, so a CDN-rotated IP does NOT
@@ -287,34 +301,37 @@ def nxdomain_for(wire: bytes) -> bytes:
     return resp.to_wire()
 
 
-def _host_matches(qname: str, host: str, is_wildcard: bool) -> bool:
-    """Apex+subdomain (bare host) vs subdomain-only (``*.host`` wildcard) match.
+def _host_matches(qname: str, host: str, mode: str) -> bool:
+    """Does ``qname`` match ``host`` under nginx-style scope ``mode`` (#2377)?
 
     Shared by :func:`ports_for` (the DNS gate) and :func:`_forever_host_allows`
-    (the NFQUEUE gate) so the rule can't drift between them (#2256, #2372). A
-    bare host matches the apex + subdomains; a ``*.host`` wildcard matches
-    subdomains only (apex excluded). The suffix check requires a leading dot,
-    so ``evilexample.com`` does NOT match ``example.com``.
+    (the NFQUEUE gate) so the two can't drift. :data:`_EXACT` (bare host) matches
+    the apex only; :data:`_INCLUSIVE` (``.host``) matches apex + subdomains;
+    :data:`_SUBDOMAINS` (``*.host``) matches subdomains only. The suffix check
+    requires a leading dot, so ``evilexample.com`` does NOT match
+    ``example.com``.
     """
-    if is_wildcard:
+    if mode == _SUBDOMAINS:
         return qname.endswith("." + host)
-    return qname == host or qname.endswith("." + host)
+    if mode == _EXACT:
+        return qname == host
+    return qname == host or qname.endswith("." + host)  # _INCLUSIVE
 
 
 def ports_for(qname: str) -> set[int] | None:
-    """The ports a queried name is allowed on under :data:`SPECS`.
+    """The ports a queried name is allowed on under :data:`SPECS` (#2377).
 
     ``None``  — a port-less spec matched (allow all ports).
     ``set()`` — nothing matched (deny).
     ``{443, ...}`` — allow exactly these TCP ports.
 
-    A bare host matches the apex + subdomains; a ``*.host`` wildcard matches
-    subdomains only (the apex is deliberately excluded so ``*.pypi.org`` and
-    ``pypi.org`` are distinct, non-redundant scopes) (#2256).
+    Scope: a bare host is :data:`_EXACT` (apex only); ``.host`` is
+    :data:`_INCLUSIVE` (apex + subdomains); ``*.host`` is :data:`_SUBDOMAINS`
+    (subdomains only, apex excluded).
     """
     ports: set[int] = set()
-    for host, port, is_wildcard in (*SPECS, *_FOREVER_HOSTS):
-        if not _host_matches(qname, host, is_wildcard):
+    for host, port, mode in (*SPECS, *_FOREVER_HOSTS):
+        if not _host_matches(qname, host, mode):
             continue
         if port is None:
             return None  # an all-ports spec dominates
@@ -325,14 +342,16 @@ def ports_for(qname: str) -> set[int] | None:
 def _add_forever_host(host: str, port: int) -> None:
     """Allow-list ``host:port`` in-session for a `forever` consent verdict (#2372).
 
-    Adds ``(host, port, False)`` to :data:`_FOREVER_HOSTS` so :func:`ports_for`
+    Adds ``(host, port, _EXACT)`` to :data:`_FOREVER_HOSTS` so :func:`ports_for`
     treats the host as allow-listed for the rest of the session -- the DNS path
     then learns every resolved IP and allows it without NFQUEUE, so a
     CDN-rotated IP no longer re-prompts seconds after the user allowed the
-    domain. Deduped; port-scoped (callers gate on a real port -- a port-less
-    entry would broaden to all-ports).
+    host. EXACT scope: the user approved the specific qname they saw, so only
+    that host (not its subdomains) is opened (#2377). Deduped; port-scoped
+    (callers gate on a real port -- a port-less entry would broaden to
+    all-ports).
     """
-    spec = (host, port, False)
+    spec = (host, port, _EXACT)
     if all(s != spec for s in _FOREVER_HOSTS):
         _FOREVER_HOSTS.append(spec)
 
@@ -342,13 +361,14 @@ def _forever_host_allows(host: str, port: int) -> bool:
 
     Used by :func:`_cb` as the last-chance gate before prompting: a SYN to a
     host:port the user allowed forever is auto-allowed even when no fresh DNS
-    resolution re-ACCEPTed the (CDN-rotated or resolver-cached) IP. Mirrors
-    :func:`ports_for`'s apex+subdomain matching but tests a specific port.
+    resolution re-ACCEPTed the (CDN-rotated or resolver-cached) IP. Matches via
+    :func:`_host_matches` (nginx-style scope); forever entries are added EXACT
+    by :func:`_add_forever_host`, so only the approved host matches (#2377).
     """
     if not host:
         return False
-    for h, p, is_wildcard in _FOREVER_HOSTS:
-        if _host_matches(host, h, is_wildcard) and (p == port or p is None):
+    for h, p, mode in _FOREVER_HOSTS:
+        if _host_matches(host, h, mode) and (p == port or p is None):
             return True
     return False
 

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -260,7 +260,8 @@ class ConsentCoordinator:
         still works; only the cross-restart durability is at risk.
 
         Port-less verdicts (``dest_port`` falsy, e.g. an ICMP ping) are NOT
-        persisted -- a bare host would broaden to all-ports + subdomains.
+        persisted -- a port-less bare host would broaden to all-ports (apex
+        only, since bare is now exact).
         Direct-IP ``dest_host`` values are likewise poor candidates (the
         DNS-based allow-list never re-matches an IP literal after restart),
         but are left as-is here rather than special-cased.
@@ -276,9 +277,9 @@ class ConsentCoordinator:
         if not port:
             # Port-scoped only (#2368): a port-less verdict (e.g. an ICMP
             # ping, dest_port 0) must not be persisted as a bare host -- the
-            # sidecar treats a port-less spec as all-ports + apex/subdomains,
-            # durably broadening one connection's consent to everything on
-            # that name. The deciding connection still gets its in-memory
+            # sidecar treats a port-less spec as all-ports on the apex (bare is
+            # exact), durably broadening one connection's consent to every port
+            # on that host. The deciding connection still gets its in-memory
             # ACCEPT for this session; durability is simply withheld.
             logger.info(
                 "consent: forever allow of port-less dest %s ws=%s not "

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -67,12 +67,16 @@ def _valid_domain_spec(spec: str) -> bool:
     # below is unchanged (#1935).
     if "/" in spec:
         return _valid_cidr_spec(spec)
-    # Wildcard: a leading ``*.`` matches subdomains only (NOT the apex) —
-    # distinct from a bare host, which matches the apex + subdomains. Strip
-    # the ``*.`` and validate the remaining ``host[:port]`` grammar. A bare
-    # ``*`` or ``*.`` has no matchable base (#2256).
+    # nginx-style host scopes (#2377): a bare host is EXACT (apex only); a
+    # leading ``.`` is INCLUSIVE (apex + subdomains); ``*.`` is SUBDOMAINS only.
+    # Strip the sigil and validate the remaining ``host[:port]`` grammar; a bare
+    # ``*``, ``*.``, or ``.`` has no matchable base (#2256).
     if spec.startswith("*."):
         spec = spec[2:]
+        if not spec:
+            return False
+    elif spec.startswith("."):
+        spec = spec[1:]
         if not spec:
             return False
     if not _DOMAIN_RE.match(spec):

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -64,6 +64,10 @@ class TestParseAllowedDomains:
             "*.pypi.org:443",
             "*.double.example.com",  # wildcard on a multi-label base
             "*.pypi.org:65535",  # wildcard + max port
+            # #2377: leading "." inclusive scope (apex + subdomains).
+            ".pypi.org",
+            ".pypi.org:443",
+            ".double.example.com",
             # #1935: IPv4 CIDR ranges (with and without a port scope).
             "10.0.0.0/8",
             "10.0.0.0/8:443",
@@ -95,6 +99,7 @@ class TestParseAllowedDomains:
             "*pypi.org",  # missing the dot after *
             "*",  # bare wildcard — nothing to match
             "*.",  # wildcard with empty base
+            ".",  # inclusive (leading dot) with empty base
             "a*.pypi.org",  # wildcard not at the leading position
             "pypi.org.*",  # wildcard at the wrong end
             # #1935: malformed CIDR specs.

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -82,26 +82,32 @@ def learned(proxy):
 
 
 class TestParseSpecs:
-    """Env parsing → ``(host, port|None, is_wildcard)`` triples. CIDRs are
-    skipped (the entrypoint applies those statically); the grammar mirrors
-    ``klangk.netfilter.parse_allowed_domains`` (#2256)."""
+    """Env parsing → ``(host, port|None, mode)`` triples. CIDRs are skipped
+    (the entrypoint applies those statically); the grammar mirrors
+    ``klangk.netfilter.parse_allowed_domains`` (#2377 nginx-style scopes)."""
 
-    def test_ports_wildcards_cidr_skip(self, proxy, monkeypatch):
+    def test_bare_is_exact_dot_is_inclusive_wildcard_is_subdomains(
+        self, proxy, monkeypatch
+    ):
         monkeypatch.setenv(
             "KLANGKNETWORK_EGRESS_ALLOW",
-            "github.com:443,*.pypi.org,pypi.org,"
-            "10.0.0.0/8,10.0.0.0/8:53,bare.com:8443",
+            "github.com:443,*.pypi.org,.pypi.org,bare.com:8443,"
+            "10.0.0.0/8,10.0.0.0/8:53",
         )
         assert proxy.parse_specs() == [
-            ("github.com", 443, False),
-            ("pypi.org", None, True),  # *.pypi.org
-            ("pypi.org", None, False),
-            ("bare.com", 8443, False),
+            ("github.com", 443, proxy._EXACT),  # bare -> exact
+            ("pypi.org", None, proxy._SUBDOMAINS),  # *.pypi.org
+            ("pypi.org", None, proxy._INCLUSIVE),  # .pypi.org
+            ("bare.com", 8443, proxy._EXACT),
         ]
 
     def test_wildcard_with_port(self, proxy, monkeypatch):
         monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "*.pypi.org:443")
-        assert proxy.parse_specs() == [("pypi.org", 443, True)]
+        assert proxy.parse_specs() == [("pypi.org", 443, proxy._SUBDOMAINS)]
+
+    def test_inclusive_with_port(self, proxy, monkeypatch):
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", ".pypi.org:443")
+        assert proxy.parse_specs() == [("pypi.org", 443, proxy._INCLUSIVE)]
 
     def test_empty_env(self, proxy, monkeypatch):
         monkeypatch.delenv("KLANGKNETWORK_EGRESS_ALLOW", raising=False)
@@ -109,45 +115,56 @@ class TestParseSpecs:
 
 
 class TestPortsFor:
-    """``ports_for`` is the allow gate. Returns ``None`` (all ports), a port
-    ``set`` (scoped allow), or ``set()`` (deny). A suffix-match regression here
-    (e.g. a bare ``endswith(h)``) would wrongly admit ``evilgithub.com`` for an
-    allow-listed ``github.com``. Pin the exact / subdomain / wildcard / port
-    semantics so a refactor can't silently weaken it (#2256)."""
+    """``ports_for`` is the allow gate (#2377 nginx-style scopes). Returns
+    ``None`` (all ports), a port ``set`` (scoped allow), or ``set()`` (deny).
+    Bare host = EXACT (apex only); ``.host`` = INCLUSIVE (apex + subdomains);
+    ``*.host`` = SUBDOMAINS only. Pin the boundaries so a refactor can't
+    silently weaken them."""
 
-    @pytest.mark.parametrize(
-        "qname, expected",
-        [
-            ("github.com", None),  # exact -> all ports
-            ("api.github.com", None),  # subdomain -> all ports
-            ("evilgithub.com", set()),  # boundary: NOT a subdomain
-            ("github.com.attacker.test", set()),  # prefix-of, not a suffix
-        ],
-    )
-    def test_suffix_boundary(self, proxy, monkeypatch, qname, expected):
-        # The dot boundary ("." + h) stops evilgithub.com matching github.com.
-        monkeypatch.setattr(proxy, "SPECS", [("github.com", None, False)])
-        assert proxy.ports_for(qname) == expected
+    def test_bare_host_is_exact_apex_only(self, proxy, monkeypatch):
+        # bare github.com -> EXACT (#2377): apex only, NOT subdomains.
+        monkeypatch.setattr(
+            proxy, "SPECS", [("github.com", None, proxy._EXACT)]
+        )
+        assert proxy.ports_for("github.com") is None  # apex
+        assert proxy.ports_for("api.github.com") == set()  # subdomain denied
+        assert proxy.ports_for("evilgithub.com") == set()  # boundary
+        assert proxy.ports_for("github.com.attacker.test") == set()
 
-    def test_port_scope_applies_to_apex_and_subdomain(
-        self, proxy, monkeypatch
-    ):
-        monkeypatch.setattr(proxy, "SPECS", [("github.com", 443, False)])
-        assert proxy.ports_for("github.com") == {443}
-        assert proxy.ports_for("api.github.com") == {443}
+    def test_inclusive_matches_apex_and_subdomains(self, proxy, monkeypatch):
+        # .github.com -> apex + subdomains (any depth) -- the old bare behavior.
+        monkeypatch.setattr(
+            proxy, "SPECS", [("github.com", None, proxy._INCLUSIVE)]
+        )
+        assert proxy.ports_for("github.com") is None
+        assert proxy.ports_for("api.github.com") is None
+        assert proxy.ports_for("a.b.github.com") is None
+        assert proxy.ports_for("evilgithub.com") == set()  # boundary
 
     def test_wildcard_excludes_apex(self, proxy, monkeypatch):
-        # *.pypi.org matches subdomains only, NOT pypi.org itself — distinct
-        # from a bare pypi.org (apex + subdomains).
-        monkeypatch.setattr(proxy, "SPECS", [("pypi.org", None, True)])
+        # *.pypi.org -> subdomains only, NOT the apex.
+        monkeypatch.setattr(
+            proxy, "SPECS", [("pypi.org", None, proxy._SUBDOMAINS)]
+        )
         assert proxy.ports_for("pypi.org") == set()
         assert proxy.ports_for("a.pypi.org") is None
         assert proxy.ports_for("a.b.pypi.org") is None
 
     def test_wildcard_with_port(self, proxy, monkeypatch):
-        monkeypatch.setattr(proxy, "SPECS", [("pypi.org", 443, True)])
+        monkeypatch.setattr(
+            proxy, "SPECS", [("pypi.org", 443, proxy._SUBDOMAINS)]
+        )
         assert proxy.ports_for("pypi.org") == set()
         assert proxy.ports_for("x.pypi.org") == {443}
+
+    def test_port_scope_exact(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy, "SPECS", [("github.com", 443, proxy._EXACT)]
+        )
+        assert proxy.ports_for("github.com") == {443}
+        assert (
+            proxy.ports_for("api.github.com") == set()
+        )  # exact -> no subdomain
 
     def test_all_ports_spec_dominates(self, proxy, monkeypatch):
         # github.com (all ports) + github.com:443 -> all ports win.
@@ -155,8 +172,8 @@ class TestPortsFor:
             proxy,
             "SPECS",
             [
-                ("github.com", None, False),
-                ("github.com", 443, False),
+                ("github.com", None, proxy._EXACT),
+                ("github.com", 443, proxy._EXACT),
             ],
         )
         assert proxy.ports_for("github.com") is None
@@ -165,7 +182,10 @@ class TestPortsFor:
         monkeypatch.setattr(
             proxy,
             "SPECS",
-            [("github.com", 443, False), ("github.com", 8443, False)],
+            [
+                ("github.com", 443, proxy._EXACT),
+                ("github.com", 8443, proxy._EXACT),
+            ],
         )
         assert proxy.ports_for("github.com") == {443, 8443}
 
@@ -177,22 +197,24 @@ class TestPortsFor:
         self, proxy, monkeypatch
     ):
         # ports_for compares verbatim; parse_specs/query_name lowercase at the
-        # edges. Pin that contract: a mixed-case qname does NOT match a
-        # lowercased spec, so the lowercasing must not be dropped upstream.
-        monkeypatch.setattr(proxy, "SPECS", [("github.com", None, False)])
+        # edges. A mixed-case qname does NOT match a lowercased spec.
+        monkeypatch.setattr(
+            proxy, "SPECS", [("github.com", None, proxy._EXACT)]
+        )
         assert proxy.ports_for("GitHub.Com") == set()
 
     def test_forever_hosts_consulted_alongside_specs(self, proxy, monkeypatch):
-        # A `forever` consent verdict adds the host to _FOREVER_HOSTS (#2372);
-        # ports_for must treat it as allow-listed (apex + subdomain, port-scoped)
-        # just like a static spec, so a later CDN-rotated IP re-resolves and is
-        # allowed without re-prompting.
+        # A `forever` consent verdict adds the host (EXACT) to _FOREVER_HOSTS
+        # (#2372, #2377): ports_for treats that exact host as allow-listed, so a
+        # later CDN-rotated IP re-resolves and is allowed without re-prompting.
         monkeypatch.setattr(proxy, "SPECS", [])
         monkeypatch.setattr(
-            proxy, "_FOREVER_HOSTS", [("example.com", 443, False)]
+            proxy, "_FOREVER_HOSTS", [("example.com", 443, proxy._EXACT)]
         )
         assert proxy.ports_for("example.com") == {443}
-        assert proxy.ports_for("api.example.com") == {443}
+        assert (
+            proxy.ports_for("api.example.com") == set()
+        )  # exact -> no subdomain
         assert proxy.ports_for("other.com") == set()
 
     def test_add_forever_host_dedups(self, proxy):
@@ -201,35 +223,27 @@ class TestPortsFor:
         proxy._add_forever_host("example.com", 443)  # dup -> one entry
         proxy._add_forever_host("example.com", 8443)  # different port -> added
         assert proxy._FOREVER_HOSTS == [
-            ("example.com", 443, False),
-            ("example.com", 8443, False),
+            ("example.com", 443, proxy._EXACT),
+            ("example.com", 8443, proxy._EXACT),
         ]
 
     def test_forever_host_allows(self, proxy, monkeypatch):
-        # The NFQUEUE-gate predicate (#2372): apex + subdomain match, port must
-        # match, wrong host/port denied. Mirrors ports_for's matching (shared
-        # via _host_matches) -- pin the boundary cases ports_for is pinned on.
+        # The NFQUEUE-gate predicate (#2372): forever entries are EXACT (#2377),
+        # so only the approved host (not its subdomains) matches; port must
+        # match. Mirrors ports_for via the shared _host_matches.
         monkeypatch.setattr(
-            proxy, "_FOREVER_HOSTS", [("example.com", 443, False)]
+            proxy, "_FOREVER_HOSTS", [("example.com", 443, proxy._EXACT)]
         )
         assert proxy._forever_host_allows("example.com", 443)
-        assert proxy._forever_host_allows("api.example.com", 443)  # subdomain
+        assert not proxy._forever_host_allows("api.example.com", 443)  # exact
         assert not proxy._forever_host_allows("example.com", 80)  # wrong port
         assert not proxy._forever_host_allows("other.com", 443)  # wrong host
         assert not proxy._forever_host_allows("evilexample.com", 443)  # suffix
         assert not proxy._forever_host_allows("", 443)  # no host
-        # wildcard: subdomains only, NOT the apex.
-        monkeypatch.setattr(
-            proxy, "_FOREVER_HOSTS", [("example.com", 443, True)]
-        )
-        assert proxy._forever_host_allows("a.example.com", 443)
-        assert not proxy._forever_host_allows(
-            "example.com", 443
-        )  # apex excluded
         # all-ports entry (p is None) matches any port -- defensive (forever
         # entries are added port-scoped, but the predicate tolerates None).
         monkeypatch.setattr(
-            proxy, "_FOREVER_HOSTS", [("example.com", None, False)]
+            proxy, "_FOREVER_HOSTS", [("example.com", None, proxy._EXACT)]
         )
         assert proxy._forever_host_allows("example.com", 8080)
 
@@ -1137,11 +1151,13 @@ class TestNfqueueCallback:
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await self._decide(proxy, pkt, client)
         assert pkt.verdict == "accept"
-        assert ("example.com", 443, False) in proxy._FOREVER_HOSTS
-        # ports_for now treats the host as allow-listed (apex + subdomain).
+        assert ("example.com", 443, proxy._EXACT) in proxy._FOREVER_HOSTS
+        # ports_for now treats the host as allow-listed (EXACT -- apex only).
         monkeypatch.setattr(proxy, "SPECS", [])
         assert proxy.ports_for("example.com") == {443}
-        assert proxy.ports_for("api.example.com") == {443}
+        assert (
+            proxy.ports_for("api.example.com") == set()
+        )  # exact -> no subdomain
 
     async def test_cb_auto_allows_syn_to_forever_host_ip(
         self, proxy, monkeypatch


### PR DESCRIPTION
## Summary

Closes #2377. Flip `allowed_domains` / `forever`-allow host matching to **exact-by-default**, nginx-style — aligning with the firewall mainstream (Cilium `matchName`, Pi-hole / hosts-file, nginx `server_name`):

| Spec | Matches | vs. before |
|------|---------|------------|
| `example.com` (bare) | **apex only** (exact) | was apex+subdomains — behavior change |
| `.example.com` (leading dot) | apex + subdomains (any depth) | new — the old bare-host behavior |
| `*.example.com` (wildcard) | subdomains only | unchanged |

A `forever` consent allow now covers **exactly** the host the user approved (the specific qname they saw), not its subdomains — least-privilege by default, which resolves the subhost concern raised on #2374 without a special syntax. Widening to subdomains is an explicit opt-in (`.host`). **No migration required** (single deployment).

## Changes

- `proxy.py`: spec tuple `(host, port, is_wildcard)` → `(host, port, mode)` with `_EXACT` / `_INCLUSIVE` / `_SUBDOMAINS`; `parse_specs` handles the leading-dot `.host`; `_host_matches` dispatches by mode (shared by `ports_for` + `_forever_host_allows`); `_add_forever_host` now adds an `_EXACT` entry.
- `netfilter.py`: `_valid_domain_spec` accepts the leading-dot `.host` form (and rejects `.` with an empty base).
- Tests: `TestParseSpecs` / `TestPortsFor` / the forever tests rewritten for the new semantics (bare = exact, `.host` = inclusive, `*.host` = subdomains); `test_netfilter` grammar gains `.host` (+ empty-base `.` rejection).
- Changelog: `Changed` entry.

## Verification

- Full backend unit suite: **4752 passed, 100%** on `klangk`. The grammar is covered in both gates (`ports_for`, `_forever_host_allows`) and the validator.
- The consent e2e uses exact hosts (no subdomain reliance), so it's unaffected by the flip; CI's `test-backend-e2e` job (which rebuilds the sidecar) will confirm the consent flow end-to-end.

## Notes

- This completes the `forever`-allow story: #2368 (persist across restart via `allowed_domains`) + #2372/#2374 (cover the domain in-session, no CDN-rotation re-prompt) + this (exact-by-default scope). The follow-ups #2369 (forever-deny / `rejected_domains`), #2370 (revoke for list-based verdicts — must clear `_FOREVER_HOSTS` + `_VERDICT_CACHE`), #2375 (e2e sidecar rebuild), #2376 (egress flowchart) remain open.
