### PR TITLE
refactor(consent): move consent*.py into a consent/ subpackage (#2542 task 2)

### DIFF
--- a/src/klangk/klangk/consent/__init__.py
+++ b/src/klangk/klangk/consent/__init__.py
@@ -1,0 +1,33 @@
+"""Interactive egress-consent components (#2542 split of consent*.py).
+
+The three former flat modules became single-responsibility submodules:
+
+- :mod:`.egress`      — was ``klangk/consent.py``: the blocked-destination
+  receive → persist → expire loop (``EgressConsentMonitor``) plus
+  ``workspace_is_interactive``.
+- :mod:`.deciders`    — was ``klangk/consent_deciders.py``: the runtime
+  registry of live consent deciders (``ConsentDeciderRegistry``).
+- :mod:`.coordinator` — was ``klangk/consent_coordinator.py``: decision
+  fanout/verdicts/pause (``ConsentCoordinator``).
+
+``__init__`` re-exports the previous public surface so
+``from klangk.consent import X`` and ``from klangk import consent;
+consent.X`` keep working unchanged.
+
+Patch-target note: monkeypatching module globals must target the defining
+submodule (e.g. ``klangk.consent.egress.<name>``); re-exports here are
+bindings, not live cells.
+"""
+
+from .coordinator import (
+    ConsentCoordinator as ConsentCoordinator,
+    PAUSE_15M as PAUSE_15M,
+    PAUSE_1D as PAUSE_1D,
+    PAUSE_1H as PAUSE_1H,
+)
+from .deciders import ConsentDeciderRegistry as ConsentDeciderRegistry
+from .egress import (
+    EgressConsentMonitor as EgressConsentMonitor,
+    PRUNE_INTERVAL as PRUNE_INTERVAL,
+    workspace_is_interactive as workspace_is_interactive,
+)

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -35,8 +35,8 @@ import asyncio
 import logging
 import time
 
-from .consent import workspace_is_interactive
-from .model.egress_consent import (
+from .egress import workspace_is_interactive
+from ..model.egress_consent import (
     DECISION_ALLOWED,
     DECISION_DENIED,
     DECISION_PENDING,
@@ -44,7 +44,7 @@ from .model.egress_consent import (
     DURATION_FOREVER,
     DURATION_ONCE,
 )
-from .model.workspaces import EGRESS_MODE_ALLOW
+from ..model.workspaces import EGRESS_MODE_ALLOW
 
 logger = logging.getLogger(__name__)
 

--- a/src/klangk/klangk/consent/deciders.py
+++ b/src/klangk/klangk/consent/deciders.py
@@ -31,7 +31,7 @@ import asyncio
 import logging
 import time
 
-from .wshandler.safe_websocket import WS_ERRORS
+from ..wshandler.safe_websocket import WS_ERRORS
 
 logger = logging.getLogger(__name__)
 

--- a/src/klangk/klangk/consent/egress.py
+++ b/src/klangk/klangk/consent/egress.py
@@ -23,7 +23,7 @@ import asyncio
 import logging
 import time
 
-from .model.workspaces import EGRESS_MODE_INTERACTIVE
+from ..model.workspaces import EGRESS_MODE_INTERACTIVE
 
 logger = logging.getLogger(__name__)
 

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -20,8 +20,6 @@ from . import (
     auth,
     container,
     consent,
-    consent_coordinator,
-    consent_deciders,
     emailsvc,
     files,
     model,
@@ -918,8 +916,8 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # sidecar's interactive-mode LOG lines and persists pending consent
     # requests (started/stopped in the lifespan; WS notify lands with #2244).
     app.state.consent_monitor = consent.EgressConsentMonitor(app)
-    app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(app)
-    app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(app)
+    app.state.consent_coordinator = consent.ConsentCoordinator(app)
+    app.state.consent_deciders = consent.ConsentDeciderRegistry(app)
     # #2339: live network-sidecar sockets by workspace, so a revoke can push a
     # rule-drop to a workspace's sidecar + correlate the ack.
     app.state.sidecar_connections = sidecar_connections.SidecarConnections(app)

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -3,7 +3,7 @@
 A decider (a live client that can approve/deny held egress -- the ``klangk``
 CLI in #2310, or a Flutter client) connects here to register its live presence
 for a workspace (or deploy-wide) AND to act on held requests. The connection
-lifecycle drives the :class:`~klangk.consent_deciders.ConsentDeciderRegistry`:
+lifecycle drives the :class:`~klangk.consent.deciders.ConsentDeciderRegistry`:
 connect -> register, client ``ping`` -> touch (liveness), disconnect ->
 deregister. While at least one decider is registered the workspace is
 "interactive" (its blocked egress is held for a decision, #2311); with none,

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -17,7 +17,7 @@ credential; the workspace id comes straight from the token.
 This is the klangkd half of #2311. The sidecar's kernel-level hold (suspending
 DNS queries, deferring NFQUEUE verdicts) + its WS client are implemented in
 the sidecar (the ``klangksidecar`` package, ``src/klangksidecar``); #2244 wires the decider
-fanout to :meth:`klangk.consent_coordinator.ConsentCoordinator.resolve`.
+fanout to :meth:`klangk.consent.coordinator.ConsentCoordinator.resolve`.
 """
 
 from __future__ import annotations

--- a/src/klangk/klangkd-tests/tests/test_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_consent.py
@@ -250,7 +250,7 @@ class TestEgressConsentMonitor:
 
     async def test_run_sweeps_retention_on_idle_interval(self, monkeypatch):
         """Queue idle for PRUNE_INTERVAL -> one prune pass (#2303)."""
-        monkeypatch.setattr(consent, "PRUNE_INTERVAL", 0.01)
+        monkeypatch.setattr(consent.egress, "PRUNE_INTERVAL", 0.01)
         app = _app()
         app.state.model.egress_consent.prune = AsyncMock(return_value=3)
         mon = consent.EgressConsentMonitor(app)
@@ -264,7 +264,7 @@ class TestEgressConsentMonitor:
 
     async def test_run_sweep_failure_does_not_kill_loop(self, monkeypatch):
         """A failing sweep logs + retries later; events still flow."""
-        monkeypatch.setattr(consent, "PRUNE_INTERVAL", 0.01)
+        monkeypatch.setattr(consent.egress, "PRUNE_INTERVAL", 0.01)
         app = _app(egress_mode="static", static_denial=_denial())
         app.state.model.egress_consent.prune = AsyncMock(
             side_effect=RuntimeError("db locked")
@@ -295,7 +295,7 @@ class TestEgressConsentMonitor:
     async def test_run_sweep_then_event_ordering(self, monkeypatch):
         """After a sweep fires, a later event is still processed (the queue
         wait restarts after each sweep)."""
-        monkeypatch.setattr(consent, "PRUNE_INTERVAL", 0.01)
+        monkeypatch.setattr(consent.egress, "PRUNE_INTERVAL", 0.01)
         req = {
             "id": "r2",
             "workspace_id": FULL_WS,
@@ -321,7 +321,7 @@ class TestEgressConsentMonitor:
     async def test_stop_during_sweep_cancels_cleanly(self, monkeypatch):
         """Cancelling the monitor mid-sweep re-raises out of _prune and ends
         the loop via the outer CancelledError handler (no stray traceback)."""
-        monkeypatch.setattr(consent, "PRUNE_INTERVAL", 0.01)
+        monkeypatch.setattr(consent.egress, "PRUNE_INTERVAL", 0.01)
         app = _app()
         started = asyncio.Event()
         release = asyncio.Event()
@@ -360,7 +360,7 @@ class TestEgressConsentMonitor:
         """Steady event traffic must not starve the sweep: the deadline is
         wall-clock, not a queue-idle timeout (the row cap exists for exactly
         the flooding workspace that keeps the queue busy)."""
-        monkeypatch.setattr(consent, "PRUNE_INTERVAL", 0.05)
+        monkeypatch.setattr(consent.egress, "PRUNE_INTERVAL", 0.05)
         req = {
             "id": "r3",
             "workspace_id": FULL_WS,

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1,4 +1,4 @@
-"""Tests for :mod:`klangk.consent_coordinator` -- the synchronous hold/resolve
+"""Tests for :mod:`klangk.consent.coordinator` -- the synchronous hold/resolve
 coordinator (#2311) -- and the egress-sidecar WebSocket endpoint that drives it.
 
 The coordinator gate-checks each blocked egress (hold iff interactive + a live
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, Mock
 from fastapi import WebSocketDisconnect
 
 from klangk import auth
-from klangk.consent_coordinator import (
+from klangk.consent.coordinator import (
     ConsentCoordinator,
     PAUSE_15M,
     PAUSE_1D,
@@ -186,7 +186,7 @@ class TestConsentCoordinatorRevoke:
 
     async def test_revoke_sidecar_ack_timeout_returns_false(self, monkeypatch):
         # A sidecar that never acks -> wait_for times out -> leave enforced.
-        import klangk.consent_coordinator as cc
+        import klangk.consent.coordinator as cc
 
         monkeypatch.setattr(cc, "_REVOKE_ACK_TIMEOUT", 0.05)
         app = _app()

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -1,4 +1,4 @@
-"""Tests for :mod:`klangk.consent_deciders` -- the live-decider registry (#2308)."""
+"""Tests for :mod:`klangk.consent.deciders` -- the live-decider registry (#2308)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import json
 import types
 from unittest.mock import AsyncMock
 
-from klangk.consent_deciders import ConsentDeciderRegistry
+from klangk.consent.deciders import ConsentDeciderRegistry
 from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
 
 WS = "ws-aaaa1111-2222-3333-4444-555566667777"

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -20,8 +20,6 @@ from klangk import (
     auth as auth_mod,
     caddy as caddy_mod,
     consent,
-    consent_coordinator,
-    consent_deciders,
     sidecar_connections,
     emailsvc as emailsvc_mod,
     files as files_mod,
@@ -810,12 +808,8 @@ class TestLifespan:
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
-        app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
-            app
-        )
-        app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
-            app
-        )
+        app.state.consent_deciders = consent.ConsentDeciderRegistry(app)
+        app.state.consent_coordinator = consent.ConsentCoordinator(app)
         app.state.sidecar_connections = sidecar_connections.SidecarConnections(
             app
         )
@@ -873,12 +867,8 @@ class TestLifespan:
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
-        app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
-            app
-        )
-        app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
-            app
-        )
+        app.state.consent_deciders = consent.ConsentDeciderRegistry(app)
+        app.state.consent_coordinator = consent.ConsentCoordinator(app)
         app.state.sidecar_connections = sidecar_connections.SidecarConnections(
             app
         )
@@ -1421,12 +1411,8 @@ class TestStartupShutdownRestart:
         app.state.model = app_state.state.model
         app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
         app.state.consent_monitor = consent.EgressConsentMonitor(app)
-        app.state.consent_deciders = consent_deciders.ConsentDeciderRegistry(
-            app
-        )
-        app.state.consent_coordinator = consent_coordinator.ConsentCoordinator(
-            app
-        )
+        app.state.consent_deciders = consent.ConsentDeciderRegistry(app)
+        app.state.consent_coordinator = consent.ConsentCoordinator(app)
         app.state.sidecar_connections = sidecar_connections.SidecarConnections(
             app
         )


### PR DESCRIPTION
## Summary

Task 2 of #2542: the server-side consent trio moves into a `klangk/consent/` subpackage. Pure move, no behavior changes; git detects all three as renames.

| Before | After | Lines |
|---|---|---|
| `klangk/consent.py` | `consent/egress.py` | 222 |
| `klangk/consent_deciders.py` | `consent/deciders.py` | 188 |
| `klangk/consent_coordinator.py` | `consent/coordinator.py` | 802 |

`consent/__init__.py` re-exports the old public surface (`EgressConsentMonitor`, `workspace_is_interactive`, `ConsentDeciderRegistry`, `ConsentCoordinator`, `PAUSE_15M/1H/1D`, `PRUNE_INTERVAL`), so `from klangk.consent import X` and `from klangk import consent; consent.X` both keep working — same shim pattern as the container split (#2543).

## Adjustment details (all path-only)

- Intra-package relative imports deepened one level (`..model.*`, `..wshandler.*`); `coordinator` imports `workspace_is_interactive` from `.egress`.
- `main.py` constructs the owned instances through the package instead of the deleted flat modules.
- Test monkeypatch sites that must bind the defining module's globals now target `consent.egress.PRUNE_INTERVAL` (the sweep loop reads its own module globals — the package-level binding was never live, and the old flat-module patch worked only because module == package before).
- Docstring cross-references in `wshandler/sidecar.py` and `wshandler/decider.py` updated to the new module paths.

No changelog entry (pure internal refactor).

## Testing

`test-backend` (CI invocation): **4970 passed, coverage 100%**.

Task-list item "`klangk/consent*.py` trio" of #2542; checkbox ticked on merge.
