### PR TITLE
fix(egress): host-scoped memory for consent deny verdicts (#2446)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -785,6 +785,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   just allowed, when the connection resolved to a different (CDN-rotated) IP
   than the one consented.
 
+- **Timed egress-consent denials now cover the whole host (#2446).** A timed or
+  `until restart` `deny` verdict now deny-lists the consented host for its whole
+  duration — the deny-side counterpart of the allow fix in #2434 — instead of
+  only a short per-IP reject rule. A retry to an already-denied host (including
+  a CDN-rotated IP) is now refused without re-prompting the user for a host
+  they already denied (`once` stays per-connection); an in-effect `allow` still
+  overrides an in-effect deny at the gate.
+
 - **Dead-owner container reap at startup (#2342).** klangkd now stamps each
   workspace + network-sidecar container with the creating daemon's PID
   (`klangk.pid`; the sidecar also gains `klangk.managed=true`), and on startup

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -42,6 +42,14 @@ connection). **Fail-close**: a down WebSocket or a timed-out verdict resolves to
 ``deny`` immediately, so the workspace stays locked down when klangkd or the
 decider is unreachable (today's static behavior) — no new latency, no hang.
 
+A non-``once`` verdict is remembered **by host** (not just by the IP resolved
+at decision time), so a retry to a CDN-rotated IP is covered for the verdict's
+lifetime without re-prompting. An ``allow`` is host-allow-listed
+(:data:`_SESSION_HOST_ALLOWS`, #2372/#2434); a ``deny`` is host-deny-listed
+(:data:`_SESSION_HOST_DENIES`, #2446) so the user isn't re-asked for a host they
+already denied (the CARRYOVER-SURPRISE). ``once`` is per-connection (a reconnect
+re-prompts); an in-effect allow overrides an in-effect deny at the gate.
+
 Configuration (env):
   KLANGKNETWORK_EGRESS_ALLOW       comma-separated allow-list: ``host[:port]``,
                             ``*.domain[:port]``, or CIDR specs. CIDR specs are
@@ -245,6 +253,25 @@ REJECT_SPECS = parse_specs("KLANGKNETWORK_EGRESS_REJECT")
 # swept off-loop by sweep_once under _LOCK like _LEARNED/_REJECTED).
 _SESSION_HOST_ALLOWS: list[tuple[str, int | None, str, float]] = []
 
+# Hosts denied in-session by a consent ``deny`` verdict, timed or forever
+# (#2446 -- the deny-side mirror of :data:`_SESSION_HOST_ALLOWS`). Each entry is
+# (host, port, mode, expire). On a deny whose duration is not ``once``,
+# _decide_and_verdict adds the denied host:port here (expire = now + the
+# verdict's TTL) so _cb (via _session_host_denies_ttl) denies a retry fast --
+# without re-prompting -- even when a CDN rotation or a DNS-TTL lapse means the
+# per-IP _REJECTED rule no longer covers the destination. This is the fix for
+# the CARRYOVER-SURPRISE finding (#2446): a timed deny used to cover only the
+# IP resolved at decision time (plus a ~10s REJECT_TTL), so a rotated IP
+# re-entered NFQUEUE and re-prompted the user for a host they had already
+# denied. ``once`` adds nothing (per-connection, so a reconnect re-prompts).
+# Dies with the sidecar (in-memory); revocation (drop rule, decision=denied)
+# clears it via _drop_session_denies. Touched only on the event-loop thread
+# (like _SESSION_HOST_ALLOWS) -- no lock. Timed entries expire lazily via
+# _prune_session_denies. An in-effect allow still wins: _cb consults
+# _session_host_allows_ttl BEFORE _session_host_denies_ttl, so an allow
+# overrides an in-effect deny.
+_SESSION_HOST_DENIES: list[tuple[str, int | None, str, float]] = []
+
 # Learned IPs: {ip: {"expire": epoch, "ports": set[int | None], "host": str}}.
 # ``ports`` holds the ACCEPT rule ports (a ``None`` is all-ports); ``host`` is
 # the DNS name that resolved to this IP (named in the consent request). An
@@ -429,6 +456,72 @@ def _session_host_allows_ttl(host: str, port: int) -> float | None:
     now = time.time()
     best: float | None = None
     for h, p, mode, exp in _SESSION_HOST_ALLOWS:
+        if exp <= now:
+            continue  # belt-and-suspenders: _prune ran above, but a just-expired
+            # entry can survive the microseconds between its `now` and this one.
+        if _host_matches(host, h, mode) and (p == port or p is None):
+            remaining = exp - now
+            if best is None or remaining > best:
+                best = remaining
+    return best
+
+
+def _prune_session_denies() -> None:
+    """Drop expired in-session host denies (lazy sweep, #2446).
+
+    :data:`_SESSION_HOST_DENIES` is loop-only (no lock), so -- like
+    :data:`_SESSION_HOST_ALLOWS` -- its timed entries expire here, on the loop,
+    the next time a gate (:func:`_session_host_denies_ttl`,
+    :func:`_add_session_deny`, :func:`_drop_session_denies`) reads them. Cheap
+    (the list is tiny -- one entry per denied host:port) and keeps the structure
+    from growing unbounded across a long session.
+    """
+    now = time.time()
+    _SESSION_HOST_DENIES[:] = [t for t in _SESSION_HOST_DENIES if t[3] > now]
+
+
+def _add_session_deny(host: str, port: int, ttl: float) -> None:
+    """Deny ``host:port`` in-session for a consent deny verdict (#2446).
+
+    The deny-side mirror of :func:`_add_session_host`: adds
+    ``(host, port, _EXACT, now + ttl)`` to :data:`_SESSION_HOST_DENIES` so
+    :func:`_cb` (via :func:`_session_host_denies_ttl`) suppresses a re-prompt
+    for a host the user already denied -- including a CDN-rotated or
+    resolver-cached IP that the per-IP :data:`_REJECTED` rule does not cover
+    (the CARRYOVER-SURPRISE, #2446). EXACT scope (only the denied host, not its
+    subdomains, #2377); deduped, a re-deny refreshes the expiry (``max`` --
+    never shortens an unexpired entry). ``once`` adds nothing (per-connection,
+    so a reconnect re-prompts). Loop-only (no lock).
+    """
+    _prune_session_denies()
+    expire = time.time() + ttl
+    spec = (host, port, _EXACT)
+    for i, (h, p, mode, _exp) in enumerate(_SESSION_HOST_DENIES):
+        if (h, p, mode) == spec:
+            _SESSION_HOST_DENIES[i] = (h, p, mode, max(_exp, expire))
+            return
+    _SESSION_HOST_DENIES.append((host, port, _EXACT, expire))
+
+
+def _session_host_denies_ttl(host: str, port: int) -> float | None:
+    """Remaining seconds an in-session deny covers ``host`` on ``port``, or
+    ``None`` (#2446).
+
+    The deny-side mirror of :func:`_session_host_allows_ttl`, used by
+    :func:`_cb` as the last-chance gate before prompting: a SYN to a host:port
+    the user already denied (timed or forever) -- including a CDN-rotated or
+    resolver-cached IP that no fresh per-IP :data:`_REJECTED` rule covers -- is
+    denied fast (RST + short REJECT) without re-prompting. Matches via
+    :func:`_host_matches` (entries are added EXACT, so only the denied host
+    matches, #2377); port must match (or the entry is all-ports). Returns the
+    max remaining TTL across matching entries. Loop-only (no lock).
+    """
+    if not host:
+        return None
+    _prune_session_denies()
+    now = time.time()
+    best: float | None = None
+    for h, p, mode, exp in _SESSION_HOST_DENIES:
         if exp <= now:
             continue  # belt-and-suspenders: _prune ran above, but a just-expired
             # entry can survive the microseconds between its `now` and this one.
@@ -671,6 +764,23 @@ def _drop_session_hosts(host: str) -> None:
     """
     hl = host.lower()
     _SESSION_HOST_ALLOWS[:] = [t for t in _SESSION_HOST_ALLOWS if t[0].lower() != hl]
+
+
+def _drop_session_denies(host: str) -> None:
+    """Remove a host's in-session deny coverage (#2446).
+
+    The deny-side mirror of :func:`_drop_session_hosts`, called on the event
+    loop by :meth:`SidecarConsentClient._handle_drop_rule` for a ``denied``
+    revoke BEFORE :func:`drop_for_host` forks iptables in the executor: while
+    that fork runs (~tens of ms), :func:`_cb` reads :data:`_SESSION_HOST_DENIES`,
+    and a SYN arriving in that window would otherwise keep auto-denying (and
+    re-installing a REJECT for) the host the operator just un-denied. Clearing
+    it first lets the host re-prompt. :data:`_SESSION_HOST_DENIES` is loop-only
+    (no lock) -- touched on the loop, never inside :func:`drop_for_host`
+    (executor thread).
+    """
+    hl = host.lower()
+    _SESSION_HOST_DENIES[:] = [t for t in _SESSION_HOST_DENIES if t[0].lower() != hl]
 
 
 def _clear_verdict_cache(ips: set[str]) -> None:
@@ -1102,6 +1212,11 @@ class SidecarConsentClient:
             # there.)
             if decision == "allowed":
                 _drop_session_hosts(host)
+            elif decision == "denied":
+                # Clear the host-scoped deny memory (#2446) BEFORE drop_for_host
+                # forks iptables, so a SYN arriving during that window re-prompts
+                # instead of staying auto-denied (mirror of the allow revoke).
+                _drop_session_denies(host)
             try:
                 ips = await asyncio.get_running_loop().run_in_executor(
                     None, drop_for_host, host, decision
@@ -1526,6 +1641,29 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
         # passing (ports_for re-allow-lists it + this cache reuses the verdict).
         # Wired with the revoke path in #2370.
         return
+    # An in-session host deny covers the whole domain, timed or forever
+    # (#2446): a SYN to a host:port the user already denied -- including a
+    # CDN-rotated or resolver-cached IP that the per-IP _REJECTED rule does not
+    # cover -- is denied fast here, before prompting, so the user isn't re-asked
+    # for a domain they denied (the CARRYOVER-SURPRISE). Checked AFTER the allow
+    # gate above so an in-effect allow still overrides an in-effect deny.
+    deny_remaining = _session_host_denies_ttl(host, port) if port else None
+    if deny_remaining is not None:
+        # Forge the eager-deny RST so connect() fails fast (ECONNREFUSED) at
+        # once; a REJECT for the deny's remaining window backstops retransmits
+        # off-loop (reject() forks iptables under _LOCK). TCP only (port 0 is
+        # non-TCP). The _VERDICT_CACHE write covers retransmits of THIS flow.
+        if port:
+            try:
+                _send_rst(payload)
+            except Exception:
+                pass
+            asyncio.get_running_loop().run_in_executor(
+                None, reject, dst, port, deny_remaining
+            )
+        pkt.drop()
+        _VERDICT_CACHE[flow] = ("deny", now + VERDICT_CACHE_TTL)
+        return
     pkt.retain()  # keep the payload valid past this callback (deferred verdict)
     _INFLIGHT.add(flow)
     t = asyncio.create_task(_decide_and_verdict(pkt, flow, dst, port, host, client))
@@ -1573,6 +1711,14 @@ async def _decide_and_verdict(
     ttl = _duration_ttl(duration)
     if decision == "allow" and ttl is not None and port:
         _add_session_host(host, port, ttl)
+    # Symmetric host-scoped memory on the deny side (#2446): a timed/forever
+    # deny is remembered by host (not just IP) so a retry -- including a
+    # CDN-rotated IP -- is denied fast without re-prompting. ``once`` (ttl
+    # None) adds nothing (per-connection). Populated before the iptables fork
+    # below so a SYN to a different IP of this host during the yield still hits
+    # _session_host_denies_ttl in _cb.
+    if decision == "deny" and ttl is not None and port:
+        _add_session_deny(host, port, ttl)
     # Run the iptables fork (allow/reject) in the executor so it doesn't block
     # the loop thread -- matches the DNS path's _learn_all, which also runs
     # off the loop. The packet is retained, so verdicting after the await is

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -263,6 +263,46 @@ class TestPortsFor:
         )
         assert proxy._session_host_allows_ttl("example.com", 8080)
 
+    def test_add_session_deny_dedups_and_refreshes(self, proxy, monkeypatch):
+        # Mirror of test_add_session_host_dedups_and_refreshes (#2446): a
+        # re-deny of the same host:port refreshes the expiry (max -- never
+        # shortens an unexpired entry); a different port adds a new entry.
+        monkeypatch.setattr(proxy.time, "time", lambda: 1000.0)
+        proxy._SESSION_HOST_DENIES.clear()
+        proxy._add_session_deny("example.com", 443, 300)  # expire 1300
+        proxy._add_session_deny(
+            "example.com", 443, 60
+        )  # dup -> max(1300, 1060)
+        proxy._add_session_deny("example.com", 8443, 300)  # different port
+        assert proxy._SESSION_HOST_DENIES == [
+            ("example.com", 443, proxy._EXACT, 1300.0),
+            ("example.com", 8443, proxy._EXACT, 1300.0),
+        ]
+
+    def test_session_host_denies_ttl(self, proxy, monkeypatch):
+        # The deny-side NFQUEUE-gate predicate (#2446): entries are EXACT
+        # (#2377 -- only the denied host, not its subdomains); port must match.
+        # Returns the remaining TTL (truthy) or None. Mirrors
+        # test_session_host_allows_ttl via the shared _host_matches.
+        monkeypatch.setattr(
+            proxy,
+            "_SESSION_HOST_DENIES",
+            [("example.com", 443, proxy._EXACT, float("inf"))],
+        )
+        assert proxy._session_host_denies_ttl("example.com", 443)
+        assert proxy._session_host_denies_ttl("api.example.com", 443) is None
+        assert proxy._session_host_denies_ttl("example.com", 80) is None
+        assert proxy._session_host_denies_ttl("other.com", 443) is None
+        assert proxy._session_host_denies_ttl("evilexample.com", 443) is None
+        assert proxy._session_host_denies_ttl("", 443) is None
+        # all-ports entry (p is None) matches any port.
+        monkeypatch.setattr(
+            proxy,
+            "_SESSION_HOST_DENIES",
+            [("example.com", None, proxy._EXACT, float("inf"))],
+        )
+        assert proxy._session_host_denies_ttl("example.com", 8080)
+
 
 class TestRejectedFor:
     """``rejected_for`` is the static deny gate (#2367): a name matching a
@@ -1260,6 +1300,7 @@ class TestNfqueueCallback:
         proxy._INFLIGHT.clear()
         proxy._LEARNED.clear()
         proxy._SESSION_HOST_ALLOWS.clear()
+        proxy._SESSION_HOST_DENIES.clear()
         proxy._BG_TASKS.clear()
 
     async def _decide(self, proxy, pkt, client):
@@ -1444,6 +1485,140 @@ class TestNfqueueCallback:
         monkeypatch.setattr(proxy, "SPECS", [])
         assert proxy.ports_for("example.com") == set()  # pruned -> denied
         assert proxy._SESSION_HOST_ALLOWS == []
+
+    async def test_timed_deny_is_host_scoped(self, proxy, monkeypatch):
+        # #2446 regression: a TIMED deny host-scopes (mirror of the allow side).
+        # The verdict adds the host to _SESSION_HOST_DENIES, so a CDN-rotated IP
+        # of the host -- resolved AFTER the deny, with no per-IP _REJECTED rule
+        # of its own -- is auto-denied at the NFQUEUE gate WITHOUT re-prompting
+        # (the CARRYOVER-SURPRISE fix). Pre-fix this SYN re-entered NFQUEUE and
+        # re-prompted for a host the user had already denied.
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("deny", "5m"))
+        monkeypatch.setattr(proxy, "reject", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        # Decide (deny) on IP_A (the resolved IP at decision time).
+        proxy._record_hosts([("1.2.3.4", 60)], "example.com")
+        await self._decide(
+            proxy, _FakePkt(_ip_payload("1.2.3.4", 443)), client
+        )
+        specs = [(h, p, m) for (h, p, m, _exp) in proxy._SESSION_HOST_DENIES]
+        assert ("example.com", 443, proxy._EXACT) in specs  # host-scoped
+        # A CDN-rotated IP_B (no REJECT, never consented) is auto-denied at the
+        # NFQUEUE gate -- no consent prompt, no verdict task spawned.
+        proxy._record_hosts([("9.9.9.9", 60)], "example.com")
+        client2 = MagicMock()
+        client2.connected = True
+        client2.request = AsyncMock(return_value=("allow", "5s"))
+        pkt2 = _FakePkt(_ip_payload("9.9.9.9", 443))
+        proxy._cb(pkt2, client2)
+        await asyncio.sleep(0.05)
+        assert pkt2.verdict == "drop"  # auto-denied, not allowed
+        client2.request.assert_not_awaited()  # no re-prompt (the fix)
+        assert not proxy._BG_TASKS
+
+    async def test_cb_auto_denies_syn_to_session_denied_host_ip(
+        self, proxy, monkeypatch
+    ):
+        # A SYN to an IP whose host was denied (timed) is auto-denied at the
+        # NFQUEUE gate (no consent prompt): a REJECT for the deny's remaining
+        # window runs off-loop, the SYN is dropped, and the verdict is cached
+        # for retransmits (#2446). reject() runs in the executor.
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("allow", "5s"))
+        rejected = []
+        monkeypatch.setattr(
+            proxy,
+            "reject",
+            lambda ip, port, ttl: rejected.append((ip, port, ttl)),
+        )
+        self._bind(proxy, monkeypatch, client)
+        proxy._add_session_deny("example.com", 443, proxy._DURATION_FOREVER)
+        proxy._record_hosts([("2.2.2.2", 60)], "example.com")
+        pkt = _FakePkt(_ip_payload("2.2.2.2", 443))
+        proxy._cb(pkt, client)  # sync: auto-denies inline, no task
+        await asyncio.sleep(0.1)  # let the executor run reject()
+        assert pkt.verdict == "drop"
+        client.request.assert_not_awaited()  # no consent prompt
+        assert not proxy._BG_TASKS  # no verdict task spawned
+        # reject() called port-scoped, in the executor, with the deny's
+        # remaining window (~forever for a fresh forever entry).
+        assert len(rejected) == 1
+        assert rejected[0][0] == "2.2.2.2"
+        assert rejected[0][1] == 443
+        assert rejected[0][2] >= proxy._DURATION_FOREVER - 5
+        # Verdict cached so a retransmit reuses it.
+        assert any(v[0] == "deny" for v in proxy._VERDICT_CACHE.values())
+
+    async def test_cb_does_not_auto_deny_wrong_port(self, proxy, monkeypatch):
+        # The deny gate is host+port scoped end-to-end: a SYN to a denied host
+        # on a DIFFERENT port (deny was :443; this SYN is :80) is NOT
+        # auto-denied -- it reaches the consent prompt (the security property,
+        # exercised through _cb, not just the predicate).
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("deny", "once"))
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        monkeypatch.setattr(proxy, "reject", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._add_session_deny("example.com", 443, proxy._DURATION_FOREVER)
+        proxy._record_hosts([("2.2.2.2", 60)], "example.com")
+        proxy._cb(_FakePkt(_ip_payload("2.2.2.2", 80)), client)
+        await asyncio.gather(*proxy._BG_TASKS)  # the prompt task ran
+        client.request.assert_awaited_once_with("example.com", 80)
+
+    async def test_once_deny_does_not_add_session_denylist(
+        self, proxy, monkeypatch
+    ):
+        # `once` deny is per-connection (a reconnect re-prompts), so it adds
+        # nothing to _SESSION_HOST_DENIES (mirror of once-allow). Timed/forever
+        # host-scope (#2446); `once` alone stays a per-IP REJECT.
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("deny", "once"))
+        monkeypatch.setattr(proxy, "reject", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._record_hosts([("1.2.3.4", 60)], "example.com")
+        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        await self._decide(proxy, pkt, client)
+        assert proxy._SESSION_HOST_DENIES == []
+
+    def test_timed_session_deny_expires(self, proxy, monkeypatch):
+        # #2446: a timed session-deny expires (lazy prune), so the host
+        # re-enters consent-gating once its window elapses -- it does not leak
+        # like a forever entry.
+        clock = [1000.0]
+        monkeypatch.setattr(proxy.time, "time", lambda: clock[0])
+        proxy._SESSION_HOST_DENIES.clear()
+        proxy._add_session_deny("example.com", 443, 300)  # expire 1300
+        assert proxy._session_host_denies_ttl("example.com", 443) == 300.0
+        clock[0] = 1400.0  # past the 300s window
+        assert proxy._session_host_denies_ttl("example.com", 443) is None
+        assert proxy._SESSION_HOST_DENIES == []
+
+    async def test_allow_overrides_in_effect_deny_at_gate(
+        self, proxy, monkeypatch
+    ):
+        # Acceptance (#2446): an in-effect allow overrides an in-effect deny
+        # at the gate -- _cb consults _session_host_allows_ttl BEFORE
+        # _session_host_denies_ttl, so a SYN to a host that is both allowed and
+        # denied is ACCEPTED (the allow wins), not auto-denied.
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(return_value=("deny", "once"))
+        monkeypatch.setattr(proxy, "allow", lambda *a: None)
+        self._bind(proxy, monkeypatch, client)
+        proxy._add_session_deny("example.com", 443, proxy._DURATION_FOREVER)
+        proxy._add_session_host("example.com", 443, proxy._DURATION_FOREVER)
+        proxy._record_hosts([("2.2.2.2", 60)], "example.com")
+        pkt = _FakePkt(_ip_payload("2.2.2.2", 443))
+        proxy._cb(pkt, client)
+        await asyncio.sleep(0.05)
+        assert pkt.verdict == "accept"  # allow wins over the in-effect deny
+        client.request.assert_not_awaited()
+        assert not proxy._BG_TASKS
 
     async def test_deny_verdict_drops_and_rejects(self, proxy, monkeypatch):
         # deny -> drop the SYN + install a REJECT (tcp-reset) so the retransmit
@@ -2107,6 +2282,20 @@ class TestDropForHost:
         # resolved IP + the host string itself (direct-IP-allow candidate)
         assert ips == {"1.2.3.4", "evil.test"}
 
+    def test_drop_session_denies_removes_host_entries(self, proxy):
+        # A denied revoke drops the host's _SESSION_HOST_DENIES coverage
+        # (#2446); other hosts are left intact. Mirror of the allow revoke
+        # (test_drop_session_hosts_removes_host_entries).
+        proxy._SESSION_HOST_DENIES.clear()
+        proxy._SESSION_HOST_DENIES[:] = [
+            ("evil.test", 443, proxy._EXACT, float("inf")),
+            ("other.test", 80, proxy._EXACT, float("inf")),
+        ]
+        proxy._drop_session_denies("Evil.TEST")  # case-insensitive
+        assert proxy._SESSION_HOST_DENIES == [
+            ("other.test", 80, proxy._EXACT, float("inf"))
+        ]
+
     def test_drop_session_hosts_removes_host_entries(self, proxy):
         # An allowed revoke drops the host's _SESSION_HOST_ALLOWS coverage
         # (in-session allow from #2372/#2434); other hosts are left intact.
@@ -2184,6 +2373,51 @@ class TestDropForHost:
         )
         assert proxy._SESSION_HOST_ALLOWS == []
         assert proxy._VERDICT_CACHE == {}
+        assert json.loads(sent[0])["ok"] is True
+
+    async def test_dispatch_drop_rule_denied_clears_session_deny(
+        self, proxy, tmp_path, monkeypatch
+    ):
+        # #2446: a DENY revoke's drop_rule clears the in-session
+        # _SESSION_HOST_DENIES BEFORE the iptables fork, so a SYN racing that
+        # fork can't keep auto-denying the host the operator just un-denied.
+        # Mirror of test_dispatch_drop_rule_clears_session_state (allow revoke).
+        proxy._LEARNED.clear()
+        proxy._SESSION_HOST_DENIES.clear()
+        proxy._VERDICT_CACHE.clear()
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=0),
+        )
+        proxy._LEARNED["1.2.3.4"] = {
+            "expire": 9e9,
+            "ports": set(),
+            "host": "h.test",
+        }
+        proxy._SESSION_HOST_DENIES.append(
+            ("h.test", 443, proxy._EXACT, float("inf"))
+        )
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        await c._dispatch(
+            json.dumps(
+                {
+                    "type": "drop_rule",
+                    "id": "ack-2",
+                    "host": "h.test",
+                    "decision": "denied",
+                }
+            )
+        )
+        assert proxy._SESSION_HOST_DENIES == []
         assert json.loads(sent[0])["ok"] is True
 
 


### PR DESCRIPTION
## Summary

A consent **deny** verdict did not cover a retry when the destination was a CDN/rotating-IP host: the sidecar re-prompted the decider on the next connection (even though the decider had already denied it and would deny again), and the connection was refused — the `CARRYOVER-SURPRISE` smoketest finding (#2446).

**Root cause — an allow/deny asymmetry.** Verdicts are enforced at the firewall layer, which is per-IP. The **allow** path has host-scoped memory (`_SESSION_HOST_ALLOWS`, #2434/#2372): a timed/forever allow is remembered by hostname for the verdict's TTL, so a retry to a rotated IP is covered without re-prompting. The **deny** path had no equivalent — only a short per-IP `_REJECTED` REJECT rule (`KLANGKNETWORK_EGRESS_REJECT_TTL`, default 10s) plus a per-connection `_VERDICT_CACHE` entry. So for `www.google.com` the deny installed a REJECT for the one IP resolved at decision time; a retry resolved to a different CDN IP (or landed past the 10s TTL), so no rule covered it → the SYN hit NFQUEUE → re-prompt. #2399's "deny covers retries" held only for a fixed-IP destination within `REJECT_TTL`.

**Effective inconsistency seen by users:** a consent *allow is remembered for its whole duration; a deny is not* — denials nagged the user with repeated prompts for a host they had already refused.

Closes #2446.

## What changed

The deny-side mirror of `_SESSION_HOST_ALLOWS` (`src/containers/network/proxy.py`):

- **`_SESSION_HOST_DENIES`** — `(host, port, mode, expire)` list, populated on a non-`once` deny verdict for the verdict's TTL.
- **`_add_session_deny` / `_session_host_denies_ttl` / `_prune_session_denies` / `_drop_session_denies`** — exact mirrors of the allow-side helpers (EXACT scope, port-scoped, deduped + refreshed on `max`, lazy-pruned).
- **Populate** in `_decide_and_verdict` — a timed/forever deny adds the host before the iptables fork, so a rotated IP arriving during the yield is still covered.
- **Consult** in `_cb` — **after** the allow gate (so an in-effect allow still overrides an in-effect deny), a SYN to a session-denied host is RST'd + short-REJECT'd + dropped with **no re-prompt**. Covers CDN-rotated IPs the per-IP `_REJECTED` rule misses; the per-IP REJECT is the fast-fail backstop for retransmits.
- **Revoke** — `_handle_drop_rule` clears `_SESSION_HOST_DENIES` on a `denied` drop-rule (mirror of the allow revoke), before `drop_for_host` forks iptables.

`once` denies stay per-connection (a reconnect re-prompts) — unchanged. A timed/forever deny now sticks across IP rotation until it expires (lazy prune) or is revoked.

## Safety

- **A live owner is never affected** — this only changes *re-prompt* behavior for hosts the user already denied; the connection is still refused (exit 7), exactly as before.
- **Allow still wins** — the deny gate is checked strictly after the allow gate; an in-effect allow overrides an in-effect deny (acceptance criterion, tested).
- **`once` unchanged** — per-connection denies still re-prompt on a new connection.
- **Shared-IP granularity** — a host-scoped deny consulted via a shared IP could also deny a co-resident hostname on that IP, the *same* granularity the allow side already accepts (L7/SNI filtering is a separate feature, #2352).
- **Revocation still works** — a `denied` drop-rule clears the memory so the host re-prompts.

## Test plan

- [x] 11 new unit tests in `test_proxy.py`: `_add_session_deny` dedup/refresh, `_session_host_denies_ttl` matching (EXACT/port/empty/boundary), `_drop_session_denies`, `_cb` auto-deny short-circuit (RST + reject + drop, no prompt, verdict cached), wrong-port reaches the prompt, `once` adds nothing, timed session-deny expiry, allow-overrides-deny-at-gate, deny-revoke dispatch clears `_SESSION_HOST_DENIES`.
- [x] The core regression test `test_timed_deny_is_host_scoped`: a timed deny on IP_A → a CDN-rotated IP_B (no REJECT of its own) is auto-denied with **no re-prompt** (the exact CARRYOVER-SURPRISE scenario).
- [x] Full backend suite the CI way: **4956 passed, 100% coverage**.
- [ ] e2e smoketest: `CARRYOVER-SURPRISE` should stop firing for `covered:denied:verdict` retries (manual; the smoketest is e2e, not unit-covered).

## Notes

- Added a `Fixed` changelog entry under `[Unreleased]` (the deny-side counterpart of the existing #2434 allow entry).
- No new env vars; `KLANGKNETWORK_EGRESS_REJECT_TTL` still governs the per-IP REJECT lifetime (now just the fast-fail backstop, not the re-prompt gate).
