### PR TITLE
feat(egress-consent): forever deny persists via rejected_domains (#2369)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -47,6 +47,15 @@ operators or integrators to act when upgrading.
   TUI/Flutter dialogs are a follow-up (#2386); the `forever` **deny** verdict
   that mutates this list at runtime is #2369.
 
+- **`forever` egress-consent deny persists across restarts (#2369).** The deny
+  counterpart of the forever-allow: a `deny` with `duration=forever` appends
+  the consented `host:port` to the workspace's `rejected_domains`, which the
+  sidecar re-reads on (re)start and NXDOMAINs unconditionally. The deciding
+  connection still gets its immediate in-memory REJECT; the list mutation makes
+  the deny durable. Port-scoped + best-effort (failures swallowed), mirroring
+  the allow side (#2368). Revoking it must clear both the list and the audit
+  row (#2370).
+
 - **`forever` egress-consent allow persists across connections and restarts
   (#2368, #2372).** An allow with `duration=forever` allow-lists the host for
   the rest of the session AND across container restarts: the sidecar treats the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -49,12 +49,13 @@ operators or integrators to act when upgrading.
 
 - **`forever` egress-consent deny persists across restarts (#2369).** The deny
   counterpart of the forever-allow: a `deny` with `duration=forever` appends
-  the consented `host:port` to the workspace's `rejected_domains`, which the
-  sidecar re-reads on (re)start and NXDOMAINs unconditionally. The deciding
-  connection still gets its immediate in-memory REJECT; the list mutation makes
-  the deny durable. Port-scoped + best-effort (failures swallowed), mirroring
-  the allow side (#2368). Revoking it must clear both the list and the audit
-  row (#2370).
+  the host to the workspace's `rejected_domains`, which the sidecar re-reads on
+  (re)start and NXDOMAINs unconditionally. The deciding connection still gets
+  its immediate in-memory REJECT; the list mutation makes the deny durable.
+  Unlike the allow side, a port-less deny (e.g. ICMP) is persisted as a bare
+  host -- reject enforcement is name-level, so blocking the whole host is the
+  safe unit of a deny. Best-effort (failures swallowed). Revoking must clear
+  both the list entry and the audit row (#2370).
 
 - **`forever` egress-consent allow persists across connections and restarts
   (#2368, #2372).** An allow with `duration=forever` allow-lists the host for

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -330,12 +330,17 @@ class ConsentCoordinator:
         The network sidecar re-reads ``rejected_domains`` on (re)start and
         NXDOMAINs a rejected name unconditionally, so a forever deny survives
         a container/sidecar restart (the deciding connection already got its
-        in-memory REJECT from the verdict). Same port-scoped format as the
-        allow side; note the sidecar's reject enforcement is name-level (the
-        port is ignored), so the durable deny blocks the whole name.
+        in-memory REJECT from the verdict).
 
-        Best-effort (failures logged + swallowed) and port-scoped-only, exactly
-        like the allow side: a port-less verdict is not persisted. A ``forever``
+        Unlike the allow side, a *port-less* deny IS persisted (as a bare host),
+        not skipped: the sidecar's reject enforcement is name-level
+        (:func:`rejected_for` ignores port -- a rejected name is NXDOMAIN'd
+        before resolution), so the whole host is the natural unit of a deny, and
+        "block more" is the safe direction (no over-privilege concern, unlike
+        an all-ports allow). Withholding a port-less deny would make a
+        ``forever`` deny silently non-durable across restart. A ported verdict
+        is stored as ``host:port`` (port retained for symmetry + the audit row,
+        not scoping). Best-effort (failures logged + swallowed). A ``forever``
         deny also lives in an ``egress_consent`` audit row; revoking it must
         remove both (#2370).
         """
@@ -344,15 +349,7 @@ class ConsentCoordinator:
         workspace_id = row.get("workspace_id")
         if not host or not workspace_id:
             return
-        if not port:
-            logger.info(
-                "consent: forever deny of port-less dest %s ws=%s not "
-                "persisted; session still works",
-                host,
-                str(workspace_id)[:8],
-            )
-            return
-        entry = f"{host}:{port}"
+        entry = f"{host}:{port}" if port else host
         try:
             added = await self.app.state.model.workspaces.add_rejected_domain(
                 workspace_id, entry

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -195,6 +195,7 @@ class ConsentCoordinator:
         hold = self._holds.pop(request_id)
         hold["task"].cancel()
         forever_allow_row: dict | None = None
+        forever_deny_row: dict | None = None
         try:
             row = await self.app.state.model.egress_consent.decide(
                 request_id, decision, decided_by, duration
@@ -234,11 +235,17 @@ class ConsentCoordinator:
                     "duration": duration,
                 }
                 resolved = "denied"
+                # A `forever` deny persists by mutating the workspace's
+                # deny-list (#2369) -- the mirror of the allow side above.
+                if duration == DURATION_FOREVER:
+                    forever_deny_row = row
         if not hold["future"].done():
             hold["future"].set_result(verdict)
         self._broadcast_resolved(request_id, hold["workspace_id"], resolved)
         if forever_allow_row is not None:
             await self._persist_forever_allow(forever_allow_row)
+        if forever_deny_row is not None:
+            await self._persist_forever_deny(forever_deny_row)
         if resolved in ("allowed", "denied"):
             # A new verdict entered the in-effect set: refresh the deciders'
             # rule-management view (#2335 slice A) without a reconnect.
@@ -310,6 +317,62 @@ class ConsentCoordinator:
         else:
             logger.warning(
                 "consent: forever allow not persisted (%s) ws=%s "
+                "(workspace missing or malformed); session unaffected",
+                entry,
+                str(workspace_id)[:8],
+            )
+
+    async def _persist_forever_deny(self, row: dict) -> None:
+        """Persist a ``forever`` deny by appending ``host:port`` to the
+        workspace's ``rejected_domains`` (#2369) -- the mirror of
+        :meth:`_persist_forever_allow`.
+
+        The network sidecar re-reads ``rejected_domains`` on (re)start and
+        NXDOMAINs a rejected name unconditionally, so a forever deny survives
+        a container/sidecar restart (the deciding connection already got its
+        in-memory REJECT from the verdict). Same port-scoped format as the
+        allow side; note the sidecar's reject enforcement is name-level (the
+        port is ignored), so the durable deny blocks the whole name.
+
+        Best-effort (failures logged + swallowed) and port-scoped-only, exactly
+        like the allow side: a port-less verdict is not persisted. A ``forever``
+        deny also lives in an ``egress_consent`` audit row; revoking it must
+        remove both (#2370).
+        """
+        host = row.get("dest_host")
+        port = row.get("dest_port")
+        workspace_id = row.get("workspace_id")
+        if not host or not workspace_id:
+            return
+        if not port:
+            logger.info(
+                "consent: forever deny of port-less dest %s ws=%s not "
+                "persisted; session still works",
+                host,
+                str(workspace_id)[:8],
+            )
+            return
+        entry = f"{host}:{port}"
+        try:
+            added = await self.app.state.model.workspaces.add_rejected_domain(
+                workspace_id, entry
+            )
+        except Exception:
+            logger.exception(
+                "consent: forever-deny persist failed (%s) ws=%s",
+                entry,
+                str(workspace_id)[:8],
+            )
+            return
+        if added:
+            logger.info(
+                "consent: forever deny -> rejected_domains %s ws=%s",
+                entry,
+                str(workspace_id)[:8],
+            )
+        else:
+            logger.warning(
+                "consent: forever deny not persisted (%s) ws=%s "
                 "(workspace missing or malformed); session unaffected",
                 entry,
                 str(workspace_id)[:8],

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -860,6 +860,58 @@ class WorkspacesModel:
                     return True
         return False  # pragma: no cover - CAS exhausted under contention
 
+    async def add_rejected_domain(self, workspace_id: str, entry: str) -> bool:
+        """Append ``entry`` (``host[:port]``) to a workspace's
+        ``rejected_domains`` (#2369).
+
+        The deny counterpart of :meth:`add_allowed_domain`: a ``forever``
+        egress-consent deny persists by mutating the workspace's deny-list,
+        which the network sidecar re-reads on (re)start and NXDOMAINs
+        unconditionally -- so the deny survives a container/sidecar restart
+        (the deciding connection already got its in-memory REJECT from the
+        verdict). Like :meth:`add_allowed_domain` this is a server-internal
+        mutation with no owner-user gate, compare-and-swap on the JSON blob,
+        lowercased + de-duplicated case-insensitively. Returns True if the
+        workspace exists and ``entry`` is in the list afterwards; False if the
+        workspace is missing or ``entry`` is malformed.
+
+        Note: the sidecar's reject enforcement is name-level (a rejected name
+        is NXDOMAIN'd before resolution, regardless of port), so a
+        ``host:port`` entry blocks the whole name; the port is retained for
+        symmetry with :meth:`add_allowed_domain` and the audit row, not for
+        scoping.
+        """
+        try:
+            normalized = parse_allowed_domains([entry])
+        except ValueError:
+            return False
+        if not normalized:
+            return False
+        spec = normalized[0].lower()
+        for _ in range(_SETTINGS_CAS_RETRIES):
+            async with self.app.state.db.transaction() as db:
+                cursor = await db.execute(
+                    "SELECT rejected_domains FROM workspaces WHERE id = ?",
+                    (workspace_id,),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    return False
+                old_blob = row["rejected_domains"]
+                current = json.loads(old_blob) if old_blob else []
+                if spec in (s.lower() for s in current):
+                    return True  # already present (idempotent)
+                current.append(spec)
+                new_blob = json.dumps(current)
+                cursor = await db.execute(
+                    "UPDATE workspaces SET rejected_domains = ?"
+                    " WHERE id = ? AND rejected_domains IS ?",
+                    (new_blob, workspace_id, old_blob),
+                )
+                if cursor.rowcount == 1:
+                    return True
+        return False  # pragma: no cover - CAS exhausted under contention
+
     async def transfer_workspace(
         self,
         workspace_id: str,

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -589,6 +589,7 @@ class TestConsentCoordinatorResolve:
         app.state.model.workspaces.add_allowed_domain.assert_awaited_once_with(
             FULL_WS, "1.2.3.4:443"
         )
+        app.state.model.workspaces.add_rejected_domain.assert_not_awaited()
 
     async def test_timed_allow_does_not_mutate_allowed_domains(self):
         # Only `forever` mutates allowed_domains; a timed allow ("1d") is a
@@ -721,9 +722,11 @@ class TestConsentCoordinatorResolve:
         assert verdict["decision"] == "deny"
         app.state.model.workspaces.add_rejected_domain.assert_awaited_once()
 
-    async def test_forever_deny_portless_not_persisted(self):
-        # A port-less deny verdict is not persisted (mirror of the allow side:
-        # port-scoped-only). The deciding connection still gets its REJECT.
+    async def test_forever_deny_portless_persists_bare_host(self):
+        # Unlike the allow side, a port-less deny IS persisted -- as a bare
+        # host: reject enforcement is name-level (port ignored), so blocking
+        # the whole host is the safe, natural unit of a deny, and withholding
+        # it would make a `forever` deny silently non-durable across restart.
         row = _request()
         row["decision"] = "denied"
         row["dest_port"] = 0
@@ -734,7 +737,10 @@ class TestConsentCoordinatorResolve:
             "rid-1", "denied", "a@x", duration="forever"
         )
         assert verdict["decision"] == "deny"
-        app.state.model.workspaces.add_rejected_domain.assert_not_awaited()
+        app.state.model.workspaces.add_rejected_domain.assert_awaited_once_with(
+            FULL_WS,
+            "1.2.3.4",  # bare host (no port)
+        )
 
     async def test_forever_allow_portless_not_persisted(self):
         # A port-less verdict (e.g. ICMP, dest_port 0) is NOT persisted -- a

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -68,6 +68,7 @@ def _app(
         )
     )
     workspaces.add_allowed_domain = AsyncMock(return_value=True)
+    workspaces.add_rejected_domain = AsyncMock(return_value=True)
     app.state.model = types.SimpleNamespace(
         egress_consent=egress_consent, workspaces=workspaces
     )
@@ -650,16 +651,90 @@ class TestConsentCoordinatorResolve:
         assert verdict["decision"] == "allow"
         app.state.model.workspaces.add_allowed_domain.assert_awaited_once()
 
-    async def test_forever_deny_does_not_mutate_allowed_domains(self):
-        # `forever` mutates allowed_domains only for an ALLOW; a deny never
-        # touches the list (deny-forever is #2369, via rejected_domains).
-        row = _request()
+    async def test_forever_deny_appends_host_port_to_rejected_domains(self):
+        # A `forever` deny persists by appending the consented host:port to
+        # the workspace's rejected_domains (#2369) -- the mirror of the allow
+        # side. It must NOT touch allowed_domains (a deny is never an allow).
+        row = _request()  # host 1.2.3.4, port 443
         row["decision"] = "denied"
         app = _app(request=_request(), decide_row=row)
         coord = ConsentCoordinator(app)
-        await coord.hold(FULL_WS, "1.2.3.4", 443)
-        await coord.resolve("rid-1", "denied", "a@x", duration="forever")
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "denied", "a@x", duration="forever"
+        )
+        assert verdict == {
+            "decision": "deny",
+            "reason": "decided",
+            "duration": "forever",
+        }
+        assert fut.result()["decision"] == "deny"
+        app.state.model.workspaces.add_rejected_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
         app.state.model.workspaces.add_allowed_domain.assert_not_awaited()
+
+    async def test_forever_deny_persist_failure_does_not_break_verdict(self):
+        # Mirror of the allow side: a persistence failure (model raises) is
+        # swallowed -- the verdict is still deny (best-effort durability).
+        row = _request()
+        row["decision"] = "denied"
+        app = _app(request=_request(), decide_row=row)
+        app.state.model.workspaces.add_rejected_domain = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "denied", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "deny"
+        app.state.model.workspaces.add_rejected_domain.assert_awaited_once()
+
+    async def test_forever_deny_missing_host_skips_persist(self):
+        row = _request()
+        row["decision"] = "denied"
+        row["dest_host"] = None
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "denied", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "deny"
+        app.state.model.workspaces.add_rejected_domain.assert_not_awaited()
+
+    async def test_forever_deny_not_persisted_still_succeeds(self):
+        # add_rejected_domain returns False (workspace missing/malformed):
+        # logged as a warning, but the verdict still lands.
+        row = _request()
+        row["decision"] = "denied"
+        app = _app(request=_request(), decide_row=row)
+        app.state.model.workspaces.add_rejected_domain = AsyncMock(
+            return_value=False
+        )
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "denied", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "deny"
+        app.state.model.workspaces.add_rejected_domain.assert_awaited_once()
+
+    async def test_forever_deny_portless_not_persisted(self):
+        # A port-less deny verdict is not persisted (mirror of the allow side:
+        # port-scoped-only). The deciding connection still gets its REJECT.
+        row = _request()
+        row["decision"] = "denied"
+        row["dest_port"] = 0
+        app = _app(request=_request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve(
+            "rid-1", "denied", "a@x", duration="forever"
+        )
+        assert verdict["decision"] == "deny"
+        app.state.model.workspaces.add_rejected_domain.assert_not_awaited()
 
     async def test_forever_allow_portless_not_persisted(self):
         # A port-less verdict (e.g. ICMP, dest_port 0) is NOT persisted -- a

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -290,6 +290,48 @@ async def test_add_allowed_domain_ignores_blank(ws, user):
     assert got["allowed_domains"] is None
 
 
+async def test_add_rejected_domain_appends_lowercased_deduped(ws, user):
+    # A forever consent deny persists by mutating rejected_domains (#2369) --
+    # the mirror of add_allowed_domain. New entries lowercased + de-duplicated.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "forever-deny", rejected_domains=["PyPI.org:443"]
+    )
+    assert await ws.add_rejected_domain(ws_row["id"], "evil.com:443") is True
+    assert (
+        await ws.add_rejected_domain(ws_row["id"], "EVIL.COM:443") is True
+    )  # case-insensitive dedup -> no duplicate
+    assert (
+        await ws.add_rejected_domain(ws_row["id"], "evil.com:443") is True
+    )  # exact dup -> still True (idempotent)
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] == ["PyPI.org:443", "evil.com:443"]
+
+
+async def test_add_rejected_domain_from_empty(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "fresh-deny")
+    assert await ws.add_rejected_domain(ws_row["id"], "evil.com:443") is True
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] == ["evil.com:443"]
+
+
+async def test_add_rejected_domain_missing_workspace(ws):
+    assert await ws.add_rejected_domain("nope", "evil.com:443") is False
+
+
+async def test_add_rejected_domain_rejects_malformed(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "strict-deny")
+    assert await ws.add_rejected_domain(ws_row["id"], "not a domain!") is False
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] is None
+
+
+async def test_add_rejected_domain_ignores_blank(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "blank-deny")
+    assert await ws.add_rejected_domain(ws_row["id"], "   ") is False
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] is None
+
+
 async def test_transfer_workspace(ws, app_state, user):
     new_owner = await app_state.state.model.users.create_user("new@x.com", "h")
     ws_row = await ws.create_workspace_with_acl(user["id"], "transfer-me")


### PR DESCRIPTION
## Summary

Implements #2369 — the **deny counterpart of the forever-allow** (#2368): a
`deny` with `duration=forever` appends the consented `host:port` to the
workspace's `rejected_domains`, which the sidecar re-reads on (re)start and
NXDOMAINs unconditionally. The deciding connection keeps its immediate in-memory
REJECT (the existing verdict path); the list mutation makes the deny durable
across restarts.

Unblocked by #2367 (rejected_domains + sidecar enforcement), just merged.

## Changes

- `model/workspaces.py` — `add_rejected_domain`: CAS append to
  `rejected_domains`, mirroring `add_allowed_domain` (lowercased,
  de-duplicated, idempotent; returns False on missing workspace / malformed
  entry so the verdict path never breaks).
- `consent_coordinator.py` — `_persist_forever_deny` (best-effort,
  port-scoped, mirror of `_persist_forever_allow`) + `resolve()` captures a
  forever-deny row and persists it after the verdict Future resolves (the
  deciding connection's REJECT lands first).

## Scoping note

Mirrors the allow side exactly: the entry is the consented `host:port`
(port-scoped), and a port-less verdict (e.g. ICMP) is not persisted. One
semantic difference worth flagging: the sidecar's reject enforcement is
**name-level** (`rejected_for` ignores port — a rejected name is NXDOMAIN'd
before resolution), so a `host:443` entry blocks the whole name, not just port
443. The port is retained for symmetry with the allow side and the audit row,
not for scoping. Revoking a forever-deny must clear both the list entry and the
audit row (#2370).

## Tests

Full backend suite: **4774 passed, 100% coverage.** Added the deny mirror of
the #2368 coverage: forever-deny appends to `rejected_domains` (and does *not*
touch `allowed_domains`), persist failure swallowed, missing host, not-persisted
(workspace missing), port-less skip — plus the `add_rejected_domain` model tests
(append/dedup, from-empty, missing workspace, malformed, blank).
