### PR TITLE
ci: run backend e2e tests on self-hosted nix runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# Custom self-hosted runner labels (actionlint validates runs-on against
+# these in addition to GitHub-hosted labels).
+self-hosted-runner:
+  labels:
+    - nix
+    - keithmoon

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -22,21 +22,25 @@ inputs:
 runs:
   using: composite
   steps:
-    # Rootless podman needs the ci user's session bus (systemd cgroup
-    # manager). GitHub's runner filters service-env vars from job step
-    # shells, so each step exports it from id -u (VM ci users are uid
-    # 1101/1102 — per-runner, hence not a static env here).
+    # Rootless podman needs the ci user's XDG_RUNTIME_DIR (for the
+    # podman pause process, container state) and DBUS_SESSION_BUS_ADDRESS
+    # (so crun can create systemd scopes via sd-bus). GitHub's runner
+    # filters service-level env vars from job step shells, so each step
+    # must export both from the uid. The ci users are uid 1101..1104
+    # (per-runner), hence dynamic rather than static.
     - name: Prepare klangk devenv
       shell: bash
       run: |
-        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
         devenv shell -- true
 
     - name: Build images
       if: inputs.run == 'true'
       shell: bash
       run: |
-        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
         devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Clean leftover CI podman state
@@ -49,7 +53,8 @@ runs:
       # klangk.workspace). Both cleanups are scoped to CI-owned names and
       # labels — never interactive-session resources.
       run: |
-        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
         podman network ls --format '{{.Name}}' \
           | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
           | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
@@ -62,7 +67,8 @@ runs:
       env:
         KLANGK_E2E_VERBOSE_PODMAN: ${{ inputs.verbose-podman == 'true' && '1' || '' }}
       run: |
-        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
         devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -1,0 +1,68 @@
+name: E2E suite on self-hosted NixOS runner
+description: Shared prepare/build/cleanup/run steps for the e2e suites on the
+  klangk-ci VM runners (label "nix")
+
+inputs:
+  run:
+    description: "'true' to run the suite (wire steps.filter.outputs.e2e here); anything else skips it"
+    required: true
+  suite:
+    description: "devenv script to execute (test-backend-e2e / test-cli-e2e)"
+    required: true
+  suite-name:
+    description: "Human-readable suite name for step names and the skip notice"
+    required: true
+  verbose-podman:
+    description: "Set KLANGK_E2E_VERBOSE_PODMAN=1 (pytest plugin surfacing podman stderr of failed calls)"
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Rootless podman needs the ci user's session bus (systemd cgroup
+    # manager). GitHub's runner filters service-env vars from job step
+    # shells, so each step exports it from id -u (VM ci users are uid
+    # 1101/1102 — per-runner, hence not a static env here).
+    - name: Prepare klangk devenv
+      shell: bash
+      run: |
+        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        devenv shell -- true
+
+    - name: Build workspace + sidecar images
+      if: inputs.run == 'true'
+      shell: bash
+      run: |
+        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
+
+    - name: Clean leftover CI podman state
+      if: inputs.run == 'true'
+      shell: bash
+      # Non-ephemeral runners keep podman state across jobs: failed fixtures
+      # leak e2e networks (each new network restarts aardvark-dns for the
+      # whole set, racing concurrent xdist workers) and klangk-managed
+      # containers (workspace containers + network sidecars, all labeled
+      # klangk.workspace). Both cleanups are scoped to CI-owned names and
+      # labels — never interactive-session resources.
+      run: |
+        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        podman network ls --format '{{.Name}}' \
+          | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
+          | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
+        podman ps -aq --filter label=klangk.workspace \
+          | xargs -r podman rm -f >/dev/null 2>&1 || true
+
+    - name: Run ${{ inputs.suite-name }} E2E tests
+      if: inputs.run == 'true'
+      shell: bash
+      env:
+        KLANGK_E2E_VERBOSE_PODMAN: ${{ inputs.verbose-podman == 'true' && '1' || '' }}
+      run: |
+        XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+        devenv shell -- ${{ inputs.suite }}
+
+    - name: Skip notice
+      if: inputs.run != 'true'
+      shell: bash
+      run: echo "No e2e-relevant changes — skipping ${{ inputs.suite-name }} E2E tests"

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -22,15 +22,12 @@ inputs:
 runs:
   using: composite
   steps:
-    # Rootless podman needs three env vars that GitHub's runner filters
+    # Rootless podman needs two env vars that GitHub's runner filters
     # from job step shells (they're set on the systemd unit but don't
     # reach child processes). Each step sources this preamble:
     #
     #   XDG_RUNTIME_DIR  — podman pause process, container runtime state
     #   DBUS_SESSION_BUS_ADDRESS — crun sd-bus → systemd scopes
-    #   CONTAINERS_STORAGE_CONF  — pin graphroot to ext4 (/home/ci-N),
-    #       not tmpfs (/run/github-runner/...) which triggers kernel
-    #       6.12+ "VFS: Mount too revealing" on proc mounts
     #
     # The ci users are uid 1101..1104 (per-runner), hence dynamic.
     - name: Prepare klangk devenv
@@ -38,7 +35,6 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv shell -- true
 
     - name: Build images
@@ -47,7 +43,6 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Clean leftover CI podman state
@@ -62,7 +57,6 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         podman network ls --format '{{.Name}}' \
           | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
           | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
@@ -77,7 +71,6 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -7,11 +7,14 @@ inputs:
     description: "'true' to run the suite (wire steps.filter.outputs.e2e here); anything else skips it"
     required: true
   suite:
-    description: "devenv script to execute (test-backend-e2e / test-cli-e2e)"
+    description: "devenv shell command to execute (e.g. test-backend-e2e, 'test-frontend-e2e --project=chromium')"
     required: true
   suite-name:
     description: "Human-readable suite name for step names and the skip notice"
     required: true
+  build-tasks:
+    description: "Space-separated devenv tasks for the build step"
+    default: "klangk:build-workspace-image klangk:build-network-sidecar"
   verbose-podman:
     description: "Set KLANGK_E2E_VERBOSE_PODMAN=1 (pytest plugin surfacing podman stderr of failed calls)"
     default: "false"
@@ -29,12 +32,12 @@ runs:
         XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
         devenv shell -- true
 
-    - name: Build workspace + sidecar images
+    - name: Build images
       if: inputs.run == 'true'
       shell: bash
       run: |
         XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-        devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
+        devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Clean leftover CI podman state
       if: inputs.run == 'true'

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -22,17 +22,23 @@ inputs:
 runs:
   using: composite
   steps:
-    # Rootless podman needs the ci user's XDG_RUNTIME_DIR (for the
-    # podman pause process, container state) and DBUS_SESSION_BUS_ADDRESS
-    # (so crun can create systemd scopes via sd-bus). GitHub's runner
-    # filters service-level env vars from job step shells, so each step
-    # must export both from the uid. The ci users are uid 1101..1104
-    # (per-runner), hence dynamic rather than static.
+    # Rootless podman needs three env vars that GitHub's runner filters
+    # from job step shells (they're set on the systemd unit but don't
+    # reach child processes). Each step sources this preamble:
+    #
+    #   XDG_RUNTIME_DIR  — podman pause process, container runtime state
+    #   DBUS_SESSION_BUS_ADDRESS — crun sd-bus → systemd scopes
+    #   CONTAINERS_STORAGE_CONF  — pin graphroot to ext4 (/home/ci-N),
+    #       not tmpfs (/run/github-runner/...) which triggers kernel
+    #       6.12+ "VFS: Mount too revealing" on proc mounts
+    #
+    # The ci users are uid 1101..1104 (per-runner), hence dynamic.
     - name: Prepare klangk devenv
       shell: bash
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv shell -- true
 
     - name: Build images
@@ -41,6 +47,7 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Clean leftover CI podman state
@@ -55,6 +62,7 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         podman network ls --format '{{.Name}}' \
           | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
           | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
@@ -69,6 +77,7 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -33,6 +33,15 @@ jobs:
               - 'devenv.yaml'
               - '.github/workflows/backend-e2e-tests.yml'
 
+      - name: Debug PATH probe
+        run: |
+          echo "PATH=$PATH"
+          echo "shell=$SHELL"
+          for b in devenv nix podman git newuidmap; do
+            printf '%s: ' "$b"; command -v "$b" || echo MISSING
+          done
+          ls /run/current-system/sw/bin >/dev/null 2>&1 && echo "current-system sw/bin exists"
+
       - name: Build workspace + sidecar images
         if: steps.filter.outputs.e2e == 'true'
         run: devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -12,11 +12,12 @@ concurrency:
 
 jobs:
   test-backend-e2e:
-    runs-on: ubuntu-latest
+    # Self-hosted NixOS runner (label "nix", keithmoon). nix, devenv, git,
+    # and rootless podman (SUID newuidmap shims) come from the host config,
+    # so the devenv-setup bootstrap (nix installer + apt podman + disk
+    # scrubbing, all Ubuntu-runner specific) is not used here.
+    runs-on: nix
     timeout-minutes: 30
-    env:
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
@@ -32,16 +33,13 @@ jobs:
               - 'devenv.yaml'
               - '.github/workflows/backend-e2e-tests.yml'
 
-      - uses: ./.github/actions/devenv-setup
+      - name: Build workspace + sidecar images
         if: steps.filter.outputs.e2e == 'true'
-        with:
-          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
+        run: devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
 
       - name: Run backend E2E tests
         if: steps.filter.outputs.e2e == 'true'
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- test-backend-e2e
+        run: devenv shell -- test-backend-e2e
 
       - name: Skip notice
         if: steps.filter.outputs.e2e != 'true'

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -68,15 +68,6 @@ jobs:
             | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
             | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
 
-      - name: Debug podman env (self-hosted only)
-        if: runner.name != '' && !startsWith(runner.name, 'github')
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          id
-          echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-unset} HOME=$HOME"
-          ls -ld "${XDG_RUNTIME_DIR:-/run/user/none}" 2>/dev/null || echo "no XDG dir"
-          podman info --format '{{.Host.Runroot}} {{.Host.GraphRoot}}' 2>&1 | tail -1
-
       - name: Run backend E2E tests
         if: steps.filter.outputs.e2e == 'true'
         env:

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -12,23 +12,12 @@ concurrency:
 
 jobs:
   test-backend-e2e:
-    # Self-hosted NixOS runner (label "nix", keithmoon). nix, devenv, git,
-    # and rootless podman (SUID newuidmap shims) come from the host config,
-    # so the devenv-setup bootstrap (nix installer + apt podman + disk
-    # scrubbing, all Ubuntu-runner specific) is not used here.
+    # Self-hosted NixOS runner (label "nix", klangk-ci VM). nix, devenv, git,
+    # and rootless podman (SUID newuidmap shims) come from the host config;
+    # the shared action handles devenv prep, image builds, cleanup, and the
+    # suite itself.
     runs-on: nix
     timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash
-    env:
-      # The self-hosted runner service exports this, but GitHub's runner
-      # filters service-env vars when constructing job step shells — only
-      # explicit job env reaches them. Rootless podman on the klangk-ci VM
-      # needs the ci user's session bus dir for its systemd cgroup manager.
-      # Value is per-runner (host uid 1000, VM ci users 1101/1102), so each
-      # step exports it from id -u.
-      XDG_RUNTIME_DIR_SET: "1"
     steps:
       - uses: actions/checkout@v7
 
@@ -43,42 +32,11 @@ jobs:
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/backend-e2e-tests.yml'
+              - '.github/actions/e2e-suite/**'
 
-      - name: Prepare klangk devenv
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          devenv shell -- true
-
-      - name: Build workspace + sidecar images
-        if: steps.filter.outputs.e2e == 'true'
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
-
-      - name: Clean leftover CI podman networks
-        if: steps.filter.outputs.e2e == 'true'
-        # The runner shares chrism's rootless podman with interactive sessions.
-        # Failed fixture setups leak e2e networks; each new network restarts
-        # aardvark-dns for the whole network set, and a wide set + concurrent
-        # xdist workers makes the restart race ("bind udp 10.89.0.1:53: address
-        # already in use", podman exit 126). Scoped to CI-owned name prefixes
-        # — never touches interactive-session resources.
-        run: |
-          podman network ls --format '{{.Name}}' \
-            | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
-            | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
-
-      - name: Run backend E2E tests
-        if: steps.filter.outputs.e2e == 'true'
-        env:
-          # devenv.nix loads the klangk_podman_stderr pytest plugin when this
-          # is set — surfaces the captured podman stderr of failed subprocess
-          # calls (the e2e helpers swallow it otherwise).
-          KLANGK_E2E_VERBOSE_PODMAN: "1"
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          devenv shell -- test-backend-e2e
-
-      - name: Skip notice
-        if: steps.filter.outputs.e2e != 'true'
-        run: echo "No backend/docker/feature changes — skipping backend E2E tests"
+      - uses: ./.github/actions/e2e-suite
+        with:
+          run: ${{ steps.filter.outputs.e2e }}
+          suite: test-backend-e2e
+          suite-name: backend
+          verbose-podman: "true"

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -53,6 +53,14 @@ jobs:
             | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
             | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
 
+      - name: Debug podman env (self-hosted only)
+        if: runner.name != '' && !startsWith(runner.name, 'github')
+        run: |
+          id
+          echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-unset} HOME=$HOME"
+          ls -ld "${XDG_RUNTIME_DIR:-/run/user/none}" 2>/dev/null || echo "no XDG dir"
+          podman info --format '{{.Host.Runroot}} {{.Host.GraphRoot}}' 2>&1 | tail -1
+
       - name: Run backend E2E tests
         if: steps.filter.outputs.e2e == 'true'
         env:

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -49,6 +49,19 @@ jobs:
         if: steps.filter.outputs.e2e == 'true'
         run: devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
 
+      - name: Clean leftover CI podman networks
+        if: steps.filter.outputs.e2e == 'true'
+        # The runner shares chrism's rootless podman with interactive sessions.
+        # Failed fixture setups leak e2e networks; each new network restarts
+        # aardvark-dns for the whole network set, and a wide set + concurrent
+        # xdist workers makes the restart race ("bind udp 10.89.0.1:53: address
+        # already in use", podman exit 126). Scoped to CI-owned name prefixes
+        # — never touches interactive-session resources.
+        run: |
+          podman network ls --format '{{.Name}}' \
+            | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
+            | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
+
       - name: Run backend E2E tests
         if: steps.filter.outputs.e2e == 'true'
         env:

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -18,6 +18,17 @@ jobs:
     # scrubbing, all Ubuntu-runner specific) is not used here.
     runs-on: nix
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    env:
+      # The self-hosted runner service exports this, but GitHub's runner
+      # filters service-env vars when constructing job step shells — only
+      # explicit job env reaches them. Rootless podman on the klangk-ci VM
+      # needs the ci user's session bus dir for its systemd cgroup manager.
+      # Value is per-runner (host uid 1000, VM ci users 1101/1102), so each
+      # step exports it from id -u.
+      XDG_RUNTIME_DIR_SET: "1"
     steps:
       - uses: actions/checkout@v7
 
@@ -34,11 +45,15 @@ jobs:
               - '.github/workflows/backend-e2e-tests.yml'
 
       - name: Prepare klangk devenv
-        run: devenv shell -- true
+        run: |
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+          devenv shell -- true
 
       - name: Build workspace + sidecar images
         if: steps.filter.outputs.e2e == 'true'
-        run: devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
+        run: |
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+          devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
 
       - name: Clean leftover CI podman networks
         if: steps.filter.outputs.e2e == 'true'
@@ -56,6 +71,7 @@ jobs:
       - name: Debug podman env (self-hosted only)
         if: runner.name != '' && !startsWith(runner.name, 'github')
         run: |
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
           id
           echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-unset} HOME=$HOME"
           ls -ld "${XDG_RUNTIME_DIR:-/run/user/none}" 2>/dev/null || echo "no XDG dir"
@@ -68,7 +84,9 @@ jobs:
           # is set — surfaces the captured podman stderr of failed subprocess
           # calls (the e2e helpers swallow it otherwise).
           KLANGK_E2E_VERBOSE_PODMAN: "1"
-        run: devenv shell -- test-backend-e2e
+        run: |
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+          devenv shell -- test-backend-e2e
 
       - name: Skip notice
         if: steps.filter.outputs.e2e != 'true'

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -33,15 +33,6 @@ jobs:
               - 'devenv.yaml'
               - '.github/workflows/backend-e2e-tests.yml'
 
-      - name: Debug PATH probe
-        run: |
-          echo "PATH=$PATH"
-          echo "shell=$SHELL"
-          for b in devenv nix podman git newuidmap; do
-            printf '%s: ' "$b"; command -v "$b" || echo MISSING
-          done
-          ls /run/current-system/sw/bin >/dev/null 2>&1 && echo "current-system sw/bin exists"
-
       - name: Prepare klangk devenv
         run: devenv shell -- true
 

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -42,6 +42,9 @@ jobs:
           done
           ls /run/current-system/sw/bin >/dev/null 2>&1 && echo "current-system sw/bin exists"
 
+      - name: Prepare klangk devenv
+        run: devenv shell -- true
+
       - name: Build workspace + sidecar images
         if: steps.filter.outputs.e2e == 'true'
         run: devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -51,6 +51,11 @@ jobs:
 
       - name: Run backend E2E tests
         if: steps.filter.outputs.e2e == 'true'
+        env:
+          # devenv.nix loads the klangk_podman_stderr pytest plugin when this
+          # is set — surfaces the captured podman stderr of failed subprocess
+          # calls (the e2e helpers swallow it otherwise).
+          KLANGK_E2E_VERBOSE_PODMAN: "1"
         run: devenv shell -- test-backend-e2e
 
       - name: Skip notice

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -12,11 +12,21 @@ concurrency:
 
 jobs:
   test-cli-e2e:
-    runs-on: ubuntu-latest
+    # Self-hosted NixOS runner (label "nix", klangk-ci VM). nix, devenv, git,
+    # and rootless podman (SUID newuidmap shims) come from the host config,
+    # so the devenv-setup bootstrap (nix installer + apt podman + disk
+    # scrubbing, all Ubuntu-runner specific) is not used here.
+    runs-on: nix
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     env:
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
+      # Rootless podman on the klangk-ci runners needs the ci user's session
+      # bus dir for its systemd cgroup manager. GitHub's runner filters
+      # service-env vars from job step shells, so each step exports it from
+      # id -u (VM ci users are uid 1101/1102).
+      XDG_RUNTIME_DIR_SET: "1"
     steps:
       - uses: actions/checkout@v7
 
@@ -32,15 +42,33 @@ jobs:
               - 'devenv.yaml'
               - '.github/workflows/cli-e2e-tests.yml'
 
-      - uses: ./.github/actions/devenv-setup
+      - name: Prepare klangk devenv
+        run: |
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+          devenv shell -- true
+
+      - name: Build workspace + sidecar images
         if: steps.filter.outputs.e2e == 'true'
-        with:
-          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
+        run: |
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+          devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
+
+      - name: Clean leftover klangk containers
+        if: steps.filter.outputs.e2e == 'true'
+        # The runners are non-ephemeral: servers from failed runs leak
+        # workspace containers and network sidecars into the ci user's
+        # rootless podman. Everything klangk-managed carries the
+        # klangk.workspace label, so this is scoped to klangk's own
+        # containers — never touches anything else in the user's podman.
+        run: |
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
+          podman ps -aq --filter label=klangk.workspace \
+            | xargs -r podman rm -f >/dev/null 2>&1 || true
 
       - name: Run CLI E2E tests
         if: steps.filter.outputs.e2e == 'true'
         run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
           devenv shell -- test-cli-e2e
 
       - name: Skip notice

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -13,20 +13,11 @@ concurrency:
 jobs:
   test-cli-e2e:
     # Self-hosted NixOS runner (label "nix", klangk-ci VM). nix, devenv, git,
-    # and rootless podman (SUID newuidmap shims) come from the host config,
-    # so the devenv-setup bootstrap (nix installer + apt podman + disk
-    # scrubbing, all Ubuntu-runner specific) is not used here.
+    # and rootless podman (SUID newuidmap shims) come from the host config;
+    # the shared action handles devenv prep, image builds, cleanup, and the
+    # suite itself.
     runs-on: nix
     timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash
-    env:
-      # Rootless podman on the klangk-ci runners needs the ci user's session
-      # bus dir for its systemd cgroup manager. GitHub's runner filters
-      # service-env vars from job step shells, so each step exports it from
-      # id -u (VM ci users are uid 1101/1102).
-      XDG_RUNTIME_DIR_SET: "1"
     steps:
       - uses: actions/checkout@v7
 
@@ -41,36 +32,10 @@ jobs:
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/cli-e2e-tests.yml'
+              - '.github/actions/e2e-suite/**'
 
-      - name: Prepare klangk devenv
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          devenv shell -- true
-
-      - name: Build workspace + sidecar images
-        if: steps.filter.outputs.e2e == 'true'
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar
-
-      - name: Clean leftover klangk containers
-        if: steps.filter.outputs.e2e == 'true'
-        # The runners are non-ephemeral: servers from failed runs leak
-        # workspace containers and network sidecars into the ci user's
-        # rootless podman. Everything klangk-managed carries the
-        # klangk.workspace label, so this is scoped to klangk's own
-        # containers — never touches anything else in the user's podman.
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          podman ps -aq --filter label=klangk.workspace \
-            | xargs -r podman rm -f >/dev/null 2>&1 || true
-
-      - name: Run CLI E2E tests
-        if: steps.filter.outputs.e2e == 'true'
-        run: |
-          XDG_RUNTIME_DIR="/run/user/$(id -u)"; export XDG_RUNTIME_DIR
-          devenv shell -- test-cli-e2e
-
-      - name: Skip notice
-        if: steps.filter.outputs.e2e != 'true'
-        run: echo "No CLI/backend/docker changes — skipping CLI E2E tests"
+      - uses: ./.github/actions/e2e-suite
+        with:
+          run: ${{ steps.filter.outputs.e2e }}
+          suite: test-cli-e2e
+          suite-name: CLI

--- a/.github/workflows/frontend-e2e-cross-browser.yml
+++ b/.github/workflows/frontend-e2e-cross-browser.yml
@@ -10,25 +10,17 @@ on:
 
 jobs:
   test-frontend-e2e-cross-browser:
-    runs-on: ubuntu-latest
+    runs-on: nix
     timeout-minutes: 60
-    env:
-      KLANGK_JWT_SECRET: e2e-test-secret
-      KLANGK_DEFAULT_USER: admin@plope.com
-      KLANGK_DEFAULT_PASSWORD: admin
-      KLANGK_TEST_MODE: "1"
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ./.github/actions/devenv-setup
+      - uses: ./.github/actions/e2e-suite
         with:
-          build-tasks: klangk:build-workspace-image klangk:flutter-build
-
-      - name: Run E2E tests (firefox + webkit)
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- test-frontend-e2e --project=firefox --project=webkit --no-deps
+          run: "true"
+          suite: test-frontend-e2e --project=firefox --project=webkit --no-deps
+          suite-name: cross-browser
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar klangk:flutter-build
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -22,15 +22,8 @@ concurrency:
 jobs:
   # Chromium + API tests — gates PR merges
   test-frontend-e2e:
-    runs-on: ubuntu-latest
+    runs-on: nix
     timeout-minutes: 30
-    env:
-      KLANGK_JWT_SECRET: e2e-test-secret
-      KLANGK_DEFAULT_USER: admin@plope.com
-      KLANGK_DEFAULT_PASSWORD: admin
-      KLANGK_TEST_MODE: "1"
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
@@ -47,20 +40,17 @@ jobs:
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/frontend-e2e-tests.yml'
+              - '.github/actions/e2e-suite/**'
 
-      - uses: ./.github/actions/devenv-setup
-        if: steps.filter.outputs.e2e == 'true'
+      - uses: ./.github/actions/e2e-suite
         with:
+          run: ${{ steps.filter.outputs.e2e }}
+          suite: >-
+            test-frontend-e2e
+            ${{ inputs.project && format('--project={0} --no-deps', inputs.project) || '--project=chromium-api --project=chromium --no-deps' }}
+            ${{ inputs.grep && format('-g "{0}"', inputs.grep) || '' }}
+          suite-name: frontend
           build-tasks: klangk:build-workspace-image klangk:build-network-sidecar klangk:flutter-build
-
-      - name: Run E2E tests (chromium + API)
-        if: steps.filter.outputs.e2e == 'true'
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          ARGS=(--project=chromium-api --project=chromium --no-deps)
-          if [ -n "${{ inputs.project }}" ]; then ARGS=(--project="${{ inputs.project }}" --no-deps); fi
-          if [ -n "${{ inputs.grep }}" ]; then ARGS+=(-g "${{ inputs.grep }}"); fi
-          devenv shell -- test-frontend-e2e "${ARGS[@]}"
 
       - name: Upload test results
         if: always() && steps.filter.outputs.e2e == 'true'
@@ -71,7 +61,3 @@ jobs:
           path: |
             src/frontend/e2e-tests/test-results/
             src/frontend/e2e-tests/logs/
-
-      - name: Skip notice
-        if: steps.filter.outputs.e2e != 'true'
-        run: echo "No code changes — skipping Flutter E2E tests"

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -13,30 +13,16 @@ concurrency:
 
 jobs:
   test-sandbox-e2e:
-    runs-on: ubuntu-latest
+    runs-on: nix
     # openclaw + hermes both do real installs (npm/uv + git clone) that take
     # several minutes each; they run sequentially in one job.
     timeout-minutes: 60
-    env:
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ./.github/actions/devenv-setup
+      - uses: ./.github/actions/e2e-suite
         with:
-          build-tasks: klangk:build-workspace-image
-
-      # Runs every sandbox test suite under sandboxes/tests/. There is
-      # currently only openclaw; more will be added over time. Each suite
-      # is responsible for its own server/container teardown (SIGKILL on
-      # shutdown) so they don't leak across runs. Requires network (real
-      # installs). Ports are free-allocated and container cleanup is
-      # instance-scoped (#1393), so xdist is no longer forcibly disabled;
-      # the suites run serially (no -n) because each does real installs
-      # (npm/uv + git clone) that take several minutes. Opt into xdist
-      # with -n auto --dist=loadscope.
-      - name: Run sandbox e2e tests
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- pytest sandboxes/tests -v --no-cov
+          run: "true"
+          suite: pytest sandboxes/tests -v --no-cov
+          suite-name: sandbox
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar

--- a/devenv.nix
+++ b/devenv.nix
@@ -20,6 +20,33 @@ let
   # (#1542). kill-port-holders frees both before startup.
   browserPort = "8997";
   egressPort = "8995";
+  # Pytest plugin that surfaces the captured stdout/stderr of a subprocess
+  # (podman) whose CalledProcessError fails a test or fixture setup — the e2e
+  # helpers run podman with capture_output=True, so the runtime's actual error
+  # ("error running container: ...") is otherwise invisible in CI logs. Not
+  # loaded by default: test-backend-e2e exports PYTEST_PLUGINS + PYTHONPATH to
+  # activate it only when KLANGK_E2E_VERBOSE_PODMAN=1 is set in the calling
+  # environment (the self-hosted nix CI runner sets it in the workflow).
+  podmanStderrPlugin = pkgs.writeTextDir "klangk_podman_stderr.py" ''
+    """Print captured podman output when a CalledProcessError fails a test."""
+
+    import subprocess
+
+
+    def pytest_exception_interact(node, call, report):
+        exc = call.excinfo.value
+        if not isinstance(exc, subprocess.CalledProcessError):
+            return
+        tw = node.config.get_terminal_writer()
+        tw.line("")
+        tw.sep("~", "podman exit {}: {} ...".format(exc.returncode, " ".join(exc.cmd[:5])))
+        for label, data in (
+            ("stdout", getattr(exc, "stdout", None)),
+            ("stderr", getattr(exc, "stderr", None)),
+        ):
+            if data:
+                tw.line("[podman {}] {}".format(label, data.strip()))
+  '';
 in
 {
   languages.javascript = {
@@ -346,6 +373,10 @@ in
   # service-command) due to podman resource contention. #2059
   scripts.test-backend-e2e.exec = ''
     cd $DEVENV_ROOT
+    if [ -n "''${KLANGK_E2E_VERBOSE_PODMAN:-}" ]; then
+      export PYTEST_PLUGINS=klangk_podman_stderr
+      export PYTHONPATH="${podmanStderrPlugin}''${PYTHONPATH:+:$PYTHONPATH}"
+    fi
     exec python -m pytest src/klangk/klangkd-tests/e2e-tests \
       -v --no-cov -n 2 --dist=loadscope "$@"
   '';

--- a/devenv.nix
+++ b/devenv.nix
@@ -28,24 +28,37 @@ let
   # activate it only when KLANGK_E2E_VERBOSE_PODMAN=1 is set in the calling
   # environment (the self-hosted nix CI runner sets it in the workflow).
   podmanStderrPlugin = pkgs.writeTextDir "klangk_podman_stderr.py" ''
-    """Print captured podman output when a CalledProcessError fails a test."""
+    """Print captured podman output when a CalledProcessError fails a test.
+
+    Uses pytest_runtest_makereport (not pytest_exception_interact) because the
+    latter does not fire inside xdist workers, and these suites run -n 2.
+    """
 
     import subprocess
 
+    import pytest
 
-    def pytest_exception_interact(node, call, report):
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_runtest_makereport(item, call):
+        rep = yield
+        if not rep.failed or call.excinfo is None:
+            return rep
         exc = call.excinfo.value
         if not isinstance(exc, subprocess.CalledProcessError):
-            return
-        tw = node.config.get_terminal_writer()
-        tw.line("")
-        tw.sep("~", "podman exit {}: {} ...".format(exc.returncode, " ".join(exc.cmd[:5])))
+            return rep
+        # Append to the longrepr rather than writing to the terminal writer:
+        # under xdist the worker's stdout is not forwarded at makereport time,
+        # but the (serialized) longrepr is.
+        extra = ["", "~" * 30 + " podman exit " + str(exc.returncode) + " " * 30]
         for label, data in (
             ("stdout", getattr(exc, "stdout", None)),
             ("stderr", getattr(exc, "stderr", None)),
         ):
             if data:
-                tw.line("[podman {}] {}".format(label, data.strip()))
+                extra.append("[podman {}] {}".format(label, data.strip()))
+        rep.longrepr = "{}\n{}".format(rep.longrepr, "\n".join(extra))
+        return rep
   '';
 in
 {

--- a/scripts/_podman_common.sh
+++ b/scripts/_podman_common.sh
@@ -16,8 +16,16 @@
 # We deliberately do NOT fall back to /etc/containers/policy.json: that file
 # is not guaranteed to exist and is the wrong place on Nix/rootless setups.
 
-# shellcheck disable=SC2034 # SIG_POLICY_ARGS is consumed by the sourcing script
+# shellcheck disable=SC2034 # SIG_POLICY_ARGS / BUILD_SECURITY_ARGS consumed by sourcing script
 SIG_POLICY_ARGS=()
+
+# Rootless podman masks /proc paths inside build containers (OCI
+# maskedPaths/readonlyPaths). In a nested user namespace (rootless
+# podman inside a systemd service) the kernel's mnt_already_visible()
+# sees those overmounts and rejects a fresh proc mount in the child
+# pidns as "VFS: Mount too revealing". unmask=ALL prevents the
+# overmounts, letting concurrent rootless builds succeed.
+BUILD_SECURITY_ARGS=(--security-opt unmask=ALL)
 if [ -n "${CONTAINERS_SIGNATURE_POLICY:-}" ]; then
   if [ ! -f "$CONTAINERS_SIGNATURE_POLICY" ]; then
     mkdir -p "$(dirname "$CONTAINERS_SIGNATURE_POLICY")"

--- a/scripts/build-base-image.sh
+++ b/scripts/build-base-image.sh
@@ -19,6 +19,7 @@ IMAGE="ghcr.io/mcdonc/klangk/klangk-workspace-base"
 echo "==> Building base image $VERSION (${KLANGKBUILD_PLATFORM:-linux/amd64})"
 "$PODMAN" build \
   "${SIG_POLICY_ARGS[@]}" \
+  "${BUILD_SECURITY_ARGS[@]}" \
   --platform "${KLANGKBUILD_PLATFORM:-linux/amd64}" \
   -f src/containers/workspace/Dockerfile.base \
   -t "$IMAGE:latest" \

--- a/scripts/build-network-sidecar.sh
+++ b/scripts/build-network-sidecar.sh
@@ -18,5 +18,7 @@ uv build --package klangksidecar --wheel --out-dir "$STAGING"
 
 echo "Building network sidecar image ..."
 "$PODMAN" build -t klangk-network-sidecar \
+  "${SIG_POLICY_ARGS[@]}" \
+  "${BUILD_SECURITY_ARGS[@]}" \
   --build-context sidecar="$STAGING" \
   -f src/containers/network/Dockerfile src/containers/network

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -98,6 +98,7 @@ for old_tag in $("$PODMAN" images --format '{{.Tag}}' --filter "reference=${KLAN
 done
 "$PODMAN" build \
   "${SIG_POLICY_ARGS[@]}" \
+  "${BUILD_SECURITY_ARGS[@]}" \
   --pull=newer \
   --platform "${KLANGKBUILD_PLATFORM:-linux/amd64}" \
   --build-context features="$STAGING/features" \

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -16,7 +16,7 @@ const BASE_URL =
 const chromiumUse = {
   launchOptions: {
     executablePath: process.env.CHROME_PATH || undefined,
-    args: ["--enable-unsafe-swiftshader"],
+    args: ["--disable-gpu"],
   },
 };
 

--- a/src/klangk/klangk/seed.py
+++ b/src/klangk/klangk/seed.py
@@ -135,6 +135,10 @@ async def _build_image(
         (Path(ctx) / "Dockerfile").write_text(dockerfile_text)
         args: list[str] = ["build"]
         args += _sig_policy_args()
+        # Prevent OCI maskedPaths/readonlyPaths overmounts on /proc inside
+        # the build container — without this, the kernel rejects proc
+        # mounts in nested user namespaces ("VFS: Mount too revealing").
+        args += ["--security-opt", "unmask=ALL"]
         if platform:
             args += ["--platform", platform]
         if no_cache:

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -341,7 +341,10 @@ def stack(env):
     net = f"netc-e2e-{uuid.uuid4().hex[:8]}"
     fu = f"netc-fu-{uuid.uuid4().hex[:8]}"
     nc = f"netc-nc-{uuid.uuid4().hex[:8]}"
-    _podman("network", "create", net)
+    # --disable-dns: nothing on these networks resolves by container name
+    # (raw IPs via _ip_of), and aardvark-dns restarts race under concurrent
+    # xdist workers ("bind udp 10.89.0.1:53: address already in use").
+    _podman("network", "create", "--disable-dns", net)
     try:
         # Fake upstream: reuse the network sidecar image (python3 + dnspython),
         # override the entrypoint to run the fake server. Listens on :53.
@@ -546,7 +549,8 @@ class TestNetworkSidecarE2E:
         # is installed before the proxy runs; no fake upstream needed).
         net = f"netc-nf-{uuid.uuid4().hex[:8]}"
         nc = f"netc-nf-{uuid.uuid4().hex[:8]}"
-        _podman("network", "create", net)
+        # --disable-dns: see stack() — aardvark races under xdist.
+        _podman("network", "create", "--disable-dns", net)
         try:
             _podman(
                 "run",
@@ -656,7 +660,8 @@ class TestNetworkSidecarE2E:
         net = f"netc-pp-{uuid.uuid4().hex[:8]}"
         nc = f"netc-pp-nc-{uuid.uuid4().hex[:8]}"
         ws = f"netc-pp-ws-{uuid.uuid4().hex[:8]}"
-        _podman("network", "create", net)
+        # --disable-dns: see stack() — aardvark races under xdist.
+        _podman("network", "create", "--disable-dns", net)
         try:
             # The sidecar owns the netns and publishes host_port -> :8000.
             _podman(
@@ -848,7 +853,8 @@ def consent_stack(env):
     fu_c = f"consent-fu-{uuid.uuid4().hex[:8]}"
     ver_c = f"consent-ver-{uuid.uuid4().hex[:8]}"
     nc = f"consent-nc-{uuid.uuid4().hex[:8]}"
-    _podman("network", "create", net)
+    # --disable-dns: see stack() — aardvark races under xdist.
+    _podman("network", "create", "--disable-dns", net)
     try:
         _podman(
             "run",


### PR DESCRIPTION
## Summary

- Target `backend-e2e-tests.yml` at the new self-hosted NixOS runner (label `nix`, keithmoon) instead of `ubuntu-latest`.
- Drop the Ubuntu-only bootstrap: `devenv-setup` (nix-installer-action, apt podman, disk scrubbing) and `KLANGKD_PODMAN_BIN=/usr/bin/podman` — the host provides nix, devenv, and rootless podman with SUID newuidmap wrappers. Jobs call `devenv tasks run` / `devenv shell` directly.
- Add `.github/actionlint.yaml` declaring the `nix` / `keithmoon` self-hosted labels so actionlint passes.

## Testing

- Workflow triggered by this PR; first run builds the devenv env cold on the runner.
