### PR TITLE
fix(cli): keep rules-screen focus across burst rebuilds

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -881,6 +881,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Rules-screen focus race (#2362).** In `klangk consent-decide`'s rules
+  view, two rule-set changes landing within one refresh cycle could drop
+  the row highlight to the top of the list, so a subsequent `x` revoked
+  the newest rule instead of the focused one. Focus is now remembered
+  across rebuilds and restored to the focused rule (or a deterministic
+  neighbor if it was revoked elsewhere).
 - **Stale pause in the consent-decide TUI after expiry (#2498).** A finite
   pause window (15m/1h/1d) whose time elapsed in an idle workspace no longer
   lingers as `paused 0s` on the pause bar and `Filtering paused (resumes in

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -1344,6 +1344,30 @@ class RulesScreen(Screen):
         ("x", "revoke", "Revoke"),
     ]
 
+    # #2362: the last highlighted revoke target (id + position), remembered
+    # from ``ListView.Highlighted`` events. ``lv.clear()`` inside a rebuild
+    # resets the highlight to None; without this memory a second rebuild
+    # bursting within the same refresh cycle would capture "no focus" and
+    # drop the restore, leaving the highlight on index 0 -- the newest rule
+    # -- so a subsequent ``x`` would revoke the wrong row.
+    _last_focused_rule_id: str | None = None
+    _last_focused_rule_index: int = 0
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        """Track the highlighted revoke target (#2362).
+
+        The None event (posted when ``clear()`` or a reset drops the
+        highlight) is ignored so the memory keeps the decider's last real
+        focus through rebuild bursts.
+        """
+        if event.item is None:
+            return
+        self._last_focused_rule_id = getattr(event.item, "rule_id", None)
+        for index, child in enumerate(event.list_view.children):
+            if child is event.item:
+                self._last_focused_rule_index = index
+                break
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static(id="rules-status")
@@ -1430,6 +1454,19 @@ class RulesScreen(Screen):
         rebuilt when the set of revocable rule ids changes, so the 1s refresh
         never flickers it. The static allow-list is intentionally absent -> it
         is never a revoke target.
+
+        Focus survives the rebuild (#2362): the focused rule id is captured
+        *before* ``lv.clear()`` resets the highlight, and restored once the
+        rebuild lands. The capture never reads None-through-a-burst: when
+        ``highlighted_child`` is already None (a first rebuild in the same
+        refresh cycle cleared it and its deferred restore has not landed), it
+        falls back to the id remembered from the last ``Highlighted`` event
+        (:attr:`_last_focused_rule_id`), which a ``clear()`` cannot clobber.
+        So two rule-set changes inside one refresh cycle -- an ``egress_rules``
+        refresh plus a ``revoke_ack``, or two near-simultaneous verdicts --
+        still restore the row the decider focused, never silently index 0
+        (the newest rule) of a reordered list. A subsequent ``x`` then
+        revokes the intended row.
         """
         lv = self.query_one("#rules-list", ListView)
         desired: list[str] = []
@@ -1444,6 +1481,11 @@ class RulesScreen(Screen):
             if lv.highlighted_child is not None
             else None
         )
+        if focused is None:
+            # Burst window: a prior rebuild in this same refresh cycle
+            # cleared the highlight and its restore has not landed yet --
+            # the remembered id is the decider's actual focus (#2362).
+            focused = self._last_focused_rule_id
         lv.clear()
         if rules is not None:
             for r in rules.allowed:
@@ -1458,7 +1500,15 @@ class RulesScreen(Screen):
                 for index, child in enumerate(_lv.children):
                     if getattr(child, "rule_id", None) == _focused:
                         _lv.index = index
-                        break
+                        return
+                # The focused rule left the snapshot (revoke ack elsewhere /
+                # expiry): fall to a deterministic neighbor -- the old focus
+                # position clamped to the new list -- never silently index 0
+                # of a reordered list.
+                if _lv.children:
+                    _lv.index = min(
+                        self._last_focused_rule_index, len(_lv.children) - 1
+                    )
 
             lv.call_after_refresh(_restore_focus)
 

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -2580,6 +2580,80 @@ class TestRulesRevoke:
             assert lv.highlighted_child is not None
             assert getattr(lv.highlighted_child, "rule_id", None) == "a2"
 
+    async def test_burst_rebuilds_keep_focus_on_focused_rule(self):
+        # #2362: two rule-set-changing frames delivered back-to-back -- no
+        # refresh cycle between them, so the first rebuild's clear() has
+        # reset the highlight before the second captures it -- must not
+        # drop the restore. The capture falls back to the id remembered
+        # from the last Highlighted event, so `x` afterwards revokes the
+        # row the decider actually focused, not index 0 (the newest rule).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("a1"), _rule("a2"), _rule("a3")])
+            )
+            app.action_rules()
+            await pilot.pause()
+            lv = app.screen.query_one("#rules-list", ListView)
+            lv.index = 2  # focus a3; index 0 is the newest rule
+            await pilot.pause()
+            # Burst: a1 revoked elsewhere while n1 is allowed elsewhere.
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("n1"), _rule("a2"), _rule("a3")])
+            )
+            app.screen.refresh_rules()  # rebuild 1 clears the highlight
+            app.controller.apply_frame(
+                _rules_frame(
+                    allowed=[
+                        _rule("n1"),
+                        _rule("n2"),
+                        _rule("a2"),
+                        _rule("a3"),
+                    ]
+                )
+            )
+            app.screen.refresh_rules()  # rebuild 2, same refresh cycle
+            assert lv.highlighted_child is None  # the burst reset it
+            await pilot.pause()
+            await pilot.pause()  # deferred restores land
+            lv = app.screen.query_one("#rules-list", ListView)
+            assert lv.highlighted_child is not None
+            assert getattr(lv.highlighted_child, "rule_id", None) == "a3"
+            # `x` revokes the focused row (a3), not the newest (n2).
+            app.screen.action_revoke()
+            await pilot.pause()
+            assert any('"revoke"' in s and '"a3"' in s for s in ws.sent), (
+                ws.sent
+            )
+            assert not any('"n2"' in s for s in ws.sent), ws.sent
+
+    async def test_focus_clamps_to_neighbor_when_focused_rule_removed(self):
+        # #2362: when the focused rule itself leaves the snapshot (revoke
+        # ack elsewhere / expiry), the highlight falls to a deterministic
+        # neighbor -- the old focus position clamped -- never silently to
+        # index 0 of a reordered list.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("a1"), _rule("a2"), _rule("a3")])
+            )
+            app.action_rules()
+            await pilot.pause()
+            lv = app.screen.query_one("#rules-list", ListView)
+            lv.index = 2  # focus the last row, a3
+            await pilot.pause()
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("a1"), _rule("a2")])
+            )
+            app.screen.refresh_rules()
+            await pilot.pause()
+            await pilot.pause()  # restore lands; a3 is gone -> clamp
+            lv = app.screen.query_one("#rules-list", ListView)
+            assert lv.highlighted_child is not None
+            assert getattr(lv.highlighted_child, "rule_id", None) == "a2"
+
 
 # ---------------------------------------------------------------------------
 # Persistent popup role: q hides the viewer, Q confirms a real quit (#2383).


### PR DESCRIPTION
Closes #2362.

## What

Fixes the focus-restore race in `consent-decide`'s rules screen where two
rule-set-changing frames landing within one Textual refresh cycle could
drop the row highlight to index 0 (the newest rule) — so a subsequent `x`
revoked the **wrong** row.

`RulesScreen` now remembers the last highlighted revoke target (rule id +
position) from `ListView.Highlighted` events, ignoring the `None` event
that `lv.clear()` posts. When `_rebuild_rule_list` captures focus inside
the burst window — `highlighted_child` already None because a prior
rebuild in the same cycle cleared it and its deferred restore hasn't
landed — it falls back to the remembered id, so the restore always targets
the row the decider actually focused. If the focused rule itself left the
snapshot (revoked elsewhere / expired), the highlight clamps to the old
focus position in the new list — a deterministic neighbor, never silently
index 0 of a reordered list.

Design note: I first implemented the issue's diff-style rebuild (in-place
mount/move/remove without `clear()`), but Textual's deferred node removal
(`remove_children` lands via `call_next`) makes the restore-vs-prune
ordering timing-fragile — verified flaky under pytest vs standalone. The
remembered-highlight capture keeps the proven `clear()`+append flow and
eliminates the actual failure mode (the None capture + index-into-
reordered-list restore) deterministically.

## Tests

- Burst: two `refresh_rules()` calls with no pause between frames — the
  highlight stays on the focused row and `x` revokes it, not the newest.
- Focused-rule-removed: highlight clamps to the deterministic neighbor.
- Existing focus-restore test unchanged and green.

Full backend suite: 4934 passed, 100% coverage. Re-verified post-rebase.
