### PR TITLE
feat(consent): Flutter egress-rules management tab (#2387)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -46,6 +46,16 @@ operators or integrators to act when upgrading.
   interactive-everywhere. The
   TUI/Flutter dialogs are a follow-up (#2386); the `forever` **deny** verdict
   that mutates this list at runtime is #2369.
+- **Consent rules-management tab in the Flutter workspace (#2387).**
+  Interactive-egress workspaces now show a **Rules** tab in the workspace
+  IDE tab strip (alongside Files/Terminal/Settings), the Flutter counterpart
+  of the TUI `consent-decide` rules screen. It lists the static allow-list,
+  active consent allows (with `expires in 5m` / `until restart` / `forever`
+  labels), and active denies (with remaining window), all live off the
+  existing `egress_rules` stream. Each active verdict has a **Revoke** action
+  (confirm → the row leaves once the server acks; a failed ack surfaces an
+  error and leaves the rule enforced). It mirrors the TUI exactly; static
+  allow-list entries are not revocable from this tab.
 
 - **`forever` egress-consent allow persists across connections and restarts
   (#2368, #2372).** An allow with `duration=forever` allow-lists the host for

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -13,6 +13,10 @@ class IdeLayout extends StatefulWidget {
   final Widget? sharing;
   final Widget? debug;
 
+  /// Egress consent rules-management tab (#2387). Shown only for
+  /// interactive-egress workspaces (the caller passes null otherwise).
+  final Widget? consentRules;
+
   /// Feature-contributed workspace tabs (#1975). Each entry contributes a
   /// tab (title + icon + builder) to the strip; only active features' tabs
   /// are passed in (the active-set filter lives in main.dart, which registers
@@ -36,6 +40,7 @@ class IdeLayout extends StatefulWidget {
     this.settings,
     this.sharing,
     this.debug,
+    this.consentRules,
     this.featureTabs = const [],
     this.terminalKey,
     this.fileViewerKey,
@@ -266,6 +271,12 @@ class IdeLayoutState extends State<IdeLayout> {
             : null,
         badgeHighlight: badgeValue?.highlight ?? false,
       );
+    }
+    // Consent rules tab (#2387): only for interactive-egress workspaces
+    // (the caller passes null otherwise), mounted with the other management
+    // tabs before Sharing/Settings.
+    if (widget.consentRules != null) {
+      addTab('Rules', Icons.shield_outlined, widget.consentRules!);
     }
     if (widget.sharing != null) {
       addTab('Sharing', Icons.people_outline, widget.sharing!);

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -41,6 +41,23 @@ const List<String> kConsentDurations = [
 ];
 const String kConsentDurationDefault = 'tilrestart';
 
+/// Seconds each *timed* duration adds to `decided_at` (mirror of the server's
+/// `_DURATION_SECONDS`; duplicated per client isolation). `once` is consumed by
+/// the single connection and `tilrestart`/`forever` have no fixed expiry, so
+/// they are absent -- a rule with one of those (or null) has no countdown.
+const Map<String, int> kConsentDurationSeconds = {
+  '5m': 300,
+  '15m': 900,
+  '1h': 3600,
+  '1d': 86400,
+  '1w': 604800,
+};
+
+/// Duration tokens that carry no fixed expiry (open-ended) -- the rules view
+/// renders a label, not a countdown, for these. Mirror of the TUI.
+const String kConsentDurationForever = 'forever';
+const String kConsentDurationTilrestart = 'tilrestart';
+
 /// Inbound-frame application outcomes returned by [ConsentDeciderService.applyFrame].
 enum ConsentFrameOutcome {
   /// A new held request (snapshot or live); [ConsentFrameResult.request] is set.
@@ -56,6 +73,14 @@ enum ConsentFrameOutcome {
   /// The server rejected a verdict; [ConsentFrameResult.message] is set.
   error,
 
+  /// A refreshed in-effect rules snapshot (#2387); [ConsentFrameResult.rules]
+  /// is set.
+  rules,
+
+  /// The server replied to a revoke (#2339/#2341); [ConsentFrameResult.revokeAckId]
+  /// and [ConsentFrameResult.revokeOk] are set.
+  revokeAck,
+
   /// Non-JSON / unknown frame (ignored).
   ignored,
 }
@@ -68,8 +93,24 @@ class ConsentFrameResult {
   final String? resolvedId;
   final String? message;
 
+  /// Parsed `egress_rules` snapshot (outcome == [ConsentFrameOutcome.rules]).
+  final EgressRules? rules;
+
+  /// The request id a `revoke_ack` refers to (outcome ==
+  /// [ConsentFrameOutcome.revokeAck]); null on a malformed frame.
+  final String? revokeAckId;
+
+  /// Whether a `revoke_ack` confirmed success (outcome ==
+  /// [ConsentFrameOutcome.revokeAck]).
+  final bool revokeOk;
+
   const ConsentFrameResult(this.outcome,
-      {this.request, this.resolvedId, this.message});
+      {this.request,
+      this.resolvedId,
+      this.message,
+      this.rules,
+      this.revokeAckId,
+      this.revokeOk = false});
 
   static const ignored = ConsentFrameResult(ConsentFrameOutcome.ignored);
 }
@@ -123,6 +164,188 @@ class PendingRequest {
   @override
   int get hashCode =>
       Object.hash(id, destHost, destPort, processName, requestedAt);
+}
+
+/// One in-effect consent verdict (allow or deny) for the rules view (#2387).
+/// Mirrors the TUI `ConsentRule` (``cli/tui/consent.py``).
+@immutable
+class ConsentRule {
+  final String id;
+  final String destHost;
+  final int? destPort;
+  final String? processName;
+
+  /// [kDecisionAllowed] or [kDecisionDenied].
+  final String decision;
+  final String? duration;
+
+  /// Epoch seconds the verdict was decided (for timed countdowns); null when
+  /// the server didn't send one.
+  final double? decidedAt;
+  final String? decidedBy;
+
+  const ConsentRule({
+    required this.id,
+    required this.destHost,
+    this.destPort,
+    this.processName,
+    required this.decision,
+    this.duration,
+    this.decidedAt,
+    this.decidedBy,
+  });
+
+  /// Parse one row of an `egress_rules` frame. Returns null on a non-map;
+  /// missing fields degrade to empty/null rather than failing the whole row.
+  static ConsentRule? fromJson(Object? obj) {
+    if (obj is! Map<String, dynamic>) return null;
+    final port = obj['dest_port'];
+    final decidedAt = obj['decided_at'];
+    final duration = obj['duration'];
+    return ConsentRule(
+      id: obj['id']?.toString() ?? '',
+      destHost: obj['dest_host']?.toString() ?? '',
+      destPort: port is int ? port : (port is num ? port.toInt() : null),
+      processName: obj['process_name']?.toString(),
+      decision: obj['decision']?.toString() ?? '',
+      duration: duration is String ? duration : null,
+      decidedAt: decidedAt is num ? decidedAt.toDouble() : null,
+      decidedBy: obj['decided_by']?.toString(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConsentRule &&
+          id == other.id &&
+          destHost == other.destHost &&
+          destPort == other.destPort &&
+          processName == other.processName &&
+          decision == other.decision &&
+          duration == other.duration &&
+          decidedAt == other.decidedAt &&
+          decidedBy == other.decidedBy;
+
+  @override
+  int get hashCode => Object.hash(id, destHost, destPort, processName, decision,
+      duration, decidedAt, decidedBy);
+}
+
+/// Pause window from the `egress_rules` frame (#2332; absent today). `until`
+/// is the epoch second the pause ends, or null for an indefinite pause (e.g.
+/// until restart). Mirrors the TUI `PauseState`.
+@immutable
+class EgressPause {
+  final double? until;
+
+  const EgressPause({this.until});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is EgressPause && until == other.until;
+
+  @override
+  int get hashCode => until.hashCode;
+}
+
+/// Parsed `egress_rules` frame: the workspace's in-effect decisions (#2387).
+/// `allowed`/`denied` are newest-decided-first (matching the backend's
+/// `list_active` `ORDER BY decided_at DESC`); `allowList` is the static
+/// `allowed_domains` config, order preserved; `paused` is null unless
+/// filtering is actually paused (#2332). Mirrors the TUI `EgressRules`.
+@immutable
+class EgressRules {
+  final String workspaceId;
+  final List<String> allowList;
+  final List<ConsentRule> allowed;
+  final List<ConsentRule> denied;
+  final EgressPause? paused;
+
+  const EgressRules({
+    required this.workspaceId,
+    required this.allowList,
+    required this.allowed,
+    required this.denied,
+    this.paused,
+  });
+
+  /// Build from an `egress_rules` frame. Returns null only if the frame lacks
+  /// a `workspace_id`; a missing/malformed `allow_list`/`allowed`/`denied`
+  /// degrades to empty rather than dropping the frame, and rows that fail to
+  /// parse are skipped. Mirrors the TUI `_parse_rules`.
+  static EgressRules? fromJson(Map<String, dynamic> msg) {
+    final wid = msg['workspace_id'];
+    if (wid is! String) return null;
+    final rawAllow = msg['allow_list'];
+    final allowList = <String>[
+      for (final d in (rawAllow is List ? rawAllow : <Object>[])) d.toString(),
+    ];
+    final allowed = <ConsentRule>[
+      for (final o
+          in (msg['allowed'] is List ? msg['allowed'] as List : <Object>[]))
+        if (ConsentRule.fromJson(o) case final r?) r,
+    ];
+    final denied = <ConsentRule>[
+      for (final o
+          in (msg['denied'] is List ? msg['denied'] as List : <Object>[]))
+        if (ConsentRule.fromJson(o) case final r?) r,
+    ];
+    // Newest-decided-first (mirror backend ORDER BY decided_at DESC); rows
+    // with no decided_at sort last. List.sort isn't stable, so use a stable
+    // helper that breaks ties by original index (matches the TUI's sorted()).
+    _sortRulesStable(allowed);
+    _sortRulesStable(denied);
+    return EgressRules(
+      workspaceId: wid,
+      allowList: allowList,
+      allowed: allowed,
+      denied: denied,
+      paused: _parsePause(msg['paused']),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EgressRules &&
+          workspaceId == other.workspaceId &&
+          listEquals(allowList, other.allowList) &&
+          listEquals(allowed, other.allowed) &&
+          listEquals(denied, other.denied) &&
+          paused == other.paused;
+
+  @override
+  int get hashCode => Object.hash(workspaceId, Object.hashAll(allowList),
+      Object.hashAll(allowed), Object.hashAll(denied), paused);
+}
+
+/// Parse the `paused` field of an `egress_rules` frame (#2332). Returns null
+/// unless filtering is actually paused, so the rules view renders no pause
+/// section until then. Mirrors the TUI `_parse_pause`.
+EgressPause? _parsePause(Object? obj) {
+  if (obj is! Map<String, dynamic> || obj['paused'] != true) return null;
+  final until = obj['until'];
+  return EgressPause(until: until is num ? until.toDouble() : null);
+}
+
+/// Stable in-place ordering of consent rules: decided rows newest-first,
+/// rows with no `decided_at` last, ties broken by original index (Dart's
+/// [List.sort] isn't stable). Mirrors the TUI's `sorted(...)` over the frame.
+void _sortRulesStable(List<ConsentRule> rules) {
+  final indexed = [
+    for (var i = 0; i < rules.length; i++) (i, rules[i]),
+  ];
+  indexed.sort((a, b) {
+    final aT = a.$2.decidedAt;
+    final bT = b.$2.decidedAt;
+    if (aT == null && bT == null) return a.$1.compareTo(b.$1);
+    if (aT == null) return 1;
+    if (bT == null) return -1;
+    final c = bT.compareTo(aT); // descending
+    return c != 0 ? c : a.$1.compareTo(b.$1);
+  });
+  rules.setAll(0, [for (final e in indexed) e.$2]);
 }
 
 /// Manages the WebSocket to ``/ws/consent-decider`` for one workspace.
@@ -192,9 +415,17 @@ class ConsentDeciderService extends ChangeNotifier {
 
   final Map<String, PendingRequest> _pending = {};
 
+  /// Latest in-effect rules snapshot (#2387), or null until the first
+  /// `egress_rules` frame lands (on connect). Mirrors the TUI controller's
+  /// `rules`; the rules tab renders an empty state until then.
+  EgressRules? _rules;
+
   /// Pending requests, oldest-first (stable UI ordering by requested_at).
   List<PendingRequest> get pending => _pending.values.toList()
     ..sort((a, b) => a.requestedAt.compareTo(b.requestedAt));
+
+  /// The latest in-effect rules snapshot, or null before the first frame.
+  EgressRules? get rules => _rules;
 
   bool get connected => _connected;
 
@@ -230,6 +461,10 @@ class ConsentDeciderService extends ChangeNotifier {
     // disconnected -- and thus never sent us an `egress_resolved` -- must not
     // linger. The snapshot `egress_request` frames that follow repopulate.
     _pending.clear();
+    // The server re-sends the `egress_rules` snapshot on (re)connect, so a
+    // stale snapshot from a prior session must not linger -- mirrors the
+    // TUI controller's `reset()`.
+    _rules = null;
     _connected = true;
     _attempt = 0;
     _authFailed = false;
@@ -256,6 +491,13 @@ class ConsentDeciderService extends ChangeNotifier {
       case ConsentFrameOutcome.resolved:
         notifyListeners();
         break;
+      case ConsentFrameOutcome.rules:
+        _rules = res.rules;
+        notifyListeners();
+        break;
+      case ConsentFrameOutcome.revokeAck:
+        _applyRevokeAck(res.revokeAckId, res.revokeOk);
+        break;
       case ConsentFrameOutcome.error:
         // Surface the rejection to the user (the TUI flashes it); a verdict
         // the server refused must not vanish silently.
@@ -266,6 +508,28 @@ class ConsentDeciderService extends ChangeNotifier {
       case ConsentFrameOutcome.ignored:
         break;
     }
+  }
+
+  /// Apply a `revoke_ack`: on success drop the rule from the cached snapshot
+  /// (idempotent -- the server also pushes a refreshed `egress_rules`); on
+  /// failure leave it enforced and flash (a still-enforced rule must never be
+  /// hidden silently). Mirrors the TUI controller's `revoke_ack` handling.
+  void _applyRevokeAck(String? id, bool ok) {
+    if (!ok) {
+      _flash('revoke failed — still in effect');
+      return;
+    }
+    final r = _rules;
+    if (id != null && r != null) {
+      _rules = EgressRules(
+        workspaceId: r.workspaceId,
+        allowList: r.allowList,
+        allowed: r.allowed.where((e) => e.id != id).toList(),
+        denied: r.denied.where((e) => e.id != id).toList(),
+        paused: r.paused,
+      );
+    }
+    notifyListeners();
   }
 
   void _onClosed(WebSocketChannel ch) {
@@ -339,6 +603,24 @@ class ConsentDeciderService extends ChangeNotifier {
     }
   }
 
+  /// Revoke an active verdict (#2341). The row stays in the cached snapshot
+  /// until the server's `revoke_ack` confirms success -- never removed
+  /// optimistically, so a still-enforced rule is never hidden (mirrors the
+  /// TUI). Flashes (not silent) when disconnected or the send fails.
+  void sendRevoke(String requestId) {
+    final ch = _channel;
+    if (ch == null || !_connected) {
+      _flash('disconnected — reconnecting');
+      return;
+    }
+    try {
+      ch.sink.add(buildRevoke(requestId));
+    } catch (e) {
+      debugPrint('[ConsentDecider] revoke send failed: $e');
+      _flash('revoke send failed — reconnecting');
+    }
+  }
+
   @override
   void dispose() {
     _stopped = true;
@@ -393,6 +675,16 @@ class ConsentDeciderService extends ChangeNotifier {
       return ConsentFrameResult(ConsentFrameOutcome.error,
           message: msg['message']?.toString() ?? '');
     }
+    if (mtype == 'egress_rules') {
+      final rules = EgressRules.fromJson(msg);
+      if (rules == null) return ConsentFrameResult.ignored;
+      return ConsentFrameResult(ConsentFrameOutcome.rules, rules: rules);
+    }
+    if (mtype == 'revoke_ack') {
+      final rid = msg['request_id'];
+      return ConsentFrameResult(ConsentFrameOutcome.revokeAck,
+          revokeAckId: rid is String ? rid : null, revokeOk: msg['ok'] == true);
+    }
     return ConsentFrameResult.ignored;
   }
 
@@ -409,6 +701,14 @@ class ConsentDeciderService extends ChangeNotifier {
     });
   }
 
+  /// Build an outbound revoke frame (JSON string) for an active verdict
+  /// (#2341). Asks the server (#2339) to drop the verdict's sidecar rule and
+  /// mark the row revoked.
+  @visibleForTesting
+  static String buildRevoke(String requestId) {
+    return jsonEncode({'type': 'revoke', 'request_id': requestId});
+  }
+
   /// Seconds until this hold's countdown hits zero (clamped at 0). The server
   /// is the source of truth (it auto-denies at the real timeout); this is only
   /// a UX hint.
@@ -416,6 +716,30 @@ class ConsentDeciderService extends ChangeNotifier {
     final expire = req.requestedAt + holdTimeout.inSeconds;
     final now = clock().millisecondsSinceEpoch / 1000.0;
     final left = expire - now;
+    return left < 0 ? 0 : left.round();
+  }
+
+  /// Seconds left on a timed verdict, or null if it has no fixed expiry
+  /// (`forever`/`tilrestart`/`once`/unknown/missing `decided_at`). The rules
+  /// view shows a label, not a countdown, for the open-ended ones. Mirrors
+  /// the TUI `rule_remaining`.
+  int? ruleRemainingSeconds(ConsentRule rule) {
+    final decidedAt = rule.decidedAt;
+    if (decidedAt == null) return null;
+    final secs = kConsentDurationSeconds[rule.duration];
+    if (secs == null) return null;
+    final now = clock().millisecondsSinceEpoch / 1000.0;
+    final left = decidedAt + secs - now;
+    return left < 0 ? 0 : left.round();
+  }
+
+  /// Seconds left in the pause window, or null if not paused / indefinite.
+  /// Mirrors the TUI `pause_remaining`; used by the rules view's pause label.
+  int? pauseRemainingSeconds(EgressRules rules) {
+    final until = rules.paused?.until;
+    if (until == null) return null;
+    final now = clock().millisecondsSinceEpoch / 1000.0;
+    final left = until - now;
     return left < 0 ? 0 : left.round();
   }
 }

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -1,0 +1,433 @@
+/// Egress consent rules-management panel for the workspace page (#2387).
+///
+/// A workspace tab that shows the workspace's in-effect consent decisions
+/// (the static allow-list, and the active allow/deny verdicts already
+/// decided) and lets the user revoke an active verdict. It is the Flutter
+/// counterpart of the TUI `consent-decide` `RulesScreen`
+/// (``cli/tui/consent.py``): the same grouped read-only body
+/// (allow-list / active allows / active denies) plus a revoke action, driven
+/// by the `egress_rules` frame the [ConsentDeciderService] already receives
+/// over `/ws/consent-decider` (#2335).
+///
+/// Countdowns tick live (1s) but the server is the source of truth (it drops
+/// a rule at the real expiry); this only repaints the remaining-time hint.
+/// Revoke is never optimistic: the row stays until the server's `revoke_ack`
+/// confirms success -- a still-enforced rule is never hidden silently (mirrors
+/// the TUI). A failed ack surfaces via the service's [flashMessage].
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+import 'consent_decider_service.dart';
+
+/// Compact remaining-time label: ``5m``, ``2h``, ``3d``, ``1w`` (#2387).
+/// Mirrors the TUI ``_fmt_duration``.
+String formatDurationCompact(int secs) {
+  if (secs < 60) return '${secs}s';
+  if (secs < 3600) return '${secs ~/ 60}m';
+  if (secs < 86400) return '${secs ~/ 3600}h';
+  if (secs < 604800) return '${secs ~/ 86400}d';
+  return '${secs ~/ 604800}w';
+}
+
+/// The human-readable expiry/countdown label for one rule, mirroring the TUI
+/// `RulesScreen._rule_line`. `remaining` is null when the rule has no fixed
+/// expiry (``forever``/``tilrestart``/``once``/unknown/missing
+/// ``decided_at``); open-ended durations still render a label, timed ones with
+/// a null remaining render nothing.
+String ruleExpiryLabel(ConsentRule rule, int? remaining, {required bool deny}) {
+  if (rule.duration == kConsentDurationForever) return 'forever';
+  if (rule.duration == kConsentDurationTilrestart) return 'until restart';
+  if (remaining == null) return '';
+  final t = formatDurationCompact(remaining);
+  return deny ? '$t left' : 'expires in $t';
+}
+
+/// Whether anything in the rules view has a ticking countdown (a timed verdict
+/// or an active pause). When false, the 1s refresh has nothing to repaint.
+/// Pure (and unit-tested) so the [ConsentRulesPanel] tick -- a real Timer the
+/// coverage gate ignores -- can call it without leaving a coverage gap.
+bool hasLiveCountdown(
+    EgressRules? rules, int? Function(ConsentRule) remaining) {
+  if (rules == null) return false;
+  if (rules.paused != null) return true;
+  return rules.allowed.any((r) => remaining(r) != null) ||
+      rules.denied.any((r) => remaining(r) != null);
+}
+
+/// A workspace tab managing the workspace's in-effect egress consent rules.
+class ConsentRulesPanel extends StatefulWidget {
+  const ConsentRulesPanel({super.key, required this.service});
+
+  final ConsentDeciderService service;
+
+  @override
+  State<ConsentRulesPanel> createState() => _ConsentRulesPanelState();
+}
+
+class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
+  Timer? _tick;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.service.addListener(_onChange);
+    // coverage:ignore-start
+    // 1s countdown refresh only when something on screen actually ticks (a
+    // timed verdict or an active pause). The panel stays mounted in
+    // IndexedStack even when its tab is hidden, so an unconditional tick would
+    // rebuild it every second forever; hasLiveCountdown is false for a
+    // forever/tilrestart-only workspace (the server is the source of truth;
+    // this only repaints the remaining-time hints).
+    _tick = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted &&
+          hasLiveCountdown(
+              widget.service.rules, widget.service.ruleRemainingSeconds)) {
+        _onChange();
+      }
+    });
+    // coverage:ignore-end
+  }
+
+  @override
+  void dispose() {
+    widget.service.removeListener(_onChange);
+    _tick?.cancel();
+    super.dispose();
+  }
+
+  void _onChange() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _confirmRevoke(ConsentRule rule) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Revoke consent rule?'),
+        content: Text(_describe(rule)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Revoke'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return; // page/dialog torn down during the await (#2393)
+    if (ok == true) widget.service.sendRevoke(rule.id);
+  }
+
+  String _describe(ConsentRule rule) {
+    final host = rule.destPort != null
+        ? '${rule.destHost}:${rule.destPort}'
+        : rule.destHost;
+    final verb = rule.decision == kDecisionAllowed ? 'allow' : 'deny';
+    final proc = rule.processName == null || rule.processName!.isEmpty
+        ? ''
+        : ' (${rule.processName})';
+    return 'Remove the $verb rule for $host$proc? It will be re-consented on the next request.';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = widget.service;
+    final rules = service.rules;
+    final flash = service.flashMessage;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _Header(service: service),
+        if (flash != null) _Flash(message: flash),
+        Expanded(
+          child: rules == null
+              ? const _Empty(text: 'Loading consent rules…')
+              : SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _Section(
+                        title: 'Static allow-list',
+                        emptyText: '(none)',
+                        children: rules.allowList.isEmpty
+                            ? null
+                            : [
+                                for (final d in rules.allowList)
+                                  Padding(
+                                    padding:
+                                        const EdgeInsets.symmetric(vertical: 2),
+                                    child: Text(d, style: _KStyles.mono),
+                                  ),
+                              ],
+                      ),
+                      _RulesSection(
+                        title: 'Active allows',
+                        rules: rules.allowed,
+                        deny: false,
+                        remaining: service.ruleRemainingSeconds,
+                        onRevoke: _confirmRevoke,
+                      ),
+                      _RulesSection(
+                        title: 'Active denies',
+                        rules: rules.denied,
+                        deny: true,
+                        remaining: service.ruleRemainingSeconds,
+                        onRevoke: _confirmRevoke,
+                      ),
+                      if (rules.paused != null) _Pause(service: service),
+                    ],
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Status header: connection state + held-request count (mirrors the TUI
+/// status line, scoped to the rules view).
+class _Header extends StatelessWidget {
+  const _Header({required this.service});
+  final ConsentDeciderService service;
+
+  @override
+  Widget build(BuildContext context) {
+    final conn = service.connected ? 'connected' : 'reconnecting';
+    final held = service.pending.length;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: KColors.borderDefault)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.shield_outlined, size: 18),
+          const SizedBox(width: 8),
+          Text('Egress consent rules', style: _KStyles.heading),
+          const SizedBox(width: 12),
+          Text('$conn · $held held',
+              style:
+                  const TextStyle(fontSize: 13, color: KColors.textSecondary)),
+        ],
+      ),
+    );
+  }
+}
+
+/// A transient error flash row (a failed revoke, server error, etc.).
+class _Flash extends StatelessWidget {
+  const _Flash({required this.message});
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
+      color: KColors.accentRed.withValues(alpha: 0.12),
+      child: Row(
+        children: [
+          const Icon(Icons.error_outline, size: 16, color: KColors.accentRed),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(message,
+                style: const TextStyle(fontSize: 13, color: KColors.accentRed)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A titled grouping of the rules body (allow-list, allows, denies). When
+/// [children] is null the section renders its [emptyText] placeholder.
+class _Section extends StatelessWidget {
+  const _Section({
+    required this.title,
+    required this.emptyText,
+    this.children,
+  });
+  final String title;
+  final String emptyText;
+  final List<Widget>? children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: _KStyles.title),
+          const SizedBox(height: 6),
+          if (children == null || children!.isEmpty)
+            Text(emptyText, style: _KStyles.muted)
+          else
+            ...children!,
+        ],
+      ),
+    );
+  }
+}
+
+/// The active-allows / active-denies section: a count, one row per rule with
+/// its expiry/countdown label and a revoke button.
+class _RulesSection extends StatelessWidget {
+  const _RulesSection({
+    required this.title,
+    required this.rules,
+    required this.deny,
+    required this.remaining,
+    required this.onRevoke,
+  });
+  final String title;
+  final List<ConsentRule> rules;
+  final bool deny;
+  final int? Function(ConsentRule) remaining;
+  final ValueChanged<ConsentRule> onRevoke;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('$title (${rules.length})', style: _KStyles.title),
+          const SizedBox(height: 6),
+          if (rules.isEmpty)
+            Text('(none)', style: _KStyles.muted)
+          else
+            for (final r in rules)
+              _RuleRow(
+                rule: r,
+                deny: deny,
+                remaining: remaining(r),
+                onRevoke: onRevoke,
+              ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One rule row: ``host:port (process)`` + expiry/countdown label + revoke.
+class _RuleRow extends StatelessWidget {
+  const _RuleRow({
+    required this.rule,
+    required this.deny,
+    required this.remaining,
+    required this.onRevoke,
+  });
+  final ConsentRule rule;
+  final bool deny;
+  final int? remaining;
+  final ValueChanged<ConsentRule> onRevoke;
+
+  @override
+  Widget build(BuildContext context) {
+    final host = rule.destPort != null
+        ? '${rule.destHost}:${rule.destPort}'
+        : rule.destHost;
+    final proc = rule.processName == null || rule.processName!.isEmpty
+        ? ''
+        : '  ·  ${rule.processName}';
+    final label = ruleExpiryLabel(rule, remaining, deny: deny);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Icon(deny ? Icons.block : Icons.check_circle_outline,
+              size: 16, color: deny ? KColors.accentRed : KColors.accentGreen),
+          const SizedBox(width: 8),
+          Expanded(
+            child: RichText(
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              text: TextSpan(
+                style: _KStyles.mono,
+                children: [
+                  TextSpan(text: '$host$proc'),
+                  if (label.isNotEmpty)
+                    TextSpan(text: '   $label', style: _KStyles.mutedSpan),
+                ],
+              ),
+            ),
+          ),
+          IconButton(
+            key: ValueKey('revoke-${rule.id}'),
+            tooltip: 'Revoke',
+            icon: const Icon(Icons.delete_outline, size: 18),
+            visualDensity: VisualDensity.compact,
+            onPressed: () => onRevoke(rule),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The pause section (#2332; hidden unless the frame reports a pause).
+class _Pause extends StatelessWidget {
+  const _Pause({required this.service});
+  final ConsentDeciderService service;
+
+  @override
+  Widget build(BuildContext context) {
+    final rules = service.rules!;
+    final rem = service.pauseRemainingSeconds(rules);
+    final text = rem == null
+        ? 'Filtering paused until restart'
+        : 'Filtering paused (resumes in ${formatDurationCompact(rem)})';
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        children: [
+          const Icon(Icons.pause_circle_outline,
+              size: 16, color: KColors.accentAmber),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(text,
+                style:
+                    const TextStyle(fontSize: 13, color: KColors.accentAmber)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Centered placeholder text for the loading / empty state.
+class _Empty extends StatelessWidget {
+  const _Empty({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(text, style: const TextStyle(color: KColors.textSecondary)),
+      ),
+    );
+  }
+}
+
+/// Shared text styles (kept here so the panel matches the rest of the app's
+/// look without reaching into theme internals).
+class _KStyles {
+  static const heading = TextStyle(fontSize: 14, fontWeight: FontWeight.bold);
+  static const title = TextStyle(
+      fontSize: 13, fontWeight: FontWeight.bold, color: KColors.textSecondary);
+  static const mono = TextStyle(
+      fontFamily: 'monospace', fontSize: 13, color: KColors.textPrimary);
+  static const muted = TextStyle(fontSize: 13, color: KColors.textMuted);
+  static const mutedSpan = TextStyle(color: KColors.textMuted);
+}

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -20,6 +20,7 @@ import 'workspace_file_api.dart';
 import 'workspace_overlays.dart';
 import 'consent_banner.dart';
 import 'consent_decider_service.dart';
+import 'consent_rules_panel.dart';
 import 'package:http/http.dart' as http;
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
@@ -562,6 +563,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
       sharing: _hasPerm('share')
           ? WorkspaceSharingPanel(workspaceId: widget.workspaceId)
           : null,
+      consentRules:
+          _consent != null ? ConsentRulesPanel(service: _consent!) : null,
       terminalKey: _terminalKey,
       fileViewerKey: _fileViewerKey,
       initialFile: widget.initialFile,

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -84,6 +84,43 @@ Map<String, dynamic> _request(
       'requested_at': at,
     };
 
+Map<String, dynamic> _ruleJson({
+  String id = 'v1',
+  String host = 'a.io',
+  int port = 443,
+  String? proc = 'curl',
+  String decision = 'allowed',
+  String? duration = '5m',
+  double? decidedAt = 1000.0,
+  String? decidedBy = 'alice',
+}) =>
+    {
+      'id': id,
+      'dest_host': host,
+      'dest_port': port,
+      if (proc != null) 'process_name': proc,
+      'decision': decision,
+      if (duration != null) 'duration': duration,
+      if (decidedAt != null) 'decided_at': decidedAt,
+      if (decidedBy != null) 'decided_by': decidedBy,
+    };
+
+Map<String, dynamic> _rulesFrame({
+  String workspaceId = 'ws-1',
+  List<String> allowList = const [],
+  List<Map<String, dynamic>> allowed = const [],
+  List<Map<String, dynamic>> denied = const [],
+  Object? paused,
+}) =>
+    {
+      'type': 'egress_rules',
+      'workspace_id': workspaceId,
+      'allow_list': allowList,
+      'allowed': allowed,
+      'denied': denied,
+      if (paused != null) 'paused': paused,
+    };
+
 void main() {
   group('applyFrame', () {
     test('egress_request adds the request', () {
@@ -136,7 +173,7 @@ void main() {
 
     test('unknown type is ignored', () {
       final res = ConsentDeciderService.applyFrame(
-          {}, jsonEncode({'type': 'egress_rules', 'rules': []}));
+          {}, jsonEncode({'type': 'totally_unknown', 'x': 1}));
       expect(res.outcome, ConsentFrameOutcome.ignored);
     });
 
@@ -160,6 +197,278 @@ void main() {
         'scope': 'once',
         'duration': '5m',
       });
+    });
+  });
+
+  group('buildRevoke', () {
+    test('produces a well-formed revoke frame', () {
+      final msg = jsonDecode(ConsentDeciderService.buildRevoke('v1'))
+          as Map<String, dynamic>;
+      expect(msg, {'type': 'revoke', 'request_id': 'v1'});
+    });
+  });
+
+  group('ConsentRule.fromJson', () {
+    test('parses a full payload', () {
+      final r = ConsentRule.fromJson(_ruleJson())!;
+      expect(r.id, 'v1');
+      expect(r.destHost, 'a.io');
+      expect(r.destPort, 443);
+      expect(r.processName, 'curl');
+      expect(r.decision, 'allowed');
+      expect(r.duration, '5m');
+      expect(r.decidedAt, 1000.0);
+      expect(r.decidedBy, 'alice');
+    });
+
+    test('coerces a numeric (double) dest_port to int', () {
+      final r = ConsentRule.fromJson({..._ruleJson(), 'dest_port': 443.0})!;
+      expect(r.destPort, 443);
+    });
+
+    test(
+        'missing dest_port -> null; non-string duration -> null; '
+        'non-num decidedAt -> null', () {
+      final r = ConsentRule.fromJson({
+        'id': 'x',
+        'dest_host': 'h',
+        'decision': 'allowed',
+        'duration': 5,
+        'decided_at': 'nope',
+      })!;
+      expect(r.destPort, isNull);
+      expect(r.duration, isNull);
+      expect(r.decidedAt, isNull);
+    });
+
+    test('non-map / null -> null', () {
+      expect(ConsentRule.fromJson('nope'), isNull);
+      expect(ConsentRule.fromJson(null), isNull);
+    });
+  });
+
+  group('ConsentRule equality', () {
+    final a = ConsentRule(
+        id: 'v1',
+        destHost: 'h',
+        destPort: 443,
+        processName: 'curl',
+        decision: 'allowed',
+        duration: '5m',
+        decidedAt: 1.0,
+        decidedBy: 'alice');
+
+    test('equal on all fields with matching hashCode', () {
+      final b = ConsentRule(
+          id: 'v1',
+          destHost: 'h',
+          destPort: 443,
+          processName: 'curl',
+          decision: 'allowed',
+          duration: '5m',
+          decidedAt: 1.0,
+          decidedBy: 'alice');
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('a differing field breaks equality', () {
+      expect(
+          a,
+          isNot(equals(
+              ConsentRule(id: 'v2', destHost: 'h', decision: 'allowed'))));
+      expect(
+          a,
+          isNot(equals(
+              ConsentRule(id: 'v1', destHost: 'h2', decision: 'allowed'))));
+      expect(a, isNot(equals('not a rule')));
+    });
+  });
+
+  group('EgressRules.fromJson', () {
+    test('returns null without a workspace_id', () {
+      expect(EgressRules.fromJson({'type': 'egress_rules', 'allow_list': []}),
+          isNull);
+    });
+
+    test('non-list allow_list/allowed/denied degrade to empty', () {
+      final r = EgressRules.fromJson({
+        'workspace_id': 'w',
+        'allow_list': 'oops',
+        'allowed': 'oops',
+        'denied': 3,
+      })!;
+      expect(r.workspaceId, 'w');
+      expect(r.allowList, isEmpty);
+      expect(r.allowed, isEmpty);
+      expect(r.denied, isEmpty);
+    });
+
+    test('skips rows that fail to parse', () {
+      final r = EgressRules.fromJson({
+        'workspace_id': 'w',
+        'allow_list': ['a.io'],
+        'allowed': [
+          {'id': 'ok', 'dest_host': 'h', 'decision': 'allowed'},
+          'badrow',
+          5
+        ],
+      })!;
+      expect(r.allowList, ['a.io']);
+      expect(r.allowed, hasLength(1));
+      expect(r.allowed.single.id, 'ok');
+    });
+
+    test('sorts decided newest-first; null decided_at last', () {
+      final r = EgressRules.fromJson({
+        'workspace_id': 'w',
+        'allowed': [
+          {
+            'id': 'old',
+            'dest_host': 'h',
+            'decision': 'allowed',
+            'decided_at': 10.0
+          },
+          {
+            'id': 'new',
+            'dest_host': 'h',
+            'decision': 'allowed',
+            'decided_at': 90.0
+          },
+          {'id': 'unknown', 'dest_host': 'h', 'decision': 'allowed'},
+        ],
+      })!;
+      expect(r.allowed.map((e) => e.id), ['new', 'old', 'unknown']);
+    });
+
+    test('stable: same decided_at keeps frame order; nulls keep order last',
+        () {
+      // List.sort isn't stable; ties (same decided_at, or both null) must keep
+      // the frame's relative order (matches the TUI's stable sorted()).
+      final r = EgressRules.fromJson({
+        'workspace_id': 'w',
+        'allowed': [
+          {
+            'id': 'first',
+            'dest_host': 'h',
+            'decision': 'allowed',
+            'decided_at': 50.0
+          },
+          {
+            'id': 'second',
+            'dest_host': 'h',
+            'decision': 'allowed',
+            'decided_at': 50.0
+          },
+          {'id': 'n1', 'dest_host': 'h', 'decision': 'allowed'},
+          {'id': 'n2', 'dest_host': 'h', 'decision': 'allowed'},
+        ],
+      })!;
+      expect(r.allowed.map((e) => e.id), ['first', 'second', 'n1', 'n2']);
+    });
+  });
+
+  group('EgressRules paused parsing', () {
+    test('absent / not paused -> null', () {
+      expect(EgressRules.fromJson({'workspace_id': 'w'})!.paused, isNull);
+      expect(
+          EgressRules.fromJson({
+            'workspace_id': 'w',
+            'paused': {'paused': false}
+          })!
+              .paused,
+          isNull);
+    });
+
+    test('paused true with until -> EgressPause(until); without -> null until',
+        () {
+      expect(
+          EgressRules.fromJson({
+            'workspace_id': 'w',
+            'paused': {'paused': true, 'until': 99.0}
+          })!
+              .paused!
+              .until,
+          99.0);
+      expect(
+          EgressRules.fromJson({
+            'workspace_id': 'w',
+            'paused': {'paused': true}
+          })!
+              .paused!
+              .until,
+          isNull);
+    });
+  });
+
+  group('EgressPause + EgressRules equality', () {
+    test('EgressPause equality', () {
+      expect(
+          const EgressPause(until: 1.0), equals(const EgressPause(until: 1.0)));
+      expect(const EgressPause(until: 1.0).hashCode,
+          const EgressPause(until: 1.0).hashCode);
+      expect(const EgressPause(until: 1.0),
+          isNot(equals(const EgressPause(until: 2.0))));
+      expect(const EgressPause(until: 1.0), isNot(equals(const EgressPause())));
+    });
+
+    test('EgressRules equality by content', () {
+      final a = EgressRules(
+          workspaceId: 'w',
+          allowList: ['a'],
+          allowed: [ConsentRule(id: '1', destHost: 'h', decision: 'allowed')],
+          denied: const [],
+          paused: const EgressPause(until: 1.0));
+      final b = EgressRules(
+          workspaceId: 'w',
+          allowList: ['a'],
+          allowed: [ConsentRule(id: '1', destHost: 'h', decision: 'allowed')],
+          denied: const [],
+          paused: const EgressPause(until: 1.0));
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(
+          a,
+          isNot(equals(EgressRules(
+              workspaceId: 'w2',
+              allowList: ['a'],
+              allowed: const [],
+              denied: const []))));
+      expect(
+          a,
+          isNot(equals(EgressRules(
+              workspaceId: 'w',
+              allowList: ['b'],
+              allowed: const [],
+              denied: const []))));
+    });
+  });
+
+  group('applyFrame egress_rules + revoke_ack', () {
+    test('egress_rules -> rules outcome with the snapshot', () {
+      final res = ConsentDeciderService.applyFrame(
+          {}, jsonEncode(_rulesFrame(allowList: ['a.io'])));
+      expect(res.outcome, ConsentFrameOutcome.rules);
+      expect(res.rules!.allowList, ['a.io']);
+    });
+
+    test('egress_rules without workspace_id -> ignored', () {
+      final res = ConsentDeciderService.applyFrame(
+          {}, jsonEncode({'type': 'egress_rules', 'allow_list': []}));
+      expect(res.outcome, ConsentFrameOutcome.ignored);
+    });
+
+    test('revoke_ack ok true/false and id coercion', () {
+      final ok = ConsentDeciderService.applyFrame({},
+          jsonEncode({'type': 'revoke_ack', 'request_id': 'v1', 'ok': true}));
+      expect(ok.outcome, ConsentFrameOutcome.revokeAck);
+      expect(ok.revokeAckId, 'v1');
+      expect(ok.revokeOk, isTrue);
+      final bad = ConsentDeciderService.applyFrame(
+          {}, jsonEncode({'type': 'revoke_ack', 'request_id': 5}));
+      expect(bad.outcome, ConsentFrameOutcome.revokeAck);
+      expect(bad.revokeAckId, isNull);
+      expect(bad.revokeOk, isFalse);
     });
   });
 
@@ -370,7 +679,7 @@ void main() {
       expect(svc.pending, hasLength(1));
       // A pong and an unknown frame neither mutate pending nor throw.
       channel.serverSend({'type': 'pong'});
-      channel.serverSend({'type': 'egress_rules', 'rules': []});
+      channel.serverSend({'type': 'totally_unknown', 'x': 1});
       await Future.delayed(Duration.zero);
       expect(svc.pending, hasLength(1));
       svc.dispose();
@@ -391,6 +700,175 @@ void main() {
       await Future.delayed(Duration.zero);
       expect(svc.connected, isFalse);
       expect(svc.authFailed, isFalse);
+      svc.dispose();
+    });
+
+    test('egress_rules frame populates service.rules (sorted, parsed)',
+        () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend(_rulesFrame(
+        allowList: ['github.com', 'pypi.org'],
+        allowed: [
+          _ruleJson(id: 'a', decidedAt: 100, host: 'a.io'),
+          _ruleJson(id: 'b', decidedAt: 200, host: 'b.io'),
+        ],
+        denied: [
+          _ruleJson(id: 'd', decision: 'denied', host: 'x.io', decidedAt: 50)
+        ],
+      ));
+      await Future.delayed(Duration.zero);
+      expect(svc.rules, isNotNull);
+      expect(svc.rules!.allowList, ['github.com', 'pypi.org']);
+      expect(svc.rules!.allowed.map((r) => r.id), ['b', 'a']); // newest first
+      expect(svc.rules!.denied.single.id, 'd');
+      svc.dispose();
+    });
+
+    test('revoke_ack success removes the rule; failure flashes', () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend(
+          _rulesFrame(allowed: [_ruleJson(id: 'a', decidedAt: 100)]));
+      await Future.delayed(Duration.zero);
+      expect(svc.rules!.allowed, hasLength(1));
+      channel.serverSend({'type': 'revoke_ack', 'request_id': 'a', 'ok': true});
+      await Future.delayed(Duration.zero);
+      expect(svc.rules!.allowed, isEmpty);
+      // failure leaves the row in place and flashes
+      channel.serverSend(_rulesFrame(
+          denied: [_ruleJson(id: 'd', decision: 'denied', decidedAt: 100)]));
+      await Future.delayed(Duration.zero);
+      channel
+          .serverSend({'type': 'revoke_ack', 'request_id': 'd', 'ok': false});
+      await Future.delayed(Duration.zero);
+      expect(svc.rules!.denied, hasLength(1));
+      expect(svc.flashMessage, contains('revoke failed'));
+      svc.dispose();
+    });
+
+    test('revoke_ack ok before any rules is a no-op (no crash)', () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend({'type': 'revoke_ack', 'request_id': 'a', 'ok': true});
+      await Future.delayed(Duration.zero);
+      expect(svc.rules, isNull);
+      svc.dispose();
+    });
+
+    test('sendRevoke sends a revoke frame on the socket', () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      svc.sendRevoke('v1');
+      expect(channel.sent, isNotEmpty);
+      final out =
+          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+      expect(out, {'type': 'revoke', 'request_id': 'v1'});
+      svc.dispose();
+    });
+
+    test('sendRevoke flashes when disconnected', () {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.sendRevoke('v1');
+      expect(channel.sent, isEmpty);
+      expect(svc.flashMessage, contains('disconnected'));
+      svc.dispose();
+    });
+
+    test('sendRevoke flashes when the socket send throws', () {
+      ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      svc.sendRevoke('v1');
+      expect(svc.flashMessage, contains('revoke send failed'));
+      svc.dispose();
+    });
+
+    test(
+        'ruleRemainingSeconds: timed -> value; open-ended/unknown/missing -> null',
+        () {
+      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws', token: 't', clock: () => now);
+      // decided at 1000s, 5m (300s) -> 300s left at now=1000s
+      expect(
+          svc.ruleRemainingSeconds(ConsentRule(
+              id: 'a',
+              destHost: 'h',
+              decision: 'allowed',
+              duration: '5m',
+              decidedAt: 1000.0)),
+          300);
+      // forever / tilrestart / unknown duration -> null
+      expect(
+          svc.ruleRemainingSeconds(ConsentRule(
+              id: 'b',
+              destHost: 'h',
+              decision: 'allowed',
+              duration: 'forever',
+              decidedAt: 1000.0)),
+          isNull);
+      expect(
+          svc.ruleRemainingSeconds(ConsentRule(
+              id: 'c',
+              destHost: 'h',
+              decision: 'allowed',
+              duration: 'tilrestart',
+              decidedAt: 1000.0)),
+          isNull);
+      expect(
+          svc.ruleRemainingSeconds(ConsentRule(
+              id: 'd',
+              destHost: 'h',
+              decision: 'allowed',
+              duration: 'bogus',
+              decidedAt: 1000.0)),
+          isNull);
+      // missing decided_at -> null
+      expect(
+          svc.ruleRemainingSeconds(ConsentRule(
+              id: 'e', destHost: 'h', decision: 'allowed', duration: '5m')),
+          isNull);
+      // clamped at 0 past expiry
+      expect(
+          svc.ruleRemainingSeconds(ConsentRule(
+              id: 'f',
+              destHost: 'h',
+              decision: 'allowed',
+              duration: '5m',
+              decidedAt: 100.0)),
+          0);
+      svc.dispose();
+    });
+
+    test(
+        'pauseRemainingSeconds: null when not paused / indefinite; value when set',
+        () {
+      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws', token: 't', clock: () => now);
+      final base = EgressRules(
+          workspaceId: 'w',
+          allowList: const [],
+          allowed: const [],
+          denied: const []);
+      expect(svc.pauseRemainingSeconds(base), isNull); // paused null
+      expect(
+          svc.pauseRemainingSeconds(EgressRules(
+              workspaceId: 'w',
+              allowList: const [],
+              allowed: const [],
+              denied: const [],
+              paused: const EgressPause())),
+          isNull); // until null
+      expect(
+          svc.pauseRemainingSeconds(EgressRules(
+              workspaceId: 'w',
+              allowList: const [],
+              allowed: const [],
+              denied: const [],
+              paused: const EgressPause(until: 1300.0))),
+          300); // 1300 - 1000
       svc.dispose();
     });
   });

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -1,0 +1,391 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/workspace/consent_decider_service.dart';
+import 'package:klangk_frontend/workspace/consent_rules_panel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class _FakeChannel extends Fake implements WebSocketChannel {
+  final _incoming = StreamController<dynamic>.broadcast();
+  final _sinkImpl = _FakeSink();
+  int? _closeCode;
+
+  @override
+  Stream<dynamic> get stream => _incoming.stream;
+
+  @override
+  WebSocketSink get sink => _sinkImpl;
+
+  @override
+  int? get closeCode => _closeCode;
+
+  @override
+  Future<void> get ready => Future.value();
+
+  void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
+
+  void serverClose([int? code]) {
+    _closeCode = code;
+    _incoming.close();
+  }
+
+  List<dynamic> get sent => _sinkImpl.sent;
+}
+
+class _FakeSink extends Fake implements WebSocketSink {
+  final List<dynamic> sent = [];
+
+  @override
+  void add(dynamic data) => sent.add(data);
+
+  @override
+  Future close([int? code, String? reason]) async {}
+}
+
+Map<String, dynamic> _ruleJson({
+  String id = 'v1',
+  String host = 'a.io',
+  int? port = 443,
+  String? proc = 'curl',
+  String decision = 'allowed',
+  String? duration = '5m',
+  double? decidedAt = 1000.0,
+}) =>
+    {
+      'id': id,
+      'dest_host': host,
+      if (port != null) 'dest_port': port,
+      if (proc != null) 'process_name': proc,
+      'decision': decision,
+      if (duration != null) 'duration': duration,
+      if (decidedAt != null) 'decided_at': decidedAt,
+    };
+
+Map<String, dynamic> _rulesFrame({
+  String workspaceId = 'ws-1',
+  List<String> allowList = const [],
+  List<Map<String, dynamic>> allowed = const [],
+  List<Map<String, dynamic>> denied = const [],
+  Object? paused,
+}) =>
+    {
+      'type': 'egress_rules',
+      'workspace_id': workspaceId,
+      'allow_list': allowList,
+      'allowed': allowed,
+      'denied': denied,
+      if (paused != null) 'paused': paused,
+    };
+
+DateTime _at(int epochSec) =>
+    DateTime.fromMillisecondsSinceEpoch(epochSec * 1000, isUtc: true);
+
+ConsentDeciderService _serviceWithChannel(_FakeChannel channel,
+    {DateTime Function()? clock}) {
+  ConsentDeciderService.testChannelFactory = (_) => channel;
+  return ConsentDeciderService(
+      workspaceId: 'ws', token: 't', clock: clock ?? _wallClock);
+}
+
+DateTime _wallClock() => DateTime.now();
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  tearDown(() {
+    ConsentDeciderService.testChannelFactory = null;
+  });
+
+  group('formatDurationCompact', () {
+    test('<60s -> Ns', () => expect(formatDurationCompact(5), '5s'));
+    test('<1h -> Nm', () => expect(formatDurationCompact(125), '2m'));
+    test('<1d -> Nh', () => expect(formatDurationCompact(7200), '2h'));
+    test('<1w -> Nd', () => expect(formatDurationCompact(90000), '1d'));
+    test('>=1w -> Nw', () => expect(formatDurationCompact(700000), '1w'));
+  });
+
+  group('ruleExpiryLabel', () {
+    ConsentRule rule(String? duration, {double? decidedAt}) => ConsentRule(
+        id: 'r',
+        destHost: 'h',
+        decision: 'allowed',
+        duration: duration,
+        decidedAt: decidedAt);
+
+    test('forever', () {
+      expect(ruleExpiryLabel(rule('forever'), null, deny: false), 'forever');
+    });
+    test('tilrestart', () {
+      expect(ruleExpiryLabel(rule('tilrestart'), null, deny: false),
+          'until restart');
+    });
+    test('allow timed -> expires in', () {
+      expect(ruleExpiryLabel(rule('5m'), 300, deny: false), 'expires in 5m');
+    });
+    test('deny timed -> left', () {
+      expect(ruleExpiryLabel(rule('5m'), 300, deny: true), '5m left');
+    });
+    test('timed but null remaining -> empty', () {
+      expect(ruleExpiryLabel(rule('5m'), null, deny: false), '');
+    });
+  });
+
+  group('hasLiveCountdown', () {
+    int? remaining(ConsentRule r) => r.duration == '5m' ? 5 : null;
+    final timed = ConsentRule(
+        id: 'a',
+        destHost: 'h',
+        decision: 'allowed',
+        duration: '5m',
+        decidedAt: 1.0);
+    final forever = ConsentRule(
+        id: 'b',
+        destHost: 'h',
+        decision: 'allowed',
+        duration: 'forever',
+        decidedAt: 1.0);
+    EgressRules rules(List<ConsentRule> allowed, {EgressPause? paused}) =>
+        EgressRules(
+            workspaceId: 'w',
+            allowList: const [],
+            allowed: allowed,
+            denied: const [],
+            paused: paused);
+
+    test('null rules -> false',
+        () => expect(hasLiveCountdown(null, remaining), isFalse));
+    test('only forever/tilrestart rules -> false', () {
+      expect(hasLiveCountdown(rules([forever]), remaining), isFalse);
+    });
+    test('a timed rule -> true', () {
+      expect(hasLiveCountdown(rules([timed]), remaining), isTrue);
+    });
+    test('a pause -> true', () {
+      expect(
+          hasLiveCountdown(
+              rules([forever], paused: const EgressPause(until: 1.0)),
+              remaining),
+          isTrue);
+    });
+  });
+
+  group('ConsentRulesPanel', () {
+    testWidgets('shows the loading state before the first frame',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      expect(find.text('Loading consent rules…'), findsOneWidget);
+      svc.dispose();
+    });
+
+    testWidgets('renders allow-list + allows + denies sections with labels',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch, clock: () => _at(1000));
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(
+        allowList: ['github.com'],
+        allowed: [
+          _ruleJson(id: 'a', host: 'f.io', duration: 'forever', decidedAt: 100),
+          _ruleJson(
+              id: 'b', host: 't.io', duration: 'tilrestart', decidedAt: 100),
+          _ruleJson(id: 'c', host: 'm.io', duration: '5m', decidedAt: 1000),
+          _ruleJson(
+              id: 'd',
+              host: 'n.io',
+              port: null,
+              proc: null,
+              duration: '5m',
+              decidedAt: null),
+        ],
+        denied: const [],
+      ));
+      await tester.pump();
+      expect(find.text('Static allow-list'), findsOneWidget);
+      expect(find.text('github.com'), findsOneWidget);
+      expect(find.text('Active allows (4)'), findsOneWidget);
+      expect(find.text('Active denies (0)'), findsOneWidget);
+      expect(find.text('(none)'), findsOneWidget); // empty denies
+      // four revocable allow rows (label branches: forever/tilrestart/timed/empty)
+      expect(find.byKey(const ValueKey('revoke-a')), findsOneWidget);
+      expect(find.byKey(const ValueKey('revoke-b')), findsOneWidget);
+      expect(find.byKey(const ValueKey('revoke-c')), findsOneWidget);
+      expect(find.byKey(const ValueKey('revoke-d')), findsOneWidget);
+      expect(find.textContaining('connected'), findsOneWidget);
+      svc.dispose();
+    });
+
+    testWidgets('revoke confirms then sends (with process in the prompt)',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(
+          allowed: [_ruleJson(id: 'v1', host: 'a.io', proc: 'curl')]));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('revoke-v1')));
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Revoke consent rule?'), findsOneWidget);
+      expect(find.textContaining('a.io:443'), findsOneWidget);
+      expect(find.textContaining('(curl)'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String),
+          {'type': 'revoke', 'request_id': 'v1'});
+      svc.dispose();
+    });
+
+    testWidgets('revoke prompt for a rule with no process', (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(
+          allowed: [_ruleJson(id: 'v2', host: 'b.io', proc: null)]));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('revoke-v2')));
+      await tester.pump();
+      await tester.pump();
+      expect(find.textContaining('b.io:443'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String),
+          {'type': 'revoke', 'request_id': 'v2'});
+      svc.dispose();
+    });
+
+    testWidgets('cancel does not send a revoke', (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(allowed: [_ruleJson(id: 'v3')]));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('revoke-v3')));
+      await tester.pump();
+      await tester.pump();
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pump();
+      expect(ch.sent, isEmpty);
+      svc.dispose();
+    });
+
+    testWidgets('shows the service flash row', (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(allowList: ['a.io']));
+      await tester.pump();
+      ch.serverSend({'type': 'error', 'message': 'verdict rejected'});
+      await tester.pump();
+      expect(find.text('verdict rejected'), findsOneWidget);
+      svc.dispose();
+    });
+
+    testWidgets('renders the pause section (countdown then until-restart)',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch, clock: () => _at(1000));
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
+      await tester.pump();
+      expect(find.textContaining('resumes in 5m'), findsOneWidget);
+      // switch to an indefinite pause
+      ch.serverSend(_rulesFrame(paused: {'paused': true}));
+      await tester.pump();
+      expect(find.text('Filtering paused until restart'), findsOneWidget);
+      svc.dispose();
+    });
+
+    testWidgets('a revoked row stays until revoke_ack succeeds',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(
+          _rulesFrame(allowed: [_ruleJson(id: 'v1', decidedAt: 100)]));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('revoke-v1')), findsOneWidget);
+      // confirm revoke -> frame sent, but the row stays (never optimistic)
+      await tester.tap(find.byKey(const ValueKey('revoke-v1')));
+      await tester.pump();
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String),
+          {'type': 'revoke', 'request_id': 'v1'});
+      expect(find.byKey(const ValueKey('revoke-v1')), findsOneWidget);
+      // server acks success -> row leaves
+      ch.serverSend({'type': 'revoke_ack', 'request_id': 'v1', 'ok': true});
+      await tester.pump();
+      expect(find.byKey(const ValueKey('revoke-v1')), findsNothing);
+      svc.dispose();
+    });
+
+    testWidgets('static allow-list rows are not revocable', (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(allowList: ['github.com', 'pypi.org']));
+      await tester.pump();
+      expect(find.text('github.com'), findsOneWidget);
+      expect(find.byKey(const ValueKey('revoke-github.com')), findsNothing);
+      expect(find.byKey(const ValueKey('revoke-pypi.org')), findsNothing);
+      svc.dispose();
+    });
+
+    testWidgets('confirm after the panel is disposed does not send (#2393)',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(
+          _rulesFrame(allowed: [_ruleJson(id: 'v1', decidedAt: 100)]));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('revoke-v1')));
+      await tester.pump();
+      await tester.pump();
+      // The confirm dialog lives on the root navigator, so it outlives the
+      // panel: tearing the panel down (e.g. navigate away) while it is open
+      // must NOT let a later Revoke tap reach the disposed service.
+      await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
+      await tester.pump();
+      expect(ch.sent, isEmpty); // the mounted guard short-circuited sendRevoke
+      svc.dispose();
+    });
+
+    testWidgets('header shows reconnecting when disconnected', (tester) async {
+      final ch = _FakeChannel();
+      ConsentDeciderService.testChannelFactory = (_) => ch;
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          // Long delay so the reconnect Timer never fires during the test
+          // (dispose cancels it regardless).
+          reconnectDelays: const [Duration(minutes: 5)]);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(allowList: ['a.io']));
+      await tester.pump();
+      ch.serverClose();
+      await tester.pump();
+      await tester.pump(); // flush onDone -> notifyListeners -> rebuild
+      expect(find.textContaining('reconnecting'), findsOneWidget);
+      svc.dispose();
+    });
+  });
+}

--- a/src/frontend/test/ide_layout_test.dart
+++ b/src/frontend/test/ide_layout_test.dart
@@ -89,6 +89,7 @@ void main() {
     Widget? settings,
     Widget? sharing,
     Widget? debug,
+    Widget? consentRules,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -101,6 +102,7 @@ void main() {
             sharing: sharing,
             settings: settings,
             debug: debug ?? const Text('Debug'),
+            consentRules: consentRules,
           ),
         ),
       ),
@@ -265,6 +267,27 @@ void main() {
         settings: const Text('SETTINGS_CONTENT'),
       ));
       expect(find.text('Settings'), findsOneWidget);
+    });
+
+    testWidgets('has Rules tab when consentRules provided', (tester) async {
+      await tester.pumpWidget(buildLayout(
+        consentRules: const Text('RULES_CONTENT'),
+      ));
+      expect(find.text('Rules'), findsOneWidget);
+    });
+
+    testWidgets('Rules tab content is visible after switch', (tester) async {
+      await tester.pumpWidget(buildLayout(
+        consentRules: const Text('RULES_CONTENT'),
+      ));
+      await tester.tap(find.text('Rules'));
+      await tester.pumpAndSettle();
+      expect(find.text('RULES_CONTENT'), findsOneWidget);
+    });
+
+    testWidgets('no Rules tab when consentRules is null', (tester) async {
+      await tester.pumpWidget(buildLayout());
+      expect(find.text('Rules'), findsNothing);
     });
 
     testWidgets('settings tab content is visible after switch', (tester) async {


### PR DESCRIPTION
## Summary

Adds a **Rules** tab to the workspace IDE strip for `interactive`-egress workspaces — the Flutter counterpart of the TUI `consent-decide` rules screen (`cli/tui/consent.py` `RulesScreen`). It shows the workspace's in-effect consent decisions and lets the user revoke an active verdict, all driven by the `egress_rules` stream the consent service already receives over `/ws/consent-decider` (#2335). Closes #2387.

The tab appears only for interactive-egress workspaces (same gate as the consent banner) — alongside Files / Terminal / Settings / Sharing.

## What's in it

- **Static allow-list** (read-only; the configured `allowed_domains`).
- **Active allows (N)** — `host:port (process)` + `forever` / `until restart` / `expires in 5m`.
- **Active denies (N)** — `host:port (process)` + `5m left`.
- **Pause** section (rendered only when #2332 lands a pause window).
- **Revoke** per active verdict (allows + denies): confirm → the row leaves once the server's `revoke_ack` confirms; a failed ack flashes and leaves the rule enforced. Static allow-list entries are **not** revocable (structural guard, as in the TUI).

Countdowns tick live (1s); the server remains the source of truth.

## Changes

- **`consent_decider_service.dart`** — `ConsentRule` / `EgressPause` / `EgressRules` (+`_parsePause`); parse the `egress_rules` and `revoke_ack` frames; a `_rules` snapshot + getter (cleared on reconnect); `sendRevoke` / `buildRevoke`; `ruleRemainingSeconds` / `pauseRemainingSeconds`. Mirrors the TUI `ConsentDeciderController` (`apply_frame` / `rule_remaining` / `revoke`).
- **`consent_rules_panel.dart`** (new) — the tab UI: grouped body, live countdowns, revoke confirm dialog. Pure `formatDurationCompact` / `ruleExpiryLabel` helpers (mirror the TUI `_fmt_duration` / `_rule_line`).
- **`ide_layout.dart`** — a new `consentRules` named panel → a Rules tab (Files stays at index 1, so file/dir deep-links are unaffected).
- **`workspace_page.dart`** — construct `ConsentRulesPanel(service: _consent!)`, gated to `null` (tab hidden) for non-interactive workspaces.

Built as a named panel (like `settings`/`sharing`/`debug`) rather than a `WorkspaceTabPlugin`, since the view is tightly coupled to the page-local `ConsentDeciderService`.

## Verification

- 927 frontend tests pass; **100% line coverage** (repo gate).
- `flutter analyze` clean (the lone `pubspec.yaml` 'PLACEHOLDER' warning is pre-existing and unrelated).

A real bug the tests caught: the revoke prompt originally wrote `' ($rule.processName)'`, which interpolated the whole object (`$rule`) — fixed to `${rule.processName}` in both the dialog and the rule row.
