### PR TITLE
fix(container): reap workspaces before their network sidecars (#2476)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -826,13 +826,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   A workspace joins its sidecar's netns via `--network container:<sidecar>`,
   so podman refuses to remove a sidecar while its workspace still shares that
   netns ("has dependent containers"), and `rm -f` does not override that.
-  klangk creates the sidecar before the workspace, so any bulk/iterative
-  removal ordered oldest-first hit the sidecar first, removed only the
-  workspaces, and left every sidecar running. The startup reapers
-  (`reap_instance_containers`, `reap_dead_owner_containers`) and the e2e
-  teardown sweep now remove `role=workspace` containers before
-  `role=network-sidecar` containers, so both come down in one pass instead of
-  the sidecar lingering until a second startup.
+  klangk creates the sidecar before the workspace, so a bulk removal that did
+  not order by role could hit the sidecar first, remove only the workspaces,
+  and leave every sidecar running. The startup container reapers and the e2e
+  teardown sweep now remove workspace containers before network sidecar
+  containers, so both come down in one pass instead of the sidecar lingering
+  until a second startup.
 - **Egress activity resets the idle timer (#2479).** A workspace whose only
   activity was outbound network egress used to be treated as idle and stopped by
   the idle timeout, because egress (workspace → network sidecar → internet)

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -822,6 +822,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Network sidecar containers no longer orphaned on reap/sweep (#2476).**
+  A workspace joins its sidecar's netns via `--network container:<sidecar>`,
+  so podman refuses to remove a sidecar while its workspace still shares that
+  netns ("has dependent containers"), and `rm -f` does not override that.
+  klangk creates the sidecar before the workspace, so any bulk/iterative
+  removal ordered oldest-first hit the sidecar first, removed only the
+  workspaces, and left every sidecar running. The startup reapers
+  (`reap_instance_containers`, `reap_dead_owner_containers`) and the e2e
+  teardown sweep now remove `role=workspace` containers before
+  `role=network-sidecar` containers, so both come down in one pass instead of
+  the sidecar lingering until a second startup.
 - **Egress activity resets the idle timer (#2479).** A workspace whose only
   activity was outbound network egress used to be treated as idle and stopped by
   the idle timeout, because egress (workspace → network sidecar → internet)

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -142,12 +142,12 @@ def _reap_sort_key(c: dict) -> int:
     ``--network container:<sidecar>``, so the sidecar cannot be removed
     while the workspace still references it — podman refuses with "has
     dependent containers", and ``rm -f`` does **not** override that check.
-    klangk creates the sidecar *before* the workspace, and
-    :meth:`Podman.list_containers` returns oldest-first, so an unsorted
-    reap hits the sidecar first, skips it (logged ``PodmanError``), removes
-    the workspace, and orphans the sidecar until the next startup (#2476).
-    Ordering workspaces (``klangk.role=workspace``) ahead of everything else
-    lets each sidecar removal succeed in the same pass.
+    ``list_containers`` returns containers in no guaranteed role order, so an
+    unsorted reap may hit a sidecar before its workspace, skip it (logged
+    ``PodmanError``), remove the workspace, and orphan the sidecar until the
+    next startup (#2476). Ordering workspaces (``klangk.role=workspace``)
+    ahead of everything else lets each sidecar removal succeed in the same
+    pass regardless of the list order.
     """
     return (
         0 if (c.get("Labels") or {}).get("klangk.role") == "workspace" else 1

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -135,6 +135,25 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+def _reap_sort_key(c: dict) -> int:
+    """Sort key: remove netns *dependents* (workspaces) before sidecars.
+
+    A workspace joins its network sidecar's netns via
+    ``--network container:<sidecar>``, so the sidecar cannot be removed
+    while the workspace still references it — podman refuses with "has
+    dependent containers", and ``rm -f`` does **not** override that check.
+    klangk creates the sidecar *before* the workspace, and
+    :meth:`Podman.list_containers` returns oldest-first, so an unsorted
+    reap hits the sidecar first, skips it (logged ``PodmanError``), removes
+    the workspace, and orphans the sidecar until the next startup (#2476).
+    Ordering workspaces (``klangk.role=workspace``) ahead of everything else
+    lets each sidecar removal succeed in the same pass.
+    """
+    return (
+        0 if (c.get("Labels") or {}).get("klangk.role") == "workspace" else 1
+    )
+
+
 class ContainerState:
     """Per-workspace container lifecycle state."""
 
@@ -2610,6 +2629,9 @@ class ContainerRegistry:
         except (podman.PodmanError, OSError) as e:
             logger.warning("Error scanning for leftover containers: %s", e)
             return
+        # Remove dependents (workspaces) before the sidecars they reference,
+        # or every sidecar is skipped this pass (#2476 — see _reap_sort_key).
+        containers.sort(key=_reap_sort_key)
         for c in containers:
             cid = c.get("Id") or c.get("ID", "")
             if not cid:
@@ -2672,6 +2694,9 @@ class ContainerRegistry:
         except (podman.PodmanError, OSError) as e:
             logger.warning("Error scanning for dead-owner containers: %s", e)
             return
+        # Remove dependents (workspaces) before the sidecars they reference,
+        # or every sidecar is skipped this pass (#2476 — see _reap_sort_key).
+        containers.sort(key=_reap_sort_key)
         for c in containers:
             cid = c.get("Id") or c.get("ID", "")
             if not cid:

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -285,10 +285,10 @@ def _cleanup_containers(data_dir: str) -> None:
     not one bulk ``podman rm -f``. A workspace joins its sidecar's netns via
     ``--network container:<sidecar>``, so podman refuses to remove a sidecar
     whose netns a live workspace still shares ("has dependent containers"),
-    and ``-f`` does not override that. ``podman ps`` lists oldest-first and
-    klangk creates the sidecar before the workspace, so a single bulk removal
-    hits the sidecar first, removes only the workspaces, and orphans every
-    sidecar (#2476). Removing the dependents first tears both down in one go.
+    and ``-f`` does not override that. A single bulk removal puts sidecars
+    and workspaces in an unspecified order, so a sidecar attempted before its
+    workspace is skipped and left running (#2476). Removing the dependents
+    first tears both down in one go, regardless of list order.
     """
     id_file = os.path.join(data_dir, "instance-id")
     instance_id = ""

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -280,6 +280,15 @@ def _cleanup_containers(data_dir: str) -> None:
     The instance id is written to ``<data_dir>/instance-id`` at startup
     (#1553). A crashed/timed-out test can leave workspace containers behind;
     this best-effort sweep prevents them from accumulating across runs.
+
+    Removal is two role-scoped passes — workspaces, then network sidecars —
+    not one bulk ``podman rm -f``. A workspace joins its sidecar's netns via
+    ``--network container:<sidecar>``, so podman refuses to remove a sidecar
+    whose netns a live workspace still shares ("has dependent containers"),
+    and ``-f`` does not override that. ``podman ps`` lists oldest-first and
+    klangk creates the sidecar before the workspace, so a single bulk removal
+    hits the sidecar first, removes only the workspaces, and orphans every
+    sidecar (#2476). Removing the dependents first tears both down in one go.
     """
     id_file = os.path.join(data_dir, "instance-id")
     instance_id = ""
@@ -291,21 +300,26 @@ def _cleanup_containers(data_dir: str) -> None:
     if not instance_id:
         return
     try:
-        result = subprocess.run(
-            [
-                "podman",
-                "ps",
-                "-a",
-                "--filter",
-                f"label=klangk.instance={instance_id}",
-                "-q",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        ids = result.stdout.split()
-        if ids:
-            subprocess.run(["podman", "rm", "-f", *ids], capture_output=True)
+        for role in ("workspace", "network-sidecar"):
+            result = subprocess.run(
+                [
+                    "podman",
+                    "ps",
+                    "-a",
+                    "-q",
+                    "--filter",
+                    f"label=klangk.instance={instance_id}",
+                    "--filter",
+                    f"label=klangk.role={role}",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            ids = result.stdout.split()
+            if ids:
+                subprocess.run(
+                    ["podman", "rm", "-f", *ids], capture_output=True
+                )
     except FileNotFoundError:
         # podman not on PATH (e.g. a partial dev env) — nothing to clean.
         pass

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -4676,6 +4676,42 @@ class TestReapInstanceContainers:
             await self.registry.reap_instance_containers()
         mocks.remove_container.assert_awaited_once_with("good-1")
 
+    async def test_removes_workspaces_before_their_sidecars(self):
+        """Dependents (workspaces) are reaped before the sidecars whose netns
+        they share, so no sidecar is skipped this pass (#2476).
+
+        ``list_containers`` returns oldest-first and klangk creates the
+        sidecar before the workspace, so the sidecar is listed first.
+        Without the dependency-order sort that sidecar would be removed
+        first and (against real podman) fail with "has dependent
+        containers"; here we assert the awaited removal order directly.
+        """
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "sidecar-1",
+                        "Labels": {
+                            "klangk.role": "network-sidecar",
+                            "klangk.workspace": "ws-1",
+                        },
+                    },
+                    {
+                        "Id": "workspace-1",
+                        "Labels": {
+                            "klangk.role": "workspace",
+                            "klangk.workspace": "ws-1",
+                        },
+                    },
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            await self.registry.reap_instance_containers()
+        order = [c.args[0] for c in mocks.remove_container.await_args_list]
+        assert order == ["workspace-1", "sidecar-1"]
+
 
 class TestPidAlive:
     """Unit tests for ``container._pid_alive`` — the liveness check the
@@ -4736,6 +4772,47 @@ class TestReapDeadOwnerContainers:
             with patch("klangk.container._pid_alive", return_value=False):
                 await self.registry.reap_dead_owner_containers()
         mocks.remove_container.assert_awaited_once_with("dead-owner-1")
+
+    async def test_removes_workspaces_before_their_sidecars(self):
+        """Dependents (workspaces) are reaped before their sidecars (#2476).
+
+        Same netns-dependency ordering as the per-instance reap
+        (:class:`TestReapInstanceContainers`): the sidecar is listed first
+        (created first) but must be removed after the workspace that joins
+        its netns, or its removal is skipped this pass.
+        """
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "sidecar-ghost",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.instance": "ghost",
+                            "klangk.pid": "99999",
+                            "klangk.role": "network-sidecar",
+                            "klangk.workspace": "ws-ghost",
+                        },
+                    },
+                    {
+                        "Id": "workspace-ghost",
+                        "Labels": {
+                            "klangk.managed": "true",
+                            "klangk.instance": "ghost",
+                            "klangk.pid": "99999",
+                            "klangk.role": "workspace",
+                            "klangk.workspace": "ws-ghost",
+                        },
+                    },
+                ]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            with patch("klangk.container._pid_alive", return_value=False):
+                await self.registry.reap_dead_owner_containers()
+        order = [c.args[0] for c in mocks.remove_container.await_args_list]
+        assert order == ["workspace-ghost", "sidecar-ghost"]
 
     async def test_skips_container_whose_owner_pid_is_alive(self):
         # A live owner (sibling klangkd, possibly mid-shutdown) always holds


### PR DESCRIPTION
## Summary

Fixes #2476.

The openclaw sandbox e2e suite left its three per-workspace network sidecar containers running after teardown, accumulating across re-runs and holding published host ports.

## Root cause

A workspace joins its network sidecar's netns via `--network container:<sidecar>`, so podman **refuses to remove a sidecar while its workspace still shares that netns** (`container <sidecar> has dependent containers which must be removed before it`), and `rm -f` does **not** override that check (verified empirically against real podman).

klangk creates the sidecar *before* the workspace, and `podman ps` lists oldest-first. So every bulk, label-based removal that iterated the `podman ps` order hit the sidecar first, failed to remove it, removed the dependent workspace, and left the sidecar orphaned.

This affected all three sites that do bulk instance/dead-owner sweeps:

- `_cleanup_containers` (e2e teardown in `_e2e_server.py`) — the direct cause of the reported leak; klangkd is `SIGKILL`ed, so its graceful `shutdown()` (which removes workspace-then-sidecar per workspace via `stop_and_remove_container`) never runs, leaving the sweep as the only backstop.
- `reap_instance_containers` (startup reaper for this instance's own leftovers)
- `reap_dead_owner_containers` (startup reaper for dead-owner containers)

The latter two are why sidecars **accumulated across re-runs** instead of being reaped on the next klangkd startup: the next run's reaper hit the same ordering bug and skipped the sidecars again.

The per-workspace stop path (`stop_and_remove_container` → remove workspace → `_stop_network_sidecar`) already removes workspace-then-sidecar, so it is unaffected, as is `shutdown()` which fans out through that path.

## Fix

Order removal `klangk.role=workspace` before `klangk.role=network-sidecar` at each bulk-sweep site:

- `_cleanup_containers`: two role-scoped passes instead of one bulk `podman rm -f`.
- Both startup reapers: a shared `_reap_sort_key` sorts the listed containers so workspaces come first.

## Tests

- `TestReapInstanceContainers::test_removes_workspaces_before_their_sidecars`
- `TestReapDeadOwnerContainers::test_removes_workspaces_before_their_sidecars`

Both assert the awaited `remove_container` order is `[workspace, sidecar]` given a sidecar-first (creation-order) list. Full backend suite: 4822 passed, 100% coverage.

The openclaw e2e suite itself is network/image-dependent and gated to its own workflow; the teardown fix is covered by the empirical podman check above and the unit tests for the production reapers.

## Changelog

Added a `Fixed` entry under `[Unreleased]`.
