### PR TITLE
test(cli): make test_resize_loop deterministic (#2574)

### DIFF
--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -49,6 +49,7 @@ _WS_MAX_SIZE = int(os.environ.get("KLANGK_WEBSOCKET_MSG_SIZE_MAX", 2**24))
 logger = logging.getLogger(__name__)
 
 _RETRY_ATTEMPTS = 3
+_RESIZE_POLL_INTERVAL = 1.0  # seconds between terminal size checks
 _RETRY_BACKOFF = 2.0  # seconds, doubled each retry
 
 _WS_CONNECT_TIMEOUT = 60  # seconds to wait for container_ready
@@ -1606,7 +1607,9 @@ class TerminalSession(_ShellSession):
     async def resize_loop(self) -> None:
         while not self.stop.is_set():
             try:
-                await asyncio.wait_for(self.stop.wait(), timeout=1)
+                await asyncio.wait_for(
+                    self.stop.wait(), timeout=_RESIZE_POLL_INTERVAL
+                )
                 return  # pragma: no cover
             except asyncio.TimeoutError:
                 pass

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -828,6 +828,9 @@ class TestRunShell:
             return (120, 40) if call_idx[0] > 1 else (80, 24)
 
         monkeypatch.setattr(cli_client, "get_terminal_size", cycling_size)
+        # Shrink the poll interval so the test does not race the 1s tick
+        # on slow runners (#2574).
+        monkeypatch.setattr(cli_client, "_RESIZE_POLL_INTERVAL", 0.05)
 
         # select returns empty so stdin_loop keeps looping without reading EOF
         with patch(
@@ -837,7 +840,15 @@ class TestRunShell:
             task = asyncio.create_task(
                 cli_client.run_shell(ws, 80, 24, stdin=fake_buf)
             )
-            await asyncio.sleep(2.5)
+            # Wait (bounded) for the resize send instead of a fixed sleep,
+            # so a loaded runner cannot cancel before the send lands.
+            for _ in range(250):  # 5s ceiling
+                if any(
+                    "terminal_resize" in c[0][0]
+                    for c in ws.send.call_args_list
+                ):
+                    break
+                await asyncio.sleep(0.02)
             task.cancel()
             try:
                 await task
@@ -853,6 +864,12 @@ class TestRunShell:
             f"Expected at least 1 resize send, got {ws.send.call_count} total "
             f"sends: {[c[0][0] for c in ws.send.call_args_list]}"
         )
+        # Exactly the changed size is sent, with the new dimensions.
+        assert json.loads(resize_msgs[0]) == {
+            "cmd": "terminal_resize",
+            "cols": 120,
+            "rows": 40,
+        }
 
 
 class TestIsTerminalResponse:


### PR DESCRIPTION
## Summary

`TestRunShell::test_resize_loop_sends_on_size_change` raced `resize_loop`'s 1s poll tick against a fixed 2.5s sleep. The monkeypatched `get_terminal_size` returns the initial size `(80, 24)` on its **first** call, so the first possible `terminal_resize` send lands at the ~2s tick — on a loaded macOS runner (seen in #2572's CI run) that tick slipped past the sleep+cancel and the assertion saw zero sends.

Fixes #2574

## Changes

- Extract the hardcoded `timeout=1` in `TerminalSession.resize_loop` to a module constant `_RESIZE_POLL_INTERVAL` (behavior unchanged, still 1s in production).
- In the test, monkeypatch `_RESIZE_POLL_INTERVAL` to 50ms and replace the fixed `sleep(2.5)` with a bounded wait-for-condition loop (5s ceiling), so a loaded runner cannot cancel before the send lands.
- Also assert the sent payload dimensions (`cols=120, rows=40`).

Test duration drops from ~2.5s of wall clock to ~0.15s, and it no longer depends on tick timing.
