### PR TITLE
feat(egress): expose egress-mode picker in TUI + Flutter create/edit (#2409)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -44,6 +44,13 @@ operators or integrators to act when upgrading.
   set up, so it never fail-closes. `klangk sandbox` now creates `allow`-mode
   workspaces instead of the prior static-no-list-unrestricted degenerate case.
 
+- **Egress-mode picker in the TUI + Flutter create/edit dialogs (#2409).** The
+  workspace create and edit forms now expose an egress-mode selector
+  (allow / static / interactive, default `interactive`), so the mode is
+  settable from the clients rather than API-only; a change on a running
+  workspace applies on the next start/restart (both clients prompt). The
+  `allow` mode itself landed in #2406.
+
 - **`rejected_domains` in the TUI + Flutter workspace dialogs (#2386).** The
   static deny-list is now editable end to end, mirroring `allowed_domains`:
   the TUI create/edit forms (a second list editor in the Netfilter pane, with

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -392,7 +392,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                             ),
                             DropdownMenuItem(
                               value: 'allow',
-                              child: Text('allow (unrestricted)'),
+                              child: Text('allow (default-permit)'),
                             ),
                           ],
                           onChanged: (v) => setState(

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -72,6 +72,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _rejectedDomains = <String>[];
   bool _autoStart = false;
   bool _nixEnabled = false;
+  // #2409: per-workspace egress mode. 'interactive' is the server default for
+  // new workspaces (consent-gated egress on out of the box).
+  String _egressMode = 'interactive';
   String? _errorMessage;
   String? _mountError;
   String? _envError;
@@ -223,6 +226,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     if (_rejectedDomains.isNotEmpty) {
       body['rejected_domains'] = List<String>.from(_rejectedDomains);
     }
+    body['egress_mode'] = _egressMode;
     if (widget.allowAutostart && _autoStart) {
       body['auto_start'] = true;
     }
@@ -368,6 +372,34 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                       icon: Icons.shield,
                       title: 'Netfilter',
                       children: [
+                        DropdownButtonFormField<String>(
+                          initialValue: _egressMode,
+                          decoration: InputDecoration(
+                            labelText: 'Egress Mode',
+                            labelStyle: _labelStyle,
+                            floatingLabelStyle: _labelStyle,
+                            floatingLabelBehavior: FloatingLabelBehavior.always,
+                            border: const OutlineInputBorder(),
+                          ),
+                          items: const [
+                            DropdownMenuItem(
+                              value: 'interactive',
+                              child: Text('interactive (ask first)'),
+                            ),
+                            DropdownMenuItem(
+                              value: 'static',
+                              child: Text('static (deny + record)'),
+                            ),
+                            DropdownMenuItem(
+                              value: 'allow',
+                              child: Text('allow (unrestricted)'),
+                            ),
+                          ],
+                          onChanged: (v) => setState(
+                            () => _egressMode = v ?? 'interactive',
+                          ),
+                        ),
+                        const SizedBox(height: 16),
                         ..._buildAllowedDomainsEditor(),
                         const SizedBox(height: 16),
                         ..._buildRejectedDomainsEditor(),

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -231,6 +231,12 @@ bool _hasCreateTimeFieldChanged(
       prev['rejected_domains'], fields['rejected_domains'])) {
     return true;
   }
+  // egress_mode — the network sidecar is set up at container create
+  // time, so switching modes takes effect on the next start/restart (#2409).
+  if ((fields['egress_mode'] ?? 'interactive') !=
+      (prev['egress_mode'] ?? 'interactive')) {
+    return true;
+  }
   // nix — the per-workspace /nix mount is set up at container create
   // time, so toggling it won't take effect until restart (#2233). Only
   // compare when this save actually emitted a nix value (the toggle was
@@ -314,6 +320,8 @@ class _SettingsFormState extends State<_SettingsForm> {
   late Map<String, String> _envVars;
   late List<String> _allowedDomains;
   late List<String> _rejectedDomains;
+  // #2409: per-workspace egress mode, seeded from the workspace.
+  late String _egressMode;
   bool _autoStart = false;
   // #2233: per-workspace nix toggle (Mount /nix dir). Only meaningful
   // when the server has a nix backend (widget.nixAvailable).
@@ -375,6 +383,7 @@ class _SettingsFormState extends State<_SettingsForm> {
       (widget.workspace['rejected_domains'] as List?)?.cast<String>() ??
           <String>[],
     );
+    _egressMode = (widget.workspace['egress_mode'] as String?) ?? 'interactive';
     _autoStart = (widget.workspace['auto_start'] as bool?) ?? false;
     final settings =
         (widget.workspace['settings'] as Map<String, dynamic>?) ?? {};
@@ -455,6 +464,11 @@ class _SettingsFormState extends State<_SettingsForm> {
             <String>[],
       );
     }
+    if (old.workspace['egress_mode'] != widget.workspace['egress_mode']) {
+      // coverage:ignore-start
+      _egressMode =
+          (widget.workspace['egress_mode'] as String?) ?? 'interactive';
+    } // coverage:ignore-end
   }
 
   @override
@@ -516,6 +530,7 @@ class _SettingsFormState extends State<_SettingsForm> {
       'env': _envVars.isNotEmpty ? _envVars : null,
       'allowed_domains': _allowedDomains.isNotEmpty ? _allowedDomains : null,
       'rejected_domains': _rejectedDomains.isNotEmpty ? _rejectedDomains : null,
+      'egress_mode': _egressMode,
       if (widget.allowAutostart) 'auto_start': _autoStart,
       if (settings.isNotEmpty) 'settings': settings,
     });
@@ -811,6 +826,33 @@ class _SettingsFormState extends State<_SettingsForm> {
       icon: Icons.shield,
       title: 'Netfilter',
       children: [
+        DropdownButtonFormField<String>(
+          initialValue: _egressMode,
+          decoration: InputDecoration(
+            labelText: 'Egress Mode',
+            labelStyle: labelStyle,
+            floatingLabelBehavior: FloatingLabelBehavior.always,
+            border: const OutlineInputBorder(),
+          ),
+          items: const [
+            DropdownMenuItem(
+              value: 'interactive',
+              child: Text('interactive (ask first)'),
+            ),
+            DropdownMenuItem(
+              value: 'static',
+              child: Text('static (deny + record)'),
+            ),
+            DropdownMenuItem(
+              value: 'allow',
+              child: Text('allow (unrestricted)'),
+            ),
+          ],
+          onChanged: (v) => setState(
+            () => _egressMode = v ?? 'interactive',
+          ),
+        ),
+        const SizedBox(height: 16),
         _buildAllowedDomainsEditor(labelStyle),
         const SizedBox(height: 16),
         _buildRejectedDomainsEditor(labelStyle),

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -845,7 +845,7 @@ class _SettingsFormState extends State<_SettingsForm> {
             ),
             DropdownMenuItem(
               value: 'allow',
-              child: Text('allow (unrestricted)'),
+              child: Text('allow (default-permit)'),
             ),
           ],
           onChanged: (v) => setState(

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -107,7 +107,7 @@ void main() {
       expect(find.text('Cancel'), findsOneWidget);
       expect(find.text('Create'), findsOneWidget);
       expect(find.byType(TextField), findsNWidgets(11));
-      expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
+      expect(find.byType(DropdownButtonFormField<String>), findsNWidgets(2));
     });
 
     testWidgets('does not submit with empty name', (tester) async {
@@ -348,6 +348,43 @@ void main() {
       expect(find.text('/a:/b'), findsOneWidget);
     });
 
+    testWidgets(
+        'egress mode dropdown defaults to interactive and sends selection (#2409)',
+        (tester) async {
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'x', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog());
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      // Default selection is interactive (the server default).
+      expect(find.text('interactive (ask first)'), findsOneWidget);
+      // The egress-mode picker is the second DropdownButtonFormField
+      // (after the image picker in the General section).
+      final egressDropdown = find.byType(DropdownButtonFormField<String>).at(1);
+      await tester.ensureVisible(egressDropdown);
+      await tester.tap(egressDropdown);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('allow (unrestricted)').last);
+      await tester.pump();
+
+      await tester.enterText(_nameField(), 'Allow');
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(postedBody!['egress_mode'], 'allow');
+    });
+
     testWidgets('image dropdown changes selection', (tester) async {
       Map<String, dynamic>? postedBody;
       testAuthHttpClientOverride = mockClient((request) async {
@@ -366,8 +403,11 @@ void main() {
 
       // Open dropdown and select non-default (now near the dialog's
       // bottom after the field reordering, so scroll it into view first).
-      await tester.ensureVisible(find.byType(DropdownButtonFormField<String>));
-      await tester.tap(find.byType(DropdownButtonFormField<String>));
+      // The image picker is the first DropdownButtonFormField (the second
+      // is the egress-mode picker added in #2409).
+      final imageDropdown = find.byType(DropdownButtonFormField<String>).at(0);
+      await tester.ensureVisible(imageDropdown);
+      await tester.tap(imageDropdown);
       await tester.pumpAndSettle();
       await tester.tap(find.text('klangk-full').last);
       await tester.pump();

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -374,7 +374,7 @@ void main() {
       await tester.ensureVisible(egressDropdown);
       await tester.tap(egressDropdown);
       await tester.pumpAndSettle();
-      await tester.tap(find.text('allow (unrestricted)').last);
+      await tester.tap(find.text('allow (default-permit)').last);
       await tester.pump();
 
       await tester.enterText(_nameField(), 'Allow');

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1174,7 +1174,8 @@ void main() {
           find.descendant(
               of: find.byType(AlertDialog), matching: find.byType(TextField)),
           findsNWidgets(11));
-      expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
+      // Image picker + egress-mode picker (#2409).
+      expect(find.byType(DropdownButtonFormField<String>), findsNWidgets(2));
     });
 
     testWidgets('cancel button closes create dialog', (tester) async {
@@ -1635,9 +1636,12 @@ void main() {
       expect(find.text('Klangk'), findsWidgets);
 
       // Select non-default image (dropdown is near the dialog's bottom
-      // after the field reorder, so scroll it into view first).
-      await tester.ensureVisible(find.byType(DropdownButtonFormField<String>));
-      await tester.tap(find.byType(DropdownButtonFormField<String>));
+      // after the field reorder, so scroll it into view first). The image
+      // picker is the first DropdownButtonFormField (the second is the
+      // egress-mode picker added in #2409).
+      final imageDropdown = find.byType(DropdownButtonFormField<String>).at(0);
+      await tester.ensureVisible(imageDropdown);
+      await tester.tap(imageDropdown);
       await tester.pumpAndSettle();
       await tester.tap(find.text('klangk-custom').last);
       await tester.pumpAndSettle();

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -1217,6 +1217,97 @@ void main() {
     });
   });
 
+  group('egress mode (#2409)', () {
+    testWidgets('seeds the picker from the workspace and saves a change',
+        (tester) async {
+      Map<String, dynamic>? savedBody;
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/config') return http.Response(jsonEncode({}), 200);
+        if (p == '/api/v1/workspaces') {
+          return http.Response(
+            jsonEncode([
+              {
+                'id': _wsId,
+                'name': 'my-ws',
+                'image': 'klangk-pi',
+                'service_command': 'pi',
+                'mounts': <String>['/host:/cont'],
+                'env': <String, String>{'FOO': 'bar'},
+                'egress_mode': 'static',
+              }
+            ]),
+            200,
+          );
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi', 'other:latest'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+          savedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(jsonEncode({'status': 'updated'}), 200);
+        }
+        return http.Response('not found', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Seeded from the workspace (static), not the default interactive.
+      expect(find.text('static (deny + record)'), findsOneWidget);
+      // Open the egress picker and switch to allow.
+      await _scrollToAndTap(tester, find.text('static (deny + record)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('allow (unrestricted)').last);
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(savedBody, isNotNull);
+      expect(savedBody!['egress_mode'], 'allow');
+      // Drain the 2s auto-clear timer.
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+        'changing egress mode on a running container shows the restart notice',
+        (tester) async {
+      testAuthHttpClientOverride = _client(
+        workspace: {
+          ..._workspace,
+          'running': true,
+          'egress_mode': 'interactive',
+        },
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Switch interactive -> static (a create-time change).
+      await _scrollToAndTap(tester, find.text('interactive (ask first)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('static (deny + record)').last);
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(find.textContaining('Restart the workspace to apply'),
+          findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+  });
+
   group('auto start', () {
     testWidgets('hides the checkbox when auto-start is not allowed',
         (tester) async {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -1263,7 +1263,7 @@ void main() {
       // Open the egress picker and switch to allow.
       await _scrollToAndTap(tester, find.text('static (deny + record)'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('allow (unrestricted)').last);
+      await tester.tap(find.text('allow (default-permit)').last);
       await tester.pumpAndSettle();
 
       await _scrollToAndTap(tester, find.text('Save'));

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -176,6 +176,7 @@ class Workspace:
     health_check: str | None = None
     allowed_domains: list[str] | None = None
     rejected_domains: list[str] | None = None
+    egress_mode: str | None = None
     owner_email: str | None = None
     running: bool = False
     health: str | None = None
@@ -484,6 +485,7 @@ class KlangkClient:
             health_message=w.get("health_message"),
             allowed_domains=w.get("allowed_domains"),
             rejected_domains=w.get("rejected_domains"),
+            egress_mode=w.get("egress_mode"),
             service_started_at=w.get("service_started_at"),
             settings=w.get("settings"),
         )

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -65,7 +65,7 @@ EGRESS_MODE_DEFAULT = EGRESS_MODE_INTERACTIVE
 _EGRESS_MODE_OPTIONS = [
     (Text("interactive (ask first)"), EGRESS_MODE_INTERACTIVE),
     (Text("static (deny + record)"), EGRESS_MODE_STATIC),
-    (Text("allow (unrestricted)"), EGRESS_MODE_ALLOW),
+    (Text("allow (default-permit)"), EGRESS_MODE_ALLOW),
 ]
 
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -53,6 +53,22 @@ def _collect_settings(screen: Screen) -> dict | None:
     return settings or None
 
 
+# Egress-mode picker options for the create/edit Netfilter tab (#2409).
+# The CLI is an isolated client (AGENTS.md "CLI subpackage isolation") and
+# cannot import the server's EGRESS_MODE_* constants, so the mode strings are
+# duplicated here -- they are part of the public HTTP API contract
+# (api/workspaces.py CreateWorkspaceRequest / UpdateWorkspaceRequest).
+EGRESS_MODE_INTERACTIVE = "interactive"
+EGRESS_MODE_STATIC = "static"
+EGRESS_MODE_ALLOW = "allow"
+EGRESS_MODE_DEFAULT = EGRESS_MODE_INTERACTIVE
+_EGRESS_MODE_OPTIONS = [
+    (Text("interactive (ask first)"), EGRESS_MODE_INTERACTIVE),
+    (Text("static (deny + record)"), EGRESS_MODE_STATIC),
+    (Text("allow (unrestricted)"), EGRESS_MODE_ALLOW),
+]
+
+
 class CreateWorkspaceScreen(TabSkipMixin, Screen):
     """Full-screen workspace create form (parity with Flutter
     ``CreateWorkspaceDialog``).
@@ -83,6 +99,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         "nix",
         "mount_input",
         "env_input",
+        "egress_mode",
         "allow_input",
         "reject_input",
         "idle_timeout",
@@ -106,7 +123,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         "general_pane": "name",
         "mounts_pane": "mount_input",
         "env_pane": "env_input",
-        "netfilter_pane": "allow_input",
+        "netfilter_pane": "egress_mode",
         "resources_pane": "idle_timeout",
         "advanced_pane": "command",
     }
@@ -202,6 +219,15 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                     )
                     yield OptionList(id="env_list", classes="editor-list")
                 with TabPane("Netfilter", id="netfilter_pane"):
+                    yield Horizontal(
+                        Static("Egress mode"),
+                        Select(
+                            _EGRESS_MODE_OPTIONS,
+                            value=EGRESS_MODE_DEFAULT,
+                            id="egress_mode",
+                        ),
+                        classes="field-row",
+                    )
                     yield Static(
                         "Allowed Domains  "
                         "(host or host:port; empty = unrestricted)",
@@ -515,6 +541,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         env = dict(self._env) or None
         allowed_domains = list(self._allowed_domains) or None
         rejected_domains = list(self._rejected_domains) or None
+        egress_mode = self.query_one("#egress_mode", Select).value
         settings = _collect_settings(self)
         if self._nix_available and self.query_one("#nix", Checkbox).value:
             settings = {**(settings or {}), "nix": True}
@@ -530,6 +557,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                 allowed_domains,
                 rejected_domains,
                 settings,
+                egress_mode,
             ),
             exit_on_error=False,
         )
@@ -546,6 +574,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         allowed_domains,
         rejected_domains,
         settings,
+        egress_mode,
     ) -> None:
         try:
             ws = await asyncio.to_thread(
@@ -560,6 +589,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                 allowed_domains=allowed_domains,
                 rejected_domains=rejected_domains,
                 settings=settings,
+                egress_mode=egress_mode,
             )
         except AuthError:
             self.app.session_expired()
@@ -655,6 +685,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         "nix",
         "mount_input",
         "env_input",
+        "egress_mode",
         "allow_input",
         "reject_input",
         "idle_timeout",
@@ -678,7 +709,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         "general_pane": "name",
         "mounts_pane": "mount_input",
         "env_pane": "env_input",
-        "netfilter_pane": "allow_input",
+        "netfilter_pane": "egress_mode",
         "resources_pane": "idle_timeout",
         "advanced_pane": "command",
     }
@@ -715,6 +746,9 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         self._rejected_domains: list[str] = list(
             workspace.rejected_domains or []
         )
+        # #2409: the workspace's egress mode, seeded for the Netfilter
+        # picker. Falls back to the deploy default when unset.
+        self._egress_mode: str = workspace.egress_mode or EGRESS_MODE_DEFAULT
         # In-place editor state (#1778): when set, the next Add *replaces*
         # the item at this index/key instead of appending. Cleared on Add.
         self._editing_mount: int | None = None
@@ -795,6 +829,15 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
                     )
                     yield OptionList(id="env_list", classes="editor-list")
                 with TabPane("Netfilter", id="netfilter_pane"):
+                    yield Horizontal(
+                        Static("Egress mode"),
+                        Select(
+                            _EGRESS_MODE_OPTIONS,
+                            value=self._egress_mode,
+                            id="egress_mode",
+                        ),
+                        classes="field-row",
+                    )
                     yield Static(
                         "Allowed Domains  "
                         "(host or host:port; empty = unrestricted)",
@@ -1217,6 +1260,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         env = dict(self._env) or None
         allowed_domains = list(self._allowed_domains) or None
         rejected_domains = list(self._rejected_domains) or None
+        egress_mode = self.query_one("#egress_mode", Select).value
         settings = _collect_settings(self)
         # #2233: emit an explicit nix value (True/False) whenever the
         # toggle is shown. PUT settings is a full-replace bag, so we must
@@ -1241,6 +1285,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
             "env": env,
             "allowed_domains": allowed_domains,
             "rejected_domains": rejected_domains,
+            "egress_mode": egress_mode,
         }
         if settings is not None:
             body["settings"] = settings
@@ -1256,6 +1301,9 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
             or (command or None) != (ws.service_command or None)
             or allowed_domains != orig_domains
             or rejected_domains != orig_rejected
+            # #2409: egress_mode is a container-create-time field (it sets
+            # up --network container:<sidecar>), so a change needs a restart.
+            or egress_mode != (ws.egress_mode or EGRESS_MODE_DEFAULT)
             # #2233: the per-workspace /nix mount is set up at create
             # time, so toggling it on a running workspace needs a restart.
             or (

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -225,6 +225,7 @@ class TuiState:
         allowed_domains: list[str] | None = None,
         rejected_domains: list[str] | None = None,
         settings: dict | None = None,
+        egress_mode: str | None = None,
     ) -> Workspace:
         return self.client().create_workspace(
             name,
@@ -237,6 +238,7 @@ class TuiState:
             allowed_domains=allowed_domains,
             rejected_domains=rejected_domains,
             settings=settings,
+            egress_mode=egress_mode,
         )
 
     def update_workspace(self, workspace_id: str, **fields) -> None:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2105,6 +2105,7 @@ def test_tui_state_workspace_methods(monkeypatch, redirect_xdg):
         allowed_domains=None,
         rejected_domains=None,
         settings=None,
+        egress_mode=None,
     )
     fake.list_images.assert_called_once_with()
 
@@ -7387,6 +7388,36 @@ async def test_create_screen_renders_defaults(monkeypatch):
         assert cs.query_one("#image", Select).value == "base"  # server default
 
 
+async def test_create_screen_egress_mode_default_and_selectable(monkeypatch):
+    """#2409: the Netfilter tab has an egress-mode picker (interactive by
+    default), and the chosen mode reaches the create request body."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    captured = {}
+
+    def create(name, **k):
+        captured["k"] = k
+        return _wsobj(name)
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        # Default is interactive (the server default for new workspaces).
+        assert cs.query_one("#egress_mode", Select).value == "interactive"
+        # Switch to allow and submit; the selection reaches the request.
+        cs.query_one("#egress_mode", Select).value = "allow"
+        cs.query_one("#name").value = "ws"
+        cs._create()
+        await app.workers.wait_for_complete()
+        assert captured["k"]["egress_mode"] == "allow"
+
+
 async def test_create_screen_autostart_hidden_when_not_allowed(monkeypatch):
     async def noop(*a, **k):
         return None
@@ -8164,6 +8195,61 @@ async def test_edit_screen_allowed_domains_editor(monkeypatch):
         es.query_one("#allow_list").highlighted = 0
         es._remove_allowed_domain()
         assert es._allowed_domains == ["pypi.org:443"]
+
+
+async def test_edit_screen_egress_mode_pre_populates_and_saves(monkeypatch):
+    """#2409: the edit form seeds the picker from the workspace's current
+    egress_mode and sends a change through the update body."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    captured = {}
+
+    def update(wid, **f):
+        captured["id"] = wid
+        captured.update(f)
+
+    ws = _wsobj("alpha", egress_mode="static", running=False)
+    app = KlangkApp(_edit_state(ws, update=update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # Seeded from the workspace (static), not the default interactive.
+        assert es.query_one("#egress_mode", Select).value == "static"
+        es.query_one("#egress_mode", Select).value = "allow"
+        es._save()
+        await app.workers.wait_for_complete()
+        assert captured["egress_mode"] == "allow"
+        # Not running => no restart offer.
+        assert not isinstance(app.screen, ConfirmScreen)
+
+
+async def test_edit_screen_restart_needed_when_egress_mode_changed(
+    monkeypatch,
+):
+    """#2409: egress_mode is a container-create-time field, so changing it on
+    a running workspace offers a restart (parity with image/mounts)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    restarted = []
+    ws = _wsobj("alpha", egress_mode="interactive", running=True)
+    app = KlangkApp(
+        _edit_state(ws, restart=lambda *a, **k: restarted.append(a))
+    )
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#egress_mode", Select).value = "static"
+        es._save()
+        await app.workers.wait_for_complete()
+        assert isinstance(app.screen, ConfirmScreen)  # restart offered
 
 
 async def test_edit_screen_save_calls_update(monkeypatch):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1747,6 +1747,31 @@ class TestWorkspaceRoutes:
         assert data["name"] == "test-ws"
         assert "id" in data
 
+    async def test_create_with_allow_egress_mode(self, client, user):
+        # #2409: 'allow' is a valid egress_mode at create time and is
+        # persisted on the workspace.
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "allow-ws", "egress_mode": "allow"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["egress_mode"] == "allow"
+
+    async def test_create_with_unknown_egress_mode_rejected(
+        self, client, user
+    ):
+        # #2409: the Literal is allow/static/interactive; anything else is a
+        # 422 (pydantic validation), not a silent accept.
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "bad", "egress_mode": "permissive"},
+        )
+        assert resp.status_code == 422
+
     async def test_create_duplicate(self, client, user):
         headers = await _auth_headers(client)
         await client.post(
@@ -2485,6 +2510,35 @@ class TestWorkspaceRoutes:
         match = [w for w in resp.json() if w["id"] == ws_id]
         assert match[0]["name"] == "renamed"
         assert match[0]["service_command"] == "pi"
+
+    async def test_update_workspace_egress_mode(self, client, user):
+        # #2409: egress_mode is editable (PUT), taking effect on next start.
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "mode-ws"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        # Default is interactive; switch to allow, then static.
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"egress_mode": "allow"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["egress_mode"] == "allow"
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"egress_mode": "static"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["egress_mode"] == "static"
 
     async def test_update_workspace_allowed_domains(self, client, user):
         headers = await _auth_headers(client)


### PR DESCRIPTION
## Summary

Exposes an **egress-mode picker** (allow / static / interactive, default `interactive`) in the **TUI create/edit forms** and the **Flutter create + settings dialogs**, so the mode is settable from the clients. Closes #2409.

> **Re-scoped after #2411 landed.** While this branch was in review, #2411 merged the `allow` egress mode to the backend (model/container/api/decider) **and** added the `klangk create/edit --egress-mode` CLI flag. This PR was rebased onto that and reduced to **UI-only**: it drops the now-duplicated backend changes and keeps the TUI + Flutter pickers (which #2411 did not touch). The diff is 10 source/test files + the changelog.

Before this, a user could only set `egress_mode` via the API or the CLI flag; the TUI/Flutter forms baked in the `interactive` default with no control.

## Changes

**TUI (`klangk` CLI)**
- Egress-mode `Select` in the Netfilter pane of both the create and edit forms (`workspace_form.py`), default `interactive`, wired into Tab order + spatial navigation (no focus traps).
- Sent on create (`POST`) and update (`PUT`); a change on a running workspace offers a restart (egress mode is a container-create-time field).
- `egress_mode` added to the `Workspace` dataclass + `_workspace_from_json` so the edit form can show the current mode.

**Flutter**
- Egress-mode dropdown in `CreateWorkspaceDialog` (create) and `WorkspaceSettingsPanel` (edit), seeded from the workspace, sent on create/save.
- A running-workspace mode change now triggers the "Restart the workspace to apply" notice (`_hasCreateTimeFieldChanged`).

**Tests**
- TUI: picker default + selection reaches the create body; edit seeds from the workspace, saves, and offers a restart.
- Flutter: picker default + selection reaches the create body; settings seeds + saves; running-workspace change shows the restart notice.
- HTTP-layer coverage for the `egress_mode` create/update paths (the allow mode itself is covered by #2411's model/container/decider tests).

## Test results
Backend: **100% coverage**, 4906 passed. Flutter: 949 passed. (One pre-existing, unrelated flake — `test_edit_screen_editor_add_buttons_clickable`, a `pilot.click` timing race under `-n auto` — passes reliably in isolation.)

## Out of scope (noted, not addressed here)
- The TUI **detail** screen doesn't yet display the current egress mode (settable in the form, just not shown on the read-only view).
- `klangk` **archive export/import** doesn't round-trip `egress_mode` (`workspace_metadata` doesn't serialize it), so an imported workspace inherits the default. Pre-existing, surfaced by the fresh-eyes review of this PR.
