### PR TITLE
feat(egress): sample workspace egress to extend the idle timeout (#2485)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -55,6 +55,15 @@ operators or integrators to act when upgrading.
   decider registered) and `Q` confirms a real quit. Standalone `q` still
   quits immediately.
 
+- **Egress traffic extends the workspace idle timeout (#2485).** The
+  network sidecar now samples real workspace egress — any TCP/UDP traffic,
+  including long-lived connections and non-DNS UDP that the existing DNS/SYN
+  hooks (#2479) miss — and resets the container's idle timer while bytes are
+  flowing, so an egress-only workload is no longer reaped mid-transfer.
+  Best-effort and scoped to exclude the sidecar's own control traffic. No new
+  config: it reuses `KLANGKNETWORK_EGRESS_ACTIVITY_GATE` (default 60s) as the
+  sample cadence.
+
 - **`KLANGKNETWORK_EGRESS_UPSTREAM` — operator-pinnable sidecar DNS upstream (#2424).**
   When set in `klangkd`'s environment, the network sidecar's FQDN proxy forwards
   workspace DNS to this resolver verbatim instead of auto-detecting a host

--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -11,6 +11,7 @@ import asyncio
 import signal
 import socket
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from . import allowlist, config, consent, nfqueue, packets, resolve, rules
 from .config import DEBUG, HOLD_TIMEOUT, LISTEN_PORT, UPSTREAM, WORKSPACE_TOKEN_PATH
@@ -32,6 +33,7 @@ async def _shutdown(
     nfq,
     sock: socket.socket,
     sweep: asyncio.Task | None,
+    sampler: asyncio.Task | None = None,
 ) -> None:
     """Clean teardown on SIGTERM (#2400): stop the consent client, cancel the
     TTL sweeper, unbind NFQUEUE, close the DNS socket.
@@ -57,6 +59,12 @@ async def _shutdown(
             await sweep
         except (asyncio.CancelledError, Exception):
             pass
+    if sampler is not None:
+        sampler.cancel()
+        try:
+            await sampler
+        except (asyncio.CancelledError, Exception):
+            pass
     if nfq is not None:
         try:
             asyncio.get_running_loop().remove_reader(nfq.get_fd())
@@ -70,6 +78,23 @@ async def _shutdown(
         sock.close()
     except Exception:
         pass
+
+
+def _resolve_ws_host(consent_url: str) -> str | None:
+    """Resolve the klangkd WS host to an IP so the egress-accounting rule can
+    exclude it (#2485) -- the WS is the sidecar's own persistent control socket
+    and its keepalives must not self-sustain the idle timer. Best-effort: None
+    on any failure (the rule then also counts the WS keepalive; a minor
+    over-keep, the safe direction -- the workspace stays alive slightly past
+    true idle rather than being reaped mid-flow).
+    """
+    try:
+        host = urlparse(consent_url).hostname
+        if not host:
+            return None
+        return socket.gethostbyname(host)
+    except Exception:
+        return None
 
 
 async def _async_main() -> None:
@@ -101,6 +126,7 @@ async def _async_main() -> None:
     _BG_TASKS.add(_sweep)  # strong ref for the loop's lifetime
     _sweep.add_done_callback(_BG_TASKS.discard)
     nfq = None
+    _sampler: asyncio.Task | None = None
     # NFQUEUE consumer is driven by this event loop (get_fd + add_reader) so a
     # slow verdict on one SYN doesn't serialize others (#2324, #2329).
     if config.CONSENT_URL:
@@ -108,6 +134,18 @@ async def _async_main() -> None:
         nfq = nfqueue._setup_nfq_consumer(
             client
         )  # bound NFQUEUE, for _shutdown (#2400)
+        # #2485: egress byte-accounting rule + the sampler that bumps the idle
+        # timer on real workspace traffic (long-lived / UDP flows the #2481
+        # DNS+SYN hooks miss). Best-effort; a missing rule -> flat zero counter
+        # -> sampler never bumps (falls back to #2481). _resolve_ws_host scopes
+        # the rule to exclude the sidecar's own WS so its keepalives can't
+        # self-sustain the timer.
+        rules.install_acct(_resolve_ws_host(config.CONSENT_URL))
+        _sampler = asyncio.create_task(
+            consent._activity_sampler(client, rules.acct_bytes, config.ACTIVITY_GATE_S)
+        )
+        _BG_TASKS.add(_sampler)
+        _sampler.add_done_callback(_BG_TASKS.discard)
     # The sidecar is PID 1 (entrypoint.sh execs python). The kernel suppresses
     # default terminate/stop dispositions for a PID-namespace init: a SIGTERM
     # with no handler installed is effectively ignored, so podman's `stop -t 5`
@@ -148,7 +186,7 @@ async def _async_main() -> None:
         if DEBUG:
             print("dns-proxy: stop signal received, shutting down", flush=True)
     finally:
-        await _shutdown(client, nfq, s, _sweep)
+        await _shutdown(client, nfq, s, _sweep, _sampler)
 
 
 def main() -> None:

--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -83,18 +83,29 @@ async def _shutdown(
 def _resolve_ws_host(consent_url: str) -> str | None:
     """Resolve the klangkd WS host to an IP so the egress-accounting rule can
     exclude it (#2485) -- the WS is the sidecar's own persistent control socket
-    and its keepalives must not self-sustain the idle timer. Best-effort: None
-    on any failure (the rule then also counts the WS keepalive; a minor
-    over-keep, the safe direction -- the workspace stays alive slightly past
-    true idle rather than being reaped mid-flow).
+    and its keepalives must not self-sustain the idle timer.
+
+    Returns None on any failure (no host in the URL, or unresolvable). IMPORTANT:
+    a None DEFEATS the idle timeout -- the WS keepalive (~50-100 bytes per 20s
+    ping) then counts as workspace egress and bumps the timer every tick, so the
+    workspace is never reaped. In the default deployment CONSENT_URL is
+    host.containers.internal (a /etc/hosts entry, single IP) and resolves
+    locally, so this is a round-robin / DNS-only-backend edge case; it is logged
+    so an operator whose workspaces never idle can find it.
     """
     try:
         host = urlparse(consent_url).hostname
-        if not host:
-            return None
-        return socket.gethostbyname(host)
+        ip = socket.gethostbyname(host) if host else None
     except Exception:
-        return None
+        ip = None
+    if not ip:
+        print(
+            "egress-sidecar: could not resolve the klangkd WS host to exclude "
+            "it from egress accounting -- its keepalives will count as workspace "
+            "egress and the workspace idle timer may never fire (#2485)",
+            flush=True,
+        )
+    return ip
 
 
 async def _async_main() -> None:
@@ -139,8 +150,10 @@ async def _async_main() -> None:
         # DNS+SYN hooks miss). Best-effort; a missing rule -> flat zero counter
         # -> sampler never bumps (falls back to #2481). _resolve_ws_host scopes
         # the rule to exclude the sidecar's own WS so its keepalives can't
-        # self-sustain the timer.
-        rules.install_acct(_resolve_ws_host(config.CONSENT_URL))
+        # self-sustain the timer. Resolve + install run off-loop (gethostbyname
+        # + 2 iptables forks are blocking), matching the rest of startup.
+        ws_ip = await loop.run_in_executor(None, _resolve_ws_host, config.CONSENT_URL)
+        await loop.run_in_executor(None, rules.install_acct, ws_ip)
         _sampler = asyncio.create_task(
             consent._activity_sampler(client, rules.acct_bytes, config.ACTIVITY_GATE_S)
         )

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -314,3 +314,64 @@ class SidecarConsentClient:
                 return f.read().strip()
         except OSError:
             return ""
+
+
+# ---------------------------------------------------------------------------
+# Idle-activity sampler (#2485): poll the workspace-egress byte counter and
+# bump the idle timer on real traffic (long-lived / UDP flows the #2481 DNS+SYN
+# hooks miss). The per-tick logic is factored into _activity_delta so it is
+# unit-testable without driving the infinite loop.
+# ---------------------------------------------------------------------------
+
+
+def _safe_bytes(get_bytes) -> int:
+    """Read the accounting counter; 0 on any failure (so a transient read
+    error or a missing rule reads as a flat baseline, never as activity)."""
+    try:
+        n = get_bytes()
+    except Exception:
+        return 0
+    try:
+        return int(n)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _activity_delta(get_bytes, prev: int) -> tuple[bool, int]:
+    """One sample tick's logic (#2485), factored out for unit tests.
+
+    Returns ``(bumped, new_prev)``: ``bumped`` is True iff the workspace-egress
+    byte counter advanced since the last tick (real traffic), in which case
+    the caller bumps the idle timer. A counter that did NOT advance (quiet) or
+    that RESET (rule re-added / sidecar restart -> counter wraps back below
+    prev) re-baselines without bumping, so a reset can never masquerade as a
+    burst of activity.
+    """
+    cur = _safe_bytes(get_bytes)
+    return cur > prev, cur
+
+
+async def _activity_sampler(client, get_bytes, interval: float) -> None:
+    """Background task: sample the workspace-egress byte counter and, on a
+    positive delta, call ``client.bump_activity`` (#2485).
+
+    ``get_bytes`` -> int is the (mockable) counter reader
+    (:func:`klangksidecar.rules.acct_bytes`); ``interval`` is the sample cadence
+    (= :data:`ACTIVITY_GATE_S`, so one tick yields at most one activity frame
+    per window -- the send itself is flood-gated by ``bump_activity``). The
+    per-tick work is exactly one counter read; the kernel does all the
+    per-packet accounting. Best-effort, like the #2481 hooks: a read failure
+    re-baselines (:func:`_activity_delta`) and ``bump_activity`` is silent on a
+    down WS, so sampling never breaks egress. Mirrors
+    :func:`klangksidecar.rules._async_sweeper` (sleep + work, swallow per-tick
+    errors so one bad tick doesn't kill the task).
+    """
+    _, prev = _activity_delta(get_bytes, 0)
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            bumped, prev = _activity_delta(get_bytes, prev)
+            if bumped:
+                client.bump_activity()
+        except Exception:
+            pass  # a transient tick failure defers to the next interval

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -360,17 +360,22 @@ async def _activity_sampler(client, get_bytes, interval: float) -> None:
     (= :data:`ACTIVITY_GATE_S`, so one tick yields at most one activity frame
     per window -- the send itself is flood-gated by ``bump_activity``). The
     per-tick work is exactly one counter read; the kernel does all the
-    per-packet accounting. Best-effort, like the #2481 hooks: a read failure
-    re-baselines (:func:`_activity_delta`) and ``bump_activity`` is silent on a
-    down WS, so sampling never breaks egress. Mirrors
-    :func:`klangksidecar.rules._async_sweeper` (sleep + work, swallow per-tick
-    errors so one bad tick doesn't kill the task).
+    per-packet accounting. The read runs OFF the event loop via
+    ``run_in_executor`` (like :func:`klangksidecar.rules._async_sweeper` runs
+    :func:`sweep_once`), because the production reader forks iptables and would
+    otherwise stall the DNS recv loop once per interval. Best-effort, like the
+    #2481 hooks: a read failure re-baselines (:func:`_activity_delta`) and
+    ``bump_activity`` is silent on a down WS, so sampling never breaks egress.
+    Per-tick errors are swallowed so one bad tick doesn't kill the task.
     """
-    _, prev = _activity_delta(get_bytes, 0)
+    loop = asyncio.get_running_loop()
+    _, prev = await loop.run_in_executor(None, _activity_delta, get_bytes, 0)
     while True:
         await asyncio.sleep(interval)
         try:
-            bumped, prev = _activity_delta(get_bytes, prev)
+            bumped, prev = await loop.run_in_executor(
+                None, _activity_delta, get_bytes, prev
+            )
             if bumped:
                 client.bump_activity()
         except Exception:

--- a/src/klangksidecar/klangksidecar/rules.py
+++ b/src/klangksidecar/klangksidecar/rules.py
@@ -335,6 +335,85 @@ def check_mark() -> None:
         probe.close()
 
 
+# --- workspace-egress accounting (#2485) -------------------------------------
+# A mangle-OUTPUT rule whose in-kernel byte counter the idle-activity sampler
+# (consent._activity_sampler) polls once per ACTIVITY_GATE_S. The kernel bumps
+# the counter on every matching packet at packet-processing time; our code only
+# reads it -- no per-packet/per-flow Python. The match is scoped to UNmarked
+# traffic (the proxy's own upstream DNS carries SO_MARK=MARK; the workspace
+# cannot mark), optionally excluding the klangkd WS host, so it counts only the
+# workspace's real egress -- not the sidecar's own control plane, which would
+# otherwise self-sustain (an activity frame / WS keepalive moves bytes -> looks
+# like traffic -> bumps the timer -> the workspace never goes idle). Mangle,
+# not filter, so the rule never fights the learned ACCEPT/REJECT rules'
+# `-I OUTPUT 1` inserts; `-j ACCEPT` terminates only the mangle chain, leaving
+# the nat REDIRECT + filter OUTPUT path intact.
+_ACCT_COMMENT = "klangk-acct"
+
+
+def _acct_match(exclude_ip: str | None) -> list[str]:
+    """iptables match/target args for the accounting rule: unmarked traffic
+    (workspace egress), optionally excluding the klangkd WS host."""
+    args = ["-m", "mark", "!", "--mark", str(MARK)]
+    if exclude_ip:
+        args += ["!", "-d", exclude_ip]
+    args += ["-m", "comment", "--comment", _ACCT_COMMENT, "-j", "ACCEPT"]
+    return args
+
+
+def install_acct(exclude_ip: str | None = None) -> None:
+    """Install the mangle-OUTPUT egress-accounting rule (#2485), idempotently.
+
+    Best-effort: a failure to install is silent -- the sampler then reads a
+    flat zero counter and never bumps, i.e. falls back to the #2481 DNS/SYN
+    behavior (an egress-only long-lived flow could be reaped, but egress itself
+    is unaffected). Sync (forks iptables) like allow/sweep.
+    """
+    try:
+        check = subprocess.run(
+            [config.IPT, "-t", "mangle", "-C", "OUTPUT", *_acct_match(exclude_ip)],
+            capture_output=True,
+        )
+        if check.returncode == 0:
+            return  # already present
+        subprocess.run(
+            [config.IPT, "-t", "mangle", "-A", "OUTPUT", *_acct_match(exclude_ip)],
+            capture_output=True,
+        )
+    except Exception:
+        pass
+
+
+def acct_bytes() -> int:
+    """Current byte count on the accounting rule, or 0 if absent/unreadable.
+
+    Parsed from ``iptables -t mangle -L OUTPUT -v -x -n``: with ``-v`` the first
+    two columns are pkts/bytes, ``-x`` makes bytes exact (no K/M suffix), and
+    the ``--comment`` tag uniquely identifies the rule line. 0 on any parse /
+    subprocess failure so the sampler treats a missing rule as a flat baseline
+    (never as a burst of activity).
+    """
+    try:
+        out = subprocess.run(
+            [config.IPT, "-t", "mangle", "-L", "OUTPUT", "-v", "-x", "-n"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except Exception:
+        return 0
+    for line in out.splitlines():
+        if _ACCT_COMMENT in line:
+            parts = line.split()  # parts[0]=pkts, parts[1]=bytes (the -v cols)
+            if len(parts) >= 2:
+                try:
+                    return int(parts[1])
+                except ValueError:
+                    return 0
+            return 0
+    return 0
+
+
 def _learn_all(
     recs: list[tuple[str, int]],
     ports: set[int | None],

--- a/src/klangksidecar/klangksidecar/rules.py
+++ b/src/klangksidecar/klangksidecar/rules.py
@@ -347,7 +347,10 @@ def check_mark() -> None:
 # like traffic -> bumps the timer -> the workspace never goes idle). Mangle,
 # not filter, so the rule never fights the learned ACCEPT/REJECT rules'
 # `-I OUTPUT 1` inserts; `-j ACCEPT` terminates only the mangle chain, leaving
-# the nat REDIRECT + filter OUTPUT path intact.
+# the nat REDIRECT + filter OUTPUT path intact. (The forged eager-deny RST
+# from packets.py is also unmarked + not the WS host, so it is counted too --
+# harmless: it correlates 1:1 with a SYN the #2481 NFQUEUE hook already bumped,
+# and bump_activity's flood gate dedupes.)
 _ACCT_COMMENT = "klangk-acct"
 
 

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -1719,6 +1719,29 @@ class TestEgressAcct:
         monkeypatch.setattr(proxy.subprocess, "run", boom)
         assert proxy.rules.acct_bytes() == 0
 
+    def test_acct_bytes_non_integer_column_is_zero(self, proxy, monkeypatch):
+        # Safety net if an iptables-nft version emits an unexpected -v layout:
+        # the comment-tagged line's bytes column isn't an int -> 0.
+        out = (
+            "   42 notanumber ACCEPT all -- * * 0.0.0.0/0 0.0.0.0/0 /* klangk-acct */\n"
+        )
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(stdout=out, returncode=0),
+        )
+        assert proxy.rules.acct_bytes() == 0
+
+    def test_acct_bytes_malformed_line_is_zero(self, proxy, monkeypatch):
+        # Comment tag present but too few columns to hold pkts+bytes -> 0.
+        out = "klangk-acct\n"
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(stdout=out, returncode=0),
+        )
+        assert proxy.rules.acct_bytes() == 0
+
 
 class TestActivitySampler:
     """Workspace-egress byte sampling -> idle bump (#2485): the sampler polls
@@ -1760,9 +1783,9 @@ class TestActivitySampler:
                 bumps.append(1)
 
         task = asyncio.create_task(
-            proxy.consent._activity_sampler(C(), lambda: next(readings), 0.001)
+            proxy.consent._activity_sampler(C(), lambda: next(readings), 0.0)
         )
-        await asyncio.sleep(0.1)  # plenty of 1ms ticks to drain the readings
+        await asyncio.sleep(0.1)  # plenty of 0-interval ticks to drain readings
         task.cancel()
         try:
             await task
@@ -3069,6 +3092,12 @@ class TestSigtermShutdown:
         )
         monkeypatch.setattr(proxy.rules, "check_mark", lambda: None)
         monkeypatch.setattr(proxy.packets, "check_rst_socket", lambda: None)
+        # #2485: the egress-accounting resolve/install/read are blocking (DNS +
+        # iptables) -- stub them so this unit test does no real I/O, like the
+        # other startup mocks above.
+        monkeypatch.setattr(proxy.app, "_resolve_ws_host", lambda url: None)
+        monkeypatch.setattr(proxy.rules, "install_acct", lambda *a, **k: None)
+        monkeypatch.setattr(proxy.rules, "acct_bytes", lambda: 0)
         started = []
 
         class _FakeClient:
@@ -3122,6 +3151,12 @@ class TestSigtermShutdown:
         monkeypatch.setattr(proxy.config, "CONSENT_URL", "http://k/ev")
         monkeypatch.setattr(proxy.rules, "check_mark", lambda: None)
         monkeypatch.setattr(proxy.packets, "check_rst_socket", lambda: None)
+        # #2485: the egress-accounting resolve/install/read are blocking (DNS +
+        # iptables) -- stub them so this unit test does no real I/O, like the
+        # other startup mocks above.
+        monkeypatch.setattr(proxy.app, "_resolve_ws_host", lambda url: None)
+        monkeypatch.setattr(proxy.rules, "install_acct", lambda *a, **k: None)
+        monkeypatch.setattr(proxy.rules, "acct_bytes", lambda: 0)
 
         in_stop = asyncio.Event()
         release_stop = asyncio.Event()

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -1635,6 +1635,142 @@ class TestBumpActivity:
         await self._drain(c)  # the scheduled send raises internally, swallowed
 
 
+class TestEgressAcct:
+    """mangle-OUTPUT egress byte accounting (#2485): the in-kernel rule the
+    idle-activity sampler polls, scoped to unmarked (workspace) traffic and
+    excluding the WS host so the sidecar's own control plane can't self-sustain
+    the idle timer."""
+
+    def test_acct_match_unmarked_with_exclude(self, proxy):
+        m = proxy.rules._acct_match("10.0.0.1")
+        # mark negation (workspace egress is unmarked) ...
+        assert "mark" in m and "--mark" in m and str(proxy.config.MARK) in m
+        # ... WS-host dest exclusion ...
+        assert "-d" in m and "10.0.0.1" in m
+        # ... comment tag (so acct_bytes can find the line) + ACCEPT target.
+        assert proxy.rules._ACCT_COMMENT in m
+        assert m[-1] == "ACCEPT"
+
+    def test_acct_match_omits_exclude_when_none(self, proxy):
+        m = proxy.rules._acct_match(None)
+        assert "-d" not in m  # no WS host to exclude
+        assert proxy.rules._ACCT_COMMENT in m
+
+    def test_install_acct_idempotent_when_present(self, proxy, monkeypatch):
+        runs = []
+
+        def fake_run(args, **kw):
+            runs.append(args)
+            return types.SimpleNamespace(returncode=0)  # rule exists -> no -A
+
+        monkeypatch.setattr(proxy.subprocess, "run", fake_run)
+        proxy.rules.install_acct("1.2.3.4")
+        assert any("-C" in a for a in runs)  # checked
+        assert not any("-A" in a for a in runs)  # present -> no append
+        # all ops hit the mangle table (never filter, to avoid fighting learned
+        # rules' -I OUTPUT 1 inserts).
+        assert all("-t" in a and "mangle" in a for a in runs)
+
+    def test_install_acct_appends_when_absent(self, proxy, monkeypatch):
+        runs = []
+
+        def fake_run(args, **kw):
+            runs.append(args)
+            return types.SimpleNamespace(returncode=1)  # absent -> -A
+
+        monkeypatch.setattr(proxy.subprocess, "run", fake_run)
+        proxy.rules.install_acct(None)
+        assert any("-A" in a and "OUTPUT" in a for a in runs)
+
+    def test_install_acct_swallows_failure(self, proxy, monkeypatch):
+        def boom(args, **kw):
+            raise OSError("no iptables / no mangle module")
+
+        monkeypatch.setattr(proxy.subprocess, "run", boom)
+        proxy.rules.install_acct(None)  # must not raise
+
+    def test_acct_bytes_parses_counter_line(self, proxy, monkeypatch):
+        out = (
+            "Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)\n"
+            " pkts bytes target prot opt in out source destination\n"
+            "   42 1000000 ACCEPT all -- * * 0.0.0.0/0 0.0.0.0/0"
+            " mark match ! 0x4b /* klangk-acct */\n"
+        )
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(stdout=out, returncode=0),
+        )
+        assert proxy.rules.acct_bytes() == 1000000
+
+    def test_acct_bytes_zero_when_rule_absent(self, proxy, monkeypatch):
+        out = "Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)\n"  # no acct line
+        monkeypatch.setattr(
+            proxy.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(stdout=out, returncode=0),
+        )
+        assert proxy.rules.acct_bytes() == 0
+
+    def test_acct_bytes_zero_on_subprocess_failure(self, proxy, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("gone")
+
+        monkeypatch.setattr(proxy.subprocess, "run", boom)
+        assert proxy.rules.acct_bytes() == 0
+
+
+class TestActivitySampler:
+    """Workspace-egress byte sampling -> idle bump (#2485): the sampler polls
+    the scoped byte counter once per gate window and, on a positive delta,
+    bumps the idle timer via bump_activity (which flood-gates the WS send).
+    Per-tick logic is factored into _activity_delta for deterministic tests."""
+
+    def test_delta_positive_bumps(self, proxy):
+        bumped, prev = proxy.consent._activity_delta(lambda: 1000, 0)
+        assert bumped and prev == 1000
+
+    def test_delta_zero_no_bump(self, proxy):
+        bumped, prev = proxy.consent._activity_delta(lambda: 500, 500)
+        assert not bumped and prev == 500
+
+    def test_delta_reset_rebaselines_without_bump(self, proxy):
+        # counter wrapped below prev (rule re-added / restart): NOT activity.
+        bumped, prev = proxy.consent._activity_delta(lambda: 5, 1000)
+        assert not bumped and prev == 5
+
+    def test_safe_bytes_read_failure_is_zero(self, proxy):
+        def boom():
+            raise OSError("iptables gone")
+
+        assert proxy.consent._safe_bytes(boom) == 0
+
+    def test_safe_bytes_non_int_is_zero(self, proxy):
+        assert proxy.consent._safe_bytes(lambda: "nonsense") == 0
+
+    async def test_sampler_bumps_only_on_real_traffic(self, proxy):
+        # One init read then a sequence: quiet, +100 (bump), flat, +150 (bump),
+        # flat, reset (no bump). Once readings exhaust, get_bytes raises
+        # StopIteration -> _safe_bytes -> 0 -> flat. Bumps must total 2.
+        readings = iter([0, 0, 100, 100, 250, 250, 10])
+        bumps = []
+
+        class C:
+            def bump_activity(self):
+                bumps.append(1)
+
+        task = asyncio.create_task(
+            proxy.consent._activity_sampler(C(), lambda: next(readings), 0.001)
+        )
+        await asyncio.sleep(0.1)  # plenty of 1ms ticks to drain the readings
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert len(bumps) == 2  # only the two positive deltas bumped
+
+
 class _FakePkt:
     def __init__(self, payload: bytes) -> None:
         self._payload = payload


### PR DESCRIPTION
## What

A workspace doing sustained network I/O over a long-lived connection, or
non-DNS UDP (QUIC, NTP), was reaped by the idle timeout. After the SYN,
conntrack `ESTABLISHED,RELATED` carries the flow and the #2481 DNS+SYN
activity hooks never see it again — so an established connection held open
past `KLANGKD_IDLE_TIMEOUT_SECONDS` with no other activity gets stopped
mid-flow. The network sidecar now samples a **mangle-OUTPUT byte counter**
and, on a positive delta, calls the existing flood-gated `bump_activity` so
klangkd resets the workspace's idle timer.

Closes #2485.

## How

The sidecar is the workspace's network gateway (it shares the workspace's
netns via `--network container:`), so it sees every flow — including the
established ones the #2481 hooks miss. The cost model is **just reading a
counter**: the kernel bumps an iptables rule's byte counter on every matching
packet at packet-processing time; our code reads it once per
`ACTIVITY_GATE_S` (default 60s) and compares to the last value. No
per-packet / per-flow / per-connection Python.

- **Counter source** (`klangksidecar/rules.py`): a `mangle -A OUTPUT` rule
  whose in-kernel byte counter `acct_bytes()` parses from
  `iptables -t mangle -L OUTPUT -v -x -n` (the `--comment` tag finds the line;
  `parts[1]` is bytes with `-x`).
- **Why mangle, not filter**: the learned ACCEPT/REJECT rules insert at
  `-I OUTPUT 1` and would displace a filter accounting rule (or swallow
  allow-learned traffic before it). Mangle is a separate table that runs
  before filter, so the rule sees **all** workspace egress regardless of the
  filter verdict and never fights the learned-rule inserts. `-j ACCEPT` there
  terminates only the mangle chain, leaving the nat REDIRECT + filter OUTPUT
  path intact.
- **Scoping out the sidecar's own control plane** (the #2485 gotcha): the
  rule matches **unmarked** traffic (`! --mark 75`) — the proxy's own upstream
  DNS is `SO_MARK`'d, the workspace cannot mark — and excludes the klangkd WS
  host (`_resolve_ws_host`). Otherwise an activity frame / WS keepalive would
  move bytes → look like traffic → bump the timer → the workspace would never
  go idle.
- **Sampler** (`klangksidecar/consent.py`): `_activity_sampler` is a periodic
  asyncio task on the same pattern as `rules._async_sweeper` (sleep + work,
  per-tick errors swallowed). The per-tick logic is factored into
  `_activity_delta(get_bytes, prev)` for unit tests: a positive delta bumps; a
  flat reading (quiet) or a reset (rule re-added / restart → counter wraps
  below prev) re-baselines without bumping. `app.py` wires both in alongside
  the sweeper and cancels the task in `_shutdown`.
- **Best-effort throughout**: a missing/unreadable rule → flat zero counter →
  sampler never bumps → falls back to the #2481 DNS/SYN behavior. Egress is
  never affected.

## Tests

- `TestEgressAcct` — `_acct_match` shape (mark negation, optional WS
  exclusion, comment tag); `install_acct` idempotency (check-before-append,
  all in the mangle table), append-when-absent, failure-swallowing;
  `acct_bytes` parses a real `iptables -L` line, returns 0 when the rule is
  absent and on subprocess failure.
- `TestActivitySampler` — `_activity_delta` positive/zero/reset cases;
  `_safe_bytes` failure/non-int → 0; the loop bumps only on the two positive
  deltas across a quiet/traffic/reset sequence.

Sidecar suite 185 passed; backend suite 4820 passed at 100% coverage.

## Config

No new setting. The sample cadence reuses `KLANGKNETWORK_EGRESS_ACTIVITY_GATE`
(default 60s) — one tick per window, and `bump_activity`'s existing flood-gate
already caps the WS send at ≤1 frame/window.
