### PR TITLE
feat(frontend): per-row duration menus on consent banner split buttons

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -597,9 +597,9 @@ operators or integrators to act when upgrading.
   Purely presentational — keys and behavior unchanged.
 - **Consent banner per-row duration menus (#2499).** Each row of the
   egress-consent banner has a split Allow/Deny button: a bare click sends
-  the verdict with the default duration (`until restart`), and the attached
-  ▾ menu sends it with any other duration (`just once`, `5 minutes`, …,
-  `forever`) in one step. The duration is chosen with the click, never armed
+  the verdict with the default duration (until restart), and the attached
+  ▾ menu sends it with any other duration (just once, 5 minutes, …,
+  forever) in one step. The duration is chosen with the click, never armed
   beforehand, and no longer takes up a button row of its own.
 - **`KLANGKD_IDLE_TIMEOUT_SECONDS` default 30m → 60m (#2480).** The workspace container idle timeout now defaults to 3600s (was 1800s). Existing
   deployments get a longer idle window on upgrade unless the env var is already

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -223,8 +223,8 @@ operators or integrators to act when upgrading.
 
 - **Interactive egress-consent banner in the web UI (#2246).** Workspaces
   in `interactive` egress mode now show a banner on the workspace page listing
-  pending held egress requests (host:port, process, countdown) with a global
-  duration selector + per-row Allow/Deny, mirroring the `consent-decide`
+  pending held egress requests (host:port, process, countdown) with per-row
+  Allow/Deny verdict buttons, alongside the `consent-decide`
   TUI; verdicts go live over the `/ws/consent-decider` stream. Server error
   frames, verdict send failures, and verdicts attempted while disconnected
   surface as a transient flash so a rejected/lost verdict is never silent.
@@ -590,16 +590,17 @@ operators or integrators to act when upgrading.
   previously titled **Net Rules** (originally "Rules", #2457) is now
   titled **Network**. Presentation only; the tab's contents are
   unchanged.
-- **Restyled pause/duration option buttons (#2502).** The Net Rules pause
-  controls (Unpause / Pause 15m / 1h / 1d) and the consent banner's duration
-  selector now share one pill-shaped option-button look with equal sizing,
-  pause/play icons, and tooltips; the active choice keeps the amber fill.
+- **Restyled pause option buttons (#2502).** The Network tab's pause
+  controls (Unpause / Pause 15m / 1h / 1d) now share one pill-shaped
+  option-button look with equal sizing, pause/play icons, and tooltips;
+  the active choice keeps the amber fill.
   Purely presentational — keys and behavior unchanged.
-- **Consent banner duration buttons (#2499).** The egress-consent banner's
-  verdict-duration dropdown is now a row of compact buttons (one per
-  duration, the selected one highlighted), matching the `consent-decide`
-  TUI's duration selector. Behavior is unchanged: one global selection,
-  default `tilrestart`, applied on the next Allow/Deny.
+- **Consent banner per-row duration menus (#2499).** Each row of the
+  egress-consent banner has a split Allow/Deny button: a bare click sends
+  the verdict with the default duration (`until restart`), and the attached
+  ▾ menu sends it with any other duration (`just once`, `5 minutes`, …,
+  `forever`) in one step. The duration is chosen with the click, never armed
+  beforehand, and no longer takes up a button row of its own.
 - **`KLANGKD_IDLE_TIMEOUT_SECONDS` default 30m → 60m (#2480).** The workspace container idle timeout now defaults to 3600s (was 1800s). Existing
   deployments get a longer idle window on upgrade unless the env var is already
   set; set `KLANGKD_IDLE_TIMEOUT_SECONDS=1800` to keep the old 30-minute default.

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -164,8 +164,10 @@ left pending forever.
   shell in a local tmux that floats the decider over it as a popup: a
   held request pops up without leaving the shell (`C-a p` reopens it;
   skip the wrapper with `--no-consent-popup`) (#2383).
-- **Web UI** — the workspace page shows a consent banner with the same
-  allow/deny + duration controls (#2246), plus a **Network** tab
+- **Web UI** — the workspace page shows a consent banner with per-row
+  allow/deny split buttons: a bare click uses the default duration
+  (`until restart`), and the attached ▾ menu sends the verdict with any
+  other duration (#2246, #2499), plus a **Network** tab
   listing the in-effect rules with revoke actions.
 - **Deploy-wide** — an admin may connect a decider without a workspace
   scope (via the `/ws/consent-decider` WebSocket) to decide for every

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -166,7 +166,7 @@ left pending forever.
   skip the wrapper with `--no-consent-popup`) (#2383).
 - **Web UI** — the workspace page shows a consent banner with per-row
   allow/deny split buttons: a bare click uses the default duration
-  (`until restart`), and the attached ▾ menu sends the verdict with any
+  (until restart), and the attached ▾ menu sends the verdict with any
   other duration (#2246, #2499), plus a **Network** tab
   listing the in-effect rules with revoke actions.
 - **Deploy-wide** — an admin may connect a decider without a workspace

--- a/src/frontend/lib/widgets/option_button.dart
+++ b/src/frontend/lib/widgets/option_button.dart
@@ -3,8 +3,7 @@ import 'package:flutter/material.dart';
 import '../theme/colors.dart';
 
 /// One option button in a group of mutually-exclusive choices — e.g. the
-/// pause windows on the Network tab and the verdict durations on the
-/// consent banner. Gives every such group the same look so it reads as one
+/// pause windows on the Network tab. Gives every such group the same look so it reads as one
 /// intentional control instead of a loose row of default buttons (#2502):
 /// pill-shaped, a shared minimum size (so the buttons align), the amber
 /// fill marking the active choice, and optional leading icon + tooltip.

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -179,6 +179,8 @@ class _ConsentBannerState extends State<ConsentBanner> {
             label: 'Allow',
             color: Colors.green,
             menuKey: ValueKey('allow-dur-${req.id}'),
+            service: service,
+            requestId: req.id,
             onVerdict: (d) => service.sendVerdict(req.id, kDecisionAllowed, d),
           ),
           const SizedBox(width: 6),
@@ -186,6 +188,8 @@ class _ConsentBannerState extends State<ConsentBanner> {
             label: 'Deny',
             color: Colors.red,
             menuKey: ValueKey('deny-dur-${req.id}'),
+            service: service,
+            requestId: req.id,
             onVerdict: (d) => service.sendVerdict(req.id, kDecisionDenied, d),
           ),
         ],
@@ -219,6 +223,8 @@ class _VerdictButton extends StatelessWidget {
     required this.label,
     required this.color,
     required this.menuKey,
+    required this.service,
+    required this.requestId,
     required this.onVerdict,
   });
 
@@ -228,9 +234,20 @@ class _VerdictButton extends StatelessWidget {
   /// Key on the `▾` segment (unique per row, e.g. `allow-dur-<requestId>`).
   final Key menuKey;
 
+  /// The banner's service -- watched while the menu is open so the menu can
+  /// close itself if its row's request resolves mid-menu (see [_openMenu]).
+  final ConsentDeciderService service;
+
+  /// The row's request id (the verdict target).
+  final String requestId;
+
   /// Sends this button's decision with `duration` (a [kConsentDurations]
   /// token).
   final void Function(String duration) onVerdict;
+
+  /// Display label for a duration token; falls back to the raw token if the
+  /// map ever lags behind [kConsentDurations] (degrades, never crashes).
+  static String _label(String d) => _durationLabels[d] ?? d;
 
   ButtonStyle _style(Color color, BorderRadius radius) {
     return FilledButton.styleFrom(
@@ -251,9 +268,7 @@ class _VerdictButton extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Tooltip(
-          message:
-              '$label ${_durationLabels[kConsentDurationDefault]!.toLowerCase()}'
-              ' — ▾ picks another duration',
+          message: '$label ${_label(kConsentDurationDefault).toLowerCase()}',
           child: FilledButton(
             onPressed: () => onVerdict(kConsentDurationDefault),
             style: _style(
@@ -265,14 +280,17 @@ class _VerdictButton extends StatelessWidget {
         ),
         // Builder so the menu anchors to the ▾ segment's own render box.
         Builder(
-          builder: (ctx) => FilledButton(
-            key: menuKey,
-            onPressed: () => _openMenu(ctx),
-            style: _style(
-              color,
-              const BorderRadius.horizontal(right: Radius.circular(6)),
+          builder: (ctx) => Tooltip(
+            message: 'Choose duration',
+            child: FilledButton(
+              key: menuKey,
+              onPressed: () => _openMenu(ctx),
+              style: _style(
+                color,
+                const BorderRadius.horizontal(right: Radius.circular(6)),
+              ),
+              child: const Icon(Icons.arrow_drop_down, size: 18),
             ),
-            child: const Icon(Icons.arrow_drop_down, size: 18),
           ),
         ),
       ],
@@ -281,24 +299,54 @@ class _VerdictButton extends StatelessWidget {
 
   /// Open the duration menu below the `▾` segment; a pick submits the verdict
   /// with the chosen duration, dismissing without a pick sends nothing.
+  ///
+  /// The position is the button's bottom edge expressed relative to the
+  /// overlay (`RelativeRect.fromRect`), so the menu's placement delegate
+  /// clamps it inside the viewport -- a plain `RelativeRect.fromLTRB(dx, dy,
+  /// dx, dy)` inverts its right edge once the button sits right of the
+  /// viewport's midpoint and pushes menu items off-screen at phone widths.
+  ///
+  /// If the row's request resolves while the menu is open, the menu closes
+  /// itself: the verdict target is gone, and a pick would otherwise send a
+  /// verdict the server silently drops (the banner's no-silent-loss promise
+  /// covers rejected sends, not ones aimed at a dead id).
   void _openMenu(BuildContext context) {
-    final box = context.findRenderObject() as RenderBox;
-    final pos = box.localToGlobal(Offset(0, box.size.height + 4));
-    showMenu<String>(
+    final button = context.findRenderObject() as RenderBox;
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final topLeft = button.localToGlobal(
+      Offset(0, button.size.height + 4),
+      ancestor: overlay,
+    );
+    final position = RelativeRect.fromRect(
+      Rect.fromLTWH(topLeft.dx, topLeft.dy, button.size.width, 0),
+      Offset.zero & overlay.size,
+    );
+    final nav = Navigator.of(context);
+    void closeIfGone() {
+      if (service.pending.every((r) => r.id != requestId)) {
+        service.removeListener(closeIfGone);
+        if (nav.mounted) nav.pop(); // dismiss the menu; no verdict is sent
+      }
+    }
+
+    service.addListener(closeIfGone);
+    final menu = showMenu<String>(
       context: context,
-      position: RelativeRect.fromLTRB(pos.dx, pos.dy, pos.dx, pos.dy),
+      position: position,
       items: [
         for (final d in kConsentDurations)
           PopupMenuItem(
             value: d,
             child: Text(
               d == kConsentDurationDefault
-                  ? '${_durationLabels[d]} (default)'
-                  : _durationLabels[d]!,
+                  ? '${_label(d)} (default)'
+                  : _label(d),
             ),
           ),
       ],
-    ).then((d) {
+    );
+    menu.whenComplete(() => service.removeListener(closeIfGone));
+    menu.then((d) {
       if (d != null) onVerdict(d);
     });
   }

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -1,15 +1,17 @@
 /// Interactive egress-consent banner for the workspace page (#2246).
 ///
 /// A compact banner shown above the workspace body when [ConsentDeciderService]
-/// has pending held requests (interactive `egress_mode` only). Below the
-/// header it carries a single *global* duration selector (#2499) -- one
-/// compact button per selectable duration (default `tilrestart`), the active
-/// one filled, mirroring the TUI's `#duration-selector` button row -- and
-/// each row shows the destination host:port (+ process + a countdown) and
-/// Allow/Deny buttons that send a `verdict` frame carrying the selected
-/// duration. One selector for the whole list, applied at allow/deny time --
-/// not per row -- matching the standalone `klangk consent-decide` TUI,
-/// adapted to an inline Flutter banner.
+/// has pending held requests (interactive `egress_mode` only). Each row shows
+/// the destination host:port (+ process + a countdown) and an Allow/Deny
+/// **split button**: a bare click sends the `verdict` frame with the default
+/// duration (`tilrestart`), and the attached `▾` segment opens a menu of
+/// durations -- picking one sends the verdict with that duration immediately.
+/// The duration is chosen with the click, never armed beforehand: the earlier
+/// global duration pill row (#2499) put the selector far from the row actions
+/// and left a selection armed that silently applied to whichever row was
+/// clicked next, so it was replaced by this per-row pattern (the
+/// pointer-first web analogue of the keyboard-first `klangk consent-decide`
+/// TUI's global selector).
 ///
 /// Server error frames, verdict send failures, and verdicts attempted while
 /// disconnected surface as a transient flash row (the service's
@@ -28,7 +30,20 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'consent_decider_service.dart';
-import '../widgets/option_button.dart';
+
+/// Human labels for the verdict durations (menu display only -- the wire
+/// tokens from [kConsentDurations] stay raw). The default gets its "(default)"
+/// suffix in the menu item, not here.
+const Map<String, String> _durationLabels = {
+  'once': 'Just once',
+  '5m': '5 minutes',
+  '15m': '15 minutes',
+  '1h': '1 hour',
+  '1d': '1 day',
+  '1w': '1 week',
+  'tilrestart': 'Until restart',
+  'forever': 'Forever',
+};
 
 /// A banner over the workspace body showing held egress requests + actions.
 ///
@@ -44,10 +59,6 @@ class ConsentBanner extends StatefulWidget {
 }
 
 class _ConsentBannerState extends State<ConsentBanner> {
-  /// The chosen verdict duration, applied to whichever row's Allow/Deny is
-  /// tapped. One selector for the whole banner (default `tilrestart`), mirroring
-  /// the TUI's single global `#duration-selector` -- not a per-row choice.
-  String _duration = kConsentDurationDefault;
   Timer? _tick;
 
   @override
@@ -115,16 +126,6 @@ class _ConsentBannerState extends State<ConsentBanner> {
               ],
             ),
           ),
-          // One global duration selector (TUI parity, #2499): applies to the
-          // next Allow/Deny tapped on any row. Not per row. Selecting does NOT
-          // submit -- only a row's Allow/Deny submits with this duration.
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
-            child: _DurationSelector(
-              value: _duration,
-              onChanged: (v) => setState(() => _duration = v),
-            ),
-          ),
           if (flash != null)
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 4, 16, 2),
@@ -174,18 +175,18 @@ class _ConsentBannerState extends State<ConsentBanner> {
             ),
           ),
           const SizedBox(width: 8),
-          _ActionChip(
+          _VerdictButton(
             label: 'Allow',
             color: Colors.green,
-            onPressed: () =>
-                service.sendVerdict(req.id, kDecisionAllowed, _duration),
+            menuKey: ValueKey('allow-dur-${req.id}'),
+            onVerdict: (d) => service.sendVerdict(req.id, kDecisionAllowed, d),
           ),
-          const SizedBox(width: 4),
-          _ActionChip(
+          const SizedBox(width: 6),
+          _VerdictButton(
             label: 'Deny',
             color: Colors.red,
-            onPressed: () =>
-                service.sendVerdict(req.id, kDecisionDenied, _duration),
+            menuKey: ValueKey('deny-dur-${req.id}'),
+            onVerdict: (d) => service.sendVerdict(req.id, kDecisionDenied, d),
           ),
         ],
       ),
@@ -208,64 +209,97 @@ class _BannerSurface extends StatelessWidget {
   }
 }
 
-/// The global duration selector (#2499): one compact button per selectable
-/// duration, the active one filled -- TUI parity (the `#duration-selector`
-/// row with its accent `dur-sel` class, cli/tui/consent.py), styled like the
-/// Network pause buttons (#2497). Selecting does NOT submit -- only a
-/// row's Allow/Deny submits with the chosen duration.
-class _DurationSelector extends StatelessWidget {
-  const _DurationSelector({required this.value, required this.onChanged});
-  final String value;
-  final ValueChanged<String> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 6,
-      runSpacing: 4,
-      children: [for (final d in kConsentDurations) _button(d)],
-    );
-  }
-
-  Widget _button(String d) {
-    // Shared option-button look (#2502): amber fill for the active choice,
-    // pill shape, aligned minimum size -- same control language as the Net
-    // Rules pause buttons.
-    return KOptionButton(
-      buttonKey: ValueKey('dur-$d'),
-      label: d,
-      active: d == value,
-      onPressed: () => onChanged(d),
-    );
-  }
-}
-
-/// A small colored action button (Allow/Deny) for a request row.
-class _ActionChip extends StatelessWidget {
-  const _ActionChip({
+/// A split action button (Allow/Deny) for one request row: the main segment
+/// submits with the default duration, the attached `▾` segment opens a menu
+/// and a pick submits with that duration right away. Attaching the menu to
+/// the action keeps the duration choice next to the Allow/Deny it applies to
+/// (the #2499 global pill row was replaced by this per-row pattern).
+class _VerdictButton extends StatelessWidget {
+  const _VerdictButton({
     required this.label,
     required this.color,
-    required this.onPressed,
+    required this.menuKey,
+    required this.onVerdict,
   });
+
   final String label;
   final Color color;
-  final VoidCallback onPressed;
+
+  /// Key on the `▾` segment (unique per row, e.g. `allow-dur-<requestId>`).
+  final Key menuKey;
+
+  /// Sends this button's decision with `duration` (a [kConsentDurations]
+  /// token).
+  final void Function(String duration) onVerdict;
+
+  ButtonStyle _style(Color color, BorderRadius radius) {
+    return FilledButton.styleFrom(
+      backgroundColor: color,
+      foregroundColor: Colors.white,
+      minimumSize: const Size(0, 28),
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      textStyle: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+      visualDensity: VisualDensity.compact,
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      shape: RoundedRectangleBorder(borderRadius: radius),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 28,
-      child: FilledButton.icon(
-        onPressed: onPressed,
-        style: FilledButton.styleFrom(
-          backgroundColor: color,
-          foregroundColor: Colors.white,
-          padding: const EdgeInsets.symmetric(horizontal: 10),
-          textStyle: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Tooltip(
+          message:
+              '$label ${_durationLabels[kConsentDurationDefault]!.toLowerCase()}'
+              ' — ▾ picks another duration',
+          child: FilledButton(
+            onPressed: () => onVerdict(kConsentDurationDefault),
+            style: _style(
+              color,
+              const BorderRadius.horizontal(left: Radius.circular(6)),
+            ),
+            child: Text(label),
+          ),
         ),
-        icon: const SizedBox.shrink(),
-        label: Text(label),
-      ),
+        // Builder so the menu anchors to the ▾ segment's own render box.
+        Builder(
+          builder: (ctx) => FilledButton(
+            key: menuKey,
+            onPressed: () => _openMenu(ctx),
+            style: _style(
+              color,
+              const BorderRadius.horizontal(right: Radius.circular(6)),
+            ),
+            child: const Icon(Icons.arrow_drop_down, size: 18),
+          ),
+        ),
+      ],
     );
+  }
+
+  /// Open the duration menu below the `▾` segment; a pick submits the verdict
+  /// with the chosen duration, dismissing without a pick sends nothing.
+  void _openMenu(BuildContext context) {
+    final box = context.findRenderObject() as RenderBox;
+    final pos = box.localToGlobal(Offset(0, box.size.height + 4));
+    showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(pos.dx, pos.dy, pos.dx, pos.dy),
+      items: [
+        for (final d in kConsentDurations)
+          PopupMenuItem(
+            value: d,
+            child: Text(
+              d == kConsentDurationDefault
+                  ? '${_durationLabels[d]} (default)'
+                  : _durationLabels[d]!,
+            ),
+          ),
+      ],
+    ).then((d) {
+      if (d != null) onVerdict(d);
+    });
   }
 }

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -31,7 +31,8 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 const String kDecisionAllowed = 'allowed';
 const String kDecisionDenied = 'denied';
 
-/// Ordered for the duration selector; the default is `tilrestart` (#2328).
+/// Offered (in order) by the banner's per-row duration menus; the default
+/// is `tilrestart` (#2328).
 /// The test-only `5s` is NOT offered (#2487) -- it's not meant for end users --
 /// but stays recognized for in-effect/countdown math and programmatic/test
 /// callers (it remains in `kConsentDurationSeconds` below).

--- a/src/frontend/test/consent_banner_test.dart
+++ b/src/frontend/test/consent_banner_test.dart
@@ -150,6 +150,8 @@ void main() {
     final out = jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
     expect(out['decision'], 'denied');
     expect(out['request_id'], 'r2');
+    // A bare Deny click carries the default duration, like Allow.
+    expect(out['duration'], 'tilrestart');
     svc.dispose();
   });
 
@@ -179,7 +181,7 @@ void main() {
   });
 
   testWidgets(
-    'the global duration selector is one button per duration (#2499)',
+    'the Allow ▾ menu offers every duration and submits the choice',
     (tester) async {
       final channel = _FakeChannel();
       final svc = _serviceWithChannel(channel);
@@ -196,70 +198,73 @@ void main() {
       });
       await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
       await tester.pump();
-      // No dropdown anywhere; one button per selectable duration (TUI parity),
-      // and the test-only 5s is not offered (#2487).
-      expect(find.byType(DropdownButton<String>), findsNothing);
-      expect(find.byKey(const ValueKey('dur-5s')), findsNothing);
-      for (final d in kConsentDurations) {
-        expect(find.byKey(ValueKey('dur-$d')), findsOneWidget);
-      }
-      // The default (tilrestart) is the active filled button; others outlined.
-      expect(
-        tester.widget(find.byKey(const ValueKey('dur-tilrestart'))),
-        isA<FilledButton>(),
-      );
-      expect(
-        tester.widget(find.byKey(const ValueKey('dur-1d'))),
-        isA<OutlinedButton>(),
-      );
+      // The #2499 global pill row is gone; durations live on the row's menu.
+      expect(find.byKey(const ValueKey('dur-1d')), findsNothing);
+      // Open the menu anchored to the ▾ segment.
+      await tester.tap(find.byKey(const ValueKey('allow-dur-r1')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      // Every selectable duration is offered (human labels, default marked);
+      // the test-only 5s is not (#2487).
+      expect(find.text('Just once'), findsOneWidget);
+      expect(find.text('1 day'), findsOneWidget);
+      expect(find.text('Until restart (default)'), findsOneWidget);
+      expect(find.text('Forever'), findsOneWidget);
+      expect(find.text('5 seconds'), findsNothing);
+      // Dismissing without a pick sends nothing.
+      await tester.tapAt(const Offset(5, 5));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(channel.sent, isEmpty);
+      // Picking a duration submits the verdict with it immediately.
+      await tester.tap(find.byKey(const ValueKey('allow-dur-r1')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('1 day'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      final out =
+          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+      expect(out['type'], 'verdict');
+      expect(out['request_id'], 'r1');
+      expect(out['decision'], 'allowed');
+      expect(out['duration'], '1d');
       svc.dispose();
     },
   );
 
-  testWidgets('selecting a duration applies it to the next Allow', (
-    tester,
-  ) async {
-    final channel = _FakeChannel();
-    final svc = _serviceWithChannel(channel);
-    svc.connect();
-    channel.serverSend({
-      'type': 'egress_request',
-      'request': {
-        'id': 'r1',
-        'workspace_id': 'ws',
-        'dest_host': 'example.com',
-        'dest_port': 443,
-        'requested_at': 2000.0,
-      },
-    });
-    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
-    await tester.pump();
-    // Tap the already-active button (tilrestart): a no-op reselect that
-    // keeps it active -- and exercises the filled button's onPressed.
-    await tester.tap(find.byKey(const ValueKey('dur-tilrestart')));
-    await tester.pump();
-    expect(tester.widget(find.byKey(const ValueKey('dur-tilrestart'))),
-        isA<FilledButton>());
-
-    // Tap the 1d duration button -- selecting does NOT submit, it only moves
-    // the highlight; the verdict still needs an Allow/Deny tap.
-    await tester.tap(find.byKey(const ValueKey('dur-1d')));
-    await tester.pump();
-    expect(
-      tester.widget(find.byKey(const ValueKey('dur-1d'))),
-      isA<FilledButton>(),
-    );
-    expect(
-      tester.widget(find.byKey(const ValueKey('dur-tilrestart'))),
-      isA<OutlinedButton>(),
-    );
-    // The chosen duration now rides on the verdict.
-    await tester.tap(find.text('Allow'));
-    await tester.pump();
-    final out = jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
-    expect(out['duration'], '1d');
-    svc.dispose();
-  });
+  testWidgets(
+    'the Deny ▾ menu submits a deny verdict with the chosen duration',
+    (tester) async {
+      final channel = _FakeChannel();
+      final svc = _serviceWithChannel(channel);
+      svc.connect();
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'r2',
+          'workspace_id': 'ws',
+          'dest_host': 'bad.io',
+          'dest_port': 22,
+          'requested_at': 2000.0,
+        },
+      });
+      await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('deny-dur-r2')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Forever'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      final out =
+          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+      expect(out['decision'], 'denied');
+      expect(out['request_id'], 'r2');
+      expect(out['duration'], 'forever');
+      svc.dispose();
+    },
+  );
 
   testWidgets('shows a flash for a server error frame', (tester) async {
     final channel = _FakeChannel();

--- a/src/frontend/test/consent_banner_test.dart
+++ b/src/frontend/test/consent_banner_test.dart
@@ -266,6 +266,80 @@ void main() {
     },
   );
 
+  testWidgets(
+    'the duration menu stays on screen at phone widths',
+    (tester) async {
+      tester.view.physicalSize = const Size(420, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final channel = _FakeChannel();
+      final svc = _serviceWithChannel(channel);
+      svc.connect();
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'r1',
+          'workspace_id': 'ws',
+          'dest_host': 'example.com',
+          'dest_port': 443,
+          'requested_at': 2000.0,
+        },
+      });
+      await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('allow-dur-r1')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      // Regression (PR review): an overlay-relative position keeps every
+      // menu item inside the viewport even when the ▾ sits right of the
+      // viewport's midpoint (the Expanded host label pushes it there).
+      final item = find.text('Forever');
+      expect(item, findsOneWidget);
+      expect(tester.getTopLeft(item).dx, greaterThanOrEqualTo(0));
+      // On-screen means actually tappable: the pick lands on the socket.
+      await tester.tap(item);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      final out =
+          jsonDecode(channel.sent.last as String) as Map<String, dynamic>;
+      expect(out['duration'], 'forever');
+      svc.dispose();
+    },
+  );
+
+  testWidgets(
+    'the menu closes itself if its request resolves while open',
+    (tester) async {
+      final channel = _FakeChannel();
+      final svc = _serviceWithChannel(channel);
+      svc.connect();
+      channel.serverSend({
+        'type': 'egress_request',
+        'request': {
+          'id': 'r1',
+          'workspace_id': 'ws',
+          'dest_host': 'example.com',
+          'dest_port': 443,
+          'requested_at': 2000.0,
+        },
+      });
+      await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('allow-dur-r1')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Forever'), findsOneWidget);
+      // The row resolves (another decider / timeout) while the menu is
+      // open: the menu must close and no verdict may be sent afterwards.
+      channel.serverSend({'type': 'egress_resolved', 'request_id': 'r1'});
+      await tester.pump(); // flush the stream event -> listener -> menu pop
+      await tester.pumpAndSettle(); // exit transition fully unmounts
+      expect(find.text('Forever'), findsNothing);
+      expect(channel.sent, isEmpty);
+      svc.dispose();
+    },
+  );
+
   testWidgets('shows a flash for a server error frame', (tester) async {
     final channel = _FakeChannel();
     final svc = _serviceWithChannel(channel);


### PR DESCRIPTION
## Summary

Replaces the consent banner's global duration pill row (#2499) with
**per-row split Allow/Deny buttons** — the pointer-first analogue of the
Little Snitch pattern:

- A bare **Allow** / **Deny** click sends the verdict with the default
  duration (`tilrestart`) — the common case stays one click.
- The attached **▾** segment opens a menu of durations (*Just once*,
  *5 minutes*, *15 minutes*, *1 hour*, *1 day*, *1 week*,
  *Until restart (default)*, *Forever*); picking one submits that row's
  verdict immediately. Dismissing without a pick sends nothing.

The duration is now chosen **with** the click, never armed beforehand.
This fixes two problems with the global pill row: the selector sat far
from the row actions it applied to, and an armed non-default selection
silently applied to whichever row was clicked next (easy to allow
`once`-grade traffic for `forever` by accident). It also reclaims the
whole selector row of horizontal space.

## Details

- `consent_banner.dart`: `_DurationSelector` and the `_duration` state
  are gone; each row renders two `_VerdictButton`s (main segment +
  ▾ menu segment, `showMenu` + `PopupMenuItem`, anchored to the ▾).
  Human labels for display; raw tokens (`once`, `5m`, `1d`,
  `tilrestart`, …) stay on the wire, so no server change.
- The test-only `5s` duration stays unoffered (#2487).
- Keys: `allow-dur-<requestId>` / `deny-dur-<requestId>` on the ▾
  segments (no e2e/other tests referenced the old `dur-*` keys).
- Docs: the changelog's Unreleased #2499/#2502/#2246 entries are folded
  to describe the final design (nothing has shipped yet), and the
  Web UI bullet in `features/egress-filtering.md` is updated.
- TUI parity follow-up filed separately: #2511.

## Testing

- `consent_banner_test.dart`: pill-row tests replaced with menu tests —
  menu offers every duration with human labels (no `5s`), dismissal
  without a pick sends nothing, Allow ▾ + *1 day* → `allowed`/`1d`,
  Deny ▾ + *Forever* → `denied`/`forever`, bare Deny also carries
  `tilrestart`.
- `flutter test --coverage`: **974 passed**; `flutter analyze` clean
  except the pre-existing `PLACEHOLDER` pubspec warning.
