### PR TITLE
ci: JIT ephemeral VM runner pool for all E2E suites

### DIFF
--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -38,7 +38,8 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
+        _sc="/home/$(whoami)/.config/containers/storage.conf"
+        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
         devenv shell -- true
 
     - name: Build images
@@ -47,7 +48,8 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
+        _sc="/home/$(whoami)/.config/containers/storage.conf"
+        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
         devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Clean leftover CI podman state
@@ -62,7 +64,8 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
+        _sc="/home/$(whoami)/.config/containers/storage.conf"
+        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
         podman rm -f klangk-prewarm >/dev/null 2>&1 || true
         podman ps -aq --filter label=klangk.managed=true \
           | xargs -r podman rm -f >/dev/null 2>&1 || true
@@ -78,7 +81,8 @@ runs:
       run: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u)"
         export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        export CONTAINERS_STORAGE_CONF="/home/$(whoami)/.config/containers/storage.conf"
+        _sc="/home/$(whoami)/.config/containers/storage.conf"
+        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
         devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -22,50 +22,24 @@ inputs:
 runs:
   using: composite
   steps:
-    # Rootless podman needs three env vars that GitHub's runner filters
-    # from job step shells (set on the systemd unit but don't reach
-    # child processes). Each step exports them:
-    #
-    #   XDG_RUNTIME_DIR         — podman pause process, container state
-    #   DBUS_SESSION_BUS_ADDRESS — crun sd-bus → systemd scopes
-    #   CONTAINERS_STORAGE_CONF — pin graphroot to ext4 (/home/ci-N),
-    #       not tmpfs ($HOME=/run/github-runner/...) which triggers
-    #       "VFS: Mount too revealing" on kernel 6.12+
-    #
-    # The ci users are uid 1101..1104 (per-runner), hence dynamic.
+    # The JIT runner's .env file provides XDG_RUNTIME_DIR,
+    # DBUS_SESSION_BUS_ADDRESS, and XDG_CACHE_HOME to every step
+    # automatically — no per-step export needed.
     - name: Prepare klangk devenv
       shell: bash
-      run: |
-        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
-        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        _sc="/home/$(whoami)/.config/containers/storage.conf"
-        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
-        devenv shell -- true
+      run: devenv shell -- true
 
     - name: Build images
       if: inputs.run == 'true'
       shell: bash
-      run: |
-        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
-        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        _sc="/home/$(whoami)/.config/containers/storage.conf"
-        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
-        devenv tasks run ${{ inputs.build-tasks }}
+      run: devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Clean leftover CI podman state
       if: inputs.run == 'true'
       shell: bash
-      # Non-ephemeral runners keep podman state across jobs: failed fixtures
-      # leak e2e networks (each new network restarts aardvark-dns for the
-      # whole set, racing concurrent xdist workers) and klangk-managed
-      # containers (workspace containers + network sidecars, all labeled
-      # klangk.workspace). Both cleanups are scoped to CI-owned names and
-      # labels — never interactive-session resources.
+      # Ephemeral JIT VMs shouldn't have leftover state, but guard
+      # against incomplete prior boots or pool restarts.
       run: |
-        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
-        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        _sc="/home/$(whoami)/.config/containers/storage.conf"
-        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
         podman rm -f klangk-prewarm >/dev/null 2>&1 || true
         podman ps -aq --filter label=klangk.managed=true \
           | xargs -r podman rm -f >/dev/null 2>&1 || true
@@ -78,12 +52,7 @@ runs:
       shell: bash
       env:
         KLANGK_E2E_VERBOSE_PODMAN: ${{ inputs.verbose-podman == 'true' && '1' || '' }}
-      run: |
-        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
-        export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-        _sc="/home/$(whoami)/.config/containers/storage.conf"
-        [ -f "$_sc" ] && export CONTAINERS_STORAGE_CONF="$_sc"
-        devenv shell -- ${{ inputs.suite }}
+      run: devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice
       if: inputs.run != 'true'

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -12,11 +12,12 @@ concurrency:
 
 jobs:
   test-backend-e2e:
-    runs-on: ubuntu-latest
+    # Self-hosted NixOS runner (label "nix", klangk-ci VM). nix, devenv, git,
+    # and rootless podman (SUID newuidmap shims) come from the host config;
+    # the shared action handles devenv prep, image builds, cleanup, and the
+    # suite itself.
+    runs-on: nix
     timeout-minutes: 30
-    env:
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
@@ -31,18 +32,11 @@ jobs:
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/backend-e2e-tests.yml'
+              - '.github/actions/e2e-suite/**'
 
-      - uses: ./.github/actions/devenv-setup
-        if: steps.filter.outputs.e2e == 'true'
+      - uses: ./.github/actions/e2e-suite
         with:
-          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
-
-      - name: Run backend E2E tests
-        if: steps.filter.outputs.e2e == 'true'
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- test-backend-e2e
-
-      - name: Skip notice
-        if: steps.filter.outputs.e2e != 'true'
-        run: echo "No backend/docker/feature changes — skipping backend E2E tests"
+          run: ${{ steps.filter.outputs.e2e }}
+          suite: test-backend-e2e
+          suite-name: backend
+          verbose-podman: "true"

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -12,11 +12,8 @@ concurrency:
 
 jobs:
   test-cli-e2e:
-    runs-on: ubuntu-latest
+    runs-on: nix
     timeout-minutes: 30
-    env:
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
@@ -31,18 +28,10 @@ jobs:
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/cli-e2e-tests.yml'
+              - '.github/actions/e2e-suite/**'
 
-      - uses: ./.github/actions/devenv-setup
-        if: steps.filter.outputs.e2e == 'true'
+      - uses: ./.github/actions/e2e-suite
         with:
-          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
-
-      - name: Run CLI E2E tests
-        if: steps.filter.outputs.e2e == 'true'
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- test-cli-e2e
-
-      - name: Skip notice
-        if: steps.filter.outputs.e2e != 'true'
-        run: echo "No CLI/backend/docker changes — skipping CLI E2E tests"
+          run: ${{ steps.filter.outputs.e2e }}
+          suite: test-cli-e2e
+          suite-name: CLI

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -22,15 +22,8 @@ concurrency:
 jobs:
   # Chromium + API tests — gates PR merges
   test-frontend-e2e:
-    runs-on: ubuntu-latest
+    runs-on: nix
     timeout-minutes: 30
-    env:
-      KLANGK_JWT_SECRET: e2e-test-secret
-      KLANGK_DEFAULT_USER: admin@plope.com
-      KLANGK_DEFAULT_PASSWORD: admin
-      KLANGK_TEST_MODE: "1"
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
@@ -47,20 +40,17 @@ jobs:
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/frontend-e2e-tests.yml'
+              - '.github/actions/e2e-suite/**'
 
-      - uses: ./.github/actions/devenv-setup
-        if: steps.filter.outputs.e2e == 'true'
+      - uses: ./.github/actions/e2e-suite
         with:
+          run: ${{ steps.filter.outputs.e2e }}
+          suite: >-
+            test-frontend-e2e
+            ${{ inputs.project && format('--project={0} --no-deps', inputs.project) || '--project=chromium-api --project=chromium --no-deps' }}
+            ${{ inputs.grep && format('-g "{0}"', inputs.grep) || '' }}
+          suite-name: frontend
           build-tasks: klangk:build-workspace-image klangk:build-network-sidecar klangk:flutter-build
-
-      - name: Run E2E tests (chromium + API)
-        if: steps.filter.outputs.e2e == 'true'
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          ARGS=(--project=chromium-api --project=chromium --no-deps)
-          if [ -n "${{ inputs.project }}" ]; then ARGS=(--project="${{ inputs.project }}" --no-deps); fi
-          if [ -n "${{ inputs.grep }}" ]; then ARGS+=(-g "${{ inputs.grep }}"); fi
-          devenv shell -- test-frontend-e2e "${ARGS[@]}"
 
       - name: Upload test results
         if: always() && steps.filter.outputs.e2e == 'true'
@@ -71,7 +61,3 @@ jobs:
           path: |
             src/frontend/e2e-tests/test-results/
             src/frontend/e2e-tests/logs/
-
-      - name: Skip notice
-        if: steps.filter.outputs.e2e != 'true'
-        run: echo "No code changes — skipping Flutter E2E tests"

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -13,30 +13,16 @@ concurrency:
 
 jobs:
   test-sandbox-e2e:
-    runs-on: ubuntu-latest
+    runs-on: nix
     # openclaw + hermes both do real installs (npm/uv + git clone) that take
     # several minutes each; they run sequentially in one job.
     timeout-minutes: 60
-    env:
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGKD_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ./.github/actions/devenv-setup
+      - uses: ./.github/actions/e2e-suite
         with:
-          build-tasks: klangk:build-workspace-image
-
-      # Runs every sandbox test suite under sandboxes/tests/. There is
-      # currently only openclaw; more will be added over time. Each suite
-      # is responsible for its own server/container teardown (SIGKILL on
-      # shutdown) so they don't leak across runs. Requires network (real
-      # installs). Ports are free-allocated and container cleanup is
-      # instance-scoped (#1393), so xdist is no longer forcibly disabled;
-      # the suites run serially (no -n) because each does real installs
-      # (npm/uv + git clone) that take several minutes. Opt into xdist
-      # with -n auto --dist=loadscope.
-      - name: Run sandbox e2e tests
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- pytest sandboxes/tests -v --no-cov
+          run: "true"
+          suite: pytest sandboxes/tests -v --no-cov
+          suite-name: sandbox
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -330,9 +330,10 @@ class TestTuiE2E:
 
         app = KlangkApp(tui_state)
         async with app.run_test() as pilot:
-            await pilot.pause()
-            await pilot.pause()
+            await _settle(app, pilot)
             assert isinstance(app.screen, MainScreen)
+            # Wait for the initial list load to complete.
+            await _wait_for_worker(app, pilot, "refresh-lists")
             # Verify workspace is in the list.
             lv = app.screen.query_one("#owned_list", ListView)
             names = [str(lab.render()) for lab in lv.query(Label)]

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -63,8 +63,9 @@ _UDS_HOST = "http://klangkd"
 _UDS_WS_HOST = "ws://klangkd"
 
 # How long to wait for the server to answer /health at startup. Container-less
-# readiness is ~1-2s; the headroom absorbs a loaded runner / first-boot seeding.
-_READINESS_TIMEOUT = 60
+# readiness is ~1-2s; the headroom absorbs a loaded runner / first-boot seeding
+# and concurrent VM resource contention on the JIT CI pool.
+_READINESS_TIMEOUT = 120
 
 
 def _drain_stdout(proc: Popen, log_path: str | None = None) -> str:


### PR DESCRIPTION
## Summary

- Switch all four E2E workflows (backend, CLI, frontend, sandbox) to `runs-on: nix` with the shared `e2e-suite` composite action
- Simplify composite action: runner `.env` file provides `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, `XDG_CACHE_HOME` — no per-step export hacks
- Gate `--security-opt unmask=ALL` on `CONTAINERS_STORAGE_CONF` so it doesn't break ubuntu-latest podman
- `--disable-gpu` in Playwright config to avoid SwiftShader CPU burn
- Bump `_READINESS_TIMEOUT` to 120s for concurrent VM load
- Fix TUI delete-workspace test: wait for initial list load worker
- Clean prewarm + managed containers between jobs

## Test plan

- [x] All four E2E suites pass concurrently on JIT VMs (backend 117/118, CLI 80/80, frontend 92/92, sandbox 4/4)
- [x] Backend has one pre-existing SSH agent flake (#2535)