### PR TITLE
test(egress-smoketest): controlled-DNS fixture + host/port-scope phases (#2424)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,15 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`KLANGKNETWORK_EGRESS_UPSTREAM` — operator-pinnable sidecar DNS upstream (#2424).**
+  When set in `klangkd`'s environment, the network sidecar's FQDN proxy forwards
+  workspace DNS to this resolver verbatim instead of auto-detecting a host
+  resolver. An operator may want every filtered workspace to use a specific
+  resolver (e.g. a corporate DNS); the interactive-egress smoketest also uses
+  it to point the sidecar at a controlled-DNS test fixture so chosen hostnames
+  resolve to single stable test IPs. Absent, behavior is unchanged (auto-detect).
+  Mirrors the existing `KLANGKNETWORK_EGRESS_MIN_TTL` / `SWEEP_INTERVAL` forwarding.
+
 - **`egress_mode: "allow"` — default-permit egress (#2406).** A third
   egress mode alongside `static` (default-deny) and `interactive`
   (consent-gated). An `allow` workspace permits every host except names in

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1272,9 +1272,22 @@ class ContainerRegistry:
             )
         name = self._network_sidecar_name(workspace_id, slug)
         # Pick an upstream that differs from the REDIRECT target (1.1.1.1).
-        nf = getattr(self.app.state, "netfilter", None)
-        resolvers = nf.resolvers() if nf else []
-        upstream = next((r for r in resolvers if r != "1.1.1.1"), "8.8.8.8")
+        # KLANGKNETWORK_EGRESS_UPSTREAM (when set in klangkd's env) pins the
+        # sidecar's upstream resolver verbatim, mirroring the MIN_TTL /
+        # SWEEP_INTERVAL forwarding below — an operator may want workspaces to
+        # use a specific resolver (e.g. a corporate DNS), and the egress
+        # smoketest uses it to point the sidecar at a controlled-DNS fixture
+        # (#2424) so chosen hostnames resolve to single stable test IPs.
+        # Absent -> auto-detect a host resolver that differs from 1.1.1.1.
+        env_upstream = os.environ.get("KLANGKNETWORK_EGRESS_UPSTREAM")
+        if env_upstream:
+            upstream = env_upstream
+        else:
+            nf = getattr(self.app.state, "netfilter", None)
+            resolvers = nf.resolvers() if nf else []
+            upstream = next(
+                (r for r in resolvers if r != "1.1.1.1"), "8.8.8.8"
+            )
         env = [
             f"KLANGKNETWORK_EGRESS_ALLOW={','.join(allowed_domains or [])}",
             f"KLANGKNETWORK_EGRESS_REJECT={','.join(rejected_domains or [])}",

--- a/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
@@ -1,0 +1,630 @@
+"""Controlled-DNS test fixture for the interactive-egress smoketest (#2424).
+
+A reusable, self-contained fixture that makes the workspace's DNS resolution
+deterministic: chosen hostnames resolve to single, stable, test-controlled IPs
+(each fronted by a test HTTP/HTTPS server on :80 + :443), while every other
+name is forwarded to a real upstream unchanged. This removes the two properties
+of real hosts that today make three smoketest checklist items indeterminate
+(#2392):
+
+1. **CDN IP rotation / multiple A records** -- a later connection to the "same"
+   host resolves to a *different* IP, masquerading as a snapshot-replay event
+   (#2412). A controlled name has exactly one IP, so there is no cascade.
+2. **The L3/L4 allow rule** -- once an apex IP is allow-listed, a subdomain that
+   *shares* that IP is allowed at L3/L4 regardless of the L7 hostname spec. By
+   putting the apex and the subdomain on *distinct* controlled IPs the L7 spec
+   (``bare`` = exact/apex-only, ``.host`` = apex+subdomains, ``*.host`` =
+   subdomains-only, #2377) is observable.
+
+Delivery -- no new production code paths
+----------------------------------------
+The fixture drives the real stack only. It brings up two ordinary podman
+containers on the default ``podman`` network and points the real network
+sidecar's upstream resolver at the DNS container via the existing operator
+knob ``KLANGKNETWORK_EGRESS_UPSTREAM`` (honored by
+:meth:`ContainerManager._start_network_sidecar`, mirroring the
+``KLANGKNETWORK_EGRESS_MIN_TTL`` / ``SWEEP_INTERVAL`` forwarding). The sidecar's
+proxy then forwards the workspace's :53 queries to this fixture as it would any
+upstream -- the same REDIRECT + mark + learn path production uses.
+
+Topology (two containers, both on the default ``podman`` network so the
+sidecar -- also on that network -- reaches them by bridge IP):
+
+* **target** -- one container that holds N secondary IPs (added with
+  ``--cap-add NET_ADMIN``) and serves HTTP (:80) + HTTPS (:443, self-signed,
+  ``curl -k``) bound to ``0.0.0.0`` so a single server answers on *every* IP it
+  holds. Controlled names resolve to one of these IPs; distinct names get
+  distinct IPs so the L3/L4 rule can't paper over the L7 spec.
+* **dns** -- one container running a UDP :53 forwarding resolver. A controlled
+  name (read from a live, bind-mounted JSON map the fixture updates as it
+  allocates names) is answered with its single mapped IP; anything else is
+  forwarded to a real upstream so the rest of the smoketest (real hosts in the
+  fuzz pool) keeps resolving.
+
+The fixture is intentionally process-driven (``podman`` via ``subprocess``),
+not a Python import of server internals: it stands up alongside -- and is torn
+down by -- the human-run smoketest, never linked into the server.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+
+# The default network-sidecar image has python3 + dnspython + openssl (the
+# proxy's deps), so a single image serves as both the DNS forwarder and the
+# multi-IP HTTP/HTTPS target -- no second image build. Overridable via the
+# smoketest's --sidecar-image for a non-default deploy.
+DEFAULT_IMAGE = "localhost/klangk-network-sidecar:latest"
+DEFAULT_NETWORK = "podman"
+# Secondary IPs are assigned in a high slice of the subnet's /24 (the gateway
+# is reliably the .1, so <gw-first-three>.200+ is free of podman's low DHCP
+# range). 16 IPs is plenty for the host-scope phase's ~6 distinct names plus
+# the snapshot/port phases, with headroom.
+_IP_SLICE_START = 200
+_IP_SLICE_SIZE = 16
+# Forward unknown queries here (a public resolver the container can reach over
+# its unrestricted egress). The rest of the smoketest's real hosts resolve
+# through this, so the controlled upstream is a drop-in replacement.
+_DEFAULT_FORWARD = "1.1.1.1"
+_DNS_TTL = 60  # seconds; long enough that a learned IP isn't swept mid-phase
+
+
+# --- in-container server scripts (embedded so no extra files ship) ----------
+# Both run with the sidecar image's entrypoint cleared (else the image's
+# iptables entrypoint runs). python3 + dnspython + openssl are present.
+
+_TARGET_PY = r"""\
+import os, socket, ssl, threading, time
+
+# (The secondary IPs this target holds are added by the fixture after start via
+# `podman exec ... ip addr add` -- see ControlledDns._install_target_ips. Each
+# added IP is an address the bridge ARP-responds for, so a peer (the sidecar)
+# reaches the one 0.0.0.0-bound server on any of them.)
+
+# One self-signed cert (generated on the host, bind-mounted here) covers every
+# IP/name (curl -k skips validation). The sidecar image ships no openssl, so the
+# cert is produced on the host where openssl is available.
+_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+try:
+    _ctx.load_cert_chain("/mnt/ctrl-cert.pem", "/mnt/ctrl-key.pem")
+except Exception:
+    _ctx = None
+
+_BODY = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+
+
+def _serve(port, tls):
+    l = socket.socket()
+    l.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    l.bind(("0.0.0.0", port))
+    l.listen(64)
+    while True:
+        c, _ = l.accept()
+        try:
+            if tls and _ctx is not None:
+                c = _ctx.wrap_socket(c, server_side=True)
+            c.recv(4096)
+            c.sendall(_BODY)
+        except Exception:
+            pass
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
+
+threading.Thread(target=_serve, args=(80, False), daemon=True).start()
+threading.Thread(target=_serve, args=(443, True), daemon=True).start()
+print("ctrl-target up", flush=True)
+while True:
+    time.sleep(60)
+"""
+
+_DNS_PY = r"""\
+import json, os, socket
+import dns.message, dns.rrset
+
+_MAP_PATH = os.environ.get("CTRL_DNS_MAP", "/map/map.json")
+_FORWARD = os.environ.get("CTRL_DNS_FORWARD", "1.1.1.1")
+_TTL = int(os.environ.get("CTRL_DNS_TTL", "60"))
+
+
+def _load():
+    try:
+        with open(_MAP_PATH) as f:
+            m = json.load(f)
+        return {str(k).rstrip(".").lower(): str(v) for k, v in m.items()}
+    except Exception:
+        return {}
+
+
+def _ip_for(qname, m):
+    return m.get(qname.rstrip(".").lower())
+
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(("0.0.0.0", 53))
+print("ctrl-dns listening", flush=True)
+while True:
+    try:
+        data, addr = s.recvfrom(65535)
+    except Exception:
+        continue
+    try:
+        q = dns.message.from_wire(data)
+    except Exception:
+        continue
+    if not q.question:
+        continue
+    name = q.question[0].name
+    ip = _ip_for(name.to_text(), _load())
+    if ip:
+        resp = dns.message.make_response(q)
+        resp.answer.append(
+            dns.rrset.from_text(name, _TTL, "IN", "A", ip)
+        )
+        try:
+            s.sendto(resp.to_wire(), addr)
+        except Exception:
+            pass
+        continue
+    # Unknown name -> forward to the real upstream (a fresh socket per query so
+    # responses can't cross-match). Failure -> NXDOMAIN (fail-closed: the
+    # smoketest treats an unresolvable real host as a finding, not a leak).
+    try:
+        f = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        f.settimeout(4)
+        f.sendto(data, (_FORWARD, 53))
+        rd, _ = f.recvfrom(65535)
+        f.close()
+        s.sendto(rd, addr)
+    except Exception:
+        try:
+            f.close()
+        except Exception:
+            pass
+        resp = dns.message.make_response(q)
+        import dns.rcode
+        resp.set_rcode(dns.rcode.NXDOMAIN)
+        try:
+            s.sendto(resp.to_wire(), addr)
+        except Exception:
+            pass
+"""
+
+
+@dataclass
+class _Procs:
+    """Names of the fixture's containers + the host dir bind-mounted into dns."""
+
+    target: str = ""
+    dns: str = ""
+    dir: str = ""
+    base: str = ""  # "<gw-first-three-octets>", e.g. "10.88.0"
+    ips: list[str] = field(
+        default_factory=list
+    )  # secondary IPs the target holds
+    upstream_ip: str = (
+        ""  # the dns container's bridge IP (the sidecar upstream)
+    )
+    map_path: str = ""  # host path of map.json (bind-mounted into dns)
+
+
+def _podman(*args: str, timeout: float = 60) -> str:
+    """Run podman, return stdout (stripped); raise on non-zero."""
+    r = subprocess.run(
+        ["podman", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"podman {' '.join(args)} failed (rc={r.returncode}): "
+            f"{r.stderr.strip()}"
+        )
+    return r.stdout.strip()
+
+
+def _net_ip(name: str, network: str = DEFAULT_NETWORK) -> str:
+    """The container's bridge IP on ``network`` via inspect."""
+    out = _podman(
+        "inspect",
+        name,
+        "--format",
+        '{{(index .NetworkSettings.Networks "%s").IPAddress}}' % network,
+    )
+    return out.strip()
+
+
+def _net_gw(name: str, network: str = DEFAULT_NETWORK) -> str:
+    out = _podman(
+        "inspect",
+        name,
+        "--format",
+        '{{(index .NetworkSettings.Networks "%s").Gateway}}' % network,
+    )
+    return out.strip()
+
+
+class ControlledDns:
+    """A controlled-DNS + multi-IP HTTP/HTTPS fixture (#2424).
+
+    Usage::
+
+        dns = ControlledDns()
+        dns.start()                          # brings up target + dns containers
+        ip_a = dns.allocate("snap-a.test")   # single stable IP
+        ip_b = dns.allocate("snap-b.test")   # a *different* stable IP
+        # ... point the sidecar at dns.upstream_ip via KLANGKNETWORK_EGRESS_UPSTREAM
+        dns.stop()
+
+    Allocate before the sidecar queries the name (the dns container reads the
+    live map per query, so late allocations are picked up). ``stop()`` is
+    idempotent and safe from any thread.
+    """
+
+    def __init__(
+        self,
+        image: str = DEFAULT_IMAGE,
+        network: str = DEFAULT_NETWORK,
+        forward_upstream: str = _DEFAULT_FORWARD,
+        ip_slice_size: int = _IP_SLICE_SIZE,
+    ) -> None:
+        self.image = image
+        self.network = network
+        self.forward_upstream = forward_upstream
+        self.ip_slice_size = ip_slice_size
+        self._p = _Procs()
+        self._lock = threading.Lock()
+        self._next = 0  # next secondary-IP slot to hand out
+        self._map: dict[str, str] = {}
+        self._target_script = ""
+        self._dns_script = ""
+
+    # -- lifecycle --------------------------------------------------------
+    def start(self) -> None:
+        """Bring up the target + dns containers and publish an empty map."""
+        if self._p.target:
+            return  # already started
+        d = tempfile.mkdtemp(prefix="ctrl-dns-")
+        self._p.dir = d
+        self._p.map_path = os.path.join(d, "map.json")
+        self._write_map()
+
+        # Write the two in-container scripts into the shared dir; the whole dir
+        # is bind-mounted read-only into both containers at /mnt (the scripts +
+        # the cert below + the live map all live there).
+        self._target_script = os.path.join(d, "target.py")
+        self._dns_script = os.path.join(d, "cdns_server.py")
+        with open(self._target_script, "w") as f:
+            f.write(_TARGET_PY)
+        with open(self._dns_script, "w") as f:
+            f.write(_DNS_PY)
+
+        # Self-signed cert for the target's HTTPS listener, generated on the
+        # host (the sidecar image ships no openssl). curl -k skips validation,
+        # so any CN/validity is fine; 100 days so a checked-out worktree doesn't
+        # need it regenerated for a long while.
+        self._gen_cert(d)
+
+        # 1) target: dynamic primary IP (for subnet detection) + NET_ADMIN so it
+        #    can add the secondary slice it serves on. The secondary slice is
+        #    derived from the gateway once we know it (below).
+        self._p.target = "ctrl-dns-target-%d" % os.getpid()
+        _podman(
+            "run",
+            "-d",
+            "--name",
+            self._p.target,
+            "--network",
+            self.network,
+            "--cap-add",
+            "NET_ADMIN",
+            "--entrypoint",
+            "[]",
+            "-v",
+            "%s:/mnt:ro" % d,
+            self.image,
+            "python3",
+            "/mnt/target.py",
+        )
+        gw = _net_gw(self._p.target, self.network)  # e.g. 10.88.0.1
+        if not gw or gw == "none":
+            raise RuntimeError(
+                "controlled-dns: could not detect the podman gateway for "
+                f"{self._p.target}; is the '{self.network}' network up?"
+            )
+        self._p.base = gw.rsplit(".", 1)[0]  # "10.88.0"
+        self._p.ips = [
+            "%s.%d" % (self._p.base, _IP_SLICE_START + i)
+            for i in range(self.ip_slice_size)
+        ]
+
+        # Have the target actually add its secondary IPs and confirm each is
+        # reachable from a peer before declaring readiness (avoids a race where
+        # a phase curls before the addresses are installed).
+        self._install_target_ips()
+        self._wait_target_ready()
+
+        # 2) dns: dynamic IP (this IS the sidecar upstream). Bind-mount the
+        #    shared dir so it reads the live map at /mnt/map.json.
+        self._p.dns = "ctrl-dns-dns-%d" % os.getpid()
+        _podman(
+            "run",
+            "-d",
+            "--name",
+            self._p.dns,
+            "--network",
+            self.network,
+            "--entrypoint",
+            "[]",
+            "-v",
+            "%s:/mnt:ro" % d,
+            "-e",
+            "CTRL_DNS_MAP=/mnt/map.json",
+            "-e",
+            "CTRL_DNS_FORWARD=%s" % self.forward_upstream,
+            "-e",
+            "CTRL_DNS_TTL=%d" % _DNS_TTL,
+            self.image,
+            "python3",
+            "/mnt/cdns_server.py",
+        )
+        self._p.upstream_ip = _net_ip(self._p.dns, self.network)
+        if not self._p.upstream_ip or self._p.upstream_ip == "none":
+            raise RuntimeError(
+                "controlled-dns: dns container has no IP on '%s'"
+                % self.network
+            )
+        self._wait_dns_ready()
+
+    def stop(self) -> None:
+        """Tear down both containers + the temp dir (idempotent)."""
+        with self._lock:
+            for attr in ("dns", "target"):
+                name = getattr(self._p, attr, "")
+                if name:
+                    try:
+                        _podman("rm", "-f", name, timeout=30)
+                    except Exception:
+                        pass
+                    setattr(self._p, attr, "")
+            if self._p.dir and os.path.isdir(self._p.dir):
+                try:
+                    import shutil
+
+                    shutil.rmtree(self._p.dir, ignore_errors=True)
+                except Exception:
+                    pass
+                self._p.dir = ""
+
+    # -- the live name->IP map -------------------------------------------
+    def allocate(self, name: str) -> str:
+        """Assign ``name`` a single stable target IP (distinct per name).
+
+        Returns the IP. Repeated calls for the same name return the same IP.
+        The map is published atomically so the dns container picks it up on its
+        next query.
+        """
+        with self._lock:
+            key = name.rstrip(".").lower()
+            if key in self._map:
+                return self._map[key]
+            if self._next >= len(self._p.ips):
+                raise RuntimeError(
+                    "controlled-dns: IP slice exhausted (%d names); raise "
+                    "ip_slice_size" % len(self._p.ips)
+                )
+            ip = self._p.ips[self._next]
+            self._next += 1
+            self._map[key] = ip
+            self._write_map()
+            return ip
+
+    def allocate_pair(self, apex: str, sub: str) -> tuple[str, str]:
+        """Two names guaranteed to resolve to *distinct* IPs."""
+        return self.allocate(apex), self.allocate(sub)
+
+    def ip_for(self, name: str) -> str:
+        with self._lock:
+            return self._map.get(name.rstrip(".").lower(), "")
+
+    @property
+    def upstream_ip(self) -> str:
+        """The dns container's bridge IP -- set this as the sidecar upstream."""
+        return self._p.upstream_ip
+
+    @property
+    def target_ips(self) -> list[str]:
+        return list(self._p.ips)
+
+    # -- internals --------------------------------------------------------
+    def _write_map(self) -> None:
+        """Atomically publish the name->IP map (tmp file + rename)."""
+        tmp = self._p.map_path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(self._map, f)
+        os.replace(tmp, self._p.map_path)
+
+    def _gen_cert(self, d: str) -> None:
+        """Generate a self-signed cert+key into ``d`` (host openssl)."""
+        cert = os.path.join(d, "ctrl-cert.pem")
+        key = os.path.join(d, "ctrl-key.pem")
+        r = subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                key,
+                "-out",
+                cert,
+                "-days",
+                "100",
+                "-nodes",
+                "-subj",
+                "/CN=controlled-dns",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if (
+            r.returncode != 0
+            or not os.path.exists(cert)
+            or not os.path.exists(key)
+        ):
+            raise RuntimeError(
+                "controlled-dns: host openssl cert generation failed (rc=%d): %s"
+                % (r.returncode, r.stderr.strip()[:200])
+            )
+
+    def _install_target_ips(self) -> None:
+        env = "CTRL_TARGET_IPS=" + ",".join(self._p.ips)
+        # exec ip addr add for each; ignore "already exists" duplicates.
+        _podman(
+            "exec",
+            "-e",
+            env,
+            self._p.target,
+            "sh",
+            "-c",
+            "for ip in $(echo $CTRL_TARGET_IPS | tr ',' ' '); do "
+            "ip addr add $ip/16 dev eth0 2>/dev/null || true; done",
+        )
+
+    def _wait_target_ready(self, timeout: float = 20.0) -> None:
+        """A peer on the network can open a TCP connection to each target IP."""
+        deadline = time.time() + timeout
+        last = ""
+        while time.time() < deadline:
+            last = self._probe_target()
+            if not last:
+                return
+            time.sleep(0.5)
+        raise RuntimeError(
+            "controlled-dns: target did not become reachable on all IPs within "
+            f"{timeout:.0f}s; last={last!r}"
+        )
+
+    def _probe_target(self) -> str:
+        """'' if every target IP accepts a TCP :443 connect, else an error."""
+        # Run a single ephemeral probe container that tries every IP at once.
+        script = (
+            "import socket,sys\n"
+            "bad=[]\n"
+            "for ip in %r:\n"
+            "    try:\n"
+            "        s=socket.create_connection((ip,443),timeout=3); s.close()\n"
+            "    except Exception as e:\n"
+            "        bad.append(ip+':'+type(e).__name__)\n"
+            "print('BAD '+','.join(bad) if bad else 'OK')\n"
+        ) % (self._p.ips,)
+        try:
+            r = subprocess.run(
+                [
+                    "podman",
+                    "run",
+                    "--rm",
+                    "--network",
+                    self.network,
+                    "--entrypoint",
+                    "[]",
+                    self.image,
+                    "python3",
+                    "-c",
+                    script,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except Exception as e:  # noqa: BLE001
+            return "probe raised: %r" % (e,)
+        out = (r.stdout or "").strip()
+        if out == "OK":
+            return ""
+        return out or r.stderr.strip()
+
+    def _wait_dns_ready(self, timeout: float = 20.0) -> None:
+        """The dns container forwards a real-name query (proves it's up)."""
+        deadline = time.time() + timeout
+        last = ""
+        while time.time() < deadline:
+            last = self._probe_dns_forward()
+            if not last:
+                return
+            time.sleep(0.5)
+        raise RuntimeError(
+            "controlled-dns: dns did not forward a real query within %.0fs; "
+            "last=%r" % (timeout, last)
+        )
+
+    def _probe_dns_forward(self) -> str:
+        """'' if the dns forwards example.com to a real A record, else error."""
+        script = (
+            "import socket\n"
+            "import dns.message, dns.rdatatype\n"
+            "q=dns.message.make_query('example.com','A')\n"
+            "s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(5)\n"
+            "s.sendto(q.to_wire(),(%r,53))\n"
+            "try:\n"
+            "    d,_=s.recvfrom(65535); r=dns.message.from_wire(d)\n"
+            "    ips=[a.address for an in r.answer if an.rdtype==dns.rdatatype.A for a in an]\n"
+            "    print('OK' if ips else 'EMPTY')\n"
+            "except Exception as e:\n"
+            "    print('ERR '+type(e).__name__)\n"
+        ) % (self._p.upstream_ip,)
+        try:
+            r = subprocess.run(
+                [
+                    "podman",
+                    "run",
+                    "--rm",
+                    "--network",
+                    self.network,
+                    "--entrypoint",
+                    "[]",
+                    self.image,
+                    "python3",
+                    "-c",
+                    script,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except Exception as e:  # noqa: BLE001
+            return "probe raised: %r" % (e,)
+        out = (r.stdout or "").strip()
+        return "" if out == "OK" else (out or r.stderr.strip())
+
+
+# Convenience for ad-hoc / debug use from a shell.
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    c = ControlledDns()
+    try:
+        c.start()
+        a = c.allocate("snap-a.test")
+        b = c.allocate("snap-b.test")
+        print("upstream_ip =", c.upstream_ip)
+        print("snap-a.test =", a)
+        print("snap-b.test =", b)
+        print("target_ips  =", c.target_ips)
+        print("OK -- Ctrl-C to stop")
+        while True:
+            time.sleep(5)
+    finally:
+        c.stop()
+        sys.exit(0)

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -47,6 +47,8 @@ import httpx  # noqa: E402
 
 from _e2e_server import start_server, stop_server, ws_connect  # noqa: E402
 
+from _controlled_dns import ControlledDns  # noqa: E402
+
 from klangk.cli.tui.consent import (  # noqa: E402
     ConsentDeciderApp,
     DECISION_ALLOWED,
@@ -254,10 +256,17 @@ def _container_for_workspace(ws_id: str) -> str:
     return names[0]
 
 
-def _trigger(container: str, host: str, outfile: str) -> None:
+def _trigger(
+    container: str,
+    host: str,
+    outfile: str,
+    port: int = 443,
+    scheme: str = "https",
+) -> None:
     # Detached curl: blocks on the held SYN until a verdict/timeout, then writes
     # EXIT:$?. -k skips cert validation so an IP/cert-mismatch still gives a
-    # clean connect(0)/refuse(7) signal.
+    # clean connect(0)/refuse(7) signal. ``port``/``scheme`` let the port-scope
+    # phase drive :80 (http) vs :443 (https) on the same controlled IP (#2424).
     subprocess.run(
         [
             "podman",
@@ -267,7 +276,7 @@ def _trigger(container: str, host: str, outfile: str) -> None:
             "bash",
             "-c",
             "curl -sS -k --max-time 30 -o /dev/null "
-            f"https://{shlex.quote(host)} > {outfile} 2>&1; "
+            f"{scheme}://{shlex.quote(host)}:{port} > {outfile} 2>&1; "
             f'echo "EXIT:$?" >> {outfile}',
         ],
         check=True,
@@ -577,6 +586,13 @@ _DETAIL_PREFIX_NAMES: list[tuple[str, str]] = [
     ("off-list hung (not a clean static denial)", "STATIC-HELD"),
     ("off-list succeeded with no decider", "STATIC-LEAK"),
     ("step raised", "UNEXPECTED-ERROR"),
+    # Controlled-DNS phases (#2424): host-scope / port-scope / snapshot-replay.
+    ("A replayed in reconnect snapshot", "SNAPSHOT-REPLAY"),
+    ("B missing from reconnect snapshot", "SNAPSHOT-REPLAY"),
+    ("host-scope phase failed", "UNEXPECTED-ERROR"),
+    ("host scope: ", "HOST-SCOPE-VIOLATION"),
+    ("port-scope phase failed", "UNEXPECTED-ERROR"),
+    ("port scope: ", "PORT-SCOPE-VIOLATION"),
 ]
 
 OUTCOME_NAMES: dict[str, str] = {
@@ -602,6 +618,9 @@ OUTCOME_NAMES: dict[str, str] = {
     "UNEXPECTED-ERROR": "a phase bring-up or per-step exception (an unexpected error).",
     "AUDIT-MISLABELED": "expired/denied audit distinction broken (timeout audited as deny, or vice-versa). #2392",
     "ALLOWLIST-PROMPTED": "an allow-list-covered host prompted for consent (a real static-allow invariant break). #2419",
+    "HOST-SCOPE-VIOLATION": "an nginx-style host scope (exact/inclusive/subdomains, #2377) let the wrong name through / blocked the right one.",
+    "PORT-SCOPE-VIOLATION": "a port-scoped allow (host:443) permitted a different port (:80), or vice-versa.",
+    "SNAPSHOT-REPLAY": "a resolved-while-away row replayed (or a held row vanished) in the reconnect snapshot -- now deterministic under controlled DNS (#2424).",
 }
 
 _EXPECT_CONN_NAMES = {
@@ -678,6 +697,18 @@ class SmokeTest:
         self.app: ConsentDeciderApp | None = None
         self.container: str | None = None
         self._shared_d2: RawDecider | None = None
+        # The controlled-DNS fixture (#2424): None unless --controlled-dns is on.
+        # When started it points the real sidecar's upstream at a test DNS that
+        # resolves chosen names to single stable IPs (fronted by a test HTTP/HTTPS
+        # server), removing the CDN-IP-rotation + L3/L4 confounds that made the
+        # snapshot-replay / host-scope / port-scope phases indeterminate.
+        self.dns: ControlledDns | None = None
+        # Path to a temp containers.conf (netns=bridge) the smoketest writes when
+        # controlled DNS is on, so klangkd's sidecar + the fixture's containers
+        # land on the same bridge network (the default rootless netns here is
+        # pasta, which isolates containers -- the sidecar couldn't reach the
+        # fixture's DNS/target containers). Cleared in teardown.
+        self._containers_conf: str | None = None
         # Extra deciders / workspaces / terminal-WS opened by the decider-scope
         # + audit phases. Closed + deleted in teardown so nothing leaks into
         # the no-decider phase (the #2413 leak class) or past the run. A phase
@@ -689,26 +720,34 @@ class SmokeTest:
 
     # -- setup ------------------------------------------------------------
     def _start_server(self) -> dict:
+        kwargs = dict(
+            uds=False,
+            log_path=os.environ.get("SMOKE_KLANGKD_LOG") or None,
+            KLANGKD_JWT_SECRET="smoketest-egress-secret",
+            KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
+            KLANGKD_DEFAULT_USER="smoke@example.com",
+            KLANGKD_DEFAULT_PASSWORD="smokepass",
+            KLANGKD_TEST_MODE="1",
+            KLANGKD_ALLOW_AUTOSTART="1",
+            KLANGKD_IDLE_TIMEOUT_SECONDS="3600",
+            KLANGKD_EGRESS_CONSENT_TIMEOUT=str(self.args.consent_timeout),
+            # Shorten the sidecar's learned-IP TTL floor + sweep cadence
+            # (forwarded to the sidecar by klangkd) so a `5s` verdict really
+            # expires in ~5s, not the 30s floor -- lets the run test a timed
+            # verdict's within/exceeding in seconds (#2363).
+            KLANGKNETWORK_EGRESS_MIN_TTL="1",
+            KLANGKNETWORK_EGRESS_SWEEP_INTERVAL="1",
+            LOGFIRE_TOKEN="",
+        )
+        # Point the real sidecar's upstream at the controlled-DNS fixture
+        # (#2424): when --controlled-dns is on, every workspace the smoketest
+        # creates resolves chosen names to single stable test IPs and forwards
+        # the rest to a real resolver. Honored verbatim by
+        # _start_network_sidecar (mirrors the MIN_TTL/SWEEP forwarding above).
+        if self.dns is not None:
+            kwargs["KLANGKNETWORK_EGRESS_UPSTREAM"] = self.dns.upstream_ip
         try:
-            return start_server(
-                uds=False,
-                log_path=os.environ.get("SMOKE_KLANGKD_LOG") or None,
-                KLANGKD_JWT_SECRET="smoketest-egress-secret",
-                KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
-                KLANGKD_DEFAULT_USER="smoke@example.com",
-                KLANGKD_DEFAULT_PASSWORD="smokepass",
-                KLANGKD_TEST_MODE="1",
-                KLANGKD_ALLOW_AUTOSTART="1",
-                KLANGKD_IDLE_TIMEOUT_SECONDS="3600",
-                KLANGKD_EGRESS_CONSENT_TIMEOUT=str(self.args.consent_timeout),
-                # Shorten the sidecar's learned-IP TTL floor + sweep cadence
-                # (forwarded to the sidecar by klangkd) so a `5s` verdict really
-                # expires in ~5s, not the 30s floor -- lets the run test a timed
-                # verdict's within/exceeding in seconds (#2363).
-                KLANGKNETWORK_EGRESS_MIN_TTL="1",
-                KLANGKNETWORK_EGRESS_SWEEP_INTERVAL="1",
-                LOGFIRE_TOKEN="",
-            )
+            return start_server(**kwargs)
         except Exception as exc:  # noqa: BLE001
             print(
                 f"\n!! could not start klangkd: {exc!r}\n\n"
@@ -743,7 +782,13 @@ class SmokeTest:
         }
 
     @staticmethod
-    def _create_workspace(server: dict, auth: dict) -> str:
+    def _create_workspace(
+        server: dict,
+        auth: dict,
+        allow_list: list[str] | None = None,
+        rejected_list: list[str] | None = None,
+        name: str | None = None,
+    ) -> str:
         client = httpx.Client(
             base_url=server["url"], headers=auth["headers"], timeout=120
         )
@@ -751,9 +796,16 @@ class SmokeTest:
             r = client.post(
                 "/api/v1/workspaces",
                 json={
-                    "name": f"smoke-{int(time.time() * 1000) % 100000}",
-                    "allowed_domains": _ALLOW_LIST,
-                    "rejected_domains": _REJECTED_LIST,
+                    "name": name
+                    or f"smoke-{int(time.time() * 1000) % 100000}",
+                    "allowed_domains": (
+                        _ALLOW_LIST if allow_list is None else allow_list
+                    ),
+                    "rejected_domains": (
+                        _REJECTED_LIST
+                        if rejected_list is None
+                        else (rejected_list or [])
+                    ),
                     "egress_mode": "interactive",
                     "auto_start": True,
                 },
@@ -819,7 +871,52 @@ class SmokeTest:
         except Exception:
             pass
 
+    def _enable_bridge_networking(self) -> None:
+        """Point podman at a temp containers.conf with ``netns = "bridge"``.
+
+        The fixture's DNS + target containers and klangkd's sidecar must share
+        a bridge network so the sidecar can reach them by IP. The default
+        rootless netns on many hosts is ``pasta``, which gives each container
+        its OWN isolated netns (no inter-container routing) -- under it the
+        sidecar cannot reach the fixture, and no controlled-DNS prompt ever
+        surfaces (#2424). Setting ``netns = "bridge"`` via CONTAINERS_CONF
+        (inherited by both the fixture's podman calls and the owned klangkd
+        subprocess) puts them on the shared ``podman`` bridge instead. No-op if
+        the ambient CONTAINERS_CONF already sets a netns.
+        """
+        import tempfile
+
+        if os.environ.get("CONTAINERS_CONF"):
+            return  # operator supplied their own; respect it
+        d = tempfile.mkdtemp(prefix="klangk-smoke-cc-")
+        path = os.path.join(d, "containers.conf")
+        with open(path, "w") as f:
+            f.write('[containers]\nnetns = "bridge"\n')
+        os.environ["CONTAINERS_CONF"] = path
+        self._containers_conf = path
+
     async def setup(self) -> None:
+        # Start the controlled-DNS fixture BEFORE the owned klangkd so its
+        # upstream IP is known when the sidecar is created (the env is read at
+        # workspace/sidecar-creation time). Skipped for an external --server
+        # (the operator must set KLANGKNETWORK_EGRESS_UPSTREAM on it themselves)
+        # or when --no-controlled-dns is passed.
+        if self.args.controlled_dns and not self.args.server:
+            self._enable_bridge_networking()
+            try:
+                self.dns = ControlledDns(image=self.args.sidecar_image)
+                self.dns.start()
+                print(
+                    f"controlled-dns up: sidecar upstream -> "
+                    f"{self.dns.upstream_ip} (target slice "
+                    f"{self.dns.target_ips[0]}..{self.dns.target_ips[-1]})"
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"!! controlled-dns failed to start: {exc!r}",
+                    file=sys.stderr,
+                )
+                self.dns = None
         if self.args.server:
             url = self.args.server.rstrip("/")
             self.server = {
@@ -1484,11 +1581,25 @@ class SmokeTest:
     async def run_snapshot_replay_phase(self, pilot) -> None:
         """Reconnect snapshot replay: a request resolved while a decider is
         disconnected does NOT replay in the snapshot it gets on reconnect; a
-        still-held one does."""
+        still-held one does.
+
+        Default-ON under controlled DNS (#2424): with a single stable IP per
+        host there is no CDN IP-cascade respawn to masquerade as a replay
+        event, so the phase is a hard PASS/FAIL rather than the indeterminate
+        FINDING it was on real multi-IP hosts. Skipped (with a note) when
+        controlled DNS is off, since without it the result is indeterminate."""
         if not self.args.snapshot:
             return
+        if self.dns is None:
+            print(
+                "\n--- reconnect snapshot replay: SKIPPED "
+                "(--no-controlled-dns; the result is indeterminate without "
+                "single-IP test hosts, #2424) ---"
+            )
+            return
         print(
-            "\n--- reconnect snapshot replay: resolved-while-away rows don't replay ---"
+            "\n--- reconnect snapshot replay: resolved-while-away rows don't "
+            "replay (controlled DNS -> hard PASS/FAIL) ---"
         )
         step = _Step(
             self.summary.total, "snapshot", "n/a", False, "snapshot", "-"
@@ -1507,7 +1618,11 @@ class SmokeTest:
             if not self.args.continue_run:
                 self._abort = True
             return
-        host_a, host_b = "amazon.com", "microsoft.com"
+        # Controlled, single-IP hosts (distinct IPs so A and B are two distinct
+        # consent flows; each has exactly one IP, so denying A can't cascade into
+        # a fresh held request that looks like a replay bug).
+        host_a, host_b = "snap-a.test", "snap-b.test"
+        self.dns.allocate_pair(host_a, host_b)
         ca, cb = _canonical(host_a), _canonical(host_b)
         of_a, of_b = "/tmp/smoke_sr_a.out", "/tmp/smoke_sr_b.out"
         _trigger(self.container, host_a, of_a)
@@ -1575,17 +1690,20 @@ class SmokeTest:
                 "snapshot has the still-held B, not the resolved A",
             )
         elif has_b and has_a:
-            # A denied on one IP -> curl tries the next IP (CDN cascade) -> a NEW
-            # held request for A appears; can't cleanly distinguish from a replay
-            # bug with real multi-IP hosts -> finding, not a failure.
+            # Controlled DNS -> A has a single IP -> a deny can't cascade into a
+            # fresh held request. So A present in the reconnect snapshot IS a
+            # real replay bug (a resolved-while-away row replayed), not timing.
             status, detail = (
-                FINDING,
-                "A present (likely a CDN-cascade respawn, not a replay bug)",
+                MISMATCH,
+                "A replayed in reconnect snapshot (resolved-while-away row "
+                "replayed; a real snapshot bug, not a CDN cascade under "
+                "controlled DNS)",
             )
         else:
             status, detail = (
-                FINDING,
-                f"B missing from snapshot (timing/cascade): B={has_b} A={has_a}",
+                MISMATCH,
+                f"B missing from reconnect snapshot (a still-held row "
+                f"vanished): B={has_b} A={has_a}",
             )
         self._record_probe(
             step,
@@ -1601,6 +1719,374 @@ class SmokeTest:
         await _wait_resolved(self.app, rb, 15.0)
         await _wait_result(self.container, of_a, timeout=10.0)
         await _wait_result(self.container, of_b, timeout=10.0)
+
+    async def _raw_wait_no_request(
+        self, d: RawDecider, canon: str, window: float = 5.0
+    ) -> str | None:
+        """None if no request for ``canon`` surfaces in ``window`` (draining
+        frames so a late egress_request is actually seen), else the request id.
+        Mirrors :func:`_wait_no_request` for the textual app, for a RawDecider."""
+        deadline = time.time() + window
+        while time.time() < deadline:
+            rid = next((r for r, h in d.held.items() if h == canon), None)
+            if rid is not None:
+                return rid
+            await d._recv(0.3)
+        return None
+
+    async def _raw_wait_for_any(
+        self, d: RawDecider, canons: set[str], timeout: float = 12.0
+    ) -> str | None:
+        """The request id of the first held request whose canonical dest is in
+        ``canons``, or None on timeout. Used by the port-scope phase, where an
+        off-port request to an allow-listed host surfaces named by IP (the
+        allow-list DNS-learn path leaves the record's host=None), so the request
+        matches the controlled IP, not the hostname."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rid = next((r for r, h in d.held.items() if h in canons), None)
+            if rid is not None:
+                return rid
+            await d._recv(0.4)
+        return None
+
+    async def _probe_sidecar_ready_raw(
+        self, d: RawDecider, cont: str, host: str, budget: float = 60.0
+    ) -> bool:
+        """True once a throwaway off-list host surfaces a consent request in
+        ``d`` (the sidecar consent-WS is wired), else False. Allows the hold so
+        the probe can't perturb later assertions. Mirrors _wait_sidecar_ready
+        for a workspace driven via a RawDecider (#2417) -- a fresh workspace's
+        sidecar WS connects on its own backoff, so a missing prompt for the
+        FIRST scored host is readiness, not a scope violation."""
+        canon = _canonical(host)
+        deadline = time.time() + budget
+        attempt = 0
+        while time.time() < deadline:
+            of = f"/tmp/smoke_rawready_{attempt}.out"
+            _trigger(cont, host, of)
+            rid = await d.wait_for(canon, timeout=6.0)
+            if rid is not None:
+                await d.verdict(rid, DECISION_ALLOWED, DURATION_ONCE)
+                await d.wait_resolution(rid, 15.0)
+                return True
+            attempt += 1
+            await asyncio.sleep(0.5)
+        return False
+
+    async def run_host_scope_phase(self, pilot) -> None:
+        """nginx-style host scopes (#2377) against distinct controlled IPs (#2424).
+
+        With the apex and its subdomain on DIFFERENT controlled IPs, the L3/L4
+        allow rule (per IP) can't paper over the L7 hostname spec, so each scope
+        mode is observable on the real stack:
+          * bare ``exact.test`` (EXACT): apex covered, subdomain NOT.
+          * ``.incl.test`` (INCLUSIVE): apex + subdomains covered.
+          * ``*.wild.test`` (SUBDOMAINS): subdomains covered, apex NOT.
+        Driven via a dedicated interactive workspace + a raw decider scoped to
+        it. Needs controlled DNS (skipped otherwise)."""
+        if not self.args.host_scope:
+            return
+        if self.dns is None:
+            print(
+                "\n--- host scope: SKIPPED (--no-controlled-dns; needs distinct "
+                "controlled IPs so the L3/L4 rule can't mask the L7 spec, #2424) ---"
+            )
+            return
+        print(
+            "\n--- host scope: exact / inclusive / subdomains (#2377) on "
+            "distinct controlled IPs ---"
+        )
+        parent = _Step(
+            self.summary.total, "host-scope", "n/a", False, "host-scope", "-"
+        )
+        # Distinct controlled IPs per name. The (apex, sub) pairs MUST differ so
+        # an allow-learned ACCEPT for the apex IP can't cover the subdomain's IP.
+        cases = [
+            ("exact.test", True, "exact(apex) covered"),
+            ("sub.exact.test", False, "exact(sub) NOT covered"),
+            ("incl.test", True, "inclusive(apex) covered"),
+            ("sub.incl.test", True, "inclusive(sub) covered"),
+            ("wild.test", False, "subdomains(apex) NOT covered"),
+            ("sub.wild.test", True, "subdomains(sub) covered"),
+        ]
+        for host, _covered, _label in cases:
+            self.dns.allocate(host)
+        allow = ["exact.test", ".incl.test", "*.wild.test"]
+        ws_id = None
+        d: RawDecider | None = None
+        cont: str | None = None
+        conn = None
+        try:
+            ws_id = await asyncio.to_thread(
+                self._create_workspace,
+                self.server,
+                self.auth,
+                allow,
+                [],
+                f"smoke-hostscope-{int(time.time() * 1000) % 100000}",
+            )
+            self._extra_ws_ids.append(ws_id)
+            print(f"host-scope workspace {ws_id}  allow={allow}")
+            conn = await self._open_terminal_ws(ws_id)
+            self._extra_ws_conns.append(
+                (conn, asyncio.create_task(self._drain(conn)))
+            )
+            cont = _container_for_workspace(ws_id)
+            d = await self._connect_raw_decider(ws_id, ping=True)
+            self._extra_deciders.append(d)
+            await d.settle()
+            # Wait for the sidecar consent-WS to wire before the scored hosts
+            # (#2417): a fresh workspace's sidecar connects on its own backoff,
+            # so the first non-covered host could fail-close (no prompt) and
+            # false-positive as a scope violation.
+            ready_host = "hs-ready.test"
+            self.dns.allocate(ready_host)
+            if not await self._probe_sidecar_ready_raw(d, cont, ready_host):
+                self._record_probe(
+                    parent,
+                    "sidecar ready",
+                    "no-request(!)",
+                    None,
+                    FINDING,
+                    "host-scope phase failed: sidecar consent-WS did not wire "
+                    "(#2417); cannot assert scope boundaries",
+                )
+                await d.close()
+                return
+
+            for host, expect_covered, label in cases:
+                if self._abort:
+                    return
+                canon = _canonical(host)
+                of = f"/tmp/smoke_hs_{canon.replace('.', '_')}.out"
+                _trigger(cont, host, of)
+                if expect_covered:
+                    # Covered -> no consent request, and the connection succeeds
+                    # (the learned ACCEPT + the test server -> exit 0).
+                    rid = await self._raw_wait_no_request(d, canon, window=5.0)
+                    text = await _wait_result(cont, of, timeout=20.0)
+                    ec = _parse_exit(text)
+                    if rid is None and ec == 0:
+                        sx, dx = PASS, ""
+                    elif rid is not None:
+                        sx, dx = (
+                            MISMATCH,
+                            (
+                                f"host scope: {label} -- {host} prompted for consent "
+                                f"(should be covered by the allow-list)"
+                            ),
+                        )
+                    else:
+                        sx, dx = (
+                            FINDING,
+                            (
+                                f"host scope: {label} -- covered host did not connect "
+                                f"cleanly (exit {ec})"
+                            ),
+                        )
+                    self._record_probe(parent, label, "covered", ec, sx, dx)
+                else:
+                    # NOT covered -> a consent request surfaces; allow it so the
+                    # connection completes (exit 0) and clean up.
+                    rid = await d.wait_for(canon, 12.0)
+                    if rid is None:
+                        self._record_probe(
+                            parent,
+                            label,
+                            "no-request(!)",
+                            None,
+                            MISMATCH,
+                            f"host scope: {label} -- {host} did NOT prompt "
+                            f"(should be uncovered by the allow-list)",
+                        )
+                        if not self.args.continue_run:
+                            self._abort = True
+                        return
+                    await d.verdict(rid, DECISION_ALLOWED, DURATION_ONCE)
+                    await d.wait_resolution(rid, 15.0)
+                    text = await _wait_result(cont, of)
+                    ec = _parse_exit(text)
+                    if ec == 0:
+                        sx, dx = PASS, ""
+                    else:
+                        sx, dx = (
+                            FINDING,
+                            (
+                                f"host scope: {label} -- allowed but did not connect "
+                                f"cleanly (exit {ec})"
+                            ),
+                        )
+                    self._record_probe(
+                        parent, label, "prompted+allow", ec, sx, dx
+                    )
+                if sx == MISMATCH and not self.args.continue_run:
+                    self._abort = True
+                    return
+        except Exception as e:  # noqa: BLE001
+            self._record_probe(
+                parent,
+                "bring up host-scope ws",
+                "error",
+                None,
+                MISMATCH,
+                f"host-scope phase failed: {e!r}",
+            )
+            if not self.args.continue_run:
+                self._abort = True
+        finally:
+            if d is not None:
+                await d.close()
+
+    async def run_port_scope_phase(self, pilot) -> None:
+        """Port-scoped allow specs (#2377 / #2256) on a controlled IP (#2424).
+
+        ``svc.test:443`` allow-lists ONLY :443; ``:80`` on the same controlled
+        IP must still prompt. Same IP (the port scoping is at L4, so the L3/L4
+        rule is per IP+port and the confound the host-scope phase works around
+        does not apply). Needs controlled DNS (skipped otherwise)."""
+        if not self.args.port_scope:
+            return
+        if self.dns is None:
+            print(
+                "\n--- port scope: SKIPPED (--no-controlled-dns; needs a "
+                "controlled IP with a test server on :80 + :443, #2424) ---"
+            )
+            return
+        print(
+            "\n--- port scope: host:443 does not permit :80 on the same "
+            "controlled IP ---"
+        )
+        parent = _Step(
+            self.summary.total, "port-scope", "n/a", False, "port-scope", "-"
+        )
+        self.dns.allocate("svc.test")
+        allow = ["svc.test:443"]
+        ws_id = None
+        d: RawDecider | None = None
+        cont: str | None = None
+        conn = None
+        try:
+            ws_id = await asyncio.to_thread(
+                self._create_workspace,
+                self.server,
+                self.auth,
+                allow,
+                [],
+                f"smoke-portscope-{int(time.time() * 1000) % 100000}",
+            )
+            self._extra_ws_ids.append(ws_id)
+            print(f"port-scope workspace {ws_id}  allow={allow}")
+            conn = await self._open_terminal_ws(ws_id)
+            self._extra_ws_conns.append(
+                (conn, asyncio.create_task(self._drain(conn)))
+            )
+            cont = _container_for_workspace(ws_id)
+            d = await self._connect_raw_decider(ws_id, ping=True)
+            self._extra_deciders.append(d)
+            await d.settle()
+            ready_host = "ps-ready.test"
+            self.dns.allocate(ready_host)
+            if not await self._probe_sidecar_ready_raw(d, cont, ready_host):
+                self._record_probe(
+                    parent,
+                    "sidecar ready",
+                    "no-request(!)",
+                    None,
+                    FINDING,
+                    "port-scope phase failed: sidecar consent-WS did not wire "
+                    "(#2417); cannot assert port scoping",
+                )
+                await d.close()
+                return
+
+            # 1) :443 is covered -> no prompt, connect OK (exit 0).
+            of443 = "/tmp/smoke_ps_443.out"
+            _trigger(cont, "svc.test", of443, port=443, scheme="https")
+            rid = await self._raw_wait_no_request(
+                d, _canonical("svc.test"), window=5.0
+            )
+            text = await _wait_result(cont, of443, timeout=20.0)
+            ec = _parse_exit(text)
+            if rid is None and ec == 0:
+                sx, dx = PASS, ""
+            elif rid is not None:
+                sx, dx = (
+                    MISMATCH,
+                    ("port scope: svc.test:443 prompted (should be covered)"),
+                )
+            else:
+                sx, dx = (
+                    FINDING,
+                    (
+                        f"port scope: :443 covered host did not connect cleanly (exit {ec})"
+                    ),
+                )
+            self._record_probe(parent, ":443 covered", "covered", ec, sx, dx)
+            if sx == MISMATCH and not self.args.continue_run:
+                self._abort = True
+                await d.close()
+                return
+
+            # 2) :80 is NOT covered -> a prompt surfaces; allow + clean up.
+            # NOTE: the request is named by IP, not hostname. svc.test IS
+            # allow-listed (on :443), so the proxy's allow-list DNS-learn path
+            # (allow(), which leaves the learned record's host=None) recorded
+            # the IP without a host name -- only the non-allow-listed
+            # _record_hosts path names the host. So this off-port request
+            # surfaces as the controlled IP, not "svc.test". Port-scoping itself
+            # is correct (:80 is not covered -> prompts); match either name.
+            svc_ip = self.dns.ip_for("svc.test")
+            of80 = "/tmp/smoke_ps_80.out"
+            _trigger(cont, "svc.test", of80, port=80, scheme="http")
+            rid = await self._raw_wait_for_any(
+                d, {_canonical("svc.test"), _canonical(svc_ip)}, 12.0
+            )
+            if rid is None:
+                self._record_probe(
+                    parent,
+                    ":80 NOT covered",
+                    "no-request(!)",
+                    None,
+                    MISMATCH,
+                    "port scope: svc.test:80 did NOT prompt (host:443 leaked to :80)",
+                )
+                if not self.args.continue_run:
+                    self._abort = True
+                await d.close()
+                return
+            await d.verdict(rid, DECISION_ALLOWED, DURATION_ONCE)
+            await d.wait_resolution(rid, 15.0)
+            text = await _wait_result(cont, of80)
+            ec = _parse_exit(text)
+            if ec == 0:
+                sx, dx = PASS, ""
+            else:
+                sx, dx = (
+                    FINDING,
+                    (
+                        f"port scope: :80 allowed but did not connect cleanly (exit {ec})"
+                    ),
+                )
+            self._record_probe(
+                parent, ":80 prompted+allow", "prompted+allow", ec, sx, dx
+            )
+            if sx == MISMATCH and not self.args.continue_run:
+                self._abort = True
+        except Exception as e:  # noqa: BLE001
+            self._record_probe(
+                parent,
+                "bring up port-scope ws",
+                "error",
+                None,
+                MISMATCH,
+                f"port-scope phase failed: {e!r}",
+            )
+            if not self.args.continue_run:
+                self._abort = True
+        finally:
+            if d is not None:
+                await d.close()
 
     async def run_static_refusal_phase(self) -> None:
         """#2395: a workspace with ``egress_mode='static'`` must refuse
@@ -2429,6 +2915,13 @@ class SmokeTest:
                     await self.run_decider_scope_phase(pilot)
                 if not stop and not self._abort:
                     await self.run_audit_distinction_phase(pilot)
+                # Controlled-DNS phases (#2424): host-scope + port-scope use their
+                # own workspace + raw decider (independent of the textual app),
+                # so they run last inside run_test.
+                if not stop and not self._abort:
+                    await self.run_host_scope_phase(pilot)
+                if not stop and not self._abort:
+                    await self.run_port_scope_phase(pilot)
             # run_test exited -> the decider WS dropped -> the server deregistered
             # the decider -> the workspace reverted to static allow-list (#2308).
             # _shared_d2 (the multi-decider / snapshot raw decider) is a SEPARATE
@@ -2448,6 +2941,23 @@ class SmokeTest:
         return 1 if self.summary.mismatches else 0
 
     async def teardown(self) -> None:
+        if self.dns is not None:
+            try:
+                self.dns.stop()
+            except Exception:
+                pass
+            self.dns = None
+        if self._containers_conf is not None:
+            import shutil
+
+            os.environ.pop("CONTAINERS_CONF", None)
+            try:
+                shutil.rmtree(
+                    os.path.dirname(self._containers_conf), ignore_errors=True
+                )
+            except Exception:
+                pass
+            self._containers_conf = None
         if self._shared_d2 is not None:
             await self._shared_d2.close()
             self._shared_d2 = None
@@ -2611,11 +3121,12 @@ def main() -> int:
     p.add_argument(
         "--snapshot",
         dest="snapshot",
-        action="store_true",
-        help="enable the reconnect snapshot-replay phase (DEFAULT OFF: with "
-        "real multi-IP hosts the result is indeterminate — a "
-        "resolved-while-away row is indistinguishable from a CDN "
-        "IP-cascade respawn — so it records a finding, not a pass/fail)",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="the reconnect snapshot-replay phase (DEFAULT ON under controlled "
+        "DNS, #2424: with single-IP test hosts it is a hard PASS/FAIL; use "
+        "--no-snapshot to skip. Without --controlled-dns the phase is skipped "
+        "(indeterminate on real multi-IP hosts).",
     )
     p.add_argument(
         "--no-revoke",
@@ -2664,6 +3175,35 @@ def main() -> int:
         dest="delete_workspace",
         action="store_false",
         help="do not delete the workspace on exit",
+    )
+    p.add_argument(
+        "--controlled-dns",
+        dest="controlled_dns",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="bring up the controlled-DNS fixture (#2424) and point the real "
+        "sidecar at it so chosen hostnames resolve to single stable test IPs "
+        "(default ON). Disabling reverts the snapshot/host-scope/port-scope "
+        "phases to their pre-#2424 behavior (skipped / indeterminate).",
+    )
+    p.add_argument(
+        "--sidecar-image",
+        default="localhost/klangk-network-sidecar:latest",
+        help="the network-sidecar image the controlled-DNS fixture reuses for "
+        "its DNS forwarder + multi-IP HTTP/HTTPS target (default: "
+        "localhost/klangk-network-sidecar:latest).",
+    )
+    p.add_argument(
+        "--no-host-scope",
+        dest="host_scope",
+        action="store_false",
+        help="skip the host-scope (exact/inclusive/subdomains) phase (#2377/#2424)",
+    )
+    p.add_argument(
+        "--no-port-scope",
+        dest="port_scope",
+        action="store_false",
+        help="skip the port-scope (host:443 vs :80) phase (#2424)",
     )
     args = p.parse_args()
     if args.seed is None:

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -825,6 +825,36 @@ class TestStartContainer:
         assert "KLANGKNETWORK_EGRESS_MIN_TTL=1" in kwargs["env"]
         assert "KLANGKNETWORK_EGRESS_SWEEP_INTERVAL=1" in kwargs["env"]
 
+    async def test_start_network_sidecar_upstream_env_override(
+        self, monkeypatch
+    ):
+        # KLANGKNETWORK_EGRESS_UPSTREAM, when set in klangkd's env, pins the
+        # sidecar's upstream verbatim (operator-pinnable workspace DNS, and the
+        # path the egress smoketest's controlled-DNS fixture uses, #2424).
+        # Mirrors the MIN_TTL/SWEEP forwarding: set -> honored, absent -> the
+        # detected resolver (the next test pins the fallback explicitly).
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        from klangk import netfilter as _nf
+
+        # Detection would return 8.8.8.8; the override must win.
+        monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_UPSTREAM", "10.88.0.23")
+        with patch_podman(self.registry) as p:
+            await self.registry._start_network_sidecar(
+                ws_id, ["github.com:443"]
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert "KLANGKNETWORK_EGRESS_UPSTREAM=10.88.0.23" in kwargs["env"]
+        assert not any(
+            e.startswith("KLANGKNETWORK_EGRESS_UPSTREAM=8.8.8.8")
+            for e in kwargs["env"]
+        )
+
     async def test_start_network_sidecar_publishes_host_ports(
         self, monkeypatch
     ):


### PR DESCRIPTION
Closes #2424 — the leftover test-infrastructure work spun out of the interactive-egress fuzz smoketest (#2392).

## What this adds

A **controlled-DNS fixture** so chosen hostnames resolve to single, stable, test-controlled IPs (each fronted by a test HTTP/HTTPS server on :80 + :443). This removes the two properties of real hosts that made three smoketest checklist items indeterminate:

1. **CDN IP rotation / multiple A records** — a later connection to the "same" host resolving to a different IP masquerades as a snapshot-replay event (#2412).
2. **The L3/L4 allow rule** — once an apex IP is allow-listed, a subdomain sharing that IP is allowed at L3/L4 regardless of the L7 hostname spec.

### The three items this unblocks

- **Snapshot-replay → default-on hard PASS/FAIL.** Promoted from opt-in `--snapshot`; with single-IP test hosts there's no CDN cascade to distinguish from a replay bug, so it asserts hard PASS/FAIL (new `SNAPSHOT-REPLAY` outcome) instead of a `FINDING`.
- **Host-scope phase (new).** `bare` / `.host` / `*.host` (#2377) exercised on **distinct** controlled IPs so the per-IP allow rule can't paper over the L7 spec (new `HOST-SCOPE-VIOLATION` outcome).
- **Port-scope phase (new).** `host:443` does not permit `:80` on the same controlled IP (new `PORT-SCOPE-VIOLATION` outcome).

## How it works (no new code paths beyond one config knob)

The fixture (`src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py`) drives the real stack only — two ordinary podman containers on the shared bridge network:

- a **forwarding UDP :53 DNS** that answers chosen names with their single mapped IP and forwards everything else to a real resolver (so the fuzz loop's real hosts still resolve);
- one **multi-IP HTTP/HTTPS target** (a single container holding N secondary IPs via `NET_ADMIN`, serving :80 + :443 on `0.0.0.0`). Distinct names get distinct IPs.

The smoketest points the real sidecar at the DNS container via `KLANGKNETWORK_EGRESS_UPSTREAM`, and sets `CONTAINERS_CONF` with `netns="bridge"` — the default rootless netns here is `pasta`, which isolates containers (the sidecar couldn't reach the fixture's containers otherwise). No test hooks in the consent/proxy/security logic.

### The one server touch

`container.py` honors `KLANGKNETWORK_EGRESS_UPSTREAM` when set in klangkd's env, mirroring the existing `MIN_TTL`/`SWEEP_INTERVAL` forwarding — an operator-pinnable sidecar DNS upstream (e.g. a corporate resolver). This is **necessary**, not optional: rootless podman can't bind host `:53` (`ip_unprivileged_port_start=1024`) or rewrite the root-owned `/etc/resolv.conf` symlink, so the only way to point the real sidecar at the fixture is via the upstream env. Absent → unchanged auto-detect. Changelog entry added; unit test added.

## Verification

- **Live through the real stack** (klangkd + real network sidecar + real `ConsentDeciderApp` decider), seeds 7 and 42: snapshot ✅, host-scope 6/6 ✅, port-scope ✅ — **12–13/12–13 pass, 0 mismatches**, deterministic.
- `--no-controlled-dns` cleanly skips the three phases (backward-compatible).
- Full backend suite: **4910 passed, 100% coverage** (the `klangk` package gate).

### One finding worth noting

An off-port request to an *allow-listed* host (e.g. `svc.test:80` when `svc.test:443` is allow-listed) surfaces in the decider named by **IP**, not hostname: the allow-list DNS-learn path (`allow()`, which leaves the learned record's `host=None`) differs from the non-allow-listed `_record_hosts` path that names the host. The port-scope assertion matches the IP accordingly. It's a minor decider-UX wart (the human sees the raw IP for a new port on an allow-listed host), not a security issue — out of scope here; flagging for a follow-up if it matters.
