### PR TITLE
refactor(container): dedupe repeated patterns in klangk/container (#2548)

### DIFF
--- a/src/klangk/klangk/container/health.py
+++ b/src/klangk/klangk/container/health.py
@@ -200,6 +200,31 @@ class HealthMonitor:
         if new_status != old_status:
             self._broadcast(state, new_status, state.health_message)
 
+    def _emit(
+        self,
+        state: ContainerState,
+        *,
+        healthy: bool,
+        message: str | None,
+        running: bool,
+    ) -> None:
+        """Single emit point for ``service_health`` frames (#2548).
+
+        Both the transition (:meth:`_broadcast`) and death
+        (:meth:`broadcast_death`) paths bump ``health_seq`` and fan out
+        the same payload shape; keeping one emit means the #1175 contract
+        fields can never diverge between them again.
+        """
+        state.health_seq += 1
+        self.connections.notify_service_health(
+            state.workspace_id,
+            healthy=healthy,
+            message=message,
+            running=running,
+            health_checked_at=state.health_checked_at,
+            seq=state.health_seq,
+        )
+
     def _broadcast(
         self,
         state: ContainerState,
@@ -221,14 +246,11 @@ class HealthMonitor:
         ``seq`` (#1175 item 4) bumped on every emit so a reconnecting
         consumer can detect a missed transition.
         """
-        state.health_seq += 1
-        self.connections.notify_service_health(
-            state.workspace_id,
+        self._emit(
+            state,
             healthy=status == "healthy",
             message=message,
             running=True,
-            health_checked_at=state.health_checked_at,
-            seq=state.health_seq,
         )
 
     def broadcast_death(self, state: ContainerState) -> None:
@@ -245,14 +267,11 @@ class HealthMonitor:
         and ``healthy=False`` *before* the state is dropped, so a single
         stream is a single source of truth.
         """
-        state.health_seq += 1
-        self.connections.notify_service_health(
-            state.workspace_id,
+        self._emit(
+            state,
             healthy=False,
             message=None,
             running=False,
-            health_checked_at=state.health_checked_at,
-            seq=state.health_seq,
         )
 
     async def run_health_loop(self) -> None:

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -29,7 +29,7 @@ from .ports import (
     DEFAULT_PORTS_PER_WORKSPACE,
     PortAllocator,
 )
-from .sidecar import NetworkSidecarMixin
+from .sidecar import NetworkSidecarMixin, container_ident
 from .state import ContainerState
 
 logger = logging.getLogger(__name__)
@@ -108,6 +108,22 @@ def _reap_sort_key(c: dict) -> int:
     return (
         0 if (c.get("Labels") or {}).get("klangk.role") == "workspace" else 1
     )
+
+
+async def safe_remove(podman_inst, container_id: str, *, what: str) -> bool:
+    """Remove a container, 404-tolerant, logging failures as warnings.
+
+    The shared tail of every reap/sweep path (#2548):
+    ``remove_container`` itself is 404-tolerant; any other error is
+    logged with *what* context and swallowed so one bad container never
+    aborts a sweep. Returns True on success.
+    """
+    try:
+        await podman_inst.remove_container(container_id)
+        return True
+    except podman.PodmanError as e:
+        logger.warning("Failed to reap %s %s: %s", what, container_id[:12], e)
+        return False
 
 
 class ContainerRegistry(NetworkSidecarMixin):
@@ -581,6 +597,15 @@ class ContainerRegistry(NetworkSidecarMixin):
             setup_state=setup_state,
         )
 
+    def _ws_setting(self, workspace_settings: dict | None):
+        """Wrap a workspace-settings dict for the ``ws_settings`` resolvers.
+
+        The resolvers (#864) take ``{"settings": ...}``; every per-workspace
+        limit below resolves with the same wrapper shape, so build it once
+        (#2548).
+        """
+        return {"settings": workspace_settings}
+
     def _resolve_cpu_limit(
         self, workspace_settings: dict | None
     ) -> float | None:
@@ -592,7 +617,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         as-is with no clamping.
         """
         return ws_settings.resolve_cpu_limit(
-            {"settings": workspace_settings},
+            self._ws_setting(workspace_settings),
             self.app.state.settings.container_cpu_limit,
         )
 
@@ -601,7 +626,7 @@ class ContainerRegistry(NetworkSidecarMixin):
     ) -> str | None:
         """Per-workspace memory limit (``--memory``), #864 / #34."""
         return ws_settings.resolve_memory_limit(
-            {"settings": workspace_settings},
+            self._ws_setting(workspace_settings),
             self.app.state.settings.container_memory_limit,
         )
 
@@ -610,7 +635,7 @@ class ContainerRegistry(NetworkSidecarMixin):
     ) -> int | None:
         """Per-workspace PIDs limit (``--pids-limit``), #864 / #34."""
         return ws_settings.resolve_pids_limit(
-            {"settings": workspace_settings},
+            self._ws_setting(workspace_settings),
             self.app.state.settings.container_pids_limit,
         )
 
@@ -622,7 +647,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         explicit ``size=`` option (podman sizes it at half of RAM).
         """
         return ws_settings.resolve_tmp_size(
-            {"settings": workspace_settings},
+            self._ws_setting(workspace_settings),
             self.app.state.settings.container_tmp_size,
         )
 
@@ -1078,7 +1103,7 @@ class ContainerRegistry(NetworkSidecarMixin):
             f"klangk.instance={self.app.state.util.instance_id()}"
         )
         for c in stale:
-            stale_id = c.get("Id") or c.get("ID", "")
+            stale_id = container_ident(c)
             if stale_id == cid:
                 continue
             info = await podman.inspect_container(stale_id)
@@ -1728,16 +1753,13 @@ class ContainerRegistry(NetworkSidecarMixin):
         # or every sidecar is skipped this pass (#2476 — see _reap_sort_key).
         containers.sort(key=_reap_sort_key)
         for c in containers:
-            cid = c.get("Id") or c.get("ID", "")
+            cid = container_ident(c)
             if not cid:
                 continue
             logger.info("Reaping leftover container %s on startup", cid[:12])
-            try:
-                await self.app.state.podman.remove_container(cid)
-            except podman.PodmanError as e:
-                logger.warning(
-                    "Failed to reap leftover container %s: %s", cid[:12], e
-                )
+            await safe_remove(
+                self.app.state.podman, cid, what="leftover container"
+            )
 
     async def reap_dead_owner_containers(self) -> None:
         """Reap managed containers whose owning klangkd is no longer running.
@@ -1793,7 +1815,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         # or every sidecar is skipped this pass (#2476 — see _reap_sort_key).
         containers.sort(key=_reap_sort_key)
         for c in containers:
-            cid = c.get("Id") or c.get("ID", "")
+            cid = container_ident(c)
             if not cid:
                 continue
             labels = c.get("Labels") or {}
@@ -1813,14 +1835,9 @@ class ContainerRegistry(NetworkSidecarMixin):
                 cid[:12],
                 owner_pid,
             )
-            try:
-                await self.app.state.podman.remove_container(cid)
-            except podman.PodmanError as e:
-                logger.warning(
-                    "Failed to reap dead-owner container %s: %s",
-                    cid[:12],
-                    e,
-                )
+            await safe_remove(
+                self.app.state.podman, cid, what="dead-owner container"
+            )
 
     # --- Shutdown ---
 
@@ -1846,7 +1863,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                 f"klangk.instance={self.app.state.util.instance_id()}"
             )
             for c in containers:
-                cid = c.get("Id") or c.get("ID", "")
+                cid = container_ident(c)
                 if cid not in tracked_ids:
                     logger.info(
                         "Removing orphaned klangk container %s",

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -35,6 +35,21 @@ _NETWORK_SIDECAR_NFQUEUE = 5139
 ORPHAN_TOKEN_SWEEP_INTERVAL = 300
 
 
+def container_ident(c: dict) -> str:
+    """Best-effort identifier for a ``podman ps`` container dict.
+
+    ``podman ps --format json`` emits ``Id`` on some versions and ``ID``
+    on others; fall back to the first container name when neither is
+    present. Shared by the sidecar removal sweep and the registry reaps
+    (#2548).
+    """
+    ident = c.get("Id") or c.get("ID") or ""
+    if not ident:
+        names = c.get("Names") or []
+        ident = names[0] if names else ""
+    return ident
+
+
 class NetworkSidecarMixin:
     """Sidecar lifecycle methods mixed into ``ContainerRegistry``.
 
@@ -376,10 +391,7 @@ class NetworkSidecarMixin:
             labels = c.get("Labels") or {}
             if labels.get("klangk.role") != "network-sidecar":
                 continue
-            ident = c.get("Id") or c.get("ID") or ""
-            if not ident:
-                names = c.get("Names") or []
-                ident = names[0] if names else ""
+            ident = container_ident(c)
             if not ident:
                 continue
             try:


### PR DESCRIPTION
## Summary

Closes #2548. Same treatment as #2546/#2547, for the `klangk/container/` package from the #2543 split. Four behavior-preserving extractions; log messages and call shapes are byte-identical (tests pin them):

| Extraction | Module | Replaces |
|---|---|---|
| `HealthMonitor._emit(state, *, healthy, message, running)` | `health.py` | the seq-bump + `notify_service_health` payload hand-built twice (`_broadcast`, `broadcast_death`) — they drifted once already (#1175 item 2); now they can't |
| `ContainerRegistry._ws_setting(ws_settings_dict)` | `registry.py` | the `{"settings": ...}` wrapper rebuilt by all four `_resolve_*_limit` resolvers (which keep their named, documented seams) |
| `safe_remove(podman, cid, what)` | `registry.py` | the 404-tolerant remove-and-log-warning tail of the instance reap and dead-owner reap |
| `container_ident(c)` | `sidecar.py` | the podman-ps `Id`/`ID`/name-fallback identifier extraction — 5 sites across the sidecar sweep, both reaps, the port-conflict scan, and shutdown |

## Audited and deliberately left (issue constraint: leave-and-note)

- The four `_resolve_*` methods stay four methods — they're documented seams with per-limit docstrings; collapsing the dispatch would trade clarity for −12 lines.
- `sidecar.py`'s list/remove exception tuples (`ValueError`-tolerant on the sweep) and log wordings differ from the reaps **by design** (best-effort vs startup-critical); unifying would blur that.
- `unhealthy_message`'s bounded-tail truncation has no second copy in the package.

## Testing

`test-backend` (CI invocation): **4970 passed, coverage 100%**. No test assertions changed — the one near-miss was `safe_remove` initially passing `force=True` where the original reaps didn't; the exact original call shape was preserved instead.
