### PR TITLE
feat(egress-consent): revoke forever verdicts + reject_list rules view (#2370)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -61,12 +61,17 @@ operators or integrators to act when upgrading.
   the `consent-decide` TUI (`Pause: 15m | 1h | 1d | Cancel`) silences ALL
   consent prompts for the workspace for the chosen window: a destination with
   no allow-list rule and no in-effect recorded verdict is auto-allowed (no
-  hold) instead of prompting. The pause does not bypass policy —
+  hold) instead of prompting. The pause does not bypass policy --
   `allowed_domains`/`rejected_domains` rules and existing `egress_consent`
   verdicts (a recorded deny still blocks) keep applying. The window
   self-expires (the gate re-checks on every connection), the status line
   shows the remaining time, and a refreshed `egress_rules` frame carries the
   live `paused` window to every decider.
+
+- **`reject_list` in the `egress_rules` frame (#2370, #2340).** The read-only
+  rules view (`ConsentCoordinator.rules_frame`) now surfaces the workspace's
+  `rejected_domains` alongside the existing `allow_list`, so deciders see the
+  static deny-list in the rule-management screen.
 
 - **`forever` egress-consent allow persists across connections and restarts
   (#2368, #2372).** An allow with `duration=forever` allow-lists the host for
@@ -462,6 +467,17 @@ operators or integrators to act when upgrading.
   `KLANGKD_ALLOW_INSECURE_NO_AUTH`.
 
 ### Changed
+
+- **Revoking a `forever` verdict retracts its durable list entry (#2370,
+  #2339).** Revoking a `forever` allow/deny now removes the host from
+  `allowed_domains`/`rejected_domains` (not just the in-memory sidecar rule),
+  and the sidecar clears its in-session `_FOREVER_HOSTS`/`_VERDICT_CACHE` for
+  the host -- so the verdict stops taking effect immediately and no longer
+  re-applies on the next sidecar restart. The retract is best-effort (failures
+  logged + swallowed); the verdict row is marked revoked regardless. A
+  statically-configured list entry (set via the API, not a verdict) is only
+  affected if it matches the revoked verdict's host, and clears on the next
+  restart as with any list edit.
 
 - **Egress-consent duration token `restart` renamed to `tilrestart` (#2357).**
   The verdict `duration` value `restart` is now `tilrestart` ("until restart")

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -527,7 +527,7 @@ def reject(ip: str, port: int, ttl: float) -> None:
         _REJECTED[(ip, port)] = max(_REJECTED.get((ip, port), 0.0), expire)
 
 
-def drop_for_host(host: str, decision: str) -> None:
+def drop_for_host(host: str, decision: str) -> set[str]:
     """Drop the sidecar's rules for a host (revocation, #2339).
 
     ``allowed``: remove the learned ACCEPT rules (+ ``_LEARNED`` records) for
@@ -535,16 +535,24 @@ def drop_for_host(host: str, decision: str) -> None:
     ``denied``: remove the temporary REJECT rules for the host's IPs (stop
     force-rejecting; the host is again subject to the allow-list).
 
+    Returns the set of candidate IPs (the host's resolved IPs + the host
+    string itself, for a direct-IP connect) so the caller --
+    :meth:`SidecarConsentClient._handle_drop_rule`, on the event loop -- can
+    clear the loop-only ``_FOREVER_HOSTS``/``_VERDICT_CACHE`` state via
+    :func:`_clear_forever_state`. Those structures are documented loop-only
+    (no lock) and must NOT be mutated here, since this function runs off the
+    loop in the executor.
+
     Host->IP comes from ``_LEARNED[ip]["host"]`` (set by ``_record_hosts`` for
     every resolved name, allow-listed or not), so a deny's IPs are found too;
     the host string itself is also a candidate IP (a direct-IP connect that
     never went through DNS, and a direct-IP allow whose ``host`` is ``None``).
     Best-effort: a failed delete drops one rule, not the whole revoke. Sync
-    (forks iptables) — run off the loop; under ``_LOCK`` like allow/sweep.
+    (forks iptables) -- run off the loop; under ``_LOCK`` like allow/sweep.
 
     L3/L4 limit (co-resident hosts): the egress rules are per IP+port, so two
     DNS names that resolve to the SAME IP share one rule and cannot be revoked
-    individually — revoking one name removes the shared rule, affecting the
+    individually -- revoking one name removes the shared rule, affecting the
     other too. A correct per-host revoke for co-resident hosts (CDN/S3/Cloudflare
     fronted sites) needs L7/SNI filtering, which is a separate feature (#2352).
     """
@@ -555,13 +563,13 @@ def drop_for_host(host: str, decision: str) -> None:
             for ip, rec in _LEARNED.items()
             if (rec.get("host") or "").lower() == host_l
         ]
+        # IPs that resolved to this host, plus the host itself if it's a
+        # direct-IP connect/allow (the scan above misses a direct-IP allow,
+        # whose host record is None).
+        targets = {ip for ip in ips}
+        targets.add(host_l)
+        targets.add(host)
         if decision == "allowed":
-            # IPs that resolved to this host, plus the host itself if it's a
-            # direct-IP allow (allow() records host=None, so the scan above
-            # misses it).
-            targets = {ip for ip in ips}
-            targets.add(host_l)
-            targets.add(host)
             for ip in [i for i in targets if i in _LEARNED]:
                 for port in list(_LEARNED[ip]["ports"]):
                     try:
@@ -570,17 +578,38 @@ def drop_for_host(host: str, decision: str) -> None:
                         pass
                 del _LEARNED[ip]
         elif decision == "denied":
-            # IPs that resolved to this host, plus the host itself if it's a
-            # direct-IP connect (never DNS host-recorded).
-            targets = {ip for ip in ips}
-            targets.add(host_l)
-            targets.add(host)
             for key in [k for k in _REJECTED if k[0] in targets]:
                 try:
                     _remove_reject(*key)
                 except Exception:
                     pass
                 del _REJECTED[key]
+    return targets
+
+
+def _clear_forever_state(host: str, decision: str, ips: set[str]) -> None:
+    """Clear the in-session ``forever``-verdict state for a revoked host (#2370).
+
+    Called on the event-loop thread by
+    :meth:`SidecarConsentClient._handle_drop_rule` AFTER :func:`drop_for_host`
+    (which cleared the learned iptables rules + per-IP records under
+    :data:`_LOCK` in the executor and returned ``ips``). ``_FOREVER_HOSTS`` and
+    ``_VERDICT_CACHE`` are documented loop-only (no lock), so they must be
+    touched here -- never inside :func:`drop_for_host` (executor thread).
+
+    For an ``allowed`` revoke, ``_FOREVER_HOSTS`` is the in-session coverage a
+    ``forever`` allow added (#2372): without clearing it, the next DNS
+    resolution for the host re-learns the IP with an ACCEPT -- the allow would
+    persist in-session. ``_VERDICT_CACHE`` holds the per-connection SYN
+    verdicts (both decisions); without clearing the revoked host's entries, a
+    retransmit reuses the stale verdict for up to the cache TTL.
+    """
+    if decision == "allowed":
+        hl = host.lower()
+        _FOREVER_HOSTS[:] = [t for t in _FOREVER_HOSTS if t[0].lower() != hl]
+    if ips:
+        for key in [c for c in _VERDICT_CACHE if c[2] in ips]:
+            del _VERDICT_CACHE[key]
 
 
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
@@ -959,9 +988,15 @@ class SidecarConsentClient:
         ok = False
         if isinstance(host, str) and decision in ("allowed", "denied"):
             try:
-                await asyncio.get_running_loop().run_in_executor(
+                ips = await asyncio.get_running_loop().run_in_executor(
                     None, drop_for_host, host, decision
                 )
+                # Clear the loop-only in-session state (#2370) ON the event
+                # loop -- _FOREVER_HOSTS/_VERDICT_CACHE must not be touched
+                # inside drop_for_host (executor thread). Without this a
+                # `forever`-allow revoke would keep re-learning the host via
+                # _FOREVER_HOSTS, and cached verdicts would persist til TTL.
+                _clear_forever_state(host, decision, ips)
                 ok = True
             except Exception:
                 ok = False

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -587,26 +587,41 @@ def drop_for_host(host: str, decision: str) -> set[str]:
     return targets
 
 
-def _clear_forever_state(host: str, decision: str, ips: set[str]) -> None:
-    """Clear the in-session ``forever``-verdict state for a revoked host (#2370).
+def _drop_forever_hosts(host: str) -> None:
+    """Remove a host's in-session ``forever``-allow coverage (#2370, #2372).
 
-    Called on the event-loop thread by
-    :meth:`SidecarConsentClient._handle_drop_rule` AFTER :func:`drop_for_host`
-    (which cleared the learned iptables rules + per-IP records under
-    :data:`_LOCK` in the executor and returned ``ips``). ``_FOREVER_HOSTS`` and
-    ``_VERDICT_CACHE`` are documented loop-only (no lock), so they must be
-    touched here -- never inside :func:`drop_for_host` (executor thread).
-
-    For an ``allowed`` revoke, ``_FOREVER_HOSTS`` is the in-session coverage a
-    ``forever`` allow added (#2372): without clearing it, the next DNS
-    resolution for the host re-learns the IP with an ACCEPT -- the allow would
-    persist in-session. ``_VERDICT_CACHE`` holds the per-connection SYN
-    verdicts (both decisions); without clearing the revoked host's entries, a
-    retransmit reuses the stale verdict for up to the cache TTL.
+    Drops every :data:`_FOREVER_HOSTS` entry whose host matches
+    (case-insensitive). Called on the **event loop** by
+    :meth:`SidecarConsentClient._handle_drop_rule` **before** :func:`drop_for_host`
+    forks iptables in the executor: while that fork runs (~tens of ms), the
+    NFQUEUE consumer (:func:`_cb` -> :func:`_forever_host_allows`) and the DNS
+    path (:func:`ports_for`) both read :data:`_FOREVER_HOSTS`, and a SYN/resolve
+    arriving in that window would otherwise re-install a fresh ~1-year ACCEPT
+    (:data:`_DURATION_FOREVER`, via :func:`allow`) that the revoke never clears.
+    Clearing it first makes both gates deny during the window, so no fresh rule
+    can be installed; :func:`drop_for_host` then removes the existing ACCEPTs.
+    :data:`_FOREVER_HOSTS` is loop-only (no lock) -- touched on the loop, never
+    inside :func:`drop_for_host` (executor thread). A deny revoke does not call
+    this (a deny never adds to :data:`_FOREVER_HOSTS`).
     """
-    if decision == "allowed":
-        hl = host.lower()
-        _FOREVER_HOSTS[:] = [t for t in _FOREVER_HOSTS if t[0].lower() != hl]
+    hl = host.lower()
+    _FOREVER_HOSTS[:] = [t for t in _FOREVER_HOSTS if t[0].lower() != hl]
+
+
+def _clear_verdict_cache(ips: set[str]) -> None:
+    """Drop cached SYN verdicts for a revoked host's IPs (#2370).
+
+    Called on the **event loop** by :meth:`SidecarConsentClient._handle_drop_rule`
+    AFTER :func:`drop_for_host` (which returned the host's candidate IPs).
+    :data:`_VERDICT_CACHE` is keyed by ``(src_ip, src_port, dst, port)``; dst is
+    ``key[2]``. A cache hit only ``pkt.accept()``s a retransmit -- it does NOT
+    re-install an ACCEPT rule (see :func:`_cb`) -- so this needs no
+    pre-``drop_for_host`` window protection and may run after the drop.
+    Loop-only dict (no lock). If a host's IP was already TTL-swept from
+    :data:`_LEARNED` before the revoke, it is absent from ``ips`` and its cache
+    entry self-expires at the ``_VERDICT_CACHE`` TTL (harmless: no ACCEPT rule,
+    so a new flow re-prompts).
+    """
     if ips:
         for key in [c for c in _VERDICT_CACHE if c[2] in ips]:
             del _VERDICT_CACHE[key]
@@ -987,16 +1002,26 @@ class SidecarConsentClient:
         decision = msg.get("decision")
         ok = False
         if isinstance(host, str) and decision in ("allowed", "denied"):
+            # #2370: close the `forever` gates BEFORE the executor window. While
+            # drop_for_host forks iptables off-loop (~tens of ms), a racing
+            # SYN/DNS could read _FOREVER_HOSTS and re-install a fresh
+            # ~1-year ACCEPT (_DURATION_FOREVER) the revoke never clears.
+            # _drop_forever_hosts runs on the loop (loop-only structure) and
+            # makes _cb's _forever_host_allows + ports_for deny during the
+            # window. (A deny never adds to _FOREVER_HOSTS, so skip it there.)
+            if decision == "allowed":
+                _drop_forever_hosts(host)
             try:
                 ips = await asyncio.get_running_loop().run_in_executor(
                     None, drop_for_host, host, decision
                 )
-                # Clear the loop-only in-session state (#2370) ON the event
-                # loop -- _FOREVER_HOSTS/_VERDICT_CACHE must not be touched
-                # inside drop_for_host (executor thread). Without this a
-                # `forever`-allow revoke would keep re-learning the host via
-                # _FOREVER_HOSTS, and cached verdicts would persist til TTL.
-                _clear_forever_state(host, decision, ips)
+                # Drop the host's cached verdicts on the loop AFTER the rule
+                # removal (loop-only dict). A cache hit only pkt.accept()s a
+                # retransmit -- it does not re-install an ACCEPT -- so this is
+                # safe after the drop and needs no window protection.
+                _clear_verdict_cache(ips)
+                # The ack means "the rule is dropped" (#2339); the loop-state
+                # clears above are pure dict ops and don't affect it.
                 ok = True
             except Exception:
                 ok = False

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -473,6 +473,53 @@ class ConsentCoordinator:
                 str(workspace_id)[:8],
             )
 
+    async def _retract_forever_entry(self, row: dict, decision: str) -> None:
+        """Retract the durable list entry a ``forever`` verdict added (#2370).
+
+        The inverse of :meth:`_persist_forever_allow` /
+        :meth:`_persist_forever_deny`: removes the consented host from
+        ``allowed_domains`` (allow) or ``rejected_domains`` (deny) so the
+        verdict does not re-apply on the next sidecar restart. The deciding
+        connection's in-memory ACCEPT/REJECT + ``_FOREVER_HOSTS``/
+        ``_VERDICT_CACHE`` were already cleared by the drop the caller sent.
+
+        Best-effort (failures logged + swallowed): the row is already revoked,
+        so a persistence failure only risks the entry re-applying on restart,
+        not a broken revoke. A port-less allow was never persisted
+        (:meth:`_persist_forever_allow` skips it), so there is nothing to
+        retract; a port-less deny was persisted as a bare host, so retract that.
+        """
+        host = row.get("dest_host")
+        port = row.get("dest_port")
+        workspace_id = row.get("workspace_id")
+        if not host or not workspace_id:
+            return
+        if decision == DECISION_ALLOWED:
+            if not port:
+                return  # port-less allow was never persisted
+            entry = f"{host}:{port}"
+            remove = self.app.state.model.workspaces.remove_allowed_domain
+        else:
+            entry = f"{host}:{port}" if port else host
+            remove = self.app.state.model.workspaces.remove_rejected_domain
+        try:
+            retracted = await remove(workspace_id, entry)
+        except Exception:
+            logger.exception(
+                "consent: forever-%s retract failed (%s) ws=%s",
+                decision,
+                entry,
+                str(workspace_id)[:8],
+            )
+            return
+        if retracted:
+            logger.info(
+                "consent: forever %s retracted from list (%s) ws=%s",
+                decision,
+                entry,
+                str(workspace_id)[:8],
+            )
+
     async def revoke(
         self,
         request_id: str,
@@ -502,11 +549,12 @@ class ConsentCoordinator:
             return False
         host = row["dest_host"]
         decision = row["decision"]
-        # NOTE (#2370): a `forever` allow also lives in the workspace's
-        # allowed_domains (added in resolve, #2368), which the sidecar re-reads
-        # on restart. Dropping only the in-memory rule + marking the row
-        # revoked does NOT remove that durable entry, so the allow would
-        # re-apply on the next container restart. Removing it is #2370.
+        # NOTE (#2370): a `forever` verdict also lives in the workspace's
+        # allowed_domains/rejected_domains (added in resolve, #2368/#2369),
+        # which the sidecar re-reads on restart. The drop above cleared the
+        # in-memory rules + _FOREVER_HOSTS/_VERDICT_CACHE; retract the durable
+        # entry too (after the row is marked revoked) so the verdict does not
+        # re-apply on the next sidecar restart.
         # Ask the sidecar to drop its rule for this host+decision. No live
         # sidecar -> nothing is enforced (its in-memory rules die with it), so
         # proceed to mark revoked. A live sidecar must ack first: else a
@@ -529,6 +577,13 @@ class ConsentCoordinator:
             is None
         ):
             return False
+        # #2370: retract the durable list entry a `forever` verdict added so it
+        # does not re-apply on the next sidecar restart. Best-effort (failures
+        # logged + swallowed): the row is already revoked and the in-memory
+        # rules already dropped, so a failure only risks re-application on
+        # restart, not a broken revoke.
+        if row.get("duration") == DURATION_FOREVER:
+            await self._retract_forever_entry(row, decision)
         await self._broadcast_rules(workspace_id)
         return True
 
@@ -658,6 +713,8 @@ class ConsentCoordinator:
             "type": "egress_rules",
             "workspace_id": workspace_id,
             "allow_list": ws.get("allowed_domains") or [],
+            # #2370: surface the reject list alongside the allow list (#2340).
+            "reject_list": ws.get("rejected_domains") or [],
             "allowed": [r for r in rows if r["decision"] == DECISION_ALLOWED],
             "denied": [r for r in rows if r["decision"] == DECISION_DENIED],
             # #2332 (pause control): the live pause window, or None when not

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -947,6 +947,106 @@ class WorkspacesModel:
                     return True
         return False  # pragma: no cover - CAS exhausted under contention
 
+    async def remove_allowed_domain(
+        self, workspace_id: str, entry: str
+    ) -> bool:
+        """Remove ``entry`` (``host[:port]``) from a workspace's
+        ``allowed_domains`` (#2370) -- the inverse of :meth:`add_allowed_domain`.
+
+        Revoking a ``forever`` egress-consent allow retracts the durable entry
+        it added (so the allow does not re-apply on the next sidecar restart);
+        the in-memory ACCEPT rules are dropped separately by the sidecar.
+        Compare-and-swap on the JSON blob, case-insensitive match, mirroring
+        :meth:`add_allowed_domain`. Returns True if the workspace exists and
+        ``entry`` is absent from the list afterwards (removed or already
+        absent -- idempotent); False if the workspace is missing or ``entry``
+        is malformed.
+        """
+        try:
+            normalized = parse_allowed_domains([entry])
+        except ValueError:
+            return False
+        if not normalized:
+            return False
+        spec = normalized[0].lower()
+        for _ in range(_SETTINGS_CAS_RETRIES):
+            async with self.app.state.db.transaction() as db:
+                cursor = await db.execute(
+                    "SELECT allowed_domains FROM workspaces WHERE id = ?",
+                    (workspace_id,),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    return False
+                old_blob = row["allowed_domains"]
+                current = json.loads(old_blob) if old_blob else []
+                idx = next(
+                    (i for i, s in enumerate(current) if s.lower() == spec),
+                    None,
+                )
+                if idx is None:
+                    return True  # already absent (idempotent)
+                current.pop(idx)
+                new_blob = json.dumps(current)
+                cursor = await db.execute(
+                    "UPDATE workspaces SET allowed_domains = ?"
+                    " WHERE id = ? AND allowed_domains IS ?",
+                    (new_blob, workspace_id, old_blob),
+                )
+                if cursor.rowcount == 1:
+                    return True
+        return False  # pragma: no cover - CAS exhausted under contention
+
+    async def remove_rejected_domain(
+        self, workspace_id: str, entry: str
+    ) -> bool:
+        """Remove ``entry`` from a workspace's ``rejected_domains`` (#2370) --
+        the inverse of :meth:`add_rejected_domain`.
+
+        Revoking a ``forever`` egress-consent deny retracts the durable entry
+        it added (so the deny does not re-apply on the next sidecar restart);
+        the in-memory REJECT rules are dropped separately by the sidecar.
+        Compare-and-swap on the JSON blob, case-insensitive match, mirroring
+        :meth:`add_rejected_domain`. Returns True if the workspace exists and
+        ``entry`` is absent from the list afterwards (removed or already
+        absent -- idempotent); False if the workspace is missing or ``entry``
+        is malformed.
+        """
+        try:
+            normalized = parse_allowed_domains([entry])
+        except ValueError:
+            return False
+        if not normalized:
+            return False
+        spec = normalized[0].lower()
+        for _ in range(_SETTINGS_CAS_RETRIES):
+            async with self.app.state.db.transaction() as db:
+                cursor = await db.execute(
+                    "SELECT rejected_domains FROM workspaces WHERE id = ?",
+                    (workspace_id,),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    return False
+                old_blob = row["rejected_domains"]
+                current = json.loads(old_blob) if old_blob else []
+                idx = next(
+                    (i for i, s in enumerate(current) if s.lower() == spec),
+                    None,
+                )
+                if idx is None:
+                    return True  # already absent (idempotent)
+                current.pop(idx)
+                new_blob = json.dumps(current)
+                cursor = await db.execute(
+                    "UPDATE workspaces SET rejected_domains = ?"
+                    " WHERE id = ? AND rejected_domains IS ?",
+                    (new_blob, workspace_id, old_blob),
+                )
+                if cursor.rowcount == 1:
+                    return True
+        return False  # pragma: no cover - CAS exhausted under contention
+
     async def transfer_workspace(
         self,
         workspace_id: str,

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -49,6 +49,7 @@ def _app(
     pending_rows=None,
     active_rows=None,
     allowed_domains=None,
+    rejected_domains=None,
 ):
     app = types.SimpleNamespace()
     app.state = types.SimpleNamespace()
@@ -70,13 +71,19 @@ def _app(
     workspaces = AsyncMock()
     workspaces.get_workspace = AsyncMock(
         return_value=(
-            {"egress_mode": egress_mode, "allowed_domains": allowed_domains}
+            {
+                "egress_mode": egress_mode,
+                "allowed_domains": allowed_domains,
+                "rejected_domains": rejected_domains,
+            }
             if workspace_exists
             else None
         )
     )
     workspaces.add_allowed_domain = AsyncMock(return_value=True)
     workspaces.add_rejected_domain = AsyncMock(return_value=True)
+    workspaces.remove_allowed_domain = AsyncMock(return_value=True)
+    workspaces.remove_rejected_domain = AsyncMock(return_value=True)
     # #2332: consent-pause state. Defaults: not paused (None), set succeeds.
     workspaces.get_consent_pause = AsyncMock(return_value=None)
     workspaces.set_consent_pause = AsyncMock(return_value=True)
@@ -220,6 +227,130 @@ class TestConsentCoordinatorRevoke:
         app.state.model.egress_consent.revoke = AsyncMock(return_value=None)
         coord = ConsentCoordinator(app)
         assert await coord.revoke("rid-1", "a@x") is False
+
+    async def test_revoke_forever_allow_retracts_allowed_domains(self):
+        # #2370: revoking a forever allow retracts the durable allowed_domains
+        # entry (host:port) so it does not re-apply on the next sidecar restart.
+        # The in-memory rules were cleared by the drop (mocked None here).
+        app = _app()
+        row = _active_row(decision="allowed")
+        row["duration"] = "forever"
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=row
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+        app.state.model.workspaces.remove_rejected_domain.assert_not_awaited()
+
+    async def test_revoke_forever_deny_retracts_rejected_domains(self):
+        # The deny mirror: revoking a forever deny retracts rejected_domains.
+        app = _app()
+        row = _active_row(decision="denied")
+        row["duration"] = "forever"
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=row
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_rejected_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+        app.state.model.workspaces.remove_allowed_domain.assert_not_awaited()
+
+    async def test_revoke_forever_deny_portless_retracts_bare_host(self):
+        # A port-less forever deny was persisted as a bare host; retract that.
+        app = _app()
+        row = _active_row(decision="denied")
+        row["duration"] = "forever"
+        row["dest_port"] = 0
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=row
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_rejected_domain.assert_awaited_once_with(
+            FULL_WS,
+            "1.2.3.4",  # bare host (no port)
+        )
+
+    async def test_revoke_forever_allow_portless_skips_retract(self):
+        # A port-less forever allow was never persisted (resolve skips it), so
+        # revoke has nothing to retract -- but the revoke still succeeds.
+        app = _app()
+        row = _active_row(decision="allowed")
+        row["duration"] = "forever"
+        row["dest_port"] = 0
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=row
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_not_awaited()
+        app.state.model.workspaces.remove_rejected_domain.assert_not_awaited()
+
+    async def test_revoke_forever_retract_failure_does_not_break_revoke(self):
+        # Best-effort: a persistence failure is logged + swallowed; the row is
+        # already revoked, so the revoke still returns True.
+        app = _app()
+        row = _active_row(decision="allowed")
+        row["duration"] = "forever"
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=row
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        app.state.model.workspaces.remove_allowed_domain = AsyncMock(
+            side_effect=RuntimeError("db down")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+
+    async def test_revoke_non_forever_does_not_retract(self):
+        # A tilrestart/once verdict has no durable entry -- nothing to retract.
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row()  # duration tilrestart
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_not_awaited()
+        app.state.model.workspaces.remove_rejected_domain.assert_not_awaited()
+
+    async def test_revoke_forever_missing_host_skips_retract(self):
+        # Defensive: a forever row missing dest_host retracts nothing, but the
+        # revoke still succeeds (the row is revoked; only durability is skipped).
+        app = _app()
+        row = _active_row(decision="allowed")
+        row["duration"] = "forever"
+        row["dest_host"] = None
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=row
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_not_awaited()
 
 
 class TestConsentCoordinatorGate:
@@ -450,6 +581,7 @@ class TestConsentCoordinatorRules:
         app = _app(
             active_rows=[allowed, denied],
             allowed_domains=["static.example.com"],
+            rejected_domains=["bad.example.com"],
         )
         coord = ConsentCoordinator(app)
         frame = await coord.rules_frame(FULL_WS)
@@ -457,6 +589,7 @@ class TestConsentCoordinatorRules:
             "type": "egress_rules",
             "workspace_id": FULL_WS,
             "allow_list": ["static.example.com"],
+            "reject_list": ["bad.example.com"],
             "allowed": [allowed],
             "denied": [denied],
             "paused": None,

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -362,6 +362,121 @@ async def test_add_rejected_domain_ignores_blank(ws, user):
     assert got["rejected_domains"] is None
 
 
+async def test_remove_allowed_domain_removes_case_insensitive(ws, user):
+    # The inverse of add (#2370): revoking a forever allow retracts the entry.
+    # Case-insensitive match; only the matched entry is removed.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"],
+        "retract-allow",
+        allowed_domains=["PyPI.org:443", "github.com:443"],
+    )
+    assert (
+        await ws.remove_allowed_domain(ws_row["id"], "GITHUB.COM:443") is True
+    )  # case-insensitive
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["allowed_domains"] == ["PyPI.org:443"]
+
+
+async def test_remove_allowed_domain_idempotent_absent(ws, user):
+    # Removing an absent entry is a no-op success (mirrors add's idempotency):
+    # the desired post-state (entry absent) already holds.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "retract-absent", allowed_domains=["example.com:443"]
+    )
+    assert (
+        await ws.remove_allowed_domain(ws_row["id"], "other.com:443") is True
+    )
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["allowed_domains"] == ["example.com:443"]  # unchanged
+
+
+async def test_remove_allowed_domain_from_null(ws, user):
+    # NULL allowed_domains (never set) -> absent -> True, still NULL.
+    ws_row = await ws.create_workspace(user["id"], "retract-null")
+    assert (
+        await ws.remove_allowed_domain(ws_row["id"], "example.com:443") is True
+    )
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["allowed_domains"] is None
+
+
+async def test_remove_allowed_domain_missing_workspace(ws):
+    assert await ws.remove_allowed_domain("nope", "example.com:443") is False
+
+
+async def test_remove_allowed_domain_rejects_malformed(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "retract-bad")
+    assert (
+        await ws.remove_allowed_domain(ws_row["id"], "not a domain!") is False
+    )
+
+
+async def test_remove_rejected_domain_removes_case_insensitive(ws, user):
+    # The deny mirror (#2370): revoking a forever deny retracts the entry.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"],
+        "retract-deny",
+        rejected_domains=["Evil.com:443", "bad.com"],
+    )
+    assert (
+        await ws.remove_rejected_domain(ws_row["id"], "evil.COM:443") is True
+    )
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] == ["bad.com"]
+
+
+async def test_remove_rejected_domain_bare_host(ws, user):
+    # A port-less deny was persisted as a bare host; retract the bare host.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "retract-bare", rejected_domains=["bad.com"]
+    )
+    assert await ws.remove_rejected_domain(ws_row["id"], "bad.com") is True
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] == []
+
+
+async def test_remove_rejected_domain_missing_workspace(ws):
+    assert await ws.remove_rejected_domain("nope", "bad.com") is False
+
+
+async def test_remove_rejected_domain_rejects_malformed(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "retract-deny-bad")
+    assert (
+        await ws.remove_rejected_domain(ws_row["id"], "not a domain!") is False
+    )
+
+
+async def test_remove_allowed_domain_ignores_blank(ws, user):
+    # A blank entry normalizes to nothing -> no removal, returns False.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "retract-blank", allowed_domains=["example.com:443"]
+    )
+    assert await ws.remove_allowed_domain(ws_row["id"], "   ") is False
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["allowed_domains"] == ["example.com:443"]  # unchanged
+
+
+async def test_remove_rejected_domain_ignores_blank(ws, user):
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "retract-deny-blank", rejected_domains=["bad.com"]
+    )
+    assert await ws.remove_rejected_domain(ws_row["id"], "   ") is False
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] == ["bad.com"]  # unchanged
+
+
+async def test_remove_rejected_domain_idempotent_absent(ws, user):
+    # Removing an absent entry is a no-op success (mirrors allow's idempotency).
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "retract-deny-absent", rejected_domains=["bad.com"]
+    )
+    assert (
+        await ws.remove_rejected_domain(ws_row["id"], "other.com:443") is True
+    )
+    got = await ws.get_workspace_by_id(ws_row["id"])
+    assert got["rejected_domains"] == ["bad.com"]  # unchanged
+
+
 async def test_transfer_workspace(ws, app_state, user):
     new_owner = await app_state.state.model.users.create_user("new@x.com", "h")
     ws_row = await ws.create_workspace_with_acl(user["id"], "transfer-me")

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1888,50 +1888,32 @@ class TestDropForHost:
         # resolved IP + the host string itself (direct-IP-allow candidate)
         assert ips == {"1.2.3.4", "evil.test"}
 
-    def test_clear_forever_state_allow_drops_forever_hosts_and_cache(
-        self, proxy
-    ):
-        # An allowed revoke clears _FOREVER_HOSTS (in-session coverage from
-        # #2372) + cached verdicts for the host's IPs.
+    def test_drop_forever_hosts_removes_host_entries(self, proxy):
+        # An allowed revoke drops the host's _FOREVER_HOSTS coverage (in-session
+        # forever-allow from #2372); other hosts are left intact.
         proxy._FOREVER_HOSTS.clear()
-        proxy._VERDICT_CACHE.clear()
         proxy._FOREVER_HOSTS[:] = [
             ("evil.test", 443, proxy._EXACT),
             ("other.test", 80, proxy._EXACT),
         ]
-        # _VERDICT_CACHE keyed by (src_ip, src_port, dst, port); dst is key[2].
+        proxy._drop_forever_hosts("Evil.TEST")  # case-insensitive
+        assert proxy._FOREVER_HOSTS == [("other.test", 80, proxy._EXACT)]
+
+    def test_clear_verdict_cache_drops_host_entries(self, proxy):
+        # Cached verdicts keyed by (src_ip, src_port, dst, port); dst is key[2].
+        # Only the revoked host's IPs are cleared; an unrelated IP is kept.
+        proxy._VERDICT_CACHE.clear()
         proxy._VERDICT_CACHE[("10.0.0.1", 1, "1.2.3.4", 443)] = ("allow", 9e9)
         proxy._VERDICT_CACHE[("10.0.0.1", 2, "5.6.7.8", 443)] = ("deny", 9e9)
-        proxy._clear_forever_state(
-            "evil.test", "allowed", {"1.2.3.4", "evil.test"}
-        )
-        assert proxy._FOREVER_HOSTS == [("other.test", 80, proxy._EXACT)]
+        proxy._clear_verdict_cache({"1.2.3.4", "evil.test"})
         assert ("10.0.0.1", 1, "1.2.3.4", 443) not in proxy._VERDICT_CACHE
-        # an unrelated IP's cached verdict is left intact
         assert ("10.0.0.1", 2, "5.6.7.8", 443) in proxy._VERDICT_CACHE
 
-    def test_clear_forever_state_deny_clears_cache_only(self, proxy):
-        # A denied revoke clears cached verdicts for the host's IPs; _FOREVER_HOSTS
-        # is left untouched (deny has no forever-host entry, but is not cleared).
-        proxy._FOREVER_HOSTS.clear()
+    def test_clear_verdict_cache_empty_ips_is_noop(self, proxy):
+        # No resolved IPs (host never seen / swept) -> nothing to clear.
         proxy._VERDICT_CACHE.clear()
-        proxy._FOREVER_HOSTS.append(("evil.test", 443, proxy._EXACT))
-        proxy._VERDICT_CACHE[("10.0.0.1", 1, "1.2.3.4", 443)] = ("deny", 9e9)
-        proxy._clear_forever_state(
-            "evil.test", "denied", {"1.2.3.4", "evil.test"}
-        )
-        assert proxy._FOREVER_HOSTS == [("evil.test", 443, proxy._EXACT)]
-        assert proxy._VERDICT_CACHE == {}
-
-    def test_clear_forever_state_empty_ips_is_noop(self, proxy):
-        # No resolved IPs (host never seen) -> nothing to clear from the cache;
-        # _FOREVER_HOSTS still cleared for an allow.
-        proxy._FOREVER_HOSTS.clear()
-        proxy._VERDICT_CACHE.clear()
-        proxy._FOREVER_HOSTS.append(("ghost.test", 443, proxy._EXACT))
         proxy._VERDICT_CACHE[("10.0.0.1", 1, "9.9.9.9", 443)] = ("allow", 9e9)
-        proxy._clear_forever_state("ghost.test", "allowed", set())
-        assert proxy._FOREVER_HOSTS == []
+        proxy._clear_verdict_cache(set())
         assert proxy._VERDICT_CACHE == {
             ("10.0.0.1", 1, "9.9.9.9", 443): ("allow", 9e9)
         }
@@ -1940,8 +1922,9 @@ class TestDropForHost:
         self, proxy, tmp_path, monkeypatch
     ):
         # End-to-end (#2370): a forever-allow revoke's drop_rule clears the
-        # in-session _FOREVER_HOSTS + _VERDICT_CACHE (via the loop-side
-        # _clear_forever_state), else the next DNS resolution re-learns the host.
+        # in-session _FOREVER_HOSTS (BEFORE the iptables fork, so a racing SYN
+        # can't re-install a fresh ACCEPT during the window) + _VERDICT_CACHE
+        # (after), else the next DNS resolution re-learns the host.
         proxy._LEARNED.clear()
         proxy._FOREVER_HOSTS.clear()
         proxy._VERDICT_CACHE.clear()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1868,3 +1868,114 @@ class TestDropForHost:
         )
         ack = json.loads(sent[0])
         assert ack["ok"] is False
+
+    def test_drop_for_host_returns_candidate_ips(self, proxy, monkeypatch):
+        # #2370: drop_for_host returns the candidate IP set so the loop-side
+        # _clear_forever_state can clear _VERDICT_CACHE for those IPs.
+        proxy._LEARNED.clear()
+        proxy._REJECTED.clear()
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=0),
+        )
+        proxy._LEARNED["1.2.3.4"] = {
+            "expire": 9999.0,
+            "ports": {443},
+            "host": "evil.test",
+        }
+        ips = proxy.drop_for_host("evil.test", "allowed")
+        # resolved IP + the host string itself (direct-IP-allow candidate)
+        assert ips == {"1.2.3.4", "evil.test"}
+
+    def test_clear_forever_state_allow_drops_forever_hosts_and_cache(
+        self, proxy
+    ):
+        # An allowed revoke clears _FOREVER_HOSTS (in-session coverage from
+        # #2372) + cached verdicts for the host's IPs.
+        proxy._FOREVER_HOSTS.clear()
+        proxy._VERDICT_CACHE.clear()
+        proxy._FOREVER_HOSTS[:] = [
+            ("evil.test", 443, proxy._EXACT),
+            ("other.test", 80, proxy._EXACT),
+        ]
+        # _VERDICT_CACHE keyed by (src_ip, src_port, dst, port); dst is key[2].
+        proxy._VERDICT_CACHE[("10.0.0.1", 1, "1.2.3.4", 443)] = ("allow", 9e9)
+        proxy._VERDICT_CACHE[("10.0.0.1", 2, "5.6.7.8", 443)] = ("deny", 9e9)
+        proxy._clear_forever_state(
+            "evil.test", "allowed", {"1.2.3.4", "evil.test"}
+        )
+        assert proxy._FOREVER_HOSTS == [("other.test", 80, proxy._EXACT)]
+        assert ("10.0.0.1", 1, "1.2.3.4", 443) not in proxy._VERDICT_CACHE
+        # an unrelated IP's cached verdict is left intact
+        assert ("10.0.0.1", 2, "5.6.7.8", 443) in proxy._VERDICT_CACHE
+
+    def test_clear_forever_state_deny_clears_cache_only(self, proxy):
+        # A denied revoke clears cached verdicts for the host's IPs; _FOREVER_HOSTS
+        # is left untouched (deny has no forever-host entry, but is not cleared).
+        proxy._FOREVER_HOSTS.clear()
+        proxy._VERDICT_CACHE.clear()
+        proxy._FOREVER_HOSTS.append(("evil.test", 443, proxy._EXACT))
+        proxy._VERDICT_CACHE[("10.0.0.1", 1, "1.2.3.4", 443)] = ("deny", 9e9)
+        proxy._clear_forever_state(
+            "evil.test", "denied", {"1.2.3.4", "evil.test"}
+        )
+        assert proxy._FOREVER_HOSTS == [("evil.test", 443, proxy._EXACT)]
+        assert proxy._VERDICT_CACHE == {}
+
+    def test_clear_forever_state_empty_ips_is_noop(self, proxy):
+        # No resolved IPs (host never seen) -> nothing to clear from the cache;
+        # _FOREVER_HOSTS still cleared for an allow.
+        proxy._FOREVER_HOSTS.clear()
+        proxy._VERDICT_CACHE.clear()
+        proxy._FOREVER_HOSTS.append(("ghost.test", 443, proxy._EXACT))
+        proxy._VERDICT_CACHE[("10.0.0.1", 1, "9.9.9.9", 443)] = ("allow", 9e9)
+        proxy._clear_forever_state("ghost.test", "allowed", set())
+        assert proxy._FOREVER_HOSTS == []
+        assert proxy._VERDICT_CACHE == {
+            ("10.0.0.1", 1, "9.9.9.9", 443): ("allow", 9e9)
+        }
+
+    async def test_dispatch_drop_rule_clears_forever_state(
+        self, proxy, tmp_path, monkeypatch
+    ):
+        # End-to-end (#2370): a forever-allow revoke's drop_rule clears the
+        # in-session _FOREVER_HOSTS + _VERDICT_CACHE (via the loop-side
+        # _clear_forever_state), else the next DNS resolution re-learns the host.
+        proxy._LEARNED.clear()
+        proxy._FOREVER_HOSTS.clear()
+        proxy._VERDICT_CACHE.clear()
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=0),
+        )
+        proxy._LEARNED["1.2.3.4"] = {
+            "expire": 9e9,
+            "ports": {443},
+            "host": "h.test",
+        }
+        proxy._FOREVER_HOSTS.append(("h.test", 443, proxy._EXACT))
+        proxy._VERDICT_CACHE[("10.0.0.1", 1, "1.2.3.4", 443)] = ("allow", 9e9)
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        await c._dispatch(
+            json.dumps(
+                {
+                    "type": "drop_rule",
+                    "id": "ack-1",
+                    "host": "h.test",
+                    "decision": "allowed",
+                }
+            )
+        )
+        assert proxy._FOREVER_HOSTS == []
+        assert proxy._VERDICT_CACHE == {}
+        assert json.loads(sent[0])["ok"] is True


### PR DESCRIPTION
## Summary

Closes #2370 (blocked-on #2368 + #2369, both merged). Two deliverables:

1. **Revoking a `forever` verdict fully retracts it (#2339).** The durable
   list entry the verdict added is removed, and the sidecar's in-session
   `forever` state is cleared — so the verdict stops taking effect immediately
   and no longer re-applies on the next sidecar restart.
2. **The read-only rules view surfaces the reject list (#2340).**
   `rules_frame` adds `reject_list` alongside `allow_list`.

## What changed

**Revoke retracts the durable entry** (`consent_coordinator.revoke`):
- After marking the row revoked, a `forever` verdict's host is removed from
  `allowed_domains` (allow) / `rejected_domains` (deny) via two new model
  methods — `remove_allowed_domain` / `remove_rejected_domain` — the inverse of
  the `add_*` methods from #2368/#2369 (CAS, case-insensitive, idempotent).
- Entry construction mirrors `resolve()`: allow → `host:port` (a port-less allow
  was never persisted, so nothing to retract); deny → `host:port` or bare host.
- Best-effort (failures logged + swallowed): the row is already revoked, so a
  failure only risks re-application on restart.

**The sidecar clears its in-session `forever` state** (`proxy.py`):
- `drop_for_host` now returns the host's candidate IP set.
- `_handle_drop_rule` calls a new **loop-side** `_clear_forever_state(host,
  decision, ips)` after `drop_for_host`. For an allow it clears `_FOREVER_HOSTS`
  (the in-session coverage from #2372 — without this the next DNS resolution
  re-learns the host and the allow persists); for both decisions it clears the
  revoked host's `_VERDICT_CACHE` entries (else a retransmit reuses the stale
  verdict up to the cache TTL).
- `_FOREVER_HOSTS` / `_VERDICT_CACHE` are documented **loop-only (no lock)**, so
  they are touched here on the event loop — never inside `drop_for_host`, which
  runs in the executor. `SPECS`/`REJECT_SPECS` (parsed at sidecar start) are
  deliberately **not** mutated at runtime, preserving their "config-at-start"
  semantics; a statically-configured entry that matches the revoked host clears
  on the next restart, like any list edit.

**Rules view** (`consent_coordinator.rules_frame`): adds `reject_list`
(`ws["rejected_domains"]`) next to `allow_list`.

## Tests

- Model: `remove_*` (case-insensitive, idempotent-absent, blank, malformed,
  missing-workspace, bare-host, from-NULL).
- Coordinator: revoke-forever retract (allow / deny / port-less-allow-skips /
  port-less-deny-bare / best-effort-failure / missing-host / non-forever-no-op).
- Proxy: `drop_for_host` returns IPs; `_clear_forever_state` (allow clears
  `_FOREVER_HOSTS`+cache, deny clears cache only, empty-ips); dispatch
  integration (drop_rule clears the in-session state end-to-end).

Full backend suite: **4852 passed, 100% coverage**. Rebased onto `main`
(picks up #2389 pause control — `rules_frame`'s `paused` field merged cleanly).
