### PR TITLE
feat(egress-consent): rejected_domains in TUI + Flutter + CLI dialogs (#2386)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,15 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`rejected_domains` in the TUI + Flutter workspace dialogs (#2386).** The
+  static deny-list is now editable end to end, mirroring `allowed_domains`:
+  the TUI create/edit forms (a second list editor in the Netfilter pane, with
+  focus-aware Delete/'e' for either list), the Flutter create + settings
+  dialogs, and the `klangk create/edit --reject` CLI flags. The shared
+  validator rejects CIDR specs for `rejected_domains` up front (NXDOMAIN is
+  name-level), matching the API. The list page also badges a workspace whose
+  `rejected_domains` is set but netfilter is disabled.
+
 - **`rejected_domains` workspace setting + sidecar enforcement (#2367).**
   The deny counterpart to `allowed_domains`: a persisted, host-only list whose
   names the network sidecar NXDOMAINs unconditionally (no resolution, no SYN,

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -806,6 +806,30 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
           ),
         ],
       ),
+      if (_rejectedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: Colors.amber.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: const Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.warning_amber, size: 18),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Egress filtering is not active on this server — the '
+                  'rejected-domains list will NOT be enforced until an '
+                  'operator enables netfilter.',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     ];
   }
 }

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -60,6 +60,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _mountController = TextEditingController();
   final _envController = TextEditingController();
   final _allowedDomainsController = TextEditingController();
+  final _rejectedDomainsController = TextEditingController();
   final _idleTimeoutController = TextEditingController();
   final _cpuLimitController = TextEditingController();
   final _memoryLimitController = TextEditingController();
@@ -68,12 +69,14 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _mounts = <String>[];
   final _envVars = <String, String>{};
   final _allowedDomains = <String>[];
+  final _rejectedDomains = <String>[];
   bool _autoStart = false;
   bool _nixEnabled = false;
   String? _errorMessage;
   String? _mountError;
   String? _envError;
   String? _allowedDomainsError;
+  String? _rejectedDomainsError;
 
   // Section anchors for the section-nav strip (#2229): each key is attached
   // to the pane that opens the section so tapping a nav label scrolls it
@@ -108,6 +111,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     _mountController.dispose();
     _envController.dispose();
     _allowedDomainsController.dispose();
+    _rejectedDomainsController.dispose();
     _idleTimeoutController.dispose();
     _cpuLimitController.dispose();
     _memoryLimitController.dispose();
@@ -162,6 +166,22 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     });
   }
 
+  void _tryAddRejectedDomain() {
+    final v = _rejectedDomainsController.text.trim();
+    if (v.isEmpty) return;
+    // CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+    final err = validateAllowedDomainSpec(v, allowCidr: false);
+    if (err != null) {
+      setState(() => _rejectedDomainsError = err);
+      return;
+    }
+    setState(() {
+      if (!_rejectedDomains.contains(v)) _rejectedDomains.add(v);
+      _rejectedDomainsController.clear();
+      _rejectedDomainsError = null;
+    });
+  }
+
   static String? _validateEnvEntry(String input) {
     if (!input.contains('=')) return 'Expected KEY=VALUE format';
     final key = input.substring(0, input.indexOf('='));
@@ -199,6 +219,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     }
     if (_allowedDomains.isNotEmpty) {
       body['allowed_domains'] = List<String>.from(_allowedDomains);
+    }
+    if (_rejectedDomains.isNotEmpty) {
+      body['rejected_domains'] = List<String>.from(_rejectedDomains);
     }
     if (widget.allowAutostart && _autoStart) {
       body['auto_start'] = true;
@@ -344,7 +367,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                       key: _netfilterKey,
                       icon: Icons.shield,
                       title: 'Netfilter',
-                      children: _buildAllowedDomainsEditor(),
+                      children: [
+                        ..._buildAllowedDomainsEditor(),
+                        const SizedBox(height: 16),
+                        ..._buildRejectedDomainsEditor(),
+                      ],
                     ),
                     const SizedBox(height: 16),
                     WorkspaceSectionPane(
@@ -714,6 +741,71 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
           ),
         ),
       ],
+    ];
+  }
+
+  List<Widget> _buildRejectedDomainsEditor() {
+    return [
+      Text('Rejected Domains', style: _labelStyle),
+      const SizedBox(height: 4),
+      Text(
+        'Hosts NXDOMAIN\'d unconditionally (no resolution, no consent).',
+        style: const TextStyle(fontSize: 12, color: KColors.textSecondary),
+      ),
+      const SizedBox(height: 8),
+      ..._rejectedDomains.asMap().entries.map(
+            (e) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: SelectableText(
+                      e.value,
+                      style: const TextStyle(fontSize: 13),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () =>
+                        setState(() => _rejectedDomains.removeAt(e.key)),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      if (_rejectedDomainsError != null) ...[
+        Text(
+          _rejectedDomainsError!,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.error,
+            fontSize: 12,
+          ),
+        ),
+        const SizedBox(height: 4),
+      ],
+      Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _rejectedDomainsController,
+              decoration: const InputDecoration(
+                hintText: 'evil.example.com',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              style: const TextStyle(fontSize: 13),
+              onSubmitted: (_) => _tryAddRejectedDomain(),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: _tryAddRejectedDomain,
+          ),
+        ],
+      ),
     ];
   }
 }

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -49,7 +49,11 @@ String? validateMountSpec(String spec) {
 /// failure, ``null`` on success. The server validates definitively; this
 /// catches typos at the boundary (#1935 added CIDR support, #2256 added
 /// wildcards).
-String? validateAllowedDomainSpec(String spec) {
+///
+/// ``allowCidr`` is ``false`` for ``rejected_domains`` (#2386): NXDOMAIN
+/// enforcement is name-level (no IP dimension), so a CIDR is meaningless and
+/// is rejected up front rather than round-tripping to the API.
+String? validateAllowedDomainSpec(String spec, {bool allowCidr = true}) {
   if (spec.contains(' ')) {
     return 'Expected host, host:port, or *.domain';
   }
@@ -57,6 +61,10 @@ String? validateAllowedDomainSpec(String spec) {
   // 10.0.0.0/8:443). Validate it separately — the host regex below
   // excludes "/", and a CIDR isn't a hostname (#1935).
   if (spec.contains('/')) {
+    if (!allowCidr) {
+      return 'CIDR ranges are not supported for rejected domains '
+          '(NXDOMAIN is name-level)';
+    }
     return _validateCidrDomainSpec(spec);
   }
   // Wildcard: a leading "*." matches subdomains only (NOT the apex) —
@@ -739,14 +747,16 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     );
   }
 
-  /// #1769: true when this workspace declares allowed_domains but the
-  /// deploy has netfilter disabled, so the allow-list is NOT enforced
-  /// (deliberate fail-open). Used to badge such workspaces in the list —
-  /// the gap is otherwise visible only in operator logs.
+  /// #1769: true when this workspace declares allowed_domains or
+  /// rejected_domains but the deploy has netfilter disabled, so the list is
+  /// NOT enforced (deliberate fail-open). Used to badge such workspaces in
+  /// the list — the gap is otherwise visible only in operator logs.
   bool _hasUnenforcedEgress(Map<String, dynamic> ws) {
     if (_auth.netfilterEnabled) return false;
-    final domains = ws['allowed_domains'] as List?;
-    return domains != null && domains.isNotEmpty;
+    final allowed = ws['allowed_domains'] as List?;
+    final rejected = ws['rejected_domains'] as List?;
+    return (allowed != null && allowed.isNotEmpty) ||
+        (rejected != null && rejected.isNotEmpty);
   }
 
   Widget _buildTabBody(_Section section) {

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -191,9 +191,10 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
   }
 }
 
-/// Compare two allowed_domains values (each a ``List?`` of ``String``) for
-/// order-independent equality, so the restart notice fires only on a real
-/// change — not a harmless reorder or the null/empty equivalence (#1365).
+/// Compare two domain-list values (``allowed_domains`` or ``rejected_domains``,
+/// each a ``List?`` of ``String``) for order-independent equality, so the
+/// restart notice fires only on a real change — not a harmless reorder or the
+/// null/empty equivalence (#1365, #2386).
 bool _domainListsEqual(Object? a, Object? b) {
   final la = (a is List ? a.cast<String>() : const <String>[]);
   final lb = (b is List ? b.cast<String>() : const <String>[]);
@@ -1004,7 +1005,12 @@ class _SettingsFormState extends State<_SettingsForm> {
         ),
         if (_allowedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
           const SizedBox(height: 8),
-          _buildEgressNotEnforcedNotice(),
+          _buildEgressNotEnforcedNotice(
+            listLabel: 'allowed-domains list',
+            consequence: 'This workspace will start with unrestricted '
+                'outbound network until an operator enables netfilter on the '
+                'server.',
+          ),
         ],
       ],
     );
@@ -1040,6 +1046,14 @@ class _SettingsFormState extends State<_SettingsForm> {
             fontSize: 12,
           ),
         ),
+        if (_rejectedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
+          const SizedBox(height: 8),
+          _buildEgressNotEnforcedNotice(
+            listLabel: 'rejected-domains list',
+            consequence: 'Hosts on this list will be reachable until an '
+                'operator enables netfilter on the server.',
+          ),
+        ],
       ],
     );
   }
@@ -1049,24 +1063,25 @@ class _SettingsFormState extends State<_SettingsForm> {
   /// container starts with unrestricted egress (deliberate fail-open).
   /// Surface the gap to the user who set the list (the party at risk);
   /// the server only logs the warning to operator logs otherwise.
-  Widget _buildEgressNotEnforcedNotice() {
+  Widget _buildEgressNotEnforcedNotice({
+    required String listLabel,
+    required String consequence,
+  }) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
         color: KColors.accentAmber.withValues(alpha: 0.12),
         borderRadius: BorderRadius.circular(4),
       ),
-      child: const Row(
+      child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.warning_amber, size: 18),
-          SizedBox(width: 8),
+          const Icon(Icons.warning_amber, size: 18),
+          const SizedBox(width: 8),
           Expanded(
             child: Text(
               'Egress filtering is not active on this server — the '
-              'allowed-domains list above is NOT being enforced. This '
-              'workspace will start with unrestricted outbound network '
-              'until an operator enables netfilter on the server.',
+              '$listLabel above is NOT being enforced. $consequence',
             ),
           ),
         ],

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -225,6 +225,11 @@ bool _hasCreateTimeFieldChanged(
   if (!_domainListsEqual(prev['allowed_domains'], fields['allowed_domains'])) {
     return true;
   }
+  // rejected_domains — set comparison (#2386)
+  if (!_domainListsEqual(
+      prev['rejected_domains'], fields['rejected_domains'])) {
+    return true;
+  }
   // nix — the per-workspace /nix mount is set up at container create
   // time, so toggling it won't take effect until restart (#2233). Only
   // compare when this save actually emitted a nix value (the toggle was
@@ -298,6 +303,7 @@ class _SettingsFormState extends State<_SettingsForm> {
   final _mountCtrl = TextEditingController();
   final _envCtrl = TextEditingController();
   final _allowedDomainsCtrl = TextEditingController();
+  final _rejectedDomainsCtrl = TextEditingController();
   late TextEditingController _idleTimeoutCtrl;
   late TextEditingController _cpuLimitCtrl;
   late TextEditingController _memoryLimitCtrl;
@@ -306,6 +312,7 @@ class _SettingsFormState extends State<_SettingsForm> {
   late List<String> _mounts;
   late Map<String, String> _envVars;
   late List<String> _allowedDomains;
+  late List<String> _rejectedDomains;
   bool _autoStart = false;
   // #2233: per-workspace nix toggle (Mount /nix dir). Only meaningful
   // when the server has a nix backend (widget.nixAvailable).
@@ -313,6 +320,7 @@ class _SettingsFormState extends State<_SettingsForm> {
   String? _mountError;
   String? _envError;
   String? _allowedDomainsError;
+  String? _rejectedDomainsError;
   bool _saving = false;
   bool _exporting = false;
 
@@ -360,6 +368,10 @@ class _SettingsFormState extends State<_SettingsForm> {
     );
     _allowedDomains = List<String>.from(
       (widget.workspace['allowed_domains'] as List?)?.cast<String>() ??
+          <String>[],
+    );
+    _rejectedDomains = List<String>.from(
+      (widget.workspace['rejected_domains'] as List?)?.cast<String>() ??
           <String>[],
     );
     _autoStart = (widget.workspace['auto_start'] as bool?) ?? false;
@@ -435,6 +447,13 @@ class _SettingsFormState extends State<_SettingsForm> {
             <String>[],
       );
     }
+    if (old.workspace['rejected_domains'] !=
+        widget.workspace['rejected_domains']) {
+      _rejectedDomains = List<String>.from(
+        (widget.workspace['rejected_domains'] as List?)?.cast<String>() ??
+            <String>[],
+      );
+    }
   }
 
   @override
@@ -445,6 +464,7 @@ class _SettingsFormState extends State<_SettingsForm> {
     _mountCtrl.dispose();
     _envCtrl.dispose();
     _allowedDomainsCtrl.dispose();
+    _rejectedDomainsCtrl.dispose();
     _idleTimeoutCtrl.dispose();
     _cpuLimitCtrl.dispose();
     _memoryLimitCtrl.dispose();
@@ -494,6 +514,7 @@ class _SettingsFormState extends State<_SettingsForm> {
       'mounts': _mounts.isNotEmpty ? _mounts : null,
       'env': _envVars.isNotEmpty ? _envVars : null,
       'allowed_domains': _allowedDomains.isNotEmpty ? _allowedDomains : null,
+      'rejected_domains': _rejectedDomains.isNotEmpty ? _rejectedDomains : null,
       if (widget.allowAutostart) 'auto_start': _autoStart,
       if (settings.isNotEmpty) 'settings': settings,
     });
@@ -546,6 +567,22 @@ class _SettingsFormState extends State<_SettingsForm> {
       if (!_allowedDomains.contains(v)) _allowedDomains.add(v);
       _allowedDomainsCtrl.clear();
       _allowedDomainsError = null;
+    });
+  }
+
+  void _tryAddRejectedDomain() {
+    final v = _rejectedDomainsCtrl.text.trim();
+    if (v.isEmpty) return;
+    // CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+    final err = validateAllowedDomainSpec(v, allowCidr: false);
+    if (err != null) {
+      setState(() => _rejectedDomainsError = err);
+      return;
+    }
+    setState(() {
+      if (!_rejectedDomains.contains(v)) _rejectedDomains.add(v);
+      _rejectedDomainsCtrl.clear();
+      _rejectedDomainsError = null;
     });
   }
 
@@ -772,7 +809,11 @@ class _SettingsFormState extends State<_SettingsForm> {
       key: _netfilterKey,
       icon: Icons.shield,
       title: 'Netfilter',
-      children: [_buildAllowedDomainsEditor(labelStyle)],
+      children: [
+        _buildAllowedDomainsEditor(labelStyle),
+        const SizedBox(height: 16),
+        _buildRejectedDomainsEditor(labelStyle),
+      ],
     );
   }
 
@@ -934,6 +975,8 @@ class _SettingsFormState extends State<_SettingsForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        Text('Allowed Domains', style: labelStyle),
+        const SizedBox(height: 4),
         _buildEditableList(
           labelStyle: labelStyle,
           hint: 'github.com:443',
@@ -963,6 +1006,40 @@ class _SettingsFormState extends State<_SettingsForm> {
           const SizedBox(height: 8),
           _buildEgressNotEnforcedNotice(),
         ],
+      ],
+    );
+  }
+
+  Widget _buildRejectedDomainsEditor(TextStyle labelStyle) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Rejected Domains', style: labelStyle),
+        const SizedBox(height: 4),
+        _buildEditableList(
+          labelStyle: labelStyle,
+          hint: 'evil.example.com',
+          controller: _rejectedDomainsCtrl,
+          error: _rejectedDomainsError,
+          onAdd: _tryAddRejectedDomain,
+          items: _rejectedDomains.asMap().entries.map(
+                (e) => _buildEditableListItem(
+                  text: e.value,
+                  onCopy: e.value,
+                  onRemove: () =>
+                      setState(() => _rejectedDomains.removeAt(e.key)),
+                ),
+              ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Hosts NXDOMAIN\'d unconditionally (no resolution, no consent). '
+          'CIDR ranges are not supported.',
+          style: TextStyle(
+            color: KColors.textSecondary,
+            fontSize: 12,
+          ),
+        ),
       ],
     );
   }

--- a/src/frontend/test/allowed_domain_spec_test.dart
+++ b/src/frontend/test/allowed_domain_spec_test.dart
@@ -97,5 +97,22 @@ void main() {
       expect(validateAllowedDomainSpec('0.0.0.0/0'), isNull);
       expect(validateAllowedDomainSpec('0.0.0.0'), isNull);
     });
+
+    // #2386: rejected_domains is name-level (NXDOMAIN), so a CIDR is
+    // meaningless and is rejected when allowCidr is false.
+    test('allowCidr=false rejects CIDR for rejected domains', () {
+      expect(
+          validateAllowedDomainSpec('10.0.0.0/8', allowCidr: false), isNotNull);
+      expect(validateAllowedDomainSpec('10.0.0.0/8:443', allowCidr: false),
+          isNotNull);
+      // A plain host / host:port is still accepted.
+      expect(validateAllowedDomainSpec('evil.example.com', allowCidr: false),
+          isNull);
+      expect(
+          validateAllowedDomainSpec('evil.example.com:443', allowCidr: false),
+          isNull);
+      // The default still accepts CIDRs.
+      expect(validateAllowedDomainSpec('10.0.0.0/8'), isNull);
+    });
   });
 }

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -106,7 +106,7 @@ void main() {
       expect(find.text('New Workspace'), findsOneWidget);
       expect(find.text('Cancel'), findsOneWidget);
       expect(find.text('Create'), findsOneWidget);
-      expect(find.byType(TextField), findsNWidgets(10));
+      expect(find.byType(TextField), findsNWidgets(11));
       expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     });
 
@@ -434,6 +434,36 @@ void main() {
       await tester.pump();
 
       expect(postedBody!['allowed_domains'], ['github.com:443']);
+    });
+
+    testWidgets('includes rejected domains in body', (tester) async {
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'x', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      final input = find.widgetWithText(TextField, 'evil.example.com');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'evil.example.com');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      await tester.enterText(_nameField(), 'Filtered');
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(postedBody!['rejected_domains'], ['evil.example.com']);
     });
 
     testWidgets('pre-fills allowed domains from the deploy default',

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -466,6 +466,52 @@ void main() {
       expect(postedBody!['rejected_domains'], ['evil.example.com']);
     });
 
+    testWidgets('rejects a CIDR for rejected domains', (tester) async {
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      final input = find.widgetWithText(TextField, 'evil.example.com');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, '10.0.0.0/8');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      // CIDR is meaningless for a name-level NXDOMAIN deny-list.
+      expect(
+          find.textContaining('CIDR ranges are not supported'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is SelectableText && (w.data ?? '') == '10.0.0.0/8',
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('removes a rejected domain via its close button',
+        (tester) async {
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      // Use a value distinct from the input's hint ('evil.example.com') so
+      // find.text matches only the list chip, not the rendered hint.
+      final input = find.widgetWithText(TextField, 'evil.example.com');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'blocked.example.com');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(find.text('blocked.example.com'), findsOneWidget);
+
+      // The rejected chip's close icon is the last one on screen.
+      final closeIcons = find.byIcon(Icons.close);
+      await tester.ensureVisible(closeIcons.last);
+      await tester.tap(closeIcons.last);
+      await tester.pump();
+
+      expect(find.text('blocked.example.com'), findsNothing);
+    });
+
     testWidgets('pre-fills allowed domains from the deploy default',
         (tester) async {
       // #1365: the editor inherits KLANGKD_NETFILTER_DEFAULT_DOMAINS so a

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -703,6 +703,28 @@ void main() {
       expect(find.textContaining('NOT be enforced'), findsOneWidget);
     });
 
+    testWidgets(
+      'shows not-enforced notice for rejected domains when netfilter disabled (#2386)',
+      (tester) async {
+        testAuthHttpClientOverride =
+            mockClient((_) async => http.Response('Not found', 404));
+        await tester.pumpWidget(buildDialog(netfilterEnabled: false));
+        await tester.pump();
+        await tester.pump();
+
+        final input = find.widgetWithText(TextField, 'evil.example.com');
+        await tester.ensureVisible(input);
+        await tester.enterText(input, 'blocked.example.com');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pump();
+
+        expect(
+          find.textContaining('rejected-domains list will NOT be enforced'),
+          findsOneWidget,
+        );
+      },
+    );
+
     testWidgets('hides not-enforced notice when netfilter enabled',
         (tester) async {
       testAuthHttpClientOverride = mockClient(

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1148,7 +1148,7 @@ void main() {
       expect(
           find.descendant(
               of: find.byType(AlertDialog), matching: find.byType(TextField)),
-          findsNWidgets(10));
+          findsNWidgets(11));
       expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     });
 

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -394,6 +394,31 @@ void main() {
         expect(find.byIcon(Icons.warning_amber), findsOneWidget);
       });
 
+      testWidgets('badges a workspace with rejected_domains only (#2386)',
+          (tester) async {
+        testAuthHttpClientOverride = withPermissions((request) async {
+          if (request.url.path == '/api/v1/workspaces') {
+            return http.Response(
+              jsonEncode(_envelope([
+                {
+                  'id': 'ws-1',
+                  'name': 'Filtered',
+                  'container_id': null,
+                  'created_at': '2026-01-15 14:30:00',
+                  'rejected_domains': ['evil.example.com'],
+                },
+              ])),
+              200,
+            );
+          }
+          return http.Response('Not found', 404);
+        });
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.warning_amber), findsOneWidget);
+      });
+
       testWidgets('no badge when netfilter is enabled (allow-list enforced)',
           (tester) async {
         testAuthHttpClientOverride = withPermissions(

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -833,6 +833,30 @@ void main() {
     );
 
     testWidgets(
+      'shows the notice when rejected_domains are set and netfilter is off (#2386)',
+      (tester) async {
+        testAuthHttpClientOverride = _client(
+          workspace: {
+            ..._workspace,
+            'rejected_domains': <String>['blocked.example.com'],
+          },
+        );
+        await tester.pumpWidget(_buildPanel());
+        await tester.pumpAndSettle();
+
+        // The reject-list notice (distinct from the allow-list one).
+        expect(
+          find.textContaining('rejected-domains list'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('will be reachable'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
       'hides the notice when netfilter is enabled (allow-list enforced)',
       (tester) async {
         testAuthHttpClientOverride = _client(

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -26,6 +26,9 @@ Finder _envInput() => find.byWidgetPredicate(
 Finder _allowedDomainsInput() => find.byWidgetPredicate(
       (w) => w is TextField && w.decoration?.hintText == 'github.com:443',
     );
+Finder _rejectedDomainsInput() => find.byWidgetPredicate(
+      (w) => w is TextField && w.decoration?.hintText == 'evil.example.com',
+    );
 
 /// JWT with sub=test-user (logged in) so AuthService.isLoggedIn is true.
 String _jwt() {
@@ -697,6 +700,110 @@ void main() {
 
       // Advance past the 2s save-message auto-clear timer so no timer is
       // pending at dispose (flutter_test fails on pending timers).
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+  });
+
+  // #2386: the rejected-domains editor mirrors allowed-domains.
+  group('rejected domains editor', () {
+    testWidgets('adds a valid host', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Use a value distinct from the input's hint ('evil.example.com').
+      await tester.enterText(_rejectedDomainsInput(), 'blocked.example.com');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(find.text('blocked.example.com'), findsOneWidget);
+    });
+
+    testWidgets('rejects a CIDR (name-level NXDOMAIN)', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(_rejectedDomainsInput(), '10.0.0.0/8');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      // 'for rejected domains' appears only in the error, not the help text.
+      expect(find.textContaining('for rejected domains'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is SelectableText && (w.data ?? '') == '10.0.0.0/8',
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('removes a rejected domain via its close button',
+        (tester) async {
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'mounts': <String>[],
+        'env': <String, String>{},
+        'allowed_domains': null,
+        'rejected_domains': <String>['blocked.example.com'],
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      expect(find.text('blocked.example.com'), findsOneWidget);
+      // Only the rejected chip is on screen (mounts/env/allowed empty), so
+      // the single close icon belongs to it.
+      await tester.ensureVisible(find.byIcon(Icons.close));
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(find.text('blocked.example.com'), findsNothing);
+    });
+
+    testWidgets('reload after save re-reads rejected_domains from server',
+        (tester) async {
+      // didUpdateWidget must re-read rejected_domains (#2386) so the editor
+      // tracks server state instead of holding a stale local copy.
+      List<String>? rejected = ['old.example.com'];
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/workspaces') {
+          final ws = <String, dynamic>{..._workspace};
+          if (rejected != null)
+            ws['rejected_domains'] = List<String>.from(rejected!);
+          return http.Response(jsonEncode([ws]), 200);
+        }
+        if (p == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi', 'other:latest'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+          rejected = null;
+          return http.Response(jsonEncode({'status': 'updated'}), 200);
+        }
+        return http.Response('not found', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+      expect(find.text('old.example.com'), findsOneWidget);
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // After the post-save reload the server no longer carries
+      // rejected_domains, so didUpdateWidget refreshed _rejectedDomains to
+      // empty and the chip is gone.
+      expect(find.text('old.example.com'), findsNothing);
+
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
     });

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -175,6 +175,7 @@ class Workspace:
     env: dict[str, str] | None = None
     health_check: str | None = None
     allowed_domains: list[str] | None = None
+    rejected_domains: list[str] | None = None
     owner_email: str | None = None
     running: bool = False
     health: str | None = None
@@ -482,6 +483,7 @@ class KlangkClient:
             health=w.get("health"),
             health_message=w.get("health_message"),
             allowed_domains=w.get("allowed_domains"),
+            rejected_domains=w.get("rejected_domains"),
             service_started_at=w.get("service_started_at"),
             settings=w.get("settings"),
         )
@@ -498,6 +500,7 @@ class KlangkClient:
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
         egress_mode: str | None = None,
+        rejected_domains: list[str] | None = None,
         settings: dict | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
@@ -519,6 +522,8 @@ class KlangkClient:
             body["allowed_domains"] = allowed_domains
         if egress_mode:
             body["egress_mode"] = egress_mode
+        if rejected_domains:
+            body["rejected_domains"] = rejected_domains
         if settings:
             body["settings"] = settings
         resp = self.post("/api/v1/workspaces", json=body)

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -632,6 +632,14 @@ def create(
         "--allow",
         help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
     ),
+    reject: list[str] | None = typer.Option(
+        None,
+        "--reject",
+        help=(
+            "Rejected egress domain (NXDOMAIN'd), repeatable "
+            "(e.g. evil.example.com). CIDR ranges are not supported."
+        ),
+    ),
     idle_timeout: int | None = typer.Option(
         None,
         "--idle-timeout",
@@ -661,6 +669,13 @@ def create(
             if err:
                 _err.print(f"[red]{err}[/red]")
                 raise typer.Exit(code=1)
+    if isinstance(reject, list):
+        for spec in reject:
+            # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+            err = validate_allowed_domain_spec(spec, allow_cidr=False)
+            if err:
+                _err.print(f"[red]{err}[/red]")
+                raise typer.Exit(code=1)
     env_dict = _parse_env_list(env) if isinstance(env, list) else None
     settings = _build_settings(
         idle_timeout, cpu_limit, memory_limit, pids_limit
@@ -675,6 +690,7 @@ def create(
             env=env_dict,
             health_check=health_check,
             allowed_domains=allow or None,
+            rejected_domains=reject or None,
             settings=settings,
         )
     except httpx.HTTPStatusError as exc:
@@ -997,6 +1013,14 @@ def edit(
         "--allow",
         help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
     ),
+    reject: list[str] | None = typer.Option(
+        None,
+        "--reject",
+        help=(
+            "Rejected egress domain (NXDOMAIN'd), repeatable "
+            "(e.g. evil.example.com). CIDR ranges are not supported."
+        ),
+    ),
     idle_timeout: int | None = typer.Option(
         None,
         "--idle-timeout",
@@ -1034,6 +1058,7 @@ def edit(
         or isinstance(mount, list)
         or isinstance(env, list)
         or isinstance(allow, list)
+        or isinstance(reject, list)
         or idle_timeout is not None
         or cpu_limit is not None
         or memory_limit is not None
@@ -1177,6 +1202,49 @@ def edit(
 
             break  # both add and remove were skipped
 
+        # Interactive rejected-domains editing loop (#2386)
+        current_rejected = list(ws.rejected_domains or [])
+        rejected_changed = False
+        while True:
+            if current_rejected:
+                typer.echo("\nRejected egress domains (NXDOMAIN'd):")
+                for i, d in enumerate(current_rejected, 1):
+                    typer.echo(f"  {i}. {d}")
+            else:
+                typer.echo("\nNo egress denylist.")
+
+            add = input(
+                "\nAdd rejected domain (e.g. evil.example.com, or Enter to skip): "
+            ).strip()
+            if add:
+                # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+                err = validate_allowed_domain_spec(add, allow_cidr=False)
+                if err:
+                    typer.echo(err)
+                    continue
+                current_rejected.append(add)
+                rejected_changed = True
+                continue
+
+            if current_rejected:
+                rm = input("Remove domain number (or Enter to skip): ").strip()
+                if rm:
+                    try:
+                        idx = int(rm) - 1
+                        if 0 <= idx < len(current_rejected):
+                            removed = current_rejected.pop(idx)
+                            typer.echo(f"Removed: {removed}")
+                            rejected_changed = True
+                            continue
+                        else:
+                            typer.echo("Invalid number.")
+                            continue
+                    except ValueError:
+                        typer.echo("Invalid number.")
+                        continue
+
+            break  # both add and remove were skipped
+
         body: dict = {}
         if new_name is not _SENTINEL:
             body["name"] = new_name or ws.name  # don't allow empty name
@@ -1192,6 +1260,8 @@ def edit(
             body["env"] = current_env or None
         if domains_changed:
             body["allowed_domains"] = current_domains or None
+        if rejected_changed:
+            body["rejected_domains"] = current_rejected or None
     else:
         # Flags mode — only send provided fields
         body = {}
@@ -1221,6 +1291,14 @@ def edit(
                     _err.print(f"[red]{err}[/red]")
                     raise typer.Exit(code=1)
             body["allowed_domains"] = allow or None
+        if isinstance(reject, list):
+            for spec in reject:
+                # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+                err = validate_allowed_domain_spec(spec, allow_cidr=False)
+                if err:
+                    _err.print(f"[red]{err}[/red]")
+                    raise typer.Exit(code=1)
+            body["rejected_domains"] = reject or None
         edit_settings = _build_settings(
             idle_timeout, cpu_limit, memory_limit, pids_limit
         )
@@ -1241,6 +1319,7 @@ def edit(
         "env",
         "service_command",
         "allowed_domains",
+        "rejected_domains",
     }
     restart_needed = ws.running and bool(body.keys() & _CREATE_TIME_KEYS)
 

--- a/src/klangk/klangk/cli/mount.py
+++ b/src/klangk/klangk/cli/mount.py
@@ -62,17 +62,23 @@ _ALLOWED_DOMAIN_RE = re.compile(
 )
 
 
-def validate_allowed_domain_spec(spec: str) -> str | None:
-    """Validate an egress allowed-domain entry.
+def validate_allowed_domain_spec(
+    spec: str, *, allow_cidr: bool = True
+) -> str | None:
+    """Validate an egress allowed/rejected-domain entry.
 
     Returns None if valid, or an error message. Accepts a DNS name, an IPv4
-    address (optionally followed by ``:port``), or an IPv4 CIDR range
-    (``10.0.0.0/8``, optionally scoped to a port as ``10.0.0.0/8:443``).
-    Empty / whitespace / IPv6 literals (``[::1]``) / IPv6 CIDRs are rejected
-    — IPv6 is disabled inside filtered containers (#1936), so a v6
-    destination is neither reachable nor enforceable. Mirrors the Flutter
+    address (optionally followed by ``:port``), or -- when ``allow_cidr`` is
+    True -- an IPv4 CIDR range (``10.0.0.0/8``, optionally scoped to a port as
+    ``10.0.0.0/8:443``). Empty / whitespace / IPv6 literals (``[::1]``) / IPv6
+    CIDRs are rejected — IPv6 is disabled inside filtered containers (#1936),
+    so a v6 destination is neither reachable nor enforceable. Mirrors the Flutter
     ``validateAllowedDomainSpec`` and the TUI editor; the server does the
     authoritative validation (#1365, #1745, #1935).
+
+    ``allow_cidr=False`` is used for ``rejected_domains`` (#2367): NXDOMAIN
+    enforcement is name-level (no IP dimension), so a CIDR is meaningless there
+    and is rejected up front rather than round-tripping to the API.
     """
     s = spec.strip()
     if not s:
@@ -80,6 +86,11 @@ def validate_allowed_domain_spec(spec: str) -> str | None:
     # A "/" denotes an IPv4 CIDR range; route it to the CIDR check before
     # the host regex (which excludes "/").
     if "/" in s:
+        if not allow_cidr:
+            return (
+                f"Invalid rejected-domain {spec!r}: CIDR ranges are not "
+                "supported (NXDOMAIN is name-level)"
+            )
         return _validate_cidr_domain_spec(spec, s)
     if not _ALLOWED_DOMAIN_RE.match(s):
         return (

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -356,6 +356,13 @@ class WorkspaceDetailScreen(Screen):
                     "\n".join(str(d) for d in ws.allowed_domains),
                 )
             )
+        if ws.rejected_domains:
+            rows.append(
+                (
+                    "rejected domains",
+                    "\n".join(str(d) for d in ws.rejected_domains),
+                )
+            )
         if ws.owner_email:
             rows.append(("owner", ws.owner_email))
         return rows

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -84,6 +84,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         "mount_input",
         "env_input",
         "allow_input",
+        "reject_input",
         "idle_timeout",
         "cpu_limit",
         "memory_limit",
@@ -97,6 +98,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         "mount_list": "mount_input",
         "env_list": "env_input",
         "allow_list": "allow_input",
+        "reject_list": "reject_input",
     }
     # Spatial nav around the form tab strip (#1891): the first focusable
     # field of each pane — Down from the strip lands here, Up returns.
@@ -116,6 +118,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         default: str,
         allow_autostart: bool,
         default_allowed_domains: list[str] | None = None,
+        default_rejected_domains: list[str] | None = None,
         nix_available: bool = False,
     ) -> None:
         super().__init__()
@@ -131,6 +134,11 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         # (KLANGKD_NETFILTER_DEFAULT_DOMAINS) so the TUI create form matches
         # the Flutter dialog — a starting set the user can edit/remove (#1931).
         self._allowed_domains: list[str] = list(default_allowed_domains or [])
+        # #2386: the static deny-list (rejected_domains), mirroring the
+        # allow-list editor. No deploy default (only allow has one).
+        self._rejected_domains: list[str] = list(
+            default_rejected_domains or []
+        )
         if self._allowed:
             # Select tuples are (prompt, value). Prompts are rich Text so an
             # image name containing brackets can't trigger markup parsing.
@@ -205,6 +213,19 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                         Button("Remove", id="rm_allow"),
                     )
                     yield OptionList(id="allow_list", classes="editor-list")
+                    yield Static(
+                        "Rejected Domains  "
+                        "(host or host:port; NXDOMAIN'd unconditionally)",
+                        classes="editor-label",
+                    )
+                    yield Horizontal(
+                        Input(
+                            id="reject_input", placeholder="evil.example.com"
+                        ),
+                        Button("Add", id="add_reject"),
+                        Button("Remove", id="rm_reject"),
+                    )
+                    yield OptionList(id="reject_list", classes="editor-list")
                 with TabPane("Resources", id="resources_pane"):
                     yield Horizontal(
                         Static("Idle timeout (s)"),
@@ -264,6 +285,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()
+        self._render_rejected_domains()
         # General tab is active on entry — focus Name so the user can start
         # typing immediately (the tab strip is one Up away, #1891).
         self.query_one("#name", Input).focus()
@@ -392,6 +414,41 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         del self._allowed_domains[idx]
         self._render_allowed_domains()
 
+    # --- rejected-domains list editor (#2386, mirrors allowed-domains) ---
+
+    def _render_rejected_domains(self) -> None:
+        ol = self.query_one("#reject_list", OptionList)
+        ol.clear_options()
+        if not self._rejected_domains:
+            ol.add_option(Option(Text("(none)"), id="", disabled=True))
+            return
+        for i, d in enumerate(self._rejected_domains):
+            ol.add_option(Option(Text(d), id=f"r{i}"))
+
+    def _add_rejected_domain(self) -> None:
+        inp = self.query_one("#reject_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+        err = validate_allowed_domain_spec(v, allow_cidr=False)
+        if err:
+            self._msg(err, error=True)
+            return
+        if v not in self._rejected_domains:
+            self._rejected_domains.append(v)
+        inp.value = ""
+        self._msg("")
+        self._render_rejected_domains()
+
+    def _remove_rejected_domain(self) -> None:
+        ol = self.query_one("#reject_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._rejected_domains):
+            return
+        del self._rejected_domains[idx]
+        self._render_rejected_domains()
+
     # --- tab + keyboard navigation (#1891) ---
 
     def _active_tab(self) -> str:
@@ -455,6 +512,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         mounts = list(self._mounts) or None
         env = dict(self._env) or None
         allowed_domains = list(self._allowed_domains) or None
+        rejected_domains = list(self._rejected_domains) or None
         settings = _collect_settings(self)
         if self._nix_available and self.query_one("#nix", Checkbox).value:
             settings = {**(settings or {}), "nix": True}
@@ -468,6 +526,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                 env,
                 health_check,
                 allowed_domains,
+                rejected_domains,
                 settings,
             ),
             exit_on_error=False,
@@ -483,6 +542,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         env,
         health_check,
         allowed_domains,
+        rejected_domains,
         settings,
     ) -> None:
         try:
@@ -496,6 +556,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                 env=env,
                 health_check=health_check,
                 allowed_domains=allowed_domains,
+                rejected_domains=rejected_domains,
                 settings=settings,
             )
         except AuthError:
@@ -533,6 +594,10 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
             self._add_allowed_domain()
         elif bid == "rm_allow":
             self._remove_allowed_domain()
+        elif bid == "add_reject":
+            self._add_rejected_domain()
+        elif bid == "rm_reject":
+            self._remove_rejected_domain()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         eid = event.input.id
@@ -542,6 +607,8 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
             self._add_env()
         elif eid == "allow_input":
             self._add_allowed_domain()
+        elif eid == "reject_input":
+            self._add_rejected_domain()
         elif eid in (
             "name",
             "command",
@@ -587,6 +654,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         "mount_input",
         "env_input",
         "allow_input",
+        "reject_input",
         "idle_timeout",
         "cpu_limit",
         "memory_limit",
@@ -600,6 +668,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         "mount_list": "mount_input",
         "env_list": "env_input",
         "allow_list": "allow_input",
+        "reject_list": "reject_input",
     }
     # Spatial nav around the form tab strip (#1891): the first focusable
     # field of each pane — Down from the strip lands here, Up returns.
@@ -642,11 +711,16 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         self._allowed_domains: list[str] = list(
             workspace.allowed_domains or []
         )
+        # #2386: the static deny-list, seeded from the workspace.
+        self._rejected_domains: list[str] = list(
+            workspace.rejected_domains or []
+        )
         # In-place editor state (#1778): when set, the next Add *replaces*
         # the item at this index/key instead of appending. Cleared on Add.
         self._editing_mount: int | None = None
         self._editing_env: str | None = None
         self._editing_allow: int | None = None
+        self._editing_reject: int | None = None
         # Image picker: include the workspace's current image even if it
         # isn't in the server's allowed list, pre-selected (untouched = no
         # change). Prompts are rich Text so bracket-laden names can't crash.
@@ -732,6 +806,19 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
                         Button("Remove", id="rm_allow"),
                     )
                     yield OptionList(id="allow_list", classes="editor-list")
+                    yield Static(
+                        "Rejected Domains  "
+                        "(host or host:port; NXDOMAIN'd unconditionally)",
+                        classes="editor-label",
+                    )
+                    yield Horizontal(
+                        Input(
+                            id="reject_input", placeholder="evil.example.com"
+                        ),
+                        Button("Add", id="add_reject"),
+                        Button("Remove", id="rm_reject"),
+                    )
+                    yield OptionList(id="reject_list", classes="editor-list")
                 with TabPane("Resources", id="resources_pane"):
                     _s = self._ws.settings or {}
                     yield Horizontal(
@@ -813,6 +900,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()
+        self._render_rejected_domains()
         # General tab is active on entry — focus Name so the user can start
         # typing immediately (the tab strip is one Up away, #1891).
         self.query_one("#name", Input).focus()
@@ -990,6 +1078,57 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         inp.focus()
         self._msg("Editing allowed-domain — press Add to update.")
 
+    # --- rejected-domains list editor (#2386, mirrors allowed-domains) ---
+
+    def _render_rejected_domains(self) -> None:
+        ol = self.query_one("#reject_list", OptionList)
+        ol.clear_options()
+        if not self._rejected_domains:
+            ol.add_option(Option(Text("(none)"), id="", disabled=True))
+            return
+        for i, d in enumerate(self._rejected_domains):
+            ol.add_option(Option(Text(d), id=f"r{i}"))
+
+    def _add_rejected_domain(self) -> None:
+        inp = self.query_one("#reject_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+        err = validate_allowed_domain_spec(v, allow_cidr=False)
+        if err:
+            self._msg(err, error=True)
+            return
+        idx = self._editing_reject
+        if idx is not None and 0 <= idx < len(self._rejected_domains):
+            self._rejected_domains[idx] = v
+            self._editing_reject = None
+        elif v not in self._rejected_domains:
+            self._rejected_domains.append(v)
+        inp.value = ""
+        self._msg("")
+        self._render_rejected_domains()
+
+    def _remove_rejected_domain(self) -> None:
+        ol = self.query_one("#reject_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._rejected_domains):
+            return
+        del self._rejected_domains[idx]
+        self._editing_reject = None
+        self._render_rejected_domains()
+
+    def _edit_rejected_domain(self) -> None:
+        ol = self.query_one("#reject_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._rejected_domains):
+            return
+        self._editing_reject = idx
+        inp = self.query_one("#reject_input", Input)
+        inp.value = self._rejected_domains[idx]
+        inp.focus()
+        self._msg("Editing rejected-domain — press Add to update.")
+
     # --- tab + keyboard navigation (#1891) ---
 
     def _active_tab(self) -> str:
@@ -1023,13 +1162,29 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
 
     # --- keyboard remove/edit of the active tab's list (#1778, #1891) ---
 
+    def _list_handlers(self) -> tuple[str, str] | None:
+        """(remove, edit) handlers for the active pane's focused list.
+
+        Most panes hold one list, so :data:`_PANE_LIST_HANDLER` keys on the
+        pane. The netfilter pane holds TWO (#2386: allow + reject), so dispatch
+        on the focused widget -- Delete/'e' acts on whichever list owns focus,
+        defaulting to the allow list (the pane's first field).
+        """
+        pane = self._active_tab()
+        if pane == "netfilter_pane":
+            focused = self.focused.id if self.focused else None
+            if focused == "reject_list":
+                return ("_remove_rejected_domain", "_edit_rejected_domain")
+            return ("_remove_allowed_domain", "_edit_allowed_domain")
+        return self._PANE_LIST_HANDLER.get(pane)
+
     def action_remove_item(self) -> None:
-        handler = self._PANE_LIST_HANDLER.get(self._active_tab())
+        handler = self._list_handlers()
         if handler:
             getattr(self, handler[0])()
 
     def action_edit_item(self) -> None:
-        handler = self._PANE_LIST_HANDLER.get(self._active_tab())
+        handler = self._list_handlers()
         if handler:
             getattr(self, handler[1])()
 
@@ -1054,6 +1209,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         mounts = list(self._mounts) or None
         env = dict(self._env) or None
         allowed_domains = list(self._allowed_domains) or None
+        rejected_domains = list(self._rejected_domains) or None
         settings = _collect_settings(self)
         # #2233: emit an explicit nix value (True/False) whenever the
         # toggle is shown. PUT settings is a full-replace bag, so we must
@@ -1077,6 +1233,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
             "mounts": mounts,
             "env": env,
             "allowed_domains": allowed_domains,
+            "rejected_domains": rejected_domains,
         }
         if settings is not None:
             body["settings"] = settings
@@ -1084,12 +1241,14 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         orig_mounts = list(ws.mounts or []) or None
         orig_env = dict(ws.env or {}) or None
         orig_domains = list(ws.allowed_domains or []) or None
+        orig_rejected = list(ws.rejected_domains or []) or None
         restart_needed = bool(ws.running) and (
             (image or None) != (ws.image or None)
             or mounts != orig_mounts
             or env != orig_env
             or (command or None) != (ws.service_command or None)
             or allowed_domains != orig_domains
+            or rejected_domains != orig_rejected
             # #2233: the per-workspace /nix mount is set up at create
             # time, so toggling it on a running workspace needs a restart.
             or (
@@ -1175,6 +1334,10 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
             self._add_allowed_domain()
         elif bid == "rm_allow":
             self._remove_allowed_domain()
+        elif bid == "add_reject":
+            self._add_rejected_domain()
+        elif bid == "rm_reject":
+            self._remove_rejected_domain()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         eid = event.input.id
@@ -1184,6 +1347,8 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
             self._add_env()
         elif eid == "allow_input":
             self._add_allowed_domain()
+        elif eid == "reject_input":
+            self._add_rejected_domain()
         elif eid in (
             "name",
             "command",

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -304,6 +304,8 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
             "rm_env",
             "add_allow",
             "rm_allow",
+            "add_reject",
+            "rm_reject",
         ):
             self.query_one(f"#{wid}").can_focus = False
 
@@ -680,14 +682,12 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         "resources_pane": "idle_timeout",
         "advanced_pane": "command",
     }
-    # Delete/'e' act on the list under the active tab (#1891).
+    # Delete/'e' act on the list under the active tab (#1891). The
+    # netfilter pane holds two lists (allow + reject, #2386), so it is NOT
+    # in this table -- :meth:`_list_handlers` dispatches it on focus instead.
     _PANE_LIST_HANDLER = {
         "mounts_pane": ("_remove_mount", "_edit_mount"),
         "env_pane": ("_remove_env", "_edit_env"),
-        "netfilter_pane": (
-            "_remove_allowed_domain",
-            "_edit_allowed_domain",
-        ),
     }
 
     def __init__(
@@ -919,6 +919,8 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
             "rm_env",
             "add_allow",
             "rm_allow",
+            "add_reject",
+            "rm_reject",
         ):
             self.query_one(f"#{wid}").can_focus = False
 
@@ -1172,6 +1174,11 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         """
         pane = self._active_tab()
         if pane == "netfilter_pane":
+            # Two lists share this pane (#2386): dispatch on the focused
+            # widget. Focus on a reject *input* (not the list) falls through
+            # to the allow default -- harmless, because an Input consumes
+            # Delete/'e' before the Screen binding fires, so these actions
+            # never run while typing in an input.
             focused = self.focused.id if self.focused else None
             if focused == "reject_list":
                 return ("_remove_rejected_domain", "_edit_rejected_domain")

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -223,6 +223,7 @@ class TuiState:
         env: dict[str, str] | None = None,
         health_check: str | None = None,
         allowed_domains: list[str] | None = None,
+        rejected_domains: list[str] | None = None,
         settings: dict | None = None,
     ) -> Workspace:
         return self.client().create_workspace(
@@ -234,6 +235,7 @@ class TuiState:
             env=env,
             health_check=health_check,
             allowed_domains=allowed_domains,
+            rejected_domains=rejected_domains,
             settings=settings,
         )
 

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -948,10 +948,10 @@ class TestMounts:
         try:
             # Interactive: keep name, keep image, keep command,
             # add mount "/tmp:/mnt/test", skip add, skip remove,
-            # skip add env
+            # skip add env, skip allowed-domains add, skip rejected-domains add
             result = _run(
                 ["klangk", "edit", "e2e-mount-int"],
-                input="\n\n\n/tmp:/mnt/test\n\n\n\n",
+                input="\n\n\n/tmp:/mnt/test\n\n\n\n\n",
                 env=env,
             )
             assert result.returncode == 0

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1182,6 +1182,24 @@ class TestKlangkClient:
                 "allowed_domains" not in client.post.call_args.kwargs["json"]
             )
 
+    def test_create_workspace_includes_rejected_domains(self):
+        # #2386: rejected_domains threads through to the create POST body.
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "id": "ws-1",
+            "name": "n",
+            "created_at": "x",
+        }
+        with patch.object(client, "post", return_value=mock_resp):
+            client.create_workspace("n", rejected_domains=["evil.example.com"])
+            body = client.post.call_args.kwargs["json"]
+            assert body["rejected_domains"] == ["evil.example.com"]
+            client.create_workspace("n2")
+            assert (
+                "rejected_domains" not in client.post.call_args.kwargs["json"]
+            )
+
     def test_update_workspace_puts_fields(self):
         client = KlangkClient("http://test:8995", "token")
         with patch.object(
@@ -1202,10 +1220,12 @@ class TestKlangkClient:
                 "name": "n",
                 "created_at": "x",
                 "allowed_domains": ["github.com:443"],
+                "rejected_domains": ["evil.example.com"],
             },
             shared=False,
         )
         assert ws.allowed_domains == ["github.com:443"]
+        assert ws.rejected_domains == ["evil.example.com"]
         # Absent key -> None (unrestricted).
         ws2 = KlangkClient._workspace_from_json(
             {"id": "ws-2", "name": "n2", "created_at": "x"}, shared=False

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1921,7 +1921,8 @@ class TestMainCLI:
         # keep name, keep image, change command, skip add mount, skip add env
         with patch.object(main, "_client", return_value=client):
             with patch(
-                "builtins.input", side_effect=["", "", "pi", "", "", "", ""]
+                "builtins.input",
+                side_effect=["", "", "pi", "", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1953,7 +1954,16 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "curl -sf http://x/h", "", "", ""],
+                side_effect=[
+                    "",
+                    "",
+                    "",
+                    "curl -sf http://x/h",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
             ):
                 from typer.testing import CliRunner
 
@@ -1983,7 +1993,16 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["renamed", "klangk-custom", "pi", "", "", "", ""],
+                side_effect=[
+                    "renamed",
+                    "klangk-custom",
+                    "pi",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
             ):
                 from typer.testing import CliRunner
 
@@ -2023,6 +2042,7 @@ class TestMainCLI:
                     "",
                     "",
                     "",
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2051,7 +2071,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "1", "", "", "", ""],
+                side_effect=["", "", "", "", "", "1", "", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2094,6 +2114,7 @@ class TestMainCLI:
                     "",
                     "",
                     "",
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2138,6 +2159,7 @@ class TestMainCLI:
                     "",
                     "",
                     "",
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2168,7 +2190,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "1", "", "", ""],
+                side_effect=["", "", "", "", "", "1", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2198,7 +2220,19 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "bad", "/a:/b", "", "", "", ""],
+                side_effect=[
+                    "",
+                    "",
+                    "",
+                    "",
+                    "bad",
+                    "/a:/b",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
             ):
                 from typer.testing import CliRunner
 
@@ -2300,6 +2334,53 @@ class TestMainCLI:
             "/data:/mnt/data:ro",
         ]
 
+    def test_edit_with_reject_flag(self, logged_in_cfg, monkeypatch):
+        # #2386: --reject threads rejected_domains into the edit PUT body.
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["edit", "my-ws", "--reject", "evil.example.com"],
+            )
+            assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["rejected_domains"] == ["evil.example.com"]
+
+    def test_edit_with_reject_cidr_rejected(self, logged_in_cfg, monkeypatch):
+        # A CIDR is meaningless for a name-level NXDOMAIN deny-list.
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        monkeypatch.setattr(main, "_client", lambda: client)
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app, ["edit", "my-ws", "--reject", "10.0.0.0/8"]
+        )
+        assert result.exit_code == 1
+        client.put.assert_not_called()
+
     def test_edit_interactive_no_changes(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main
 
@@ -2314,7 +2395,7 @@ class TestMainCLI:
         # keep name, image, command; skip add mount (no mounts, no remove prompt)
         with patch.object(main, "_client", return_value=client):
             with patch(
-                "builtins.input", side_effect=["", "", "", "", "", "", ""]
+                "builtins.input", side_effect=["", "", "", "", "", "", "", ""]
             ):
                 from typer.testing import CliRunner
 
@@ -2341,7 +2422,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "FOO=bar", "", "", ""],
+                side_effect=["", "", "", "", "", "FOO=bar", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2370,7 +2451,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "bad", "A=1", "", "", ""],
+                side_effect=["", "", "", "", "", "bad", "A=1", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2408,6 +2489,7 @@ class TestMainCLI:
             env={"FOO": "bar", "X": "1"},
             health_check=None,
             allowed_domains=None,
+            rejected_domains=None,
             settings=None,
         )
 
@@ -2435,6 +2517,7 @@ class TestMainCLI:
             env=None,
             health_check=None,
             allowed_domains=None,
+            rejected_domains=None,
             settings=None,
         )
 
@@ -2485,8 +2568,58 @@ class TestMainCLI:
             env=None,
             health_check=None,
             allowed_domains=["github.com:443", "pypi.org"],
+            rejected_domains=None,
             settings=None,
         )
+
+    def test_create_with_reject_flag(self, logged_in_cfg, monkeypatch):
+        # #2386: --reject threads rejected_domains through to create_workspace.
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="new-id", name="ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client = MagicMock()
+        client.create_workspace.return_value = ws
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app,
+            ["create", "ws", "--reject", "evil.example.com"],
+        )
+        assert result.exit_code == 0
+        client.create_workspace.assert_called_once_with(
+            "ws",
+            image=None,
+            service_command=None,
+            auto_start=False,
+            mounts=None,
+            env=None,
+            health_check=None,
+            allowed_domains=None,
+            rejected_domains=["evil.example.com"],
+            settings=None,
+        )
+
+    def test_create_with_reject_cidr_rejected(
+        self, logged_in_cfg, monkeypatch
+    ):
+        # A CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+        from klangk.cli import main
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app, ["create", "ws", "--reject", "10.0.0.0/8"]
+        )
+        assert result.exit_code == 1
+        client.create_workspace.assert_not_called()
 
     def test_create_with_settings_flags(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main
@@ -2526,6 +2659,7 @@ class TestMainCLI:
             env=None,
             health_check=None,
             allowed_domains=None,
+            rejected_domains=None,
             settings={
                 "idle_timeout": 600,
                 "cpu_limit": 1.5,
@@ -2629,6 +2763,7 @@ class TestMainCLI:
                     "github.com:443",  # domain add
                     "",  # domain add (skip)
                     "",  # done
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2639,6 +2774,133 @@ class TestMainCLI:
 
         body = client.put.call_args[1]["json"]
         assert body["allowed_domains"] == ["github.com:443"]
+
+    def test_edit_interactive_add_rejected_domain(
+        self, logged_in_cfg, monkeypatch
+    ):
+        # #2386: the interactive rejected-domains loop appends to rejected_domains.
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "",  # allowed-domains add (skip)
+                    "10.0.0.0/8",  # rejected-domains add (CIDR -> error)
+                    "evil.example.com",  # rejected-domains add
+                    "",  # rejected-domains add (skip)
+                    "",  # rejected-domains remove (skip)
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["rejected_domains"] == ["evil.example.com"]
+
+    def test_edit_interactive_remove_rejected_domain(
+        self, logged_in_cfg, monkeypatch
+    ):
+        # #2386: the interactive rejected-domains remove path.
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            rejected_domains=["old.example.com"],
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "",  # allowed-domains add (skip)
+                    "",  # rejected-domains add (skip)
+                    "1",  # rejected-domains remove number
+                    "",  # rejected-domains add (skip)
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["rejected_domains"] is None  # removed -> empty -> None
+
+    def test_edit_interactive_invalid_rejected_remove_number(
+        self, logged_in_cfg, monkeypatch
+    ):
+        # #2386: invalid remove numbers in the rejected-domains loop are
+        # rejected with a message (out-of-range + non-numeric).
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            rejected_domains=["old.example.com"],
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "",  # allowed-domains add (skip)
+                    "",  # rejected-domains add (skip)
+                    "99",  # invalid number (out of range)
+                    "",  # rejected-domains add (skip)
+                    "abc",  # non-numeric
+                    "",  # rejected-domains add (skip)
+                    "",  # rejected-domains remove (skip)
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        # No valid change was made -> "No changes", no PUT.
+        client.put.assert_not_called()
 
     def test_edit_interactive_add_domain_with_existing(
         self, logged_in_cfg, monkeypatch
@@ -2669,6 +2931,7 @@ class TestMainCLI:
                     "",  # domain add (skip)
                     "",  # domain remove (skip)
                     "",  # done
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2709,6 +2972,7 @@ class TestMainCLI:
                     "",  # domain add (skip)
                     "",  # domain remove (skip)
                     "",  # done
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2749,6 +3013,7 @@ class TestMainCLI:
                     "github.com",  # valid domain
                     "",  # domain add (skip)
                     "",  # done
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2792,6 +3057,7 @@ class TestMainCLI:
                     "",  # domain add (skip)
                     "",  # domain remove (skip)
                     "",  # done
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner
@@ -2819,7 +3085,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "", "1", "", "", ""],
+                side_effect=["", "", "", "", "", "", "1", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2862,6 +3128,7 @@ class TestMainCLI:
                     "",
                     "",
                     "",
+                    "",  # rejected-domains add (skip)
                 ],
             ):
                 from typer.testing import CliRunner

--- a/src/klangk/klangkc-tests/tests/test_mount.py
+++ b/src/klangk/klangkc-tests/tests/test_mount.py
@@ -123,3 +123,26 @@ class TestValidateAllowedDomainSpec:
     def test_strips_whitespace(self):
         assert validate_allowed_domain_spec("  github.com:443  ") is None
         assert validate_allowed_domain_spec("  10.0.0.0/8  ") is None
+
+    def test_allow_cidr_false_rejects_cidr_for_rejected_domains(self):
+        # #2386: rejected_domains is name-level (NXDOMAIN), so a CIDR is
+        # meaningless and is rejected up front when allow_cidr=False.
+        err = validate_allowed_domain_spec("10.0.0.0/8", allow_cidr=False)
+        assert err is not None
+        assert "CIDR" in err
+        assert validate_allowed_domain_spec("10.0.0.0/8:443", allow_cidr=False)
+        # A plain host / host:port is still accepted.
+        assert (
+            validate_allowed_domain_spec("evil.example.com", allow_cidr=False)
+            is None
+        )
+        assert (
+            validate_allowed_domain_spec(
+                "evil.example.com:443", allow_cidr=False
+            )
+            is None
+        )
+
+    def test_allow_cidr_default_true_unchanged(self):
+        # The default (allow) still accepts CIDRs.
+        assert validate_allowed_domain_spec("10.0.0.0/8") is None

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2103,6 +2103,7 @@ def test_tui_state_workspace_methods(monkeypatch, redirect_xdg):
         env=None,
         health_check=None,
         allowed_domains=None,
+        rejected_domains=None,
         settings=None,
     )
     fake.list_images.assert_called_once_with()
@@ -4659,7 +4660,11 @@ async def test_detail_renders_allowed_domains(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    a = _wsobj("alpha", allowed_domains=["github.com:443", "pypi.org"])
+    a = _wsobj(
+        "alpha",
+        allowed_domains=["github.com:443", "pypi.org"],
+        rejected_domains=["evil.example.com"],
+    )
     st = _ws()
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
@@ -4670,6 +4675,8 @@ async def test_detail_renders_allowed_domains(monkeypatch):
         assert _detail_value(body, "allowed domains") is not None
         assert "github.com:443" in body
         assert "pypi.org" in body
+        assert _detail_value(body, "rejected domains") is not None
+        assert "evil.example.com" in body
 
 
 async def test_detail_renders_aligned_two_column_table(monkeypatch):
@@ -10991,6 +10998,153 @@ async def test_create_screen_editor_add_buttons_clickable(monkeypatch):
         assert captured["k"]["health_check"] == "curl localhost"
 
 
+async def test_create_screen_rejected_domains_editor(monkeypatch):
+    """#2386: the create form's rejected-domains editor reaches create_workspace."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    captured = {}
+
+    def fake_create(*a, **k):
+        captured["k"] = k
+        return _wsobj("zzz")
+
+    app = KlangkApp(_create_state(create=fake_create))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name", Input).value = "myws"
+        tabs = cs.query_one("#form_tabs", TabbedContent)
+        tabs.active = "netfilter_pane"
+        await pilot.pause()
+        # Add a rejected domain via the Add button handler (#2386).
+        cs.query_one("#reject_input", Input).value = "evil.example.com"
+        cs.on_button_pressed(FakeBtnPress("add_reject"))
+        await pilot.pause()
+        assert cs._rejected_domains == ["evil.example.com"]
+        # A CIDR is rejected client-side (name-level NXDOMAIN deny-list).
+        cs.query_one("#reject_input", Input).value = "10.0.0.0/8"
+        cs.on_button_pressed(FakeBtnPress("add_reject"))
+        await pilot.pause()
+        assert cs._rejected_domains == ["evil.example.com"]  # unchanged
+        assert cs.query_one("#reject_input", Input).value == "10.0.0.0/8"
+        # Remove via the Remove button handler, then re-add.
+        cs.query_one("#reject_list", OptionList).highlighted = 0
+        cs.on_button_pressed(FakeBtnPress("rm_reject"))
+        await pilot.pause()
+        assert cs._rejected_domains == []
+        cs.query_one("#reject_input", Input).value = "bad.example.com"
+        cs.on_button_pressed(FakeBtnPress("add_reject"))
+        await pilot.pause()
+        # Edge branches: empty input is a no-op; Enter in the input adds too.
+        cs.query_one("#reject_input", Input).value = ""
+        cs._add_rejected_domain()
+        assert cs._rejected_domains == ["bad.example.com"]
+        rinp = cs.query_one("#reject_input", Input)
+        rinp.value = "extra.example.com"
+        cs.on_input_submitted(Input.Submitted(input=rinp, value=rinp.value))
+        await pilot.pause()
+        assert cs._rejected_domains == ["bad.example.com", "extra.example.com"]
+        # Remove with nothing highlighted is a no-op; then remove index 0.
+        cs.query_one("#reject_list", OptionList).highlighted = None
+        cs.on_button_pressed(FakeBtnPress("rm_reject"))
+        assert cs._rejected_domains == ["bad.example.com", "extra.example.com"]
+        cs.query_one("#reject_list", OptionList).highlighted = 0
+        cs.on_button_pressed(FakeBtnPress("rm_reject"))
+        await pilot.pause()
+        assert cs._rejected_domains == ["extra.example.com"]
+        # Create from a shorter pane so #create is in view (#1891).
+        tabs.active = "advanced_pane"
+        await pilot.pause()
+        assert await pilot.click("#create")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+    assert captured["k"]["rejected_domains"] == ["extra.example.com"]
+
+
+async def test_edit_screen_rejected_domains_editor(monkeypatch):
+    """#2386: the edit form's rejected-domains editor (add/remove/edit) reaches
+    the PUT body, and the focus-aware Delete/Edit dispatches to the reject list."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = _wsobj("alpha", running=False, rejected_domains=["old.example.com"])
+    captured = {}
+
+    def fake_update(*a, **k):
+        captured["k"] = k
+
+    app = KlangkApp(_edit_state(ws, update=fake_update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        assert es._rejected_domains == ["old.example.com"]
+        tabs = es.query_one("#form_tabs", TabbedContent)
+        tabs.active = "netfilter_pane"
+        await pilot.pause()
+        # Edit-in-place: 'e' on the focused reject list loads the entry.
+        rl = es.query_one("#reject_list", OptionList)
+        rl.highlighted = 0
+        rl.focus()
+        await pilot.pause()
+        # Focus-aware dispatch: _list_handlers picks the reject pair when the
+        # reject list owns focus; 'e' then runs _edit_rejected_domain.
+        assert es._list_handlers() == (
+            "_remove_rejected_domain",
+            "_edit_rejected_domain",
+        )
+        es.action_edit_item()
+        await pilot.pause()
+        assert es._editing_reject == 0
+        assert es.query_one("#reject_input", Input).value == "old.example.com"
+        es.query_one("#reject_input", Input).value = "new.example.com"
+        es.on_button_pressed(FakeBtnPress("add_reject"))  # Add replaces it
+        await pilot.pause()
+        assert es._rejected_domains == ["new.example.com"]
+        # Edge branches: empty input no-op; a CIDR is rejected; a plain append
+        # (no edit in progress) hits the append branch; Enter in the input adds.
+        es.query_one("#reject_input", Input).value = ""
+        es._add_rejected_domain()
+        assert es._rejected_domains == ["new.example.com"]
+        es.query_one("#reject_input", Input).value = "10.0.0.0/8"
+        es._add_rejected_domain()
+        assert es._rejected_domains == ["new.example.com"]  # CIDR rejected
+        erinp = es.query_one("#reject_input", Input)
+        erinp.value = "added.example.com"
+        es.on_input_submitted(Input.Submitted(input=erinp, value=erinp.value))
+        await pilot.pause()
+        assert es._rejected_domains == ["new.example.com", "added.example.com"]
+        # Remove/edit with nothing highlighted are no-ops; then button-remove.
+        es.query_one("#reject_list", OptionList).highlighted = None
+        es._remove_rejected_domain()
+        es._edit_rejected_domain()
+        assert es._rejected_domains == ["new.example.com", "added.example.com"]
+        es.query_one("#reject_list", OptionList).highlighted = 0
+        es.on_button_pressed(FakeBtnPress("rm_reject"))
+        await pilot.pause()
+        assert es._rejected_domains == ["added.example.com"]
+        # Delete (focus-aware) removes the focused reject entry.
+        es.query_one("#reject_list", OptionList).highlighted = 0
+        es.query_one("#reject_list", OptionList).focus()  # reclaim focus
+        await pilot.pause()
+        es.action_remove_item()
+        await pilot.pause()
+        assert es._rejected_domains == []
+        es.query_one("#save").scroll_visible()
+        await pilot.pause()
+        assert await pilot.click("#save")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+    assert captured["k"]["rejected_domains"] is None
+
+
 async def test_edit_screen_editor_add_buttons_clickable(monkeypatch):
     """Regression (#1891): same as the create-screen case but for the edit
     form — Add buttons inside each editor tab must be clickable and the
@@ -11029,6 +11183,8 @@ async def test_edit_screen_editor_add_buttons_clickable(monkeypatch):
         es.query_one("#allow_input", Input).value = "github.com:443"
         await pilot.pause()
         assert await pilot.click("#add_allow")
+        await pilot.pause()
+        es.query_one("#save").scroll_visible()
         await pilot.pause()
         assert await pilot.click("#save")
         await app.workers.wait_for_complete()


### PR DESCRIPTION
## Summary

Closes #2386 (blocked on #2367, merged). Mirrors the `allowed_domains` surface
end to end for `rejected_domains` so a user can manage the static deny-list
without hitting the API directly — across the TUI, the Flutter dialogs, and the
CLI.

## What changed

**TUI** (`src/klangk/klangk/cli/`):
- `workspace_form.py` — a second list editor (Rejected Domains) in the
  Netfilter pane of **both** the create + edit forms: render / add / remove,
  plus in-place edit (`_edit_rejected_domain`) on the edit form. The edit
  form's keyboard **Delete/'e' is now focus-aware** (`_list_handlers`): it
  dispatches to whichever of the two netfilter lists (allow or reject) owns
  focus, defaulting to allow. The create/edit builds thread `rejected_domains`;
  the edit form's restart-needed check compares it.
- `workspace_detail.py` — display `rejected_domains`.
- `tui/state.py` + `client.py` — `Workspace.rejected_domains` +
  `create_workspace` threading.

**CLI** (`klangk create/edit --reject`):
- `main.py` — `--reject` flag on both commands, flags-mode validation + body,
  and an interactive rejected-domains editing loop; added to
  `_CREATE_TIME_KEYS`.
- `mount.py` — `validate_allowed_domain_spec` gains `allow_cidr` (default
  `true`); `rejected_domains` passes `allow_cidr=False` — a CIDR is meaningless
  for a name-level NXDOMAIN deny-list (#2367), so it's rejected up front,
  matching the API.

**Flutter** (`src/frontend/lib/workspace/`):
- `create_workspace_dialog.dart` + `workspace_settings_panel.dart` — a
  rejected-domains editor mirroring allowed-domains (incl. the restart-needed
  comparison); submitted as `body['rejected_domains']`.
- `workspace_list_page.dart` — `validateAllowedDomainSpec` gains `allowCidr`;
  the unenforced-egress badge now also flags a `rejected_domains` set with
  netfilter disabled.

## Tests

Validator CIDR-rejection (Python + Dart), create/edit `--reject` flags +
interactive (add / remove / invalid-number), TUI form reject editor
(add / remove / edit + focus-aware dispatch + empty/no-highlight/CIDR/append
edge branches), client `from_json`/body, detail display, Flutter dialog body +
TextField counts. **Python 4864 passed / 100%; Flutter 173 passed.** Rebased
onto `main`.
