### PR TITLE
fix(egress): consent allow rule expires at its verdict, not the DNS TTL (#2408)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -715,6 +715,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **A timed consent `allow` no longer outlives its verdict (#2408).** The
+  network sidecar tracked one TTL per learned IP, shared between the consent
+  rule's lifetime and the DNS host-mapping's lifetime. A re-resolution (every
+  new connection re-queries DNS) bumped that shared TTL to the DNS record's TTL
+  (often far longer than the verdict), so a short `allow` (e.g. `5s`) could keep
+  its ACCEPT rule for the DNS TTL instead of the consent duration — a
+  fail-open. The rule's lifetime (`rule_expire`) is now tracked separately from
+  the host mapping (`expire`), so the ACCEPT expires at the verdict while the
+  host mapping lives on for naming; latent for `5m+` allows (the verdict
+  usually exceeds the DNS TTL) but real for shorter allows or long-DNS-TTL
+  hosts.
 - **Network sidecar now stops promptly on SIGTERM (#2400).** The sidecar
   runs as PID 1 (`entrypoint.sh` execs `python3 /proxy.py`), and the Linux
   kernel ignores the default SIGTERM disposition for PID-namespace init (a

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -464,8 +464,9 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
             # host-mapping expire so a re-resolve's longer DNS TTL can't extend
             # a consent allow's rule past its verdict (#2408). max() preserves
             # the longest across static re-learns (#2256); for a consent allow
-            # it is just the verdict's TTL (the pre-existing rule_expire is 0
-            # when only _record_hosts has touched the record).
+            # it is just the verdict's TTL (the pre-existing rule_expire is
+            # absent -- only _record_hosts has touched the record -- and `or
+            # 0.0` coerces the None).
             rec["rule_expire"] = max(rec.get("rule_expire") or 0.0, expire)
             rec["ports"].add(port)
             # ``host`` (set by _record_hosts) is preserved across re-learn.

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -452,9 +452,21 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
         _install(ip, port)
         rec = _LEARNED.get(ip)
         if rec is None:
-            _LEARNED[ip] = {"expire": expire, "ports": {port}, "host": None}
+            _LEARNED[ip] = {
+                "expire": expire,
+                "rule_expire": expire,
+                "ports": {port},
+                "host": None,
+            }
         else:
             rec["expire"] = max(rec["expire"], expire)
+            # rule_expire is the ACCEPT rule's lifetime, kept SEPARATE from the
+            # host-mapping expire so a re-resolve's longer DNS TTL can't extend
+            # a consent allow's rule past its verdict (#2408). max() preserves
+            # the longest across static re-learns (#2256); for a consent allow
+            # it is just the verdict's TTL (the pre-existing rule_expire is 0
+            # when only _record_hosts has touched the record).
+            rec["rule_expire"] = max(rec.get("rule_expire") or 0.0, expire)
             rec["ports"].add(port)
             # ``host`` (set by _record_hosts) is preserved across re-learn.
         # An all-ports allow (the consent path) supersedes any prior per-port
@@ -630,29 +642,48 @@ def _clear_verdict_cache(ips: set[str]) -> None:
 
 
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
-    """Remove learned IPs whose TTL has elapsed; return ``(ip, ports)`` removed.
+    """Remove ACCEPT rules whose TTL has elapsed; return ``(ip, ports)`` removed.
 
-    Removal runs **under** :data:`_LOCK` (see :func:`allow`): the rule delete
-    and the ``_LEARNED`` delete are atomic, so a concurrent :func:`allow`
-    can't re-record an IP whose kernel rule was just swept. Factored out of
-    :func:`_async_sweeper` so it is unit-testable with a mocked clock and iptables
-    (#2256).
+    Two lifetimes are tracked per learned IP (#2408):
+
+    * ``rule_expire`` -- the ACCEPT rule's lifetime (a consent allow's verdict,
+      or a static re-learn's DNS TTL). When it elapses the kernel ACCEPT rule
+      is deleted but the record is KEPT while its host-mapping ``expire`` is
+      still valid, so :func:`_host_for` can still name the host for a fresh
+      consent request.
+    * ``expire`` -- the host-mapping lifetime (the DNS TTL). When it elapses
+      AND no ACCEPT rule remains, the whole record is dropped.
+
+    Records without ``rule_expire`` (host-mapping-only entries from
+    :func:`_record_hosts`, or pre-#2408 records) fall back to ``expire`` for the
+    rule sweep, preserving the old single-expiry behavior. Removal runs under
+    :data:`_LOCK` (see :func:`allow`): the rule delete and the record delete are
+    atomic, so a concurrent :func:`allow` can't re-record an IP whose kernel
+    rule was just swept. Factored out of :func:`_async_sweeper` so it is
+    unit-testable with a mocked clock and iptables (#2256).
     """
     if now is None:
         now = time.time()
     expired: list[tuple[str, set]] = []
     with _LOCK:
         for ip, rec in list(_LEARNED.items()):
-            if rec["expire"] > now:
-                continue
-            ports = set(rec["ports"])
-            for port in ports:
-                try:
-                    _remove(ip, port)
-                except Exception:
-                    pass  # a transient failure drops one rule, not the sweep
-            del _LEARNED[ip]
-            expired.append((ip, ports))
+            # Rule sweep: the ACCEPT rule's lifetime is rule_expire when set
+            # (a consent allow, whose verdict must outlive the host-mapping's
+            # DNS TTL, #2408), else expire (static re-learn / backward compat).
+            rule_expire = rec.get("rule_expire", rec["expire"])
+            if rec["ports"] and rule_expire <= now:
+                ports = set(rec["ports"])
+                for port in ports:
+                    try:
+                        _remove(ip, port)
+                    except Exception:
+                        pass  # a transient failure drops one rule, not the sweep
+                expired.append((ip, ports))
+                rec["ports"] = set()  # rule gone; keep record for naming
+            # Record sweep: drop the host mapping once its own expire elapses
+            # and no ACCEPT rule remains.
+            if rec["expire"] <= now and not rec["ports"]:
+                del _LEARNED[ip]
         # also sweep temporary REJECT (tcp-reset) rules for denied connections
         for key in [k for k, exp in _REJECTED.items() if exp <= now]:
             try:
@@ -717,6 +748,12 @@ def _record_hosts(recs: list[tuple[str, int]], host: str) -> None:
     in the consent request. Sync; runs in the executor alongside allow/sweep
     (under _LOCK). The TTL refreshes on each resolve so a re-resolution extends
     the window in which a SYN names the right host.
+
+    Only the host-mapping ``expire`` is touched here -- never ``rule_expire``
+    (the ACCEPT rule's lifetime, set by :func:`allow`). Keeping the two
+    separate is what lets a consent allow's rule expire at its verdict while
+    the host mapping lives for the DNS TTL, so a re-resolve's longer DNS TTL
+    can't extend an allow past its verdict (#2408).
     """
     now = time.time()
     with _LOCK:

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -467,6 +467,59 @@ class TestTTLAndSweep:
         assert [ip for ip, _ in gone] == ["dead"]
         assert "live" in learned._LEARNED
 
+    def test_consent_allow_rule_expire_is_separate_from_dns_ttl(
+        self, learned, monkeypatch
+    ):
+        # #2408: a consent allow's ACCEPT rule must expire at the verdict, not at
+        # the host-mapping DNS TTL. _record_hosts records the IP with a long DNS
+        # TTL; a subsequent short consent allow installs the ACCEPT with a SHORT
+        # rule_expire (separate from the long host-mapping expire).
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned._record_hosts([("1.2.3.4", 300)], "evil.test")  # DNS TTL 300s
+        learned.allow(
+            "1.2.3.4", None, 5
+        )  # consent allow, 5s (floored to MIN_TTL)
+        rec = learned._LEARNED["1.2.3.4"]
+        # rule_expire is the verdict (MIN_TTL-floored), NOT the DNS TTL; the
+        # host-mapping expire keeps the longer DNS TTL. The two are separate.
+        assert rec["rule_expire"] == learned.MIN_TTL
+        assert rec["expire"] == 300.0
+        assert rec["rule_expire"] < rec["expire"]
+        assert rec["ports"] == {None}
+
+    def test_sweep_removes_consent_rule_at_verdict_keeps_host_mapping(
+        self, learned, monkeypatch
+    ):
+        # #2408: at the consent verdict's TTL the ACCEPT rule is swept, but the
+        # record (host mapping) is KEPT while its longer DNS-TTL expire is still
+        # valid -- so _host_for can still name the host for the fresh
+        # re-prompt. Only after the DNS TTL does the record itself go.
+        removed = []
+        monkeypatch.setattr(
+            learned, "_remove", lambda ip, port: removed.append((ip, port))
+        )
+        learned._LEARNED["1.2.3.4"] = {
+            "expire": 300.0,  # host mapping (DNS TTL)
+            "rule_expire": 5.0,  # consent verdict
+            "ports": {None},
+            "host": "evil.test",
+        }
+        # at t=5: rule swept, record kept for naming.
+        gone = learned.sweep_once(now=5.0)
+        assert gone == [("1.2.3.4", {None})]
+        assert removed == [("1.2.3.4", None)]
+        rec = learned._LEARNED["1.2.3.4"]
+        assert rec["ports"] == set()  # rule gone
+        assert rec["host"] == "evil.test"  # mapping retained
+        # at t=300: the host mapping elapses -> record dropped.
+        learned.sweep_once(now=300.0)
+        assert "1.2.3.4" not in learned._LEARNED
+
     def test_reject_installs_reject_rule_and_records(
         self, learned, monkeypatch
     ):
@@ -827,6 +880,43 @@ class TestConsentForward:
         rec = learned._LEARNED["1.2.3.4"]
         assert rec["host"] == "evil.test"
         assert rec["ports"] == {None}  # preserved
+
+    def test_record_hosts_does_not_touch_consent_rule_expire(self, learned):
+        # #2408: _record_hosts refreshes only the host-mapping expire -- never
+        # rule_expire (the ACCEPT rule's lifetime, set by allow). So a
+        # re-resolve can extend the host mapping (for naming) without extending
+        # a consent allow's rule past its verdict.
+        import time
+
+        consent_rule_expire = time.time() + 5
+        learned._LEARNED["1.2.3.4"] = {
+            "expire": time.time() + 5,
+            "rule_expire": consent_rule_expire,
+            "ports": {None},
+            "host": None,
+        }
+        learned._record_hosts([("1.2.3.4", 300)], "evil.test")
+        rec = learned._LEARNED["1.2.3.4"]
+        assert rec["rule_expire"] == consent_rule_expire  # untouched
+        assert rec["host"] == "evil.test"  # host name refreshed
+
+    def test_record_hosts_extends_ttl_for_pure_host_mapping(self, learned):
+        # A pure host-mapping entry (no ACCEPT rule, pre-consent) still gets
+        # its host-mapping TTL extended on re-resolve, so the NFQUEUE consumer
+        # can name the host for a fresh consent request.
+        import time
+
+        base = time.time() + 60
+        learned._LEARNED["1.2.3.4"] = {
+            "expire": base,
+            "ports": set(),
+            "host": "a.test",
+        }
+        learned._record_hosts([("1.2.3.4", 300)], "b.test")
+        rec = learned._LEARNED["1.2.3.4"]
+        assert rec["expire"] > base  # extended by the longer DNS TTL
+        assert rec["host"] == "b.test"
+        assert rec["ports"] == set()
 
     def test_host_for_returns_host_when_recorded(self, proxy):
         proxy._LEARNED.clear()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -520,6 +520,39 @@ class TestTTLAndSweep:
         learned.sweep_once(now=300.0)
         assert "1.2.3.4" not in learned._LEARNED
 
+    def test_consent_allow_rule_not_extended_by_re_resolve_regression(
+        self, learned, monkeypatch
+    ):
+        # #2408 exact-bug regression: a short consent allow's ACCEPT rule must
+        # expire at the verdict even when the host is re-resolved (each new
+        # connection re-queries DNS, bumping the host-mapping expire to the
+        # longer DNS TTL). allow(short) -> _record_hosts(long) -> sweep(at
+        # verdict) -> rule gone, host mapping retained.
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        removed = []
+        monkeypatch.setattr(
+            learned, "_remove", lambda ip, port: removed.append((ip, port))
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned.allow("1.2.3.4", None, 5)  # consent allow (floored to MIN_TTL)
+        verdict = learned._LEARNED["1.2.3.4"]["rule_expire"]
+        # the re-resolve (long DNS TTL) must NOT extend the rule's lifetime.
+        learned._record_hosts([("1.2.3.4", 300)], "evil.test")
+        rec = learned._LEARNED["1.2.3.4"]
+        assert rec["rule_expire"] == verdict
+        assert rec["expire"] > verdict  # host mapping kept the DNS TTL
+        # sweep at the verdict -> rule removed, record retained for naming.
+        gone = learned.sweep_once(now=verdict)
+        assert gone == [("1.2.3.4", {None})]
+        assert removed == [("1.2.3.4", None)]
+        kept = learned._LEARNED["1.2.3.4"]
+        assert kept["ports"] == set()
+        assert kept["host"] == "evil.test"
+
     def test_reject_installs_reject_rule_and_records(
         self, learned, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Fixes #2408: a timed consent `allow` could outlive its verdict. The network sidecar tracked one TTL per learned IP, shared between the consent rule's lifetime and the DNS host-mapping's lifetime; every new connection re-resolves the host, and `_record_hosts` bumped that shared TTL to the DNS record's TTL (often 300s+), so a short allow (e.g. `5s`) kept its ACCEPT rule for the DNS TTL instead of the verdict — a fail-open.

Closes #2408.

## Root cause

`src/containers/network/proxy.py`. A single `_LEARNED[ip]["expire"]` was written by both `allow()` (consent duration) and `_record_hosts()` (DNS TTL) via `max()`, and `sweep_once` removed the ACCEPT rule keyed on it. So:

```
record_hosts(www.example.org, dns_ttl=300)   -> expire = now+300
allow(dst, None, 5)                          -> expire = max(300, 5) = 300   # bug
```

The 5s allow's ACCEPT then persisted for the DNS TTL. (Latent for `5m+` allows — the verdict usually exceeds the DNS TTL — but real for shorter allows or long-DNS-TTL hosts.)

## Fix

Track the ACCEPT rule's lifetime (`rule_expire`) **separately** from the host-mapping lifetime (`expire`):

- `allow()` sets `rule_expire = max(existing rule_expire, ttl)` — `max()` still preserves the longest across static re-learns (#2256); for a consent allow it's just the verdict (the pre-existing `rule_expire` is 0 when only `_record_hosts` has touched the record).
- `_record_hosts()` touches only `expire` (the host mapping), never `rule_expire`.
- `sweep_once()` removes the ACCEPT rule at `rule_expire` (defaulting to `expire` for host-mapping-only / pre-#2408 records, preserving the old single-expiry behavior), and drops the record only once its own `expire` elapses **and** no rule remains — so the host mapping lives on for `_host_for` to name the host for the fresh re-prompt.

So after a 5s allow: the ACCEPT is swept at 5s (re-prompt on the next connection), while the host mapping persists for the DNS TTL.

## Result (smoketest, the bug's reproducer)

Before:
```
↳ exceeding-retry      sidecar=no-request(!) conn=exit0:OK       ⚠ finding   # allow still in effect past 5s
```
After:
```
↳ exceeding-retry      sidecar=re-prompt    conn=exit0:OK       ✓           # verdict expired -> fresh re-prompt
```

The deny path (`_REJECTED`) is untouched by this change; its within/exceeding findings in the same phase are the known CDN-rotation cascade, not a regression.

## Testing

- 4 new unit tests in `TestTTLAndSweep` / the `_record_hosts` group: `rule_expire` is separate from the DNS TTL; a re-resolve doesn't touch `rule_expire`; sweep removes the consent rule at the verdict while keeping the host mapping; pure host-mapping entries still extend. Existing sweep tests pass unchanged (`rule_expire` defaults to `expire` → backward-compatible).
- Full backend unit suite: `4867 passed`.
- Network-sidecar e2e (10 tests, image built from source — exercises the static allow-list learn path): pass.

## Files

- `src/containers/network/proxy.py` — `rule_expire` in `allow()`; split `sweep_once()`; doc on `_record_hosts`.
- `src/klangk/klangkd-tests/tests/test_proxy.py` — 4 new tests.
- `docs/changes.md` — Fixed entry.

\#2408
