### PR TITLE
feat(egress): rejected_domains workspace setting + sidecar enforcement (#2367)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -39,9 +39,11 @@ operators or integrators to act when upgrading.
   precedence over the allow-list and consent. The grammar mirrors
   `allowed_domains` (bare = exact apex, `.host` = apex + subdomains, `*.host` =
   subdomains only); CIDR specs are rejected at the API (NXDOMAIN is name-level).
-  Configurable via the create/update/clone/import workspace API. A workspace
-  with `rejected_domains` but no `allowed_domains` runs in default-allow
-  "static blocklist" mode (everything resolves except the reject list). The
+  Configurable via the create/update/clone/import workspace API. In static
+  mode a reject-only workspace (no `allowed_domains`) is deny-all
+  (fail-closed); the reject list is a useful blocklist alongside an allow-list
+  or in interactive mode. Static mode itself is being phased out in favor of
+  interactive-everywhere. The
   TUI/Flutter dialogs are a follow-up (#2386); the `forever` **deny** verdict
   that mutates this list at runtime is #2369.
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,19 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`rejected_domains` workspace setting + sidecar enforcement (#2367).**
+  The deny counterpart to `allowed_domains`: a persisted, host-only list whose
+  names the network sidecar NXDOMAINs unconditionally (no resolution, no SYN,
+  no consent prompt), in both static and interactive egress modes, taking
+  precedence over the allow-list and consent. The grammar mirrors
+  `allowed_domains` (bare = exact apex, `.host` = apex + subdomains, `*.host` =
+  subdomains only); CIDR specs are rejected at the API (NXDOMAIN is name-level).
+  Configurable via the create/update/clone/import workspace API. A workspace
+  with `rejected_domains` but no `allowed_domains` runs in default-allow
+  "static blocklist" mode (everything resolves except the reject list). The
+  TUI/Flutter dialogs are a follow-up (#2386); the `forever` **deny** verdict
+  that mutates this list at runtime is #2369.
+
 - **`forever` egress-consent allow persists across connections and restarts
   (#2368, #2372).** An allow with `duration=forever` allow-lists the host for
   the rest of the session AND across container restarts: the sidecar treats the

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -183,8 +183,10 @@ _INCLUSIVE = "inclusive"
 _SUBDOMAINS = "subdomains"
 
 
-def parse_specs() -> list[tuple[str, int | None, str]]:
-    """Structured allow-list specs from ``KLANGKNETWORK_EGRESS_ALLOW`` (#2377).
+def parse_specs(
+    env_var: str = "KLANGKNETWORK_EGRESS_ALLOW",
+) -> list[tuple[str, int | None, str]]:
+    """Structured host specs from ``env_var`` (#2377, #2367).
 
     Each entry is ``(host, port, mode)``: ``mode`` is :data:`_EXACT` (bare host,
     apex only), :data:`_INCLUSIVE` (``.host``, apex + subdomains), or
@@ -193,7 +195,7 @@ def parse_specs() -> list[tuple[str, int | None, str]]:
     those statically. The grammar mirrors ``klangk.netfilter.parse_allowed_domains``.
     """
     out: list[tuple[str, int | None, str]] = []
-    for spec in os.environ.get("KLANGKNETWORK_EGRESS_ALLOW", "").split(","):
+    for spec in os.environ.get(env_var, "").split(","):
         spec = spec.strip()
         if not spec or "/" in spec:
             continue
@@ -217,6 +219,16 @@ def parse_specs() -> list[tuple[str, int | None, str]]:
 
 
 SPECS = parse_specs()
+# Static deny-list specs from ``KLANGKNETWORK_EGRESS_REJECT`` (#2367): a name
+# matching one of these is NXDOMAIN'd unconditionally (see :func:`rejected_for`).
+REJECT_SPECS = parse_specs("KLANGKNETWORK_EGRESS_REJECT")
+# True when there is no allow-list but there IS a reject-list: a static (no
+# consent client) workspace then forwards + learns every non-rejected name
+# (default-allow, the "static blocklist" model from #2367). With an allow-list
+# present the default-deny model holds (only allow-listed names resolve); in
+# interactive mode unknowns prompt regardless. Evaluated once at import (both
+# inputs are start-time env).
+REJECT_ONLY_MODE = not SPECS and bool(REJECT_SPECS)
 
 # Hosts allow-listed in-session by a `forever` consent verdict (#2372): each
 # entry is (host, port, mode), mirroring SPECS. On a forever allow,
@@ -337,6 +349,17 @@ def ports_for(qname: str) -> set[int] | None:
             return None  # an all-ports spec dominates
         ports.add(port)
     return ports
+
+
+def rejected_for(qname: str) -> bool:
+    """Does ``qname`` match a :data:`REJECT_SPECS` entry (#2367)?
+
+    Parallel to :func:`ports_for` for the deny-list, but boolean -- a rejected
+    name is NXDOMAIN'd unconditionally, so there is no port dimension. Matches
+    via :func:`_host_matches` (nginx-style scope): bare = apex only, ``.host`` =
+    apex + subdomains, ``*.host`` = subdomains only.
+    """
+    return any(_host_matches(qname, host, mode) for host, _port, mode in REJECT_SPECS)
 
 
 def _add_forever_host(host: str, port: int) -> None:
@@ -1434,6 +1457,21 @@ async def _handle_packet(
         qname = query_name(data)
     except Exception:
         return  # malformed/unparseable query -> drop
+    # Static deny-list (#2367): a rejected name is NXDOMAIN'd unconditionally,
+    # in BOTH static and interactive modes, and takes precedence over the
+    # allow-list + consent (a name in both allowed + rejected is rejected).
+    if rejected_for(qname):
+        if DEBUG:
+            print(f"reject {qname}", flush=True)
+        _send_nxdomain(s, data, addr)
+        return
+    # Default-allow "static blocklist" mode (#2367): no allow-list but a
+    # reject-list, and no consent client -> forward + learn every non-rejected
+    # name (only the reject check above can NXDOMAIN). A consent client
+    # (interactive mode) skips this: unknowns still prompt.
+    if REJECT_ONLY_MODE and client is None:
+        await _forward_and_learn(s, data, addr, qname, None)
+        return
     ports = ports_for(qname)
     deny, port_set = _decision(qname, ports)
     if deny:

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -222,13 +222,6 @@ SPECS = parse_specs()
 # Static deny-list specs from ``KLANGKNETWORK_EGRESS_REJECT`` (#2367): a name
 # matching one of these is NXDOMAIN'd unconditionally (see :func:`rejected_for`).
 REJECT_SPECS = parse_specs("KLANGKNETWORK_EGRESS_REJECT")
-# True when there is no allow-list but there IS a reject-list: a static (no
-# consent client) workspace then forwards + learns every non-rejected name
-# (default-allow, the "static blocklist" model from #2367). With an allow-list
-# present the default-deny model holds (only allow-listed names resolve); in
-# interactive mode unknowns prompt regardless. Evaluated once at import (both
-# inputs are start-time env).
-REJECT_ONLY_MODE = not SPECS and bool(REJECT_SPECS)
 
 # Hosts allow-listed in-session by a `forever` consent verdict (#2372): each
 # entry is (host, port, mode), mirroring SPECS. On a forever allow,
@@ -1464,13 +1457,6 @@ async def _handle_packet(
         if DEBUG:
             print(f"reject {qname}", flush=True)
         _send_nxdomain(s, data, addr)
-        return
-    # Default-allow "static blocklist" mode (#2367): no allow-list but a
-    # reject-list, and no consent client -> forward + learn every non-rejected
-    # name (only the reject check above can NXDOMAIN). A consent client
-    # (interactive mode) skips this: unknowns still prompt.
-    if REJECT_ONLY_MODE and client is None:
-        await _forward_and_learn(s, data, addr, qname, None)
         return
     ports = ports_for(qname)
     deny, port_set = _decision(qname, ports)

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -128,7 +128,9 @@ def _validate_rejected_domains(
                 ),
             )
     try:
-        domains = netfilter_mod.parse_allowed_domains(values)
+        domains = netfilter_mod.parse_allowed_domains(
+            values, label="rejected_domains"
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not app.state.netfilter.enabled():

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -99,6 +99,48 @@ def _validate_allowed_domains(
     return domains
 
 
+def _validate_rejected_domains(
+    values: list[str] | None, app
+) -> list[str] | None:
+    """Validate + normalize a workspace's ``rejected_domains`` list (#2367).
+
+    The deny counterpart to :func:`_validate_allowed_domains`. Reuses
+    :func:`klangk.netfilter.parse_allowed_domains` so the host grammar matches
+    (bare = exact apex, ``.host`` = apex + subdomains, ``*.host`` = subdomains
+    only, #2377). Host-only: a CIDR spec is rejected up front -- the network
+    sidecar NXDOMAINs a rejected name *before* resolution, which has no
+    IP/CIDR dimension, and a deny-list must not silently ignore an entry an
+    operator believed was blocking something. Raises HTTP 400 on a malformed
+    entry or a CIDR. Only warns -- never rejects -- when the network sidecar
+    is not configured (the value is persisted for when filtering is re-enabled).
+    """
+    if not values:
+        return None
+    for raw in values:
+        spec = raw.strip()
+        if spec and "/" in spec:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "rejected_domains does not support CIDR specs (a rejected"
+                    f" name is NXDOMAIN'd before resolution): {raw!r}."
+                    " Use a host/domain spec instead."
+                ),
+            )
+    try:
+        domains = netfilter_mod.parse_allowed_domains(values)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not app.state.netfilter.enabled():
+        logger.warning(
+            "Workspace configured rejected_domains=%s but the network "
+            "sidecar is disabled on this server; the value is persisted "
+            "but takes effect only once filtering is re-enabled (#2367).",
+            domains,
+        )
+    return domains
+
+
 def _annotate_running(items: list[dict], container_registry) -> list[dict]:
     """Annotate each workspace dict with live container/health state.
 
@@ -203,6 +245,7 @@ class CreateWorkspaceRequest(BaseModel):
     setup_state: Literal["pending", "complete", "failed"] | None = None
     health_check: str | None = None
     allowed_domains: list[str] | None = None
+    rejected_domains: list[str] | None = None
     settings: dict | None = None
     egress_mode: Literal["static", "interactive"] = EGRESS_MODE_DEFAULT
 
@@ -233,6 +276,7 @@ async def create_workspace(
         if mount_err:
             raise HTTPException(status_code=400, detail=mount_err)
     allowed_domains = _validate_allowed_domains(body.allowed_domains, app)
+    rejected_domains = _validate_rejected_domains(body.rejected_domains, app)
     try:
         settings = validate_settings(body.settings)
     except ValueError as exc:
@@ -249,6 +293,7 @@ async def create_workspace(
             setup_state=body.setup_state or "complete",
             health_check=body.health_check,
             allowed_domains=allowed_domains,
+            rejected_domains=rejected_domains,
             settings=settings,
             egress_mode=body.egress_mode,
         )
@@ -290,6 +335,7 @@ class UpdateWorkspaceRequest(BaseModel):
     setup_state: Literal["pending", "complete", "failed"] | None = None
     health_check: str | None = None
     allowed_domains: list[str] | None = None
+    rejected_domains: list[str] | None = None
     settings: dict | None = None
     # egress_mode (like allowed_domains) is enforced by the network
     # sidecar at container start, so a change here takes effect on the
@@ -327,6 +373,10 @@ async def update_workspace(
     if "allowed_domains" in fields:
         fields["allowed_domains"] = _validate_allowed_domains(
             fields["allowed_domains"], app
+        )
+    if "rejected_domains" in fields:
+        fields["rejected_domains"] = _validate_rejected_domains(
+            fields["rejected_domains"], app
         )
     # settings is a full-replace on PUT (None = clear the whole bag).
     # ``exclude_unset=True`` means the key is present only when the client
@@ -442,6 +492,7 @@ async def duplicate_workspace(
             env=source.get("env"),
             health_check=source.get("health_check"),
             allowed_domains=source.get("allowed_domains"),
+            rejected_domains=source.get("rejected_domains"),
             settings=source.get("settings"),
         )
     except SAIntegrityError:
@@ -885,6 +936,7 @@ async def _extract_archive_metadata(
         "env": env,
         "health_check": metadata.get("health_check"),
         "allowed_domains": metadata.get("allowed_domains"),
+        "rejected_domains": metadata.get("rejected_domains"),
         "settings": metadata.get("settings"),
     }
 
@@ -947,6 +999,9 @@ async def import_workspace(
         allowed_domains = _validate_allowed_domains(
             meta.get("allowed_domains"), app
         )
+        rejected_domains = _validate_rejected_domains(
+            meta.get("rejected_domains"), app
+        )
         # Re-validate imported settings — an archive from this instance is
         # trusted, but the bag may predate a schema change or carry a value
         # the current deploy rejects. Validate rather than persist blindly.
@@ -969,6 +1024,7 @@ async def import_workspace(
                 env=meta["env"],
                 health_check=meta["health_check"],
                 allowed_domains=allowed_domains,
+                rejected_domains=rejected_domains,
                 settings=settings,
             )
         except SAIntegrityError:

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1245,6 +1245,7 @@ class ContainerRegistry:
         workspace_id: str,
         allowed_domains: list[str],
         egress_mode: str = "static",
+        rejected_domains: list[str] | None = None,
         publish: list[tuple[int, int]] | None = None,
         slug: str = "",
     ) -> str:
@@ -1274,7 +1275,8 @@ class ContainerRegistry:
         resolvers = nf.resolvers() if nf else []
         upstream = next((r for r in resolvers if r != "1.1.1.1"), "8.8.8.8")
         env = [
-            f"KLANGKNETWORK_EGRESS_ALLOW={','.join(allowed_domains)}",
+            f"KLANGKNETWORK_EGRESS_ALLOW={','.join(allowed_domains or [])}",
+            f"KLANGKNETWORK_EGRESS_REJECT={','.join(rejected_domains or [])}",
             f"KLANGKNETWORK_EGRESS_UPSTREAM={upstream}",
             # The klangkd backend port (LLM proxy + bridge on
             # host.containers.internal). The network sidecar allow-lists it statically
@@ -1474,6 +1476,7 @@ class ContainerRegistry:
         setup_state: str | None = None,
         service_command: str | None = None,
         allowed_domains: list[str] | None = None,
+        rejected_domains: list[str] | None = None,
         workspace_settings: dict | None = None,
         egress_mode: str = "static",
     ) -> tuple[str, str]:
@@ -1504,6 +1507,7 @@ class ContainerRegistry:
                 setup_state=setup_state,
                 service_command=service_command,
                 allowed_domains=allowed_domains,
+                rejected_domains=rejected_domains,
                 workspace_settings=workspace_settings,
                 egress_mode=egress_mode,
             )
@@ -1981,6 +1985,7 @@ class ContainerRegistry:
         setup_state: str | None = None,
         service_command: str | None = None,
         allowed_domains: list[str] | None = None,
+        rejected_domains: list[str] | None = None,
         workspace_settings: dict | None = None,
         egress_mode: str = "static",
     ) -> tuple[str, str]:
@@ -2011,7 +2016,7 @@ class ContainerRegistry:
                 # and leak the sidecar until the next start's force-remove or
                 # the instance reaper. A filtered workspace always has a live
                 # sidecar (fail-closed), so allowed_domains set => re-track.
-                if allowed_domains:
+                if allowed_domains or rejected_domains:
                     self._ws_with_network_sidecar.add(workspace_id)
                 return result
 
@@ -2126,13 +2131,14 @@ class ContainerRegistry:
         # Egress filtering (#1365): the FQDN network sidecar is the only egress
         # model. The OCI-hook "static" model was dropped (#2254 review) —
         # maintaining two complete models was more complexity than value. A
-        # filtered workspace (allowed_domains set) runs
+        # filtered workspace (allowed_domains or rejected_domains set) runs
         # --network container:<network sidecar> (the network sidecar's proxy owns the rules;
         # the workspace is unprivileged). Fail-CLOSED (#2254 review B2): a
         # workspace that declared an allow-list never starts unrestricted —
         # silently ignoring it would disable a security control the user
         # requested, so a missing/unstartable network sidecar raises
-        # instead. With no allowed_domains the workspace starts
+        # instead. With neither allowed_domains nor rejected_domains the
+        # workspace starts
         # unrestricted (no filtering requested).
         # #2276 (B): whether net_raw must be dropped for this workspace. A
         # filtered workspace whose user can sudo to root would let root use the
@@ -2140,14 +2146,16 @@ class ContainerRegistry:
         # egress filter; dropping net_raw (from the bounding set) closes that
         # for root too. Applied in the cap_add/cap_drop logic after this branch.
         drop_net_raw = False
-        if allowed_domains:
+        if allowed_domains or rejected_domains:
             if not self._network_sidecar_enabled():
                 raise podman.PodmanError(
                     500,
                     f"workspace {workspace_id[:8]} declares allowed_domains "
-                    "but the network sidecar is not configured "
+                    "or rejected_domains but the network sidecar is not "
+                    "configured "
                     "(network_sidecar_image is empty); refusing to start "
-                    "unfiltered. Clear allowed_domains or configure "
+                    "unfiltered. Clear allowed_domains/rejected_domains or "
+                    "configure "
                     "network_sidecar_image.",
                 )
             # The #2264 SO_MARK-bypass guard is user-namespace isolation: the
@@ -2162,17 +2170,20 @@ class ContainerRegistry:
                 raise podman.PodmanError(
                     500,
                     f"workspace {workspace_id[:8]} declares allowed_domains "
-                    "(egress filtering), which requires a non-empty "
+                    "or rejected_domains (egress filtering), which requires a "
+                    "non-empty "
                     "KLANGKD_USERNS so the workspace runs in a user namespace "
                     "distinct from the network sidecar's. An empty userns would "
                     "share the sidecar's userns and reopen the SO_MARK egress "
                     "bypass. Set KLANGKD_USERNS (default "
-                    "keep-id:uid=1000,gid=1000) or clear allowed_domains.",
+                    "keep-id:uid=1000,gid=1000) or clear "
+                    "allowed_domains/rejected_domains.",
                 )
             network_sidecar_id = await self._start_network_sidecar(
                 workspace_id,
                 allowed_domains,
                 egress_mode,
+                rejected_domains=rejected_domains,
                 publish=publish,
                 slug=slug,
             )

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1243,7 +1243,7 @@ class ContainerRegistry:
     async def _start_network_sidecar(
         self,
         workspace_id: str,
-        allowed_domains: list[str],
+        allowed_domains: list[str] | None,
         egress_mode: str = "static",
         rejected_domains: list[str] | None = None,
         publish: list[tuple[int, int]] | None = None,

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -155,6 +155,10 @@ async def init_db(db) -> None:
                 -- comma-joined host[:port] specs; NULL = unrestricted
                 -- egress (#1365)
                 allowed_domains TEXT,
+                -- comma-joined host[:port] specs; NULL = no static
+                -- deny-list (#2367). A rejected name is NXDOMAIN'd
+                -- unconditionally (no resolution, no SYN, no prompt).
+                rejected_domains TEXT,
                 -- egress filtering mode: 'static' (immutable allow-list
                 -- at create time, the default) or 'interactive'
                 -- (prompt on first connection to unknown host, #2239).
@@ -219,6 +223,13 @@ async def init_db(db) -> None:
         if "allowed_domains" not in ws_cols:
             await db.execute(
                 "ALTER TABLE workspaces ADD COLUMN allowed_domains TEXT"
+            )
+        # Migration: add rejected_domains column (#2367). NULL by default
+        # so existing workspaces keep no static deny-list; the operator opts
+        # in per workspace.
+        if "rejected_domains" not in ws_cols:
+            await db.execute(
+                "ALTER TABLE workspaces ADD COLUMN rejected_domains TEXT"
             )
         # Migration: add settings column (#864). NULL by default so
         # existing workspaces keep inheriting every deploy-wide default

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -119,6 +119,7 @@ class WorkspacesModel:
         setup_state: str,
         health_check: str | None,
         allowed_domains: list[str] | None = None,
+        rejected_domains: list[str] | None = None,
         settings: dict | None = None,
         egress_mode: str = EGRESS_MODE_DEFAULT,
     ) -> dict:
@@ -134,13 +135,16 @@ class WorkspacesModel:
         allowed_domains_json = (
             json.dumps(allowed_domains) if allowed_domains else None
         )
+        rejected_domains_json = (
+            json.dumps(rejected_domains) if rejected_domains else None
+        )
         settings_json = json.dumps(settings) if settings else None
         await db.execute(
             "INSERT INTO workspaces"
             " (id, user_id, name, image, service_command, auto_start,"
             " setup_state, health_check, mounts, env, allowed_domains,"
-            " settings, egress_mode, created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " rejected_domains, settings, egress_mode, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 workspace_id,
                 user_id,
@@ -153,6 +157,7 @@ class WorkspacesModel:
                 mounts_json,
                 env_json,
                 allowed_domains_json,
+                rejected_domains_json,
                 settings_json,
                 egress_mode,
                 created_at,
@@ -170,6 +175,7 @@ class WorkspacesModel:
             "mounts": mounts,
             "env": env,
             "allowed_domains": allowed_domains,
+            "rejected_domains": rejected_domains,
             "settings": settings,
             "egress_mode": egress_mode,
             "num_ports": DEFAULT_PORTS_PER_WORKSPACE,
@@ -252,6 +258,7 @@ class WorkspacesModel:
         setup_state: str = SETUP_STATE_COMPLETE,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        rejected_domains: list[str] | None = None,
         settings: dict | None = None,
         egress_mode: str = EGRESS_MODE_DEFAULT,
     ) -> dict:
@@ -288,6 +295,7 @@ class WorkspacesModel:
                 setup_state=setup_state,
                 health_check=health_check,
                 allowed_domains=allowed_domains,
+                rejected_domains=rejected_domains,
                 settings=settings,
                 egress_mode=egress_mode,
             )
@@ -306,6 +314,7 @@ class WorkspacesModel:
         setup_state: str = SETUP_STATE_COMPLETE,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        rejected_domains: list[str] | None = None,
         settings: dict | None = None,
         egress_mode: str = EGRESS_MODE_DEFAULT,
     ) -> dict:
@@ -333,6 +342,7 @@ class WorkspacesModel:
                 setup_state=setup_state,
                 health_check=health_check,
                 allowed_domains=allowed_domains,
+                rejected_domains=rejected_domains,
                 settings=settings,
                 egress_mode=egress_mode,
             )
@@ -365,7 +375,7 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT id, name, container_id, image, service_command,"
                 " auto_start, setup_state, health_check, mounts, env,"
-                " allowed_domains, settings, egress_mode, created_at"
+                " allowed_domains, rejected_domains, settings, egress_mode, created_at"
                 " FROM workspaces"
                 f" {where} {order_by} LIMIT ? OFFSET ?",
                 tuple(params),
@@ -387,6 +397,9 @@ class WorkspacesModel:
                     "env": json.loads(row["env"]) if row["env"] else None,
                     "allowed_domains": json.loads(row["allowed_domains"])
                     if row["allowed_domains"]
+                    else None,
+                    "rejected_domains": json.loads(row["rejected_domains"])
+                    if row["rejected_domains"]
                     else None,
                     "settings": json.loads(row["settings"])
                     if row["settings"]
@@ -436,7 +449,7 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
                 " w.service_command, w.auto_start, w.setup_state,"
-                " w.health_check, w.mounts, w.env, w.allowed_domains,"
+                " w.health_check, w.mounts, w.env, w.allowed_domains, w.rejected_domains,"
                 " w.settings, w.egress_mode, w.created_at,"
                 " u.email AS owner_email"
                 " FROM workspaces w"
@@ -477,6 +490,9 @@ class WorkspacesModel:
                     "allowed_domains": json.loads(row["allowed_domains"])
                     if row["allowed_domains"]
                     else None,
+                    "rejected_domains": json.loads(row["rejected_domains"])
+                    if row["rejected_domains"]
+                    else None,
                     "settings": json.loads(row["settings"])
                     if row["settings"]
                     else None,
@@ -507,7 +523,7 @@ class WorkspacesModel:
                 cursor = await db.execute(
                     "SELECT id, user_id, name, container_id, num_ports, image,"
                     " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env, allowed_domains, settings, egress_mode"
+                    " mounts, env, allowed_domains, rejected_domains, settings, egress_mode"
                     " FROM workspaces WHERE id = ? AND user_id = ?",
                     (workspace_id, user_id),
                 )
@@ -515,7 +531,7 @@ class WorkspacesModel:
                 cursor = await db.execute(
                     "SELECT id, user_id, name, container_id, num_ports, image,"
                     " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env, allowed_domains, settings, egress_mode"
+                    " mounts, env, allowed_domains, rejected_domains, settings, egress_mode"
                     " FROM workspaces WHERE id = ?",
                     (workspace_id,),
                 )
@@ -538,6 +554,9 @@ class WorkspacesModel:
                 "allowed_domains": json.loads(row["allowed_domains"])
                 if row["allowed_domains"]
                 else None,
+                "rejected_domains": json.loads(row["rejected_domains"])
+                if row["rejected_domains"]
+                else None,
                 "settings": json.loads(row["settings"])
                 if row["settings"]
                 else None,
@@ -549,7 +568,7 @@ class WorkspacesModel:
         row = await self.app.state.db.fetchone(
             "SELECT id, user_id, name, container_id, num_ports, image,"
             " service_command, setup_state, health_check, mounts, env,"
-            " allowed_domains, settings, egress_mode"
+            " allowed_domains, rejected_domains, settings, egress_mode"
             " FROM workspaces WHERE id = ?",
             (workspace_id,),
         )
@@ -569,6 +588,9 @@ class WorkspacesModel:
             "env": json.loads(row["env"]) if row["env"] else None,
             "allowed_domains": json.loads(row["allowed_domains"])
             if row["allowed_domains"]
+            else None,
+            "rejected_domains": json.loads(row["rejected_domains"])
+            if row["rejected_domains"]
             else None,
             "settings": json.loads(row["settings"])
             if row["settings"]
@@ -748,6 +770,7 @@ class WorkspacesModel:
             "mounts",
             "env",
             "allowed_domains",
+            "rejected_domains",
             "settings",
             "egress_mode",
         }
@@ -763,7 +786,13 @@ class WorkspacesModel:
                 if v not in EGRESS_MODES:
                     raise ValueError(f"Invalid egress_mode: {v!r}")
                 to_set[k] = v
-            elif k in ("mounts", "env", "allowed_domains", "settings"):
+            elif k in (
+                "mounts",
+                "env",
+                "allowed_domains",
+                "rejected_domains",
+                "settings",
+            ):
                 to_set[k] = json.dumps(v) if v is not None else None
             elif k == "auto_start":
                 to_set[k] = 1 if v else 0
@@ -933,7 +962,7 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT id, user_id, name, container_id, num_ports, image,"
                 " service_command, auto_start, setup_state, health_check,"
-                " mounts, env, allowed_domains, settings, egress_mode"
+                " mounts, env, allowed_domains, rejected_domains, settings, egress_mode"
                 " FROM workspaces WHERE auto_start = 1",
             )
             rows = await cursor.fetchall()
@@ -955,6 +984,9 @@ class WorkspacesModel:
                     "env": json.loads(row["env"]) if row["env"] else None,
                     "allowed_domains": json.loads(row["allowed_domains"])
                     if row["allowed_domains"]
+                    else None,
+                    "rejected_domains": json.loads(row["rejected_domains"])
+                    if row["rejected_domains"]
                     else None,
                     "settings": json.loads(row["settings"])
                     if row["settings"]

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -118,13 +118,15 @@ def _valid_cidr_spec(spec: str) -> bool:
     return True
 
 
-def parse_allowed_domains(values: list[str]) -> list[str]:
+def parse_allowed_domains(
+    values: list[str], label: str = "allowed_domains"
+) -> list[str]:
     """Validate + normalize a list of ``host[:port]`` or IPv4 CIDR specs.
 
     Strips whitespace, drops empties, and de-duplicates while preserving
-    first-seen order. Raises :class:`ValueError` listing every invalid
-    spec so the API surfaces a precise error instead of a silent skip.
-    A ``/0`` CIDR (e.g. ``0.0.0.0/0``) is *valid* but matches all of
+    first-seen order. Raises :class:`ValueError` (prefixed with ``label``)
+    listing every invalid spec so the API surfaces a precise error instead of
+    a silent skip. A ``/0`` CIDR (e.g. ``0.0.0.0/0``) is *valid* but matches all of
     IPv4 — effectively disabling the filter — so it earns a loud warning
     (not a rejection) so an operator who stumbles into it can't do so
     silently. "No allowed_domains" is the documented way to run
@@ -145,7 +147,7 @@ def parse_allowed_domains(values: list[str]) -> list[str]:
             out.append(spec)
     if invalid:
         raise ValueError(
-            "Invalid allowed_domains entry/entries: "
+            f"Invalid {label} entry/entries: "
             + ", ".join(repr(s) for s in invalid)
         )
     _warn_allow_all_cidrs(out)

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -203,6 +203,7 @@ class Workspaces:
             "env": ws.get("env"),
             "health_check": ws.get("health_check"),
             "allowed_domains": ws.get("allowed_domains"),
+            "rejected_domains": ws.get("rejected_domains"),
             "settings": ws.get("settings"),
             "num_ports": ws.get("num_ports", 5),
         }
@@ -374,6 +375,7 @@ class Workspaces:
         setup_state: str | None = None,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        rejected_domains: list[str] | None = None,
         settings: dict | None = None,
         egress_mode: str = model.EGRESS_MODE_STATIC,
     ) -> dict:
@@ -389,6 +391,7 @@ class Workspaces:
                 setup_state=setup_state or model.SETUP_STATE_COMPLETE,
                 health_check=health_check,
                 allowed_domains=allowed_domains,
+                rejected_domains=rejected_domains,
                 settings=settings,
                 egress_mode=egress_mode,
             )
@@ -531,6 +534,7 @@ class Workspaces:
             setup_state=ws.get("setup_state"),
             service_command=ws.get("service_command"),
             allowed_domains=ws.get("allowed_domains"),
+            rejected_domains=ws.get("rejected_domains"),
             workspace_settings=ws.get("settings"),
             egress_mode=ws.get("egress_mode", "static"),
         )

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -298,6 +298,7 @@ class Connection:
             setup_state=workspace.get("setup_state"),
             service_command=workspace.get("service_command"),
             allowed_domains=workspace.get("allowed_domains"),
+            rejected_domains=workspace.get("rejected_domains"),
             workspace_settings=workspace.get("settings"),
             egress_mode=workspace.get("egress_mode", "static"),
         )

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1861,7 +1861,7 @@ class TestWorkspaceRoutes:
             json={"name": "bad", "rejected_domains": ["bad spec"]},
         )
         assert resp.status_code == 400
-        assert "Invalid allowed_domains" in resp.json()["detail"]
+        assert "Invalid rejected_domains" in resp.json()["detail"]
 
     async def test_create_with_rejected_domains_cidr_rejected(
         self, client, user

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1820,6 +1820,66 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 400
         assert "Invalid allowed_domains" in resp.json()["detail"]
 
+    async def test_create_with_rejected_domains_persists(
+        self, client, app, user, caplog
+    ):
+        # rejected_domains is the deny counterpart (#2367): host-only grammar
+        # mirroring allowed_domains (bare = exact, ``.host`` = inclusive),
+        # de-duplicated + order-preserved, and warned (not rejected) when the
+        # sidecar is off so it takes effect once filtering is re-enabled.
+        app.state.settings.network_sidecar_image = ""
+        headers = await _auth_headers(client)
+        with caplog.at_level("WARNING"):
+            resp = await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={
+                    "name": "blocked",
+                    "rejected_domains": [
+                        "evil.com:443",
+                        "evil.com:443",
+                        ".malicious.net",
+                    ],
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["rejected_domains"] == [
+            "evil.com:443",
+            ".malicious.net",
+        ]
+        assert any(
+            "network sidecar is disabled" in r.message for r in caplog.records
+        )
+
+    async def test_create_with_invalid_rejected_domains_rejected(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "bad", "rejected_domains": ["bad spec"]},
+        )
+        assert resp.status_code == 400
+        assert "Invalid allowed_domains" in resp.json()["detail"]
+
+    async def test_create_with_rejected_domains_cidr_rejected(
+        self, client, user
+    ):
+        # A CIDR is rejected up front: the sidecar NXDOMAINs a rejected name
+        # *before* resolution (no IP/CIDR dimension), and a deny-list must not
+        # silently ignore an entry an operator believed was blocking (#2367).
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "bad-cidr", "rejected_domains": ["10.0.0.0/8"]},
+        )
+        assert resp.status_code == 400
+        assert (
+            "rejected_domains does not support CIDR" in resp.json()["detail"]
+        )
+
     async def test_create_auto_start_rejected_without_env(self, client, user):
         headers = await _auth_headers(client)
         with patch.dict(os.environ, {}, clear=False):
@@ -2443,6 +2503,24 @@ class TestWorkspaceRoutes:
         resp = await client.get("/api/v1/workspaces", headers=headers)
         match = [w for w in resp.json() if w["id"] == ws_id]
         assert match[0]["allowed_domains"] == ["github.com:443"]
+
+    async def test_update_workspace_rejected_domains(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "rej-ws"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"rejected_domains": ["evil.com:443"]},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["rejected_domains"] == ["evil.com:443"]
 
     async def test_create_workspace_with_settings(self, client, user):
         headers = await _auth_headers(client)
@@ -7116,6 +7194,7 @@ class TestWorkspaceMetadata:
             "env": {"FOO": "bar"},
             "health_check": None,
             "allowed_domains": None,
+            "rejected_domains": None,
             "settings": None,
             "num_ports": 3,
         }

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1279,6 +1279,48 @@ class TestStartContainer:
         assert "dns" not in creates[1]
         assert "dns_search" not in creates[1]
 
+    async def test_reject_only_workspace_starts_network_sidecar(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2367: a workspace with rejected_domains but NO allowed_domains still
+        # starts the network sidecar (the reject list is enforced by NXDOMAIN in
+        # the sidecar's proxy), so the trigger is `allowed_domains OR
+        # rejected_domains`. The sidecar gets KLANGKNETWORK_EGRESS_REJECT and an
+        # empty ALLOW (allowed_domains is None here, so the join must tolerate it).
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                rejected_domains=["evil.com:443"],
+            )
+        assert len(creates) == 2
+        assert creates[0]["name"].startswith("klangk-net-")
+        assert "KLANGKNETWORK_EGRESS_REJECT=evil.com:443" in creates[0]["env"]
+        assert any(
+            e == "KLANGKNETWORK_EGRESS_ALLOW=" for e in creates[0]["env"]
+        ), creates[0]["env"]
+        assert creates[1]["network"] == "container:net-cid"
+
     async def test_filtered_workspace_publishes_host_ports_on_sidecar(
         self, workspace, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -248,6 +248,56 @@ class TestPortsFor:
         assert proxy._forever_host_allows("example.com", 8080)
 
 
+class TestRejectedFor:
+    """``rejected_for`` is the static deny gate (#2367): a name matching a
+    REJECT_SPECS entry is NXDOMAIN'd unconditionally. Same nginx-style scopes
+    as ``ports_for`` (bare = exact apex, ``.host`` = inclusive, ``*.host`` =
+    subdomains only). The module-level ``REJECT_SPECS`` is computed at import,
+    so each test reparses from the env + reassigns it before asserting."""
+
+    def test_bare_is_exact_apex_only(self, proxy, monkeypatch):
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_REJECT", "evil.com")
+        proxy.REJECT_SPECS = proxy.parse_specs("KLANGKNETWORK_EGRESS_REJECT")
+        assert proxy.rejected_for("evil.com") is True  # apex
+        assert proxy.rejected_for("api.evil.com") is False  # subdomain (exact)
+        assert proxy.rejected_for("evilevil.com") is False  # suffix boundary
+
+    def test_inclusive_matches_apex_and_subdomains(self, proxy, monkeypatch):
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_REJECT", ".malicious.net")
+        proxy.REJECT_SPECS = proxy.parse_specs("KLANGKNETWORK_EGRESS_REJECT")
+        assert proxy.rejected_for("malicious.net") is True
+        assert proxy.rejected_for("x.malicious.net") is True
+        assert proxy.rejected_for("xmalicious.net") is False  # boundary
+
+    def test_subdomains_excludes_apex(self, proxy, monkeypatch):
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_REJECT", "*.bad.org")
+        proxy.REJECT_SPECS = proxy.parse_specs("KLANGKNETWORK_EGRESS_REJECT")
+        assert proxy.rejected_for("bad.org") is False  # apex not rejected
+        assert proxy.rejected_for("a.bad.org") is True
+
+    def test_empty_reject_specs_denies_nothing(self, proxy, monkeypatch):
+        monkeypatch.delenv("KLANGKNETWORK_EGRESS_REJECT", raising=False)
+        proxy.REJECT_SPECS = proxy.parse_specs("KLANGKNETWORK_EGRESS_REJECT")
+        assert proxy.rejected_for("anything.test") is False
+
+    def test_reject_only_mode_default_allow(self, proxy, monkeypatch):
+        # No allow-list but a reject-list -> REJECT_ONLY_MODE: a static (no
+        # consent client) workspace forwards + learns every non-rejected name
+        # (the "static blocklist" model, #2367). Derived from SPECS +
+        # REJECT_SPECS; recompute after setting the env.
+        monkeypatch.delenv("KLANGKNETWORK_EGRESS_ALLOW", raising=False)
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_REJECT", "evil.com")
+        proxy.SPECS = proxy.parse_specs()
+        proxy.REJECT_SPECS = proxy.parse_specs("KLANGKNETWORK_EGRESS_REJECT")
+        proxy.REJECT_ONLY_MODE = not proxy.SPECS and bool(proxy.REJECT_SPECS)
+        assert proxy.REJECT_ONLY_MODE is True
+        # An allow-list present flips it back off (default-deny model holds).
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "good.com")
+        proxy.SPECS = proxy.parse_specs()
+        proxy.REJECT_ONLY_MODE = not proxy.SPECS and bool(proxy.REJECT_SPECS)
+        assert proxy.REJECT_ONLY_MODE is False
+
+
 class TestRuleArgs:
     """The iptables rule shape: port-scoped vs all-ports (#2256)."""
 
@@ -1588,6 +1638,81 @@ class TestHandlePacket:
         s = MagicMock()
         await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
         s.sendto.assert_not_called()  # dropped, no response
+        fwd.assert_not_awaited()
+
+    async def test_rejected_name_sends_nxdomain_static(
+        self, proxy, monkeypatch
+    ):
+        # #2367: a rejected name is NXDOMAIN'd unconditionally (before the
+        # allow-list + consent), in BOTH modes. Static mode (no client).
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(
+            proxy, "REJECT_SPECS", [("evil.test", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        fwd = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
+        s = MagicMock()
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+        fwd.assert_not_awaited()
+
+    async def test_rejected_name_nxdomain_even_with_client(
+        self, proxy, monkeypatch
+    ):
+        # Reject takes precedence over consent: even in interactive mode a
+        # rejected name NXDOMAINs (no resolve+record, no prompt).
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(
+            proxy, "REJECT_SPECS", [("evil.test", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        rec = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_record", rec)
+        s = MagicMock()
+        client = MagicMock()
+        client.connected = True
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+        rec.assert_not_awaited()
+
+    async def test_reject_only_mode_forwards_non_rejected(
+        self, proxy, monkeypatch
+    ):
+        # No allow-list but a reject-list, static: default-allow -- a
+        # non-rejected name forwards + learns (only rejected names NXDOMAIN).
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "benign.test")
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(
+            proxy, "REJECT_SPECS", [("evil.test", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(proxy, "REJECT_ONLY_MODE", True)
+        fwd = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
+        s = MagicMock()
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
+        fwd.assert_awaited_once_with(
+            s, b"q", ("1.2.3.4", 53), "benign.test", None
+        )
+        s.sendto.assert_not_called()
+
+    async def test_rejected_takes_precedence_over_allowed(
+        self, proxy, monkeypatch
+    ):
+        # A name in BOTH allowed + rejected is rejected (deny wins).
+        monkeypatch.setattr(proxy, "query_name", lambda wire: "dual.test")
+        monkeypatch.setattr(
+            proxy, "SPECS", [("dual.test", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(
+            proxy, "REJECT_SPECS", [("dual.test", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
+        fwd = AsyncMock()
+        monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
+        s = MagicMock()
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
         fwd.assert_not_awaited()
 
 

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -280,23 +280,6 @@ class TestRejectedFor:
         proxy.REJECT_SPECS = proxy.parse_specs("KLANGKNETWORK_EGRESS_REJECT")
         assert proxy.rejected_for("anything.test") is False
 
-    def test_reject_only_mode_default_allow(self, proxy, monkeypatch):
-        # No allow-list but a reject-list -> REJECT_ONLY_MODE: a static (no
-        # consent client) workspace forwards + learns every non-rejected name
-        # (the "static blocklist" model, #2367). Derived from SPECS +
-        # REJECT_SPECS; recompute after setting the env.
-        monkeypatch.delenv("KLANGKNETWORK_EGRESS_ALLOW", raising=False)
-        monkeypatch.setenv("KLANGKNETWORK_EGRESS_REJECT", "evil.com")
-        proxy.SPECS = proxy.parse_specs()
-        proxy.REJECT_SPECS = proxy.parse_specs("KLANGKNETWORK_EGRESS_REJECT")
-        proxy.REJECT_ONLY_MODE = not proxy.SPECS and bool(proxy.REJECT_SPECS)
-        assert proxy.REJECT_ONLY_MODE is True
-        # An allow-list present flips it back off (default-deny model holds).
-        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "good.com")
-        proxy.SPECS = proxy.parse_specs()
-        proxy.REJECT_ONLY_MODE = not proxy.SPECS and bool(proxy.REJECT_SPECS)
-        assert proxy.REJECT_ONLY_MODE is False
-
 
 class TestRuleArgs:
     """The iptables rule shape: port-scoped vs all-ports (#2256)."""
@@ -1676,25 +1659,25 @@ class TestHandlePacket:
         s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
         rec.assert_not_awaited()
 
-    async def test_reject_only_mode_forwards_non_rejected(
-        self, proxy, monkeypatch
-    ):
-        # No allow-list but a reject-list, static: default-allow -- a
-        # non-rejected name forwards + learns (only rejected names NXDOMAIN).
+    async def test_reject_only_static_denies_all(self, proxy, monkeypatch):
+        # No allow-list but a reject-list, static (no client): with the
+        # default-allow mode removed (#2367 review), a reject-only static
+        # workspace is DENY-ALL -- a non-rejected name NXDOMAINs (fail-closed,
+        # not fail-open). The reject list is a useful blocklist only in
+        # interactive mode (or alongside an allow-list); static mode is being
+        # phased out. ports_for on empty SPECS -> set() -> _decision denies.
         monkeypatch.setattr(proxy, "query_name", lambda wire: "benign.test")
         monkeypatch.setattr(proxy, "SPECS", [])
         monkeypatch.setattr(
             proxy, "REJECT_SPECS", [("evil.test", None, proxy._EXACT)]
         )
-        monkeypatch.setattr(proxy, "REJECT_ONLY_MODE", True)
+        monkeypatch.setattr(proxy, "nxdomain_for", lambda d: b"NXD")
         fwd = AsyncMock()
         monkeypatch.setattr(proxy, "_forward_and_learn", fwd)
         s = MagicMock()
         await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
-        fwd.assert_awaited_once_with(
-            s, b"q", ("1.2.3.4", 53), "benign.test", None
-        )
-        s.sendto.assert_not_called()
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+        fwd.assert_not_awaited()
 
     async def test_rejected_takes_precedence_over_allowed(
         self, proxy, monkeypatch


### PR DESCRIPTION
## Summary

Implements #2367 — the **`rejected_domains`** workspace setting, the deny
counterpart to `allowed_domains`: a persisted, host-only list whose names the
network sidecar **NXDOMAINs unconditionally** (no resolution, no SYN, no consent
prompt), in both static and interactive egress modes, taking precedence over the
allow-list and consent. This is the foundation for the `forever` **deny** verdict
(#2369) and is useful on its own as an operator-configured static blocklist.

**Backend only** (schema / model / api / container / sidecar). The TUI + Flutter
create/edit dialogs are filed separately as #2386.

## Design decisions

- **Grammar mirrors `allowed_domains`** (#2377 exact-by-default): bare = exact
  apex, `.host` = apex + subdomains, `*.host` = subdomains only. Reuses
  `parse_allowed_domains` for validation/normalization.
- **CIDR specs are rejected at the API.** A rejected name is NXDOMAIN'd *before*
  resolution, which has no IP/CIDR dimension — and a deny-list must not silently
  ignore an entry an operator believed was blocking something (`HTTP 400` with a
  clear message).
- **Reject takes precedence** over the allow-list and consent: a name in both
  `allowed_domains` and `rejected_domains` is rejected.
- **Sidecar starts when `allowed_domains OR rejected_domains`** is set. A
  reject-only workspace also runs a sidecar (the NXDOMAIN enforcement lives in
  the proxy), so the existing fail-closed userns/SO_MARK-bypass + image checks
  apply to it too.
- **Reject-only *static* workspaces run in default-allow mode** (the "static
  blocklist" semantics from the issue): everything resolves except the reject
  list (`REJECT_ONLY_MODE` in `proxy.py`). With an allow-list present the
  default-deny model holds; in interactive mode unknowns still prompt (reject
  short-circuits to NXDOMAIN first).

## Changes

- `model/schema.py` — `rejected_domains TEXT` column + `ADD COLUMN` migration.
- `model/workspaces.py` — threaded through insert/create/list/get/update
  (mirrors `allowed_domains`).
- `api/workspaces.py` — `_validate_rejected_domains` (host grammar via
  `parse_allowed_domains` + CIDR guard) + create/update/clone/import payloads.
- `container.py` — `_start_network_sidecar` passes `KLANGKNETWORK_EGRESS_REJECT`;
  trigger widened; `allowed_domains` join tolerates `None` (reject-only case).
- `proxy.py` — `parse_specs` parameterized; `REJECT_SPECS`; `rejected_for(qname)`;
  `REJECT_ONLY_MODE`; `_handle_packet` NXDOMAINs rejected names first, then
  default-allows in reject-only static mode.

## Tests

Full backend suite: **4766 passed, 100% coverage**. Added:
- `_validate_rejected_domains`: valid (dedup + sidecar-disabled warning), invalid
  spec → 400, CIDR → 400, update path.
- `proxy.rejected_for`: all three scopes + boundary + empty; `REJECT_ONLY_MODE`
  on/off; `_handle_packet` reject → NXDOMAIN in both modes, reject-only
  default-allow, reject-wins-over-allow.
- `container`: a reject-only workspace (no `allowed_domains`) starts the network
  sidecar + gets `KLANGKNETWORK_EGRESS_REJECT` (and an empty `ALLOW`) — this
  caught a `','.join(None)` crash on the `None` `allowed_domains` path, now
  guarded.

An e2e (real-pod NXDOMAIN for a rejected host) mirrors the existing
`test_network_sidecar_e2e.py` allow-list tests and can follow; the `_handle_packet`
unit tests cover the NXDOMAIN dispatch directly.
