### PR TITLE
feat(consent): persistent popup role for consent-decide + doctor tmux check (#2383) PR 1

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,17 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`klangk shell` consent-decider popup (#2383).** Shelling into an
+  `interactive`-egress workspace now wraps the shell in a local tmux that
+  floats the egress-consent decider over it as a `tmux display-popup`, so
+  held egress requests can be acted on without leaving the shell. The shell
+  itself is unchanged (the normal container tmux, full window machinery
+  incl. the status-bar `+`); the outer local tmux is nearly invisible
+  (`C-a` prefix, no status bar, mouse passes through to the container tmux).
+  `C-a p` reopens the popup, `q` hides it (decider stays registered), `Q`
+  quits for real. Falls back to the plain shell when host tmux < 3.2, stdin
+  is not a tty, or `--no-consent-popup` is passed.
+
 - **`klangkd doctor` tmux version check (#2383).** Doctor now reports the
   host tmux version and warns when it is below 3.2 — the minimum for the
   upcoming TUI consent-decider popup over the shell (`tmux display-popup`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,18 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`klangkd doctor` tmux version check (#2383).** Doctor now reports the
+  host tmux version and warns when it is below 3.2 — the minimum for the
+  upcoming TUI consent-decider popup over the shell (`tmux display-popup`
+  landed in 3.2). Below 3.2 the shell layer will fall back to a plain
+  attach, so the check is a warning, not an error.
+- **`klangk consent-decide` persistent popup role (#2383).** The decider
+  accepts internal `--popup-socket` / `--popup-session` options (set by the
+  shell-layer wrapper) for its upcoming persistent role inside a hidden tmux
+  session: in that role `q` hides the popup viewer (detaching it, leaving the
+  decider registered) and `Q` confirms a real quit. Standalone `q` still
+  quits immediately.
+
 - **`KLANGKNETWORK_EGRESS_UPSTREAM` — operator-pinnable sidecar DNS upstream (#2424).**
   When set in `klangkd`'s environment, the network sidecar's FQDN proxy forwards
   workspace DNS to this resolver verbatim instead of auto-detecting a host

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -2876,6 +2876,25 @@ def consent_decide(
             "(match the server's KLANGKD_EGRESS_CONSENT_TIMEOUT)."
         ),
     ),
+    popup_socket: str = typer.Option(
+        None,
+        "--popup-socket",
+        hidden=True,
+        help=(
+            "Internal: tmux socket of the hidden decider session. Set by "
+            "the shell-layer wrapper to enable the persistent popup role "
+            "(#2383); `q` hides the viewer instead of quitting."
+        ),
+    ),
+    popup_session: str = typer.Option(
+        None,
+        "--popup-session",
+        hidden=True,
+        help=(
+            "Internal: name of the hidden decider tmux session (#2383). "
+            "Set together with --popup-socket."
+        ),
+    ),
 ) -> None:
     """Decide a workspace's held egress requests live (#2310).
 
@@ -2900,6 +2919,8 @@ def consent_decide(
         ws.name,
         hold_timeout=hold_timeout,
         max_size=ws_max_size(),
+        popup_socket=popup_socket,
+        popup_session=popup_session,
     ).run()
 
 

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -69,6 +69,16 @@ from .sandbox import (
     load_sandbox_config,
     resolve_setup_command,
 )
+from .shell_popup import (
+    EGRESS_INTERACTIVE,
+    OUTER_PREFIX,
+    REOPEN_KEY,
+    hidden_session_name,
+    host_tmux_version,
+    run_consent_shell,
+    should_use_popup,
+    socket_path,
+)
 
 app = typer.Typer(
     name="klangk",
@@ -1363,6 +1373,82 @@ def resolve_forward_agent(
     return result
 
 
+# ---------------------------------------------------------------------------
+# Consent-popup shell wrapper (the "tmux russian-doll", #2383)
+# ---------------------------------------------------------------------------
+
+
+def _klangk_argv(*args: str) -> list[str]:
+    """Argv re-invoking this klangk CLI (same interpreter + module)."""
+    return [sys.executable, "-m", "klangk.cli.main", *args]
+
+
+def _popup_inner_shell_argv(
+    server: str, ws_name: str, target: str | None, forward_agent: bool
+) -> list[str]:
+    """The normal ``klangk shell`` that runs inside the outer tmux window.
+
+    Adds ``--no-consent-popup`` as a recursion guard so the inner does the
+    plain attach instead of re-wrapping.
+    """
+    argv = _klangk_argv("--server", server, "shell", ws_name)
+    if target:
+        argv.append(target)
+    argv.append("--no-consent-popup")
+    argv.append("--forward-agent" if forward_agent else "--no-forward-agent")
+    return argv
+
+
+def _popup_decider_argv(
+    server: str, ws_arg: str, socket: str, hidden: str
+) -> list[str]:
+    """The ``klangk consent-decide`` invocation for the hidden decider session."""
+    return _klangk_argv(
+        "--server",
+        server,
+        "consent-decide",
+        ws_arg,
+        "--popup-socket",
+        socket,
+        "--popup-session",
+        hidden,
+    )
+
+
+def _consent_popup_enabled(ws, no_consent_popup: bool) -> bool:
+    """True when ``klangk shell`` should wrap in the consent-popup russian-doll."""
+    # Cheap checks first so non-interactive / non-tty contexts (incl. the test
+    # suite, which calls shell() directly) never spawn `tmux -V`.
+    if (
+        no_consent_popup
+        or ws.egress_mode != EGRESS_INTERACTIVE
+        or not sys.stdin.isatty()
+    ):
+        return False
+    return should_use_popup(
+        ws.egress_mode,
+        isatty=True,
+        tmux_version=host_tmux_version(),
+    )
+
+
+def _run_consent_popup(ws, terminal: str | None, forward_agent: bool) -> int:
+    """Bring up the consent-popup russian-doll + attach the user to it (#2383)."""
+    server = server_url()
+    socket = socket_path(ws.id)
+    hidden = hidden_session_name(ws.id)
+    inner = _popup_inner_shell_argv(server, ws.name, terminal, forward_agent)
+    decider = _popup_decider_argv(server, ws.name, socket, hidden)
+    _err.print(f"Connecting to [bold]{ws.name}[/bold] with consent popup…")
+    _err.print(
+        f"[dim]A consent popup appears when an egress request is held; "
+        f"{OUTER_PREFIX} {REOPEN_KEY} reopens  ·  q/Q hides[/dim]"
+    )
+    return run_consent_shell(
+        workspace_id=ws.id, inner_argv=inner, decider_argv=decider
+    )
+
+
 @app.command()
 def shell(
     workspace: str | None = typer.Argument(
@@ -1382,12 +1468,24 @@ def shell(
         "-A",
         help="Forward local SSH agent into the container",
     ),
+    no_consent_popup: bool = typer.Option(
+        False,
+        "--no-consent-popup",
+        hidden=True,
+        help=(
+            "Internal: skip the consent-popup shell wrapper. Set by the "
+            "wrapper itself when it re-runs the shell inside the outer tmux "
+            "(#2383)."
+        ),
+    ),
 ) -> None:
     """Connect to a workspace shell."""
     # When called directly (not via typer CLI), forward_agent may be a
     # typer.models.OptionInfo instead of bool/None.  Normalize to None.
     if not isinstance(forward_agent, bool):
         forward_agent = None
+    if not isinstance(no_consent_popup, bool):
+        no_consent_popup = False
     token = _state().get_token(server_url())
     if not token:  # pragma: no cover
         _err.print(
@@ -1430,6 +1528,12 @@ def shell(
         forward_agent,
         config_default=_cfg().get_forward_agent(server_url()) or False,
     )
+    if _consent_popup_enabled(ws, no_consent_popup):
+        # Wrap the normal shell in the consent-popup russian-doll (#2383).
+        # Falls back to the plain attach below when tmux is prevented, opted
+        # out (--no-consent-popup / the inner re-invocation), or the workspace
+        # is not interactive-egress.
+        raise typer.Exit(code=_run_consent_popup(ws, terminal, forward_agent))
     try:
         asyncio.run(
             ws_shell(

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -1,0 +1,444 @@
+"""Client-side consent-popup shell wrapper — the "tmux russian-doll" (#2383).
+
+When a user shells into an ``interactive``-egress workspace, ``klangk shell``
+wraps the normal shell in a *local* tmux (on the user's machine) that also
+hosts the consent decider, and floats the decider over the shell in a
+``display-popup``. The shell itself is unchanged — it is the normal
+``klangk shell`` (the container's tmux, full machinery) running in the outer
+tmux's window.
+
+Layout (one local tmux server, per-workspace socket):
+
+- **outer session** ``klangk-shell-<ws>`` — window 0 runs the inner
+  ``klangk shell`` (today's container-tmux shell). Configured to be nearly
+  invisible: ``prefix C-a`` (distinct from the inner ``C-b``), ``status off``,
+  ``mouse off``. Because the outer tmux is first in the keypath, it consumes
+  only ``C-a``; everything else (``C-b``, raw mouse clicks) passes through to
+  the inner container tmux — so the inner status-bar ``+`` and window keys
+  keep working exactly as today.
+- **hidden session** ``klangk-consent-<ws>`` — runs ``klangk consent-decide``
+  in its persistent popup role (PR 1). Always registered while you shell.
+- **popup viewer** — a ``display-popup`` on the outer tmux that attaches to
+  the hidden session, auto-shown on client-attach and reopened with ``C-a p``.
+  ``q`` (in the decider) detaches the viewer (hides it; decider stays
+  registered); ``Q`` confirms a real quit.
+
+No server change: the inner shell is the normal ``klangk shell`` and the
+decider / popup are purely client-side. Stays within ``klangk.cli`` (only
+stdlib + third-party + sibling cli modules).
+
+The tmux command sequence is built by pure, unit-tested builders; the
+orchestrator runs them through an injectable runner so the sequence is
+testable without a live tmux. Interactive tmux behaviour (popup rendering,
+hook targeting, sizing) is validated manually.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+# display-popup landed in tmux 3.2; below that the wrapper falls back to a
+# plain attach.
+TMUX_MIN_VERSION = (3, 2)
+
+# Only interactive-egress workspaces hold egress requests for the decider to
+# act on; for allow/static egress there is nothing to decide, so no wrapper.
+EGRESS_INTERACTIVE = "interactive"
+
+# The outer (local) tmux prefix is deliberately NOT C-b: the inner container
+# tmux uses C-b, and the outer must steal a different prefix so its popup
+# controls are reachable. C-a is the conventional nested-tmux outer prefix.
+OUTER_PREFIX = "C-a"
+# Reopen the (hidden) consent popup: <outer-prefix> + this key.
+REOPEN_KEY = "p"
+
+# Default consent-popup viewer size (cols x rows). Sized to read the decider
+# comfortably without covering the whole shell.
+DEFAULT_POPUP_SIZE = (70, 14)
+
+
+# ---------------------------------------------------------------------------
+# tmux detection + naming
+# ---------------------------------------------------------------------------
+
+
+def parse_tmux_version(out: str) -> tuple[int, int] | None:
+    """Parse ``tmux -V`` output (e.g. ``"tmux 3.6a"``) -> ``(3, 6)``.
+
+    Returns None when no ``MAJOR.MINOR`` pair is present.
+    """
+    m = re.search(r"(\d+)\.(\d+)", out)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def host_tmux_version() -> tuple[int, int] | None:
+    """The host tmux version, or None if tmux is absent / unparseable."""
+    if not shutil.which("tmux"):
+        return None
+    try:
+        proc = subprocess.run(
+            ["tmux", "-V"], capture_output=True, text=True, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return parse_tmux_version(proc.stdout)
+
+
+def tmux_usable(version: tuple[int, int] | None) -> bool:
+    """True when the host tmux is present and new enough for display-popup."""
+    return version is not None and version >= TMUX_MIN_VERSION
+
+
+def _sanitize(name: str) -> str:
+    """Make a tmux-safe session-name fragment (no ``.`` or ``:``)."""
+    return re.sub(r"[^A-Za-z0189_-]", "-", name)[:24] or "ws"
+
+
+def socket_path(workspace_id: str) -> str:
+    """Stable per-workspace local tmux socket path.
+
+    Per-user dir under the temp dir so concurrent users don't collide and a
+    startup sweep can find leftovers.
+    """
+    uid = os.getuid() if hasattr(os, "getuid") else 0
+    base = os.path.join(tempfile.gettempdir(), f"klangk-shell-{uid}")
+    try:
+        os.makedirs(base, exist_ok=True)
+    except OSError:
+        # Fall back to a process-specific path if the shared dir is unwritable;
+        # the wrapper still works, just not sweepable across runs.
+        base = os.path.join(
+            tempfile.gettempdir(), f"klangk-shell-{uid}-{os.getpid()}"
+        )
+        os.makedirs(base, exist_ok=True)
+    return os.path.join(base, f"{_sanitize(workspace_id)}.sock")
+
+
+def outer_session_name(workspace_id: str) -> str:
+    return f"klangk-shell-{_sanitize(workspace_id)}"
+
+
+def hidden_session_name(workspace_id: str) -> str:
+    return f"klangk-consent-{_sanitize(workspace_id)}"
+
+
+# ---------------------------------------------------------------------------
+# pure tmux command builders
+# ---------------------------------------------------------------------------
+
+
+def _tmux(socket: str, *args: str) -> list[str]:
+    return ["tmux", "-S", socket, *args]
+
+
+def new_detached_session(
+    socket: str, session: str, argv: list[str], *, x: int, y: int
+) -> list[str]:
+    """``tmux new-session -d`` running *argv* at the given size."""
+    return _tmux(
+        socket,
+        "new-session",
+        "-d",
+        "-s",
+        session,
+        "-x",
+        str(x),
+        "-y",
+        str(y),
+        *argv,
+    )
+
+
+def configure_hidden_session(socket: str, session: str) -> list[list[str]]:
+    """Hide the hidden session's status bar so the popup shows only the decider.
+
+    Without this the consent popup renders the decider PLUS a tmux status bar
+    across its bottom (#2383).
+    """
+    return [_tmux(socket, "set-option", "-t", session, "status", "off")]
+
+
+def configure_outer_session(socket: str, session: str) -> list[list[str]]:
+    """Make the outer session nearly invisible + pass-through for the inner.
+
+    - ``prefix C-a``: steal a prefix distinct from the inner container tmux's
+      ``C-b`` so the outer's popup controls are reachable.
+    - ``status off``: no second status bar — only the inner container tmux's
+      familiar status bar (with its ``+``) shows.
+    - ``mouse off``: the outer does not intercept mouse events, so raw mouse
+      sequences pass through to the inner container tmux (its ``+`` etc.).
+    """
+    return [
+        _tmux(socket, "set-option", "-t", session, "prefix", OUTER_PREFIX),
+        _tmux(socket, "set-option", "-t", session, "status", "off"),
+        _tmux(socket, "set-option", "-t", session, "mouse", "off"),
+    ]
+
+
+def popup_viewer_shell_string(socket: str, hidden: str) -> str:
+    """Shell command the popup runs: a client attaching to the hidden session.
+
+    ``env -u TMUX`` unsets TMUX so the nested attach is permitted (the popup
+    itself runs inside the outer tmux, where TMUX is set).
+    """
+    return f"env -u TMUX tmux -S {socket} attach -t {hidden}"
+
+
+def display_popup_command(socket: str, hidden: str, *, w: int, h: int) -> str:
+    """tmux command string that shows the consent popup (hook + binding value).
+
+    ``-E`` closes the popup when its command (the viewer attach) exits — i.e.
+    when the user hides it with ``q`` (which detaches the viewer). The popup
+    uses tmux's default centered position; an earlier bottom-right ``-x/-y``
+    docking was dropped — the ``#{e|-:...}`` arithmetic value made tmux
+    reject the command ("-x expects an argument").
+
+    The shell-command MUST be the final positional: tmux's ``display-popup``
+    treats it as absorbing every trailing token, so all options (``-w -h``)
+    have to come before it or they get swallowed into the command and the
+    popup renders blank.
+    """
+    viewer = popup_viewer_shell_string(socket, hidden)
+    return f"display-popup -E -w {w} -h {h} {shlex.quote(viewer)}"
+
+
+def popup_binding_cmds(
+    socket: str, hidden: str, *, w: int, h: int
+) -> list[list[str]]:
+    """The ``<outer-prefix> p`` reopen binding.
+
+    No auto-show hook: the popup is shown only when the decider receives a
+    held request (it runs :func:`show_popup_argv` itself), so the user is not
+    bothered at shell startup when there is nothing to decide.
+    """
+    cmd = display_popup_command(socket, hidden, w=w, h=h)
+    # bind-key in the prefix table -> <outer-prefix> + REOPEN_KEY.
+    return [_tmux(socket, "bind-key", REOPEN_KEY, cmd)]
+
+
+def outer_clients(socket: str, hidden: str) -> list[str]:
+    """tmux clients attached to a session other than the hidden one.
+
+    These are the user's shell client(s) to show the popup on. The hidden
+    session's own viewer client (when the popup is open) is excluded.
+    """
+    try:
+        proc = subprocess.run(
+            _tmux(
+                socket,
+                "list-clients",
+                "-F",
+                "#{client_name}\t#{client_session}",
+            ),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    clients: list[str] = []
+    for line in proc.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1] != hidden:
+            clients.append(parts[0])
+    return clients
+
+
+def hidden_has_client(socket: str, hidden: str) -> bool:
+    """True when the hidden session has a viewer client attached (popup open)."""
+    try:
+        proc = subprocess.run(
+            _tmux(socket, "list-clients", "-t", hidden),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return bool(proc.stdout.strip())
+
+
+def show_popup_argv(
+    socket: str, hidden: str, client: str, *, w: int, h: int
+) -> list[str]:
+    """Argv to show the popup on a specific client (the decider's show path).
+
+    Unlike :func:`display_popup_command` (a string for the key binding, which
+    targets the invoking client), this is run server-side by the decider when a
+    held request arrives, so it names the target client explicitly with ``-c``.
+    """
+    viewer = popup_viewer_shell_string(socket, hidden)
+    return _tmux(
+        socket,
+        "display-popup",
+        "-c",
+        client,
+        "-E",
+        "-w",
+        str(w),
+        "-h",
+        str(h),
+        viewer,
+    )
+
+
+def attach_cmd(socket: str, session: str) -> list[str]:
+    return _tmux(socket, "attach", "-t", session)
+
+
+def kill_session_cmd(socket: str, session: str) -> list[str]:
+    return _tmux(socket, "kill-session", "-t", session)
+
+
+def has_session_cmd(socket: str, session: str) -> list[str]:
+    return _tmux(socket, "has-session", "-t", session)
+
+
+# ---------------------------------------------------------------------------
+# gate
+# ---------------------------------------------------------------------------
+
+
+def should_use_popup(
+    egress_mode: str | None,
+    *,
+    isatty: bool,
+    tmux_version: tuple[int, int] | None,
+    enabled: bool = True,
+) -> bool:
+    """True when ``klangk shell`` should wrap in the consent-popup russian-doll.
+
+    All four must hold, else today's plain attach:
+    - ``enabled``: not opted out / not the inner re-invocation (recursion guard).
+    - interactive egress (nothing to decide otherwise).
+    - a real tty (the wrapper attaches interactively).
+    - host tmux new enough for display-popup (>= 3.2).
+    """
+    if not enabled:
+        return False
+    if egress_mode != EGRESS_INTERACTIVE:
+        return False
+    if not isatty:
+        return False
+    return tmux_usable(tmux_version)
+
+
+# ---------------------------------------------------------------------------
+# orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _default_run(argv: list[str]) -> int:
+    """Run a tmux control command, logging failures (never raising)."""
+    try:
+        return subprocess.run(argv, check=False).returncode
+    except OSError as exc:
+        logger.warning(
+            "consent-popup tmux command failed: %s (%s)", argv[0], exc
+        )
+        return 1
+
+
+def _default_attach(argv: list[str]) -> int:
+    """Attach the user's terminal to the outer session (blocks until detach)."""
+    return subprocess.call(argv)
+
+
+def run_consent_shell(
+    *,
+    workspace_id: str,
+    inner_argv: list[str],
+    decider_argv: list[str],
+    popup_size: tuple[int, int] = DEFAULT_POPUP_SIZE,
+    term_size: tuple[int, int] | None = None,
+    run=_default_run,
+    attach=_default_attach,
+) -> int:
+    """Bring up the consent-popup russian-doll and attach the user to it.
+
+    *inner_argv* is the normal ``klangk shell`` invocation (re-runs the plain
+    attach inside the outer session's window, with the recursion guard so it
+    does not re-wrap). *decider_argv* is the ``klangk consent-decide``
+    invocation in its persistent popup role. Returns the attach's exit code.
+
+    On any setup failure the outer session may not exist; cleanup is
+    best-effort and never raises.
+    """
+    socket = socket_path(workspace_id)
+    outer = outer_session_name(workspace_id)
+    hidden = hidden_session_name(workspace_id)
+    cols, rows = term_size or _term_size()
+    pw, ph = popup_size
+
+    # 1. outer session running the inner (normal) shell.
+    run(new_detached_session(socket, outer, inner_argv, x=cols, y=rows))
+    # 2. make the outer nearly invisible + inner-friendly.
+    for cmd in configure_outer_session(socket, outer):
+        run(cmd)
+    # 3. hidden decider session (sized to the popup so it doesn't reflow).
+    run(new_detached_session(socket, hidden, decider_argv, x=pw, y=ph))
+    # 3b. hide the hidden session's status bar so the popup shows only the
+    #     decider (no tmux status bar across the popup's bottom).
+    for cmd in configure_hidden_session(socket, hidden):
+        run(cmd)
+    # 4. the C-a p reopen binding (no auto-show — the decider shows the popup
+    #    itself when a held request arrives, so the shell isn't bothered at
+    #    startup when there's nothing to decide).
+    for cmd in popup_binding_cmds(socket, hidden, w=pw, h=ph):
+        run(cmd)
+    # 5. attach the user's terminal to the outer session (blocks).
+    rc = attach(attach_cmd(socket, outer))
+    # 6. cleanup: reap the hidden decider session (and a lingering outer).
+    run(kill_session_cmd(socket, hidden))
+    run(kill_session_cmd(socket, outer))
+    return rc
+
+
+def _term_size() -> tuple[int, int]:
+    try:
+        size = os.get_terminal_size()
+        return size.columns, size.lines
+    except OSError:
+        return 80, 24
+
+
+# Re-exported for the shell command to build the inner/decider invocations.
+__all__ = [
+    "DEFAULT_POPUP_SIZE",
+    "EGRESS_INTERACTIVE",
+    "OUTER_PREFIX",
+    "REOPEN_KEY",
+    "TMUX_MIN_VERSION",
+    "attach_cmd",
+    "configure_hidden_session",
+    "configure_outer_session",
+    "display_popup_command",
+    "has_session_cmd",
+    "hidden_has_client",
+    "hidden_session_name",
+    "host_tmux_version",
+    "kill_session_cmd",
+    "new_detached_session",
+    "outer_clients",
+    "outer_session_name",
+    "parse_tmux_version",
+    "popup_binding_cmds",
+    "popup_viewer_shell_string",
+    "run_consent_shell",
+    "should_use_popup",
+    "show_popup_argv",
+    "socket_path",
+    "tmux_usable",
+]

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -34,12 +34,19 @@ from dataclasses import dataclass, replace
 import websockets
 from rich.markup import escape
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
 
 from ..auth import refresh_token
+from ..shell_popup import (
+    DEFAULT_POPUP_SIZE,
+    hidden_has_client,
+    outer_clients,
+    show_popup_argv,
+)
 from ..transport import ws_connect
 
 logger = logging.getLogger(__name__)
@@ -522,9 +529,17 @@ class ConsentDeciderApp(App):
     :class:`ConsentDeciderController`; all protocol logic lives there.
     """
 
+    # The command palette's "^p palette" Footer entry is noise in the small
+    # consent popup -- disable it there (#2383).
+    ENABLE_COMMAND_PALETTE = False
+
     CSS = """
     Screen { layout: vertical; }
     #status { padding: 0 1; background: $panel; color: $text-muted; }
+    /* #queue holds the request list + empty state and fills the space between
+    the duration selector and the pause bar, so the pause bar pins to just
+    above the Footer (#2383). */
+    #queue { height: 1fr; }
     #requests { height: 1fr; }
     #requests ListItem { height: 2; }
     #empty { padding: 1 2; color: $text-muted; }
@@ -556,8 +571,15 @@ class ConsentDeciderApp(App):
         ("a", "allow", "Allow"),
         ("d", "deny", "Deny"),
         ("r", "rules", "Rules"),
+        # q, Q, Escape, and Ctrl-A all hide the viewer in persistent mode (the
+        # decider is persistent — it never quits on a key, only when the shell
+        # ends) and all quit in standalone (#2383). Ctrl-A lets "C-a p" close
+        # the popup while it's open: the outer C-a p binding can't fire then
+        # (the popup captures input), but C-a passes through to the decider.
         ("q", "q_key", "Quit"),
-        ("Q", "confirm_quit", "Quit"),
+        ("Q", "q_key", "Quit"),
+        ("escape", "q_key", "Quit"),
+        ("ctrl+a", "q_key", "Quit"),
     ]
 
     def __init__(  # noqa: PLR0913
@@ -589,6 +611,10 @@ class ConsentDeciderApp(App):
         self._flash_msg = ""
         self._flash_until = 0.0
         self._duration = DURATION_DEFAULT
+        # #2332 pause window the user last requested (None = Unpaused). Drives
+        # which pause button is highlighted; the live countdown is shown next
+        # to the buttons (#2383).
+        self._pause_duration: str | None = None
         # Persistent popup role (#2383): the decider runs inside a hidden
         # tmux session a popup viewer attaches to. Set (with popup_socket)
         # when launched by the shell-layer wrapper; None for standalone use.
@@ -603,37 +629,58 @@ class ConsentDeciderApp(App):
     def _apply_bindings(self) -> None:
         """Install persistent vs standalone keybindings, then refresh Footer.
 
-        `q` hides the viewer in persistent mode (so it can't accidentally
-        quit + deregister the always-on decider); `q` quits in standalone.
-        `Q` always confirms a real quit. The label on `q` follows the role
-        so the Footer reads correctly in each.
+        ``q``, ``Q``, ``Escape`` and ``Ctrl-A`` all hide the viewer in
+        persistent mode (the decider is persistent — it never quits on a key,
+        only when the shell ends) and all quit in standalone. In persistent
+        mode the Footer advertises the shell wrapper's ``C-a p`` toggle
+        (``Ctrl-A`` is the close half — the popup captures input while open,
+        so the outer ``C-a p`` binding can't fire then); ``q``/``Q``/``Esc``
+        are active but hidden. In standalone the Footer shows ``q Quit``.
         """
-        q_label = "Hide" if self._persistent else "Quit"
-        self.BINDINGS = [
-            ("a", "allow", "Allow"),
-            ("d", "deny", "Deny"),
-            ("r", "rules", "Rules"),
-            ("q", "q_key", q_label),
-            ("Q", "confirm_quit", "Quit"),
-        ]
+        if self._persistent:
+            self.BINDINGS = [
+                Binding("a", "allow", "Allow"),
+                Binding("d", "deny", "Deny"),
+                Binding("r", "rules", "Rules"),
+                Binding(
+                    "ctrl+a",
+                    "q_key",
+                    "Hide/Show",
+                    key_display="Ctrl-a p",
+                    show=True,
+                ),
+                Binding("q", "q_key", "Hide", show=False),
+                Binding("Q", "q_key", "Hide", show=False),
+                Binding("escape", "q_key", "Hide", show=False),
+            ]
+        else:
+            self.BINDINGS = [
+                Binding("a", "allow", "Allow"),
+                Binding("d", "deny", "Deny"),
+                Binding("r", "rules", "Rules"),
+                Binding("q", "q_key", "Quit", show=True),
+                Binding("Q", "q_key", "Quit", show=False),
+                Binding("escape", "q_key", "Quit", show=False),
+                Binding("ctrl+a", "q_key", "Quit", show=False),
+            ]
         self.refresh_bindings()
 
     def compose(self) -> ComposeResult:
-        yield Header()
         yield Static(id="status")
         # Global duration selector (default `tilrestart`): click to choose; selecting
         # does NOT submit -- only a row's Allow/Deny submits with this duration.
         yield Horizontal(*self._duration_buttons(), id="duration-selector")
-        # #2332 pause control: silences ALL prompts for the workspace for a
-        # window. Flagged yellow; the status line shows the remaining window.
-        yield Horizontal(
-            Static("Pause:", id="pause-label"),
-            *self._pause_buttons(),
-            id="pause-bar",
-        )
-        with Vertical():
+        with Vertical(id="queue"):
             yield ListView(id="requests")
             yield Static("No held requests — connected, waiting.", id="empty")
+        # #2332 pause control: silences ALL prompts for the workspace for a
+        # window. Pinned just above the Footer; the active window is
+        # highlighted and its countdown shows next to the buttons (#2383).
+        yield Horizontal(
+            *self._pause_buttons(),
+            Static("", id="pause-countdown"),
+            id="pause-bar",
+        )
         yield Footer()
 
     def _duration_buttons(self) -> list[Button]:
@@ -649,24 +696,24 @@ class ConsentDeciderApp(App):
         return btns
 
     def _pause_buttons(self) -> list[Button]:
-        """The pause-control buttons (#2332): 5m / 15m / 1h / Cancel.
+        """Unpaused / Paused 15m / 1h / 1d (#2332, restyled #2383).
 
-        ``pause_duration`` on each button is the window token, or None for the
-        Cancel button (clears an active pause). Highlighted via ``pause-active``
-        when a pause is live so the bar reads as "filtering off".
+        ``pause_duration`` is None for Unpaused (clears a pause) or a window
+        token; the button matching the user's last request is highlighted via
+        ``pause-active`` (Unpaused is active when nothing is paused).
         """
         btns: list[Button] = []
         for label, dur in (
-            (DURATION_15M, DURATION_15M),
-            (DURATION_1H, DURATION_1H),
-            (DURATION_1D, DURATION_1D),
+            ("Unpause", None),
+            ("Pause 15m", DURATION_15M),
+            ("Pause 1h", DURATION_1H),
+            ("Pause 1d", DURATION_1D),
         ):
-            b = Button(label, id=f"pause-{dur}")
+            b = Button(
+                label, id="pause-none" if dur is None else f"pause-{dur}"
+            )
             b.pause_duration = dur  # type: ignore[attr-defined]
             btns.append(b)
-        cancel = Button("Cancel", id="pause-cancel")
-        cancel.pause_duration = None  # type: ignore[attr-defined]
-        btns.append(cancel)
         return btns
 
     def on_mount(self) -> None:
@@ -766,6 +813,10 @@ class ConsentDeciderApp(App):
                     auth_close = code in (4001, 4002)
                     break
                 action, payload = self.controller.apply_frame(raw)
+                if action == ADDED:
+                    # A held request arrived: surface it as the popup over the
+                    # shell (no-op in standalone, skipped if already shown).
+                    self._show_popup()
                 try:
                     if action == ERROR:
                         self._flash(str(payload))
@@ -850,6 +901,7 @@ class ConsentDeciderApp(App):
         ordered = self.controller.ordered()
         current_ids = {req.id for req in ordered}
         focused_id = self._focused_request_id()
+        focused_index = lv.index  # to refocus above a resolved hold
         # Drop resolved/expired rows (leave survivors untouched -> no flicker).
         for child in list(lv.children):
             rid = getattr(child, "request_id", None)
@@ -857,13 +909,24 @@ class ConsentDeciderApp(App):
                 child.remove()
         # Repaint survivors' countdown in place; append only new rows.
         existing = {getattr(c, "request_id", None): c for c in lv.children}
+        new_ids: list[str] = []
         for req in ordered:
             item = existing.get(req.id)
             if item is None:
                 lv.append(self._render_item(req))
+                new_ids.append(req.id)
             else:
                 self._update_item(item, req)
-        self._select_by_id(focused_id)
+        # Focus policy (#2383): a newly-arrived hold grabs focus; else keep
+        # focus on the previously-focused survivor; else (the focused hold was
+        # just resolved) move focus to the hold above it (or the new top) so
+        # deciding doesn't strand the user on an unfocused list.
+        if new_ids:
+            self._select_by_id(new_ids[0])
+        elif focused_id is not None and focused_id in current_ids:
+            self._select_by_id(focused_id)
+        elif focused_id is not None:
+            self._select_index((focused_index or 0) - 1)
         empty.display = not ordered
         if self._flash_until > time.time():
             status.update(self._flash_msg)
@@ -873,17 +936,8 @@ class ConsentDeciderApp(App):
                 f" {escape(self.workspace_name)}  ·  {conn}"
                 f"  ·  {len(ordered)} held"
             )
-            # #2332: surface an active pause window in the status line so the
-            # "silences ALL prompts" state is always visible while queuing.
-            rules = self.controller.rules
-            if rules is not None and rules.paused is not None:
-                rem = self.controller.pause_remaining(rules)
-                if rem is None:
-                    line += "  ·  paused until restart"
-                else:
-                    line += f"  ·  paused {_fmt_duration(rem)}"
             status.update(line)
-        # Reflect an active pause on the control bar (highlight the window).
+        # Pause state + countdown live on the pause bar (next to the buttons).
         self._refresh_pause_highlight()
 
     def _host_line(self, req: ConsentRequest) -> str:
@@ -937,6 +991,13 @@ class ConsentDeciderApp(App):
                 lv.index = index
                 return
 
+    def _select_index(self, index: int) -> None:
+        """Focus the request row at *index*, clamped to the list bounds."""
+        lv = self.query_one("#requests", ListView)
+        if not lv.children:
+            return
+        lv.index = max(0, min(index, len(lv.children) - 1))
+
     def _flash(self, message: str, ttl: float = _FLASH_TTL) -> None:
         """Show a transient message in the status line for ``ttl`` seconds.
 
@@ -986,12 +1047,14 @@ class ConsentDeciderApp(App):
         button.add_class("dur-sel")
 
     def _handle_pause_button(self, button: Button) -> None:
-        """Send a pause (window token) or unpause (Cancel) frame (#2332)."""
+        """Send a pause (window token) or unpause (Unpaused) frame (#2332)."""
         ws = self._ws
         if ws is None:
             self._flash("disconnected — reconnecting")
             return
         dur = getattr(button, "pause_duration", None)
+        # Track the user's request so the matching button stays highlighted.
+        self._pause_duration = dur
         if dur is None:
             asyncio.create_task(self._send_unpause(ws))
         else:
@@ -1010,16 +1073,30 @@ class ConsentDeciderApp(App):
             self._flash("unpause send failed — reconnecting")
 
     def _refresh_pause_highlight(self) -> None:
-        """Flag the pause bar while a pause window is active (#2332).
+        """Highlight the pause button matching the user's last request + show
+        the live countdown next to the buttons (#2332, restyled #2383).
 
-        The pause ``until`` carries no "which button" info, so the whole bar is
-        flagged (the status line + rules screen show the exact remaining
-        window) rather than guessing the pressed button from remaining time.
+        The server's pause frame carries only ``until`` (not which window),
+        so the active button is the one matching the user's last pause/unpause
+        request (``self._pause_duration``); Unpaused is active when nothing is
+        paused. The exact remaining window comes from the rules frame.
         """
-        label = self.query_one("#pause-label", Static)
+        target = self._pause_duration
+        for b in self.query("#pause-bar Button"):
+            b.set_class(
+                getattr(b, "pause_duration", None) == target, "pause-active"
+            )
+        countdown = self.query_one("#pause-countdown", Static)
         rules = self.controller.rules
-        paused = rules is not None and rules.paused is not None
-        label.set_class(paused, "pause-active")
+        if rules is not None and rules.paused is not None:
+            rem = self.controller.pause_remaining(rules)
+            countdown.update(
+                "paused until restart"
+                if rem is None
+                else f"paused {_fmt_duration(rem)}"
+            )
+        else:
+            countdown.update("")
 
     def action_allow(self) -> None:
         # `a` key -> the highlighted row (keyboard path). No-op on the rules
@@ -1041,28 +1118,18 @@ class ConsentDeciderApp(App):
         self.push_screen(RulesScreen())
 
     def action_q_key(self) -> None:
-        """`q`: hide the popup viewer (persistent) or quit (standalone).
+        """``q``/``Q``/``Esc``: hide the popup viewer (persistent) or quit.
 
-        Persistent mode runs the decider inside a hidden tmux session; `q`
-        detaches the viewer so a stray key can't quit + deregister the
-        always-on decider. Standalone `q` quits as before. Press `Q` to quit
-        for real in either mode.
+        Persistent mode runs the decider inside a hidden tmux session; ``q``,
+        ``Q``, and ``Escape`` detach the viewer so the always-on decider is
+        never quit by a key (it dies only when the shell ends). Standalone
+        quits as before. (On the rules screen ``Esc`` still returns to the
+        queue — that screen's own binding takes precedence.) Reopen the popup
+        with the shell wrapper's reopen key.
         """
         if self._persistent:
             self._hide_viewer()
         else:
-            self.exit()
-
-    def action_confirm_quit(self) -> None:
-        """`Q`: confirm, then quit + deregister the decider (#2383).
-
-        A deliberate two-step so neither mode quits on a single keypress.
-        Cancelled (`n`/`Esc`) returns to the queue with the decider intact.
-        """
-        self.push_screen(QuitConfirmScreen(), self._on_confirm_quit)
-
-    def _on_confirm_quit(self, confirmed: bool) -> None:
-        if confirmed:
             self.exit()
 
     def _hide_viewer(self) -> None:
@@ -1084,6 +1151,31 @@ class ConsentDeciderApp(App):
             )
         except Exception:  # noqa: BLE001
             logger.debug("consent-decide viewer detach failed")
+
+    def _show_popup(self) -> None:
+        """Show the popup on the user's shell client when a request arrives.
+
+        No-op when not running under a popup (standalone ``consent-decide``).
+        Skipped when the popup is already open (the hidden session has a
+        viewer client attached). A failed show is swallowed -- the decider
+        keeps running and the user can reopen with the shell's reopen key.
+        """
+        sock = self.popup_socket
+        sess = self.popup_session
+        if not sock or not sess:
+            return
+        if hidden_has_client(sock, sess):
+            return  # popup already open
+        w, h = DEFAULT_POPUP_SIZE
+        for client in outer_clients(sock, sess):
+            try:
+                subprocess.run(
+                    show_popup_argv(sock, sess, client, w=w, h=h),
+                    capture_output=True,
+                    timeout=3,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("consent-decide popup show failed")
 
     def _decide(self, decision: str) -> None:
         rid = self._focused_request_id()
@@ -1110,51 +1202,6 @@ class ConsentDeciderApp(App):
             await ws.send(make_verdict(rid, decision, duration))
         except Exception:
             self._flash("verdict send failed — reconnecting")
-
-
-class QuitConfirmScreen(Screen):
-    """Confirm deregistering the decider (the `Q` path, #2383).
-
-    A deliberate two-step so neither role quits on a single keypress: in
-    the persistent popup role a stray key must not quit + deregister the
-    always-on decider, and in standalone `Q` matches `q`'s old behaviour
-    behind a guard. `y` quits; `n`/`Esc` cancels back to the queue.
-    """
-
-    CSS = """
-    QuitConfirmScreen { align: center middle; }
-    QuitConfirmScreen #confirm-box {
-        width: 60;
-        height: auto;
-        padding: 1 2;
-        border: round $warning;
-        background: $panel;
-    }
-    QuitConfirmScreen #confirm-msg { width: 1fr; }
-    """
-
-    BINDINGS = [
-        ("y", "yes", "Yes"),
-        ("n", "no", "No"),
-        ("escape", "no", "No"),
-    ]
-
-    def compose(self) -> ComposeResult:
-        with Vertical(id="confirm-box"):
-            yield Static(
-                "Quit and deregister this consent decider?\n"
-                "Held requests auto-deny on timeout.\n\n"
-                "[y] quit   [n] cancel",
-                id="confirm-msg",
-                markup=False,
-            )
-        yield Footer()
-
-    def action_yes(self) -> None:
-        self.dismiss(True)
-
-    def action_no(self) -> None:
-        self.dismiss(False)
 
 
 class RulesScreen(Screen):

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import subprocess
 import time
 from dataclasses import dataclass, replace
 
@@ -242,6 +243,20 @@ def make_pause(duration: str) -> str:
 def make_unpause() -> str:
     """Build an outbound unpause frame (JSON string) -- resume prompting (#2332)."""
     return json.dumps({"type": "unpause"})
+
+
+def build_detach_command(socket_path: str, session: str) -> list[str]:
+    """tmux argv to detach clients attached to the decider's hidden session.
+
+    In the persistent popup role (#2383) the decider runs inside a hidden
+    tmux session and a popup *viewer* attaches to it. Detaching every client
+    of *session* on local socket *socket_path* hides that viewer (the only
+    client) while the decider process inside the session keeps running -- so
+    the held-request stream stays open and the decider stays registered.
+    Returns the argv only; the caller runs it and tolerates failure (a stale
+    session or no viewer attached is not an error).
+    """
+    return ["tmux", "-S", socket_path, "detach-client", "-s", session]
 
 
 class ConsentDeciderController:
@@ -541,7 +556,8 @@ class ConsentDeciderApp(App):
         ("a", "allow", "Allow"),
         ("d", "deny", "Deny"),
         ("r", "rules", "Rules"),
-        ("q", "quit", "Quit"),
+        ("q", "q_key", "Quit"),
+        ("Q", "confirm_quit", "Quit"),
     ]
 
     def __init__(  # noqa: PLR0913
@@ -555,6 +571,8 @@ class ConsentDeciderApp(App):
         max_size: int | None = None,
         ping_interval: float = _PING_INTERVAL,
         reconnect_delays: tuple[float, ...] = _RECONNECT_DELAYS,
+        popup_socket: str | None = None,
+        popup_session: str | None = None,
     ) -> None:
         super().__init__()
         self.server_url = server_url
@@ -571,6 +589,34 @@ class ConsentDeciderApp(App):
         self._flash_msg = ""
         self._flash_until = 0.0
         self._duration = DURATION_DEFAULT
+        # Persistent popup role (#2383): the decider runs inside a hidden
+        # tmux session a popup viewer attaches to. Set (with popup_socket)
+        # when launched by the shell-layer wrapper; None for standalone use.
+        self.popup_socket = popup_socket
+        self.popup_session = popup_session
+
+    @property
+    def _persistent(self) -> bool:
+        """True when running inside the hidden popup session (#2383)."""
+        return self.popup_session is not None
+
+    def _apply_bindings(self) -> None:
+        """Install persistent vs standalone keybindings, then refresh Footer.
+
+        `q` hides the viewer in persistent mode (so it can't accidentally
+        quit + deregister the always-on decider); `q` quits in standalone.
+        `Q` always confirms a real quit. The label on `q` follows the role
+        so the Footer reads correctly in each.
+        """
+        q_label = "Hide" if self._persistent else "Quit"
+        self.BINDINGS = [
+            ("a", "allow", "Allow"),
+            ("d", "deny", "Deny"),
+            ("r", "rules", "Rules"),
+            ("q", "q_key", q_label),
+            ("Q", "confirm_quit", "Quit"),
+        ]
+        self.refresh_bindings()
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -625,6 +671,7 @@ class ConsentDeciderApp(App):
 
     def on_mount(self) -> None:
         self.title = f"consent-decide · {self.workspace_name}"
+        self._apply_bindings()
         self.run_worker(
             self._ws_loop, exclusive=True, group="ws", exit_on_error=False
         )
@@ -993,6 +1040,51 @@ class ConsentDeciderApp(App):
             return
         self.push_screen(RulesScreen())
 
+    def action_q_key(self) -> None:
+        """`q`: hide the popup viewer (persistent) or quit (standalone).
+
+        Persistent mode runs the decider inside a hidden tmux session; `q`
+        detaches the viewer so a stray key can't quit + deregister the
+        always-on decider. Standalone `q` quits as before. Press `Q` to quit
+        for real in either mode.
+        """
+        if self._persistent:
+            self._hide_viewer()
+        else:
+            self.exit()
+
+    def action_confirm_quit(self) -> None:
+        """`Q`: confirm, then quit + deregister the decider (#2383).
+
+        A deliberate two-step so neither mode quits on a single keypress.
+        Cancelled (`n`/`Esc`) returns to the queue with the decider intact.
+        """
+        self.push_screen(QuitConfirmScreen(), self._on_confirm_quit)
+
+    def _on_confirm_quit(self, confirmed: bool) -> None:
+        if confirmed:
+            self.exit()
+
+    def _hide_viewer(self) -> None:
+        """Detach the popup viewer so it hides; the decider stays registered.
+
+        No-op when not running under a popup (standalone `consent-decide`).
+        A failed/stale detach is swallowed -- the decider keeps running
+        either way, and the viewer is reopened with the reopen key.
+        """
+        sock = self.popup_socket
+        sess = self.popup_session
+        if not sock or not sess:
+            return
+        try:
+            subprocess.run(
+                build_detach_command(sock, sess),
+                capture_output=True,
+                timeout=3,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("consent-decide viewer detach failed")
+
     def _decide(self, decision: str) -> None:
         rid = self._focused_request_id()
         if rid is None:
@@ -1018,6 +1110,47 @@ class ConsentDeciderApp(App):
             await ws.send(make_verdict(rid, decision, duration))
         except Exception:
             self._flash("verdict send failed — reconnecting")
+
+
+class QuitConfirmScreen(Screen):
+    """Confirm deregistering the decider (the `Q` path, #2383).
+
+    A deliberate two-step so neither role quits on a single keypress: in
+    the persistent popup role a stray key must not quit + deregister the
+    always-on decider, and in standalone `Q` matches `q`'s old behaviour
+    behind a guard. `y` quits; `n`/`Esc` cancels back to the queue.
+    """
+
+    CSS = """
+    QuitConfirmScreen { align: center middle; }
+    QuitConfirmScreen #confirm-box {
+        width: auto; max-width: 64; padding: 1 2;
+        border: round $warning;
+        background: $panel;
+    }
+    """
+
+    BINDINGS = [
+        ("y", "yes", "Yes"),
+        ("n", "no", "No"),
+        ("escape", "no", "No"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-box"):
+            yield Static(
+                "Quit and deregister this consent decider?\n"
+                "Held requests auto-deny on timeout.\n\n"
+                "[y] quit   [n] cancel",
+                id="confirm-msg",
+            )
+        yield Footer()
+
+    def action_yes(self) -> None:
+        self.dismiss(True)
+
+    def action_no(self) -> None:
+        self.dismiss(False)
 
 
 class RulesScreen(Screen):

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -1124,10 +1124,13 @@ class QuitConfirmScreen(Screen):
     CSS = """
     QuitConfirmScreen { align: center middle; }
     QuitConfirmScreen #confirm-box {
-        width: auto; max-width: 64; padding: 1 2;
+        width: 60;
+        height: auto;
+        padding: 1 2;
         border: round $warning;
         background: $panel;
     }
+    QuitConfirmScreen #confirm-msg { width: 1fr; }
     """
 
     BINDINGS = [
@@ -1143,6 +1146,7 @@ class QuitConfirmScreen(Screen):
                 "Held requests auto-deny on timeout.\n\n"
                 "[y] quit   [n] cancel",
                 id="confirm-msg",
+                markup=False,
             )
         yield Footer()
 

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -220,6 +221,71 @@ def check_binary(
             hint=install_hint(name, manager),
         )
     return CheckResult(name=name, ok=True, message=f"{name} ok ({path})")
+
+
+# tmux display-popup (used by the TUI consent-decider popup over the
+# shell, #2383) landed in 3.2. Below this the shell layer falls back to a
+# plain attach, so an old/unknown host tmux is a warning, not an error.
+TMUX_MIN_VERSION = (3, 2)
+
+
+def parse_tmux_version(out: str) -> tuple[int, int] | None:
+    """Parse ``tmux -V`` output (e.g. ``"tmux 3.6a"``) -> ``(3, 6)``.
+
+    Returns None when no ``MAJOR.MINOR`` pair is present (unparseable /
+    unexpected output) so the caller can flag it as an unknown-version
+    warning rather than guessing.
+    """
+    m = re.search(r"(\d+)\.(\d+)", out)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def check_tmux_version(manager: str | None) -> CheckResult:
+    """Check host tmux is new enough for the consent-popup shell layer (#2383).
+
+    A missing tmux is already reported as an error by the required-binary
+    check above; here that case is a passing no-op (no version to check).
+    A present-but-old or unparseable version is a warning: the shell layer
+    degrades to a plain attach, so doctor must not hard-fail the host.
+    """
+    if not shutil.which("tmux"):
+        return CheckResult(
+            name="tmux (consent popup)",
+            ok=True,
+            message="no host tmux (reported by the tmux check above)",
+        )
+    rc, out, _err = _run(["tmux", "-V"])
+    ver = parse_tmux_version(out) if rc == 0 else None
+    label = ".".join(map(str, ver)) if ver is not None else "unknown"
+    if ver is None:
+        return CheckResult(
+            name="tmux (consent popup)",
+            ok=False,
+            is_warning=True,
+            message=(
+                f"tmux version unparseable ({out.strip()[:40] or 'tmux -V failed'});"
+                " consent popup needs >= 3.2"
+            ),
+            hint=install_hint("tmux", manager),
+        )
+    if ver < TMUX_MIN_VERSION:
+        return CheckResult(
+            name="tmux (consent popup)",
+            ok=False,
+            is_warning=True,
+            message=(
+                f"tmux {label} < 3.2 — consent popup unavailable"
+                " (plain shell attach used)"
+            ),
+            hint=install_hint("tmux", manager),
+        )
+    return CheckResult(
+        name="tmux (consent popup)",
+        ok=True,
+        message=f"tmux {label} ok for consent popup (>= 3.2)",
+    )
 
 
 def check_gnu_tar(manager: str | None) -> CheckResult:
@@ -471,6 +537,10 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
     # 1. Required binaries
     for name, check_cmd in _REQUIRED_BINARIES:
         report.add(check_binary(name, check_cmd, manager))
+
+    # 1b. tmux version for the consent-popup shell layer (#2383): display-popup
+    # needs >= 3.2; below it the shell falls back to a plain attach (warning).
+    report.add(check_tmux_version(manager))
 
     # GNU tar and GNU du (special: must verify GNU, not just present)
     report.add(check_gnu_tar(manager))

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -103,7 +103,7 @@ def _cli_check_window(ws_name, env, timeout=25):
     script = f"""
 set timeout {timeout}
 log_user 0
-spawn klangk shell {ws_name}
+spawn klangk shell {ws_name} --no-consent-popup
 expect {{
     -re {{\\$ }} {{}}
     timeout {{ puts "TIMEOUT"; exit 1 }}
@@ -135,9 +135,9 @@ wait
 def _cli_hold_and_check(ws_name, window_name, hold_seconds, env):
     """Start CLI shell, check window before and after a hold period."""
     if window_name:
-        cmd = f"klangk shell {ws_name} {window_name}"
+        cmd = f"klangk shell {ws_name} {window_name} --no-consent-popup"
     else:
-        cmd = f"klangk shell {ws_name}"
+        cmd = f"klangk shell {ws_name} --no-consent-popup"
     script = f"""
 set timeout 30
 log_user 0
@@ -420,7 +420,7 @@ class TestTerminalWindows:
         script = f"""
 set timeout 30
 log_user 0
-spawn klangk shell {WS_NAME}
+spawn klangk shell {WS_NAME} --no-consent-popup
 set s1 $spawn_id
 expect -re {{\\$ }}
 sleep 3
@@ -428,7 +428,7 @@ send "echo B1S; tmux display-message -p '#I:#W'; echo B1E\\r"
 expect -re {{B1S\\r?\\n(\\d+:\\S+)\\r?\\nB1E}}
 set b1 $expect_out(1,string)
 
-spawn klangk shell {WS_NAME} named1
+spawn klangk shell {WS_NAME} named1 --no-consent-popup
 set s2 $spawn_id
 expect -re {{\\$ }}
 sleep 3
@@ -616,7 +616,7 @@ puts "AFTER=$a1"
             script = f"""
 set timeout 25
 log_user 0
-spawn klangk shell {WS_NAME} shared
+spawn klangk shell {WS_NAME} shared --no-consent-popup
 expect {{
     -re {{\\$ }} {{}}
     timeout {{ puts "TIMEOUT"; exit 1 }}

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1296,6 +1296,40 @@ class TestMainCLI:
 
         client.resolve_workspace.assert_called_once_with("target-ws")
 
+    def test_shell_runs_consent_popup_when_gate_passes(
+        self, logged_in_cfg, monkeypatch, reset_env
+    ):
+        """When the gate passes, shell() runs the popup wrapper + exits (#2383).
+
+        It must NOT fall through to the plain ws_shell attach.
+        """
+        import typer
+
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="wid" + "0" * 51,
+            name="ws",
+            created_at="2025-01-01T00:00:00Z",
+            egress_mode="interactive",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+
+        with patch.object(main, "_client", return_value=client):
+            with patch.object(
+                main, "_consent_popup_enabled", return_value=True
+            ):
+                with patch.object(
+                    main, "_run_consent_popup", return_value=0
+                ) as fake_popup:
+                    with patch.object(main, "ws_shell") as fake_shell:
+                        with pytest.raises(typer.Exit) as exc:
+                            main.shell("ws", "@1")
+        assert exc.value.exit_code == 0
+        fake_popup.assert_called_once()  # the wrapper ran
+        fake_shell.assert_not_called()  # the plain attach did not
+
     def test_shell_with_terminal_arg(
         self, logged_in_cfg, monkeypatch, reset_env
     ):

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5735,3 +5735,37 @@ class TestConsentDecideCommand:
 
             result = CliRunner().invoke(main.app, ["consent-decide", "ghost"])
         assert result.exit_code == 1
+
+    def test_popup_options_enable_persistent_role(self, logged_in_cfg):
+        """--popup-socket/--popup-session put the decider in persistent role (#2383)."""
+        from klangk.cli import main
+        from klangk.cli.tui import consent as tui_consent
+
+        ws = Workspace(id="wsid", name="my-ws", created_at="x")
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        client.list_shared_workspaces.return_value = []
+        launched, fake_run = self._launch_capture()
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(tui_consent.ConsentDeciderApp, "run", fake_run),
+        ):
+            from typer.testing import CliRunner
+
+            result = CliRunner().invoke(
+                main.app,
+                [
+                    "consent-decide",
+                    "my-ws",
+                    "--popup-socket",
+                    "/tmp/klangk.sock",
+                    "--popup-session",
+                    "klangk-consent-wsid",
+                ],
+            )
+        assert result.exit_code == 0
+        app = launched["app"]
+        assert app.popup_socket == "/tmp/klangk.sock"
+        assert app.popup_session == "klangk-consent-wsid"
+        assert app._persistent

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -34,7 +34,6 @@ from klangk.cli.tui.consent import (
     ConsentRule,
     EgressRules,
     PauseState,
-    QuitConfirmScreen,
     RulesScreen,
     build_detach_command,
     make_pause,
@@ -490,6 +489,113 @@ class TestAppRender:
             await pilot.pause()
             assert app._focused_request_id() == "r2"
 
+    async def test_refresh_focuses_newly_arrived_hold(self):
+        # A newly-arrived hold grabs focus so the user can act on it at once.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0  # focus r1
+            await pilot.pause()
+            # a new hold arrives
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            assert app._focused_request_id() == "r2"
+
+    async def test_refresh_focuses_hold_above_after_resolution(self):
+        # r1 (older, above) and r2; focus r2; r2 resolved -> focus r1 (above).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 1  # focus r2
+            await pilot.pause()
+            app.controller.apply_frame(
+                json.dumps(
+                    {
+                        "type": "egress_resolved",
+                        "request_id": "r2",
+                        "decision": "denied",
+                    }
+                )
+            )
+            app._refresh()
+            await pilot.pause()
+            assert app._focused_request_id() == "r1"  # the hold above
+
+    async def test_refresh_focuses_new_top_when_resolved_hold_was_topmost(
+        self,
+    ):
+        # Focus the topmost hold; resolve it -> focus the new top (was below).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0  # focus r1 (top)
+            await pilot.pause()
+            app.controller.apply_frame(
+                json.dumps(
+                    {
+                        "type": "egress_resolved",
+                        "request_id": "r1",
+                        "decision": "allowed",
+                    }
+                )
+            )
+            app._refresh()
+            await pilot.pause()
+            assert app._focused_request_id() == "r2"  # now the top
+
+    def test_select_by_id_none_is_noop(self):
+        # Defensive guard: must not raise and must not query unmounted widgets.
+        _make_app()._select_by_id(None)
+
+    async def test_select_index_clamps_to_bounds(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            app._select_index(99)  # above the top -> last row
+            await pilot.pause()
+            assert app.query_one("#requests", ListView).index == 1
+            app._select_index(-5)  # below the bottom -> first row
+            await pilot.pause()
+            assert app.query_one("#requests", ListView).index == 0
+
+    async def test_select_index_empty_list_is_noop(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._select_index(0)  # no rows -> must not raise
+            await pilot.pause()
+            assert app.query_one("#requests", ListView).index is None
+
+    async def test_refresh_no_focus_when_last_hold_resolved(self):
+        # Resolving the only hold empties the list; _select_index must no-op.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            app.query_one("#requests", ListView).index = 0
+            await pilot.pause()
+            app.controller.apply_frame(
+                json.dumps({"type": "egress_resolved", "request_id": "r1"})
+            )
+            app._refresh()
+            await pilot.pause()
+            assert (
+                app._focused_request_id() is None
+            )  # list empty, nothing focused
+
     async def test_render_item_with_process_and_port(self):
         app = _make_app()
         req = ConsentRequest(
@@ -803,40 +909,28 @@ class TestAppActions:
             assert app._duration == "tilrestart"  # unchanged (default)
 
     async def test_pause_bar_mounts(self):
-        # #2332: the pause control bar mounts with a window button + Cancel.
+        # #2332: the pause control bar mounts Unpaused + the three windows +
+        # a countdown.
         app = _make_app()
         async with app.run_test() as pilot:
             await pilot.pause()
-            assert app.query_one("#pause-15m", Button) is not None
-            assert app.query_one("#pause-1h", Button) is not None
-            assert app.query_one("#pause-1d", Button) is not None
-            assert app.query_one("#pause-cancel", Button) is not None
+            for bid in ("#pause-none", "#pause-15m", "#pause-1h", "#pause-1d"):
+                assert app.query_one(bid, Button) is not None, bid
+            assert app.query_one("#pause-countdown", Static) is not None
 
     async def test_pause_buttons_render_on_screen(self):
-        # Regression (#2332): the ``Pause:`` label must not expand to fill the
-        # bar (which pushed the window buttons off-screen). All four controls
-        # must sit within the viewport, in order, after the label.
+        # All four controls sit on-screen, in order.
         app = _make_app()
         async with app.run_test(size=(120, 24)) as pilot:
             app._refresh()
             await pilot.pause()
             await pilot.pause()
-            lbl = app.query_one("#pause-label", Static)
-            assert (
-                lbl.outer_size.width < 20
-            )  # "Pause:" + padding, not full width
-            prev_x = lbl.region.x
-            for bid in (
-                "#pause-15m",
-                "#pause-1h",
-                "#pause-1d",
-                "#pause-cancel",
-            ):
+            prev_x = 0
+            for bid in ("#pause-none", "#pause-15m", "#pause-1h", "#pause-1d"):
                 b = app.query_one(bid, Button)
-                # each button starts where the previous ended and is on-screen
-                assert b.region.x >= prev_x
+                assert b.region.x >= prev_x, bid
                 assert b.region.x + b.region.width <= 120, bid
-                assert b.region.width > 0
+                assert b.region.width > 0, bid
                 prev_x = b.region.x + b.region.width
 
     async def test_pause_button_sends_pause_frame(self):
@@ -856,8 +950,8 @@ class TestAppActions:
                 ws.sent
             )
 
-    async def test_cancel_button_sends_unpause_frame(self):
-        # The Cancel button clears an active pause.
+    async def test_unpaused_button_sends_unpause_frame(self):
+        # The Unpaused button clears an active pause.
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -865,7 +959,7 @@ class TestAppActions:
             await pilot.pause()
             app.on_button_pressed(
                 types.SimpleNamespace(
-                    button=app.query_one("#pause-cancel", Button)
+                    button=app.query_one("#pause-none", Button)
                 )
             )
             await pilot.pause()
@@ -884,21 +978,35 @@ class TestAppActions:
             await pilot.pause()
             assert app._flash_until > 0  # a flash was set
 
-    async def test_pause_highlights_bar_when_active(self):
-        # An egress_rules frame with a live pause flags the bar label.
+    async def test_pause_highlights_matching_button(self):
+        # The button matching the user's last pause request is highlighted.
         app = _make_app()
         async with app.run_test() as pilot:
             await pilot.pause()
-            app.controller.apply_frame(
-                _rules_frame(paused={"paused": True, "until": 9999.0})
-            )
+            app._pause_duration = "15m"
             app._refresh()
             await pilot.pause()
-            label = app.query_one("#pause-label", Static)
-            assert label.has_class("pause-active")
+            assert app.query_one("#pause-15m", Button).has_class(
+                "pause-active"
+            )
+            assert not app.query_one("#pause-none", Button).has_class(
+                "pause-active"
+            )
 
-    async def test_status_shows_indefinite_pause(self):
-        # A pause with no fixed expiry (until=None) reads "paused until restart".
+    async def test_unpaused_highlighted_by_default(self):
+        # With no pause requested, the Unpaused button is the active one.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._refresh()
+            await pilot.pause()
+            assert app.query_one("#pause-none", Button).has_class(
+                "pause-active"
+            )
+
+    async def test_countdown_shows_indefinite_pause(self):
+        # An indefinite pause (until=None) reads "paused until restart" next to
+        # the pause buttons (#2383).
         app = _make_app()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -907,8 +1015,8 @@ class TestAppActions:
             )
             app._refresh()
             await pilot.pause()
-            status = app.query_one("#status", Static)
-            assert "paused until restart" in str(status.content)
+            countdown = app.query_one("#pause-countdown", Static)
+            assert "paused until restart" in str(countdown.content)
 
     async def test_pump_flashes_failed_pause_ack(self):
         # A pause_ack with ok=False flashes so the decider knows it didn't take.
@@ -2252,18 +2360,41 @@ class TestPersistentPopupRole:
     def test_apply_bindings_standalone_labels_q_quit(self):
         app = _make_app()
         app._apply_bindings()
-        labels = {b[0]: b[2] for b in app.BINDINGS}
-        assert labels["q"] == "Quit"
-        assert labels["Q"] == "Quit"
+        shown = {b.key: b.description for b in app.BINDINGS if b.show}
+        assert shown == {
+            "a": "Allow",
+            "d": "Deny",
+            "r": "Rules",
+            "q": "Quit",
+        }
+        # Q, Esc, Ctrl-A are active but hidden from the Footer
+        assert {b.key for b in app.BINDINGS if not b.show} == {
+            "Q",
+            "escape",
+            "ctrl+a",
+        }
 
-    def test_apply_bindings_persistent_labels_q_hide(self):
+    def test_apply_bindings_persistent_labels_ctrl_a_toggle(self):
         app = _make_app(
             popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
         )
         app._apply_bindings()
-        labels = {b[0]: b[2] for b in app.BINDINGS}
-        assert labels["q"] == "Hide"
-        assert labels["Q"] == "Quit"
+        shown = {b.key: b.description for b in app.BINDINGS if b.show}
+        # The Footer advertises the shell wrapper's C-a p toggle.
+        assert shown == {
+            "a": "Allow",
+            "d": "Deny",
+            "r": "Rules",
+            "ctrl+a": "Hide/Show",
+        }
+        ctrl_a = next(b for b in app.BINDINGS if b.key == "ctrl+a" and b.show)
+        assert ctrl_a.key_display == "Ctrl-a p"
+        # q, Q, Esc are active but hidden from the Footer
+        assert {b.key for b in app.BINDINGS if not b.show} == {
+            "q",
+            "Q",
+            "escape",
+        }
 
     def test_q_key_standalone_exits(self):
         # No popup context -> q quits immediately (today's behaviour).
@@ -2288,6 +2419,34 @@ class TestPersistentPopupRole:
         assert exited == []
         assert ran == [build_detach_command("/tmp/k.sock", "klangk-consent-w")]
 
+    async def test_escape_hides_in_persistent_mode(self, monkeypatch):
+        # Escape detaches the viewer (hides) and does NOT quit/deregister.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        exited = []
+        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
+        ran: list[list[str]] = []
+        monkeypatch.setattr(
+            tui_consent.subprocess, "run", lambda cmd, **kw: ran.append(cmd)
+        )
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+        assert exited == []
+        assert ran == [build_detach_command("/tmp/k.sock", "klangk-consent-w")]
+
+    async def test_escape_quits_in_standalone_mode(self):
+        app = _make_app()
+        exited = []
+        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+        assert exited == [True]
+
     def test_hide_viewer_noop_without_popup(self, monkeypatch):
         from unittest.mock import MagicMock
 
@@ -2309,56 +2468,76 @@ class TestPersistentPopupRole:
         monkeypatch.setattr(tui_consent.subprocess, "run", boom)
         app._hide_viewer()  # must not raise
 
-    def test_on_confirm_quit_true_exits(self):
-        app = _make_app()
-        exited = []
-        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
-        app._on_confirm_quit(True)
-        assert exited == [True]
+    def test_show_popup_noop_without_popup_context(self, monkeypatch):
+        # Standalone: no popup socket/session, nothing to show.
+        from unittest.mock import MagicMock
 
-    def test_on_confirm_quit_false_does_not_exit(self):
         app = _make_app()
-        exited = []
-        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
-        app._on_confirm_quit(False)
-        assert exited == []
+        run = MagicMock()
+        monkeypatch.setattr(tui_consent.subprocess, "run", run)
+        app._show_popup()
+        assert not run.called
 
-    async def test_confirm_quit_pushes_confirm_screen(self):
-        app = _make_app()
-        async with app.run_test() as pilot:
-            app.action_confirm_quit()
-            await pilot.pause()
-            assert isinstance(app.screen, QuitConfirmScreen)
+    def test_show_popup_noop_when_already_open(self, monkeypatch):
+        # Hidden session already has a viewer (popup open) -> don't re-show.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(
+            tui_consent, "hidden_has_client", lambda sock, sess: True
+        )
+        called: list = []
+        monkeypatch.setattr(
+            tui_consent.subprocess, "run", lambda *a, **k: called.append(a)
+        )
+        app._show_popup()
+        assert called == []
 
-    async def test_quit_confirm_yes_dismisses_true(self):
-        got: list[bool] = []
-        app = _make_app()
-        async with app.run_test() as pilot:
-            app.push_screen(QuitConfirmScreen(), lambda v: got.append(v))
-            await pilot.pause()
-            app.screen.action_yes()
-            await pilot.pause()
-        assert got == [True]
+    def test_show_popup_targets_outer_clients(self, monkeypatch):
+        # A held request arrived: show the popup on each outer (shell) client.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(
+            tui_consent, "hidden_has_client", lambda sock, sess: False
+        )
+        monkeypatch.setattr(
+            tui_consent,
+            "outer_clients",
+            lambda sock, sess: ["clientA", "clientB"],
+        )
+        ran: list[list[str]] = []
+        monkeypatch.setattr(
+            tui_consent.subprocess, "run", lambda cmd, **kw: ran.append(cmd)
+        )
+        app._show_popup()
+        assert len(ran) == 2
+        # each is a display-popup -c <client> on the local socket
+        assert ran[0][:5] == [
+            "tmux",
+            "-S",
+            "/tmp/k.sock",
+            "display-popup",
+            "-c",
+        ]
+        assert ran[0][5] == "clientA"
+        assert ran[1][5] == "clientB"
+        # the viewer attaches to the hidden session (last positional)
+        assert ran[0][-1].endswith("attach -t klangk-consent-w")
 
-    async def test_quit_confirm_no_dismisses_false(self):
-        got: list[bool] = []
-        app = _make_app()
-        async with app.run_test() as pilot:
-            app.push_screen(QuitConfirmScreen(), lambda v: got.append(v))
-            await pilot.pause()
-            app.screen.action_no()
-            await pilot.pause()
-        assert got == [False]
+    def test_show_popup_swallows_subprocess_error(self, monkeypatch):
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(
+            tui_consent, "hidden_has_client", lambda sock, sess: False
+        )
+        monkeypatch.setattr(
+            tui_consent, "outer_clients", lambda sock, sess: ["clientA"]
+        )
 
-    async def test_quit_confirm_box_renders_text(self):
-        # Regression: the confirm box must not collapse to an empty strip.
-        # The "[y]"/"[n]" in the message are literal (markup=False) and the
-        # box has an explicit width, so the prompt text is visible (#2383).
-        app = _make_app()
-        async with app.run_test(size=(80, 24)) as pilot:
-            app.push_screen(QuitConfirmScreen())
-            await pilot.pause()
-            box = app.screen.query_one("#confirm-box")
-            msg = app.screen.query_one("#confirm-msg", Static)
-            assert box.size.width >= 50  # not a collapsed thin strip
-            assert "deregister" in str(msg.content)
+        def boom(*a, **k):
+            raise OSError("boom")
+
+        monkeypatch.setattr(tui_consent.subprocess, "run", boom)
+        app._show_popup()  # must not raise

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -34,7 +34,9 @@ from klangk.cli.tui.consent import (
     ConsentRule,
     EgressRules,
     PauseState,
+    QuitConfirmScreen,
     RulesScreen,
+    build_detach_command,
     make_pause,
     make_ping,
     make_revoke,
@@ -2216,3 +2218,134 @@ class TestRulesRevoke:
             lv = app.screen.query_one("#rules-list", ListView)
             assert lv.highlighted_child is not None
             assert getattr(lv.highlighted_child, "rule_id", None) == "a2"
+
+
+# ---------------------------------------------------------------------------
+# Persistent popup role: q hides the viewer, Q confirms a real quit (#2383).
+# ---------------------------------------------------------------------------
+
+
+class TestPersistentPopupRole:
+    """The decider's behaviour when launched inside the hidden tmux session."""
+
+    def test_build_detach_command(self):
+        # The hide action detaches the popup viewer from the hidden session.
+        assert build_detach_command("/tmp/k.sock", "klangk-consent-w") == [
+            "tmux",
+            "-S",
+            "/tmp/k.sock",
+            "detach-client",
+            "-s",
+            "klangk-consent-w",
+        ]
+
+    def test_persistent_flag_off_by_default(self):
+        app = _make_app()
+        assert not app._persistent
+
+    def test_persistent_flag_on_with_session(self):
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        assert app._persistent
+
+    def test_apply_bindings_standalone_labels_q_quit(self):
+        app = _make_app()
+        app._apply_bindings()
+        labels = {b[0]: b[2] for b in app.BINDINGS}
+        assert labels["q"] == "Quit"
+        assert labels["Q"] == "Quit"
+
+    def test_apply_bindings_persistent_labels_q_hide(self):
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        app._apply_bindings()
+        labels = {b[0]: b[2] for b in app.BINDINGS}
+        assert labels["q"] == "Hide"
+        assert labels["Q"] == "Quit"
+
+    def test_q_key_standalone_exits(self):
+        # No popup context -> q quits immediately (today's behaviour).
+        app = _make_app()
+        exited = []
+        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
+        app.action_q_key()
+        assert exited == [True]
+
+    def test_q_key_persistent_hides_not_quit(self, monkeypatch):
+        # Popup context -> q detaches the viewer and does NOT quit/deregister.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        exited = []
+        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
+        ran: list[list[str]] = []
+        monkeypatch.setattr(
+            tui_consent.subprocess, "run", lambda cmd, **kw: ran.append(cmd)
+        )
+        app.action_q_key()
+        assert exited == []
+        assert ran == [build_detach_command("/tmp/k.sock", "klangk-consent-w")]
+
+    def test_hide_viewer_noop_without_popup(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        app = _make_app()
+        run = MagicMock()
+        monkeypatch.setattr(tui_consent.subprocess, "run", run)
+        app._hide_viewer()
+        assert not run.called
+
+    def test_hide_viewer_swallows_subprocess_error(self, monkeypatch):
+        # A stale session / missing tmux must never crash the decider.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+
+        def boom(*a, **k):
+            raise OSError("no tmux")
+
+        monkeypatch.setattr(tui_consent.subprocess, "run", boom)
+        app._hide_viewer()  # must not raise
+
+    def test_on_confirm_quit_true_exits(self):
+        app = _make_app()
+        exited = []
+        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
+        app._on_confirm_quit(True)
+        assert exited == [True]
+
+    def test_on_confirm_quit_false_does_not_exit(self):
+        app = _make_app()
+        exited = []
+        app.exit = lambda: exited.append(True)  # type: ignore[method-assign]
+        app._on_confirm_quit(False)
+        assert exited == []
+
+    async def test_confirm_quit_pushes_confirm_screen(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.action_confirm_quit()
+            await pilot.pause()
+            assert isinstance(app.screen, QuitConfirmScreen)
+
+    async def test_quit_confirm_yes_dismisses_true(self):
+        got: list[bool] = []
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.push_screen(QuitConfirmScreen(), lambda v: got.append(v))
+            await pilot.pause()
+            app.screen.action_yes()
+            await pilot.pause()
+        assert got == [True]
+
+    async def test_quit_confirm_no_dismisses_false(self):
+        got: list[bool] = []
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.push_screen(QuitConfirmScreen(), lambda v: got.append(v))
+            await pilot.pause()
+            app.screen.action_no()
+            await pilot.pause()
+        assert got == [False]

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -2349,3 +2349,16 @@ class TestPersistentPopupRole:
             app.screen.action_no()
             await pilot.pause()
         assert got == [False]
+
+    async def test_quit_confirm_box_renders_text(self):
+        # Regression: the confirm box must not collapse to an empty strip.
+        # The "[y]"/"[n]" in the message are literal (markup=False) and the
+        # box has an explicit width, so the prompt text is visible (#2383).
+        app = _make_app()
+        async with app.run_test(size=(80, 24)) as pilot:
+            app.push_screen(QuitConfirmScreen())
+            await pilot.pause()
+            box = app.screen.query_one("#confirm-box")
+            msg = app.screen.query_one("#confirm-msg", Static)
+            assert box.size.width >= 50  # not a collapsed thin strip
+            assert "deregister" in str(msg.content)

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -1,0 +1,631 @@
+"""Tests for the client-side consent-popup shell wrapper (#2383).
+
+Covers the pure tmux command builders, the gate, and the orchestrator's
+command sequence (with the tmux runner / attach injected as recorders).
+"""
+
+from __future__ import annotations
+
+import shlex
+from unittest.mock import MagicMock, patch
+
+
+from klangk.cli import shell_popup as sp
+
+
+# ---------------------------------------------------------------------------
+# version parsing + detection
+# ---------------------------------------------------------------------------
+
+
+class TestTmuxVersion:
+    def test_parse_typical(self):
+        assert sp.parse_tmux_version("tmux 3.6a") == (3, 6)
+
+    def test_parse_no_suffix(self):
+        assert sp.parse_tmux_version("tmux 3.2") == (3, 2)
+
+    def test_parse_garbage(self):
+        assert sp.parse_tmux_version("nope") is None
+
+    def test_parse_empty(self):
+        assert sp.parse_tmux_version("") is None
+
+    def test_min_version_is_3_2(self):
+        assert sp.TMUX_MIN_VERSION == (3, 2)
+
+    def test_usable_new_enough(self):
+        assert sp.tmux_usable((3, 6)) is True
+        assert sp.tmux_usable((3, 2)) is True
+
+    def test_usable_old(self):
+        assert sp.tmux_usable((3, 1)) is False
+
+    def test_usable_absent(self):
+        assert sp.tmux_usable(None) is False
+
+    def test_host_version_parses(self):
+        with (
+            patch(
+                "klangk.cli.shell_popup.shutil.which",
+                return_value="/usr/bin/tmux",
+            ),
+            patch(
+                "klangk.cli.shell_popup.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="tmux 3.6a"),
+            ),
+        ):
+            assert sp.host_tmux_version() == (3, 6)
+
+    def test_host_version_absent(self):
+        with patch("klangk.cli.shell_popup.shutil.which", return_value=None):
+            assert sp.host_tmux_version() is None
+
+    def test_host_version_run_fails(self):
+        with (
+            patch(
+                "klangk.cli.shell_popup.shutil.which",
+                return_value="/usr/bin/tmux",
+            ),
+            patch(
+                "klangk.cli.shell_popup.subprocess.run",
+                return_value=MagicMock(returncode=1, stdout=""),
+            ),
+        ):
+            assert sp.host_tmux_version() is None
+
+    def test_host_version_oserror(self):
+        with (
+            patch(
+                "klangk.cli.shell_popup.shutil.which",
+                return_value="/usr/bin/tmux",
+            ),
+            patch(
+                "klangk.cli.shell_popup.subprocess.run",
+                side_effect=OSError("boom"),
+            ),
+        ):
+            assert sp.host_tmux_version() is None
+
+
+# ---------------------------------------------------------------------------
+# naming
+# ---------------------------------------------------------------------------
+
+
+class TestNaming:
+    def test_socket_path_stable_and_sanitized(self):
+        a = sp.socket_path("wsid")
+        b = sp.socket_path("wsid")
+        assert a == b
+        assert a.endswith("wsid.sock")
+
+    def test_socket_path_no_dot_or_colon(self):
+        # tmux session names / sockets can't contain '.' or ':'; ids with them
+        # must be sanitized so the session name is valid.
+        p = sp.socket_path("w.s:i")
+        assert ":" not in p and "w.s:i.sock" not in p
+
+    def test_session_names_prefixed_and_safe(self):
+        outer = sp.outer_session_name("wsid")
+        hidden = sp.hidden_session_name("wsid")
+        assert outer == "klangk-shell-wsid"
+        assert hidden == "klangk-consent-wsid"
+        # No tmux-illegal chars even for hostile input.
+        bad = sp.outer_session_name("a.b:c")
+        assert "." not in bad and ":" not in bad
+
+
+# ---------------------------------------------------------------------------
+# pure command builders
+# ---------------------------------------------------------------------------
+
+
+class TestBuilders:
+    def test_new_detached_session(self):
+        cmd = sp.new_detached_session(
+            "/tmp/s.sock", "sess", ["bash", "-l"], x=80, y=24
+        )
+        assert cmd == [
+            "tmux",
+            "-S",
+            "/tmp/s.sock",
+            "new-session",
+            "-d",
+            "-s",
+            "sess",
+            "-x",
+            "80",
+            "-y",
+            "24",
+            "bash",
+            "-l",
+        ]
+
+    def test_configure_outer_session(self):
+        cmds = sp.configure_outer_session("/tmp/s.sock", "outer")
+        assert cmds == [
+            [
+                "tmux",
+                "-S",
+                "/tmp/s.sock",
+                "set-option",
+                "-t",
+                "outer",
+                "prefix",
+                "C-a",
+            ],
+            [
+                "tmux",
+                "-S",
+                "/tmp/s.sock",
+                "set-option",
+                "-t",
+                "outer",
+                "status",
+                "off",
+            ],
+            [
+                "tmux",
+                "-S",
+                "/tmp/s.sock",
+                "set-option",
+                "-t",
+                "outer",
+                "mouse",
+                "off",
+            ],
+        ]
+
+    def test_configure_hidden_session(self):
+        # Hide the hidden session's status bar so the popup shows only the
+        # decider (no tmux status bar across the popup's bottom).
+        assert sp.configure_hidden_session("/tmp/s.sock", "hidden") == [
+            [
+                "tmux",
+                "-S",
+                "/tmp/s.sock",
+                "set-option",
+                "-t",
+                "hidden",
+                "status",
+                "off",
+            ],
+        ]
+
+    def test_popup_viewer_shell_string(self):
+        assert sp.popup_viewer_shell_string("/tmp/s.sock", "hidden") == (
+            "env -u TMUX tmux -S /tmp/s.sock attach -t hidden"
+        )
+
+    def test_display_popup_command(self):
+        cmd = sp.display_popup_command("/tmp/s.sock", "hidden", w=70, h=14)
+        assert cmd.startswith("display-popup -E ")
+        assert "env -u TMUX tmux -S /tmp/s.sock attach -t hidden" in cmd
+        assert "-w 70 -h 14" in cmd
+        # The shell-command MUST be the final positional (options first) or
+        # tmux swallows the trailing -w/-h into the command and the popup
+        # renders blank (#2383).
+        assert cmd.endswith(
+            shlex.quote(sp.popup_viewer_shell_string("/tmp/s.sock", "hidden"))
+        )
+
+    def test_popup_binding_cmds(self):
+        # Just the <prefix> reopen binding — no auto-show hook (the decider
+        # shows the popup itself when a request arrives).
+        cmds = sp.popup_binding_cmds("/tmp/s.sock", "hidden", w=70, h=14)
+        assert len(cmds) == 1
+        assert cmds[0][:4] == ["tmux", "-S", "/tmp/s.sock", "bind-key"]
+        assert cmds[0][4] == sp.REOPEN_KEY
+        assert "display-popup" in cmds[0][5]
+
+    def test_show_popup_argv(self):
+        argv = sp.show_popup_argv(
+            "/tmp/s.sock", "hidden", "clientA", w=70, h=14
+        )
+        assert argv == [
+            "tmux",
+            "-S",
+            "/tmp/s.sock",
+            "display-popup",
+            "-c",
+            "clientA",
+            "-E",
+            "-w",
+            "70",
+            "-h",
+            "14",
+            "env -u TMUX tmux -S /tmp/s.sock attach -t hidden",
+        ]
+
+    def test_outer_clients_excludes_hidden(self):
+        clients = "myclient\touter\nviewer\thidden\nother\touter\n"
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout=clients),
+        ):
+            assert sp.outer_clients("/tmp/s.sock", "hidden") == [
+                "myclient",
+                "other",
+            ]
+
+    def test_outer_clients_empty_on_error(self):
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run", side_effect=OSError("x")
+        ):
+            assert sp.outer_clients("/tmp/s.sock", "hidden") == []
+
+    def test_hidden_has_client(self):
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="clientA\n"),
+        ):
+            assert sp.hidden_has_client("/tmp/s.sock", "hidden") is True
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout=""),
+        ):
+            assert sp.hidden_has_client("/tmp/s.sock", "hidden") is False
+
+    def test_hidden_has_client_false_on_error(self):
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run", side_effect=OSError("x")
+        ):
+            assert sp.hidden_has_client("/tmp/s.sock", "hidden") is False
+
+    def test_attach_kill_has_session(self):
+        assert sp.attach_cmd("/tmp/s.sock", "s") == [
+            "tmux",
+            "-S",
+            "/tmp/s.sock",
+            "attach",
+            "-t",
+            "s",
+        ]
+        assert sp.kill_session_cmd("/tmp/s.sock", "s") == [
+            "tmux",
+            "-S",
+            "/tmp/s.sock",
+            "kill-session",
+            "-t",
+            "s",
+        ]
+        assert sp.has_session_cmd("/tmp/s.sock", "s") == [
+            "tmux",
+            "-S",
+            "/tmp/s.sock",
+            "has-session",
+            "-t",
+            "s",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# gate
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUsePopup:
+    def test_all_conditions_met(self):
+        assert sp.should_use_popup(
+            "interactive", isatty=True, tmux_version=(3, 6)
+        )
+
+    def test_disabled_flag(self):
+        assert not sp.should_use_popup(
+            "interactive", isatty=True, tmux_version=(3, 6), enabled=False
+        )
+
+    def test_non_interactive_egress(self):
+        for mode in (None, "allow", "static"):
+            assert not sp.should_use_popup(
+                mode, isatty=True, tmux_version=(3, 6)
+            )
+
+    def test_no_tty(self):
+        assert not sp.should_use_popup(
+            "interactive", isatty=False, tmux_version=(3, 6)
+        )
+
+    def test_old_tmux(self):
+        assert not sp.should_use_popup(
+            "interactive", isatty=True, tmux_version=(3, 1)
+        )
+
+    def test_missing_tmux(self):
+        assert not sp.should_use_popup(
+            "interactive", isatty=True, tmux_version=None
+        )
+
+
+# ---------------------------------------------------------------------------
+# orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestRunConsentShell:
+    @staticmethod
+    def _run(**kwargs):
+        """Drive run_consent_shell with recording run/attach stubs."""
+        ran: list[list[str]] = []
+
+        def fake_run(argv):
+            ran.append(argv)
+            return 0
+
+        def fake_attach(argv):
+            ran.append(argv)
+            return 0
+
+        rc = sp.run_consent_shell(run=fake_run, attach=fake_attach, **kwargs)
+        return rc, ran
+
+    def test_command_sequence(self):
+        rc, ran = self._run(
+            workspace_id="wsid",
+            inner_argv=["klangk", "shell", "ws", "--no-consent-popup"],
+            decider_argv=["klangk", "consent-decide", "ws"],
+        )
+        assert rc == 0
+        socket = sp.socket_path("wsid")
+        outer = sp.outer_session_name("wsid")
+        hidden = sp.hidden_session_name("wsid")
+        # 1 outer + 3 outer-config + 1 hidden + 1 hidden-config + 1 binding
+        # + 1 attach + 2 kills = 10
+        assert len(ran) == 10
+        # outer session created with the inner argv, then configured
+        assert (
+            ran[0]
+            == sp.new_detached_session(
+                socket,
+                outer,
+                ["klangk", "shell", "ws", "--no-consent-popup"],
+                x=80,
+                y=24,
+            )
+            or ran[0][3] == outer
+        )  # size may differ; check the session
+        assert ran[0][1:4] == ["-S", socket, "new-session"]
+        assert ran[0][4] == "-d"
+        assert ran[0][ran[0].index("-s") + 1] == outer
+        # configure: prefix/status/mouse
+        assert ran[1:4] == sp.configure_outer_session(socket, outer)
+        # hidden session
+        assert ran[4][1:4] == ["-S", socket, "new-session"]
+        assert ran[4][ran[4].index("-s") + 1] == hidden
+        # hidden session status bar hidden (popup shows only the decider)
+        assert ran[5:6] == sp.configure_hidden_session(socket, hidden)
+        # the reopen binding (no auto-show hook)
+        assert ran[6:7] == sp.popup_binding_cmds(
+            socket,
+            hidden,
+            w=sp.DEFAULT_POPUP_SIZE[0],
+            h=sp.DEFAULT_POPUP_SIZE[1],
+        )
+        # attach to outer
+        assert ran[7] == sp.attach_cmd(socket, outer)
+        # cleanup: kill hidden then outer
+        assert ran[8] == sp.kill_session_cmd(socket, hidden)
+        assert ran[9] == sp.kill_session_cmd(socket, outer)
+
+    def test_returns_attach_exit_code(self):
+        def fake_run(argv):
+            return 0
+
+        def fake_attach(argv):
+            return 42
+
+        rc = sp.run_consent_shell(
+            workspace_id="wsid",
+            inner_argv=["x"],
+            decider_argv=["y"],
+            run=fake_run,
+            attach=fake_attach,
+        )
+        assert rc == 42
+
+    def test_cleanup_runs_even_if_setup_fails(self):
+        # A failing run (nonzero rc) must not skip cleanup.
+        ran: list[list[str]] = []
+
+        def fake_run(argv):
+            ran.append(argv)
+            return 1  # simulate a failing tmux command
+
+        def fake_attach(argv):
+            ran.append(argv)
+            return 0
+
+        sp.run_consent_shell(
+            workspace_id="wsid",
+            inner_argv=["x"],
+            decider_argv=["y"],
+            run=fake_run,
+            attach=fake_attach,
+        )
+        # final two commands are the cleanup kills regardless
+        socket = sp.socket_path("wsid")
+        assert ran[-2] == sp.kill_session_cmd(
+            socket, sp.hidden_session_name("wsid")
+        )
+        assert ran[-1] == sp.kill_session_cmd(
+            socket, sp.outer_session_name("wsid")
+        )
+
+    def test_custom_popup_and_term_size(self):
+        ran: list[list[str]] = []
+
+        def fake_run(argv):
+            ran.append(argv)
+            return 0
+
+        def fake_attach(argv):
+            ran.append(argv)
+            return 0
+
+        sp.run_consent_shell(
+            workspace_id="wsid",
+            inner_argv=["x"],
+            decider_argv=["y"],
+            popup_size=(50, 10),
+            term_size=(100, 30),
+            run=fake_run,
+            attach=fake_attach,
+        )
+        outer_cmd = ran[0]
+        # outer session sized to the terminal
+        assert outer_cmd[outer_cmd.index("-x") + 1] == "100"
+        assert outer_cmd[outer_cmd.index("-y") + 1] == "30"
+        hidden_cmd = ran[4]
+        # hidden session sized to the popup
+        assert hidden_cmd[hidden_cmd.index("-x") + 1] == "50"
+        assert hidden_cmd[hidden_cmd.index("-y") + 1] == "10"
+        # popup command (the reopen binding) uses the popup size
+        assert "-w 50 -h 10" in ran[6][5]
+
+
+# ---------------------------------------------------------------------------
+# real-subprocess helpers (the orchestrator's defaults)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultHelpers:
+    def test_socket_path_falls_back_on_unwritable_dir(self):
+        # First makedirs (shared per-user dir) fails; the pid-suffixed
+        # fallback must still produce a usable socket path.
+        with patch(
+            "klangk.cli.shell_popup.os.makedirs",
+            side_effect=[OSError("x"), None],
+        ):
+            p = sp.socket_path("wsid")
+        assert str(sp.os.getpid()) in p
+
+    def test_default_run_returns_returncode(self):
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run",
+            return_value=MagicMock(returncode=7),
+        ):
+            assert sp._default_run(["tmux"]) == 7
+
+    def test_default_run_oserror_returns_1(self):
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run",
+            side_effect=OSError("boom"),
+        ):
+            assert sp._default_run(["tmux"]) == 1
+
+    def test_default_attach_returns_returncode(self):
+        with patch("klangk.cli.shell_popup.subprocess.call", return_value=3):
+            assert sp._default_attach(["tmux"]) == 3
+
+    def test_term_size_from_terminal(self):
+        with patch(
+            "klangk.cli.shell_popup.os.get_terminal_size",
+            return_value=MagicMock(columns=100, lines=40),
+        ):
+            assert sp._term_size() == (100, 40)
+
+    def test_term_size_fallback(self):
+        with patch(
+            "klangk.cli.shell_popup.os.get_terminal_size", side_effect=OSError
+        ):
+            assert sp._term_size() == (80, 24)
+
+
+# ---------------------------------------------------------------------------
+# shell() wiring (klangk.cli.main helpers)
+# ---------------------------------------------------------------------------
+
+
+from types import SimpleNamespace  # noqa: E402
+
+from klangk.cli import main as cli_main  # noqa: E402
+
+
+class TestShellWiring:
+    def test_klangk_argv(self):
+        a = cli_main._klangk_argv("shell", "ws")
+        assert a[:4] == [
+            cli_main.sys.executable,
+            "-m",
+            "klangk.cli.main",
+            "shell",
+        ]
+        assert a[4] == "ws"
+
+    def test_popup_inner_shell_argv_with_target_and_agent(self):
+        a = cli_main._popup_inner_shell_argv("http://s", "ws", "@1", True)
+        assert a[:4] == [
+            cli_main.sys.executable,
+            "-m",
+            "klangk.cli.main",
+            "--server",
+        ]
+        assert a[3] == "--server" and a[4] == "http://s"
+        assert "shell" in a and "ws" in a and "@1" in a
+        assert "--no-consent-popup" in a
+        assert "--forward-agent" in a
+
+    def test_popup_inner_shell_argv_no_target_no_agent(self):
+        a = cli_main._popup_inner_shell_argv("http://s", "ws", None, False)
+        assert "--no-consent-popup" in a
+        assert "--no-forward-agent" in a
+        assert "@1" not in a
+
+    def test_popup_decider_argv(self):
+        a = cli_main._popup_decider_argv(
+            "http://s", "ws", "/tmp/x.sock", "klangk-consent-ws"
+        )
+        assert "consent-decide" in a and "ws" in a
+        assert "--popup-socket" in a and "/tmp/x.sock" in a
+        assert "--popup-session" in a and "klangk-consent-ws" in a
+
+    def test_consent_popup_enabled_false_when_disabled(self):
+        ws = SimpleNamespace(egress_mode="interactive")
+        assert cli_main._consent_popup_enabled(ws, True) is False
+
+    def test_consent_popup_enabled_false_when_not_interactive(self):
+        ws = SimpleNamespace(egress_mode="allow")
+        with patch("klangk.cli.main.sys.stdin.isatty", return_value=True):
+            assert cli_main._consent_popup_enabled(ws, False) is False
+
+    def test_consent_popup_enabled_false_when_no_tty(self):
+        ws = SimpleNamespace(egress_mode="interactive")
+        with patch("klangk.cli.main.sys.stdin.isatty", return_value=False):
+            assert cli_main._consent_popup_enabled(ws, False) is False
+
+    def test_consent_popup_enabled_true(self):
+        ws = SimpleNamespace(egress_mode="interactive")
+        with (
+            patch("klangk.cli.main.sys.stdin.isatty", return_value=True),
+            patch("klangk.cli.main.host_tmux_version", return_value=(3, 6)),
+        ):
+            assert cli_main._consent_popup_enabled(ws, False) is True
+
+    def test_consent_popup_enabled_false_when_old_tmux(self):
+        ws = SimpleNamespace(egress_mode="interactive")
+        with (
+            patch("klangk.cli.main.sys.stdin.isatty", return_value=True),
+            patch("klangk.cli.main.host_tmux_version", return_value=(3, 1)),
+        ):
+            assert cli_main._consent_popup_enabled(ws, False) is False
+
+    def test_run_consent_popup_builds_argv_and_returns_rc(self):
+        ws = SimpleNamespace(id="wsid", name="ws")
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured.update(kwargs)
+            return 7
+
+        with (
+            patch("klangk.cli.main.run_consent_shell", side_effect=fake_run),
+            patch("klangk.cli.main.server_url", return_value="http://server"),
+        ):
+            rc = cli_main._run_consent_popup(ws, "@1", True)
+        assert rc == 7
+        assert captured["workspace_id"] == "wsid"
+        assert "--no-consent-popup" in captured["inner_argv"]
+        assert "ws" in captured["inner_argv"]
+        assert "--popup-socket" in captured["decider_argv"]
+        assert "--popup-session" in captured["decider_argv"]

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -10,15 +10,18 @@ from unittest.mock import patch
 from klangk.doctor import (
     CheckResult,
     DoctorReport,
+    TMUX_MIN_VERSION,
     check_binary,
     check_gnu_du,
     check_gnu_stat,
     check_gnu_tar,
     check_podman_policy,
     check_subuid,
+    check_tmux_version,
     detect_package_manager,
     format_report,
     install_hint,
+    parse_tmux_version,
     run_doctor,
 )
 
@@ -153,6 +156,82 @@ class TestCheckBinary:
             r = check_binary("suid-helper", [], "apt")
             assert r.ok
             assert "suid-helper ok" in r.message
+
+
+class TestCheckTmuxVersion:
+    """Host tmux >= 3.2 gate for the consent-popup shell layer (#2383)."""
+
+    def test_parse_typical(self):
+        assert parse_tmux_version("tmux 3.6a") == (3, 6)
+
+    def test_parse_no_suffix(self):
+        assert parse_tmux_version("tmux 3.2") == (3, 2)
+
+    def test_parse_double_digit_minor(self):
+        assert parse_tmux_version("tmux 3.10") == (3, 10)
+
+    def test_parse_garbage_is_none(self):
+        assert parse_tmux_version("not a version") is None
+
+    def test_parse_empty_is_none(self):
+        assert parse_tmux_version("") is None
+
+    def test_min_version_is_3_2(self):
+        assert TMUX_MIN_VERSION == (3, 2)
+
+    def test_new_enough_is_ok(self):
+        with (
+            patch("klangk.doctor.shutil.which", return_value="/usr/bin/tmux"),
+            patch("klangk.doctor._run", return_value=(0, "tmux 3.6a", "")),
+        ):
+            r = check_tmux_version("apt")
+        assert r.ok
+        assert not r.is_warning
+        assert "3.6" in r.message
+
+    def test_boundary_3_2_is_ok(self):
+        with (
+            patch("klangk.doctor.shutil.which", return_value="/usr/bin/tmux"),
+            patch("klangk.doctor._run", return_value=(0, "tmux 3.2", "")),
+        ):
+            r = check_tmux_version("apt")
+        assert r.ok
+
+    def test_old_version_is_warning(self):
+        with (
+            patch("klangk.doctor.shutil.which", return_value="/usr/bin/tmux"),
+            patch("klangk.doctor._run", return_value=(0, "tmux 3.1", "")),
+        ):
+            r = check_tmux_version("apt")
+        assert not r.ok
+        assert r.is_warning
+        assert "< 3.2" in r.message
+        assert r.hint  # actionable install hint
+
+    def test_unparseable_version_is_warning(self):
+        with (
+            patch("klangk.doctor.shutil.which", return_value="/usr/bin/tmux"),
+            patch("klangk.doctor._run", return_value=(0, "weird output", "")),
+        ):
+            r = check_tmux_version("apt")
+        assert not r.ok
+        assert r.is_warning
+
+    def test_tmux_v_fails_is_warning(self):
+        with (
+            patch("klangk.doctor.shutil.which", return_value="/usr/bin/tmux"),
+            patch("klangk.doctor._run", return_value=(1, "", "segfault")),
+        ):
+            r = check_tmux_version("apt")
+        assert not r.ok
+        assert r.is_warning
+
+    def test_absent_tmux_is_ok(self):
+        # A missing tmux is already flagged by the required-binary check;
+        # the version check has nothing to assess, so it passes.
+        with patch("klangk.doctor.shutil.which", return_value=None):
+            r = check_tmux_version("apt")
+        assert r.ok
 
 
 class TestCheckGnuTar:
@@ -400,6 +479,12 @@ class TestRunDoctor:
         report = run_doctor()
         assert isinstance(report, DoctorReport)
         assert len(report.results) > 0
+
+    def test_includes_tmux_version_check(self):
+        """run_doctor checks host tmux version for the consent popup (#2383)."""
+        report = run_doctor()
+        names = [r.name for r in report.results]
+        assert "tmux (consent popup)" in names
 
     def test_no_fuse_overlayfs_or_slirp4netns_checks(self):
         """fuse-overlayfs and slirp4netns are not checked — modern podman


### PR DESCRIPTION
## Summary

PR 1 of the TUI **consent-decider popup over the shell** feature (#2383). This lands the testable foundations for the decider's *persistent popup role* (running inside a hidden tmux session a `display-popup` viewer attaches to) plus a `doctor` gate. The local-tmux shell layer that launches it lands in a follow-up.

## Background

The goal (#2383): present `klangk consent-decide` as a persistent popup over the user's shell when they shell into an `interactive`-egress workspace, so they can act on held egress requests without leaving the shell — without leaking the consent surface into the Flutter app (which has its own banner). The decider must **stay registered while shelling, even with the popup hidden**.

The full design (validated against the spike #2385) is: one local per-workspace tmux server hosting (a) the user's shell session and (b) a **hidden** `klangk-consent-<ws>` session running the decider; a `display-popup` viewer attaches to the hidden session, auto-shown on shell attach and reopenable via a key; hide detaches the viewer (decider keeps running). No nested tmux — the outer session is a bare shell so the local tmux owns the prefix.

That shell layer needs a server change first (a per-shell `tmux:false` on `terminal_start`, since today tmux on/off is the global `KLANGKD_DISABLE_TMUX`), so this PR ships only the pieces that are independent of it.

## What's in this PR

- **`klangk consent-decide` persistent role.** New internal `--popup-socket` / `--popup-session` options (hidden from `--help`; set by the shell-layer wrapper in the follow-up). In that role:
  - `q` **hides the viewer** — detaches it via `tmux -S <socket> detach-client -s <session>`, leaving the decider registered and the held-request stream open (so a stray `q` can't deregister the always-on decider).
  - `Q` **confirms a real quit** via a `QuitConfirmScreen` (deliberate two-step).
  - Standalone `q` still quits immediately (unchanged).
  - `build_detach_command()` is the pure builder for the detach argv.
- **`klangkd doctor` tmux version check.** Reports the host tmux version and **warns** below 3.2 — `display-popup` landed in 3.2. Below it the shell layer will fall back to a plain attach, so it's a warning, not an error. A missing tmux is already caught by the existing required-binary check (no double-report).

## What's deliberately not in this PR

- The server per-shell `tmux:false` terminal flag (PR 2).
- The local-tmux shell layer + `--consent-popup` wiring + TUI detail-screen auto-enable for interactive-egress + leftover-session cleanup sweep (PR 3).

## Tests

Full Python suite green at **100% coverage (5011 tests)**, `-n auto` as CI runs it. New coverage:
- `TestPersistentPopupRole` — detach builder, persistent-flag, `q` quits (standalone) vs hides (persistent), `_hide_viewer` detach / no-op-without-popup / swallows-subprocess-error, confirm-quit push + `_on_confirm_quit` both branches, `QuitConfirmScreen` yes/no dismiss, binding labels.
- `TestCheckTmuxVersion` — version parsing, ok at 3.2/3.6, warning at 3.1 / unparseable / `tmux -V` failure, absent-is-ok; `run_doctor` includes the check.
- `consent-decide --popup-*` options flow through to the app.

## Checklist

- [x] Backend suite (`-n auto`, 100% coverage)
- [ ] Flutter `--coverage` (no frontend change in this PR)
- [x] `docs/changes.md` entry

Refs #2383.
