### PR TITLE
feat(sandbox): reset egress to interactive after install (#2404)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -529,6 +529,12 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **`klangk sandbox` resets egress to interactive after install (#2404).**
+  A sandbox workspace is still created in `allow` mode so `setup.sh` installs
+  proceed, but once setup returns the driver resets `egress_mode` to
+  `interactive` and stops the container; the next `klangk shell` start applies
+  interactive (consent-gated) egress. `--force` re-setup flips back to `allow`
+  and restarts first, so re-running setup still egresses freely.
 - **Workspace Pi agent hides thinking blocks by default (#2459).** The
   per-user `~/.pi/agent/settings.json` provisioned at first login now sets
   `hideThinkingBlock: true` instead of the previous `defaultThinkingLevel:

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -532,11 +532,13 @@ operators or integrators to act when upgrading.
 - **`klangk sandbox` drops to interactive egress after install, where safe (#2404).**
   A sandbox workspace is still created in `allow` mode so `setup.sh` installs
   proceed; once setup returns, the driver resets `egress_mode` to `interactive`
-  and stops the container when the server has a network sidecar — the next
-  `klangk shell` start then applies consent-gated egress. It stays in `allow`
-  for auto-start workspaces (which boot unattended, with no decider to consent)
-  and on servers with no sidecar (where interactive is fail-closed).
-  `--force` re-setup flips back to `allow` and restarts first, so re-running
+  and stops the container when the server has a network sidecar and the
+  workspace is not auto-start — the next `klangk shell` start then applies
+  consent-gated egress. It stays in `allow` (and its service command still
+  fires post-setup) for auto-start workspaces (which boot unattended, with no
+  decider to consent) and on servers with no sidecar (where interactive is
+  fail-closed). `--force` re-setup flips back to `allow` and restarts first
+  (deferring the service command until the re-setup completes), so re-running
   setup still egresses freely.
 - **Workspace Pi agent hides thinking blocks by default (#2459).** The
   per-user `~/.pi/agent/settings.json` provisioned at first login now sets

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -529,12 +529,15 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
-- **`klangk sandbox` resets egress to interactive after install (#2404).**
+- **`klangk sandbox` drops to interactive egress after install, where safe (#2404).**
   A sandbox workspace is still created in `allow` mode so `setup.sh` installs
-  proceed, but once setup returns the driver resets `egress_mode` to
-  `interactive` and stops the container; the next `klangk shell` start applies
-  interactive (consent-gated) egress. `--force` re-setup flips back to `allow`
-  and restarts first, so re-running setup still egresses freely.
+  proceed; once setup returns, the driver resets `egress_mode` to `interactive`
+  and stops the container when the server has a network sidecar — the next
+  `klangk shell` start then applies consent-gated egress. It stays in `allow`
+  for auto-start workspaces (which boot unattended, with no decider to consent)
+  and on servers with no sidecar (where interactive is fail-closed).
+  `--force` re-setup flips back to `allow` and restarts first, so re-running
+  setup still egresses freely.
 - **Workspace Pi agent hides thinking blocks by default (#2459).** The
   per-user `~/.pi/agent/settings.json` provisioned at first login now sets
   `hideThinkingBlock: true` instead of the previous `defaultThinkingLevel:

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -639,6 +639,16 @@ class KlangkClient:
         self.check_auth(resp)
         self._raise_for_status(resp)
 
+    def restart_workspace_by_id(self, workspace_id: str) -> None:
+        """Restart a workspace container by id.
+
+        Id-based counterpart to :meth:`restart_workspace` for callers (the
+        sandbox driver) that already hold the workspace id.
+        """
+        resp = self.post(f"/api/v1/workspaces/{workspace_id}/restart")
+        self.check_auth(resp)
+        self._raise_for_status(resp)
+
     def stop_workspace(self, name: str) -> None:
         ws = self.resolve_workspace(name)
         resp = self.post(f"/api/v1/workspaces/{ws.id}/stop")

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -645,6 +645,17 @@ class KlangkClient:
         self.check_auth(resp)
         self._raise_for_status(resp)
 
+    def stop_workspace_by_id(self, workspace_id: str) -> None:
+        """Stop a running workspace container by id.
+
+        Id-based counterpart to :meth:`stop_workspace` for callers (the
+        sandbox driver) that already hold the workspace id and want to
+        skip the name→id resolution round-trip.
+        """
+        resp = self.post(f"/api/v1/workspaces/{workspace_id}/stop")
+        self.check_auth(resp)
+        self._raise_for_status(resp)
+
     def start_workspace(self, name: str) -> None:
         ws = self.resolve_workspace(name)
         resp = self.post(f"/api/v1/workspaces/{ws.id}/start")

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1891,16 +1891,19 @@ def sandbox(
             if resolve_setup_command(config, handle)
             else None,
             health_check=config.health_check,
-            # #2325 / #2406: a sandbox is an automated install context
-            # (setup.sh runs npm/git/... that need unrestricted outbound
-            # network). Default workspaces are interactive (hold every egress
-            # for consent), which would block the install with no decider
-            # present. Create the sandbox workspace in ``allow`` mode so its
-            # egress is default-permit (installs proceed), with off-list
-            # destinations recorded through the consent pipeline for
-            # observability and rejected_domains still enforced. Allow mode
-            # degrades to plain unrestricted when the server has no network
-            # sidecar configured, so the sandbox keeps working everywhere.
+            # #2325 / #2406 / #2404: a sandbox is an automated install
+            # context (setup.sh runs npm/git/... that need unrestricted
+            # outbound network). Default workspaces are interactive (hold
+            # every egress for consent), which would block the install with
+            # no decider present. Create the sandbox workspace in ``allow``
+            # mode so its egress is default-permit (installs proceed), with
+            # off-list destinations recorded through the consent pipeline
+            # for observability and rejected_domains still enforced.
+            # sandbox_setup_only resets egress_mode back to ``interactive``
+            # and stops the container once setup.sh returns (#2404), so the
+            # next start is consent-gated. Allow mode degrades to plain
+            # unrestricted when the server has no network sidecar
+            # configured, so the sandbox keeps working everywhere.
             egress_mode="allow",
         )
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
@@ -1909,6 +1912,15 @@ def sandbox(
     need_setup = created or force
 
     if need_setup:
+        # #2404: on --force re-setup the workspace may have been reset to
+        # 'interactive' by a prior sandbox run (sandbox_setup_only resets
+        # it after setup). setup.sh needs unrestricted egress, and
+        # egress_mode only takes effect at container start -- so flip back
+        # to 'allow' and restart before re-running setup. Skipped on the
+        # create path (the workspace is freshly created in 'allow' above).
+        if force and not created:
+            client.update_workspace(ws.id, egress_mode="allow")
+            client.restart_workspace(workspace)
         _err.print(f"Connecting to [bold]{workspace}[/bold] for setup...")
         try:
             asyncio.run(
@@ -1939,6 +1951,10 @@ def sandbox(
         f"[green]Done.[/green] Run [bold]klangk shell"
         f" {workspace}[/bold] to connect."
     )
+    _err.print(
+        "[dim]Workspace stopped; egress reset to interactive for the"
+        " next start.[/dim]"
+    )
 
 
 async def sandbox_setup_only(
@@ -1955,12 +1971,13 @@ async def sandbox_setup_only(
 
     After setup.sh returns, marks the workspace's ``setup_state``
     (#1033): ``complete`` on success (or when no setup command is
-    configured), ``failed`` otherwise. Only fires the service command
-    via ``terminal_start`` on success -- a failed setup must not
-    auto-run the service command (that is the failure-masquerade the
-    issue objects to). The state is marked BEFORE ``terminal_start``
-    is sent, so the server reads ``complete`` from the DB when it
-    decides whether to create the service-cmd window.
+    configured), ``failed`` otherwise. Then (#2404) resets the
+    workspace's ``egress_mode`` from the create-time ``allow`` back to
+    ``interactive`` and stops the container: ``egress_mode`` is applied
+    by the network sidecar at container start, so the stop forces the
+    next start (the user's ``klangk shell``) up in interactive,
+    consent-gated mode. The service command is not fired here -- it
+    re-fires at the create choke point on that next start.
     """
     async with ws_connect(server_spec, token=token, max_size=max_size) as ws:
         await wait_container_ready(ws, workspace_id)
@@ -1997,29 +2014,36 @@ async def sandbox_setup_only(
                     f" = {new_state}: {e}[/yellow]"
                 )
 
-        # After setup, start a terminal so the service command runs
-        # in a dedicated "service-cmd" tmux window (visible as a tab
-        # but not occupying the user's interactive window 0). Skipped
-        # on setup failure -- the service command's prerequisites are
-        # not met.
-        if config.service_command and setup_ok:
-            await ws.send(
-                json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
-            )
-            # Wait (bounded) for the terminal to start so the default
-            # command actually runs before we disconnect.  Other
-            # messages are ignored.
-            deadline = asyncio.get_event_loop().time() + 30
-            while True:
-                remaining = deadline - asyncio.get_event_loop().time()
-                if remaining <= 0:  # pragma: no cover
-                    break
-                try:
-                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-                except (asyncio.TimeoutError, websockets.ConnectionClosed):
-                    break
-                if json.loads(raw).get("type") == "terminal_started":
-                    break
+        # #2404: the workspace was created in 'allow' mode so setup.sh's
+        # npm/git/pip could egress without a consent decider. Now that the
+        # install is done, reset to the safe 'interactive' default and stop
+        # the container. egress_mode is applied by the network sidecar at
+        # container START (not on the live container), so the stop forces
+        # the next start -- the user's `klangk shell` -- up in interactive,
+        # consent-gated mode. The service command is not fired here: it
+        # re-fires at the create choke point on that next start, so firing
+        # it now just to kill it on stop would be wasted.
+        if client is not None:
+            try:
+                await asyncio.to_thread(
+                    client.update_workspace,
+                    workspace_id,
+                    egress_mode="interactive",
+                )
+            except Exception as e:  # pragma: no cover
+                _err.print(
+                    "[yellow]Warning: could not reset egress_mode to"
+                    f" interactive: {e}[/yellow]"
+                )
+            try:
+                await asyncio.to_thread(
+                    client.stop_workspace_by_id, workspace_id
+                )
+            except Exception as e:  # pragma: no cover
+                _err.print(
+                    "[yellow]Warning: could not stop container after"
+                    f" setup: {e}[/yellow]"
+                )
 
 
 terminal_app = typer.Typer(

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1920,7 +1920,7 @@ def sandbox(
         # create path (the workspace is freshly created in 'allow' above).
         if force and not created:
             client.update_workspace(ws.id, egress_mode="allow")
-            client.restart_workspace(workspace)
+            client.restart_workspace_by_id(ws.id)
         _err.print(f"Connecting to [bold]{workspace}[/bold] for setup...")
         try:
             asyncio.run(
@@ -1951,10 +1951,6 @@ def sandbox(
         f"[green]Done.[/green] Run [bold]klangk shell"
         f" {workspace}[/bold] to connect."
     )
-    _err.print(
-        "[dim]Workspace stopped; egress reset to interactive for the"
-        " next start.[/dim]"
-    )
 
 
 async def sandbox_setup_only(
@@ -1971,12 +1967,18 @@ async def sandbox_setup_only(
 
     After setup.sh returns, marks the workspace's ``setup_state``
     (#1033): ``complete`` on success (or when no setup command is
-    configured), ``failed`` otherwise. Then (#2404) resets the
-    workspace's ``egress_mode`` from the create-time ``allow`` back to
-    ``interactive`` and stops the container: ``egress_mode`` is applied
-    by the network sidecar at container start, so the stop forces the
-    next start (the user's ``klangk shell``) up in interactive,
-    consent-gated mode. The service command is not fired here -- it
+    configured), ``failed`` otherwise. Then (#2404) chooses the
+    post-install egress posture: drop the create-time ``allow`` back to
+    the safe ``interactive`` default and stop the container -- but only
+    when that is safe and meaningful. ``interactive`` is fail-closed
+    without a network sidecar (``start_container`` refuses to start
+    unfiltered), and it DENIES egress when no consent decider is
+    connected, so an auto-start service workspace left interactive
+    could never boot healthy. So the reset is skipped (workspace stays
+    in ``allow``) for auto-start workspaces or when the server has no
+    sidecar; otherwise ``egress_mode`` is reset to ``interactive`` and
+    the container is stopped, so the next ``klangk shell`` start applies
+    consent-gated egress. The service command is not fired here -- it
     re-fires at the create choke point on that next start.
     """
     async with ws_connect(server_spec, token=token, max_size=max_size) as ws:
@@ -2014,35 +2016,70 @@ async def sandbox_setup_only(
                     f" = {new_state}: {e}[/yellow]"
                 )
 
-        # #2404: the workspace was created in 'allow' mode so setup.sh's
-        # npm/git/pip could egress without a consent decider. Now that the
-        # install is done, reset to the safe 'interactive' default and stop
-        # the container. egress_mode is applied by the network sidecar at
-        # container START (not on the live container), so the stop forces
-        # the next start -- the user's `klangk shell` -- up in interactive,
-        # consent-gated mode. The service command is not fired here: it
-        # re-fires at the create choke point on that next start, so firing
-        # it now just to kill it on stop would be wasted.
+        # #2404: choose the post-install egress posture. The workspace was
+        # created in 'allow' so setup.sh could egress without a decider; now
+        # drop to the safe 'interactive' default -- but only when that is
+        # safe and meaningful:
+        #   - auto-start workspaces boot unattended (no decider connected),
+        #     and interactive DENIES egress with no decider, so their service
+        #     command could never reach its upstream. Leave them in allow.
+        #   - interactive is fail-closed: start_container refuses to start
+        #     unfiltered when no network sidecar is configured. So only reset
+        #     when the server can actually enforce it (netfilter_enabled).
+        # When neither skip applies, reset egress_mode to interactive and
+        # stop the container. egress_mode is applied by the sidecar at
+        # container START (not on the live container), so the stop forces the
+        # next start -- the user's `klangk shell` -- up in interactive mode.
+        # The service command is not fired here: it re-fires at the create
+        # choke point on that next start.
         if client is not None:
-            try:
-                await asyncio.to_thread(
-                    client.update_workspace,
-                    workspace_id,
-                    egress_mode="interactive",
-                )
-            except Exception as e:  # pragma: no cover
+            reset_to_interactive = False
+            skipped_reason = None
+            if config.auto_start:
+                skipped_reason = "auto-start workspace boots unattended"
+            else:
+                try:
+                    cfg = await asyncio.to_thread(client.config)
+                except Exception as e:  # pragma: no cover
+                    cfg = {}
+                    _err.print(
+                        "[yellow]Warning: could not read server config"
+                        f" ({e}); leaving workspace in allow[/yellow]"
+                    )
+                if not cfg.get("netfilter_enabled"):
+                    skipped_reason = "no network sidecar on this server"
+                else:
+                    reset_to_interactive = True
+
+            if reset_to_interactive:
+                try:
+                    await asyncio.to_thread(
+                        client.update_workspace,
+                        workspace_id,
+                        egress_mode="interactive",
+                    )
+                except Exception as e:  # pragma: no cover
+                    _err.print(
+                        "[yellow]Warning: could not reset egress_mode"
+                        f" to interactive: {e}[/yellow]"
+                    )
+                try:
+                    await asyncio.to_thread(
+                        client.stop_workspace_by_id, workspace_id
+                    )
+                except Exception as e:  # pragma: no cover
+                    _err.print(
+                        "[yellow]Warning: could not stop container"
+                        f" after setup: {e}[/yellow]"
+                    )
                 _err.print(
-                    "[yellow]Warning: could not reset egress_mode to"
-                    f" interactive: {e}[/yellow]"
+                    "[dim]Workspace stopped; egress reset to interactive"
+                    " for the next start.[/dim]"
                 )
-            try:
-                await asyncio.to_thread(
-                    client.stop_workspace_by_id, workspace_id
-                )
-            except Exception as e:  # pragma: no cover
+            else:
                 _err.print(
-                    "[yellow]Warning: could not stop container after"
-                    f" setup: {e}[/yellow]"
+                    "[dim]Workspace left in allow mode"
+                    f" ({skipped_reason}).[/dim]"
                 )
 
 

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1919,7 +1919,14 @@ def sandbox(
         # to 'allow' and restart before re-running setup. Skipped on the
         # create path (the workspace is freshly created in 'allow' above).
         if force and not created:
-            client.update_workspace(ws.id, egress_mode="allow")
+            # #2404: flip back to allow for the re-setup. Also reset
+            # setup_state to 'pending' so the restart's create choke point
+            # DEFERS the service command until the re-setup completes --
+            # otherwise /restart reads the stale 'complete' from the prior
+            # run and fires the service against half-reinstalled state.
+            client.update_workspace(
+                ws.id, egress_mode="allow", setup_state="pending"
+            )
             client.restart_workspace_by_id(ws.id)
         _err.print(f"Connecting to [bold]{workspace}[/bold] for setup...")
         try:
@@ -1978,8 +1985,11 @@ async def sandbox_setup_only(
     in ``allow``) for auto-start workspaces or when the server has no
     sidecar; otherwise ``egress_mode`` is reset to ``interactive`` and
     the container is stopped, so the next ``klangk shell`` start applies
-    consent-gated egress. The service command is not fired here -- it
-    re-fires at the create choke point on that next start.
+    consent-gated egress. When the workspace stays in ``allow`` the
+    container keeps running, so the service command is fired via
+    ``terminal_start`` after setup (deferred until ``setup_state`` is
+    complete, #1033); when the container is stopped it instead re-fires
+    at the create choke point on the next start.
     """
     async with ws_connect(server_spec, token=token, max_size=max_size) as ws:
         await wait_container_ready(ws, workspace_id)
@@ -2032,51 +2042,88 @@ async def sandbox_setup_only(
         # next start -- the user's `klangk shell` -- up in interactive mode.
         # The service command is not fired here: it re-fires at the create
         # choke point on that next start.
-        if client is not None:
-            reset_to_interactive = False
-            skipped_reason = None
-            if config.auto_start:
-                skipped_reason = "auto-start workspace boots unattended"
-            else:
-                try:
-                    cfg = await asyncio.to_thread(client.config)
-                except Exception as e:  # pragma: no cover
-                    cfg = {}
-                    _err.print(
-                        "[yellow]Warning: could not read server config"
-                        f" ({e}); leaving workspace in allow[/yellow]"
-                    )
-                if not cfg.get("netfilter_enabled"):
-                    skipped_reason = "no network sidecar on this server"
-                else:
-                    reset_to_interactive = True
-
-            if reset_to_interactive:
-                try:
-                    await asyncio.to_thread(
-                        client.update_workspace,
-                        workspace_id,
-                        egress_mode="interactive",
-                    )
-                except Exception as e:  # pragma: no cover
-                    _err.print(
-                        "[yellow]Warning: could not reset egress_mode"
-                        f" to interactive: {e}[/yellow]"
-                    )
-                try:
-                    await asyncio.to_thread(
-                        client.stop_workspace_by_id, workspace_id
-                    )
-                except Exception as e:  # pragma: no cover
-                    _err.print(
-                        "[yellow]Warning: could not stop container"
-                        f" after setup: {e}[/yellow]"
-                    )
+        reset_to_interactive = False
+        skipped_reason = None
+        if config.auto_start:
+            skipped_reason = "auto-start workspace boots unattended"
+        elif client is not None:
+            try:
+                cfg = await asyncio.to_thread(client.config)
+            except Exception as e:  # pragma: no cover
+                cfg = {}
                 _err.print(
-                    "[dim]Workspace stopped; egress reset to interactive"
-                    " for the next start.[/dim]"
+                    "[yellow]Warning: could not read server config"
+                    f" ({e}); leaving workspace in allow[/yellow]"
                 )
+            if not cfg.get("netfilter_enabled"):
+                skipped_reason = "no network sidecar on this server"
             else:
+                reset_to_interactive = True
+
+        if reset_to_interactive and client is not None:
+            # Drop to the safe interactive default and stop the container.
+            # egress_mode applies at the next container START (not on the
+            # live container), so the stop forces the next `klangk shell`
+            # up in consent-gated mode. The service command is NOT fired
+            # here -- the container is being stopped, and it re-fires at
+            # the create choke point on that next start.
+            try:
+                await asyncio.to_thread(
+                    client.update_workspace,
+                    workspace_id,
+                    egress_mode="interactive",
+                )
+            except Exception as e:  # pragma: no cover
+                _err.print(
+                    "[yellow]Warning: could not reset egress_mode"
+                    f" to interactive: {e}[/yellow]"
+                )
+            try:
+                await asyncio.to_thread(
+                    client.stop_workspace_by_id, workspace_id
+                )
+            except Exception as e:  # pragma: no cover
+                _err.print(
+                    "[yellow]Warning: could not stop container"
+                    f" after setup: {e}[/yellow]"
+                )
+            _err.print(
+                "[dim]Workspace stopped; egress reset to interactive"
+                " for the next start.[/dim]"
+            )
+        else:
+            # Stay in allow (auto-start, no sidecar, or no client to
+            # decide). The container keeps running, so fire the service
+            # command now so it's up (#1033: deferred until setup_state is
+            # complete, then launched via terminal_start in the dedicated
+            # service-cmd tmux window). Skipped on setup failure -- the
+            # service command's prerequisites are not met.
+            if config.service_command and setup_ok:
+                await ws.send(
+                    json.dumps(
+                        {"cmd": "terminal_start", "cols": 80, "rows": 24}
+                    )
+                )
+                # Wait (bounded) for the terminal to start so the command
+                # actually runs before we disconnect. Other messages are
+                # ignored.
+                deadline = asyncio.get_event_loop().time() + 30
+                while True:
+                    remaining = deadline - asyncio.get_event_loop().time()
+                    if remaining <= 0:  # pragma: no cover
+                        break
+                    try:
+                        raw = await asyncio.wait_for(
+                            ws.recv(), timeout=remaining
+                        )
+                    except (
+                        asyncio.TimeoutError,
+                        websockets.ConnectionClosed,
+                    ):
+                        break
+                    if json.loads(raw).get("type") == "terminal_started":
+                        break
+            if client is not None:
                 _err.print(
                     "[dim]Workspace left in allow mode"
                     f" ({skipped_reason}).[/dim]"

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -1214,6 +1214,19 @@ class TestClientLines:
 
         mock_post.assert_called_once_with("/api/v1/workspaces/ws1/restart")
 
+    def test_restart_workspace_by_id_calls_post(self):
+        # Id-based variant skips the name→id list resolution (#2404).
+        from klangk.cli.client import KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        restart_resp = MagicMock()
+        restart_resp.status_code = 200
+        with patch.object(
+            client, "post", return_value=restart_resp
+        ) as mock_post:
+            client.restart_workspace_by_id("ws1")
+        mock_post.assert_called_once_with("/api/v1/workspaces/ws1/restart")
+
     def test_stop_workspace_calls_post(self):
         from klangk.cli.client import KlangkClient
 

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -1240,6 +1240,17 @@ class TestClientLines:
                 client.stop_workspace("ws1")
         mock_post.assert_called_once_with("/api/v1/workspaces/ws1/stop")
 
+    def test_stop_workspace_by_id_calls_post(self):
+        # Id-based variant skips the name→id list resolution (#2404).
+        from klangk.cli.client import KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        stop_resp = MagicMock()
+        stop_resp.status_code = 200
+        with patch.object(client, "post", return_value=stop_resp) as mock_post:
+            client.stop_workspace_by_id("ws1")
+        mock_post.assert_called_once_with("/api/v1/workspaces/ws1/stop")
+
     def test_start_workspace_calls_post(self):
         from klangk.cli.client import KlangkClient
 

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4230,6 +4230,11 @@ class TestSandboxCommand:
         assert call_kwargs[1]["egress_mode"] == "allow"
         assert "Creating workspace" in result.output
         assert "klangk shell" in result.output
+        # #2404: create path creates in allow (above); the allow-flip+restart
+        # only runs on --force re-setup, so neither is called here.
+        client.update_workspace.assert_not_called()
+        client.restart_workspace.assert_not_called()
+        assert "egress reset to interactive" in result.output
 
     def test_existing_workspace_errors_without_force(
         self, logged_in_cfg, tmp_path
@@ -4297,6 +4302,12 @@ class TestSandboxCommand:
         assert result.exit_code == 0
         assert setup_called == [True]
         assert "re-applying config" in result.output
+        # #2404: --force re-setup flips egress_mode back to 'allow' and
+        # restarts first (a prior run reset it to interactive).
+        client.update_workspace.assert_called_once_with(
+            ws.id, egress_mode="allow"
+        )
+        client.restart_workspace.assert_called_once_with("myws")
 
     def test_setup_connection_error(self, logged_in_cfg, tmp_path):
         from klangk.cli import main
@@ -4369,7 +4380,15 @@ class TestSandboxSetupOnly:
                 mock_ws, config, Path("/tmp"), "admin"
             )
 
-    async def test_starts_terminal_after_setup_when_service_command(self):
+    async def test_resets_egress_and_stops_after_setup(self):
+        """After setup, egress_mode resets to interactive and container stops (#2404).
+
+        The sandbox is created in 'allow' so setup.sh can install freely; once
+        setup returns the driver drops back to the safe 'interactive' default
+        and stops the container (egress_mode applies at the next start). The
+        service command is NOT fired here -- it re-fires at the create choke
+        point on the next `klangk shell` start.
+        """
         from pathlib import Path
 
         from klangk.cli.main import sandbox_setup_only
@@ -4381,11 +4400,9 @@ class TestSandboxSetupOnly:
 
         mock_ws = AsyncMock()
         mock_ws.recv = AsyncMock(
-            side_effect=[
-                json.dumps({"type": "container_ready"}),
-                json.dumps({"type": "terminal_started"}),
-            ]
+            return_value=json.dumps({"type": "container_ready"})
         )
+        mock_client = MagicMock()
 
         with (
             patch("klangk.cli.transport.websockets.connect") as mock_connect,
@@ -4403,54 +4420,17 @@ class TestSandboxSetupOnly:
                 config,
                 Path("/tmp"),
                 "admin",
-            )
-            mock_setup.assert_called_once_with(
-                mock_ws, config, Path("/tmp"), "admin"
+                client=mock_client,
             )
 
-        # terminal_start was sent after setup so the service command runs.
+        # egress_mode reset to interactive, then container stopped.
+        mock_client.update_workspace.assert_called_once_with(
+            "ws-id", egress_mode="interactive"
+        )
+        mock_client.stop_workspace_by_id.assert_called_once_with("ws-id")
+        # The service command is not fired during sandbox -- no terminal_start.
         sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
-        assert any(m.get("cmd") == "terminal_start" for m in sent)
-
-    async def test_terminal_start_disconnect_is_not_fatal(self):
-        """A closed connection while awaiting terminal_started is tolerated."""
-        from pathlib import Path
-
-        import websockets
-
-        from klangk.cli.main import sandbox_setup_only
-        from klangk.cli.sandbox import SandboxConfig
-
-        config = SandboxConfig(
-            setup="setup.sh", service_command="openclaw gateway"
-        )
-
-        mock_ws = AsyncMock()
-        mock_ws.recv = AsyncMock(
-            side_effect=[
-                json.dumps({"type": "container_ready"}),
-                websockets.ConnectionClosed(None, None),
-            ]
-        )
-
-        with (
-            patch("klangk.cli.transport.websockets.connect") as mock_connect,
-            patch("klangk.cli.main.sandbox_setup") as mock_setup,
-        ):
-            mock_connect.return_value.__aenter__ = AsyncMock(
-                return_value=mock_ws
-            )
-            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_setup.return_value = 0
-            # Must not raise / hang waiting for terminal_started.
-            await sandbox_setup_only(
-                "http://test",
-                "token",
-                "ws-id",
-                config,
-                Path("/tmp"),
-                "admin",
-            )
+        assert not any(m.get("cmd") == "terminal_start" for m in sent)
 
     async def test_marks_setup_state_pending_then_complete(self):
         """With a client, sandbox_setup_only marks pending then complete (#1033)."""
@@ -4537,9 +4517,12 @@ class TestSandboxSetupOnly:
 
         calls = [c.args for c in mock_client.set_setup_state.call_args_list]
         assert ("ws-id", "failed") in calls
-        # terminal_start NOT sent on failure
-        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
-        assert not any(m.get("cmd") == "terminal_start" for m in sent)
+        # #2404: even on failure the workspace drops back to interactive and
+        # is stopped (don't leave a broken install in wide-open allow mode).
+        mock_client.update_workspace.assert_called_once_with(
+            "ws-id", egress_mode="interactive"
+        )
+        mock_client.stop_workspace_by_id.assert_called_once_with("ws-id")
 
     async def test_copies_files(self, tmp_path):
         from klangk.cli.main import sandbox_setup

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4305,7 +4305,7 @@ class TestSandboxCommand:
         # #2404: --force re-setup flips egress_mode back to 'allow' and
         # restarts first (a prior run reset it to interactive).
         client.update_workspace.assert_called_once_with(
-            ws.id, egress_mode="allow"
+            ws.id, egress_mode="allow", setup_state="pending"
         )
         client.restart_workspace_by_id.assert_called_once_with(ws.id)
 
@@ -4449,7 +4449,6 @@ class TestSandboxSetupOnly:
 
         config = SandboxConfig(
             setup="setup.sh",
-            service_command="openclaw gateway",
             auto_start=True,
         )
 
@@ -4498,7 +4497,7 @@ class TestSandboxSetupOnly:
         from klangk.cli.sandbox import SandboxConfig
 
         config = SandboxConfig(
-            setup="setup.sh", service_command="openclaw gateway"
+            setup="setup.sh",
         )
 
         mock_ws = AsyncMock()
@@ -4530,6 +4529,104 @@ class TestSandboxSetupOnly:
         mock_client.config.assert_called_once_with()
         mock_client.update_workspace.assert_not_called()
         mock_client.stop_workspace_by_id.assert_not_called()
+
+    async def test_fires_service_command_when_left_in_allow(self):
+        """Staying in allow keeps the container running -> fire the service cmd.
+
+        An auto-start sandbox is left in allow with its container running, so
+        the service command must still fire after setup (#1033, deferred until
+        setup_state is complete) -- otherwise an unattended service workspace
+        would never start its service. The reset branch omits this (it stops
+        the container; the service re-fires on the next start).
+        """
+        from pathlib import Path
+
+        from klangk.cli.main import sandbox_setup_only
+        from klangk.cli.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh",
+            service_command="openclaw gateway",
+            auto_start=True,
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "container_ready"}),
+                json.dumps({"type": "terminal_started"}),
+            ]
+        )
+        mock_client = MagicMock()
+
+        with (
+            patch("klangk.cli.transport.websockets.connect") as mock_connect,
+            patch("klangk.cli.main.sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
+            await sandbox_setup_only(
+                "http://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+                client=mock_client,
+            )
+
+        # Left in allow (not reset / not stopped) AND the service command fired.
+        mock_client.update_workspace.assert_not_called()
+        mock_client.stop_workspace_by_id.assert_not_called()
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        assert any(m.get("cmd") == "terminal_start" for m in sent)
+
+    async def test_terminal_start_disconnect_when_left_in_allow(self):
+        """A closed connection while awaiting terminal_started is tolerated."""
+        from pathlib import Path
+
+        import websockets
+
+        from klangk.cli.main import sandbox_setup_only
+        from klangk.cli.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh",
+            service_command="openclaw gateway",
+            auto_start=True,
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "container_ready"}),
+                websockets.ConnectionClosed(None, None),
+            ]
+        )
+        mock_client = MagicMock()
+
+        with (
+            patch("klangk.cli.transport.websockets.connect") as mock_connect,
+            patch("klangk.cli.main.sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
+            # Must not raise / hang waiting for terminal_started.
+            await sandbox_setup_only(
+                "http://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+                client=mock_client,
+            )
 
     async def test_marks_setup_state_pending_then_complete(self):
         """With a client, sandbox_setup_only marks pending then complete (#1033)."""

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4234,7 +4234,7 @@ class TestSandboxCommand:
         # only runs on --force re-setup, so neither is called here.
         client.update_workspace.assert_not_called()
         client.restart_workspace.assert_not_called()
-        assert "egress reset to interactive" in result.output
+        client.restart_workspace_by_id.assert_not_called()
 
     def test_existing_workspace_errors_without_force(
         self, logged_in_cfg, tmp_path
@@ -4307,7 +4307,7 @@ class TestSandboxCommand:
         client.update_workspace.assert_called_once_with(
             ws.id, egress_mode="allow"
         )
-        client.restart_workspace.assert_called_once_with("myws")
+        client.restart_workspace_by_id.assert_called_once_with(ws.id)
 
     def test_setup_connection_error(self, logged_in_cfg, tmp_path):
         from klangk.cli import main
@@ -4403,6 +4403,8 @@ class TestSandboxSetupOnly:
             return_value=json.dumps({"type": "container_ready"})
         )
         mock_client = MagicMock()
+        # Server has a network sidecar, so the reset to interactive is safe.
+        mock_client.config.return_value = {"netfilter_enabled": True}
 
         with (
             patch("klangk.cli.transport.websockets.connect") as mock_connect,
@@ -4431,6 +4433,103 @@ class TestSandboxSetupOnly:
         # The service command is not fired during sandbox -- no terminal_start.
         sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
         assert not any(m.get("cmd") == "terminal_start" for m in sent)
+
+    async def test_leaves_allow_for_auto_start_workspace(self):
+        """An auto-start workspace stays in allow (#2404).
+
+        Auto-start workspaces boot unattended with no consent decider
+        connected; interactive mode DENIES egress then, so their service
+        command could never reach its upstream. The driver leaves them in
+        allow rather than resetting.
+        """
+        from pathlib import Path
+
+        from klangk.cli.main import sandbox_setup_only
+        from klangk.cli.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh",
+            service_command="openclaw gateway",
+            auto_start=True,
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps({"type": "container_ready"})
+        )
+        mock_client = MagicMock()
+
+        with (
+            patch("klangk.cli.transport.websockets.connect") as mock_connect,
+            patch("klangk.cli.main.sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
+            await sandbox_setup_only(
+                "http://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+                client=mock_client,
+            )
+
+        # Not reset / not stopped; config isn't even consulted (auto-start
+        # short-circuits the sidecar check).
+        mock_client.config.assert_not_called()
+        mock_client.update_workspace.assert_not_called()
+        mock_client.stop_workspace_by_id.assert_not_called()
+
+    async def test_leaves_allow_when_no_network_sidecar(self):
+        """No server sidecar -> stay in allow (#2404).
+
+        interactive is fail-closed without a sidecar (start_container
+        refuses to start unfiltered), so resetting would make the workspace
+        unconnectable. The driver reads netfilter_enabled from the config
+        and leaves the workspace in allow when it's off.
+        """
+        from pathlib import Path
+
+        from klangk.cli.main import sandbox_setup_only
+        from klangk.cli.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh", service_command="openclaw gateway"
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps({"type": "container_ready"})
+        )
+        mock_client = MagicMock()
+        mock_client.config.return_value = {"netfilter_enabled": False}
+
+        with (
+            patch("klangk.cli.transport.websockets.connect") as mock_connect,
+            patch("klangk.cli.main.sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
+            await sandbox_setup_only(
+                "http://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+                client=mock_client,
+            )
+
+        mock_client.config.assert_called_once_with()
+        mock_client.update_workspace.assert_not_called()
+        mock_client.stop_workspace_by_id.assert_not_called()
 
     async def test_marks_setup_state_pending_then_complete(self):
         """With a client, sandbox_setup_only marks pending then complete (#1033)."""
@@ -4495,6 +4594,7 @@ class TestSandboxSetupOnly:
         )
         mock_client = MagicMock()
         mock_client.set_setup_state = MagicMock()
+        mock_client.config.return_value = {"netfilter_enabled": True}
 
         with (
             patch("klangk.cli.transport.websockets.connect") as mock_connect,


### PR DESCRIPTION
## Summary

Closes #2404.

`klangk sandbox` already created the workspace in `allow` mode (#2406) so
`setup.sh`'s `npm`/`git`/`pip` could egress without a consent decider — but it
then **stayed in `allow` mode indefinitely**. This PR adds the missing posture
transition: once `setup.sh` returns, the driver resets `egress_mode` to
`interactive` and stops the container.

`egress_mode` is enforced by the network sidecar at container **start**, not on
the live container, so the stop is what makes the reset take effect — the next
`klangk shell` brings the workspace up in consent-gated `interactive` mode, with
the connecting human as the decider. This replaces the earlier
"default-allow curated host list" idea from the issue (no list to curate or
maintain).

The service command is **no longer fired during `klangk sandbox`** — it re-fires
at the create choke point on that next start, so firing it just to kill it on
stop would be wasted.

## Changes

- **`sandbox_setup_only`** — after marking `setup_state`, resets
  `egress_mode` → `interactive` and stops the container (best-effort, warns on
  failure). Removed the `terminal_start` service-command firing (moot once the
  container is stopped).
- **`sandbox()`** — on `--force` re-setup, flips `egress_mode` back to `allow`
  and restarts *before* re-running setup (a prior sandbox run would have left
  the workspace `interactive`, which would hang the re-install). Skipped on the
  create path (already `allow`).
- **`KlangkClient.stop_workspace_by_id`** — id-based counterpart to
  `stop_workspace`, for the sandbox driver which already holds the workspace id.
- Changelog entry under `### Changed`.

## Tests

- Replaced the two obsolete `terminal_start` tests with
  `test_resets_egress_and_stops_after_setup`.
- Extended `test_force_reruns_setup` (asserts the `allow` flip + restart) and
  `test_creates_workspace` (asserts neither runs on the create path).
- `test_marks_setup_state_failed_on_setup_failure` now also asserts the reset +
  stop happen on failure (don't leave a broken install in wide-open `allow`).
- Added `test_stop_workspace_by_id_calls_post`.

Full suite: **4960 passed, 100% coverage**.
