### PR TITLE
fix(container): reap containers leaked by an uncleanly-killed klangkd (#2342)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -762,6 +762,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Dead-owner container reap at startup (#2342).** klangkd now stamps each
+  workspace + network-sidecar container with the creating daemon's PID
+  (`klangk.pid`; the sidecar also gains `klangk.managed=true`), and on startup
+  removes any `klangk.managed=true` container whose recorded PID is no longer
+  a live process — cleaning up workspaces a crashed or killed klangkd left
+  running. Containers without a `klangk.pid` (from an older klangkd, possibly
+  still running) are skipped, and a container whose owner is still alive is
+  never touched.
+
 - **Workspace export/import now round-trips `egress_mode` (#2402).** The
   export endpoint previously omitted `egress_mode` from the serialized
   metadata, and import did not read it, so a `static` (or `allow`)

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -104,6 +104,37 @@ def _is_named_volume(source: str) -> bool:
     return "/" not in source and not source.startswith(".")
 
 
+def _pid_alive(pid: int) -> bool:
+    """Return True if a process with ``pid`` is currently running.
+
+    Used by the dead-owner container reap
+    (:meth:`ContainerRegistry.reap_dead_owner_containers`) to decide whether
+    the klangkd that created a container (its PID recorded in the
+    ``klangk.pid`` label) is still alive.
+
+    ``os.kill(pid, 0)`` sends no signal — it only checks existence:
+    success ⇒ alive; ``ProcessLookupError`` (ESRCH) ⇒ no such process ⇒
+    dead; ``PermissionError`` (EPERM) ⇒ the process exists but is owned by
+    another user (e.g. a sibling klangkd run under a different account) ⇒
+    treat as alive so we leave its containers alone.
+
+    Deliberately a plain liveness check, **not** a process-identity check.
+    PIDs recycle, so a dead owner's PID can be reused by an unrelated
+    process and read falsely as "alive" — but that failure mode only ever
+    *misses a reap* (the leaked container keeps running, the pre-feature
+    behavior); it can never reap a live owner's containers, because a live
+    owner always holds its own PID and so always reads alive (#2342, #1556).
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but not ours — another user's process; assume alive.
+        return True
+    return True
+
+
 class ContainerState:
     """Per-workspace container lifecycle state."""
 
@@ -1325,9 +1356,16 @@ class ContainerRegistry:
         # Label the network sidecar with this klangk instance so the startup reaper
         # (reap_instance_containers) and the shutdown orphan sweep cull any
         # network sidecar left behind by a failed stop — the same culling workspace
-        # containers get (#2254 review).
+        # containers get (#2254 review). #2342: klangk.managed + klangk.pid also
+        # let the dead-owner reap (reap_dead_owner_containers) cull a sidecar
+        # whose creating klangkd died uncleanly, the same as a workspace container.
         labels = {
+            "klangk.managed": "true",
             "klangk.instance": self.app.state.util.instance_id(),
+            # The main klangkd daemon process's PID — the liveness signal the
+            # dead-owner reap keys on (#2342). Not conmon / the container's
+            # PID 1 / a podman subprocess: those die with the daemon anyway.
+            "klangk.pid": str(os.getpid()),
             # #2286: a shared klangk.workspace label + a klangk.role label let
             # one `podman ps --filter label=klangk.workspace=<id>` correlate
             # the sidecar with its workspace; the slug is mirrored for
@@ -2139,6 +2177,9 @@ class ContainerRegistry:
             labels={
                 "klangk.managed": "true",
                 "klangk.instance": iid,
+                # The main klangkd daemon process's PID — the liveness signal
+                # the dead-owner reap keys on (#2342).
+                "klangk.pid": str(os.getpid()),
                 # #2286: shared label + role so one `podman ps --filter
                 # label=klangk.workspace=<id>` correlates the workspace with its
                 # network sidecar; the slug mirrors the name for exact-match
@@ -2546,6 +2587,83 @@ class ContainerRegistry:
             except podman.PodmanError as e:
                 logger.warning(
                     "Failed to reap leftover container %s: %s", cid[:12], e
+                )
+
+    async def reap_dead_owner_containers(self) -> None:
+        """Reap managed containers whose owning klangkd is no longer running.
+
+        The companion to :meth:`reap_instance_containers`. That one removes
+        *this* instance's own leftovers (always safe — the in-memory registry
+        starts empty, so there is nothing to adopt). This one removes
+        containers created by **other** klangkd instances whose owner process
+        has since died, which is the #2342 leak: an uncleanly-killed klangkd's
+        containers carry an instance ID no live instance matches, so they
+        would otherwise run forever (consuming memory, CPU, and the
+        NFQUEUE/iptables state in their netns).
+
+        Runs once at :func:`startup`, right after the per-instance reap, so
+        this instance's own leftovers are already gone before this scan. The
+        decision per container (listed by ``klangk.managed=true``, which spans
+        all instances):
+
+        - **No ``klangk.pid`` label → skip.** The container predates this
+          feature (an older klangkd that did not stamp the label — possibly
+          still running) or the label is unreadable; either way liveness
+          cannot be decided, so it is left alone. Tolerating label-less
+          containers keeps a new klangkd from culling an older sibling's live
+          work on a mixed-version host (#2342).
+        - **``klangk.pid`` names a live process → skip.** The owning klangkd
+          is still running — possibly a sibling, possibly mid-``shutdown``
+          (still alive, still owns its containers; its own ``shutdown()``
+          finishes the job). A live owner always holds its own PID, so its
+          containers always read alive and are never reaped here (#1556).
+        - **``klangk.pid`` names no live process → reap.** The owner is dead.
+          ``remove_container(force=True)`` stops-then-removes gracefully and
+          treats "already gone" / "being removed" (404) as success, so a
+          container whose owner died mid-shutdown — leaving podman finishing a
+          stop — is handled without racing conmon.
+
+        Liveness is a plain "is there a process with this PID?" check
+        (:func:`_pid_alive`), not a process-identity check. PID recycling can
+        make a dead owner's PID read falsely alive, but that only ever
+        *misses* a reap; it never reaps a live owner's containers. See #2342
+        for the full rationale.
+        """
+        try:
+            containers = await self.app.state.podman.list_containers(
+                "klangk.managed=true"
+            )
+        except (podman.PodmanError, OSError) as e:
+            logger.warning("Error scanning for dead-owner containers: %s", e)
+            return
+        for c in containers:
+            cid = c.get("Id") or c.get("ID", "")
+            if not cid:
+                continue
+            labels = c.get("Labels") or {}
+            pid_label = labels.get("klangk.pid")
+            if not pid_label:
+                # Tolerant: no pid label → can't decide liveness → leave it.
+                continue
+            try:
+                owner_pid = int(pid_label)
+            except (TypeError, ValueError):
+                continue  # unparseable pid → treat as no label → leave it
+            if owner_pid <= 0 or _pid_alive(owner_pid):
+                continue  # owner still running → leave it (#1556)
+            logger.info(
+                "Reaping dead-owner container %s "
+                "(owner pid %d no longer running)",
+                cid[:12],
+                owner_pid,
+            )
+            try:
+                await self.app.state.podman.remove_container(cid)
+            except podman.PodmanError as e:
+                logger.warning(
+                    "Failed to reap dead-owner container %s: %s",
+                    cid[:12],
+                    e,
                 )
 
     # --- Shutdown ---

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -2619,9 +2619,12 @@ class ContainerRegistry:
           containers always read alive and are never reaped here (#1556).
         - **``klangk.pid`` names no live process → reap.** The owner is dead.
           ``remove_container(force=True)`` stops-then-removes gracefully and
-          treats "already gone" / "being removed" (404) as success, so a
-          container whose owner died mid-shutdown — leaving podman finishing a
-          stop — is handled without racing conmon.
+          treats an already-gone container (404) as success; any other error
+          (e.g. a 409 from a concurrent removal) is caught and logged below,
+          so it never aborts the sweep. A container whose owner died
+          mid-shutdown — leaving podman finishing a stop — is thus handled
+          without racing conmon (at worst it surfaces as a logged warning on
+          one of the racers).
 
         Liveness is a plain "is there a process with this PID?" check
         (:func:`_pid_alive`), not a process-identity check. PID recycling can

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -366,6 +366,10 @@ class Lifecycle:
         registry = state.container_registry
         await registry.prewarm_podman()
         await registry.reap_instance_containers()
+        # #2342: reap containers whose creating klangkd died uncleanly (a
+        # different instance whose ID no live instance matches). Tolerant of
+        # label-less containers, so an older klangkd's live work is not culled.
+        await registry.reap_dead_owner_containers()
         registry.start_cleanup_loop()
         registry.start_health_loop()
         n = await state.workspaces.auto_start_workspaces()

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -745,6 +745,11 @@ class TestStartContainer:
         assert ws_container["labels"]["klangk.role"] == "workspace"
         assert sidecar["labels"]["klangk.workspace-name"] == slug
         assert ws_container["labels"]["klangk.workspace-name"] == slug
+        # #2342: both carry klangk.managed + the creating daemon's PID, so the
+        # dead-owner reap can cull either if its klangkd dies uncleanly.
+        for c in (sidecar, ws_container):
+            assert c["labels"]["klangk.managed"] == "true"
+            assert c["labels"]["klangk.pid"].isdigit()
 
     # --- #2254: FQDN network sidecar lifecycle ---
 
@@ -793,6 +798,10 @@ class TestStartContainer:
             kwargs["labels"]["klangk.instance"]
             == self.registry.app.state.util.instance_id()
         )
+        # #2342: managed + the creating daemon's PID, same as a workspace
+        # container, so the dead-owner reap covers sidecars too.
+        assert kwargs["labels"]["klangk.managed"] == "true"
+        assert kwargs["labels"]["klangk.pid"].isdigit()
         # #2286: shared klangk.workspace + role labels correlate the sidecar
         # with its workspace (supersedes the old klangk.network-sidecar).
         assert kwargs["labels"]["klangk.workspace"] == ws_id
@@ -2872,6 +2881,8 @@ class TestStartContainer:
         args, kwargs = p.create_container.call_args
         assert args[1] == self.registry.image_name
         assert kwargs["labels"]["klangk.managed"] == "true"
+        # #2342: the creating daemon's PID (dead-owner reap liveness signal).
+        assert kwargs["labels"]["klangk.pid"].isdigit()
         # #2286: shared label + role (supersedes klangk.workspace-id).
         assert kwargs["labels"]["klangk.workspace"] == workspace["id"]
         assert kwargs["labels"]["klangk.role"] == "workspace"
@@ -4584,6 +4595,198 @@ class TestReapInstanceContainers:
         ) as mocks:
             await self.registry.reap_instance_containers()
         mocks.remove_container.assert_awaited_once_with("good-1")
+
+
+class TestPidAlive:
+    """Unit tests for ``container._pid_alive`` — the liveness check the
+    dead-owner reap keys on (#2342)."""
+
+    def test_alive_when_process_exists(self):
+        with patch("klangk.container.os.kill", return_value=None):
+            assert container._pid_alive(12345) is True
+
+    def test_dead_when_no_such_process(self):
+        with patch("klangk.container.os.kill", side_effect=ProcessLookupError):
+            assert container._pid_alive(12345) is False
+
+    def test_alive_when_permission_denied(self):
+        # EPERM: the process exists but belongs to another user (e.g. a
+        # sibling klangkd under a different account) — assume alive so its
+        # containers are left alone.
+        with patch("klangk.container.os.kill", side_effect=PermissionError):
+            assert container._pid_alive(12345) is True
+
+
+class TestReapDeadOwnerContainers:
+    """Tests for ``ContainerRegistry.reap_dead_owner_containers`` (#2342).
+
+    The companion to the per-instance reap: it culls ``klangk.managed=true``
+    containers whose owning klangkd (recorded in ``klangk.pid``) is no longer
+    running, while leaving label-less / live-owner / self-owned containers
+    alone.
+    """
+
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.state.container_registry
+
+    async def test_reaps_container_whose_owner_pid_is_dead(self):
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "dead-owner-1",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.instance": "ghost",
+                            "klangk.pid": "99999",
+                        },
+                    }
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            with patch("klangk.container._pid_alive", return_value=False):
+                await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_awaited_once_with("dead-owner-1")
+
+    async def test_skips_container_whose_owner_pid_is_alive(self):
+        # A live owner (sibling klangkd, possibly mid-shutdown) always holds
+        # its own PID, so its containers read alive and are left alone (#1556).
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "live-owner-1",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.instance": "sibling",
+                            "klangk.pid": "4242",
+                        },
+                    }
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            with patch("klangk.container._pid_alive", return_value=True):
+                await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_not_awaited()
+
+    async def test_skips_container_without_pid_label(self):
+        # Tolerant: a label-less container (older klangkd that did not stamp
+        # klangk.pid, possibly still running) is left alone — liveness cannot
+        # be decided (#2342 backwards-compat).
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "no-pid-label",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.instance": "old-version",
+                        },
+                    }
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_not_awaited()
+
+    async def test_skips_container_with_unparseable_pid(self):
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "bad-pid",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.pid": "not-a-number",
+                        },
+                    }
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_not_awaited()
+
+    async def test_skips_nonpositive_pid(self):
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "zero-pid",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.pid": "0",
+                        },
+                    }
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_not_awaited()
+
+    async def test_skips_empty_id(self):
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {"Labels": {"klangk.pid": "99999"}},
+                    {"Id": "real-1", "Labels": {"klangk.pid": "99998"}},
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            with patch("klangk.container._pid_alive", return_value=False):
+                await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_awaited_once_with("real-1")
+
+    async def test_lists_all_managed_containers(self):
+        # The sweep spans all instances (not just this one), keyed on
+        # klangk.managed=true so it covers workspace + network-sidecar.
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(return_value=[]),
+        ) as mocks:
+            await self.registry.reap_dead_owner_containers()
+        mocks.list_containers.assert_awaited_once_with("klangk.managed=true")
+
+    async def test_podman_error_on_list_handled(self):
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                side_effect=podman.PodmanError(500, "fail")
+            ),
+        ):
+            await self.registry.reap_dead_owner_containers()
+        # Should not raise.
+
+    async def test_podman_error_on_remove_handled(self):
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "dead-owner-bad",
+                        "Labels": {"klangk.pid": "99999"},
+                    }
+                ]
+            ),
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(500, "remove failed")
+            ),
+        ) as mocks:
+            with patch("klangk.container._pid_alive", return_value=False):
+                await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_awaited_once_with("dead-owner-bad")
 
 
 class TestBrowserRegistry:

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1,6 +1,7 @@
 """Tests for container: idle timeout parsing, activity tracking, callbacks, port allocation."""
 
 import asyncio
+import os
 import time
 import types
 from contextlib import ExitStack, contextmanager
@@ -4616,6 +4617,12 @@ class TestPidAlive:
         with patch("klangk.container.os.kill", side_effect=PermissionError):
             assert container._pid_alive(12345) is True
 
+    def test_current_process_is_alive_without_mock(self):
+        # The real liveness check (no os.kill mock) must see the running test
+        # process as alive — the property the dead-owner reap relies on to
+        # never self-reap (#1556).
+        assert container._pid_alive(os.getpid()) is True
+
 
 class TestReapDeadOwnerContainers:
     """Tests for ``ContainerRegistry.reap_dead_owner_containers`` (#2342).
@@ -4672,6 +4679,31 @@ class TestReapDeadOwnerContainers:
         ) as mocks:
             with patch("klangk.container._pid_alive", return_value=True):
                 await self.registry.reap_dead_owner_containers()
+        mocks.remove_container.assert_not_awaited()
+
+    async def test_never_reaps_current_instance_own_pid(self):
+        # Security property (#1556): a container stamped with THIS daemon's
+        # pid is skipped via the REAL liveness check — no _pid_alive mock —
+        # so a startup sweep can never self-reap. An inverted _pid_alive or a
+        # pid-label mis-parse would fail here.
+        mine = str(os.getpid())
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "self-1",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.instance": "sibling",
+                            "klangk.pid": mine,
+                        },
+                    }
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            await self.registry.reap_dead_owner_containers()
         mocks.remove_container.assert_not_awaited()
 
     async def test_skips_container_without_pid_label(self):

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -835,6 +835,11 @@ class TestLifespan:
                 "reap_instance_containers",
                 new_callable=AsyncMock,
             ) as mock_adopt,
+            patch.object(
+                registry,
+                "reap_dead_owner_containers",
+                new_callable=AsyncMock,
+            ),
             patch.object(registry, "start_cleanup_loop") as mock_start,
             patch.object(
                 registry,
@@ -893,6 +898,11 @@ class TestLifespan:
                 "reap_instance_containers",
                 new_callable=AsyncMock,
             ),
+            patch.object(
+                registry,
+                "reap_dead_owner_containers",
+                new_callable=AsyncMock,
+            ),
             patch.object(registry, "start_cleanup_loop"),
             patch.object(registry, "shutdown", new_callable=AsyncMock),
             patch.object(util_mod.Util, "check_pid_file", return_value=None),
@@ -948,6 +958,11 @@ class TestStartupShutdownRestart:
                 "reap_instance_containers",
                 new_callable=AsyncMock,
             ) as mock_adopt,
+            patch.object(
+                registry,
+                "reap_dead_owner_containers",
+                new_callable=AsyncMock,
+            ),
             patch.object(registry, "start_cleanup_loop") as mock_cleanup,
             patch.object(registry, "start_health_loop") as mock_health,
             patch.object(
@@ -1436,6 +1451,11 @@ class TestStartupShutdownRestart:
             patch.object(
                 registry,
                 "reap_instance_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                registry,
+                "reap_dead_owner_containers",
                 new_callable=AsyncMock,
             ),
             patch.object(registry, "start_cleanup_loop"),


### PR DESCRIPTION
## Summary

Workspace + network-sidecar containers a klangkd started can outlive it
indefinitely when it dies uncleanly (SIGKILL, crash, worktree deleted under
it). `reap_instance_containers()` only removes the **current** instance's
containers, so a dead instance's containers carry an instance ID no live
instance matches and are never reaped — they keep running, consuming memory,
CPU, and the NFQUEUE/iptables state in their netns (#2342).

This stamps the creating daemon's PID on each managed container and adds a
startup sweep that reaps any whose owner is no longer alive.

Closes #2342.

## What changed

- **`klangk.pid` label** on each workspace container **and** network sidecar
  at create time — the PID of the **main klangkd daemon process** (the event
  loop owner that calls `create_container`), not conmon / the container's PID 1
  / a podman subprocess. The network sidecar also gains `klangk.managed=true`
  (it previously lacked it) so the sweep covers it.
- **`reap_dead_owner_containers()`** — new `startup()` step, run right after
  the per-instance reap. Lists every `klangk.managed=true` container and, for
  each, decides by owner liveness:
  - **no `klangk.pid` → skip** — the container predates this feature (an older
    klangkd that didn't stamp the label, possibly still running); can't decide
    liveness, so leave it;
  - **`klangk.pid` is a live process → skip** — the owning klangkd is still
    running (a sibling, or mid-`shutdown`);
  - **`klangk.pid` is no live process → reap.**
- **`_pid_alive(pid)`** helper — plain `os.kill(pid, 0)`: success ⇒ alive,
  `ESRCH` ⇒ dead, `EPERM` ⇒ alive (process exists but is another user's, e.g.
  a sibling klangkd under a different account → leave its containers alone).

## Safety

- **#1556 preserved — a live owner is never reaped.** It always holds its own
  PID, so its containers always read alive. A klangkd mid-`shutdown()` is
  still alive, so it is never raced; its own `shutdown()` finishes the job.
- **Tolerant of label-less containers** — older klangkd's live work on a
  mixed-version host is not culled.
- **PID recycling is softness, not hazard.** Plain liveness (no identity
  check) means a recycled PID can read falsely "alive" — but that only ever
  *misses* a reap (the leaked container keeps running, the pre-feature
  behavior); it can never reap a live owner's containers. An identity check
  (e.g. `/proc/<pid>/cmdline`) was considered and **rejected as a hazard**:
  klangkd invoked as `python -m klangk…` has cmdline `python`, so it would
  read a live owner as "not klangkd" and wrongfully reap it. A `(pid,
  starttime)` refinement would close the recycling gap safely and is noted as
  a future option if misses ever matter.
- **No shutdown race.** `remove_container(force=True)` already does a graceful
  `podman stop -t 5` then `rm -f` and swallows 404, so a container whose owner
  died mid-shutdown (leaving podman finishing a stop) is handled without
  racing conmon; the sweep logs-and-continues on `PodmanError`, same as the
  existing per-instance reap.

## Test plan

- [x] `TestPidAlive` — `_pid_alive` alive / dead (`ESRCH`) / alive-on-`EPERM`.
- [x] `TestReapDeadOwnerContainers` — reaps dead-owner; skips live-owner /
      label-less / unparseable-pid / non-positive-pid / empty-id; lists
      `klangk.managed=true`; handles `PodmanError` on list and on remove.
- [x] Create-path label assertions — both workspace and sidecar carry
      `klangk.pid` (+ the sidecar now carries `klangk.managed`).
- [x] Existing lifespan/startup tests patched for the new `startup()` step.
- [x] Full backend suite the CI way: **4921 passed, 100% coverage**.

## Changelog

Added a `Fixed` entry under `[Unreleased]` in `docs/changes.md`.
