### PR TITLE
fix(frontend): break consent-banner redirect loop for logged-in users

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -881,6 +881,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Login-banner redirect loop on return visits.** Opening the app with
+  a saved login token while a login banner was pending (`login_banner_every_visit`
+  on, or a banner whose text changed since it was last accepted) hit a
+  `/consent` ⇄ `/workspaces` redirect loop instead of showing the banner.
+  The banner gate is now terminal while a banner is pending, so the
+  consent page renders and accepting it proceeds as before.
 - **Rules-screen focus race (#2362).** In `klangk consent-decide`'s rules
   view, two rule-set changes landing within one refresh cycle could drop
   the row highlight to the top of the list, so a subsequent `x` revoked

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -100,6 +100,14 @@ String? guardRoot({required bool isLoggedIn, required String loc}) {
 ///
 /// [publicRoutes] should already include the feature paths; [featurePaths]
 /// is passed separately so [guardLoggedInPublicRoute] can exclude them.
+///
+/// While a banner is pending, the banner gate is **terminal**: `/consent`
+/// is the only legal location, for logged-out and logged-in users alike.
+/// Falling through to the guards below would let [guardLoggedInPublicRoute]
+/// bounce a logged-in user off `/consent` (a public route) straight back
+/// into the banner gate — the `/consent => /workspaces => /consent`
+/// redirect loop hit whenever `bannerRequired` is true with a persisted
+/// token (`login_banner_every_visit`, or a changed banner text).
 String? evaluateGuards({
   required bool isLoggedIn,
   required bool bannerRequired,
@@ -108,7 +116,10 @@ String? evaluateGuards({
   required Set<String> publicRoutes,
   required Set<String> featurePaths,
 }) {
-  return guardBanner(bannerRequired: bannerRequired, loc: loc) ??
+  if (bannerRequired) {
+    return guardBanner(bannerRequired: true, loc: loc);
+  }
+  return guardBanner(bannerRequired: false, loc: loc) ??
       guardAuth(
         isLoggedIn: isLoggedIn,
         loc: loc,

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -212,6 +212,38 @@ void main() {
       expect(pendingRedirect, isNull);
     });
 
+    test('banner gate is terminal: logged-in user stays on /consent', () {
+      // Regression: with a persisted token and bannerRequired true
+      // (login_banner_every_visit on a return visit), the logged-in-on-
+      // public guard used to bounce /consent -> /workspaces -> /consent
+      // in an infinite loop. The banner gate must decide alone here.
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: true,
+          loc: '/consent',
+          currentUri: '/consent',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+        ),
+        isNull,
+      );
+    });
+
+    test('banner gate forces /consent even for logged-in users', () {
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: true,
+          loc: '/workspaces',
+          currentUri: '/workspaces',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+        ),
+        '/consent',
+      );
+    });
+
     test('logged-out protected route -> /login with pendingRedirect', () {
       expect(
         evaluateGuards(


### PR DESCRIPTION
# Pull request

## What this changes

Makes the login-banner gate terminal in `evaluateGuards` (`src/frontend/lib/app_guards.dart`): while a banner is pending, `guardBanner`'s verdict alone decides the navigation, and the other guards are not consulted. Previously a logged-in user on `/consent` fell through to `guardLoggedInPublicRoute`, which bounces logged-in users off public routes to `/workspaces`; the banner gate then sent them back to `/consent` — GoRouter aborted with `redirect loop detected /consent => /workspaces => /consent`. Also adds a `Fixed` entry to `docs/changes.md`.

## Why

Any session with a persisted token plus a pending banner hit the loop and rendered a blank screen. That combination is exactly what `login_banner_every_visit: true` produces on every return visit (acceptance is session-only by design, #1544), and it also occurs after an operator edits the banner text (hash mismatch vs. the stored acceptance). The user-facing setting is `login_banner_every_visit`; a `login_banner_every_time` key in klangk.yaml is silently ignored.

## How it was tested

- Two regression tests in `test/app_guards_test.dart`: a logged-in user at `/consent` with `bannerRequired: true` is allowed to stay (previously the loop), and a logged-in user at `/workspaces` is still forced to `/consent`.
- Full frontend suite the CI way (`test-frontend`, i.e. `flutter test --coverage`): 974 tests pass, 100% coverage maintained.
- Reproduced the original report (`login_banner` + `login_banner_every_visit` + accepted banner, restart browser): before the fix the console shows the loop; after it the consent page renders.

## Checklist

- [x] I've described what and why above.
- [x] I've noted how I tested this.
- [x] This is my own, reviewed work — not an unreviewed automated/LLM-generated
      drive-by.
