### PR TITLE
feat(frontend): rename Net Rules tab to Network (#2510)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -586,6 +586,10 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Egress rules tab renamed to Network (#2510).** The workspace tab
+  previously titled **Net Rules** (originally "Rules", #2457) is now
+  titled **Network**. Presentation only; the tab's contents are
+  unchanged.
 - **Restyled pause/duration option buttons (#2502).** The Net Rules pause
   controls (Unpause / Pause 15m / 1h / 1d) and the consent banner's duration
   selector now share one pill-shaped option-button look with equal sizing,

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -165,7 +165,7 @@ left pending forever.
   held request pops up without leaving the shell (`C-a p` reopens it;
   skip the wrapper with `--no-consent-popup`) (#2383).
 - **Web UI** — the workspace page shows a consent banner with the same
-  allow/deny + duration controls (#2246), plus a **Net Rules** tab
+  allow/deny + duration controls (#2246), plus a **Network** tab
   listing the in-effect rules with revoke actions.
 - **Deploy-wide** — an admin may connect a decider without a workspace
   scope (via the `/ws/consent-decider` WebSocket) to decide for every

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -276,7 +276,7 @@ class IdeLayoutState extends State<IdeLayout> {
     // (the caller passes null otherwise), mounted with the other management
     // tabs before Sharing/Settings.
     if (widget.consentRules != null) {
-      addTab('Net Rules', Icons.shield_outlined, widget.consentRules!);
+      addTab('Network', Icons.shield_outlined, widget.consentRules!);
     }
     if (widget.sharing != null) {
       addTab('Sharing', Icons.people_outline, widget.sharing!);

--- a/src/frontend/lib/widgets/option_button.dart
+++ b/src/frontend/lib/widgets/option_button.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../theme/colors.dart';
 
 /// One option button in a group of mutually-exclusive choices — e.g. the
-/// pause windows on the Net Rules tab and the verdict durations on the
+/// pause windows on the Network tab and the verdict durations on the
 /// consent banner. Gives every such group the same look so it reads as one
 /// intentional control instead of a loose row of default buttons (#2502):
 /// pill-shaped, a shared minimum size (so the buttons align), the amber

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -211,7 +211,7 @@ class _BannerSurface extends StatelessWidget {
 /// The global duration selector (#2499): one compact button per selectable
 /// duration, the active one filled -- TUI parity (the `#duration-selector`
 /// row with its accent `dur-sel` class, cli/tui/consent.py), styled like the
-/// Net Rules pause buttons (#2497). Selecting does NOT submit -- only a
+/// Network pause buttons (#2497). Selecting does NOT submit -- only a
 /// row's Allow/Deny submits with the chosen duration.
 class _DurationSelector extends StatelessWidget {
   const _DurationSelector({required this.value, required this.onChanged});

--- a/src/frontend/test/ide_layout_test.dart
+++ b/src/frontend/test/ide_layout_test.dart
@@ -269,26 +269,25 @@ void main() {
       expect(find.text('Settings'), findsOneWidget);
     });
 
-    testWidgets('has Net Rules tab when consentRules provided', (tester) async {
+    testWidgets('has Network tab when consentRules provided', (tester) async {
       await tester.pumpWidget(buildLayout(
         consentRules: const Text('RULES_CONTENT'),
       ));
-      expect(find.text('Net Rules'), findsOneWidget);
+      expect(find.text('Network'), findsOneWidget);
     });
 
-    testWidgets('Net Rules tab content is visible after switch',
-        (tester) async {
+    testWidgets('Network tab content is visible after switch', (tester) async {
       await tester.pumpWidget(buildLayout(
         consentRules: const Text('RULES_CONTENT'),
       ));
-      await tester.tap(find.text('Net Rules'));
+      await tester.tap(find.text('Network'));
       await tester.pumpAndSettle();
       expect(find.text('RULES_CONTENT'), findsOneWidget);
     });
 
-    testWidgets('no Net Rules tab when consentRules is null', (tester) async {
+    testWidgets('no Network tab when consentRules is null', (tester) async {
       await tester.pumpWidget(buildLayout());
-      expect(find.text('Net Rules'), findsNothing);
+      expect(find.text('Network'), findsNothing);
     });
 
     testWidgets('settings tab content is visible after switch', (tester) async {


### PR DESCRIPTION
# Pull request

Closes #2510.

## What this changes

Renames the workspace tab **"Net Rules"** → **"Network"** in `src/frontend/lib/layout/ide_layout.dart` (the `addTab(...)` call). Also updates the three `ide_layout_test.dart` tests that assert/tap the label, two code comments (`option_button.dart`, `consent_banner.dart`), the `docs/features/egress-filtering.md` reference to the tab, and adds a changelog entry under `[Unreleased]` → `Changed`.

## Why

Requested in #2510. The tab was named "Rules" → "Net Rules" (#2457); "Network" is the settled choice. Presentation only — the tab's contents and behavior are unchanged.

## How it was tested

- `flutter test test/ide_layout_test.dart` — 26 passed.
- Full frontend suite the CI way (`test-frontend`, `flutter test --coverage`) — 975 tests passed, 100% coverage maintained.
- `grep -rn "Net Rules"` across `src/frontend`, `docs`, `src/klangk` returns nothing except historical `docs/changes.md` entries (left as-is intentionally).

## Checklist

- [x] I've described what and why above.
- [x] I've noted how I tested this.
- [x] This is my own, reviewed work — not an unreviewed automated/LLM-generated
      drive-by.
