### PR TITLE
fix(cli): prune expired pause locally in consent-decide TUI

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -867,6 +867,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Stale pause in the consent-decide TUI after expiry (#2498).** A finite
+  pause window (15m/1h/1d) whose time elapsed in an idle workspace no longer
+  lingers as `paused 0s` on the pause bar and `Filtering paused (resumes in
+0s)` on the rules screen. Both views now clear the pause locally the
+  moment the window lapses; indefinite (until-restart) pauses and live
+  countdowns still render.
+
 - **Consent-decider 403 storm on refused registration (#2490).** A refused
   decider WebSocket handshake (uvicorn answers every pre-accept close with
   a bare HTTP 403 — e.g. the workspace is no longer `interactive` egress

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -414,6 +414,24 @@ class ConsentDeciderController:
             return None
         return max(0.0, rules.paused.until - self._clock())
 
+    def pause_expired(self, rules: EgressRules) -> bool:
+        """Whether a finite pause window has elapsed (#2498).
+
+        The server reverts to prompting at the real expiry but only
+        re-broadcasts ``egress_rules`` on the next discrete event
+        (verdict/revoke/pause/reconnect) -- never on natural expiry -- so an
+        idle workspace must prune the stale pause locally, off the injected
+        clock, or the views keep claiming prompts are suppressed ("paused
+        0s") after holds have actually resumed. An indefinite pause
+        (``until`` None, "until restart") and a not-paused workspace never
+        expire. Mirrors the web client's ``isPauseExpired`` (#2497) and the
+        timed-verdict prune of #2467.
+        """
+        paused = rules.paused
+        if paused is None or paused.until is None:
+            return False
+        return paused.until <= self._clock()
+
     def reset(self) -> None:
         """Drop all pending requests + the cached rules snapshot.
 
@@ -1164,16 +1182,26 @@ class ConsentDeciderApp(App):
         The server's pause frame carries only ``until`` (not which window),
         so the active button is the one matching the user's last pause/unpause
         request (``self._pause_duration``); Unpaused is active when nothing is
-        paused. The exact remaining window comes from the rules frame.
+        paused. The exact remaining window comes from the rules frame. A
+        finite window that has elapsed is treated as not paused (#2498).
         """
+        rules = self.controller.rules
+        expired = rules is not None and self.controller.pause_expired(rules)
+        if expired:
+            # #2498: the finite window elapsed locally -- the workspace is
+            # effectively unpaused, so clear the stale countdown and fall
+            # back to the Unpaused highlight instead of freezing at "paused
+            # 0s" until the next server frame. Forget the requested window
+            # too, so a post-expiry re-broadcast (paused=None) can't
+            # re-light the stale Pause button.
+            self._pause_duration = None
         target = self._pause_duration
         for b in self.query("#pause-bar Button"):
             b.set_class(
                 getattr(b, "pause_duration", None) == target, "pause-active"
             )
         countdown = self.query_one("#pause-countdown", Static)
-        rules = self.controller.rules
-        if rules is not None and rules.paused is not None:
+        if rules is not None and rules.paused is not None and not expired:
             rem = self.controller.pause_remaining(rules)
             countdown.update(
                 "paused until restart"
@@ -1478,8 +1506,15 @@ class RulesScreen(Screen):
         else:
             lines.append("  [dim](none)[/dim]")
 
-        # Pause window (#2332; absent today -> section hidden).
-        if rules is not None and rules.paused is not None:
+        # Pause window (#2332; absent today -> section hidden). A finite
+        # window that already elapsed renders nothing (#2498): the 1s
+        # refresh clears the stale section locally until the next frame
+        # confirms the server's post-expiry state.
+        if (
+            rules is not None
+            and rules.paused is not None
+            and not controller.pause_expired(rules)
+        ):
             lines.append("")
             lines.append("[bold]Pause[/bold]")
             rem = controller.pause_remaining(rules)

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -1043,6 +1043,55 @@ class TestAppActions:
             countdown = app.query_one("#pause-countdown", Static)
             assert "paused until restart" in str(countdown.content)
 
+    async def test_countdown_shows_live_pause(self):
+        # A live finite window counts down next to the buttons.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pause_duration = "15m"
+            app.controller._clock = lambda: 100.0  # deterministic countdown
+            app.controller.apply_frame(
+                _rules_frame(paused={"paused": True, "until": 200.0})
+            )
+            app._refresh()
+            await pilot.pause()
+            countdown = app.query_one("#pause-countdown", Static)
+            assert "paused 1m" in str(countdown.content)
+            assert app.query_one("#pause-15m", Button).has_class(
+                "pause-active"
+            )
+
+    async def test_expired_pause_clears_countdown_and_highlight(self):
+        # #2498: a finite window that elapsed locally renders no pause state
+        # -- no stale "paused 0s", and the Unpaused button re-lights -- without
+        # waiting for a server frame (the 1s refresh drives it).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pause_duration = "15m"
+            app.controller._clock = lambda: 300.0  # past until=200
+            app.controller.apply_frame(
+                _rules_frame(paused={"paused": True, "until": 200.0})
+            )
+            app._refresh()
+            await pilot.pause()
+            countdown = app.query_one("#pause-countdown", Static)
+            assert str(countdown.content) == ""
+            assert app.query_one("#pause-none", Button).has_class(
+                "pause-active"
+            )
+            assert not app.query_one("#pause-15m", Button).has_class(
+                "pause-active"
+            )
+            # And the stale window doesn't re-light when a post-expiry frame
+            # (paused=None) eventually lands.
+            app.controller.apply_frame(_rules_frame())
+            app._refresh()
+            await pilot.pause()
+            assert app.query_one("#pause-none", Button).has_class(
+                "pause-active"
+            )
+
     async def test_pump_flashes_failed_pause_ack(self):
         # A pause_ack with ok=False flashes so the decider knows it didn't take.
         app = _make_app()
@@ -1770,6 +1819,65 @@ class TestControllerRulesExpiry:
         )
         assert c.pause_remaining(rules) is None
 
+    def test_pause_expired_timed_window_elapsed(self):
+        # #2498: a finite until in the past is expired -- the views must
+        # prune it locally (the server never re-broadcasts on natural expiry).
+        c = ConsentDeciderController(clock=lambda: 150.0)
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=PauseState(until=100.0),
+        )
+        assert c.pause_expired(rules) is True
+
+    def test_pause_expired_at_boundary(self):
+        # until == clock counts as elapsed (nothing left to count down).
+        c = ConsentDeciderController(clock=lambda: 150.0)
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=PauseState(until=150.0),
+        )
+        assert c.pause_expired(rules) is True
+
+    def test_pause_expired_live_window_is_false(self):
+        c = ConsentDeciderController(clock=lambda: 150.0)
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=PauseState(until=200.0),
+        )
+        assert c.pause_expired(rules) is False
+
+    def test_pause_expired_indefinite_is_false(self):
+        # "until restart" has no window to elapse -- it must keep rendering.
+        c = ConsentDeciderController()
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=PauseState(until=None),
+        )
+        assert c.pause_expired(rules) is False
+
+    def test_pause_expired_not_paused_is_false(self):
+        c = ConsentDeciderController()
+        rules = EgressRules(
+            workspace_id="wsid",
+            allow_list=(),
+            allowed=(),
+            denied=(),
+            paused=None,
+        )
+        assert c.pause_expired(rules) is False
+
 
 def test_fmt_duration_tiers():
     assert tui_consent._fmt_duration(5) == "5s"
@@ -2037,6 +2145,21 @@ class TestRulesScreen:
             await pilot.pause()
             body = str(app.screen.query_one("#rules-content", Static).content)
             assert "paused until restart" in body
+
+    async def test_screen_hides_expired_pause(self):
+        # #2498: a finite window that elapsed locally renders no Pause section
+        # (no stale "resumes in 0s") -- cleared by the 1s refresh, not a frame.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller._clock = lambda: 300.0  # past until=200
+            app.controller.apply_frame(
+                _rules_frame(paused={"paused": True, "until": 200.0})
+            )
+            app.action_rules()
+            await pilot.pause()
+            body = str(app.screen.query_one("#rules-content", Static).content)
+            assert "Filtering paused" not in body
+            assert "[bold]Pause[/bold]" not in body
 
     async def test_screen_status_shows_held_count(self):
         app = _make_app()


### PR DESCRIPTION
## Summary

- Fixes #2498: after a finite pause window (15m/1h/1d) elapsed in an idle
  workspace, the `consent-decide` TUI kept rendering the stale pause
  ("paused 0s" on the pause bar, "Filtering paused (resumes in 0s)" on the
  rules screen) indefinitely — the server reverts to prompting at the real
  expiry but only re-broadcasts `egress_rules` on a discrete event, never
  on natural expiry.
- Mirrors the web client's fix from #2497 (`isPauseExpired`):
  - `ConsentDeciderController.pause_expired(rules)` — a finite `until` at
    or before the injected clock counts as elapsed; an indefinite pause
    (`until is None`, until-restart) and not-paused never expire.
  - `_refresh_pause_highlight` (driven by the existing 1s refresh) clears
    the stale countdown, falls back to the Unpaused highlight, and
    forgets the stale requested window so a post-expiry re-broadcast
    can't re-light the old Pause button.
  - `RulesScreen._render_body` hides the Pause section entirely.
- Changelog entry under `[Unreleased]` → Fixed.

## Testing

- Unit tests on `pause_expired`: elapsed window, `until == clock`
  boundary, live window, indefinite, not-paused.
- TUI e2e (injected controller clock): live countdown still renders;
  expired pause clears the countdown + re-lights Unpaused (and stays
  un-lit after a post-expiry `paused=None` frame); rules screen hides the
  section for an expired window.
- Full CI Python suite green with the 100% coverage gate:

```
devenv --quiet -O dotenv.enable:bool false shell -- python -m pytest \
  src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto
# 4932 passed, coverage 100%
```
