### PR TITLE
feat(egress): interactive consent no longer gated on allowed_domains (#2325)

### DIFF
--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -27,6 +27,7 @@ jobs:
             e2e:
               - 'src/klangk/**'
               - 'src/containers/workspace/**'
+              - 'src/containers/network/**'
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/cli-e2e-tests.yml'
@@ -34,7 +35,7 @@ jobs:
       - uses: ./.github/actions/devenv-setup
         if: steps.filter.outputs.e2e == 'true'
         with:
-          build-tasks: klangk:build-workspace-image
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
 
       - name: Run CLI E2E tests
         if: steps.filter.outputs.e2e == 'true'

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -42,6 +42,7 @@ jobs:
               - 'src/klangk/**'
               - 'src/frontend/**'
               - 'src/containers/workspace/**'
+              - 'src/containers/network/**'
               - 'features/**'
               - 'devenv.nix'
               - 'devenv.yaml'
@@ -50,7 +51,7 @@ jobs:
       - uses: ./.github/actions/devenv-setup
         if: steps.filter.outputs.e2e == 'true'
         with:
-          build-tasks: klangk:build-workspace-image klangk:flutter-build
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar klangk:flutter-build
 
       - name: Run E2E tests (chromium + API)
         if: steps.filter.outputs.e2e == 'true'

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: ./.github/actions/devenv-setup
         with:
-          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
+          build-tasks: klangk:build-workspace-image
 
       # Runs every sandbox test suite under sandboxes/tests/. There is
       # currently only openclaw; more will be added over time. Each suite

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: ./.github/actions/devenv-setup
         with:
-          build-tasks: klangk:build-workspace-image
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
 
       # Runs every sandbox test suite under sandboxes/tests/. There is
       # currently only openclaw; more will be added over time. Each suite

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,16 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Interactive egress consent no longer gated on `allowed_domains` (#2325).**
+  A workspace in `egress_mode=interactive` (the default) now always runs the
+  FQDN network sidecar and holds every not-yet-approved egress for a consent
+  decision, even with an empty `allowed_domains`; `allowed_domains` now means
+  "pre-approved, skip consent" rather than the prerequisite for consent to
+  exist. Static mode with no lists stays unrestricted. Because every
+  interactive workspace now needs a sidecar, an interactive workspace
+  **fails closed** (refuses to start) if `network_sidecar_image` is unset or
+  `KLANGKD_USERNS` is empty, instead of starting unrestricted.
+
 - **`rejected_domains` workspace setting + sidecar enforcement (#2367).**
   The deny counterpart to `allowed_domains`: a persisted, host-only list whose
   names the network sidecar NXDOMAINs unconditionally (no resolution, no SYN,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -40,7 +40,11 @@ operators or integrators to act when upgrading.
   exist. Static mode with no lists stays unrestricted. Because every
   interactive workspace now needs a sidecar, an interactive workspace
   **fails closed** (refuses to start) if `network_sidecar_image` is unset or
-  `KLANGKD_USERNS` is empty, instead of starting unrestricted.
+  `KLANGKD_USERNS` is empty, instead of starting unrestricted. The
+  `klangk sandbox` command now creates its workspace in `static` mode so
+  automated installs (npm/git/…) keep their unrestricted egress —
+  interactive would hold every install connection for a consent decision
+  with no decider present.
 
 - **`rejected_domains` workspace setting + sidecar enforcement (#2367).**
   The deny counterpart to `allowed_domains`: a persisted, host-only list whose

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,20 +32,6 @@ operators or integrators to act when upgrading.
 
 ### Added
 
-- **Interactive egress consent no longer gated on `allowed_domains` (#2325).**
-  A workspace in `egress_mode=interactive` (the default) now always runs the
-  FQDN network sidecar and holds every not-yet-approved egress for a consent
-  decision, even with an empty `allowed_domains`; `allowed_domains` now means
-  "pre-approved, skip consent" rather than the prerequisite for consent to
-  exist. Static mode with no lists stays unrestricted. Because every
-  interactive workspace now needs a sidecar, an interactive workspace
-  **fails closed** (refuses to start) if `network_sidecar_image` is unset or
-  `KLANGKD_USERNS` is empty, instead of starting unrestricted. The
-  `klangk sandbox` command now creates its workspace in `static` mode so
-  automated installs (npm/git/…) keep their unrestricted egress —
-  interactive would hold every install connection for a consent decision
-  with no decider present.
-
 - **`rejected_domains` workspace setting + sidecar enforcement (#2367).**
   The deny counterpart to `allowed_domains`: a persisted, host-only list whose
   names the network sidecar NXDOMAINs unconditionally (no resolution, no SYN,
@@ -511,6 +497,15 @@ operators or integrators to act when upgrading.
   affected if it matches the revoked verdict's host, and clears on the next
   restart as with any list edit.
 
+- **Interactive egress consent no longer gated on `allowed_domains` (#2325).**
+  A workspace in `egress_mode=interactive` (the default) now always runs the
+  FQDN network sidecar and holds every not-yet-approved egress for a consent
+  decision, even with an empty `allowed_domains`; `allowed_domains` now means
+  "pre-approved, skip consent" rather than the prerequisite for consent to
+  exist. Static mode with no lists stays unrestricted. `klangk sandbox` now
+  creates its workspace in `static` mode so its automated installs keep
+  unrestricted egress.
+
 - **Egress-consent duration token `restart` renamed to `tilrestart` (#2357).**
   The verdict `duration` value `restart` is now `tilrestart` ("until restart")
   everywhere — the model constant, the wire/DB token, the `consent-decide` TUI
@@ -699,6 +694,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   custom `features.yaml` if present.
 
 ### Breaking
+
+- **Interactive workspaces now require the network sidecar (#2325).** Every
+  `egress_mode=interactive` workspace (the default) spawns a network sidecar
+  and holds each new outbound host for a consent decision. On upgrade, an
+  existing interactive workspace's next start requires a configured
+  `network_sidecar_image` and a non-empty `KLANGKD_USERNS`; if either is
+  missing it **fails closed** (refuses to start) instead of egressing
+  unrestricted. An interactive workspace with `allow_sudo` also has `net_raw`
+  dropped (defense-in-depth against the SO_MARK bypass), disabling setuid
+  `ping` for it. Static workspaces with no allow/reject lists are unaffected.
 
 - **(#1653)** Environment variables renamed to `KLANGKD_*` / `KLANGKBUILD_*` /
   `KLANGKWS_*` / `KLANGK_*`. Old `KLANGK_*` names are not accepted. Update

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -496,6 +496,7 @@ async def duplicate_workspace(
             allowed_domains=source.get("allowed_domains"),
             rejected_domains=source.get("rejected_domains"),
             settings=source.get("settings"),
+            egress_mode=source.get("egress_mode"),
         )
     except SAIntegrityError:
         raise HTTPException(

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -497,6 +497,7 @@ class KlangkClient:
         setup_state: str | None = None,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        egress_mode: str | None = None,
         settings: dict | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
@@ -516,6 +517,8 @@ class KlangkClient:
             body["health_check"] = health_check
         if allowed_domains:
             body["allowed_domains"] = allowed_domains
+        if egress_mode:
+            body["egress_mode"] = egress_mode
         if settings:
             body["settings"] = settings
         resp = self.post("/api/v1/workspaces", json=body)

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1812,6 +1812,13 @@ def sandbox(
             if resolve_setup_command(config, handle)
             else None,
             health_check=config.health_check,
+            # #2325: a sandbox is an automated install context (setup.sh runs
+            # npm/git/... that need unrestricted outbound network). Default
+            # workspaces are now interactive (hold every egress for consent),
+            # which would block the install with no decider present. Create the
+            # sandbox workspace as static so its egress is unrestricted -- the
+            # pre-#2325 behavior this automated path has always relied on.
+            egress_mode="static",
         )
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
         created = True

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -8,6 +8,7 @@ import time
 
 from . import podman
 from . import workspace_settings as ws_settings
+from .model.workspaces import EGRESS_MODE_INTERACTIVE
 from .podman import PodmanError
 
 logger = logging.getLogger(__name__)
@@ -1998,6 +1999,18 @@ class ContainerRegistry:
                 f"list: {sorted(self.allowed_images)}"
             )
 
+        # #2325: a workspace needs the FQDN network sidecar whenever it is
+        # egress-filtered. That's either (a) it declares an allow/reject list
+        # (the sidecar NXDOMAINs/holds those names), or (b) it is in
+        # interactive mode, which holds EVERY not-yet-approved egress for a
+        # consent decision even with empty lists (the "ask first" default
+        # posture). Static mode with no lists stays unrestricted (no point
+        # filtering nothing). Used by both the reconnect re-track below and
+        # the create-path sidecar start further down.
+        needs_sidecar = egress_mode == EGRESS_MODE_INTERACTIVE or bool(
+            allowed_domains or rejected_domains
+        )
+
         # Reuse a running container or remove a stopped one.
         if existing_container_id:
             result = await self._handle_existing_container(
@@ -2009,14 +2022,14 @@ class ContainerRegistry:
                 setup_state=setup_state,
             )
             if result is not None:
-                # Re-track a filtered workspace's network sidecar on reconnect.
+                # Re-track a sidecar'd workspace's network sidecar on reconnect.
                 # _ws_with_network_sidecar is in-memory and lost on a process
                 # restart; without this, a reconnect-then-stop would skip
                 # _stop_network_sidecar (only the create path added it before)
                 # and leak the sidecar until the next start's force-remove or
-                # the instance reaper. A filtered workspace always has a live
-                # sidecar (fail-closed), so allowed_domains set => re-track.
-                if allowed_domains or rejected_domains:
+                # the instance reaper. A sidecar'd workspace always has a live
+                # sidecar (fail-closed), so needs_sidecar => re-track.
+                if needs_sidecar:
                     self._ws_with_network_sidecar.add(workspace_id)
                 return result
 
@@ -2131,31 +2144,33 @@ class ContainerRegistry:
         # Egress filtering (#1365): the FQDN network sidecar is the only egress
         # model. The OCI-hook "static" model was dropped (#2254 review) —
         # maintaining two complete models was more complexity than value. A
-        # filtered workspace (allowed_domains or rejected_domains set) runs
+        # sidecar'd workspace (needs_sidecar: interactive mode, or an
+        # allow/reject list set) runs
         # --network container:<network sidecar> (the network sidecar's proxy owns the rules;
         # the workspace is unprivileged). Fail-CLOSED (#2254 review B2): a
-        # workspace that declared an allow-list never starts unrestricted —
+        # workspace that needs filtering never starts unrestricted —
         # silently ignoring it would disable a security control the user
-        # requested, so a missing/unstartable network sidecar raises
-        # instead. With neither allowed_domains nor rejected_domains the
-        # workspace starts
-        # unrestricted (no filtering requested).
+        # requested (an interactive workspace asked for "ask first"; an
+        # allow-listed one asked for filtering), so a missing/unstartable
+        # network sidecar raises instead. Static mode with no lists is the
+        # one case that starts unrestricted (no filtering requested) (#2325).
         # #2276 (B): whether net_raw must be dropped for this workspace. A
-        # filtered workspace whose user can sudo to root would let root use the
+        # sidecar'd workspace whose user can sudo to root would let root use the
         # net_raw that enable_ping grants to setsockopt(SO_MARK) and bypass the
         # egress filter; dropping net_raw (from the bounding set) closes that
         # for root too. Applied in the cap_add/cap_drop logic after this branch.
         drop_net_raw = False
-        if allowed_domains or rejected_domains:
+        if needs_sidecar:
             if not self._network_sidecar_enabled():
                 raise podman.PodmanError(
                     500,
-                    f"workspace {workspace_id[:8]} declares allowed_domains "
-                    "or rejected_domains but the network sidecar is not "
+                    f"workspace {workspace_id[:8]} is egress-filtered "
+                    "(interactive mode, or allowed_domains/rejected_domains "
+                    "set) but the network sidecar is not "
                     "configured "
                     "(network_sidecar_image is empty); refusing to start "
-                    "unfiltered. Clear allowed_domains/rejected_domains or "
-                    "configure "
+                    "unfiltered. Switch the workspace to static mode with no "
+                    "lists, or configure "
                     "network_sidecar_image.",
                 )
             # The #2264 SO_MARK-bypass guard is user-namespace isolation: the
@@ -2169,15 +2184,16 @@ class ContainerRegistry:
             if not self.app.state.settings.userns:
                 raise podman.PodmanError(
                     500,
-                    f"workspace {workspace_id[:8]} declares allowed_domains "
-                    "or rejected_domains (egress filtering), which requires a "
+                    f"workspace {workspace_id[:8]} is egress-filtered "
+                    "(interactive mode, or allowed_domains/rejected_domains "
+                    "set), which requires a "
                     "non-empty "
                     "KLANGKD_USERNS so the workspace runs in a user namespace "
                     "distinct from the network sidecar's. An empty userns would "
                     "share the sidecar's userns and reopen the SO_MARK egress "
                     "bypass. Set KLANGKD_USERNS (default "
-                    "keep-id:uid=1000,gid=1000) or clear "
-                    "allowed_domains/rejected_domains.",
+                    "keep-id:uid=1000,gid=1000) or switch the workspace to "
+                    "static mode with no lists.",
                 )
             network_sidecar_id = await self._start_network_sidecar(
                 workspace_id,

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -2166,12 +2166,11 @@ class ContainerRegistry:
                     500,
                     f"workspace {workspace_id[:8]} is egress-filtered "
                     "(interactive mode, or allowed_domains/rejected_domains "
-                    "set) but the network sidecar is not "
-                    "configured "
-                    "(network_sidecar_image is empty); refusing to start "
+                    "set) but egress filtering is disabled "
+                    "(netfilter_enabled is off or network_sidecar_image is "
+                    "unset); refusing to start "
                     "unfiltered. Switch the workspace to static mode with no "
-                    "lists, or configure "
-                    "network_sidecar_image.",
+                    "lists, or enable egress filtering.",
                 )
             # The #2264 SO_MARK-bypass guard is user-namespace isolation: the
             # workspace must run in a user namespace DISTINCT from the one that

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -377,7 +377,7 @@ class Workspaces:
         allowed_domains: list[str] | None = None,
         rejected_domains: list[str] | None = None,
         settings: dict | None = None,
-        egress_mode: str = model.EGRESS_MODE_STATIC,
+        egress_mode: str = model.EGRESS_MODE_DEFAULT,
     ) -> dict:
         workspace = (
             await self.app.state.model.workspaces.create_workspace_with_acl(
@@ -536,7 +536,7 @@ class Workspaces:
             allowed_domains=ws.get("allowed_domains"),
             rejected_domains=ws.get("rejected_domains"),
             workspace_settings=ws.get("settings"),
-            egress_mode=ws.get("egress_mode", "static"),
+            egress_mode=ws.get("egress_mode", model.EGRESS_MODE_INTERACTIVE),
         )
         # Apply the per-workspace idle-timeout override from the settings
         # bag (#864), *only* when the workspace actually declares one.

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -300,7 +300,9 @@ class Connection:
             allowed_domains=workspace.get("allowed_domains"),
             rejected_domains=workspace.get("rejected_domains"),
             workspace_settings=workspace.get("settings"),
-            egress_mode=workspace.get("egress_mode", "static"),
+            egress_mode=workspace.get(
+                "egress_mode", model.EGRESS_MODE_INTERACTIVE
+            ),
         )
         self.container_status = container_status
         self.workspace_id = workspace_id

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1146,6 +1146,22 @@ class TestKlangkClient:
             assert cfg["netfilter_default_domains"] == ["github.com:443"]
             client.get.assert_called_once_with("/api/v1/config")
 
+    def test_create_workspace_includes_egress_mode(self):
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "id": "ws-1",
+            "name": "n",
+            "created_at": "x",
+        }
+        with patch.object(client, "post", return_value=mock_resp):
+            client.create_workspace("n", egress_mode="static")
+            body = client.post.call_args.kwargs["json"]
+            assert body["egress_mode"] == "static"
+            # Omitted when not provided (server applies the deploy default).
+            client.create_workspace("n2")
+            assert "egress_mode" not in client.post.call_args.kwargs["json"]
+
     def test_create_workspace_includes_allowed_domains(self):
         client = KlangkClient("http://test:8995", "token")
         mock_resp = MagicMock(status_code=200)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -3954,6 +3954,10 @@ class TestSandboxCommand:
         client.create_workspace.assert_called_once()
         call_kwargs = client.create_workspace.call_args
         assert call_kwargs[0][0] == "myws"
+        # #2325: a sandbox is an automated install context needing unrestricted
+        # egress, so it creates a STATIC workspace (interactive would hold every
+        # install connection for consent with no decider present).
+        assert call_kwargs[1]["egress_mode"] == "static"
         assert "Creating workspace" in result.output
         assert "klangk shell" in result.output
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1321,6 +1321,196 @@ class TestStartContainer:
         ), creates[0]["env"]
         assert creates[1]["network"] == "container:net-cid"
 
+    async def test_interactive_workspace_starts_sidecar_without_lists(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2325: a workspace in interactive mode gets the network sidecar EVEN
+        # WITH EMPTY allowed_domains/rejected_domains -- every not-yet-
+        # approved egress is held for a consent decision (the "ask first"
+        # default posture). The sidecar gets an empty ALLOW (nothing
+        # pre-approved) and an empty REJECT; the proxy + NFQUEUE hold do the
+        # rest. The workspace runs --network container:<sidecar> just like a
+        # list-filtered workspace.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                egress_mode="interactive",
+            )
+        assert len(creates) == 2  # sidecar + workspace
+        assert creates[0]["name"].startswith("klangk-net-")
+        # Empty allow/reject lists: nothing pre-approved, nothing pre-rejected.
+        assert any(
+            e == "KLANGKNETWORK_EGRESS_ALLOW=" for e in creates[0]["env"]
+        ), creates[0]["env"]
+        assert any(
+            e == "KLANGKNETWORK_EGRESS_REJECT=" for e in creates[0]["env"]
+        ), creates[0]["env"]
+        assert creates[1]["network"] == "container:net-cid"
+        # Tracked so a later stop tears the sidecar down.
+        assert workspace["id"] in self.registry._ws_with_network_sidecar
+
+    async def test_static_workspace_no_lists_starts_unrestricted(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2325: static mode with NO lists is the one case that still starts
+        # unrestricted (no filtering requested). Only one container is
+        # created (the workspace) -- no network sidecar.
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                egress_mode="static",
+            )
+        assert len(creates) == 1  # workspace only, no sidecar
+        assert not creates[0]["name"].startswith("klangk-net-")
+        # No sidecar => the workspace is not --network container:<sidecar>.
+        assert not creates[0].get("network", "").startswith("container:")
+        assert workspace["id"] not in self.registry._ws_with_network_sidecar
+
+    async def test_interactive_workspace_without_sidecar_image_refuses_to_start(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2325: an interactive workspace needs the sidecar (it asked for "ask
+        # first"), so a missing sidecar image must fail-closed -- NEVER start
+        # unrestricted (that would silently disable the interactive posture).
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "network_sidecar_image", ""
+        )
+        with patch_podman(self.registry):
+            with pytest.raises(podman.PodmanError):
+                await self.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="interactive",
+                )
+
+    async def test_interactive_workspace_refuses_empty_userns(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2325: an interactive workspace runs behind the same sidecar, so the
+        # #2264 SO_MARK-bypass userns-isolation guard applies to it too. An
+        # empty KLANGKD_USERNS would share the sidecar's userns and reopen the
+        # bypass -- fail-closed.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        monkeypatch.setattr(self.registry.app.state.settings, "userns", "")
+        with patch_podman(self.registry):
+            with pytest.raises(podman.PodmanError) as exc:
+                await self.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="interactive",
+                )
+        assert "KLANGKD_USERNS" in str(exc.value)
+
+    async def test_interactive_workspace_with_allow_sudo_drops_net_raw(
+        self, workspace, tmp_path, monkeypatch, caplog
+    ):
+        # #2325 + #2276 (B): an interactive workspace is egress-filtered (every
+        # connection held), so the sudo->root net_raw/SO_MARK defense-in-depth
+        # applies: net_raw is dropped, not added.
+        import logging
+
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "allow_sudo", "true"
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            with caplog.at_level(logging.INFO, logger="klangk.container"):
+                await self.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="interactive",
+                )
+        ws = creates[1]  # creates[0] is the network sidecar
+        assert ws["cap_drop"] == ["net_raw"]
+        assert "net_raw" not in ws.get("cap_add", [])
+
+    async def test_reuse_running_interactive_container_retracks_sidecar(
+        self, workspace, monkeypatch
+    ):
+        # #2325: reconnecting to a running INTERACTIVE workspace (no lists)
+        # must re-track its sidecar so a later stop tears it down instead of
+        # leaking it. Mirror of the filtered re-track test, but via egress_mode.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        assert workspace["id"] not in self.registry._ws_with_network_sidecar
+        with patch_podman(
+            self.registry, inspect_container=_running(True)
+        ) as p:
+            cid, status = await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                existing_container_id="existing-cid",
+                egress_mode="interactive",
+            )
+        assert cid == "existing-cid"
+        assert status == "connected"
+        p.create_container.assert_not_awaited()
+        assert workspace["id"] in self.registry._ws_with_network_sidecar
+
     async def test_filtered_workspace_publishes_host_ports_on_sidecar(
         self, workspace, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -29,6 +29,29 @@ class TestCreateWorkspace:
         assert users_dir.exists()
         assert users_dir.is_dir()
 
+    async def test_default_workspace_flows_interactive_to_start(
+        self, user, app_state, monkeypatch
+    ):
+        # #2325: a workspace created via the model picks up the deploy default
+        # egress_mode (interactive) and start_workspace forwards it to the
+        # container registry. This pins the wiring the container tests (which
+        # call start_container directly with an explicit egress_mode) can't
+        # catch -- a regression that dropped the kwarg at workspaces.py's
+        # start_workspace, or flipped its .get() default back to "static",
+        # would silently start the workspace unrestricted with every other
+        # test still green.
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "ws-interactive"
+        )
+        # The model default is interactive (EGRESS_MODE_DEFAULT).
+        assert ws["egress_mode"] == "interactive"
+        registry = app_state.state.container_registry
+        fake = AsyncMock(return_value=("cid", "created"))
+        monkeypatch.setattr(registry, "start_container", fake)
+        await app_state.state.workspaces.start_workspace(ws)
+        fake.assert_awaited_once()
+        assert fake.call_args.kwargs["egress_mode"] == "interactive"
+
     async def test_allocates_ports(self, user, app_state):
         ws = await app_state.state.workspaces.create_workspace(
             user["id"], "ported"


### PR DESCRIPTION
## What

Closes #2325. Interactive egress consent is no longer gated on `allowed_domains`: a workspace in `egress_mode=interactive` (the model default) now always runs the FQDN network sidecar and holds **every** not-yet-approved egress for a consent decision, even with an empty `allowed_domains`/`rejected_domains`. `allowed_domains` now means "pre-approved, skip consent" (an always-allow set) rather than the prerequisite for consent to exist at all. Static mode with no lists stays unrestricted (no point filtering nothing).

This makes the `EGRESS_MODE_DEFAULT=interactive` default (#2310) actually mean something: a freshly-created workspace now gets the OpenSnitch / Little Snitch "ask before every connection" posture instead of silently egressing unrestricted.

## How

One predicate in `container.py`:

```python
needs_sidecar = egress_mode == EGRESS_MODE_INTERACTIVE or bool(
    allowed_domains or rejected_domains
)
```

Both the reconnect re-track and the create-path sidecar start use it. Because every existing fail-closed guard (`network_sidecar_image` configured, non-empty `KLANGKD_USERNS` for the #2264 SO-MARK-isolation guard) and the #2276 `drop_net_raw` defense-in-depth now sit under `if needs_sidecar:`, they correctly cover interactive workspaces too. An interactive workspace that can't get a sidecar **fails closed** (refuses to start) rather than starting unrestricted — which would silently disable the posture the user asked for.

No proxy change is needed: the sidecar's hold-for-consent behavior is already driven by `KLANGKNETWORK_EGRESS_CONSENT_URL` (set whenever the consent monitor is wired), so with an empty allow-list every non-allow-listed name reaches the NFQUEUE consent hold.

## Tests

Mirror the filtered-workspace coverage for the interactive-no-lists case, plus pin the preserved static-no-lists behavior:

- `test_interactive_workspace_starts_sidecar_without_lists` — interactive + empty lists → sidecar + workspace, empty ALLOW/REJECT env.
- `test_static_workspace_no_lists_starts_unrestricted` — static + no lists → single create, no sidecar.
- `test_interactive_workspace_without_sidecar_image_refuses_to_start` — fail-closed.
- `test_interactive_workspace_refuses_empty_userns` — fail-closed (SO-MARK guard applies).
- `test_interactive_workspace_with_allow_sudo_drops_net_raw` — #2276 applies to interactive too.
- `test_reuse_running_interactive_container_retracks_sidecar` — reconnect re-tracks.

Full backend suite: **4834 passed, 100% coverage**.

## Notes for review / operators

- Every interactive workspace now spawns a network sidecar (DNS redirect + NFQUEUE) — a per-workspace resource/cost change called out in the issue.
- Because interactive now requires a sidecar, an interactive workspace fails closed if `network_sidecar_image` is unset or `KLANGKD_USERNS` is empty. Defaults are non-empty (`klangk-network-sidecar`, `keep-id:uid=1000,gid=1000`), so standard installs are unaffected; the changelog notes the Breaking-ish implication.
- Interacts with #2324 (DNS resolver ≤30s timeout) and the search-domain expansion (#2310) — both pre-existing, now more visible since everything is held. The SYN-hold (#2324, landed in #2326) is the real fix.
