### PR TITLE
fix(egress-smoke): clean exit on Ctrl-C or an uncaught error (#2456)

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -741,6 +741,7 @@ _DETAIL_PREFIX_NAMES: list[tuple[str, str]] = [
     ("no hold surfaced for the", "NO-EXPECTED-REQUEST"),
     ("concurrent same-host deduped to one prompt, but both", "ALLOW-REFUSED"),
     ("fan-out phase failed", "UNEXPECTED-ERROR"),
+    ("run aborted", "UNEXPECTED-ERROR"),
 ]
 
 OUTCOME_NAMES: dict[str, str] = {
@@ -4571,6 +4572,22 @@ class SmokeTest:
                     await self._shared_d2.close()
                     self._shared_d2 = None
                 await self.run_no_decider_phase(pilot)
+        except Exception as exc:
+            # An uncaught exception escaped a phase (e.g. a podman exec against
+            # a workspace container that disappeared mid-run). Record it so the
+            # summary reflects the abort instead of dumping a raw asyncio
+            # traceback on exit (#2456). KeyboardInterrupt / CancelledError is
+            # deliberately NOT caught here (they are BaseException, not
+            # Exception) -- Ctrl-C propagates to main()'s clean exit-130.
+            self._record_probe(
+                _Step(self.summary.total, "(run)", "n/a", False, "run", "-"),
+                "uncaught exception",
+                "error",
+                None,
+                MISMATCH,
+                f"run aborted: uncaught {exc!r}",
+            )
+            stop = True
         finally:
             await self.teardown()
         self._print_summary(stop)
@@ -4923,6 +4940,21 @@ def main() -> int:
     signal.signal(signal.SIGTERM, _on_term)
     try:
         return asyncio.run(inst.run())
+    except KeyboardInterrupt:
+        # Ctrl-C: asyncio.run cancels the main task (run()'s async ``finally``
+        # still runs teardown during the cancellation) then re-raises
+        # KeyboardInterrupt. Catch it for a clean exit -- the conventional
+        # 128+SIGINT (130) and no traceback (#2456). The ``finally`` below
+        # (_cleanup_sync) is the backstop if a second Ctrl-C interrupts
+        # teardown itself.
+        print("\ninterrupted", file=sys.stderr)
+        return 128 + signal.SIGINT
+    except Exception as exc:
+        # Backstop for an exception that escaped run()'s own handling (e.g.
+        # setup() or teardown() raised). Print a concise error -- not the full
+        # asyncio-internals traceback -- and exit non-zero (#2456).
+        print(f"\nsmoketest aborted: {exc!r}", file=sys.stderr)
+        return 1
     finally:
         # Normal exit / uncaught exception / KeyboardInterrupt: belt-and-
         # suspenders in case the async ``finally`` was itself interrupted


### PR DESCRIPTION
Closes #2456.

## What

The smoketest dumped a raw `asyncio` traceback on **any** ungraceful exit — not
only Ctrl-C, but also when an uncaught exception escaped a phase (e.g.
`run_duration_lifecycle`'s `_trigger` hitting a workspace container that had
disappeared mid-run → `CalledProcessError`). Container teardown still ran (the
`finally` + `_cleanup_sync` backstop), but the process exited via an uncaught
exception out of `asyncio.run`.

Two-layer fix:

- **`run()`** — add `except Exception` alongside the existing `try/finally`. An
  uncaught phase error is now recorded as a result row and the summary still
  prints, instead of propagating to `asyncio.run`.
- **`main()`** — catch `KeyboardInterrupt` (→ exit `128 + SIGINT`, with an
  `interrupted` message) and `Exception` (→ a concise `smoketest aborted: …`
  message + non-zero exit) around `asyncio.run`. These are backstops for
  `setup()`/`teardown()` failures that escape `run()`.

`KeyboardInterrupt` / `asyncio.CancelledError` are `BaseException`, not
`Exception`, so `run()`'s `except Exception` deliberately does **not** swallow a
Ctrl-C — it propagates to `main()`'s clean exit-130 handler. The issue's own
traceback confirmed `asyncio.run` raises `KeyboardInterrupt` on Ctrl-C, and
`CalledProcessError` is an `Exception`, so it's caught by `run()`'s new handler.

## Verification

- `test-backend`: 4956 passed, 100% coverage.
- ruff F + import-time outcome-name registration asserts pass; pre-commit clean.

(A full real-stack Ctrl-C run wasn't used here — the environment had several
concurrent smoketest + klangkd processes contending for containers, making a
clean repro slow/flaky. The fix is standard `try/except` control flow: the
exception types and the `asyncio.run` → `KeyboardInterrupt` behavior are
confirmed by reading + the issue's tracebacks.)
