### PR TITLE
fix(export/import): round-trip egress_mode (#2402)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -755,6 +755,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace export/import now round-trips `egress_mode` (#2402).** The
+  export endpoint previously omitted `egress_mode` from the serialized
+  metadata, and import did not read it, so a `static` (or `allow`)
+  workspace silently imported as the deploy default `interactive` —
+  starting a network sidecar and gating egress on consent with no
+  indication. Export now serializes `egress_mode`; import restores it,
+  validating it against the allowed `EGRESS_MODES` (`static` |
+  `interactive` | `allow`) and falling back to the deploy default on an
+  unknown or missing value.
 - **A timed consent `allow` no longer outlives its verdict (#2408).** The
   network sidecar tracked one TTL per learned IP, shared between the consent
   rule's lifetime and the DNS host-mapping's lifetime. A re-resolution (every

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -39,6 +39,7 @@ from ._common import get_app_dep
 from ..model import (
     ACTION_ALLOW,
     EGRESS_MODE_DEFAULT,
+    EGRESS_MODES,
     PRINCIPAL_GROUP,
     PRINCIPAL_USER,
 )
@@ -932,6 +933,14 @@ async def _extract_archive_metadata(
     else:
         env = None
 
+    # Preserve egress posture across export -> import (#2402). Validate
+    # against the allowed EGRESS_MODES; an unknown/missing value falls back
+    # to the deploy default so a tampered or stale archive cannot smuggle in
+    # a less restrictive posture than the instance ships with.
+    egress_mode = metadata.get("egress_mode")
+    if egress_mode not in EGRESS_MODES:
+        egress_mode = EGRESS_MODE_DEFAULT
+
     return {
         "name": ws_name,
         "image": image,
@@ -943,6 +952,7 @@ async def _extract_archive_metadata(
         "allowed_domains": metadata.get("allowed_domains"),
         "rejected_domains": metadata.get("rejected_domains"),
         "settings": metadata.get("settings"),
+        "egress_mode": egress_mode,
     }
 
 
@@ -1031,6 +1041,7 @@ async def import_workspace(
                 allowed_domains=allowed_domains,
                 rejected_domains=rejected_domains,
                 settings=settings,
+                egress_mode=meta["egress_mode"],
             )
         except SAIntegrityError:
             raise HTTPException(

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -206,6 +206,8 @@ class Workspaces:
             "rejected_domains": ws.get("rejected_domains"),
             "settings": ws.get("settings"),
             "num_ports": ws.get("num_ports", 5),
+            # Preserve egress posture across export -> import (#2402).
+            "egress_mode": ws.get("egress_mode"),
         }
 
     # --- path helpers (close over root) ---

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -7197,6 +7197,7 @@ class TestWorkspaceMetadata:
             "rejected_domains": None,
             "settings": None,
             "num_ports": 3,
+            "egress_mode": None,
         }
 
     def test_defaults_num_ports(self):
@@ -7709,6 +7710,96 @@ class TestWorkspaceExportImport:
         resp = await client.get("/api/v1/workspaces", headers=headers)
         match = [w for w in resp.json() if w["id"] == ws_id]
         assert match[0]["settings"] == {"idle_timeout": 300, "cpu_limit": 1.5}
+
+    async def test_export_serializes_egress_mode(
+        self, client, admin_user, user
+    ):
+        """egress_mode is included in the exported metadata (#2402)."""
+        import io
+        import json
+        import tarfile
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "egress-export", "egress_mode": "static"},
+        )
+        assert resp.status_code == 200
+        ws = resp.json()
+
+        admin_headers = await self._admin_headers(client)
+        export_resp = await client.get(
+            f"/api/v1/workspaces/{ws['id']}/export", headers=admin_headers
+        )
+        assert export_resp.status_code == 200
+
+        buf = io.BytesIO(export_resp.content)
+        with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+            metadata = json.loads(tar.extractfile("workspace.json").read())
+        assert metadata["egress_mode"] == "static"
+
+    async def test_import_roundtrips_egress_mode(self, client, user):
+        """egress_mode survives export -> import (#2402)."""
+        import io
+        import json
+        import tarfile
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps(
+                self._meta(name="egress-roundtrip", egress_mode="static")
+            ).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+        buf.seek(0)
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces/import",
+            headers=headers,
+            files={
+                "file": ("archive.tar.gz", buf.getvalue(), "application/gzip")
+            },
+        )
+        assert resp.status_code == 200
+        ws_id = resp.json()["id"]
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["egress_mode"] == "static"
+
+    async def test_import_invalid_egress_mode_falls_back(self, client, user):
+        """An unknown/missing egress_mode falls back to the deploy default."""
+        import io
+        import json
+        import tarfile
+
+        from klangk.model import EGRESS_MODE_DEFAULT
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps(
+                self._meta(name="egress-fallback", egress_mode="bogus")
+            ).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+        buf.seek(0)
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces/import",
+            headers=headers,
+            files={
+                "file": ("archive.tar.gz", buf.getvalue(), "application/gzip")
+            },
+        )
+        assert resp.status_code == 200
+        ws_id = resp.json()["id"]
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["egress_mode"] == EGRESS_MODE_DEFAULT
 
     async def test_import_notifies_importer(self, client, user, sockets):
         import io


### PR DESCRIPTION
## Summary

Workspace export/import dropped `egress_mode`, so a `static` (or `allow`)
workspace silently imported as the deploy default `interactive` — starting a
network sidecar and gating egress on consent with no indication. This is the
remaining round-trip path called out in #2402 (after #2397 fixed `clone` to
inherit `egress_mode`).

## Changes

- **Export** (`Workspaces.workspace_metadata`) now serializes `egress_mode`.
  This covers both `GET /workspaces/{id}/export` and `archive_user_data` (user
  data export), which share the metadata builder.
- **Import** (`_extract_archive_metadata`) reads `egress_mode` from the
  archive, validates it against `EGRESS_MODES` (`static` | `interactive` |
  `allow`), and falls back to `EGRESS_MODE_DEFAULT` on an unknown or missing
  value — so a tampered or stale archive can't smuggle in a posture the
  instance wouldn't otherwise allow.
- **Import** (`import_workspace`) passes the restored `egress_mode` through to
  `create_workspace`.

## Tests

Three new tests in `TestWorkspaceExportImport`:
- `test_export_serializes_egress_mode` — a `static` workspace exports with
  `egress_mode == "static"` in the archive metadata.
- `test_import_roundtrips_egress_mode` — a `static` archive imports as
  `static`.
- `test_import_invalid_egress_mode_falls_back` — an unknown `egress_mode`
  imports as the deploy default.

Full backend suite passes with 100% coverage.

Closes #2402.
