### PR TITLE
fix(egress): fail-fast off-list deny when the consent WS is down (#2413)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -771,6 +771,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   validating it against the allowed `EGRESS_MODES` (`static` |
   `interactive` | `allow`) and falling back to the deploy default on an
   unknown or missing value.
+- **Off-list egress fails fast when consent is unavailable (#2413).** When
+  the network sidecar's WebSocket to klangkd is down (a klangkd restart or a
+  proxy hiccup), off-list egress now fails fast with a connection refused
+  (forged RST + a short REJECT backstop) instead of hanging for the kernel's
+  ~127s SYN-retransmit window. On-list egress is unaffected (learned ACCEPT
+  rules sit above the NFQUEUE gate); the temporary deny is bounded by
+  `KLANGKNETWORK_EGRESS_REJECT_TTL` (default 10s), so no rule lingers past the
+  outage and fresh off-list egress prompts again once the sidecar reconnects.
 - **A timed consent `allow` no longer outlives its verdict (#2408).** The
   network sidecar tracked one TTL per learned IP, shared between the consent
   rule's lifetime and the DNS host-mapping's lifetime. A re-resolution (every

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -1402,8 +1402,27 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
         dst, port = tdst, tport
     else:  # non-TCP (UDP/other): no source port -> destination granularity
         dst, port = parse_dest(payload)
-    if not dst or client is None or not client.connected:
-        pkt.drop()  # unparseable / no consent / WS down -> fail-close
+    if not dst or client is None:
+        pkt.drop()  # unparseable / pure-static (no consent configured) -> drop
+        return
+    if not client.connected:
+        # Consent WS down: consent is unavailable, so fail the off-list SYN
+        # FAST (ECONNREFUSED) like a deny verdict -- NOT a bare drop. A bare
+        # drop makes the kernel retransmit the SYN for ~127s (tcp_syn_retries),
+        # dangling the connection (#2308: no consent available -> a clean,
+        # prompt denial, not a hang). Forge the eager-deny RST inline
+        # (non-blocking sendto) so THIS connect() gets ECONNREFUSED at once,
+        # + a short REJECT (tcp-reset) backstop off-loop so retransmits are
+        # RST'd above NFQUEUE, then drop. On-list egress is unaffected
+        # (learned ACCEPT rules sit above NFQUEUE); once the WS reconnects,
+        # fresh off-list egress prompts again. The REJECT TTL is short, so no
+        # rule lingers past the outage (#2413).
+        if port:
+            _send_rst(payload)
+            asyncio.get_running_loop().run_in_executor(
+                None, reject, dst, port, CONSENT_REJECT_TTL
+            )
+        pkt.drop()
         return
     flow = (src_ip, src_port, dst, port)
     now = time.time()

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -484,6 +484,7 @@ class SmokeTest:
         try:
             return start_server(
                 uds=False,
+                log_path=os.environ.get("SMOKE_KLANGKD_LOG") or None,
                 KLANGKD_JWT_SECRET="smoketest-egress-secret",
                 KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
                 KLANGKD_DEFAULT_USER="smoke@example.com",
@@ -1781,7 +1782,16 @@ class SmokeTest:
                     await self.run_fail_closed_phase(pilot)
             # run_test exited -> the decider WS dropped -> the server deregistered
             # the decider -> the workspace reverted to static allow-list (#2308).
+            # _shared_d2 (the multi-decider / snapshot raw decider) is a SEPARATE
+            # WS that outlives run_test (closed only in teardown) and never
+            # pings, so close it explicitly here -- otherwise it can still be
+            # live (within the 45s reap window) during the static phase,
+            # keeping the workspace interactive and producing a false "held"
+            # mismatch (#2413).
             if not stop and not self._abort and self.args.static_phase:
+                if self._shared_d2 is not None:
+                    await self._shared_d2.close()
+                    self._shared_d2 = None
                 await self.run_no_decider_phase(pilot)
         finally:
             await self.teardown()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1415,15 +1415,35 @@ class TestNfqueueCallback:
         await self._decide(proxy, pkt, client)
         assert pkt.verdict == "drop"
 
-    async def test_ws_down_drops_without_request(self, proxy, monkeypatch):
+    async def test_ws_down_fails_fast_not_hang(self, proxy, monkeypatch):
+        # WS down -> consent unavailable -> fail the off-list SYN FAST
+        # (ECONNREFUSED via a forged RST + a short REJECT backstop), not a
+        # bare drop the kernel retransmits for ~127s (#2308/#2413: no consent
+        # -> clean prompt denial, not a dangling connection). On-list egress
+        # is unaffected (learned ACCEPT rules sit above NFQUEUE).
         client = MagicMock()
         client.connected = False
         client.request = AsyncMock()
+        rejected = []
+        monkeypatch.setattr(
+            proxy,
+            "reject",
+            lambda ip, port, ttl: rejected.append((ip, port, ttl)),
+        )
+        rst = []
+        monkeypatch.setattr(
+            proxy, "_send_rst", lambda payload: rst.append(payload)
+        )
         self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
-        await self._decide(proxy, pkt, client)  # _cb drops inline (no task)
+        proxy._cb(pkt, client)  # _cb fails fast inline (no _BG_TASK)
+        await asyncio.sleep(0.05)  # let the off-loop REJECT install run
         assert pkt.verdict == "drop"
         client.request.assert_not_awaited()
+        assert rst  # eager-deny RST forged so connect() gets ECONNREFUSED
+        assert rejected == [
+            ("1.2.3.4", 443, proxy.CONSENT_REJECT_TTL)
+        ]  # retransmit backstop (above NFQUEUE)
 
     async def test_unparseable_dest_drops(self, proxy, monkeypatch):
         client = MagicMock()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1437,7 +1437,12 @@ class TestNfqueueCallback:
         self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         proxy._cb(pkt, client)  # _cb fails fast inline (no _BG_TASK)
-        await asyncio.sleep(0.05)  # let the off-loop REJECT install run
+        # poll (not a fixed sleep) for the off-loop REJECT install to land --
+        # robust under CI load; the RST is forged inline so it's already in.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 1.0
+        while not rejected and loop.time() < deadline:
+            await asyncio.sleep(0.01)
         assert pkt.verdict == "drop"
         client.request.assert_not_awaited()
         assert rst  # eager-deny RST forged so connect() gets ECONNREFUSED


### PR DESCRIPTION
## Summary

Fixes #2413.

**The reported "static-allow-list fallback not reverting cleanly" is not a product bug in the revert itself** — with no decider registered, off-list egress is denied cleanly (exit 7, sub-second). That was confirmed by the issue's own minimal repro and 7 full smoketest runs (seeds 7/11/42/99 + 3 random): the no-decider phase now passes reliably. Two real defects were found and fixed underneath the report.

## Fix 1 — off-list egress fails fast when the consent WS is down (the actual hang)

`src/containers/network/proxy.py`, `_cb`. When the sidecar's consent WebSocket to klangkd was down, the NFQUEUE callback did a bare `pkt.drop()` on the off-list SYN. A dropped SYN has no REJECT rule on a fresh host, so the kernel retransmits it for ~127s (`tcp_syn_retries`) — the connection **dangles** instead of failing. This is exactly the issue's "held, not denied … dangles rather than fails fast," and it's why on-list egress kept working throughout (learned ACCEPT rules sit above the NFQUEUE gate).

Now fail **fast**, mirroring the deny-verdict path: forge the eager-deny RST inline (non-blocking `sendto`) so *this* `connect()` gets `ECONNREFUSED` at once, and install a short REJECT (tcp-reset) backstop off-loop so retransmits are RST'd above NFQUEUE. Bounded by `KLANGKNETWORK_EGRESS_REJECT_TTL` (default 10s), so no rule lingers past the outage and fresh off-list egress re-prompts once the sidecar reconnects. Still fail-closed (blocked); only the failure mode changes (hang → prompt refused). The `#2308` "clean, prompt denial when consent is unavailable" guarantee now holds for the WS-down case too.

## Fix 2 — the smoketest leaked a raw decider into the no-decider phase (intermittent false mismatch)

`smoketest_egress.py`. `_shared_d2` (the multi-decider/snapshot raw decider) **never pings** and was closed only in `teardown()`, so it outlived `run_test` and could still be live (within the 45s reap window) during the no-decider phase — keeping the workspace interactive and producing the intermittent "static off-list held" mismatch. Close it explicitly before the phase so its premise ("no decider registered") actually holds.

## Result

```
--- no decider registered: off-list must be denied (static mode) ---
    ↳ static allow-list    sidecar=allowed      conn=exit0:OK       ✓
    ↳ static off-list      sidecar=denied       conn=exit7:REFUSED  ✓
    ↳ static off-list      sidecar=denied       conn=exit7:REFUSED  ✓
```
Reliable across seeds 7/11/42/99 + 3 random (was: intermittent `static off-list held(!)` mismatches).

## Testing

- New unit test `test_ws_down_fails_fast_not_hang` (replaces the old `test_ws_down_drops_without_request`): asserts the WS-down path forges the RST + installs the REJECT backstop (not a bare drop).
- Full backend unit suite: **4900 passed, 100% coverage**.
- Network-sidecar e2e (10 tests, image built from source with the fix): pass.
- Smoketest `--count 1 --snapshot --continue`: no-decider phase passes reliably across 6 runs.

The 2 mismatches that remain in a smoketest run are in the **snapshot phase** (`hold … no-request(!)` — "hold A+B"), which is the already-filed #2398 (TCP proxy flakes on concurrent holds / decider reconnect), not this issue.

## Files

- `src/containers/network/proxy.py` — `_cb` fail-fast on WS-down.
- `src/klangk/klangkd-tests/tests/test_proxy.py` — updated test.
- `src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py` — close `_shared_d2` before the no-decider phase; env-gated `SMOKE_KLANGKD_LOG` server-log diagnostic.
- `docs/changes.md` — Fixed entry.

\#2413
