### PR TITLE
fix(smoketest): gate scored loop on sidecar consent-WS readiness (#2417)

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -94,6 +94,24 @@ _EDGE_VARIANTS = [  # exploratory: sidecar may canonicalize differently
     ("cloudflare.com.", "domain", True),
     ("www.Google.com", "domain", True),
 ]
+# Throwaway off-list hosts for the sidecar-readiness probe (#2417). Fresh (not
+# in the fuzz pool or any phase) so a probe can't perturb the run's model, and
+# enough of them that cycling back to one -- after a fail-close forged RST
+# installs a ~10s REJECT backstop on its IP -- lands well past that backstop.
+_SIDECAR_PROBE_HOSTS = [
+    "ietf.org",
+    "iana.org",
+    "w3.org",
+    "isc.org",
+    "openssl.org",
+    "python.org",
+    "rust-lang.org",
+    "gnupg.org",
+]
+# Worst-case sidecar connect backoff (1->2->4->8->15s) plus margin for the
+# workspace JWT file to appear; the readiness probe retries fresh hosts across
+# this whole window before giving up.
+_SIDECAR_READY_BUDGET = 60.0
 _FUZZ_DURATIONS = [
     DURATION_ONCE,
     DURATION_5S,  # test-only (#2363); exercises timed within/exceeding at run speed
@@ -642,6 +660,53 @@ class SmokeTest:
             f"stop_on_mismatch={'no' if self.args.continue_run else 'yes'}\n"
         )
 
+    async def _wait_sidecar_ready(self, pilot) -> None:
+        """Gate the scored loop on the sidecar consent WS being wired (#2417).
+
+        ``_wait_connected`` only proves the *decider's* WS reached klangkd. The
+        sidecar's own consent-WS client -- a separate connection from inside the
+        container -- connects on its own backoff schedule, gated on the
+        workspace JWT file. If the scored loop starts before the sidecar WS is
+        up, an off-list SYN hits the NFQUEUE fail-close branch (forge RST + a
+        short REJECT backstop, #2415): no egress frame reaches the decider, so
+        the iteration scores a hard MISMATCH. Probe a throwaway off-list host
+        and retry until a request actually surfaces in the decider (proving
+        sidecar-WS -> coordinator -> decider are wired), then settle it with an
+        allow/once (releases just this SYN; no learned rule) so the probe can't
+        perturb the scored run.
+        """
+        print(
+            "verifying sidecar consent WS is wired before the scored loop ..."
+        )
+        deadline = time.time() + _SIDECAR_READY_BUDGET
+        attempt = 0
+        while time.time() < deadline:
+            host = _SIDECAR_PROBE_HOSTS[attempt % len(_SIDECAR_PROBE_HOSTS)]
+            canon = _canonical(host)
+            outfile = f"/tmp/smoke_ready_{attempt}.out"
+            _trigger(self.container, host, outfile)
+            # A wired sidecar holds the SYN and surfaces a request within ~1s;
+            # a fail-close forges the RST, so curl exits at once and no request
+            # ever arrives. A short window is enough either way.
+            rid = await _wait_for_request(self.app, canon, timeout=5.0)
+            if rid is not None:
+                self.app._decide_id(rid, DECISION_ALLOWED, DURATION_ONCE)
+                await pilot.pause()
+                await _wait_resolved(self.app, rid, timeout=15.0)
+                print(f"  sidecar wired (probe {host} surfaced a request)\n")
+                return
+            attempt += 1
+            print(
+                f"  probe {host}: no request yet (sidecar WS still "
+                f"connecting?); retrying ..."
+            )
+            await asyncio.sleep(0.5)
+        raise RuntimeError(
+            "sidecar consent WS did not surface a request within "
+            f"{_SIDECAR_READY_BUDGET:.0f}s; aborting before the scored loop "
+            "would mismatch (#2417)"
+        )
+
     # -- per-iteration -----------------------------------------------------
     async def _run_step(self, pilot, step: _Step) -> _Result:
         canon = _canonical(step.host)
@@ -680,7 +745,7 @@ class SmokeTest:
                     detail = "expected a request; connection hung (NFQUEUE/DNS, not a consent failure)"
                 else:
                     status = FINDING if expl else MISMATCH
-                    detail = "expected a request, none arrived (connection resolved cleanly)"
+                    detail = f"expected a request, none arrived (curl {_exit_label(ec)})"
                 return self._record(
                     _Result(
                         step,
@@ -889,8 +954,7 @@ class SmokeTest:
                     "no-request(!)",
                     ec,
                     status,
-                    "expected a re-prompt; none arrived but the "
-                    "connection resolved cleanly",
+                    f"expected a re-prompt; none arrived (curl {_exit_label(ec)})",
                 )
             # settle so the held request doesn't dangle: allow/once releases
             # just this SYN (ttl None -> no learn, no REJECT) so it can't
@@ -1743,6 +1807,7 @@ class SmokeTest:
                 await self.run_static_refusal_phase()
             async with self.app.run_test() as pilot:
                 await _wait_connected(self.app)
+                await self._wait_sidecar_ready(pilot)
                 for step in plan:
                     try:
                         res = await self._run_step(pilot, step)


### PR DESCRIPTION
## Summary

`smoketest_egress` started its scored off-list loop as soon as the **decider**
WS connected, but never waited for the **sidecar's** consent WS to be up. When
the sidecar WS wasn't connected yet, an off-list SYN hit the NFQUEUE fail-close
branch (forge RST + short REJECT backstop, #2415): no egress frame reached the
decider, so the iteration scored a hard `MISMATCH`. Intermittent — depends on
sidecar-WS connect timing vs. when the loop starts, so it passes most runs and
bites occasionally (e.g. iteration 2 of `--seed 47`).

Closes #2417.

## Changes

- **Gate the scored loop on sidecar readiness.** Before scoring, probe a
  throwaway off-list host and retry until a request actually surfaces in the
  decider (proving sidecar-WS → coordinator → decider are wired), then start
  the scored loop. A pool of fresh hosts avoids a fail-close's ~10s REJECT
  backstop swallowing a retry of the same IP; the probe is bounded (60s, the
  worst-case sidecar connect backoff + JWT-file margin) and raises rather than
  hangs if the sidecar truly can't connect. Uses an allow/once to settle the
  probe (no learned rule) so it can't perturb the run.
- **Correct the misleading `"connection resolved cleanly"` detail** — it was
  printed for any non-hang exit, including exit 7 (the forged RST) — to report
  the curl exit code.

## Verification

Ran the issue's repro locally (focused scored loop, optional phases off):

```
python src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py --count 25 --seed 47 --continue ...
```

- The readiness gate fires and confirms wiring:
  `verifying sidecar consent WS is wired ...` → `sidecar wired (probe ietf.org surfaced a request)`.
- The previously-failing iteration-2 `github.com` startup `MISMATCH` now passes.
- The corrected detail reads `expected a request, none arrived (curl exit7:REFUSED)`.

Residual mismatches sometimes seen later in a run (CDN IP-rotation verdict
carryover; sporadic mid-run sidecar-WS dropouts) are pre-existing flakiness with
real multi-IP hosts and are outside this issue's scope (the startup race this
fixes is distinct from a WS that flaps mid-run).

## Out of scope

- A server-side sidecar-liveness status endpoint (`SidecarConnections._conns`
  tracks liveness but exposes none) — deliberately avoided per the issue; the
  probe-and-wait needs no new endpoint.
