### PR TITLE
feat(egress): add "allow" egress mode (default-permit)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,18 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`egress_mode: "allow"` — default-permit egress (#2406).** A third
+  egress mode alongside `static` (default-deny) and `interactive`
+  (consent-gated). An `allow` workspace permits every host except names in
+  `rejected_domains` (NXDOMAIN'd at the sidecar DNS layer); off-list egress is
+  recorded through the consent pipeline for observability and auto-allowed
+  with no consent prompt, behaving as if an internal always-allow decider were
+  registered. External consent deciders are refused (as with `static`). The
+  network sidecar runs when one is configured (for logging + reject-list
+  enforcement) but degrades to plain unrestricted egress when filtering isn't
+  set up, so it never fail-closes. `klangk sandbox` now creates `allow`-mode
+  workspaces instead of the prior static-no-list-unrestricted degenerate case.
+
 - **`rejected_domains` in the TUI + Flutter workspace dialogs (#2386).** The
   static deny-list is now editable end to end, mirroring `allowed_domains`:
   the TUI create/edit forms (a second list editor in the Netfilter pane, with

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -249,7 +249,9 @@ class CreateWorkspaceRequest(BaseModel):
     allowed_domains: list[str] | None = None
     rejected_domains: list[str] | None = None
     settings: dict | None = None
-    egress_mode: Literal["static", "interactive"] = EGRESS_MODE_DEFAULT
+    egress_mode: Literal["static", "interactive", "allow"] = (
+        EGRESS_MODE_DEFAULT
+    )
 
 
 @router.post("/workspaces")
@@ -342,7 +344,7 @@ class UpdateWorkspaceRequest(BaseModel):
     # egress_mode (like allowed_domains) is enforced by the network
     # sidecar at container start, so a change here takes effect on the
     # next start/restart, not on the live container (PR #2248 review N3).
-    egress_mode: Literal["static", "interactive"] | None = None
+    egress_mode: Literal["static", "interactive", "allow"] | None = None
 
 
 @router.put("/workspaces/{workspace_id}")

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1891,13 +1891,17 @@ def sandbox(
             if resolve_setup_command(config, handle)
             else None,
             health_check=config.health_check,
-            # #2325: a sandbox is an automated install context (setup.sh runs
-            # npm/git/... that need unrestricted outbound network). Default
-            # workspaces are now interactive (hold every egress for consent),
-            # which would block the install with no decider present. Create the
-            # sandbox workspace as static so its egress is unrestricted -- the
-            # pre-#2325 behavior this automated path has always relied on.
-            egress_mode="static",
+            # #2325 / #2406: a sandbox is an automated install context
+            # (setup.sh runs npm/git/... that need unrestricted outbound
+            # network). Default workspaces are interactive (hold every egress
+            # for consent), which would block the install with no decider
+            # present. Create the sandbox workspace in ``allow`` mode so its
+            # egress is default-permit (installs proceed), with off-list
+            # destinations recorded through the consent pipeline for
+            # observability and rejected_domains still enforced. Allow mode
+            # degrades to plain unrestricted when the server has no network
+            # sidecar configured, so the sandbox keeps working everywhere.
+            egress_mode="allow",
         )
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
         created = True

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -44,6 +44,7 @@ from .model.egress_consent import (
     DURATION_FOREVER,
     DURATION_ONCE,
 )
+from .model.workspaces import EGRESS_MODE_ALLOW
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,31 @@ class ConsentCoordinator:
         """
         loop = asyncio.get_running_loop()
         try:
+            if await self._is_allow(workspace_id):
+                # #2406: egress_mode == allow is default-permit. Record the
+                # off-list destination (logging -- mirrors how static records
+                # a denial via record_static_denial) and allow at once -- no
+                # hold, no prompt. Behaves as if an internal always-allow
+                # decider were registered, but is a short-circuit branch (no
+                # decider object, no consent round-trip beyond the verdict).
+                # rejected_domains is enforced earlier at the sidecar DNS layer
+                # (rejected_for -> NXDOMAIN), so a host reaching this gate is
+                # already not rejected. duration=tilrestart (DURATION_DEFAULT)
+                # so the sidecar learns the IP all-ports for its lifetime (no
+                # per-connection re-prompt); nothing persists to
+                # allowed_domains (this branch bypasses resolve()).
+                await self.app.state.model.egress_consent.record_static_allow(
+                    workspace_id, dst, dport
+                )
+                fut = loop.create_future()
+                fut.set_result(
+                    {
+                        "decision": VERDICT_ALLOW,
+                        "reason": "allow_mode",
+                        "duration": DURATION_DEFAULT,
+                    }
+                )
+                return fut
             if await self._is_paused(workspace_id):
                 # #2332: prompting is paused workspace-wide. A destination
                 # with an in-effect recorded DENY is still blocked (the pause
@@ -769,3 +795,8 @@ class ConsentCoordinator:
     async def _is_interactive(self, workspace_id: str) -> bool:
         """Interactive iff the workspace opted in AND a live decider exists (#2308)."""
         return await workspace_is_interactive(self.app, workspace_id)
+
+    async def _is_allow(self, workspace_id: str) -> bool:
+        """egress_mode == allow: default-permit (record + allow, no prompt) (#2406)."""
+        ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
+        return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_ALLOW

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -8,7 +8,7 @@ import time
 
 from . import podman
 from . import workspace_settings as ws_settings
-from .model.workspaces import EGRESS_MODE_INTERACTIVE
+from .model.workspaces import EGRESS_MODE_ALLOW, EGRESS_MODE_INTERACTIVE
 from .podman import PodmanError
 
 logger = logging.getLogger(__name__)
@@ -2018,9 +2018,24 @@ class ContainerRegistry:
         # posture). Static mode with no lists stays unrestricted (no point
         # filtering nothing). Used by both the reconnect re-track below and
         # the create-path sidecar start further down.
-        needs_sidecar = egress_mode == EGRESS_MODE_INTERACTIVE or bool(
+        #
+        # #2406: ``allow`` mode requests permissiveness, not filtering -- it
+        # runs the sidecar WHEN one is configured (so off-list egress is logged
+        # via the consent pipeline and ``rejected_domains`` is enforced at the
+        # sidecar DNS layer), but degrades to unrestricted when filtering isn't
+        # set up. Fail-closing an allow-mode workspace would be wrong (it never
+        # asked to be locked down), so allow is best-effort, not mandatory --
+        # unlike interactive / list-declaring workspaces, which fail-closed.
+        sidecar_required = egress_mode == EGRESS_MODE_INTERACTIVE or bool(
             allowed_domains or rejected_domains
         )
+        sidecar_optional = (
+            egress_mode == EGRESS_MODE_ALLOW
+            and not sidecar_required
+            and self._network_sidecar_enabled()
+            and bool(self.app.state.settings.userns)
+        )
+        needs_sidecar = sidecar_required or sidecar_optional
 
         # Reuse a running container or remove a stopped one.
         if existing_container_id:
@@ -2172,39 +2187,45 @@ class ContainerRegistry:
         # for root too. Applied in the cap_add/cap_drop logic after this branch.
         drop_net_raw = False
         if needs_sidecar:
-            if not self._network_sidecar_enabled():
-                raise podman.PodmanError(
-                    500,
-                    f"workspace {workspace_id[:8]} is egress-filtered "
-                    "(interactive mode, or allowed_domains/rejected_domains "
-                    "set) but egress filtering is disabled "
-                    "(netfilter_enabled is off or network_sidecar_image is "
-                    "unset); refusing to start "
-                    "unfiltered. Switch the workspace to static mode with no "
-                    "lists, or enable egress filtering.",
-                )
-            # The #2264 SO_MARK-bypass guard is user-namespace isolation: the
-            # workspace must run in a user namespace DISTINCT from the one that
-            # owns the network sidecar's netns. The sidecar is launched with no
-            # --userns (podman's default), so an empty KLANGKD_USERNS here would
-            # emit no --userns either, putting the workspace in that same default
-            # userns and reopening the bypass (review #2). Fail-closed: require
-            # an explicit, non-empty userns. (Default keep-id:uid=1000,gid=1000
-            # satisfies this; pinned by test_filtered_workspace_userns_isolates_netns.)
-            if not self.app.state.settings.userns:
-                raise podman.PodmanError(
-                    500,
-                    f"workspace {workspace_id[:8]} is egress-filtered "
-                    "(interactive mode, or allowed_domains/rejected_domains "
-                    "set), which requires a "
-                    "non-empty "
-                    "KLANGKD_USERNS so the workspace runs in a user namespace "
-                    "distinct from the network sidecar's. An empty userns would "
-                    "share the sidecar's userns and reopen the SO_MARK egress "
-                    "bypass. Set KLANGKD_USERNS (default "
-                    "keep-id:uid=1000,gid=1000) or switch the workspace to "
-                    "static mode with no lists.",
-                )
+            # Interactive / list-declaring workspaces REQUEST filtering, so a
+            # missing/unstartable sidecar is fail-closed (silently starting
+            # unrestricted would disable a security control the user asked
+            # for). ``allow`` mode is best-effort (sidecar_optional already
+            # gated on these), so it never reaches this fail-close (#2406).
+            if sidecar_required:
+                if not self._network_sidecar_enabled():
+                    raise podman.PodmanError(
+                        500,
+                        f"workspace {workspace_id[:8]} is egress-filtered "
+                        "(interactive mode, or allowed_domains/rejected_domains "
+                        "set) but egress filtering is disabled "
+                        "(netfilter_enabled is off or network_sidecar_image is "
+                        "unset); refusing to start "
+                        "unfiltered. Switch the workspace to static mode with no "
+                        "lists, or enable egress filtering.",
+                    )
+                # The #2264 SO_MARK-bypass guard is user-namespace isolation: the
+                # workspace must run in a user namespace DISTINCT from the one that
+                # owns the network sidecar's netns. The sidecar is launched with no
+                # --userns (podman's default), so an empty KLANGKD_USERNS here would
+                # emit no --userns either, putting the workspace in that same default
+                # userns and reopening the bypass (review #2). Fail-closed: require
+                # an explicit, non-empty userns. (Default keep-id:uid=1000,gid=1000
+                # satisfies this; pinned by test_filtered_workspace_userns_isolates_netns.)
+                if not self.app.state.settings.userns:
+                    raise podman.PodmanError(
+                        500,
+                        f"workspace {workspace_id[:8]} is egress-filtered "
+                        "(interactive mode, or allowed_domains/rejected_domains "
+                        "set), which requires a "
+                        "non-empty "
+                        "KLANGKD_USERNS so the workspace runs in a user namespace "
+                        "distinct from the network sidecar's. An empty userns would "
+                        "share the sidecar's userns and reopen the SO_MARK egress "
+                        "bypass. Set KLANGKD_USERNS (default "
+                        "keep-id:uid=1000,gid=1000) or switch the workspace to "
+                        "static mode with no lists.",
+                    )
             network_sidecar_id = await self._start_network_sidecar(
                 workspace_id,
                 allowed_domains,

--- a/src/klangk/klangk/model/__init__.py
+++ b/src/klangk/klangk/model/__init__.py
@@ -63,6 +63,7 @@ from .workspaces import (
     SETUP_STATES,
     EGRESS_MODE_STATIC,
     EGRESS_MODE_INTERACTIVE,
+    EGRESS_MODE_ALLOW,
     EGRESS_MODE_DEFAULT,
     EGRESS_MODES,
 )
@@ -131,6 +132,7 @@ __all__ = (
     "SETUP_STATES",
     "EGRESS_MODE_STATIC",
     "EGRESS_MODE_INTERACTIVE",
+    "EGRESS_MODE_ALLOW",
     "EGRESS_MODE_DEFAULT",
     "EGRESS_MODES",
     # ports — constants + pure socket probe (re-exported via util too)

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -180,6 +180,57 @@ class EgressConsentModel:
             "decided_by": None,
         }
 
+    async def record_static_allow(
+        self,
+        workspace_id: str,
+        dest_host: str,
+        dest_port: int | None = None,
+    ) -> dict | None:
+        """Insert an allow-mode allow: permitted by policy, no human
+        (``decided_by`` NULL), immediately -- no pending state, no timeout.
+
+        ``allow`` egress mode (#2406) is default-permit: every off-list
+        destination is recorded (logged) + auto-allowed with no consent prompt,
+        mirroring how :meth:`record_static_denial` records a static mode denial.
+        Dedup: at most one allow-mode row per (workspace, host, port) via
+        ``idx_egress_consent_static_allow_dedup`` (INSERT OR IGNORE), so a
+        flooding workspace can't spam allow rows. Returns the row, or None if
+        one already exists.
+        """
+        request_id = str(uuid.uuid4())
+        now = time.time()
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "INSERT OR IGNORE INTO egress_consent"
+                " (id, workspace_id, dest_host, dest_port,"
+                "  decision, requested_at, decided_at, decided_by)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    request_id,
+                    workspace_id,
+                    dest_host,
+                    dest_port,
+                    DECISION_ALLOWED,
+                    now,
+                    now,
+                    None,
+                ),
+            )
+            if cursor.rowcount == 0:
+                return None
+        return {
+            "id": request_id,
+            "workspace_id": workspace_id,
+            "dest_host": dest_host,
+            "dest_port": dest_port,
+            "pid": None,
+            "process_name": None,
+            "decision": DECISION_ALLOWED,
+            "requested_at": now,
+            "decided_at": now,
+            "decided_by": None,
+        }
+
     async def get_request(self, request_id: str) -> dict | None:
         """Get a single consent request by ID."""
         row = await self.app.state.db.fetchone(

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -475,6 +475,15 @@ async def init_db(db) -> None:
             ON egress_consent(workspace_id, dest_host, COALESCE(dest_port, -1))
             WHERE decision = 'denied' AND decided_by IS NULL
         """)
+        # At most one allow-mode allow per (workspace, host, port). Allow mode
+        # (#2406) permits off-list egress by policy with no human (decided_by
+        # NULL) + records it; dedup so a flooding workspace can't spam allow
+        # rows (mirrors the static-denial dedup above).
+        await db.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_egress_consent_static_allow_dedup
+            ON egress_consent(workspace_id, dest_host, COALESCE(dest_port, -1))
+            WHERE decision = 'allowed' AND decided_by IS NULL
+        """)
         # Migration: drop legacy role and workspace_access tables
         for table in ("user_roles", "roles", "workspace_access"):
             await db.execute(f"DROP TABLE IF EXISTS {table}")  # noqa: S608

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -59,13 +59,19 @@ SETUP_STATES = frozenset(
 
 # egress_mode values (#2239). 'static' = deny + record denied attempts (no
 # human prompt); 'interactive' = a pending request a human can allow/deny via
-# the consent-decide client (#2310). The default for NEW workspaces is
-# 'interactive' so consent-gated egress is on out of the box; set a workspace
-# to 'static' to opt back into silent deny + record.
+# the consent-decide client (#2310); 'allow' = default-permit -- every host is
+# reachable except names in rejected_domains (NXDOMAIN'd), off-list egress is
+# recorded (logged) + auto-allowed with no consent prompt (#2406). The default
+# for NEW workspaces is 'interactive' so consent-gated egress is on out of the
+# box; set a workspace to 'static' to opt back into silent deny + record, or
+# 'allow' for permit-with-deny-list.
 EGRESS_MODE_STATIC = "static"
 EGRESS_MODE_INTERACTIVE = "interactive"
+EGRESS_MODE_ALLOW = "allow"
 EGRESS_MODE_DEFAULT = EGRESS_MODE_INTERACTIVE
-EGRESS_MODES = frozenset({EGRESS_MODE_STATIC, EGRESS_MODE_INTERACTIVE})
+EGRESS_MODES = frozenset(
+    {EGRESS_MODE_STATIC, EGRESS_MODE_INTERACTIVE, EGRESS_MODE_ALLOW}
+)
 
 # Whitelisted sort columns for workspace list queries. Values are the
 # real column names; the prefix (e.g. "w.") is applied by the caller.

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -108,7 +108,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
             return
         if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
             await websocket.close(
-                code=4003, reason="workspace egress mode is static"
+                code=4003, reason="workspace egress mode is not interactive"
             )
             return
 

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4221,10 +4221,13 @@ class TestSandboxCommand:
         client.create_workspace.assert_called_once()
         call_kwargs = client.create_workspace.call_args
         assert call_kwargs[0][0] == "myws"
-        # #2325: a sandbox is an automated install context needing unrestricted
-        # egress, so it creates a STATIC workspace (interactive would hold every
-        # install connection for consent with no decider present).
-        assert call_kwargs[1]["egress_mode"] == "static"
+        # #2325 / #2406: a sandbox is an automated install context needing
+        # unrestricted egress, so it creates an ALLOW-mode workspace
+        # (default-permit: installs proceed, off-list egress logged, no consent
+        # decider needed; degrades to plain unrestricted if the server has no
+        # network sidecar). Interactive would hold every install connection for
+        # consent with no decider present.
+        assert call_kwargs[1]["egress_mode"] == "allow"
         assert "Creating workspace" in result.output
         assert "klangk shell" in result.output
 

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -61,6 +61,7 @@ def _app(
     egress_consent.count_pending = AsyncMock(return_value=count_pending)
     egress_consent.create_request = AsyncMock(return_value=request)
     egress_consent.record_static_denial = AsyncMock(return_value=_denial())
+    egress_consent.record_static_allow = AsyncMock(return_value=_allow())
     egress_consent.decide = AsyncMock(return_value=decide_row)
     egress_consent.expire_pending = AsyncMock(return_value=True)
     egress_consent.list_requests = AsyncMock(return_value=pending_rows or [])
@@ -109,6 +110,18 @@ def _denial():
         "dest_host": "1.2.3.4",
         "dest_port": 443,
         "decision": "denied",
+        "decided_by": None,
+    }
+
+
+def _allow():
+    """A recorded allow-mode allow row (mirrors :func:`_denial`) (#2406)."""
+    return {
+        "id": "aid",
+        "workspace_id": FULL_WS,
+        "dest_host": "1.2.3.4",
+        "dest_port": 443,
+        "decision": "allowed",
         "decided_by": None,
     }
 
@@ -371,6 +384,41 @@ class TestConsentCoordinatorGate:
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
         assert fut.result()["reason"] == "static"
+
+    async def test_allow_mode_records_and_allows_at_once(self):
+        # #2406: egress_mode == allow is default-permit. It records the
+        # off-list destination (logging) and allows at once -- no hold, no
+        # prompt -- behaving as if an internal always-allow decider were
+        # registered. rejected_domains is enforced earlier at the sidecar
+        # DNS layer, not here.
+        app = _app(egress_mode="allow", has_decider=False)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = fut.result()
+        assert verdict["decision"] == "allow"
+        assert verdict["reason"] == "allow_mode"
+        # tilrestart so the sidecar learns the IP for its lifetime (no
+        # per-connection re-prompt).
+        assert verdict["duration"] == "tilrestart"
+        app.state.model.egress_consent.record_static_allow.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 443
+        )
+        app.state.model.egress_consent.create_request.assert_not_awaited()
+        app.state.model.egress_consent.record_static_denial.assert_not_awaited()
+        assert coord._holds == {}
+
+    async def test_allow_mode_ignores_presence_of_decider(self):
+        # A registered external decider is irrelevant to allow mode (allow
+        # mode refuses deciders; it auto-allows). Even with a live decider
+        # present, the gate short-circuits to allow + record, never holding.
+        app = _app(egress_mode="allow", has_decider=True, request=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = fut.result()
+        assert verdict["decision"] == "allow"
+        assert verdict["reason"] == "allow_mode"
+        app.state.model.egress_consent.create_request.assert_not_awaited()
+        assert coord._holds == {}
 
     async def test_rate_limited_denies_without_hold(self):
         app = _app(count_pending=50, rate_limit=50, request=_request())

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -316,7 +316,21 @@ class TestConsentDeciderWS:
         app = _ws_app({"id": "u1", "email": "a@x"}, egress_mode="static")
         ws = _FakeWS({"token": "tok", "workspace": WS}, [])
         await handle_consent_decider(ws, app)
-        assert ws.closed == (4003, "workspace egress mode is static")
+        assert ws.closed == (4003, "workspace egress mode is not interactive")
+        assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_allow_workspace_scoped_decider_is_forbidden(self):
+        # #2406: an allow-mode workspace is default-permit and auto-allows
+        # off-list egress (no consent prompt), so it must refuse a
+        # workspace-scoped consent decider at registration just like static --
+        # the decider TUI must never offer to decide for an allow workspace.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"}, egress_mode="allow")
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4003, "workspace egress mode is not interactive")
         assert ws.accepted is False
         assert app.state.consent_deciders.has_decider(WS) is False
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1540,6 +1540,46 @@ class TestStartContainer:
         assert len(creates) == 1  # degraded to unrestricted, no sidecar
         assert workspace["id"] not in self.registry._ws_with_network_sidecar
 
+    async def test_allow_workspace_passes_rejected_domains_to_sidecar(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2406: allow mode is default-permit but rejected_domains is STILL
+        # enforced -- the reject list is NXDOMAIN'd at the sidecar DNS layer
+        # (proxy rejected_for), upstream of the consent allow path. Pin that an
+        # allow-mode workspace passes KLANGKNETWORK_EGRESS_REJECT into the
+        # sidecar env so the proxy can enforce it (a regression here would let
+        # allow mode silently drop the deny-list).
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                egress_mode="allow",
+                rejected_domains=["evil.com:443"],
+            )
+        assert len(creates) == 2  # sidecar + workspace
+        assert creates[0]["name"].startswith("klangk-net-")
+        assert "KLANGKNETWORK_EGRESS_REJECT=evil.com:443" in creates[0]["env"]
+        assert creates[1]["network"] == "container:net-cid"
+
     async def test_interactive_workspace_without_sidecar_image_refuses_to_start(
         self, workspace, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1428,6 +1428,118 @@ class TestStartContainer:
         assert not creates[0].get("network", "").startswith("container:")
         assert workspace["id"] not in self.registry._ws_with_network_sidecar
 
+    async def test_allow_workspace_starts_sidecar_when_configured(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2406: allow mode is default-permit but still runs the sidecar WHEN
+        # one is configured (so off-list egress is logged via the consent
+        # pipeline and rejected_domains is enforced at the sidecar DNS layer).
+        # The workspace runs --network container:<sidecar> like an interactive /
+        # list-filtered workspace.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "net-cid" if "klangk-net-" in name else "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                egress_mode="allow",
+            )
+        assert len(creates) == 2  # sidecar + workspace
+        assert creates[0]["name"].startswith("klangk-net-")
+        assert creates[1]["network"] == "container:net-cid"
+        # Tracked so a later stop tears the sidecar down.
+        assert workspace["id"] in self.registry._ws_with_network_sidecar
+
+    async def test_allow_workspace_degrades_to_unrestricted_without_sidecar(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2406: allow mode requests permissiveness, not filtering, so it NEVER
+        # fail-closes -- unlike interactive / list-declaring workspaces. With
+        # the sidecar image unset it degrades to plain unrestricted (one
+        # container, no sidecar), the same surface a static-no-list workspace
+        # gets. This is what keeps `klangk sandbox` working on deployments
+        # without the network sidecar configured.
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "network_sidecar_image", ""
+        )
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                egress_mode="allow",
+            )
+        assert len(creates) == 1  # workspace only, no sidecar
+        assert not creates[0]["name"].startswith("klangk-net-")
+        assert not creates[0].get("network", "").startswith("container:")
+        assert workspace["id"] not in self.registry._ws_with_network_sidecar
+
+    async def test_allow_workspace_degrades_to_unrestricted_without_userns(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        # #2406: an empty userns would reopen the #2264 SO_MARK bypass for a
+        # FILTERED workspace, so interactive/lists fail-close on it. Allow
+        # mode instead degrades to unrestricted (no sidecar) -- it never asked
+        # to be filtered, so it does not insist on the sidecar's isolation.
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "test-net",
+        )
+        monkeypatch.setattr(self.registry.app.state.settings, "userns", "")
+        from klangk import netfilter as _nf_mod
+
+        monkeypatch.setattr(
+            _nf_mod, "_detect_host_resolvers", lambda: ["8.8.8.8"]
+        )
+        creates = []
+
+        async def _fake_create(name, image, **kw):
+            creates.append({"name": name, "image": image, **kw})
+            return "ws-cid"
+
+        with patch_podman(
+            self.registry, create_container=AsyncMock(side_effect=_fake_create)
+        ):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                egress_mode="allow",
+            )
+        assert len(creates) == 1  # degraded to unrestricted, no sidecar
+        assert workspace["id"] not in self.registry._ws_with_network_sidecar
+
     async def test_interactive_workspace_without_sidecar_image_refuses_to_start(
         self, workspace, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -17,6 +17,7 @@ from klangk.model.egress_consent import (
     DURATION_TILRESTART,
 )
 from klangk.model.workspaces import (
+    EGRESS_MODE_ALLOW,
     EGRESS_MODE_DEFAULT,
     EGRESS_MODE_INTERACTIVE,
 )
@@ -50,6 +51,16 @@ async def test_workspace_create_interactive_mode(ws, user):
     assert got["egress_mode"] == EGRESS_MODE_INTERACTIVE
 
 
+async def test_workspace_create_allow_mode(ws, user):
+    # #2406: "allow" is a valid egress_mode (default-permit).
+    row = await ws.create_workspace(
+        user["id"], "allow-mode", egress_mode=EGRESS_MODE_ALLOW
+    )
+    assert row["egress_mode"] == EGRESS_MODE_ALLOW
+    got = await ws.get_workspace(row["id"])
+    assert got["egress_mode"] == EGRESS_MODE_ALLOW
+
+
 async def test_workspace_create_invalid_egress_mode(ws, user):
     with pytest.raises(ValueError, match="Invalid egress_mode"):
         await ws.create_workspace(user["id"], "bad-mode", egress_mode="bogus")
@@ -71,6 +82,17 @@ async def test_workspace_update_egress_mode(ws, user):
     assert updated
     got = await ws.get_workspace(row["id"])
     assert got["egress_mode"] == EGRESS_MODE_INTERACTIVE
+
+
+async def test_workspace_update_egress_mode_to_allow(ws, user):
+    # #2406: a workspace can be switched to allow mode via update.
+    row = await ws.create_workspace(user["id"], "update-to-allow")
+    updated = await ws.update_workspace(
+        row["id"], user["id"], egress_mode=EGRESS_MODE_ALLOW
+    )
+    assert updated
+    got = await ws.get_workspace(row["id"])
+    assert got["egress_mode"] == EGRESS_MODE_ALLOW
 
 
 async def test_workspace_update_invalid_egress_mode(ws, user):
@@ -155,6 +177,40 @@ async def test_record_static_denial_dedup_per_destination(ec, ws, user):
     second = await ec.record_static_denial(w["id"], "evil.com", 443)
     assert first is not None
     assert second is None
+
+
+async def test_record_static_allow_inserts_allowed_no_human(ec, ws, user):
+    # #2406: allow mode records an off-list destination as allowed, no human,
+    # immediately (the logging side effect of default-permit egress).
+    w = await ws.create_workspace(user["id"], "static-allow-ws")
+    req = await ec.record_static_allow(w["id"], "registry.npmjs.org", 443)
+    assert req["decision"] == DECISION_ALLOWED
+    assert req["decided_by"] is None  # no human
+    assert req["decided_at"] is not None  # decided immediately
+    row = await ec.get_request(req["id"])
+    assert row["decision"] == DECISION_ALLOWED
+    assert row["decided_by"] is None
+
+
+async def test_record_static_allow_dedup_per_destination(ec, ws, user):
+    # One allow-mode allow per (workspace, host, port); a second returns None.
+    w = await ws.create_workspace(user["id"], "static-allow-dedup-ws")
+    first = await ec.record_static_allow(w["id"], "registry.npmjs.org", 443)
+    second = await ec.record_static_allow(w["id"], "registry.npmjs.org", 443)
+    assert first is not None
+    assert second is None
+
+
+async def test_record_static_allow_distinct_from_denial(ec, ws, user):
+    # The allow and denial static rows are independent (distinct dedup indexes):
+    # the same (workspace, host, port) can carry both an allow-mode allow and
+    # a static denial without colliding.
+    w = await ws.create_workspace(user["id"], "static-allow-vs-deny-ws")
+    allow = await ec.record_static_allow(w["id"], "dual.example", 443)
+    denial = await ec.record_static_denial(w["id"], "dual.example", 443)
+    assert allow is not None
+    assert denial is not None
+    assert allow["id"] != denial["id"]
 
 
 async def test_create_request_dedup_no_port(ec, ws, user):


### PR DESCRIPTION
## Summary

Implements #2406: a third `egress_mode` value **`allow`** alongside `static` and `interactive`.

An `allow` workspace is **default-permit**: every host connects except names in `rejected_domains` (NXDOMAIN'd at the sidecar DNS layer, upstream of consent). Off-list egress resolves, its SYN is gated at NFQUEUE, and the consent coordinator short-circuits to **record + allow** with no hold and no prompt — behaving as if an internal always-allow decider were registered, so it inherits `static`'s logging as a side effect. External consent deciders are refused (same non-interactive gate as `static`).

The network sidecar runs when one is configured (for logging + reject-list enforcement) but **degrades to plain unrestricted egress** when filtering isn't set up — `allow` requests permissiveness, not filtering, so it never fail-closes (unlike interactive / list-declaring workspaces). `klangk sandbox` now creates `allow`-mode workspaces instead of the prior static-no-list-unrestricted degenerate case.

No change to `static` or `interactive`; unset `egress_mode` keeps today's default (`interactive`).

## Changes

- `model/workspaces.py` + `__init__.py`: `EGRESS_MODE_ALLOW` constant, added to `EGRESS_MODES`, exported.
- `api/workspaces.py`: widened both create/update `Literal` schemas to `"allow"`.
- `model/egress_consent.py` + `schema.py`: `record_static_allow` (mirrors `record_static_denial`) + a parallel dedup index.
- `consent_coordinator.py`: `_is_allow` + an allow branch in `hold()` (mirrors the static record+deny branch, opposite verdict, `duration=tilrestart` so the sidecar learns each IP for its lifetime without persisting to `allowed_domains`).
- `container.py`: `sidecar_required` / `sidecar_optional` split so `allow` starts the sidecar best-effort (when configured + userns set) without triggering the interactive/lists fail-close.
- `cli/main.py`: `klangk sandbox` uses `egress_mode="allow"`.
- `docs/changes.md`: changelog entry.

No `proxy.py` change — the existing consent-hold path already routes off-list names to the coordinator, where the new branch fires; `rejected_for` already NXDOMAINs reject-list names first in both modes. The Dart frontend stores `egress_mode` as a string and treats any non-`interactive` value uniformly, so it degrades gracefully (no crash); the TUI has no egress-mode picker.

## Tests

11 new tests + 1 updated, covering: the coordinator allow branch (record + allow, ignores a present decider), `record_static_allow` (insert, dedup, distinct from denial), model validation (create/update accept `allow`), and the container sidecar gate (starts when configured; degrades to unrestricted without sidecar image or userns).

Full CI suite: **4893 passed, 100% coverage**; `ruff` clean.

Closes #2406.
