### PR TITLE
feat(frontend): consent banner duration buttons replace dropdown

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -581,8 +581,12 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
-- **`KLANGKD_IDLE_TIMEOUT_SECONDS` default 30m → 60m (#2480).** The
-  workspace container idle timeout now defaults to 3600s (was 1800s). Existing
+- **Consent banner duration buttons (#2499).** The egress-consent banner's
+  verdict-duration dropdown is now a row of compact buttons (one per
+  duration, the selected one highlighted), matching the `consent-decide`
+  TUI's duration selector. Behavior is unchanged: one global selection,
+  default `tilrestart`, applied on the next Allow/Deny.
+- **`KLANGKD_IDLE_TIMEOUT_SECONDS` default 30m → 60m (#2480).** The workspace container idle timeout now defaults to 3600s (was 1800s). Existing
   deployments get a longer idle window on upgrade unless the env var is already
   set; set `KLANGKD_IDLE_TIMEOUT_SECONDS=1800` to keep the old 30-minute default.
   The auto-computed idle-check interval (`timeout/3`, clamped 10–60s) follows.

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -1,13 +1,15 @@
 /// Interactive egress-consent banner for the workspace page (#2246).
 ///
 /// A compact banner shown above the workspace body when [ConsentDeciderService]
-/// has pending held requests (interactive `egress_mode` only). The header
-/// carries a single *global* duration selector (default `tilrestart`); each row
-/// shows the destination host:port (+ process + a countdown) and Allow/Deny
-/// buttons that send a `verdict` frame carrying the selected duration. Mirrors
-/// the standalone `klangk consent-decide` TUI (one `#duration-selector` for the
-/// whole list, applied at allow/deny time -- not per row), adapted to an inline
-/// Flutter banner.
+/// has pending held requests (interactive `egress_mode` only). Below the
+/// header it carries a single *global* duration selector (#2499) -- one
+/// compact button per selectable duration (default `tilrestart`), the active
+/// one filled, mirroring the TUI's `#duration-selector` button row -- and
+/// each row shows the destination host:port (+ process + a countdown) and
+/// Allow/Deny buttons that send a `verdict` frame carrying the selected
+/// duration. One selector for the whole list, applied at allow/deny time --
+/// not per row -- matching the standalone `klangk consent-decide` TUI,
+/// adapted to an inline Flutter banner.
 ///
 /// Server error frames, verdict send failures, and verdicts attempted while
 /// disconnected surface as a transient flash row (the service's
@@ -24,6 +26,7 @@ library;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 import 'consent_decider_service.dart';
 
@@ -103,18 +106,23 @@ class _ConsentBannerState extends State<ConsentBanner> {
                   'Pending egress consent',
                   style: Theme.of(context).textTheme.labelLarge,
                 ),
-                const SizedBox(width: 12),
-                // One global duration selector (TUI parity): applies to the
-                // next Allow/Deny tapped on any row. Not per row.
-                _DurationMenu(
-                  value: _duration,
-                  onChanged: (v) => setState(() => _duration = v),
-                ),
                 const Spacer(),
                 if (!service.connected)
-                  const Text('reconnecting…',
-                      style: TextStyle(fontStyle: FontStyle.italic)),
+                  const Text(
+                    'reconnecting…',
+                    style: TextStyle(fontStyle: FontStyle.italic),
+                  ),
               ],
+            ),
+          ),
+          // One global duration selector (TUI parity, #2499): applies to the
+          // next Allow/Deny tapped on any row. Not per row. Selecting does NOT
+          // submit -- only a row's Allow/Deny submits with this duration.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+            child: _DurationSelector(
+              value: _duration,
+              onChanged: (v) => setState(() => _duration = v),
             ),
           ),
           if (flash != null)
@@ -122,14 +130,19 @@ class _ConsentBannerState extends State<ConsentBanner> {
               padding: const EdgeInsets.fromLTRB(16, 4, 16, 2),
               child: Row(
                 children: [
-                  const Icon(Icons.error_outline,
-                      size: 16, color: Colors.redAccent),
+                  const Icon(
+                    Icons.error_outline,
+                    size: 16,
+                    color: Colors.redAccent,
+                  ),
                   const SizedBox(width: 6),
                   Expanded(
                     child: Text(
                       flash,
                       style: const TextStyle(
-                          color: Colors.redAccent, fontSize: 13),
+                        color: Colors.redAccent,
+                        fontSize: 13,
+                      ),
                     ),
                   ),
                 ],
@@ -195,24 +208,53 @@ class _BannerSurface extends StatelessWidget {
   }
 }
 
-/// A compact duration selector for one request row.
-class _DurationMenu extends StatelessWidget {
-  const _DurationMenu({required this.value, required this.onChanged});
+/// The global duration selector (#2499): one compact button per selectable
+/// duration, the active one filled -- TUI parity (the `#duration-selector`
+/// row with its accent `dur-sel` class, cli/tui/consent.py), styled like the
+/// Net Rules pause buttons (#2497). Selecting does NOT submit -- only a
+/// row's Allow/Deny submits with the chosen duration.
+class _DurationSelector extends StatelessWidget {
+  const _DurationSelector({required this.value, required this.onChanged});
   final String value;
   final ValueChanged<String> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    return DropdownButton<String>(
-      value: value,
-      isDense: true,
-      underline: const SizedBox.shrink(),
-      items: kConsentDurations
-          .map((d) => DropdownMenuItem(value: d, child: Text(d)))
-          .toList(),
-      onChanged: (v) {
-        if (v != null) onChanged(v);
-      },
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      children: [for (final d in kConsentDurations) _button(d)],
+    );
+  }
+
+  Widget _button(String d) {
+    // The active button mirrors the pause buttons (#2497): amber
+    // background, canvas foreground; inactive stays outlined.
+    final active = d == value;
+    final key = ValueKey('dur-$d');
+    if (active) {
+      return FilledButton(
+        key: key,
+        style: FilledButton.styleFrom(
+          backgroundColor: KColors.accentAmber,
+          foregroundColor: KColors.bgCanvas,
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          textStyle: const TextStyle(fontSize: 12),
+        ),
+        onPressed: () => onChanged(d),
+        child: Text(d),
+      );
+    }
+    return OutlinedButton(
+      key: key,
+      style: OutlinedButton.styleFrom(
+        visualDensity: VisualDensity.compact,
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        textStyle: const TextStyle(fontSize: 12),
+      ),
+      onPressed: () => onChanged(d),
+      child: Text(d),
     );
   }
 }

--- a/src/frontend/test/consent_banner_test.dart
+++ b/src/frontend/test/consent_banner_test.dart
@@ -61,8 +61,9 @@ void main() {
     ConsentDeciderService.testChannelFactory = null;
   });
 
-  testWidgets('renders nothing when there are no pending requests',
-      (tester) async {
+  testWidgets('renders nothing when there are no pending requests', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -72,8 +73,9 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('shows the host + Allow/Deny for a pending request',
-      (tester) async {
+  testWidgets('shows the host + Allow/Deny for a pending request', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -97,8 +99,9 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('tapping Allow sends an allow verdict on the socket',
-      (tester) async {
+  testWidgets('tapping Allow sends an allow verdict on the socket', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -124,8 +127,9 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('tapping Deny sends a deny verdict on the socket',
-      (tester) async {
+  testWidgets('tapping Deny sends a deny verdict on the socket', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -149,8 +153,9 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('Allow carries the default duration (tilrestart)',
-      (tester) async {
+  testWidgets('Allow carries the default duration (tilrestart)', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -173,31 +178,47 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('the global duration selector is a single dropdown',
-      (tester) async {
-    final channel = _FakeChannel();
-    final svc = _serviceWithChannel(channel);
-    svc.connect();
-    channel.serverSend({
-      'type': 'egress_request',
-      'request': {
-        'id': 'r1',
-        'workspace_id': 'ws',
-        'dest_host': 'example.com',
-        'dest_port': 443,
-        'requested_at': 2000.0,
-      },
-    });
-    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
-    await tester.pump();
-    // Exactly one duration selector (global, in the header) -- not one per row.
-    expect(find.byType(DropdownButton<String>), findsOneWidget);
-    expect(find.text('tilrestart'), findsOneWidget);
-    svc.dispose();
-  });
+  testWidgets(
+    'the global duration selector is one button per duration (#2499)',
+    (tester) async {
+      final channel = _FakeChannel();
+      final svc = _serviceWithChannel(channel);
+      svc.connect();
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'r1',
+          'workspace_id': 'ws',
+          'dest_host': 'example.com',
+          'dest_port': 443,
+          'requested_at': 2000.0,
+        },
+      });
+      await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+      await tester.pump();
+      // No dropdown anywhere; one button per selectable duration (TUI parity),
+      // and the test-only 5s is not offered (#2487).
+      expect(find.byType(DropdownButton<String>), findsNothing);
+      expect(find.byKey(const ValueKey('dur-5s')), findsNothing);
+      for (final d in kConsentDurations) {
+        expect(find.byKey(ValueKey('dur-$d')), findsOneWidget);
+      }
+      // The default (tilrestart) is the active filled button; others outlined.
+      expect(
+        tester.widget(find.byKey(const ValueKey('dur-tilrestart'))),
+        isA<FilledButton>(),
+      );
+      expect(
+        tester.widget(find.byKey(const ValueKey('dur-1d'))),
+        isA<OutlinedButton>(),
+      );
+      svc.dispose();
+    },
+  );
 
-  testWidgets('selecting a duration applies it to the next Allow',
-      (tester) async {
+  testWidgets('selecting a duration applies it to the next Allow', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -213,12 +234,25 @@ void main() {
     });
     await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
     await tester.pump();
-    // Open the single global duration selector and pick '1d'.
-    await tester.tap(find.byType(DropdownButton<String>));
+    // Tap the already-active button (tilrestart): a no-op reselect that
+    // keeps it active -- and exercises the filled button's onPressed.
+    await tester.tap(find.byKey(const ValueKey('dur-tilrestart')));
     await tester.pump();
+    expect(tester.widget(find.byKey(const ValueKey('dur-tilrestart'))),
+        isA<FilledButton>());
+
+    // Tap the 1d duration button -- selecting does NOT submit, it only moves
+    // the highlight; the verdict still needs an Allow/Deny tap.
+    await tester.tap(find.byKey(const ValueKey('dur-1d')));
     await tester.pump();
-    await tester.tap(find.text('1d').last);
-    await tester.pump();
+    expect(
+      tester.widget(find.byKey(const ValueKey('dur-1d'))),
+      isA<FilledButton>(),
+    );
+    expect(
+      tester.widget(find.byKey(const ValueKey('dur-tilrestart'))),
+      isA<OutlinedButton>(),
+    );
     // The chosen duration now rides on the verdict.
     await tester.tap(find.text('Allow'));
     await tester.pump();
@@ -250,8 +284,9 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('shows a re-login notice when the session auth-failed',
-      (tester) async {
+  testWidgets('shows a re-login notice when the session auth-failed', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);
     svc.connect();
@@ -262,8 +297,9 @@ void main() {
     svc.dispose();
   });
 
-  testWidgets('shows "reconnecting…" when disconnected mid-hold',
-      (tester) async {
+  testWidgets('shows "reconnecting…" when disconnected mid-hold', (
+    tester,
+  ) async {
     final channel = _FakeChannel();
     ConsentDeciderService.testChannelFactory = (_) => channel;
     final svc = ConsentDeciderService(


### PR DESCRIPTION
Closes #2499.

## What

Replaces the egress-consent banner's `DropdownButton` duration selector
with a row of compact buttons, one per selectable duration, the active one
filled (amber/canvas, same styling as the Net Rules pause buttons from
#2497). This matches the `consent-decide` TUI's `#duration-selector`
button row (`cli/tui/consent.py`), which the banner explicitly mirrors.

- Layout mirrors the TUI: header line (icon + title + reconnecting), then
  the duration-button row, then the flash row and request rows. Buttons
  `Wrap` if the row overflows.
- Behavior unchanged: one global selection (not per row), default
  `tilrestart` (`kConsentDurationDefault`), selecting does **not** submit —
  only a row's Allow/Deny sends the `verdict` with the chosen duration.
  The test-only `5s` stays unoffered (#2487).
- Buttons are keyed `dur-<token>` for tests; the dropdown is gone.

## Tests

- Selector test: no dropdown; one button per `kConsentDurations` entry, no
  `5s`; default `tilrestart` filled, others outlined.
- Selection test: re-tapping the active button is a no-op; tapping `1d`
  moves the highlight; the next Allow carries `duration: '1d'`.
- Existing Allow/Deny/default-duration tests unchanged and green.

Full frontend suite: 968 tests, 100.0% coverage (4531/4531 lines).
