### PR TITLE
fix(security): parse cli_redirect URL instead of prefix-matching (#2571)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1328,6 +1328,15 @@ users(id)`, so the decider handler passing the decider's email violated the
 
 ### Security
 
+- **OIDC `cli_redirect` userinfo bypass (#2571).** The localhost-only
+  guard on the CLI login redirect used prefix matching, so a crafted
+  `cli_redirect` like `http://localhost:1@attacker.example/` passed the
+  check while actually routing to the attacker's host — a victim
+  completing a normal IdP login had their session token redirected to
+  it. The target is now parsed and must be plain `http` to `localhost`
+  or `127.0.0.1` with a port and no userinfo; anything else falls back to
+  the web flow.
+
 - **Network sidecar: filtered workspaces with `allow_sudo` drop `net_raw` as
   defense-in-depth (#2276).** The primary `SO_MARK`-bypass guard is
   user-namespace isolation — the workspace runs in its own keep-id userns,

--- a/src/klangk/klangk/api/oidc_auth.py
+++ b/src/klangk/klangk/api/oidc_auth.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import secrets
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import (
@@ -33,10 +34,25 @@ def _valid_cli_redirect(url: str | None) -> bool:
     cli_redirect stored there must be re-validated at callback time —
     otherwise a tampered cookie could redirect the freshly-minted
     access token to an attacker-controlled host (#936).
+
+    The URL is parsed rather than prefix-matched: ``startswith`` is
+    blind to userinfo, so ``http://localhost:1@attacker.example/``
+    would pass the guard while routing to ``attacker.example`` (#2571).
     """
-    return bool(url) and url.startswith(
-        ("http://localhost:", "http://127.0.0.1:")
-    )
+    if not url:
+        return False
+    try:
+        parsed = urlparse(url)
+        return (
+            parsed.scheme == "http"
+            and parsed.username is None
+            and parsed.password is None
+            and parsed.hostname in ("localhost", "127.0.0.1")
+            and parsed.port is not None
+        )
+    except ValueError:
+        # Malformed URL (e.g. non-integer port) — reject, don't 500.
+        return False
 
 
 # --- OIDC endpoints ---

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -9420,6 +9420,43 @@ class TestOIDCLogin:
         assert resp.status_code == 400
         assert "localhost" in resp.json()["detail"]
 
+    async def test_cli_redirect_userinfo_bypass_rejected(
+        self, client, app, monkeypatch
+    ):
+        """URLs whose *prefix* looks localhost-y but whose userinfo makes
+        them route to an attacker host must be rejected at login time.
+
+        Regression test for #2571: ``startswith`` prefix matching was
+        blind to userinfo, so ``http://localhost:1@attacker.example/``
+        passed the guard while ``urlparse(...).hostname`` is
+        ``attacker.example``.
+        """
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(
+            app.state.oidc, "oidc_login_allowed", lambda *args: True
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
+        for payload in (
+            "http://localhost:1@attacker.example/steal",
+            "http://localhost:@attacker.example/steal",
+            "http://127.0.0.1:80@attacker.example/steal",
+            # Non-integer port: urlparse raises ValueError on .port —
+            # must be rejected, not 500.
+            "http://localhost:notaport/callback",
+        ):
+            resp = await client.get(
+                "/api/v1/auth/oidc/test/login",
+                params={"cli_redirect": payload},
+            )
+            assert resp.status_code == 400, payload
+            assert "localhost" in resp.json()["detail"]
+
     async def test_oidc_login_redirects(self, client, app, monkeypatch):
         provider = api.oidc.OIDCProvider(
             id="test",
@@ -9732,6 +9769,71 @@ class TestOIDCCallback:
         # Falls back to the web flow, still carrying the token in-house.
         assert "oidc-complete" in location
         assert "token=" in location
+
+    async def test_callback_userinfo_cli_redirect_falls_back(
+        self, client, app, monkeypatch, db
+    ):
+        """A cli_redirect with userinfo smuggling an attacker host in the
+        state cookie must NOT receive the token — fall back to web flow.
+
+        Regression test for #2571: the callback-time re-validation used
+        the same prefix-match guard as login, so userinfo payloads
+        (``http://localhost:1@attacker.example/steal``) slipped through
+        both checks and exfiltrated the token to ``attacker.example``.
+        """
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            app.state.oidc,
+            "exchange_code",
+            AsyncMock(return_value={"id_token": "idt", "access_token": "at"}),
+        )
+        monkeypatch.setattr(
+            app.state.oidc,
+            "validate_id_token",
+            AsyncMock(
+                return_value={
+                    "sub": "evil-sub",
+                    "email": "evil@example.com",
+                    "email_verified": True,
+                }
+            ),
+        )
+        for payload in (
+            "http://localhost:1@attacker.example/steal",
+            "http://localhost:@attacker.example/steal",
+            "http://127.0.0.1:80@attacker.example/steal",
+        ):
+            cookie_data = json_mod.dumps(
+                {
+                    "state": "s",
+                    "verifier": "v",
+                    "redirect_uri": "https://klangk.example.com/cb",
+                    "cli_redirect": payload,
+                }
+            )
+            client.cookies.set("oidc_test", cookie_data)
+            resp = await client.get(
+                "/api/v1/auth/oidc/test/callback",
+                params={"code": "code", "state": "s"},
+                follow_redirects=False,
+            )
+            assert resp.status_code == 302, payload
+            location = resp.headers["location"]
+            # Must NOT redirect to the attacker host with the token.
+            assert "attacker.example" not in location, payload
+            # Falls back to the web flow, still carrying the token in-house.
+            assert "oidc-complete" in location, payload
+            assert "token=" in location, payload
+            client.cookies.delete("oidc_test")
 
     async def test_callback_token_exchange_failure(
         self, client, app, monkeypatch, db


### PR DESCRIPTION
## Summary

- Replaces the `startswith` prefix match in `_valid_cli_redirect` with real URL parsing (`urlparse`): the target must be plain `http`, carry no userinfo, have a hostname of exactly `localhost` or `127.0.0.1`, and include a port. Anything else falls back to the web `oidc-complete` flow.
- Prefix matching was blind to URL userinfo, so `http://localhost:1@attacker.example/steal` passed both the login-time check and the callback-time re-validation while actually routing to `attacker.example` — handing the freshly-minted session token to an attacker host after a normal IdP login.
- Malformed URLs (e.g. non-integer port, which makes `urlparse().port` raise `ValueError`) are rejected instead of 500ing.
- Regression tests pin the three userinfo payloads (`http://localhost:1@…`, `http://localhost:@…`, `http://127.0.0.1:80@…`) at **both** validation points: login returns 400; callback falls back to the web flow without the attacker host in the redirect.

Fixes #2571.

## Testing

- Full backend suite as CI runs it: 4972 passed, coverage 100% (`api/oidc_auth.py` 100%).
