### PR TITLE
feat(frontend): shared option-button look for pause + duration groups

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -581,6 +581,11 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Restyled pause/duration option buttons (#2502).** The Net Rules pause
+  controls (Unpause / Pause 15m / 1h / 1d) and the consent banner's duration
+  selector now share one pill-shaped option-button look with equal sizing,
+  pause/play icons, and tooltips; the active choice keeps the amber fill.
+  Purely presentational — keys and behavior unchanged.
 - **Consent banner duration buttons (#2499).** The egress-consent banner's
   verdict-duration dropdown is now a row of compact buttons (one per
   duration, the selected one highlighted), matching the `consent-decide`

--- a/src/frontend/lib/widgets/option_button.dart
+++ b/src/frontend/lib/widgets/option_button.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+import '../theme/colors.dart';
+
+/// One option button in a group of mutually-exclusive choices — e.g. the
+/// pause windows on the Net Rules tab and the verdict durations on the
+/// consent banner. Gives every such group the same look so it reads as one
+/// intentional control instead of a loose row of default buttons (#2502):
+/// pill-shaped, a shared minimum size (so the buttons align), the amber
+/// fill marking the active choice, and optional leading icon + tooltip.
+///
+/// Deliberately built on [FilledButton] / [OutlinedButton] (rather than a
+/// custom paint or [SegmentedButton]) so widget tests can keep asserting
+/// the active/inactive button types via [buttonKey], and so a tap on the
+/// already-active choice still fires [onPressed] (SegmentedButton swallows
+/// it in single-select mode).
+class KOptionButton extends StatelessWidget {
+  const KOptionButton({
+    required this.buttonKey,
+    required this.label,
+    required this.active,
+    required this.onPressed,
+    this.icon,
+    this.tooltip,
+  });
+
+  /// Key placed on the inner Material button (not this wrapper) so tests
+  /// can find and type-assert the FilledButton/OutlinedButton itself.
+  final Key buttonKey;
+  final String label;
+  final bool active;
+  final VoidCallback onPressed;
+
+  /// Optional leading affordance (e.g. pause/play on the pause windows).
+  final IconData? icon;
+
+  /// Optional hover/long-press explanation of what the choice does.
+  final String? tooltip;
+
+  /// Shared metrics: equal minimum footprint + pill shape across a group.
+  static const _minSize = Size(84, 34);
+  static const _shape = StadiumBorder();
+  static const _text = TextStyle(fontSize: 12);
+  static const _pad = EdgeInsets.symmetric(horizontal: 14);
+
+  Widget get _child {
+    if (icon == null) return Text(label);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14),
+        const SizedBox(width: 6),
+        Text(label),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final button = active
+        ? FilledButton(
+            key: buttonKey,
+            style: FilledButton.styleFrom(
+              backgroundColor: KColors.accentAmber,
+              foregroundColor: KColors.bgCanvas,
+              minimumSize: _minSize,
+              padding: _pad,
+              textStyle: _text,
+              visualDensity: VisualDensity.compact,
+              shape: _shape,
+            ),
+            onPressed: onPressed,
+            child: _child,
+          )
+        : OutlinedButton(
+            key: buttonKey,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: KColors.textSecondary,
+              side: const BorderSide(color: KColors.borderDefault),
+              minimumSize: _minSize,
+              padding: _pad,
+              textStyle: _text,
+              visualDensity: VisualDensity.compact,
+              shape: _shape,
+            ),
+            onPressed: onPressed,
+            child: _child,
+          );
+    if (tooltip == null) return button;
+    return Tooltip(message: tooltip!, child: button);
+  }
+}

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -26,9 +26,9 @@ library;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 import 'consent_decider_service.dart';
+import '../widgets/option_button.dart';
 
 /// A banner over the workspace body showing held egress requests + actions.
 ///
@@ -228,33 +228,14 @@ class _DurationSelector extends StatelessWidget {
   }
 
   Widget _button(String d) {
-    // The active button mirrors the pause buttons (#2497): amber
-    // background, canvas foreground; inactive stays outlined.
-    final active = d == value;
-    final key = ValueKey('dur-$d');
-    if (active) {
-      return FilledButton(
-        key: key,
-        style: FilledButton.styleFrom(
-          backgroundColor: KColors.accentAmber,
-          foregroundColor: KColors.bgCanvas,
-          visualDensity: VisualDensity.compact,
-          padding: const EdgeInsets.symmetric(horizontal: 10),
-          textStyle: const TextStyle(fontSize: 12),
-        ),
-        onPressed: () => onChanged(d),
-        child: Text(d),
-      );
-    }
-    return OutlinedButton(
-      key: key,
-      style: OutlinedButton.styleFrom(
-        visualDensity: VisualDensity.compact,
-        padding: const EdgeInsets.symmetric(horizontal: 10),
-        textStyle: const TextStyle(fontSize: 12),
-      ),
+    // Shared option-button look (#2502): amber fill for the active choice,
+    // pill shape, aligned minimum size -- same control language as the Net
+    // Rules pause buttons.
+    return KOptionButton(
+      buttonKey: ValueKey('dur-$d'),
+      label: d,
+      active: d == value,
       onPressed: () => onChanged(d),
-      child: Text(d),
     );
   }
 }

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -31,6 +31,7 @@ import 'package:flutter/material.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 import 'consent_decider_service.dart';
+import '../widgets/option_button.dart';
 
 /// Compact remaining-time label: ``5m``, ``2h``, ``3d``, ``1w`` (#2387).
 /// Mirrors the TUI ``_fmt_duration``.
@@ -418,9 +419,14 @@ class _PauseSection extends StatelessWidget {
             spacing: 8,
             runSpacing: 4,
             children: [
-              _pauseButton(null, 'Unpause'),
+              _pauseButton(null, 'Unpause',
+                  icon: Icons.play_arrow_outlined,
+                  tooltip: 'Consent prompts resume immediately'),
               for (final d in kConsentPauseDurations)
-                _pauseButton(d, 'Pause $d'),
+                _pauseButton(d, 'Pause $d',
+                    icon: Icons.pause_outlined,
+                    tooltip: 'Silence all consent prompts for '
+                        '${_pauseTooltip(d)}'),
             ],
           ),
         ],
@@ -428,30 +434,28 @@ class _PauseSection extends StatelessWidget {
     );
   }
 
-  Widget _pauseButton(String? duration, String label) {
+  /// Human wording for a window token in the button tooltip.
+  static String _pauseTooltip(String duration) => switch (duration) {
+        '15m' => '15 minutes',
+        '1h' => '1 hour',
+        '1d' => '1 day',
+        _ => duration,
+      };
+
+  Widget _pauseButton(String? duration, String label,
+      {IconData? icon, String? tooltip}) {
     // The active button mirrors the TUI's `pause-active` style: amber
-    // background, canvas foreground.
-    final active = duration == service.lastPauseRequest;
-    final key = ValueKey('pause-${duration ?? 'none'}');
-    final onPressed = () =>
-        duration == null ? service.sendUnpause() : service.sendPause(duration);
-    if (active) {
-      return FilledButton(
-        key: key,
-        style: FilledButton.styleFrom(
-          backgroundColor: KColors.accentAmber,
-          foregroundColor: KColors.bgCanvas,
-          visualDensity: VisualDensity.compact,
-        ),
-        onPressed: onPressed,
-        child: Text(label),
-      );
-    }
-    return OutlinedButton(
-      key: key,
-      style: OutlinedButton.styleFrom(visualDensity: VisualDensity.compact),
-      onPressed: onPressed,
-      child: Text(label),
+    // background, canvas foreground (#2502 restyle: shared pill shape +
+    // icon/tooltip affordances via [KOptionButton]).
+    return KOptionButton(
+      buttonKey: ValueKey('pause-${duration ?? 'none'}'),
+      label: label,
+      active: duration == service.lastPauseRequest,
+      icon: icon,
+      tooltip: tooltip,
+      onPressed: () => duration == null
+          ? service.sendUnpause()
+          : service.sendPause(duration),
     );
   }
 }

--- a/src/frontend/test/option_button_test.dart
+++ b/src/frontend/test/option_button_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/widgets/option_button.dart';
+
+void main() {
+  // The option-button group styling (#2502): active renders as a
+  // FilledButton (amber), inactive as an OutlinedButton, with the key on
+  // the Material button itself so tests can type-assert via the key —
+  // the contract the pause-window and duration-selector groups rely on.
+  testWidgets('active renders FilledButton, inactive OutlinedButton, by key',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: [
+            KOptionButton(
+              buttonKey: const ValueKey('opt-a'),
+              label: 'Choice A',
+              active: true,
+              onPressed: () {},
+            ),
+            KOptionButton(
+              buttonKey: const ValueKey('opt-b'),
+              label: 'Choice B',
+              active: false,
+              onPressed: () {},
+            ),
+          ],
+        ),
+      ),
+    ));
+    expect(find.text('Choice A'), findsOneWidget);
+    expect(find.text('Choice B'), findsOneWidget);
+    expect(tester.widget(find.byKey(const ValueKey('opt-a'))),
+        isA<FilledButton>());
+    expect(tester.widget(find.byKey(const ValueKey('opt-b'))),
+        isA<OutlinedButton>());
+  });
+
+  testWidgets('icon + tooltip render; onPressed fires on tap', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: KOptionButton(
+          buttonKey: const ValueKey('opt-x'),
+          label: 'Pause 15m',
+          active: false,
+          icon: Icons.pause_outlined,
+          tooltip: 'Silence all consent prompts for 15 minutes',
+          onPressed: () => taps++,
+        ),
+      ),
+    ));
+    expect(find.byIcon(Icons.pause_outlined), findsOneWidget);
+    expect(find.byTooltip('Silence all consent prompts for 15 minutes'),
+        findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('opt-x')));
+    expect(taps, 1);
+  });
+
+  testWidgets('without a tooltip no Tooltip widget is added', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: KOptionButton(
+          buttonKey: const ValueKey('opt-plain'),
+          label: 'plain',
+          active: false,
+          onPressed: () {},
+        ),
+      ),
+    ));
+    expect(find.byType(Tooltip), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

- Fixes #2502: the pause controls on the **Net Rules** tab (and the
  consent banner's duration selector, which mirrors them) rendered as a
  loose row of default Material buttons — no icons, tooltips, or
  consistent sizing, so the group read as a gray blob.
- New shared `KOptionButton` (`lib/widgets/option_button.dart`): pill
  shape (`StadiumBorder`), shared minimum size so a group aligns, amber
  fill (`accentAmber`/`bgCanvas`) for the active choice, optional leading
  icon + tooltip.
  - Pause buttons get pause/play icons and tooltips ("Silence all consent
    prompts for 15 minutes" / "Consent prompts resume immediately").
  - Both groups adopt it, so the two controls share one visual language.
- Deliberately **not** `SegmentedButton`: in single-select mode it
  swallows a tap on the already-selected segment, which would change the
  tested "re-tap active Unpause re-sends (idempotent)" behavior — and the
  issue scopes this to pure presentation. Keys stay on the inner
  `FilledButton`/`OutlinedButton`, so all existing widget tests pass
  unchanged.
- Changelog entry under `[Unreleased]` → Changed.

## Testing

- New `test/option_button_test.dart`: active/inactive widget types by
  key, icon + tooltip rendering, tap fires `onPressed`, no `Tooltip`
  wrapper when none is given.
- Full frontend suite (CI invocation):

```
devenv --quiet -O dotenv.enable:bool false shell -- flutter test --coverage
# 971 passed
```
