### PR TITLE
feat(egress-consent): static mode refuses consent decider registration (#2394)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -79,6 +79,14 @@ operators or integrators to act when upgrading.
   shown) and de-duplicated. The `forever` deny counterpart is a follow-up
   (#2369).
 
+- **Static egress mode refuses consent deciders (#2394).** A workspace-scoped
+  consent decider connecting to a workspace with `egress_mode = "static"` is
+  now refused at registration with a `4003 Forbidden` close
+  (`workspace egress mode is static`), so the static/interactive boundary is
+  structural rather than only enforced at hold time. Deploy-wide deciders are
+  unaffected. The coordinator's existing `_is_interactive` gate remains as
+  defense-in-depth.
+
 - **Revoke action in `consent-decide` (#2341).** On the rules screen
   (`r`), focus an active consent allow/deny row and press `x` to revoke it:
   klangkd drops the sidecar rule and marks the verdict spent, so the row

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -93,6 +93,12 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     # as defense-in-depth). Reads the same egress_mode the coordinator does.
     # Deploy-wide deciders (workspace None) are unaffected -- they cover
     # interactive workspaces without flipping a static one.
+    #
+    # NB: these closes run before websocket.accept(), so the ASGI server
+    # (uvicorn) answers the handshake with a bare HTTP 403 -- the close code
+    # and reason are NOT transmitted to the client (same as the authz close
+    # above). The distinct reason string is still worth setting: it lands in
+    # the server log for debugging why a connection was refused.
     if workspace is not None:
         ws = await app.state.model.workspaces.get_workspace(workspace)
         if ws is None:

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -48,6 +48,7 @@ from ..model.egress_consent import (
     DURATIONS,
     DURATION_DEFAULT,
 )
+from ..model.workspaces import EGRESS_MODE_INTERACTIVE
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,27 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     if not allowed:
         await websocket.close(code=4003, reason="Forbidden")
         return
+
+    # #2394: a static-mode workspace never holds egress for a human decision
+    # (its non-allow-listed egress is denied immediately with a static
+    # verdict). Refuse a workspace-scoped decider at registration so the
+    # static/interactive boundary is structural (enforced here), not just
+    # behavioral (the coordinator's hold-time ``_is_interactive`` gate stays
+    # as defense-in-depth). Reads the same egress_mode the coordinator does.
+    # Deploy-wide deciders (workspace None) are unaffected -- they cover
+    # interactive workspaces without flipping a static one.
+    if workspace is not None:
+        ws = await app.state.model.workspaces.get_workspace(workspace)
+        if ws is None:
+            # Vanished between the authz check and now (a delete race) -- the
+            # workspace authz just passed against can no longer be registered.
+            await websocket.close(code=4003, reason="Forbidden")
+            return
+        if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
+            await websocket.close(
+                code=4003, reason="workspace egress mode is static"
+            )
+            return
 
     await websocket.accept()
     safe_ws = SafeWebSocket(websocket)

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -8,6 +8,7 @@ import types
 from unittest.mock import AsyncMock
 
 from klangk.consent_deciders import ConsentDeciderRegistry
+from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
 
 WS = "ws-aaaa1111-2222-3333-4444-555566667777"
 WS2 = "ws-bbbb2222-3333-4444-5555-666677778888"
@@ -209,11 +210,22 @@ def _ws_app(
     allowed: bool = True,
     snapshot=None,
     rules_frame=None,
+    egress_mode: str = EGRESS_MODE_INTERACTIVE,
 ):
     """App with mocked auth + acl + coordinator, and a real registry."""
     app = types.SimpleNamespace()
     app.state = types.SimpleNamespace()
     app.state.settings = types.SimpleNamespace(consent_decider_timeout=45.0)
+    # #2394: a workspace-scoped decider's egress_mode is checked at connect.
+    # Default interactive so existing connect/register tests keep working;
+    # pass egress_mode="static" to exercise the structural rejection.
+    app.state.model = types.SimpleNamespace(
+        workspaces=types.SimpleNamespace(
+            get_workspace=AsyncMock(
+                return_value={"id": WS, "egress_mode": egress_mode}
+            ),
+        ),
+    )
     app.state.consent_deciders = ConsentDeciderRegistry(app)
     app.state.auth = types.SimpleNamespace(
         get_user_from_token=AsyncMock(return_value=token_result)
@@ -293,6 +305,52 @@ class TestConsentDeciderWS:
         assert ws.closed == (4003, "Forbidden")
         assert ws.accepted is False
         assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_static_workspace_scoped_decider_is_forbidden(self):
+        # #2394: a workspace with egress_mode=static must refuse a
+        # workspace-scoped consent decider at registration -- the
+        # static/interactive boundary is structural, not just the
+        # coordinator's hold-time gate.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"}, egress_mode="static")
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4003, "workspace egress mode is static")
+        assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_missing_workspace_is_forbidden(self):
+        # A workspace that vanished between the authz check and the egress_mode
+        # read (a delete race) is refused just like an unauthorized one.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        app.state.model.workspaces.get_workspace = AsyncMock(return_value=None)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4003, "Forbidden")
+        assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_deploy_wide_decider_unaffected_by_static_mode(self):
+        # #2394: deploy-wide deciders (no ?workspace=) cover all interactive
+        # workspaces without flipping a static one's behavior, so the
+        # egress_mode check is skipped for them -- they register normally and
+        # the workspace model is never consulted.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "admin@x"}, egress_mode="static")
+        ws = _FakeWS(
+            {"token": "tok"},  # no workspace -> deploy-wide
+            [WebSocketDisconnect()],
+        )
+        await handle_consent_decider(ws, app)
+        assert ws.accepted is True
+        assert ws.closed is None
+        app.state.model.workspaces.get_workspace.assert_not_awaited()
 
     async def test_non_admin_deploy_wide_is_forbidden(self):
         from klangk.wshandler.decider import handle_consent_decider


### PR DESCRIPTION
## Summary

A workspace with `egress_mode = "static"` now refuses consent-decider WebSocket registration, making the static/interactive boundary **structural** (enforced at the decider endpoint) rather than only **behavioral** (the coordinator's hold-time gate).

Closes #2394.

## What changed

The consent-decider handler (`/ws/consent-decider`) now checks the workspace's `egress_mode` after authz passes, before accepting the connection. A **workspace-scoped** decider (`?workspace=<id>`) connecting to a workspace whose `egress_mode != "interactive"` is refused with a `4003 Forbidden` close, reason `workspace egress mode is static`.

- Reads the same `egress_mode` the coordinator does (`get_workspace`) — so both gates agree: registration requires interactive mode, and the hold gate (`_is_interactive`) requires interactive mode.
- The coordinator's existing `_is_interactive` gate is intentionally **left in place** as defense-in-depth.
- **Deploy-wide deciders** (no `?workspace=`) are unaffected — they cover all interactive workspaces without flipping a static one's behavior (the `_is_interactive` check already gates on `egress_mode`).
- A workspace that vanishes between the authz check and the mode read (a delete race) is refused with a generic `4003 Forbidden`.

## Why structural, not just behavioral

Today a static workspace denies non-allow-listed egress immediately (`record_static_denial` + `{decision: "deny", reason: "static"}`), but that record differs from a human deny (no `decided_by`, excluded from `list_active`, no persistent REJECT rule). Letting a decider register against a static workspace would let it flip the workspace into interactive mode purely by connecting. Refusing at registration makes that impossible without relying solely on the hold-time gate.

## Acceptance criteria

- [x] A workspace-scoped decider connecting to a `static` workspace gets a 4003 close
- [x] The existing `_is_interactive` gate in the coordinator remains as defense-in-depth (untouched)
- [x] Deploy-wide deciders are unaffected (the egress_mode check is skipped; the workspace model is never consulted)
- [x] Tests cover the rejection (static → 4003, deploy-wide unaffected + model never read, missing-workspace delete-race → 4003)

## Test plan

Full Python suite green at 100% coverage (4831 tests). New tests in `test_consent_deciders.py`:
- `test_static_workspace_scoped_decider_is_forbidden` — `egress_mode="static"` → 4003 with the static reason, not accepted, not registered.
- `test_deploy_wide_decider_unaffected_by_static_mode` — deploy-wide decider registers normally even with `egress_mode="static"`; `get_workspace` is never awaited.
- `test_missing_workspace_is_forbidden` — workspace vanishes between authz and the mode read → 4003 Forbidden.

The existing connection tests keep passing via the `_ws_app` default `egress_mode="interactive"`.
