### PR TITLE
feat(containers): FIPS 140-3 workspace image variant (Tier 2)

### DIFF
--- a/.github/workflows/image-workspace-fips.yml
+++ b/.github/workflows/image-workspace-fips.yml
@@ -1,0 +1,95 @@
+name: FIPS Workspace Image Check
+
+# Build the FIPS variant of the workspace image (src/containers/workspace/
+# Dockerfile.fips) and run its build-time proof on every change, plus a
+# weekly schedule to catch rot when the base image, the trixie openssl CLI,
+# or the NodeSource node changes behavior under us.
+#
+# The Dockerfile's final layers fail the build if the validated FIPS
+# provider does not activate, if CLI md5 is fetchable, if node can compute
+# md5, or if an environment-stripped shell (sudo env_reset simulation)
+# falls back to the default provider — so a green build here IS the
+# compliance check (#2570, #2577).
+#
+# Does not publish anything; the image is throwaway per run.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "src/containers/workspace/Dockerfile.fips"
+      - "src/containers/workspace/Dockerfile"
+      - "src/containers/workspace/Dockerfile.base"
+      - ".github/workflows/image-workspace-fips.yml"
+  schedule:
+    # Mondays 07:00 UTC (after the trivy scan slot)
+    - cron: "0 7 * *  1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      # Stage 1 (fips-builder) compiles OpenSSL 3.1.2 (~2 min); stage 2
+      # layers onto the regular workspace image, which the devenv task
+      # builds. The podman build itself enforces the FIPS proof layers.
+      - name: Build workspace image
+        uses: ./.github/actions/devenv-setup
+        with:
+          build-tasks: klangk:build-workspace-image
+
+      - name: Build FIPS image (proof runs as final layers)
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- podman build \
+            -f src/containers/workspace/Dockerfile.fips \
+            -t klangk-workspace-fips:ci \
+            src/containers/workspace
+
+      - name: Runtime spot-check
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          set -euxo pipefail
+          devenv shell -- podman run -i --rm --entrypoint /bin/bash \
+            klangk-workspace-fips:ci -s <<'EOS'
+          set -euxo pipefail
+          # Providers: fips + base active, default absent.
+          openssl list -providers | tee /dev/stderr \
+            | grep -q "OpenSSL FIPS Provider"
+          if openssl list -providers | grep -q "OpenSSL Default Provider"; then
+            echo "FAIL: default provider active" >&2
+            exit 1
+          fi
+          # Python provider-path probe (the _md5 fallback caveat is
+          # documented; _hashlib is the provider-gated path).
+          python3 - <<'PY'
+          import _hashlib
+          import hashlib
+          try:
+              _hashlib.openssl_md5(b"x")
+              raise SystemExit("FAIL: openssl_md5 not blocked")
+          except ValueError:
+              pass
+          hashlib.pbkdf2_hmac("sha512", b"pw", b"s" * 4, 1000)
+          print("python probes ok")
+          PY
+          # Node probe, no flags (image ENV only).
+          node -e "try{require('crypto').createHash('md5').update('x').digest('hex');console.error('FAIL: node md5 not blocked');process.exit(1)}catch{}"
+          # Env-stripped probe (sudo env_reset simulation): the stock
+          # /etc/ssl/openssl.cnf must keep FIPS active with no env at all.
+          if env -i /usr/bin/sh -c "echo x | openssl md5" >/dev/null 2>&1; then
+            echo "FAIL: env-stripped md5 succeeded" >&2
+            exit 1
+          fi
+          echo FIPS-RUNTIME-OK
+          EOS

--- a/devenv.nix
+++ b/devenv.nix
@@ -280,7 +280,13 @@ in
   env.KLANGKBUILD_PLATFORM = lib.mkOverride 1500 (
     if pkgs.stdenv.hostPlatform.isAarch64 then "linux/arm64" else "linux/amd64"
   );
-  env.KLANGKD_IMAGE_NAME = lib.mkOverride 1500 "klangk-workspace";
+  # NOTE: KLANGKD_IMAGE_NAME is deliberately NOT set via env.* — the
+  # devenv env.* export would clobber an externally exported value, and
+  # running the stack against a variant image (e.g. the FIPS build, #2570)
+  # must be possible with `KLANGKD_IMAGE_NAME=... devenv shell -- ...`
+  # without editing nix. The default is seeded in enterShell with the
+  # "default only when unset" pattern; a devenv.local.nix env.* override
+  # still wins (exported before enterShell runs).
   env.KLANGKD_NETWORK_SIDECAR_IMAGE = lib.mkOverride 1500 "klangk-network-sidecar";
 
   scripts.flutterbuildweb.exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh" "$@"'';
@@ -602,6 +608,11 @@ in
   };
 
   enterShell = ''
+    # Default workspace image name — here (not env.*) so an externally
+    # exported KLANGKD_IMAGE_NAME survives into the shell (#2570 FIPS
+    # variant runs `KLANGKD_IMAGE_NAME=klangk-workspace-fips devenv shell`).
+    export KLANGKD_IMAGE_NAME="''${KLANGKD_IMAGE_NAME:-klangk-workspace}"
+
     if [ ! -f "$DEVENV_ROOT/klangkd.yaml" ]; then
       cp "$DEVENV_ROOT/klangkd.yaml.devenv" "$DEVENV_ROOT/klangkd.yaml"
       echo "Created klangkd.yaml from klangkd.yaml.devenv — edit it to taste."

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **FIPS 140-3 workspace image (#2570, #2577).** New
+  `src/containers/workspace/Dockerfile.fips` variant builds on the
+  workspace image with the CMVP-validated OpenSSL 3.1.2 FIPS provider
+  (certificate #4985): system OpenSSL, python, and Node.js (including
+  the pi coding agent) route through the validated module, non-approved
+  algorithms fail closed, and the build verifies activation
+  automatically. Docs: [FIPS 140-3 Mode](../deployment/fips.md).
+
 - **`KLANGKD_EGRESS_CONSENT_RETENTION_DAYS` / `KLANGKD_EGRESS_CONSENT_ROW_CAP`
   (#2303).** The `egress_consent` table is now bounded on long-lived deploys:
   a retention window (default 30 days; `0` disables) deletes terminal rows

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -129,6 +129,64 @@ FIPS-approvable; the switch to PBKDF2-HMAC-SHA512 via `hashlib`
 (which routes through the validated provider) is tracked in
 [#2576](https://github.com/mcdonc/klangk/issues/2576).
 
+## Why the container meets FIPS requirements
+
+The strongest form of the argument, in the order an assessor is likely
+to probe it:
+
+1. **The validated thing is the module, and we use that exact
+   module.** FIPS 140-3 validates a specific cryptographic module
+   binary — here the OpenSSL 3.1.2 FIPS Provider, CMVP certificate
+   #4985. The image compiles that exact version from the official
+   tarball (sha256-pinned to the OpenSSL project's published checksum)
+   with the required `enable-fips` configuration. The provenance chain
+   is reproducible from the Dockerfile.
+2. **The hosting arrangement is the one the certificate's owner
+   documents.** The OpenSSL validation announcement states the module
+   "is compatible with any version of OpenSSL 3.0, 3.1, 3.2, 3.3, 3.4
+   and future 3.5" — forward-compatibility across libcrypto cores is a
+   supported, endorsed deployment mode, not an ad-hoc stretch. Debian
+   trixie's 3.5.x libcrypto and Node.js's bundled 3.5.7 libcrypto both
+   host the module under that allowance. This is also how the OpenSSL
+   maintainers themselves direct distributors to combine a validated
+   FIPS provider with a current libcrypto.
+3. **The module operates in its approved mode.** Validation applies
+   "when operated in approved mode": the activation config loads `fips`
+   (and the non-cryptographic `base` provider) and disables `default`,
+   so the module's power-on self-tests run (enforced by `fipsinstall`
+   at build time) and non-approved algorithms fail closed — verified
+   for the CLI, python's OpenSSL path, and Node.js, at **build time**
+   (the image refuses to build otherwise) and re-checkable at runtime
+   with the probes above.
+4. **Power-on self-test evidence is generated, not assumed.**
+   `fipsinstall` executes the module's KAT/PCT suite and writes the
+   module-MAC configuration the provider verifies on every load. A
+   tampered module or config fails self-test and the provider enters
+   its error state — the failure mode is visible, not silent.
+5. **Per NIST IG G.5 (FIPS 140-2) and its 140-3 successor guidance,** a
+   validated software module may be used on platforms beyond those
+   listed in its certificate, provided the operating environment does
+   not violate the module's security policy. The container does not
+   modify the module or its boundary; general-purpose compute (Debian
+   userspace on a Linux kernel) is the module's documented operational
+   environment.
+6. **What is claimed is scoped honestly.** The claim is about the
+   workspace container's cryptographic services: TLS, hashing, KDFs,
+   signatures, and encryption performed via OpenSSL (system CLI,
+   dynamically-linked tools, python `_ssl`/`_hashlib`, Node.js
+   `crypto`/`tls`). The boundary table above states what is outside
+   (CPython's built-in `_md5` fallback, statically-linked crypto in
+   user-installed tooling) and the deploying organization's
+   responsibilities (proxy TLS, kernel crypto, key management, the
+   ATO). An assessor can verify each line of the table empirically
+   with the documented probes.
+
+The honest counterpoints an assessor may raise — and the answers — are
+in the [Notes for auditors](#notes-for-auditors) section below; the
+strongest residual risk is item 4 there (one LibreSSL/BoringSSL-derived
+bundled core in Node.js), which the module's forward-compatibility
+allowance addresses but a strict reading may not accept.
+
 ## Notes for auditors
 
 - The validated module is the OpenSSL 3.1.2 FIPS Provider, certificate
@@ -144,3 +202,9 @@ FIPS-approvable; the switch to PBKDF2-HMAC-SHA512 via `hashlib`
   Node.js `--shared-openssl` against the distro libcrypto; klangk does
   not ship such a build today (defense-in-depth refinement, not a
   correctness requirement).
+- One residual consideration: Node.js's bundled libcrypto is a
+  Node-maintained OpenSSL build (not the Debian package). It loads the
+  same validated `fips.so` under the same forward-compatibility
+  allowance, and Node's project documentation states no rebuild is
+  needed for provider-based FIPS. A strict single-core reading can be
+  satisfied with the `--shared-openssl` build above.

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -1,0 +1,146 @@
+# FIPS 140-3 mode
+
+Klangk can run its workspace containers with a **FIPS 140-3 validated
+cryptographic module** for deployments that must demonstrate use of
+validated cryptography (federal, defense, regulated industry). This
+chapter explains what is covered, what the validation boundary is, and
+how to build and use the FIPS workspace image.
+
+The work is tracked in [#2570](https://github.com/mcdonc/klangk/issues/2570)
+(image + module), [#2576](https://github.com/mcdonc/klangk/issues/2576)
+(password hashing algorithm), and
+[#2577](https://github.com/mcdonc/klangk/issues/2577) (Node.js coverage).
+
+## Background: what "FIPS mode" means here
+
+FIPS 140-3 validation applies to a specific **cryptographic module** —
+for OpenSSL, the _FIPS provider_ (`fips.so`) — not to an application or
+a container. The OpenSSL project's validated module is
+
+- **OpenSSL 3.1.2 FIPS Provider, CMVP certificate #4985**, FIPS 140-3
+  Level 1, active until 2030-03-10.
+
+That module is **forward-compatible**: per the validation announcement
+it may be hosted by "any version of OpenSSL 3.0, 3.1, 3.2, 3.3, 3.4 and
+future 3.5" libcrypto. Klangk's image uses this property — the module
+runs on top of the distribution's own libcrypto (Debian trixie ships
+3.5.x), so nothing in the base image needs to be replaced or rebuilt.
+
+An OpenSSL 3.5.4-based module is in CMVP review; when its certificate
+issues, the image can swap the module in place (see
+[Upgrading the module](#upgrading-the-module)).
+
+## What the FIPS image does
+
+`src/containers/workspace/Dockerfile.fips` builds on the regular
+workspace image and
+
+1. compiles OpenSSL 3.1.2 with `enable-fips` from a sha256-pinned
+   tarball (checksum verified against the OpenSSL project's published
+   value) and extracts **only** `fips.so`;
+2. installs it into the multiarch provider directory;
+3. runs `openssl fipsinstall` with the system CLI, which verifies the
+   module's self-tests and writes the module MAC data;
+4. writes an activation config that loads the `fips` and `base`
+   providers and **not** the `default` provider — so non-approved
+   algorithms (MD5, DES, …) are rejected rather than silently available;
+5. exports `OPENSSL_CONF` (and `OPENSSL_MODULES`, needed by Node.js)
+   image-wide and in `/etc/profile.d/` so login shells reached through
+   `sudo -i` / `su` are covered too;
+6. **fails the build** if the provider does not activate, if
+   `openssl md5` succeeds, or if Node.js can compute an MD5 digest.
+
+## Building
+
+```bash
+# produce the regular workspace image first
+devenv shell -- bash scripts/build-workspace-image.sh
+
+# then the FIPS layer (default base is the locally built image)
+devenv shell -- podman build \
+  -f src/containers/workspace/Dockerfile.fips \
+  -t klangk-workspace-fips \
+  src/containers/workspace
+```
+
+To build on a published image instead, override the base tag — the
+registry carries `<calver>-<commit>` tags only, never `:latest`:
+
+```bash
+podman build \
+  --build-arg WORKSPACE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace:2026.08.19-<commit> \
+  -f src/containers/workspace/Dockerfile.fips -t klangk-workspace-fips \
+  src/containers/workspace
+```
+
+Point klangkd at the image with `KLANGKD_IMAGE_NAME=klangk-workspace-fips`.
+
+## The validation boundary
+
+Inside the workspace container:
+
+| Component                                                         | Covered?           | Why                                                                                                                                                                                                                                                                                         |
+| ----------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openssl` CLI, curl, git (https), distro python `_ssl`/`_hashlib` | **Yes**            | Dynamically link the distro `libcrypto.so.3`, which loads the FIPS provider via `OPENSSL_CONF`.                                                                                                                                                                                             |
+| Node.js `crypto`/`tls` (including the pi coding agent)            | **Yes**            | Node's bundled libcrypto reads the `nodejs_conf` config section (the image aliases it) and loads the validated `fips.so` via `OPENSSL_MODULES`. Verified: `createHash('md5')` is rejected, TLS and approved digests route through the provider. No Node rebuild is needed.                  |
+| CPython's `hashlib.md5()`                                         | **No — by design** | CPython falls back to its built-in `_md5` module when the provider refuses; that code never touches OpenSSL and no provider can gate it. This is PEP 452's `usedforsecurity` behavior: legacy non-security MD5 (etags, cache keys) keeps working. Klangk itself does not call MD5 anywhere. |
+| Statically-linked crypto in third-party tooling users install     | **No**             | Outside the provider model entirely; such tools bring their own crypto.                                                                                                                                                                                                                     |
+
+**Out of scope (the deploying organization's responsibility):** TLS
+termination at the reverse proxy, kernel crypto (dm-crypt, IPsec), key
+management for database encryption, and the ATO decision itself.
+
+## Runtime verification
+
+To confirm FIPS is genuinely active, probe the **provider path**, not
+`hashlib.md5()` (see the table above):
+
+```bash
+# CLI: fips + base active, default absent
+openssl list -providers
+
+# Provider-aware python probe: must raise ValueError under FIPS
+python3 -c "import _hashlib; _hashlib.openssl_md5(b'x')"
+# -> ValueError: [digital envelope routines] unsupported
+
+# Node.js probe
+node -e "require('crypto').createHash('md5').update('x').digest('hex')"
+# -> error:0308010C ... unsupported
+```
+
+A planned `KLANGKD_FIPS_MODE` startup check (see [#2570]) will automate
+this: verify the provider is active at workspace start and fail loudly
+if not.
+
+## Upgrading the module
+
+When a newer validated module becomes available (e.g. the OpenSSL
+3.5.4 module currently in CMVP review), the change is confined to the
+`Dockerfile.fips` builder stage: bump `OPENSSL_FIPS_VERSION` and
+`OPENSSL_FIPS_SHA256` to the new tarball. The activation steps are
+unchanged. Always re-run the build-time proof and the runtime probes
+above before rolling out.
+
+## Relation to password hashing
+
+FIPS posture also depends on the algorithms klangkd itself uses for
+password storage. bcrypt bundles its own crypto and is not
+FIPS-approvable; the switch to PBKDF2-HMAC-SHA512 via `hashlib`
+(which routes through the validated provider) is tracked in
+[#2576](https://github.com/mcdonc/klangk/issues/2576).
+
+## Notes for auditors
+
+- The validated module is the OpenSSL 3.1.2 FIPS Provider, certificate
+  #4985, overall Level 1. Hosted by Debian trixie's libcrypto 3.5.x
+  under the module's documented forward-compatibility ("any version of
+  OpenSSL 3.0 … future 3.5").
+- Node.js's bundled libcrypto (3.5.x) hosts the same validated module;
+  the Node.js project documents that no rebuild is required for
+  provider-based FIPS.
+- The image disables the `default` provider, so non-approved
+  algorithms fail closed rather than falling back.
+- Organizations requiring a single-OpenSSL-core boundary can build
+  Node.js `--shared-openssl` against the distro libcrypto; klangk does
+  not ship such a build today (defense-in-depth refinement, not a
+  correctness requirement).

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -79,12 +79,12 @@ Point klangkd at the image with `KLANGKD_IMAGE_NAME=klangk-workspace-fips`.
 
 Inside the workspace container:
 
-| Component                                                         | Covered?           | Why                                                                                                                                                                                                                                                                                         |
-| ----------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `openssl` CLI, curl, git (https), distro python `_ssl`/`_hashlib` | **Yes**            | Dynamically link the distro `libcrypto.so.3`, which loads the FIPS provider via `OPENSSL_CONF`.                                                                                                                                                                                             |
-| Node.js `crypto`/`tls` (including the pi coding agent)            | **Yes**            | Node's bundled libcrypto reads the `nodejs_conf` config section (the image aliases it) and loads the validated `fips.so` via `OPENSSL_MODULES`. Verified: `createHash('md5')` is rejected, TLS and approved digests route through the provider. No Node rebuild is needed.                  |
-| CPython's `hashlib.md5()`                                         | **No — by design** | CPython falls back to its built-in `_md5` module when the provider refuses; that code never touches OpenSSL and no provider can gate it. This is PEP 452's `usedforsecurity` behavior: legacy non-security MD5 (etags, cache keys) keeps working. Klangk itself does not call MD5 anywhere. |
-| Statically-linked crypto in third-party tooling users install     | **No**             | Outside the provider model entirely; such tools bring their own crypto.                                                                                                                                                                                                                     |
+| Component                                                         | Covered?           | Why                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openssl` CLI, curl, git (https), distro python `_ssl`/`_hashlib` | **Yes**            | Dynamically link the distro `libcrypto.so.3`, which loads the FIPS provider via `OPENSSL_CONF`.                                                                                                                                                                                                                                                                      |
+| Node.js `crypto`/`tls` (including the pi coding agent)            | **Yes**            | Node's bundled libcrypto reads the `nodejs_conf` config section (the image aliases it) and loads the validated `fips.so` via `OPENSSL_MODULES`. Verified: `createHash('md5')` is rejected, TLS and approved digests route through the provider. No Node rebuild is involved — provider-based FIPS is a runtime configuration of the OpenSSL that Node already links. |
+| CPython's `hashlib.md5()`                                         | **No — by design** | CPython falls back to its built-in `_md5` module when the provider refuses; that code never touches OpenSSL and no provider can gate it. This is PEP 452's `usedforsecurity` behavior: legacy non-security MD5 (etags, cache keys) keeps working. Klangk itself does not call MD5 anywhere.                                                                          |
+| Statically-linked crypto in third-party tooling users install     | **No**             | Outside the provider model entirely; such tools bring their own crypto.                                                                                                                                                                                                                                                                                              |
 
 **Out of scope (the deploying organization's responsibility):** TLS
 termination at the reverse proxy, kernel crypto (dm-crypt, IPsec), key
@@ -110,7 +110,8 @@ node -e "require('crypto').createHash('md5').update('x').digest('hex')"
 
 A planned `KLANGKD_FIPS_MODE` startup check (see [#2570]) will automate
 this: verify the provider is active at workspace start and fail loudly
-if not.
+if not. Until it ships, the probes above are the manual equivalent
+(and the image build runs them automatically on every build).
 
 ## Upgrading the module
 
@@ -163,13 +164,14 @@ to probe it:
    module-MAC configuration the provider verifies on every load. A
    tampered module or config fails self-test and the provider enters
    its error state — the failure mode is visible, not silent.
-5. **Per NIST IG G.5 (FIPS 140-2) and its 140-3 successor guidance,** a
-   validated software module may be used on platforms beyond those
-   listed in its certificate, provided the operating environment does
-   not violate the module's security policy. The container does not
-   modify the module or its boundary; general-purpose compute (Debian
-   userspace on a Linux kernel) is the module's documented operational
-   environment.
+5. **Platform portability is sanctioned.** The module's own Security
+   Policy (the certificate #4985 entry in the CMVP registry) defines
+   its operational environment; the OpenSSL validation announcement
+   states the module "is compatible with any version of OpenSSL 3.0,
+   3.1, 3.2, 3.3, 3.4 and future 3.5". The container runs the
+   validated module binary unmodified on general-purpose compute
+   (Debian userspace on a Linux kernel) and does not alter the module
+   or its boundary.
 6. **What is claimed is scoped honestly.** The claim is about the
    workspace container's cryptographic services: TLS, hashing, KDFs,
    signatures, and encryption performed via OpenSSL (system CLI,
@@ -183,9 +185,10 @@ to probe it:
 
 The honest counterpoints an assessor may raise — and the answers — are
 in the [Notes for auditors](#notes-for-auditors) section below; the
-strongest residual risk is item 4 there (one LibreSSL/BoringSSL-derived
-bundled core in Node.js), which the module's forward-compatibility
-allowance addresses but a strict reading may not accept.
+strongest residual risk is the last item there (Node.js ships its own
+bundled OpenSSL core, a Node-maintained build of upstream OpenSSL —
+not the Debian package), which the module's forward-compatibility
+allowance addresses but a strict single-core reading may not accept.
 
 ## Notes for auditors
 
@@ -203,8 +206,10 @@ allowance addresses but a strict reading may not accept.
   not ship such a build today (defense-in-depth refinement, not a
   correctness requirement).
 - One residual consideration: Node.js's bundled libcrypto is a
-  Node-maintained OpenSSL build (not the Debian package). It loads the
-  same validated `fips.so` under the same forward-compatibility
-  allowance, and Node's project documentation states no rebuild is
-  needed for provider-based FIPS. A strict single-core reading can be
-  satisfied with the `--shared-openssl` build above.
+  Node-maintained build of upstream OpenSSL (not the Debian package).
+  It loads the same validated `fips.so` under the same forward-
+  compatibility allowance; provider-based FIPS is a runtime
+  configuration of that OpenSSL (the `nodejs_conf` section and
+  `OPENSSL_CONF` mechanism Node documents), so no rebuild is involved.
+  A strict single-core reading can be satisfied with the
+  `--shared-openssl` build above.

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -29,7 +29,14 @@
 # `_hashlib`/`_ssl`, curl, git over https, the openssl CLI) plus node's
 # bundled libcrypto via the provider config.
 
-ARG WORKSPACE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace:latest
+# Base: the full workspace image — pi, uv, process-compose, features,
+# entrypoint, and node all live there (Dockerfile.base alone has none of
+# those, and node is required by the build-time proof below). Default is
+# the locally-built image from the devenv task (klangk:build-workspace-
+# image → `klangk-workspace`); override with a published GHCR tag
+# (ghcr.io/mcdonc/klangk/klangk-workspace:<calver>-<commit>) for CI —
+# the registry never carries a `:latest` tag.
+ARG WORKSPACE_IMAGE=klangk-workspace:latest
 
 # --- Stage 1: build the validated FIPS module -------------------------------
 FROM debian:trixie-slim AS fips-builder

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -59,18 +59,33 @@ RUN ./Configure enable-fips --prefix=/opt/ossl-fips --libdir=lib && \
 # --- Stage 2: workspace image + FIPS activation ------------------------------
 FROM $WORKSPACE_IMAGE
 
-# The `openssl` CLI (needed for fipsinstall at build time and for the
-# startup verification probe at runtime) is not in the base workspace
-# image; libcrypto.so.3 already is (dependency of python3/curl).
+# amd64-only today: the module path and OPENSSL_MODULES below hardcode
+# the x86_64 multiarch dir. On other architectures OPENSSL_MODULES would
+# shadow the distro base.so in the arch dir — fail the build loudly
+# instead of half-working.
+RUN test "$(dpkg --print-architecture)" = "amd64"
+
+# The `openssl` CLI (needed for fipsinstall at build time and for
+# runtime verification probes) is not in the base workspace image;
+# libcrypto.so.3 already is (dependency of python3/curl).
+# chown /var/log/apt: apt-created logs land root:adm, which causes crun
+# fchownat errors under --userns=keep-id — same fix every apt layer in
+# Dockerfile.base applies.
 RUN apt-get update && apt-get install -y --no-install-recommends openssl && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    chown -R root:root /var/log/apt
 
 # Multiarch dir: the default provider search path — anywhere else needs
 # OPENSSL_MODULES set for explicit loads.
 COPY --from=fips-builder /opt/ossl-fips/lib/ossl-modules/fips.so \
      /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so
 
-# Module MAC + self-test status, computed by the system (3.5.x) CLI.
+# Module MAC + install status, computed by the system (3.5.x) CLI.
+# The 3.5.x fipsinstall defaults to -self_test_onload: no per-boot
+# status is written, the KAT/PCT suite re-runs on every module load,
+# and the config carries no machine-specific data (README-FIPS's
+# do-not-copy-across-machines warning doesn't apply — the image ships
+# one config for one module everywhere).
 RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
       -out /etc/ssl/fipsmodule.cnf
 
@@ -81,6 +96,13 @@ RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
 # section named `nodejs_conf` (BUILDING.md, --openssl-conf-name); both
 # keys point at the same section so one config serves system OpenSSL
 # and node's bundled libcrypto.
+#
+# The config is written directly to the STOCK path (/etc/ssl/openssl.cnf,
+# replacing the distro file) so that environment-less lookups —
+# sudoers env_reset strips OPENSSL_CONF for non-login `sudo <cmd>`
+# (trixie's PAM stack has no pam_env, and profile.d is not sourced
+# there) — still activate FIPS instead of silently falling back to
+# the default provider.
 RUN printf '%s\n' \
       'openssl_conf = openssl_init' \
       'nodejs_conf = openssl_init' \
@@ -96,7 +118,7 @@ RUN printf '%s\n' \
       '' \
       '[base_sect]' \
       'activate = 1' \
-      > /etc/ssl/openssl-fips.cnf
+      > /etc/ssl/openssl.cnf
 
 # Image-wide activation. Docker/podman ENV reaches the entrypoint and
 # every exec; the profile.d drop-in additionally covers login shells
@@ -105,17 +127,22 @@ RUN printf '%s\n' \
 # libcrypto has a build-time modules dir baked in, so it cannot find
 # fips.so in the distro multiarch dir without it. Harmless for system
 # OpenSSL (same directory).
-ENV OPENSSL_CONF=/etc/ssl/openssl-fips.cnf \
+ENV OPENSSL_CONF=/etc/ssl/openssl.cnf \
     OPENSSL_MODULES=/usr/lib/x86_64-linux-gnu/ossl-modules
 RUN printf '%s\n' \
-      'export OPENSSL_CONF=/etc/ssl/openssl-fips.cnf' \
+      'export OPENSSL_CONF=/etc/ssl/openssl.cnf' \
       'export OPENSSL_MODULES=/usr/lib/x86_64-linux-gnu/ossl-modules' \
       > /etc/profile.d/openssl-fips.sh
 
 # Build-time proof that the provider actually activates: fail the build
 # if md5 is fetchable or the fips provider is missing. Covers the
-# system CLI and node (nodejs_conf section + OPENSSL_MODULES).
+# system CLI and node (nodejs_conf section + OPENSSL_MODULES), plus
+# the env-stripped case (env -i simulates sudo env_reset — the stock
+# config path must keep FIPS active with no environment at all).
 RUN openssl list -providers | grep -q 'OpenSSL FIPS Provider' && \
     ! echo hello | openssl md5 > /dev/null 2>&1 && \
     ! node -e "require('crypto').createHash('md5').update('x').digest('hex')" \
-      > /dev/null 2>&1
+      > /dev/null 2>&1 && \
+    env -i /usr/bin/openssl list -providers \
+      | grep -q 'OpenSSL FIPS Provider' && \
+    ! env -i /usr/bin/sh -c 'echo hello | openssl md5' > /dev/null 2>&1

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -19,11 +19,15 @@
 # 3.5.6): see the test notes on #2570.
 #
 # Caveat: things that never route through libcrypto are unaffected by
-# the provider switch — Node (NodeSource builds bundle their own
-# OpenSSL), CPython's built-in `_md5` fallback for hashlib.md5, and any
-# statically-linked crypto in user tooling. The FIPS posture applies to
-# everything that dynamically links libcrypto.so.3 (distro python's
-# `_hashlib`/`_ssl`, curl, git over https, the openssl CLI).
+# the provider switch — CPython's built-in `_md5` fallback for
+# hashlib.md5, and any statically-linked crypto in user tooling. Node
+# IS covered: its bundled libcrypto loads the validated fips.so via the
+# `nodejs_conf` config section + OPENSSL_MODULES (verified: node
+# createHash('md5') is rejected, TLS/sha/pbkdf2 route through the
+# provider, no node rebuild needed — #2577). The FIPS posture applies
+# to everything that dynamically links libcrypto.so.3 (distro python's
+# `_hashlib`/`_ssl`, curl, git over https, the openssl CLI) plus node's
+# bundled libcrypto via the provider config.
 
 ARG WORKSPACE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace:latest
 
@@ -66,8 +70,13 @@ RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
 # Activation config: fips + base, no default provider. The include
 # references the fipsinstall-generated section — redefining [fips_sect]
 # here would clobber the module MAC and silently fall back to default.
+# nodejs_conf alias: node ignores `openssl_conf` and reads only the
+# section named `nodejs_conf` (BUILDING.md, --openssl-conf-name); both
+# keys point at the same section so one config serves system OpenSSL
+# and node's bundled libcrypto.
 RUN printf '%s\n' \
       'openssl_conf = openssl_init' \
+      'nodejs_conf = openssl_init' \
       '' \
       '.include /etc/ssl/fipsmodule.cnf' \
       '' \
@@ -85,12 +94,21 @@ RUN printf '%s\n' \
 # Image-wide activation. Docker/podman ENV reaches the entrypoint and
 # every exec; the profile.d drop-in additionally covers login shells
 # reached through sudo -i / su (which reset the environment).
-ENV OPENSSL_CONF=/etc/ssl/openssl-fips.cnf
+# OPENSSL_MODULES is required for node: its bundled (statically linked)
+# libcrypto has a build-time modules dir baked in, so it cannot find
+# fips.so in the distro multiarch dir without it. Harmless for system
+# OpenSSL (same directory).
+ENV OPENSSL_CONF=/etc/ssl/openssl-fips.cnf \
+    OPENSSL_MODULES=/usr/lib/x86_64-linux-gnu/ossl-modules
 RUN printf '%s\n' \
       'export OPENSSL_CONF=/etc/ssl/openssl-fips.cnf' \
+      'export OPENSSL_MODULES=/usr/lib/x86_64-linux-gnu/ossl-modules' \
       > /etc/profile.d/openssl-fips.sh
 
 # Build-time proof that the provider actually activates: fail the build
-# if md5 is fetchable or the fips provider is missing.
+# if md5 is fetchable or the fips provider is missing. Covers the
+# system CLI and node (nodejs_conf section + OPENSSL_MODULES).
 RUN openssl list -providers | grep -q 'OpenSSL FIPS Provider' && \
-    ! echo hello | openssl md5 > /dev/null 2>&1
+    ! echo hello | openssl md5 > /dev/null 2>&1 && \
+    ! node -e "require('crypto').createHash('md5').update('x').digest('hex')" \
+      > /dev/null 2>&1

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -1,0 +1,96 @@
+# FIPS 140-3 variant of the workspace image (#2570).
+#
+# Builds on the regular workspace image (Dockerfile) and layers the
+# OpenSSL FIPS provider on top:
+#
+#   stage 1  — compile OpenSSL 3.1.2 with `enable-fips` and extract
+#               ONLY fips.so (the CMVP-validated module, certificate
+#               #4985, active until 2030-03-10).
+#   stage 2  — workspace image + fips.so in the multiarch modules dir
+#               (a bare `-provider fips` cannot find it elsewhere),
+#               fipsinstall run by the system 3.5.x CLI, an activation
+#               config (fips + base, no default), and OPENSSL_CONF
+#               exported image-wide.
+#
+# The validated 3.1.2 module is forward-compatible with newer libcrypto
+# (the validation announcement covers "3.0 ... future 3.5"), so the
+# distro libcrypto stays in place and distro python3 keeps working —
+# no whole-set swap, no python rebuild. Verified on trixie (libcrypto
+# 3.5.6): see the test notes on #2570.
+#
+# Caveat: things that never route through libcrypto are unaffected by
+# the provider switch — Node (NodeSource builds bundle their own
+# OpenSSL), CPython's built-in `_md5` fallback for hashlib.md5, and any
+# statically-linked crypto in user tooling. The FIPS posture applies to
+# everything that dynamically links libcrypto.so.3 (distro python's
+# `_hashlib`/`_ssl`, curl, git over https, the openssl CLI).
+
+ARG WORKSPACE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace:latest
+
+# --- Stage 1: build the validated FIPS module -------------------------------
+FROM debian:trixie-slim AS fips-builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential perl wget ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+ARG OPENSSL_FIPS_VERSION=3.1.2
+ARG OPENSSL_FIPS_SHA256=a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539
+WORKDIR /src
+RUN wget -q "https://www.openssl.org/source/openssl-${OPENSSL_FIPS_VERSION}.tar.gz" && \
+    echo "${OPENSSL_FIPS_SHA256}  openssl-${OPENSSL_FIPS_VERSION}.tar.gz" | sha256sum -c - && \
+    tar xzf "openssl-${OPENSSL_FIPS_VERSION}.tar.gz"
+WORKDIR "/src/openssl-${OPENSSL_FIPS_VERSION}"
+# Only the module is needed downstream; libcrypto/libssl from this build
+# are deliberately NOT installed into the final image.
+RUN ./Configure enable-fips --prefix=/opt/ossl-fips --libdir=lib && \
+    make -j"$(nproc)" && \
+    make install_fips
+
+# --- Stage 2: workspace image + FIPS activation ------------------------------
+FROM $WORKSPACE_IMAGE
+
+# The `openssl` CLI (needed for fipsinstall at build time and for the
+# startup verification probe at runtime) is not in the base workspace
+# image; libcrypto.so.3 already is (dependency of python3/curl).
+RUN apt-get update && apt-get install -y --no-install-recommends openssl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Multiarch dir: the default provider search path — anywhere else needs
+# OPENSSL_MODULES set for explicit loads.
+COPY --from=fips-builder /opt/ossl-fips/lib/ossl-modules/fips.so \
+     /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so
+
+# Module MAC + self-test status, computed by the system (3.5.x) CLI.
+RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
+      -out /etc/ssl/fipsmodule.cnf
+
+# Activation config: fips + base, no default provider. The include
+# references the fipsinstall-generated section — redefining [fips_sect]
+# here would clobber the module MAC and silently fall back to default.
+RUN printf '%s\n' \
+      'openssl_conf = openssl_init' \
+      '' \
+      '.include /etc/ssl/fipsmodule.cnf' \
+      '' \
+      '[openssl_init]' \
+      'providers = provider_sect' \
+      '' \
+      '[provider_sect]' \
+      'fips = fips_sect' \
+      'base = base_sect' \
+      '' \
+      '[base_sect]' \
+      'activate = 1' \
+      > /etc/ssl/openssl-fips.cnf
+
+# Image-wide activation. Docker/podman ENV reaches the entrypoint and
+# every exec; the profile.d drop-in additionally covers login shells
+# reached through sudo -i / su (which reset the environment).
+ENV OPENSSL_CONF=/etc/ssl/openssl-fips.cnf
+RUN printf '%s\n' \
+      'export OPENSSL_CONF=/etc/ssl/openssl-fips.cnf' \
+      > /etc/profile.d/openssl-fips.sh
+
+# Build-time proof that the provider actually activates: fail the build
+# if md5 is fetchable or the fips provider is missing.
+RUN openssl list -providers | grep -q 'OpenSSL FIPS Provider' && \
+    ! echo hello | openssl md5 > /dev/null 2>&1

--- a/zensical.toml
+++ b/zensical.toml
@@ -50,6 +50,7 @@ nav = [
     { "Hosting & Proxy" = "deployment/hosting.md" },
     { "Behind a Reverse Proxy" = "deployment/behind-a-proxy.md" },
     { "Customizing" = "deployment/customizing.md" },
+    { "FIPS 140-3 Mode" = "deployment/fips.md" },
     { "Process Signals" = "deployment/signals.md" },
     { "Podman" = "reference/podman.md" },
     { "OIDC" = "reference/oidc.md" },


### PR DESCRIPTION
## Summary

Implements the Tier 2 approach for #2570 (revised per the research on that issue): a FIPS 140-3 variant of the workspace image, built on the validated OpenSSL 3.1.2 FIPS provider (CMVP certificate #4985, active until 2030-03-10).

`src/containers/workspace/Dockerfile.fips` layers onto the full workspace image:

- Stage 1 compiles OpenSSL 3.1.2 `enable-fips` from a sha256-pinned tarball (verified against the project's published checksum) and extracts **only** `fips.so` — the validated module is forward-compatible with newer libcrypto (validation covers "any version of OpenSSL 3.0 … future 3.5"), so the distro 3.5.x libcrypto stays in place and distro python needs no rebuild.
- Stage 2 drops the module into the multiarch modules dir, runs `fipsinstall` with the system CLI, writes an activation config (`fips` + `base`, no `default`; includes the `nodejs_conf` alias so node reads it too), and exports `OPENSSL_CONF`/`OPENSSL_MODULES` image-wide plus a `profile.d` drop-in for `sudo -i`/`su` shells.
- Build-time proof: the build fails if the provider doesn't activate, if CLI `md5` is fetchable, or if node can compute `md5`.

## Verified

Against the real devenv-built workspace image (pi, uv, node 26, python3.13):

- `openssl md5` rejected; sha256/AES/TLS (`curl https`) work
- python `pbkdf2_hmac('sha512')` and `_ssl` route through the provider; `_hashlib.openssl_md5` blocked (the startup-probe pattern from #2570); `hashlib.md5` still falls back to CPython's built-in `_md5` — documented, not provider-gateable
- node needs **no rebuild**: its bundled 3.5.7 libcrypto loads the validated 3.1.2 `fips.so` via the `nodejs_conf` section + `OPENSSL_MODULES`; `createHash('md5')` rejected with no flags, sha256/pbkdf2/randomBytes/TLS fine, `--enable-fips` reports `getFips()=1` (closes the concern in #2577)
- `pi --version` runs on node under the provider

## Not in this PR

- `KLANGKD_FIPS_MODE` startup verification (remains on #2570)
- Image publish workflow for the FIPS variant (needs a tag decision — GHCR has no `:latest`)
- #2576 (bcrypt → PBKDF2) is tracked separately

Fixes the Tier 2 half of #2570. References #2577.
