### PR TITLE
feat(cli): attach duration choice to Allow/Deny in consent-decide TUI (#2511)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -590,11 +590,16 @@ operators or integrators to act when upgrading.
   previously titled **Net Rules** (originally "Rules", #2457) is now
   titled **Network**. Presentation only; the tab's contents are
   unchanged.
+- **`consent-decide` TUI: duration attached to the verdict action (#2511).**
+  The global duration-selector row is gone. `a`/`d` (and the row buttons)
+  now always send the default duration (`tilrestart`); `A`/`D` open a
+  per-request duration picker (Enter sends, Esc cancels). A duration can
+  no longer be pre-armed and silently applied to the next Allow/Deny —
+  matching the web banner's split Allow/Deny controls.
 - **Restyled pause option buttons (#2502).** The Network tab's pause
   controls (Unpause / Pause 15m / 1h / 1d) now share one pill-shaped
   option-button look with equal sizing, pause/play icons, and tooltips;
-  the active choice keeps the amber fill.
-  Purely presentational — keys and behavior unchanged.
+  the active choice keeps the amber fill. Purely presentational — keys and behavior unchanged.
 - **Consent banner per-row duration menus (#2499).** Each row of the
   egress-consent banner has a split Allow/Deny button: a bare click sends
   the verdict with the default duration (until restart), and the attached

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -157,8 +157,10 @@ left pending forever.
 ### Deciding
 
 - **`klangk consent-decide <workspace>`** — a standalone TUI decider
-  (#2310): a live queue of held requests (host:port and a countdown), a
-  duration selector, allow/deny per row, a rules screen (`r`) with revoke
+  (#2310): a live queue of held requests (host:port and a countdown),
+  allow/deny per row with the duration chosen at the action — bare
+  `a`/`d` (or the row buttons) send the default `tilrestart`, `A`/`D`
+  open a duration picker first (#2511) — a rules screen (`r`) with revoke
   (`x`) (#2340, #2341), and pause controls (#2332).
 - **`klangk shell`** — shelling into an interactive workspace wraps the
   shell in a local tmux that floats the decider over it as a popup: a
@@ -187,8 +189,10 @@ workspace. Pausing prompting (below) additionally requires
 
 ### Decision durations
 
-A verdict carries a duration, chosen from one selector at allow/deny time
-(default `tilrestart`, #2328):
+A verdict carries a duration, chosen with the allow/deny action (default
+`tilrestart`, #2328): bare `a`/`d` in the TUI — or a plain button click
+on the web banner — send the default; the TUI's `A`/`D` picker (#2511)
+chooses any other duration in the same step.
 
 | Duration                          | Meaning                                                                                                                                                                                                                         |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -38,8 +38,16 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
-from textual.screen import Screen
-from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
+from textual.screen import ModalScreen, Screen
+from textual.widgets import (
+    Button,
+    Footer,
+    Header,
+    ListItem,
+    ListView,
+    OptionList,
+    Static,
+)
 
 from ..auth import refresh_token
 from ..shell_popup import (
@@ -57,11 +65,12 @@ logger = logging.getLogger(__name__)
 DECISION_ALLOWED = "allowed"
 DECISION_DENIED = "denied"
 # Duration tokens mirror the server (model/egress_consent.py); duplicated here
-# per CLI isolation. Ordered for the TUI selector; default is `tilrestart` (#2328).
+# per CLI isolation. Ordered for the duration picker; default is `tilrestart`
+# (#2328).
 DURATION_ONCE = "once"
 # Test-only short duration (#2363, subsumed by #2392): recognized for in-effect
 # math (a `5s` verdict in a rules snapshot counts down correctly) and for
-# programmatic/test callers, but NOT exposed in the human-facing selector
+# programmatic/test callers, but NOT offered in the human-facing picker
 # (see SELECTABLE_DURATIONS below).
 DURATION_5S = "5s"
 DURATION_5M = "5m"
@@ -72,7 +81,7 @@ DURATION_1W = "1w"
 DURATION_TILRESTART = "tilrestart"
 DURATION_FOREVER = "forever"
 # Full set the CLI recognizes (mirrors the server's DURATIONS, incl. the
-# test-only 5s). Drives in-effect/countdown math, not the selector.
+# test-only 5s). Drives in-effect/countdown math, not the picker.
 DURATIONS = (
     DURATION_ONCE,
     DURATION_5S,
@@ -84,10 +93,10 @@ DURATIONS = (
     DURATION_TILRESTART,
     DURATION_FOREVER,
 )
-# Human-facing duration selector: every duration a user can pick. The
-# test-only 5s is NOT offered (#2487) -- it's not meant for end users -- but
-# stays recognized for in-effect/countdown math and programmatic/test callers
-# (it remains in DURATIONS above).
+# Human-facing durations: every duration a user can pick (the `A`/`D`
+# duration picker). The test-only 5s is NOT offered (#2487) -- it's not meant
+# for end users -- but stays recognized for in-effect/countdown math and
+# programmatic/test callers (it remains in DURATIONS above).
 SELECTABLE_DURATIONS = tuple(d for d in DURATIONS if d != DURATION_5S)
 DURATION_DEFAULT = DURATION_TILRESTART
 
@@ -575,7 +584,7 @@ class ConsentDeciderApp(App):
     Screen { layout: vertical; }
     #status { padding: 0 1; background: $panel; color: $text-muted; }
     /* #queue holds the request list + empty state and fills the space between
-    the duration selector and the pause bar, so the pause bar pins to just
+    the status line and the pause bar, so the pause bar pins to just
     above the Footer (#2383). */
     #queue { height: 1fr; }
     #requests { height: 1fr; }
@@ -583,18 +592,6 @@ class ConsentDeciderApp(App):
     #empty { padding: 1 2; color: $text-muted; }
     .req-host { color: $text; }
     #requests Button { height: 1; border: none; padding: 0 1; }
-    #duration-selector { width: auto; height: 1; }
-    /* Non-selected duration buttons carry no background -- not even when focused
-    (#2360). The first button grabs initial focus on mount; without an explicit
-    transparent :focus it rendered with the white focus background, so it read
-    as "selected" alongside the real ``dur-sel`` default (``tilrestart``). The
-    ``dur-sel`` rules are qualified under ``#duration-selector`` so they outrank
-    these ID-based transparent rules on specificity (an unqualified ``.dur-sel``
-    loses to ``#duration-selector Button:focus`` and the accent vanishes). */
-    #duration-selector Button { width: auto; min-width: 0; height: 1; border: none; padding: 0 1; background: transparent; }
-    #duration-selector Button:focus { background: transparent; }
-    #duration-selector .dur-sel { background: $accent; color: $background; }
-    #duration-selector .dur-sel:focus { background: $accent; color: $background; }
     /* #2332 pause control bar: a compact top-bar that silences ALL prompts for
     the workspace for a window. Flagged yellow so it reads as "filtering off". */
     #pause-bar { height: 1; background: $panel; }
@@ -607,7 +604,9 @@ class ConsentDeciderApp(App):
 
     BINDINGS = [
         ("a", "allow", "Allow"),
+        ("A", "allow_duration", "Allow…"),
         ("d", "deny", "Deny"),
+        ("D", "deny_duration", "Deny…"),
         ("r", "rules", "Rules"),
         # q, Q, Escape, and Ctrl-A all hide the viewer in persistent mode (the
         # decider is persistent — it never quits on a key, only when the shell
@@ -653,7 +652,6 @@ class ConsentDeciderApp(App):
         self._refused = False
         self._flash_msg = ""
         self._flash_until = 0.0
-        self._duration = DURATION_DEFAULT
         # #2332 pause window the user last requested (None = Unpaused). Drives
         # which pause button is highlighted; the live countdown is shown next
         # to the buttons (#2383).
@@ -683,7 +681,9 @@ class ConsentDeciderApp(App):
         if self._persistent:
             self.BINDINGS = [
                 Binding("a", "allow", "Allow"),
+                Binding("A", "allow_duration", "Allow…"),
                 Binding("d", "deny", "Deny"),
+                Binding("D", "deny_duration", "Deny…"),
                 Binding("r", "rules", "Rules"),
                 Binding(
                     "ctrl+a",
@@ -699,7 +699,9 @@ class ConsentDeciderApp(App):
         else:
             self.BINDINGS = [
                 Binding("a", "allow", "Allow"),
+                Binding("A", "allow_duration", "Allow…"),
                 Binding("d", "deny", "Deny"),
+                Binding("D", "deny_duration", "Deny…"),
                 Binding("r", "rules", "Rules"),
                 Binding("q", "q_key", "Quit", show=True),
                 Binding("Q", "q_key", "Quit", show=False),
@@ -710,9 +712,6 @@ class ConsentDeciderApp(App):
 
     def compose(self) -> ComposeResult:
         yield Static(id="status")
-        # Global duration selector (default `tilrestart`): click to choose; selecting
-        # does NOT submit -- only a row's Allow/Deny submits with this duration.
-        yield Horizontal(*self._duration_buttons(), id="duration-selector")
         with Vertical(id="queue"):
             yield ListView(id="requests")
             yield Static("No held requests — connected, waiting.", id="empty")
@@ -725,18 +724,6 @@ class ConsentDeciderApp(App):
             id="pause-bar",
         )
         yield Footer()
-
-    def _duration_buttons(self) -> list[Button]:
-        btns = []
-        for d in SELECTABLE_DURATIONS:
-            b = Button(
-                d,
-                id=f"dur-{d}",
-                classes=("dur-sel" if d == self._duration else ""),
-            )
-            b.duration = d  # type: ignore[attr-defined]
-            btns.append(b)
-        return btns
 
     def _pause_buttons(self) -> list[Button]:
         """Unpaused / Paused 15m / 1h / 1d (#2332, restyled #2383).
@@ -1054,9 +1041,11 @@ class ConsentDeciderApp(App):
         return escape(f"{host}{proc}  ({secs}s)")
 
     def _render_item(self, req: ConsentRequest) -> ListItem:
-        # Host line + per-row Allow/Deny (the only submit actions). The duration
-        # is chosen once via the global selector above the list (#2328), so the
-        # row stays compact.
+        # Host line + per-row Allow/Deny (the only submit actions). Bare
+        # Allow/Deny (button or `a`/`d`) sends the default duration
+        # (`tilrestart`); `A`/`D` open the per-row duration picker first
+        # (#2511) -- the duration travels with the action, never armed
+        # beforehand.
         item = ListItem(
             Static(self._host_line(req), classes="req-host"),
             Horizontal(
@@ -1124,30 +1113,18 @@ class ConsentDeciderApp(App):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         bid = event.button.id or ""
-        if bid.startswith("dur-"):
-            # Selecting a duration does NOT submit -- it only sets the global
-            # choice (Allow/Deny submit with it).
-            self._select_duration(event.button)
-        elif bid.startswith("pause-"):
+        if bid.startswith("pause-"):
             self._handle_pause_button(event.button)
         elif bid.startswith("allow-"):
             self._decide_id(
-                bid.removeprefix("allow-"), DECISION_ALLOWED, self._duration
+                bid.removeprefix("allow-"),
+                DECISION_ALLOWED,
+                DURATION_DEFAULT,
             )
         elif bid.startswith("deny-"):
             self._decide_id(
-                bid.removeprefix("deny-"), DECISION_DENIED, self._duration
+                bid.removeprefix("deny-"), DECISION_DENIED, DURATION_DEFAULT
             )
-
-    def _select_duration(self, button: Button) -> None:
-        """Set the global selected duration + highlight it (no submit)."""
-        d = getattr(button, "duration", None)
-        if d is None:
-            return
-        self._duration = d
-        for b in self.query(".dur-sel"):
-            b.remove_class("dur-sel")
-        button.add_class("dur-sel")
 
     def _handle_pause_button(self, button: Button) -> None:
         """Send a pause (window token) or unpause (Unpaused) frame (#2332)."""
@@ -1211,17 +1188,46 @@ class ConsentDeciderApp(App):
         else:
             countdown.update("")
 
+    def _on_queue_screen(self) -> bool:
+        """True when the held-request queue is the active screen.
+
+        ``a``/``d``/``A``/``D`` must be inert on the rules screen (no row is
+        visible there) and while the duration picker modal is up (a stray
+        keypress through the modal must not decide a row behind it).
+        """
+        return not isinstance(self.screen, (RulesScreen, DurationPickerScreen))
+
     def action_allow(self) -> None:
-        # `a` key -> the highlighted row (keyboard path). No-op on the rules
-        # screen so a/d can't decide a queue row that isn't visible there.
-        if isinstance(self.screen, RulesScreen):
+        # `a` key -> the highlighted row, with the default duration
+        # (`tilrestart`): the common case stays one keypress (#2511).
+        if not self._on_queue_screen():
             return
         self._decide(DECISION_ALLOWED)
 
     def action_deny(self) -> None:
-        if isinstance(self.screen, RulesScreen):
+        if not self._on_queue_screen():
             return
         self._decide(DECISION_DENIED)
+
+    def action_allow_duration(self) -> None:
+        """``A``: allow the highlighted row with a picked duration (#2511)."""
+        self._open_duration_picker(DECISION_ALLOWED)
+
+    def action_deny_duration(self) -> None:
+        """``D``: deny the highlighted row with a picked duration (#2511)."""
+        self._open_duration_picker(DECISION_DENIED)
+
+    def _open_duration_picker(self, decision: str) -> None:
+        if not self._on_queue_screen():
+            return
+        rid = self._focused_request_id()
+        if rid is None:
+            return
+        host = next(
+            (r.dest_host for r in self.controller.ordered() if r.id == rid),
+            rid,
+        )
+        self.push_screen(DurationPickerScreen(rid, decision, host))
 
     def action_rules(self) -> None:
         # `r` opens the read-only rules screen (#2335 slice B). Guard against
@@ -1294,7 +1300,7 @@ class ConsentDeciderApp(App):
         rid = self._focused_request_id()
         if rid is None:
             return
-        self._decide_id(rid, decision, self._duration)
+        self._decide_id(rid, decision, DURATION_DEFAULT)
 
     def _decide_id(self, rid: str, decision: str, duration: str) -> None:
         ws = self._ws
@@ -1315,6 +1321,75 @@ class ConsentDeciderApp(App):
             await ws.send(make_verdict(rid, decision, duration))
         except Exception:
             self._flash("verdict send failed — reconnecting")
+
+
+class DurationPickerScreen(ModalScreen[None]):
+    """Per-row duration picker (#2511): pick a duration for one verdict.
+
+    The TUI analogue of the web banner's split Allow/Deny ▾ menu
+    (post-#2499 design): the duration is chosen **with** the action, never
+    armed beforehand -- `a`/`d` (or a row button) send the default
+    (`tilrestart`) directly; `A`/`D` open this picker for the highlighted
+    row first. Enter on an option submits that row's verdict with the chosen
+    duration; ``Esc``/``q`` dismiss without sending anything. A modal screen
+    (centered overlay) because Textual cannot anchor a widget to a specific
+    ListView row -- the row is named in the title instead.
+    """
+
+    CSS = """
+    DurationPickerScreen { align: center middle; background: transparent; }
+    #picker-panel {
+        width: auto; max-width: 64; height: auto;
+        border: round $accent; background: $panel; padding: 0 1;
+    }
+    #picker-title { padding: 0 1; color: $text; }
+    #picker-durations { width: 24; height: auto; max-height: 12; }
+    """
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+        ("q", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, request_id: str, decision: str, host: str) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.decision = decision
+        self.host = host
+
+    @property
+    def _verb(self) -> str:
+        return "Allow" if self.decision == DECISION_ALLOWED else "Deny"
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="picker-panel"):
+            yield Static(
+                f"{self._verb} {escape(self.host)} — pick a duration",
+                id="picker-title",
+            )
+            yield OptionList(*SELECTABLE_DURATIONS, id="picker-durations")
+            yield Static("Enter sends · Esc cancels", id="picker-hint")
+
+    def on_mount(self) -> None:
+        ol = self.query_one("#picker-durations", OptionList)
+        # The default duration starts highlighted, so Enter alone repeats
+        # the bare-`a` outcome; arrows then Enter pick any other duration.
+        ol.highlighted = SELECTABLE_DURATIONS.index(DURATION_DEFAULT)
+        ol.focus()
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        """Enter: submit the row's verdict with the chosen duration."""
+        duration = SELECTABLE_DURATIONS[event.option_index]
+        app = self.app
+        if isinstance(app, ConsentDeciderApp):
+            app._decide_id(self.request_id, self.decision, duration)
+        self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        """``Esc``/``q``: dismiss without sending anything."""
+        self.dismiss(None)
 
 
 class RulesScreen(Screen):

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -16,7 +16,7 @@ import types
 
 import pytest
 import websockets
-from textual.widgets import Button, ListView, Static
+from textual.widgets import Button, ListView, OptionList, Static
 
 from klangk.cli.tui import consent as tui_consent
 from klangk.cli.tui.consent import (
@@ -865,9 +865,9 @@ class TestAppActions:
             await pilot.pause()
             assert any('"denied"' in s and '"r1"' in s for s in ws.sent)
 
-    async def test_duration_selection_does_not_submit(self):
-        # Clicking a global duration button selects it (highlights + stores) but
-        # sends NO verdict -- only Allow/Deny submit (#2328).
+    async def test_allow_defaults_to_tilrestart(self):
+        # A bare Allow (button or `a`) sends the default duration; the
+        # duration is never armed beforehand (#2511).
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -875,25 +875,6 @@ class TestAppActions:
             app.controller.apply_frame(_req_frame("r1", host="a.com"))
             app._refresh()
             await pilot.pause()
-            btn = app.query_one("#dur-1d", Button)
-            app.on_button_pressed(types.SimpleNamespace(button=btn))
-            await pilot.pause()
-            assert ws.sent == []  # selecting a duration does NOT submit
-            assert app._duration == "1d"
-            assert btn.has_class("dur-sel")
-
-    async def test_allow_submits_with_selected_duration(self):
-        # Allow sends the verdict carrying the global selected duration.
-        app = _make_app()
-        async with app.run_test() as pilot:
-            ws = FakeWS([])
-            app._ws = ws
-            app.controller.apply_frame(_req_frame("r1", host="a.com"))
-            app._refresh()
-            await pilot.pause()
-            app.on_button_pressed(
-                types.SimpleNamespace(button=app.query_one("#dur-1h", Button))
-            )
             app.on_button_pressed(
                 types.SimpleNamespace(
                     button=types.SimpleNamespace(id="allow-r1")
@@ -901,13 +882,13 @@ class TestAppActions:
             )
             await pilot.pause()
             assert any(
-                '"allowed"' in s and '"r1"' in s and '"1h"' in s
+                '"allowed"' in s and '"r1"' in s and '"tilrestart"' in s
                 for s in ws.sent
             ), ws.sent
 
-    async def test_duration_defaults_to_tilrestart(self):
-        # A fresh row defaults to `tilrestart`; Allow without changing it sends
-        # `tilrestart`.
+    async def test_a_key_allows_with_default_duration(self):
+        # `a` on the highlighted row sends allowed + tilrestart directly --
+        # the common case stays one keypress (#2511).
         app = _make_app()
         async with app.run_test() as pilot:
             ws = FakeWS([])
@@ -915,23 +896,207 @@ class TestAppActions:
             app.controller.apply_frame(_req_frame("r1", host="a.com"))
             app._refresh()
             await pilot.pause()
-            app.on_button_pressed(
-                types.SimpleNamespace(
-                    button=types.SimpleNamespace(id="allow-r1")
-                )
-            )
+            await pilot.press("a")
             await pilot.pause()
-            assert any('"tilrestart"' in s for s in ws.sent), ws.sent
+            assert any(
+                '"allowed"' in s and '"r1"' in s and '"tilrestart"' in s
+                for s in ws.sent
+            ), ws.sent
 
-    async def test_duration_selector_guards(self):
-        # Defensive guard: a button without a duration attr is a no-op.
+    async def test_d_key_denies_with_default_duration(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("d")
+            await pilot.pause()
+            assert any(
+                '"denied"' in s and '"r1"' in s and '"tilrestart"' in s
+                for s in ws.sent
+            ), ws.sent
+
+    async def test_A_opens_picker_enter_sends_picked_duration(self):
+        # `A` opens the per-row picker; Enter on a picked duration submits
+        # allow with exactly that duration (#2511).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("A")
+            await pilot.pause()
+            assert isinstance(app.screen, tui_consent.DurationPickerScreen)
+            picker = app.screen
+            assert picker.request_id == "r1"
+            assert picker.decision == tui_consent.DECISION_ALLOWED
+            ol = app.screen.query_one("#picker-durations", OptionList)
+            ol.highlighted = tui_consent.SELECTABLE_DURATIONS.index("1d")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+            assert any(
+                '"allowed"' in s and '"r1"' in s and '"1d"' in s
+                for s in ws.sent
+            ), ws.sent
+            # The modal is gone after submit.
+            assert not isinstance(app.screen, tui_consent.DurationPickerScreen)
+
+    async def test_D_opens_picker_enter_sends_picked_duration(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("D")
+            await pilot.pause()
+            assert isinstance(app.screen, tui_consent.DurationPickerScreen)
+            ol = app.screen.query_one("#picker-durations", OptionList)
+            ol.highlighted = tui_consent.SELECTABLE_DURATIONS.index("forever")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+            assert any(
+                '"denied"' in s and '"r1"' in s and '"forever"' in s
+                for s in ws.sent
+            ), ws.sent
+
+    async def test_picker_enter_alone_sends_default_duration(self):
+        # The picker highlights the default first, so bare Enter repeats the
+        # bare-`a` outcome (#2511).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("A")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+            assert any(
+                '"allowed"' in s and '"tilrestart"' in s for s in ws.sent
+            ), ws.sent
+
+    async def test_picker_escape_sends_nothing(self):
+        # Dismissing the picker without a pick sends no verdict (#2511).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("A")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert ws.sent == []
+            assert not isinstance(app.screen, tui_consent.DurationPickerScreen)
+
+    async def test_picker_offers_selectable_durations_only(self):
+        # Every human-facing duration is offered, in token order; the
+        # test-only 5s is not (#2487).
         app = _make_app()
         async with app.run_test() as pilot:
             app.controller.apply_frame(_req_frame("r1", host="a.com"))
             app._refresh()
             await pilot.pause()
-            app._select_duration(types.SimpleNamespace(duration=None))
-            assert app._duration == "tilrestart"  # unchanged (default)
+            await pilot.press("A")
+            await pilot.pause()
+            ol = app.screen.query_one("#picker-durations", OptionList)
+            assert ol.option_count == len(tui_consent.SELECTABLE_DURATIONS)
+            prompts = [
+                str(ol.get_option_at_index(i).prompt)
+                for i in range(ol.option_count)
+            ]
+            assert prompts == list(tui_consent.SELECTABLE_DURATIONS)
+            assert "5s" not in prompts
+
+    async def test_A_with_no_focused_row_is_noop(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.press("A")
+            await pilot.press("D")
+            await pilot.pause()
+            assert not isinstance(app.screen, tui_consent.DurationPickerScreen)
+
+    async def test_A_on_rules_screen_is_noop(self):
+        # No row is visible on the rules screen, so A/D must not open a
+        # picker (nor a/d decide) there.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("r")
+            await pilot.pause()
+            assert isinstance(app.screen, tui_consent.RulesScreen)
+            await pilot.press("A")
+            await pilot.press("a")
+            await pilot.pause()
+            assert isinstance(app.screen, tui_consent.RulesScreen)
+
+    async def test_keys_inert_while_picker_open(self):
+        # While the picker modal is up, a/d/A/D must not decide the row
+        # behind it -- only Enter submits, Esc cancels (#2511).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("A")
+            await pilot.pause()
+            await pilot.press("a")
+            await pilot.press("d")
+            await pilot.press("A")
+            await pilot.press("D")
+            await pilot.pause()
+            assert ws.sent == []
+            assert isinstance(app.screen, tui_consent.DurationPickerScreen)
+            await pilot.press("escape")
+            await pilot.pause()
+            assert ws.sent == []
+
+    async def test_picker_decides_second_row(self):
+        # The picker targets the *highlighted* row, not always the first.
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app.controller.apply_frame(_req_frame("r2", host="b.com"))
+            app._refresh()
+            await pilot.pause()
+            lv = app.query_one("#requests", ListView)
+            lv.index = 1
+            await pilot.pause()
+            await pilot.press("A")
+            await pilot.pause()
+            picker = app.screen
+            assert isinstance(picker, tui_consent.DurationPickerScreen)
+            assert picker.request_id == "r2"
+            assert "b.com" in str(
+                app.screen.query_one("#picker-title", Static).content
+            )
+            ol = app.screen.query_one("#picker-durations", OptionList)
+            ol.highlighted = tui_consent.SELECTABLE_DURATIONS.index("1w")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+            assert any(
+                '"allowed"' in s and '"r2"' in s and '"1w"' in s
+                for s in ws.sent
+            ), ws.sent
 
     async def test_pause_bar_mounts(self):
         # #2332: the pause control bar mounts Unpaused + the three windows +
@@ -1123,54 +1288,6 @@ class TestAppActions:
             await pilot.pause()
             status = app.query_one("#status", Static)
             assert "unpause send failed" in str(status.content)
-
-    async def test_only_selected_duration_has_background_at_first_render(self):
-        # Regression (#2360): the first duration button ("once") grabbed
-        # initial focus on mount and, with no explicit transparent :focus,
-        # rendered the white focus background -- so it read as "selected"
-        # alongside the real ``dur-sel`` default (``tilrestart``). Only the
-        # selected button may carry a background; every other (focused or
-        # not) must be transparent at first render. Asserted opacity-only so
-        # it holds across light/dark themes (the exact accent hue is the
-        # theme's business; the bug was a *second* visible background).
-        app = _make_app()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            opaque = [
-                d
-                for d in tui_consent.SELECTABLE_DURATIONS
-                if app.query_one(f"#dur-{d}", Button).styles.background.a != 0
-            ]
-            assert opaque == [tui_consent.DURATION_DEFAULT], (
-                f"expected only {tui_consent.DURATION_DEFAULT!r} to carry a "
-                f"background at first render, got {opaque!r}"
-            )
-
-    async def test_selected_duration_keeps_accent_when_focused(self):
-        # The ``.dur-sel`` rules must be specific enough to outrank the
-        # transparent ``#duration-selector Button:focus`` (#2360): selecting a
-        # duration both adds ``dur-sel`` and focuses the button, and the
-        # accent must survive focus -- else the just-selected button goes
-        # transparent and looks unselected. The previously-selected default
-        # drops to transparent.
-        app = _make_app()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            btn = app.query_one(f"#dur-{tui_consent.DURATION_5M}", Button)
-            app.on_button_pressed(types.SimpleNamespace(button=btn))
-            btn.focus()
-            await pilot.pause()
-            assert app.focused is btn  # focus really landed on it
-            assert btn.has_class("dur-sel")
-            assert btn.styles.background.a != 0, (
-                f"selected+focused button lost its background "
-                f"(got {btn.styles.background!r})"
-            )
-            default_btn = app.query_one(
-                f"#dur-{tui_consent.DURATION_DEFAULT}", Button
-            )
-            assert not default_btn.has_class("dur-sel")
-            assert default_btn.styles.background.a == 0
 
 
 class TestWsLoop:
@@ -2690,7 +2807,9 @@ class TestPersistentPopupRole:
         shown = {b.key: b.description for b in app.BINDINGS if b.show}
         assert shown == {
             "a": "Allow",
+            "A": "Allow…",
             "d": "Deny",
+            "D": "Deny…",
             "r": "Rules",
             "q": "Quit",
         }
@@ -2710,7 +2829,9 @@ class TestPersistentPopupRole:
         # The Footer advertises the shell wrapper's C-a p toggle.
         assert shown == {
             "a": "Allow",
+            "A": "Allow…",
             "d": "Deny",
+            "D": "Deny…",
             "r": "Rules",
             "ctrl+a": "Hide/Show",
         }


### PR DESCRIPTION
## Summary

Gives the `klangk consent-decide` TUI the same interaction the web consent
banner has (#2246; the banner's split buttons are #2512): the verdict
duration is chosen **with** the Allow/Deny action, never armed beforehand
on a global selector (#2511).

- The global `#duration-selector` button row is gone.
- `a` / `d` (and the per-row Allow/Deny buttons) send the default duration
  (`tilrestart`) directly — the common case stays one keypress.
- `A` / `D` open a per-row duration picker (`DurationPickerScreen`, a small
  centered modal): Enter submits that row's verdict with the chosen
  duration, Esc/q cancel without sending anything. The default starts
  highlighted, so bare `A` + Enter equals `a`.
- `a`/`d`/`A`/`D` are inert on the rules screen and while the picker modal
  is up (a stray keypress can't decide the row behind it).
- The test-only `5s` duration stays unoffered (#2487).

The issue's open question — whether Textual can anchor a popup to a
specific row — is answered **no** for our Textual (8.2.8 has no
popover/anchored widget), so the accepted fallback is used: a modal with
the target row's verb + host named in its title ("Allow evil.example.com —
pick a duration").

## Testing

- `test_consent_decide.py`: the global-selector tests (selection,
  armed-duration submit, `dur-sel` CSS regressions #2360) are replaced by
  picker tests — `a`/`d` default-duration submits, `A`/`D` + Enter with a
  picked duration, bare-Enter = default, Esc sends nothing, picker offers
  every selectable duration and no `5s`, no-focused-row / rules-screen /
  open-picker inertness, and second-row targeting. Full backend suite:
  4940 passed, 100% coverage.

Closes #2511.
