### PR TITLE
fix(egress): scope once-deny REJECT to the connection (#2463)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -798,6 +798,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **A `once` egress-consent deny no longer blocks later same-host connects (#2463).**
+  Denying a single connection once used to install a destination-scoped REJECT
+  rule that silently rejected every _new_ connection to the same `host:port` for
+  the fail-close window (~10s by default), with no re-prompt and no rule in the
+  DB. The fail-close REJECT for a `once` deny is now scoped to the denied
+  connection's source port, so a new connection (different source port)
+  re-prompts as expected; `once` adds no DB rule and nothing keeps denying it.
+  Timed/forever denies are unchanged (their destination-scoped REJECT is
+  correct — the persisted rule governs re-prompting).
+
 - **Timed egress-consent allows now cover the whole host (#2434).** A timed or
   `until restart` `allow` verdict now allow-lists the consented host for its
   whole duration — the same as `allow forever` already did — instead of only

--- a/src/containers/network/proxy.py
+++ b/src/containers/network/proxy.py
@@ -301,11 +301,17 @@ _VERDICT_CACHE: dict[tuple[str, int, str, int], tuple[str, float]] = {}
 # event-loop thread -- no lock. Added in :func:`_cb`, discarded in
 # :func:`_decide_and_verdict` once the verdict is cached.
 _INFLIGHT: set[tuple[str, int, str, int]] = set()
-# Temporary REJECT (tcp-reset) rules for denied connections: {(ip, port): expire}.
-# Swept by sweep_once alongside _LEARNED. Makes a deny fail-fast (ECONNREFUSED)
-# instead of waiting for tcp_syn_retries (~127s) -- dropping a SYN alone doesn't
-# fail connect(); the kernel just retransmits until its own timeout.
-_REJECTED: dict[tuple[str, int], float] = {}
+# Temporary REJECT (tcp-reset) rules for denied connections, keyed by
+# (ip, port, sport): sport=0 is destination-scoped (catches every connection to
+# ip:port, used for a timed/forever deny whose over-deny is intended + the
+# WS-down fail-close); a nonzero sport is connection-scoped (catches only
+# retransmits of THAT connection, used for a ``once`` deny so a NEW connection
+# to the same host:port re-prompts instead of being rejected above NFQUEUE,
+# #2463). Swept by sweep_once alongside _LEARNED. Makes a deny fail-fast
+# (ECONNREFUSED) instead of waiting for tcp_syn_retries (~127s) -- dropping a
+# SYN alone doesn't fail connect(); the kernel just retransmits until its own
+# timeout.
+_REJECTED: dict[tuple[str, int, int], float] = {}
 # Strong refs to background asyncio tasks (the TTL sweeper) so CPython doesn't
 # GC a sleeping task. A done-callback discards each entry on completion.
 _BG_TASKS: set[asyncio.Task] = set()
@@ -624,51 +630,49 @@ def allow(ip: str, port: int | None, ttl: int | float) -> None:
                 del _REJECTED[key]
 
 
-def _reject_rule_args(ip: str, port: int) -> list[str]:
-    """iptables OUTPUT rule args for REJECT (tcp-reset) to ``ip:port``."""
-    return [
-        "-d",
-        ip,
-        "-p",
-        "tcp",
-        "--dport",
-        str(port),
-        "-j",
-        "REJECT",
-        "--reject-with",
-        "tcp-reset",
-    ]
+def _reject_rule_args(ip: str, port: int, sport: int = 0) -> list[str]:
+    """iptables OUTPUT rule args for REJECT (tcp-reset) to ``ip:port``.
+
+    ``sport`` (the denied connection's source port) scopes the rule to
+    retransmits of THAT connection only (#2463); 0/omitted leaves it
+    destination-scoped (every connection to ``ip:port``).
+    """
+    args = ["-d", ip, "-p", "tcp", "--dport", str(port)]
+    if sport:
+        args += ["--sport", str(sport)]
+    args += ["-j", "REJECT", "--reject-with", "tcp-reset"]
+    return args
 
 
-def _reject_rule_exists(ip: str, port: int) -> bool:
+def _reject_rule_exists(ip: str, port: int, sport: int = 0) -> bool:
     return (
         subprocess.run(
-            [IPT, "-C", "OUTPUT", *_reject_rule_args(ip, port)],
+            [IPT, "-C", "OUTPUT", *_reject_rule_args(ip, port, sport)],
             capture_output=True,
         ).returncode
         == 0
     )
 
 
-def _install_reject(ip: str, port: int) -> None:
+def _install_reject(ip: str, port: int, sport: int = 0) -> None:
     """Insert the REJECT (tcp-reset) rule at the top of OUTPUT if not present."""
-    if _reject_rule_exists(ip, port):
+    if _reject_rule_exists(ip, port, sport):
         return
     subprocess.run(
-        [IPT, "-I", "OUTPUT", "1", *_reject_rule_args(ip, port)],
+        [IPT, "-I", "OUTPUT", "1", *_reject_rule_args(ip, port, sport)],
         capture_output=True,
     )
 
 
-def _remove_reject(ip: str, port: int) -> None:
+def _remove_reject(ip: str, port: int, sport: int = 0) -> None:
     """Delete the REJECT rule; swallow failure if it's already gone."""
     subprocess.run(
-        [IPT, "-D", "OUTPUT", *_reject_rule_args(ip, port)],
+        [IPT, "-D", "OUTPUT", *_reject_rule_args(ip, port, sport)],
         capture_output=True,
     )
 
 
-def reject(ip: str, port: int, ttl: float) -> None:
+def reject(ip: str, port: int, ttl: float, sport: int = 0) -> None:
     """Install a temporary REJECT (tcp-reset) for ``ip:port`` + set its TTL.
 
     A denied SYN is dropped, but dropping a SYN doesn't fail ``connect()`` --
@@ -676,11 +680,21 @@ def reject(ip: str, port: int, ttl: float) -> None:
     REJECT rule makes the next retransmit get a RST, so ``connect()`` returns
     ECONNREFUSED at once (eager deny). Like :func:`allow`, the install + the
     ``_REJECTED`` record are atomic under :data:`_LOCK` w.r.t. :func:`sweep_once`.
+
+    ``sport`` (the denied connection's source port) scopes the rule to
+    retransmits of THAT connection only, so a NEW connection (different source
+    port) to the same ``ip:port`` is NOT rejected above NFQUEUE and re-enters
+    consent-gating (#2463). 0/omitted leaves the rule destination-scoped
+    (every connection to ``ip:port``), which is correct for a timed/forever
+    deny (its over-deny is intended -- the DB rule + ``_SESSION_HOST_DENIES``
+    govern re-prompting) and the WS-down fail-close.
     """
     expire = time.time() + ttl
     with _LOCK:
-        _install_reject(ip, port)
-        _REJECTED[(ip, port)] = max(_REJECTED.get((ip, port), 0.0), expire)
+        _install_reject(ip, port, sport)
+        _REJECTED[(ip, port, sport)] = max(
+            _REJECTED.get((ip, port, sport), 0.0), expire
+        )
 
 
 def drop_for_host(host: str, decision: str) -> set[str]:
@@ -1582,7 +1596,12 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
         # RST'd above NFQUEUE, then drop. On-list egress is unaffected
         # (learned ACCEPT rules sit above NFQUEUE); once the WS reconnects,
         # fresh off-list egress prompts again. The REJECT TTL is short, so no
-        # rule lingers past the outage (#2413).
+        # rule lingers past the outage (#2413). Unlike a `once` deny (#2463),
+        # this REJECT stays destination-scoped deliberately: during a WS outage
+        # no connection can be consented, so fail-fast (ECONNREFUSED) for every
+        # off-list connect to the same ip:port is the intended #2308 behavior,
+        # and this path writes no _VERDICT_CACHE entry, so connection-scoping
+        # would gain nothing.
         if port:
             _send_rst(payload)
             asyncio.get_running_loop().run_in_executor(
@@ -1740,6 +1759,16 @@ async def _decide_and_verdict(
             # rule flaky (#2345). The REJECT rule stays as a belt-and-suspenders
             # backstop for any retransmit the RST missed. `once` -> the short
             # fail-close reject window; a timed duration -> that long.
+            # ``once`` is per-connection: scope the REJECT to THIS connection's
+            # source port so a NEW connection (different sport) to the same
+            # host:port re-prompts instead of being rejected above NFQUEUE for
+            # the fail-close window (#2463). A timed/forever deny stays
+            # destination-scoped -- its over-deny is correct (the DB rule +
+            # _SESSION_HOST_DENIES govern re-prompting). The source port is
+            # guarded: a real TCP SYN never has src port 0 (RFC 793), so a
+            # truthy flow[1] is the normal case; if it is ever 0 (a
+            # non-TCP/unparseable flow), fall back to destination-scoped so a
+            # future parse change can't silently re-introduce the over-deny.
             if port:
                 try:
                     _send_rst(pkt.get_payload())
@@ -1747,7 +1776,12 @@ async def _decide_and_verdict(
                     pass
                 reject_ttl = ttl if ttl is not None else CONSENT_REJECT_TTL
                 try:
-                    await loop.run_in_executor(None, reject, dst, port, reject_ttl)
+                    if ttl is None and flow[1]:
+                        await loop.run_in_executor(
+                            None, reject, dst, port, reject_ttl, flow[1]
+                        )
+                    else:
+                        await loop.run_in_executor(None, reject, dst, port, reject_ttl)
                 except Exception:
                     pass
             pkt.drop()

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -624,7 +624,32 @@ class TestTTLAndSweep:
         assert any(
             "-I" in a and "REJECT" in a and "tcp-reset" in a for a in runs
         )
-        assert learned._REJECTED[("1.2.3.4", 80)] == 1010.0
+        assert not any(
+            "--sport" in a for a in runs
+        )  # dest-scoped omits --sport
+        assert learned._REJECTED[("1.2.3.4", 80, 0)] == 1010.0
+
+    def test_reject_connection_scoped_adds_sport(self, learned, monkeypatch):
+        # #2463: a connection-scoped REJECT (nonzero sport) carries --sport so a
+        # real iptables rule matches only retransmits of THAT connection; a
+        # destination-scoped reject (sport 0) omits it. The (ip, port, sport)
+        # key keeps the two rule kinds distinct in _REJECTED.
+        runs = []
+
+        def fake_run(args, **kw):
+            runs.append(args)
+            return types.SimpleNamespace(returncode=1)  # rule absent -> -I
+
+        monkeypatch.setattr(learned.subprocess, "run", fake_run)
+        monkeypatch.setattr(learned.time, "time", lambda: 1000.0)
+        learned._REJECTED.clear()
+        learned.reject("1.2.3.4", 443, 10, 50000)  # connection-scoped
+        scoped = [a for a in runs if "--sport" in a][0]
+        assert "-d" in scoped and "1.2.3.4" in scoped
+        assert "--dport" in scoped and "443" in scoped
+        assert scoped[scoped.index("--sport") + 1] == "50000"
+        assert "REJECT" in scoped and "tcp-reset" in scoped
+        assert learned._REJECTED[("1.2.3.4", 443, 50000)] == 1010.0
 
     def test_sweep_removes_expired_reject_rules(self, learned, monkeypatch):
         removed = []
@@ -637,15 +662,15 @@ class TestTTLAndSweep:
         monkeypatch.setattr(learned.subprocess, "run", fake_run)
         learned._LEARNED.clear()
         learned._REJECTED.clear()
-        learned._REJECTED[("1.2.3.4", 80)] = 100.0  # expired
-        learned._REJECTED[("5.6.7.8", 443)] = 9999.0  # live
+        learned._REJECTED[("1.2.3.4", 80, 0)] = 100.0  # expired
+        learned._REJECTED[("5.6.7.8", 443, 0)] = 9999.0  # live
         learned.sweep_once(now=500.0)
         assert any(
             "1.2.3.4" in a and "REJECT" in a and "tcp-reset" in a
             for a in removed
         )
-        assert ("1.2.3.4", 80) not in learned._REJECTED
-        assert ("5.6.7.8", 443) in learned._REJECTED  # live one kept
+        assert ("1.2.3.4", 80, 0) not in learned._REJECTED
+        assert ("5.6.7.8", 443, 0) in learned._REJECTED  # live one kept
 
     def test_all_ports_allow_supersedes_prior_port_denies(
         self, learned, monkeypatch
@@ -657,19 +682,21 @@ class TestTTLAndSweep:
         monkeypatch.setattr(
             learned,
             "_remove_reject",
-            lambda ip, port: removed.append((ip, port)),
+            lambda ip, port, sport=0: removed.append((ip, port, sport)),
         )
         monkeypatch.setattr(learned, "_install", lambda *a: None)
         learned._REJECTED.clear()
-        learned._REJECTED[("1.2.3.4", 443)] = 9999.0
-        learned._REJECTED[("1.2.3.4", 80)] = 9999.0
-        learned._REJECTED[("5.6.7.8", 443)] = 9999.0  # different IP, untouched
+        learned._REJECTED[("1.2.3.4", 443, 0)] = 9999.0
+        learned._REJECTED[("1.2.3.4", 80, 0)] = 9999.0
+        learned._REJECTED[("5.6.7.8", 443, 0)] = (
+            9999.0  # different IP, untouched
+        )
         learned.allow("1.2.3.4", None, 60)  # all-ports (consent path)
-        assert ("1.2.3.4", 443) in removed
-        assert ("1.2.3.4", 80) in removed
-        assert ("5.6.7.8", 443) not in removed  # different IP kept
-        assert ("1.2.3.4", 443) not in learned._REJECTED
-        assert ("5.6.7.8", 443) in learned._REJECTED
+        assert ("1.2.3.4", 443, 0) in removed
+        assert ("1.2.3.4", 80, 0) in removed
+        assert ("5.6.7.8", 443, 0) not in removed  # different IP kept
+        assert ("1.2.3.4", 443, 0) not in learned._REJECTED
+        assert ("5.6.7.8", 443, 0) in learned._REJECTED
 
 
 class TestARecordsWithTtl:
@@ -1622,7 +1649,10 @@ class TestNfqueueCallback:
 
     async def test_deny_verdict_drops_and_rejects(self, proxy, monkeypatch):
         # deny -> drop the SYN + install a REJECT (tcp-reset) so the retransmit
-        # gets RST'd (ECONNREFUSED), not a ~127s tcp_syn_retries wait.
+        # gets RST'd (ECONNREFUSED), not a ~127s tcp_syn_retries wait. A `once`
+        # deny is connection-scoped (#2463): the REJECT carries the denying
+        # connection's source port (here 50000) so a NEW connection to the same
+        # host:port re-prompts instead of being rejected above NFQUEUE.
         client = MagicMock()
         client.connected = True
         client.request = AsyncMock(return_value=("deny", "once"))
@@ -1630,15 +1660,17 @@ class TestNfqueueCallback:
         monkeypatch.setattr(
             proxy,
             "reject",
-            lambda ip, port, ttl: rejected.append((ip, port, ttl)),
+            lambda ip, port, ttl, sport=0: rejected.append(
+                (ip, port, ttl, sport)
+            ),
         )
         self._bind(proxy, monkeypatch, client)
-        pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
+        pkt = _FakePkt(_syn_payload("10.0.0.5", 50000, "1.2.3.4", 443, 0x1111))
         await self._decide(proxy, pkt, client)
         assert pkt.verdict == "drop"
         assert rejected == [
-            ("1.2.3.4", 443, proxy.CONSENT_REJECT_TTL)
-        ]  # eager deny
+            ("1.2.3.4", 443, proxy.CONSENT_REJECT_TTL, 50000)
+        ]  # eager deny, connection-scoped to this connection's source port
 
     async def test_request_error_drops(self, proxy, monkeypatch):
         client = MagicMock()
@@ -1812,9 +1844,7 @@ class TestNfqueueCallback:
         client.connected = True
         client.request = AsyncMock(return_value=("deny", "once"))
         rejected = []
-        monkeypatch.setattr(
-            proxy, "reject", lambda ip, port, ttl: rejected.append(ttl)
-        )
+        monkeypatch.setattr(proxy, "reject", lambda *a: rejected.append(a[2]))
         self._bind(proxy, monkeypatch, client)
         pkt = _FakePkt(_ip_payload("1.2.3.4", 443))
         await self._decide(proxy, pkt, client)
@@ -1951,6 +1981,75 @@ class TestNfqueueCallback:
             "a new connection (new source port) must re-prompt after an "
             "allow-once, not reuse the prior verdict"
         )
+
+    async def test_deny_once_re_prompts_new_connection_same_host(
+        self, proxy, monkeypatch
+    ):
+        # #2463: a `once` deny governs only the deciding connection. A NEW
+        # connection (new source port) to the same (dst, port) must re-prompt --
+        # the connection-scoped REJECT (keyed on the source port) does not catch
+        # it, the verdict cache misses (distinct flow), and `once` adds no
+        # _SESSION_HOST_DENIES entry. This is the deny-side mirror of
+        # test_distinct_source_port_re_prompts_after_allow_once, and the
+        # unit-level grounding of the #2463 fix.
+        requests = []
+
+        async def fast_request(host, port):
+            requests.append((host, port))
+            return ("deny", "once")
+
+        client = MagicMock()
+        client.connected = True
+        client.request = AsyncMock(side_effect=fast_request)
+        monkeypatch.setattr(proxy, "reject", lambda *a: None)
+        monkeypatch.setattr(proxy, "_RST_SOCK", None)
+        self._bind(proxy, monkeypatch, client)
+        # Connection A (sport 50000) -> deny/once -> fail-close + connection-
+        # scoped REJECT for sport 50000 only.
+        proxy._cb(
+            _FakePkt(_syn_payload("10.0.0.5", 50000, "1.2.3.4", 443, 1)),
+            client,
+        )
+        await asyncio.gather(*proxy._BG_TASKS)
+        assert proxy._SESSION_HOST_DENIES == []  # `once` adds no host-deny
+        # Connection B (sport 50001, same dst) -> DISTINCT flow -> the
+        # connection-scoped REJECT (sport 50000) does not match, the verdict
+        # cache misses, and there is no session-deny gate -> re-prompts.
+        proxy._cb(
+            _FakePkt(_syn_payload("10.0.0.5", 50001, "1.2.3.4", 443, 1)),
+            client,
+        )
+        await asyncio.gather(*proxy._BG_TASKS)
+        assert len(requests) == 2, (
+            "a new connection (new source port) must re-prompt after a "
+            "deny-once, not be silently rejected for the fail-close window"
+        )
+
+    async def test_deny_once_reject_is_connection_scoped(
+        self, proxy, monkeypatch
+    ):
+        # #2463: the fail-close REJECT installed by a `once` deny carries the
+        # denying connection's source port (--sport), so a real iptables rule
+        # would catch only retransmits of THAT connection, leaving a NEW
+        # connection (different sport) to re-enter NFQUEUE and re-prompt. A
+        # timed/forever deny, by contrast, stays destination-scoped (sport 0)
+        # -- its over-deny is intended.
+        for duration, expect_sport in [("once", 50000), ("15m", 0)]:
+            client = MagicMock()
+            client.connected = True
+            client.request = AsyncMock(return_value=("deny", duration))
+            rejected = []
+            monkeypatch.setattr(
+                proxy,
+                "reject",
+                lambda ip, port, ttl, sport=0: rejected.append(sport),
+            )
+            self._bind(proxy, monkeypatch, client)
+            pkt = _FakePkt(
+                _syn_payload("10.0.0.5", 50000, "1.2.3.4", 443, 0x1111)
+            )
+            await self._decide(proxy, pkt, client)
+            assert rejected == [expect_sport], duration
 
 
 def test_duration_ttl_mapping(proxy):


### PR DESCRIPTION
## Summary

A `once` egress-consent deny left a destination-scoped REJECT rule in the
sidecar that silently rejected every *new* connection to the same
`host:port` for the fail-close window (~10s default + 5s sweep), with no
re-prompt and no rule in the DB. The deny was `once`, so nothing persisted
to explain the rejections (#2463).

Root cause: the fail-close REJECT installed by `_decide_and_verdict`'s deny
path was keyed on the **destination** `(ip, port)` and sits above NFQUEUE in
OUTPUT, so it caught new connections (different source ports), not just the
denied connection's SYN retransmits. Same root cause as the
concurrent-same-host REJECT-clobber finding noted in #2454.

## Fix

Scope the fail-close REJECT for a `once` deny to the denying connection's
**source port** (`--sport`), so it catches only that connection's retransmits.
A new connection (different source port) misses the rule, re-enters NFQUEUE,
and re-prompts — matching the issue's expected behavior.

- `reject()` / `_reject_rule_args` / `_install_reject` / `_remove_reject`
  gained an optional `sport` param; `_REJECTED` is now keyed on
  `(ip, port, sport)` where `sport=0` is destination-scoped.
- `_decide_and_verdict` passes `flow[1]` (the source port) **only** for
  `once` denies. Timed/forever denies stay destination-scoped — their
  over-deny is intended (the persisted DB rule + `_SESSION_HOST_DENIES`
  govern re-prompting). The WS-down fail-close is unchanged.
- `sweep_once` / `drop_for_host` work unchanged (they iterate keys and
  splat into `_remove_reject`).

This preserves the #2308/#2345 fail-close guarantee for the denied
connection (retransmits are still RST'd, now via both the forged RST and
the connection-scoped REJECT), while letting new connections re-prompt.

## Test plan

- [x] Full Python suite: `4959 passed`, 100% coverage on the `klangk` package
- [x] `ruff check` / `ruff format` / `prettier` / `markdownlint` clean (pre-commit)
- [x] New regression tests:
  - `test_deny_once_re_prompts_new_connection_same_host` — a new connection
    (new source port) re-prompts after a `once` deny (deny-side mirror of the
    existing allow-once test)
  - `test_deny_once_reject_is_connection_scoped` — `once` passes the source
    port; a timed deny passes `0` (destination-scoped)
  - `test_reject_connection_scoped_adds_sport` — the `--sport` arg is emitted
    and the `(ip, port, sport)` key is distinct in `_REJECTED`
- [x] Updated the existing reject/`_REJECTED`/sweep/drop tests for the 3-tuple key

Closes #2463.
