### PR TITLE
refactor(egress-consent): rename duration token `restart` -> `tilrestart` (#2357)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -427,6 +427,15 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Egress-consent duration token `restart` renamed to `tilrestart` (#2357).**
+  The verdict `duration` value `restart` is now `tilrestart` ("until restart")
+  everywhere — the model constant, the wire/DB token, the `consent-decide` TUI
+  selector, the web consent banner, and the network sidecar. The semantics are
+  unchanged (the verdict holds for the workspace container's lifetime and is
+  cleared on restart); only the token name changes. `restart` reads ambiguously
+  (valid _until_ restart vs. starting _at_ restart), `tilrestart` states the
+  window directly.
+
 - **New workspaces default to `egress_mode=interactive`.** The default is
   `interactive`, so held egress requests reach a decider out of the box without
   a manual per-workspace flip (`EGRESS_MODE_DEFAULT` in `model/workspaces.py`);

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -159,10 +159,10 @@ _DURATION_FOREVER = 365 * 86400  # ~a year; practically until restart
 
 
 def _duration_ttl(duration: str) -> float | None:
-    """Seconds for a timed/restart/forever duration, or None for ``once``."""
+    """Seconds for a timed/tilrestart/forever duration, or None for ``once``."""
     if duration in _DURATION_SECONDS:
         return _DURATION_SECONDS[duration]
-    if duration in ("restart", "forever"):
+    if duration in ("tilrestart", "forever"):
         return _DURATION_FOREVER
     return None  # "once" or unknown -> caller handles (no learn / short reject)
 

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -2,7 +2,7 @@
 ///
 /// A compact banner shown above the workspace body when [ConsentDeciderService]
 /// has pending held requests (interactive `egress_mode` only). The header
-/// carries a single *global* duration selector (default `restart`); each row
+/// carries a single *global* duration selector (default `tilrestart`); each row
 /// shows the destination host:port (+ process + a countdown) and Allow/Deny
 /// buttons that send a `verdict` frame carrying the selected duration. Mirrors
 /// the standalone `klangk consent-decide` TUI (one `#duration-selector` for the
@@ -42,7 +42,7 @@ class ConsentBanner extends StatefulWidget {
 
 class _ConsentBannerState extends State<ConsentBanner> {
   /// The chosen verdict duration, applied to whichever row's Allow/Deny is
-  /// tapped. One selector for the whole banner (default `restart`), mirroring
+  /// tapped. One selector for the whole banner (default `tilrestart`), mirroring
   /// the TUI's single global `#duration-selector` -- not a per-row choice.
   String _duration = kConsentDurationDefault;
   Timer? _tick;
@@ -51,11 +51,13 @@ class _ConsentBannerState extends State<ConsentBanner> {
   void initState() {
     super.initState();
     widget.service.addListener(_onChange);
+    // coverage:ignore-start
     // 1s countdown refresh while requests are held (the server is the source
     // of truth; this only repaints the remaining-seconds hint).
     _tick = Timer.periodic(const Duration(seconds: 1), (_) {
       if (mounted && widget.service.pending.isNotEmpty) _onChange();
     });
+    // coverage:ignore-end
   }
 
   @override

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -28,7 +28,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 const String kDecisionAllowed = 'allowed';
 const String kDecisionDenied = 'denied';
 
-/// Ordered for the duration selector; the default is `restart` (#2328).
+/// Ordered for the duration selector; the default is `tilrestart` (#2328).
 const List<String> kConsentDurations = [
   'once',
   '5m',
@@ -36,10 +36,10 @@ const List<String> kConsentDurations = [
   '1h',
   '1d',
   '1w',
-  'restart',
+  'tilrestart',
   'forever',
 ];
-const String kConsentDurationDefault = 'restart';
+const String kConsentDurationDefault = 'tilrestart';
 
 /// Inbound-frame application outcomes returned by [ConsentDeciderService.applyFrame].
 enum ConsentFrameOutcome {
@@ -241,7 +241,9 @@ class ConsentDeciderService extends ChangeNotifier {
       (raw) {
         if (raw is String) _onMessage(raw);
       },
+      // coverage:ignore-start
       onError: (Object e) => debugPrint('[ConsentDecider] stream error: $e'),
+      // coverage:ignore-end
       onDone: () => _onClosed(ch),
       cancelOnError: true,
     );

--- a/src/frontend/test/consent_banner_test.dart
+++ b/src/frontend/test/consent_banner_test.dart
@@ -149,7 +149,8 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('Allow carries the default duration (restart)', (tester) async {
+  testWidgets('Allow carries the default duration (tilrestart)',
+      (tester) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -168,7 +169,7 @@ void main() {
     await tester.tap(find.text('Allow'));
     await tester.pump();
     final out = jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
-    expect(out['duration'], 'restart');
+    expect(out['duration'], 'tilrestart');
     svc.dispose();
   });
 
@@ -191,7 +192,7 @@ void main() {
     await tester.pump();
     // Exactly one duration selector (global, in the header) -- not one per row.
     expect(find.byType(DropdownButton<String>), findsOneWidget);
-    expect(find.text('restart'), findsOneWidget);
+    expect(find.text('tilrestart'), findsOneWidget);
     svc.dispose();
   });
 
@@ -258,6 +259,40 @@ void main() {
     await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
     await tester.pumpAndSettle();
     expect(find.textContaining('please log in again'), findsOneWidget);
+    svc.dispose();
+  });
+
+  testWidgets('shows "reconnecting…" when disconnected mid-hold',
+      (tester) async {
+    final channel = _FakeChannel();
+    ConsentDeciderService.testChannelFactory = (_) => channel;
+    final svc = ConsentDeciderService(
+      workspaceId: 'ws',
+      token: 't',
+      // Long delay so the reconnect Timer never fires during the test
+      // (dispose cancels it regardless).
+      reconnectDelays: const [Duration(minutes: 5)],
+      clock: () =>
+          DateTime.fromMillisecondsSinceEpoch(2000 * 1000, isUtc: true),
+    );
+    svc.connect();
+    channel.serverSend({
+      'type': 'egress_request',
+      'request': {
+        'id': 'r1',
+        'workspace_id': 'ws',
+        'dest_host': 'example.com',
+        'dest_port': 443,
+        'requested_at': 2000.0,
+      },
+    });
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pump();
+    expect(find.text('reconnecting…'), findsNothing); // still connected
+    channel.serverClose(); // clean drop, no code -> not an auth failure
+    await tester.pump(); // flush onDone -> notifyListeners -> rebuild
+    await tester.pump();
+    expect(find.text('reconnecting…'), findsOneWidget);
     svc.dispose();
   });
 }

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -192,6 +192,43 @@ void main() {
     });
   });
 
+  group('PendingRequest equality', () {
+    final a = PendingRequest(
+        id: 'r1',
+        destHost: 'h',
+        destPort: 443,
+        processName: 'curl',
+        requestedAt: 1.0);
+
+    test('equal on all fields, with matching hashCode', () {
+      final b = PendingRequest(
+          id: 'r1',
+          destHost: 'h',
+          destPort: 443,
+          processName: 'curl',
+          requestedAt: 1.0);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, equals(a)); // identical
+    });
+
+    test('any differing field breaks equality', () {
+      expect(
+          a,
+          isNot(equals(PendingRequest(
+              id: 'r1',
+              destHost: 'h',
+              destPort: 443,
+              processName: 'curl',
+              requestedAt: 2.0)))); // requestedAt differs
+      expect(
+          a,
+          isNot(equals(PendingRequest(
+              id: 'r2', destHost: 'h', requestedAt: 1.0)))); // id differs
+      expect(a, isNot(equals('not a request'))); // wrong type
+    });
+  });
+
   group('ConsentDeciderService', () {
     late _FakeChannel channel;
 
@@ -321,6 +358,39 @@ void main() {
       );
       final req = PendingRequest(id: 'r', destHost: 'h', requestedAt: 1000.0);
       expect(svc.remainingSeconds(req), 120);
+      svc.dispose();
+    });
+
+    test('pong and unknown frames are no-ops through the live socket',
+        () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend({'type': 'egress_request', 'request': _request()});
+      await Future.delayed(Duration.zero);
+      expect(svc.pending, hasLength(1));
+      // A pong and an unknown frame neither mutate pending nor throw.
+      channel.serverSend({'type': 'pong'});
+      channel.serverSend({'type': 'egress_rules', 'rules': []});
+      await Future.delayed(Duration.zero);
+      expect(svc.pending, hasLength(1));
+      svc.dispose();
+    });
+
+    test('a non-auth close clears connected and schedules a reconnect',
+        () async {
+      final svc = ConsentDeciderService(
+        workspaceId: 'ws',
+        token: 't',
+        // Long delay so the reconnect Timer never fires during the test
+        // (dispose cancels it regardless).
+        reconnectDelays: const [Duration(minutes: 5)],
+      );
+      svc.connect();
+      expect(svc.connected, isTrue);
+      channel.serverClose(); // clean close, no code -> not an auth failure
+      await Future.delayed(Duration.zero);
+      expect(svc.connected, isFalse);
+      expect(svc.authFailed, isFalse);
       svc.dispose();
     });
   });

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -48,14 +48,14 @@ logger = logging.getLogger(__name__)
 DECISION_ALLOWED = "allowed"
 DECISION_DENIED = "denied"
 # Duration tokens mirror the server (model/egress_consent.py); duplicated here
-# per CLI isolation. Ordered for the TUI selector; default is `restart` (#2328).
+# per CLI isolation. Ordered for the TUI selector; default is `tilrestart` (#2328).
 DURATION_ONCE = "once"
 DURATION_5M = "5m"
 DURATION_15M = "15m"
 DURATION_1H = "1h"
 DURATION_1D = "1d"
 DURATION_1W = "1w"
-DURATION_RESTART = "restart"
+DURATION_TILRESTART = "tilrestart"
 DURATION_FOREVER = "forever"
 DURATIONS = (
     DURATION_ONCE,
@@ -64,14 +64,14 @@ DURATIONS = (
     DURATION_1H,
     DURATION_1D,
     DURATION_1W,
-    DURATION_RESTART,
+    DURATION_TILRESTART,
     DURATION_FOREVER,
 )
-DURATION_DEFAULT = DURATION_RESTART
+DURATION_DEFAULT = DURATION_TILRESTART
 
 # Seconds each *timed* duration adds to ``decided_at`` (mirror of the server's
 # ``_DURATION_SECONDS``; duplicated per CLI isolation). ``once`` is consumed by
-# the single connection and ``restart``/``forever`` have no fixed expiry, so
+# the single connection and ``tilrestart``/``forever`` have no fixed expiry, so
 # they are absent -- a rule with one of those (or None) has no countdown.
 _DURATION_SECONDS = {
     DURATION_5M: 300,
@@ -308,7 +308,7 @@ class ConsentDeciderController:
     def rule_remaining(self, rule: ConsentRule) -> float | None:
         """Seconds left on a timed verdict, or None if it has no fixed expiry.
 
-        None covers ``restart``/``forever`` (open-ended), ``once`` (consumed,
+        None covers ``tilrestart``/``forever`` (open-ended), ``once`` (consumed,
         never in ``list_active``), and unknown/NULL durations -- the rules view
         shows ``until restart``/``forever`` for those instead of a countdown.
         """
@@ -472,7 +472,7 @@ class ConsentDeciderApp(App):
     /* Non-selected duration buttons carry no background -- not even when focused
     (#2360). The first button grabs initial focus on mount; without an explicit
     transparent :focus it rendered with the white focus background, so it read
-    as "selected" alongside the real ``dur-sel`` default (``restart``). The
+    as "selected" alongside the real ``dur-sel`` default (``tilrestart``). The
     ``dur-sel`` rules are qualified under ``#duration-selector`` so they outrank
     these ID-based transparent rules on specificity (an unqualified ``.dur-sel``
     loses to ``#duration-selector Button:focus`` and the accent vanishes). */
@@ -520,7 +520,7 @@ class ConsentDeciderApp(App):
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static(id="status")
-        # Global duration selector (default `restart`): click to choose; selecting
+        # Global duration selector (default `tilrestart`): click to choose; selecting
         # does NOT submit -- only a row's Allow/Deny submits with this duration.
         yield Horizontal(*self._duration_buttons(), id="duration-selector")
         with Vertical():
@@ -1091,7 +1091,7 @@ class RulesScreen(Screen):
         proc = f"  ({rule.process_name})" if rule.process_name else ""
         if rule.duration == DURATION_FOREVER:
             label = "forever"
-        elif rule.duration == DURATION_RESTART:
+        elif rule.duration == DURATION_TILRESTART:
             label = "until restart"
         else:
             rem = controller.rule_remaining(rule)

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -2021,7 +2021,7 @@ class ContainerRegistry:
         # previous container. Reap those rows so list_active (#2335) matches
         # the enforced set (#2346). Safe on a first-ever start (no rows yet);
         # `forever`/time-bounded/`once`/pending/static rows are left alone.
-        await self.app.state.model.egress_consent.clear_restart_duration(
+        await self.app.state.model.egress_consent.clear_tilrestart_duration(
             workspace_id
         )
 

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -28,8 +28,9 @@ DECISIONS = frozenset(
 
 # Duration values for an allow/deny decision (#2328): how long the sidecar
 # honors it (allow learns the IP for T; deny REJECTs for T). `once` = this
-# connection only; `restart` = the workspace container's lifetime (the sidecar's
-# in-memory rules); `forever` = the workspace's lifetime -- persists across
+# connection only; `tilrestart` ("until restart") = the workspace container's
+# lifetime (the sidecar's in-memory rules); `forever` = the workspace's lifetime
+# -- persists across
 # container/sidecar restarts: an allow persists via an `allowed_domains`
 # mutation the sidecar re-reads on start (#2368) -- best-effort, so a failed
 # mutation means the allow won't survive restart despite the audit row here;
@@ -40,7 +41,7 @@ DURATION_15M = "15m"
 DURATION_1H = "1h"
 DURATION_1D = "1d"
 DURATION_1W = "1w"
-DURATION_RESTART = "restart"
+DURATION_TILRESTART = "tilrestart"
 DURATION_FOREVER = "forever"
 DURATIONS = frozenset(
     {
@@ -50,11 +51,11 @@ DURATIONS = frozenset(
         DURATION_1H,
         DURATION_1D,
         DURATION_1W,
-        DURATION_RESTART,
+        DURATION_TILRESTART,
         DURATION_FOREVER,
     }
 )
-DURATION_DEFAULT = DURATION_RESTART
+DURATION_DEFAULT = DURATION_TILRESTART
 
 # Canonical column list for SELECTs + _row_to_dict, so the read shape cannot
 # drift from the schema (a column added to the table is added here once).
@@ -209,7 +210,7 @@ class EgressConsentModel:
             return [_row_to_dict(row) for row in rows]
 
     # Duration string -> seconds, for the time-bounded in-effect window
-    # (#2328). `once`/`restart`/`forever` are not time-bounded (handled
+    # (#2328). `once`/`tilrestart`/`forever` are not time-bounded (handled
     # separately in :meth:`_duration_in_effect`), so they're absent here.
     _DURATION_SECONDS = {
         DURATION_5M: 300,
@@ -230,8 +231,8 @@ class EgressConsentModel:
         - ``once`` -> excluded (consumed by the single connection).
         - ``5m``/``15m``/``1h``/``1d``/``1w`` -> in effect iff
           ``decided_at + duration`` > now.
-        - ``restart`` -> in effect (container lifetime). Reaped when the
-          workspace container (re)starts (:meth:`clear_restart_duration`,
+        - ``tilrestart`` -> in effect (container lifetime). Reaped when the
+          workspace container (re)starts (:meth:`clear_tilrestart_duration`,
           #2346), so the recorded set matches what the sidecar enforces across
           container restarts; a sidecar-only restart (no container restart)
           is the one residual gap.
@@ -270,7 +271,7 @@ class EgressConsentModel:
         """Whether a decision is still in effect at ``now`` (#2335 slice A)."""
         if decided_at is None:
             return False
-        if duration in (DURATION_RESTART, DURATION_FOREVER):
+        if duration in (DURATION_TILRESTART, DURATION_FOREVER):
             return True
         if duration == DURATION_ONCE:
             return False
@@ -409,7 +410,7 @@ class EgressConsentModel:
         Uses ``DECISION_EXPIRED`` so the audit trail distinguishes a
         human deny from an unattended timeout. The duration is ``once`` -- a
         timeout is a non-persistent deny (just this connection), distinct from
-        an active deny (which defaults to `restart`).
+        an active deny (which defaults to `tilrestart`).
         """
         decided_at = time.time()
         async with self.app.state.db.transaction() as db:
@@ -455,10 +456,11 @@ class EgressConsentModel:
             )
             return cursor.rowcount
 
-    async def clear_restart_duration(self, workspace_id: str) -> int:
-        """Delete decided ``restart``-duration verdicts for a workspace (#2346).
+    async def clear_tilrestart_duration(self, workspace_id: str) -> int:
+        """Delete decided ``tilrestart``-duration verdicts for a workspace (#2346).
 
-        A ``restart`` verdict means "for the workspace container's lifetime" --
+        A ``tilrestart`` ("until restart") verdict means "for the workspace
+        container's lifetime" --
         the sidecar honors it via an in-memory rule (a learned ACCEPT for an
         allow, a REJECT for a deny) that dies when the sidecar/container
         restarts. But this row persists, so without reaping :meth:`list_active`
@@ -481,7 +483,7 @@ class EgressConsentModel:
                 " AND decision IN (?, ?)",
                 (
                     workspace_id,
-                    DURATION_RESTART,
+                    DURATION_TILRESTART,
                     DECISION_ALLOWED,
                     DECISION_DENIED,
                 ),

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -357,7 +357,7 @@ class TestFrameBuilders:
             "type": "verdict",
             "request_id": "r1",
             "decision": "allowed",
-            "duration": "restart",
+            "duration": "tilrestart",
         }
 
     def test_make_verdict_carries_duration(self):
@@ -367,7 +367,7 @@ class TestFrameBuilders:
     def test_make_verdict_denied(self):
         msg = json.loads(make_verdict("r1", "denied"))
         assert msg["decision"] == "denied"
-        assert msg["duration"] == "restart"
+        assert msg["duration"] == "tilrestart"
 
     def test_make_ping(self):
         assert json.loads(make_ping()) == {"type": "ping"}
@@ -758,9 +758,9 @@ class TestAppActions:
                 for s in ws.sent
             ), ws.sent
 
-    async def test_duration_defaults_to_restart(self):
-        # A fresh row defaults to `restart`; Allow without changing it sends
-        # `restart`.
+    async def test_duration_defaults_to_tilrestart(self):
+        # A fresh row defaults to `tilrestart`; Allow without changing it sends
+        # `tilrestart`.
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -774,7 +774,7 @@ class TestAppActions:
                 )
             )
             await pilot.pause()
-            assert any('"restart"' in s for s in ws.sent), ws.sent
+            assert any('"tilrestart"' in s for s in ws.sent), ws.sent
 
     async def test_duration_selector_guards(self):
         # Defensive guard: a button without a duration attr is a no-op.
@@ -784,13 +784,13 @@ class TestAppActions:
             app._refresh()
             await pilot.pause()
             app._select_duration(types.SimpleNamespace(duration=None))
-            assert app._duration == "restart"  # unchanged (default)
+            assert app._duration == "tilrestart"  # unchanged (default)
 
     async def test_only_selected_duration_has_background_at_first_render(self):
         # Regression (#2360): the first duration button ("once") grabbed
         # initial focus on mount and, with no explicit transparent :focus,
         # rendered the white focus background -- so it read as "selected"
-        # alongside the real ``dur-sel`` default (``restart``). Only the
+        # alongside the real ``dur-sel`` default (``tilrestart``). Only the
         # selected button may carry a background; every other (focused or
         # not) must be transparent at first render. Asserted opacity-only so
         # it holds across light/dark themes (the exact accent hue is the
@@ -828,11 +828,11 @@ class TestAppActions:
                 f"selected+focused button lost its background "
                 f"(got {btn.styles.background!r})"
             )
-            restart = app.query_one(
+            default_btn = app.query_one(
                 f"#dur-{tui_consent.DURATION_DEFAULT}", Button
             )
-            assert not restart.has_class("dur-sel")
-            assert restart.styles.background.a == 0
+            assert not default_btn.has_class("dur-sel")
+            assert default_btn.styles.background.a == 0
 
 
 class TestWsLoop:
@@ -1287,7 +1287,7 @@ class TestControllerRulesExpiry:
         )
         assert c.rule_remaining(rule) == 0.0
 
-    def test_rule_remaining_restart_is_none(self):
+    def test_rule_remaining_tilrestart_is_none(self):
         c = ConsentDeciderController()
         rule = ConsentRule(
             id="a1",
@@ -1295,7 +1295,7 @@ class TestControllerRulesExpiry:
             dest_port=1,
             process_name=None,
             decision="allowed",
-            duration="restart",
+            duration="tilrestart",
             decided_at=100.0,
             decided_by=None,
         )
@@ -1564,7 +1564,7 @@ class TestRulesScreen:
                 _rules_frame(
                     allowed=[
                         _rule("a1", duration="forever"),
-                        _rule("a2", duration="restart"),
+                        _rule("a2", duration="tilrestart"),
                     ],
                 )
             )

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
@@ -37,7 +37,7 @@ from klangk.cli.tui.consent import (
     DECISION_DENIED,
     DURATION_FOREVER,
     DURATION_ONCE,
-    DURATION_RESTART,
+    DURATION_TILRESTART,
 )
 
 # Short consent timeout so test 4 (no-decision -> timeout) doesn't keep the
@@ -266,7 +266,7 @@ class TestConsentDecisionEndStates:
 
                 rid = await _wait_for_request(app, "example.com")
                 # The user allows (default duration).
-                app._decide_id(rid, DECISION_ALLOWED, DURATION_RESTART)
+                app._decide_id(rid, DECISION_ALLOWED, DURATION_TILRESTART)
                 await _wait_resolved(app, rid)
                 await pilot.pause()
 
@@ -310,7 +310,7 @@ class TestConsentDecisionEndStates:
 
                 rid = await _wait_for_request(app, "example.com")
                 # The user denies.
-                app._decide_id(rid, DECISION_DENIED, DURATION_RESTART)
+                app._decide_id(rid, DECISION_DENIED, DURATION_TILRESTART)
                 await _wait_resolved(app, rid)
                 await pilot.pause()
 
@@ -350,7 +350,7 @@ class TestConsentDecisionEndStates:
                 # Allow a connection to example.com.
                 _trigger(container, "example.com", "/tmp/iso1.out")
                 rid1 = await _wait_for_request(app, "example.com")
-                app._decide_id(rid1, DECISION_ALLOWED, DURATION_RESTART)
+                app._decide_id(rid1, DECISION_ALLOWED, DURATION_TILRESTART)
                 await _wait_resolved(app, rid1)
                 await pilot.pause()
 
@@ -452,8 +452,10 @@ class TestConsentDecisionEndStates:
                 assert rid_deny in app.controller.pending
 
                 # The user allows one and denies the OTHER while both are held.
-                app._decide_id(rid_allow, DECISION_ALLOWED, DURATION_RESTART)
-                app._decide_id(rid_deny, DECISION_DENIED, DURATION_RESTART)
+                app._decide_id(
+                    rid_allow, DECISION_ALLOWED, DURATION_TILRESTART
+                )
+                app._decide_id(rid_deny, DECISION_DENIED, DURATION_TILRESTART)
                 await _wait_resolved(app, rid_allow)
                 await _wait_resolved(app, rid_deny)
                 await pilot.pause()
@@ -624,7 +626,7 @@ class TestConsentDecisionEndStates:
                 # 1st connection: held, then denied until restart.
                 _trigger(container, "example.com", "/tmp/r_restart_0.out")
                 rid = await _wait_for_request(app, "example.com")
-                app._decide_id(rid, DECISION_DENIED, DURATION_RESTART)
+                app._decide_id(rid, DECISION_DENIED, DURATION_TILRESTART)
                 await _wait_resolved(app, rid)
                 await pilot.pause()
                 res0 = await _wait_result(container, "/tmp/r_restart_0.out")
@@ -683,7 +685,7 @@ class TestConsentDecisionEndStates:
                     "not reuse the reaped request"
                 )
                 # Clean up: deny so the held connection doesn't outlive the test.
-                app._decide_id(rid2, DECISION_DENIED, DURATION_RESTART)
+                app._decide_id(rid2, DECISION_DENIED, DURATION_TILRESTART)
                 await _wait_resolved(app, rid2)
         finally:
             await ws_conn.close()

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -102,7 +102,7 @@ def _active_row(req_id="rid-1", decision="allowed", host="1.2.3.4"):
         "dest_host": host,
         "dest_port": 443,
         "decision": decision,
-        "duration": "restart",
+        "duration": "tilrestart",
     }
 
 
@@ -315,7 +315,7 @@ class TestConsentCoordinatorFanout:
         row = _request()
         row["decision"] = "allowed"
         row["duration"] = (
-            "restart"  # a real in-effect duration (once would be excluded)
+            "tilrestart"  # a real in-effect duration (once would be excluded)
         )
         app = _app(
             request=_request(),
@@ -425,7 +425,7 @@ class TestConsentCoordinatorRules:
             "dest_host": "allow.com",
             "dest_port": 443,
             "decision": "allowed",
-            "duration": "restart",
+            "duration": "tilrestart",
         }
         denied = {
             "id": "d1",

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -2058,7 +2058,7 @@ class TestStartContainer:
         # with the previous container, so list_active must not report them.
         ec = self.registry.app.state.model.egress_consent
         a = await ec.create_request(workspace["id"], "stale.com", 443)
-        await ec.decide(a["id"], "allowed", user["id"], "restart")
+        await ec.decide(a["id"], "allowed", user["id"], "tilrestart")
         # sanity: in effect before the start
         assert {
             r["dest_host"] for r in await ec.list_active(workspace["id"])
@@ -2076,7 +2076,7 @@ class TestStartContainer:
         # container didn't restart, so its in-memory rules are still alive.
         ec = self.registry.app.state.model.egress_consent
         a = await ec.create_request(workspace["id"], "live.com", 443)
-        await ec.decide(a["id"], "allowed", user["id"], "restart")
+        await ec.decide(a["id"], "allowed", user["id"], "tilrestart")
         with patch_podman(self.registry, inspect_container=_running(True)):
             cid, status = await self.registry.start_container(
                 workspace["id"],

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -280,7 +280,7 @@ async def test_decide_default_duration_is_restart(ec, ws, user):
     row = await ec.app.state.db.fetchone(
         "SELECT duration FROM egress_consent WHERE id = ?", (req["id"],)
     )
-    assert row["duration"] == "restart"
+    assert row["duration"] == "tilrestart"
 
 
 async def test_decide_invalid_duration_raises(ec, ws, user):
@@ -396,7 +396,7 @@ async def test_cascade_delete_on_workspace_delete(ec, ws, user):
 async def test_list_active_groups_allowed_and_denied(ec, ws, user):
     w = await ws.create_workspace(user["id"], "active-grp")
     a = await ec.create_request(w["id"], "allow.com", 443)
-    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "restart")
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "tilrestart")
     d = await ec.create_request(w["id"], "deny.com", 443)
     await ec.decide(d["id"], DECISION_DENIED, user["id"], "forever")
     rows = await ec.list_active(w["id"])
@@ -407,7 +407,7 @@ async def test_list_active_groups_allowed_and_denied(ec, ws, user):
     }
     # each row carries its duration (the read fix, #2338)
     by_host = {r["dest_host"]: r for r in rows}
-    assert by_host["allow.com"]["duration"] == "restart"
+    assert by_host["allow.com"]["duration"] == "tilrestart"
     assert by_host["deny.com"]["duration"] == "forever"
 
 
@@ -466,30 +466,31 @@ def test_duration_in_effect_unknown_and_null_duration():
     assert EgressConsentModel._duration_in_effect("5m", None, 2.0) is False
     # restart/forever are event-bounded, not time-bounded -> always in effect.
     assert (
-        EgressConsentModel._duration_in_effect("restart", 0.0, 999.0) is True
+        EgressConsentModel._duration_in_effect("tilrestart", 0.0, 999.0)
+        is True
     )
     assert (
         EgressConsentModel._duration_in_effect("forever", 0.0, 999.0) is True
     )
 
 
-# -- clear_restart_duration (container-restart reaping, #2346) --
+# -- clear_tilrestart_duration (container-restart reaping, #2346) --
 
 
-async def test_clear_restart_duration_clears_allow_and_deny(ec, ws, user):
+async def test_clear_tilrestart_duration_clears_allow_and_deny(ec, ws, user):
     # A restart allow AND a restart deny both die with the container.
     w = await ws.create_workspace(user["id"], "clr-rst")
     a = await ec.create_request(w["id"], "allow.com", 443)
-    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "restart")
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "tilrestart")
     d = await ec.create_request(w["id"], "deny.com", 443)
-    await ec.decide(d["id"], DECISION_DENIED, user["id"], "restart")
-    count = await ec.clear_restart_duration(w["id"])
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], "tilrestart")
+    count = await ec.clear_tilrestart_duration(w["id"])
     assert count == 2
     # Neither survives in list_active (the rule-management view).
     assert await ec.list_active(w["id"]) == []
 
 
-async def test_clear_restart_duration_leaves_other_durations(ec, ws, user):
+async def test_clear_tilrestart_duration_leaves_other_durations(ec, ws, user):
     # forever / time-bounded (5m) / once are governed by their own lifetime,
     # not the container's -- left untouched.
     w = await ws.create_workspace(user["id"], "clr-keep")
@@ -503,36 +504,38 @@ async def test_clear_restart_duration_leaves_other_durations(ec, ws, user):
     await ec.decide(once["id"], DECISION_ALLOWED, user["id"], "once")
     # one restart row to clear, to confirm only it is reaped.
     ra = await ec.create_request(w["id"], "restart.com")
-    await ec.decide(ra["id"], DECISION_ALLOWED, user["id"], "restart")
+    await ec.decide(ra["id"], DECISION_ALLOWED, user["id"], "tilrestart")
 
-    count = await ec.clear_restart_duration(w["id"])
+    count = await ec.clear_tilrestart_duration(w["id"])
     assert count == 1
     # forever (allow + deny) + the fresh 5m are still in effect; once excluded.
     hosts = {r["dest_host"] for r in await ec.list_active(w["id"])}
     assert hosts == {"forever-allow.com", "forever-deny.com", "timed.com"}
 
 
-async def test_clear_restart_duration_leaves_pending_and_static(ec, ws, user):
+async def test_clear_tilrestart_duration_leaves_pending_and_static(
+    ec, ws, user
+):
     # Pending requests + static policy denials are not restart verdicts.
     w = await ws.create_workspace(user["id"], "clr-pend")
     await ec.create_request(w["id"], "pending.com", 443)  # stays pending
     await ec.record_static_denial(w["id"], "static.com", 443)
-    count = await ec.clear_restart_duration(w["id"])
+    count = await ec.clear_tilrestart_duration(w["id"])
     assert count == 0
     # Both rows still present (list_active excludes them, so check list_requests).
     hosts = {r["dest_host"] for r in await ec.list_requests(w["id"])}
     assert hosts == {"pending.com", "static.com"}
 
 
-async def test_clear_restart_duration_is_scoped_to_workspace(ec, ws, user):
+async def test_clear_tilrestart_duration_is_scoped_to_workspace(ec, ws, user):
     # Only the named workspace's restart rows are reaped.
     w1 = await ws.create_workspace(user["id"], "clr-a")
     w2 = await ws.create_workspace(user["id"], "clr-b")
     a = await ec.create_request(w1["id"], "a.com", 443)
-    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "restart")
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], "tilrestart")
     b = await ec.create_request(w2["id"], "b.com", 443)
-    await ec.decide(b["id"], DECISION_ALLOWED, user["id"], "restart")
-    count = await ec.clear_restart_duration(w1["id"])
+    await ec.decide(b["id"], DECISION_ALLOWED, user["id"], "tilrestart")
+    count = await ec.clear_tilrestart_duration(w1["id"])
     assert count == 1
     # w2's restart row survives.
     assert {r["dest_host"] for r in await ec.list_active(w2["id"])} == {
@@ -541,10 +544,10 @@ async def test_clear_restart_duration_is_scoped_to_workspace(ec, ws, user):
     assert await ec.list_active(w1["id"]) == []
 
 
-async def test_clear_restart_duration_no_rows_is_zero(ec, ws, user):
+async def test_clear_tilrestart_duration_no_rows_is_zero(ec, ws, user):
     # First-ever start: no restart rows -> no-op, returns 0.
     w = await ws.create_workspace(user["id"], "clr-empty")
-    assert await ec.clear_restart_duration(w["id"]) == 0
+    assert await ec.clear_tilrestart_duration(w["id"]) == 0
 
 
 # -- revoke (#2339) --
@@ -553,7 +556,7 @@ async def test_clear_restart_duration_no_rows_is_zero(ec, ws, user):
 async def test_revoke_flips_active_allow(ec, ws, user):
     w = await ws.create_workspace(user["id"], "revoke-allow")
     req = await ec.create_request(w["id"], "allow.com", 443)
-    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "restart")
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "tilrestart")
     row = await ec.revoke(req["id"], user["id"])
     assert row["decision"] == DECISION_REVOKED
     assert row["revoked_at"] is not None
@@ -590,7 +593,7 @@ async def test_revoke_unknown_returns_none(ec, ws, user):
 async def test_revoke_idempotent_second_call_returns_none(ec, ws, user):
     w = await ws.create_workspace(user["id"], "revoke-idem")
     req = await ec.create_request(w["id"], "idem.com")
-    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "restart")
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "tilrestart")
     assert await ec.revoke(req["id"], user["id"]) is not None
     assert await ec.revoke(req["id"], user["id"]) is None  # already revoked
 
@@ -598,7 +601,7 @@ async def test_revoke_idempotent_second_call_returns_none(ec, ws, user):
 async def test_list_active_excludes_revoked(ec, ws, user):
     w = await ws.create_workspace(user["id"], "revoke-excluded")
     req = await ec.create_request(w["id"], "rev.com")
-    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "restart")
+    await ec.decide(req["id"], DECISION_ALLOWED, user["id"], "tilrestart")
     assert len(await ec.list_active(w["id"])) == 1
     await ec.revoke(req["id"], user["id"])
     assert await ec.list_active(w["id"]) == []

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1087,7 +1087,7 @@ class TestNfqueueCallback:
     ):
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value=("allow", "restart"))
+        client.request = AsyncMock(return_value=("allow", "tilrestart"))
         learned = []
         monkeypatch.setattr(
             proxy,
@@ -1108,7 +1108,7 @@ class TestNfqueueCallback:
     async def test_allow_names_host_from_ip_map(self, proxy, monkeypatch):
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value=("allow", "restart"))
+        client.request = AsyncMock(return_value=("allow", "tilrestart"))
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
         self._bind(proxy, monkeypatch, client)
         proxy._record_hosts(
@@ -1194,7 +1194,7 @@ class TestNfqueueCallback:
         # allow is a plain in-memory IP learn (no domain-level coverage).
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value=("allow", "restart"))
+        client.request = AsyncMock(return_value=("allow", "tilrestart"))
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
         self._bind(proxy, monkeypatch, client)
         proxy._record_hosts([("1.2.3.4", 60)], "example.com")
@@ -1255,7 +1255,7 @@ class TestNfqueueCallback:
     async def test_unparseable_dest_drops(self, proxy, monkeypatch):
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value=("allow", "restart"))
+        client.request = AsyncMock(return_value=("allow", "tilrestart"))
         self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(b"\x00" * 24)  # version nibble 0 -> parse_dest ("", 0)
         await self._decide(proxy, pkt, client)
@@ -1269,7 +1269,7 @@ class TestNfqueueCallback:
         # cached verdict so it doesn't re-prompt the decider.
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value=("allow", "restart"))
+        client.request = AsyncMock(return_value=("allow", "tilrestart"))
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
         self._bind(proxy, monkeypatch, client)
         pkt1 = _FakePkt(_ip_payload("1.2.3.4", 443))
@@ -1515,7 +1515,7 @@ def test_duration_ttl_mapping(proxy):
     assert proxy._duration_ttl("5m") == 300
     assert proxy._duration_ttl("1h") == 3600
     assert proxy._duration_ttl("1w") == 604800
-    assert proxy._duration_ttl("restart") == proxy._DURATION_FOREVER
+    assert proxy._duration_ttl("tilrestart") == proxy._DURATION_FOREVER
     assert proxy._duration_ttl("forever") == proxy._DURATION_FOREVER
     assert proxy._duration_ttl("bogus") is None  # unknown -> None
 


### PR DESCRIPTION
## Summary

Renames the egress-consent verdict duration token `restart` → `tilrestart` ("until restart") everywhere it is a value (#2357).

`restart` reads ambiguously (valid *until* restart? starting *at* restart?). `tilrestart` states the actual semantics directly: the verdict holds for the workspace container's lifetime and is cleared when the container restarts. **Semantics are unchanged — only the token name.**

## What changed

- **Model** (`model/egress_consent.py`): `DURATION_RESTART` → `DURATION_TILRESTART` (`"tilrestart"`), in `DURATIONS`/`DURATION_DEFAULT`/`_duration_in_effect`; method `clear_restart_duration` → `clear_tilrestart_duration`.
- **TUI** (`cli/tui/consent.py`): same constant/symbol rename (duplicated per CLI isolation). The human-readable rules-screen label stays `"until restart"`.
- **Container** (`container.py`): the one caller of the renamed reaper updated.
- **Network sidecar** (`containers/network/proxy.py`): `_duration_ttl` keys on `"tilrestart"`.
- **Web UI** (`consent_decider_service.dart`, `consent_banner.dart`): `kConsentDurations`/`kConsentDurationDefault` → `tilrestart`.

## Scope decision: no migration, no transition shim

Per discussion, this is the **single deployment**, so the rename is atomic — no DB migration and no wire-protocol backward-compat shim. The duration `CHECK` on `egress_consent` picks up the new token from `DURATIONS` at table-create time; the decider WS endpoint validates strictly against the new token.

## Test plan

- [x] Backend suite (CI way): **4749 passed, 100% coverage**
- [x] Frontend suite: **875 passed**
- [x] `flutter analyze`: clean (only the pre-existing `klangk_features` PLACEHOLDER warning)

Closes #2357.
