### PR TITLE
fix(smoketest): reclaim leaked containers on interrupt (#2443)

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
@@ -254,6 +254,54 @@ def _net_gw(name: str, network: str = DEFAULT_NETWORK) -> str:
     return out.strip()
 
 
+_FIXTURE_PREFIXES = ("ctrl-dns-target-", "ctrl-dns-dns-")
+
+
+def cleanup_stale_containers() -> list[str]:
+    """Remove leftover ``ctrl-dns-*`` containers from prior, interrupted runs.
+
+    The fixture names its containers ``ctrl-dns-target-<pid>`` /
+    ``ctrl-dns-dns-<pid>`` (``<pid>`` = the creating process's PID), so a new
+    run gets fresh names and never reclaims an interrupted prior run's set.
+    Those prior containers are created via raw ``podman run`` and carry **no**
+    ``klangk.*`` labels, so klangkd's dead-owner reaper (#2430) cannot see
+    them — they would run forever (#2443). This sweep is the only cleanup
+    path for them, so the smoketest calls it before starting its own fixture
+    (clean slate) and exposes it via ``--cleanup`` for recovering an existing
+    mess.
+
+    Returns the names removed. Best-effort: podman being absent or timing out
+    is not fatal (returns whatever was removed so far).
+    """
+    removed: list[str] = []
+    try:
+        res = subprocess.run(
+            ["podman", "ps", "-a", "--format", "{{.Names}}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return removed
+    for name in res.stdout.split():
+        # Match only the fixture's own prefixes (``--filter name=`` is a
+        # substring match and could over-select); an unrelated container is
+        # never touched.
+        if not name.startswith(_FIXTURE_PREFIXES):
+            continue
+        try:
+            subprocess.run(
+                ["podman", "rm", "-f", name],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            removed.append(name)
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            break
+    return removed
+
+
 class ControlledDns:
     """A controlled-DNS + multi-IP HTTP/HTTPS fixture (#2424).
 

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -28,11 +28,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import atexit
 import json
 import os
 import random
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import time
@@ -47,7 +49,10 @@ import httpx  # noqa: E402
 
 from _e2e_server import start_server, stop_server, ws_connect  # noqa: E402
 
-from _controlled_dns import ControlledDns  # noqa: E402
+from _controlled_dns import (  # noqa: E402
+    ControlledDns,
+    cleanup_stale_containers,
+)
 
 from klangk.cli.tui.consent import (  # noqa: E402
     ConsentDeciderApp,
@@ -717,6 +722,57 @@ class SmokeTest:
         self._extra_deciders: list[RawDecider] = []
         self._extra_ws_ids: list[str] = []
         self._extra_ws_conns: list[tuple] = []
+        # Guard for _cleanup_sync(): the container-removing teardown (dns.stop
+        # + stop_server) must run exactly once even though it is reachable
+        # from the async finally, atexit, and the SIGTERM handler (#2443).
+        self._cleaned_up = False
+
+    # -- interrupt-safe cleanup -----------------------------------------
+    @staticmethod
+    def _pid_alive(pid: int) -> bool:
+        """True iff a process with ``pid`` exists (mirrors klangkd's check)."""
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True  # another user's process -> assume alive
+        return True
+
+    def _cleanup_sync(self) -> None:
+        """Synchronous, idempotent container teardown (#2443).
+
+        Removes the ctrl-dns fixtures (``self.dns.stop()``) and the owned
+        klangkd subprocess + its labelled sidecar containers
+        (``stop_server()``). Both are synchronous and need no event loop, so
+        this is safe to call from ``atexit`` and a ``SIGTERM`` handler — the
+        paths the async ``teardown()`` never reaches when the smoketest is
+        killed (Ctrl-C under asyncio runs the async ``finally``, but
+        ``SIGTERM``/``SIGKILL`` terminate with no cleanup, leaking the
+        unlabelled ctrl-dns fixtures forever and orphaning the klangkd).
+
+        Idempotent and best-effort: the async ``teardown()`` nulls these
+        fields after its own cleanup, so a double-call is a no-op.
+        """
+        if self._cleaned_up:
+            return
+        self._cleaned_up = True
+        dns = self.dns
+        owned = self._owned_server
+        # Null first so the async teardown (which may run concurrently on a
+        # Ctrl-C) sees nothing to do and cannot race us.
+        self.dns = None
+        self._owned_server = None
+        if dns is not None:
+            try:
+                dns.stop()
+            except Exception:
+                pass
+        if owned is not None:
+            try:
+                stop_server(owned)
+            except Exception:
+                pass
 
     # -- setup ------------------------------------------------------------
     def _start_server(self) -> dict:
@@ -896,6 +952,10 @@ class SmokeTest:
         self._containers_conf = path
 
     async def setup(self) -> None:
+        # Register the interrupt-safe teardown up front so a partial setup
+        # failure (or a kill mid-setup) still removes whatever fixtures this
+        # far exist. _cleanup_sync is idempotent and no-ops on absent fixtures.
+        atexit.register(self._cleanup_sync)
         # Start the controlled-DNS fixture BEFORE the owned klangkd so its
         # upstream IP is known when the sidecar is created (the env is read at
         # workspace/sidecar-creation time). Skipped for an external --server
@@ -903,6 +963,15 @@ class SmokeTest:
         # or when --no-controlled-dns is passed.
         if self.args.controlled_dns and not self.args.server:
             self._enable_bridge_networking()
+            # Clean slate: reclaim ctrl-dns-* containers left by a prior run
+            # that was SIGKILLed (or whose teardown never ran). These carry no
+            # klangk.* labels, so klangkd's reaper cannot see them (#2443).
+            stale = await asyncio.to_thread(cleanup_stale_containers)
+            if stale:
+                print(
+                    f"reclaimed {len(stale)} stale ctrl-dns container(s): "
+                    f"{', '.join(stale)}"
+                )
             try:
                 self.dns = ControlledDns(image=self.args.sidecar_image)
                 self.dns.start()
@@ -3228,12 +3297,124 @@ def main() -> int:
         action="store_false",
         help="skip the port-scope (host:443 vs :80) phase (#2424)",
     )
+    p.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="don't run the smoketest; reclaim leaked containers from prior "
+        "interrupted runs (ctrl-dns-* fixtures + klangk-net-* sidecars whose "
+        "owning klangkd is dead) then exit (#2443)",
+    )
     args = p.parse_args()
+    if args.cleanup:
+        return _run_cleanup()
     if args.seed is None:
         args.seed = random.randrange(1 << 30)
     if args.consent_timeout < 4:
         p.error("--consent-timeout must be >= 4")
-    return asyncio.run(SmokeTest(args).run())
+    inst = SmokeTest(args)
+
+    def _on_term(signum, frame):
+        # SIGTERM (``kill <pid>``, agent timeouts) terminates without running
+        # the async ``finally`` or ``atexit`` — which is how the unlabelled
+        # ctrl-dns fixtures leak (#2443). Run the synchronous container
+        # teardown here, then exit with the conventional 128+signal code.
+        inst._cleanup_sync()
+        sys.exit(128 + signum)
+
+    signal.signal(signal.SIGTERM, _on_term)
+    try:
+        return asyncio.run(inst.run())
+    finally:
+        # Normal exit / uncaught exception / KeyboardInterrupt: belt-and-
+        # suspenders in case the async ``finally`` was itself interrupted
+        # (e.g. a second Ctrl-C). Idempotent — no-ops if already cleaned.
+        inst._cleanup_sync()
+
+
+def _run_cleanup() -> int:
+    """Reclaim leaked smoketest containers without a full run (#2443).
+
+    Removes:
+
+      * every ``ctrl-dns-*`` fixture (unlabelled, so invisible to klangkd's
+        reaper — this sweep is the only path for them);
+      * every ``klangk-net-*`` sidecar whose ``klangk.pid`` owner is no longer
+        alive (the same rule as ``reap_dead_owner_containers`` in
+        ``container.py``, applied standalone so a fresh klangkd need not be
+        started to clear the pile-up).
+
+    ``klangk-net-*`` sidecars with no ``klangk.pid`` (predating #2430) cannot
+    be decided safe and are printed with a paste-ready ``podman rm`` line
+    rather than removed automatically.
+    """
+    fixtures = cleanup_stale_containers()
+    for name in fixtures:
+        print(f"removed ctrl-dns fixture: {name}")
+
+    names: list[str] = []
+    try:
+        res = subprocess.run(
+            ["podman", "ps", "-a", "--format", "{{.Names}}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        names = [n for n in res.stdout.split() if n.startswith("klangk-net-")]
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    dead_sidecars: list[str] = []
+    legacy_sidecars: list[str] = []
+    for name in names:
+        try:
+            r = subprocess.run(
+                [
+                    "podman",
+                    "inspect",
+                    "-f",
+                    '{{index .Config.Labels "klangk.pid"}}',
+                    name,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        pid = r.stdout.strip()
+        try:
+            owner = int(pid)
+        except ValueError:
+            legacy_sidecars.append(name)
+            continue
+        if owner > 0 and not SmokeTest._pid_alive(owner):
+            dead_sidecars.append(name)
+
+    for name in dead_sidecars:
+        try:
+            subprocess.run(
+                ["podman", "rm", "-f", name],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            print(f"removed dead-owner sidecar: {name}")
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            break
+
+    if legacy_sidecars:
+        print(
+            "\nlegacy label-less sidecars (pre-#2430; owner cannot be "
+            "decided — remove manually if stale):"
+        )
+        print("  podman rm -f " + " ".join(legacy_sidecars))
+
+    total = len(fixtures) + len(dead_sidecars)
+    extra = (
+        f", {len(legacy_sidecars)} legacy listed" if legacy_sidecars else ""
+    )
+    print(f"\ncleanup done: removed {total} container(s){extra}.")
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/klangk/klangkd-tests/tests/test_controlled_dns.py
+++ b/src/klangk/klangkd-tests/tests/test_controlled_dns.py
@@ -1,0 +1,110 @@
+"""Unit tests for the controlled-DNS e2e fixture helpers.
+
+These cover the container-reclamation logic added for #2443 (the
+``ctrl-dns-*`` fixtures carry no ``klangk.*`` labels, so klangkd's dead-owner
+reaper cannot see them — ``cleanup_stale_containers`` is the only sweep path
+for them). ``subprocess.run`` is faked so no real ``podman`` is needed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Make the e2e-tests dir importable (it's not on sys.path by default for the
+# unit test suite) — same pattern as test_e2e_env.py.
+_E2E_DIR = Path(__file__).resolve().parents[1] / "e2e-tests"
+if str(_E2E_DIR) not in sys.path:
+    sys.path.insert(0, str(_E2E_DIR))
+
+import _controlled_dns as cd  # type: ignore[import-not-found]  # noqa: E402
+
+
+def _ok(stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(["podman"], 0, stdout=stdout, stderr="")
+
+
+def test_cleanup_removes_only_ctrl_dns_fixtures(monkeypatch):
+    """Only ``ctrl-dns-target-*`` / ``ctrl-dns-dns-*`` are removed; the rest
+    of ``podman ps`` is left alone, and each removal uses ``podman rm -f``."""
+    invocations: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        invocations.append(list(args))
+        if args[1] == "ps":
+            return _ok(
+                "ctrl-dns-target-111\n"
+                "klangk-net-smoke-abc\n"  # not a fixture -> ignored
+                "ctrl-dns-dns-222\n"
+                "someone-elses-container\n"
+            )
+        return _ok()  # podman rm -f
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+
+    removed = cd.cleanup_stale_containers()
+
+    assert removed == ["ctrl-dns-target-111", "ctrl-dns-dns-222"]
+    # exactly one list + one rm per fixture, nothing else
+    rms = [a for a in invocations if a[1] == "rm"]
+    assert rms == [
+        ["podman", "rm", "-f", "ctrl-dns-target-111"],
+        ["podman", "rm", "-f", "ctrl-dns-dns-222"],
+    ]
+
+
+def test_cleanup_returns_empty_when_podman_absent(monkeypatch):
+    """No podman on PATH -> nothing removed, no crash (partial dev env)."""
+
+    def fake_run(args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+    assert cd.cleanup_stale_containers() == []
+
+
+def test_cleanup_stops_on_rm_timeout(monkeypatch):
+    """A mid-sweep ``podman rm`` timeout stops the sweep and returns whatever
+    was removed so far (no crash, no hang)."""
+    state = {"listed": False}
+
+    def fake_run(args, **kwargs):
+        if args[1] == "ps":
+            state["listed"] = True
+            return _ok("ctrl-dns-target-1\nctrl-dns-dns-2\n")
+        # first rm succeeds, second times out
+        if "ctrl-dns-dns-2" in args:
+            raise subprocess.TimeoutExpired(cmd=args, timeout=30)
+        return _ok()
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+    removed = cd.cleanup_stale_containers()
+    assert removed == ["ctrl-dns-target-1"]  # second never appended
+
+
+def test_cleanup_ps_timeout_returns_empty(monkeypatch):
+    """A ``podman ps`` timeout means we never learn what to remove."""
+
+    def fake_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args, timeout=30)
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+    assert cd.cleanup_stale_containers() == []
+
+
+def test_cleanup_prefix_guard_avoids_substring_match(monkeypatch):
+    """A container whose name merely *contains* ``ctrl-dns-`` (but is not a
+    fixture) is not removed — the startswith prefix guard is the safety net
+    over podman's substring ``--filter name=``."""
+    removed_via_rm: list[str] = []
+
+    def fake_run(args, **kwargs):
+        if args[1] == "ps":
+            return _ok("my-ctrl-dns-thing\nctrl-dns-target-9\n")
+        removed_via_rm.append(args[-1])
+        return _ok()
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+    assert cd.cleanup_stale_containers() == ["ctrl-dns-target-9"]
+    assert removed_via_rm == ["ctrl-dns-target-9"]


### PR DESCRIPTION
## Summary

The e2e egress smoketest leaked `klangk-network-sidecar` containers on the dev host (#2443). Its teardown was **async-only** (`try/finally: await self.teardown()`), so `SIGTERM`/`SIGKILL` — `kill <pid>`, agent timeouts, a forced interrupt — terminated the process with no cleanup. That leaked:

- the **`ctrl-dns-*` fixtures** (created via raw `podman run`, no `klangk.*` labels) forever — klangkd's dead-owner reaper (#2430) can't see them, so nothing ever reclaimed them;
- the **owned `klangkd` subprocess** + its labelled sidecar containers — orphaned (reparented to init), staying alive until manually killed.

Closes #2443.

## What changed

- **`_cleanup_sync()`** — a synchronous, idempotent container teardown (`dns.stop()` + `stop_server()`, both sync — no event loop needed) wired to **`atexit`**, a **`SIGTERM` handler**, and a `finally` in `main()`. This is the path the async `teardown()` never reaches on `SIGTERM`/`SIGKILL`. Idempotent (guarded by a flag; nulls the fields first so the async teardown can't race it), and no-ops when fixtures are absent (e.g. external `--server`, `--no-controlled-dns`).
- **`cleanup_stale_containers()`** (in `_controlled_dns.py`) — reclaims stale `ctrl-dns-*` fixtures by **exact prefix** (`ctrl-dns-target-` / `ctrl-dns-dns-`, not podman's substring `name=` filter), called at `setup()` before bringing up the fixture. This is the backstop for `SIGKILL`, which no signal handler can catch: the *next* run starts clean regardless of how the previous died.
- **`--cleanup` flag** — reclaims leaked containers without a full run: removes `ctrl-dns-*` fixtures + `klangk-net-*` sidecars whose `klangk.pid` owner is dead (the same rule as `reap_dead_owner_containers` in `container.py`, applied standalone so a fresh daemon need not be started). Legacy label-less (pre-#2430) sidecars can't be decided safe, so they're **listed** with a paste-ready `podman rm` line rather than auto-removed.

## Safety

- **A live owner is never touched.** `--cleanup`'s sidecar sweep uses the exact `_pid_alive` rule from #2430; only dead-owner containers are removed. Label-less containers are listed, not removed.
- **`_cleanup_sync` is idempotent and race-free** — reachable from the async `finally`, `atexit`, and the `SIGTERM` handler, but guarded so it runs exactly once; it captures local refs and nulls the instance fields before calling stop, so the async teardown sees nothing to do.
- **Scope is the ctrl-dns + owned-klangkd cleanup only.** Workspace API deletion (a nice-to-have; `stop_server`'s `data_dir` rmtree already clears the DB) and websocket teardown remain in the async path; the critical container/subprocess leak is what the sync path guarantees.

## Test plan

- [x] `test_controlled_dns.py` — 5 unit tests for `cleanup_stale_containers`: removes only fixtures (ignores unrelated + the substring-trap), returns `[]` when podman absent, stops on `rm` timeout (returns partial), returns `[]` on `ps` timeout, and the prefix guard avoids a substring false-match.
- [x] `--cleanup` validated read-only against the live leaked set (2 `ctrl-dns-*` + 4 dead-owner sidecars (pid `2155151`) identified; 3 legacy listed), then run for real: removed 6, host back to a clean slate.
- [x] `--help` shows the new flag; both e2e scripts import clean.
- [x] Full backend suite the CI way: **4944 passed, 100% coverage** (changes are isolated to e2e scripts + the new test; the coverage-gated `klangk` package is untouched).

## Notes

- No changelog entry: this is e2e test tooling (`smoketest_egress.py` / `_controlled_dns.py`), not shipped product behavior — per the changelog rule, test-infra churn with no operator-visible effect is skipped.
