### PR TITLE
fix(network-sidecar): honor SIGTERM for prompt, clean stop (#2400)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -715,6 +715,18 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Network sidecar now stops promptly on SIGTERM (#2400).** The sidecar
+  runs as PID 1 (`entrypoint.sh` execs `python3 /proxy.py`), and the Linux
+  kernel ignores the default SIGTERM disposition for PID-namespace init (a
+  handler must be installed), so every sidecar removal fell back to SIGKILL
+  after the full 5s `podman stop -t 5` window — and occasionally wedged in
+  `Stopping`, leaking a NET_ADMIN container. The sidecar now installs an
+  explicit SIGTERM handler that cancels its event loop for a clean teardown
+  (closes the consent WebSocket, unbinds NFQUEUE, closes the DNS socket); the
+  teardown is bounded so it completes well within the stop timeout rather than
+  re-introducing the 5s window. Workspace teardown and klangkd shutdown are no
+  longer gated on the 5s SIGKILL fallback per filtered workspace.
+
 - **`consent-decide` duration selector no longer shows two highlighted
   buttons at first render (#2360).** The first duration button ("once")
   grabbed initial focus on mount and rendered with the default focus

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -86,6 +86,7 @@ import asyncio
 import json
 import logging
 import os
+import signal
 import socket
 import struct
 import subprocess
@@ -1296,7 +1297,7 @@ def _send_rst(payload: bytes) -> None:
         pass
 
 
-def _setup_nfq_consumer(client: SidecarConsentClient | None) -> None:
+def _setup_nfq_consumer(client: SidecarConsentClient | None):
     """Bind the sidecar's NFQUEUE + drive it from the event loop (#2324, #2329).
 
     Consent gates the connection SYN, not the DNS query: a non-allow-listed name
@@ -1313,13 +1314,14 @@ def _setup_nfq_consumer(client: SidecarConsentClient | None) -> None:
     (netfilterqueue supports deferred verdicts; outstanding packets count
     against the kernel queue size, and the iptables rate-limit bounds arrivals).
     netfilterqueue is a sidecar-only dep, imported lazily so the module loads
-    without it.
+    without it. Returns the bound ``NetfilterQueue`` (so :func:`_shutdown` can
+    unbind it on SIGTERM, #2400) or ``None`` on failure.
     """
     try:
         from netfilterqueue import NetfilterQueue
     except Exception as exc:
         print(f"nfqueue: netfilterqueue unavailable ({exc})", flush=True)
-        return
+        return None
     try:
         nfq = NetfilterQueue()
         nfq.bind(QUEUE_NUM, lambda pkt: _cb(pkt, client))
@@ -1328,8 +1330,10 @@ def _setup_nfq_consumer(client: SidecarConsentClient | None) -> None:
         # this (loop) thread; _cb then hands each off to a verdict task.
         loop.add_reader(nfq.get_fd(), lambda: _drain(nfq))
         print(f"nfqueue consumer bound to queue {QUEUE_NUM}", flush=True)
+        return nfq
     except Exception as exc:
         print(f"nfqueue consumer failed: {exc}", flush=True)
+        return None
 
 
 def _drain(nfq) -> None:
@@ -1534,10 +1538,67 @@ async def _handle_packet(
     await _forward_and_learn(s, data, addr, qname, port_set)
 
 
+# Bound on the consent client's teardown during SIGTERM shutdown (#2400):
+# client.stop() closes the WS (close_timeout=5s), and during klangkd shutdown
+# the server may be going away, so an unbounded close handshake could
+# re-introduce the 5s window this fix eliminates. Bounded so the whole
+# teardown fits well inside podman's `stop -t 5`.
+_SHUTDOWN_CLIENT_TIMEOUT = 2.0
+
+
+async def _shutdown(
+    client: SidecarConsentClient | None,
+    nfq,
+    sock: socket.socket,
+    sweep: asyncio.Task | None,
+) -> None:
+    """Clean teardown on SIGTERM (#2400): stop the consent client, cancel the
+    TTL sweeper, unbind NFQUEUE, close the DNS socket.
+
+    The consent client's stop is bounded (:data:`_SHUTDOWN_CLIENT_TIMEOUT`) so a
+    stalled WebSocket close handshake can't re-introduce the 5s window. Best-
+    effort — a failure (or the bound) in one step must not skip the rest
+    (process exit reaps whatever remains). Runs in :func:`_async_main`'s
+    ``finally`` after the SIGTERM handler cancels the main task, so the proxy
+    exits promptly instead of relying on podman's SIGKILL fallback — which a
+    PID-1 sidecar always hit, because the kernel ignores default SIGTERM
+    dispositions for a PID-namespace init (SIGNAL_UNKILLABLE: a fatal signal
+    with no explicit handler is skipped for init).
+    """
+    if client is not None:
+        try:
+            await asyncio.wait_for(client.stop(), _SHUTDOWN_CLIENT_TIMEOUT)
+        except Exception:
+            pass
+    if sweep is not None:
+        sweep.cancel()
+        try:
+            await sweep
+        except (asyncio.CancelledError, Exception):
+            pass
+    if nfq is not None:
+        try:
+            asyncio.get_running_loop().remove_reader(nfq.get_fd())
+        except Exception:
+            pass
+        try:
+            nfq.unbind()
+        except Exception:
+            pass
+    try:
+        sock.close()
+    except Exception:
+        pass
+
+
 async def _async_main() -> None:
     """The asyncio DNS loop (#2311 half B, #2324): allow-listed + denied names
     resolve inline; a denied name in interactive mode records IP->host so its
     connection SYN is consent-gated at NFQUEUE (a separate thread).
+
+    Installs an explicit SIGTERM handler (#2400) so podman's ``stop`` signal
+    triggers a clean, prompt teardown instead of being ignored (the sidecar is
+    PID 1, and the kernel suppresses default terminate dispositions for init).
     """
     loop = asyncio.get_running_loop()
     client: SidecarConsentClient | None = None
@@ -1556,17 +1617,53 @@ async def _async_main() -> None:
     _sweep = asyncio.create_task(_async_sweeper())
     _BG_TASKS.add(_sweep)  # strong ref for the loop's lifetime
     _sweep.add_done_callback(_BG_TASKS.discard)
+    nfq = None
     # NFQUEUE consumer is driven by this event loop (get_fd + add_reader) so a
     # slow verdict on one SYN doesn't serialize others (#2324, #2329).
     if CONSENT_URL:
         check_rst_socket()  # eager-deny RST forge (#2345); best-effort (NET_RAW)
-        _setup_nfq_consumer(client)
-    while True:
-        try:
-            data, addr = await loop.sock_recvfrom(s, 65535)
-        except Exception:
-            continue
-        await _handle_packet(s, data, addr, client)
+        nfq = _setup_nfq_consumer(client)  # bound NFQUEUE, for _shutdown (#2400)
+    # The sidecar is PID 1 (entrypoint.sh execs python). The kernel suppresses
+    # default terminate/stop dispositions for a PID-namespace init: a SIGTERM
+    # with no handler installed is effectively ignored, so podman's `stop -t 5`
+    # SIGTERM was no-op'd and EVERY removal fell back to SIGKILL after the full
+    # 5s window (occasionally wedging in Stopping). Install an explicit handler
+    # that cancels this task -> _shutdown closes the WS, unbinds NFQUEUE, closes
+    # the socket -> prompt exit (#2400). (SIGKILL/SIGSTOP bypass this and always
+    # work, which is why podman's SIGKILL fallback eventually cleared it.)
+    main_task = asyncio.current_task()
+    stopping = False
+
+    def _on_sigterm() -> None:
+        # Idempotent: a second SIGTERM arriving while _shutdown is mid-await
+        # must NOT re-cancel the main task -- that CancelledError is a
+        # BaseException, so _shutdown's `except Exception` guards don't catch
+        # it and teardown would be aborted (skipping nfq.unbind/sock.close).
+        # The first signal cancels; subsequent ones are no-ops (SIGKILL remains
+        # podman's hard backstop if teardown hangs) (#2400).
+        nonlocal stopping
+        if stopping:
+            return
+        stopping = True
+        if main_task is not None:
+            main_task.cancel()
+
+    try:
+        loop.add_signal_handler(signal.SIGTERM, _on_sigterm)
+    except (NotImplementedError, RuntimeError):
+        pass  # signal handlers need the main thread + a supported loop backend
+    try:
+        while True:
+            try:
+                data, addr = await loop.sock_recvfrom(s, 65535)
+            except Exception:
+                continue
+            await _handle_packet(s, data, addr, client)
+    except asyncio.CancelledError:
+        if DEBUG:
+            print("dns-proxy: stop signal received, shutting down", flush=True)
+    finally:
+        await _shutdown(client, nfq, s, _sweep)
 
 
 def main() -> None:

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import json
+import signal
 import sys
 import types
 from pathlib import Path
@@ -1962,3 +1963,247 @@ class TestDropForHost:
         assert proxy._FOREVER_HOSTS == []
         assert proxy._VERDICT_CACHE == {}
         assert json.loads(sent[0])["ok"] is True
+
+
+class TestSigtermShutdown:
+    """SIGTERM teardown (#2400): the sidecar is PID 1 (entrypoint.sh execs
+    python), and the kernel ignores default terminate dispositions for a
+    PID-namespace init (``SIGNAL_UNKILLABLE``: a fatal signal with no explicit
+    handler is skipped for init), so podman's ``stop`` SIGTERM was no-op'd and
+    every removal fell back to SIGKILL after the 5s timeout. ``proxy.py`` now
+    installs an explicit SIGTERM handler that cancels the main task -> clean
+    teardown (close the WS, unbind NFQUEUE, close the DNS socket) -> prompt exit."""
+
+    async def test_setup_nfq_consumer_returns_nfq_for_unbind(
+        self, proxy, monkeypatch
+    ):
+        # _setup_nfq_consumer returns the bound NFQUEUE so _shutdown can unbind
+        # it on SIGTERM (clean PID-1 teardown, #2400).
+        nfq = MagicMock()
+        nfq.get_fd = MagicMock(return_value=7)
+        fake_mod = types.SimpleNamespace(
+            NetfilterQueue=MagicMock(return_value=nfq)
+        )
+        monkeypatch.setitem(sys.modules, "netfilterqueue", fake_mod)
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(loop, "add_reader", MagicMock())
+        assert proxy._setup_nfq_consumer(None) is nfq
+        nfq.bind.assert_called_once()
+
+    async def test_setup_nfq_consumer_bind_failure_returns_none(
+        self, proxy, monkeypatch, capsys
+    ):
+        fake_mod = types.SimpleNamespace(
+            NetfilterQueue=MagicMock(side_effect=RuntimeError("bind boom"))
+        )
+        monkeypatch.setitem(sys.modules, "netfilterqueue", fake_mod)
+        assert proxy._setup_nfq_consumer(None) is None
+        assert "nfqueue consumer failed" in capsys.readouterr().out
+
+    async def test_shutdown_closes_socket_stops_client_unbinds_nfq(
+        self, proxy
+    ):
+        # _shutdown best-effort-closes every resource (#2400); a failure in one
+        # step must not skip the rest.
+        sock = MagicMock()
+        nfq = MagicMock()
+        nfq.get_fd = MagicMock(return_value=9)
+        client = MagicMock()
+        client.stop = AsyncMock()
+        sweep = asyncio.get_running_loop().create_task(asyncio.sleep(100))
+        await proxy._shutdown(client, nfq, sock, sweep)
+        client.stop.assert_awaited_once()
+        nfq.unbind.assert_called_once()
+        sock.close.assert_called_once()
+        assert sweep.cancelled()
+
+    async def test_sigterm_handler_cancels_main_and_runs_teardown(
+        self, proxy, monkeypatch
+    ):
+        # The sidecar is PID 1; the kernel ignores a default-disposition
+        # SIGTERM, so an explicit handler is what lets podman's `stop` prompt
+        # the exit (#2400). Registering the handler + cancelling the main task
+        # must unwind _async_main and run _shutdown (close the DNS socket).
+        monkeypatch.setattr(proxy, "CONSENT_URL", "")  # no WS client / NFQUEUE
+        monkeypatch.setattr(proxy, "check_mark", lambda: None)
+        fake_sock = MagicMock()
+        fake_sock.close = MagicMock()
+        monkeypatch.setattr(proxy.socket, "socket", lambda *a, **k: fake_sock)
+
+        loop = asyncio.get_running_loop()
+        handlers = {}
+
+        def fake_add_signal_handler(sig, cb, *args):
+            handlers[sig] = cb
+
+        monkeypatch.setattr(
+            loop, "add_signal_handler", fake_add_signal_handler
+        )
+
+        gate = asyncio.Event()
+
+        async def hang(*a, **k):
+            await gate.wait()
+            return b"", ("127.0.0.1", 0)
+
+        monkeypatch.setattr(loop, "sock_recvfrom", hang)
+
+        task = asyncio.create_task(proxy._async_main())
+        # Let the task run to its first await; the SIGTERM handler is registered
+        # synchronously before it.
+        for _ in range(100):
+            if signal.SIGTERM in handlers:
+                break
+            await asyncio.sleep(0.01)
+        assert signal.SIGTERM in handlers, "SIGTERM handler not registered"
+
+        # Simulate podman's SIGTERM arriving at PID 1.
+        handlers[signal.SIGTERM]()
+        await asyncio.wait_for(task, timeout=2)
+        assert task.done()
+        # Clean teardown ran: the DNS listen socket was closed.
+        fake_sock.close.assert_called()
+
+    async def test_sigterm_handler_registered_even_with_consent(
+        self, proxy, monkeypatch
+    ):
+        # The handler is installed on the consent path too (where NFQUEUE + the
+        # WS client must be torn down); only the registration is asserted, since
+        # fully driving the WS client + NFQUEUE is the e2e's job (#2327).
+        monkeypatch.setattr(
+            proxy, "CONSENT_URL", "http://klangkd/ws/egress-sidecar"
+        )
+        monkeypatch.setattr(proxy, "check_mark", lambda: None)
+        monkeypatch.setattr(proxy, "check_rst_socket", lambda: None)
+        started = []
+
+        class _FakeClient:
+            async def start(self):
+                started.append(True)
+
+        monkeypatch.setattr(
+            proxy, "SidecarConsentClient", lambda *a: _FakeClient()
+        )
+        fake_nfq = MagicMock()
+        monkeypatch.setattr(
+            proxy, "_setup_nfq_consumer", lambda client: fake_nfq
+        )
+        fake_sock = MagicMock()
+        fake_sock.close = MagicMock()
+        monkeypatch.setattr(proxy.socket, "socket", lambda *a, **k: fake_sock)
+
+        loop = asyncio.get_running_loop()
+        handlers = {}
+        monkeypatch.setattr(
+            loop,
+            "add_signal_handler",
+            lambda sig, cb, *a: handlers.__setitem__(sig, cb),
+        )
+        gate = asyncio.Event()
+        monkeypatch.setattr(
+            loop,
+            "sock_recvfrom",
+            lambda *a, **k: gate.wait(),
+        )
+
+        task = asyncio.create_task(proxy._async_main())
+        for _ in range(100):
+            if signal.SIGTERM in handlers:
+                break
+            await asyncio.sleep(0.01)
+        assert started  # consent client brought up
+        assert signal.SIGTERM in handlers
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_second_sigterm_does_not_abort_teardown(
+        self, proxy, monkeypatch
+    ):
+        # Regression (#2400 review): a second SIGTERM arriving while _shutdown
+        # is mid-await must NOT re-cancel the main task. The CancelledError is a
+        # BaseException, so _shutdown's `except Exception` guards don't catch
+        # it -- without the idempotency flag, nfq.unbind()/sock.close() get
+        # skipped and the clean teardown the PR exists to provide is aborted.
+        monkeypatch.setattr(proxy, "CONSENT_URL", "http://k/ev")
+        monkeypatch.setattr(proxy, "check_mark", lambda: None)
+        monkeypatch.setattr(proxy, "check_rst_socket", lambda: None)
+
+        in_stop = asyncio.Event()
+        release_stop = asyncio.Event()
+
+        class _BlockingClient:
+            async def start(self):
+                pass
+
+            async def stop(self):
+                in_stop.set()
+                await release_stop.wait()  # hold teardown mid-flight
+
+        monkeypatch.setattr(
+            proxy, "SidecarConsentClient", lambda *a: _BlockingClient()
+        )
+        nfq = MagicMock()
+        nfq.get_fd = MagicMock(return_value=11)
+        monkeypatch.setattr(proxy, "_setup_nfq_consumer", lambda client: nfq)
+        fake_sock = MagicMock()
+        fake_sock.close = MagicMock()
+        monkeypatch.setattr(proxy.socket, "socket", lambda *a, **k: fake_sock)
+
+        loop = asyncio.get_running_loop()
+        handlers = {}
+        monkeypatch.setattr(
+            loop,
+            "add_signal_handler",
+            lambda sig, cb, *a: handlers.__setitem__(sig, cb),
+        )
+        gate = asyncio.Event()
+        monkeypatch.setattr(loop, "sock_recvfrom", lambda *a, **k: gate.wait())
+
+        task = asyncio.create_task(proxy._async_main())
+        for _ in range(100):
+            if signal.SIGTERM in handlers:
+                break
+            await asyncio.sleep(0.01)
+        # First SIGTERM -> main task cancels -> _shutdown -> client.stop() blocks.
+        handlers[signal.SIGTERM]()
+        for _ in range(100):
+            if in_stop.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert in_stop.is_set()  # teardown reached client.stop()
+        # Second SIGTERM WHILE client.stop() is blocked. With the idempotency
+        # guard this is a no-op; without it the re-cancel aborts _shutdown.
+        handlers[signal.SIGTERM]()
+        await asyncio.sleep(0.05)  # let the (no-op) second signal settle
+        release_stop.set()  # unblock client.stop(); teardown must finish
+        await asyncio.wait_for(task, timeout=3)
+        assert task.done()
+        nfq.unbind.assert_called()  # teardown was NOT aborted
+        fake_sock.close.assert_called()
+
+    async def test_shutdown_bounds_a_slow_client_stop(
+        self, proxy, monkeypatch
+    ):
+        # _shutdown bounds client.stop() so a stalled WS close handshake (its
+        # close_timeout can be 5s, and the server may be going away during
+        # klangkd shutdown) can't re-introduce the 5s SIGKILL window (#2400).
+        monkeypatch.setattr(proxy, "_SHUTDOWN_CLIENT_TIMEOUT", 0.1)
+        nfq = MagicMock()
+        nfq.get_fd = MagicMock(return_value=11)
+        sock = MagicMock()
+
+        class _SlowClient:
+            async def stop(self):
+                await asyncio.sleep(100)  # never completes in time
+
+        loop = asyncio.get_running_loop()
+        sweep = loop.create_task(asyncio.sleep(100))
+        t0 = loop.time()
+        await proxy._shutdown(_SlowClient(), nfq, sock, sweep)
+        elapsed = loop.time() - t0
+        assert elapsed < 1.0  # bounded well under the 5s window
+        nfq.unbind.assert_called()  # teardown proceeded past the timed-out stop
+        sock.close.assert_called()


### PR DESCRIPTION
## Summary

The network sidecar didn't honor SIGTERM, so **every** removal fell back to SIGKILL after the full 5 s `podman stop -t 5` window, and occasionally wedged in `Stopping`, leaking a NET_ADMIN + netns container.

Fixes #2400.

## Root cause

The sidecar runs as **PID 1** — `entrypoint.sh` does `exec python3 /proxy.py`. The Linux kernel ignores the default terminate disposition for a PID-namespace init unless an explicit handler is installed (`pid_namespaces(7)`: only SIGKILL/SIGSTOP are forcibly delivered; other signals require a handler). Python never installed a SIGTERM handler, so podman's `stop` SIGTERM was effectively ignored and the 5 s timeout elapsed on every removal. (SIGKILL bypasses this, which is why podman's fallback eventually cleared the container.)

## Fix

`src/containers/network/proxy.py` installs an explicit SIGTERM handler (`loop.add_signal_handler(SIGTERM, ...)`) that cancels the main asyncio task, triggering a clean teardown (`_shutdown`): stop the consent client, unbind NFQUEUE, cancel the TTL sweeper, close the DNS socket.

Two hardening details surfaced by an adversarial review pass:
- **Idempotent handler.** A *second* SIGTERM arriving while `_shutdown` is mid-await must not re-cancel the main task — that `CancelledError` is a `BaseException`, so `_shutdown`'s `except Exception` guards don't catch it and teardown would be aborted (skipping `nfq.unbind()`/`sock.close()`). The first signal cancels; subsequent ones are no-ops (SIGKILL remains podman's backstop).
- **Bounded `client.stop()`.** Its `ws.close()` is `close_timeout=5 s`, and during klangkd shutdown the server may be going away, so an unbounded close handshake could re-introduce the 5 s window. It's bounded (`_SHUTDOWN_CLIENT_TIMEOUT = 2 s`) so the whole teardown fits well inside `stop -t 5`.

## The other two hypotheses — ruled out

- **NFQUEUE consumer "blocked in a recv"**: it's event-loop-driven (`get_fd()` + `add_reader`), not a blocking thread. Not the cause.
- **netns-provider stop ordering with dependents**: no ordering change is needed. Per call, `stop_and_remove_container` removes the **workspace** (netns consumer) *before* the **sidecar** (netns owner). On the concurrent `shutdown()` path the orphan sweep *can* stop a sidecar independently, but the netns survives by refcount while dependents exist, so this prompt-SIGTERM fix mitigates the window without reordering.

## Tests

`proxy.py` is a container script (not in the coverage-gated `klangk` package). Tests in `test_proxy.py::TestSigtermShutdown` cover:
- `_setup_nfq_consumer` returns the bound NFQUEUE (so it can be unbound) / returns `None` on failure.
- `_shutdown` best-effort-closes every resource (socket, WS client, NFQUEUE, sweeper).
- The SIGTERM handler is registered on **both** the static and consent paths, and invoking it cancels the main task and runs `_shutdown` (asserts `signal.SIGTERM` *specifically*).
- **Re-entrancy guard**: a second SIGTERM during teardown does not abort it (`nfq.unbind`/`sock.close` still run).
- **Bounded `client.stop`**: a stalled close is abandoned within the bound and teardown proceeds.

Both regression tests were verified to *fail* without their respective fixes.

Full backend suite: **4862 passed, 100 % coverage**.
