### PR TITLE
fix(frontend): rename egress rules tab + de-jargon rejected-domains copy

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -529,6 +529,12 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Network egress UI copy (#2457).** The workspace consent-rules tab is
+  now labeled **"Net Rules"** (was "Rules") to disambiguate it, and the
+  rejected-domains help text plus its validation error replaced the DNS
+  jargon "NXDOMAIN" with plain language (e.g. "Hosts blocked unconditionally
+  (never resolved, no consent asked)."). Display-only; no behavior change.
+
 - **Revoking a `forever` verdict retracts its durable list entry (#2370,
   #2339).** Revoking a `forever` allow/deny now removes the host from
   `allowed_domains`/`rejected_domains` (not just the in-memory sidecar rule),

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -276,7 +276,7 @@ class IdeLayoutState extends State<IdeLayout> {
     // (the caller passes null otherwise), mounted with the other management
     // tabs before Sharing/Settings.
     if (widget.consentRules != null) {
-      addTab('Rules', Icons.shield_outlined, widget.consentRules!);
+      addTab('Net Rules', Icons.shield_outlined, widget.consentRules!);
     }
     if (widget.sharing != null) {
       addTab('Sharing', Icons.people_outline, widget.sharing!);

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -804,7 +804,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       Text('Rejected Domains', style: _labelStyle),
       const SizedBox(height: 4),
       Text(
-        'Hosts NXDOMAIN\'d unconditionally (no resolution, no consent).',
+        'Hosts blocked unconditionally (never resolved, no consent asked).',
         style: const TextStyle(fontSize: 12, color: KColors.textSecondary),
       ),
       const SizedBox(height: 8),

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -63,7 +63,7 @@ String? validateAllowedDomainSpec(String spec, {bool allowCidr = true}) {
   if (spec.contains('/')) {
     if (!allowCidr) {
       return 'CIDR ranges are not supported for rejected domains '
-          '(NXDOMAIN is name-level)';
+          '(matched by hostname, not IP)';
     }
     return _validateCidrDomainSpec(spec);
   }

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -1105,7 +1105,7 @@ class _SettingsFormState extends State<_SettingsForm> {
         ),
         const SizedBox(height: 4),
         Text(
-          'Hosts NXDOMAIN\'d unconditionally (no resolution, no consent). '
+          'Hosts blocked unconditionally (never resolved, no consent asked). '
           'CIDR ranges are not supported.',
           style: TextStyle(
             color: KColors.textSecondary,

--- a/src/frontend/test/ide_layout_test.dart
+++ b/src/frontend/test/ide_layout_test.dart
@@ -269,25 +269,26 @@ void main() {
       expect(find.text('Settings'), findsOneWidget);
     });
 
-    testWidgets('has Rules tab when consentRules provided', (tester) async {
+    testWidgets('has Net Rules tab when consentRules provided', (tester) async {
       await tester.pumpWidget(buildLayout(
         consentRules: const Text('RULES_CONTENT'),
       ));
-      expect(find.text('Rules'), findsOneWidget);
+      expect(find.text('Net Rules'), findsOneWidget);
     });
 
-    testWidgets('Rules tab content is visible after switch', (tester) async {
+    testWidgets('Net Rules tab content is visible after switch',
+        (tester) async {
       await tester.pumpWidget(buildLayout(
         consentRules: const Text('RULES_CONTENT'),
       ));
-      await tester.tap(find.text('Rules'));
+      await tester.tap(find.text('Net Rules'));
       await tester.pumpAndSettle();
       expect(find.text('RULES_CONTENT'), findsOneWidget);
     });
 
-    testWidgets('no Rules tab when consentRules is null', (tester) async {
+    testWidgets('no Net Rules tab when consentRules is null', (tester) async {
       await tester.pumpWidget(buildLayout());
-      expect(find.text('Rules'), findsNothing);
+      expect(find.text('Net Rules'), findsNothing);
     });
 
     testWidgets('settings tab content is visible after switch', (tester) async {


### PR DESCRIPTION
## Summary

Two Flutter UI copy nits from #2457:

- The network egress **consent-rules tab** is now labeled **"Net Rules"** (was "Rules") to disambiguate it from any other rules.
- The **rejected-domains** help text (in both the workspace Settings panel and the create-workspace dialog) and the rejected-domains CIDR validation error no longer use the DNS jargon **"NXDOMAIN"** — replaced with plain language:
  - `"Hosts blocked unconditionally (never resolved, no consent asked)."`
  - `"CIDR ranges are not supported for rejected domains (matched by hostname, not IP)"`

Display-only; no behavior change. Developer-facing code comments that reference NXDOMAIN (accurate internal terminology) are left as-is.

Closes #2457.
