### PR TITLE
fix(egress): sidecar NFQUEUE overflow fail-fast + timed-allow retry test (#2399)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -727,6 +727,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   re-introducing the 5s window. Workspace teardown and klangkd shutdown are no
   longer gated on the 5s SIGKILL fallback per filtered workspace.
 
+- **Rate-limited egress connections now fail fast instead of hanging
+  (#2399).** A SYN past the network sidecar's NFQUEUE rate limit previously
+  fell through to the OUTPUT DROP policy, so `connect()` hung for
+  `tcp_syn_retries` (~127s) / a `curl --max-time` (exit 28) with no consent
+  request. The overflow is now REJECTed (tcp-reset) so the connection gets
+  ECONNREFUSED at once. Still fail-closed (denied); only the failure mode
+  changes. Normal consent holds are unaffected (a new SYN matches NFQUEUE
+  under the limit).
+
 - **`consent-decide` duration selector no longer shows two highlighted
   buttons at first render (#2360).** The first duration button ("once")
   grabbed initial focus on mount and rendered with the default focus

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -111,6 +111,15 @@ esac
 if [ -n "${KLANGKNETWORK_EGRESS_CONSENT_URL:-}" ]; then
   $IPT -A OUTPUT -m limit --limit 5/sec --limit-burst 20 \
     -j NFQUEUE --queue-num "${KLANGKNETWORK_EGRESS_NFQUEUE_NUM:-5139}"
+  # Fail-FAST on consent-queue overflow (#2399): a SYN past the rate limit
+  # above misses the NFQUEUE match and would otherwise fall through to the
+  # OUTPUT DROP policy -- a dropped SYN makes connect() hang for
+  # tcp_syn_retries (~127s) / a curl --max-time (exit 28) instead of failing,
+  # with NO consent request surfaced (the SYN never reached the consumer).
+  # REJECT (tcp-reset) the overflow so a rate-limited TCP connection gets
+  # ECONNREFUSED at once. Still fail-closed (denied); only the failure mode
+  # changes (hang -> fast). TCP only: the consent gate is the TCP SYN.
+  $IPT -A OUTPUT -p tcp -j REJECT --reject-with tcp-reset
 fi
 
 # --- nat OUTPUT: REDIRECT ALL :53 to the proxy, EXCEPT the proxy's own marked

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
@@ -35,6 +35,7 @@ from klangk.cli.tui.consent import (
     ConsentDeciderApp,
     DECISION_ALLOWED,
     DECISION_DENIED,
+    DURATION_5M,
     DURATION_FOREVER,
     DURATION_ONCE,
     DURATION_TILRESTART,
@@ -596,6 +597,77 @@ class TestConsentDecisionEndStates:
             assert "EXIT:7" in res1, (
                 f"the later connection should be refused fast (ECONNREFUSED) "
                 f"by the forever-deny REJECT rule, got: {res1!r}"
+            )
+        finally:
+            await ws_conn.close()
+
+    @pytest.mark.asyncio
+    async def test_timed_allow_persists_without_reprompting(
+        self, server, auth, workspace
+    ):
+        # #2399 Finding 1: a TIMED allow (5m/1h/5s) must cover a later
+        # connection to the same host WITHOUT re-prompting -- the same way a
+        # timed deny does. Unlike `forever` (covered by the in-session
+        # _FOREVER_HOSTS gate in _cb + the DNS path), a timed allow has NO
+        # Python gate: a new connection is covered ONLY by the learned
+        # iptables ACCEPT rule (top of OUTPUT, ahead of NFQUEUE) installed by
+        # allow(dst, None, ttl). This test pins that path.
+        ws_id = workspace
+        ws_conn = await ws_connect(server, auth, ws_id)
+        try:
+            container = _container_for_workspace(ws_id)
+            app = ConsentDeciderApp(
+                server_url=server["url"],
+                token=auth["token"],
+                workspace_id=ws_id,
+                workspace_name="timed-allow-test",
+                hold_timeout=_CONSENT_TIMEOUT,
+            )
+            async with app.run_test() as pilot:
+                await _wait_connected(app)
+                # 1st connection: held, then allowed for 5m (timed). A raw IP
+                # (1.1.1.1) is used so DNS/CDN rotation can't change the dst
+                # between connections -- a re-prompt here is unambiguously the
+                # learned ACCEPT rule failing to cover the 2nd SYN (#2399).
+                _trigger(container, "1.1.1.1", "/tmp/r_tallow_0.out")
+                rid = await _wait_for_request(app, "1.1.1.1")
+                app._decide_id(rid, DECISION_ALLOWED, DURATION_5M)
+                await _wait_resolved(app, rid)
+                await pilot.pause()
+                # Wait for the 1st curl to succeed (confirms the verdict was
+                # applied) and let the learned ACCEPT rule settle into OUTPUT
+                # before the 2nd curl: the rule installs in a worker thread
+                # that lags the decider's egress_resolved broadcast, so an
+                # instant 2nd SYN would race it.
+                res0 = await _wait_result(container, "/tmp/r_tallow_0.out")
+                assert "EXIT:0" in res0, (
+                    f"the allowed connection should succeed, got: {res0!r}"
+                )
+                await asyncio.sleep(2)
+                # 2nd connection: the timed-allow ACCEPT rule must pass it
+                # with NO new prompt. Watch the decider's in-memory pending
+                # set for a short window; a prompt here is the regression
+                # (#2399: the new SYN reached NFQUEUE because the learned
+                # ACCEPT did not cover it).
+                _trigger(container, "1.1.1.1", "/tmp/r_tallow_1.out")
+                prompted = False
+                deadline = time.time() + 8
+                while time.time() < deadline:
+                    if any(
+                        "1.1.1.1" in (r.dest_host or "")
+                        for r in app.controller.pending.values()
+                    ):
+                        prompted = True
+                        break
+                    await asyncio.sleep(0.3)
+                res1 = await _wait_result(container, "/tmp/r_tallow_1.out")
+            assert not prompted, (
+                "timed-allow must not re-prompt a later connection "
+                "(persistence is via the learned ACCEPT rule, #2399)"
+            )
+            assert "EXIT:0" in res1, (
+                f"the later connection should succeed under the timed-allow "
+                f"ACCEPT rule, got: {res1!r}"
             )
         finally:
             await ws_conn.close()


### PR DESCRIPTION
## Summary

Investigates #2399 (two egress-sidecar findings from the interactive-egress smoketest). **Finding 1 is not a bug; Finding 2 is not a standalone sidecar logic bug** — and ships the one real sidecar-side fix it surfaced plus a regression test for a previously-untested path.

Closes #2399 (the remaining, proxy-routed cause of Finding 2 is tracked by #2398).

## Finding 1 — timed allow DOES cover retries (smoketest signal is CDN DNS rotation)

Not a bug. A new e2e test (`test_timed_allow_persists_without_reprompting`) on a **fixed-IP** destination (`1.1.1.1`) passes deterministically (3/3). An iptables dump taken right before the 2nd SYN shows the learned rule correctly placed:

```
-A OUTPUT -d 1.1.1.1/32 -j ACCEPT        # learned, position 1 — ahead of NFQUEUE
...
-A OUTPUT -m limit --limit 5/sec --limit-burst 20 -j NFQUEUE --queue-num 5139
```

The smoketest's `allow/<timed>` within-retry `request(!)` **findings** are the upstream resolver (8.8.8.8) returning a **rotated CDN IP** for the 2nd curl — a different IP than the allow learned, so the per-IP ACCEPT doesn't cover it. That's the expected L3/L4 limitation (rules are per-IP, not per-name), which is why the smoketest already classified it a *finding*, not a mismatch. A timed allow and a timed deny are symmetric (both per-IP position-1 rules); `forever` is the only allow with an extra Python gate (`_FOREVER_HOSTS`), which is why it never re-prompts on rotation. The issue's "even for a fixed IP (1.1.1.1)" line did not reproduce.

## Finding 2 — not a sidecar logic bug; largely #2398 + a now-hardened failure mode

Couldn't reproduce an exit-28/no-request in a clean run. The focused e2e suite (concurrent holds) is CI-green at 100%, so this isn't a common sidecar logic bug. The intermittent symptom resolves to two causes:

1. **Proxy-routed decider phases** (multi-decider, snapshot) → **#2398**: the request is sent but never surfaces to the decider through the flaky TCP proxy → the sidecar holds to `HOLD_TIMEOUT` (120s) → curl aborts at `--max-time` (25s, exit 28).
2. **NFQUEUE rate-limit overflow** → a SYN past `-m limit --limit 5/sec --limit-burst 20 -j NFQUEUE` fell through to the OUTPUT **DROP** policy → `connect()` hung (~127s / curl exit 28) with no consent request (the SYN never reached the consumer).

## The fix (Finding 2, cause 2)

`src/containers/network/entrypoint.sh`: after the NFQUEUE rule, REJECT (tcp-reset) TCP that missed it, so a rate-limited connection gets ECONNREFUSED at once instead of hanging.

- Still **fail-closed** (denied); only the failure mode changes (hang → fast).
- **Inert in normal consent operation** — a new SYN matches NFQUEUE under the limit and never reaches the catch-all.
- TCP only (the consent gate is the TCP SYN); non-TCP still falls to DROP.

## Testing

- New `test_timed_allow_persists_without_reprompting` (fixed-IP, deterministic) pins the timed-allow retry path — previously untested.
- Consent e2e (`test_timed_allow...` + `test_forever_deny_persists...`) pass with the rebuilt sidecar image.
- Full network-sidecar e2e (10 tests, builds the image from source) passes.
- Full backend unit suite: `4863 passed`.

## Files

- `src/containers/network/entrypoint.sh` — overflow TCP → REJECT.
- `src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py` — new timed-allow retry test (+ `DURATION_5M` import).
- `docs/changes.md` — Fixed entry.

\#2399
