### PR TITLE
fix(ssh-agent): gate ssh_agent_started on relay socket being bound

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -897,6 +897,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **SSH agent forwarding readiness (#2535).** The `ssh_agent_started`
+  event now fires only after the in-container relay socket is actually
+  bound, instead of when the relay process was merely spawned. Commands
+  issued immediately after starting forwarding (e.g. a scripted
+  `ssh-add`) no longer race the relay startup under load.
 - **Per-workspace idle timeout ignored on web-UI starts (#2514).** A
   workspace's `idle_timeout` settings override (#864) was only applied
   when started via `POST /workspaces/{id}/start`; a workspace started by

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -29,6 +29,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# SSH-agent relay readiness (#2535): ``ssh_agent_started`` must mean the
+# container-side socat is *listening*, not merely that the local
+# ``podman exec`` client was spawned. ``create_subprocess_exec`` returns
+# as soon as the client process exists — the container-side socat appears
+# some conmon/crun latency later — so a client that fires a follow-up exec
+# immediately (the e2e suite's ``pgrep -c socat``, or any scripted
+# ``ssh-add``) can land before the relay is visible, and under load that
+# window widens. socat's stderr is DEVNULL (no startup message to poll
+# for), so the readiness signal is the bound socket file: ``unlink-early``
+# removes any stale file and ``bind()`` creates this one, so its existence
+# means a live listener.
+_SSH_AGENT_READY_TIMEOUT = 10.0
+_SSH_AGENT_READY_POLL = 0.1
+
 # Read-only ("spectate") terminal-input whitelist (issue #1716).
 #
 # A read-only joiner may only send the terminal-protocol RESPONSES that
@@ -203,6 +217,19 @@ class SshAgentForwarder:
         self.proc = proc
         self.socket = sock_path
         self.task = asyncio.create_task(self.forward_output())
+        # Gate the "started" event on the relay actually listening
+        # (#2535). A timeout is not fatal — the socat exec may still be
+        # working its way through the runtime (headroom under load), so
+        # the event is emitted anyway and the failure mode stays the old
+        # one (a too-early client sees an inert socket) instead of a new
+        # one (clients waiting on an event that never comes).
+        if not await self._wait_until_listening(container_id, sock_path):
+            logger.warning(
+                "SSH agent socket %s not bound after %.0fs; "
+                "continuing anyway (relay may still be starting)",
+                sock_path,
+                _SSH_AGENT_READY_TIMEOUT,
+            )
         self._conn.sock.send_json(
             {
                 "type": "ssh_agent_started",
@@ -214,6 +241,35 @@ class SshAgentForwarder:
             user_id,
             sock_path,
         )
+
+    async def _wait_until_listening(
+        self, container_id: str, sock_path: str
+    ) -> bool:
+        """True once socat has bound *sock_path*; False on timeout or error.
+
+        Polls ``test -S`` inside the container until the socket file exists
+        (see the constants above for why the file is the readiness
+        signal). A podman launch failure returns False immediately — the
+        relay is dead either way, and ``stop()`` (on disconnect or the
+        next start) handles teardown.
+        """
+        deadline = time.monotonic() + _SSH_AGENT_READY_TIMEOUT
+        while True:
+            try:
+                (
+                    rc,
+                    _out,
+                    _err,
+                ) = await self._conn.app.state.podman.exec_container(
+                    container_id, ["test", "-S", sock_path], timeout=5.0
+                )
+            except Exception:
+                return False
+            if rc == 0:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            await asyncio.sleep(_SSH_AGENT_READY_POLL)
 
     async def forward_output(self) -> None:
         """Read from socat stdout and send to the CLI as ssh_agent_response."""

--- a/src/klangk/klangkd-tests/e2e-tests/test_ssh_agent_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_ssh_agent_e2e.py
@@ -30,6 +30,7 @@ import re
 import socket
 import struct
 import subprocess
+import time
 
 import pytest
 import websockets
@@ -37,6 +38,16 @@ import websockets
 from _e2e_server import start_server, stop_server, ws_connect as _ws_dial
 
 _AGENT_PROTOCOL_TIMEOUT = 3.0  # per local-agent round-trip, seconds
+
+
+def _socat_count(out: str) -> int | None:
+    """Parse ``pgrep -c socat`` output: last non-empty integer line."""
+    counts = [
+        int(ln.strip())
+        for ln in out.strip().splitlines()
+        if ln.strip().isdigit()
+    ]
+    return counts[-1] if counts else None
 
 
 def _have(*bins: str) -> bool:
@@ -262,8 +273,15 @@ async def _exec_collect(received, *, start_idx: int, timeout=30.0):
     deadline = loop.time() + timeout
     buf = bytearray()
     code: int | None = None
+    # Cursor over *received*: advance past each processed message so a
+    # chunk is appended exactly once. Re-scanning the whole slice each
+    # poll pass (the old behavior) re-appended every prior chunk once per
+    # 0.1s pass — a single "0" line became "0\n0\n0\n0\n" and garbled
+    # both the assertions and their failure messages (#2535).
+    cursor = start_idx
     while loop.time() < deadline:
-        for m in received[start_idx:]:
+        for m in received[cursor:]:
+            cursor += 1
             if m.get("type") == "exec_output":
                 buf.extend(base64.b64decode(m.get("data", "")))
             elif m.get("type") == "exec_exit":
@@ -271,6 +289,26 @@ async def _exec_collect(received, *, start_idx: int, timeout=30.0):
                 return bytes(buf), code
         await asyncio.sleep(0.1)
     return bytes(buf), code
+
+
+async def _exec_once(ws, received, *, command: list[str], login: bool = False):
+    """Run one exec_start and collect its (stdout, exit_code).
+
+    No agent relay: for commands that don't touch the forwarded socket
+    (like the socat count check), so a retry doesn't restart the relay
+    under test (#2535).
+    """
+    # Index-based boundary: only consider messages received AFTER this
+    # point as the exec's own output (the reader appends without a
+    # timestamp, so time-windowing would misclassify them as old).
+    start_idx = len(received)
+    await ws.send(
+        json.dumps({"cmd": "exec_start", "command": command, "login": login})
+    )
+    out, code = await _exec_collect(
+        received, start_idx=start_idx, timeout=30.0
+    )
+    return out.decode("utf-8", "replace"), code
 
 
 async def _run_agent_and_exec(
@@ -282,7 +320,10 @@ async def _run_agent_and_exec(
     ``ssh-add`` can reach the host agent through the forwarded socket.
     """
     # (Re)start the relay. ssh_agent_start is idempotent-ish: the server
-    # reaps any prior relay on the deterministic path first (#2001).
+    # reaps any prior relay on the deterministic path first (#2001), and
+    # gates the ssh_agent_started event on the relay socket being bound
+    # (#2535), so by the time the exec below runs the new socat is
+    # visible in the container.
     await ws.send(json.dumps({"cmd": "ssh_agent_start"}))
     started = await _drain(
         received,
@@ -296,19 +337,10 @@ async def _run_agent_and_exec(
         _pump_relay(received, ws, agent_sock, stop=stop)
     )
     try:
-        # Index-based boundary: only consider messages received AFTER this
-        # point as the exec's own output (the reader appends without a
-        # timestamp, so time-windowing would misclassify them as old).
-        start_idx = len(received)
-        await ws.send(
-            json.dumps(
-                {"cmd": "exec_start", "command": command, "login": login}
-            )
+        out, code = await _exec_once(
+            ws, received, command=command, login=login
         )
-        out, code = await _exec_collect(
-            received, start_idx=start_idx, timeout=30.0
-        )
-        return out.decode("utf-8", "replace"), code
+        return out, code
     finally:
         stop.set()
         try:
@@ -431,8 +463,14 @@ class TestSshAgentForwarding:
             )
             assert code2 == 0 and fingerprint in out2, (code2, out2)
 
-            # Exactly one socat listening on the per-user path: a leak would
-            # show >= 2. pgrep -c returns the count (login shell for PATH).
+            # Exactly one socat listening on the per-user path: a leak
+            # would show >= 2 (pgrep -c prints one number; login shell for
+            # PATH). The server gates ssh_agent_started on the socket
+            # being bound (#2535), so a count of 0 should no longer
+            # happen — but if one slips through (readiness timeout under
+            # load), retry briefly instead of failing: the assertion
+            # under test is "no leak", and a leak shows >= 2 on the very
+            # first check, not after a delay.
             out3, code3 = await _run_agent_and_exec(
                 ws,
                 received,
@@ -441,15 +479,23 @@ class TestSshAgentForwarding:
                 login=True,
             )
             assert code3 == 0, (code3, out3)
-            # Take the last non-empty integer line (pgrep -c prints one number).
-            counts = [
-                int(ln.strip())
-                for ln in out3.strip().splitlines()
-                if ln.strip().isdigit()
-            ]
-            assert counts, f"no socat count in output: {out3!r}"
-            assert counts[-1] == 1, (
-                f"expected exactly 1 socat after reconnect, got {counts[-1]} "
+            count = _socat_count(out3)
+            deadline = time.monotonic() + 10.0
+            while count == 0 and time.monotonic() < deadline:
+                # Retry with a bare exec (no ssh_agent_start) so the
+                # retry doesn't itself restart the relay under test.
+                out3, code3 = await _exec_once(
+                    ws,
+                    received,
+                    command=["bash", "-lc", "pgrep -c socat || true"],
+                    login=True,
+                )
+                assert code3 == 0, (code3, out3)
+                count = _socat_count(out3)
+                if count == 0:
+                    await asyncio.sleep(0.5)
+            assert count == 1, (
+                f"expected exactly 1 socat after reconnect, got {count} "
                 f"(relay leak): {out3!r}"
             )
         finally:

--- a/src/klangk/klangkd-tests/tests/test_seed.py
+++ b/src/klangk/klangkd-tests/tests/test_seed.py
@@ -189,12 +189,17 @@ async def test_build_image_args(tmp_path, monkeypatch):
     monkeypatch.setenv(
         "CONTAINERS_SIGNATURE_POLICY", str(tmp_path / "pol.json")
     )
+    # nix CI runner signal: --security-opt unmask=ALL must be applied
+    # (d66ec5cc) — set explicitly so the branch is covered on every
+    # runner, not only where the env happens to carry it.
+    monkeypatch.setenv("CONTAINERS_STORAGE_CONF", "/tmp/storage.conf")
     await seed._build_image(_PODMAN, "FROM x\n", no_cache=True)
     a = captured["args"]
     assert a[0] == "build"
     assert "--signature-policy" in a
     assert "--platform" in a and "linux/arm64" in a
     assert "--no-cache" in a
+    assert "--security-opt" in a and "unmask=ALL" in a
     assert "-t" in a and seed._IMAGE in a
     assert captured["kw"]["timeout"] == 2400.0
 
@@ -210,11 +215,13 @@ async def test_build_image_minimal(monkeypatch):
     monkeypatch.setattr(seed, "_run", fake_run)
     monkeypatch.delenv("KLANGKBUILD_PLATFORM", raising=False)
     monkeypatch.delenv("CONTAINERS_SIGNATURE_POLICY", raising=False)
+    monkeypatch.delenv("CONTAINERS_STORAGE_CONF", raising=False)
     await seed._build_image(_PODMAN, "FROM x\n", no_cache=False)
     a = captured["args"]
     assert "--platform" not in a
     assert "--signature-policy" not in a
     assert "--no-cache" not in a
+    assert "--security-opt" not in a
 
 
 # --- _export_to_dir_sync (the streaming tarfile extraction) ----------------

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -27,6 +27,7 @@ from klangk import (
     workspaces as ws_mod,
 )
 from klangk.exceptions import ContainerGoneError, TerminalError
+from klangk.podman import PodmanError
 from klangk.model.chat import ChatModel
 from _helpers import make_settings
 from klangk.wshandler import (
@@ -3214,7 +3215,7 @@ class TestSSHAgentHandlers:
             patch.object(
                 _mock_pod,
                 "exec_container",
-                new=AsyncMock(),
+                new=AsyncMock(return_value=(0, "", "")),
             ),
             patch(
                 "asyncio.create_subprocess_exec",
@@ -3231,6 +3232,116 @@ class TestSSHAgentHandlers:
         msg = sock.send_json.call_args[0][0]
         assert msg["type"] == "ssh_agent_started"
         assert "socket" in msg
+
+    async def test_ssh_agent_start_waits_for_socket_bound(self):
+        """ssh_agent_start polls until the relay socket is bound (#2535).
+
+        The first readiness poll misses (socket not bound yet), the second
+        hits — the event must fire only after the bound poll.
+        """
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stdin = AsyncMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        # exec_container call order in start(): pkill, rm, then readiness
+        # polls. First poll misses (rc=1), second sees the bound socket.
+        exec_mock = AsyncMock(
+            side_effect=[
+                (0, "", ""),
+                (0, "", ""),
+                (1, "", ""),
+                (0, "", ""),
+            ]
+        )
+        with (
+            patch.object(_mock_pod, "exec_container", new=exec_mock),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ),
+            patch("klangk.wshandler.controllers._SSH_AGENT_READY_POLL", 0.0),
+        ):
+            await conn.handle_ssh_agent_start()
+            assert conn.ssh_agent.task is not None
+            await conn.ssh_agent.task
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "ssh_agent_started"
+        # Exactly one readiness poll missed then one hit: 4 exec calls.
+        assert exec_mock.await_count == 4
+
+    async def test_ssh_agent_start_ready_timeout_sends_started_anyway(self):
+        """Readiness timeout still emits ssh_agent_started (#2535).
+
+        The event is best-effort gated: a slow runtime must not leave
+        clients waiting on an event that never comes.
+        """
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stdin = AsyncMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        # Every readiness poll misses.
+        exec_mock = AsyncMock(return_value=(1, "", ""))
+        with (
+            patch.object(_mock_pod, "exec_container", new=exec_mock),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "klangk.wshandler.controllers._SSH_AGENT_READY_TIMEOUT", 0.05
+            ),
+            patch("klangk.wshandler.controllers._SSH_AGENT_READY_POLL", 0.01),
+        ):
+            await conn.handle_ssh_agent_start()
+            assert conn.ssh_agent.task is not None
+            await conn.ssh_agent.task
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "ssh_agent_started"
+        # pkill + rm + at least one (timed-out) readiness poll.
+        assert exec_mock.await_count >= 3
+
+    async def test_ssh_agent_start_ready_error_sends_started_anyway(self):
+        """A podman failure during the readiness poll is not fatal (#2535)."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stdin = AsyncMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        # pkill/rm succeed; the readiness poll itself blows up.
+        exec_mock = AsyncMock(
+            side_effect=[
+                (0, "", ""),
+                (0, "", ""),
+                PodmanError(1, "podman exec exploded"),
+            ]
+        )
+        with (
+            patch.object(_mock_pod, "exec_container", new=exec_mock),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ),
+        ):
+            await conn.handle_ssh_agent_start()
+            assert conn.ssh_agent.task is not None
+            await conn.ssh_agent.task
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "ssh_agent_started"
+        assert exec_mock.await_count == 3
 
     async def test_ssh_agent_data_writes_to_stdin(self):
         import base64


### PR DESCRIPTION
## Summary

Fixes the intermittent `test_reconnect_does_not_leak_relay` failure (#2535) at the root instead of papering over the assertion.

**Root cause.** `ssh_agent_started` fired as soon as the *local* `podman exec` client was spawned — the container-side socat only appears some conmon/crun latency later. The e2e test's immediate follow-up exec (`pgrep -c socat`) could land before socat was visible in the container, returning 0 instead of 1. The window widens under CI load. A second, purely harness-side bug made the failure output misleading: `_exec_collect` re-scanned its slice on every 0.1s poll pass, re-appending each chunk once per pass — a single `0` line rendered as `'0\n0\n0\n0\n'`.

## Changes

- **Server (`wshandler/controllers.py`)**: `SshAgentForwarder.start()` now polls the container (`test -S`) until socat has actually bound the socket before emitting `ssh_agent_started` (10s budget, 0.1s polls; socat's stderr is `DEVNULL`, and `unlink-early` makes the file's existence mean a live listener). On timeout the event is still emitted (best-effort) with a warning, so clients never wait on an event that never comes — the failure mode degrades to the old one instead of a new one. This also benefits real clients: a scripted `ssh-add` right after `klangk shell -A` no longer races relay startup.
- **E2E harness**: `_exec_collect` advances a cursor so each chunk is appended once; new `_exec_once` helper runs a bare exec without restarting the relay; the leak check retries briefly on a zero count (readiness escape hatch) and still fails fast on ≥ 2 — the actual leak condition.
- **Unit tests**: readiness hit-on-first-poll, hit-on-second-poll, timeout, and podman-error paths.
- **Drive-by (separate commit)**: `test_seed.py` now covers the `CONTAINERS_STORAGE_CONF` → `--security-opt unmask=ALL` branch (d66ec5cc) that was breaking the 100% gate on any runner without the env var — a pre-existing gap on `main`, verified on a pristine tree.

## Testing

- `test-backend` (CI invocation): 4944 passed, 100% coverage.
- Targeted: `-k ssh_agent` unit tests (17 passed); e2e file collects (2 tests — the suite itself needs real podman and runs in the `test-backend-e2e` job).

Fixes #2535
