### PR TITLE
refactor(container): consolidate registry duplication, extract spec module

### DIFF
--- a/src/klangk/klangk/cli/context.py
+++ b/src/klangk/klangk/cli/context.py
@@ -91,7 +91,10 @@ def resolve_or_exit(client, name: str):
     command modules (#2546): on ``WorkspaceNotFoundError`` prints
     ``No workspace named '<name>'`` to stderr and raises ``typer.Exit(1)``.
     """
-    from .client import WorkspaceNotFoundError
+    # Deferred: context is imported by every command module; this keeps
+    # client.py's httpx/websockets import weight off commands that never
+    # build a client (check_deferred_imports allowlist).
+    from .client import WorkspaceNotFoundError  # noqa: allow-deferred-import
 
     try:
         return client.resolve_workspace(name)

--- a/src/klangk/klangk/container/__init__.py
+++ b/src/klangk/klangk/container/__init__.py
@@ -12,6 +12,8 @@ patch/import) so callers keep working unchanged:
 - :mod:`.idle`     - ``IdleMonitor``
 - :mod:`.health`   - ``HealthMonitor`` + ``unhealthy_message``
 - :mod:`.sidecar`  - network sidecar lifecycle (mixin + constants)
+- :mod:`.spec`    - container spec assembly (``ContainerStartSpec``, env/
+  mounts/volumes/nix builders, limit resolvers, create kwargs)
 - :mod:`.registry` - ``ContainerRegistry`` (lifecycle, bringup, reaps)
 
 Patch-target note: monkeypatching module globals must now target the
@@ -43,4 +45,5 @@ from .registry import (
     _reap_sort_key as _reap_sort_key,
 )
 from .sidecar import NetworkSidecarMixin as NetworkSidecarMixin
+from .spec import ContainerStartSpec as ContainerStartSpec
 from .state import ContainerState as ContainerState

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -3,8 +3,10 @@
 ``ContainerRegistry`` composes :class:`PortAllocator`,
 :class:`BrowserRouter`, :class:`IdleMonitor`, and :class:`HealthMonitor`
 as collaborators, and mixes in :class:`NetworkSidecarMixin` for the FQDN
-egress sidecar.  Constructed once in :func:`build_app` and stored on
-``app.state.container_registry`` (#1426).
+egress sidecar.  Spec assembly (env/mounts/volumes/limits/create
+kwargs, plus the :class:`ContainerStartSpec` start-parameter object)
+lives in :mod:`.spec` (#2566).  Constructed once in :func:`build_app`
+and stored on ``app.state.container_registry`` (#1426).
 """
 
 import asyncio
@@ -13,13 +15,9 @@ import os
 import time
 
 from .. import podman
-from .. import workspace_settings as ws_settings
 from ..model.workspaces import EGRESS_MODE_ALLOW, EGRESS_MODE_INTERACTIVE
 from ..podman import PodmanError
-from ..ssl_trust import (  # noqa: F401 (re-exported via the package)
-    SSL_MOUNT_DEST as _SSL_MOUNT_DEST,
-    ssl_env_vars,
-)
+from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST
 from .browsers import BrowserRouter
 from .health import HealthMonitor
 from .idle import IdleMonitor
@@ -30,12 +28,21 @@ from .ports import (
     PortAllocator,
 )
 from .sidecar import NetworkSidecarMixin, container_ident
+from .spec import (
+    ContainerStartSpec,
+    _is_named_volume,
+    _split_csv,
+    build_create_kwargs,
+    build_env,
+    build_mounts,
+    ensure_volumes,
+    image_pull_policy,
+    nix_binds,
+)
 from .state import ContainerState
 
 logger = logging.getLogger(__name__)
 
-
-_VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
 
 _VALID_MOUNT_OPTIONS = {
     "ro",
@@ -53,11 +60,6 @@ _PROTECTED_PATHS = [
     "/run/docker.sock",
     "/run/podman/podman.sock",
 ]
-
-
-def _is_named_volume(source: str) -> bool:
-    """A mount source with no '/' that doesn't start with '.' is a volume."""
-    return "/" not in source and not source.startswith(".")
 
 
 def _pid_alive(pid: int) -> bool:
@@ -182,25 +184,16 @@ class ContainerRegistry(NetworkSidecarMixin):
         return self.app.state.settings.image_name or "klangk-workspace"
 
     @property
-    def terminal_banner(self) -> str:
-        return self.app.state.settings.terminal_banner or ""
-
-    @property
     def allowed_images(self) -> set[str]:
-        imgs: set[str] = set()
-        raw = self.app.state.settings.allowed_images
-        if raw:
-            imgs = {i.strip() for i in raw.split(",") if i.strip()}
+        imgs = set(_split_csv(self.app.state.settings.allowed_images))
         imgs.add(self.image_name)
         return imgs
 
     @property
     def allowed_mount_roots(self) -> list[str]:
-        raw = self.app.state.settings.allowed_mount_roots
-        if not raw:
-            return []
         return [
-            os.path.realpath(p.strip()) for p in raw.split(",") if p.strip()
+            os.path.realpath(p)
+            for p in _split_csv(self.app.state.settings.allowed_mount_roots)
         ]
 
     @property
@@ -225,25 +218,15 @@ class ContainerRegistry(NetworkSidecarMixin):
 
     def container_dns_config(self) -> list[str]:
         """Return DNS server list from settings.dns_servers."""
-        raw = self.app.state.settings.dns_servers
-        return [d.strip() for d in raw.split(",") if d.strip()]
+        return _split_csv(self.app.state.settings.dns_servers)
 
     def container_dns_search_config(self) -> list[str]:
         """Return DNS search-domain list from settings.dns_search (#2055)."""
-        raw = self.app.state.settings.dns_search
-        return [d.strip() for d in raw.split(",") if d.strip()]
+        return _split_csv(self.app.state.settings.dns_search)
 
     def image_pull_policy(self) -> str:
         """Resolve the workspace-image pull policy from settings."""
-        policy = self.app.state.settings.image_pull_policy
-        if policy not in _VALID_PULL_POLICIES:
-            logger.warning(
-                "Invalid KLANGKD_IMAGE_PULL_POLICY=%r (valid: %s); using 'never'.",
-                policy,
-                ", ".join(sorted(_VALID_PULL_POLICIES)),
-            )
-            return "never"
-        return policy
+        return image_pull_policy(self.app)
 
     def _is_protected(self, source: str) -> bool:
         """True if source is a protected host path that must never be mounted."""
@@ -597,82 +580,8 @@ class ContainerRegistry(NetworkSidecarMixin):
             setup_state=setup_state,
         )
 
-    def _ws_setting(self, workspace_settings: dict | None):
-        """Wrap a workspace-settings dict for the ``ws_settings`` resolvers.
-
-        The resolvers (#864) take ``{"settings": ...}``; every per-workspace
-        limit below resolves with the same wrapper shape, so build it once
-        (#2548).
-        """
-        return {"settings": workspace_settings}
-
-    def _resolve_cpu_limit(
-        self, workspace_settings: dict | None
-    ) -> float | None:
-        """Per-workspace CPU limit (``--cpus``), #864 / #34.
-
-        Workspace override > deploy default > None (no flag, unbounded).
-        Override semantics (#34): a deploy-wide value is a plain default,
-        not a cap or floor — a creator may go larger *or* smaller, applied
-        as-is with no clamping.
-        """
-        return ws_settings.resolve_cpu_limit(
-            self._ws_setting(workspace_settings),
-            self.app.state.settings.container_cpu_limit,
-        )
-
-    def _resolve_memory_limit(
-        self, workspace_settings: dict | None
-    ) -> str | None:
-        """Per-workspace memory limit (``--memory``), #864 / #34."""
-        return ws_settings.resolve_memory_limit(
-            self._ws_setting(workspace_settings),
-            self.app.state.settings.container_memory_limit,
-        )
-
-    def _resolve_pids_limit(
-        self, workspace_settings: dict | None
-    ) -> int | None:
-        """Per-workspace PIDs limit (``--pids-limit``), #864 / #34."""
-        return ws_settings.resolve_pids_limit(
-            self._ws_setting(workspace_settings),
-            self.app.state.settings.container_pids_limit,
-        )
-
-    def _resolve_tmp_size(self, workspace_settings: dict | None) -> str | None:
-        """Per-workspace ``/tmp`` tmpfs size (``--tmpfs /tmp:...,size=<n>``).
-
-        #2378: same precedence as the other resolvers (workspace override >
-        deploy default > none). ``None`` means mount ``/tmp`` with no
-        explicit ``size=`` option (podman sizes it at half of RAM).
-        """
-        return ws_settings.resolve_tmp_size(
-            self._ws_setting(workspace_settings),
-            self.app.state.settings.container_tmp_size,
-        )
-
     async def start_container(
-        self,
-        workspace_id: str,
-        host_path: str,
-        home_path: str,
-        existing_container_id: str | None = None,
-        num_ports: int = DEFAULT_PORTS_PER_WORKSPACE,
-        hosting_hostname: str | None = None,
-        hosting_proto: str | None = None,
-        hosting_base_path: str | None = None,
-        image: str | None = None,
-        config_path: str | None = None,
-        extra_mounts: list[str] | None = None,
-        extra_env: dict[str, str] | None = None,
-        user_id: str | None = None,
-        health_check: str | None = None,
-        setup_state: str | None = None,
-        service_command: str | None = None,
-        allowed_domains: list[str] | None = None,
-        rejected_domains: list[str] | None = None,
-        workspace_settings: dict | None = None,
-        egress_mode: str = "static",
+        self, spec: ContainerStartSpec
     ) -> tuple[str, str]:
         """Start (or restart) a Pi container for a workspace.
 
@@ -680,50 +589,33 @@ class ContainerRegistry(NetworkSidecarMixin):
         'connected' (already running), 'restarted', or 'created'.
 
         Serialized per workspace so concurrent WebSocket connections
-        don't race to create the same container.
+        don't race to create the same container. All parameters travel
+        on the :class:`ContainerStartSpec` (#2566) shared with
+        :meth:`_start_container_inner`, so adding a start parameter is a
+        single spec field instead of a two-signature edit.
+
+        Applies the per-workspace idle-timeout override from the
+        settings bag (#864) at this single start choke point, so
+        EVERY start path gets it -- a workspace started by a
+        WebSocket connect (the normal web-UI flow,
+        wshandler.connection) lands here just like POST /start
+        (Workspaces.start_workspace), and previously only the
+        latter applied the bag, so a WS-started workspace silently
+        ignored its override (found by the idle fuzz harness,
+        #2514). Only when actually declared: an absent key leaves
+        the container state's ``idle_timeout`` at None so
+        ``get_idle_timeout()`` lazily follows the live deploy
+        default (a SIGHUP settings reload stays effective for
+        running containers). The auto_start boot path pins 0 after
+        this returns, so a service workspace never idles out
+        regardless of its bag (#1244).
         """
-        async with self._get_workspace_lock(workspace_id):
-            result = await self._start_container_inner(
-                workspace_id,
-                host_path,
-                home_path,
-                existing_container_id=existing_container_id,
-                num_ports=num_ports,
-                hosting_hostname=hosting_hostname,
-                hosting_proto=hosting_proto,
-                hosting_base_path=hosting_base_path,
-                image=image,
-                config_path=config_path,
-                extra_mounts=extra_mounts,
-                extra_env=extra_env,
-                user_id=user_id,
-                health_check=health_check,
-                setup_state=setup_state,
-                service_command=service_command,
-                allowed_domains=allowed_domains,
-                rejected_domains=rejected_domains,
-                workspace_settings=workspace_settings,
-                egress_mode=egress_mode,
-            )
-            # Apply the per-workspace idle-timeout override from the
-            # settings bag (#864) at this single start choke point, so
-            # EVERY start path gets it -- a workspace started by a
-            # WebSocket connect (the normal web-UI flow,
-            # wshandler.connection) lands here just like POST /start
-            # (Workspaces.start_workspace), and previously only the
-            # latter applied the bag, so a WS-started workspace silently
-            # ignored its override (found by the idle fuzz harness,
-            # #2514). Only when actually declared: an absent key leaves
-            # the container state's ``idle_timeout`` at None so
-            # ``get_idle_timeout()`` lazily follows the live deploy
-            # default (a SIGHUP settings reload stays effective for
-            # running containers). The auto_start boot path pins 0 after
-            # this returns, so a service workspace never idles out
-            # regardless of its bag (#1244).
-            bag = workspace_settings or {}
+        async with self._get_workspace_lock(spec.workspace_id):
+            result = await self._start_container_inner(spec)
+            bag = spec.workspace_settings or {}
             if "idle_timeout" in bag:
                 self.idle.set_workspace_idle_timeout(
-                    workspace_id, bag["idle_timeout"]
+                    spec.workspace_id, bag["idle_timeout"]
                 )
             return result
 
@@ -792,7 +684,8 @@ class ContainerRegistry(NetworkSidecarMixin):
         ``num_ports`` is clamped down to the server-wide cap
         (``KLANGKD_HOSTED_PORTS_PER_WORKSPACE``). At cap 0 every workspace
         releases all of its allocations; the returned empty list then
-        suppresses the hosting env in :meth:`_build_env` (#1237).
+        suppresses the hosting env in :func:`klangk.container.spec.build_env`
+        (#1237).
         """
         num_ports = min(num_ports, self.ports_per_workspace_cap())
         async with self.port_lock:
@@ -815,181 +708,6 @@ class ContainerRegistry(NetworkSidecarMixin):
                 )
                 host_ports = host_ports[:num_ports]
         return host_ports
-
-    def _build_env(
-        self,
-        workspace_id: str,
-        host_ports: list[int],
-        hosting_hostname: str | None,
-        hosting_proto: str | None,
-        hosting_base_path: str | None,
-        agent_home: str,
-        extra_env: dict[str, str] | None,
-        ssl_dir: str | None = None,
-    ) -> list[str]:
-        """Build the container environment variable list.
-
-        ``hosting_hostname``/``hosting_proto``/``hosting_base_path`` are
-        optional: callers with a live request pass the values they derived
-        from its headers (``wshandler.connection``), and callers without one
-        (``start_workspace`` — autostart/create, no connection yet) pass
-        ``None``. Resolving the floor here, at the single choke point, means
-        no start path can bypass the override: when a caller omits them we
-        derive the env / bare-localhost floor via ``derive_hosting_info``
-        (the same resolver the request paths use), so a deployer's
-        ``KLANGKD_HOSTING_HOSTNAME`` is honored on every start — eager or not.
-        """
-        if (
-            hosting_hostname is None
-            or hosting_proto is None
-            or hosting_base_path is None
-        ):
-            h, p, b = self.app.state.util.derive_hosting_info(None, None)
-            # Use ``is None`` (not ``or``): an explicit empty base_path
-            # (root deployment) is a legitimate value that must survive,
-            # not be clobbered by the resolved floor.
-            if hosting_hostname is None:
-                hosting_hostname = h
-            if hosting_proto is None:
-                hosting_proto = p
-            if hosting_base_path is None:
-                hosting_base_path = b
-        env_vars: list[str] = []
-        egress_port = self.app.state.settings.egress_port
-        proxy_url = f"http://host.containers.internal:{egress_port}/llm-proxy"
-        env_vars.append(f"KLANGKWS_LLM_PROXY_URL={proxy_url}")
-        env_vars.append("PI_SKIP_VERSION_CHECK=1")
-        logger.info("Container LLM proxy: %s", proxy_url)
-
-        # Hosted-app serving env. Omit entirely when the workspace has
-        # no host ports (KLANGKD_HOSTED_PORTS_PER_WORKSPACE=0, or a
-        # per-workspace value of 0): KLANGKWS_PORT_MAPPINGS absent makes
-        # klangk-hosted-url / get_hosted_url error out cleanly, and the
-        # KLANGKWS_HOSTING_* vars are meaningless without hosting. #1237
-        if host_ports:
-            mappings = [
-                f"{CONTAINER_PORT_START + i}:{hp}"
-                for i, hp in enumerate(host_ports)
-            ]
-            env_vars.append(f"KLANGKWS_PORT_MAPPINGS={','.join(mappings)}")
-            env_vars.append(f"KLANGKWS_HOSTING_HOSTNAME={hosting_hostname}")
-            env_vars.append(f"KLANGKWS_HOSTING_PROTO={hosting_proto}")
-            env_vars.append(f"KLANGKWS_HOSTING_BASE_PATH={hosting_base_path}")
-        env_vars.append(f"KLANGKWS_WORKSPACE_ID={workspace_id}")
-        env_vars.append(f"KLANGKWS_AGENT_HOME={agent_home}")
-        env_vars.append(
-            f"KLANGKWS_BRIDGE_URL=http://host.containers.internal:{egress_port}"
-        )
-        # #2153: Set USER/LOGNAME so tools inside the container (git,
-        # shell prompts, sudo audit, Pi agent identity) see the correct
-        # UNIX user — containers have no login process to set these.
-        env_vars.append("USER=klangk")
-        env_vars.append("LOGNAME=klangk")
-        if self.terminal_banner:
-            env_vars.append(f"KLANGKWS_TERMINAL_BANNER={self.terminal_banner}")
-
-        # Runtime SSL/CA trust (#1181): point OpenSSL/Python/curl/Node
-        # at the bundle the entrypoint builds from the mounted certs.
-        # Appended before feature/extra env so a deployer can override if
-        # ever needed. Emitted only when a trustable cert dir is present.
-        env_vars.extend(ssl_env_vars(ssl_dir))
-
-        for k, v in self.app.state.features.container_env().items():
-            env_vars.append(f"{k}={v}")
-
-        if extra_env:
-            for k, v in extra_env.items():
-                env_vars.append(f"{k}={v}")
-
-        return env_vars
-
-    async def _ensure_volumes(
-        self,
-        extra_mounts: list[str] | None,
-        user_id: str | None,
-        podman,
-    ) -> None:
-        """Create named volumes and validate bind-mount sources."""
-        if not extra_mounts:
-            return
-        for mount_spec in extra_mounts:
-            source = mount_spec.split(":")[0]
-            if _is_named_volume(source):
-                info = await podman.inspect_volume(source)
-                if info is None:
-                    labels = {
-                        "klangk.managed": "true",
-                        "klangk.instance": self.app.state.util.instance_id(),
-                    }
-                    if user_id:
-                        labels["klangk.user-id"] = user_id
-                    await podman.create_volume(source, labels)
-                else:
-                    vol_labels = info.get("Labels") or {}
-                    if (
-                        vol_labels.get("klangk.instance")
-                        != self.app.state.util.instance_id()
-                    ):
-                        raise ValueError(
-                            f"Volume {source!r} is not managed "
-                            "by this klangk instance"
-                        )
-                    vol_owner = vol_labels.get("klangk.user-id")
-                    if vol_owner and user_id and vol_owner != user_id:
-                        raise ValueError(
-                            f"Volume {source!r} belongs to another user"
-                        )
-            elif not os.path.exists(source):
-                raise ValueError(f"Bind mount source does not exist: {source}")
-
-    async def _nix_binds(
-        self, workspace_id: str, workspace_settings: dict | None
-    ) -> tuple[list[str], list[str]]:
-        """Bind specs + env for the workspace's per-workspace /nix (#2201), or ([], []).
-
-        Only when the workspace has its per-workspace ``nix`` setting enabled
-        (#2202) AND a nix backend is configured (``nix_seed``, #2219/#2220) does
-        ensure_workspace_nix provision the per-workspace
-        /nix and return a mountpoint; the mountpoint's /nix + nix.conf are
-        bind-mounted into the container, and KLANGKWS_NIX=1 is set so the
-        baked /etc/profile.d activation (see src/containers/workspace/Dockerfile)
-        puts nix on PATH by default. Image selection is untouched.
-
-        Returns ``(binds, env_extras)``.
-        """
-        if not (workspace_settings or {}).get("nix"):
-            return [], []
-        mountpoint = await self.app.state.nix.ensure_workspace_nix(
-            workspace_id
-        )
-        if not mountpoint:
-            return [], []
-        return (
-            [
-                f"{mountpoint}/nix:/nix",
-                f"{mountpoint}/nix.conf:/etc/nix/nix.conf:ro",
-            ],
-            # Signal the baked profile.d activation that the feature mounted
-            # /nix (checked alongside /nix/nix-profile presence).
-            ["KLANGKWS_NIX=1"],
-        )
-
-    @staticmethod
-    def _build_mounts(
-        home_path: str,
-        config_path: str | None,
-        extra_mounts: list[str] | None,
-        ssl_dir: str | None = None,
-    ) -> list[str]:
-        """Build the bind-mount list for the container."""
-        binds = [f"{home_path}:/home"]
-        if config_path:
-            binds.append(f"{config_path}:/opt/klangk/config:ro")
-        if ssl_dir:
-            # Read-only mount of deployer CA certs (#1181).
-            binds.append(f"{ssl_dir}:{_SSL_MOUNT_DEST}:ro")
-        binds += extra_mounts or []
-        return binds
 
     async def _create_and_start(
         self,
@@ -1182,29 +900,34 @@ class ContainerRegistry(NetworkSidecarMixin):
                 raise last_exc
 
     async def _start_container_inner(
-        self,
-        workspace_id: str,
-        host_path: str,
-        home_path: str,
-        existing_container_id: str | None = None,
-        num_ports: int = DEFAULT_PORTS_PER_WORKSPACE,
-        hosting_hostname: str | None = None,
-        hosting_proto: str | None = None,
-        hosting_base_path: str | None = None,
-        image: str | None = None,
-        config_path: str | None = None,
-        extra_mounts: list[str] | None = None,
-        extra_env: dict[str, str] | None = None,
-        user_id: str | None = None,
-        health_check: str | None = None,
-        setup_state: str | None = None,
-        service_command: str | None = None,
-        allowed_domains: list[str] | None = None,
-        rejected_domains: list[str] | None = None,
-        workspace_settings: dict | None = None,
-        egress_mode: str = "static",
+        self, spec: ContainerStartSpec
     ) -> tuple[str, str]:
-        """Inner implementation of start_container (called under lock)."""
+        """Inner implementation of start_container (called under lock).
+
+        Unpacks the spec once (#2566); the body reads plain locals, same
+        as the pre-spec signature. ``spec.host_path`` is accepted for
+        interface compatibility but unused here — mounts are driven by
+        ``home_path`` / ``config_path`` / ``extra_mounts``.
+        """
+        workspace_id = spec.workspace_id
+        home_path = spec.home_path
+        existing_container_id = spec.existing_container_id
+        num_ports = spec.num_ports
+        hosting_hostname = spec.hosting_hostname
+        hosting_proto = spec.hosting_proto
+        hosting_base_path = spec.hosting_base_path
+        image = spec.image
+        config_path = spec.config_path
+        extra_mounts = spec.extra_mounts
+        extra_env = spec.extra_env
+        user_id = spec.user_id
+        health_check = spec.health_check
+        setup_state = spec.setup_state
+        service_command = spec.service_command
+        allowed_domains = spec.allowed_domains
+        rejected_domains = spec.rejected_domains
+        workspace_settings = spec.workspace_settings
+        egress_mode = spec.egress_mode
         t_start = time.monotonic()
         resolved_image = image or self.image_name
         if resolved_image not in self.allowed_images:
@@ -1282,7 +1005,7 @@ class ContainerRegistry(NetworkSidecarMixin):
 
         # Build environment and mounts.
         t_env = time.monotonic()
-        # Resolve the agent home at this async seam (``_build_env`` is
+        # Resolve the agent home at this async seam (``build_env`` is
         # sync) so every exec process inherits KLANGKWS_AGENT_HOME (#1157).
         agent_home = f"/home/{await self.app.state.model.users.agent_handle()}"
         ssl_dir = self.app.state.ssl_trust.ssl_cert_dir()
@@ -1292,7 +1015,8 @@ class ContainerRegistry(NetworkSidecarMixin):
                 ssl_dir,
                 _SSL_MOUNT_DEST,
             )
-        env_vars = self._build_env(
+        env_vars = build_env(
+            self.app,
             workspace_id,
             host_ports,
             hosting_hostname,
@@ -1302,19 +1026,17 @@ class ContainerRegistry(NetworkSidecarMixin):
             extra_env,
             ssl_dir,
         )
-        await self._ensure_volumes(
-            extra_mounts, user_id, self.app.state.podman
+        await ensure_volumes(
+            self.app, extra_mounts, user_id, self.app.state.podman
         )
-        binds = self._build_mounts(
-            home_path, config_path, extra_mounts, ssl_dir
-        )
+        binds = build_mounts(home_path, config_path, extra_mounts, ssl_dir)
         # #2201: when nix is enabled, bind the workspace's btrfs-snapshot /nix
         # (and the seed's nix.conf) into the container, and signal the baked
         # /etc/profile.d activation (KLANGKWS_NIX) so nix is on PATH by default.
-        nix_binds, nix_env = await self._nix_binds(
-            workspace_id, workspace_settings
+        nix_bind_specs, nix_env = await nix_binds(
+            self.app, workspace_id, workspace_settings
         )
-        binds += nix_binds
+        binds += nix_bind_specs
         env_vars += nix_env
 
         publish = [
@@ -1337,47 +1059,15 @@ class ContainerRegistry(NetworkSidecarMixin):
             "true",
             "yes",
         )
-        # #2378: per-workspace /tmp tmpfs size. Default (``2g``) preserves
-        # the pre-#2378 mount; ``None`` (explicit unset) -> no ``size=``
-        # option, so podman sizes it at half of RAM.
-        tmp_size = self._resolve_tmp_size(workspace_settings)
-        tmp_opts = "rw,exec,nosuid"
-        if tmp_size:
-            tmp_opts += f",size={tmp_size}"
-
-        create_kwargs = dict(
-            labels={
-                "klangk.managed": "true",
-                "klangk.instance": iid,
-                # The main klangkd daemon process's PID — the liveness signal
-                # the dead-owner reap keys on (#2342).
-                "klangk.pid": str(os.getpid()),
-                # #2286: shared label + role so one `podman ps --filter
-                # label=klangk.workspace=<id>` correlates the workspace with its
-                # network sidecar; the slug mirrors the name for exact-match
-                # filtering. (Supersedes the old write-only klangk.workspace-id.)
-                "klangk.workspace": workspace_id,
-                "klangk.role": "workspace",
-                "klangk.workspace-name": slug,
-            },
+        create_kwargs = build_create_kwargs(
+            self.app,
+            workspace_id=workspace_id,
+            iid=iid,
+            slug=slug,
             binds=binds,
-            tmpfs={
-                "/tmp": tmp_opts,
-                "/run": "rw,noexec,nosuid,size=256m",
-                "/var/log": "rw,noexec,nosuid,size=256m",
-            },
+            env_vars=env_vars,
             publish=publish,
-            add_hosts=["host.containers.internal:host-gateway"],
-            dns=self.container_dns_config() or None,
-            dns_search=self.container_dns_search_config() or None,
-            env=env_vars,
-            init=True,
-            interactive=True,
-            userns=self.app.state.settings.userns,
-            cpus=self._resolve_cpu_limit(workspace_settings),
-            memory=self._resolve_memory_limit(workspace_settings),
-            pids_limit=self._resolve_pids_limit(workspace_settings),
-            pull=self.image_pull_policy(),
+            workspace_settings=workspace_settings,
         )
 
         # Egress filtering (#1365): the FQDN network sidecar is the only egress

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -1,0 +1,389 @@
+"""Container spec assembly (#2566 split of registry.py).
+
+The "what exactly do we ask podman to create" cluster, extracted from
+``container/registry.py``:
+
+- :class:`ContainerStartSpec` — the parameter object shared by
+  ``ContainerRegistry.start_container`` and its under-lock inner
+  implementation, replacing the duplicated ~20-parameter signatures
+  (adding a start parameter is now a single field).
+- env / mount / volume / nix builders (``build_env``, ``build_mounts``,
+  ``ensure_volumes``, ``nix_binds``).
+- the per-workspace resource-limit resolvers (``resolve_*``).
+- ``build_create_kwargs`` — the ``podman create`` kwargs builder.
+
+Functions take the app-state object and read settings-derived values
+live off ``app.state`` (the app-ownership rule, #1608).
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+
+from .. import workspace_settings as ws_settings
+from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST, ssl_env_vars
+from .ports import CONTAINER_PORT_START, DEFAULT_PORTS_PER_WORKSPACE
+
+logger = logging.getLogger(__name__)
+
+_VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
+
+
+def _split_csv(raw: str | None) -> list[str]:
+    """Split a comma-separated settings string into stripped parts.
+
+    Shared by the registry's CSV-shaped settings accessors
+    (``allowed_images``, ``allowed_mount_roots``, DNS configs) and the
+    create-kwargs builder (#2566). Empty/absent -> ``[]``.
+    """
+    if not raw:
+        return []
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def _is_named_volume(source: str) -> bool:
+    """A mount source with no '/' that doesn't start with '.' is a volume."""
+    return "/" not in source and not source.startswith(".")
+
+
+@dataclass(slots=True)
+class ContainerStartSpec:
+    """Parameters for :meth:`ContainerRegistry.start_container` (#2566).
+
+    Collapses the previously duplicated ``start_container`` /
+    ``_start_container_inner`` signature pair into one shared shape:
+    the public method takes (and forwards) this spec, the inner
+    under-lock implementation unpacks it once, and adding a start
+    parameter becomes a single field here instead of a two-signature
+    edit. Field order and defaults match the pre-spec positional
+    signature.
+    """
+
+    workspace_id: str
+    host_path: str
+    home_path: str
+    existing_container_id: str | None = None
+    num_ports: int = DEFAULT_PORTS_PER_WORKSPACE
+    hosting_hostname: str | None = None
+    hosting_proto: str | None = None
+    hosting_base_path: str | None = None
+    image: str | None = None
+    config_path: str | None = None
+    extra_mounts: list[str] | None = None
+    extra_env: dict[str, str] | None = None
+    user_id: str | None = None
+    health_check: str | None = None
+    setup_state: str | None = None
+    service_command: str | None = None
+    allowed_domains: list[str] | None = None
+    rejected_domains: list[str] | None = None
+    workspace_settings: dict | None = None
+    egress_mode: str = "static"
+
+
+def image_pull_policy(app) -> str:
+    """Resolve the workspace-image pull policy from settings."""
+    policy = app.state.settings.image_pull_policy
+    if policy not in _VALID_PULL_POLICIES:
+        logger.warning(
+            "Invalid KLANGKD_IMAGE_PULL_POLICY=%r (valid: %s); using 'never'.",
+            policy,
+            ", ".join(sorted(_VALID_PULL_POLICIES)),
+        )
+        return "never"
+    return policy
+
+
+# --- per-workspace resource limits (#864 / #34) ---
+
+
+def _ws_setting(workspace_settings: dict | None):
+    """Wrap a workspace-settings dict for the ``ws_settings`` resolvers.
+
+    The resolvers (#864) take ``{"settings": ...}``; every per-workspace
+    limit below resolves with the same wrapper shape, so build it once.
+    """
+    return {"settings": workspace_settings}
+
+
+def resolve_cpu_limit(app, workspace_settings: dict | None) -> float | None:
+    """Per-workspace CPU limit (``--cpus``), #864 / #34.
+
+    Workspace override > deploy default > None (no flag, unbounded).
+    Override semantics (#34): a deploy-wide value is a plain default,
+    not a cap or floor — a creator may go larger *or* smaller, applied
+    as-is with no clamping.
+    """
+    return ws_settings.resolve_cpu_limit(
+        _ws_setting(workspace_settings),
+        app.state.settings.container_cpu_limit,
+    )
+
+
+def resolve_memory_limit(app, workspace_settings: dict | None) -> str | None:
+    """Per-workspace memory limit (``--memory``), #864 / #34."""
+    return ws_settings.resolve_memory_limit(
+        _ws_setting(workspace_settings),
+        app.state.settings.container_memory_limit,
+    )
+
+
+def resolve_pids_limit(app, workspace_settings: dict | None) -> int | None:
+    """Per-workspace PIDs limit (``--pids-limit``), #864 / #34."""
+    return ws_settings.resolve_pids_limit(
+        _ws_setting(workspace_settings),
+        app.state.settings.container_pids_limit,
+    )
+
+
+def resolve_tmp_size(app, workspace_settings: dict | None) -> str | None:
+    """Per-workspace ``/tmp`` tmpfs size (``--tmpfs /tmp:...,size=<n>``).
+
+    #2378: same precedence as the other resolvers (workspace override >
+    deploy default > none). ``None`` means mount ``/tmp`` with no
+    explicit ``size=`` option (podman sizes it at half of RAM).
+    """
+    return ws_settings.resolve_tmp_size(
+        _ws_setting(workspace_settings),
+        app.state.settings.container_tmp_size,
+    )
+
+
+def build_env(
+    app,
+    workspace_id: str,
+    host_ports: list[int],
+    hosting_hostname: str | None,
+    hosting_proto: str | None,
+    hosting_base_path: str | None,
+    agent_home: str,
+    extra_env: dict[str, str] | None,
+    ssl_dir: str | None = None,
+) -> list[str]:
+    """Build the container environment variable list.
+
+    ``hosting_hostname``/``hosting_proto``/``hosting_base_path`` are
+    optional: callers with a live request pass the values they derived
+    from its headers (``wshandler.connection``), and callers without one
+    (``start_workspace`` — autostart/create, no connection yet) pass
+    ``None``. Resolving the floor here, at the single choke point, means
+    no start path can bypass the override: when a caller omits them we
+    derive the env / bare-localhost floor via ``derive_hosting_info``
+    (the same resolver the request paths use), so a deployer's
+    ``KLANGKD_HOSTING_HOSTNAME`` is honored on every start — eager or not.
+    """
+    if (
+        hosting_hostname is None
+        or hosting_proto is None
+        or hosting_base_path is None
+    ):
+        h, p, b = app.state.util.derive_hosting_info(None, None)
+        # Use ``is None`` (not ``or``): an explicit empty base_path
+        # (root deployment) is a legitimate value that must survive,
+        # not be clobbered by the resolved floor.
+        if hosting_hostname is None:
+            hosting_hostname = h
+        if hosting_proto is None:
+            hosting_proto = p
+        if hosting_base_path is None:
+            hosting_base_path = b
+    env_vars: list[str] = []
+    egress_port = app.state.settings.egress_port
+    proxy_url = f"http://host.containers.internal:{egress_port}/llm-proxy"
+    env_vars.append(f"KLANGKWS_LLM_PROXY_URL={proxy_url}")
+    env_vars.append("PI_SKIP_VERSION_CHECK=1")
+    logger.info("Container LLM proxy: %s", proxy_url)
+
+    # Hosted-app serving env. Omit entirely when the workspace has
+    # no host ports (KLANGKD_HOSTED_PORTS_PER_WORKSPACE=0, or a
+    # per-workspace value of 0): KLANGKWS_PORT_MAPPINGS absent makes
+    # klangk-hosted-url / get_hosted_url error out cleanly, and the
+    # KLANGKWS_HOSTING_* vars are meaningless without hosting. #1237
+    if host_ports:
+        mappings = [
+            f"{CONTAINER_PORT_START + i}:{hp}"
+            for i, hp in enumerate(host_ports)
+        ]
+        env_vars.append(f"KLANGKWS_PORT_MAPPINGS={','.join(mappings)}")
+        env_vars.append(f"KLANGKWS_HOSTING_HOSTNAME={hosting_hostname}")
+        env_vars.append(f"KLANGKWS_HOSTING_PROTO={hosting_proto}")
+        env_vars.append(f"KLANGKWS_HOSTING_BASE_PATH={hosting_base_path}")
+    env_vars.append(f"KLANGKWS_WORKSPACE_ID={workspace_id}")
+    env_vars.append(f"KLANGKWS_AGENT_HOME={agent_home}")
+    env_vars.append(
+        f"KLANGKWS_BRIDGE_URL=http://host.containers.internal:{egress_port}"
+    )
+    # #2153: Set USER/LOGNAME so tools inside the container (git,
+    # shell prompts, sudo audit, Pi agent identity) see the correct
+    # UNIX user — containers have no login process to set these.
+    env_vars.append("USER=klangk")
+    env_vars.append("LOGNAME=klangk")
+    banner = app.state.settings.terminal_banner or ""
+    if banner:
+        env_vars.append(f"KLANGKWS_TERMINAL_BANNER={banner}")
+
+    # Runtime SSL/CA trust (#1181): point OpenSSL/Python/curl/Node
+    # at the bundle the entrypoint builds from the mounted certs.
+    # Appended before feature/extra env so a deployer can override if
+    # ever needed. Emitted only when a trustable cert dir is present.
+    env_vars.extend(ssl_env_vars(ssl_dir))
+
+    for k, v in app.state.features.container_env().items():
+        env_vars.append(f"{k}={v}")
+
+    if extra_env:
+        for k, v in extra_env.items():
+            env_vars.append(f"{k}={v}")
+
+    return env_vars
+
+
+def build_mounts(
+    home_path: str,
+    config_path: str | None,
+    extra_mounts: list[str] | None,
+    ssl_dir: str | None = None,
+) -> list[str]:
+    """Build the bind-mount list for the container."""
+    binds = [f"{home_path}:/home"]
+    if config_path:
+        binds.append(f"{config_path}:/opt/klangk/config:ro")
+    if ssl_dir:
+        # Read-only mount of deployer CA certs (#1181).
+        binds.append(f"{ssl_dir}:{_SSL_MOUNT_DEST}:ro")
+    binds += extra_mounts or []
+    return binds
+
+
+async def ensure_volumes(
+    app,
+    extra_mounts: list[str] | None,
+    user_id: str | None,
+    podman,
+) -> None:
+    """Create named volumes and validate bind-mount sources."""
+    if not extra_mounts:
+        return
+    for mount_spec in extra_mounts:
+        source = mount_spec.split(":")[0]
+        if _is_named_volume(source):
+            info = await podman.inspect_volume(source)
+            if info is None:
+                labels = {
+                    "klangk.managed": "true",
+                    "klangk.instance": app.state.util.instance_id(),
+                }
+                if user_id:
+                    labels["klangk.user-id"] = user_id
+                await podman.create_volume(source, labels)
+            else:
+                vol_labels = info.get("Labels") or {}
+                if (
+                    vol_labels.get("klangk.instance")
+                    != app.state.util.instance_id()
+                ):
+                    raise ValueError(
+                        f"Volume {source!r} is not managed "
+                        "by this klangk instance"
+                    )
+                vol_owner = vol_labels.get("klangk.user-id")
+                if vol_owner and user_id and vol_owner != user_id:
+                    raise ValueError(
+                        f"Volume {source!r} belongs to another user"
+                    )
+        elif not os.path.exists(source):
+            raise ValueError(f"Bind mount source does not exist: {source}")
+
+
+async def nix_binds(
+    app, workspace_id: str, workspace_settings: dict | None
+) -> tuple[list[str], list[str]]:
+    """Bind specs + env for the workspace's per-workspace /nix (#2201), or ([], []).
+
+    Only when the workspace has its per-workspace ``nix`` setting enabled
+    (#2202) AND a nix backend is configured (``nix_seed``, #2219/#2220) does
+    ensure_workspace_nix provision the per-workspace
+    /nix and return a mountpoint; the mountpoint's /nix + nix.conf are
+    bind-mounted into the container, and KLANGKWS_NIX=1 is set so the
+    baked /etc/profile.d activation (see src/containers/workspace/Dockerfile)
+    puts nix on PATH by default. Image selection is untouched.
+
+    Returns ``(binds, env_extras)``.
+    """
+    if not (workspace_settings or {}).get("nix"):
+        return [], []
+    mountpoint = await app.state.nix.ensure_workspace_nix(workspace_id)
+    if not mountpoint:
+        return [], []
+    return (
+        [
+            f"{mountpoint}/nix:/nix",
+            f"{mountpoint}/nix.conf:/etc/nix/nix.conf:ro",
+        ],
+        # Signal the baked profile.d activation that the feature mounted
+        # /nix (checked alongside /nix/nix-profile presence).
+        ["KLANGKWS_NIX=1"],
+    )
+
+
+def build_create_kwargs(
+    app,
+    *,
+    workspace_id: str,
+    iid: str,
+    slug: str,
+    binds: list[str],
+    env_vars: list[str],
+    publish: list[tuple[int, int]],
+    workspace_settings: dict | None,
+) -> dict:
+    """Build the ``podman create`` kwargs for a workspace container.
+
+    Everything static that every workspace create shares: labels,
+    bind/tmpfs mounts, DNS, resource limits, pull policy. The
+    egress-model-specific pieces (``network``, cap add/drop, port
+    moves to the sidecar) are layered on by the caller — see
+    ``ContainerRegistry._start_container_inner``.
+    """
+    # #2378: per-workspace /tmp tmpfs size. Default (``2g``) preserves
+    # the pre-#2378 mount; ``None`` (explicit unset) -> no ``size=``
+    # option, so podman sizes it at half of RAM.
+    tmp_size = resolve_tmp_size(app, workspace_settings)
+    tmp_opts = "rw,exec,nosuid"
+    if tmp_size:
+        tmp_opts += f",size={tmp_size}"
+
+    return dict(
+        labels={
+            "klangk.managed": "true",
+            "klangk.instance": iid,
+            # The main klangkd daemon process's PID — the liveness signal
+            # the dead-owner reap keys on (#2342).
+            "klangk.pid": str(os.getpid()),
+            # #2286: shared label + role so one `podman ps --filter
+            # label=klangk.workspace=<id>` correlates the workspace with its
+            # network sidecar; the slug mirrors the name for exact-match
+            # filtering. (Supersedes the old write-only klangk.workspace-id.)
+            "klangk.workspace": workspace_id,
+            "klangk.role": "workspace",
+            "klangk.workspace-name": slug,
+        },
+        binds=binds,
+        tmpfs={
+            "/tmp": tmp_opts,
+            "/run": "rw,noexec,nosuid,size=256m",
+            "/var/log": "rw,noexec,nosuid,size=256m",
+        },
+        publish=publish,
+        add_hosts=["host.containers.internal:host-gateway"],
+        dns=_split_csv(app.state.settings.dns_servers) or None,
+        dns_search=_split_csv(app.state.settings.dns_search) or None,
+        env=env_vars,
+        init=True,
+        interactive=True,
+        userns=app.state.settings.userns,
+        cpus=resolve_cpu_limit(app, workspace_settings),
+        memory=resolve_memory_limit(app, workspace_settings),
+        pids_limit=resolve_pids_limit(app, workspace_settings),
+        pull=image_pull_policy(app),
+    )

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -521,25 +521,29 @@ class Workspaces:
         h_path = str(self.get_home_host_path(workspace_id))
         cfg_path = str(self.get_config_host_path(workspace_id))
         cid, status = await self.app.state.container_registry.start_container(
-            workspace_id,
-            host_path,
-            h_path,
-            ws.get("container_id"),
-            num_ports=ws.get(
-                "num_ports", container.DEFAULT_PORTS_PER_WORKSPACE
-            ),
-            image=ws.get("image"),
-            config_path=cfg_path,
-            extra_mounts=ws.get("mounts"),
-            extra_env=ws.get("env"),
-            user_id=owner_id,
-            health_check=ws.get("health_check"),
-            setup_state=ws.get("setup_state"),
-            service_command=ws.get("service_command"),
-            allowed_domains=ws.get("allowed_domains"),
-            rejected_domains=ws.get("rejected_domains"),
-            workspace_settings=ws.get("settings"),
-            egress_mode=ws.get("egress_mode", model.EGRESS_MODE_INTERACTIVE),
+            container.ContainerStartSpec(
+                workspace_id=workspace_id,
+                host_path=host_path,
+                home_path=h_path,
+                existing_container_id=ws.get("container_id"),
+                num_ports=ws.get(
+                    "num_ports", container.DEFAULT_PORTS_PER_WORKSPACE
+                ),
+                image=ws.get("image"),
+                config_path=cfg_path,
+                extra_mounts=ws.get("mounts"),
+                extra_env=ws.get("env"),
+                user_id=owner_id,
+                health_check=ws.get("health_check"),
+                setup_state=ws.get("setup_state"),
+                service_command=ws.get("service_command"),
+                allowed_domains=ws.get("allowed_domains"),
+                rejected_domains=ws.get("rejected_domains"),
+                workspace_settings=ws.get("settings"),
+                egress_mode=ws.get(
+                    "egress_mode", model.EGRESS_MODE_INTERACTIVE
+                ),
+            )
         )
         return cid, status
 

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -279,30 +279,32 @@ class Connection:
             container_id,
             container_status,
         ) = await self.app.state.container_registry.start_container(
-            workspace_id,
-            host_path,
-            home_path,
-            workspace.get("container_id"),
-            num_ports=workspace.get(
-                "num_ports", container.DEFAULT_PORTS_PER_WORKSPACE
-            ),
-            hosting_hostname=hosting_hostname,
-            hosting_proto=hosting_proto,
-            hosting_base_path=hosting_base_path,
-            image=workspace.get("image"),
-            config_path=cfg_path,
-            extra_mounts=workspace.get("mounts"),
-            extra_env=workspace.get("env"),
-            user_id=self.user["id"],
-            health_check=workspace.get("health_check"),
-            setup_state=workspace.get("setup_state"),
-            service_command=workspace.get("service_command"),
-            allowed_domains=workspace.get("allowed_domains"),
-            rejected_domains=workspace.get("rejected_domains"),
-            workspace_settings=workspace.get("settings"),
-            egress_mode=workspace.get(
-                "egress_mode", model.EGRESS_MODE_INTERACTIVE
-            ),
+            container.ContainerStartSpec(
+                workspace_id=workspace_id,
+                host_path=host_path,
+                home_path=home_path,
+                existing_container_id=workspace.get("container_id"),
+                num_ports=workspace.get(
+                    "num_ports", container.DEFAULT_PORTS_PER_WORKSPACE
+                ),
+                hosting_hostname=hosting_hostname,
+                hosting_proto=hosting_proto,
+                hosting_base_path=hosting_base_path,
+                image=workspace.get("image"),
+                config_path=cfg_path,
+                extra_mounts=workspace.get("mounts"),
+                extra_env=workspace.get("env"),
+                user_id=self.user["id"],
+                health_check=workspace.get("health_check"),
+                setup_state=workspace.get("setup_state"),
+                service_command=workspace.get("service_command"),
+                allowed_domains=workspace.get("allowed_domains"),
+                rejected_domains=workspace.get("rejected_domains"),
+                workspace_settings=workspace.get("settings"),
+                egress_mode=workspace.get(
+                    "egress_mode", model.EGRESS_MODE_INTERACTIVE
+                ),
+            )
         )
         self.container_status = container_status
         self.workspace_id = workspace_id

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -20,6 +20,7 @@ from klangk import (
     ssl_trust,
     util as util_mod,
 )
+from klangk.container.spec import nix_binds
 from _helpers import make_settings
 
 
@@ -638,9 +639,11 @@ class TestStartContainer:
     async def test_create_new_container(self, workspace):
         with patch_podman(self.registry) as p:
             cid, status = await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         assert cid == "new-cid"
         assert status == "created"
@@ -652,7 +655,9 @@ class TestStartContainer:
         # keeps podman's default hooks-dir behavior (unrestricted). #1365
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert "annotations" not in kwargs
@@ -670,7 +675,9 @@ class TestStartContainer:
         # the sidecar).
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         iid = self.registry.app.state.util.instance_id()
         slug = container._workspace_name_slug(workspace["name"])
@@ -690,7 +697,7 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                ws["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(ws["id"], "/tmp/ws", "/tmp/home")
             )
         iid = self.registry.app.state.util.instance_id()
         assert p.create_container.call_args.args[0] == (
@@ -726,10 +733,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                allowed_domains=["github.com:443"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                )
             )
         assert len(creates) == 2
         sidecar, ws_container = creates[0], creates[1]
@@ -1315,10 +1324,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                allowed_domains=["github.com:443"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                )
             )
         assert len(creates) == 2
         assert creates[0]["name"].startswith("klangk-net-")
@@ -1374,10 +1385,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                rejected_domains=["evil.com:443"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    rejected_domains=["evil.com:443"],
+                )
             )
         assert len(creates) == 2
         assert creates[0]["name"].startswith("klangk-net-")
@@ -1418,10 +1431,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                egress_mode="interactive",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="interactive",
+                )
             )
         assert len(creates) == 2  # sidecar + workspace
         assert creates[0]["name"].startswith("klangk-net-")
@@ -1457,10 +1472,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                egress_mode="static",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="static",
+                )
             )
         assert len(creates) == 1  # workspace only, no sidecar
         assert not creates[0]["name"].startswith("klangk-net-")
@@ -1496,10 +1513,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                egress_mode="allow",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="allow",
+                )
             )
         assert len(creates) == 2  # sidecar + workspace
         assert creates[0]["name"].startswith("klangk-net-")
@@ -1534,10 +1553,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                egress_mode="allow",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="allow",
+                )
             )
         assert len(creates) == 1  # workspace only, no sidecar
         assert not creates[0]["name"].startswith("klangk-net-")
@@ -1572,10 +1593,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                egress_mode="allow",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="allow",
+                )
             )
         assert len(creates) == 1  # degraded to unrestricted, no sidecar
         assert workspace["id"] not in self.registry._ws_with_network_sidecar
@@ -1609,11 +1632,13 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                egress_mode="allow",
-                rejected_domains=["evil.com:443"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    egress_mode="allow",
+                    rejected_domains=["evil.com:443"],
+                )
             )
         assert len(creates) == 2  # sidecar + workspace
         assert creates[0]["name"].startswith("klangk-net-")
@@ -1632,10 +1657,12 @@ class TestStartContainer:
         with patch_podman(self.registry):
             with pytest.raises(podman.PodmanError):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    egress_mode="interactive",
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        egress_mode="interactive",
+                    )
                 )
 
     async def test_interactive_workspace_refuses_empty_userns(
@@ -1654,10 +1681,12 @@ class TestStartContainer:
         with patch_podman(self.registry):
             with pytest.raises(podman.PodmanError) as exc:
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    egress_mode="interactive",
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        egress_mode="interactive",
+                    )
                 )
         assert "KLANGKD_USERNS" in str(exc.value)
 
@@ -1693,10 +1722,12 @@ class TestStartContainer:
         ):
             with caplog.at_level(logging.INFO, logger="klangk.container"):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    egress_mode="interactive",
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        egress_mode="interactive",
+                    )
                 )
         ws = creates[1]  # creates[0] is the network sidecar
         assert ws["cap_drop"] == ["net_raw"]
@@ -1718,11 +1749,13 @@ class TestStartContainer:
             self.registry, inspect_container=_running(True)
         ) as p:
             cid, status = await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                existing_container_id="existing-cid",
-                egress_mode="interactive",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="existing-cid",
+                    egress_mode="interactive",
+                )
             )
         assert cid == "existing-cid"
         assert status == "connected"
@@ -1763,11 +1796,13 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                allowed_domains=["github.com:443"],
-                num_ports=2,
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                    num_ports=2,
+                )
             )
         assert len(creates) == 2
         # Host ports land on the SIDECAR (container-side ports are
@@ -1809,11 +1844,13 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                allowed_domains=["github.com:443"],
-                num_ports=0,
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                    num_ports=0,
+                )
             )
         assert len(creates) == 2
         # No host ports -> the sidecar publishes nothing.
@@ -1853,10 +1890,12 @@ class TestStartContainer:
             self.registry, create_container=AsyncMock(side_effect=_fake_create)
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                allowed_domains=["github.com:443"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    allowed_domains=["github.com:443"],
+                )
             )
         sidecar, ws = creates[0], creates[1]
         # The sidecar (netns owner) launches with NO --userns (podman default).
@@ -1883,10 +1922,12 @@ class TestStartContainer:
         with patch_podman(self.registry):
             with pytest.raises(podman.PodmanError) as exc:
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    allowed_domains=["github.com:443"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        allowed_domains=["github.com:443"],
+                    )
                 )
         assert "KLANGKD_USERNS" in str(exc.value)
 
@@ -1926,10 +1967,12 @@ class TestStartContainer:
         ):
             with caplog.at_level(logging.INFO, logger="klangk.container"):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    allowed_domains=["github.com:443"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        allowed_domains=["github.com:443"],
+                    )
                 )
         ws = creates[1]  # creates[0] is the network sidecar
         # net_raw is dropped, not added (podman rejects a cap in both).
@@ -1972,10 +2015,12 @@ class TestStartContainer:
         ):
             with pytest.raises(podman.PodmanError):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    allowed_domains=["github.com:443"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        allowed_domains=["github.com:443"],
+                    )
                 )
 
     async def test_start_network_sidecar_raises_on_readiness_timeout(
@@ -2012,10 +2057,12 @@ class TestStartContainer:
         ):
             with pytest.raises(podman.PodmanError):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    allowed_domains=["github.com:443"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        allowed_domains=["github.com:443"],
+                    )
                 )
 
     async def test_network_sidecar_failure_refuses_to_start(
@@ -2043,10 +2090,12 @@ class TestStartContainer:
         ):
             with pytest.raises(podman.PodmanError):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    allowed_domains=["github.com:443"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        allowed_domains=["github.com:443"],
+                    )
                 )
 
     async def test_workspace_create_failure_cleans_up_sidecar(
@@ -2085,10 +2134,12 @@ class TestStartContainer:
         ) as p:
             with pytest.raises(podman.PodmanError):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    allowed_domains=["github.com:443"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        allowed_domains=["github.com:443"],
+                    )
                 )
         # #2286: the sidecar was removed (by label/id) on the workspace-create
         # failure.
@@ -2107,10 +2158,12 @@ class TestStartContainer:
         with patch_podman(self.registry):
             with pytest.raises(podman.PodmanError):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    allowed_domains=["github.com:443"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        allowed_domains=["github.com:443"],
+                    )
                 )
 
     async def test_resource_limits_defaults_emit_flags(self, workspace):
@@ -2121,7 +2174,9 @@ class TestStartContainer:
         # no flag; see test_settings.py.)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 2.0
@@ -2139,7 +2194,9 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_tmp_size", "4g")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["tmpfs"]["/tmp"] == "rw,exec,nosuid,size=4g"
@@ -2153,10 +2210,12 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_tmp_size", "4g")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                workspace_settings={"tmp_size": "512m"},
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    workspace_settings={"tmp_size": "512m"},
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["tmpfs"]["/tmp"] == "rw,exec,nosuid,size=512m"
@@ -2171,7 +2230,9 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_tmp_size", None)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["tmpfs"]["/tmp"] == "rw,exec,nosuid"
@@ -2183,7 +2244,9 @@ class TestStartContainer:
         # setcap alternatives don't work under rootless podman (#2045).
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cap_add"] == ["net_raw"]
@@ -2197,7 +2260,9 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "enable_ping", False)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert "cap_add" not in kwargs
@@ -2215,7 +2280,9 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_pids_limit", 512)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 1.5
@@ -2234,14 +2301,16 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_pids_limit", 512)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                workspace_settings={
-                    "cpu_limit": 4.0,
-                    "memory_limit": "8g",
-                    "pids_limit": 2048,
-                },
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    workspace_settings={
+                        "cpu_limit": 4.0,
+                        "memory_limit": "8g",
+                        "pids_limit": 2048,
+                    },
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 4.0
@@ -2259,10 +2328,12 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_pids_limit", 2048)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                workspace_settings={"cpu_limit": 0.5, "pids_limit": 100},
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    workspace_settings={"cpu_limit": 0.5, "pids_limit": 100},
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 0.5
@@ -2279,10 +2350,12 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_pids_limit", 512)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                workspace_settings={"cpu_limit": 3.0},
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    workspace_settings={"cpu_limit": 3.0},
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 3.0
@@ -2302,10 +2375,12 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_pids_limit", None)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                workspace_settings={"cpu_limit": 2.0},
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    workspace_settings={"cpu_limit": 2.0},
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 2.0
@@ -2320,10 +2395,12 @@ class TestStartContainer:
         monkeypatch.setattr(settings, "container_cpu_limit", 1.5)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                workspace_settings={},
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    workspace_settings={},
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         assert kwargs["cpus"] == 1.5
@@ -2331,7 +2408,9 @@ class TestStartContainer:
     async def test_sudo_disabled_by_default(self, workspace):
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         call = _sudo_call(p)
         assert call.kwargs.get("user") == "root"
@@ -2343,7 +2422,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         call = _sudo_call(p)
         assert call.kwargs.get("user") == "root"
@@ -2355,7 +2436,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
 
@@ -2365,7 +2448,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
 
@@ -2378,7 +2463,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
 
@@ -2392,7 +2479,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert "NOPASSWD:ALL" in str(_sudo_call(p).args[1])
 
@@ -2405,7 +2494,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert "NOPASSWD:ALL" in str(_sudo_call(p).args[1])
 
@@ -2418,7 +2509,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
 
@@ -2434,7 +2527,9 @@ class TestStartContainer:
         ):
             with pytest.raises(RuntimeError, match="boom"):
                 await self.registry.start_container(
-                    workspace["id"], "/tmp/ws", "/tmp/home"
+                    container.ContainerStartSpec(
+                        workspace["id"], "/tmp/ws", "/tmp/home"
+                    )
                 )
         ws = await app_state.state.model.workspaces.get_workspace(
             workspace["id"], user["id"]
@@ -2460,7 +2555,9 @@ class TestStartContainer:
         ) as p:
             task = asyncio.create_task(
                 self.registry.start_container(
-                    workspace["id"], "/tmp/ws", "/tmp/home"
+                    container.ContainerStartSpec(
+                        workspace["id"], "/tmp/ws", "/tmp/home"
+                    )
                 )
             )
             await started.wait()
@@ -2482,10 +2579,12 @@ class TestStartContainer:
             self.registry, inspect_container=_running(True)
         ) as p:
             cid, status = await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                existing_container_id="existing-cid",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="existing-cid",
+                )
             )
         assert cid == "existing-cid"
         assert status == "connected"
@@ -2509,11 +2608,13 @@ class TestStartContainer:
             self.registry, inspect_container=_running(True)
         ) as p:
             cid, status = await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                existing_container_id="existing-cid",
-                allowed_domains=["github.com:443"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="existing-cid",
+                    allowed_domains=["github.com:443"],
+                )
             )
         assert cid == "existing-cid"
         assert status == "connected"
@@ -2527,10 +2628,12 @@ class TestStartContainer:
             self.registry, inspect_container=_running(False)
         ) as p:
             cid, status = await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                existing_container_id="old-cid",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="old-cid",
+                )
             )
         assert cid == "new-cid"
         assert status == "created"
@@ -2540,10 +2643,12 @@ class TestStartContainer:
         # inspect_container returns None (default) → treated as gone.
         with patch_podman(self.registry) as p:
             cid, status = await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                existing_container_id="gone-cid",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="gone-cid",
+                )
             )
         assert cid == "new-cid"
         assert status == "created"
@@ -2564,7 +2669,9 @@ class TestStartContainer:
         } == {"stale.com"}
         with patch_podman(self.registry):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert await ec.list_active(workspace["id"]) == []
 
@@ -2578,10 +2685,12 @@ class TestStartContainer:
         await ec.decide(a["id"], "allowed", user["id"], "tilrestart")
         with patch_podman(self.registry, inspect_container=_running(True)):
             cid, status = await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                existing_container_id="existing-cid",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="existing-cid",
+                )
             )
         assert status == "connected"
         assert {
@@ -2591,7 +2700,9 @@ class TestStartContainer:
     async def test_disallowed_image_raises(self, workspace):
         with pytest.raises(ValueError, match="not in the allowed list"):
             await self.registry.start_container(
-                workspace["id"], "/work", "/home", image="evil:latest"
+                container.ContainerStartSpec(
+                    workspace["id"], "/work", "/home", image="evil:latest"
+                )
             )
 
     async def test_llm_proxy_env_vars(self, workspace, monkeypatch):
@@ -2602,9 +2713,11 @@ class TestStartContainer:
 
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         kwargs = p.create_container.call_args.kwargs
         env = kwargs["env"]
@@ -2630,9 +2743,11 @@ class TestStartContainer:
         correct UNIX user (#2153)."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         env = p.create_container.call_args.kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env)
@@ -2652,7 +2767,9 @@ class TestStartContainer:
             ) as mock_set,
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         mock_set.assert_called_once()
         cid, token = mock_set.call_args.args
@@ -2664,7 +2781,9 @@ class TestStartContainer:
     async def test_pull_policy_default_never(self, workspace):
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert p.create_container.call_args.kwargs["pull"] == "never"
 
@@ -2674,7 +2793,9 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert p.create_container.call_args.kwargs["pull"] == "missing"
 
@@ -2682,10 +2803,12 @@ class TestStartContainer:
         """Container gets read-only config mount when config_path is set."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                config_path="/tmp/config",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    config_path="/tmp/config",
+                )
             )
         binds = p.create_container.call_args.kwargs["binds"]
         assert "/tmp/config:/opt/klangk/config:ro" in binds
@@ -2694,9 +2817,11 @@ class TestStartContainer:
         """Container has no config mount when config_path is not set."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         binds = p.create_container.call_args.kwargs["binds"]
         assert not any("config" in b for b in binds)
@@ -2705,9 +2830,11 @@ class TestStartContainer:
         """Home path is mounted at /home (not /home/klangk)."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         binds = p.create_container.call_args.kwargs["binds"]
         assert "/tmp/home:/home" in binds
@@ -2715,12 +2842,14 @@ class TestStartContainer:
     async def test_hosting_env_vars(self, workspace):
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                hosting_hostname="example.com",
-                hosting_proto="https",
-                hosting_base_path="/klangk",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    hosting_hostname="example.com",
+                    hosting_proto="https",
+                    hosting_base_path="/klangk",
+                )
             )
         env = p.create_container.call_args.kwargs["env"]
         assert "KLANGKWS_HOSTING_HOSTNAME=example.com" in env
@@ -2740,9 +2869,11 @@ class TestStartContainer:
         """
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         env = p.create_container.call_args.kwargs["env"]
         assert "KLANGKWS_HOSTING_HOSTNAME=localhost" in env
@@ -2753,9 +2884,11 @@ class TestStartContainer:
         """Default terminal banner is empty, so env var is not passed."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         env = p.create_container.call_args.kwargs["env"]
         assert not any(e.startswith("KLANGKWS_TERMINAL_BANNER=") for e in env)
@@ -2769,9 +2902,11 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         env = p.create_container.call_args.kwargs["env"]
         assert "KLANGKWS_TERMINAL_BANNER=Custom warning" in env
@@ -2789,9 +2924,11 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         binds = p.create_container.call_args.kwargs["binds"]
         assert f"{ssl_dir.resolve()}:/opt/klangk/ssl:ro" in binds
@@ -2805,9 +2942,11 @@ class TestStartContainer:
         """Without certs in <customize_dir>/certs/ there is no mount and no trust env."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         binds = p.create_container.call_args.kwargs["binds"]
         assert not any("/opt/klangk/ssl" in b for b in binds)
@@ -2829,9 +2968,11 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         binds = p.create_container.call_args.kwargs["binds"]
         assert not any("/opt/klangk/ssl" in b for b in binds)
@@ -2841,10 +2982,12 @@ class TestStartContainer:
     async def test_port_allocation_on_create(self, workspace):
         with patch_podman(self.registry):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                num_ports=3,
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    num_ports=3,
+                )
             )
         # Ports should have been allocated
         ports = await self.registry.get_workspace_ports(workspace["id"])
@@ -2857,10 +3000,12 @@ class TestStartContainer:
         )
         with patch_podman(self.registry):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                num_ports=2,
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    num_ports=2,
+                )
             )
         ports = await self.registry.get_workspace_ports(workspace["id"])
         assert len(ports) == 2
@@ -2872,10 +3017,12 @@ class TestStartContainer:
         )
         with patch_podman(self.registry):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                num_ports=5,  # DB default; cap is 3
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    num_ports=5,  # DB default; cap is 3
+                )
             )
         ports = await self.registry.get_workspace_ports(workspace["id"])
         assert len(ports) == 3
@@ -2892,10 +3039,12 @@ class TestStartContainer:
         )
         with patch_podman(self.registry):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                num_ports=5,
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    num_ports=5,
+                )
             )
         ports = await self.registry.get_workspace_ports(workspace["id"])
         assert ports == []
@@ -2907,10 +3056,12 @@ class TestStartContainer:
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                num_ports=5,
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    num_ports=5,
+                )
             )
         env = p.create_container.call_args.kwargs["env"]
         assert not any(e.startswith("KLANGKWS_PORT_MAPPINGS=") for e in env)
@@ -2939,10 +3090,12 @@ class TestStartContainer:
         """Sanity: with the default cap, hosting env is injected as before."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                num_ports=5,
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    num_ports=5,
+                )
             )
         env = p.create_container.call_args.kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env)
@@ -2954,9 +3107,11 @@ class TestStartContainer:
     async def test_container_config_structure(self, workspace):
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                )
             )
         args, kwargs = p.create_container.call_args
         assert args[1] == self.registry.image_name
@@ -2972,10 +3127,12 @@ class TestStartContainer:
     async def test_create_container_with_extra_env(self, workspace):
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_env={"MY_VAR": "hello", "FOO": "bar"},
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_env={"MY_VAR": "hello", "FOO": "bar"},
+                )
             )
         env_list = p.create_container.call_args.kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env_list)
@@ -2997,7 +3154,9 @@ class TestStartContainer:
         monkeypatch.setenv("KLANGKWS_FEATURE_TEST_VAR", "feature-val")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         env_list = p.create_container.call_args.kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env_list)
@@ -3048,7 +3207,9 @@ class TestStartContainerPortConflict:
             inspect_container=AsyncMock(return_value=stale_info),
         ) as p:
             cid, status = await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert status == "created"
         assert len(start_calls) == 2
@@ -3087,7 +3248,9 @@ class TestStartContainerPortConflict:
             ),
         ) as p:
             cid, _ = await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         # Should not have tried to remove its own container
         for call in p.remove_container.call_args_list:
@@ -3116,7 +3279,9 @@ class TestStartContainerPortConflict:
             ),
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         # other-cid doesn't hold our ports — should not be removed
 
@@ -3141,7 +3306,9 @@ class TestStartContainerPortConflict:
             inspect_container=AsyncMock(return_value=None),
         ) as p:
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         # gone-cid vanished — no remove attempted
         assert not any(
@@ -3179,7 +3346,9 @@ class TestStartContainerPortConflict:
             ),
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
 
     async def test_port_conflict_remove_error_logged(
@@ -3217,7 +3386,9 @@ class TestStartContainerPortConflict:
             ),
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
 
     async def test_non_port_conflict_error_raised(self, workspace):
@@ -3231,7 +3402,9 @@ class TestStartContainerPortConflict:
             pytest.raises(podman.PodmanError, match="some other error"),
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
 
     async def test_port_conflict_pasta_bind_error(self, workspace, app_state):
@@ -3259,7 +3432,9 @@ class TestStartContainerPortConflict:
             inspect_container=AsyncMock(return_value=None),
         ):
             cid, status = await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
         assert status == "created"
         assert len(start_calls) == 2
@@ -3288,7 +3463,9 @@ class TestStartContainerPortConflict:
             pytest.raises(podman.PodmanError, match="Address already in use"),
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
 
     async def test_port_conflict_retry_non_conflict_error(
@@ -3322,7 +3499,9 @@ class TestStartContainerPortConflict:
             pytest.raises(podman.PodmanError, match="container vanished"),
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
 
 
@@ -3552,11 +3731,13 @@ class TestExtraMountsVolumeCreation:
         # inspect_volume returns None (default) → volume is created.
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["nix-store:/nix"],
-                user_id="user-123",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["nix-store:/nix"],
+                    user_id="user-123",
+                )
             )
         p.create_volume.assert_awaited_once()
         name, labels = p.create_volume.call_args.args
@@ -3583,11 +3764,13 @@ class TestExtraMountsVolumeCreation:
             ),
         ) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["existing:/data"],
-                user_id="user-123",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["existing:/data"],
+                    user_id="user-123",
+                )
             )
         p.create_volume.assert_not_awaited()
 
@@ -3604,10 +3787,12 @@ class TestExtraMountsVolumeCreation:
         ):
             with pytest.raises(ValueError, match="not managed by this"):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    extra_mounts=["stolen:/data"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        extra_mounts=["stolen:/data"],
+                    )
                 )
 
     async def test_unlabelled_volume_rejected(self, workspace):
@@ -3618,10 +3803,12 @@ class TestExtraMountsVolumeCreation:
         ):
             with pytest.raises(ValueError, match="not managed by this"):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    extra_mounts=["bare:/data"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        extra_mounts=["bare:/data"],
+                    )
                 )
 
     async def test_cross_user_volume_rejected(self, workspace, app_state):
@@ -3640,11 +3827,13 @@ class TestExtraMountsVolumeCreation:
         ):
             with pytest.raises(ValueError, match="belongs to another user"):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    extra_mounts=["private:/data"],
-                    user_id="user-me",
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        extra_mounts=["private:/data"],
+                        user_id="user-me",
+                    )
                 )
 
     async def test_volume_without_user_label_allowed(
@@ -3663,11 +3852,13 @@ class TestExtraMountsVolumeCreation:
             ),
         ) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["legacy:/data"],
-                user_id="user-123",
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["legacy:/data"],
+                    user_id="user-123",
+                )
             )
         p.create_volume.assert_not_awaited()
 
@@ -3678,10 +3869,12 @@ class TestExtraMountsVolumeCreation:
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["/home/me/src:/work/src"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["/home/me/src:/work/src"],
+                )
             )
         p.inspect_volume.assert_not_awaited()
 
@@ -3690,10 +3883,12 @@ class TestExtraMountsVolumeCreation:
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["/data/shared:/mnt/data:ro"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["/data/shared:/mnt/data:ro"],
+                )
             )
         # Bind mount, not a volume — inspect_volume should not be called
         p.inspect_volume.assert_not_awaited()
@@ -3702,10 +3897,12 @@ class TestExtraMountsVolumeCreation:
         """Named volume with options (vol:container:ro) — auto-creates."""
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["my-vol:/data:ro"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["my-vol:/data:ro"],
+                )
             )
         p.create_volume.assert_awaited_once()
 
@@ -3716,10 +3913,12 @@ class TestExtraMountsVolumeCreation:
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["./relative/path:/work/rel"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["./relative/path:/work/rel"],
+                )
             )
         p.inspect_volume.assert_not_awaited()
 
@@ -3735,10 +3934,12 @@ class TestExtraMountsVolumeCreation:
             pytest.raises(podman.PodmanError),
         ):
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["bad-vol:/data"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["bad-vol:/data"],
+                )
             )
 
     async def test_mount_source_with_special_characters(
@@ -3748,10 +3949,14 @@ class TestExtraMountsVolumeCreation:
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
-                workspace["id"],
-                "/tmp/ws",
-                "/tmp/home",
-                extra_mounts=["/path/with spaces\x00and\x01binary:/work/bad"],
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=[
+                        "/path/with spaces\x00and\x01binary:/work/bad"
+                    ],
+                )
             )
         # Has leading /, so treated as bind mount
         p.inspect_volume.assert_not_awaited()
@@ -3761,10 +3966,12 @@ class TestExtraMountsVolumeCreation:
         with patch_podman(self.registry):
             with pytest.raises(ValueError, match="does not exist"):
                 await self.registry.start_container(
-                    workspace["id"],
-                    "/tmp/ws",
-                    "/tmp/home",
-                    extra_mounts=["/nonexistent/path:/work/src"],
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/ws",
+                        "/tmp/home",
+                        extra_mounts=["/nonexistent/path:/work/src"],
+                    )
                 )
 
     async def test_browsers_revoked_on_creation_failure(self, workspace):
@@ -3779,7 +3986,9 @@ class TestExtraMountsVolumeCreation:
             pytest.raises(RuntimeError, match="podman broke"),
         ):
             await self.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
             )
 
         # No browser registrations should remain for this workspace
@@ -5995,17 +6204,15 @@ class TestRegistrySettingsDerived:
 async def test_nix_binds_empty_without_flag():
     """No /nix bind or env when the workspace hasn't enabled nix."""
     app_state = _make_app_state()
-    reg = app_state.state.container_registry
-    assert await reg._nix_binds("ws1", None) == ([], [])
-    assert await reg._nix_binds("ws1", {}) == ([], [])
-    assert await reg._nix_binds("ws1", {"nix": False}) == ([], [])
+    assert await nix_binds(app_state, "ws1", None) == ([], [])
+    assert await nix_binds(app_state, "ws1", {}) == ([], [])
+    assert await nix_binds(app_state, "ws1", {"nix": False}) == ([], [])
 
 
 async def test_nix_binds_empty_when_btrfs_not_configured():
     """Flag on but nix not configured -> ensure returns None -> no bind/env."""
     app_state = _make_app_state()  # no nix_seed -> not configured
-    reg = app_state.state.container_registry
-    assert await reg._nix_binds("ws1", {"nix": True}) == ([], [])
+    assert await nix_binds(app_state, "ws1", {"nix": True}) == ([], [])
 
 
 async def test_nix_binds_mounts_snapshot_when_enabled():
@@ -6014,8 +6221,7 @@ async def test_nix_binds_mounts_snapshot_when_enabled():
     app_state.state.nix.ensure_workspace_nix = AsyncMock(
         return_value="/mnt/nix-ws1"
     )
-    reg = app_state.state.container_registry
-    binds, env = await reg._nix_binds("ws1", {"nix": True})
+    binds, env = await nix_binds(app_state, "ws1", {"nix": True})
     assert binds == [
         "/mnt/nix-ws1/nix:/nix",
         "/mnt/nix-ws1/nix.conf:/etc/nix/nix.conf:ro",

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from klangk import container
 from klangk import workspaces as ws_mod
 
 
@@ -50,7 +51,7 @@ class TestCreateWorkspace:
         monkeypatch.setattr(registry, "start_container", fake)
         await app_state.state.workspaces.start_workspace(ws)
         fake.assert_awaited_once()
-        assert fake.call_args.kwargs["egress_mode"] == "interactive"
+        assert fake.call_args.args[0].egress_mode == "interactive"
 
     async def test_allocates_ports(self, user, app_state):
         ws = await app_state.state.workspaces.create_workspace(
@@ -584,7 +585,7 @@ class TestStartWorkspace:
             mock_start.assert_awaited_once()
             # The service_command is threaded through to start_container
             # so the create choke point (bringup) can fire it.
-            assert mock_start.call_args.kwargs["service_command"] == (
+            assert mock_start.call_args.args[0].service_command == (
                 "openclaw gateway"
             )
         finally:
@@ -643,10 +644,12 @@ class TestStartWorkspace:
                 return_value=("cid-z", "created"),
             ):
                 await registry.start_container(
-                    "ws-apply",
-                    "/host",
-                    "/home",
-                    workspace_settings={"idle_timeout": 600},
+                    container.ContainerStartSpec(
+                        "ws-apply",
+                        "/host",
+                        "/home",
+                        workspace_settings={"idle_timeout": 600},
+                    )
                 )
             # The override is materialized onto the live state.
             assert state.idle_timeout == 600
@@ -668,10 +671,12 @@ class TestStartWorkspace:
                 return_value=("cid-w", "created"),
             ):
                 await registry.start_container(
-                    "ws-lazy",
-                    "/host",
-                    "/home",
-                    workspace_settings={"cpu_limit": 2.0},  # not idle
+                    container.ContainerStartSpec(
+                        "ws-lazy",
+                        "/host",
+                        "/home",
+                        workspace_settings={"cpu_limit": 2.0},  # not idle
+                    )
                 )
             assert state.idle_timeout is None
         finally:
@@ -700,10 +705,12 @@ async def test_idle_timeout_zero_pins_alive(user, app_state):
             return_value=("cid-0", "created"),
         ):
             await registry.start_container(
-                "ws-zero",
-                "/host",
-                "/home",
-                workspace_settings={"idle_timeout": 0},
+                container.ContainerStartSpec(
+                    "ws-zero",
+                    "/host",
+                    "/home",
+                    workspace_settings={"idle_timeout": 0},
+                )
             )
         # 0 is materialized (not treated as "absent" by a truthiness check).
         assert state.idle_timeout == 0


### PR DESCRIPTION
## Summary

Third-pass consolidation of `container/registry.py` (#2566, follows #2548). Behavior-preserving: identical log lines, identical podman argv, same lock structure (#1520). `test-backend` green at 100% coverage (4970 passed). No changelog entry (internal refactor).

## Item 1 — `ContainerStartSpec` (done)

`ContainerRegistry.start_container` and `_start_container_inner` now share one `ContainerStartSpec` dataclass (in `container/spec.py`, re-exported via the package `__init__`) instead of duplicated ~20-parameter signatures; the inner method unpacks it once. Production call sites (`workspaces.start_workspace`, `wshandler.connection.start_workspace_container`, which the restart path also funnels through) build the spec; the 107 test call sites were rewritten mechanically to wrap their existing args in the spec (positional order and defaults match the old signature exactly).

## Item 2 — `_resolve_port_conflict` (leave-noted)

- `container_ident`: **already adopted** — the sweep uses `stale_id = container_ident(c)`; that landed in #2548 (`afdb6243`), after this issue was drafted.
- `safe_remove` for the remove-and-log tail: **left as-is.** The sweep's success log carries call-site data `safe_remove` can't express (`"Removed stale container %s (ports %s)"`), and its failure wording (`"Could not remove stale container %s: %s"`) has a different arity than `safe_remove`'s (`"Failed to reap %s %s: %s"` takes `what`). Adopting it while keeping the pinned wording means parameterizing `safe_remove` with per-call format strings of differing arity — more complexity than the 4-line duplication it removes.

## Item 3 — settings-derived boilerplate (done)

Added `spec._split_csv(raw)` and rewrote the four CSV-shaped accessors on top of it: `allowed_images`, `allowed_mount_roots`, `container_dns_config`, `container_dns_search_config`. The other shapes genuinely differ (realpath mapping, int/float parsing, pull-policy validation), so they stay as-is per the issue's leave-and-note instruction. The `terminal_banner` property became dead once `_build_env` moved (nothing else reads it) and was removed; `build_env` reads `settings.terminal_banner` directly.

## Item 4 — `container/spec.py` extraction (done)

New module holds the spec-assembly cluster: `ContainerStartSpec`, `build_env`, `build_mounts`, `ensure_volumes`, `nix_binds`, the four per-workspace limit resolvers (`resolve_cpu/memory/pids/tmp_size`), `image_pull_policy` resolution, and `build_create_kwargs` (the labels/tmpfs/dns/userns/limits `podman create` dict, lifted out of `_start_container_inner`). Functions take the app-state object and read settings live off `app.state` (app-ownership rule). Registry keeps thin delegators where tests pin the method (`image_pull_policy`, dns configs); the three `_nix_binds` tests now call the module function. Package `__init__` re-exports `ContainerStartSpec` per the split pattern.

`registry.py`: **1879 → 1569 lines.** That's short of the aspirational ~1500: the remainder is lifecycle (start/stop paths, conflict retry, reaps, shutdown) and the collaborator proxies, none of which is spec assembly — going further would mean fragmenting the start path itself, which trades cohesion for a line count.

## Note

The first commit fixes the `deferred-imports` pre-commit hook, which has been failing on every commit since #2547: it scans the whole package from any staged file and flags a deferred import in `klangk/cli/context.py` that landed without the documented `# noqa: allow-deferred-import` marker. One-line fix using the hook's own suppression mechanism; the deferral itself is kept (hoisting would pull `client.py`'s httpx/websockets into every command module).

Closes #2566.

