### PR TITLE
Switch workspace base image to debian:trixie-slim, Node via NodeSource apt

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -543,6 +543,13 @@ operators or integrators to act when upgrading.
   jargon "NXDOMAIN" with plain language (e.g. "Hosts blocked unconditionally
   (never resolved, no consent asked)."). Display-only; no behavior change.
 
+- **Workspace base image is now `debian:trixie-slim`, Node installed via apt (#2432).**
+  The workspace container derives from `debian:trixie-slim` (pinned by digest)
+  instead of `node:26-slim`, and Node.js 26 + npm are installed explicitly
+  from the NodeSource apt repo (`nodejs=26.7.0-1nodesource1`) rather than
+  coming from the base image. Node major is unchanged (still 26), so workspace
+  behavior is unaffected.
+
 - **Revoking a `forever` verdict retracts its durable list entry (#2370,
   #2339).** Revoking a `forever` allow/deny now removes the host from
   `allowed_domains`/`rejected_domains` (not just the in-memory sidecar rule),

--- a/docs/features/container-packages.md
+++ b/docs/features/container-packages.md
@@ -1,7 +1,7 @@
 # Container Packages
 
 Every workspace runs inside a container built from
-`node:26-slim` (Debian). The image ships a curated set of packages
+`debian:trixie-slim` (Debian 13). The image ships a curated set of packages
 so common development tasks work out of the box.
 
 > **Note:** This page documents the default `klangk-workspace` image.
@@ -10,12 +10,12 @@ so common development tasks work out of the box.
 
 ## Language Runtimes
 
-| Runtime        | Source                      | Notes                          |
-| -------------- | --------------------------- | ------------------------------ |
-| **Node.js 26** | Base image (`node:26-slim`) | Includes `npm`                 |
-| **Python 3**   | `python3` system package    | `pip` and `venv` included      |
-| **Bash**       | Default shell               | `/bin/sh` is symlinked to bash |
-| **Zsh**        | `zsh` system package        | Available but not the default  |
+| Runtime        | Source                                 | Notes                              |
+| -------------- | -------------------------------------- | ---------------------------------- |
+| **Node.js 26** | NodeSource apt repo (`nodejs` package) | Includes `npm`; pinned to `26.7.0` |
+| **Python 3**   | `python3` system package               | `pip` and `venv` included          |
+| **Bash**       | Default shell                          | `/bin/sh` is symlinked to bash     |
+| **Zsh**        | `zsh` system package                   | Available but not the default      |
 
 ## Build Tools
 

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -1,9 +1,14 @@
-FROM node:26-slim
+# debian:trixie-slim pinned by digest (multi-arch manifest list) for
+# reproducible base-image builds; aligns with src/containers/nix-seed/Dockerfile.
+# Bump the digest (and let the base-image workflow re-tag) to pull in Debian
+# security updates. (#2432)
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
+    gnupg \
     python3 \
     python3-pip \
     python3-venv \
@@ -64,6 +69,27 @@ RUN chmod u+s /usr/bin/ping
 RUN sed -i '/en_US.UTF-8/s/^# //' /etc/locale.gen && locale-gen
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
+
+# Node.js 26 + npm from the NodeSource apt repo, pinned to an exact patch via
+# apt. Matches the Node major the previous `node:26-slim` base shipped, so
+# workspace behavior is unchanged; Node is now an explicit apt dependency
+# instead of an artifact of the base image. Debian trixie's own nodejs is 20.x
+# (EOL, and below Pi's engine floor of >=22.19.0), so the distro package is not
+# used. NodeSource's nodejs package bundles npm (Provides: npm); we do NOT
+# install Debian's separate `npm`, which would pull distro Node 20 as a
+# dependency. NodeSource keeps every 26.x patch in its repo, so this pin is
+# durable. (#2432)
+ARG NODEJS_VERSION=26.7.0-1nodesource1
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && chmod 644 /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_26.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+       nodejs=${NODEJS_VERSION} \
+    && node --version && npm --version \
+    && rm -rf /var/lib/apt/lists/* \
+    && chown -R root:root /var/log/apt
 
 # GitHub CLI (not in default Debian repos)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
Closes #2432.

## What

Switches the workspace base image from `node:26-slim` to `debian:trixie-slim` (pinned by digest), and installs Node.js 26 + npm explicitly from the NodeSource apt repo instead of inheriting them from the base image.

- `src/containers/workspace/Dockerfile.base`: `FROM debian:trixie-slim@sha256:...` (multi-arch manifest-list digest); adds `gnupg` to the base apt install; new layer adds the NodeSource repo and installs `nodejs=26.7.0-1nodesource1` (bundles npm) with a build-time `node --version && npm --version` check.
- `docs/features/container-packages.md`: base-image and Node row updated.
- `docs/changes.md`: `Changed` entry.

## Two deviations from the issue's literal text (both verified)

1. **Trixie's `nodejs` is 20.x, not 22.x as the issue states.** `20.19.2` is EOL (April 2026) and below Pi's engine floor (`>=22.19.0`), so `npm install -g @earendil-works/pi-coding-agent` would fail or break at runtime. Used the NodeSource apt repo instead — still "via apt", same third-party signed-source pattern the Dockerfile already uses for the GitHub CLI.
2. **Kept Node 26** (via NodeSource `node_26.x`, latest `26.7.0`) rather than downgrading to 22. Node major is unchanged, so workspace behavior is unaffected. Pinning is to an exact patch and durable (NodeSource keeps every 26.x release in its repo).

## Verification

Built the base image locally (single arch); inside it:

```
$ node --version  -> v26.7.0
$ npm --version   -> 11.19.0
$ npm install -g @earendil-works/pi-coding-agent@0.83.0  # what Dockerfile does on this base
$ pi --version    -> 0.83.0
```

No `EBADENGINE`; Pi installs and runs.

Dockerfile/docs only — no `klangk` package code changed, so the pytest suite is unaffected.

## Note

Merging to `main` triggers `image-workspace-base.yml`, which builds/publishes the new base image and auto-opens a PR to bump the `WORKSPACE_BASE_IMAGE` pin in `src/containers/workspace/Dockerfile`.
