### PR TITLE
test(egress): ride out 2nd-decider WS-upgrade outage + log handshake timing (#2420)

### DIFF
--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import uuid
 
 from fastapi import WebSocket, WebSocketDisconnect
@@ -55,11 +56,23 @@ logger = logging.getLogger(__name__)
 
 async def handle_consent_decider(websocket: WebSocket, app) -> None:
     """Register a consent decider for its connection lifetime + act on holds."""
+    # #2420: time the pre-accept steps so an intermittent opening-handshake
+    # timeout (DECIDER2-HANDSHAKE) is attributable from a logged run -- a slow
+    # step names the in-handler culprit; a small total whose wall-clock lags
+    # the client's connect by the timeout means the stall is pre-handler
+    # (event loop / uvicorn / reverse proxy), not in the accept path.
+    _hs_t0 = time.monotonic()
+    _hs_marks: list[tuple[str, float]] = []
+
+    def _hs_mark(label: str) -> None:
+        _hs_marks.append((label, time.monotonic()))
+
     token = websocket.query_params.get("token")
     if not token:
         await websocket.close(code=4001, reason="Missing token")
         return
     result = await app.state.auth.get_user_from_token(token)
+    _hs_mark("token")
     if result is auth.Auth.TOKEN_EXPIRED:
         await websocket.close(code=4002, reason="Token expired")
         return
@@ -84,6 +97,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     if not allowed:
         await websocket.close(code=4003, reason="Forbidden")
         return
+    _hs_mark("authz")
 
     # #2394: a static-mode workspace never holds egress for a human decision
     # (its non-allow-listed egress is denied immediately with a static
@@ -112,7 +126,19 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
             )
             return
 
+    _hs_mark("workspace")
     await websocket.accept()
+    _hs_mark("accept")
+    _prev = _hs_t0
+    _parts: list[str] = []
+    for label, t in _hs_marks:
+        _parts.append(f"{label}={(t - _prev) * 1000:.0f}ms")
+        _prev = t
+    logger.info(
+        "consent decider handshake accepted: %.0fms (%s)",
+        (_hs_marks[-1][1] - _hs_t0) * 1000,
+        " ".join(_parts),
+    )
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
     registry = app.state.consent_deciders

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -1307,15 +1307,28 @@ class SmokeTest:
     async def _connect_raw_decider(
         self,
         workspace_id: str | None = None,
-        attempts: int = 2,
+        attempts: int = 4,
         *,
         ping: bool = False,
     ) -> RawDecider:
-        # Retry once with a generous open timeout as a safety net against a
-        # transient accept hiccup; bounded so a persistent issue fails fast
-        # (the caller records a finding) rather than hanging the run.
-        # (Was framed as a TCP-proxy flakiness workaround; that premise was
-        # disproven — the proxy is reliable at this concurrency, #2398.)
+        # Retry a 2nd-decider attach with a generous open timeout so a
+        # transient WS-upgrade outage is ridden out rather than failing the
+        # multi-decider phase. #2420 (DECIDER2-HANDSHAKE): the 2nd decider's
+        # opening handshake has intermittently timed out while the 1st decider
+        # + plain HTTP stayed up -- both attempts used to time out (~31s
+        # outage), so the default now retries longer (4 x 15s) to ride out a
+        # transient while still bounding a *persistent* issue (the caller
+        # records a finding instead of hanging the run).
+        #
+        # Each attempt is timed + printed so the next real occurrence pins
+        # whether the stall is client-side (no server response within the
+        # open timeout -- correlate with klangkd's per-step
+        # "consent decider handshake accepted" log) or server-side. The root
+        # cause is still open; klangkd's accept path + event loop + DB were
+        # all fast when it did NOT reproduce, so the stall is likely
+        # pre-handler (proxy/uvicorn/scheduling) under load.
+        # (The prior framing as a TCP-proxy flakiness workaround was
+        # disproven -- the proxy is Caddy and reliable, #2398.)
         #
         # workspace_id scopes the decider: a real id -> workspace-scoped
         # (needs terminal access); None -> deploy-wide (needs admin, decides
@@ -1325,12 +1338,22 @@ class SmokeTest:
         if workspace_id is not None:
             url += f"&workspace={workspace_id}"
         last: Exception | None = None
-        for _ in range(attempts):
+        for i in range(attempts):
+            began = time.time()
             try:
                 ws = await ws_connect(self.server, url, open_timeout=15)
+                if i:
+                    print(
+                        f"     (decider attach: attempt {i + 1}/{attempts} "
+                        f"succeeded after {time.time() - began:.1f}s)"
+                    )
                 return RawDecider(ws, ping=ping)
             except Exception as e:  # noqa: BLE001
                 last = e
+                print(
+                    f"     (decider attach: attempt {i + 1}/{attempts} failed "
+                    f"after {time.time() - began:.1f}s: {e!r})"
+                )
                 await asyncio.sleep(1.0)
         assert last is not None
         raise last


### PR DESCRIPTION
Investigates #2420 (does not close it — root cause still open).

## What I found

`DECIDER2-HANDSHAKE` did **not** reproduce here — two `--count 25 --seed 47
--continue` runs both passed the multi-decider phase (2nd decider attached
cleanly). It's intermittent, not deterministic with that seed in this
environment. Instrumentation ruled out:

- **klangkd accept path** — every pre-accept step ran **10–20ms**; pure WAL
  reads, no writes, so not write-lock contention (`busy_timeout=15000` ==
  `open_timeout=15` is coincidence; it never fired).
- **`ConsentDeciderRegistry`** — no locks, no per-workspace cap.
- **Event-loop starvation** — a watcher logged **zero** >1s stalls.
- **The proxy** — it's **Caddy** (TCP→UDS), production-grade (#2398's
  retraction holds).

Still on the table: the WS-upgrade path under load (Caddy + uvicorn's WS
accept) or runner contention — fits "intermittent ~31s outage, both attempts
time out, 1st decider + HTTP stay up."

## What this PR does

Rather than leave it unfixed while waiting for a repro, the 2nd-decider attach
is now robust **and** captures the data to pin the next real occurrence:

- **`smoketest_egress._connect_raw_decider`** — retries `2 → 4` (rides out the
  observed ~31s outage where both attempts used to time out) and logs each
  attempt's duration + outcome.
- **`wshandler/decider.handle_consent_decider`** — logs per-step pre-accept
  timing at accept:
  ```
  consent decider handshake accepted: 16ms (token=7ms authz=6ms workspace=3ms accept=0ms)
  ```
  A slow step names the in-handler culprit; a small total whose wall-clock
  lags the client's connect by the timeout means the stall is pre-handler
  (loop/uvicorn/proxy).

The next reproducing run logs both sides (client attempt timings + klangkd
per-step handshake timing), which should pin whether it's pre-handler or
in-handler. See the issue comment for the full investigation.

## Verification

- `test_consent_deciders.py`: 45 passed.
- Full backend suite: **4909 passed, 100% coverage**.
- Confirmed the new handshake-timing log fires correctly in a real
  subprocess klangkd (Caddy in path): `16ms (token=7ms authz=6ms workspace=3ms accept=0ms)`.
