### PR TITLE
fix(frontend): title the allowed-domains editor in the Add Workspace dialog

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -881,6 +881,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Add Workspace dialog netfilter section (#2508).** The
+  allowed-domains editor now has an "Allowed Domains" title and
+  description, matching the rejected-domains editor and the workspace
+  settings panel.
 - **Login-banner redirect loop on return visits.** Opening the app with
   a saved login token while a login banner was pending (`login_banner_every_visit`
   on, or a banner whose text changed since it was last accepted) hit a

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -712,6 +712,13 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
 
   List<Widget> _buildAllowedDomainsEditor() {
     return [
+      Text('Allowed Domains', style: _labelStyle),
+      const SizedBox(height: 4),
+      Text(
+        'Hosts the workspace may always contact (egress allowlist).',
+        style: const TextStyle(fontSize: 12, color: KColors.textSecondary),
+      ),
+      const SizedBox(height: 8),
       ..._allowedDomains.asMap().entries.map(
             (e) => Padding(
               padding: const EdgeInsets.only(bottom: 4),

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -552,6 +552,21 @@ void main() {
       expect(find.text('blocked.example.com'), findsNothing);
     });
 
+    testWidgets('labels both domains editors with titles (#2508)',
+        (tester) async {
+      // The allowed-domains editor previously had no title, unlike the
+      // rejected-domains editor below it and the settings panel's copy.
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Allowed Domains'), findsOneWidget);
+      expect(find.text('Rejected Domains'), findsOneWidget);
+    });
+
     testWidgets('pre-fills allowed domains from the deploy default',
         (tester) async {
       // #1365: the editor inherits KLANGKD_NETFILTER_DEFAULT_DOMAINS so a


### PR DESCRIPTION
## Summary

Adds the missing **Allowed Domains** title (plus a one-line description) to the allowed-domains editor in the Add Workspace dialog's Netfilter section, matching the rejected-domains editor below it and the settings panel's copy of the control.

Fixes #2508.

## Changes

- `create_workspace_dialog.dart`: `_buildAllowedDomainsEditor()` now opens with `Text('Allowed Domains', style: _labelStyle)` + description, mirroring `_buildRejectedDomainsEditor()`.
- Test: asserts both editors render their titles.
- Changelog entry under `[Unreleased]` / `Fixed`.

## Testing

`flutter test --coverage` — all 975 tests pass.
