### PR TITLE
fix(workspace): hide Pi thinking block by default instead of no-op thinking off

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -529,6 +529,14 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Workspace Pi agent hides thinking blocks by default (#2459).** The
+  per-user `~/.pi/agent/settings.json` provisioned at first login now sets
+  `hideThinkingBlock: true` instead of the previous `defaultThinkingLevel:
+"off"`, which had no effect behind the LLM proxy (the model kept thinking
+  regardless). Thinking still runs and costs tokens; only its block is hidden
+  in the web-terminal TUI, where the Ctrl+T toggle is swallowed by the
+  browser. Existing `settings.json` files are left untouched.
+
 - **Network egress UI copy (#2457).** The workspace consent-rules tab is
   now labeled **"Net Rules"** (was "Rules") to disambiguate it, and the
   rejected-domains help text plus its validation error replaced the DNS

--- a/src/containers/workspace/klangk-setup-pi.py
+++ b/src/containers/workspace/klangk-setup-pi.py
@@ -66,9 +66,9 @@ def write_settings():
     model = os.environ.get("KLANGKWS_LLM_MODEL", "")
     image_settings["defaultProvider"] = "llm-proxy"
     image_settings["defaultModel"] = model
-    # Disable thinking by default — Ctrl+T toggle doesn't work in web
+    # Hide the thinking block — Ctrl+T toggle doesn't work in web
     # terminals because the browser captures it.
-    image_settings["defaultThinkingLevel"] = "off"
+    image_settings["hideThinkingBlock"] = True
     # Point at image dirs directly — Pi also auto-discovers
     # ~/.pi/agent/{extensions,skills,prompts}/ for user-installed ones.
     image_settings["extensions"] = [str(IMAGE_DIR / "extensions")]

--- a/src/klangk/klangkd-tests/tests/test_setup_pi.py
+++ b/src/klangk/klangkd-tests/tests/test_setup_pi.py
@@ -55,7 +55,7 @@ class TestWriteSettings:
         settings = json.loads((agent / "settings.json").read_text())
         assert settings["defaultProvider"] == "llm-proxy"
         assert settings["defaultModel"] == "test-model"
-        assert settings["defaultThinkingLevel"] == "off"
+        assert settings["hideThinkingBlock"] is True
         assert settings["extensions"] == [str(sc.IMAGE_DIR / "extensions")]
         assert settings["skills"] == [str(sc.IMAGE_DIR / "skills")]
         assert settings["prompts"] == [str(sc.IMAGE_DIR / "prompts")]
@@ -97,7 +97,7 @@ class TestWriteSettings:
         settings = json.loads((agent / "settings.json").read_text())
         assert settings["defaultProvider"] == "llm-proxy"
         assert settings["defaultModel"] == "test-model"
-        assert settings["defaultThinkingLevel"] == "off"
+        assert settings["hideThinkingBlock"] is True
         assert settings["extensions"] == [str(image_dir / "extensions")]
         assert settings["skills"] == [str(image_dir / "skills")]
         assert settings["prompts"] == [str(image_dir / "prompts")]


### PR DESCRIPTION
## Summary

`klangk-setup-pi.py` set `defaultThinkingLevel: "off"` in the freshly-provisioned `~/.pi/agent/settings.json`, but that setting has no effect behind the LLM proxy — the model keeps thinking regardless. This swaps it for `hideThinkingBlock: true`, which actually hides the thinking block in the web-terminal TUI.

Thinking still runs and still costs tokens/latency; only its display is hidden. The Ctrl+T toggle (the only way to flip it at runtime) is swallowed by the browser in web terminals, so hiding it by default is the only effective lever.

## Changes

- `src/containers/workspace/klangk-setup-pi.py` — in `write_settings()`, replace the `defaultThinkingLevel: "off"` assignment with `hideThinkingBlock: True` and reword the comment. `write_settings()` only runs when `settings.json` is absent, so **existing users are never touched**. `ensure_settings_keys()` is deliberately left alone — backfilling would override a user's own preference.
- Tests updated to assert `hideThinkingBlock is True` and the absence of the old key.
- Changelog entry under `### Changed`.

Closes #2459.
