### PR TITLE
fix(tui): wait for refresh worker in delete-workspace E2E test (#2530)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Fall back to the full suite (or re-baseline) when testmon can under-select:
 `--no-cov` in the task is intentional: a scoped run exercises only a
 fraction of the package, so the 100% gate does not apply to it.
 
-### Before commit: the full suite, always
+### Before commit: the full unit-test suite, always
 
 testmon is a **local accelerator only**. CI always runs the full suite
 with `-n auto` and coverage, so before committing (and before trusting any
@@ -85,6 +85,14 @@ devenv --quiet -O dotenv.enable:bool false shell -- test-backend
 Operational notes: `.testmondata` is per-worktree (rootdir-relative) and
 gitignored; concurrent `testmon` runs in the same worktree serialize on
 sqlite's busy-lock (a brief stall, not corruption).
+
+### Do not run E2E tests locally "to make sure"
+
+Do **not** run the E2E suites (`test-backend-e2e`, `test-cli-e2e`) locally
+as a pre-commit sanity check. The CI runner is a VM on the same machine, so
+a local E2E run duplicates exactly the same work CI will do moments later —
+it wastes time without adding signal. Run targeted E2E tests locally only
+when actively debugging a specific E2E failure (with `-k <test_name>`).
 
 ## Verifying behavior empirically (avoid repro loops)
 

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -813,6 +813,7 @@ class MainScreen(Screen):
         """Kick off an async refresh (non-blocking)."""
         self.run_worker(
             self._refresh_lists_async,
+            name="refresh-lists",
             exit_on_error=False,
             exclusive=True,
         )

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -53,6 +53,19 @@ async def _settle(app, pilot):
     await pilot.pause()
 
 
+async def _wait_for_worker(app, pilot, name, timeout=10.0):
+    """Wait for a named worker to finish, with a timeout."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        workers = [
+            w for w in app.workers if w.name == name and not w.is_finished
+        ]
+        if not workers:
+            break
+        await pilot.pause()
+    await pilot.pause()
+
+
 # ── server fixture ──────────────────────────────────────────────────────
 
 
@@ -328,8 +341,7 @@ class TestTuiE2E:
             # Delete via API and refresh the list.
             _api_delete_workspace(base_url, token, ws_id)
             app.screen.refresh_lists()
-            await pilot.pause()
-            await pilot.pause()
+            await _wait_for_worker(app, pilot, "refresh-lists")
 
             # Verify it's gone — check .ws-name labels specifically.
             lv = app.screen.query_one("#owned_list", ListView)


### PR DESCRIPTION
## Summary

- Name the `refresh_lists` worker `"refresh-lists"` so tests can wait for it specifically
- Add `_wait_for_worker` helper that polls until a named worker finishes (with timeout)
- Replace fragile two-`pilot.pause()` pattern with deterministic worker wait in `test_delete_workspace_disappears_from_list`
- Document E2E test policy in AGENTS.md: don't run E2E locally as a sanity check since CI runs on the same machine

Closes #2530

## Test plan

- [x] `test_delete_workspace_disappears_from_list` passes reliably (4/4 local runs)
- [x] Full backend unit tests pass (4941 passed, 100% coverage)
- [ ] CI E2E suites pass