### PR TITLE
ci: revert CLI E2E to ubuntu-latest, fix nix runner cleanup (#2533)

### DIFF
--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -22,12 +22,15 @@ inputs:
 runs:
   using: composite
   steps:
-    # Rootless podman needs two env vars that GitHub's runner filters
-    # from job step shells (they're set on the systemd unit but don't
-    # reach child processes). Each step sources this preamble:
+    # Rootless podman needs three env vars that GitHub's runner filters
+    # from job step shells (set on the systemd unit but don't reach
+    # child processes). Each step exports them:
     #
-    #   XDG_RUNTIME_DIR  — podman pause process, container runtime state
+    #   XDG_RUNTIME_DIR         — podman pause process, container state
     #   DBUS_SESSION_BUS_ADDRESS — crun sd-bus → systemd scopes
+    #   CONTAINERS_STORAGE_CONF — pin graphroot to ext4 (/home/ci-N),
+    #       not tmpfs ($HOME=/run/github-runner/...) which triggers
+    #       "VFS: Mount too revealing" on kernel 6.12+
     #
     # The ci users are uid 1101..1104 (per-runner), hence dynamic.
     - name: Prepare klangk devenv
@@ -35,6 +38,7 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv shell -- true
 
     - name: Build images
@@ -43,6 +47,7 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Clean leftover CI podman state
@@ -57,6 +62,7 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         podman network ls --format '{{.Name}}' \
           | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
           | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
@@ -71,6 +77,7 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
         devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -63,11 +63,12 @@ runs:
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
         export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
+        podman rm -f klangk-prewarm >/dev/null 2>&1 || true
+        podman ps -aq --filter label=klangk.managed=true \
+          | xargs -r podman rm -f >/dev/null 2>&1 || true
         podman network ls --format '{{.Name}}' \
           | grep -E '^(netc-e2e|consent-e2e|egress-e2e|netc-pp)' \
           | xargs -r -n1 podman network rm -f >/dev/null 2>&1 || true
-        podman ps -aq --filter label=klangk.workspace \
-          | xargs -r podman rm -f >/dev/null 2>&1 || true
 
     - name: Run ${{ inputs.suite-name }} E2E tests
       if: inputs.run == 'true'

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -12,12 +12,11 @@ concurrency:
 
 jobs:
   test-cli-e2e:
-    # Self-hosted NixOS runner (label "nix", klangk-ci VM). nix, devenv, git,
-    # and rootless podman (SUID newuidmap shims) come from the host config;
-    # the shared action handles devenv prep, image builds, cleanup, and the
-    # suite itself.
-    runs-on: nix
+    runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
+      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
@@ -32,10 +31,18 @@ jobs:
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/cli-e2e-tests.yml'
-              - '.github/actions/e2e-suite/**'
 
-      - uses: ./.github/actions/e2e-suite
+      - uses: ./.github/actions/devenv-setup
+        if: steps.filter.outputs.e2e == 'true'
         with:
-          run: ${{ steps.filter.outputs.e2e }}
-          suite: test-cli-e2e
-          suite-name: CLI
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
+
+      - name: Run CLI E2E tests
+        if: steps.filter.outputs.e2e == 'true'
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- test-cli-e2e
+
+      - name: Skip notice
+        if: steps.filter.outputs.e2e != 'true'
+        run: echo "No CLI/backend/docker changes — skipping CLI E2E tests"


### PR DESCRIPTION
## Summary

- Revert CLI E2E workflow to ubuntu-latest — container interaction tests have never passed on the nix runner
- Add `CONTAINERS_STORAGE_CONF` export to pin podman graphroot to ext4
- Clean prewarm container and all `klangk.managed` containers between jobs on non-ephemeral runners

Backend, frontend, and sandbox E2E remain on the nix runner.

Closes #2533