### PR TITLE
feat(terminal): per-shell tmux override on terminal_start (#2383) PR 2

### DIFF
--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -1082,6 +1082,7 @@ async def ws_shell(
     forward_agent: bool = False,
     sandbox_setup=None,
     max_size: int = _WS_MAX_SIZE,
+    tmux: bool | None = None,
 ) -> None:
     """Run the interactive PTY shell over WebSocket.
 
@@ -1092,6 +1093,9 @@ async def ws_shell(
     sandbox_setup, if set, is an async callable(ws) invoked after the
     workspace is ready but before the terminal starts.  Used by
     ``sandbox`` to run copy/setup on the same connection.
+    tmux, when set, requests a bare (``False``) or tmux-wrapped (``True``)
+    shell for this connection regardless of the server's global
+    ``KLANGKD_DISABLE_TMUX`` (#2383); None (default) defers to the server.
     """
     async with ws_connect(server_spec, token=token, max_size=max_size) as ws:
         # 1. Connect to workspace
@@ -1131,16 +1135,17 @@ async def ws_shell(
 
         # 2c. Start terminal
         cols, rows = get_terminal_size()
-        await ws.send(
-            json.dumps(
-                {
-                    "cmd": "terminal_start",
-                    "cols": cols,
-                    "rows": rows,
-                    "browser_id": "klangkshell",
-                }
-            )
-        )
+        term_start = {
+            "cmd": "terminal_start",
+            "cols": cols,
+            "rows": rows,
+            "browser_id": "klangkshell",
+        }
+        # Only send the per-shell tmux override when the caller set it; an
+        # absent key lets the server use its global KLANGKD_DISABLE_TMUX.
+        if tmux is not None:
+            term_start["tmux"] = tmux
+        await ws.send(json.dumps(term_start))
 
         # 3. Drain messages until we have what window selection needs.
         # terminal_output may arrive before terminal_windows due to async

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -897,6 +897,7 @@ class TerminalSession:
         ssh_agent_socket: str | None = None,
         terminal: Terminal | None = None,
         workspace_name: str | None = None,
+        tmux: bool | None = None,
     ):
         self.container_id = container_id
         self._terminal = terminal
@@ -909,6 +910,10 @@ class TerminalSession:
         self.user_handle = user_handle
         self.ssh_agent_socket = ssh_agent_socket
         self.workspace_name = workspace_name
+        # Per-shell tmux override (#2383): a terminal_start may request a
+        # bare (non-tmux) shell for the consent-popup path so the local
+        # tmux layer owns the prefix with no nesting. None -> global setting.
+        self.tmux = tmux
         self._shell: ShellProcess | None = None
         self._output_queue: BoundedOutputQueue[str] = BoundedOutputQueue(
             maxsize=64
@@ -921,6 +926,18 @@ class TerminalSession:
     def _podman(self):
         """Reach podman via the Terminal instance (#1480)."""
         return self._terminal.podman
+
+    @property
+    def _use_tmux(self) -> bool:
+        """Effective tmux for this session: per-shell override else global.
+
+        A ``terminal_start`` may request a bare shell (``tmux=False``) for the
+        consent-popup shell layer (#2383); otherwise the global
+        ``KLANGKD_DISABLE_TMUX`` setting decides, as before.
+        """
+        if self.tmux is not None:
+            return self.tmux
+        return self._terminal.tmux_enabled()
 
     async def start(
         self,
@@ -936,7 +953,7 @@ class TerminalSession:
             self.session_name
             and not self.join_session
             and not self.socket_path
-            and self._terminal.tmux_enabled()
+            and self._use_tmux
         ):
             await self._terminal.ensure_base_session(
                 self.container_id,
@@ -950,7 +967,7 @@ class TerminalSession:
         # bar picks it up.  Runs on every terminal_start (idempotent)
         # because the base session may have been created by older code
         # that didn't set it (#1880).
-        if self.workspace_name and self._terminal.tmux_enabled():
+        if self.workspace_name and self._use_tmux:
             await self._terminal.set_workspace_name(
                 self.container_id, self.workspace_name
             )
@@ -966,7 +983,7 @@ class TerminalSession:
             socket_path=self.socket_path,
             join_session=self.join_session,
             read_only=self.read_only,
-            tmux_enabled=self._terminal.tmux_enabled(),
+            tmux_enabled=self._use_tmux,
             ssh_agent_socket=self.ssh_agent_socket,
             user_id=self.user_id,
             user_handle=self.user_handle,

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -663,6 +663,12 @@ class TerminalController:
         )
         self.cols = cols
         self.rows = rows
+        # Per-shell tmux override (#2383): a bare (non-tmux) shell for the
+        # consent-popup path so the local tmux layer owns the prefix with no
+        # nesting. Only an explicit JSON bool is honoured; anything else
+        # (absent, string, number) falls back to the global setting.
+        tmux_flag = msg.get("tmux")
+        tmux = tmux_flag if isinstance(tmux_flag, bool) else None
 
         # The service command no longer lives in any user's session --
         # it runs in the standalone ``service`` session owned by the agent
@@ -689,6 +695,7 @@ class TerminalController:
             ssh_agent_socket=ssh_agent_socket_path(self._conn.user["id"]),
             terminal=self._conn.app.state.terminal,
             workspace_name=ws.get("name") if ws else None,
+            tmux=tmux,
         )
 
         browser_id = msg.get("browser_id")

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -129,6 +129,112 @@ class TestWsShell:
         assert any("terminal_start" in s for s in sent)
 
     @pytest.mark.asyncio
+    async def test_ws_shell_tmux_false_sent_in_terminal_start(self):
+        """tmux=False is forwarded as a per-shell override (#2383)."""
+        from klangk.cli.client import ws_shell
+
+        ws_mock = MagicMock()
+
+        async def fake_enter(self):
+            return ws_mock
+
+        async def fake_exit(self, *args):
+            return None
+
+        ws_mock.__aenter__ = fake_enter
+        ws_mock.__aexit__ = fake_exit
+        ws_mock.send = AsyncMock()
+        ws_mock.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "container_ready", "workspaceId": "ws1"}),
+                json.dumps({"type": "terminal_output", "data": ""}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            }
+                        ],
+                    }
+                ),
+                Exception("stop"),
+            ]
+        )
+        with patch(
+            "klangk.cli.transport.websockets.connect", return_value=ws_mock
+        ):
+            with (
+                patch("termios.tcgetattr", return_value=None),
+                patch("termios.tcsetattr"),
+                patch("tty.setraw"),
+            ):
+                try:
+                    await ws_shell(
+                        "http://localhost", "token", "ws1", tmux=False
+                    )
+                except Exception:
+                    pass
+        sent = [c[0][0] for c in ws_mock.send.call_args_list]
+        start = next(json.loads(s) for s in sent if "terminal_start" in s)
+        assert start.get("tmux") is False
+
+    @pytest.mark.asyncio
+    async def test_ws_shell_omits_tmux_when_default(self):
+        """No tmux kwarg -> no per-shell override sent (server uses global)."""
+        from klangk.cli.client import ws_shell
+
+        ws_mock = MagicMock()
+
+        async def fake_enter(self):
+            return ws_mock
+
+        async def fake_exit(self, *args):
+            return None
+
+        ws_mock.__aenter__ = fake_enter
+        ws_mock.__aexit__ = fake_exit
+        ws_mock.send = AsyncMock()
+        ws_mock.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "container_ready", "workspaceId": "ws1"}),
+                json.dumps({"type": "terminal_output", "data": ""}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            }
+                        ],
+                    }
+                ),
+                Exception("stop"),
+            ]
+        )
+        with patch(
+            "klangk.cli.transport.websockets.connect", return_value=ws_mock
+        ):
+            with (
+                patch("termios.tcgetattr", return_value=None),
+                patch("termios.tcsetattr"),
+                patch("tty.setraw"),
+            ):
+                try:
+                    await ws_shell("http://localhost", "token", "ws1")
+                except Exception:
+                    pass
+        sent = [c[0][0] for c in ws_mock.send.call_args_list]
+        start = next(json.loads(s) for s in sent if "terminal_start" in s)
+        assert "tmux" not in start
+
+    @pytest.mark.asyncio
     async def test_ws_shell_collects_windows_and_shared(self):
         """Drain loop collects terminal_windows and shared_terminals."""
         from klangk.cli.client import ws_shell

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -207,6 +207,51 @@ class TestStart:
         assert s.tmux_session_name is None
         await s.stop()
 
+    async def test_start_per_session_tmux_false_overrides_global(self):
+        # Global tmux enabled, but this terminal_start requested a bare shell
+        # for the consent-popup path (#2383).
+        assert _terminal.tmux_enabled() is True  # global is on
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
+            s = TerminalSession(
+                "cid", session_name="uid", terminal=_terminal, tmux=False
+            )
+            await s.start(120, 40)
+        argv = fake.argv
+        assert argv[-2:] == ["bash", "-l"]
+        assert "tmux" not in argv
+        assert s.tmux_session_name is None
+        await s.stop()
+
+    async def test_start_per_session_tmux_true_overrides_disabled_global(self):
+        # Global tmux disabled, but this session explicitly wants tmux.
+        _mock_settings.disable_tmux = "1"
+        assert _terminal.tmux_enabled() is False  # global is off
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
+            s = TerminalSession(
+                "cid", session_name="uid", terminal=_terminal, tmux=True
+            )
+            await s.start(120, 40)
+        assert "tmux" in fake.argv and "new-session" in fake.argv
+        assert s.tmux_session_name is not None
+        await s.stop()
+
+    def test_use_tmux_resolves_override_then_global(self):
+        # Per-shell override wins when set; otherwise the global setting applies.
+        assert _terminal.tmux_enabled() is True
+        assert (
+            TerminalSession("cid", terminal=_terminal, tmux=False)._use_tmux
+            is False
+        )
+        assert (
+            TerminalSession("cid", terminal=_terminal, tmux=True)._use_tmux
+            is True
+        )
+        assert TerminalSession("cid", terminal=_terminal)._use_tmux is True
+        _mock_settings.disable_tmux = "1"
+        assert TerminalSession("cid", terminal=_terminal)._use_tmux is False
+
     async def test_start_unsets_sensitive_env_vars(self, monkeypatch):
         monkeypatch.setenv("KLANGKD_LLM_API_KEY", "secret")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "secret2")

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -782,6 +782,7 @@ class TestHandleTerminalStart:
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
             terminal=_mock_term,
             workspace_name=None,
+            tmux=None,
         )
         # Should have sent terminal_windows and shared_terminals
         sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -820,6 +821,83 @@ class TestHandleTerminalStart:
             pass
         registry.revoke_workspace_browsers("ws")
         registry.states.pop("ws", None)
+
+    async def _run_terminal_start(self, msg: dict):
+        """Drive handle_terminal_start to the TerminalSession construction.
+
+        Returns the TerminalSession mock so a test can assert its kwargs
+        (e.g. the per-shell tmux override, #2383).
+        """
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+
+        async def _perm(*a):
+            return True
+
+        conn._has_perm = _perm  # type: ignore[method-assign]
+        registry.track_activity("cid", "ws")
+        session = sockets.get_or_create_session("ws", app_state)
+        await session.add_subscriber(sock, "cid")
+        sockets.connections[sock] = conn
+
+        with (
+            patch.object(_ws_controllers, "TerminalSession") as MockTS,
+            patch.object(
+                _mock_term,
+                "list_windows",
+                return_value=[
+                    {"id": "@0", "index": 0, "name": "bash", "active": True}
+                ],
+            ),
+            patch.object(_mock_term, "attach_browser", new_callable=AsyncMock),
+            patch.object(
+                _ws_controllers.TerminalController,
+                "_sync_service_windows",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            mock_session = _mock_terminal()
+            MockTS.return_value = mock_session
+
+            async def fake_output():
+                return
+                yield  # make it an async generator
+
+            mock_session.output = fake_output
+            await conn.handle_terminal_start(msg)
+            await asyncio.sleep(0)
+
+        # Clean up the background task.
+        if conn.terminal_task is not None:
+            conn.terminal_task.cancel()
+            try:
+                await conn.terminal_task
+            except asyncio.CancelledError:
+                pass
+        sockets.sessions.pop("ws", None)
+        sockets.connections.pop(sock, None)
+        registry.states.pop("ws", None)
+        return MockTS
+
+    async def test_terminal_start_passes_tmux_false(self):
+        """A ``tmux: false`` terminal_start reaches the session (#2383)."""
+        mock_ts = await self._run_terminal_start(
+            {"cols": 80, "rows": 24, "tmux": False}
+        )
+        assert mock_ts.call_args.kwargs["tmux"] is False
+
+    async def test_terminal_start_coerces_non_bool_tmux_to_none(self):
+        """Only a JSON bool is honoured; a string/number falls back to global."""
+        mock_ts = await self._run_terminal_start(
+            {"cols": 80, "rows": 24, "tmux": "false"}
+        )
+        assert mock_ts.call_args.kwargs["tmux"] is None
 
     async def test_terminal_start_fires_service_command(self, app_state):
         """terminal_start fires the service command in the agent's service
@@ -1429,6 +1507,7 @@ class TestHandleTerminalStart:
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
             terminal=_mock_term,
             workspace_name=None,
+            tmux=None,
         )
         mock_ess.assert_awaited_once_with(
             "cid",
@@ -3370,6 +3449,7 @@ class TestSSHAgentHandlers:
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
             terminal=_mock_term,
             workspace_name=None,
+            tmux=None,
         )
 
     async def test_terminal_start_wires_agent_socket_without_relay(


### PR DESCRIPTION
## Summary

PR 2 of the TUI **consent-decider popup over the shell** feature (#2383). **Stacked on PR 1 (#2478)** — review/merge #2478 first.

This adds the server capability PR 3 (the local-tmux shell layer) needs: a **per-shell `tmux` override** on `terminal_start`, so one specific shell can be a bare (non-tmux) shell while every other terminal keeps using the container's tmux. No user-facing behavior change yet (no caller passes `tmux`); PR 3 wires the bare-shell request into the consent-popup path.

## Why

The popup design (no nested tmux): the user attaches to a **local** per-workspace tmux whose outer session runs the workspace shell, and a `display-popup` floats the consent decider over it. For the local tmux to own `Ctrl-b` (so the popup's reopen binding is reachable) the outer session must be a **bare** shell — not the container's tmux relayed inside the local one. But tmux on/off is currently the global `KLANGKD_DISABLE_TMUX`, applied to every shell. Disabling it globally would break the multi-window terminal model for everyone; we need per-shell control.

## What changed

- **`terminal_start` gains an optional `"tmux"` field** (JSON bool). The controller honours only an explicit bool; absent / non-bool (string, number) defers to the global `KLANGKD_DISABLE_TMUX` — **fully backward compatible** (existing TUI/Flutter clients send nothing and behave exactly as before).
- **`TerminalSession` carries the override.** New `_use_tmux` resolves per-session-override-then-global; `start()` uses it for the base-session guard, the workspace-name guard, and `build_shell_command` (replacing the three direct `Terminal.tmux_enabled()` reads).
- **`ws_shell` (client) gains a `tmux` kwarg** (`None` = omit the key → server global; `False`/`True` = per-shell override). PR 3 passes `tmux=False` for the consent-popup shell.

## What's not in this PR

- The local-tmux shell layer that actually requests the bare shell, plus the `display-popup` viewer + TUI wiring — **PR 3**.

## Tests

Full Python suite green at **100% coverage (5019 tests)**, `-n auto` as CI runs it. New coverage:
- `TerminalSession` per-session override: `tmux=False` → bare `bash -l` even with global on; `tmux=True` → tmux even with global off; `_use_tmux` resolution (override vs global both directions).
- Controller plumbing: `terminal_start {"tmux": false}` → `TerminalSession(tmux=False)`; `{"tmux": "false"}` (string) → coerced to `None`. Existing full-kwargs assertions updated for the new `tmux=None` default.
- Client wire: `ws_shell(tmux=False)` sends `"tmux": false` in `terminal_start`; default omits the key.

## Checklist

- [x] Backend suite (`-n auto`, 100% coverage)
- [ ] Flutter `--coverage` (no frontend change)
- [x] No changelog entry (internal plumbing; the user-visible entry lands with PR 3)

Refs #2383. Stacked on #2478.
