### PR TITLE
fix(frontend): drop expired timed consent rules from Net Rules

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -808,6 +808,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   Timed/forever denies are unchanged (their destination-scoped REJECT is
   correct — the persisted rule governs re-prompting).
 
+- **Flutter Net Rules page drops expired timed verdicts (#2467).** A timed
+  active allow/deny now disappears from the Net Rules view the moment its
+  window elapses, instead of lingering with a "0s left" label. The server
+  only re-broadcasts the rules snapshot on discrete events (verdict/revoke/
+  pause/reconnect), so the client prunes elapsed rules on its 1s tick.
+
 - **Timed egress-consent allows now cover the whole host (#2434).** A timed or
   `until restart` `allow` verdict now allow-lists the consented host for its
   whole duration — the same as `allow forever` already did — instead of only

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -742,6 +742,44 @@ class ConsentDeciderService extends ChangeNotifier {
     final left = until - now;
     return left < 0 ? 0 : left.round();
   }
+
+  /// Whether a timed verdict's window has elapsed (its countdown reached zero)
+  /// and the rule should be hidden from the rules view. The server drops it
+  /// from `list_active` at the same instant, but only re-broadcasts
+  /// `egress_rules` on the next discrete event (verdict/revoke/pause/
+  /// reconnect) -- not on natural expiry -- so the client prunes it locally
+  /// ([pruneExpiredRules]) to hide the row the moment it expires rather than
+  /// freezing at "0s left". Open-ended verdicts (`forever`/`tilrestart`) and
+  /// unknown/missing-`decided_at` rows never expire (they have no countdown).
+  bool isRuleExpired(ConsentRule rule) {
+    final remaining = ruleRemainingSeconds(rule);
+    return remaining != null && remaining <= 0;
+  }
+
+  /// Drop timed verdicts whose window has elapsed from the cached snapshot,
+  /// notifying listeners if anything changed. Called by the rules view's 1s
+  /// tick so an expired rule disappears at the first tick past its expiry
+  /// instead of lingering at "0s left". Returns whether any rule was pruned.
+  /// No-op (returns false) before the first `egress_rules` frame lands.
+  bool pruneExpiredRules() {
+    final r = _rules;
+    if (r == null) return false;
+    final allowed = r.allowed.where((e) => !isRuleExpired(e)).toList();
+    final denied = r.denied.where((e) => !isRuleExpired(e)).toList();
+    if (allowed.length == r.allowed.length &&
+        denied.length == r.denied.length) {
+      return false;
+    }
+    _rules = EgressRules(
+      workspaceId: r.workspaceId,
+      allowList: r.allowList,
+      allowed: allowed,
+      denied: denied,
+      paused: r.paused,
+    );
+    notifyListeners();
+    return true;
+  }
 }
 
 DateTime _wallClock() => DateTime.now();

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -9,8 +9,12 @@
 /// by the `egress_rules` frame the [ConsentDeciderService] already receives
 /// over `/ws/consent-decider` (#2335).
 ///
-/// Countdowns tick live (1s) but the server is the source of truth (it drops
-/// a rule at the real expiry); this only repaints the remaining-time hint.
+/// Countdowns tick live (1s) but the server is the source of truth: it drops
+/// a rule from `list_active` at the real expiry. The server only re-broadcasts
+/// the `egress_rules` frame on a discrete event (verdict/revoke/pause/
+/// reconnect), though -- not on natural expiry -- so the tick also prunes
+/// elapsed rules from the cached snapshot ([ConsentDeciderService.pruneExpiredRules])
+/// to hide the row the instant it expires rather than freezing at "0s left".
 /// Revoke is never optimistic: the row stays until the server's `revoke_ack`
 /// confirms success -- a still-enforced rule is never hidden silently (mirrors
 /// the TUI). A failed ack surfaces via the service's [flashMessage].
@@ -83,9 +87,15 @@ class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
     // forever/tilrestart-only workspace (the server is the source of truth;
     // this only repaints the remaining-time hints).
     _tick = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (mounted &&
-          hasLiveCountdown(
-              widget.service.rules, widget.service.ruleRemainingSeconds)) {
+      if (!mounted) return;
+      // Drop timed verdicts whose window just elapsed: the server only
+      // re-broadcasts egress_rules on a discrete event (verdict/revoke/pause/
+      // reconnect), not on natural expiry, so prune locally to hide the row
+      // the instant it expires (notifyListeners rebuilds if anything changed)
+      // rather than freezing at "0s left".
+      widget.service.pruneExpiredRules();
+      if (hasLiveCountdown(
+          widget.service.rules, widget.service.ruleRemainingSeconds)) {
         _onChange();
       }
     });

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -872,4 +872,96 @@ void main() {
       svc.dispose();
     });
   });
+
+  group('isRuleExpired', () {
+    test('timed past expiry -> true; open-ended / unknown / missing -> false',
+        () {
+      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws', token: 't', clock: () => now);
+      ConsentRule rule(String? duration, {double? decidedAt}) => ConsentRule(
+          id: 'r',
+          destHost: 'h',
+          decision: 'allowed',
+          duration: duration,
+          decidedAt: decidedAt);
+      // decided at 1000s, 5m (300s) -> expires at 1300s; now=1000s -> live.
+      expect(svc.isRuleExpired(rule('5m', decidedAt: 1000.0)), isFalse);
+      // decided at 100s -> expired long ago (remaining clamps to 0).
+      expect(svc.isRuleExpired(rule('5m', decidedAt: 100.0)), isTrue);
+      // open-ended / unknown / missing decided_at -> never expire.
+      expect(svc.isRuleExpired(rule('forever', decidedAt: 100.0)), isFalse);
+      expect(svc.isRuleExpired(rule('tilrestart', decidedAt: 100.0)), isFalse);
+      expect(svc.isRuleExpired(rule('bogus', decidedAt: 100.0)), isFalse);
+      expect(svc.isRuleExpired(rule('5m')), isFalse);
+      svc.dispose();
+    });
+  });
+
+  group('pruneExpiredRules', () {
+    test('no-op (returns false) before the first egress_rules frame', () {
+      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws', token: 't', clock: () => now);
+      expect(svc.pruneExpiredRules(), isFalse);
+      expect(svc.rules, isNull);
+      svc.dispose();
+    });
+
+    test('drops expired timed rules, keeps the rest, and notifies', () async {
+      var now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final ch = _FakeChannel();
+      ConsentDeciderService.testChannelFactory = (_) => ch;
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws', token: 't', clock: () => now);
+      svc.connect();
+      ch.serverSend(_rulesFrame(
+        allowList: ['github.com'],
+        allowed: [
+          // timed: decided now (t=1000), 5m -> expires at t=1300; live for now.
+          _ruleJson(id: 'timed', host: 't.io', decidedAt: 1000.0),
+          // open-ended: never expires.
+          _ruleJson(
+              id: 'forever', host: 'f.io', duration: 'forever', decidedAt: 1.0),
+        ],
+        denied: [
+          // timed deny: also expires at t=1300.
+          _ruleJson(
+              id: 'd-timed',
+              host: 'dt.io',
+              decision: 'denied',
+              decidedAt: 1000.0),
+        ],
+      ));
+      await Future.delayed(Duration.zero); // flush the broadcast listener
+      // Sorted newest-decided-first: 'timed' (1000) before 'forever' (1).
+      expect(svc.rules!.allowed.map((r) => r.id), ['timed', 'forever']);
+      expect(svc.rules!.denied.map((r) => r.id), ['d-timed']);
+      expect(svc.rules!.allowList, ['github.com']);
+
+      var notifications = 0;
+      svc.addListener(() => notifications++);
+
+      // Nothing has elapsed yet (clock still at t=1000): no-op, no notify.
+      expect(svc.pruneExpiredRules(), isFalse);
+      expect(notifications, 0);
+      expect(svc.rules!.allowed.map((r) => r.id), ['timed', 'forever']);
+
+      // Advance past the timed rules' expiry (t=1300) and prune again: both
+      // timed rows drop, the open-ended allow stays, the allow-list is
+      // preserved, and listeners were notified.
+      now = DateTime.fromMillisecondsSinceEpoch(1400 * 1000, isUtc: true);
+      expect(svc.pruneExpiredRules(), isTrue);
+      expect(notifications, 1);
+      expect(svc.rules!.allowed.map((r) => r.id), ['forever']);
+      expect(svc.rules!.denied, isEmpty);
+      expect(svc.rules!.allowList, ['github.com']);
+
+      // Idempotent: pruning the already-pruned snapshot is a no-op.
+      expect(svc.pruneExpiredRules(), isFalse);
+      expect(notifications, 1);
+      ConsentDeciderService.testChannelFactory = null;
+      svc.dispose();
+    });
+  });
 }

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -387,5 +387,39 @@ void main() {
       expect(find.textContaining('reconnecting'), findsOneWidget);
       svc.dispose();
     });
+
+    testWidgets('an expired timed rule disappears on the next tick (#2467)',
+        (tester) async {
+      var now = _at(1000); // epoch seconds
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch, clock: () => now);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      // A timed allow (decided now, expires in 5m / at t=1300) + a forever
+      // allow (no expiry).
+      ch.serverSend(_rulesFrame(allowed: [
+        _ruleJson(id: 'timed', host: 't.io', duration: '5m', decidedAt: 1000),
+        _ruleJson(
+            id: 'forever', host: 'f.io', duration: 'forever', decidedAt: 1.0),
+      ]));
+      await tester.pump();
+      expect(find.text('Active allows (2)'), findsOneWidget);
+      expect(find.byKey(const ValueKey('revoke-timed')), findsOneWidget);
+      expect(find.byKey(const ValueKey('revoke-forever')), findsOneWidget);
+
+      // Past the timed rule's expiry. Before the 1s tick fires the row is
+      // still the cached snapshot (no rebuild has pruned it yet).
+      now = _at(1400);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('revoke-timed')), findsOneWidget);
+
+      // The 1s tick prunes the elapsed rule: it vanishes, the count drops,
+      // and the open-ended rule stays (no "0s left" linger).
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.text('Active allows (1)'), findsOneWidget);
+      expect(find.byKey(const ValueKey('revoke-timed')), findsNothing);
+      expect(find.byKey(const ValueKey('revoke-forever')), findsOneWidget);
+      svc.dispose();
+    });
   });
 }


### PR DESCRIPTION
## Summary

A timed active allow/deny lingered in the Flutter **Net Rules** view with a
"0s left" label after its window elapsed, instead of disappearing.

Root cause: the server drops an expired rule from `list_active` at the real
expiry, but it only re-broadcasts the `egress_rules` snapshot on a discrete
event (verdict / revoke / pause / reconnect) — never on natural expiry. So the
client's cached snapshot kept the stale row, and `ruleRemainingSeconds` clamped
its countdown to 0, rendering "0s left" / "expires in 0s" indefinitely.

## Fix

`ConsentDeciderService.pruneExpiredRules()` removes elapsed timed verdicts
from the cached snapshot and notifies listeners. The rules panel's existing 1s
tick calls it, so an expired rule (and its section count) disappears at the
first tick past its expiry. Open-ended verdicts (`forever` / `tilrestart`) and
unknown / missing-`decided_at` rows are never pruned (they have no countdown).

This is a client-side display fix only — the enforcement gate (server
`list_active` + the sidecar) is unchanged and was already correct.

## Testing

- `isRuleExpired` / `pruneExpiredRules` unit tests in
  `consent_decider_service_test.dart` (expiry predicate, no-op before first
  frame, drop + keep + notify + idempotence).
- Panel widget test in `consent_rules_panel_test.dart` asserting a timed rule
  disappears on the next tick after expiry while a `forever` rule stays.

Full frontend suite passes (`flutter test --coverage`, 953 tests); both touched
files are at 100% line coverage.

Closes #2467.
