### PR TITLE
Egress activity resets the idle timer (#2479)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -816,6 +816,18 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Egress activity resets the idle timer (#2479).** A workspace whose only
+  activity was outbound network egress used to be treated as idle and stopped by
+  the idle timeout, because egress (workspace → network sidecar → internet)
+  bypasses klangkd and never bumped the container's `last_activity`. The network
+  sidecar now sends a flood-gated `{type:activity}` frame to klangkd on every
+  DNS query and queued connection SYN (`KLANGKNETWORK_EGRESS_ACTIVITY_GATE`,
+  default 60s, jittered to 0.5×–1.0× per send so a fleet of sidecars never herds
+  onto a synchronized frame rate — at most one frame per workspace per ~30–60s,
+  with the first event after a quiet period forwarding immediately), and klangkd
+  bumps the workspace's idle timer on receipt. Reloadable on sidecar restart; no
+  operator action on upgrade.
+
 - **A `once` egress-consent deny no longer blocks later same-host connects (#2463).**
   Denying a single connection once used to install a destination-scoped REJECT
   rule that silently rejected every _new_ connection to the same `host:port` for

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -86,6 +86,16 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
                     msg.get("id"), bool(msg.get("ok", False))
                 )
                 continue
+            if mtype == "activity":
+                # Sidecar reports egress/network activity (#2479): an
+                # egress-only workload bypasses klangkd, so without this its
+                # idle timer would never advance and the container would be
+                # reaped mid-egress. The sidecar flood-gates the frame; here
+                # the bump is a single float write on this loop thread.
+                state = app.state.container_registry.states.get(workspace_id)
+                if state is not None:
+                    state.record_activity()
+                continue
             if mtype != "egress":
                 continue
             local_id = msg.get("id")

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1357,6 +1357,44 @@ class TestEgressSidecarWS:
         await ws.feed(WebSocketDisconnect())
         await handler
 
+    async def test_activity_frame_bumps_idle_timer(self):
+        # #2479: a {type:activity} frame from the sidecar bumps the workspace's
+        # idle timer so an egress-only workload (whose traffic bypasses klangkd)
+        # is not reaped by the idle timeout.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, _ = _sidecar_app()
+        state = types.SimpleNamespace(record_activity=Mock())
+        app.state.container_registry = types.SimpleNamespace(
+            states={FULL_WS: state}
+        )
+        ws = _FakeWS({"token": FULL_WS})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(json.dumps({"type": "activity"}))
+        await asyncio.sleep(0.02)
+        state.record_activity.assert_called_once_with()
+        await ws.feed(WebSocketDisconnect())
+        await handler
+
+    async def test_activity_frame_no_tracked_state_is_noop(self):
+        # #2479: an activity frame for a workspace with no live ContainerState
+        # (container not started / already reaped) must not raise -- there is
+        # simply nothing to bump.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, _ = _sidecar_app()
+        app.state.container_registry = types.SimpleNamespace(states={})
+        ws = _FakeWS({"token": FULL_WS})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(json.dumps({"type": "activity"}))
+        await asyncio.sleep(0.02)
+        await ws.feed(WebSocketDisconnect())
+        await handler
+
     async def test_drop_ack_resolves_pending(self):
         # a drop_ack frame from the sidecar -> resolve_ack on the registry (#2339)
         from fastapi import WebSocketDisconnect

--- a/src/klangksidecar/klangksidecar/config.py
+++ b/src/klangksidecar/klangksidecar/config.py
@@ -69,6 +69,18 @@ VERDICT_CACHE_TTL = float(
 )
 
 
+# Min seconds between idle-activity reports to klangkd (#2479): the sidecar
+# bumps the workspace's idle timer on egress/network activity (a DNS query or a
+# queued connection SYN) so an egress-only workload -- whose traffic bypasses
+# klangkd entirely -- is not reaped by the idle timeout. Flood-gated: at most
+# one frame per workspace per interval (jittered to 0.5x-1.0x of the base so
+# workspaces don't herd onto a shared send cadence), so a connect-heavy workload
+# (a build, a crawler) does not spam the daemon. The first event after a quiet
+# period (>= the jittered interval since the last send) forwards at once, so a
+# single connect after a long idle stretch resets the timer promptly.
+ACTIVITY_GATE_S = float(os.environ.get("KLANGKNETWORK_EGRESS_ACTIVITY_GATE", "60"))
+
+
 # How long a deny keeps its REJECT (tcp-reset) rule so the denied connection
 # fails fast (ECONNREFUSED) instead of waiting for tcp_syn_retries (~127s).
 # Only needs to catch the SYN retransmit (~1 RTO); the verdict cache separately

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -9,15 +9,28 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
+import time
 import uuid
 
 from . import allowlist, rules
-from .config import DEBUG
+from .config import ACTIVITY_GATE_S, DEBUG
 from .state import _VERDICT_CACHE, _clear_verdict_cache
 
 # ---------------------------------------------------------------------------
 # Interactive consent: egress-sidecar WS client + hold paths (#2311 half B).
 # ---------------------------------------------------------------------------
+
+
+def _jittered_gate() -> float:
+    """The activity flood gate, jittered to 0.5x-1.0x of :data:`ACTIVITY_GATE_S`.
+
+    Full-jitter (the AWS-backoff idiom): the suppression window lands randomly
+    in [0.5x, 1.0x] of the base, so the per-workspace send cadence drifts and a
+    fleet of sidecars never herds onto a synchronized frame rate against
+    klangkd. The floor stays at half the base, so the window never collapses.
+    """
+    return ACTIVITY_GATE_S * random.uniform(0.5, 1.0)
 
 
 def _ws_url(consent_url: str) -> str:
@@ -62,6 +75,10 @@ class SidecarConsentClient:
         self._stop = False
         self._no_token_warned = False
         self._task: asyncio.Task | None = None
+        # Idle-activity flood gate (#2479): monotonic timestamp of the last
+        # ``{type:activity}`` frame sent. 0.0 so the first event always forwards.
+        self._last_activity_send = 0.0
+        self._activity_tasks: set[asyncio.Task] = set()
 
     @property
     def connected(self) -> bool:
@@ -240,6 +257,45 @@ class SidecarConsentClient:
         except asyncio.TimeoutError:
             self._pending.pop(lid, None)
             return "deny", "once"
+
+    def bump_activity(self) -> None:
+        """Best-effort, flood-gated idle-activity signal to klangkd (#2479).
+
+        Called from the DNS proxy (every query) and the NFQUEUE consumer (every
+        queued connection SYN) so klangkd's idle timer reflects egress-only
+        workloads, whose traffic bypasses the daemon entirely and would
+        otherwise be reaped by the idle timeout. Throttled by a jittered flood
+        gate (:func:`_jittered_gate` -- 0.5x-1.0x of :data:`ACTIVITY_GATE_S`):
+        a connect-heavy workload (a build, a crawler) generates a bounded,
+        desynchronized frame rate, while the first event after a quiet period
+        (>= the jittered window since the last send) forwards at once so a
+        single connect after a long idle stretch resets the timer promptly. A
+        dropped / disconnected send is silent -- activity signaling must never
+        break egress. Sync-safe: the NFQUEUE callback runs on the loop thread
+        but is itself sync, so the coroutine WS send is scheduled as a task.
+        """
+        if not self._connected.is_set() or self._ws is None:
+            return
+        now = time.monotonic()
+        if now - self._last_activity_send < _jittered_gate():
+            return
+        self._last_activity_send = now
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # not on a loop (defensive) -> nothing to schedule
+        t = loop.create_task(self._send_activity())
+        self._activity_tasks.add(t)  # strong ref so the send isn't GC'd mid-flight
+        t.add_done_callback(self._activity_tasks.discard)
+
+    async def _send_activity(self) -> None:
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            await ws.send(json.dumps({"type": "activity"}))
+        except Exception:
+            pass  # best-effort: a dropped frame just delays the next idle bump
 
     def _fail_close_pending(self) -> None:
         # A lost connection is a fresh session against a (possibly restarted)

--- a/src/klangksidecar/klangksidecar/nfqueue.py
+++ b/src/klangksidecar/klangksidecar/nfqueue.py
@@ -84,6 +84,12 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
     drain (distinct connections are held concurrently, not serialized behind
     the first).
     """
+    # Every queued SYN is outbound egress activity -- bump klangkd's idle timer
+    # (flood-gated inside the client) so an egress-only workload is not reaped
+    # (#2479). First, before any classification: even a SYN we drop (cached
+    # deny / retransmit) is real network activity.
+    if client is not None:
+        client.bump_activity()
     payload = pkt.get_payload()
     # Connection-level key (src IP+port + dst IP+port): a SYN retransmit shares
     # its connection's tuple, a NEW connection has a new source port. Keying the

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -231,6 +231,13 @@ async def _handle_packet(
         qname = query_name(data)
     except Exception:
         return  # malformed/unparseable query -> drop
+    # Every DNS query is outbound egress activity -- bump klangkd's idle timer
+    # (flood-gated inside the client) so an egress-only workload is not reaped
+    # (#2479). DNS is the broadest signal: every domain connect starts here,
+    # including repeats to an already-allow-listed host whose connects then
+    # bypass NFQUEUE entirely.
+    if client is not None:
+        client.bump_activity()
     # Static deny-list (#2367): a rejected name is NXDOMAIN'd unconditionally,
     # in BOTH static and interactive modes, and takes precedence over the
     # allow-list + consent (a name in both allowed + rejected is rejected).

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import signal
 import sys
+import time
 import types
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1537,6 +1538,101 @@ def _syn_payload(src: str, sport: int, dst: str, dport: int, seq: int) -> bytes:
     b[24:28] = seq.to_bytes(4, "big")
     b[33] = 0x02  # SYN flag
     return bytes(b)
+
+
+class TestBumpActivity:
+    """Idle-activity flood gate (#2479): the sidecar bumps klangkd's idle timer
+    on egress/network activity, throttled to <=1 frame per ACTIVITY_GATE_S."""
+
+    def _client(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        return c, sent
+
+    async def _drain(self, c):
+        # run any scheduled activity-send tasks to completion (deterministic)
+        if c._activity_tasks:
+            await asyncio.gather(*c._activity_tasks, return_exceptions=True)
+
+    async def test_first_call_sends_activity_frame(self, proxy, tmp_path):
+        c, sent = self._client(proxy, tmp_path)
+        c.bump_activity()
+        await self._drain(c)
+        assert [json.loads(f) for f in sent] == [{"type": "activity"}]
+
+    async def test_rapid_calls_within_gate_send_once(self, proxy, tmp_path):
+        c, sent = self._client(proxy, tmp_path)
+        for _ in range(50):
+            c.bump_activity()
+        await self._drain(c)
+        assert len(sent) == 1  # flood-gated: <=1 per ACTIVITY_GATE_S
+
+    async def test_sends_again_after_gate_window_elapses(
+        self, proxy, tmp_path, monkeypatch
+    ):
+        c, sent = self._client(proxy, tmp_path)
+        base = proxy.config.ACTIVITY_GATE_S
+        # Pin the jitter to the full base so the window is deterministic here;
+        # the jitter range itself is covered by test_gate_jittered_below_base.
+        monkeypatch.setattr(proxy.consent, "_jittered_gate", lambda: base)
+        c.bump_activity()  # first -> sends (sets _last_activity_send = now)
+        c.bump_activity()  # within base -> suppressed
+        await self._drain(c)
+        assert len(sent) == 1
+        # simulate the gate window elapsing (first event after a quiet period)
+        c._last_activity_send = time.monotonic() - (base + 1)
+        c.bump_activity()  # past base -> sends again
+        await self._drain(c)
+        assert len(sent) == 2
+
+    async def test_gate_jittered_below_base_lets_early_send_through(
+        self, proxy, tmp_path, monkeypatch
+    ):
+        # #2479: the suppression window is jittered (0.5x..1.0x of the base) so
+        # workspaces don't herd onto a shared send cadence. At minimum jitter a
+        # send just past HALF the base forwards; at maximum jitter (the full
+        # base) that same elapsed time is still suppressed.
+        base = proxy.config.ACTIVITY_GATE_S
+        elapsed = base * 0.5 + 1  # just past half the base
+
+        c1, sent1 = self._client(proxy, tmp_path)
+        monkeypatch.setattr(proxy.consent, "_jittered_gate", lambda: base * 0.5)
+        c1._last_activity_send = time.monotonic() - elapsed
+        c1.bump_activity()
+        await self._drain(c1)
+        assert len(sent1) == 1  # jitter collapsed the window to 0.5x -> forwards
+
+        c2, sent2 = self._client(proxy, tmp_path)
+        monkeypatch.setattr(proxy.consent, "_jittered_gate", lambda: base)
+        c2._last_activity_send = time.monotonic() - elapsed
+        c2.bump_activity()
+        await self._drain(c2)
+        assert sent2 == []  # full-base window still suppresses at half-base elapsed
+
+    async def test_disconnected_is_noop(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c.bump_activity()  # not connected, no _ws -> must not schedule/raise
+        await self._drain(c)
+        assert c._activity_tasks == set()
+
+    async def test_send_error_is_swallowed(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+
+        class _BadWS:
+            async def send(self, frame):
+                raise OSError("gone")
+
+        c._ws = _BadWS()
+        c.bump_activity()  # must not raise
+        await self._drain(c)  # the scheduled send raises internally, swallowed
 
 
 class _FakePkt:


### PR DESCRIPTION
Closes #2479.

## What

An egress-only workload (a build pulling deps, a sync agent, a poll loop) was treated as idle and stopped by the idle timeout, because egress (workspace → network sidecar → internet) bypasses klangkd entirely and never reset the container's `last_activity`. The egress fuzzer hit this directly: it drove connects via direct `podman exec curl`, klangkd saw no activity after the initial connect, and at the idle window it stopped the container mid-fuzz (surfacing as a spurious `HUNG` + a `CONTAINER-GONE`).

## How

The network sidecar is the workspace's gateway — it sees every outbound flow — so it is the natural place to observe egress activity that klangkd can't see.

- **Sidecar** (`klangksidecar`): new `SidecarConsentClient.bump_activity()` — a flood-gated idle-activity signal. Throttled to ≤1 frame per `KLANGKNETWORK_EGRESS_ACTIVITY_GATE` (default 5s, env-overridable), with `_last_activity_send` initialized to `0.0` so the **first event after a quiet period forwards immediately** (a single connect following a long idle stretch resets the timer without waiting out the throttle). Hooked at both observation points: `resolve._handle_packet` (every DNS query — the broadest signal, since it catches repeats to allow-listed hosts whose connects then bypass NFQUEUE) and `nfqueue._cb` (every queued connection SYN). Best-effort: a dropped/disconnected send is silent — activity signaling never breaks egress.
- **klangkd** (`wshandler/sidecar.py`): the existing `/ws/egress-sidecar` socket now handles `{type:activity}` → `container_registry.states[ws].record_activity()` (a single float write on the loop thread).

This covers every verdict path uniformly — off-list consent holds, covered/cached-allow egress resolved entirely in the sidecar, and allow-mode default-permit egress — because the sidecar observes all of it regardless of which path a flow takes.

## Tests

- Sidecar (`test_proxy.py::TestBumpActivity`): first call sends the activity frame; 50 rapid calls within the gate send once; after the gate window elapses it sends again; disconnected is a no-op; a send error is swallowed.
- klangkd (`test_consent_coordinator.py`): an `activity` frame bumps `record_activity` when a state exists, and is a safe no-op when the workspace has no live state.

Sidecar suite 170 passed; backend 4820 passed at 100% coverage.
