### PR TITLE
fix(oidc): add secure=True to OIDC state cookie (#2580)

### DIFF
--- a/src/klangk/klangk/api/oidc_auth.py
+++ b/src/klangk/klangk/api/oidc_auth.py
@@ -106,6 +106,7 @@ async def oidc_login(
         key=f"oidc_{provider_id}",
         value=cookie_value,
         httponly=True,
+        secure=True,
         max_age=600,
         samesite="lax",
         path="/",


### PR DESCRIPTION
## Summary

Add `secure=True` to the OIDC state cookie. Browsers treat localhost as a secure context (W3C Secure Contexts spec), so this doesn't break local development.

Closes #2580

## Test plan

- [x] Backend tests pass (4972 passed, 100% coverage)