### PR TITLE
test(egress-smoketest): fix controlled-DNS probe timeout + silent degradation (#2473)

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
@@ -573,8 +573,14 @@ class ControlledDns:
             "ip addr add $ip/16 dev eth0 2>/dev/null || true; done",
         )
 
-    def _wait_target_ready(self, timeout: float = 20.0) -> None:
-        """A peer on the network can open a TCP connection to each target IP."""
+    def _wait_target_ready(self, timeout: float = 30.0) -> None:
+        """A peer on the network can open a TCP connection to each target IP.
+
+        Retries until ``timeout``. Each :meth:`_probe_target` iteration is
+        bounded by the single per-IP connect timeout (the IPs are probed in
+        parallel), so this budget buys several retries rather than being eaten
+        by one slow iteration (#2473).
+        """
         deadline = time.time() + timeout
         last = ""
         while time.time() < deadline:
@@ -588,17 +594,29 @@ class ControlledDns:
         )
 
     def _probe_target(self) -> str:
-        """'' if every target IP accepts a TCP :443 connect, else an error."""
+        """'' if every target IP accepts a TCP :443 connect, else an error.
+
+        The probe container connects to every target IP **in parallel** (one
+        thread per IP, each with its own 3s connect timeout), so one iteration
+        is bounded by ~3s + podman overhead rather than 31x3s. A sequential
+        probe made the readiness deadline shorter than a single iteration, so
+        a transiently slow target never got a retry (#2473).
+        """
         # Run a single ephemeral probe container that tries every IP at once.
         script = (
-            "import socket,sys\n"
+            "import socket,threading\n"
+            "ips=%r\n"
             "bad=[]\n"
-            "for ip in %r:\n"
+            "lock=threading.Lock()\n"
+            "def probe(ip):\n"
             "    try:\n"
             "        s=socket.create_connection((ip,443),timeout=3); s.close()\n"
             "    except Exception as e:\n"
-            "        bad.append(ip+':'+type(e).__name__)\n"
-            "print('BAD '+','.join(bad) if bad else 'OK')\n"
+            "        with lock: bad.append(ip+':'+type(e).__name__)\n"
+            "ts=[threading.Thread(target=probe,args=(ip,)) for ip in ips]\n"
+            "for t in ts: t.start()\n"
+            "for t in ts: t.join()\n"
+            "print('BAD '+','.join(sorted(bad)) if bad else 'OK')\n"
         ) % (self._p.ips,)
         try:
             r = subprocess.run(

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -1207,7 +1207,27 @@ class SmokeTest:
                     f"!! controlled-dns failed to start: {exc!r}",
                     file=sys.stderr,
                 )
-                self.dns = None
+                # Remove the partially-started fixture (e.g. a target container
+                # created before the readiness probe failed) so it isn't left
+                # running. _cleanup_sync/atexit would also catch it, but this is
+                # the direct path.
+                if self.dns is not None:
+                    await asyncio.to_thread(self.dns.stop)
+                    self.dns = None
+                # Fail hard: controlled-DNS was requested (the default) and the
+                # whole point of the fixture is to make the fuzz run
+                # deterministic (#2424). Silently degrading to real DNS makes
+                # every later phase's result indeterminate while the run still
+                # prints a healthy-looking plan line, so the operator must opt
+                # out explicitly with --no-controlled-dns to accept real DNS
+                # (#2473).
+                raise RuntimeError(
+                    "controlled-DNS is required for a deterministic fuzz run, "
+                    "but the fixture failed to start (see above). Re-run with "
+                    "--no-controlled-dns to allow real DNS (the "
+                    "snapshot/host-scope/port-scope/co-resident phases will be "
+                    "skipped)."
+                ) from exc
         if self.args.server:
             url = self.args.server.rstrip("/")
             self.server = {

--- a/src/klangk/klangkd-tests/tests/test_controlled_dns.py
+++ b/src/klangk/klangkd-tests/tests/test_controlled_dns.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 # Make the e2e-tests dir importable (it's not on sys.path by default for the
 # unit test suite) — same pattern as test_e2e_env.py.
 _E2E_DIR = Path(__file__).resolve().parents[1] / "e2e-tests"
@@ -108,3 +110,95 @@ def test_cleanup_prefix_guard_avoids_substring_match(monkeypatch):
     monkeypatch.setattr(cd.subprocess, "run", fake_run)
     assert cd.cleanup_stale_containers() == ["ctrl-dns-target-9"]
     assert removed_via_rm == ["ctrl-dns-target-9"]
+
+
+def test_probe_target_empty_on_ok(monkeypatch):
+    """``_probe_target`` returns ``''`` when the probe container prints ``OK``,
+    and the probe connects to every IP concurrently (one thread per IP) so a
+    single iteration is bounded by the per-IP timeout, not N x it (#2473)."""
+    captured: dict[str, str] = {}
+
+    def fake_run(args, **kwargs):
+        captured["script"] = args[-1]
+        return _ok("OK")
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+    c = cd.ControlledDns()
+    c._p.ips = ["10.88.0.200", "10.88.0.201"]
+    assert c._probe_target() == ""
+    assert "threading" in captured["script"]
+    assert "create_connection" in captured["script"]
+
+
+def test_probe_target_returns_bad_list(monkeypatch):
+    """A probe that finds unreachable IPs returns the ``BAD ...`` line (so the
+    readiness loop can retry)."""
+    monkeypatch.setattr(
+        cd.subprocess,
+        "run",
+        lambda *a, **k: _ok("BAD 10.88.0.201:TimeoutError"),
+    )
+    c = cd.ControlledDns()
+    c._p.ips = ["10.88.0.200", "10.88.0.201"]
+    assert c._probe_target() == "BAD 10.88.0.201:TimeoutError"
+
+
+def test_probe_target_reports_subprocess_failure(monkeypatch):
+    """A ``podman run`` timeout surfaces as ``'probe raised: ...'`` rather than
+    crashing the readiness loop."""
+
+    def fake_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args, timeout=30)
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+    c = cd.ControlledDns()
+    c._p.ips = ["10.88.0.200"]
+    assert c._probe_target().startswith("probe raised:")
+
+
+def test_wait_target_ready_retries_until_ok(monkeypatch):
+    """Readiness retries: a target unreachable-then-reachable returns rather
+    than raising — the deadline must outlast more than one probe (#2473)."""
+    seq = ["BAD 10.88.0.200:TimeoutError", "OK"]
+    calls = {"n": 0}
+
+    def fake_run(args, **kwargs):
+        i = calls["n"]
+        calls["n"] += 1
+        return _ok(seq[min(i, len(seq) - 1)])
+
+    monkeypatch.setattr(cd.subprocess, "run", fake_run)
+    monkeypatch.setattr(cd.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(cd.time, "time", lambda: 100.0)  # deadline never hit
+
+    c = cd.ControlledDns()
+    c._p.ips = ["10.88.0.200"]
+    c._wait_target_ready(timeout=30.0)  # returns, does not raise
+    assert calls["n"] >= 2  # retried at least once before success
+
+
+def test_wait_target_ready_raises_when_never_reachable(monkeypatch):
+    """If the target never becomes reachable the loop exhausts its deadline and
+    raises (rather than silently succeeding or hanging)."""
+    monkeypatch.setattr(
+        cd.subprocess,
+        "run",
+        lambda *a, **k: _ok("BAD 10.88.0.200:TimeoutError"),
+    )
+    monkeypatch.setattr(cd.time, "sleep", lambda *_a, **_k: None)
+    # time.time(): 100 for the deadline set + first while-check, then far in the
+    # future so the next while-check sees the deadline exceeded and exits.
+    times = [100.0, 100.0, 1e12]
+    idx = {"i": 0}
+
+    def fake_time():
+        v = times[min(idx["i"], len(times) - 1)]
+        idx["i"] += 1
+        return v
+
+    monkeypatch.setattr(cd.time, "time", fake_time)
+
+    c = cd.ControlledDns()
+    c._p.ips = ["10.88.0.200", "10.88.0.201"]
+    with pytest.raises(RuntimeError, match="did not become reachable"):
+        c._wait_target_ready(timeout=30.0)


### PR DESCRIPTION
## Summary

Fixes #2473 — the egress fuzzer's controlled-DNS fixture failed its target-readiness probe and the smoketest **silently degraded to real DNS**, defeating the determinism the fixture exists to provide (#2424). The run kept printing a healthy-looking `plan:` line while every later phase lost its single-stable-IP guarantee.

Two linked root causes, both fixed:

1. **Readiness deadline shorter than one probe iteration.** `_probe_target` connected to all 31 secondary target IPs *sequentially* (31 × 3s worst case), but `_wait_target_ready` gave up after **20s** and a single `podman run` already had a 30s subprocess timeout. So the first transiently-slow probe exhausted the readiness budget and `start()` raised on attempt #1 — no retry.

2. **Silent degradation.** On fixture start failure the smoketest set `self.dns = None` and continued, so the fuzzer ran against real hosts/CDN IP rotation — the indeterminism #2424 was built to remove — with only an easily-missed `!!` stderr line to signal it.

## Changes

- **`_controlled_dns.py` → `_probe_target`**: probe the IPs **in parallel** (one thread per IP, each with its own 3s connect timeout) so a single iteration is bounded by ~3s + podman overhead rather than ~93s.
- **`_controlled_dns.py` → `_wait_target_ready`**: deadline bumped 20s → 30s so the loop actually retries before giving up (each iteration is now bounded, so 30s buys ~5–6 retries).
- **`smoketest_egress.py`**: on controlled-DNS start failure, stop the partially-started fixture and **raise** instead of setting `self.dns = None`. `main()`'s existing backstop turns that into a clean `smoketest aborted: …` message + exit 1. The operator must explicitly pass `--no-controlled-dns` to accept real DNS (the snapshot/host-scope/port-scope/co-resident phases self-skip under that flag, as before).
- **`test_controlled_dns.py`**: 5 new tests — `_probe_target`'s return-value contract (incl. an assertion that the probe script uses `threading`, guarding against a regression to sequential), and `_wait_target_ready`'s retry-then-succeed and deadline-exhausted paths.

## Verification

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` → **4978 passed, 100% coverage**.
- Ran the interpolated parallel probe script locally against fast-refusing targets → concurrent, correct `BAD <ip>:<Error>` output (~0.09s for 2 IPs).

No `docs/changes.md` entry — this is test-harness-only (`klangkd-tests/`), no shipped product behavior change.
