### PR TITLE
feat(frontend): pause egress filtering from the Net Rules tab

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,12 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Pause egress filtering from the web UI (#2494).** The workspace page's
+  **Net Rules** tab now has a pause control (Unpause / Pause 15m / 1h / 1d)
+  that silences consent prompts workspace-wide for a window, matching the
+  `consent-decide` TUI control (#2332). Requires the same
+  `share-terminals` permission as the TUI; the server nacks otherwise.
+
 - **Egress request-flow diagram (#2376).** New "Anatomy of an egressing
   request" page under Architecture: a Mermaid flowchart of a single
   egressing request — DNS gate → NFQUEUE SYN gate → consent loop →

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -6,8 +6,9 @@
 /// and sends ``verdict`` frames so the deciding user can allow/deny each held
 /// connection *while the sidecar holds it* (#2311), plus ``pause``/``unpause``
 /// frames that silence prompts workspace-wide for a window (#2332). The
-/// verdict + pause protocol and frame shapes are duplicated from the server
-/// (``model/egress_consent.py``) per the isolation boundary the web client
+/// verdict protocol + frame shapes are duplicated from the server
+/// (``model/egress_consent.py``, pause handling in ``wshandler/decider.py`` +
+/// ``consent_coordinator.py``) per the isolation boundary the web client
 /// shares with the CLI.
 ///
 /// A decider that goes silent is reaped by the server after
@@ -65,8 +66,9 @@ const String kConsentDurationForever = 'forever';
 const String kConsentDurationTilrestart = 'tilrestart';
 
 /// Pause-window tokens the server accepts for silencing prompts (#2332).
-/// A focused set (not the full verdict-duration list); mirrors the TUI's
-/// `PAUSE_DURATIONS` (`cli/tui/consent.py`).
+/// A focused set (not the full verdict-duration list); mirrors the server's
+/// `PAUSE_DURATIONS` (`consent_coordinator.py`) and the TUI pause bar's
+/// buttons (`cli/tui/consent.py`).
 const List<String> kConsentPauseDurations = ['15m', '1h', '1d'];
 
 /// Inbound-frame application outcomes returned by [ConsentDeciderService.applyFrame].
@@ -93,7 +95,7 @@ enum ConsentFrameOutcome {
   revokeAck,
 
   /// The server replied to a pause/unpause (#2332); [ConsentFrameResult.pauseOk]
-  /// is set.
+  /// and [ConsentFrameResult.pauseUntil] are set.
   pauseAck,
 
   /// Non-JSON / unknown frame (ignored).
@@ -123,6 +125,11 @@ class ConsentFrameResult {
   /// [ConsentFrameOutcome.pauseAck]).
   final bool pauseOk;
 
+  /// The pause-window end (epoch seconds) a successful `pause_ack` carries,
+  /// or null (outcome == [ConsentFrameOutcome.pauseAck]; null `until` on an
+  /// ok ack means the pause was cleared).
+  final double? pauseUntil;
+
   const ConsentFrameResult(this.outcome,
       {this.request,
       this.resolvedId,
@@ -130,7 +137,8 @@ class ConsentFrameResult {
       this.rules,
       this.revokeAckId,
       this.revokeOk = false,
-      this.pauseOk = false});
+      this.pauseOk = false,
+      this.pauseUntil});
 
   static const ignored = ConsentFrameResult(ConsentFrameOutcome.ignored);
 }
@@ -414,6 +422,24 @@ class ConsentDeciderService extends ChangeNotifier {
   String? _flashMessage;
   DateTime? _flashUntil;
 
+  /// Duration of the user's last pause request, or null after Unpause
+  /// (#2494). Set when a pause/unpause is sent and **reverted on a failed
+  /// ack**, so the highlighted button never claims a window the server
+  /// refused. The server's frame carries only `until` (not which window),
+  /// so the active button follows the user's last acknowledged request --
+  /// mirrors the TUI `_pause_duration`, minus its stale-on-nack flaw. Owned
+  /// by the service (not the panel) so it survives a panel remount.
+  String? _lastPauseRequest;
+
+  /// The pause/unpause op awaiting its ack: a duration token ('15m'...) or
+  /// 'unpause'. Lets a nack flash which op failed; cleared on any ack.
+  String? _pendingPauseOp;
+
+  /// The button-highlight source for the pause controls -- the user's last
+  /// acknowledged pause request (null = Unpause is active). See
+  /// [_lastPauseRequest].
+  String? get lastPauseRequest => _lastPauseRequest;
+
   /// The active flash message, or null once it has expired. Clock-based (not a
   /// real timer) so it is unit-testable by advancing the injected [clock]; the
   /// banner's 1s tick repaint re-reads this and the flash visually clears.
@@ -519,11 +545,7 @@ class ConsentDeciderService extends ChangeNotifier {
         _applyRevokeAck(res.revokeAckId, res.revokeOk);
         break;
       case ConsentFrameOutcome.pauseAck:
-        // A failed pause/unpause flashes so the decider knows the window is
-        // unchanged; success needs no flash -- the refreshed `egress_rules`
-        // frame the server broadcasts carries the new pause state. Mirrors
-        // the TUI's `pause_ack` handling.
-        if (!res.pauseOk) _flash('pause failed');
+        _applyPauseAck(res.pauseOk, res.pauseUntil);
         break;
       case ConsentFrameOutcome.error:
         // Surface the rejection to the user (the TUI flashes it); a verdict
@@ -554,6 +576,36 @@ class ConsentDeciderService extends ChangeNotifier {
         allowed: r.allowed.where((e) => e.id != id).toList(),
         denied: r.denied.where((e) => e.id != id).toList(),
         paused: r.paused,
+      );
+    }
+    notifyListeners();
+  }
+
+  /// Apply a `pause_ack` (#2494 review): a nack reverts the highlight (the
+  /// server refused -- missing `share-terminals`, deploy-wide decider, bad
+  /// duration -- so no window was set) and flashes which op failed; a
+  /// success applies the ack's own pause state as an authoritative fallback
+  /// -- the refreshed `egress_rules` broadcast normally lands first (the
+  /// server awaits it before acking), but the broadcast is best-effort
+  /// server-side, so without this the display could sit stale after a
+  /// successful pause. Null `until` on an ok ack means the pause was cleared
+  /// (unpause).
+  void _applyPauseAck(bool ok, double? until) {
+    final op = _pendingPauseOp;
+    _pendingPauseOp = null;
+    if (!ok) {
+      _lastPauseRequest = null;
+      _flash(op == 'unpause' ? 'unpause failed' : 'pause failed');
+      return;
+    }
+    final r = _rules;
+    if (r != null) {
+      _rules = EgressRules(
+        workspaceId: r.workspaceId,
+        allowList: r.allowList,
+        allowed: r.allowed,
+        denied: r.denied,
+        paused: until != null ? EgressPause(until: until) : null,
       );
     }
     notifyListeners();
@@ -655,6 +707,9 @@ class ConsentDeciderService extends ChangeNotifier {
   /// the refreshed `egress_rules` frame. Flashes (not silent) when
   /// disconnected or the send fails. Mirrors the TUI.
   void sendPause(String duration) {
+    _lastPauseRequest = duration;
+    _pendingPauseOp = duration;
+    notifyListeners();
     final ch = _channel;
     if (ch == null || !_connected) {
       _flash('disconnected — reconnecting');
@@ -670,6 +725,9 @@ class ConsentDeciderService extends ChangeNotifier {
 
   /// Resume prompting (clear an active pause) (#2332). Mirrors the TUI.
   void sendUnpause() {
+    _lastPauseRequest = null;
+    _pendingPauseOp = 'unpause';
+    notifyListeners();
     final ch = _channel;
     if (ch == null || !_connected) {
       _flash('disconnected — reconnecting');
@@ -748,8 +806,10 @@ class ConsentDeciderService extends ChangeNotifier {
           revokeAckId: rid is String ? rid : null, revokeOk: msg['ok'] == true);
     }
     if (mtype == 'pause_ack') {
+      final until = msg['until'];
       return ConsentFrameResult(ConsentFrameOutcome.pauseAck,
-          pauseOk: msg['ok'] == true);
+          pauseOk: msg['ok'] == true,
+          pauseUntil: until is num ? until.toDouble() : null);
     }
     return ConsentFrameResult.ignored;
   }
@@ -838,18 +898,35 @@ class ConsentDeciderService extends ChangeNotifier {
     return remaining != null && remaining <= 0;
   }
 
-  /// Drop timed verdicts whose window has elapsed from the cached snapshot,
-  /// notifying listeners if anything changed. Called by the rules view's 1s
-  /// tick so an expired rule disappears at the first tick past its expiry
-  /// instead of lingering at "0s left". Returns whether any rule was pruned.
-  /// No-op (returns false) before the first `egress_rules` frame lands.
+  /// Whether the pause window has elapsed -- a finite `until` in the past
+  /// (#2494 review). The server reverts to prompting at the real expiry but,
+  /// like a rule, only re-broadcasts `egress_rules` on the next discrete
+  /// event -- so without a local prune the panel would show "Filtering
+  /// paused (resumes in 0s)" forever, claiming prompts are suppressed when
+  /// holds have actually resumed. An indefinite pause (`until` null) and a
+  /// not-paused workspace never expire. Mirrors [isRuleExpired] (#2467).
+  bool isPauseExpired(EgressRules rules) {
+    final until = rules.paused?.until;
+    if (until == null) return false;
+    final now = clock().millisecondsSinceEpoch / 1000.0;
+    return until <= now;
+  }
+
+  /// Drop timed verdicts whose window has elapsed -- and a self-expired
+  /// pause -- from the cached snapshot, notifying listeners if anything
+  /// changed. Called by the rules view's 1s tick so an expired rule (or
+  /// pause) disappears at the first tick past its expiry instead of
+  /// lingering at "0s left". Returns whether anything was pruned. No-op
+  /// (returns false) before the first `egress_rules` frame lands.
   bool pruneExpiredRules() {
     final r = _rules;
     if (r == null) return false;
     final allowed = r.allowed.where((e) => !isRuleExpired(e)).toList();
     final denied = r.denied.where((e) => !isRuleExpired(e)).toList();
+    final paused = isPauseExpired(r) ? null : r.paused;
     if (allowed.length == r.allowed.length &&
-        denied.length == r.denied.length) {
+        denied.length == r.denied.length &&
+        paused == r.paused) {
       return false;
     }
     _rules = EgressRules(
@@ -857,7 +934,7 @@ class ConsentDeciderService extends ChangeNotifier {
       allowList: r.allowList,
       allowed: allowed,
       denied: denied,
-      paused: r.paused,
+      paused: paused,
     );
     notifyListeners();
     return true;

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -4,9 +4,11 @@
 /// (``cli/tui/consent.py``): connects to the server's ``/ws/consent-decider``
 /// stream for a workspace, holds the snapshot + live pending egress requests,
 /// and sends ``verdict`` frames so the deciding user can allow/deny each held
-/// connection *while the sidecar holds it* (#2311). The verdict protocol +
-/// frame shapes are duplicated from the server (``model/egress_consent.py``)
-/// per the isolation boundary the web client shares with the CLI.
+/// connection *while the sidecar holds it* (#2311), plus ``pause``/``unpause``
+/// frames that silence prompts workspace-wide for a window (#2332). The
+/// verdict + pause protocol and frame shapes are duplicated from the server
+/// (``model/egress_consent.py``) per the isolation boundary the web client
+/// shares with the CLI.
 ///
 /// A decider that goes silent is reaped by the server after
 /// ``consent_decider_timeout`` (45s), reverting the workspace to static
@@ -62,6 +64,11 @@ const Map<String, int> kConsentDurationSeconds = {
 const String kConsentDurationForever = 'forever';
 const String kConsentDurationTilrestart = 'tilrestart';
 
+/// Pause-window tokens the server accepts for silencing prompts (#2332).
+/// A focused set (not the full verdict-duration list); mirrors the TUI's
+/// `PAUSE_DURATIONS` (`cli/tui/consent.py`).
+const List<String> kConsentPauseDurations = ['15m', '1h', '1d'];
+
 /// Inbound-frame application outcomes returned by [ConsentDeciderService.applyFrame].
 enum ConsentFrameOutcome {
   /// A new held request (snapshot or live); [ConsentFrameResult.request] is set.
@@ -84,6 +91,10 @@ enum ConsentFrameOutcome {
   /// The server replied to a revoke (#2339/#2341); [ConsentFrameResult.revokeAckId]
   /// and [ConsentFrameResult.revokeOk] are set.
   revokeAck,
+
+  /// The server replied to a pause/unpause (#2332); [ConsentFrameResult.pauseOk]
+  /// is set.
+  pauseAck,
 
   /// Non-JSON / unknown frame (ignored).
   ignored,
@@ -108,13 +119,18 @@ class ConsentFrameResult {
   /// [ConsentFrameOutcome.revokeAck]).
   final bool revokeOk;
 
+  /// Whether a `pause_ack` confirmed success (outcome ==
+  /// [ConsentFrameOutcome.pauseAck]).
+  final bool pauseOk;
+
   const ConsentFrameResult(this.outcome,
       {this.request,
       this.resolvedId,
       this.message,
       this.rules,
       this.revokeAckId,
-      this.revokeOk = false});
+      this.revokeOk = false,
+      this.pauseOk = false});
 
   static const ignored = ConsentFrameResult(ConsentFrameOutcome.ignored);
 }
@@ -502,6 +518,13 @@ class ConsentDeciderService extends ChangeNotifier {
       case ConsentFrameOutcome.revokeAck:
         _applyRevokeAck(res.revokeAckId, res.revokeOk);
         break;
+      case ConsentFrameOutcome.pauseAck:
+        // A failed pause/unpause flashes so the decider knows the window is
+        // unchanged; success needs no flash -- the refreshed `egress_rules`
+        // frame the server broadcasts carries the new pause state. Mirrors
+        // the TUI's `pause_ack` handling.
+        if (!res.pauseOk) _flash('pause failed');
+        break;
       case ConsentFrameOutcome.error:
         // Surface the rejection to the user (the TUI flashes it); a verdict
         // the server refused must not vanish silently.
@@ -625,6 +648,41 @@ class ConsentDeciderService extends ChangeNotifier {
     }
   }
 
+  /// Pause interactive consent prompting for the workspace for `duration`
+  /// (#2332; one of [kConsentPauseDurations]). While paused, a destination
+  /// with no allow-list rule and no recorded deny is auto-allowed instead of
+  /// prompting. Never optimistic: the UI follows the server's `pause_ack` +
+  /// the refreshed `egress_rules` frame. Flashes (not silent) when
+  /// disconnected or the send fails. Mirrors the TUI.
+  void sendPause(String duration) {
+    final ch = _channel;
+    if (ch == null || !_connected) {
+      _flash('disconnected — reconnecting');
+      return;
+    }
+    try {
+      ch.sink.add(buildPause(duration));
+    } catch (e) {
+      debugPrint('[ConsentDecider] pause send failed: $e');
+      _flash('pause send failed — reconnecting');
+    }
+  }
+
+  /// Resume prompting (clear an active pause) (#2332). Mirrors the TUI.
+  void sendUnpause() {
+    final ch = _channel;
+    if (ch == null || !_connected) {
+      _flash('disconnected — reconnecting');
+      return;
+    }
+    try {
+      ch.sink.add(buildUnpause());
+    } catch (e) {
+      debugPrint('[ConsentDecider] unpause send failed: $e');
+      _flash('unpause send failed — reconnecting');
+    }
+  }
+
   @override
   void dispose() {
     _stopped = true;
@@ -689,6 +747,10 @@ class ConsentDeciderService extends ChangeNotifier {
       return ConsentFrameResult(ConsentFrameOutcome.revokeAck,
           revokeAckId: rid is String ? rid : null, revokeOk: msg['ok'] == true);
     }
+    if (mtype == 'pause_ack') {
+      return ConsentFrameResult(ConsentFrameOutcome.pauseAck,
+          pauseOk: msg['ok'] == true);
+    }
     return ConsentFrameResult.ignored;
   }
 
@@ -711,6 +773,22 @@ class ConsentDeciderService extends ChangeNotifier {
   @visibleForTesting
   static String buildRevoke(String requestId) {
     return jsonEncode({'type': 'revoke', 'request_id': requestId});
+  }
+
+  /// Build an outbound pause frame (JSON string) silencing prompts for a
+  /// window (#2332). `duration` is one of [kConsentPauseDurations]; the
+  /// server replies `pause_ack` and re-broadcasts `egress_rules` with the
+  /// live `paused` window. Mirrors the TUI `make_pause`.
+  @visibleForTesting
+  static String buildPause(String duration) {
+    return jsonEncode({'type': 'pause', 'duration': duration});
+  }
+
+  /// Build an outbound unpause frame (JSON string) resuming prompting
+  /// (#2332). Mirrors the TUI `make_unpause`.
+  @visibleForTesting
+  static String buildUnpause() {
+    return jsonEncode({'type': 'unpause'});
   }
 
   /// Seconds until this hold's countdown hits zero (clamped at 0). The server

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -80,24 +80,6 @@ class ConsentRulesPanel extends StatefulWidget {
 class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
   Timer? _tick;
 
-  /// Duration of the user's last pause request, or null after Unpause
-  /// (#2332). The server's pause frame carries only `until` (not which
-  /// window), so the active button follows the user's last request --
-  /// mirrors the TUI `_pause_duration`.
-  String? _lastPauseRequest;
-
-  /// Send a pause (`duration` != null) or unpause (null) frame and highlight
-  /// the tapped button. The sent state itself is never optimistic: the
-  /// server's `pause_ack` + refreshed `egress_rules` frame drive the display.
-  void _onPauseTap(String? duration) {
-    setState(() => _lastPauseRequest = duration);
-    if (duration == null) {
-      widget.service.sendUnpause();
-    } else {
-      widget.service.sendPause(duration);
-    }
-  }
-
   @override
   void initState() {
     super.initState();
@@ -111,11 +93,12 @@ class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
     // this only repaints the remaining-time hints).
     _tick = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
-      // Drop timed verdicts whose window just elapsed: the server only
-      // re-broadcasts egress_rules on a discrete event (verdict/revoke/pause/
-      // reconnect), not on natural expiry, so prune locally to hide the row
-      // the instant it expires (notifyListeners rebuilds if anything changed)
-      // rather than freezing at "0s left".
+      // Drop timed verdicts (and a self-expired pause) whose window just
+      // elapsed: the server only re-broadcasts egress_rules on a discrete
+      // event (verdict/revoke/pause/reconnect), not on natural expiry, so
+      // prune locally to hide the row the instant it expires
+      // (notifyListeners rebuilds if anything changed) rather than freezing
+      // at "0s left".
       widget.service.pruneExpiredRules();
       if (hasLiveCountdown(
           widget.service.rules, widget.service.ruleRemainingSeconds)) {
@@ -215,11 +198,7 @@ class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
                         remaining: service.ruleRemainingSeconds,
                         onRevoke: _confirmRevoke,
                       ),
-                      _PauseSection(
-                        service: service,
-                        lastRequest: _lastPauseRequest,
-                        onTap: _onPauseTap,
-                      ),
+                      _PauseSection(service: service),
                     ],
                   ),
                 ),
@@ -414,18 +393,14 @@ class _RuleRow extends StatelessWidget {
 /// The pause section (#2332/#2494): the live window status (when paused)
 /// plus the pause controls -- Unpause / Pause 15m / 1h / 1d -- modeled after
 /// the TUI pause bar (`cli/tui/consent.py`). The button matching the user's
-/// last request is highlighted (Unpause is active when nothing was last
-/// paused); the window itself follows the server's `pause_ack` + refreshed
-/// `egress_rules` frame.
+/// last acknowledged request ([ConsentDeciderService.lastPauseRequest]) is
+/// highlighted (Unpause is active when nothing was last paused); the window
+/// itself follows the server's `pause_ack` + refreshed `egress_rules`
+/// frames -- a refused pause reverts the highlight, and a self-expired
+/// window is pruned by the 1s tick rather than lingering at "0s".
 class _PauseSection extends StatelessWidget {
-  const _PauseSection({
-    required this.service,
-    required this.lastRequest,
-    required this.onTap,
-  });
+  const _PauseSection({required this.service});
   final ConsentDeciderService service;
-  final String? lastRequest;
-  final ValueChanged<String?> onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -456,8 +431,10 @@ class _PauseSection extends StatelessWidget {
   Widget _pauseButton(String? duration, String label) {
     // The active button mirrors the TUI's `pause-active` style: amber
     // background, canvas foreground.
-    final active = duration == lastRequest;
+    final active = duration == service.lastPauseRequest;
     final key = ValueKey('pause-${duration ?? 'none'}');
+    final onPressed = () =>
+        duration == null ? service.sendUnpause() : service.sendPause(duration);
     if (active) {
       return FilledButton(
         key: key,
@@ -466,14 +443,14 @@ class _PauseSection extends StatelessWidget {
           foregroundColor: KColors.bgCanvas,
           visualDensity: VisualDensity.compact,
         ),
-        onPressed: () => onTap(duration),
+        onPressed: onPressed,
         child: Text(label),
       );
     }
     return OutlinedButton(
       key: key,
       style: OutlinedButton.styleFrom(visualDensity: VisualDensity.compact),
-      onPressed: () => onTap(duration),
+      onPressed: onPressed,
       child: Text(label),
     );
   }

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -18,6 +18,11 @@
 /// Revoke is never optimistic: the row stays until the server's `revoke_ack`
 /// confirms success -- a still-enforced rule is never hidden silently (mirrors
 /// the TUI). A failed ack surfaces via the service's [flashMessage].
+///
+/// The panel also carries the pause controls (#2494): Unpause / Pause 15m /
+/// 1h / 1d, modeled after the TUI pause bar (#2332). Pause is workspace-wide
+/// and never optimistic -- the server's `pause_ack` + refreshed `egress_rules`
+/// frame drive the displayed state.
 library;
 
 import 'dart:async';
@@ -74,6 +79,24 @@ class ConsentRulesPanel extends StatefulWidget {
 
 class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
   Timer? _tick;
+
+  /// Duration of the user's last pause request, or null after Unpause
+  /// (#2332). The server's pause frame carries only `until` (not which
+  /// window), so the active button follows the user's last request --
+  /// mirrors the TUI `_pause_duration`.
+  String? _lastPauseRequest;
+
+  /// Send a pause (`duration` != null) or unpause (null) frame and highlight
+  /// the tapped button. The sent state itself is never optimistic: the
+  /// server's `pause_ack` + refreshed `egress_rules` frame drive the display.
+  void _onPauseTap(String? duration) {
+    setState(() => _lastPauseRequest = duration);
+    if (duration == null) {
+      widget.service.sendUnpause();
+    } else {
+      widget.service.sendPause(duration);
+    }
+  }
 
   @override
   void initState() {
@@ -192,7 +215,11 @@ class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
                         remaining: service.ruleRemainingSeconds,
                         onRevoke: _confirmRevoke,
                       ),
-                      if (rules.paused != null) _Pause(service: service),
+                      _PauseSection(
+                        service: service,
+                        lastRequest: _lastPauseRequest,
+                        onTap: _onPauseTap,
+                      ),
                     ],
                   ),
                 ),
@@ -384,9 +411,78 @@ class _RuleRow extends StatelessWidget {
   }
 }
 
-/// The pause section (#2332; hidden unless the frame reports a pause).
-class _Pause extends StatelessWidget {
-  const _Pause({required this.service});
+/// The pause section (#2332/#2494): the live window status (when paused)
+/// plus the pause controls -- Unpause / Pause 15m / 1h / 1d -- modeled after
+/// the TUI pause bar (`cli/tui/consent.py`). The button matching the user's
+/// last request is highlighted (Unpause is active when nothing was last
+/// paused); the window itself follows the server's `pause_ack` + refreshed
+/// `egress_rules` frame.
+class _PauseSection extends StatelessWidget {
+  const _PauseSection({
+    required this.service,
+    required this.lastRequest,
+    required this.onTap,
+  });
+  final ConsentDeciderService service;
+  final String? lastRequest;
+  final ValueChanged<String?> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final paused = service.rules?.paused;
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Pause prompts', style: _KStyles.title),
+          const SizedBox(height: 6),
+          if (paused != null) _PauseStatus(service: service),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              _pauseButton(null, 'Unpause'),
+              for (final d in kConsentPauseDurations)
+                _pauseButton(d, 'Pause $d'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _pauseButton(String? duration, String label) {
+    // The active button mirrors the TUI's `pause-active` style: amber
+    // background, canvas foreground.
+    final active = duration == lastRequest;
+    final key = ValueKey('pause-${duration ?? 'none'}');
+    if (active) {
+      return FilledButton(
+        key: key,
+        style: FilledButton.styleFrom(
+          backgroundColor: KColors.accentAmber,
+          foregroundColor: KColors.bgCanvas,
+          visualDensity: VisualDensity.compact,
+        ),
+        onPressed: () => onTap(duration),
+        child: Text(label),
+      );
+    }
+    return OutlinedButton(
+      key: key,
+      style: OutlinedButton.styleFrom(visualDensity: VisualDensity.compact),
+      onPressed: () => onTap(duration),
+      child: Text(label),
+    );
+  }
+}
+
+/// The live pause-window status line (#2332; rendered only while the frame
+/// reports a pause).
+class _PauseStatus extends StatelessWidget {
+  const _PauseStatus({required this.service});
   final ConsentDeciderService service;
 
   @override
@@ -397,7 +493,7 @@ class _Pause extends StatelessWidget {
         ? 'Filtering paused until restart'
         : 'Filtering paused (resumes in ${formatDurationCompact(rem)})';
     return Padding(
-      padding: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.only(bottom: 4),
       child: Row(
         children: [
           const Icon(Icons.pause_circle_outline,

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -806,25 +806,29 @@ void main() {
       svc.dispose();
     });
 
-    test('sendPause sends a pause frame on the socket', () {
+    test('sendPause sends a pause frame and tracks the request', () {
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       svc.connect();
+      expect(svc.lastPauseRequest, isNull);
       svc.sendPause('1h');
       expect(channel.sent, isNotEmpty);
       final out =
           jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
       expect(out, {'type': 'pause', 'duration': '1h'});
+      expect(svc.lastPauseRequest, '1h');
       svc.dispose();
     });
 
-    test('sendUnpause sends an unpause frame on the socket', () {
+    test('sendUnpause sends an unpause frame and clears the request', () {
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       svc.connect();
+      svc.sendPause('1h');
       svc.sendUnpause();
       expect(channel.sent, isNotEmpty);
       final out =
           jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
       expect(out, {'type': 'unpause'});
+      expect(svc.lastPauseRequest, isNull);
       svc.dispose();
     });
 
@@ -854,18 +858,56 @@ void main() {
       svc2.dispose();
     });
 
-    test('pause_ack failure flashes; success is silent', () async {
+    test('pause_ack nack reverts the highlight and flashes which op failed',
+        () async {
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       svc.connect();
-      // Success first: no flash -- the refreshed `egress_rules` frame the
-      // server broadcasts right after carries the new pause state.
-      channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
-      await Future<void>.delayed(Duration.zero);
-      expect(svc.flashMessage, isNull);
-      // Failure flashes so the decider knows the window is unchanged.
+      // A refused pause must not leave its button highlighted as active.
+      svc.sendPause('1h');
+      expect(svc.lastPauseRequest, '1h');
       channel.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
       await Future<void>.delayed(Duration.zero);
       expect(svc.flashMessage, contains('pause failed'));
+      expect(svc.lastPauseRequest, isNull);
+      // A refused unpause names itself in the flash.
+      svc.sendUnpause();
+      channel.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
+      await Future<void>.delayed(Duration.zero);
+      expect(svc.flashMessage, contains('unpause failed'));
+      expect(svc.lastPauseRequest, isNull);
+      svc.dispose();
+    });
+
+    test('pause_ack ok applies the acked window (authoritative fallback)',
+        () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      channel.serverSend(_rulesFrame(allowList: ['a.io']));
+      await Future<void>.delayed(Duration.zero);
+      expect(svc.rules!.paused, isNull);
+      // The refreshed egress_rules broadcast normally lands first, but it is
+      // best-effort server-side -- the ack's own until must apply alone.
+      svc.sendPause('15m');
+      channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
+      await Future<void>.delayed(Duration.zero);
+      expect(svc.rules!.paused, const EgressPause(until: 1300.0));
+      expect(svc.flashMessage, isNull); // success never flashes
+      // A successful unpause (ok, until null) clears the window.
+      svc.sendUnpause();
+      channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': null});
+      await Future<void>.delayed(Duration.zero);
+      expect(svc.rules!.paused, isNull);
+      svc.dispose();
+    });
+
+    test('pause_ack ok before any rules snapshot is a safe no-op', () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      svc.sendPause('15m');
+      channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
+      await Future<void>.delayed(Duration.zero);
+      expect(svc.rules, isNull); // no crash; the connect snapshot carries truth
+      expect(svc.lastPauseRequest, '15m');
       svc.dispose();
     });
 
@@ -983,6 +1025,33 @@ void main() {
     });
   });
 
+  group('isPauseExpired', () {
+    EgressRules rules(EgressPause? paused) => EgressRules(
+        workspaceId: 'w',
+        allowList: const [],
+        allowed: const [],
+        denied: const [],
+        paused: paused);
+
+    test('finite until past -> true; future / indefinite / not paused -> false',
+        () {
+      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws', token: 't', clock: () => now);
+      // until 1300s, now 1000s -> live.
+      expect(
+          svc.isPauseExpired(rules(const EgressPause(until: 1300.0))), isFalse);
+      // until 900s -> elapsed.
+      expect(
+          svc.isPauseExpired(rules(const EgressPause(until: 900.0))), isTrue);
+      // Indefinite (until restart) and not-paused never expire.
+      expect(
+          svc.isPauseExpired(rules(const EgressPause(until: null))), isFalse);
+      expect(svc.isPauseExpired(rules(null)), isFalse);
+      svc.dispose();
+    });
+  });
+
   group('pruneExpiredRules', () {
     test('no-op (returns false) before the first egress_rules frame', () {
       final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
@@ -1045,6 +1114,34 @@ void main() {
       // Idempotent: pruning the already-pruned snapshot is a no-op.
       expect(svc.pruneExpiredRules(), isFalse);
       expect(notifications, 1);
+      ConsentDeciderService.testChannelFactory = null;
+      svc.dispose();
+    });
+
+    test('drops a self-expired pause; keeps a live or indefinite one (#2494)',
+        () async {
+      var now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+      final ch = _FakeChannel();
+      ConsentDeciderService.testChannelFactory = (_) => ch;
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws', token: 't', clock: () => now);
+      svc.connect();
+      // Live window: until t=1300, now t=1000.
+      ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
+      await Future.delayed(Duration.zero);
+      expect(svc.pruneExpiredRules(), isFalse); // still live -> kept
+      expect(svc.rules!.paused, const EgressPause(until: 1300.0));
+
+      // Past expiry: the pause is pruned (never lingers at "resumes in 0s").
+      now = DateTime.fromMillisecondsSinceEpoch(1400 * 1000, isUtc: true);
+      expect(svc.pruneExpiredRules(), isTrue);
+      expect(svc.rules!.paused, isNull);
+
+      // An indefinite pause (until restart) never expires.
+      ch.serverSend(_rulesFrame(paused: {'paused': true}));
+      await Future.delayed(Duration.zero);
+      expect(svc.pruneExpiredRules(), isFalse);
+      expect(svc.rules!.paused, const EgressPause(until: null));
       ConsentDeciderService.testChannelFactory = null;
       svc.dispose();
     });

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -208,6 +208,17 @@ void main() {
     });
   });
 
+  group('buildPause / buildUnpause', () {
+    test('produces well-formed pause/unpause frames', () {
+      final pause = jsonDecode(ConsentDeciderService.buildPause('15m'))
+          as Map<String, dynamic>;
+      expect(pause, {'type': 'pause', 'duration': '15m'});
+      final unpause = jsonDecode(ConsentDeciderService.buildUnpause())
+          as Map<String, dynamic>;
+      expect(unpause, {'type': 'unpause'});
+    });
+  });
+
   group('ConsentRule.fromJson', () {
     test('parses a full payload', () {
       final r = ConsentRule.fromJson(_ruleJson())!;
@@ -469,6 +480,17 @@ void main() {
       expect(bad.outcome, ConsentFrameOutcome.revokeAck);
       expect(bad.revokeAckId, isNull);
       expect(bad.revokeOk, isFalse);
+    });
+
+    test('pause_ack ok true/false', () {
+      final ok = ConsentDeciderService.applyFrame(
+          {}, jsonEncode({'type': 'pause_ack', 'ok': true, 'until': 1300.0}));
+      expect(ok.outcome, ConsentFrameOutcome.pauseAck);
+      expect(ok.pauseOk, isTrue);
+      final bad = ConsentDeciderService.applyFrame(
+          {}, jsonEncode({'type': 'pause_ack', 'ok': false, 'until': null}));
+      expect(bad.outcome, ConsentFrameOutcome.pauseAck);
+      expect(bad.pauseOk, isFalse);
     });
   });
 
@@ -781,6 +803,69 @@ void main() {
       svc.connect();
       svc.sendRevoke('v1');
       expect(svc.flashMessage, contains('revoke send failed'));
+      svc.dispose();
+    });
+
+    test('sendPause sends a pause frame on the socket', () {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      svc.sendPause('1h');
+      expect(channel.sent, isNotEmpty);
+      final out =
+          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+      expect(out, {'type': 'pause', 'duration': '1h'});
+      svc.dispose();
+    });
+
+    test('sendUnpause sends an unpause frame on the socket', () {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      svc.sendUnpause();
+      expect(channel.sent, isNotEmpty);
+      final out =
+          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+      expect(out, {'type': 'unpause'});
+      svc.dispose();
+    });
+
+    test('sendPause/sendUnpause flash when disconnected', () {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.sendPause('15m');
+      expect(channel.sent, isEmpty);
+      expect(svc.flashMessage, contains('disconnected'));
+      svc.dispose();
+      final svc2 = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc2.sendUnpause();
+      expect(svc2.flashMessage, contains('disconnected'));
+      svc2.dispose();
+    });
+
+    test('sendPause/sendUnpause flash when the socket send throws', () {
+      ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      svc.sendPause('15m');
+      expect(svc.flashMessage, contains('pause send failed'));
+      svc.dispose();
+      final svc2 = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc2.connect();
+      svc2.sendUnpause();
+      expect(svc2.flashMessage, contains('unpause send failed'));
+      svc2.dispose();
+    });
+
+    test('pause_ack failure flashes; success is silent', () async {
+      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+      svc.connect();
+      // Success first: no flash -- the refreshed `egress_rules` frame the
+      // server broadcasts right after carries the new pause state.
+      channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
+      await Future<void>.delayed(Duration.zero);
+      expect(svc.flashMessage, isNull);
+      // Failure flashes so the decider knows the window is unchanged.
+      channel.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
+      await Future<void>.delayed(Duration.zero);
+      expect(svc.flashMessage, contains('pause failed'));
       svc.dispose();
     });
 

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -306,6 +306,104 @@ void main() {
       svc.dispose();
     });
 
+    testWidgets(
+        'pause controls render once rules land; highlight follows the last request (#2494)',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      // No controls before the first egress_rules frame (loading state).
+      expect(find.text('Pause prompts'), findsNothing);
+      ch.serverSend(_rulesFrame(allowList: ['a.io']));
+      await tester.pump();
+
+      // All four buttons render (Unpause / Pause 15m / 1h / 1d, mirroring
+      // the TUI pause bar); nothing is paused so there is no status line.
+      expect(find.text('Pause prompts'), findsOneWidget);
+      expect(find.text('Unpause'), findsOneWidget);
+      expect(find.text('Pause 15m'), findsOneWidget);
+      expect(find.text('Pause 1h'), findsOneWidget);
+      expect(find.text('Pause 1d'), findsOneWidget);
+      expect(find.textContaining('Filtering paused'), findsNothing);
+
+      // Unpause is the active (filled) button when nothing was last paused.
+      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<FilledButton>());
+      expect(tester.widget(find.byKey(const ValueKey('pause-15m'))),
+          isA<OutlinedButton>());
+
+      // Tapping the active button sends too (unpause is idempotent
+      // server-side) and keeps Unpause as the last request.
+      await tester.tap(find.byKey(const ValueKey('pause-none')));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
+
+      // Tapping Pause 15m sends the frame and moves the highlight.
+      await tester.tap(find.byKey(const ValueKey('pause-15m')));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String),
+          {'type': 'pause', 'duration': '15m'});
+      expect(tester.widget(find.byKey(const ValueKey('pause-15m'))),
+          isA<FilledButton>());
+      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<OutlinedButton>());
+
+      // The paused status line renders alongside the controls.
+      ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
+      await tester.pump();
+      expect(find.textContaining('Filtering paused'), findsOneWidget);
+
+      // Tapping Unpause sends the unpause frame; the highlight returns.
+      await tester.tap(find.byKey(const ValueKey('pause-none')));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
+      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<FilledButton>());
+      expect(tester.widget(find.byKey(const ValueKey('pause-15m'))),
+          isA<OutlinedButton>());
+      svc.dispose();
+    });
+
+    testWidgets('pause tap while disconnected flashes instead of sending',
+        (tester) async {
+      final ch = _FakeChannel();
+      ConsentDeciderService.testChannelFactory = (_) => ch;
+      final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          // Long delay so the reconnect Timer never fires during the test.
+          reconnectDelays: const [Duration(minutes: 5)]);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(allowList: ['a.io']));
+      await tester.pump();
+      ch.serverClose();
+      await tester.pump();
+      await tester.pump(); // flush onDone -> reconnecting
+      await tester.tap(find.byKey(const ValueKey('pause-1h')));
+      await tester.pump();
+      expect(ch.sent, isEmpty); // nothing left the socket
+      expect(find.textContaining('disconnected'), findsOneWidget); // the flash
+      svc.dispose();
+    });
+
+    testWidgets('a failed pause_ack flashes via the service flash row',
+        (tester) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(allowList: ['a.io']));
+      await tester.pump();
+      ch.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
+      await tester.pump();
+      expect(find.text('pause failed'), findsOneWidget);
+      // The controls stay rendered (state unchanged, never optimistic).
+      expect(find.text('Pause 15m'), findsOneWidget);
+      svc.dispose();
+    });
+
     testWidgets('a revoked row stays until revoke_ack succeeds',
         (tester) async {
       final ch = _FakeChannel();

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -307,7 +307,7 @@ void main() {
     });
 
     testWidgets(
-        'pause controls render once rules land; highlight follows the last request (#2494)',
+        'pause controls render once rules land; highlight follows the last acked request (#2494)',
         (tester) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch);
@@ -349,19 +349,61 @@ void main() {
       expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
           isA<OutlinedButton>());
 
-      // The paused status line renders alongside the controls.
-      ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
+      // A refused pause (nack) reverts the highlight: the button must not
+      // claim a window the server never set.
+      ch.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
       await tester.pump();
-      expect(find.textContaining('Filtering paused'), findsOneWidget);
-
-      // Tapping Unpause sends the unpause frame; the highlight returns.
-      await tester.tap(find.byKey(const ValueKey('pause-none')));
-      await tester.pump();
-      expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
+      expect(find.text('pause failed'), findsOneWidget);
       expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
           isA<FilledButton>());
       expect(tester.widget(find.byKey(const ValueKey('pause-15m'))),
           isA<OutlinedButton>());
+
+      // A successful pause applies from the ack alone (the egress_rules
+      // re-broadcast is best-effort server-side): the status line renders.
+      await tester.tap(find.byKey(const ValueKey('pause-1h')));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String),
+          {'type': 'pause', 'duration': '1h'});
+      ch.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
+      await tester.pump();
+      expect(find.textContaining('Filtering paused'), findsOneWidget);
+
+      // Tapping Unpause sends the frame; a successful ack clears the status.
+      await tester.tap(find.byKey(const ValueKey('pause-none')));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
+      ch.serverSend({'type': 'pause_ack', 'ok': true, 'until': null});
+      await tester.pump();
+      expect(find.textContaining('Filtering paused'), findsNothing);
+      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<FilledButton>());
+      svc.dispose();
+    });
+
+    testWidgets(
+        'a self-expired pause disappears on the next tick (never "resumes in 0s")',
+        (tester) async {
+      var now = _at(1000); // epoch seconds
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch, clock: () => now);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      // Paused until t=1300; now t=1000 -> live countdown shows.
+      ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
+      await tester.pump();
+      expect(find.textContaining('Filtering paused'), findsOneWidget);
+
+      // Past the window: before the 1s tick fires the (cached) status line
+      // still renders; the tick must prune it, not freeze at "resumes in 0s"
+      // -- the server only re-broadcasts on the next discrete event.
+      now = _at(1400);
+      await tester.pump();
+      expect(find.textContaining('Filtering paused'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.textContaining('Filtering paused'), findsNothing);
+      // The controls stay rendered for the next request.
+      expect(find.text('Pause prompts'), findsOneWidget);
       svc.dispose();
     });
 


### PR DESCRIPTION
## Summary

Adds pause/unpause controls to the workspace page's **Net Rules** tab so
egress consent filtering can be silenced for a window (15m / 1h / 1d) from
the web UI, closing #2494. Modeled after the `consent-decide` TUI pause bar
(#2332); **no backend changes** — it uses the existing decider-WS
`pause`/`unpause` frames, and authorization (`share-terminals`) stays
server-side.

## Changes

- `consent_decider_service.dart`: `buildPause`/`buildUnpause` frame
  builders; `sendPause`/`sendUnpause` (flash on disconnect or send
  failure, mirroring `sendRevoke`); `pause_ack` parsing — a failed ack
  flashes, success is silent because the refreshed `egress_rules` frame
  the server broadcasts carries the new pause state (mirrors the TUI);
  `kConsentPauseDurations` (`15m`/`1h`/`1d`).
- `consent_rules_panel.dart`: the pause section now renders controls
  alongside the existing live-window status — `Unpause / Pause 15m /
  Pause 1h / Pause 1d`. The button matching the user's last request is
  highlighted amber (Unpause active when nothing was last paused),
  mirroring the TUI's `_pause_duration` tracking, since the server frame
  carries only `until`, not which window. Nothing is optimistic: the
  displayed window follows the server's frames.
- Changelog entry under `[Unreleased]`.

## Testing

- Service: pause/unpause frame builders, send paths (socket, disconnected
  flash, throw flash), `pause_ack` ok/nack parsing, nack-flash +
  success-silent behavior.
- Panel: controls render once rules land (not before), highlight follows
  the last request, taps send the right frames, the status line renders
  alongside controls, a disconnected tap flashes instead of sending, a
  failed `pause_ack` surfaces via the flash row.
- `flutter test --coverage` — 953 tests, 100% coverage (CI gate).
