### PR TITLE
test(egress): capture sidecar logs + opt-in RST debug to diagnose deny fast-refuse misses (#2464)

### DIFF
--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -147,6 +147,31 @@ VERDICT_CACHE_TTL = float(
 # Only needs to catch the SYN retransmit (~1 RTO); the verdict cache separately
 # keeps the deny from re-prompting for VERDICT_CACHE_TTL.
 CONSENT_REJECT_TTL = float(os.environ.get("KLANGKNETWORK_EGRESS_REJECT_TTL", "10"))
+# Opt-in per-RST debug logging (#2464): the forged eager-deny RST is the
+# primary fast-refuse, so when a denied connection instead *times out* this
+# logs each forged RST (socket open? sendto ok? the 4-tuple) to the sidecar's
+# stdout. Off by default -- a denied connection's SYN retransmits each hit the
+# cached deny and re-forge an RST, which would spam a production sidecar's log.
+# The egress smoketest enables it (KLANGKNETWORK_EGRESS_DEBUG_RST=1, forwarded
+# by ContainerManager._start_network_sidecar) and captures the sidecar's podman
+# log so a fast-refuse miss is diagnosable after the run.
+_RST_DEBUG = os.environ.get("KLANGKNETWORK_EGRESS_DEBUG_RST", "") == "1"
+
+
+def _rst_debug(msg: str) -> None:
+    """Emit a forged-RST diagnostic line when ``KLANGKNETWORK_EGRESS_DEBUG_RST``
+    is on (#2464).
+
+    Centralized so the egress-smoketest diagnostic is one branch to cover, not
+    one per call site in :func:`_send_rst`. The smoketest enables the flag and
+    captures the sidecar's podman log so a fast-refuse miss (a denied
+    connection timing out instead of refusing fast) shows whether each RST
+    fired.
+    """
+    if _RST_DEBUG:
+        print(msg, flush=True)
+
+
 # Duration token -> seconds the sidecar honors a verdict (#2328): an allow
 # learns the IP for T; a deny REJECTs for T. `once` = this connection only (no
 # learn; a short deny). `restart` = the container's lifetime (the sidecar's
@@ -1485,9 +1510,11 @@ def _send_rst(payload: bytes) -> None:
     """
     sock = _RST_SOCK
     if sock is None:
+        _rst_debug("rst-forge: no raw socket (NET_RAW?) -- REJECT-only fast-refuse")
         return
     src_ip, src_port, dst_ip, dst_port, seq = parse_syn_tuple(payload)
     if not src_ip or not dst_port:
+        _rst_debug(f"rst-forge: unparseable tuple (src={src_ip} dst_port={dst_port})")
         return
     try:
         sock.sendto(
@@ -1497,8 +1524,12 @@ def _send_rst(payload: bytes) -> None:
             build_rst_packet(dst_ip, dst_port, src_ip, src_port, seq),
             (src_ip, 0),
         )
-    except OSError:
-        pass
+        _rst_debug(
+            f"rst-forge: sent {dst_ip}:{dst_port} -> {src_ip}:{src_port} "
+            f"ack={(seq + 1) & 0xFFFFFFFF}"
+        )
+    except OSError as exc:
+        _rst_debug(f"rst-forge: sendto failed: {exc!r}")
 
 
 def _setup_nfq_consumer(client: SidecarConsentClient | None):

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1351,6 +1351,7 @@ class ContainerRegistry:
         for _opt in (
             "KLANGKNETWORK_EGRESS_MIN_TTL",
             "KLANGKNETWORK_EGRESS_SWEEP_INTERVAL",
+            "KLANGKNETWORK_EGRESS_DEBUG_RST",
         ):
             _v = os.environ.get(_opt)
             if _v:

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -933,6 +933,61 @@ class SmokeTest:
             except Exception:
                 pass
 
+    def _capture_sidecar_logs(self) -> None:
+        """Dump each workspace's network-sidecar podman log to /tmp (#2464).
+
+        The forged eager-deny RST is the sidecar's primary fast-refuse; when a
+        denied connection instead *times out* (exit 28), the only way to see
+        whether the RST fired is the sidecar's own stdout -- which podman
+        discards when the sidecar is removed. This runs in ``run()``'s
+        ``finally`` BEFORE ``teardown()`` deletes the workspaces (and their
+        sidecars), so the logs survive. Targets only this run's workspaces
+        (by ``klangk.workspace`` label) so an operator's unrelated sidecars
+        aren't touched. Best-effort: no podman / no sidecar -> silent no-op.
+        """
+        ws_ids = (
+            [self.ws_id, *self._extra_ws_ids]
+            if self.ws_id
+            else list(self._extra_ws_ids)
+        )
+        for ws_id in ws_ids:
+            try:
+                ps = subprocess.run(
+                    [
+                        "podman",
+                        "ps",
+                        "-a",
+                        "--filter",
+                        f"label=klangk.workspace={ws_id}",
+                        "--filter",
+                        "label=klangk.role=network-sidecar",
+                        "--format",
+                        "{{.Names}}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+            except Exception:
+                continue
+            for name in ps.stdout.split():
+                try:
+                    logs = subprocess.run(
+                        ["podman", "logs", name],
+                        capture_output=True,
+                        text=True,
+                        timeout=20,
+                    )
+                except Exception:
+                    continue
+                path = f"/tmp/smoke_sidecar_{ws_id[:8]}.log"
+                try:
+                    with open(path, "w") as f:
+                        f.write((logs.stdout or "") + (logs.stderr or ""))
+                    print(f"sidecar logs {name} (ws {ws_id[:8]}) -> {path}")
+                except Exception:
+                    pass
+
     # -- setup ------------------------------------------------------------
     def _start_server(self) -> dict:
         kwargs = dict(
@@ -952,6 +1007,13 @@ class SmokeTest:
             # verdict's within/exceeding in seconds (#2363).
             KLANGKNETWORK_EGRESS_MIN_TTL="1",
             KLANGKNETWORK_EGRESS_SWEEP_INTERVAL="1",
+            # Opt in the sidecar's per-RST debug logging (#2464): the forged
+            # eager-deny RST is the primary fast-refuse, so when a denied
+            # connection instead times out (exit 28), the captured sidecar log
+            # shows whether each RST fired. Forwarded by
+            # ContainerManager._start_network_sidecar; captured to
+            # /tmp/smoke_sidecar_*.log by _capture_sidecar_logs at teardown.
+            KLANGKNETWORK_EGRESS_DEBUG_RST="1",
             LOGFIRE_TOKEN="",
         )
         # Point the real sidecar's upstream at the controlled-DNS fixture
@@ -4589,6 +4651,7 @@ class SmokeTest:
             )
             stop = True
         finally:
+            self._capture_sidecar_logs()
             await self.teardown()
         self._print_summary(stop)
         return 1 if self.summary.mismatches else 0

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -1858,6 +1858,44 @@ class TestNfqueueCallback:
         await self._decide(proxy, pkt, client)
         assert pkt.verdict == "drop"
 
+    def test_send_rst_paths_and_debug(self, proxy, monkeypatch, capsys):
+        # Direct coverage of _send_rst's four branches + the opt-in RST debug
+        # log (#2464): no-socket, success, sendto-failure, unparseable, and the
+        # KLANGKNETWORK_EGRESS_DEBUG_RST flag on/off. The flag defaults off so
+        # the debug print is the only branch the indirect _decide tests miss.
+        syn = _syn_payload("10.0.0.5", 50000, "1.2.3.4", 443, 0x1111)
+
+        # No socket -> no-op; with the debug flag on, note the REJECT-only fall
+        # back (covers _rst_debug's print branch).
+        monkeypatch.setattr(proxy, "_RST_SOCK", None)
+        monkeypatch.setattr(proxy, "_RST_DEBUG", True)
+        proxy._send_rst(syn)
+        assert "no raw socket" in capsys.readouterr().out
+
+        # Socket set, sendto succeeds -> forged + a "sent" debug line.
+        sock = MagicMock()
+        monkeypatch.setattr(proxy, "_RST_SOCK", sock)
+        proxy._send_rst(syn)
+        sock.sendto.assert_called_once()
+        assert "rst-forge: sent" in capsys.readouterr().out
+
+        # sendto raises -> swallowed + a "failed" debug line.
+        sock.sendto.side_effect = OSError("boom")
+        proxy._send_rst(syn)
+        assert "sendto failed" in capsys.readouterr().out
+
+        # Unparseable tuple -> no sendto + an "unparseable" debug line.
+        sock.sendto.reset_mock()
+        proxy._send_rst(b"\x00\x00\x00\x00")  # too short / not IPv4
+        assert "unparseable" in capsys.readouterr().out
+        assert sock.sendto.call_count == 0  # nothing forged for a bad tuple
+
+        # Flag off (the default) -> no debug output at all (covers the False
+        # branch of _rst_debug's `if _RST_DEBUG`).
+        monkeypatch.setattr(proxy, "_RST_DEBUG", False)
+        proxy._send_rst(syn)
+        assert capsys.readouterr().out == ""
+
     async def test_cache_hit_deny_forges_rst(self, proxy, monkeypatch):
         # A retried connect() to a denied flow reuses the cached verdict and
         # also forges the RST (fails fast), not just drops.


### PR DESCRIPTION
Contributes to #2464 (does not close it — this is the diagnostic, not the fix).

## What

A consent deny intermittently times out the connection (`exit 28`) instead of refusing fast (`exit 7`) — a recurrence of #2345's conntrack/retransmit race. The forged eager-deny RST is well-formed and its socket opens at startup, but the sidecar's stdout (where `proxy.py` logs) is discarded when the sidecar is removed, so the one smoketest occurrence we have is undiagnosable. Rather than ship a speculative fast-refuse change to a security-adjacent path I can't reproduce or validate, this makes the **next** occurrence diagnosable.

- **`proxy.py`** — `KLANGKNETWORK_EGRESS_DEBUG_RST=1` logs each forged RST (socket open? sendto ok? the 4-tuple + ack) via a centralized `_rst_debug` helper. Off by default — a denied connection's SYN retransmits each hit the cached deny and re-forge an RST, which would spam a production sidecar log.
- **`container.py`** — forward `KLANGKNETWORK_EGRESS_DEBUG_RST` to the sidecar (same loop as `MIN_TTL` / `SWEEP_INTERVAL`).
- **`smoketest_egress.py`** — enable the flag + dump each workspace's network-sidecar podman log to `/tmp/smoke_sidecar_<ws>.log` in `run()`'s `finally` (before teardown removes the sidecars), scoped to this run's workspaces so an operator's sidecars aren't touched.
- **`test_proxy.py`** — a direct `_send_rst` unit test (no-socket / success / sendto-failure / unparseable + the flag on/off) covering the new branch (the 100% gate).

The actual fast-refuse fix follows once a captured log shows where the RST is lost (sendto failure vs. conntrack delivery race vs. something else). No behavior change when the flag is off.

## Verification

- `test-backend`: **4957 passed, 100% coverage** (+1 test).
- End-to-end on the real stack (rebuilt the sidecar image, scoped audit-distinction run): the deny refused fast (`exit 7`) and the captured sidecar log contains the forged RST lines, e.g.
  ```
  rst-forge: sent 104.16.44.99:443 -> 10.88.0.192:57324 ack=3348117868
  ```
  So next time the smoketest hits `exit 28`, the captured log will show whether the RST fired and the exact 4-tuple.

(Note: the sidecar runs a prebuilt image, so the `proxy.py` change only takes effect after rebuilding it — `devenv --quiet shell -- bash scripts/build-network-sidecar.sh`.)

## Why not fix it directly

The miss is ~1/117, I can't reproduce it in the contended local env, and the sidecar image has no `conntrack` tool (so the clean conntrack-race fix — purging the denied flow's entry so the forged RST delivers fresh and retransmits hit the REJECT rule — isn't available without an image change). Shipping a speculative change (RST-retry / AF_PACKET injection / NOTRACK) to the egress fast-refuse path without being able to validate it is the wrong call. Capture-and-diagnose first.
