### PR TITLE
feat(frontend): show static reject list on the Net Rules tab

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,11 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Static reject list on the Net Rules tab (#2503).** The tab now shows
+  the workspace's `rejected_domains` (names the network sidecar blocks
+  unconditionally, e.g. from a _deny forever_ verdict) in a read-only
+  section below the static allow-list. Editing stays in the workspace
+  settings panel.
 - **Pause egress filtering from the web UI (#2494).** The workspace page's
   **Net Rules** tab now has a pause control (Unpause / Pause 15m / 1h / 1d)
   that silences consent prompts workspace-wide for a window, matching the

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -130,15 +130,17 @@ class ConsentFrameResult {
   /// ok ack means the pause was cleared).
   final double? pauseUntil;
 
-  const ConsentFrameResult(this.outcome,
-      {this.request,
-      this.resolvedId,
-      this.message,
-      this.rules,
-      this.revokeAckId,
-      this.revokeOk = false,
-      this.pauseOk = false,
-      this.pauseUntil});
+  const ConsentFrameResult(
+    this.outcome, {
+    this.request,
+    this.resolvedId,
+    this.message,
+    this.rules,
+    this.revokeAckId,
+    this.revokeOk = false,
+    this.pauseOk = false,
+    this.pauseUntil,
+  });
 
   static const ignored = ConsentFrameResult(ConsentFrameOutcome.ignored);
 }
@@ -256,8 +258,16 @@ class ConsentRule {
           decidedBy == other.decidedBy;
 
   @override
-  int get hashCode => Object.hash(id, destHost, destPort, processName, decision,
-      duration, decidedAt, decidedBy);
+  int get hashCode => Object.hash(
+        id,
+        destHost,
+        destPort,
+        processName,
+        decision,
+        duration,
+        decidedAt,
+        decidedBy,
+      );
 }
 
 /// Pause window from the `egress_rules` frame (#2332; absent today). `until`
@@ -286,6 +296,13 @@ class EgressPause {
 class EgressRules {
   final String workspaceId;
   final List<String> allowList;
+
+  /// The workspace's static reject list (`rejected_domains`, #2370/#2503):
+  /// names the sidecar NXDOMAINs unconditionally, order preserved like
+  /// [allowList]. Grows when a forever deny lands (#2369) and shrinks when
+  /// that deny is revoked. Not consent rows -- workspace config, so it is
+  /// read-only in the rules view.
+  final List<String> rejectList;
   final List<ConsentRule> allowed;
   final List<ConsentRule> denied;
   final EgressPause? paused;
@@ -295,6 +312,7 @@ class EgressRules {
     required this.allowList,
     required this.allowed,
     required this.denied,
+    this.rejectList = const [],
     this.paused,
   });
 
@@ -308,6 +326,11 @@ class EgressRules {
     final rawAllow = msg['allow_list'];
     final allowList = <String>[
       for (final d in (rawAllow is List ? rawAllow : <Object>[])) d.toString(),
+    ];
+    final rawReject = msg['reject_list'];
+    final rejectList = <String>[
+      for (final d in (rawReject is List ? rawReject : <Object>[]))
+        d.toString(),
     ];
     final allowed = <ConsentRule>[
       for (final o
@@ -327,6 +350,7 @@ class EgressRules {
     return EgressRules(
       workspaceId: wid,
       allowList: allowList,
+      rejectList: rejectList,
       allowed: allowed,
       denied: denied,
       paused: _parsePause(msg['paused']),
@@ -339,13 +363,20 @@ class EgressRules {
       other is EgressRules &&
           workspaceId == other.workspaceId &&
           listEquals(allowList, other.allowList) &&
+          listEquals(rejectList, other.rejectList) &&
           listEquals(allowed, other.allowed) &&
           listEquals(denied, other.denied) &&
           paused == other.paused;
 
   @override
-  int get hashCode => Object.hash(workspaceId, Object.hashAll(allowList),
-      Object.hashAll(allowed), Object.hashAll(denied), paused);
+  int get hashCode => Object.hash(
+        workspaceId,
+        Object.hashAll(allowList),
+        Object.hashAll(rejectList),
+        Object.hashAll(allowed),
+        Object.hashAll(denied),
+        paused,
+      );
 }
 
 /// Parse the `paused` field of an `egress_rules` frame (#2332). Returns null
@@ -361,9 +392,7 @@ EgressPause? _parsePause(Object? obj) {
 /// rows with no `decided_at` last, ties broken by original index (Dart's
 /// [List.sort] isn't stable). Mirrors the TUI's `sorted(...)` over the frame.
 void _sortRulesStable(List<ConsentRule> rules) {
-  final indexed = [
-    for (var i = 0; i < rules.length; i++) (i, rules[i]),
-  ];
+  final indexed = [for (var i = 0; i < rules.length; i++) (i, rules[i])];
   indexed.sort((a, b) {
     final aT = a.$2.decidedAt;
     final bT = b.$2.decidedAt;
@@ -573,6 +602,7 @@ class ConsentDeciderService extends ChangeNotifier {
       _rules = EgressRules(
         workspaceId: r.workspaceId,
         allowList: r.allowList,
+        rejectList: r.rejectList,
         allowed: r.allowed.where((e) => e.id != id).toList(),
         denied: r.denied.where((e) => e.id != id).toList(),
         paused: r.paused,
@@ -603,6 +633,7 @@ class ConsentDeciderService extends ChangeNotifier {
       _rules = EgressRules(
         workspaceId: r.workspaceId,
         allowList: r.allowList,
+        rejectList: r.rejectList,
         allowed: r.allowed,
         denied: r.denied,
         paused: until != null ? EgressPause(until: until) : null,
@@ -767,7 +798,9 @@ class ConsentDeciderService extends ChangeNotifier {
   /// / non-JSON / unknown frames leave [pending] untouched.
   @visibleForTesting
   static ConsentFrameResult applyFrame(
-      Map<String, PendingRequest> pending, String raw) {
+    Map<String, PendingRequest> pending,
+    String raw,
+  ) {
     Map<String, dynamic> msg;
     try {
       final decoded = jsonDecode(raw);
@@ -792,8 +825,10 @@ class ConsentDeciderService extends ChangeNotifier {
       return const ConsentFrameResult(ConsentFrameOutcome.pong);
     }
     if (mtype == 'error') {
-      return ConsentFrameResult(ConsentFrameOutcome.error,
-          message: msg['message']?.toString() ?? '');
+      return ConsentFrameResult(
+        ConsentFrameOutcome.error,
+        message: msg['message']?.toString() ?? '',
+      );
     }
     if (mtype == 'egress_rules') {
       final rules = EgressRules.fromJson(msg);
@@ -802,14 +837,19 @@ class ConsentDeciderService extends ChangeNotifier {
     }
     if (mtype == 'revoke_ack') {
       final rid = msg['request_id'];
-      return ConsentFrameResult(ConsentFrameOutcome.revokeAck,
-          revokeAckId: rid is String ? rid : null, revokeOk: msg['ok'] == true);
+      return ConsentFrameResult(
+        ConsentFrameOutcome.revokeAck,
+        revokeAckId: rid is String ? rid : null,
+        revokeOk: msg['ok'] == true,
+      );
     }
     if (mtype == 'pause_ack') {
       final until = msg['until'];
-      return ConsentFrameResult(ConsentFrameOutcome.pauseAck,
-          pauseOk: msg['ok'] == true,
-          pauseUntil: until is num ? until.toDouble() : null);
+      return ConsentFrameResult(
+        ConsentFrameOutcome.pauseAck,
+        pauseOk: msg['ok'] == true,
+        pauseUntil: until is num ? until.toDouble() : null,
+      );
     }
     return ConsentFrameResult.ignored;
   }
@@ -817,7 +857,10 @@ class ConsentDeciderService extends ChangeNotifier {
   /// Build an outbound verdict frame (JSON string) for a held request.
   @visibleForTesting
   static String buildVerdict(
-      String requestId, String decision, String duration) {
+    String requestId,
+    String decision,
+    String duration,
+  ) {
     return jsonEncode({
       'type': 'verdict',
       'request_id': requestId,
@@ -932,6 +975,7 @@ class ConsentDeciderService extends ChangeNotifier {
     _rules = EgressRules(
       workspaceId: r.workspaceId,
       allowList: r.allowList,
+      rejectList: r.rejectList,
       allowed: allowed,
       denied: denied,
       paused: paused,

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -60,7 +60,9 @@ String ruleExpiryLabel(ConsentRule rule, int? remaining, {required bool deny}) {
 /// Pure (and unit-tested) so the [ConsentRulesPanel] tick -- a real Timer the
 /// coverage gate ignores -- can call it without leaving a coverage gap.
 bool hasLiveCountdown(
-    EgressRules? rules, int? Function(ConsentRule) remaining) {
+  EgressRules? rules,
+  int? Function(ConsentRule) remaining,
+) {
   if (rules == null) return false;
   if (rules.paused != null) return true;
   return rules.allowed.any((r) => remaining(r) != null) ||
@@ -101,7 +103,9 @@ class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
       // at "0s left".
       widget.service.pruneExpiredRules();
       if (hasLiveCountdown(
-          widget.service.rules, widget.service.ruleRemainingSeconds)) {
+        widget.service.rules,
+        widget.service.ruleRemainingSeconds,
+      )) {
         _onChange();
       }
     });
@@ -178,8 +182,28 @@ class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
                             : [
                                 for (final d in rules.allowList)
                                   Padding(
-                                    padding:
-                                        const EdgeInsets.symmetric(vertical: 2),
+                                    padding: const EdgeInsets.symmetric(
+                                      vertical: 2,
+                                    ),
+                                    child: Text(d, style: _KStyles.mono),
+                                  ),
+                              ],
+                      ),
+                      // #2503: the reject list is workspace config (it grows
+                      // when a forever deny lands, #2369), not a consent row
+                      // -- read-only here, no revoke affordance. Editing stays
+                      // in the workspace settings panel.
+                      _Section(
+                        title: 'Static reject-list',
+                        emptyText: '(none)',
+                        children: rules.rejectList.isEmpty
+                            ? null
+                            : [
+                                for (final d in rules.rejectList)
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      vertical: 2,
+                                    ),
                                     child: Text(d, style: _KStyles.mono),
                                   ),
                               ],
@@ -229,9 +253,10 @@ class _Header extends StatelessWidget {
           const SizedBox(width: 8),
           Text('Egress consent rules', style: _KStyles.heading),
           const SizedBox(width: 12),
-          Text('$conn · $held held',
-              style:
-                  const TextStyle(fontSize: 13, color: KColors.textSecondary)),
+          Text(
+            '$conn · $held held',
+            style: const TextStyle(fontSize: 13, color: KColors.textSecondary),
+          ),
         ],
       ),
     );
@@ -253,8 +278,10 @@ class _Flash extends StatelessWidget {
           const Icon(Icons.error_outline, size: 16, color: KColors.accentRed),
           const SizedBox(width: 6),
           Expanded(
-            child: Text(message,
-                style: const TextStyle(fontSize: 13, color: KColors.accentRed)),
+            child: Text(
+              message,
+              style: const TextStyle(fontSize: 13, color: KColors.accentRed),
+            ),
           ),
         ],
       ),
@@ -265,11 +292,7 @@ class _Flash extends StatelessWidget {
 /// A titled grouping of the rules body (allow-list, allows, denies). When
 /// [children] is null the section renders its [emptyText] placeholder.
 class _Section extends StatelessWidget {
-  const _Section({
-    required this.title,
-    required this.emptyText,
-    this.children,
-  });
+  const _Section({required this.title, required this.emptyText, this.children});
   final String title;
   final String emptyText;
   final List<Widget>? children;
@@ -360,8 +383,11 @@ class _RuleRow extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 3),
       child: Row(
         children: [
-          Icon(deny ? Icons.block : Icons.check_circle_outline,
-              size: 16, color: deny ? KColors.accentRed : KColors.accentGreen),
+          Icon(
+            deny ? Icons.block : Icons.check_circle_outline,
+            size: 16,
+            color: deny ? KColors.accentRed : KColors.accentGreen,
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: RichText(
@@ -473,13 +499,17 @@ class _PauseStatus extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 4),
       child: Row(
         children: [
-          const Icon(Icons.pause_circle_outline,
-              size: 16, color: KColors.accentAmber),
+          const Icon(
+            Icons.pause_circle_outline,
+            size: 16,
+            color: KColors.accentAmber,
+          ),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(text,
-                style:
-                    const TextStyle(fontSize: 13, color: KColors.accentAmber)),
+            child: Text(
+              text,
+              style: const TextStyle(fontSize: 13, color: KColors.accentAmber),
+            ),
           ),
         ],
       ),
@@ -508,9 +538,15 @@ class _Empty extends StatelessWidget {
 class _KStyles {
   static const heading = TextStyle(fontSize: 14, fontWeight: FontWeight.bold);
   static const title = TextStyle(
-      fontSize: 13, fontWeight: FontWeight.bold, color: KColors.textSecondary);
+    fontSize: 13,
+    fontWeight: FontWeight.bold,
+    color: KColors.textSecondary,
+  );
   static const mono = TextStyle(
-      fontFamily: 'monospace', fontSize: 13, color: KColors.textPrimary);
+    fontFamily: 'monospace',
+    fontSize: 13,
+    color: KColors.textPrimary,
+  );
   static const muted = TextStyle(fontSize: 13, color: KColors.textMuted);
   static const mutedSpan = TextStyle(color: KColors.textMuted);
 }

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -69,12 +69,13 @@ class _ThrowingSink extends Fake implements WebSocketSink {
   Future close([int? code, String? reason]) async {}
 }
 
-Map<String, dynamic> _request(
-        {String id = 'r1',
-        String host = 'example.com',
-        int port = 443,
-        String? proc = 'curl',
-        double at = 1000.0}) =>
+Map<String, dynamic> _request({
+  String id = 'r1',
+  String host = 'example.com',
+  int port = 443,
+  String? proc = 'curl',
+  double at = 1000.0,
+}) =>
     {
       'id': id,
       'workspace_id': 'ws-1',
@@ -108,6 +109,7 @@ Map<String, dynamic> _ruleJson({
 Map<String, dynamic> _rulesFrame({
   String workspaceId = 'ws-1',
   List<String> allowList = const [],
+  List<String> rejectList = const [],
   List<Map<String, dynamic>> allowed = const [],
   List<Map<String, dynamic>> denied = const [],
   Object? paused,
@@ -116,6 +118,7 @@ Map<String, dynamic> _rulesFrame({
       'type': 'egress_rules',
       'workspace_id': workspaceId,
       'allow_list': allowList,
+      'reject_list': rejectList,
       'allowed': allowed,
       'denied': denied,
       if (paused != null) 'paused': paused,
@@ -126,11 +129,9 @@ void main() {
     test('egress_request adds the request', () {
       final pending = <String, PendingRequest>{};
       final res = ConsentDeciderService.applyFrame(
-          pending,
-          jsonEncode({
-            'type': 'egress_request',
-            'request': _request(),
-          }));
+        pending,
+        jsonEncode({'type': 'egress_request', 'request': _request()}),
+      );
       expect(res.outcome, ConsentFrameOutcome.added);
       expect(res.request!.id, 'r1');
       expect(pending, contains('r1'));
@@ -140,10 +141,12 @@ void main() {
 
     test('egress_resolved removes the request', () {
       final pending = <String, PendingRequest>{
-        'r1': PendingRequest(id: 'r1', destHost: 'h', requestedAt: 0)
+        'r1': PendingRequest(id: 'r1', destHost: 'h', requestedAt: 0),
       };
       final res = ConsentDeciderService.applyFrame(
-          pending, jsonEncode({'type': 'egress_resolved', 'request_id': 'r1'}));
+        pending,
+        jsonEncode({'type': 'egress_resolved', 'request_id': 'r1'}),
+      );
       expect(res.outcome, ConsentFrameOutcome.resolved);
       expect(res.resolvedId, 'r1');
       expect(pending, isNot(contains('r1')));
@@ -152,14 +155,18 @@ void main() {
     test('pong is non-mutating', () {
       final pending = <String, PendingRequest>{};
       final res = ConsentDeciderService.applyFrame(
-          pending, jsonEncode({'type': 'pong'}));
+        pending,
+        jsonEncode({'type': 'pong'}),
+      );
       expect(res.outcome, ConsentFrameOutcome.pong);
       expect(pending, isEmpty);
     });
 
     test('error surfaces the message', () {
       final res = ConsentDeciderService.applyFrame(
-          {}, jsonEncode({'type': 'error', 'message': 'bad verdict'}));
+        {},
+        jsonEncode({'type': 'error', 'message': 'bad verdict'}),
+      );
       expect(res.outcome, ConsentFrameOutcome.error);
       expect(res.message, 'bad verdict');
     });
@@ -173,14 +180,18 @@ void main() {
 
     test('unknown type is ignored', () {
       final res = ConsentDeciderService.applyFrame(
-          {}, jsonEncode({'type': 'totally_unknown', 'x': 1}));
+        {},
+        jsonEncode({'type': 'totally_unknown', 'x': 1}),
+      );
       expect(res.outcome, ConsentFrameOutcome.ignored);
     });
 
     test('egress_request with a bad request payload is ignored', () {
       final pending = <String, PendingRequest>{};
       final res = ConsentDeciderService.applyFrame(
-          pending, jsonEncode({'type': 'egress_request', 'request': {}}));
+        pending,
+        jsonEncode({'type': 'egress_request', 'request': {}}),
+      );
       expect(res.outcome, ConsentFrameOutcome.ignored);
       expect(pending, isEmpty);
     });
@@ -260,6 +271,18 @@ void main() {
 
   group('ConsentRule equality', () {
     final a = ConsentRule(
+      id: 'v1',
+      destHost: 'h',
+      destPort: 443,
+      processName: 'curl',
+      decision: 'allowed',
+      duration: '5m',
+      decidedAt: 1.0,
+      decidedBy: 'alice',
+    );
+
+    test('equal on all fields with matching hashCode', () {
+      final b = ConsentRule(
         id: 'v1',
         destHost: 'h',
         destPort: 443,
@@ -267,39 +290,35 @@ void main() {
         decision: 'allowed',
         duration: '5m',
         decidedAt: 1.0,
-        decidedBy: 'alice');
-
-    test('equal on all fields with matching hashCode', () {
-      final b = ConsentRule(
-          id: 'v1',
-          destHost: 'h',
-          destPort: 443,
-          processName: 'curl',
-          decision: 'allowed',
-          duration: '5m',
-          decidedAt: 1.0,
-          decidedBy: 'alice');
+        decidedBy: 'alice',
+      );
       expect(a, equals(b));
       expect(a.hashCode, b.hashCode);
     });
 
     test('a differing field breaks equality', () {
       expect(
-          a,
-          isNot(equals(
-              ConsentRule(id: 'v2', destHost: 'h', decision: 'allowed'))));
+        a,
+        isNot(
+          equals(ConsentRule(id: 'v2', destHost: 'h', decision: 'allowed')),
+        ),
+      );
       expect(
-          a,
-          isNot(equals(
-              ConsentRule(id: 'v1', destHost: 'h2', decision: 'allowed'))));
+        a,
+        isNot(
+          equals(ConsentRule(id: 'v1', destHost: 'h2', decision: 'allowed')),
+        ),
+      );
       expect(a, isNot(equals('not a rule')));
     });
   });
 
   group('EgressRules.fromJson', () {
     test('returns null without a workspace_id', () {
-      expect(EgressRules.fromJson({'type': 'egress_rules', 'allow_list': []}),
-          isNull);
+      expect(
+        EgressRules.fromJson({'type': 'egress_rules', 'allow_list': []}),
+        isNull,
+      );
     });
 
     test('non-list allow_list/allowed/denied degrade to empty', () {
@@ -322,7 +341,7 @@ void main() {
         'allowed': [
           {'id': 'ok', 'dest_host': 'h', 'decision': 'allowed'},
           'badrow',
-          5
+          5,
         ],
       })!;
       expect(r.allowList, ['a.io']);
@@ -338,13 +357,13 @@ void main() {
             'id': 'old',
             'dest_host': 'h',
             'decision': 'allowed',
-            'decided_at': 10.0
+            'decided_at': 10.0,
           },
           {
             'id': 'new',
             'dest_host': 'h',
             'decision': 'allowed',
-            'decided_at': 90.0
+            'decided_at': 90.0,
           },
           {'id': 'unknown', 'dest_host': 'h', 'decision': 'allowed'},
         ],
@@ -363,13 +382,13 @@ void main() {
             'id': 'first',
             'dest_host': 'h',
             'decision': 'allowed',
-            'decided_at': 50.0
+            'decided_at': 50.0,
           },
           {
             'id': 'second',
             'dest_host': 'h',
             'decision': 'allowed',
-            'decided_at': 50.0
+            'decided_at': 50.0,
           },
           {'id': 'n1', 'dest_host': 'h', 'decision': 'allowed'},
           {'id': 'n2', 'dest_host': 'h', 'decision': 'allowed'},
@@ -383,100 +402,156 @@ void main() {
     test('absent / not paused -> null', () {
       expect(EgressRules.fromJson({'workspace_id': 'w'})!.paused, isNull);
       expect(
-          EgressRules.fromJson({
-            'workspace_id': 'w',
-            'paused': {'paused': false}
-          })!
-              .paused,
-          isNull);
+        EgressRules.fromJson({
+          'workspace_id': 'w',
+          'paused': {'paused': false},
+        })!
+            .paused,
+        isNull,
+      );
     });
 
-    test('paused true with until -> EgressPause(until); without -> null until',
-        () {
-      expect(
+    test(
+      'paused true with until -> EgressPause(until); without -> null until',
+      () {
+        expect(
           EgressRules.fromJson({
             'workspace_id': 'w',
-            'paused': {'paused': true, 'until': 99.0}
+            'paused': {'paused': true, 'until': 99.0},
           })!
               .paused!
               .until,
-          99.0);
-      expect(
+          99.0,
+        );
+        expect(
           EgressRules.fromJson({
             'workspace_id': 'w',
-            'paused': {'paused': true}
+            'paused': {'paused': true},
           })!
               .paused!
               .until,
-          isNull);
-    });
+          isNull,
+        );
+      },
+    );
   });
 
   group('EgressPause + EgressRules equality', () {
     test('EgressPause equality', () {
       expect(
-          const EgressPause(until: 1.0), equals(const EgressPause(until: 1.0)));
-      expect(const EgressPause(until: 1.0).hashCode,
-          const EgressPause(until: 1.0).hashCode);
-      expect(const EgressPause(until: 1.0),
-          isNot(equals(const EgressPause(until: 2.0))));
+        const EgressPause(until: 1.0),
+        equals(const EgressPause(until: 1.0)),
+      );
+      expect(
+        const EgressPause(until: 1.0).hashCode,
+        const EgressPause(until: 1.0).hashCode,
+      );
+      expect(
+        const EgressPause(until: 1.0),
+        isNot(equals(const EgressPause(until: 2.0))),
+      );
       expect(const EgressPause(until: 1.0), isNot(equals(const EgressPause())));
     });
 
     test('EgressRules equality by content', () {
       final a = EgressRules(
-          workspaceId: 'w',
-          allowList: ['a'],
-          allowed: [ConsentRule(id: '1', destHost: 'h', decision: 'allowed')],
-          denied: const [],
-          paused: const EgressPause(until: 1.0));
+        workspaceId: 'w',
+        allowList: ['a'],
+        allowed: [ConsentRule(id: '1', destHost: 'h', decision: 'allowed')],
+        denied: const [],
+        paused: const EgressPause(until: 1.0),
+      );
       final b = EgressRules(
-          workspaceId: 'w',
-          allowList: ['a'],
-          allowed: [ConsentRule(id: '1', destHost: 'h', decision: 'allowed')],
-          denied: const [],
-          paused: const EgressPause(until: 1.0));
+        workspaceId: 'w',
+        allowList: ['a'],
+        allowed: [ConsentRule(id: '1', destHost: 'h', decision: 'allowed')],
+        denied: const [],
+        paused: const EgressPause(until: 1.0),
+      );
       expect(a, equals(b));
       expect(a.hashCode, b.hashCode);
       expect(
-          a,
-          isNot(equals(EgressRules(
+        a,
+        isNot(
+          equals(
+            EgressRules(
               workspaceId: 'w2',
               allowList: ['a'],
               allowed: const [],
-              denied: const []))));
+              denied: const [],
+            ),
+          ),
+        ),
+      );
       expect(
-          a,
-          isNot(equals(EgressRules(
+        a,
+        isNot(
+          equals(
+            EgressRules(
               workspaceId: 'w',
               allowList: ['b'],
               allowed: const [],
-              denied: const []))));
+              denied: const [],
+            ),
+          ),
+        ),
+      );
+      // #2503: the reject list participates in equality.
+      expect(
+        a,
+        isNot(
+          equals(
+            EgressRules(
+              workspaceId: 'w',
+              allowList: ['a'],
+              rejectList: ['bad.io'],
+              allowed: const [],
+              denied: const [],
+            ),
+          ),
+        ),
+      );
     });
   });
 
   group('applyFrame egress_rules + revoke_ack', () {
     test('egress_rules -> rules outcome with the snapshot', () {
       final res = ConsentDeciderService.applyFrame(
-          {}, jsonEncode(_rulesFrame(allowList: ['a.io'])));
+        {},
+        jsonEncode(_rulesFrame(allowList: ['a.io'], rejectList: ['bad.io'])),
+      );
       expect(res.outcome, ConsentFrameOutcome.rules);
       expect(res.rules!.allowList, ['a.io']);
+      // #2503: the static reject list rides every snapshot frame (#2370);
+      // a missing/malformed field degrades to empty, not a dropped frame.
+      expect(res.rules!.rejectList, ['bad.io']);
+      final noReject = ConsentDeciderService.applyFrame(
+        {},
+        jsonEncode({'type': 'egress_rules', 'workspace_id': 'w'}),
+      );
+      expect(noReject.rules!.rejectList, isEmpty);
     });
 
     test('egress_rules without workspace_id -> ignored', () {
       final res = ConsentDeciderService.applyFrame(
-          {}, jsonEncode({'type': 'egress_rules', 'allow_list': []}));
+        {},
+        jsonEncode({'type': 'egress_rules', 'allow_list': []}),
+      );
       expect(res.outcome, ConsentFrameOutcome.ignored);
     });
 
     test('revoke_ack ok true/false and id coercion', () {
-      final ok = ConsentDeciderService.applyFrame({},
-          jsonEncode({'type': 'revoke_ack', 'request_id': 'v1', 'ok': true}));
+      final ok = ConsentDeciderService.applyFrame(
+        {},
+        jsonEncode({'type': 'revoke_ack', 'request_id': 'v1', 'ok': true}),
+      );
       expect(ok.outcome, ConsentFrameOutcome.revokeAck);
       expect(ok.revokeAckId, 'v1');
       expect(ok.revokeOk, isTrue);
       final bad = ConsentDeciderService.applyFrame(
-          {}, jsonEncode({'type': 'revoke_ack', 'request_id': 5}));
+        {},
+        jsonEncode({'type': 'revoke_ack', 'request_id': 5}),
+      );
       expect(bad.outcome, ConsentFrameOutcome.revokeAck);
       expect(bad.revokeAckId, isNull);
       expect(bad.revokeOk, isFalse);
@@ -484,11 +559,15 @@ void main() {
 
     test('pause_ack ok true/false', () {
       final ok = ConsentDeciderService.applyFrame(
-          {}, jsonEncode({'type': 'pause_ack', 'ok': true, 'until': 1300.0}));
+        {},
+        jsonEncode({'type': 'pause_ack', 'ok': true, 'until': 1300.0}),
+      );
       expect(ok.outcome, ConsentFrameOutcome.pauseAck);
       expect(ok.pauseOk, isTrue);
       final bad = ConsentDeciderService.applyFrame(
-          {}, jsonEncode({'type': 'pause_ack', 'ok': false, 'until': null}));
+        {},
+        jsonEncode({'type': 'pause_ack', 'ok': false, 'until': null}),
+      );
       expect(bad.outcome, ConsentFrameOutcome.pauseAck);
       expect(bad.pauseOk, isFalse);
     });
@@ -525,19 +604,21 @@ void main() {
 
   group('PendingRequest equality', () {
     final a = PendingRequest(
+      id: 'r1',
+      destHost: 'h',
+      destPort: 443,
+      processName: 'curl',
+      requestedAt: 1.0,
+    );
+
+    test('equal on all fields, with matching hashCode', () {
+      final b = PendingRequest(
         id: 'r1',
         destHost: 'h',
         destPort: 443,
         processName: 'curl',
-        requestedAt: 1.0);
-
-    test('equal on all fields, with matching hashCode', () {
-      final b = PendingRequest(
-          id: 'r1',
-          destHost: 'h',
-          destPort: 443,
-          processName: 'curl',
-          requestedAt: 1.0);
+        requestedAt: 1.0,
+      );
       expect(a, equals(b));
       expect(a.hashCode, b.hashCode);
       expect(a, equals(a)); // identical
@@ -545,17 +626,25 @@ void main() {
 
     test('any differing field breaks equality', () {
       expect(
-          a,
-          isNot(equals(PendingRequest(
+        a,
+        isNot(
+          equals(
+            PendingRequest(
               id: 'r1',
               destHost: 'h',
               destPort: 443,
               processName: 'curl',
-              requestedAt: 2.0)))); // requestedAt differs
+              requestedAt: 2.0,
+            ),
+          ),
+        ),
+      ); // requestedAt differs
       expect(
-          a,
-          isNot(equals(PendingRequest(
-              id: 'r2', destHost: 'h', requestedAt: 1.0)))); // id differs
+        a,
+        isNot(
+          equals(PendingRequest(id: 'r2', destHost: 'h', requestedAt: 1.0)),
+        ),
+      ); // id differs
       expect(a, isNot(equals('not a request'))); // wrong type
     });
   });
@@ -579,38 +668,44 @@ void main() {
       svc.dispose();
     });
 
-    test('connect + snapshot populates pending + sends verdict on the socket',
-        () async {
-      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
-      svc.connect();
-      expect(svc.connected, isTrue);
-      // Server's connect snapshot. (Broadcast streams deliver on a microtask,
-      // so flush before asserting.)
-      channel.serverSend(
-          {'type': 'egress_request', 'request': _request(host: 'a.io')});
-      channel.serverSend({
-        'type': 'egress_request',
-        'request': _request(id: 'r2', host: 'b.io', at: 999)
-      });
-      await Future.delayed(Duration.zero);
-      expect(
-          svc.pending.map((r) => r.destHost), ['b.io', 'a.io']); // oldest-first
+    test(
+      'connect + snapshot populates pending + sends verdict on the socket',
+      () async {
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        svc.connect();
+        expect(svc.connected, isTrue);
+        // Server's connect snapshot. (Broadcast streams deliver on a microtask,
+        // so flush before asserting.)
+        channel.serverSend({
+          'type': 'egress_request',
+          'request': _request(host: 'a.io'),
+        });
+        channel.serverSend({
+          'type': 'egress_request',
+          'request': _request(id: 'r2', host: 'b.io', at: 999),
+        });
+        await Future.delayed(Duration.zero);
+        expect(svc.pending.map((r) => r.destHost), [
+          'b.io',
+          'a.io',
+        ]); // oldest-first
 
-      // A live resolve removes it.
-      channel.serverSend({'type': 'egress_resolved', 'request_id': 'r1'});
-      await Future.delayed(Duration.zero);
-      expect(svc.pending.map((r) => r.id), ['r2']);
+        // A live resolve removes it.
+        channel.serverSend({'type': 'egress_resolved', 'request_id': 'r1'});
+        await Future.delayed(Duration.zero);
+        expect(svc.pending.map((r) => r.id), ['r2']);
 
-      // Verdict goes out on the socket.
-      svc.sendVerdict('r2', 'denied', 'once');
-      expect(channel.sent, isNotEmpty);
-      final out =
-          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
-      expect(out['type'], 'verdict');
-      expect(out['request_id'], 'r2');
-      expect(out['decision'], 'denied');
-      svc.dispose();
-    });
+        // Verdict goes out on the socket.
+        svc.sendVerdict('r2', 'denied', 'once');
+        expect(channel.sent, isNotEmpty);
+        final out =
+            jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+        expect(out['type'], 'verdict');
+        expect(out['request_id'], 'r2');
+        expect(out['decision'], 'denied');
+        svc.dispose();
+      },
+    );
 
     test('sendVerdict flashes (not silent) when disconnected', () {
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
@@ -665,18 +760,20 @@ void main() {
       svc.dispose();
     });
 
-    test('auth-fail close (4001) sets authFailed and stops reconnecting',
-        () async {
-      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
-      svc.connect();
-      channel.serverSend({'type': 'egress_request', 'request': _request()});
-      await Future.delayed(Duration.zero);
-      expect(svc.pending, isNotEmpty);
-      channel.serverClose(4001);
-      await Future.delayed(Duration.zero);
-      expect(svc.authFailed, isTrue);
-      svc.dispose();
-    });
+    test(
+      'auth-fail close (4001) sets authFailed and stops reconnecting',
+      () async {
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        svc.connect();
+        channel.serverSend({'type': 'egress_request', 'request': _request()});
+        await Future.delayed(Duration.zero);
+        expect(svc.pending, isNotEmpty);
+        channel.serverClose(4001);
+        await Future.delayed(Duration.zero);
+        expect(svc.authFailed, isTrue);
+        svc.dispose();
+      },
+    );
 
     test('remainingSeconds counts down from requested_at + holdTimeout', () {
       // Fixed clock at epoch-second 1000; requested at 1000, hold 120s.
@@ -692,77 +789,97 @@ void main() {
       svc.dispose();
     });
 
-    test('pong and unknown frames are no-ops through the live socket',
-        () async {
-      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
-      svc.connect();
-      channel.serverSend({'type': 'egress_request', 'request': _request()});
-      await Future.delayed(Duration.zero);
-      expect(svc.pending, hasLength(1));
-      // A pong and an unknown frame neither mutate pending nor throw.
-      channel.serverSend({'type': 'pong'});
-      channel.serverSend({'type': 'totally_unknown', 'x': 1});
-      await Future.delayed(Duration.zero);
-      expect(svc.pending, hasLength(1));
-      svc.dispose();
-    });
+    test(
+      'pong and unknown frames are no-ops through the live socket',
+      () async {
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        svc.connect();
+        channel.serverSend({'type': 'egress_request', 'request': _request()});
+        await Future.delayed(Duration.zero);
+        expect(svc.pending, hasLength(1));
+        // A pong and an unknown frame neither mutate pending nor throw.
+        channel.serverSend({'type': 'pong'});
+        channel.serverSend({'type': 'totally_unknown', 'x': 1});
+        await Future.delayed(Duration.zero);
+        expect(svc.pending, hasLength(1));
+        svc.dispose();
+      },
+    );
 
-    test('a non-auth close clears connected and schedules a reconnect',
-        () async {
-      final svc = ConsentDeciderService(
-        workspaceId: 'ws',
-        token: 't',
-        // Long delay so the reconnect Timer never fires during the test
-        // (dispose cancels it regardless).
-        reconnectDelays: const [Duration(minutes: 5)],
-      );
-      svc.connect();
-      expect(svc.connected, isTrue);
-      channel.serverClose(); // clean close, no code -> not an auth failure
-      await Future.delayed(Duration.zero);
-      expect(svc.connected, isFalse);
-      expect(svc.authFailed, isFalse);
-      svc.dispose();
-    });
+    test(
+      'a non-auth close clears connected and schedules a reconnect',
+      () async {
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          // Long delay so the reconnect Timer never fires during the test
+          // (dispose cancels it regardless).
+          reconnectDelays: const [Duration(minutes: 5)],
+        );
+        svc.connect();
+        expect(svc.connected, isTrue);
+        channel.serverClose(); // clean close, no code -> not an auth failure
+        await Future.delayed(Duration.zero);
+        expect(svc.connected, isFalse);
+        expect(svc.authFailed, isFalse);
+        svc.dispose();
+      },
+    );
 
-    test('egress_rules frame populates service.rules (sorted, parsed)',
-        () async {
-      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
-      svc.connect();
-      channel.serverSend(_rulesFrame(
-        allowList: ['github.com', 'pypi.org'],
-        allowed: [
-          _ruleJson(id: 'a', decidedAt: 100, host: 'a.io'),
-          _ruleJson(id: 'b', decidedAt: 200, host: 'b.io'),
-        ],
-        denied: [
-          _ruleJson(id: 'd', decision: 'denied', host: 'x.io', decidedAt: 50)
-        ],
-      ));
-      await Future.delayed(Duration.zero);
-      expect(svc.rules, isNotNull);
-      expect(svc.rules!.allowList, ['github.com', 'pypi.org']);
-      expect(svc.rules!.allowed.map((r) => r.id), ['b', 'a']); // newest first
-      expect(svc.rules!.denied.single.id, 'd');
-      svc.dispose();
-    });
+    test(
+      'egress_rules frame populates service.rules (sorted, parsed)',
+      () async {
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        svc.connect();
+        channel.serverSend(
+          _rulesFrame(
+            allowList: ['github.com', 'pypi.org'],
+            allowed: [
+              _ruleJson(id: 'a', decidedAt: 100, host: 'a.io'),
+              _ruleJson(id: 'b', decidedAt: 200, host: 'b.io'),
+            ],
+            denied: [
+              _ruleJson(
+                id: 'd',
+                decision: 'denied',
+                host: 'x.io',
+                decidedAt: 50,
+              ),
+            ],
+          ),
+        );
+        await Future.delayed(Duration.zero);
+        expect(svc.rules, isNotNull);
+        expect(svc.rules!.allowList, ['github.com', 'pypi.org']);
+        expect(svc.rules!.allowed.map((r) => r.id), ['b', 'a']); // newest first
+        expect(svc.rules!.denied.single.id, 'd');
+        svc.dispose();
+      },
+    );
 
     test('revoke_ack success removes the rule; failure flashes', () async {
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       svc.connect();
       channel.serverSend(
-          _rulesFrame(allowed: [_ruleJson(id: 'a', decidedAt: 100)]));
+        _rulesFrame(allowed: [_ruleJson(id: 'a', decidedAt: 100)]),
+      );
       await Future.delayed(Duration.zero);
       expect(svc.rules!.allowed, hasLength(1));
       channel.serverSend({'type': 'revoke_ack', 'request_id': 'a', 'ok': true});
       await Future.delayed(Duration.zero);
       expect(svc.rules!.allowed, isEmpty);
       // failure leaves the row in place and flashes
-      channel.serverSend(_rulesFrame(
-          denied: [_ruleJson(id: 'd', decision: 'denied', decidedAt: 100)]));
+      channel.serverSend(
+        _rulesFrame(
+          denied: [_ruleJson(id: 'd', decision: 'denied', decidedAt: 100)],
+        ),
+      );
       await Future.delayed(Duration.zero);
-      channel
-          .serverSend({'type': 'revoke_ack', 'request_id': 'd', 'ok': false});
+      channel.serverSend({
+        'type': 'revoke_ack',
+        'request_id': 'd',
+        'ok': false,
+      });
       await Future.delayed(Duration.zero);
       expect(svc.rules!.denied, hasLength(1));
       expect(svc.flashMessage, contains('revoke failed'));
@@ -858,47 +975,51 @@ void main() {
       svc2.dispose();
     });
 
-    test('pause_ack nack reverts the highlight and flashes which op failed',
-        () async {
-      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
-      svc.connect();
-      // A refused pause must not leave its button highlighted as active.
-      svc.sendPause('1h');
-      expect(svc.lastPauseRequest, '1h');
-      channel.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
-      await Future<void>.delayed(Duration.zero);
-      expect(svc.flashMessage, contains('pause failed'));
-      expect(svc.lastPauseRequest, isNull);
-      // A refused unpause names itself in the flash.
-      svc.sendUnpause();
-      channel.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
-      await Future<void>.delayed(Duration.zero);
-      expect(svc.flashMessage, contains('unpause failed'));
-      expect(svc.lastPauseRequest, isNull);
-      svc.dispose();
-    });
+    test(
+      'pause_ack nack reverts the highlight and flashes which op failed',
+      () async {
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        svc.connect();
+        // A refused pause must not leave its button highlighted as active.
+        svc.sendPause('1h');
+        expect(svc.lastPauseRequest, '1h');
+        channel.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
+        await Future<void>.delayed(Duration.zero);
+        expect(svc.flashMessage, contains('pause failed'));
+        expect(svc.lastPauseRequest, isNull);
+        // A refused unpause names itself in the flash.
+        svc.sendUnpause();
+        channel.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
+        await Future<void>.delayed(Duration.zero);
+        expect(svc.flashMessage, contains('unpause failed'));
+        expect(svc.lastPauseRequest, isNull);
+        svc.dispose();
+      },
+    );
 
-    test('pause_ack ok applies the acked window (authoritative fallback)',
-        () async {
-      final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
-      svc.connect();
-      channel.serverSend(_rulesFrame(allowList: ['a.io']));
-      await Future<void>.delayed(Duration.zero);
-      expect(svc.rules!.paused, isNull);
-      // The refreshed egress_rules broadcast normally lands first, but it is
-      // best-effort server-side -- the ack's own until must apply alone.
-      svc.sendPause('15m');
-      channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
-      await Future<void>.delayed(Duration.zero);
-      expect(svc.rules!.paused, const EgressPause(until: 1300.0));
-      expect(svc.flashMessage, isNull); // success never flashes
-      // A successful unpause (ok, until null) clears the window.
-      svc.sendUnpause();
-      channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': null});
-      await Future<void>.delayed(Duration.zero);
-      expect(svc.rules!.paused, isNull);
-      svc.dispose();
-    });
+    test(
+      'pause_ack ok applies the acked window (authoritative fallback)',
+      () async {
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        svc.connect();
+        channel.serverSend(_rulesFrame(allowList: ['a.io']));
+        await Future<void>.delayed(Duration.zero);
+        expect(svc.rules!.paused, isNull);
+        // The refreshed egress_rules broadcast normally lands first, but it is
+        // best-effort server-side -- the ack's own until must apply alone.
+        svc.sendPause('15m');
+        channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
+        await Future<void>.delayed(Duration.zero);
+        expect(svc.rules!.paused, const EgressPause(until: 1300.0));
+        expect(svc.flashMessage, isNull); // success never flashes
+        // A successful unpause (ok, until null) clears the window.
+        svc.sendUnpause();
+        channel.serverSend({'type': 'pause_ack', 'ok': true, 'until': null});
+        await Future<void>.delayed(Duration.zero);
+        expect(svc.rules!.paused, isNull);
+        svc.dispose();
+      },
+    );
 
     test('pause_ack ok before any rules snapshot is a safe no-op', () async {
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
@@ -912,151 +1033,231 @@ void main() {
     });
 
     test(
-        'ruleRemainingSeconds: timed -> value; open-ended/unknown/missing -> null',
-        () {
-      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
-      final svc = ConsentDeciderService(
-          workspaceId: 'ws', token: 't', clock: () => now);
-      // decided at 1000s, 5m (300s) -> 300s left at now=1000s
-      expect(
-          svc.ruleRemainingSeconds(ConsentRule(
+      'ruleRemainingSeconds: timed -> value; open-ended/unknown/missing -> null',
+      () {
+        final now = DateTime.fromMillisecondsSinceEpoch(
+          1000 * 1000,
+          isUtc: true,
+        );
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          clock: () => now,
+        );
+        // decided at 1000s, 5m (300s) -> 300s left at now=1000s
+        expect(
+          svc.ruleRemainingSeconds(
+            ConsentRule(
               id: 'a',
               destHost: 'h',
               decision: 'allowed',
               duration: '5m',
-              decidedAt: 1000.0)),
-          300);
-      // forever / tilrestart / unknown duration -> null
-      expect(
-          svc.ruleRemainingSeconds(ConsentRule(
+              decidedAt: 1000.0,
+            ),
+          ),
+          300,
+        );
+        // forever / tilrestart / unknown duration -> null
+        expect(
+          svc.ruleRemainingSeconds(
+            ConsentRule(
               id: 'b',
               destHost: 'h',
               decision: 'allowed',
               duration: 'forever',
-              decidedAt: 1000.0)),
-          isNull);
-      expect(
-          svc.ruleRemainingSeconds(ConsentRule(
+              decidedAt: 1000.0,
+            ),
+          ),
+          isNull,
+        );
+        expect(
+          svc.ruleRemainingSeconds(
+            ConsentRule(
               id: 'c',
               destHost: 'h',
               decision: 'allowed',
               duration: 'tilrestart',
-              decidedAt: 1000.0)),
-          isNull);
-      expect(
-          svc.ruleRemainingSeconds(ConsentRule(
+              decidedAt: 1000.0,
+            ),
+          ),
+          isNull,
+        );
+        expect(
+          svc.ruleRemainingSeconds(
+            ConsentRule(
               id: 'd',
               destHost: 'h',
               decision: 'allowed',
               duration: 'bogus',
-              decidedAt: 1000.0)),
-          isNull);
-      // missing decided_at -> null
-      expect(
-          svc.ruleRemainingSeconds(ConsentRule(
-              id: 'e', destHost: 'h', decision: 'allowed', duration: '5m')),
-          isNull);
-      // clamped at 0 past expiry
-      expect(
-          svc.ruleRemainingSeconds(ConsentRule(
+              decidedAt: 1000.0,
+            ),
+          ),
+          isNull,
+        );
+        // missing decided_at -> null
+        expect(
+          svc.ruleRemainingSeconds(
+            ConsentRule(
+              id: 'e',
+              destHost: 'h',
+              decision: 'allowed',
+              duration: '5m',
+            ),
+          ),
+          isNull,
+        );
+        // clamped at 0 past expiry
+        expect(
+          svc.ruleRemainingSeconds(
+            ConsentRule(
               id: 'f',
               destHost: 'h',
               decision: 'allowed',
               duration: '5m',
-              decidedAt: 100.0)),
-          0);
-      svc.dispose();
-    });
+              decidedAt: 100.0,
+            ),
+          ),
+          0,
+        );
+        svc.dispose();
+      },
+    );
 
     test(
-        'pauseRemainingSeconds: null when not paused / indefinite; value when set',
-        () {
-      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
-      final svc = ConsentDeciderService(
-          workspaceId: 'ws', token: 't', clock: () => now);
-      final base = EgressRules(
+      'pauseRemainingSeconds: null when not paused / indefinite; value when set',
+      () {
+        final now = DateTime.fromMillisecondsSinceEpoch(
+          1000 * 1000,
+          isUtc: true,
+        );
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          clock: () => now,
+        );
+        final base = EgressRules(
           workspaceId: 'w',
           allowList: const [],
           allowed: const [],
-          denied: const []);
-      expect(svc.pauseRemainingSeconds(base), isNull); // paused null
-      expect(
-          svc.pauseRemainingSeconds(EgressRules(
+          denied: const [],
+        );
+        expect(svc.pauseRemainingSeconds(base), isNull); // paused null
+        expect(
+          svc.pauseRemainingSeconds(
+            EgressRules(
               workspaceId: 'w',
               allowList: const [],
               allowed: const [],
               denied: const [],
-              paused: const EgressPause())),
-          isNull); // until null
-      expect(
-          svc.pauseRemainingSeconds(EgressRules(
+              paused: const EgressPause(),
+            ),
+          ),
+          isNull,
+        ); // until null
+        expect(
+          svc.pauseRemainingSeconds(
+            EgressRules(
               workspaceId: 'w',
               allowList: const [],
               allowed: const [],
               denied: const [],
-              paused: const EgressPause(until: 1300.0))),
-          300); // 1300 - 1000
-      svc.dispose();
-    });
+              paused: const EgressPause(until: 1300.0),
+            ),
+          ),
+          300,
+        ); // 1300 - 1000
+        svc.dispose();
+      },
+    );
   });
 
   group('isRuleExpired', () {
-    test('timed past expiry -> true; open-ended / unknown / missing -> false',
-        () {
-      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
-      final svc = ConsentDeciderService(
-          workspaceId: 'ws', token: 't', clock: () => now);
-      ConsentRule rule(String? duration, {double? decidedAt}) => ConsentRule(
-          id: 'r',
-          destHost: 'h',
-          decision: 'allowed',
-          duration: duration,
-          decidedAt: decidedAt);
-      // decided at 1000s, 5m (300s) -> expires at 1300s; now=1000s -> live.
-      expect(svc.isRuleExpired(rule('5m', decidedAt: 1000.0)), isFalse);
-      // decided at 100s -> expired long ago (remaining clamps to 0).
-      expect(svc.isRuleExpired(rule('5m', decidedAt: 100.0)), isTrue);
-      // open-ended / unknown / missing decided_at -> never expire.
-      expect(svc.isRuleExpired(rule('forever', decidedAt: 100.0)), isFalse);
-      expect(svc.isRuleExpired(rule('tilrestart', decidedAt: 100.0)), isFalse);
-      expect(svc.isRuleExpired(rule('bogus', decidedAt: 100.0)), isFalse);
-      expect(svc.isRuleExpired(rule('5m')), isFalse);
-      svc.dispose();
-    });
+    test(
+      'timed past expiry -> true; open-ended / unknown / missing -> false',
+      () {
+        final now = DateTime.fromMillisecondsSinceEpoch(
+          1000 * 1000,
+          isUtc: true,
+        );
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          clock: () => now,
+        );
+        ConsentRule rule(String? duration, {double? decidedAt}) => ConsentRule(
+              id: 'r',
+              destHost: 'h',
+              decision: 'allowed',
+              duration: duration,
+              decidedAt: decidedAt,
+            );
+        // decided at 1000s, 5m (300s) -> expires at 1300s; now=1000s -> live.
+        expect(svc.isRuleExpired(rule('5m', decidedAt: 1000.0)), isFalse);
+        // decided at 100s -> expired long ago (remaining clamps to 0).
+        expect(svc.isRuleExpired(rule('5m', decidedAt: 100.0)), isTrue);
+        // open-ended / unknown / missing decided_at -> never expire.
+        expect(svc.isRuleExpired(rule('forever', decidedAt: 100.0)), isFalse);
+        expect(
+          svc.isRuleExpired(rule('tilrestart', decidedAt: 100.0)),
+          isFalse,
+        );
+        expect(svc.isRuleExpired(rule('bogus', decidedAt: 100.0)), isFalse);
+        expect(svc.isRuleExpired(rule('5m')), isFalse);
+        svc.dispose();
+      },
+    );
   });
 
   group('isPauseExpired', () {
     EgressRules rules(EgressPause? paused) => EgressRules(
-        workspaceId: 'w',
-        allowList: const [],
-        allowed: const [],
-        denied: const [],
-        paused: paused);
+          workspaceId: 'w',
+          allowList: const [],
+          allowed: const [],
+          denied: const [],
+          paused: paused,
+        );
 
-    test('finite until past -> true; future / indefinite / not paused -> false',
-        () {
-      final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
-      final svc = ConsentDeciderService(
-          workspaceId: 'ws', token: 't', clock: () => now);
-      // until 1300s, now 1000s -> live.
-      expect(
-          svc.isPauseExpired(rules(const EgressPause(until: 1300.0))), isFalse);
-      // until 900s -> elapsed.
-      expect(
-          svc.isPauseExpired(rules(const EgressPause(until: 900.0))), isTrue);
-      // Indefinite (until restart) and not-paused never expire.
-      expect(
-          svc.isPauseExpired(rules(const EgressPause(until: null))), isFalse);
-      expect(svc.isPauseExpired(rules(null)), isFalse);
-      svc.dispose();
-    });
+    test(
+      'finite until past -> true; future / indefinite / not paused -> false',
+      () {
+        final now = DateTime.fromMillisecondsSinceEpoch(
+          1000 * 1000,
+          isUtc: true,
+        );
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          clock: () => now,
+        );
+        // until 1300s, now 1000s -> live.
+        expect(
+          svc.isPauseExpired(rules(const EgressPause(until: 1300.0))),
+          isFalse,
+        );
+        // until 900s -> elapsed.
+        expect(
+          svc.isPauseExpired(rules(const EgressPause(until: 900.0))),
+          isTrue,
+        );
+        // Indefinite (until restart) and not-paused never expire.
+        expect(
+          svc.isPauseExpired(rules(const EgressPause(until: null))),
+          isFalse,
+        );
+        expect(svc.isPauseExpired(rules(null)), isFalse);
+        svc.dispose();
+      },
+    );
   });
 
   group('pruneExpiredRules', () {
     test('no-op (returns false) before the first egress_rules frame', () {
       final now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
       final svc = ConsentDeciderService(
-          workspaceId: 'ws', token: 't', clock: () => now);
+        workspaceId: 'ws',
+        token: 't',
+        clock: () => now,
+      );
       expect(svc.pruneExpiredRules(), isFalse);
       expect(svc.rules, isNull);
       svc.dispose();
@@ -1067,26 +1268,36 @@ void main() {
       final ch = _FakeChannel();
       ConsentDeciderService.testChannelFactory = (_) => ch;
       final svc = ConsentDeciderService(
-          workspaceId: 'ws', token: 't', clock: () => now);
+        workspaceId: 'ws',
+        token: 't',
+        clock: () => now,
+      );
       svc.connect();
-      ch.serverSend(_rulesFrame(
-        allowList: ['github.com'],
-        allowed: [
-          // timed: decided now (t=1000), 5m -> expires at t=1300; live for now.
-          _ruleJson(id: 'timed', host: 't.io', decidedAt: 1000.0),
-          // open-ended: never expires.
-          _ruleJson(
-              id: 'forever', host: 'f.io', duration: 'forever', decidedAt: 1.0),
-        ],
-        denied: [
-          // timed deny: also expires at t=1300.
-          _ruleJson(
+      ch.serverSend(
+        _rulesFrame(
+          allowList: ['github.com'],
+          allowed: [
+            // timed: decided now (t=1000), 5m -> expires at t=1300; live for now.
+            _ruleJson(id: 'timed', host: 't.io', decidedAt: 1000.0),
+            // open-ended: never expires.
+            _ruleJson(
+              id: 'forever',
+              host: 'f.io',
+              duration: 'forever',
+              decidedAt: 1.0,
+            ),
+          ],
+          denied: [
+            // timed deny: also expires at t=1300.
+            _ruleJson(
               id: 'd-timed',
               host: 'dt.io',
               decision: 'denied',
-              decidedAt: 1000.0),
-        ],
-      ));
+              decidedAt: 1000.0,
+            ),
+          ],
+        ),
+      );
       await Future.delayed(Duration.zero); // flush the broadcast listener
       // Sorted newest-decided-first: 'timed' (1000) before 'forever' (1).
       expect(svc.rules!.allowed.map((r) => r.id), ['timed', 'forever']);
@@ -1118,32 +1329,37 @@ void main() {
       svc.dispose();
     });
 
-    test('drops a self-expired pause; keeps a live or indefinite one (#2494)',
-        () async {
-      var now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
-      final ch = _FakeChannel();
-      ConsentDeciderService.testChannelFactory = (_) => ch;
-      final svc = ConsentDeciderService(
-          workspaceId: 'ws', token: 't', clock: () => now);
-      svc.connect();
-      // Live window: until t=1300, now t=1000.
-      ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
-      await Future.delayed(Duration.zero);
-      expect(svc.pruneExpiredRules(), isFalse); // still live -> kept
-      expect(svc.rules!.paused, const EgressPause(until: 1300.0));
+    test(
+      'drops a self-expired pause; keeps a live or indefinite one (#2494)',
+      () async {
+        var now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
+        final ch = _FakeChannel();
+        ConsentDeciderService.testChannelFactory = (_) => ch;
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          clock: () => now,
+        );
+        svc.connect();
+        // Live window: until t=1300, now t=1000.
+        ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
+        await Future.delayed(Duration.zero);
+        expect(svc.pruneExpiredRules(), isFalse); // still live -> kept
+        expect(svc.rules!.paused, const EgressPause(until: 1300.0));
 
-      // Past expiry: the pause is pruned (never lingers at "resumes in 0s").
-      now = DateTime.fromMillisecondsSinceEpoch(1400 * 1000, isUtc: true);
-      expect(svc.pruneExpiredRules(), isTrue);
-      expect(svc.rules!.paused, isNull);
+        // Past expiry: the pause is pruned (never lingers at "resumes in 0s").
+        now = DateTime.fromMillisecondsSinceEpoch(1400 * 1000, isUtc: true);
+        expect(svc.pruneExpiredRules(), isTrue);
+        expect(svc.rules!.paused, isNull);
 
-      // An indefinite pause (until restart) never expires.
-      ch.serverSend(_rulesFrame(paused: {'paused': true}));
-      await Future.delayed(Duration.zero);
-      expect(svc.pruneExpiredRules(), isFalse);
-      expect(svc.rules!.paused, const EgressPause(until: null));
-      ConsentDeciderService.testChannelFactory = null;
-      svc.dispose();
-    });
+        // An indefinite pause (until restart) never expires.
+        ch.serverSend(_rulesFrame(paused: {'paused': true}));
+        await Future.delayed(Duration.zero);
+        expect(svc.pruneExpiredRules(), isFalse);
+        expect(svc.rules!.paused, const EgressPause(until: null));
+        ConsentDeciderService.testChannelFactory = null;
+        svc.dispose();
+      },
+    );
   });
 }

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -66,6 +66,7 @@ Map<String, dynamic> _ruleJson({
 Map<String, dynamic> _rulesFrame({
   String workspaceId = 'ws-1',
   List<String> allowList = const [],
+  List<String> rejectList = const [],
   List<Map<String, dynamic>> allowed = const [],
   List<Map<String, dynamic>> denied = const [],
   Object? paused,
@@ -74,6 +75,7 @@ Map<String, dynamic> _rulesFrame({
       'type': 'egress_rules',
       'workspace_id': workspaceId,
       'allow_list': allowList,
+      'reject_list': rejectList,
       'allowed': allowed,
       'denied': denied,
       if (paused != null) 'paused': paused,
@@ -82,11 +84,16 @@ Map<String, dynamic> _rulesFrame({
 DateTime _at(int epochSec) =>
     DateTime.fromMillisecondsSinceEpoch(epochSec * 1000, isUtc: true);
 
-ConsentDeciderService _serviceWithChannel(_FakeChannel channel,
-    {DateTime Function()? clock}) {
+ConsentDeciderService _serviceWithChannel(
+  _FakeChannel channel, {
+  DateTime Function()? clock,
+}) {
   ConsentDeciderService.testChannelFactory = (_) => channel;
   return ConsentDeciderService(
-      workspaceId: 'ws', token: 't', clock: clock ?? _wallClock);
+    workspaceId: 'ws',
+    token: 't',
+    clock: clock ?? _wallClock,
+  );
 }
 
 DateTime _wallClock() => DateTime.now();
@@ -108,18 +115,21 @@ void main() {
 
   group('ruleExpiryLabel', () {
     ConsentRule rule(String? duration, {double? decidedAt}) => ConsentRule(
-        id: 'r',
-        destHost: 'h',
-        decision: 'allowed',
-        duration: duration,
-        decidedAt: decidedAt);
+          id: 'r',
+          destHost: 'h',
+          decision: 'allowed',
+          duration: duration,
+          decidedAt: decidedAt,
+        );
 
     test('forever', () {
       expect(ruleExpiryLabel(rule('forever'), null, deny: false), 'forever');
     });
     test('tilrestart', () {
-      expect(ruleExpiryLabel(rule('tilrestart'), null, deny: false),
-          'until restart');
+      expect(
+        ruleExpiryLabel(rule('tilrestart'), null, deny: false),
+        'until restart',
+      );
     });
     test('allow timed -> expires in', () {
       expect(ruleExpiryLabel(rule('5m'), 300, deny: false), 'expires in 5m');
@@ -135,27 +145,32 @@ void main() {
   group('hasLiveCountdown', () {
     int? remaining(ConsentRule r) => r.duration == '5m' ? 5 : null;
     final timed = ConsentRule(
-        id: 'a',
-        destHost: 'h',
-        decision: 'allowed',
-        duration: '5m',
-        decidedAt: 1.0);
+      id: 'a',
+      destHost: 'h',
+      decision: 'allowed',
+      duration: '5m',
+      decidedAt: 1.0,
+    );
     final forever = ConsentRule(
-        id: 'b',
-        destHost: 'h',
-        decision: 'allowed',
-        duration: 'forever',
-        decidedAt: 1.0);
+      id: 'b',
+      destHost: 'h',
+      decision: 'allowed',
+      duration: 'forever',
+      decidedAt: 1.0,
+    );
     EgressRules rules(List<ConsentRule> allowed, {EgressPause? paused}) =>
         EgressRules(
-            workspaceId: 'w',
-            allowList: const [],
-            allowed: allowed,
-            denied: const [],
-            paused: paused);
+          workspaceId: 'w',
+          allowList: const [],
+          allowed: allowed,
+          denied: const [],
+          paused: paused,
+        );
 
-    test('null rules -> false',
-        () => expect(hasLiveCountdown(null, remaining), isFalse));
+    test(
+      'null rules -> false',
+      () => expect(hasLiveCountdown(null, remaining), isFalse),
+    );
     test('only forever/tilrestart rules -> false', () {
       expect(hasLiveCountdown(rules([forever]), remaining), isFalse);
     });
@@ -164,16 +179,19 @@ void main() {
     });
     test('a pause -> true', () {
       expect(
-          hasLiveCountdown(
-              rules([forever], paused: const EgressPause(until: 1.0)),
-              remaining),
-          isTrue);
+        hasLiveCountdown(
+          rules([forever], paused: const EgressPause(until: 1.0)),
+          remaining,
+        ),
+        isTrue,
+      );
     });
   });
 
   group('ConsentRulesPanel', () {
-    testWidgets('shows the loading state before the first frame',
-        (tester) async {
+    testWidgets('shows the loading state before the first frame', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch);
       svc.connect();
@@ -182,35 +200,49 @@ void main() {
       svc.dispose();
     });
 
-    testWidgets('renders allow-list + allows + denies sections with labels',
-        (tester) async {
+    testWidgets('renders allow-list + allows + denies sections with labels', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch, clock: () => _at(1000));
       svc.connect();
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
-      ch.serverSend(_rulesFrame(
-        allowList: ['github.com'],
-        allowed: [
-          _ruleJson(id: 'a', host: 'f.io', duration: 'forever', decidedAt: 100),
-          _ruleJson(
-              id: 'b', host: 't.io', duration: 'tilrestart', decidedAt: 100),
-          _ruleJson(id: 'c', host: 'm.io', duration: '5m', decidedAt: 1000),
-          _ruleJson(
+      ch.serverSend(
+        _rulesFrame(
+          allowList: ['github.com'],
+          allowed: [
+            _ruleJson(
+              id: 'a',
+              host: 'f.io',
+              duration: 'forever',
+              decidedAt: 100,
+            ),
+            _ruleJson(
+              id: 'b',
+              host: 't.io',
+              duration: 'tilrestart',
+              decidedAt: 100,
+            ),
+            _ruleJson(id: 'c', host: 'm.io', duration: '5m', decidedAt: 1000),
+            _ruleJson(
               id: 'd',
               host: 'n.io',
               port: null,
               proc: null,
               duration: '5m',
-              decidedAt: null),
-        ],
-        denied: const [],
-      ));
+              decidedAt: null,
+            ),
+          ],
+          denied: const [],
+        ),
+      );
       await tester.pump();
       expect(find.text('Static allow-list'), findsOneWidget);
       expect(find.text('github.com'), findsOneWidget);
       expect(find.text('Active allows (4)'), findsOneWidget);
       expect(find.text('Active denies (0)'), findsOneWidget);
-      expect(find.text('(none)'), findsOneWidget); // empty denies
+      // empty denies + empty reject-list (the frame carries no reject_list)
+      expect(find.text('(none)'), findsNWidgets(2));
       // four revocable allow rows (label branches: forever/tilrestart/timed/empty)
       expect(find.byKey(const ValueKey('revoke-a')), findsOneWidget);
       expect(find.byKey(const ValueKey('revoke-b')), findsOneWidget);
@@ -220,14 +252,18 @@ void main() {
       svc.dispose();
     });
 
-    testWidgets('revoke confirms then sends (with process in the prompt)',
-        (tester) async {
+    testWidgets('revoke confirms then sends (with process in the prompt)', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch);
       svc.connect();
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
-      ch.serverSend(_rulesFrame(
-          allowed: [_ruleJson(id: 'v1', host: 'a.io', proc: 'curl')]));
+      ch.serverSend(
+        _rulesFrame(
+          allowed: [_ruleJson(id: 'v1', host: 'a.io', proc: 'curl')],
+        ),
+      );
       await tester.pump();
       await tester.tap(find.byKey(const ValueKey('revoke-v1')));
       await tester.pump();
@@ -237,8 +273,10 @@ void main() {
       expect(find.textContaining('(curl)'), findsOneWidget);
       await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
       await tester.pump();
-      expect(jsonDecode(ch.sent.last as String),
-          {'type': 'revoke', 'request_id': 'v1'});
+      expect(jsonDecode(ch.sent.last as String), {
+        'type': 'revoke',
+        'request_id': 'v1',
+      });
       svc.dispose();
     });
 
@@ -247,8 +285,11 @@ void main() {
       final svc = _serviceWithChannel(ch);
       svc.connect();
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
-      ch.serverSend(_rulesFrame(
-          allowed: [_ruleJson(id: 'v2', host: 'b.io', proc: null)]));
+      ch.serverSend(
+        _rulesFrame(
+          allowed: [_ruleJson(id: 'v2', host: 'b.io', proc: null)],
+        ),
+      );
       await tester.pump();
       await tester.tap(find.byKey(const ValueKey('revoke-v2')));
       await tester.pump();
@@ -256,8 +297,10 @@ void main() {
       expect(find.textContaining('b.io:443'), findsOneWidget);
       await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
       await tester.pump();
-      expect(jsonDecode(ch.sent.last as String),
-          {'type': 'revoke', 'request_id': 'v2'});
+      expect(jsonDecode(ch.sent.last as String), {
+        'type': 'revoke',
+        'request_id': 'v2',
+      });
       svc.dispose();
     });
 
@@ -290,8 +333,9 @@ void main() {
       svc.dispose();
     });
 
-    testWidgets('renders the pause section (countdown then until-restart)',
-        (tester) async {
+    testWidgets('renders the pause section (countdown then until-restart)', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch, clock: () => _at(1000));
       svc.connect();
@@ -307,115 +351,137 @@ void main() {
     });
 
     testWidgets(
-        'pause controls render once rules land; highlight follows the last acked request (#2494)',
-        (tester) async {
-      final ch = _FakeChannel();
-      final svc = _serviceWithChannel(ch);
-      svc.connect();
-      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
-      // No controls before the first egress_rules frame (loading state).
-      expect(find.text('Pause prompts'), findsNothing);
-      ch.serverSend(_rulesFrame(allowList: ['a.io']));
-      await tester.pump();
+      'pause controls render once rules land; highlight follows the last acked request (#2494)',
+      (tester) async {
+        final ch = _FakeChannel();
+        final svc = _serviceWithChannel(ch);
+        svc.connect();
+        await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+        // No controls before the first egress_rules frame (loading state).
+        expect(find.text('Pause prompts'), findsNothing);
+        ch.serverSend(_rulesFrame(allowList: ['a.io']));
+        await tester.pump();
 
-      // All four buttons render (Unpause / Pause 15m / 1h / 1d, mirroring
-      // the TUI pause bar); nothing is paused so there is no status line.
-      expect(find.text('Pause prompts'), findsOneWidget);
-      expect(find.text('Unpause'), findsOneWidget);
-      expect(find.text('Pause 15m'), findsOneWidget);
-      expect(find.text('Pause 1h'), findsOneWidget);
-      expect(find.text('Pause 1d'), findsOneWidget);
-      expect(find.textContaining('Filtering paused'), findsNothing);
+        // All four buttons render (Unpause / Pause 15m / 1h / 1d, mirroring
+        // the TUI pause bar); nothing is paused so there is no status line.
+        expect(find.text('Pause prompts'), findsOneWidget);
+        expect(find.text('Unpause'), findsOneWidget);
+        expect(find.text('Pause 15m'), findsOneWidget);
+        expect(find.text('Pause 1h'), findsOneWidget);
+        expect(find.text('Pause 1d'), findsOneWidget);
+        expect(find.textContaining('Filtering paused'), findsNothing);
 
-      // Unpause is the active (filled) button when nothing was last paused.
-      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
-          isA<FilledButton>());
-      expect(tester.widget(find.byKey(const ValueKey('pause-15m'))),
-          isA<OutlinedButton>());
+        // Unpause is the active (filled) button when nothing was last paused.
+        expect(
+          tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<FilledButton>(),
+        );
+        expect(
+          tester.widget(find.byKey(const ValueKey('pause-15m'))),
+          isA<OutlinedButton>(),
+        );
 
-      // Tapping the active button sends too (unpause is idempotent
-      // server-side) and keeps Unpause as the last request.
-      await tester.tap(find.byKey(const ValueKey('pause-none')));
-      await tester.pump();
-      expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
+        // Tapping the active button sends too (unpause is idempotent
+        // server-side) and keeps Unpause as the last request.
+        await tester.tap(find.byKey(const ValueKey('pause-none')));
+        await tester.pump();
+        expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
 
-      // Tapping Pause 15m sends the frame and moves the highlight.
-      await tester.tap(find.byKey(const ValueKey('pause-15m')));
-      await tester.pump();
-      expect(jsonDecode(ch.sent.last as String),
-          {'type': 'pause', 'duration': '15m'});
-      expect(tester.widget(find.byKey(const ValueKey('pause-15m'))),
-          isA<FilledButton>());
-      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
-          isA<OutlinedButton>());
+        // Tapping Pause 15m sends the frame and moves the highlight.
+        await tester.tap(find.byKey(const ValueKey('pause-15m')));
+        await tester.pump();
+        expect(jsonDecode(ch.sent.last as String), {
+          'type': 'pause',
+          'duration': '15m',
+        });
+        expect(
+          tester.widget(find.byKey(const ValueKey('pause-15m'))),
+          isA<FilledButton>(),
+        );
+        expect(
+          tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<OutlinedButton>(),
+        );
 
-      // A refused pause (nack) reverts the highlight: the button must not
-      // claim a window the server never set.
-      ch.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
-      await tester.pump();
-      expect(find.text('pause failed'), findsOneWidget);
-      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
-          isA<FilledButton>());
-      expect(tester.widget(find.byKey(const ValueKey('pause-15m'))),
-          isA<OutlinedButton>());
+        // A refused pause (nack) reverts the highlight: the button must not
+        // claim a window the server never set.
+        ch.serverSend({'type': 'pause_ack', 'ok': false, 'until': null});
+        await tester.pump();
+        expect(find.text('pause failed'), findsOneWidget);
+        expect(
+          tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<FilledButton>(),
+        );
+        expect(
+          tester.widget(find.byKey(const ValueKey('pause-15m'))),
+          isA<OutlinedButton>(),
+        );
 
-      // A successful pause applies from the ack alone (the egress_rules
-      // re-broadcast is best-effort server-side): the status line renders.
-      await tester.tap(find.byKey(const ValueKey('pause-1h')));
-      await tester.pump();
-      expect(jsonDecode(ch.sent.last as String),
-          {'type': 'pause', 'duration': '1h'});
-      ch.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
-      await tester.pump();
-      expect(find.textContaining('Filtering paused'), findsOneWidget);
+        // A successful pause applies from the ack alone (the egress_rules
+        // re-broadcast is best-effort server-side): the status line renders.
+        await tester.tap(find.byKey(const ValueKey('pause-1h')));
+        await tester.pump();
+        expect(jsonDecode(ch.sent.last as String), {
+          'type': 'pause',
+          'duration': '1h',
+        });
+        ch.serverSend({'type': 'pause_ack', 'ok': true, 'until': 1300.0});
+        await tester.pump();
+        expect(find.textContaining('Filtering paused'), findsOneWidget);
 
-      // Tapping Unpause sends the frame; a successful ack clears the status.
-      await tester.tap(find.byKey(const ValueKey('pause-none')));
-      await tester.pump();
-      expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
-      ch.serverSend({'type': 'pause_ack', 'ok': true, 'until': null});
-      await tester.pump();
-      expect(find.textContaining('Filtering paused'), findsNothing);
-      expect(tester.widget(find.byKey(const ValueKey('pause-none'))),
-          isA<FilledButton>());
-      svc.dispose();
-    });
+        // Tapping Unpause sends the frame; a successful ack clears the status.
+        await tester.tap(find.byKey(const ValueKey('pause-none')));
+        await tester.pump();
+        expect(jsonDecode(ch.sent.last as String), {'type': 'unpause'});
+        ch.serverSend({'type': 'pause_ack', 'ok': true, 'until': null});
+        await tester.pump();
+        expect(find.textContaining('Filtering paused'), findsNothing);
+        expect(
+          tester.widget(find.byKey(const ValueKey('pause-none'))),
+          isA<FilledButton>(),
+        );
+        svc.dispose();
+      },
+    );
 
     testWidgets(
-        'a self-expired pause disappears on the next tick (never "resumes in 0s")',
-        (tester) async {
-      var now = _at(1000); // epoch seconds
-      final ch = _FakeChannel();
-      final svc = _serviceWithChannel(ch, clock: () => now);
-      svc.connect();
-      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
-      // Paused until t=1300; now t=1000 -> live countdown shows.
-      ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
-      await tester.pump();
-      expect(find.textContaining('Filtering paused'), findsOneWidget);
+      'a self-expired pause disappears on the next tick (never "resumes in 0s")',
+      (tester) async {
+        var now = _at(1000); // epoch seconds
+        final ch = _FakeChannel();
+        final svc = _serviceWithChannel(ch, clock: () => now);
+        svc.connect();
+        await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+        // Paused until t=1300; now t=1000 -> live countdown shows.
+        ch.serverSend(_rulesFrame(paused: {'paused': true, 'until': 1300.0}));
+        await tester.pump();
+        expect(find.textContaining('Filtering paused'), findsOneWidget);
 
-      // Past the window: before the 1s tick fires the (cached) status line
-      // still renders; the tick must prune it, not freeze at "resumes in 0s"
-      // -- the server only re-broadcasts on the next discrete event.
-      now = _at(1400);
-      await tester.pump();
-      expect(find.textContaining('Filtering paused'), findsOneWidget);
-      await tester.pump(const Duration(seconds: 1));
-      expect(find.textContaining('Filtering paused'), findsNothing);
-      // The controls stay rendered for the next request.
-      expect(find.text('Pause prompts'), findsOneWidget);
-      svc.dispose();
-    });
+        // Past the window: before the 1s tick fires the (cached) status line
+        // still renders; the tick must prune it, not freeze at "resumes in 0s"
+        // -- the server only re-broadcasts on the next discrete event.
+        now = _at(1400);
+        await tester.pump();
+        expect(find.textContaining('Filtering paused'), findsOneWidget);
+        await tester.pump(const Duration(seconds: 1));
+        expect(find.textContaining('Filtering paused'), findsNothing);
+        // The controls stay rendered for the next request.
+        expect(find.text('Pause prompts'), findsOneWidget);
+        svc.dispose();
+      },
+    );
 
-    testWidgets('pause tap while disconnected flashes instead of sending',
-        (tester) async {
+    testWidgets('pause tap while disconnected flashes instead of sending', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       ConsentDeciderService.testChannelFactory = (_) => ch;
       final svc = ConsentDeciderService(
-          workspaceId: 'ws',
-          token: 't',
-          // Long delay so the reconnect Timer never fires during the test.
-          reconnectDelays: const [Duration(minutes: 5)]);
+        workspaceId: 'ws',
+        token: 't',
+        // Long delay so the reconnect Timer never fires during the test.
+        reconnectDelays: const [Duration(minutes: 5)],
+      );
       svc.connect();
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
       ch.serverSend(_rulesFrame(allowList: ['a.io']));
@@ -430,8 +496,9 @@ void main() {
       svc.dispose();
     });
 
-    testWidgets('a failed pause_ack flashes via the service flash row',
-        (tester) async {
+    testWidgets('a failed pause_ack flashes via the service flash row', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch);
       svc.connect();
@@ -446,14 +513,16 @@ void main() {
       svc.dispose();
     });
 
-    testWidgets('a revoked row stays until revoke_ack succeeds',
-        (tester) async {
+    testWidgets('a revoked row stays until revoke_ack succeeds', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch);
       svc.connect();
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
       ch.serverSend(
-          _rulesFrame(allowed: [_ruleJson(id: 'v1', decidedAt: 100)]));
+        _rulesFrame(allowed: [_ruleJson(id: 'v1', decidedAt: 100)]),
+      );
       await tester.pump();
       expect(find.byKey(const ValueKey('revoke-v1')), findsOneWidget);
       // confirm revoke -> frame sent, but the row stays (never optimistic)
@@ -462,8 +531,10 @@ void main() {
       await tester.pump();
       await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
       await tester.pump();
-      expect(jsonDecode(ch.sent.last as String),
-          {'type': 'revoke', 'request_id': 'v1'});
+      expect(jsonDecode(ch.sent.last as String), {
+        'type': 'revoke',
+        'request_id': 'v1',
+      });
       expect(find.byKey(const ValueKey('revoke-v1')), findsOneWidget);
       // server acks success -> row leaves
       ch.serverSend({'type': 'revoke_ack', 'request_id': 'v1', 'ok': true});
@@ -485,14 +556,54 @@ void main() {
       svc.dispose();
     });
 
-    testWidgets('confirm after the panel is disposed does not send (#2393)',
-        (tester) async {
+    testWidgets(
+      'static reject-list section renders below the allow-list and is read-only (#2503)',
+      (tester) async {
+        final ch = _FakeChannel();
+        final svc = _serviceWithChannel(ch);
+        svc.connect();
+        await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+        ch.serverSend(
+          _rulesFrame(
+            allowList: ['github.com'],
+            rejectList: ['bad.io', 'evil.io:443'],
+          ),
+        );
+        await tester.pump();
+        // Both static sections render, reject-list after the allow-list.
+        expect(find.text('Static allow-list'), findsOneWidget);
+        expect(find.text('Static reject-list'), findsOneWidget);
+        expect(find.text('bad.io'), findsOneWidget);
+        expect(find.text('evil.io:443'), findsOneWidget);
+        final allowIdx = tester
+            .widgetList<Text>(find.byType(Text))
+            .toList()
+            .indexWhere((t) => t.data == 'Static allow-list');
+        final rejectIdx = tester
+            .widgetList<Text>(find.byType(Text))
+            .toList()
+            .indexWhere((t) => t.data == 'Static reject-list');
+        expect(rejectIdx, greaterThan(allowIdx));
+        // Workspace config, not consent rows: no revoke affordance, and an
+        // empty list shows the shared (none) placeholder.
+        expect(find.byKey(const ValueKey('revoke-bad.io')), findsNothing);
+        ch.serverSend(_rulesFrame(rejectList: []));
+        await tester.pump();
+        expect(find.text('Static reject-list'), findsOneWidget);
+        svc.dispose();
+      },
+    );
+
+    testWidgets('confirm after the panel is disposed does not send (#2393)', (
+      tester,
+    ) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch);
       svc.connect();
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
       ch.serverSend(
-          _rulesFrame(allowed: [_ruleJson(id: 'v1', decidedAt: 100)]));
+        _rulesFrame(allowed: [_ruleJson(id: 'v1', decidedAt: 100)]),
+      );
       await tester.pump();
       await tester.tap(find.byKey(const ValueKey('revoke-v1')));
       await tester.pump();
@@ -512,11 +623,12 @@ void main() {
       final ch = _FakeChannel();
       ConsentDeciderService.testChannelFactory = (_) => ch;
       final svc = ConsentDeciderService(
-          workspaceId: 'ws',
-          token: 't',
-          // Long delay so the reconnect Timer never fires during the test
-          // (dispose cancels it regardless).
-          reconnectDelays: const [Duration(minutes: 5)]);
+        workspaceId: 'ws',
+        token: 't',
+        // Long delay so the reconnect Timer never fires during the test
+        // (dispose cancels it regardless).
+        reconnectDelays: const [Duration(minutes: 5)],
+      );
       svc.connect();
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
       ch.serverSend(_rulesFrame(allowList: ['a.io']));
@@ -528,8 +640,9 @@ void main() {
       svc.dispose();
     });
 
-    testWidgets('an expired timed rule disappears on the next tick (#2467)',
-        (tester) async {
+    testWidgets('an expired timed rule disappears on the next tick (#2467)', (
+      tester,
+    ) async {
       var now = _at(1000); // epoch seconds
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch, clock: () => now);
@@ -537,11 +650,24 @@ void main() {
       await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
       // A timed allow (decided now, expires in 5m / at t=1300) + a forever
       // allow (no expiry).
-      ch.serverSend(_rulesFrame(allowed: [
-        _ruleJson(id: 'timed', host: 't.io', duration: '5m', decidedAt: 1000),
-        _ruleJson(
-            id: 'forever', host: 'f.io', duration: 'forever', decidedAt: 1.0),
-      ]));
+      ch.serverSend(
+        _rulesFrame(
+          allowed: [
+            _ruleJson(
+              id: 'timed',
+              host: 't.io',
+              duration: '5m',
+              decidedAt: 1000,
+            ),
+            _ruleJson(
+              id: 'forever',
+              host: 'f.io',
+              duration: 'forever',
+              decidedAt: 1.0,
+            ),
+          ],
+        ),
+      );
       await tester.pump();
       expect(find.text('Active allows (2)'), findsOneWidget);
       expect(find.byKey(const ValueKey('revoke-timed')), findsOneWidget);


### PR DESCRIPTION
Closes #2503.

## What

- `EgressRules` gains `rejectList` (default empty), parsed from the
  `reject_list` field the server has included in every `egress_rules`
  snapshot since #2370; carried through the revoke/pause/prune snapshot
  rebuilds and included in equality/hashCode.
- The Net Rules panel renders a read-only **Static reject-list** section
  directly below **Static allow-list** — same `_Section` styling, `(none)`
  empty state. No revoke affordance: entries are workspace config
  (`rejected_domains`, appended by a *deny forever* verdict #2369), not
  consent rows; editing stays in the workspace settings panel (#2386).

## Tests

- Service: `reject_list` parsing (present, missing → empty) and
  `EgressRules` equality/hashCode covering the new field.
- Panel: section renders below the allow-list with entries, no revoke
  affordance, empty-list placeholder; existing empty-section count updated.

Full frontend suite: 969 tests, 100.0% coverage (4561/4561 lines).

Note: the diff carries ~900 lines of pure `dart format` churn in the two
touched test files — main's copies predate the current formatter's tall
style and the pre-commit hook enforces it, so any commit touching these
files produces the same reflow. No semantic changes in those hunks.
