### PR TITLE
Log + terminate refused consent-decider handshakes (403 storm)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -851,9 +851,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   decider WebSocket handshake (uvicorn answers every pre-accept close with
   a bare HTTP 403 — e.g. the workspace is no longer `interactive` egress
   mode, or permissions were revoked) now logs the reason, user, workspace,
-  and User-Agent in klangkd's log instead of an anonymous 403, and the
-  decider client stops retrying after one token-refresh retry instead of
-  reconnecting forever; its status line shows `refused — not retrying`.
+  and User-Agent in klangkd's log instead of an anonymous 403. The decider
+  client refreshes its token and retries once, then falls back to a slow
+  60s retry instead of reconnecting every 5s; its status line shows
+  `refused — retrying every 60s`, and it self-heals if the refusal cause
+  goes away mid-session.
 
 - **Network sidecar containers no longer orphaned on reap/sweep (#2476).**
   A workspace joins its sidecar's netns via `--network container:<sidecar>`,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -847,6 +847,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Consent-decider 403 storm on refused registration (#2490).** A refused
+  decider WebSocket handshake (uvicorn answers every pre-accept close with
+  a bare HTTP 403 — e.g. the workspace is no longer `interactive` egress
+  mode, or permissions were revoked) now logs the reason, user, workspace,
+  and User-Agent in klangkd's log instead of an anonymous 403, and the
+  decider client stops retrying after one token-refresh retry instead of
+  reconnecting forever; its status line shows `refused — not retrying`.
+
 - **Network sidecar containers no longer orphaned on reap/sweep (#2476).**
   A workspace joins its sidecar's netns via `--network container:<sidecar>`,
   so podman refuses to remove a sidecar while its workspace still shares that

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -30,6 +30,7 @@ import logging
 import subprocess
 import time
 from dataclasses import dataclass, replace
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 import websockets
 from rich.markup import escape
@@ -126,6 +127,18 @@ _PING_INTERVAL = 15.0
 
 # Reconnect backoff (seconds). Caps the spin on a repeatedly-dropping server.
 _RECONNECT_DELAYS = (1.0, 2.0, 5.0)
+
+
+# Sent as the WS handshake User-Agent so klangkd's refusal log (#2490) can
+# attribute a 403 to this client (vs a browser or anything else).
+def _user_agent() -> str:
+    try:
+        return f"klangk-consent-decide/{_pkg_version('klangk')}"
+    except PackageNotFoundError:  # running from source, not installed
+        return "klangk-consent-decide/dev"
+
+
+_USER_AGENT = _user_agent()
 
 # How long a flashed message (send failure, server error) stays on the status
 # line before the periodic refresh overwrites it.
@@ -608,6 +621,10 @@ class ConsentDeciderApp(App):
         self._ws = None
         self._connected = False
         self._stop = False
+        # #2490: set when the server refused registration (HTTP 403) twice in
+        # a row -- the reconnect loop has given up and the status line says
+        # so instead of "reconnecting".
+        self._refused = False
         self._flash_msg = ""
         self._flash_until = 0.0
         self._duration = DURATION_DEFAULT
@@ -735,10 +752,20 @@ class ConsentDeciderApp(App):
         next attempt authenticates (mirrors ``monitor``). While disconnected
         the decider is deregistered server-side, so in-flight holds auto-deny
         on their own timeout (fail-closed) -- never silently allowed.
+
+        A refused handshake (HTTP 403, #2490) is different: the server
+        closed *before* accept (authz, egress mode, vanished workspace --
+        or an expired token, since the pre-accept close code never reaches
+        us and uvicorn answers every refusal with 403). Retrying cannot
+        fix a real refusal, so after one refresh-and-retry (which recovers
+        the expired-token case) a second consecutive 403 stops the loop
+        for good instead of spamming the server log forever.
         """
         attempt = 0
+        refusals = 0
         while not self._stop:
             auth_close = False
+            refused = False
             try:
                 async with ws_connect(
                     self.server_url,
@@ -746,17 +773,45 @@ class ConsentDeciderApp(App):
                     max_size=self.max_size,
                     path="/ws/consent-decider",
                     query={"workspace": self.workspace_id},
+                    user_agent_header=_USER_AGENT,
                 ) as ws:
                     self._ws = ws
                     self._connected = True
                     attempt = 0
+                    refusals = 0
                     self._refresh()
                     auth_close = await self._pump(ws)
+            except websockets.InvalidStatus as e:
+                if e.response.status_code == 403:
+                    refused = True
+                else:
+                    # A proxy/gateway error (502/503...) is transient -- retry.
+                    logger.debug("consent-decide ws handshake failed: %s", e)
             except Exception as e:  # noqa: BLE001
                 logger.debug("consent-decide ws dropped: %s", e)
             finally:
                 self._ws = None
                 self._connected = False
+            if refused:
+                refusals += 1
+                if refusals >= 2:
+                    # Permanent refusal: the decider cannot register (see
+                    # docstring). Stop; the status line shows why (#2490).
+                    self._refused = True
+                    logger.warning(
+                        "consent-decide: registration refused (403) twice; "
+                        "not retrying"
+                    )
+                    self._refresh()
+                    break
+                # First refusal: maybe just an expired token (its 4002 close
+                # code is lost pre-accept) -- refresh and try once more.
+                new = await self._refresh_token()
+                if new:
+                    self.token = new
+                await asyncio.sleep(self._backoff(1))
+                self._refresh()
+                continue
             if self._stop:
                 break
             if auth_close:
@@ -931,7 +986,12 @@ class ConsentDeciderApp(App):
         if self._flash_until > time.time():
             status.update(self._flash_msg)
         else:
-            conn = "connected" if self._connected else "reconnecting"
+            if self._connected:
+                conn = "connected"
+            elif self._refused:
+                conn = "refused — not retrying"
+            else:
+                conn = "reconnecting"
             line = (
                 f" {escape(self.workspace_name)}  ·  {conn}"
                 f"  ·  {len(ordered)} held"

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -128,6 +128,17 @@ _PING_INTERVAL = 15.0
 # Reconnect backoff (seconds). Caps the spin on a repeatedly-dropping server.
 _RECONNECT_DELAYS = (1.0, 2.0, 5.0)
 
+# How long a flashed message (send failure, server error) stays on the status
+# line before the periodic refresh overwrites it.
+_FLASH_TTL = 5.0
+
+# After two consecutive 403 refusals the decider retries at this fixed slow
+# interval (#2490): bounded log spam (1/min vs the old 1/5s storm), but the
+# decider still self-heals if the workspace flips back to interactive (or
+# permissions are restored) mid-session instead of staying dead until the
+# shell is restarted.
+_REFUSED_RETRY_INTERVAL = 60.0
+
 
 # Sent as the WS handshake User-Agent so klangkd's refusal log (#2490) can
 # attribute a 403 to this client (vs a browser or anything else).
@@ -139,10 +150,6 @@ def _user_agent() -> str:
 
 
 _USER_AGENT = _user_agent()
-
-# How long a flashed message (send failure, server error) stays on the status
-# line before the periodic refresh overwrites it.
-_FLASH_TTL = 5.0
 
 # Frame-application outcomes returned by ConsentDeciderController.apply_frame.
 ADDED = (
@@ -621,9 +628,10 @@ class ConsentDeciderApp(App):
         self._ws = None
         self._connected = False
         self._stop = False
-        # #2490: set when the server refused registration (HTTP 403) twice in
-        # a row -- the reconnect loop has given up and the status line says
-        # so instead of "reconnecting".
+        # #2490: set once registration has been refused (HTTP 403) twice --
+        # the reconnect loop has dropped to its slow fixed interval and the
+        # status line says so instead of "reconnecting". Cleared when a
+        # connect succeeds again (self-heal).
         self._refused = False
         self._flash_msg = ""
         self._flash_until = 0.0
@@ -756,10 +764,14 @@ class ConsentDeciderApp(App):
         A refused handshake (HTTP 403, #2490) is different: the server
         closed *before* accept (authz, egress mode, vanished workspace --
         or an expired token, since the pre-accept close code never reaches
-        us and uvicorn answers every refusal with 403). Retrying cannot
-        fix a real refusal, so after one refresh-and-retry (which recovers
-        the expired-token case) a second consecutive 403 stops the loop
-        for good instead of spamming the server log forever.
+        us and uvicorn answers every refusal with 403). The first refusal
+        refreshes the JWT and retries fast (recovering the expired-token
+        case); once refusals pile up (the counter resets only on a
+        successful connect) the loop backs off to a fixed slow interval
+        (:data:`_REFUSED_RETRY_INTERVAL`) instead of stopping -- bounded
+        log spam, but the decider still self-heals if the refusal cause
+        goes away mid-session (workspace flipped back to interactive,
+        permissions restored).
         """
         attempt = 0
         refusals = 0
@@ -779,6 +791,10 @@ class ConsentDeciderApp(App):
                     self._connected = True
                     attempt = 0
                     refusals = 0
+                    if self._refused:
+                        # Healed: the refusal cause went away -- back to
+                        # normal connected/reconnect reporting.
+                        self._refused = False
                     self._refresh()
                     auth_close = await self._pump(ws)
             except websockets.InvalidStatus as e:
@@ -795,21 +811,28 @@ class ConsentDeciderApp(App):
             if refused:
                 refusals += 1
                 if refusals >= 2:
-                    # Permanent refusal: the decider cannot register (see
-                    # docstring). Stop; the status line shows why (#2490).
-                    self._refused = True
-                    logger.warning(
-                        "consent-decide: registration refused (403) twice; "
-                        "not retrying"
-                    )
-                    self._refresh()
-                    break
-                # First refusal: maybe just an expired token (its 4002 close
-                # code is lost pre-accept) -- refresh and try once more.
+                    # Repeated refusal: registration cannot succeed right
+                    # now (see docstring). Log once, then fall back to the
+                    # slow interval -- not a tight loop, not a dead stop
+                    # (#2490 review: a mid-session flip back to interactive
+                    # must self-heal without restarting the shell).
+                    if not self._refused:
+                        self._refused = True
+                        logger.warning(
+                            "consent-decide: registration refused (403) "
+                            "repeatedly; retrying every %.0fs",
+                            _REFUSED_RETRY_INTERVAL,
+                        )
+                    delay = _REFUSED_RETRY_INTERVAL
+                else:
+                    # First refusal: maybe just an expired token (its 4002
+                    # close code is lost pre-accept) -- refresh and retry
+                    # fast once.
+                    delay = self._backoff(1)
                 new = await self._refresh_token()
                 if new:
                     self.token = new
-                await asyncio.sleep(self._backoff(1))
+                await asyncio.sleep(delay)
                 self._refresh()
                 continue
             if self._stop:
@@ -989,7 +1012,9 @@ class ConsentDeciderApp(App):
             if self._connected:
                 conn = "connected"
             elif self._refused:
-                conn = "refused — not retrying"
+                conn = (
+                    f"refused — retrying every {int(_REFUSED_RETRY_INTERVAL)}s"
+                )
             else:
                 conn = "reconnecting"
             line = (

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -54,6 +54,11 @@ from ..model.workspaces import EGRESS_MODE_INTERACTIVE
 logger = logging.getLogger(__name__)
 
 
+def _log_safe(value: str) -> str:
+    """Strip CR/LF so a forged query param can't inject log lines."""
+    return value.replace("\r", " ").replace("\n", " ")
+
+
 async def _refuse(
     websocket: WebSocket, code: int, reason: str, email: str | None = None
 ) -> None:
@@ -69,8 +74,8 @@ async def _refuse(
         "workspace=%s ua=%s",
         reason,
         code,
-        email or "unknown",
-        websocket.query_params.get("workspace") or "deploy-wide",
+        _log_safe(email or "unknown"),
+        _log_safe(websocket.query_params.get("workspace") or "deploy-wide"),
         websocket.headers.get("user-agent", "?"),
     )
     await websocket.close(code=code, reason=reason)

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -54,6 +54,28 @@ from ..model.workspaces import EGRESS_MODE_INTERACTIVE
 logger = logging.getLogger(__name__)
 
 
+async def _refuse(
+    websocket: WebSocket, code: int, reason: str, email: str | None = None
+) -> None:
+    """Close a refused decider handshake before ``accept()`` (#2490).
+
+    A pre-accept close is answered by the ASGI server with a bare HTTP 403
+    -- the close code and reason never reach the client -- so log the
+    refusal server-side (reason, user, workspace, User-Agent) to make the
+    403s in the klangkd log self-explanatory instead of anonymous noise.
+    """
+    logger.warning(
+        "consent decider connection refused: %s (code %d) user=%s "
+        "workspace=%s ua=%s",
+        reason,
+        code,
+        email or "unknown",
+        websocket.query_params.get("workspace") or "deploy-wide",
+        websocket.headers.get("user-agent", "?"),
+    )
+    await websocket.close(code=code, reason=reason)
+
+
 async def handle_consent_decider(websocket: WebSocket, app) -> None:
     """Register a consent decider for its connection lifetime + act on holds."""
     # #2420: time the pre-accept steps so an intermittent opening-handshake
@@ -69,15 +91,15 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
 
     token = websocket.query_params.get("token")
     if not token:
-        await websocket.close(code=4001, reason="Missing token")
+        await _refuse(websocket, 4001, "Missing token")
         return
     result = await app.state.auth.get_user_from_token(token)
     _hs_mark("token")
     if result is auth.Auth.TOKEN_EXPIRED:
-        await websocket.close(code=4002, reason="Token expired")
+        await _refuse(websocket, 4002, "Token expired")
         return
     if result is None:
-        await websocket.close(code=4001, reason="Invalid token")
+        await _refuse(websocket, 4001, "Invalid token")
         return
     user = result
     workspace = websocket.query_params.get("workspace")  # None = deploy-wide
@@ -95,7 +117,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
             "/admin", principals, "admin"
         )
     if not allowed:
-        await websocket.close(code=4003, reason="Forbidden")
+        await _refuse(websocket, 4003, "Forbidden", user.get("email"))
         return
     _hs_mark("authz")
 
@@ -111,18 +133,21 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     # NB: these closes run before websocket.accept(), so the ASGI server
     # (uvicorn) answers the handshake with a bare HTTP 403 -- the close code
     # and reason are NOT transmitted to the client (same as the authz close
-    # above). The distinct reason string is still worth setting: it lands in
-    # the server log for debugging why a connection was refused.
+    # above). _refuse() therefore also logs the reason server-side (#2490):
+    # the log line is the only place a 403 storm is attributable.
     if workspace is not None:
         ws = await app.state.model.workspaces.get_workspace(workspace)
         if ws is None:
             # Vanished between the authz check and now (a delete race) -- the
             # workspace authz just passed against can no longer be registered.
-            await websocket.close(code=4003, reason="Forbidden")
+            await _refuse(websocket, 4003, "Forbidden", user.get("email"))
             return
         if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
-            await websocket.close(
-                code=4003, reason="workspace egress mode is not interactive"
+            await _refuse(
+                websocket,
+                4003,
+                "workspace egress mode is not interactive",
+                user.get("email"),
             )
             return
 

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -459,6 +459,30 @@ class TestAppRender:
             await pilot.pause()
             assert app.query_one("#empty", Static).display is True
 
+    async def test_refresh_shows_refused_state(self):
+        # #2490: after two 403 refusals the status line says the decider gave
+        # up ("refused — not retrying"), not "reconnecting".
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app._refused = True
+            app._refresh()
+            await pilot.pause()
+            status = app.query_one("#status", Static)
+            assert "refused — not retrying" in str(status.content)
+
+    def test_user_agent_has_distinctive_prefix(self):
+        # The UA names this client so klangkd's refusal log can attribute a
+        # 403 to the consent decider (#2490).
+        assert tui_consent._USER_AGENT.startswith("klangk-consent-decide/")
+        assert tui_consent._user_agent() == tui_consent._USER_AGENT
+
+    def test_user_agent_falls_back_when_not_installed(self, monkeypatch):
+        def boom(name):
+            raise tui_consent.PackageNotFoundError(name)
+
+        monkeypatch.setattr(tui_consent, "_pkg_version", boom)
+        assert tui_consent._user_agent() == "klangk-consent-decide/dev"
+
     async def test_refresh_shows_active_flash(self):
         # While a flash is active (within TTL), _refresh renders it instead of
         # the normal status (so flashes survive the 1s periodic refresh).
@@ -1121,6 +1145,67 @@ class TestWsLoop:
         except asyncio.CancelledError:
             pass
         assert calls["n"] >= 2  # failed once, then reconnected
+
+    async def test_refused_403_retries_once_then_stops(self, monkeypatch):
+        # #2490: a pre-accept refusal is HTTP 403 (uvicorn answers every
+        # pre-accept close with 403 -- even an expired token, whose 4002
+        # close code never reaches us). The loop refreshes the token and
+        # retries ONCE; a second consecutive 403 is permanent -- it stops
+        # instead of spamming the server log forever.
+        calls = {"n": 0}
+
+        def refuse_403(*a, **kw):
+            calls["n"] += 1
+            raise websockets.InvalidStatus(
+                types.SimpleNamespace(status_code=403)
+            )
+
+        monkeypatch.setattr(tui_consent, "ws_connect", refuse_403)
+        app = _make_app(reconnect_delays=(0.0,))
+
+        async def fake_refresh():
+            return "refreshed-token"
+
+        monkeypatch.setattr(app, "_refresh_token", fake_refresh)
+        task = asyncio.create_task(_real_ws_loop(app))
+        for _ in range(100):  # wait for the loop to give up
+            if app._refused:
+                break
+            await asyncio.sleep(0.02)
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert app._refused is True
+        assert calls["n"] == 2  # one refusal + one refresh-and-retry
+        assert app.token == "refreshed-token"
+
+    async def test_handshake_503_keeps_retrying(self, monkeypatch):
+        # A non-403 handshake failure (gateway 503) is transient: the loop
+        # keeps the normal reconnect backoff and never sets _refused.
+        calls = {"n": 0}
+
+        def refuse_503(*a, **kw):
+            calls["n"] += 1
+            raise websockets.InvalidStatus(
+                types.SimpleNamespace(status_code=503)
+            )
+
+        monkeypatch.setattr(tui_consent, "ws_connect", refuse_503)
+        app = _make_app(reconnect_delays=(0.0,))
+        task = asyncio.create_task(_real_ws_loop(app))
+        await asyncio.sleep(0.1)
+        app._stop = True
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert calls["n"] >= 2  # still retrying
+        assert app._refused is False
 
     async def test_connect_exception_logs_and_retries(self, monkeypatch):
         # ws_connect always raises: the loop keeps retrying (never crashes).

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -460,15 +460,16 @@ class TestAppRender:
             assert app.query_one("#empty", Static).display is True
 
     async def test_refresh_shows_refused_state(self):
-        # #2490: after two 403 refusals the status line says the decider gave
-        # up ("refused — not retrying"), not "reconnecting".
+        # #2490: after repeated 403 refusals the status line says the decider
+        # slowed its retry ("refused — retrying every 60s"), not
+        # "reconnecting".
         app = _make_app()
         async with app.run_test() as pilot:
             app._refused = True
             app._refresh()
             await pilot.pause()
             status = app.query_one("#status", Static)
-            assert "refused — not retrying" in str(status.content)
+            assert "refused — retrying every 60s" in str(status.content)
 
     def test_user_agent_has_distinctive_prefix(self):
         # The UA names this client so klangkd's refusal log can attribute a
@@ -1146,12 +1147,61 @@ class TestWsLoop:
             pass
         assert calls["n"] >= 2  # failed once, then reconnected
 
-    async def test_refused_403_retries_once_then_stops(self, monkeypatch):
+    async def test_refused_403_slows_retry_and_heals(
+        self, monkeypatch, caplog
+    ):
         # #2490: a pre-accept refusal is HTTP 403 (uvicorn answers every
         # pre-accept close with 403 -- even an expired token, whose 4002
-        # close code never reaches us). The loop refreshes the token and
-        # retries ONCE; a second consecutive 403 is permanent -- it stops
-        # instead of spamming the server log forever.
+        # close code never reaches us). First refusal refreshes the JWT and
+        # retries fast; once refusals pile up the loop drops to a fixed slow
+        # interval instead of stopping -- and a later successful connect
+        # clears the refused flag (self-heal: a mid-session flip back to
+        # interactive recovers without restarting the shell). The refused
+        # flag is transient (healed on connect #3), so the slow-retry branch
+        # is asserted via its one-time warning log.
+        import logging
+
+        calls = {"n": 0}
+
+        def connect(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise websockets.InvalidStatus(
+                    types.SimpleNamespace(status_code=403)
+                )
+            return FakeCM(FakeWS([]))  # 3rd+ connect succeeds, then drops
+
+        monkeypatch.setattr(tui_consent, "ws_connect", connect)
+        monkeypatch.setattr(tui_consent, "_REFUSED_RETRY_INTERVAL", 0.0)
+        app = _make_app(reconnect_delays=(0.0,))
+
+        async def fake_refresh():
+            return "refreshed-token"
+
+        monkeypatch.setattr(app, "_refresh_token", fake_refresh)
+        with caplog.at_level(logging.WARNING, logger="klangk.cli.tui.consent"):
+            task = asyncio.create_task(_real_ws_loop(app))
+            for _ in range(100):  # wait for the healing connect
+                if calls["n"] >= 3:
+                    break
+                await asyncio.sleep(0.02)
+            await asyncio.sleep(0.05)
+            app._stop = True
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        assert "registration refused (403) repeatedly" in caplog.text
+        assert app.token == "refreshed-token"
+        assert app._refused is False  # healed by the successful connect
+        assert calls["n"] >= 3  # kept retrying (no dead stop)
+
+    async def test_refused_403_keeps_slow_retrying_forever(self, monkeypatch):
+        # While refused the loop never stops on its own: it retries at the
+        # (patched-to-zero) slow interval for the app's lifetime -- bounded
+        # spam on the server side, automatic recovery on the client side.
         calls = {"n": 0}
 
         def refuse_403(*a, **kw):
@@ -1160,27 +1210,22 @@ class TestWsLoop:
                 types.SimpleNamespace(status_code=403)
             )
 
-        monkeypatch.setattr(tui_consent, "ws_connect", refuse_403)
-        app = _make_app(reconnect_delays=(0.0,))
-
         async def fake_refresh():
-            return "refreshed-token"
+            return None  # no new token available
 
+        monkeypatch.setattr(tui_consent, "ws_connect", refuse_403)
+        monkeypatch.setattr(tui_consent, "_REFUSED_RETRY_INTERVAL", 0.0)
+        app = _make_app(reconnect_delays=(0.0,))
         monkeypatch.setattr(app, "_refresh_token", fake_refresh)
         task = asyncio.create_task(_real_ws_loop(app))
-        for _ in range(100):  # wait for the loop to give up
-            if app._refused:
-                break
-            await asyncio.sleep(0.02)
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(0.2)
         task.cancel()
         try:
             await task
         except asyncio.CancelledError:
             pass
         assert app._refused is True
-        assert calls["n"] == 2  # one refusal + one refresh-and-retry
-        assert app.token == "refreshed-token"
+        assert calls["n"] > 5  # still attempting, well past the 2nd refusal
 
     async def test_handshake_503_keeps_retrying(self, monkeypatch):
         # A non-403 handshake failure (gateway 503) is transient: the loop

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -330,13 +330,15 @@ class TestConsentDeciderWS:
         assert app.state.consent_deciders.has_decider(WS) is False
 
     async def test_forbidden_logs_user_and_workspace(self, caplog):
-        # #2490: an authz refusal names the user + workspace in the log.
+        # #2490: an authz refusal names the user + workspace in the log --
+        # and never the token (it rides the query string; leaking it into
+        # the log would leak a live JWT).
         import logging
 
         from klangk.wshandler.decider import handle_consent_decider
 
         app = _ws_app({"id": "u1", "email": "a@x"}, allowed=False)
-        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        ws = _FakeWS({"token": "SEKRET-JWT", "workspace": WS}, [])
         with caplog.at_level(
             logging.WARNING, logger="klangk.wshandler.decider"
         ):
@@ -344,6 +346,22 @@ class TestConsentDeciderWS:
         assert "refused: Forbidden" in caplog.text
         assert "user=a@x" in caplog.text
         assert f"workspace={WS}" in caplog.text
+        assert "SEKRET-JWT" not in caplog.text
+
+    async def test_refusal_log_sanitizes_forged_workspace(self, caplog):
+        # #2490: the workspace query param is attacker-controlled pre-auth;
+        # a forged %0A must not inject new lines into the log record.
+        import logging
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"}, allowed=False)
+        ws = _FakeWS({"token": "tok", "workspace": f"{WS}\nFAKED line"}, [])
+        with caplog.at_level(
+            logging.WARNING, logger="klangk.wshandler.decider"
+        ):
+            await handle_consent_decider(ws, app)
+        assert "\nFAKED" not in caplog.text
 
     async def test_static_workspace_scoped_decider_is_forbidden(self):
         # #2394: a workspace with egress_mode=static must refuse a

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -177,8 +177,15 @@ class TestConsentDeciderRegistryBroadcast:
 class _FakeWS:
     """Minimal stand-in for a fastapi WebSocket for handler-level tests."""
 
-    def __init__(self, params: dict, incoming: list):
+    def __init__(
+        self, params: dict, incoming: list, headers: dict | None = None
+    ):
         self.query_params = params
+        self.headers = (
+            headers
+            if headers is not None
+            else {"user-agent": "fake-decider/1.0"}
+        )
         self._incoming = iter(incoming)
         self.sent: list[str] = []
         self.accepted = False
@@ -279,6 +286,22 @@ class TestConsentDeciderWS:
         assert ws.accepted is False
         assert app.state.consent_deciders.has_decider(WS) is False
 
+    async def test_missing_token_logs_refusal(self, caplog):
+        # #2490: every pre-accept refusal logs its reason server-side (the
+        # close code/reason never reach the client on a refused handshake).
+        import logging
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS({"workspace": WS}, [], headers={"user-agent": "ua-x/9"})
+        with caplog.at_level(
+            logging.WARNING, logger="klangk.wshandler.decider"
+        ):
+            await handle_consent_decider(ws, app)
+        assert "refused: Missing token" in caplog.text
+        assert "ua=ua-x/9" in caplog.text
+
     async def test_invalid_token_is_rejected(self):
         from klangk.wshandler.decider import handle_consent_decider
 
@@ -306,6 +329,22 @@ class TestConsentDeciderWS:
         assert ws.accepted is False
         assert app.state.consent_deciders.has_decider(WS) is False
 
+    async def test_forbidden_logs_user_and_workspace(self, caplog):
+        # #2490: an authz refusal names the user + workspace in the log.
+        import logging
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"}, allowed=False)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        with caplog.at_level(
+            logging.WARNING, logger="klangk.wshandler.decider"
+        ):
+            await handle_consent_decider(ws, app)
+        assert "refused: Forbidden" in caplog.text
+        assert "user=a@x" in caplog.text
+        assert f"workspace={WS}" in caplog.text
+
     async def test_static_workspace_scoped_decider_is_forbidden(self):
         # #2394: a workspace with egress_mode=static must refuse a
         # workspace-scoped consent decider at registration -- the
@@ -319,6 +358,24 @@ class TestConsentDeciderWS:
         assert ws.closed == (4003, "workspace egress mode is not interactive")
         assert ws.accepted is False
         assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_static_refusal_logs_reason(self, caplog):
+        # #2490: the egress-mode refusal names the mode mismatch in the log
+        # -- the most common 403-storm cause (workspace flipped out of
+        # interactive mid-session).
+        import logging
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"}, egress_mode="static")
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        with caplog.at_level(
+            logging.WARNING, logger="klangk.wshandler.decider"
+        ):
+            await handle_consent_decider(ws, app)
+        assert (
+            "refused: workspace egress mode is not interactive" in caplog.text
+        )
 
     async def test_allow_workspace_scoped_decider_is_forbidden(self):
         # #2406: an allow-mode workspace is default-permit and auto-allows
@@ -346,6 +403,22 @@ class TestConsentDeciderWS:
         assert ws.closed == (4003, "Forbidden")
         assert ws.accepted is False
         assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_vanished_workspace_refusal_is_logged(self, caplog):
+        # #2490: the delete-race refusal is logged like every other one.
+        import logging
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        app.state.model.workspaces.get_workspace = AsyncMock(return_value=None)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        with caplog.at_level(
+            logging.WARNING, logger="klangk.wshandler.decider"
+        ):
+            await handle_consent_decider(ws, app)
+        assert "refused: Forbidden" in caplog.text
+        assert "user=a@x" in caplog.text
 
     async def test_deploy_wide_decider_unaffected_by_static_mode(self):
         # #2394: deploy-wide deciders (no ?workspace=) cover all interactive


### PR DESCRIPTION
Closes #2490.

## What

Two halves of the endless-403 spam when the consent-decider WebSocket is
permanently refused:

**Server (`wshandler/decider.py`)** — every pre-accept refusal in
`handle_consent_decider` now goes through `_refuse()`, which logs a
`WARNING` with the reason, close code, user email, workspace (or
`deploy-wide`), and the client's **User-Agent**, then closes. Uvicorn
answers a pre-accept close with a bare HTTP 403 — the close code/reason
never reach the client and (contrary to the old in-code comment) were
never logged, making a 403 storm unattributable.

**Client (`cli/tui/consent.py`)** — the reconnect loop distinguishes a
*refused handshake* (HTTP 403) from a dropped connection:

- First 403: refresh the JWT and retry once (an expired token also
  masquerades as 403, since its 4002 close code is lost pre-accept).
- Second consecutive 403: stop permanently — `refused — not retrying`
  in the status line, no more reconnect spam for the shell session's
  lifetime.
- Non-403 handshake failures (gateway 502/503) keep today's backoff.
- The decider now sends a distinctive User-Agent
  (`klangk-consent-decide/<version>`) so server logs attribute 403s to
  this client vs a browser or anything else.

## Tests

- Server: refusal logs for missing token, authz (user+workspace in the
  log), egress-mode mismatch, and the vanished-workspace race (caplog).
- Client: 403 → refresh+retry once → second 403 stops (`_refused`,
  exactly 2 connect attempts); 503 keeps retrying; status-line render of
  the refused state; UA prefix + not-installed fallback.

Full backend suite green at 100% coverage (4922 tests).
