### PR TITLE
feat: configurable /tmp size on workspace creation (#2378)

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -28,10 +28,15 @@ jobs:
               - 'scripts/lcov-report.py'
               - '.github/workflows/frontend-tests.yml'
 
+      # Pin Flutter to the nixpkgs version (devenv ships 3.41.9) so CI and
+      # local dev run the same SDK. A stable bump to 3.47.0 changed the
+      # coverage tool's multi-line ternary attribution and broke the 100%
+      # gate (#2378); pinning here keeps them in lockstep. Bump alongside
+      # the nixpkgs Flutter when upgrading.
       - uses: subosito/flutter-action@v2
         if: steps.filter.outputs.frontend == 'true'
         with:
-          channel: stable
+          flutter-version: "3.41.9"
           cache: true
 
       - name: Create stub klangk_features package

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -41,6 +41,12 @@ operators or integrators to act when upgrading.
   resolve to single stable test IPs. Absent, behavior is unchanged (auto-detect).
   Mirrors the existing `KLANGKNETWORK_EGRESS_MIN_TTL` / `SWEEP_INTERVAL` forwarding.
 
+- **`KLANGKD_CONTAINER_TMP_SIZE` + `settings.tmp_size` (#2378).** The
+  per-workspace `/tmp` tmpfs size is now configurable (e.g. `2g`, `512m`);
+  the deploy default stays `2g` (the prior hardcoded value), so existing
+  installs are unchanged. Set the env var empty to mount `/tmp` with no
+  `size=` option (podman then sizes it at half of RAM). Exposed in the
+  Flutter create/settings dialogs and the TUI create/edit form.
 - **`egress_mode: "allow"` — default-permit egress (#2406).** A third
   egress mode alongside `static` (default-deny) and `interactive`
   (consent-gated). An `allow` workspace permits every host except names in

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -65,6 +65,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _cpuLimitController = TextEditingController();
   final _memoryLimitController = TextEditingController();
   final _pidsLimitController = TextEditingController();
+  final _tmpSizeController = TextEditingController();
   late String _selectedImage;
   final _mounts = <String>[];
   final _envVars = <String, String>{};
@@ -119,6 +120,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     _cpuLimitController.dispose();
     _memoryLimitController.dispose();
     _pidsLimitController.dispose();
+    _tmpSizeController.dispose();
     super.dispose();
   }
 
@@ -202,6 +204,8 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     if (mem.isNotEmpty) s['memory_limit'] = mem;
     final pids = _pidsLimitController.text.trim();
     if (pids.isNotEmpty) s['pids_limit'] = int.parse(pids);
+    final tmp = _tmpSizeController.text.trim();
+    if (tmp.isNotEmpty) s['tmp_size'] = tmp;
     return s;
   }
 
@@ -477,6 +481,25 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                                   hintText: 'e.g. 512',
                                 ),
                                 keyboardType: TextInputType.number,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextField(
+                                controller: _tmpSizeController,
+                                decoration: InputDecoration(
+                                  labelText: 'TMP Size',
+                                  labelStyle: _labelStyle,
+                                  floatingLabelStyle: _labelStyle,
+                                  floatingLabelBehavior:
+                                      FloatingLabelBehavior.always,
+                                  border: const OutlineInputBorder(),
+                                  hintText: 'e.g. 2g, 512m',
+                                ),
                               ),
                             ),
                           ],

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -492,7 +492,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                               child: TextField(
                                 controller: _tmpSizeController,
                                 decoration: InputDecoration(
-                                  labelText: 'TMP Size',
+                                  labelText: '/tmp size',
                                   labelStyle: _labelStyle,
                                   floatingLabelStyle: _labelStyle,
                                   floatingLabelBehavior:

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -942,7 +942,7 @@ class _SettingsFormState extends State<_SettingsForm> {
               child: TextField(
                 controller: _tmpSizeCtrl,
                 decoration: InputDecoration(
-                  labelText: 'TMP Size',
+                  labelText: '/tmp size',
                   labelStyle: labelStyle,
                   floatingLabelBehavior: FloatingLabelBehavior.always,
                   border: const OutlineInputBorder(),

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -315,6 +315,7 @@ class _SettingsFormState extends State<_SettingsForm> {
   late TextEditingController _cpuLimitCtrl;
   late TextEditingController _memoryLimitCtrl;
   late TextEditingController _pidsLimitCtrl;
+  late TextEditingController _tmpSizeCtrl;
   late String _selectedImage;
   late List<String> _mounts;
   late Map<String, String> _envVars;
@@ -400,6 +401,9 @@ class _SettingsFormState extends State<_SettingsForm> {
     _pidsLimitCtrl = TextEditingController(
       text: settings['pids_limit']?.toString() ?? '',
     );
+    _tmpSizeCtrl = TextEditingController(
+      text: (settings['tmp_size'] as String?) ?? '',
+    );
   }
 
   @override
@@ -484,6 +488,7 @@ class _SettingsFormState extends State<_SettingsForm> {
     _cpuLimitCtrl.dispose();
     _memoryLimitCtrl.dispose();
     _pidsLimitCtrl.dispose();
+    _tmpSizeCtrl.dispose();
     super.dispose();
   }
 
@@ -497,6 +502,8 @@ class _SettingsFormState extends State<_SettingsForm> {
     if (mem.isNotEmpty) s['memory_limit'] = mem;
     final pids = _pidsLimitCtrl.text.trim();
     if (pids.isNotEmpty) s['pids_limit'] = int.parse(pids);
+    final tmp = _tmpSizeCtrl.text.trim();
+    if (tmp.isNotEmpty) s['tmp_size'] = tmp;
     return s;
   }
 
@@ -924,6 +931,23 @@ class _SettingsFormState extends State<_SettingsForm> {
                   hintText: 'e.g. 512',
                 ),
                 keyboardType: TextInputType.number,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _tmpSizeCtrl,
+                decoration: InputDecoration(
+                  labelText: 'TMP Size',
+                  labelStyle: labelStyle,
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  border: const OutlineInputBorder(),
+                  hintText: 'e.g. 2g, 512m',
+                ),
               ),
             ),
           ],

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -936,7 +936,7 @@ void main() {
         (w) => w is TextField && w.decoration?.labelText == 'PIDs Limit',
       );
       final tmpField = find.byWidgetPredicate(
-        (w) => w is TextField && w.decoration?.labelText == 'TMP Size',
+        (w) => w is TextField && w.decoration?.labelText == '/tmp size',
       );
 
       await tester.ensureVisible(idleField);

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -106,7 +106,7 @@ void main() {
       expect(find.text('New Workspace'), findsOneWidget);
       expect(find.text('Cancel'), findsOneWidget);
       expect(find.text('Create'), findsOneWidget);
-      expect(find.byType(TextField), findsNWidgets(11));
+      expect(find.byType(TextField), findsNWidgets(12));
       expect(find.byType(DropdownButtonFormField<String>), findsNWidgets(2));
     });
 
@@ -935,6 +935,9 @@ void main() {
       final pidsField = find.byWidgetPredicate(
         (w) => w is TextField && w.decoration?.labelText == 'PIDs Limit',
       );
+      final tmpField = find.byWidgetPredicate(
+        (w) => w is TextField && w.decoration?.labelText == 'TMP Size',
+      );
 
       await tester.ensureVisible(idleField);
       await tester.enterText(idleField, '600');
@@ -944,6 +947,8 @@ void main() {
       await tester.enterText(memField, '4g');
       await tester.ensureVisible(pidsField);
       await tester.enterText(pidsField, '256');
+      await tester.ensureVisible(tmpField);
+      await tester.enterText(tmpField, '2g');
 
       await tester.tap(find.text('Create'));
       await tester.pump();
@@ -955,6 +960,7 @@ void main() {
         'cpu_limit': 1.5,
         'memory_limit': '4g',
         'pids_limit': 256,
+        'tmp_size': '2g',
       });
     });
 

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1173,7 +1173,7 @@ void main() {
       expect(
           find.descendant(
               of: find.byType(AlertDialog), matching: find.byType(TextField)),
-          findsNWidgets(11));
+          findsNWidgets(12));
       // Image picker + egress-mode picker (#2409).
       expect(find.byType(DropdownButtonFormField<String>), findsNWidgets(2));
     });

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -50,6 +50,9 @@ def _collect_settings(screen: Screen) -> dict | None:
     raw = screen.query_one("#pids_limit", Input).value.strip()
     if raw:
         settings["pids_limit"] = int(raw)
+    raw = screen.query_one("#tmp_size", Input).value.strip()
+    if raw:
+        settings["tmp_size"] = raw
     return settings or None
 
 
@@ -106,6 +109,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
         "cpu_limit",
         "memory_limit",
         "pids_limit",
+        "tmp_size",
         "command",
         "health_check",
         "cancel",
@@ -277,6 +281,11 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                     yield Horizontal(
                         Static("PIDs limit"),
                         Input(id="pids_limit", placeholder="e.g. 512"),
+                        classes="field-row",
+                    )
+                    yield Horizontal(
+                        Static("TMP size"),
+                        Input(id="tmp_size", placeholder="e.g. 2g, 512m"),
                         classes="field-row",
                     )
                 with TabPane("Advanced", id="advanced_pane"):
@@ -649,6 +658,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
             "cpu_limit",
             "memory_limit",
             "pids_limit",
+            "tmp_size",
         ):
             self._create()
 
@@ -692,6 +702,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
         "cpu_limit",
         "memory_limit",
         "pids_limit",
+        "tmp_size",
         "command",
         "health_check",
         "cancel",
@@ -903,6 +914,15 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
                             else "",
                             id="pids_limit",
                             placeholder="e.g. 512",
+                        ),
+                        classes="field-row",
+                    )
+                    yield Horizontal(
+                        Static("TMP size"),
+                        Input(
+                            value=str(_s.get("tmp_size", "")),
+                            id="tmp_size",
+                            placeholder="e.g. 2g, 512m",
                         ),
                         classes="field-row",
                     )

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -284,7 +284,7 @@ class CreateWorkspaceScreen(TabSkipMixin, Screen):
                         classes="field-row",
                     )
                     yield Horizontal(
-                        Static("TMP size"),
+                        Static("/tmp size"),
                         Input(id="tmp_size", placeholder="e.g. 2g, 512m"),
                         classes="field-row",
                     )
@@ -918,7 +918,7 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
                         classes="field-row",
                     )
                     yield Horizontal(
-                        Static("TMP size"),
+                        Static("/tmp size"),
                         Input(
                             value=str(_s.get("tmp_size", "")),
                             id="tmp_size",

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1177,6 +1177,18 @@ class ContainerRegistry:
             self.app.state.settings.container_pids_limit,
         )
 
+    def _resolve_tmp_size(self, workspace_settings: dict | None) -> str | None:
+        """Per-workspace ``/tmp`` tmpfs size (``--tmpfs /tmp:...,size=<n>``).
+
+        #2378: same precedence as the other resolvers (workspace override >
+        deploy default > none). ``None`` means mount ``/tmp`` with no
+        explicit ``size=`` option (podman sizes it at half of RAM).
+        """
+        return ws_settings.resolve_tmp_size(
+            {"settings": workspace_settings},
+            self.app.state.settings.container_tmp_size,
+        )
+
     def _network_sidecar_enabled(self) -> bool:
         """Whether the FQDN network sidecar model is configured (#2254).
 
@@ -2185,6 +2197,13 @@ class ContainerRegistry:
             "true",
             "yes",
         )
+        # #2378: per-workspace /tmp tmpfs size. Default (``2g``) preserves
+        # the pre-#2378 mount; ``None`` (explicit unset) -> no ``size=``
+        # option, so podman sizes it at half of RAM.
+        tmp_size = self._resolve_tmp_size(workspace_settings)
+        tmp_opts = "rw,exec,nosuid"
+        if tmp_size:
+            tmp_opts += f",size={tmp_size}"
 
         create_kwargs = dict(
             labels={
@@ -2203,7 +2222,7 @@ class ContainerRegistry:
             },
             binds=binds,
             tmpfs={
-                "/tmp": "rw,exec,nosuid,size=2g",
+                "/tmp": tmp_opts,
                 "/run": "rw,noexec,nosuid,size=256m",
                 "/var/log": "rw,noexec,nosuid,size=256m",
             },

--- a/src/klangk/klangk/first_run.py
+++ b/src/klangk/klangk/first_run.py
@@ -114,6 +114,11 @@ def _render_config() -> str:
 container_cpu_limit: 2.0
 container_memory_limit: 8g
 container_pids_limit: 16384
+# #2378: /tmp tmpfs size per workspace (podman size string, e.g. 2g, 512m).
+# Default 2g matches the pre-#2378 mount; a workspace may override it via
+# its settings bag (settings.tmp_size). Empty -> no size= option (podman
+# sizes /tmp at half of RAM).
+container_tmp_size: 2g
 #
 # Full settings reference:
 #   https://mcdonc.github.io/klangk/reference/klangkd-config/

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -760,6 +760,10 @@ class KlangkSettings(BaseSettings):
     container_cpu_limit: float | None = 2.0
     container_memory_limit: str | None = "8g"
     container_pids_limit: int | None = 16384
+    # #2378: per-workspace /tmp tmpfs size (``--tmpfs /tmp:...,size=<n>``).
+    # Default ``2g`` preserves the pre-#2378 hardcoded mount size; a
+    # workspace may override it via its settings bag (``settings.tmp_size``).
+    container_tmp_size: str | None = "2g"
     test_mode: str | None = None
     version_file: str | None = None
 
@@ -1233,6 +1237,33 @@ class KlangkSettings(BaseSettings):
                 f"KLANGKD_CONTAINER_PIDS_LIMIT={v!r} must be > 0."
             )
         return value
+
+    @field_validator("container_tmp_size", mode="before")
+    @classmethod
+    def _coerce_container_tmp_size(cls, v):
+        """Coerce + validate ``KLANGKD_CONTAINER_TMP_SIZE`` (#2378).
+
+        Accepts the same podman size-string grammar as
+        ``container_memory_limit`` (``2g`` / ``2gb`` / ``512m`` / ``1024``
+        bare bytes / ``1.5g`` / …). ``None`` / empty -> ``None`` (mount
+        ``/tmp`` with no explicit ``size=`` option, letting podman size it at
+        half of RAM). Default ``2g`` preserves the pre-#2378 hardcoded
+        ``/tmp`` tmpfs size. A malformed or ``<= 0`` value raises and aborts
+        startup, same posture as the other container limits (#34).
+        """
+        if v is None or v == "":
+            return None
+        s = str(v).strip()
+        m = _CONTAINER_MEM_LIMIT_RE.match(s)
+        if m is None:
+            raise ValueError(
+                f"KLANGKD_CONTAINER_TMP_SIZE={v!r} is invalid. Expected "
+                "a positive size with an optional unit suffix "
+                "(b/k/m/g/t/p, e.g. 2g, 2gb, 512m, 1024)."
+            )
+        if float(m.group("num")) <= 0:
+            raise ValueError(f"KLANGKD_CONTAINER_TMP_SIZE={v!r} must be > 0.")
+        return s
 
     @field_validator("llm_models", mode="before")
     @classmethod

--- a/src/klangk/klangk/workspace_settings.py
+++ b/src/klangk/klangk/workspace_settings.py
@@ -200,6 +200,9 @@ SCHEMA: dict[str, Callable[[str, Any], Any]] = {
     "cpu_limit": _coerce_float,
     "memory_limit": _coerce_memory,
     "pids_limit": _coerce_positive_int,
+    # #2378: per-workspace /tmp tmpfs size (podman size string, same grammar
+    # as memory_limit — a positive number + optional k/m/g/t/p unit).
+    "tmp_size": _coerce_memory,
     # #2202: per-workspace nix flag — triggers the per-workspace /nix mount
     # (Nix.ensure_workspace_nix) when a backend is configured (``nix_seed``,
     # #2219/#2220).
@@ -375,3 +378,16 @@ def resolve_pids_limit(
 ) -> int | None:
     """Resolve the per-workspace PIDs limit (``--pids-limit``, int)."""
     return resolve(workspace, "pids_limit", deploy_default)
+
+
+def resolve_tmp_size(
+    workspace: dict | None, deploy_default: str | None
+) -> str | None:
+    """Resolve the per-workspace ``/tmp`` tmpfs size (``size=<n>``, #2378).
+
+    Same precedence as the other resolvers (workspace override > deploy
+    default > none); ``None`` means "mount /tmp with no explicit size option"
+    (podman then sizes the tmpfs at half of RAM). Same size-string grammar as
+    :func:`resolve_memory_limit`.
+    """
+    return resolve(workspace, "tmp_size", deploy_default)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -11583,12 +11583,14 @@ async def test_create_screen_collects_settings(monkeypatch):
         cs.query_one("#cpu_limit", Input).value = "1.5"
         cs.query_one("#memory_limit", Input).value = "4g"
         cs.query_one("#pids_limit", Input).value = "256"
+        cs.query_one("#tmp_size", Input).value = "2g"
         result = _collect_settings(cs)
         assert result == {
             "idle_timeout": 600,
             "cpu_limit": 1.5,
             "memory_limit": "4g",
             "pids_limit": 256,
+            "tmp_size": "2g",
         }
 
 
@@ -11613,9 +11615,14 @@ async def test_edit_screen_save_includes_settings(monkeypatch):
         es = app.screen
         es.query_one("#cpu_limit", Input).value = "2.0"
         es.query_one("#pids_limit", Input).value = "512"
+        es.query_one("#tmp_size", Input).value = "1g"
         es._save()
         await app.workers.wait_for_complete()
-        assert captured["settings"] == {"cpu_limit": 2.0, "pids_limit": 512}
+        assert captured["settings"] == {
+            "cpu_limit": 2.0,
+            "pids_limit": 512,
+            "tmp_size": "1g",
+        }
 
 
 async def test_edit_screen_prepopulates_settings(monkeypatch):
@@ -11627,7 +11634,7 @@ async def test_edit_screen_prepopulates_settings(monkeypatch):
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     ws = _wsobj(
         "test-ws",
-        settings={"cpu_limit": 2.0, "idle_timeout": 300},
+        settings={"cpu_limit": 2.0, "idle_timeout": 300, "tmp_size": "3g"},
     )
     app = KlangkApp(_create_state())
     async with app.run_test(size=(140, 40)) as pilot:
@@ -11643,5 +11650,6 @@ async def test_edit_screen_prepopulates_settings(monkeypatch):
         es = app.screen
         assert es.query_one("#cpu_limit", Input).value == "2.0"
         assert es.query_one("#idle_timeout", Input).value == "300"
+        assert es.query_one("#tmp_size", Input).value == "3g"
         assert es.query_one("#memory_limit", Input).value == ""
         assert es.query_one("#pids_limit", Input).value == ""

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2586,6 +2586,7 @@ class TestWorkspaceRoutes:
                     "idle_timeout": 300,
                     "cpu_limit": "1.5",
                     "memory_limit": "2g",
+                    "tmp_size": "4g",
                 },
             },
             headers=headers,
@@ -2599,6 +2600,7 @@ class TestWorkspaceRoutes:
             "idle_timeout": 300,
             "cpu_limit": 1.5,
             "memory_limit": "2g",
+            "tmp_size": "4g",
         }
 
     async def test_create_workspace_rejects_unknown_setting(

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -2127,6 +2127,55 @@ class TestStartContainer:
         assert kwargs["cpus"] == 2.0
         assert kwargs["memory"] == "8g"
         assert kwargs["pids_limit"] == 16384
+        # #2378: /tmp tmpfs defaults to the pre-#2378 2g size.
+        assert kwargs["tmpfs"]["/tmp"] == "rw,exec,nosuid,size=2g"
+
+    async def test_tmp_size_deploy_default_passed_to_tmpfs(
+        self, workspace, monkeypatch
+    ):
+        # #2378: a deploy-wide KLANGKD_CONTAINER_TMP_SIZE flows into the
+        # /tmp tmpfs mount's size= option.
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_tmp_size", "4g")
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["tmpfs"]["/tmp"] == "rw,exec,nosuid,size=4g"
+
+    async def test_tmp_size_workspace_override_wins(
+        self, workspace, monkeypatch
+    ):
+        # #2378: settings.tmp_size overrides the deploy default (override >
+        # default), same precedence as the other resource limits.
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_tmp_size", "4g")
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                workspace_settings={"tmp_size": "512m"},
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["tmpfs"]["/tmp"] == "rw,exec,nosuid,size=512m"
+
+    async def test_tmp_size_none_omits_size_option(
+        self, workspace, monkeypatch
+    ):
+        # #2378: an explicit unset (empty env) -> None -> /tmp mounted with
+        # no size= option (podman sizes it at half of RAM). The /run and
+        # /var/log tmpfs mounts are unchanged.
+        settings = self.registry.app.state.settings
+        monkeypatch.setattr(settings, "container_tmp_size", None)
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["tmpfs"]["/tmp"] == "rw,exec,nosuid"
+        assert kwargs["tmpfs"]["/run"] == "rw,noexec,nosuid,size=256m"
 
     async def test_ping_cap_add_emitted_by_default(self, workspace):
         # #2045: enable_ping defaults to True, so the workspace container

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -378,6 +378,43 @@ class TestConfigFile:
             with pytest.raises(Exception, match="must be > 0"):
                 make_settings({"KLANGKD_CONTAINER_MEMORY_LIMIT": raw})
 
+    def test_container_tmp_size_default_is_2g(self):
+        # #2378: out-of-the-box default preserves the pre-#2378 hardcoded
+        # /tmp tmpfs size (no behavior change for existing installs).
+        assert make_settings({}).container_tmp_size == "2g"
+
+    def test_container_tmp_size_from_env(self):
+        s = make_settings({"KLANGKD_CONTAINER_TMP_SIZE": "512m"})
+        assert s.container_tmp_size == "512m"
+
+    def test_container_tmp_size_accepts_go_units_grammar(self):
+        # Same grammar as container_memory_limit (shared regex).
+        for raw, expected in [
+            ("2g", "2g"),
+            ("512mb", "512mb"),
+            ("1024", "1024"),
+        ]:
+            assert (
+                make_settings(
+                    {"KLANGKD_CONTAINER_TMP_SIZE": raw}
+                ).container_tmp_size
+                == expected
+            ), raw
+
+    def test_container_tmp_size_rejects_iec_iform(self):
+        with pytest.raises(Exception, match="Expected a positive size"):
+            make_settings({"KLANGKD_CONTAINER_TMP_SIZE": "2gib"})
+
+    def test_container_tmp_size_empty_string_is_none(self):
+        # Empty -> None -> /tmp mounted with no size= option (podman sizes
+        # it at half of RAM).
+        s = make_settings({"KLANGKD_CONTAINER_TMP_SIZE": ""})
+        assert s.container_tmp_size is None
+
+    def test_container_tmp_size_zero_aborts(self):
+        with pytest.raises(Exception, match="must be > 0"):
+            make_settings({"KLANGKD_CONTAINER_TMP_SIZE": "0"})
+
     def test_container_pids_limit_from_env(self):
         s = make_settings({"KLANGKD_CONTAINER_PIDS_LIMIT": "512"})
         assert s.container_pids_limit == 512

--- a/src/klangk/klangkd-tests/tests/test_workspace_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_workspace_settings.py
@@ -163,6 +163,22 @@ def test_validate_settings_accepts_int_bytes_memory():
     }
 
 
+# #2378: tmp_size reuses the memory-size coercer (same podman grammar).
+@pytest.mark.parametrize("val", ["2g", "512m", "1.5g", "1024"])
+def test_validate_settings_accepts_tmp_size_forms(val):
+    assert ws.validate_settings({"tmp_size": val}) == {"tmp_size": val}
+
+
+def test_validate_settings_rejects_bad_tmp_size_unit():
+    with pytest.raises(ValueError, match="not a valid memory size"):
+        ws.validate_settings({"tmp_size": "2gib"})
+
+
+def test_validate_settings_rejects_zero_tmp_size():
+    with pytest.raises(ValueError, match="not a valid memory size"):
+        ws.validate_settings({"tmp_size": "0"})
+
+
 # --- validate_settings_patch (merge semantics) ---
 
 
@@ -245,6 +261,9 @@ def test_typed_resolvers_bind_keys():
     assert ws.resolve_cpu_limit(ws_dict, 1.0) == 2.0
     assert ws.resolve_memory_limit(ws_dict, "1g") == "1g"
     assert ws.resolve_pids_limit(ws_dict, 100) == 100
+    assert ws.resolve_tmp_size({"settings": {"tmp_size": "4g"}}, "2g") == "4g"
+    assert ws.resolve_tmp_size({"settings": None}, "2g") == "2g"
+    assert ws.resolve_tmp_size({"settings": {}}, None) is None
 
 
 def test_known_settings_has_all_documented_keys():
@@ -255,6 +274,7 @@ def test_known_settings_has_all_documented_keys():
             "cpu_limit",
             "memory_limit",
             "pids_limit",
+            "tmp_size",
             "nix",
         }
     )


### PR DESCRIPTION
Implements #2378 — per-workspace `/tmp` tmpfs sizing across the full stack.

## What
A new per-workspace override `settings.tmp_size` plus a deploy default `KLANGKD_CONTAINER_TMP_SIZE` resolve into the container's `/tmp` tmpfs `size=` option. Same podman size-string grammar as `memory_limit` (`2g`, `512m`, `1.5g`, bare bytes). Default `2g` preserves the pre-#2378 hardcoded mount (no behavior change for existing workspaces); an explicit unset mounts `/tmp` with no `size=` option (podman sizes it at half of RAM).

Precedence is `workspace override > deploy default > none`, identical to `cpu_limit` / `memory_limit` / `pids_limit`.

## Surfaces
- **API** — `settings.tmp_size` flows through the existing settings bag (validated by `validate_settings`); no new request field.
- **Container** — `_resolve_tmp_size` → the `/tmp` tmpfs mount (`container.py`).
- **Config** — `KLANGKD_CONTAINER_TMP_SIZE` field + validator (`settings.py`), documented in the generated `klangkd.yaml` template (`first_run.py`).
- **Flutter** — "TMP Size" field in `CreateWorkspaceDialog` and `WorkspaceSettingsPanel`.
- **CLI TUI** — "TMP size" field in both `CreateWorkspaceScreen` and `EditWorkspaceScreen`, wired into `_collect_settings` and both `_TAB_ORDER` lists.

## Commits
1. backend (settings / workspace_settings / container / first_run) + tests
2. CLI create/edit TUI field
3. Flutter create dialog + settings panel field
4. changelog

## Verification
- Backend: full suite `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` → **4924 passed, 100% coverage**.
- Frontend: `flutter test --coverage` → the create-dialog and settings-panel suites pass (110/110 on the touched files). One unrelated pre-existing flake in `file_viewer_panel_test.dart` (file-staleness/404) that passes in isolation.

Closes #2378.
