### PR TITLE
test(tui): make #save scroll deterministic before click in edit-screen tests

### DIFF
--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -11223,7 +11223,11 @@ async def test_edit_screen_rejected_domains_editor(monkeypatch):
         es.action_remove_item()
         await pilot.pause()
         assert es._rejected_domains == []
-        es.query_one("#save").scroll_visible()
+        # animate=False: scroll_visible() animates by default, and a single
+        # pilot.pause() doesn't reliably complete the scroll animation before
+        # the click — the button stays below the fold and the click misses.
+        # Deterministic on the slower-scheduled macOS runner (see #2426).
+        es.query_one("#save").scroll_visible(animate=False)
         await pilot.pause()
         assert await pilot.click("#save")
         await app.workers.wait_for_complete()
@@ -11270,7 +11274,9 @@ async def test_edit_screen_editor_add_buttons_clickable(monkeypatch):
         await pilot.pause()
         assert await pilot.click("#add_allow")
         await pilot.pause()
-        es.query_one("#save").scroll_visible()
+        # animate=False so the scroll completes within one pilot.pause();
+        # the default animated scroll races the click (#2426).
+        es.query_one("#save").scroll_visible(animate=False)
         await pilot.pause()
         assert await pilot.click("#save")
         await app.workers.wait_for_complete()


### PR DESCRIPTION
Closes #2426.

## Root cause

The macOS-only `test_edit_screen_editor_add_buttons_clickable` failure was **not** a test-ordering issue (the original hypothesis). It is an **animated-scroll race** in the edit-screen `#save` click.

`run_test()` runs at the default **80×24**. The edit form (`edit_box`, `NonFocusableVerticalScroll`) is ~30 rows tall, so `#save` sits below the fold. The test scrolls it into view with:

```python
es.query_one("#save").scroll_visible()   # animated by default
await pilot.pause()
assert await pilot.click("#save")
```

`Widget.scroll_visible()` starts an **animated** scroll. Probing the scroll container across `pilot.pause()` cycles shows the offset stepping `0 → 4 → 8` — i.e. the scroll takes more than one pause to complete. `pilot.pause()` calls `wait_for_idle(0)`, which does **not** guarantee the scroll animation has drained:

- On **Linux** the animation usually completes within one pause (passes, but fragile).
- On the **macOS runner** (slower scheduling / fewer vCPUs under `-n auto` contention) it reliably does **not** finish in one pause → `#save` stays below the fold → `pilot.click("#save")` computes a click point off the visible region; `get_widget_at` returns a different widget and the click returns `False` (the `assert False` in CI). Deterministic on macOS, passes on Linux — exactly the observed signature.

The sibling create-screen test never failed because it ends on `pilot.click("#create")` and never calls `scroll_visible()` (its tab sequence leaves `#create` in view).

## Fix

`scroll_visible()` here is **test scaffolding** (production never calls it), so the fix is test-only: scroll with `animate=False`, eliminating the animation so one `pilot.pause()` deterministically brings `#save` into view. Applied at both sites with this pattern:

- `test_edit_screen_editor_add_buttons_clickable` (the failing test)
- `test_edit_screen_rejected_domains_editor` (same latent race)

## Verification

- `scroll_visible(animate=False)` lands `#save` at region.y=20 (fully on-screen) in one pause, 5/5 reps.
- Full backend suite: **4909 passed, 100% coverage** (`test-backend`).
- Ruled out: not flaky (3 identical macOS reruns), not a textual/dep regression (resolved set byte-identical to the green Aug-12 run; `textual==8.2.8`), not a Linux regression (Linux `Backend Tests` passed the same commit).

See the updated issue #2426 for the full investigation.
