### PR TITLE
refactor(model): dedupe row-mappers in users, workspaces, invitations (#2551)

### DIFF
--- a/src/klangk/klangk/model/invitations.py
+++ b/src/klangk/klangk/model/invitations.py
@@ -21,6 +21,23 @@ ADMIN_INVITATION_SORT_COLUMNS = {
 }
 
 
+# Shared invitation-row SELECT + mapper (#2551).
+_INVITATION_COLUMNS = (
+    "SELECT id, email, invited_by, status, created_at, accepted_at"
+)
+
+
+def _invitation_row_to_dict(row) -> dict:
+    return {
+        "id": row["id"],
+        "email": row["email"],
+        "invited_by": row["invited_by"],
+        "status": row["status"],
+        "created_at": row["created_at"],
+        "accepted_at": row["accepted_at"],
+    }
+
+
 class InvitationsModel:
     """Invitation lifecycle, resolved through ``app_state.db``.
 
@@ -61,38 +78,23 @@ class InvitationsModel:
     async def get_invitation(self, invitation_id: str) -> dict | None:
         """Get an invitation by ID."""
         row = await self.app.state.db.fetchone(
-            "SELECT id, email, invited_by, status, created_at, accepted_at"
-            " FROM invitations WHERE id = ?",
+            _INVITATION_COLUMNS + " FROM invitations WHERE id = ?",
             (invitation_id,),
         )
         if row is None:
             return None
-        return {
-            "id": row["id"],
-            "email": row["email"],
-            "invited_by": row["invited_by"],
-            "status": row["status"],
-            "created_at": row["created_at"],
-            "accepted_at": row["accepted_at"],
-        }
+        return _invitation_row_to_dict(row)
 
     async def get_pending_invitation_by_email(self, email: str) -> dict | None:
         """Get a pending invitation for the given email."""
         row = await self.app.state.db.fetchone(
-            "SELECT id, email, invited_by, status, created_at, accepted_at"
-            " FROM invitations WHERE email = ? AND status = 'pending'",
+            _INVITATION_COLUMNS
+            + " FROM invitations WHERE email = ? AND status = 'pending'",
             (email,),
         )
         if row is None:
             return None
-        return {
-            "id": row["id"],
-            "email": row["email"],
-            "invited_by": row["invited_by"],
-            "status": row["status"],
-            "created_at": row["created_at"],
-            "accepted_at": row["accepted_at"],
-        }
+        return _invitation_row_to_dict(row)
 
     async def list_invitations(
         self,

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -157,6 +157,26 @@ ADMIN_USER_SORT_COLUMNS = {
 }
 
 
+# Shared user-row SELECT fragment and mapper (#2551): every user lookup
+# selects the same columns and builds the same dict; one definition keeps
+# new columns from drifting between lookups.
+_USER_COLUMNS = (
+    "SELECT id, email, password_hash, verified, provider, external_id, handle"
+)
+
+
+def _user_row_to_dict(row) -> dict:
+    return {
+        "id": row["id"],
+        "email": row["email"],
+        "password_hash": row["password_hash"],
+        "verified": bool(row["verified"]),
+        "provider": row["provider"],
+        "external_id": row["external_id"],
+        "handle": row["handle"],
+    }
+
+
 class UsersModel:
     """User/group/handle operations, resolved through ``app_state.db``.
 
@@ -205,37 +225,15 @@ class UsersModel:
             raise ValueError(f"'{handle}' is reserved for the workspace agent")
 
     async def unique_handle(self, db, base: str) -> str:
-        """Return *base* if available, else append -2, -3, … until unique.
+        """Return a unique handle on the passed connection.
 
-        The live agent handle is always treated as taken (#1160) — even if
-        the agent row hasn't been seeded yet — so a derived handle never
-        collides with ``/home/<agent_handle>``.
-
-        Resolves the agent handle on the *passed* connection (not via the
-        cached :meth:`agent_handle`, which opens a fresh connection): this
-        runs during DB migration where the ``handle`` column's schema change
-        is uncommitted on *db* but invisible to a new connection.
+        Thin delegation to the module-level :func:`unique_handle` (the
+        single implementation — the copies had drifted only in a
+        docstring cross-reference): both the model path and the DB-migration
+        path resolve the agent handle on the *passed* connection for the
+        same uncommitted-schema reason (see that function's docstring).
         """
-        cursor = await db.execute(
-            "SELECT handle FROM users WHERE id = ?", (AGENT_USER_ID,)
-        )
-        row = await cursor.fetchone()
-        agent = row[0] if row and row[0] else _DEFAULT_AGENT_HANDLE
-        # Try base, then base-2, base-3, …; skip the agent handle each time.
-        candidate = base
-        i = 1
-        while i < 10000:
-            if candidate != agent:
-                cursor = await db.execute(
-                    "SELECT 1 FROM users WHERE handle = ?", (candidate,)
-                )
-                if await cursor.fetchone() is None:
-                    return candidate
-            i += 1
-            candidate = f"{base}-{i}"
-            if len(candidate) > MAX_HANDLE_LEN:
-                candidate = f"{base[: MAX_HANDLE_LEN - len(str(i)) - 1]}-{i}"
-        return hash_fallback_handle(base)
+        return await unique_handle(db, base)
 
     async def generate_handle(self, db, email: str) -> str:
         """Return a unique handle derived from *email* on connection *db*.
@@ -358,22 +356,13 @@ class UsersModel:
     ) -> dict | None:
         """Find a user by OIDC provider + external ID."""
         row = await self.app.state.db.fetchone(
-            "SELECT id, email, password_hash, verified, provider,"
-            " external_id, handle"
-            " FROM users WHERE provider = ? AND external_id = ?",
+            _USER_COLUMNS
+            + " FROM users WHERE provider = ? AND external_id = ?",
             (provider, external_id),
         )
         if row is None:
             return None
-        return {
-            "id": row["id"],
-            "email": row["email"],
-            "password_hash": row["password_hash"],
-            "verified": bool(row["verified"]),
-            "provider": row["provider"],
-            "external_id": row["external_id"],
-            "handle": row["handle"],
-        }
+        return _user_row_to_dict(row)
 
     async def link_oidc_identity(
         self, user_id: str, provider: str, external_id: str
@@ -610,22 +599,12 @@ class UsersModel:
 
     async def get_user_by_email(self, email: str) -> dict | None:
         row = await self.app.state.db.fetchone(
-            "SELECT id, email, password_hash, verified, provider,"
-            " external_id, handle"
-            " FROM users WHERE email = ?",
+            _USER_COLUMNS + " FROM users WHERE email = ?",
             (email,),
         )
         if row is None:
             return None
-        return {
-            "id": row["id"],
-            "email": row["email"],
-            "password_hash": row["password_hash"],
-            "verified": bool(row["verified"]),
-            "provider": row["provider"],
-            "external_id": row["external_id"],
-            "handle": row["handle"],
-        }
+        return _user_row_to_dict(row)
 
     async def get_user_by_identifier(self, identifier: str) -> dict | None:
         """Resolve a user by email or handle (#616).
@@ -642,22 +621,12 @@ class UsersModel:
         if "@" in identifier:
             return await self.get_user_by_email(identifier)
         row = await self.app.state.db.fetchone(
-            "SELECT id, email, password_hash, verified, provider,"
-            " external_id, handle"
-            " FROM users WHERE handle = ?",
+            _USER_COLUMNS + " FROM users WHERE handle = ?",
             (identifier,),
         )
         if row is None:
             return None
-        return {
-            "id": row["id"],
-            "email": row["email"],
-            "password_hash": row["password_hash"],
-            "verified": bool(row["verified"]),
-            "provider": row["provider"],
-            "external_id": row["external_id"],
-            "handle": row["handle"],
-        }
+        return _user_row_to_dict(row)
 
     async def list_users(
         self,

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -91,6 +91,41 @@ def sort_order_clause(sort: str, order: str, prefix: str = "") -> str:
     return f"ORDER BY {p}{col} {direction}, {p}id {direction}"
 
 
+# Shared workspace-row SELECT fragments + mapper (#2551): the full-row
+# lookups select the same columns and build the same dict (JSON-blob
+# fields decoded); one definition keeps them from drifting.
+_WORKSPACE_FULL_COLUMNS = (
+    "SELECT id, user_id, name, container_id, num_ports, image,"
+    " service_command, auto_start, setup_state, health_check,"
+    " mounts, env, allowed_domains, rejected_domains, settings, egress_mode"
+)
+
+
+def _workspace_row_to_dict(row, *, auto_start=True) -> dict:
+    return {
+        "id": row["id"],
+        "user_id": row["user_id"],
+        "name": row["name"],
+        "container_id": row["container_id"],
+        "num_ports": row["num_ports"],
+        "image": row["image"],
+        "service_command": row["service_command"],
+        "auto_start": bool(row["auto_start"]) if auto_start else True,
+        "setup_state": row["setup_state"],
+        "health_check": row["health_check"],
+        "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
+        "env": json.loads(row["env"]) if row["env"] else None,
+        "allowed_domains": json.loads(row["allowed_domains"])
+        if row["allowed_domains"]
+        else None,
+        "rejected_domains": json.loads(row["rejected_domains"])
+        if row["rejected_domains"]
+        else None,
+        "settings": json.loads(row["settings"]) if row["settings"] else None,
+        "egress_mode": row["egress_mode"],
+    }
+
+
 class WorkspacesModel:
     """Workspace CRUD/members/listings, resolved through ``app_state.db``.
 
@@ -527,82 +562,29 @@ class WorkspacesModel:
         async with self.app.state.db.transaction() as db:
             if user_id is not None:
                 cursor = await db.execute(
-                    "SELECT id, user_id, name, container_id, num_ports, image,"
-                    " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env, allowed_domains, rejected_domains, settings, egress_mode"
-                    " FROM workspaces WHERE id = ? AND user_id = ?",
+                    _WORKSPACE_FULL_COLUMNS
+                    + " FROM workspaces WHERE id = ? AND user_id = ?",
                     (workspace_id, user_id),
                 )
             else:
                 cursor = await db.execute(
-                    "SELECT id, user_id, name, container_id, num_ports, image,"
-                    " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env, allowed_domains, rejected_domains, settings, egress_mode"
-                    " FROM workspaces WHERE id = ?",
+                    _WORKSPACE_FULL_COLUMNS + " FROM workspaces WHERE id = ?",
                     (workspace_id,),
                 )
             row = await cursor.fetchone()
             if row is None:
                 return None
-            return {
-                "id": row["id"],
-                "user_id": row["user_id"],
-                "name": row["name"],
-                "container_id": row["container_id"],
-                "num_ports": row["num_ports"],
-                "image": row["image"],
-                "service_command": row["service_command"],
-                "auto_start": bool(row["auto_start"]),
-                "setup_state": row["setup_state"],
-                "health_check": row["health_check"],
-                "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
-                "env": json.loads(row["env"]) if row["env"] else None,
-                "allowed_domains": json.loads(row["allowed_domains"])
-                if row["allowed_domains"]
-                else None,
-                "rejected_domains": json.loads(row["rejected_domains"])
-                if row["rejected_domains"]
-                else None,
-                "settings": json.loads(row["settings"])
-                if row["settings"]
-                else None,
-                "egress_mode": row["egress_mode"],
-            }
+            return _workspace_row_to_dict(row)
 
     async def get_workspace_by_id(self, workspace_id: str) -> dict | None:
         """Get a workspace by ID without access control (for admin use)."""
         row = await self.app.state.db.fetchone(
-            "SELECT id, user_id, name, container_id, num_ports, image,"
-            " service_command, setup_state, health_check, mounts, env,"
-            " allowed_domains, rejected_domains, settings, egress_mode"
-            " FROM workspaces WHERE id = ?",
+            _WORKSPACE_FULL_COLUMNS + " FROM workspaces WHERE id = ?",
             (workspace_id,),
         )
         if row is None:
             return None
-        return {
-            "id": row["id"],
-            "user_id": row["user_id"],
-            "name": row["name"],
-            "container_id": row["container_id"],
-            "num_ports": row["num_ports"],
-            "image": row["image"],
-            "service_command": row["service_command"],
-            "setup_state": row["setup_state"],
-            "health_check": row["health_check"],
-            "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
-            "env": json.loads(row["env"]) if row["env"] else None,
-            "allowed_domains": json.loads(row["allowed_domains"])
-            if row["allowed_domains"]
-            else None,
-            "rejected_domains": json.loads(row["rejected_domains"])
-            if row["rejected_domains"]
-            else None,
-            "settings": json.loads(row["settings"])
-            if row["settings"]
-            else None,
-            "egress_mode": row["egress_mode"],
-        }
+        return _workspace_row_to_dict(row)
 
     async def existing_workspace_ids(self) -> set[str]:
         """Return the IDs of every workspace row (for orphan-file sweeps).
@@ -1153,38 +1135,13 @@ class WorkspacesModel:
         """List all workspaces with auto_start enabled."""
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
-                "SELECT id, user_id, name, container_id, num_ports, image,"
-                " service_command, auto_start, setup_state, health_check,"
-                " mounts, env, allowed_domains, rejected_domains, settings, egress_mode"
-                " FROM workspaces WHERE auto_start = 1",
+                _WORKSPACE_FULL_COLUMNS
+                + " FROM workspaces WHERE auto_start = 1",
             )
             rows = await cursor.fetchall()
+            # auto_start is pinned True by the WHERE clause; the mapper's
+            # bool() would also be True, but pass the explicit form so the
+            # query's intent stays readable at the call site.
             return [
-                {
-                    "id": row["id"],
-                    "user_id": row["user_id"],
-                    "name": row["name"],
-                    "container_id": row["container_id"],
-                    "num_ports": row["num_ports"],
-                    "image": row["image"],
-                    "service_command": row["service_command"],
-                    "auto_start": True,
-                    "setup_state": row["setup_state"],
-                    "health_check": row["health_check"],
-                    "mounts": json.loads(row["mounts"])
-                    if row["mounts"]
-                    else None,
-                    "env": json.loads(row["env"]) if row["env"] else None,
-                    "allowed_domains": json.loads(row["allowed_domains"])
-                    if row["allowed_domains"]
-                    else None,
-                    "rejected_domains": json.loads(row["rejected_domains"])
-                    if row["rejected_domains"]
-                    else None,
-                    "settings": json.loads(row["settings"])
-                    if row["settings"]
-                    else None,
-                    "egress_mode": row["egress_mode"],
-                }
-                for row in rows
+                _workspace_row_to_dict(row, auto_start=True) for row in rows
             ]


### PR DESCRIPTION
## Summary

Closes #2551 (follow-up 1 of the #2550 duplication scan). Behavior-preserving row-mapper consolidation across three model modules, net **−72 lines**:

| Module | Extraction | Call sites |
|---|---|---|
| `model/users.py` | `_USER_COLUMNS` + `_user_row_to_dict(row)` | `get_user_by_external_id`, `get_user_by_email`, `get_user_by_identifier` |
| `model/users.py` | `UsersModel.unique_handle` → delegates to the module-level `unique_handle()` | the method and module fn were byte-identical except one docstring cross-ref — the drift the scan predicted |
| `model/workspaces.py` | `_WORKSPACE_FULL_COLUMNS` + `_workspace_row_to_dict(row)` | `get_workspace` (both `user_id` branches), `get_workspace_by_id`, `list_auto_start_workspaces` |
| `model/invitations.py` | `_INVITATION_COLUMNS` + `_invitation_row_to_dict(row)` | `get_invitation`, `get_pending_invitation_by_email` |

WHERE clauses stay per-method; only the shared column fragments and dict construction (including the JSON-blob decoding for workspaces) moved. The list-page workspace queries use a different column set (no `user_id`, plus `created_at`) and were deliberately left with their own mappers.

## Testing

`test-backend` (CI invocation): **4970 passed, coverage 100%** — tests assert on dict contents, not SQL text, so no test changes were needed at all.
