### PR TITLE
feat(egress-consent): pause consent filtering (#2332)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -57,6 +57,17 @@ operators or integrators to act when upgrading.
   safe unit of a deny. Best-effort (failures swallowed). Revoking must clear
   both the list entry and the audit row (#2370).
 
+- **Pause egress-consent filtering (#2332).** A workspace-level control in
+  the `consent-decide` TUI (`Pause: 15m | 1h | 1d | Cancel`) silences ALL
+  consent prompts for the workspace for the chosen window: a destination with
+  no allow-list rule and no in-effect recorded verdict is auto-allowed (no
+  hold) instead of prompting. The pause does not bypass policy —
+  `allowed_domains`/`rejected_domains` rules and existing `egress_consent`
+  verdicts (a recorded deny still blocks) keep applying. The window
+  self-expires (the gate re-checks on every connection), the status line
+  shows the remaining time, and a refreshed `egress_rules` frame carries the
+  live `paused` window to every decider.
+
 - **`forever` egress-consent allow persists across connections and restarts
   (#2368, #2372).** An allow with `duration=forever` allow-lists the host for
   the rest of the session AND across container restarts: the sidecar treats the

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -123,6 +123,9 @@ IGNORED = "ignore"  # non-JSON / unknown frame
 REVOKE_ACK = (  # server replied to a revoke (#2339/#2341); payload=(id, ok)
     "revoke_ack"
 )
+PAUSE_ACK = (  # server replied to a pause/unpause (#2332); payload=(ok, until)
+    "pause_ack"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -211,6 +214,22 @@ def make_revoke(request_id: str) -> str:
     return json.dumps({"type": "revoke", "request_id": request_id})
 
 
+def make_pause(duration: str) -> str:
+    """Build an outbound pause frame (JSON string) -- silence prompts (#2332).
+
+    ``duration`` is one of ``"5m"``/``"15m"``/``"1h"``. While paused, a
+    destination with no allow-list rule and no in-effect verdict is
+    auto-allowed (no hold); a recorded deny still blocks. The server replies
+    with a ``pause_ack`` and broadcasts a refreshed ``egress_rules`` frame.
+    """
+    return json.dumps({"type": "pause", "duration": duration})
+
+
+def make_unpause() -> str:
+    """Build an outbound unpause frame (JSON string) -- resume prompting (#2332)."""
+    return json.dumps({"type": "unpause"})
+
+
 class ConsentDeciderController:
     """Pure state machine over the consent-decider WS protocol (#2310).
 
@@ -290,6 +309,20 @@ class ConsentDeciderController:
             return REVOKE_ACK, (
                 rid if isinstance(rid, str) else None,
                 ok,
+            )
+        if mtype == "pause_ack":
+            # #2332: server replied to a pause/unpause. The pause window itself
+            # arrives in the subsequent refreshed ``egress_rules`` frame (the
+            # server broadcasts one on every pause/unpause); this ack only
+            # signals success/failure so the view can flash on a nack. ``until``
+            # is None for an unpause or a failed pause.
+            until = msg.get("until")
+            return PAUSE_ACK, (
+                bool(msg.get("ok")),
+                float(until)
+                if isinstance(until, (int, float))
+                and not isinstance(until, bool)
+                else None,
             )
         if mtype == "pong":
             return PONG, None
@@ -480,6 +513,14 @@ class ConsentDeciderApp(App):
     #duration-selector Button:focus { background: transparent; }
     #duration-selector .dur-sel { background: $accent; color: $background; }
     #duration-selector .dur-sel:focus { background: $accent; color: $background; }
+    /* #2332 pause control bar: a compact top-bar that silences ALL prompts for
+    the workspace for a window. Flagged yellow so it reads as "filtering off". */
+    #pause-bar { height: 1; background: $panel; }
+    #pause-bar Static { width: auto; padding: 0 1; color: $text-muted; }
+    #pause-bar Button { width: auto; min-width: 0; height: 1; border: none; padding: 0 1; background: transparent; }
+    #pause-bar Button:focus { background: transparent; }
+    #pause-bar .pause-active { background: $warning; color: $background; }
+    #pause-bar .pause-active:focus { background: $warning; color: $background; }
     """
 
     BINDINGS = [
@@ -523,6 +564,13 @@ class ConsentDeciderApp(App):
         # Global duration selector (default `tilrestart`): click to choose; selecting
         # does NOT submit -- only a row's Allow/Deny submits with this duration.
         yield Horizontal(*self._duration_buttons(), id="duration-selector")
+        # #2332 pause control: silences ALL prompts for the workspace for a
+        # window. Flagged yellow; the status line shows the remaining window.
+        yield Horizontal(
+            Static("Pause:", id="pause-label"),
+            *self._pause_buttons(),
+            id="pause-bar",
+        )
         with Vertical():
             yield ListView(id="requests")
             yield Static("No held requests — connected, waiting.", id="empty")
@@ -538,6 +586,27 @@ class ConsentDeciderApp(App):
             )
             b.duration = d  # type: ignore[attr-defined]
             btns.append(b)
+        return btns
+
+    def _pause_buttons(self) -> list[Button]:
+        """The pause-control buttons (#2332): 5m / 15m / 1h / Cancel.
+
+        ``pause_duration`` on each button is the window token, or None for the
+        Cancel button (clears an active pause). Highlighted via ``pause-active``
+        when a pause is live so the bar reads as "filtering off".
+        """
+        btns: list[Button] = []
+        for label, dur in (
+            (DURATION_15M, DURATION_15M),
+            (DURATION_1H, DURATION_1H),
+            (DURATION_1D, DURATION_1D),
+        ):
+            b = Button(label, id=f"pause-{dur}")
+            b.pause_duration = dur  # type: ignore[attr-defined]
+            btns.append(b)
+        cancel = Button("Cancel", id="pause-cancel")
+        cancel.pause_duration = None  # type: ignore[attr-defined]
+        btns.append(cancel)
         return btns
 
     def on_mount(self) -> None:
@@ -650,6 +719,14 @@ class ConsentDeciderApp(App):
                         if not ok:
                             self._flash("revoke failed — still in effect")
                         self._refresh()
+                    elif action == PAUSE_ACK:
+                        # payload = (ok, until). A failed pause/unpause flashes;
+                        # success is reflected by the refreshed egress_rules
+                        # frame the server broadcasts (no flash needed).
+                        ok, _until = payload  # type: ignore[misc]
+                        if not ok:
+                            self._flash("pause failed")
+                        self._refresh()
                     else:
                         self._refresh()
                 except Exception:
@@ -731,9 +808,22 @@ class ConsentDeciderApp(App):
             status.update(self._flash_msg)
         else:
             conn = "connected" if self._connected else "reconnecting"
-            status.update(
-                f" {escape(self.workspace_name)}  ·  {conn}  ·  {len(ordered)} held"
+            line = (
+                f" {escape(self.workspace_name)}  ·  {conn}"
+                f"  ·  {len(ordered)} held"
             )
+            # #2332: surface an active pause window in the status line so the
+            # "silences ALL prompts" state is always visible while queuing.
+            rules = self.controller.rules
+            if rules is not None and rules.paused is not None:
+                rem = self.controller.pause_remaining(rules)
+                if rem is None:
+                    line += "  ·  paused until restart"
+                else:
+                    line += f"  ·  paused {_fmt_duration(rem)}"
+            status.update(line)
+        # Reflect an active pause on the control bar (highlight the window).
+        self._refresh_pause_highlight()
 
     def _host_line(self, req: ConsentRequest) -> str:
         host = req.dest_host
@@ -813,6 +903,8 @@ class ConsentDeciderApp(App):
             # Selecting a duration does NOT submit -- it only sets the global
             # choice (Allow/Deny submit with it).
             self._select_duration(event.button)
+        elif bid.startswith("pause-"):
+            self._handle_pause_button(event.button)
         elif bid.startswith("allow-"):
             self._decide_id(
                 bid.removeprefix("allow-"), DECISION_ALLOWED, self._duration
@@ -831,6 +923,42 @@ class ConsentDeciderApp(App):
         for b in self.query(".dur-sel"):
             b.remove_class("dur-sel")
         button.add_class("dur-sel")
+
+    def _handle_pause_button(self, button: Button) -> None:
+        """Send a pause (window token) or unpause (Cancel) frame (#2332)."""
+        ws = self._ws
+        if ws is None:
+            self._flash("disconnected — reconnecting")
+            return
+        dur = getattr(button, "pause_duration", None)
+        if dur is None:
+            asyncio.create_task(self._send_unpause(ws))
+        else:
+            asyncio.create_task(self._send_pause(ws, dur))
+
+    async def _send_pause(self, ws, duration: str) -> None:
+        try:
+            await ws.send(make_pause(duration))
+        except Exception:
+            self._flash("pause send failed — reconnecting")
+
+    async def _send_unpause(self, ws) -> None:
+        try:
+            await ws.send(make_unpause())
+        except Exception:
+            self._flash("unpause send failed — reconnecting")
+
+    def _refresh_pause_highlight(self) -> None:
+        """Flag the pause bar while a pause window is active (#2332).
+
+        The pause ``until`` carries no "which button" info, so the whole bar is
+        flagged (the status line + rules screen show the exact remaining
+        window) rather than guessing the pressed button from remaining time.
+        """
+        label = self.query_one("#pause-label", Static)
+        rules = self.controller.rules
+        paused = rules is not None and rules.paused is not None
+        label.set_class(paused, "pause-active")
 
     def action_allow(self) -> None:
         # `a` key -> the highlighted row (keyboard path). No-op on the rules

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -217,7 +217,7 @@ def make_revoke(request_id: str) -> str:
 def make_pause(duration: str) -> str:
     """Build an outbound pause frame (JSON string) -- silence prompts (#2332).
 
-    ``duration`` is one of ``"5m"``/``"15m"``/``"1h"``. While paused, a
+    ``duration`` is one of ``"15m"``/``"1h"``/``"1d"``. While paused, a
     destination with no allow-list rule and no in-effect verdict is
     auto-allowed (no hold); a recorded deny still blocks. The server replies
     with a ``pause_ack`` and broadcasts a refreshed ``egress_rules`` frame.

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 
 from .consent import workspace_is_interactive
 from .model.egress_consent import (
@@ -54,6 +55,16 @@ VERDICT_DENY = "deny"
 # (fail-closed: leave the row enforced). The sidecar's rule-drop is a single
 # iptables delete, so this is generous.
 _REVOKE_ACK_TIMEOUT = 5.0
+
+# Consent-pause durations (#2332): how long interactive prompting is silenced
+# workspace-wide. While paused, a destination with no allow-list rule and no
+# in-effect recorded verdict is auto-allowed (no hold, no prompt); a recorded
+# deny still blocks. A focused set for the TUI control; ``unpause`` clears it.
+PAUSE_15M = "15m"
+PAUSE_1H = "1h"
+PAUSE_1D = "1d"
+PAUSE_DURATIONS = frozenset({PAUSE_15M, PAUSE_1H, PAUSE_1D})
+_PAUSE_SECONDS = {PAUSE_15M: 900, PAUSE_1H: 3600, PAUSE_1D: 86400}
 
 
 class ConsentCoordinator:
@@ -116,6 +127,18 @@ class ConsentCoordinator:
         """
         loop = asyncio.get_running_loop()
         try:
+            if await self._is_paused(workspace_id):
+                # #2332: prompting is paused workspace-wide. A destination
+                # with an in-effect recorded DENY is still blocked (the pause
+                # does not override existing verdicts); everything else is
+                # auto-allowed (no hold, no prompt, no row -- the sidecar
+                # learns/accepts the SYN like a static allow). Allow-list
+                # rules are enforced earlier at the sidecar DNS layer, so a
+                # host reaching this gate is already not allow-listed.
+                verdict = await self._paused_verdict(workspace_id, dst, dport)
+                fut = loop.create_future()
+                fut.set_result(verdict)
+                return fut
             if not await self._is_interactive(workspace_id):
                 await self.app.state.model.egress_consent.record_static_denial(
                     workspace_id, dst, dport
@@ -147,6 +170,81 @@ class ConsentCoordinator:
             fut = loop.create_future()
             fut.set_result({"decision": VERDICT_DENY, "reason": "error"})
             return fut
+
+    async def pause(self, workspace_id: str, duration: str) -> dict:
+        """Pause interactive consent prompting workspace-wide for ``duration`` (#2332).
+
+        While paused, :meth:`hold` auto-allows any destination that has no
+        allow-list rule and no in-effect recorded verdict (instead of holding
+        it for a decider); a recorded deny still blocks. Sets
+        ``consent_paused_until`` on the workspace to ``now + duration`` and
+        broadcasts a refreshed ``egress_rules`` frame so every decider sees
+        the pause window. Returns ``{"ok": bool, "until": float | None}`` --
+        ``ok`` is False for an unknown duration or a missing workspace.
+        """
+        secs = _PAUSE_SECONDS.get(duration)
+        if secs is None:
+            return {"ok": False, "until": None}
+        until = time.time() + secs
+        if not await self.app.state.model.workspaces.set_consent_pause(
+            workspace_id, until
+        ):
+            return {"ok": False, "until": None}
+        await self._broadcast_rules(workspace_id)
+        return {"ok": True, "until": until}
+
+    async def unpause(self, workspace_id: str) -> dict:
+        """Clear the consent-pause window (#2332).
+
+        Returns ``{"ok": bool}`` -- False if the workspace is missing. Always
+        broadcasts a refreshed ``egress_rules`` frame on success so deciders
+        drop the pause indicator.
+        """
+        ok = await self.app.state.model.workspaces.set_consent_pause(
+            workspace_id, None
+        )
+        if ok:
+            await self._broadcast_rules(workspace_id)
+        return {"ok": ok}
+
+    async def _is_paused(self, workspace_id: str) -> bool:
+        """Is consent prompting paused for the workspace right now (#2332)?
+
+        Reads ``consent_paused_until`` live and compares against ``now``, so a
+        pause self-expires the moment its window elapses (no sweep needed for
+        correctness -- the gate re-evaluates on every hold).
+        """
+        until = await self.app.state.model.workspaces.get_consent_pause(
+            workspace_id
+        )
+        return until is not None and until > time.time()
+
+    async def _paused_verdict(
+        self, workspace_id: str, dst: str, dport: int | None
+    ) -> dict:
+        """Verdict for a held SYN while prompting is paused (#2332).
+
+        A destination with an in-effect recorded DENY is still blocked (the
+        pause respects existing verdicts); everything else is auto-allowed
+        with a ``once`` duration -- the sidecar accepts the SYN (conntrack
+        carries the connection) without learning the IP, so each NEW
+        connection re-gates: once the pause elapses, new connections to the
+        same host prompt again (none linger auto-allowed past the window).
+        """
+        row = await self.app.state.model.egress_consent.active_verdict_for(
+            workspace_id, dst, dport
+        )
+        if row is not None and row["decision"] == DECISION_DENIED:
+            return {
+                "decision": VERDICT_DENY,
+                "reason": "paused_deny",
+                "duration": DURATION_ONCE,
+            }
+        return {
+            "decision": VERDICT_ALLOW,
+            "reason": "paused",
+            "duration": DURATION_ONCE,
+        }
 
     def _register_hold(self, request: dict) -> asyncio.Future:
         """Register a held request + arm its timeout + fan out (interactive path)."""
@@ -547,15 +645,24 @@ class ConsentCoordinator:
         rows = await self.app.state.model.egress_consent.list_active(
             workspace_id
         )
+        until = await self.app.state.model.workspaces.get_consent_pause(
+            workspace_id
+        )
+        now = time.time()
+        paused = (
+            {"paused": True, "until": until}
+            if until is not None and until > now
+            else None
+        )
         return {
             "type": "egress_rules",
             "workspace_id": workspace_id,
             "allow_list": ws.get("allowed_domains") or [],
             "allowed": [r for r in rows if r["decision"] == DECISION_ALLOWED],
             "denied": [r for r in rows if r["decision"] == DECISION_DENIED],
-            # #2332 (pause control) not yet landed: no transient pause state
-            # exists, so this is always None until that work adds it.
-            "paused": None,
+            # #2332 (pause control): the live pause window, or None when not
+            # paused (read fresh so a self-expired pause shows as cleared).
+            "paused": paused,
         }
 
     @staticmethod

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -220,6 +220,63 @@ class EgressConsentModel:
         DURATION_1W: 604800,
     }
 
+    async def active_verdict_for(
+        self,
+        workspace_id: str,
+        dest_host: str,
+        dest_port: int | None,
+    ) -> dict | None:
+        """The most-recent in-effect verdict for an exact (host, port), or None (#2332).
+
+        Used by the consent-pause path (:meth:`ConsentCoordinator.hold`) to
+        respect a recorded verdict while prompting is paused: a destination
+        with an in-effect DENY is still blocked (not auto-allowed); everything
+        else is auto-allowed. Returns the newest decided allow/deny row whose
+        duration has not elapsed (mirrors :meth:`list_active`'s in-effect
+        window, scoped to one destination), so a later verdict overrides an
+        earlier one for the same host:port. Only verdict decisions
+        (``decided_by`` not NULL) are considered -- static policy denials are
+        the complement of the allow-list and not actionable here. Port is
+        matched exactly (NULL port matches NULL port).
+        """
+        if dest_port is not None:
+            row = await self.app.state.db.fetchone(
+                f"SELECT {_EC_COLUMNS} FROM egress_consent"
+                " WHERE workspace_id = ? AND dest_host = ?"
+                " AND dest_port = ? AND decision IN (?, ?)"
+                " AND decided_by IS NOT NULL"
+                " ORDER BY decided_at DESC LIMIT 1",
+                (
+                    workspace_id,
+                    dest_host,
+                    dest_port,
+                    DECISION_ALLOWED,
+                    DECISION_DENIED,
+                ),
+            )
+        else:
+            row = await self.app.state.db.fetchone(
+                f"SELECT {_EC_COLUMNS} FROM egress_consent"
+                " WHERE workspace_id = ? AND dest_host = ?"
+                " AND dest_port IS NULL AND decision IN (?, ?)"
+                " AND decided_by IS NOT NULL"
+                " ORDER BY decided_at DESC LIMIT 1",
+                (
+                    workspace_id,
+                    dest_host,
+                    DECISION_ALLOWED,
+                    DECISION_DENIED,
+                ),
+            )
+        if row is None:
+            return None
+        d = _row_to_dict(row)
+        if not self._duration_in_effect(
+            d["duration"], d["decided_at"], time.time()
+        ):
+            return None
+        return d
+
     async def list_active(self, workspace_id: str) -> list[dict]:
         """Consent verdicts still in effect for a workspace (#2335 slice A).
 

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -226,56 +226,61 @@ class EgressConsentModel:
         dest_host: str,
         dest_port: int | None,
     ) -> dict | None:
-        """The most-recent in-effect verdict for an exact (host, port), or None (#2332).
+        """The newest IN-EFFECT verdict for an exact (host, port), or None (#2332).
 
         Used by the consent-pause path (:meth:`ConsentCoordinator.hold`) to
         respect a recorded verdict while prompting is paused: a destination
         with an in-effect DENY is still blocked (not auto-allowed); everything
-        else is auto-allowed. Returns the newest decided allow/deny row whose
-        duration has not elapsed (mirrors :meth:`list_active`'s in-effect
-        window, scoped to one destination), so a later verdict overrides an
-        earlier one for the same host:port. Only verdict decisions
+        else is auto-allowed. Returns the newest verdict whose duration has
+        not elapsed, skipping elapsed ones, so a newer-but-elapsed allow does
+        NOT mask an older in-effect deny (mirrors :meth:`list_active`'s
+        in-effect filtering, scoped to one destination). Only verdict decisions
         (``decided_by`` not NULL) are considered -- static policy denials are
         the complement of the allow-list and not actionable here. Port is
         matched exactly (NULL port matches NULL port).
         """
         if dest_port is not None:
-            row = await self.app.state.db.fetchone(
+            query = (
                 f"SELECT {_EC_COLUMNS} FROM egress_consent"
                 " WHERE workspace_id = ? AND dest_host = ?"
                 " AND dest_port = ? AND decision IN (?, ?)"
                 " AND decided_by IS NOT NULL"
-                " ORDER BY decided_at DESC LIMIT 1",
-                (
-                    workspace_id,
-                    dest_host,
-                    dest_port,
-                    DECISION_ALLOWED,
-                    DECISION_DENIED,
-                ),
+                " ORDER BY decided_at DESC"
+            )
+            params = (
+                workspace_id,
+                dest_host,
+                dest_port,
+                DECISION_ALLOWED,
+                DECISION_DENIED,
             )
         else:
-            row = await self.app.state.db.fetchone(
+            query = (
                 f"SELECT {_EC_COLUMNS} FROM egress_consent"
                 " WHERE workspace_id = ? AND dest_host = ?"
                 " AND dest_port IS NULL AND decision IN (?, ?)"
                 " AND decided_by IS NOT NULL"
-                " ORDER BY decided_at DESC LIMIT 1",
-                (
-                    workspace_id,
-                    dest_host,
-                    DECISION_ALLOWED,
-                    DECISION_DENIED,
-                ),
+                " ORDER BY decided_at DESC"
             )
-        if row is None:
-            return None
-        d = _row_to_dict(row)
-        if not self._duration_in_effect(
-            d["duration"], d["decided_at"], time.time()
-        ):
-            return None
-        return d
+            params = (
+                workspace_id,
+                dest_host,
+                DECISION_ALLOWED,
+                DECISION_DENIED,
+            )
+        now = time.time()
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(query, params)
+            rows = await cursor.fetchall()
+        # Newest-first: return the first verdict still in effect. An elapsed
+        # newer verdict (e.g. an expired timed allow) is skipped so it can't
+        # hide an older in-effect deny -- the pause must keep blocking a host
+        # the user previously denied.
+        for row in rows:
+            d = _row_to_dict(row)
+            if self._duration_in_effect(d["duration"], d["decided_at"], now):
+                return d
+        return None
 
     async def list_active(self, workspace_id: str) -> list[dict]:
         """Consent verdicts still in effect for a workspace (#2335 slice A).

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -171,6 +171,12 @@ async def init_db(db) -> None:
                 -- and the behavioral allowed_domains) stay as their own
                 -- columns.
                 settings TEXT,
+                -- #2332: epoch second until which interactive consent
+                -- prompting is paused workspace-wide (NULL = not paused).
+                -- While now < this, a destination with no allow-list rule
+                -- and no in-effect recorded verdict is auto-allowed instead
+                -- of held for a decider; a recorded deny still blocks.
+                consent_paused_until REAL,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 UNIQUE(user_id, name),
                 -- (C) the system agent must never own a workspace.
@@ -246,6 +252,13 @@ async def init_db(db) -> None:
             await db.execute(
                 "ALTER TABLE workspaces"
                 " ADD COLUMN egress_mode TEXT NOT NULL DEFAULT 'static'"
+            )
+        # Migration: add consent_paused_until column (#2332). NULL by default
+        # so existing workspaces keep prompting normally; the pause is opt-in
+        # via the decider TUI control.
+        if "consent_paused_until" not in ws_cols:
+            await db.execute(
+                "ALTER TABLE workspaces ADD COLUMN consent_paused_until REAL"
             )
         await db.execute("""
             CREATE TABLE IF NOT EXISTS port_allocations (

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -810,6 +810,41 @@ class WorkspacesModel:
             )
             return cursor.rowcount > 0
 
+    async def get_consent_pause(self, workspace_id: str) -> float | None:
+        """The epoch second consent prompting is paused until, or None (#2332).
+
+        Returns the raw stored value WITHOUT an expiry check; the caller
+        compares it against ``now`` (a value in the past means the pause has
+        elapsed and the workspace is effectively not paused). None means not
+        paused, or the workspace does not exist.
+        """
+        row = await self.app.state.db.fetchone(
+            "SELECT consent_paused_until FROM workspaces WHERE id = ?",
+            (workspace_id,),
+        )
+        if row is None:
+            return None
+        val = row["consent_paused_until"]
+        return float(val) if isinstance(val, (int, float)) else None
+
+    async def set_consent_pause(
+        self, workspace_id: str, until: float | None
+    ) -> bool:
+        """Set (or clear, when ``until`` is None) the consent-pause window (#2332).
+
+        ``until`` is an epoch second (``now + window``), or None to clear an
+        active pause. Returns True if the workspace exists (a row was
+        updated), else False. No expiry math here: a past ``until`` is a valid
+        store (read as "not paused" by :meth:`get_consent_pause`); the caller
+        computes the window.
+        """
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "UPDATE workspaces SET consent_paused_until = ? WHERE id = ?",
+                (until, workspace_id),
+            )
+            return cursor.rowcount > 0
+
     async def add_allowed_domain(self, workspace_id: str, entry: str) -> bool:
         """Append ``entry`` (``host[:port]``) to a workspace's
         ``allowed_domains`` (#2368).

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -145,6 +145,14 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
                             "ok": ok,
                         }
                     )
+                elif mtype == "pause":
+                    # #2332: pause interactive consent prompting for this
+                    # decider's workspace for a window. A deploy-wide decider
+                    # (workspace None) has no single workspace to pause -> nack.
+                    await _handle_pause(app, safe_ws, msg, workspace)
+                elif mtype == "unpause":
+                    # #2332: clear an active pause for this decider's workspace.
+                    await _handle_unpause(app, safe_ws, workspace)
                 # unknown types are ignored
             except SlowClientError:
                 # Outbound queue full -- the client can't keep up. Drop it
@@ -162,6 +170,33 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         # registration so the workspace reverts to static (#2308).
         registry.deregister(decider_id)
         await safe_ws.stop_sender()
+
+
+async def _handle_pause(app, safe_ws, msg, workspace) -> None:
+    """Pause consent prompting for the decider's workspace (#2332)."""
+    if workspace is None:
+        # A deploy-wide (admin) decider has no single workspace to pause.
+        safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
+        return
+    result = await app.state.consent_coordinator.pause(
+        workspace, msg.get("duration")
+    )
+    safe_ws.send_json(
+        {
+            "type": "pause_ack",
+            "ok": result["ok"],
+            "until": result["until"],
+        }
+    )
+
+
+async def _handle_unpause(app, safe_ws, workspace) -> None:
+    """Clear an active consent pause for the decider's workspace (#2332)."""
+    if workspace is None:
+        safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
+        return
+    result = await app.state.consent_coordinator.unpause(workspace)
+    safe_ws.send_json({"type": "pause_ack", "ok": result["ok"], "until": None})
 
 
 async def _handle_verdict(app, safe_ws, msg, workspace, user_id) -> None:

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -149,10 +149,12 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
                     # #2332: pause interactive consent prompting for this
                     # decider's workspace for a window. A deploy-wide decider
                     # (workspace None) has no single workspace to pause -> nack.
-                    await _handle_pause(app, safe_ws, msg, workspace)
+                    await _handle_pause(
+                        app, safe_ws, msg, workspace, principals
+                    )
                 elif mtype == "unpause":
                     # #2332: clear an active pause for this decider's workspace.
-                    await _handle_unpause(app, safe_ws, workspace)
+                    await _handle_unpause(app, safe_ws, workspace, principals)
                 # unknown types are ignored
             except SlowClientError:
                 # Outbound queue full -- the client can't keep up. Drop it
@@ -172,10 +174,26 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         await safe_ws.stop_sender()
 
 
-async def _handle_pause(app, safe_ws, msg, workspace) -> None:
-    """Pause consent prompting for the decider's workspace (#2332)."""
+async def _can_pause(app, workspace, principals) -> bool:
+    """Pause/unpause authz (#2332, review I1).
+
+    Pause silences ALL consent prompts workspace-wide for a window (a
+    workspace-wide policy change, broader than deciding one request), so it
+    needs a higher bar than the connection's ``terminal`` gate: the
+    ``share-terminals`` permission (collaborators + owners). Spectators and
+    coders (terminal only) may still connect and decide individual requests.
+    """
     if workspace is None:
-        # A deploy-wide (admin) decider has no single workspace to pause.
+        return False  # deploy-wide decider has no single workspace to pause
+    return await app.state.acl.check_permission(
+        f"/workspaces/{workspace}", principals, "share-terminals"
+    )
+
+
+async def _handle_pause(app, safe_ws, msg, workspace, principals) -> None:
+    """Pause consent prompting for the decider's workspace (#2332)."""
+    if not await _can_pause(app, workspace, principals):
+        # Missing share-terminals, or a deploy-wide decider with no target.
         safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
         return
     result = await app.state.consent_coordinator.pause(
@@ -190,9 +208,9 @@ async def _handle_pause(app, safe_ws, msg, workspace) -> None:
     )
 
 
-async def _handle_unpause(app, safe_ws, workspace) -> None:
+async def _handle_unpause(app, safe_ws, workspace, principals) -> None:
     """Clear an active consent pause for the decider's workspace (#2332)."""
-    if workspace is None:
+    if not await _can_pause(app, workspace, principals):
         safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
         return
     result = await app.state.consent_coordinator.unpause(workspace)

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -23,6 +23,7 @@ from klangk.cli.tui.consent import (
     ADDED,
     ERROR,
     IGNORED,
+    PAUSE_ACK,
     PONG,
     RESOLVED,
     REVOKE_ACK,
@@ -34,8 +35,10 @@ from klangk.cli.tui.consent import (
     EgressRules,
     PauseState,
     RulesScreen,
+    make_pause,
     make_ping,
     make_revoke,
+    make_unpause,
     make_verdict,
 )
 
@@ -378,6 +381,17 @@ class TestFrameBuilders:
             "type": "revoke",
             "request_id": "r9",
         }
+
+    def test_make_pause(self):
+        # #2332: pause frame carries the window token.
+        assert json.loads(make_pause("15m")) == {
+            "type": "pause",
+            "duration": "15m",
+        }
+
+    def test_make_unpause(self):
+        # #2332: unpause frame clears the window (no payload).
+        assert json.loads(make_unpause()) == {"type": "unpause"}
 
 
 # ---------------------------------------------------------------------------
@@ -785,6 +799,146 @@ class TestAppActions:
             await pilot.pause()
             app._select_duration(types.SimpleNamespace(duration=None))
             assert app._duration == "tilrestart"  # unchanged (default)
+
+    async def test_pause_bar_mounts(self):
+        # #2332: the pause control bar mounts with a window button + Cancel.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.query_one("#pause-15m", Button) is not None
+            assert app.query_one("#pause-1h", Button) is not None
+            assert app.query_one("#pause-1d", Button) is not None
+            assert app.query_one("#pause-cancel", Button) is not None
+
+    async def test_pause_buttons_render_on_screen(self):
+        # Regression (#2332): the ``Pause:`` label must not expand to fill the
+        # bar (which pushed the window buttons off-screen). All four controls
+        # must sit within the viewport, in order, after the label.
+        app = _make_app()
+        async with app.run_test(size=(120, 24)) as pilot:
+            app._refresh()
+            await pilot.pause()
+            await pilot.pause()
+            lbl = app.query_one("#pause-label", Static)
+            assert (
+                lbl.outer_size.width < 20
+            )  # "Pause:" + padding, not full width
+            prev_x = lbl.region.x
+            for bid in (
+                "#pause-15m",
+                "#pause-1h",
+                "#pause-1d",
+                "#pause-cancel",
+            ):
+                b = app.query_one(bid, Button)
+                # each button starts where the previous ended and is on-screen
+                assert b.region.x >= prev_x
+                assert b.region.x + b.region.width <= 120, bid
+                assert b.region.width > 0
+                prev_x = b.region.x + b.region.width
+
+    async def test_pause_button_sends_pause_frame(self):
+        # Pressing a window button sends a pause frame for that window.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            await pilot.pause()
+            app.on_button_pressed(
+                types.SimpleNamespace(
+                    button=app.query_one("#pause-15m", Button)
+                )
+            )
+            await pilot.pause()
+            assert any('"pause"' in s and '"15m"' in s for s in ws.sent), (
+                ws.sent
+            )
+
+    async def test_cancel_button_sends_unpause_frame(self):
+        # The Cancel button clears an active pause.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            await pilot.pause()
+            app.on_button_pressed(
+                types.SimpleNamespace(
+                    button=app.query_one("#pause-cancel", Button)
+                )
+            )
+            await pilot.pause()
+            assert any('"unpause"' in s for s in ws.sent), ws.sent
+
+    async def test_pause_button_disconnected_flashes(self):
+        # No WS -> the press flashes instead of crashing.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_button_pressed(
+                types.SimpleNamespace(
+                    button=app.query_one("#pause-15m", Button)
+                )
+            )
+            await pilot.pause()
+            assert app._flash_until > 0  # a flash was set
+
+    async def test_pause_highlights_bar_when_active(self):
+        # An egress_rules frame with a live pause flags the bar label.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.controller.apply_frame(
+                _rules_frame(paused={"paused": True, "until": 9999.0})
+            )
+            app._refresh()
+            await pilot.pause()
+            label = app.query_one("#pause-label", Static)
+            assert label.has_class("pause-active")
+
+    async def test_status_shows_indefinite_pause(self):
+        # A pause with no fixed expiry (until=None) reads "paused until restart".
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.controller.apply_frame(
+                _rules_frame(paused={"paused": True, "until": None})
+            )
+            app._refresh()
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "paused until restart" in str(status.content)
+
+    async def test_pump_flashes_failed_pause_ack(self):
+        # A pause_ack with ok=False flashes so the decider knows it didn't take.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([json.dumps({"type": "pause_ack", "ok": False})])
+            await app._pump(ws)
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "pause failed" in str(status.content)
+
+    async def test_pause_send_failure_flashes(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([], send_fail=True)
+            app._ws = ws
+            await pilot.pause()
+            await app._send_pause(ws, "15m")
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "pause send failed" in str(status.content)
+
+    async def test_unpause_send_failure_flashes(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([], send_fail=True)
+            app._ws = ws
+            await pilot.pause()
+            await app._send_unpause(ws)
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "unpause send failed" in str(status.content)
 
     async def test_only_selected_duration_has_background_at_first_render(self):
         # Regression (#2360): the first duration button ("once") grabbed
@@ -1469,6 +1623,50 @@ class TestControllerRevokeAck:
         assert outcome == REVOKE_ACK
         assert payload == (None, True)
         assert [r.id for r in c.rules.allowed] == ["a1"]  # not removed
+
+
+class TestControllerPauseAck:
+    """``pause_ack`` frame handling (#2332)."""
+
+    def test_ok_carries_until(self):
+        c = ConsentDeciderController()
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "pause_ack", "ok": True, "until": 200.0})
+        )
+        assert outcome == PAUSE_ACK
+        assert payload == (True, 200.0)
+
+    def test_fail_returns_false_ok(self):
+        c = ConsentDeciderController()
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "pause_ack", "ok": False, "until": None})
+        )
+        assert outcome == PAUSE_ACK
+        assert payload == (False, None)
+
+    def test_missing_until_is_none(self):
+        c = ConsentDeciderController()
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "pause_ack", "ok": True})
+        )
+        assert outcome == PAUSE_ACK
+        assert payload == (True, None)
+
+    def test_non_numeric_until_is_none(self):
+        c = ConsentDeciderController()
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "pause_ack", "ok": True, "until": "soon"})
+        )
+        assert outcome == PAUSE_ACK
+        assert payload == (True, None)
+
+    def test_bool_until_rejected(self):
+        # isinstance(True, int) is True -- must not coerce True -> 1.0.
+        c = ConsentDeciderController()
+        outcome, payload = c.apply_frame(
+            json.dumps({"type": "pause_ack", "ok": True, "until": True})
+        )
+        assert payload == (True, None)
 
 
 class TestRulesScreen:

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -16,7 +16,12 @@ from unittest.mock import AsyncMock, Mock
 from fastapi import WebSocketDisconnect
 
 from klangk import auth
-from klangk.consent_coordinator import ConsentCoordinator
+from klangk.consent_coordinator import (
+    ConsentCoordinator,
+    PAUSE_15M,
+    PAUSE_1D,
+    PAUSE_1H,
+)
 
 FULL_WS = "aaaa1111bbbb-cccc-dddd-eeee-ffffffffffff"
 
@@ -59,6 +64,9 @@ def _app(
     egress_consent.expire_pending = AsyncMock(return_value=True)
     egress_consent.list_requests = AsyncMock(return_value=pending_rows or [])
     egress_consent.list_active = AsyncMock(return_value=active_rows or [])
+    # #2332: the pause path's "respect existing verdict" lookup. Default None
+    # (no in-effect verdict) so the existing not-paused behavior is unchanged.
+    egress_consent.active_verdict_for = AsyncMock(return_value=None)
     workspaces = AsyncMock()
     workspaces.get_workspace = AsyncMock(
         return_value=(
@@ -69,6 +77,9 @@ def _app(
     )
     workspaces.add_allowed_domain = AsyncMock(return_value=True)
     workspaces.add_rejected_domain = AsyncMock(return_value=True)
+    # #2332: consent-pause state. Defaults: not paused (None), set succeeds.
+    workspaces.get_consent_pause = AsyncMock(return_value=None)
+    workspaces.set_consent_pause = AsyncMock(return_value=True)
     app.state.model = types.SimpleNamespace(
         egress_consent=egress_consent, workspaces=workspaces
     )
@@ -468,6 +479,207 @@ class TestConsentCoordinatorRules:
         # matching snapshot().
         app.state.model.workspaces.get_workspace.assert_not_awaited()
         app.state.model.egress_consent.list_active.assert_not_awaited()
+
+    async def test_rules_frame_includes_active_pause_window(self):
+        # #2332: a live pause window is surfaced in the egress_rules frame so
+        # deciders render the pause indicator + remaining time.
+        import time
+
+        app = _app()
+        until = time.time() + 900
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=until
+        )
+        coord = ConsentCoordinator(app)
+        frame = await coord.rules_frame(FULL_WS)
+        assert frame["paused"] == {"paused": True, "until": until}
+
+    async def test_rules_frame_expired_pause_is_none(self):
+        # A pause whose window has elapsed reads as not-paused (self-expiry).
+        app = _app()
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=1.0  # far in the past
+        )
+        coord = ConsentCoordinator(app)
+        frame = await coord.rules_frame(FULL_WS)
+        assert frame["paused"] is None
+
+
+class TestConsentCoordinatorPause:
+    async def test_pause_sets_window_and_broadcasts(self):
+        # pause("15m") -> set_consent_pause(now+900) + a refreshed rules frame.
+        import time
+
+        before = time.time()
+        app = _app()
+        coord = ConsentCoordinator(app)
+        result = await coord.pause(FULL_WS, PAUSE_15M)
+        after = time.time()
+        assert result["ok"] is True
+        assert before + 900 <= result["until"] <= after + 900
+        app.state.model.workspaces.set_consent_pause.assert_awaited_once()
+        args = app.state.model.workspaces.set_consent_pause.call_args.args
+        assert args[0] == FULL_WS
+        assert before + 900 <= args[1] <= after + 900
+        # a refreshed egress_rules frame was broadcast to the deciders
+        frames = [
+            c.args[1]
+            for c in app.state.consent_deciders.broadcast.call_args_list
+        ]
+        assert any(f["type"] == "egress_rules" for f in frames)
+
+    async def test_pause_1d_sets_a_day_window(self):
+        # The TUI's largest window (1d) maps to 86400s.
+        import time
+
+        before = time.time()
+        app = _app()
+        coord = ConsentCoordinator(app)
+        result = await coord.pause(FULL_WS, PAUSE_1D)
+        assert result["ok"] is True
+        assert before + 86400 <= result["until"] <= before + 86400 + 5
+
+    async def test_pause_unknown_duration_nacks(self):
+        app = _app()
+        coord = ConsentCoordinator(app)
+        result = await coord.pause(FULL_WS, "2h")
+        assert result == {"ok": False, "until": None}
+        app.state.model.workspaces.set_consent_pause.assert_not_awaited()
+        app.state.consent_deciders.broadcast.assert_not_called()
+
+    async def test_pause_missing_workspace_nacks(self):
+        # set_consent_pause returns False (workspace missing) -> nack, no
+        # broadcast.
+        app = _app()
+        app.state.model.workspaces.set_consent_pause = AsyncMock(
+            return_value=False
+        )
+        coord = ConsentCoordinator(app)
+        result = await coord.pause(FULL_WS, PAUSE_1H)
+        assert result == {"ok": False, "until": None}
+        app.state.consent_deciders.broadcast.assert_not_called()
+
+    async def test_unpause_clears_and_broadcasts(self):
+        app = _app()
+        coord = ConsentCoordinator(app)
+        result = await coord.unpause(FULL_WS)
+        assert result == {"ok": True}
+        app.state.model.workspaces.set_consent_pause.assert_awaited_once_with(
+            FULL_WS, None
+        )
+        frames = [
+            c.args[1]
+            for c in app.state.consent_deciders.broadcast.call_args_list
+        ]
+        assert any(f["type"] == "egress_rules" for f in frames)
+
+    async def test_unpause_missing_workspace(self):
+        app = _app()
+        app.state.model.workspaces.set_consent_pause = AsyncMock(
+            return_value=False
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.unpause(FULL_WS) == {"ok": False}
+        app.state.consent_deciders.broadcast.assert_not_called()
+
+
+class TestConsentCoordinatorHoldPaused:
+    async def test_paused_auto_allows_no_hold(self):
+        # #2332: while paused, a destination with no in-effect verdict is
+        # auto-allowed at once -- no hold, no pending row, no static denial.
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = fut.result()
+        assert verdict["decision"] == "allow"
+        assert verdict["reason"] == "paused"
+        app.state.model.egress_consent.create_request.assert_not_awaited()
+        app.state.model.egress_consent.record_static_denial.assert_not_awaited()
+        assert coord._holds == {}
+
+    async def test_paused_respects_recorded_deny(self):
+        # A recorded in-effect deny still blocks while paused (the pause does
+        # not override existing verdicts).
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        app.state.model.egress_consent.active_verdict_for = AsyncMock(
+            return_value={
+                "id": "rid-1",
+                "workspace_id": FULL_WS,
+                "dest_host": "1.2.3.4",
+                "dest_port": 443,
+                "decision": "denied",
+            }
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = fut.result()
+        assert verdict["decision"] == "deny"
+        assert verdict["reason"] == "paused_deny"
+        app.state.model.egress_consent.active_verdict_for.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 443
+        )
+
+    async def test_paused_allow_verdict_still_allows(self):
+        # An in-effect ALLOW verdict is respected too (allow either way).
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        app.state.model.egress_consent.active_verdict_for = AsyncMock(
+            return_value={
+                "id": "rid-1",
+                "workspace_id": FULL_WS,
+                "dest_host": "1.2.3.4",
+                "dest_port": 443,
+                "decision": "allowed",
+            }
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result()["decision"] == "allow"
+
+    async def test_expired_pause_falls_through_to_normal_gate(self):
+        # A pause whose window elapsed is not paused -> the normal interactive
+        # gate applies (here: a decider is present -> hold).
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=1.0  # past
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert not fut.done()  # held for a decider, not auto-allowed
+        assert "rid-1" in coord._holds
+        # the pause-path lookup was NOT consulted (pause did not engage)
+        app.state.model.egress_consent.active_verdict_for.assert_not_awaited()
+
+    async def test_paused_db_error_fail_closes_to_deny(self):
+        # A model failure in the pause path must not strand the hold -- the
+        # outer guard fail-closes to deny.
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        app.state.model.egress_consent.active_verdict_for = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result() == {"decision": "deny", "reason": "error"}
+        assert coord._holds == {}
 
 
 class TestConsentCoordinatorResolve:
@@ -1128,3 +1340,71 @@ class TestEgressSidecarWS:
         await handler
         assert ws.sent == []  # relay cancelled before it could send
         assert not fut.done()  # the coordinator's hold Future is untouched
+
+
+# --- pause integration: real model round-trip (#2332) ------------------------
+
+
+def _wire_coordinator_extras(app_state):
+    """Add the coordinator's non-model deps (settings, deciders, sidecar)."""
+    app_state.state.settings.egress_consent_timeout = 30.0
+    app_state.state.settings.egress_consent_rate_limit = 50
+    app_state.state.consent_deciders = types.SimpleNamespace(
+        has_decider=lambda workspace_id: True,
+        broadcast=Mock(return_value=0),
+    )
+    app_state.state.sidecar_connections = types.SimpleNamespace(
+        send_drop=Mock(return_value=None)
+    )
+
+
+class TestConsentCoordinatorPauseIntegration:
+    """Real DB + real model: pause persists and gates hold() end-to-end (#2332)."""
+
+    async def test_pause_then_hold_auto_allows(self, app_state, user):
+        # With a real DB, pause() must persist consent_paused_until so a later
+        # hold() reads it and auto-allows (no pending request created).
+        from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
+
+        _wire_coordinator_extras(app_state)
+        ws = await app_state.state.model.workspaces.create_workspace(
+            user["id"], "pause-int", egress_mode=EGRESS_MODE_INTERACTIVE
+        )
+        coord = ConsentCoordinator(app_state)
+        assert (await coord.pause(ws["id"], PAUSE_15M))["ok"] is True
+        fut = await coord.hold(ws["id"], "newhost.example.com", 443)
+        verdict = fut.result()
+        assert verdict["decision"] == "allow"
+        assert verdict["reason"] == "paused"
+        # no pending request row was created (the pause suppressed the hold)
+        pending = await app_state.state.model.egress_consent.list_requests(
+            ws["id"], decision="pending"
+        )
+        assert pending == []
+
+    async def test_pause_survives_a_verdict_resolve(self, app_state, user):
+        # #2332 regression: resolving a held request rebroadcasts egress_rules;
+        # the pause window must still be reported (the highlight must not
+        # clear). Hold first (not paused), pause, then resolve.
+        from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
+
+        _wire_coordinator_extras(app_state)
+        ws = await app_state.state.model.workspaces.create_workspace(
+            user["id"], "pause-resolve", egress_mode=EGRESS_MODE_INTERACTIVE
+        )
+        coord = ConsentCoordinator(app_state)
+        # 1. hold a destination (creates a pending request + in-memory hold)
+        fut = await coord.hold(ws["id"], "holdhost.example.com", 443)
+        assert not fut.done()  # held for a decider
+        held_id = next(iter(coord._holds))
+        # 2. pause (sets the window)
+        assert (await coord.pause(ws["id"], PAUSE_1H))["ok"] is True
+        # 3. resolve the held request -> rebroadcasts egress_rules
+        await coord.resolve(held_id, "allowed", user["id"], duration="1h")
+        # 4. the pause is still set: rules_frame reports it
+        frame = await coord.rules_frame(ws["id"])
+        assert frame["paused"] is not None
+        assert frame["paused"]["paused"] is True
+        # 5. a NEW hold after the resolve still auto-allows (pause durable)
+        fut2 = await coord.hold(ws["id"], "other.example.com", 80)
+        assert fut2.result()["reason"] == "paused"

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1408,3 +1408,30 @@ class TestConsentCoordinatorPauseIntegration:
         # 5. a NEW hold after the resolve still auto-allows (pause durable)
         fut2 = await coord.hold(ws["id"], "other.example.com", 80)
         assert fut2.result()["reason"] == "paused"
+
+    async def test_paused_respects_a_real_recorded_deny(self, app_state, user):
+        # I2 (#2332): the security property -- a recorded in-effect deny still
+        # blocks while paused -- driven through the REAL model (not a mock).
+        # Records a deny, pauses, then holds the denied host and asserts the
+        # verdict is deny (paused_deny), NOT an auto-allow.
+        from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
+
+        _wire_coordinator_extras(app_state)
+        ws = await app_state.state.model.workspaces.create_workspace(
+            user["id"], "pause-deny-int", egress_mode=EGRESS_MODE_INTERACTIVE
+        )
+        ec = app_state.state.model.egress_consent
+        coord = ConsentCoordinator(app_state)
+        # record an in-effect deny for evil.example.com:443
+        req = await ec.create_request(ws["id"], "evil.example.com", 443)
+        await ec.decide(req["id"], "denied", user["id"], "tilrestart")
+        # pause the workspace
+        assert (await coord.pause(ws["id"], PAUSE_15M))["ok"] is True
+        # hold the denied host -> deny (paused_deny), NOT auto-allowed
+        fut = await coord.hold(ws["id"], "evil.example.com", 443)
+        verdict = fut.result()
+        assert verdict["decision"] == "deny"
+        assert verdict["reason"] == "paused_deny"
+        # a different, never-decided host is still auto-allowed
+        fut2 = await coord.hold(ws["id"], "unseen.example.com", 443)
+        assert fut2.result()["reason"] == "paused"

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -233,6 +233,9 @@ def _ws_app(
         resolve=AsyncMock(return_value=None),
         rules_frame=AsyncMock(return_value=rules_frame),
         revoke=AsyncMock(return_value=True),
+        # #2332: pause/unpause -- default to success (a real coordinator ack).
+        pause=AsyncMock(return_value={"ok": True, "until": 1234.5}),
+        unpause=AsyncMock(return_value={"ok": True}),
     )
     return app
 
@@ -408,6 +411,88 @@ class TestConsentDeciderWS:
         ]
         assert acks and acks[0]["ok"] is True
         assert acks[0]["request_id"] == "r1"
+
+    async def test_pause_frame_calls_coordinator_and_acks(self):
+        # #2332: a pause frame -> coordinator.pause(the decider's workspace) +
+        # a pause_ack back to the decider.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"pause","duration":"15m"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.pause.assert_awaited_once_with(WS, "15m")
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "pause_ack"
+        ]
+        assert acks and acks[0]["ok"] is True
+        assert acks[0]["until"] == 1234.5
+
+    async def test_unpause_frame_calls_coordinator_and_acks(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"unpause"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.unpause.assert_awaited_once_with(WS)
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "pause_ack"
+        ]
+        assert acks and acks[0]["ok"] is True
+
+    async def test_pause_deploy_wide_decider_nacks(self):
+        # A deploy-wide decider (no workspace) has no single workspace to
+        # pause -> nack without calling the coordinator.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "admin@x"})
+        ws = _FakeWS(
+            {"token": "tok"},  # no workspace -> deploy-wide
+            ['{"type":"pause","duration":"1h"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.pause.assert_not_awaited()
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "pause_ack"
+        ]
+        assert acks and acks[0]["ok"] is False
+
+    async def test_unpause_deploy_wide_decider_nacks(self):
+        # A deploy-wide decider has no single workspace to unpause either.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "admin@x"})
+        ws = _FakeWS(
+            {"token": "tok"},  # no workspace -> deploy-wide
+            ['{"type":"unpause"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.unpause.assert_not_awaited()
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "pause_ack"
+        ]
+        assert acks and acks[0]["ok"] is False
 
     async def test_verdict_invalid_decision_sends_error(self):
         from fastapi import WebSocketDisconnect

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -494,6 +494,85 @@ class TestConsentDeciderWS:
         ]
         assert acks and acks[0]["ok"] is False
 
+    async def test_pause_requires_share_terminals_not_just_terminal(self):
+        # I1 (#2332): pause is a workspace-wide policy change, so it needs
+        # share-terminals (collaborators + owners), not just the terminal
+        # access that gates the connection. A terminal-only member (e.g. a
+        # spectator) may connect + decide requests but NOT pause.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "spec@x"})
+
+        async def check(resource, principals, perm):
+            return perm == "terminal"  # terminal yes, share-terminals no
+
+        app.state.acl.check_permission = AsyncMock(side_effect=check)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"pause","duration":"15m"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.pause.assert_not_awaited()
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "pause_ack"
+        ]
+        assert acks and acks[0]["ok"] is False
+
+    async def test_unpause_requires_share_terminals(self):
+        # Same higher bar applies to unpause (a workspace-wide state change).
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "spec@x"})
+
+        async def check(resource, principals, perm):
+            return perm == "terminal"
+
+        app.state.acl.check_permission = AsyncMock(side_effect=check)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"unpause"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.unpause.assert_not_awaited()
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "pause_ack"
+        ]
+        assert acks and acks[0]["ok"] is False
+
+    async def test_pause_allowed_with_share_terminals(self):
+        # A collaborator (share-terminals) can pause; the coordinator is called
+        # and a success pause_ack comes back.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "collab@x"})
+
+        async def check(resource, principals, perm):
+            return perm in ("terminal", "share-terminals")
+
+        app.state.acl.check_permission = AsyncMock(side_effect=check)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            ['{"type":"pause","duration":"1h"}', WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        app.state.consent_coordinator.pause.assert_awaited_once_with(WS, "1h")
+        acks = [
+            json.loads(m)
+            for m in ws.sent
+            if json.loads(m).get("type") == "pause_ack"
+        ]
+        assert acks and acks[0]["ok"] is True
+
     async def test_verdict_invalid_decision_sends_error(self):
         from fastapi import WebSocketDisconnect
 

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -12,6 +12,9 @@ from klangk.model.egress_consent import (
     DECISION_PENDING,
     DECISION_REVOKED,
     DURATIONS,
+    DURATION_5M,
+    DURATION_FOREVER,
+    DURATION_TILRESTART,
 )
 from klangk.model.workspaces import (
     EGRESS_MODE_DEFAULT,
@@ -771,3 +774,87 @@ async def test_init_db_rebuilds_egress_consent_to_add_duration_check(
                 ("keep-1",),
             )
     assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
+
+
+# -- active_verdict_for (consent-pause "respect existing verdict", #2332) --
+
+
+async def test_active_verdict_for_returns_in_effect_deny(ec, ws, user):
+    # A recorded in-effect deny for an exact (host, port) is returned so the
+    # pause path can keep blocking it (the pause does not override verdicts).
+    w = await ws.create_workspace(user["id"], "avf-deny")
+    d = await ec.create_request(w["id"], "deny.com", 443)
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], DURATION_TILRESTART)
+    row = await ec.active_verdict_for(w["id"], "deny.com", 443)
+    assert row is not None
+    assert row["decision"] == DECISION_DENIED
+    assert row["dest_host"] == "deny.com"
+
+
+async def test_active_verdict_for_returns_in_effect_allow(ec, ws, user):
+    w = await ws.create_workspace(user["id"], "avf-allow")
+    a = await ec.create_request(w["id"], "allow.com", 443)
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], DURATION_FOREVER)
+    row = await ec.active_verdict_for(w["id"], "allow.com", 443)
+    assert row is not None
+    assert row["decision"] == DECISION_ALLOWED
+
+
+async def test_active_verdict_for_none_when_no_verdict(ec, ws, user):
+    # No recorded verdict -> None (the pause path auto-allows).
+    w = await ws.create_workspace(user["id"], "avf-none")
+    assert await ec.active_verdict_for(w["id"], "unseen.com", 443) is None
+
+
+async def test_active_verdict_for_port_exact(ec, ws, user):
+    # A verdict for host:443 does NOT match a lookup for host:80 (least
+    # privilege: a deny on one port does not block another).
+    w = await ws.create_workspace(user["id"], "avf-port")
+    d = await ec.create_request(w["id"], "deny.com", 443)
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], DURATION_TILRESTART)
+    assert await ec.active_verdict_for(w["id"], "deny.com", 80) is None
+    assert await ec.active_verdict_for(w["id"], "deny.com", 443) is not None
+
+
+async def test_active_verdict_for_excludes_expired(ec, ws, user, app_state):
+    # A verdict whose timed window has elapsed is not in effect -> None.
+    w = await ws.create_workspace(user["id"], "avf-expired")
+    a = await ec.create_request(w["id"], "stale.com", 443)
+    await ec.decide(a["id"], DECISION_DENIED, user["id"], DURATION_5M)
+    async with app_state.state.db.transaction() as conn:
+        await conn.execute(
+            "UPDATE egress_consent SET decided_at = ? WHERE id = ?",
+            (0.0, a["id"]),
+        )
+    assert await ec.active_verdict_for(w["id"], "stale.com", 443) is None
+
+
+async def test_active_verdict_for_most_recent_wins(ec, ws, user):
+    # A later verdict for the same host:port overrides an earlier one (an
+    # allow then a deny -> the deny is current).
+    w = await ws.create_workspace(user["id"], "avf-recent")
+    a = await ec.create_request(w["id"], "flip.com", 443)
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], DURATION_TILRESTART)
+    d = await ec.create_request(w["id"], "flip.com", 443)
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], DURATION_TILRESTART)
+    row = await ec.active_verdict_for(w["id"], "flip.com", 443)
+    assert row["decision"] == DECISION_DENIED
+
+
+async def test_active_verdict_for_excludes_static_denial(ec, ws, user):
+    # A static policy denial (decided_by NULL) is not an actionable verdict.
+    w = await ws.create_workspace(user["id"], "avf-static")
+    await ec.record_static_denial(w["id"], "policy.com", 443)
+    assert await ec.active_verdict_for(w["id"], "policy.com", 443) is None
+
+
+async def test_active_verdict_for_no_port(ec, ws, user):
+    # A port-less verdict (NULL port) matches a port-less lookup.
+    w = await ws.create_workspace(user["id"], "avf-noport")
+    d = await ec.create_request(w["id"], "noport.com")  # dest_port NULL
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], DURATION_FOREVER)
+    row = await ec.active_verdict_for(w["id"], "noport.com", None)
+    assert row is not None
+    assert row["decision"] == DECISION_DENIED
+    # a port-specific lookup does not match a port-less verdict
+    assert await ec.active_verdict_for(w["id"], "noport.com", 443) is None

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -841,6 +841,37 @@ async def test_active_verdict_for_most_recent_wins(ec, ws, user):
     assert row["decision"] == DECISION_DENIED
 
 
+async def test_active_verdict_for_elapsed_newer_allow_does_not_mask_older_deny(
+    ec, ws, user, app_state
+):
+    # B2 regression (#2332): a newer-but-elapsed ALLOW must NOT hide an older
+    # in-effect DENY -- the pause path must still see the deny and block. The
+    # naive "ORDER BY decided_at DESC LIMIT 1" + single-row in-effect check
+    # returned None here (auto-allowing a host the user denied).
+    import time
+
+    now = time.time()
+    w = await ws.create_workspace(user["id"], "avf-b2")
+    # older in-effect DENY (tilrestart), backdated to now-1000
+    d = await ec.create_request(w["id"], "flip.com", 443)
+    await ec.decide(d["id"], DECISION_DENIED, user["id"], DURATION_TILRESTART)
+    # newer elapsed ALLOW (5m), backdated to now-500 -> past its window
+    a = await ec.create_request(w["id"], "flip.com", 443)
+    await ec.decide(a["id"], DECISION_ALLOWED, user["id"], DURATION_5M)
+    async with app_state.state.db.transaction() as conn:
+        await conn.execute(
+            "UPDATE egress_consent SET decided_at = ? WHERE id = ?",
+            (now - 1000, d["id"]),
+        )
+        await conn.execute(
+            "UPDATE egress_consent SET decided_at = ? WHERE id = ?",
+            (now - 500, a["id"]),
+        )
+    row = await ec.active_verdict_for(w["id"], "flip.com", 443)
+    assert row is not None
+    assert row["decision"] == DECISION_DENIED
+
+
 async def test_active_verdict_for_excludes_static_denial(ec, ws, user):
     # A static policy denial (decided_by NULL) is not an actionable verdict.
     w = await ws.create_workspace(user["id"], "avf-static")

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -58,6 +58,36 @@ async def test_existing_workspace_ids(ws, user):
     assert b["id"] in ids_after
 
 
+# -- consent pause (#2332) --
+
+
+async def test_get_consent_pause_default_none(ws, user):
+    row = await ws.create_workspace(user["id"], "pause-default")
+    assert await ws.get_consent_pause(row["id"]) is None
+
+
+async def test_set_and_get_consent_pause(ws, user):
+    row = await ws.create_workspace(user["id"], "pause-set")
+    assert await ws.set_consent_pause(row["id"], 1234.5) is True
+    assert await ws.get_consent_pause(row["id"]) == 1234.5
+
+
+async def test_set_consent_pause_clear_with_none(ws, user):
+    row = await ws.create_workspace(user["id"], "pause-clear")
+    await ws.set_consent_pause(row["id"], 9999.0)
+    assert await ws.get_consent_pause(row["id"]) == 9999.0
+    assert await ws.set_consent_pause(row["id"], None) is True
+    assert await ws.get_consent_pause(row["id"]) is None
+
+
+async def test_set_consent_pause_missing_workspace_false(ws):
+    assert await ws.set_consent_pause("no-such-ws", 1234.0) is False
+
+
+async def test_get_consent_pause_missing_workspace_none(ws):
+    assert await ws.get_consent_pause("no-such-ws") is None
+
+
 async def test_create_workspace_with_acl_rejects_agent(ws):
     with pytest.raises(AgentPrincipalError):
         await ws.create_workspace_with_acl(AGENT_USER_ID, "agent-owned")


### PR DESCRIPTION
Closes #2332.

## What

A workspace-level control in the `consent-decide` TUI that **silences all consent prompts for a window** — `Pause: 15m | 1h | 1d | Cancel` in a top bar. While paused, a destination with no allow-list rule and no in-effect recorded verdict is **auto-allowed** (no hold, no prompt); the pause otherwise changes nothing.

## Behavior (per the scoping comment on #2332)

The pause only affects the *interactive prompt* path. Existing policy keeps applying:

- **(a) `allowed_domains` / `rejected_domains` rules still apply** — these are enforced at the network sidecar's DNS layer (ACCEPT / NXDOMAIN) *before* a SYN ever reaches the consent gate, so a paused workspace can't let a rejected host through or be affected by an allow-list entry.
- **(b) Existing `egress_consent` verdicts still apply** — a recorded in-effect **deny** still blocks while paused (looked up per exact `host:port`, most-recent verdict wins). A recorded allow would allow anyway.
- **(c) No rule, no verdict → auto-allow** — the only behavior the pause changes: the hold-for-prompt path becomes a silent allow.

## How

`ConsentCoordinator.hold` checks pause first (then the existing interactive/static gate):

- **Schema** — new `consent_paused_until REAL` column on `workspaces` (+ migration). The pause persists across klangkd restarts.
- **Model** — `WorkspacesModel.get/set_consent_pause`; `EgressConsentModel.active_verdict_for` (most-recent in-effect verdict for an exact `host:port`, so the pause can respect a recorded deny).
- **Coordinator** — `pause`/`unpause` (set the window + broadcast a refreshed `egress_rules` frame to every decider); `_is_paused` reads the column live so a pause **self-expires** the moment its window elapses (no sweep needed); `_paused_verdict` returns `deny` if there's an in-effect recorded deny, else `allow` with `duration=once` (so each connection re-gates and nothing lingers auto-allowed past the window). `rules_frame` carries the live `paused` window.
- **Decider WS** (`/ws/consent-decider`) — handles `pause`/`unpause` frames. Workspace-scoped only (a deploy-wide decider with no target workspace nacks); replies `pause_ack`. Authz unchanged (terminal access to the workspace).
- **TUI** — `make_pause`/`make_unpause` builders, `pause_ack` handling, the pause control bar, a status-line remaining-time readout, and a bar highlight when active. The existing read-only rules screen's "Pause" section (scaffolded earlier) now renders too.

No sidecar changes: klangkd's `hold` returns an immediate `allow` verdict, so the sidecar just accepts the SYN as it would for any allow. The pause is fail-closed on DB error (the hold's existing guard denies).

## Tests

Full backend suite green at 100% coverage (4811 tests). New coverage: model (`active_verdict_for`, `get/set_consent_pause`), coordinator (`pause`/`unpause`, hold-while-paused auto-allow / respect-deny / expired-pause-falls-through / db-error-fail-close, `rules_frame` pause field), decider WS (pause/unpause/deploy-wide-nack), and the TUI (frame builders, `pause_ack`, bar mount + send + cancel + highlight + status).

## Out of scope

- Per-request duration + the TUI per-row duration selector (#2328).
- A rule-management / revocation view (separate issue).
