### PR TITLE
test(egress): fix co-resident revoke canary to pin under-removal (#2352)

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -746,9 +746,10 @@ _DETAIL_PREFIX_NAMES: list[tuple[str, str]] = [
     ("port scope: ", "PORT-SCOPE-VIOLATION"),
     # Co-resident hosts (#2440): pin per-IP allow/revoke sharing (canary for #2352).
     ("co-resident: allow A did NOT leak to B", "CORESIDENT-ALLOW-FLIP"),
-    ("co-resident: revoke A did NOT uncover B", "CORESIDENT-REVOKE-FLIP"),
+    ("co-resident: revoke A uncovered B", "CORESIDENT-REVOKE-FLIP"),
     ("co-resident: A did NOT prompt", "NO-EXPECTED-REQUEST"),
     ("co-resident: post-revoke B hung", "HUNG-NFQUEUE-DNS"),
+    ("co-resident: post-revoke B not clean", "HUNG-NFQUEUE-DNS"),
     ("co-resident: B did not connect cleanly", "HUNG-NFQUEUE-DNS"),
     ("co-resident phase failed", "UNEXPECTED-ERROR"),
     # allow egress mode (#2411): off-list must connect (coordinator record+allow),
@@ -816,7 +817,7 @@ OUTCOME_NAMES: dict[str, str] = {
     "HOST-SCOPE-VIOLATION": "an nginx-style host scope (exact/inclusive/subdomains, #2377) let the wrong name through / blocked the right one.",
     "PORT-SCOPE-VIOLATION": "a port-scoped allow (host:443) permitted a different port (:80), or vice-versa.",
     "CORESIDENT-ALLOW-FLIP": "co-resident allow canary flipped: allowing host A no longer leaked to host B on the same IP -- per-host allow may have landed (#2352/#2440).",
-    "CORESIDENT-REVOKE-FLIP": "co-resident revoke canary flipped: revoking host A no longer dropped coverage for host B on the same IP -- per-host revoke may have landed (#2352/#2440).",
+    "CORESIDENT-REVOKE-FLIP": "co-resident revoke canary flipped: revoking host A now uncovers host B on the same IP (B re-prompted post-revoke) -- per-host or reverse-index revoke may have landed (#2352/#2440); update the pin.",
     "SNAPSHOT-REPLAY": "a resolved-while-away row replayed (or a held row vanished) in the reconnect snapshot -- now deterministic under controlled DNS (#2424).",
     "ALLOWMODE-REFUSED": "an allow-mode (default-permit) off-list host was refused or hung -- it must connect (#2411/#2406).",
     "ALLOWMODE-DECIDER-ACCEPTED": "a consent decider registered (or ambiguously attached) against an allow-mode workspace -- it must be refused, same gate as static (#2395/#2406).",
@@ -2939,16 +2940,23 @@ class SmokeTest:
     async def run_coresident_phase(self, pilot) -> None:
         """Pin co-resident-host behavior as a canary for #2352 (#2440).
 
-        Per-host allow/revoke is L3/L4-only today: two hostnames that resolve
-        to the SAME IP share one iptables rule, so allowing host A also lets
-        host B through, and revoking A drops the shared rule so B loses
-        coverage too (#2352, OPEN). This phase points two controlled hostnames
-        at one IP and pins BOTH halves of that limitation:
+        Per-host allow/revoke is L3/L4-only today: two hostnames that
+        resolve to the SAME IP share one iptables rule, so allowing host A
+        also lets host B through (#2352, OPEN). This phase points two
+        controlled hostnames at one IP and pins both halves of that
+        limitation as canaries:
 
           1. Allow A (learn a per-IP ACCEPT) -> B (same IP) connects with NO
-             prompt (today's behavior).
-          2. Revoke A -> the shared rule is dropped -> B re-prompts (today's
-             behavior).
+             prompt (the per-IP allow leak).
+          2. Revoke A -> B STILL connects with no re-prompt (the revoke is a
+             NO-op). Canary #1's B connect resolves B after A's allow, and
+             ``_record_hosts`` keeps only the LATEST name per IP, so
+             ``_LEARNED[ip]["host"]`` is ``core-b`` when
+             ``drop_for_host("core-a")`` scans it: no rule is dropped and
+             both hosts stay reachable (the under-removal half of #2352;
+             the over-removal half -- revoke A of the name still on record
+             uncovers B -- needs B to NOT resolve in between, which this
+             sequence cannot produce).
 
         Both assertions are CANARIES: they PASS while #2352 is unfixed and
         FLIP to MISMATCH when per-host allow/revoke lands, so a silent fix
@@ -3084,37 +3092,54 @@ class SmokeTest:
                 await d.close()
                 return
 
-            # 2) Revoke A -> the shared per-IP rule is dropped.
+            # 2) Revoke A -> today a NO-OP for this sequence. Canary #1's
+            #    B connect re-resolved the shared IP, and _record_hosts
+            #    keeps only the LATEST name per IP, so
+            #    _LEARNED[ip]["host"] is core-b by now;
+            #    drop_for_host("core-a") matches nothing, the shared ACCEPT
+            #    survives, and A itself also stays reachable -- the
+            #    under-removal half of #2352.
             try:
                 await d.revoke(rid_a)
             except Exception:
                 pass
             await asyncio.sleep(2.0)  # let the server + sidecar drop the rule
 
-            # CANARY #2: B re-prompts (the shared rule that covered it is
-            # gone). Today revoking A uncovers B too. When #2352 lands
-            # per-host revoke, revoking A leaves B's own coverage intact ->
-            # this flips. (Under a full #2352 fix CANARY #1 already fired
-            # above, so this pin is the second half for the per-host-REVOKE
-            # work specifically.)
+            # CANARY #2: B connects with NO re-prompt (the revoke was a
+            # no-op; the shared rule still covers it). When per-host (or
+            # reverse-index) revoke lands, revoking A drops the shared rule
+            # -> B re-prompts -> this flips. (Under a full #2352 fix CANARY
+            # #1 already fired above, so this pin is the second half for the
+            # per-host-REVOKE work specifically.)
             of_b2 = "/tmp/smoke_cr_b2.out"
             _trigger(cont, host_b, of_b2)
             rid_b2 = await d.wait_for(cb, 12.0)
             if rid_b2 is not None:
+                # B re-prompted: what covered B is gone -- the canary flip.
+                # Resolve the prompt so the run can continue cleanly.
                 await d.verdict(rid_b2, DECISION_DENIED, DURATION_ONCE)
                 await d.wait_resolution(rid_b2, 15.0)
                 ec2 = _parse_exit(await _wait_result(cont, of_b2))
                 sx2, dx2 = (
-                    PASS,
-                    "co-resident: revoke A uncovered B (shared per-IP rule "
-                    "dropped, #2352) -- CANARY: flips when per-host revoke "
-                    "lands",
+                    MISMATCH,
+                    "co-resident: revoke A uncovered B (B re-prompted; "
+                    "the shared rule was dropped) -- CANARY FLIP: per-host "
+                    "or reverse-index revoke may have landed (#2352); "
+                    "update this pin",
                 )
             else:
                 ec2 = _parse_exit(
                     await _wait_result(cont, of_b2, timeout=10.0)
                 )
-                if ec2 is None:
+                if ec2 == 0:
+                    sx2, dx2 = (
+                        PASS,
+                        "co-resident: revoke A did NOT uncover B (no "
+                        "re-prompt; revoke no-op: B's resolve overwrote the "
+                        "host record, #2352 under-removal) -- CANARY: flips "
+                        "when per-host revoke lands",
+                    )
+                elif ec2 is None:
                     sx2, dx2 = (
                         FINDING,
                         "co-resident: post-revoke B hung (NFQUEUE/DNS; not a "
@@ -3122,13 +3147,12 @@ class SmokeTest:
                     )
                 else:
                     sx2, dx2 = (
-                        MISMATCH,
-                        f"co-resident: revoke A did NOT uncover B (no "
-                        f"re-prompt, exit {ec2}) -- CANARY FLIP: per-host "
-                        f"revoke may have landed (#2352); update this pin",
+                        FINDING,
+                        f"co-resident: post-revoke B not clean (exit {ec2}, "
+                        f"no re-prompt); not a #2352 signal (NFQUEUE/DNS)",
                     )
             self._record_probe(
-                parent, "revoke A -> B", "re-prompt", ec2, sx2, dx2
+                parent, "revoke A -> B", "no-reprompt", ec2, sx2, dx2
             )
             if sx2 == MISMATCH and not self.args.continue_run:
                 self._abort = True


### PR DESCRIPTION
# Pull request

## What this changes

Re-pins the co-resident-host phase's **revoke canary** (#2440) in
`smoketest_egress.py` to pin the behavior the stack actually produces
today. The old canary #2 asserted "revoke A drops the shared per-IP rule
→ B re-prompts" (the *over-removal* half of #2352) — but that outcome is
unreachable in this phase's own sequence:

1. Allow A → per-IP ACCEPT installed, `_LEARNED[ip]["host"] = core-a`.
2. Canary #1 triggers B → B's resolve **overwrites** the record
   (`_record_hosts` keeps only the *latest* name per IP) → `core-b`.
3. Revoke A → `drop_for_host("core-a")` scans `_LEARNED` for `core-a`,
   finds nothing → **the revoke is a no-op**: the shared ACCEPT survives
   and B (and A) stay reachable.

The latest fuzz run surfaced exactly this as `[1059]
[CORESIDENT-REVOKE-FLIP] … no re-prompt, exit 0` — a standing MISMATCH
fired by determinism, not by a fix. (Canary #1 still PASSing proves
per-host allow/revoke has *not* landed.)

Now:

- PASS = "revoke A → B connects with **no** re-prompt, exit 0" (the
  deterministic *under-removal* half of #2352).
- MISMATCH/CANARY FLIP = B re-prompts post-revoke (per-host or
  reverse-index revoke landed). The flip branch still denies the prompt
  and completes the connect so the run continues cleanly.
- New outcome mapping for the "no re-prompt + unclean exit" finding
  (`HUNG-NFQUEUE-DNS`), so no branch can hit the `??` unmapped sentinel.
- Phase docstring corrected (the old "today revoking A uncovers B" claim
  was wrong for this sequence; over-removal needs B to *not* resolve
  between allow and revoke, which this phase cannot produce).

## Why

A canary that mis-pins today's behavior fires a MISMATCH on every run,
burying real flips in noise. #2352 stays OPEN; when it lands, canary #1
(allow leak) flips first, then the corrected canary #2 confirms the
revoke half.

## How it was tested

- The analyzed run: host-scope 9/9, port-scope 2/2, static 3/3 ✓; the
  single mismatch was this canary firing on the deterministic
  under-removal path (sidecar code inspected to confirm the mechanism —
  `_record_hosts` overwrite + `drop_for_host` host-scan miss).
- Module import (the `OUTCOME_NAMES` registry asserts pass) and simulated
  `_outcome_name` on all four new detail strings — all map, no `??`.
- `ruff check` + `ruff format --check` clean; file is not pytest-collected
  (manual smoketest harness).
- Expected next-run output: `revoke A → B … no-reprompt … ✓`, 0 mismatches.

Refs #2440 (the canary issue, already closed by the phase landing); #2352 stays open.

## Checklist

- [x] I've described what and why above.
- [x] I've noted how I tested this.
- [x] This is my own, reviewed work — not an unreviewed automated/LLM-generated
      drive-by.
