### PR TITLE
test(egress): assert multi-level subdomain host-scope coverage

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
@@ -64,8 +64,9 @@ DEFAULT_IMAGE = "localhost/klangk-network-sidecar:latest"
 DEFAULT_NETWORK = "podman"
 # Secondary IPs are assigned in a high slice of the subnet's /24 (the gateway
 # is reliably the .1, so <gw-first-three>.200+ is free of podman's low DHCP
-# range). 16 IPs is plenty for the host-scope phase's ~6 distinct names plus
-# the snapshot/port phases, with headroom.
+# range). 16 IPs is plenty for the host-scope phase's ~8 distinct names (apex
+# + single/deep sub per scope mode, #2442) plus the snapshot/port phases, with
+# headroom.
 _IP_SLICE_START = 200
 _IP_SLICE_SIZE = 16
 # Forward unknown queries here (a public resolver the container can reach over

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -1898,8 +1898,11 @@ class SmokeTest:
         allow rule (per IP) can't paper over the L7 hostname spec, so each scope
         mode is observable on the real stack:
           * bare ``exact.test`` (EXACT): apex covered, subdomain NOT.
-          * ``.incl.test`` (INCLUSIVE): apex + subdomains covered.
-          * ``*.wild.test`` (SUBDOMAINS): subdomains covered, apex NOT.
+          * ``.incl.test`` (INCLUSIVE): apex + subdomains covered, including
+            a *multi-level* subdomain (``a.b.incl.test``) -- pins the
+            ``endswith('.host')`` boundary at depth > 1, not just one label.
+          * ``*.wild.test`` (SUBDOMAINS): subdomains covered (incl. deep),
+            apex NOT.
         Driven via a dedicated interactive workspace + a raw decider scoped to
         it. Needs controlled DNS (skipped otherwise)."""
         if not self.args.host_scope:
@@ -1924,8 +1927,15 @@ class SmokeTest:
             ("sub.exact.test", False, "exact(sub) NOT covered"),
             ("incl.test", True, "inclusive(apex) covered"),
             ("sub.incl.test", True, "inclusive(sub) covered"),
+            # Multi-level subdomain (#2442): ``.host`` is endswith('.host'),
+            # so a >1-label-deep name must also be covered. Asserted here (not
+            # just in the model) at the sidecar DNS/consent layer via its own
+            # distinct controlled IP.
+            ("a.b.incl.test", True, "inclusive(deep sub) covered"),
             ("wild.test", False, "subdomains(apex) NOT covered"),
             ("sub.wild.test", True, "subdomains(sub) covered"),
+            # Symmetric deep-sub assertion for ``*.host`` (same endswith branch).
+            ("a.b.wild.test", True, "subdomains(deep sub) covered"),
         ]
         for host, _covered, _label in cases:
             self.dns.allocate(host)


### PR DESCRIPTION
## Summary

Closes #2442.

The smoketest's host-scope phase asserted nginx-style host matching (#2377/#2379 — bare host = exact only, `.host` = apex + subdomains, `*.host` = subdomains only) only at a **single-label** subdomain depth. The multi-level boundary the issue names (`a.b.example.com`) was never pinned, so the `endswith('.host')` semantics at depth > 1 were only checked in the model mirror, not on the real stack.

## What changed

Added two deep-subdomain cases to `run_host_scope_phase`, each on its own **distinct controlled IP** (via `_controlled_dns`) so the L7 hostname spec stays observable — the learned-IP `ACCEPT` for a shallower name can't paper over the deeper one:

- `a.b.incl.test` → **covered** by `.incl.test` (INCLUSIVE) — the case the issue explicitly asked for.
- `a.b.wild.test` → **covered** by `*.wild.test` (SUBDOMAINS) — symmetric pin for the same `endswith("." + host)` branch.

Both are asserted at the sidecar DNS/consent layer (raw decider WS + `_raw_wait_no_request`), not just the `EgressModel` set-membership mirror. Any mismatch still routes to the existing `HOST-SCOPE-VIOLATION` outcome via the `"host scope: "` prefix match — no new outcome wiring. IP budget for the controlled-DNS fixture goes 11 → 13 of the 16-IP slice; the slice-size comment in `_controlled_dns.py` is updated to match.

## Validation

- `ruff format --check` + `ruff check` clean on both files.
- `py_compile` clean.
- `python -m pytest src/klangk/klangkd-tests/tests/test_controlled_dns.py -v -n auto` — 5 passed (the only unit test that imports the touched fixture).
- The host-scope phase itself is a human-run e2e smoketest against a live `devenv up` stack (podman + controlled DNS + sidecar image); not run here per the human-facing-workflow convention.
