### PR TITLE
refactor(sidecar): collapse allow/deny mirrors + forward pair (#2554)

### DIFF
--- a/src/klangksidecar/klangksidecar/allowlist.py
+++ b/src/klangksidecar/klangksidecar/allowlist.py
@@ -140,6 +140,47 @@ def _prune_session_allows() -> None:
     ]
 
 
+def _add_session_entry(lst: list, host: str, port: int, ttl: float) -> None:
+    """Add/refresh an EXACT ``(host, port)`` entry in *lst* (#2554).
+
+    The shared body of :func:`_add_session_host` (allows) and
+    :func:`_add_session_deny` (denies): deduped, a re-add refreshes the
+    expiry (``max`` -- never shortens an unexpired entry). Loop-only
+    (no lock). Callers prune first.
+    """
+    expire = time.time() + ttl
+    spec = (host, port, _EXACT)
+    for i, (h, p, mode, _exp) in enumerate(lst):
+        if (h, p, mode) == spec:
+            lst[i] = (h, p, mode, max(_exp, expire))
+            return
+    lst.append((host, port, _EXACT, expire))
+
+
+def _session_entry_ttl(lst: list, host: str, port: int) -> float | None:
+    """Max remaining TTL of an entry in *lst* covering ``host:port``, or None.
+
+    The shared body of :func:`_session_host_allows_ttl` and
+    :func:`_session_host_denies_ttl`: matches via :func:`_host_matches`
+    (nginx-style scope; entries are added EXACT, so only the exact host
+    matches, #2377); port must match (or the entry is all-ports).
+    Loop-only (no lock). Callers prune first.
+    """
+    if not host:
+        return None
+    now = time.time()
+    best: float | None = None
+    for h, p, mode, exp in lst:
+        if exp <= now:
+            continue  # belt-and-suspenders: _prune ran above, but a just-expired
+            # entry can survive the microseconds between its `now` and this one.
+        if _host_matches(host, h, mode) and (p == port or p is None):
+            remaining = exp - now
+            if best is None or remaining > best:
+                best = remaining
+    return best
+
+
 def _add_session_host(host: str, port: int, ttl: float) -> None:
     """Allow-list ``host:port`` in-session for a consent allow verdict (#2372,
     #2434).
@@ -157,13 +198,7 @@ def _add_session_host(host: str, port: int, ttl: float) -> None:
     a reconnect re-prompts). Loop-only (no lock).
     """
     _prune_session_allows()
-    expire = time.time() + ttl
-    spec = (host, port, _EXACT)
-    for i, (h, p, mode, _exp) in enumerate(state._SESSION_HOST_ALLOWS):
-        if (h, p, mode) == spec:
-            state._SESSION_HOST_ALLOWS[i] = (h, p, mode, max(_exp, expire))
-            return
-    state._SESSION_HOST_ALLOWS.append((host, port, _EXACT, expire))
+    _add_session_entry(state._SESSION_HOST_ALLOWS, host, port, ttl)
 
 
 def _session_host_allows_ttl(host: str, port: int) -> float | None:
@@ -183,17 +218,7 @@ def _session_host_allows_ttl(host: str, port: int) -> float | None:
     if not host:
         return None
     _prune_session_allows()
-    now = time.time()
-    best: float | None = None
-    for h, p, mode, exp in state._SESSION_HOST_ALLOWS:
-        if exp <= now:
-            continue  # belt-and-suspenders: _prune ran above, but a just-expired
-            # entry can survive the microseconds between its `now` and this one.
-        if _host_matches(host, h, mode) and (p == port or p is None):
-            remaining = exp - now
-            if best is None or remaining > best:
-                best = remaining
-    return best
+    return _session_entry_ttl(state._SESSION_HOST_ALLOWS, host, port)
 
 
 def _session_allow_rule_cap(qname: str) -> float | None:
@@ -277,13 +302,7 @@ def _add_session_deny(host: str, port: int, ttl: float) -> None:
     so a reconnect re-prompts). Loop-only (no lock).
     """
     _prune_session_denies()
-    expire = time.time() + ttl
-    spec = (host, port, _EXACT)
-    for i, (h, p, mode, _exp) in enumerate(state._SESSION_HOST_DENIES):
-        if (h, p, mode) == spec:
-            state._SESSION_HOST_DENIES[i] = (h, p, mode, max(_exp, expire))
-            return
-    state._SESSION_HOST_DENIES.append((host, port, _EXACT, expire))
+    _add_session_entry(state._SESSION_HOST_DENIES, host, port, ttl)
 
 
 def _session_host_denies_ttl(host: str, port: int) -> float | None:
@@ -302,17 +321,7 @@ def _session_host_denies_ttl(host: str, port: int) -> float | None:
     if not host:
         return None
     _prune_session_denies()
-    now = time.time()
-    best: float | None = None
-    for h, p, mode, exp in state._SESSION_HOST_DENIES:
-        if exp <= now:
-            continue  # belt-and-suspenders: _prune ran above, but a just-expired
-            # entry can survive the microseconds between its `now` and this one.
-        if _host_matches(host, h, mode) and (p == port or p is None):
-            remaining = exp - now
-            if best is None or remaining > best:
-                best = remaining
-    return best
+    return _session_entry_ttl(state._SESSION_HOST_DENIES, host, port)
 
 
 def _drop_session_hosts(host: str) -> None:

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -118,6 +118,30 @@ def _decision(qname: str, ports: set[int] | None) -> tuple[bool, set[int | None]
     return False, ports if ports is not None else {None}
 
 
+async def _forward_marked(data: bytes) -> bytes | None:
+    """Forward a DNS wire to UPSTREAM on a fwmark'd non-blocking socket.
+
+    The shared preamble of :func:`_forward_and_learn` and
+    :func:`_forward_and_record` (#2554): a MARK'd UDP socket (so the
+    entrypoint's rule exempt the proxy's own egress, #2264), send +
+    bounded receive on the loop's sock_* helpers, closed on success,
+    error, AND cancellation. Returns the response wire, or None on any
+    upstream failure/timeout.
+    """
+    loop = asyncio.get_running_loop()
+    us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
+    us.setblocking(False)
+    try:
+        await asyncio.wait_for(loop.sock_sendto(us, data, UPSTREAM), 3)
+        resp, _ = await asyncio.wait_for(loop.sock_recvfrom(us, 65535), 3)
+        return resp
+    except Exception:
+        return None
+    finally:
+        us.close()  # closed on success, error, AND cancellation
+
+
 async def _forward_and_learn(
     s: socket.socket,
     data: bytes,
@@ -132,17 +156,9 @@ async def _forward_and_learn(
     socket + the loop's sock_* helpers so the await yields to other holds +
     the WS receive loop while the upstream is pending.
     """
-    loop = asyncio.get_running_loop()
-    us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
-    us.setblocking(False)
-    try:
-        await asyncio.wait_for(loop.sock_sendto(us, data, UPSTREAM), 3)
-        resp, _ = await asyncio.wait_for(loop.sock_recvfrom(us, 65535), 3)
-    except Exception:
+    resp = await _forward_marked(data)
+    if resp is None:
         return
-    finally:
-        us.close()  # closed on success, error, AND cancellation
     await _respond_allowed(s, resp, addr, qname, port_set)
 
 
@@ -192,17 +208,9 @@ async def _forward_and_record(
     resolver's <=30s getaddrinfo cap. Uses a non-blocking socket + the loop's
     sock_* helpers like :func:`_forward_and_learn`.
     """
-    loop = asyncio.get_running_loop()
-    us = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    us.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, MARK)
-    us.setblocking(False)
-    try:
-        await asyncio.wait_for(loop.sock_sendto(us, data, UPSTREAM), 3)
-        resp, _ = await asyncio.wait_for(loop.sock_recvfrom(us, 65535), 3)
-    except Exception:
+    resp = await _forward_marked(data)
+    if resp is None:
         return
-    finally:
-        us.close()
     await _respond_recorded(s, resp, addr, qname)
 
 

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -1547,6 +1547,11 @@ class TestBumpActivity:
     def _client(self, proxy, tmp_path):
         c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
         c._connected.set()
+        # Deterministic gate on the first bump regardless of machine uptime:
+        # time.monotonic() on a fresh CI VM is the boot clock (~a minute),
+        # which can be SMALLER than the jittered gate window (30-60s for the
+        # default 60s base), suppressing even the first send (#2557 CI flake).
+        c._last_activity_send = float("-inf")
         sent = []
 
         class _FakeWS:


### PR DESCRIPTION
## Summary

Closes #2554 (follow-up 4 of #2550). Behavior-preserving dedup inside `klangksidecar` only (standalone-package rule — no cross-boundary sharing):

| Extraction | Replaces |
|---|---|
| `allowlist._add_session_entry(lst, host, port, ttl)` | the dedup/refresh-expiry bodies of `_add_session_host` + `_add_session_deny` |
| `allowlist._session_entry_ttl(lst, host, port)` | the max-remaining-TTL scan bodies of `_session_host_allows_ttl` + `_session_host_denies_ttl` |
| `resolve._forward_marked(data) -> bytes \| None` | the fwmark'd non-blocking forward/receive preamble of `_forward_and_learn` + `_forward_and_record` (send + bounded recv; socket closed on success, error, **and** cancellation; `None` on any upstream failure) |

The four public allowlist functions keep their names, docstrings, and prune-then-delegate shape; the two resolve functions keep their distinct post-response steps inline. The `_drop_session_*` pair was audited and left as-is (two 3-line comprehensions — parametrizing adds more indirection than it removes).

## Testing

Sidecar suite (`test-sidecar` invocation): **187 passed**. Backend: **4970 passed, 100% coverage** (unchanged — the sidecar isn't in the coverage gate).
