### PR TITLE
fix(egress): host-scope timed consent allows (#2434)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -532,7 +532,7 @@ operators or integrators to act when upgrading.
 - **Revoking a `forever` verdict retracts its durable list entry (#2370,
   #2339).** Revoking a `forever` allow/deny now removes the host from
   `allowed_domains`/`rejected_domains` (not just the in-memory sidecar rule),
-  and the sidecar clears its in-session `_FOREVER_HOSTS`/`_VERDICT_CACHE` for
+  and the sidecar clears its in-session `_SESSION_HOST_ALLOWS`/`_VERDICT_CACHE` for
   the host -- so the verdict stops taking effect immediately and no longer
   re-applies on the next sidecar restart. The retract is best-effort (failures
   logged + swallowed); the verdict row is marked revoked regardless. A
@@ -776,6 +776,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 - **`klangk invite` → `klangk admin invitations send` (#1374).**
 
 ### Fixed
+
+- **Timed egress-consent allows now cover the whole host (#2434).** A timed or
+  `until restart` `allow` verdict now allow-lists the consented host for its
+  whole duration — the same as `allow forever` already did — instead of only
+  the IP resolved at the moment of the decision (`once` stays per-connection).
+  This fixes intermittent `ECONNREFUSED` on a connection to a host the user had
+  just allowed, when the connection resolved to a different (CDN-rotated) IP
+  than the one consented.
 
 - **Dead-owner container reap at startup (#2342).** klangkd now stamps each
   workspace + network-sidecar container with the creating daemon's PID

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -179,7 +179,7 @@ WORKSPACE_TOKEN_PATH = "/run/klangk/workspace-token"
 # EXACT (apex only); a leading-dot ``.host`` is INCLUSIVE (apex + subdomains);
 # ``*.host`` is SUBDOMAINS only. (Bare = exact is the breaking flip from the
 # old "bare = apex+subdomains" model.) One definition shared by parse_specs /
-# ports_for / _forever_host_allows.
+# ports_for / _session_host_allows_ttl.
 _EXACT = "exact"
 _INCLUSIVE = "inclusive"
 _SUBDOMAINS = "subdomains"
@@ -225,16 +225,25 @@ SPECS = parse_specs()
 # matching one of these is NXDOMAIN'd unconditionally (see :func:`rejected_for`).
 REJECT_SPECS = parse_specs("KLANGKNETWORK_EGRESS_REJECT")
 
-# Hosts allow-listed in-session by a `forever` consent verdict (#2372): each
-# entry is (host, port, mode), mirroring SPECS. On a forever allow,
-# _decide_and_verdict adds the consented host:port here so ports_for treats it
-# as allow-listed for the rest of the session -- the DNS path then learns every
+# Hosts allow-listed in-session by a consent ``allow`` verdict, timed or
+# forever (#2372, #2434): each entry is (host, port, mode, expire), mirroring
+# SPECS plus an expiry epoch. On an allow whose duration is not ``once``,
+# _decide_and_verdict adds the consented host:port here (expire = now + the
+# verdict's TTL; forever/tilrestart map to ~a year) so ports_for treats it as
+# allow-listed for the verdict's lifetime -- the DNS path then learns every
 # resolved IP and allows it without NFQUEUE, so a CDN-rotated IP does NOT
-# re-prompt seconds after the user said "allow forever." Dies with the sidecar
-# (in-memory); the persisted allowed_domains entry (#2368) covers the next
-# restart. Touched only on the event-loop thread (the NFQUEUE consumer is
-# loop-driven, and ports_for runs in the DNS loop) -- no lock, like SPECS.
-_FOREVER_HOSTS: list[tuple[str, int | None, str]] = []
+# re-prompt (and _session_host_allows_ttl short-circuits any SYN that still
+# races NFQUEUE). This is the fix for the ALLOW-REFUSED mismatch (#2434): a
+# timed allow used to cover only the IP resolved at decision time, so a
+# CDN-rotated IP re-entered NFQUEUE and a hold timeout there fail-closed to a
+# deny REJECT an in-effect allow should override. ``once`` adds nothing -- it is
+# per-connection, so a reconnect re-prompts. Dies with the sidecar (in-memory);
+# the persisted allowed_domains entry (#2368) covers the next restart. Touched
+# only on the event-loop thread (the NFQUEUE consumer is loop-driven, and
+# ports_for runs in the DNS loop) -- no lock, like SPECS. Timed entries expire
+# lazily via _prune_session_allows (the structure is loop-only, so it can't be
+# swept off-loop by sweep_once under _LOCK like _LEARNED/_REJECTED).
+_SESSION_HOST_ALLOWS: list[tuple[str, int | None, str, float]] = []
 
 # Learned IPs: {ip: {"expire": epoch, "ports": set[int | None], "host": str}}.
 # ``ports`` holds the ACCEPT rule ports (a ``None`` is all-ports); ``host`` is
@@ -311,7 +320,7 @@ def nxdomain_for(wire: bytes) -> bytes:
 def _host_matches(qname: str, host: str, mode: str) -> bool:
     """Does ``qname`` match ``host`` under nginx-style scope ``mode`` (#2377)?
 
-    Shared by :func:`ports_for` (the DNS gate) and :func:`_forever_host_allows`
+    Shared by :func:`ports_for` (the DNS gate) and :func:`_session_host_allows_ttl`
     (the NFQUEUE gate) so the two can't drift. :data:`_EXACT` (bare host) matches
     the apex only; :data:`_INCLUSIVE` (``.host``) matches apex + subdomains;
     :data:`_SUBDOMAINS` (``*.host``) matches subdomains only. The suffix check
@@ -337,7 +346,9 @@ def ports_for(qname: str) -> set[int] | None:
     (subdomains only, apex excluded).
     """
     ports: set[int] = set()
-    for host, port, mode in (*SPECS, *_FOREVER_HOSTS):
+    _prune_session_allows()
+    session = [(h, p, m) for (h, p, m, _exp) in _SESSION_HOST_ALLOWS]
+    for host, port, mode in (*SPECS, *session):
         if not _host_matches(qname, host, mode):
             continue
         if port is None:
@@ -357,38 +368,75 @@ def rejected_for(qname: str) -> bool:
     return any(_host_matches(qname, host, mode) for host, _port, mode in REJECT_SPECS)
 
 
-def _add_forever_host(host: str, port: int) -> None:
-    """Allow-list ``host:port`` in-session for a `forever` consent verdict (#2372).
+def _prune_session_allows() -> None:
+    """Drop expired in-session host allows (lazy sweep, #2434).
 
-    Adds ``(host, port, _EXACT)`` to :data:`_FOREVER_HOSTS` so :func:`ports_for`
-    treats the host as allow-listed for the rest of the session -- the DNS path
-    then learns every resolved IP and allows it without NFQUEUE, so a
-    CDN-rotated IP no longer re-prompts seconds after the user allowed the
-    host. EXACT scope: the user approved the specific qname they saw, so only
-    that host (not its subdomains) is opened (#2377). Deduped; port-scoped
-    (callers gate on a real port -- a port-less entry would broaden to
-    all-ports).
+    :data:`_SESSION_HOST_ALLOWS` is loop-only (no lock), so -- unlike
+    :data:`_LEARNED` / :data:`_REJECTED`, which are swept off-loop by
+    :func:`sweep_once` under :data:`_LOCK` -- its timed entries expire here, on
+    the loop, the next time a gate (:func:`ports_for`,
+    :func:`_session_host_allows_ttl`, :func:`_add_session_host`) reads them.
+    Cheap (the list is tiny -- one entry per consented host:port) and keeps the
+    structure from growing unbounded across a long session.
     """
+    now = time.time()
+    _SESSION_HOST_ALLOWS[:] = [t for t in _SESSION_HOST_ALLOWS if t[3] > now]
+
+
+def _add_session_host(host: str, port: int, ttl: float) -> None:
+    """Allow-list ``host:port`` in-session for a consent allow verdict (#2372,
+    #2434).
+
+    Adds ``(host, port, _EXACT, now + ttl)`` to :data:`_SESSION_HOST_ALLOWS` so
+    :func:`ports_for` (the DNS gate) treats the host as allow-listed for the
+    verdict's lifetime -- the DNS path then learns every resolved IP and allows
+    it without NFQUEUE, so a CDN-rotated IP no longer re-prompts (or, if it
+    still races NFQUEUE, :func:`_session_host_allows_ttl` short-circuits it in
+    :func:`_cb`). EXACT scope: the user approved the specific qname they saw, so
+    only that host (not its subdomains) is opened (#2377). Deduped; a re-allow
+    of the same host:port refreshes the expiry (``max`` -- never shortens an
+    unexpired entry). A timed allow (5s/5m/1h/tilrestart) is host-scoped just
+    like ``forever`` (#2434); ``once`` carries no host-allow (per-connection, so
+    a reconnect re-prompts). Loop-only (no lock).
+    """
+    _prune_session_allows()
+    expire = time.time() + ttl
     spec = (host, port, _EXACT)
-    if all(s != spec for s in _FOREVER_HOSTS):
-        _FOREVER_HOSTS.append(spec)
+    for i, (h, p, mode, _exp) in enumerate(_SESSION_HOST_ALLOWS):
+        if (h, p, mode) == spec:
+            _SESSION_HOST_ALLOWS[i] = (h, p, mode, max(_exp, expire))
+            return
+    _SESSION_HOST_ALLOWS.append((host, port, _EXACT, expire))
 
 
-def _forever_host_allows(host: str, port: int) -> bool:
-    """Does a `forever` verdict allow-list ``host`` on ``port`` (#2372)?
+def _session_host_allows_ttl(host: str, port: int) -> float | None:
+    """Remaining seconds an in-session allow covers ``host`` on ``port``, or
+    ``None`` (#2372, #2434).
 
     Used by :func:`_cb` as the last-chance gate before prompting: a SYN to a
-    host:port the user allowed forever is auto-allowed even when no fresh DNS
-    resolution re-ACCEPTed the (CDN-rotated or resolver-cached) IP. Matches via
-    :func:`_host_matches` (nginx-style scope); forever entries are added EXACT
-    by :func:`_add_forever_host`, so only the approved host matches (#2377).
+    host:port the user allowed (timed or forever) -- including a CDN-rotated or
+    resolver-cached IP that no fresh DNS resolution re-ACCEPTed -- is
+    auto-allowed, learned for the allow's remaining window, so the user isn't
+    re-asked (and a hold timeout can't fail-close a still-allowed host to a
+    deny, #2434). Matches via :func:`_host_matches` (nginx-style scope); entries
+    are added EXACT by :func:`_add_session_host`, so only the approved host
+    matches (#2377). Returns the max remaining TTL across matching entries.
+    Loop-only (no lock).
     """
     if not host:
-        return False
-    for h, p, mode in _FOREVER_HOSTS:
+        return None
+    _prune_session_allows()
+    now = time.time()
+    best: float | None = None
+    for h, p, mode, exp in _SESSION_HOST_ALLOWS:
+        if exp <= now:
+            continue  # belt-and-suspenders: _prune ran above, but a just-expired
+            # entry can survive the microseconds between its `now` and this one.
         if _host_matches(host, h, mode) and (p == port or p is None):
-            return True
-    return False
+            remaining = exp - now
+            if best is None or remaining > best:
+                best = remaining
+    return best
 
 
 def _rule_args(ip: str, port: int | None) -> list[str]:
@@ -553,8 +601,9 @@ def drop_for_host(host: str, decision: str) -> set[str]:
     Returns the set of candidate IPs (the host's resolved IPs + the host
     string itself, for a direct-IP connect) so the caller --
     :meth:`SidecarConsentClient._handle_drop_rule`, on the event loop -- can
-    clear the loop-only ``_FOREVER_HOSTS``/``_VERDICT_CACHE`` state via
-    :func:`_clear_forever_state`. Those structures are documented loop-only
+    clear the loop-only ``_SESSION_HOST_ALLOWS``/``_VERDICT_CACHE`` state
+    (via :func:`_drop_session_hosts` / :func:`_clear_verdict_cache`). Those
+    structures are documented loop-only
     (no lock) and must NOT be mutated here, since this function runs off the
     loop in the executor.
 
@@ -602,25 +651,26 @@ def drop_for_host(host: str, decision: str) -> set[str]:
     return targets
 
 
-def _drop_forever_hosts(host: str) -> None:
-    """Remove a host's in-session ``forever``-allow coverage (#2370, #2372).
+def _drop_session_hosts(host: str) -> None:
+    """Remove a host's in-session allow coverage (#2370, #2372, #2434).
 
-    Drops every :data:`_FOREVER_HOSTS` entry whose host matches
+    Drops every :data:`_SESSION_HOST_ALLOWS` entry whose host matches
     (case-insensitive). Called on the **event loop** by
     :meth:`SidecarConsentClient._handle_drop_rule` **before** :func:`drop_for_host`
     forks iptables in the executor: while that fork runs (~tens of ms), the
-    NFQUEUE consumer (:func:`_cb` -> :func:`_forever_host_allows`) and the DNS
-    path (:func:`ports_for`) both read :data:`_FOREVER_HOSTS`, and a SYN/resolve
-    arriving in that window would otherwise re-install a fresh ~1-year ACCEPT
-    (:data:`_DURATION_FOREVER`, via :func:`allow`) that the revoke never clears.
-    Clearing it first makes both gates deny during the window, so no fresh rule
-    can be installed; :func:`drop_for_host` then removes the existing ACCEPTs.
-    :data:`_FOREVER_HOSTS` is loop-only (no lock) -- touched on the loop, never
-    inside :func:`drop_for_host` (executor thread). A deny revoke does not call
-    this (a deny never adds to :data:`_FOREVER_HOSTS`).
+    NFQUEUE consumer (:func:`_cb` -> :func:`_session_host_allows_ttl`) and the DNS
+    path (:func:`ports_for`) both read :data:`_SESSION_HOST_ALLOWS`, and a
+    SYN/resolve arriving in that window would otherwise re-install a fresh
+    ACCEPT (the host's remaining allow TTL, via :func:`allow`) that the revoke
+    never clears. Clearing it first makes both gates deny during the window, so
+    no fresh rule can be installed; :func:`drop_for_host` then removes the
+    existing ACCEPTs. :data:`_SESSION_HOST_ALLOWS` is loop-only (no lock) --
+    touched on the loop, never inside :func:`drop_for_host` (executor thread). A
+    deny revoke does not call this (a deny never adds to
+    :data:`_SESSION_HOST_ALLOWS`).
     """
     hl = host.lower()
-    _FOREVER_HOSTS[:] = [t for t in _FOREVER_HOSTS if t[0].lower() != hl]
+    _SESSION_HOST_ALLOWS[:] = [t for t in _SESSION_HOST_ALLOWS if t[0].lower() != hl]
 
 
 def _clear_verdict_cache(ips: set[str]) -> None:
@@ -1042,15 +1092,16 @@ class SidecarConsentClient:
         decision = msg.get("decision")
         ok = False
         if isinstance(host, str) and decision in ("allowed", "denied"):
-            # #2370: close the `forever` gates BEFORE the executor window. While
-            # drop_for_host forks iptables off-loop (~tens of ms), a racing
-            # SYN/DNS could read _FOREVER_HOSTS and re-install a fresh
-            # ~1-year ACCEPT (_DURATION_FOREVER) the revoke never clears.
-            # _drop_forever_hosts runs on the loop (loop-only structure) and
-            # makes _cb's _forever_host_allows + ports_for deny during the
-            # window. (A deny never adds to _FOREVER_HOSTS, so skip it there.)
+            # #2370: close the session-allow gates BEFORE the executor window.
+            # While drop_for_host forks iptables off-loop (~tens of ms), a racing
+            # SYN/DNS could read _SESSION_HOST_ALLOWS and re-install a fresh
+            # ACCEPT (the host's remaining allow TTL) the revoke never clears.
+            # _drop_session_hosts runs on the loop (loop-only structure) and
+            # makes _cb's _session_host_allows_ttl + ports_for deny during the
+            # window. (A deny never adds to _SESSION_HOST_ALLOWS, so skip it
+            # there.)
             if decision == "allowed":
-                _drop_forever_hosts(host)
+                _drop_session_hosts(host)
             try:
                 ips = await asyncio.get_running_loop().run_in_executor(
                     None, drop_for_host, host, decision
@@ -1448,28 +1499,32 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
         pkt.drop()
         return
     host = _host_for(dst)  # DNS name if resolved here, else the IP
-    # A `forever` allow covers the whole domain (#2372): a SYN to a host:port
-    # the user already allowed forever -- including a CDN-rotated or
-    # resolver-cached IP that no fresh DNS resolution re-ACCEPTed -- is
-    # auto-allowed here, the last gate before prompting, so the user isn't
-    # re-asked for a domain they allowed forever.
-    if port and _forever_host_allows(host, port):
+    # An in-session host allow covers the whole domain, timed or forever
+    # (#2372, #2434): a SYN to a host:port the user already allowed -- including
+    # a CDN-rotated or resolver-cached IP that no fresh DNS resolution
+    # re-ACCEPTed -- is auto-allowed here, the last gate before prompting, so
+    # the user isn't re-asked for a domain they allowed. This is the fix for the
+    # ALLOW-REFUSED mismatch (#2434): without it a timed allow only covered the
+    # IP resolved at decision time, so a CDN-rotated IP re-entered NFQUEUE and a
+    # hold timeout there fail-closed to a deny REJECT an in-effect allow should
+    # override.
+    remaining = _session_host_allows_ttl(host, port) if port else None
+    if remaining is not None:
         # allow() forks iptables under _LOCK -- run it off the loop thread (the
         # file's invariant; every other allow/learn/reject call is in the
         # executor). Fire-and-forget: conntrack ESTABLISHED,RELATED carries THIS
         # connection after pkt.accept(); the ACCEPT rule only helps FUTURE
         # connections, and the _VERDICT_CACHE write below covers retransmits.
-        # Port-scoped (the consented port) -- deliberately stricter than the
-        # consent-allow path's all-ports learn (allow(dst, None, ...)).
-        asyncio.get_running_loop().run_in_executor(
-            None, allow, dst, port, _DURATION_FOREVER
-        )
+        # Learn for the allow's remaining window (timed) or ~forever; port-scoped
+        # (the consented port) -- deliberately stricter than the consent-allow
+        # path's all-ports learn (allow(dst, None, ...)).
+        asyncio.get_running_loop().run_in_executor(None, allow, dst, port, remaining)
         pkt.accept()
         _VERDICT_CACHE[flow] = ("allow", now + VERDICT_CACHE_TTL)
-        # NOTE (#2370): revoking a forever verdict must also drop this host
-        # from _FOREVER_HOSTS and clear _VERDICT_CACHE, or a revoked
-        # forever-allow keeps passing (ports_for re-allow-lists it + this
-        # cache reuses the verdict). Wired with the revoke path in #2370.
+        # NOTE (#2370): revoking an allow must also drop this host from
+        # _SESSION_HOST_ALLOWS and clear _VERDICT_CACHE, or a revoked allow keeps
+        # passing (ports_for re-allow-lists it + this cache reuses the verdict).
+        # Wired with the revoke path in #2370.
         return
     pkt.retain()  # keep the payload valid past this callback (deferred verdict)
     _INFLIGHT.add(flow)
@@ -1510,16 +1565,19 @@ async def _decide_and_verdict(
     _VERDICT_CACHE[flow] = (decision, now + VERDICT_CACHE_TTL)
     # Populate the in-session allow-list BEFORE the iptables fork below (which
     # yields to the executor): a SYN to a different IP of this host arriving
-    # during that yield would otherwise miss _FOREVER_HOSTS and re-prompt. Both
-    # gates (ports_for + _cb) read it (#2372).
-    if decision == "allow" and duration == "forever" and port:
-        _add_forever_host(host, port)
+    # during that yield would otherwise miss _SESSION_HOST_ALLOWS and re-prompt.
+    # Both gates (ports_for + _cb) read it (#2372). A timed allow is host-scoped
+    # too (#2434): otherwise a CDN-rotated IP of a timed-allowed host re-enters
+    # NFQUEUE, and a hold timeout there fail-closes to a deny REJECT an
+    # in-effect allow should override -- an allow that refuses.
+    ttl = _duration_ttl(duration)
+    if decision == "allow" and ttl is not None and port:
+        _add_session_host(host, port, ttl)
     # Run the iptables fork (allow/reject) in the executor so it doesn't block
     # the loop thread -- matches the DNS path's _learn_all, which also runs
     # off the loop. The packet is retained, so verdicting after the await is
     # safe; the rule is installed before the SYN is released.
     loop = asyncio.get_running_loop()
-    ttl = _duration_ttl(duration)
     try:
         if decision == "allow":
             # `once` (ttl None) -> no learn, just this connection (reconnect

--- a/src/klangk/klangk/consent_coordinator.py
+++ b/src/klangk/klangk/consent_coordinator.py
@@ -506,7 +506,7 @@ class ConsentCoordinator:
         :meth:`_persist_forever_deny`: removes the consented host from
         ``allowed_domains`` (allow) or ``rejected_domains`` (deny) so the
         verdict does not re-apply on the next sidecar restart. The deciding
-        connection's in-memory ACCEPT/REJECT + ``_FOREVER_HOSTS``/
+        connection's in-memory ACCEPT/REJECT + ``_SESSION_HOST_ALLOWS``/
         ``_VERDICT_CACHE`` were already cleared by the drop the caller sent.
 
         Best-effort (failures logged + swallowed): the row is already revoked,
@@ -578,7 +578,7 @@ class ConsentCoordinator:
         # NOTE (#2370): a `forever` verdict also lives in the workspace's
         # allowed_domains/rejected_domains (added in resolve, #2368/#2369),
         # which the sidecar re-reads on restart. The drop above cleared the
-        # in-memory rules + _FOREVER_HOSTS/_VERDICT_CACHE; retract the durable
+        # in-memory rules + _SESSION_HOST_ALLOWS/_VERDICT_CACHE; retract the durable
         # entry too (after the row is marked revoked) so the verdict does not
         # re-apply on the next sidecar restart.
         # Ask the sidecar to drop its rule for this host+decision. No live

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
@@ -607,11 +607,11 @@ class TestConsentDecisionEndStates:
     ):
         # #2399 Finding 1: a TIMED allow (5m/1h/5s) must cover a later
         # connection to the same host WITHOUT re-prompting -- the same way a
-        # timed deny does. Unlike `forever` (covered by the in-session
-        # _FOREVER_HOSTS gate in _cb + the DNS path), a timed allow has NO
-        # Python gate: a new connection is covered ONLY by the learned
-        # iptables ACCEPT rule (top of OUTPUT, ahead of NFQUEUE) installed by
-        # allow(dst, None, ttl). This test pins that path.
+        # timed deny does. Like `forever`, a timed allow now host-scopes via
+        # the in-session _SESSION_HOST_ALLOWS gate in _cb + the DNS path
+        # (#2434); a new connection is ALSO covered by the learned iptables
+        # ACCEPT rule (top of OUTPUT, ahead of NFQUEUE) installed by
+        # allow(dst, None, ttl). This test pins the no-re-prompt behavior.
         ws_id = workspace
         ws_conn = await ws_connect(server, auth, ws_id)
         try:
@@ -801,7 +801,7 @@ class TestConsentDecisionEndStates:
                 # 2nd connection (pre-restart): a `forever` allow approves the
                 # whole domain, so a later curl -- even one that resolves to a
                 # CDN-rotated IP -- must NOT re-prompt (#2372: the sidecar
-                # allow-lists the host in-session via _FOREVER_HOSTS, so the DNS
+                # allow-lists the host in-session via _SESSION_HOST_ALLOWS, so the DNS
                 # path learns every resolved IP and allows it without NFQUEUE).
                 await asyncio.sleep(2)
                 _trigger(container, "example.com", "/tmp/r_fa_1.out")

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -204,13 +204,18 @@ class TestPortsFor:
         )
         assert proxy.ports_for("GitHub.Com") == set()
 
-    def test_forever_hosts_consulted_alongside_specs(self, proxy, monkeypatch):
-        # A `forever` consent verdict adds the host (EXACT) to _FOREVER_HOSTS
-        # (#2372, #2377): ports_for treats that exact host as allow-listed, so a
-        # later CDN-rotated IP re-resolves and is allowed without re-prompting.
+    def test_session_host_allows_consulted_alongside_specs(
+        self, proxy, monkeypatch
+    ):
+        # A consent `allow` verdict (timed or forever) adds the host (EXACT) to
+        # _SESSION_HOST_ALLOWS (#2372, #2377, #2434): ports_for treats that exact
+        # host as allow-listed for the verdict's lifetime, so a later CDN-rotated
+        # IP re-resolves and is allowed without re-prompting.
         monkeypatch.setattr(proxy, "SPECS", [])
         monkeypatch.setattr(
-            proxy, "_FOREVER_HOSTS", [("example.com", 443, proxy._EXACT)]
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [("example.com", 443, proxy._EXACT, float("inf"))],
         )
         assert proxy.ports_for("example.com") == {443}
         assert (
@@ -218,35 +223,45 @@ class TestPortsFor:
         )  # exact -> no subdomain
         assert proxy.ports_for("other.com") == set()
 
-    def test_add_forever_host_dedups(self, proxy):
-        proxy._FOREVER_HOSTS.clear()
-        proxy._add_forever_host("example.com", 443)
-        proxy._add_forever_host("example.com", 443)  # dup -> one entry
-        proxy._add_forever_host("example.com", 8443)  # different port -> added
-        assert proxy._FOREVER_HOSTS == [
-            ("example.com", 443, proxy._EXACT),
-            ("example.com", 8443, proxy._EXACT),
+    def test_add_session_host_dedups_and_refreshes(self, proxy, monkeypatch):
+        # A re-allow of the same host:port refreshes the expiry (max -- never
+        # shortens an unexpired entry); a different port adds a new entry.
+        monkeypatch.setattr(proxy.time, "time", lambda: 1000.0)
+        proxy._SESSION_HOST_ALLOWS.clear()
+        proxy._add_session_host("example.com", 443, 300)  # expire 1300
+        proxy._add_session_host(
+            "example.com", 443, 60
+        )  # dup -> max(1300, 1060)
+        proxy._add_session_host("example.com", 8443, 300)  # different port
+        assert proxy._SESSION_HOST_ALLOWS == [
+            ("example.com", 443, proxy._EXACT, 1300.0),
+            ("example.com", 8443, proxy._EXACT, 1300.0),
         ]
 
-    def test_forever_host_allows(self, proxy, monkeypatch):
-        # The NFQUEUE-gate predicate (#2372): forever entries are EXACT (#2377),
-        # so only the approved host (not its subdomains) matches; port must
-        # match. Mirrors ports_for via the shared _host_matches.
+    def test_session_host_allows_ttl(self, proxy, monkeypatch):
+        # The NFQUEUE-gate predicate (#2372, #2434): session entries are EXACT
+        # (#2377), so only the approved host (not its subdomains) matches; port
+        # must match. Returns the remaining TTL (truthy) or None. Mirrors
+        # ports_for via the shared _host_matches.
         monkeypatch.setattr(
-            proxy, "_FOREVER_HOSTS", [("example.com", 443, proxy._EXACT)]
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [("example.com", 443, proxy._EXACT, float("inf"))],
         )
-        assert proxy._forever_host_allows("example.com", 443)
-        assert not proxy._forever_host_allows("api.example.com", 443)  # exact
-        assert not proxy._forever_host_allows("example.com", 80)  # wrong port
-        assert not proxy._forever_host_allows("other.com", 443)  # wrong host
-        assert not proxy._forever_host_allows("evilexample.com", 443)  # suffix
-        assert not proxy._forever_host_allows("", 443)  # no host
-        # all-ports entry (p is None) matches any port -- defensive (forever
-        # entries are added port-scoped, but the predicate tolerates None).
+        assert proxy._session_host_allows_ttl("example.com", 443)
+        assert proxy._session_host_allows_ttl("api.example.com", 443) is None
+        assert proxy._session_host_allows_ttl("example.com", 80) is None
+        assert proxy._session_host_allows_ttl("other.com", 443) is None
+        assert proxy._session_host_allows_ttl("evilexample.com", 443) is None
+        assert proxy._session_host_allows_ttl("", 443) is None
+        # all-ports entry (p is None) matches any port -- defensive (entries are
+        # added port-scoped, but the predicate tolerates None).
         monkeypatch.setattr(
-            proxy, "_FOREVER_HOSTS", [("example.com", None, proxy._EXACT)]
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [("example.com", None, proxy._EXACT, float("inf"))],
         )
-        assert proxy._forever_host_allows("example.com", 8080)
+        assert proxy._session_host_allows_ttl("example.com", 8080)
 
 
 class TestRejectedFor:
@@ -1244,7 +1259,7 @@ class TestNfqueueCallback:
         proxy._VERDICT_CACHE.clear()
         proxy._INFLIGHT.clear()
         proxy._LEARNED.clear()
-        proxy._FOREVER_HOSTS.clear()
+        proxy._SESSION_HOST_ALLOWS.clear()
         proxy._BG_TASKS.clear()
 
     async def _decide(self, proxy, pkt, client):
@@ -1296,9 +1311,9 @@ class TestNfqueueCallback:
         self, proxy, monkeypatch
     ):
         # A `forever` allow approves the host (not just the resolved IP): the
-        # sidecar adds it to _FOREVER_HOSTS so ports_for treats it as
+        # sidecar adds it to _SESSION_HOST_ALLOWS so ports_for treats it as
         # allow-listed for the session -- a later CDN-rotated IP re-resolves
-        # and is allowed without re-prompting (#2372).
+        # and is allowed without re-prompting (#2372, #2434).
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value=("allow", "forever"))
@@ -1308,7 +1323,8 @@ class TestNfqueueCallback:
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await self._decide(proxy, pkt, client)
         assert pkt.verdict == "accept"
-        assert ("example.com", 443, proxy._EXACT) in proxy._FOREVER_HOSTS
+        specs = [(h, p, m) for (h, p, m, _exp) in proxy._SESSION_HOST_ALLOWS]
+        assert ("example.com", 443, proxy._EXACT) in specs
         # ports_for now treats the host as allow-listed (EXACT -- apex only).
         monkeypatch.setattr(proxy, "SPECS", [])
         assert proxy.ports_for("example.com") == {443}
@@ -1316,7 +1332,7 @@ class TestNfqueueCallback:
             proxy.ports_for("api.example.com") == set()
         )  # exact -> no subdomain
 
-    async def test_cb_auto_allows_syn_to_forever_host_ip(
+    async def test_cb_auto_allows_syn_to_session_allowed_host_ip(
         self, proxy, monkeypatch
     ):
         # A SYN to an IP whose host was allowed forever is auto-allowed at the
@@ -1330,7 +1346,7 @@ class TestNfqueueCallback:
         allowed = []
         monkeypatch.setattr(proxy, "allow", lambda *a: allowed.append(a))
         self._bind(proxy, monkeypatch, client)
-        proxy._add_forever_host("example.com", 443)
+        proxy._add_session_host("example.com", 443, proxy._DURATION_FOREVER)
         proxy._record_hosts([("2.2.2.2", 60)], "example.com")
         pkt = _FakePkt(_ip_payload("2.2.2.2", 443))
         proxy._cb(pkt, client)  # sync: auto-allows inline, no task
@@ -1338,8 +1354,12 @@ class TestNfqueueCallback:
         assert pkt.verdict == "accept"
         client.request.assert_not_awaited()  # no consent prompt
         assert not proxy._BG_TASKS  # no verdict task spawned
-        # allow() called port-scoped, in the executor, with the forever TTL.
-        assert allowed == [("2.2.2.2", 443, proxy._DURATION_FOREVER)]
+        # allow() called port-scoped, in the executor, with the allow's remaining
+        # TTL (~forever for a fresh forever entry).
+        assert len(allowed) == 1
+        assert allowed[0][0] == "2.2.2.2"
+        assert allowed[0][1] == 443
+        assert allowed[0][2] >= proxy._DURATION_FOREVER - 5
         # Verdict cached so a retransmit reuses it without re-prompting.
         assert any(v[0] == "allow" for v in proxy._VERDICT_CACHE.values())
 
@@ -1354,26 +1374,76 @@ class TestNfqueueCallback:
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
         monkeypatch.setattr(proxy, "reject", lambda *a: None)
         self._bind(proxy, monkeypatch, client)
-        proxy._add_forever_host("example.com", 443)
+        proxy._add_session_host("example.com", 443, proxy._DURATION_FOREVER)
         proxy._record_hosts([("2.2.2.2", 60)], "example.com")
         proxy._cb(_FakePkt(_ip_payload("2.2.2.2", 80)), client)
         await asyncio.gather(*proxy._BG_TASKS)  # the prompt task ran
         client.request.assert_awaited_once_with("example.com", 80)
 
-    async def test_restart_allow_does_not_add_session_allowlist(
+    async def test_once_allow_does_not_add_session_allowlist(
         self, proxy, monkeypatch
     ):
-        # Only `forever` mutates the in-session allow-list; a restart/timed
-        # allow is a plain in-memory IP learn (no domain-level coverage).
+        # Only `once` skips the in-session host allow-list: it is per-connection
+        # (a reconnect re-prompts), so a CDN-rotated IP of a once-allowed host
+        # must NOT be auto-allowed. Timed/forever/tilrestart all host-scope
+        # (#2434); `once` alone stays an in-memory IP learn of the resolved IP.
         client = MagicMock()
         client.connected = True
-        client.request = AsyncMock(return_value=("allow", "tilrestart"))
+        client.request = AsyncMock(return_value=("allow", "once"))
         monkeypatch.setattr(proxy, "allow", lambda *a: None)
         self._bind(proxy, monkeypatch, client)
         proxy._record_hosts([("1.2.3.4", 60)], "example.com")
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await self._decide(proxy, pkt, client)
-        assert proxy._FOREVER_HOSTS == []
+        assert proxy._SESSION_HOST_ALLOWS == []
+
+    async def test_timed_allow_is_host_scoped(self, proxy, monkeypatch):
+        # #2434 regression: a TIMED allow (not just forever) host-scopes. The
+        # verdict adds the host to _SESSION_HOST_ALLOWS, so a CDN-rotated IP of
+        # the host -- resolved AFTER the allow, with no ACCEPT rule of its own
+        # -- is auto-allowed at the NFQUEUE gate WITHOUT re-prompting. Pre-fix
+        # this SYN re-entered NFQUEUE, and a hold timeout there fail-closed to a
+        # deny REJECT (the ALLOW-REFUSED mismatch: an in-effect allow that
+        # refuses).
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "5m"))
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        # Decide on IP_A (the resolved IP at decision time).
+        proxy._record_hosts([("1.2.3.4", 60)], "example.com")
+        await self._decide(
+            proxy, _FakePkt(_ip_payload("1.2.3.4", 443)), client
+        )
+        specs = [(h, p, m) for (h, p, m, _exp) in proxy._SESSION_HOST_ALLOWS]
+        assert ("example.com", 443, proxy._EXACT) in specs  # host-scoped
+        # A CDN-rotated IP_B (no ACCEPT, never consented) is auto-allowed at the
+        # NFQUEUE gate -- no consent prompt, no verdict task spawned.
+        proxy._record_hosts([("9.9.9.9", 60)], "example.com")
+        client2 = MagicMock()
+        client2.connected = True
+        client2.request = AsyncMock(return_value=("deny", "5s"))
+        pkt2 = _FakePkt(_ip_payload("9.9.9.9", 443))
+        proxy._cb(pkt2, client2)
+        await asyncio.sleep(0.05)
+        assert pkt2.verdict == "accept"  # auto-allowed, not denied
+        client2.request.assert_not_awaited()  # no re-prompt
+        assert not proxy._BG_TASKS
+
+    def test_timed_session_allow_expires(self, proxy, monkeypatch):
+        # #2434: a timed session-allow expires (lazy prune), so the host
+        # re-enters consent-gating once its window elapses -- it does not leak
+        # like a forever entry.
+        clock = [1000.0]
+        monkeypatch.setattr(proxy.time, "time", lambda: clock[0])
+        proxy._SESSION_HOST_ALLOWS.clear()
+        proxy._add_session_host("example.com", 443, 300)  # expire 1300
+        assert proxy._session_host_allows_ttl("example.com", 443) == 300.0
+        clock[0] = 1400.0  # past the 300s window
+        assert proxy._session_host_allows_ttl("example.com", 443) is None
+        monkeypatch.setattr(proxy, "SPECS", [])
+        assert proxy.ports_for("example.com") == set()  # pruned -> denied
+        assert proxy._SESSION_HOST_ALLOWS == []
 
     async def test_deny_verdict_drops_and_rejects(self, proxy, monkeypatch):
         # deny -> drop the SYN + install a REJECT (tcp-reset) so the retransmit
@@ -2020,7 +2090,7 @@ class TestDropForHost:
 
     def test_drop_for_host_returns_candidate_ips(self, proxy, monkeypatch):
         # #2370: drop_for_host returns the candidate IP set so the loop-side
-        # _clear_forever_state can clear _VERDICT_CACHE for those IPs.
+        # _clear_verdict_cache can clear _VERDICT_CACHE for those IPs.
         proxy._LEARNED.clear()
         proxy._REJECTED.clear()
         monkeypatch.setattr(
@@ -2037,16 +2107,18 @@ class TestDropForHost:
         # resolved IP + the host string itself (direct-IP-allow candidate)
         assert ips == {"1.2.3.4", "evil.test"}
 
-    def test_drop_forever_hosts_removes_host_entries(self, proxy):
-        # An allowed revoke drops the host's _FOREVER_HOSTS coverage (in-session
-        # forever-allow from #2372); other hosts are left intact.
-        proxy._FOREVER_HOSTS.clear()
-        proxy._FOREVER_HOSTS[:] = [
-            ("evil.test", 443, proxy._EXACT),
-            ("other.test", 80, proxy._EXACT),
+    def test_drop_session_hosts_removes_host_entries(self, proxy):
+        # An allowed revoke drops the host's _SESSION_HOST_ALLOWS coverage
+        # (in-session allow from #2372/#2434); other hosts are left intact.
+        proxy._SESSION_HOST_ALLOWS.clear()
+        proxy._SESSION_HOST_ALLOWS[:] = [
+            ("evil.test", 443, proxy._EXACT, float("inf")),
+            ("other.test", 80, proxy._EXACT, float("inf")),
         ]
-        proxy._drop_forever_hosts("Evil.TEST")  # case-insensitive
-        assert proxy._FOREVER_HOSTS == [("other.test", 80, proxy._EXACT)]
+        proxy._drop_session_hosts("Evil.TEST")  # case-insensitive
+        assert proxy._SESSION_HOST_ALLOWS == [
+            ("other.test", 80, proxy._EXACT, float("inf"))
+        ]
 
     def test_clear_verdict_cache_drops_host_entries(self, proxy):
         # Cached verdicts keyed by (src_ip, src_port, dst, port); dst is key[2].
@@ -2067,15 +2139,15 @@ class TestDropForHost:
             ("10.0.0.1", 1, "9.9.9.9", 443): ("allow", 9e9)
         }
 
-    async def test_dispatch_drop_rule_clears_forever_state(
+    async def test_dispatch_drop_rule_clears_session_state(
         self, proxy, tmp_path, monkeypatch
     ):
-        # End-to-end (#2370): a forever-allow revoke's drop_rule clears the
-        # in-session _FOREVER_HOSTS (BEFORE the iptables fork, so a racing SYN
-        # can't re-install a fresh ACCEPT during the window) + _VERDICT_CACHE
-        # (after), else the next DNS resolution re-learns the host.
+        # End-to-end (#2370): an allow revoke's drop_rule clears the in-session
+        # _SESSION_HOST_ALLOWS (BEFORE the iptables fork, so a racing SYN can't
+        # re-install a fresh ACCEPT during the window) + _VERDICT_CACHE (after),
+        # else the next DNS resolution re-learns the host.
         proxy._LEARNED.clear()
-        proxy._FOREVER_HOSTS.clear()
+        proxy._SESSION_HOST_ALLOWS.clear()
         proxy._VERDICT_CACHE.clear()
         monkeypatch.setattr(
             proxy.subprocess,
@@ -2087,7 +2159,9 @@ class TestDropForHost:
             "ports": {443},
             "host": "h.test",
         }
-        proxy._FOREVER_HOSTS.append(("h.test", 443, proxy._EXACT))
+        proxy._SESSION_HOST_ALLOWS.append(
+            ("h.test", 443, proxy._EXACT, float("inf"))
+        )
         proxy._VERDICT_CACHE[("10.0.0.1", 1, "1.2.3.4", 443)] = ("allow", 9e9)
         c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
         c._connected.set()
@@ -2108,7 +2182,7 @@ class TestDropForHost:
                 }
             )
         )
-        assert proxy._FOREVER_HOSTS == []
+        assert proxy._SESSION_HOST_ALLOWS == []
         assert proxy._VERDICT_CACHE == {}
         assert json.loads(sent[0])["ok"] is True
 


### PR DESCRIPTION
## Summary

Fixes #2434 — the `smoketest_egress` `ALLOW-REFUSED` hard mismatch.

A **timed** egress-consent `allow` verdict (5s/5m/1h/…) only covered the IP
resolved at the moment of the decision, not the host. A later connection that
resolved to a different (CDN-rotated) IP re-entered NFQUEUE and re-prompted; a
hold timeout there fail-closed to a `deny` REJECT an in-effect allow should
override — an allow that refuses. `forever` already host-scoped; timed allows
did not.

## Change

Generalize the forever-only in-session host allow into a timed+forever
**session allow** in the network sidecar (`src/containers/network/proxy.py`):

- The DNS gate (`ports_for`) now learns *all* of a host's IPs for the verdict's
  lifetime, so a CDN-rotated IP gets an ACCEPT and never reaches NFQUEUE.
- The NFQUEUE gate (`_cb`) short-circuits any SYN that still races NFQUEUE
  (ACCEPT install lost the race), learning the IP for the allow's remaining
  window — no re-prompt, so no hold timeout, no fail-close deny.

`once` stays per-connection (no host-allow). Timed session-allow entries expire
lazily on read; `tilrestart`/`forever` map to the existing ~1-year TTL. The
revoke path is updated to clear the new structure.

## Tests

- `test_proxy.py`: updated the 8 tests referencing the old forever-only API;
  added two regressions — `test_timed_allow_is_host_scoped` (a timed allow
  followed by a SYN to a *different* IP of the host is auto-allowed with no
  re-prompt) and `test_timed_session_allow_expires` (the host re-enters
  consent-gating once the window elapses).
- Full backend suite: **4926 passed, 100% coverage** (`-n auto`, the CI way).

## Changelog

`docs/changes.md` `Fixed` entry added.
