### PR TITLE
build(devenv): gate sidecar image rebuild on klangksidecar sources

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -154,6 +154,13 @@ in
       execIfModified = [
         "scripts/build-network-sidecar.sh"
         "src/containers/network/**"
+        # The klangksidecar wheel (#2450): only the import package + its
+        # pyproject (dep pins + wheel metadata) affect what gets baked into
+        # the image. tests/ is excluded from the wheel automatically, and
+        # uv.lock is not consulted by ``uv build`` -- keying on it would
+        # rebuild the image on every unrelated workspace dep bump.
+        "src/klangksidecar/klangksidecar/**"
+        "src/klangksidecar/pyproject.toml"
       ];
     };
     "klangk:kill-port-holders" = {


### PR DESCRIPTION
## Summary

The `klangk:build-network-sidecar` task's `execIfModified` gate only covered the
build script and `src/containers/network/`, but the task also builds the
`klangksidecar` wheel from `src/klangksidecar/` and bakes it into the image
(#2450) — sidecar source edits silently left the `klangk-network-sidecar` image
stale.

Gate on the import package + its `pyproject.toml` (dep pins + wheel metadata):

```diff
 execIfModified = [
   "scripts/build-network-sidecar.sh"
   "src/containers/network/**"
+  "src/klangksidecar/klangksidecar/**"
+  "src/klangksidecar/pyproject.toml"
 ];
```

`tests/` is excluded from the wheel automatically, and `uv.lock` is not
consulted by `uv build`, so keying on either would rebuild the image for
nothing.

Fixes #2495.
