### PR TITLE
Hide the test-only 5s consent duration in the TUI and Flutter deciders

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,13 +32,6 @@ operators or integrators to act when upgrading.
 
 ### Added
 
-- **`5s` consent-duration option (#2465).** The test-only 5-second duration
-  is temporarily exposed in the consent duration selector (TUI + Flutter) for
-  manual testing, now that a timed allow lapses at its verdict rather than the
-  `MIN_TTL` floor. Remove `5s` from `SELECTABLE_DURATIONS` (TUI) /
-  `kConsentDurations` (Flutter) to hide it again; it stays valid for
-  programmatic/test callers either way.
-
 - **`KLANGKNETWORK_EGRESS_UPSTREAM` — operator-pinnable sidecar DNS upstream (#2424).**
   When set in `klangkd`'s environment, the network sidecar's FQDN proxy forwards
   workspace DNS to this resolver verbatim instead of auto-detecting a host

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -29,13 +29,11 @@ const String kDecisionAllowed = 'allowed';
 const String kDecisionDenied = 'denied';
 
 /// Ordered for the duration selector; the default is `tilrestart` (#2328).
-/// The test-only `5s` is TEMPORARILY included (#2465) for manual testing now
-/// that a timed allow lapses at its verdict (not the MIN_TTL floor); remove
-/// it from this list to shut it off (it stays valid when sent by a
-/// programmatic caller).
+/// The test-only `5s` is NOT offered (#2487) -- it's not meant for end users --
+/// but stays recognized for in-effect/countdown math and programmatic/test
+/// callers (it remains in `kConsentDurationSeconds` below).
 const List<String> kConsentDurations = [
   'once',
-  '5s',
   '5m',
   '15m',
   '1h',

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -51,9 +51,9 @@ DECISION_DENIED = "denied"
 # per CLI isolation. Ordered for the TUI selector; default is `tilrestart` (#2328).
 DURATION_ONCE = "once"
 # Test-only short duration (#2363, subsumed by #2392): recognized for in-effect
-# math (a `5s` verdict in a rules snapshot counts down correctly). TEMPORARILY
-# exposed in the human-facing selector (#2465) for manual testing; see
-# SELECTABLE_DURATIONS below.
+# math (a `5s` verdict in a rules snapshot counts down correctly) and for
+# programmatic/test callers, but NOT exposed in the human-facing selector
+# (see SELECTABLE_DURATIONS below).
 DURATION_5S = "5s"
 DURATION_5M = "5m"
 DURATION_15M = "15m"
@@ -76,11 +76,10 @@ DURATIONS = (
     DURATION_FOREVER,
 )
 # Human-facing duration selector: every duration a user can pick. The
-# test-only 5s is TEMPORARILY included (#2465) for manual testing now that a
-# timed allow lapses at its verdict (not the MIN_TTL floor) -- it can be
-# dropped from the selector (restore the ``d != DURATION_5S`` filter) to shut
-# it off; it stays valid for programmatic/test callers either way.
-SELECTABLE_DURATIONS = DURATIONS
+# test-only 5s is NOT offered (#2487) -- it's not meant for end users -- but
+# stays recognized for in-effect/countdown math and programmatic/test callers
+# (it remains in DURATIONS above).
+SELECTABLE_DURATIONS = tuple(d for d in DURATIONS if d != DURATION_5S)
 DURATION_DEFAULT = DURATION_TILRESTART
 
 # Seconds each *timed* duration adds to ``decided_at`` (mirror of the server's


### PR DESCRIPTION
## Summary

Hides the test-only `5s` consent-duration option from both human-facing consent deciders (#2487). It was temporarily exposed in the duration selector for manual testing (#2465); that exposure is retracted here. `5s` remains a valid duration for in-effect countdown math and programmatic/test callers — only the selector entry is removed.

## Changes

- **TUI** (`src/klangk/klangk/cli/tui/consent.py`): `SELECTABLE_DURATIONS` now filters out `DURATION_5S`. `DURATION_5S` stays in `DURATIONS` and `_DURATION_SECONDS`, so a `5s` verdict in a rules snapshot still counts down and the server still accepts it from programmatic callers.
- **Flutter** (`src/frontend/lib/workspace/consent_decider_service.dart`): dropped `'5s'` from `kConsentDurations`. Kept `'5s': 5` in `kConsentDurationSeconds` so in-effect/countdown math is unchanged.
- **Changelog**: removed the now-stale `#2465` "Added" entry — the temporary exposure it described never shipped and is retracted in the same unreleased cycle, so the net user-visible effect is nil.

## Acceptance criteria

- [x] The TUI consent-decider duration selector no longer offers `5s`.
- [x] The Flutter consent decider no longer offers `5s`.
- [x] `5s` is still honored when it appears in an in-effect rules snapshot (countdown math) and remains a valid programmatic/test duration.

## Test plan

- [x] Python suite: `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — 4820 passed, 100% coverage.
- [x] Flutter suite: `flutter test --coverage` — 953 passed.

Closes #2487.
