### PR TITLE
ci: use official NixOS installer in devenv-setup

### DIFF
--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -9,26 +9,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: DeterminateSystems/determinate-nix-action@v3
-
-    - name: Disable Determinate binary-cache substituter
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        # The Determinate Nix installer configures install.determinate.systems
-        # as a binary-cache substituter in /etc/nix/nix.conf. Its NARs
-        # intermittently arrive corrupt/partial on GitHub hosted runners,
-        # causing "error: path '...' is not valid" mid-evaluation (#1420).
-        #
-        # nix.conf processes lines in order: a bare `substituters =` line
-        # REPLACES the accumulated value (including any `extra-substituters`
-        # the installer added), so appending one here leaves only
-        # cache.nixos.org. The bootstrap step's `cachix use` later appends
-        # devenv.cachix.org via `extra-substituters`. Result: paths come
-        # only from the two reliable caches — no Determinate store caching.
-        echo 'substituters = https://cache.nixos.org/' \
-          | sudo tee -a /etc/nix/nix.conf
-        sudo systemctl restart nix-daemon
+    # Official NixOS installer. Unlike the Determinate installer this only
+    # configures cache.nixos.org by default, so there is no
+    # install.determinate.systems substituter to strip out (the workaround
+    # for #1420 is no longer needed). Flakes/nix-command are turned on both
+    # by the action's built-in --enable-flakes flag and explicitly below.
+    - uses: NixOS/nix-installer-action@v1
+      with:
+        extra-conf: |
+          experimental-features = nix-command flakes
 
     - name: Free disk space
       if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

Switches the `devenv-setup` composite action from `DeterminateSystems/determinate-nix-action` to the official `NixOS/nix-installer-action`, with flakes enabled.

## Changes

- **Installer:** `DeterminateSystems/determinate-nix-action@v3` → `NixOS/nix-installer-action@v1`. Flakes / `nix-command` are enabled both by the action's built-in `--enable-flakes` flag and explicitly via `extra-conf: experimental-features = nix-command flakes`.
- **Removed the "Disable Determinate binary-cache substituter" step.** That step existed solely to strip the `install.determinate.systems` substituter the Determinate installer writes to `/etc/nix/nix.conf` (its NARs intermittently arrived corrupt on hosted runners, #1420). The official installer only configures `cache.nixos.org`, so the workaround is obsolete. Substituters now come only from `cache.nixos.org` + `devenv.cachix.org` (added by `bootstrap`'s `cachix use`).

## Validation

Ran `dist-smoke` on this branch. The `build-wheel` job (which runs `devenv-setup`) passed in 4m55s; the log confirms `Nix is ready: nix (Nix) 2.35.1`, flakes enabled, and the full bootstrap → `devenv shell` → `klangk:flutter-build` chain working with the new installer.

Run: https://github.com/mcdonc/klangk/actions/runs/31689782654

## Notes

`NixOS/nix-installer-action` is still labeled experimental upstream, but it installed cleanly here.
