### PR TITLE
fix(egress): bound a timed allow's DNS-path learn at its verdict (#2465)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,13 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`5s` consent-duration option (#2465).** The test-only 5-second duration
+  is temporarily exposed in the consent duration selector (TUI + Flutter) for
+  manual testing, now that a timed allow lapses at its verdict rather than the
+  `MIN_TTL` floor. Remove `5s` from `SELECTABLE_DURATIONS` (TUI) /
+  `kConsentDurations` (Flutter) to hide it again; it stays valid for
+  programmatic/test callers either way.
+
 - **`KLANGKNETWORK_EGRESS_UPSTREAM` — operator-pinnable sidecar DNS upstream (#2424).**
   When set in `klangkd`'s environment, the network sidecar's FQDN proxy forwards
   workspace DNS to this resolver verbatim instead of auto-detecting a host

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -815,14 +815,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   pause/reconnect), so the client prunes elapsed rules on its 1s tick.
 
 - **Timed egress-consent allows no longer outlive their duration (#2465).** A
-  timed `allow` verdict (e.g. `allow/5s`) used to keep covering retries past
-  its window: the in-session host allow let the DNS path re-learn each
-  resolved IP for the response's DNS TTL (often minutes), so the learned
-  ACCEPT rule outlived the verdict and a retry past the window connected with
-  no re-prompt. The DNS-path learn is now bounded at the verdict's remaining
-  window, so the rule lapses with the verdict and a retry re-prompts (the
-  `deny` side already behaved correctly). Static allow-list entries are
-  unaffected.
+  timed `allow` verdict used to keep covering retries past its window via two
+  leaks, both now closed. (1) Every re-resolve of the consented host re-learned
+  its resolved IP for the response's DNS TTL (often minutes), so the learned
+  ACCEPT rule outlived the verdict; the DNS-path learn is now bounded at the
+  verdict's remaining window. (2) A consent-verdict rule was floored at the
+  learned-IP `MIN_TTL` (30s), so a short verdict (the test-only `5s`) lived
+  30s; the consent paths now use the verdict verbatim (no floor). Together a
+  timed allow's rule lapses at the verdict and a retry past the window
+  re-prompts (the `deny` side already behaved correctly). Static allow-list
+  entries are unaffected (their DNS-learn floor is unchanged).
 
 - **Timed egress-consent allows now cover the whole host (#2434).** A timed or
   `until restart` `allow` verdict now allow-lists the consented host for its

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -814,6 +814,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   only re-broadcasts the rules snapshot on discrete events (verdict/revoke/
   pause/reconnect), so the client prunes elapsed rules on its 1s tick.
 
+- **Timed egress-consent allows no longer outlive their duration (#2465).** A
+  timed `allow` verdict (e.g. `allow/5s`) used to keep covering retries past
+  its window: the in-session host allow let the DNS path re-learn each
+  resolved IP for the response's DNS TTL (often minutes), so the learned
+  ACCEPT rule outlived the verdict and a retry past the window connected with
+  no re-prompt. The DNS-path learn is now bounded at the verdict's remaining
+  window, so the rule lapses with the verdict and a retry re-prompts (the
+  `deny` side already behaved correctly). Static allow-list entries are
+  unaffected.
+
 - **Timed egress-consent allows now cover the whole host (#2434).** A timed or
   `until restart` `allow` verdict now allow-lists the consented host for its
   whole duration — the same as `allow forever` already did — instead of only

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -497,6 +497,47 @@ def _session_host_allows_ttl(host: str, port: int) -> float | None:
     return best
 
 
+def _session_allow_rule_cap(qname: str) -> float | None:
+    """Min remaining TTL bounding a DNS-path learned rule for ``qname``, or
+    ``None`` (#2465).
+
+    A timed consent allow adds the host to :data:`_SESSION_HOST_ALLOWS`, so
+    :func:`ports_for` treats it as allow-listed and the DNS path
+    (:func:`_respond_allowed` -> :func:`_learn_all`) learns every resolved IP.
+    That learn used to install the ACCEPT rule for the response's DNS TTL --
+    often minutes -- so a short verdict (5s) left a rule that outlived it: a
+    retry past the window connected with no re-prompt (the allow/deny asymmetry
+    of #2465 -- the deny side records no DNS-path learn, so it expired on
+    time). The cap returned here bounds the rule's TTL at the min remaining
+    across matching session allows, so the rule lapses with the verdict and a
+    retry past the window re-prompts.
+
+    ``None`` (no cap -- use the DNS TTL) when a static :data:`SPECS` entry
+    matches: a static allow is forever, so the DNS TTL is the correct rule
+    lifetime, and capping it would expire the rule early and -- in the gap
+    between rule expiry and the next resolve -- re-prompt a forever-allowed
+    host (a static spec has no NFQUEUE gate, only the learned rule covers its
+    SYN). Also ``None`` when no session allow matches (a static-only or
+    non-allow-listed name learns at its DNS TTL). Loop-only (reads
+    :data:`_SESSION_HOST_ALLOWS`); computed on the event-loop thread in
+    :func:`_respond_allowed` and passed to :func:`_learn_all`, which runs
+    off-loop in the executor.
+    """
+    if any(_host_matches(qname, host, mode) for host, _port, mode in SPECS):
+        return None  # a static spec matches -> forever -> DNS TTL is correct
+    _prune_session_allows()
+    now = time.time()
+    best: float | None = None
+    for host, _port, mode, exp in _SESSION_HOST_ALLOWS:
+        if exp <= now:
+            continue
+        if _host_matches(qname, host, mode):
+            remaining = exp - now
+            if best is None or remaining < best:
+                best = remaining
+    return best
+
+
 def _prune_session_denies() -> None:
     """Drop expired in-session host denies (lazy sweep, #2446).
 
@@ -931,12 +972,25 @@ def check_mark() -> None:
         probe.close()
 
 
-def _learn_all(recs: list[tuple[str, int]], ports: set[int | None]) -> None:
+def _learn_all(
+    recs: list[tuple[str, int]],
+    ports: set[int | None],
+    cap: float | None = None,
+) -> None:
     """Install the ACCEPT rule for each learned IP/port (sync; runs in the
-    executor so the iptables forks don't block the event loop)."""
+    executor so the iptables forks don't block the event loop).
+
+    ``cap``, when not ``None``, bounds each rule's TTL at ``min(dns_ttl, cap)``
+    so a timed session-allow's learned rule does not outlive its verdict
+    (#2465). The host mapping -- set earlier by :func:`_record_hosts` at the
+    DNS TTL, ahead of the consent allow -- is untouched: :func:`allow`'s
+    ``max`` keeps the longer mapping lifetime so :func:`_host_for` still names
+    the host for a fresh re-prompt after the verdict lapses (#2408).
+    """
     for ip, ttl in recs:
+        rule_ttl = ttl if cap is None else min(ttl, cap)
         for port in ports:
-            allow(ip, port, ttl)
+            allow(ip, port, rule_ttl)
 
 
 def _record_hosts(recs: list[tuple[str, int]], host: str) -> None:
@@ -996,9 +1050,17 @@ async def _respond_allowed(
         recs = a_records_with_ttl(resp)
     except Exception:
         recs = []
+    # Bound a timed session-allow's learned rule at its verdict's remaining
+    # window (#2465): without this the DNS-path learn uses the response's DNS
+    # TTL (often minutes), so a 5s allow leaves a rule that outlives it and a
+    # retry past the window connects with no re-prompt. None for a static spec
+    # (forever) or no session allow -- the DNS TTL is correct then. Computed
+    # on the loop (reads loop-only _SESSION_HOST_ALLOWS) before the executor
+    # fork below.
+    cap = _session_allow_rule_cap(qname) if recs else None
     try:
         if recs:
-            await loop.run_in_executor(None, _learn_all, recs, ports)
+            await loop.run_in_executor(None, _learn_all, recs, ports, cap)
         if DEBUG:
             print(
                 f"allow {qname} -> {[ip for ip, _ in recs]} ports={_fmt_ports(ports)}",

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -183,7 +183,7 @@ def _rst_debug(msg: str) -> None:
 # persistence is #2368's `forever`-allow sub-piece; the deny counterpart is
 # #2369.)
 _DURATION_SECONDS = {
-    "5s": 5,  # test-only (#2363, subsumed by #2392); honored but never UI-offered
+    "5s": 5,  # test-only (#2363); TEMPORARILY UI-offered for manual testing (#2465)
     "5m": 300,
     "15m": 900,
     "1h": 3600,
@@ -526,9 +526,12 @@ def _session_allow_rule_cap(qname: str) -> float | None:
     The static-spec check is qname-level (any port), so a host with a
     port-scoped static spec (``example.com:443``) AND a timed session allow on
     a *different* port (``example.com:8443``) leaves the :8443 learn uncapped
-    -- pre-#2465 behavior (nothing was capped before), not a regression; the
-    :8443 session allow still covers its SYN at the NFQUEUE gate. All real
-    consent flows hit this for a single host:port, where the cap is exact.
+    -- pre-#2465 behavior (nothing was capped before), not a regression. The
+    lingering :8443 ACCEPT rule (DNS TTL) sits at the top of OUTPUT and
+    shadows NFQUEUE, so a retry past that verdict's window connects without a
+    re-prompt until the DNS TTL elapses -- a known narrow leak for that combo,
+    NOT covered by the NFQUEUE gate. All real consent flows hit this for a
+    single host:port, where the cap is exact.
     """
     if any(_host_matches(qname, host, mode) for host, _port, mode in SPECS):
         return None  # a static spec matches -> forever -> DNS TTL is correct

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -522,6 +522,13 @@ def _session_allow_rule_cap(qname: str) -> float | None:
     :data:`_SESSION_HOST_ALLOWS`); computed on the event-loop thread in
     :func:`_respond_allowed` and passed to :func:`_learn_all`, which runs
     off-loop in the executor.
+
+    The static-spec check is qname-level (any port), so a host with a
+    port-scoped static spec (``example.com:443``) AND a timed session allow on
+    a *different* port (``example.com:8443``) leaves the :8443 learn uncapped
+    -- pre-#2465 behavior (nothing was capped before), not a regression; the
+    :8443 session allow still covers its SYN at the NFQUEUE gate. All real
+    consent flows hit this for a single host:port, where the cap is exact.
     """
     if any(_host_matches(qname, host, mode) for host, _port, mode in SPECS):
         return None  # a static spec matches -> forever -> DNS TTL is correct
@@ -641,14 +648,21 @@ def _remove(ip: str, port: int | None) -> None:
     )
 
 
-def allow(ip: str, port: int | None, ttl: int | float) -> None:
+def allow(ip: str, port: int | None, ttl: int | float, floor: bool = True) -> None:
     """Install (if new) the ACCEPT for ``ip[:port]`` and refresh its TTL.
 
     ``port`` is ``None`` for an all-ports rule. The learned IP's expiry is
-    set to ``now + max(ttl, MIN_TTL)`` (a 0-TTL response must not yank the
-    rule the workspace needs to reach the IP it just resolved) and only ever
-    moves forward, so a shorter-TTL re-resolution can't prematurely expire a
-    longer-lived prior rule (#2256).
+    set to ``now + ttl`` and only ever moves forward, so a shorter-TTL
+    re-resolution can't prematurely expire a longer-lived prior rule (#2256).
+    ``floor`` (default ``True``) raises the TTL to :data:`MIN_TTL` -- the
+    0-TTL-DNS-response safety net (a resolver may hand back a 0-TTL A record,
+    and that must not yank the rule the workspace needs to reach the IP it
+    just resolved). A *consent-verdict* TTL is the user's intent, not a DNS
+    TTL, so the consent paths (:func:`_decide_and_verdict`, the ``_cb``
+    in-session auto-allow, and a capped :func:`_learn_all`) pass
+    ``floor=False`` -- a timed verdict's rule lapses at the verdict, not at
+    MIN_TTL (#2465: otherwise a ``5s`` verdict's rule lived 30s under the
+    default MIN_TTL). The static-spec DNS learn keeps the default floor.
 
     The install happens **under** :data:`_LOCK` so the kernel rule and its
     ``_LEARNED`` record are atomic w.r.t. :func:`sweep_once`'s remove+delete
@@ -660,7 +674,7 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
     executor (see :func:`_learn_all` / :func:`_async_sweeper`), so the lock
     genuinely serializes them; contention is negligible.
     """
-    expire = time.time() + max(ttl, MIN_TTL)
+    expire = time.time() + (max(ttl, MIN_TTL) if floor else ttl)
     with _LOCK:
         _install(ip, port)
         rec = _LEARNED.get(ip)
@@ -990,7 +1004,11 @@ def _learn_all(
     for ip, ttl in recs:
         rule_ttl = ttl if cap is None else min(ttl, cap)
         for port in ports:
-            allow(ip, port, rule_ttl)
+            # cap=None (static spec) -> a DNS-response TTL, floored at MIN_TTL
+            # for 0-TTL safety; cap set (session allow) -> the verdict's
+            # remaining window, NOT floored so a sub-MIN_TTL verdict (5s)
+            # lapses at the verdict, not at MIN_TTL (#2465).
+            allow(ip, port, rule_ttl, floor=cap is None)
 
 
 def _record_hosts(recs: list[tuple[str, int]], host: str) -> None:
@@ -1050,16 +1068,18 @@ async def _respond_allowed(
         recs = a_records_with_ttl(resp)
     except Exception:
         recs = []
-    # Bound a timed session-allow's learned rule at its verdict's remaining
-    # window (#2465): without this the DNS-path learn uses the response's DNS
-    # TTL (often minutes), so a 5s allow leaves a rule that outlives it and a
-    # retry past the window connects with no re-prompt. None for a static spec
-    # (forever) or no session allow -- the DNS TTL is correct then. Computed
-    # on the loop (reads loop-only _SESSION_HOST_ALLOWS) before the executor
-    # fork below.
-    cap = _session_allow_rule_cap(qname) if recs else None
     try:
         if recs:
+            # Bound a timed session-allow's learned rule at its verdict's
+            # remaining window (#2465): without this the DNS-path learn uses
+            # the response's DNS TTL (often minutes), so a 5s allow leaves a
+            # rule that outlives it and a retry past the window connects with
+            # no re-prompt. None for a static spec (forever) or no session
+            # allow -- the DNS TTL is correct then. Computed here (inside the
+            # try so a raise can't escape _respond_allowed and take down the
+            # PID-1 sidecar, #2278) on the loop (reads loop-only
+            # _SESSION_HOST_ALLOWS) before the executor fork below.
+            cap = _session_allow_rule_cap(qname)
             await loop.run_in_executor(None, _learn_all, recs, ports, cap)
         if DEBUG:
             print(
@@ -1745,7 +1765,9 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
         # Learn for the allow's remaining window (timed) or ~forever; port-scoped
         # (the consented port) -- deliberately stricter than the consent-allow
         # path's all-ports learn (allow(dst, None, ...)).
-        asyncio.get_running_loop().run_in_executor(None, allow, dst, port, remaining)
+        asyncio.get_running_loop().run_in_executor(
+            None, allow, dst, port, remaining, False
+        )
         pkt.accept()
         _VERDICT_CACHE[flow] = ("allow", now + VERDICT_CACHE_TTL)
         # NOTE (#2370): revoking an allow must also drop this host from
@@ -1842,7 +1864,7 @@ async def _decide_and_verdict(
             # re-prompts); a timed duration -> learn all-ports for it.
             if ttl is not None:
                 try:
-                    await loop.run_in_executor(None, allow, dst, None, ttl)
+                    await loop.run_in_executor(None, allow, dst, None, ttl, False)
                 except Exception:
                     pass
             pkt.accept()

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -29,8 +29,13 @@ const String kDecisionAllowed = 'allowed';
 const String kDecisionDenied = 'denied';
 
 /// Ordered for the duration selector; the default is `tilrestart` (#2328).
+/// The test-only `5s` is TEMPORARILY included (#2465) for manual testing now
+/// that a timed allow lapses at its verdict (not the MIN_TTL floor); remove
+/// it from this list to shut it off (it stays valid when sent by a
+/// programmatic caller).
 const List<String> kConsentDurations = [
   'once',
+  '5s',
   '5m',
   '15m',
   '1h',
@@ -46,6 +51,7 @@ const String kConsentDurationDefault = 'tilrestart';
 /// the single connection and `tilrestart`/`forever` have no fixed expiry, so
 /// they are absent -- a rule with one of those (or null) has no countdown.
 const Map<String, int> kConsentDurationSeconds = {
+  '5s': 5,
   '5m': 300,
   '15m': 900,
   '1h': 3600,

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -51,8 +51,9 @@ DECISION_DENIED = "denied"
 # per CLI isolation. Ordered for the TUI selector; default is `tilrestart` (#2328).
 DURATION_ONCE = "once"
 # Test-only short duration (#2363, subsumed by #2392): recognized for in-effect
-# math (a `5s` verdict in a rules snapshot counts down correctly) but kept
-# OUT of the human-facing selector via SELECTABLE_DURATIONS below.
+# math (a `5s` verdict in a rules snapshot counts down correctly). TEMPORARILY
+# exposed in the human-facing selector (#2465) for manual testing; see
+# SELECTABLE_DURATIONS below.
 DURATION_5S = "5s"
 DURATION_5M = "5m"
 DURATION_15M = "15m"
@@ -75,9 +76,11 @@ DURATIONS = (
     DURATION_FOREVER,
 )
 # Human-facing duration selector: every duration a user can pick. The
-# test-only 5s is deliberately excluded so it never appears in the UI
-# (#2363); it remains valid when sent by a programmatic/test caller.
-SELECTABLE_DURATIONS = tuple(d for d in DURATIONS if d != DURATION_5S)
+# test-only 5s is TEMPORARILY included (#2465) for manual testing now that a
+# timed allow lapses at its verdict (not the MIN_TTL floor) -- it can be
+# dropped from the selector (restore the ``d != DURATION_5S`` filter) to shut
+# it off; it stays valid for programmatic/test callers either way.
+SELECTABLE_DURATIONS = DURATIONS
 DURATION_DEFAULT = DURATION_TILRESTART
 
 # Seconds each *timed* duration adds to ``decided_at`` (mirror of the server's

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -38,8 +38,10 @@ DECISIONS = frozenset(
 DURATION_ONCE = "once"
 # Test-only short duration (#2363, subsumed by #2392): accepted by the
 # validator + honored by the sidecar so a timed verdict's expiry can be
-# exercised in seconds, but deliberately kept OUT of the human-facing
-# duration selectors (CLI TUI + Flutter). Programmatic/test callers only.
+# exercised in seconds. TEMPORARILY exposed in the human-facing duration
+# selectors (CLI TUI + Flutter) for manual testing (#2465); remove it from
+# those selectors to hide it again -- it stays valid for programmatic/test
+# callers either way.
 DURATION_5S = "5s"
 DURATION_5M = "5m"
 DURATION_15M = "15m"

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -1654,7 +1654,8 @@ class SmokeTest:
         # DNS-path learn is capped at the verdict's window (#2465) -- but it is
         # exactly the long-TTL condition that masked the bug on real hosts.
         host_allow, host_deny = "life-allow.test", "life-deny.test"
-        self.dns.allocate_pair(host_allow, host_deny)
+        self.dns.allocate(host_allow)
+        self.dns.allocate(host_deny)
         cases = [
             (host_allow, DECISION_ALLOWED, "allow", EXPECT_RELEASED),
             (host_deny, DECISION_DENIED, "deny", EXPECT_REFUSED),

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -1625,16 +1625,39 @@ class SmokeTest:
 
         For an allow and a deny: decide 5s -> within-retry (verdict in effect)
         -> wait past the 5s window -> exceeding-retry (verdict expired, fresh
-        re-prompt). The within-retry is best-effort (CDN IP rotation can
-        re-prompt a freshly-learned IP -> finding); the exceeding-retry is the
-        deterministic expiry check.
+        re-prompt). Run under controlled DNS (#2424) so each case is a single
+        stable IP: a real host's CDN rotation or long DNS TTL can leave a
+        learned ACCEPT rule past a 5s verdict and mask the expiry (the
+        allow/deny asymmetry of #2465 -- the allow's DNS-path learn used the
+        DNS TTL, so it outlived the verdict; the deny records no such learn).
+        SKIPPED (with a note) when controlled DNS is off, since without
+        single-IP hosts the exceeding-retry is indeterminate.
         """
         if not self.args.lifecycle:
             return
-        print("\n--- duration lifecycle: within vs exceeding a 5s verdict ---")
+        if self.dns is None:
+            print(
+                "\n--- duration lifecycle: SKIPPED (--no-controlled-dns; the "
+                "exceeding-retry is indeterminate without single-IP test hosts "
+                "-- a real host's CDN rotation / long DNS TTL can keep a timed "
+                "allow's learned rule past its verdict, masking the expiry, "
+                "#2424/#2465) ---"
+            )
+            return
+        print(
+            "\n--- duration lifecycle: within vs exceeding a 5s verdict "
+            "(controlled DNS -> hard PASS/FAIL) ---"
+        )
+        # Single stable IPs (one per case) so the exceeding-retry is
+        # deterministic: each controlled name fronts the fixture's :443 HTTPS
+        # target (curl -k). The fixture's 60s DNS TTL no longer matters -- the
+        # DNS-path learn is capped at the verdict's window (#2465) -- but it is
+        # exactly the long-TTL condition that masked the bug on real hosts.
+        host_allow, host_deny = "life-allow.test", "life-deny.test"
+        self.dns.allocate_pair(host_allow, host_deny)
         cases = [
-            ("www.example.org", DECISION_ALLOWED, "allow", EXPECT_RELEASED),
-            ("api.github.com", DECISION_DENIED, "deny", EXPECT_REFUSED),
+            (host_allow, DECISION_ALLOWED, "allow", EXPECT_RELEASED),
+            (host_deny, DECISION_DENIED, "deny", EXPECT_REFUSED),
         ]
         for host, decision, label, main_conn in cases:
             if self._abort:

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -263,6 +263,83 @@ class TestPortsFor:
         )
         assert proxy._session_host_allows_ttl("example.com", 8080)
 
+    def test_session_allow_rule_cap_returns_remaining(
+        self, proxy, monkeypatch
+    ):
+        # #2465: the DNS-path learn cap. A timed session allow bounds the
+        # learned ACCEPT rule at its remaining window so the rule lapses with
+        # the verdict (not the response's DNS TTL). Returns the min remaining
+        # across matching entries; EXACT scope (#2377 -- only the approved
+        # host, not its subdomains).
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(proxy.time, "time", lambda: 1000.0)
+        monkeypatch.setattr(
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [("example.com", 443, proxy._EXACT, 1005.0)],  # 5s remaining
+        )
+        assert proxy._session_allow_rule_cap("example.com") == 5.0
+        assert (
+            proxy._session_allow_rule_cap("api.example.com") is None
+        )  # exact -> no subdomain
+        assert proxy._session_allow_rule_cap("other.com") is None
+
+    def test_session_allow_rule_cap_none_for_static_spec(
+        self, proxy, monkeypatch
+    ):
+        # A static SPECS entry is a forever allow, so the DNS TTL is the correct
+        # rule lifetime -- no cap (capping would expire the rule early and
+        # re-prompt a forever-allowed host in the gap before the next resolve;
+        # a static spec has no NFQUEUE gate, only the learned rule). Returns
+        # None even when a session allow also matches.
+        monkeypatch.setattr(
+            proxy, "SPECS", [("example.com", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(proxy.time, "time", lambda: 1000.0)
+        monkeypatch.setattr(
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [("example.com", 443, proxy._EXACT, 1005.0)],
+        )
+        assert proxy._session_allow_rule_cap("example.com") is None
+
+    def test_session_allow_rule_cap_expired_entry_pruned(
+        self, proxy, monkeypatch
+    ):
+        # A session allow past its window is pruned (lazy sweep) -> no match ->
+        # None. This is the within-vs-exceeding boundary: once the verdict has
+        # lapsed, the DNS path stops bounding (and, via ports_for, stops
+        # learning) the host.
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(proxy.time, "time", lambda: 1000.0)
+        monkeypatch.setattr(
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [("example.com", 443, proxy._EXACT, 999.0)],  # already expired
+        )
+        assert proxy._session_allow_rule_cap("example.com") is None
+        assert proxy._SESSION_HOST_ALLOWS == []  # pruned
+
+    def test_session_allow_rule_cap_min_across_entries(
+        self, proxy, monkeypatch
+    ):
+        # Two session allows for the host (different ports) -> the most
+        # restrictive (min remaining) bounds the rule. (Multi-port combo is an
+        # edge case; the min is a conservative bound -- a longer-lived port's
+        # rule may lapse early, but its session allow still covers the SYN at
+        # the NFQUEUE gate, so no re-prompt.)
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(proxy.time, "time", lambda: 1000.0)
+        monkeypatch.setattr(
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [
+                ("example.com", 443, proxy._EXACT, 1005.0),  # 5s
+                ("example.com", 8443, proxy._EXACT, 1300.0),  # 300s
+            ],
+        )
+        assert proxy._session_allow_rule_cap("example.com") == 5.0
+
     def test_add_session_deny_dedups_and_refreshes(self, proxy, monkeypatch):
         # Mirror of test_add_session_host_dedups_and_refreshes (#2446): a
         # re-deny of the same host:port refreshes the expiry (max -- never
@@ -608,6 +685,71 @@ class TestTTLAndSweep:
         assert kept["ports"] == set()
         assert kept["host"] == "evil.test"
 
+    def test_consent_allow_dns_learn_cap_not_extended_past_verdict(
+        self, learned, monkeypatch
+    ):
+        # #2465 regression (the DNS-learn path -- the half #2408's
+        # _record_hosts test did NOT cover): a timed consent allow host-scopes
+        # into _SESSION_HOST_ALLOWS, so every re-resolve during the window goes
+        # through the DNS-path learn (_respond_allowed -> _learn_all). That
+        # learn used to install the ACCEPT rule for the response's DNS TTL
+        # (often minutes), extending rule_expire PAST the verdict -- so a retry
+        # past the window connected with no re-prompt. _learn_all's ``cap``
+        # bounds the rule at the verdict's remaining window; sweep removes the
+        # rule at the verdict, keeping the host mapping so _host_for names the
+        # host for the fresh re-prompt.
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        removed = []
+        monkeypatch.setattr(
+            learned, "_remove", lambda ip, port: removed.append((ip, port))
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        # initial resolve (host mapping at the DNS TTL) + a 5s consent allow.
+        learned._record_hosts([("1.2.3.4", 300)], "example.com")
+        learned.allow("1.2.3.4", 443, 5)  # verdict rule (rule_expire ~MIN_TTL)
+        verdict = learned._LEARNED["1.2.3.4"]["rule_expire"]
+        # a re-resolve during the window (DNS TTL 300), capped at the verdict's
+        # remaining window, must NOT extend rule_expire.
+        learned._learn_all([("1.2.3.4", 300)], {443}, cap=5)
+        rec = learned._LEARNED["1.2.3.4"]
+        assert (
+            rec["rule_expire"] == verdict
+        )  # NOT 300 -- bounded at the verdict
+        assert rec["expire"] > verdict  # host mapping keeps the longer DNS TTL
+        # sweep at the verdict -> rule gone, record retained for naming.
+        gone = learned.sweep_once(now=verdict)
+        assert gone == [("1.2.3.4", {443})]
+        assert removed == [("1.2.3.4", 443)]
+        kept = learned._LEARNED["1.2.3.4"]
+        assert kept["ports"] == set()
+        assert kept["host"] == "example.com"
+
+    def test_consent_allow_dns_learn_uncapped_extends_past_verdict(
+        self, learned, monkeypatch
+    ):
+        # The inverse of the cap test (documents the #2465 bug): WITHOUT the
+        # cap, the DNS-path learn uses the DNS TTL and extends rule_expire past
+        # the verdict -- the rule outlives the verdict, so sweep at the verdict
+        # leaves it in place (the retry-past-window connects with no
+        # re-prompt). This is the behavior _learn_all's ``cap`` corrects.
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned._record_hosts([("1.2.3.4", 300)], "example.com")
+        learned.allow("1.2.3.4", 443, 5)
+        verdict = learned._LEARNED["1.2.3.4"]["rule_expire"]
+        learned._learn_all([("1.2.3.4", 300)], {443})  # NO cap
+        assert (
+            learned._LEARNED["1.2.3.4"]["rule_expire"] > verdict
+        )  # extended past the verdict -> the bug
+
     def test_reject_installs_reject_rule_and_records(
         self, learned, monkeypatch
     ):
@@ -849,6 +991,114 @@ class TestRespondAllowedSwallowsFailures:
         assert ("5.6.7.8", 443, 200) in calls
         assert ("5.6.7.8", 8443, 200) in calls
         s.sendto.assert_called_once_with(b"resp", ("127.0.0.1", 1234))
+
+    async def test_respond_allowed_caps_rule_at_session_allow_window(
+        self, proxy, monkeypatch
+    ):
+        # #2465 regression: a timed session allow's DNS-path learn must NOT
+        # install the ACCEPT rule for the response's (long) DNS TTL -- that
+        # left a rule outliving a 5s verdict, so a retry past the window
+        # connected with no re-prompt. The rule TTL is bounded at the session
+        # allow's remaining window (here 5s), not the 300s DNS TTL.
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(proxy.time, "time", lambda: 1000.0)
+        monkeypatch.setattr(
+            proxy,
+            "_SESSION_HOST_ALLOWS",
+            [("example.com", 443, proxy._EXACT, 1005.0)],  # 5s remaining
+        )
+        monkeypatch.setattr(
+            proxy,
+            "a_records_with_ttl",
+            lambda wire: [("1.2.3.4", 300)],  # DNS TTL 300s
+        )
+        calls = []
+        monkeypatch.setattr(
+            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+        )
+        s = MagicMock()
+        await proxy._respond_allowed(
+            s, b"resp", ("127.0.0.1", 1234), "example.com", {443}
+        )
+        assert ("1.2.3.4", 443, 5) in calls  # capped at the verdict window
+        # the 300s DNS TTL must NOT reach the rule for this session-allowed host.
+        assert all(ttl <= 5 for _ip, _port, ttl in calls)
+
+    async def test_respond_allowed_no_cap_for_static_spec(
+        self, proxy, monkeypatch
+    ):
+        # A static SPECS entry is forever -> the DNS TTL is the correct rule
+        # lifetime (no cap). Capping would expire the rule early and, in the
+        # gap before the next resolve, re-prompt a forever-allowed host (a
+        # static spec has no NFQUEUE gate).
+        monkeypatch.setattr(
+            proxy, "SPECS", [("example.com", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(
+            proxy,
+            "a_records_with_ttl",
+            lambda wire: [("1.2.3.4", 300)],
+        )
+        calls = []
+        monkeypatch.setattr(
+            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+        )
+        s = MagicMock()
+        await proxy._respond_allowed(
+            s, b"resp", ("127.0.0.1", 1234), "example.com", {None}
+        )
+        assert ("1.2.3.4", None, 300) in calls  # DNS TTL, not capped
+
+    async def test_respond_allowed_no_cap_when_no_session_allow(
+        self, proxy, monkeypatch
+    ):
+        # No session allow and no static spec for the qname -> no cap. (In
+        # production ports_for would have denied this name, so _respond_allowed
+        # would not run; the cap helper still returns None defensively.)
+        monkeypatch.setattr(proxy, "SPECS", [])
+        monkeypatch.setattr(proxy, "_SESSION_HOST_ALLOWS", [])
+        monkeypatch.setattr(
+            proxy,
+            "a_records_with_ttl",
+            lambda wire: [("1.2.3.4", 300)],
+        )
+        calls = []
+        monkeypatch.setattr(
+            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+        )
+        s = MagicMock()
+        await proxy._respond_allowed(
+            s, b"resp", ("127.0.0.1", 1234), "example.com", {443}
+        )
+        assert ("1.2.3.4", 443, 300) in calls  # DNS TTL, not capped
+
+    def test_learn_all_cap_bounds_each_rule_ttl(self, proxy, monkeypatch):
+        # _learn_all threads the cap through to allow() as min(dns_ttl, cap),
+        # per IP/port. The host mapping (set separately by _record_hosts at the
+        # DNS TTL) is unaffected.
+        monkeypatch.setattr(proxy.time, "time", lambda: 0.0)
+        calls = []
+        monkeypatch.setattr(
+            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+        )
+        proxy._learn_all(
+            [("1.2.3.4", 300), ("5.6.7.8", 60)], {443, 8443}, cap=5
+        )
+        # every rule TTL is capped at 5 (min of dns_ttl and cap).
+        assert all(ttl == 5 for _ip, _port, ttl in calls)
+        assert ("1.2.3.4", 443, 5) in calls
+        assert ("5.6.7.8", 8443, 5) in calls
+
+    def test_learn_all_no_cap_uses_dns_ttl(self, proxy, monkeypatch):
+        # Backward compat: cap defaults to None -> the DNS TTL reaches allow()
+        # unchanged (the static-spec path).
+        monkeypatch.setattr(proxy.time, "time", lambda: 0.0)
+        calls = []
+        monkeypatch.setattr(
+            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+        )
+        proxy._learn_all([("1.2.3.4", 300)], {443})
+        assert calls == [("1.2.3.4", 443, 300)]
 
 
 class TestConsentForward:

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -792,6 +792,30 @@ class TestTTLAndSweep:
             learned._LEARNED["1.2.3.4"]["rule_expire"] == 720.0
         )  # 120+600 -> extended past the 300s verdict -> the bug
 
+    def test_static_spec_learn_0_ttl_floored_at_min_ttl(
+        self, learned, monkeypatch
+    ):
+        # Nit 3 (#2465 review): the static-spec DNS learn (cap=None) keeps the
+        # MIN_TTL floor even though `floor` is now conditional -- a 0-TTL DNS
+        # response must not yank the rule the workspace just resolved. Uses the
+        # real allow() -> _LEARNED (the floor is applied inside allow, so a mock
+        # of allow would not see it). Guards the 0-TTL safety net across the
+        # floor-is-conditional change.
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        # cap=None (default) -> floor=True -> a 0-TTL A record is floored up to
+        # MIN_TTL, not installed as a 0-lifetime rule.
+        learned._learn_all([("1.2.3.4", 0)], {443})
+        rec = learned._LEARNED["1.2.3.4"]
+        assert (
+            rec["rule_expire"] == learned.MIN_TTL
+        )  # 0 floored up, not yanked
+        assert rec["ports"] == {443}
+
     def test_reject_installs_reject_rule_and_records(
         self, learned, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -605,7 +605,9 @@ class TestTTLAndSweep:
         # #2408: a consent allow's ACCEPT rule must expire at the verdict, not at
         # the host-mapping DNS TTL. _record_hosts records the IP with a long DNS
         # TTL; a subsequent short consent allow installs the ACCEPT with a SHORT
-        # rule_expire (separate from the long host-mapping expire).
+        # rule_expire (separate from the long host-mapping expire). The consent
+        # path passes floor=False (#2465) so a 5s verdict's rule is 5s, not
+        # MIN_TTL-floored.
         monkeypatch.setattr(
             learned.subprocess,
             "run",
@@ -614,12 +616,12 @@ class TestTTLAndSweep:
         monkeypatch.setattr(learned.time, "time", lambda: 0.0)
         learned._record_hosts([("1.2.3.4", 300)], "evil.test")  # DNS TTL 300s
         learned.allow(
-            "1.2.3.4", None, 5
-        )  # consent allow, 5s (floored to MIN_TTL)
+            "1.2.3.4", None, 5, floor=False
+        )  # consent allow, 5s (NOT floored -> 5s, #2465)
         rec = learned._LEARNED["1.2.3.4"]
-        # rule_expire is the verdict (MIN_TTL-floored), NOT the DNS TTL; the
-        # host-mapping expire keeps the longer DNS TTL. The two are separate.
-        assert rec["rule_expire"] == learned.MIN_TTL
+        # rule_expire is the verdict (5s), NOT the DNS TTL and NOT MIN_TTL;
+        # the host-mapping expire keeps the longer DNS TTL. The two are separate.
+        assert rec["rule_expire"] == 5.0
         assert rec["expire"] == 300.0
         assert rec["rule_expire"] < rec["expire"]
         assert rec["ports"] == {None}
@@ -670,7 +672,9 @@ class TestTTLAndSweep:
             learned, "_remove", lambda ip, port: removed.append((ip, port))
         )
         monkeypatch.setattr(learned.time, "time", lambda: 0.0)
-        learned.allow("1.2.3.4", None, 5)  # consent allow (floored to MIN_TTL)
+        learned.allow(
+            "1.2.3.4", None, 5, floor=False
+        )  # consent allow (NOT floored -> 5s, #2465)
         verdict = learned._LEARNED["1.2.3.4"]["rule_expire"]
         # the re-resolve (long DNS TTL) must NOT extend the rule's lifetime.
         learned._record_hosts([("1.2.3.4", 300)], "evil.test")
@@ -685,19 +689,15 @@ class TestTTLAndSweep:
         assert kept["ports"] == set()
         assert kept["host"] == "evil.test"
 
-    def test_consent_allow_dns_learn_cap_not_extended_past_verdict(
+    def test_timed_allow_dns_learn_lapses_at_verdict_under_default_min_ttl(
         self, learned, monkeypatch
     ):
-        # #2465 regression (the DNS-learn path -- the half #2408's
-        # _record_hosts test did NOT cover): a timed consent allow host-scopes
-        # into _SESSION_HOST_ALLOWS, so every re-resolve during the window goes
-        # through the DNS-path learn (_respond_allowed -> _learn_all). That
-        # learn used to install the ACCEPT rule for the response's DNS TTL
-        # (often minutes), extending rule_expire PAST the verdict -- so a retry
-        # past the window connected with no re-prompt. _learn_all's ``cap``
-        # bounds the rule at the verdict's remaining window; sweep removes the
-        # rule at the verdict, keeping the host mapping so _host_for names the
-        # host for the fresh re-prompt.
+        # Reviewer I1/B1: prove the security property under PRODUCTION conditions
+        # -- a UI-offered duration (5m=300s, >> default MIN_TTL=30), a real
+        # timeline (verdict t=0, re-resolve t=120), and the REAL allow() ->
+        # _LEARNED (no mock). A mid-window re-resolve carrying a long DNS TTL
+        # must NOT extend rule_expire past the verdict; sweep at the verdict
+        # removes the rule while the longer-DNS-TTL host mapping is retained.
         monkeypatch.setattr(
             learned.subprocess,
             "run",
@@ -707,48 +707,90 @@ class TestTTLAndSweep:
         monkeypatch.setattr(
             learned, "_remove", lambda ip, port: removed.append((ip, port))
         )
+        assert learned.MIN_TTL == 30  # the production default
+        # t=0: initial resolve (host mapping at a long DNS TTL) + a 5m consent
+        # allow (floor=False -> rule_expire is the verdict, not MIN_TTL).
         monkeypatch.setattr(learned.time, "time", lambda: 0.0)
-        # initial resolve (host mapping at the DNS TTL) + a 5s consent allow.
-        learned._record_hosts([("1.2.3.4", 300)], "example.com")
-        learned.allow("1.2.3.4", 443, 5)  # verdict rule (rule_expire ~MIN_TTL)
-        verdict = learned._LEARNED["1.2.3.4"]["rule_expire"]
-        # a re-resolve during the window (DNS TTL 300), capped at the verdict's
-        # remaining window, must NOT extend rule_expire.
-        learned._learn_all([("1.2.3.4", 300)], {443}, cap=5)
+        learned._record_hosts([("1.2.3.4", 600)], "example.com")
+        learned.allow("1.2.3.4", 443, 300, floor=False)  # 5m verdict
+        assert learned._LEARNED["1.2.3.4"]["rule_expire"] == 300.0
+        # t=120: mid-window re-resolve; the session allow has 180s remaining.
+        # The DNS response carries a 600s TTL; WITHOUT the cap that would push
+        # rule_expire to 720 (120+600). The cap bounds it at min(600, 180)=180,
+        # which allow() (floor=False) lands at 120+180=300 -> rule stays at 300.
+        monkeypatch.setattr(learned.time, "time", lambda: 120.0)
+        learned._learn_all([("1.2.3.4", 600)], {443}, cap=180)
         rec = learned._LEARNED["1.2.3.4"]
-        assert (
-            rec["rule_expire"] == verdict
-        )  # NOT 300 -- bounded at the verdict
-        assert rec["expire"] > verdict  # host mapping keeps the longer DNS TTL
-        # sweep at the verdict -> rule gone, record retained for naming.
-        gone = learned.sweep_once(now=verdict)
+        assert rec["rule_expire"] == 300.0  # NOT 720 -- bounded at the verdict
+        # t=300 (the verdict): rule swept, host mapping (DNS TTL 600) retained.
+        gone = learned.sweep_once(now=300.0)
         assert gone == [("1.2.3.4", {443})]
         assert removed == [("1.2.3.4", 443)]
         kept = learned._LEARNED["1.2.3.4"]
-        assert kept["ports"] == set()
-        assert kept["host"] == "example.com"
+        assert kept["ports"] == set()  # rule gone
+        assert kept["host"] == "example.com"  # mapping retained for naming
+        assert kept["expire"] > 300  # outlives the rule (DNS TTL 600)
 
-    def test_consent_allow_dns_learn_uncapped_extends_past_verdict(
+    def test_short_verdict_lapses_at_verdict_not_min_ttl(
         self, learned, monkeypatch
     ):
-        # The inverse of the cap test (documents the #2465 bug): WITHOUT the
-        # cap, the DNS-path learn uses the DNS TTL and extends rule_expire past
-        # the verdict -- the rule outlives the verdict, so sweep at the verdict
+        # B1 (#2465 + reviewer): a sub-MIN_TTL consent verdict (the test-only
+        # 5s) must lapse at 5s, NOT at MIN_TTL=30. Pre-fix the consent path
+        # floored the rule at MIN_TTL, so a 5s verdict's rule lived 30s and a
+        # retry at ~10s connected with no re-prompt. floor=False (consent path +
+        # capped DNS learn) makes the rule lapse at the verdict even under the
+        # default MIN_TTL. Verified end-to-end on both the verdict learn and a
+        # mid-window capped re-resolve.
+        monkeypatch.setattr(
+            learned.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1),
+        )
+        removed = []
+        monkeypatch.setattr(
+            learned, "_remove", lambda ip, port: removed.append((ip, port))
+        )
+        assert learned.MIN_TTL == 30  # the production default
+        monkeypatch.setattr(learned.time, "time", lambda: 0.0)
+        learned._record_hosts([("1.2.3.4", 600)], "example.com")
+        learned.allow("1.2.3.4", 443, 5, floor=False)  # 5s verdict
+        assert learned._LEARNED["1.2.3.4"]["rule_expire"] == 5.0  # NOT 30
+        # t=2: mid-window re-resolve (cap=3 remaining); the capped, unfloored
+        # learn keeps rule_expire at the verdict (5), not MIN_TTL (30+).
+        monkeypatch.setattr(learned.time, "time", lambda: 2.0)
+        learned._learn_all([("1.2.3.4", 300)], {443}, cap=3)
+        assert learned._LEARNED["1.2.3.4"]["rule_expire"] == 5.0  # still 5
+        # sweep at the verdict (t=5) -> rule gone; host mapping retained.
+        gone = learned.sweep_once(now=5.0)
+        assert gone == [("1.2.3.4", {443})]
+        assert removed == [("1.2.3.4", 443)]
+        assert learned._LEARNED["1.2.3.4"]["host"] == "example.com"
+
+    def test_dns_learn_uncapped_extends_past_verdict(
+        self, learned, monkeypatch
+    ):
+        # The bug the cap corrects (documents #2465): a session-allow host's
+        # DNS-path learn WITH the DNS TTL (no cap) extends rule_expire past the
+        # verdict -- the rule outlives the verdict, so sweep at the verdict
         # leaves it in place (the retry-past-window connects with no
-        # re-prompt). This is the behavior _learn_all's ``cap`` corrects.
+        # re-prompt). Here _learn_all is called WITHOUT the cap (as if the
+        # _session_allow_rule_cap step were missing); the realistic test above
+        # shows the cap prevents it.
         monkeypatch.setattr(
             learned.subprocess,
             "run",
             lambda *a, **k: types.SimpleNamespace(returncode=1),
         )
         monkeypatch.setattr(learned.time, "time", lambda: 0.0)
-        learned._record_hosts([("1.2.3.4", 300)], "example.com")
-        learned.allow("1.2.3.4", 443, 5)
+        learned._record_hosts([("1.2.3.4", 600)], "example.com")
+        learned.allow("1.2.3.4", 443, 300, floor=False)  # 5m verdict
         verdict = learned._LEARNED["1.2.3.4"]["rule_expire"]
-        learned._learn_all([("1.2.3.4", 300)], {443})  # NO cap
+        assert verdict == 300.0
+        monkeypatch.setattr(learned.time, "time", lambda: 120.0)
+        learned._learn_all([("1.2.3.4", 600)], {443})  # NO cap -> DNS TTL wins
         assert (
-            learned._LEARNED["1.2.3.4"]["rule_expire"] > verdict
-        )  # extended past the verdict -> the bug
+            learned._LEARNED["1.2.3.4"]["rule_expire"] == 720.0
+        )  # 120+600 -> extended past the 300s verdict -> the bug
 
     def test_reject_installs_reject_rule_and_records(
         self, learned, monkeypatch
@@ -980,7 +1022,9 @@ class TestRespondAllowedSwallowsFailures:
         )
         calls = []
         monkeypatch.setattr(
-            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+            proxy,
+            "allow",
+            lambda ip, port, ttl, floor=True: calls.append((ip, port, ttl)),
         )
         s = MagicMock()
         await proxy._respond_allowed(
@@ -1014,7 +1058,9 @@ class TestRespondAllowedSwallowsFailures:
         )
         calls = []
         monkeypatch.setattr(
-            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+            proxy,
+            "allow",
+            lambda ip, port, ttl, floor=True: calls.append((ip, port, ttl)),
         )
         s = MagicMock()
         await proxy._respond_allowed(
@@ -1041,7 +1087,9 @@ class TestRespondAllowedSwallowsFailures:
         )
         calls = []
         monkeypatch.setattr(
-            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+            proxy,
+            "allow",
+            lambda ip, port, ttl, floor=True: calls.append((ip, port, ttl)),
         )
         s = MagicMock()
         await proxy._respond_allowed(
@@ -1064,7 +1112,9 @@ class TestRespondAllowedSwallowsFailures:
         )
         calls = []
         monkeypatch.setattr(
-            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+            proxy,
+            "allow",
+            lambda ip, port, ttl, floor=True: calls.append((ip, port, ttl)),
         )
         s = MagicMock()
         await proxy._respond_allowed(
@@ -1079,7 +1129,9 @@ class TestRespondAllowedSwallowsFailures:
         monkeypatch.setattr(proxy.time, "time", lambda: 0.0)
         calls = []
         monkeypatch.setattr(
-            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+            proxy,
+            "allow",
+            lambda ip, port, ttl, floor=True: calls.append((ip, port, ttl)),
         )
         proxy._learn_all(
             [("1.2.3.4", 300), ("5.6.7.8", 60)], {443, 8443}, cap=5
@@ -1095,7 +1147,9 @@ class TestRespondAllowedSwallowsFailures:
         monkeypatch.setattr(proxy.time, "time", lambda: 0.0)
         calls = []
         monkeypatch.setattr(
-            proxy, "allow", lambda ip, port, ttl: calls.append((ip, port, ttl))
+            proxy,
+            "allow",
+            lambda ip, port, ttl, floor=True: calls.append((ip, port, ttl)),
         )
         proxy._learn_all([("1.2.3.4", 300)], {443})
         assert calls == [("1.2.3.4", 443, 300)]
@@ -1596,7 +1650,7 @@ class TestNfqueueCallback:
         monkeypatch.setattr(
             proxy,
             "allow",
-            lambda ip, port, ttl: learned.append((ip, port, ttl)),
+            lambda ip, port, ttl, floor=True: learned.append((ip, port, ttl)),
         )
         self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
@@ -2060,7 +2114,7 @@ class TestNfqueueCallback:
         monkeypatch.setattr(
             proxy,
             "allow",
-            lambda ip, port, ttl: learned.append((ip, port, ttl)),
+            lambda ip, port, ttl, floor=True: learned.append((ip, port, ttl)),
         )
         self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))


### PR DESCRIPTION
## Summary

Fixes #2465.

A timed `allow` verdict (e.g. `allow/5s`) was outliving its TTL via **two** leaks, both now closed:

1. **The DNS-path learn used the DNS TTL.** The in-session host allow (#2434) made `ports_for` treat the host as allow-listed, so every re-resolve during the window re-learned each resolved IP via `_learn_allowed → _learn_all → allow(ip, port, dns_ttl)` — installing the ACCEPT rule for the response's DNS TTL (often minutes). That rule outlived a short verdict; a retry past the window connected with no re-prompt. Fixed by bounding the DNS-path learn's rule TTL at the verdict's remaining window (`_session_allow_rule_cap`, threaded from `_respond_allowed` on the loop into `_learn_all` in the executor).
2. **The consent-verdict rule was floored at `MIN_TTL`.** `allow()` floors every rule at `MIN_TTL` (30s), so a consent verdict's *own* rule (`allow(dst, None, ttl)`) and the capped DNS learn lived 30s even for a `5s` verdict. Fixed by adding `allow(floor=True)`; the consent paths (`_decide_and_verdict`, the `_cb` in-session auto-allow, and a capped `_learn_all`) pass `floor=False` — a consent-verdict TTL is the user's intent, not a DNS TTL, so it lapses at the verdict. The static-spec DNS learn keeps the floor (0-TTL-response safety).

The `deny` side recorded no DNS-path learn (only a per-IP `_REJECTED` rule + a `_SESSION_HOST_DENIES` entry consulted at NFQUEUE), so it expired on time — the allow/deny asymmetry the issue names.

`allow()`'s `max()` keeps the host mapping at the longer DNS TTL, so `_host_for` still names the host for the fresh re-prompt after the verdict lapses (the #2408 invariant). A static `SPECS` entry (forever) is exempt from the cap — the DNS TTL is the correct rule lifetime there.

## Adversarial review response

A fresh-eyes review (spawned via `/review`) flagged two gaps, both addressed:
- **B1** — the `MIN_TTL` floor defeating the cap for short verdicts (leak #2 above). Fixed.
- **I1** — tests mocked `allow` / froze time, asserting a ttl *argument* rather than the actual `rule_expire`/sweep property. Added realistic end-to-end tests (a UI-offered 5m duration under the default `MIN_TTL=30`, real timeline, real `allow → _LEARNED`) proving `rule_expire` stays at the verdict after a mid-window capped re-resolve and sweep at the verdict removes the rule; plus a `5s` test proving `rule_expire == 5` (not 30) under the default `MIN_TTL`.
- **N1** — the cap computation now sits inside `_respond_allowed`'s protective `try` (a raise can't take down the PID-1 sidecar).
- **I2** — documented the static-spec exemption as qname-level.

## `5s` exposed for testing

The test-only `5s` duration is temporarily added to the consent duration selector (TUI `SELECTABLE_DURATIONS` + Flutter `kConsentDurations`/`kConsentDurationSeconds`) so it can be exercised by hand, now that a timed allow lapses at its verdict. To shut it off, drop `5s` back out of those two lists; it stays valid for programmatic/test callers either way.

## Tests

Full backend suite: **4972 passed, 100% coverage** (`-n auto`). Frontend: **949 passed**. New unit tests cover `_session_allow_rule_cap` (remaining / static-spec exempt / expired-pruned / min-across-entries), `_learn_all` cap threading, `_respond_allowed` regression, and the `_LEARNED`/`sweep_once` property under default `MIN_TTL` (capped → lapses at verdict; uncapped → extends past it).

The smoketest's duration-lifecycle phase now runs under the controlled-DNS fixture (single-IP names) — the deterministic repro the issue called for — and skips with a note when controlled DNS is off.
