### PR TITLE
fix(devenv): let an exported KLANGKD_IMAGE_NAME survive the devenv shell

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -280,7 +280,13 @@ in
   env.KLANGKBUILD_PLATFORM = lib.mkOverride 1500 (
     if pkgs.stdenv.hostPlatform.isAarch64 then "linux/arm64" else "linux/amd64"
   );
-  env.KLANGKD_IMAGE_NAME = lib.mkOverride 1500 "klangk-workspace";
+  # NOTE: KLANGKD_IMAGE_NAME is deliberately NOT set via env.* — the
+  # devenv env.* export would clobber an externally exported value, and
+  # running the stack against a variant image (e.g. the FIPS build, #2570)
+  # must be possible with `KLANGKD_IMAGE_NAME=... devenv shell -- ...`
+  # without editing nix. The default is seeded in enterShell with the
+  # "default only when unset" pattern; a devenv.local.nix env.* override
+  # still wins (exported before enterShell runs).
   env.KLANGKD_NETWORK_SIDECAR_IMAGE = lib.mkOverride 1500 "klangk-network-sidecar";
 
   scripts.flutterbuildweb.exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh" "$@"'';
@@ -602,6 +608,11 @@ in
   };
 
   enterShell = ''
+    # Default workspace image name — here (not env.*) so an externally
+    # exported KLANGKD_IMAGE_NAME survives into the shell (#2570 FIPS
+    # variant runs `KLANGKD_IMAGE_NAME=klangk-workspace-fips devenv shell`).
+    export KLANGKD_IMAGE_NAME="''${KLANGKD_IMAGE_NAME:-klangk-workspace}"
+
     if [ ! -f "$DEVENV_ROOT/klangkd.yaml" ]; then
       cp "$DEVENV_ROOT/klangkd.yaml.devenv" "$DEVENV_ROOT/klangkd.yaml"
       echo "Created klangkd.yaml from klangkd.yaml.devenv — edit it to taste."


### PR DESCRIPTION
## Summary

`env.KLANGKD_IMAGE_NAME` in `devenv.nix` clobbers any ambiently-exported value, so running the stack (or tests) against a variant workspace image — e.g. the FIPS build from #2578's `Dockerfile.fips` — required editing nix or the shell script. This made it awkward to validate variant images: `KLANGKD_IMAGE_NAME=klangk-workspace-fips devenv shell -- test-all` silently ran against the stock image.

## Changes

- Drop the `env.KLANGKD_IMAGE_NAME` export; seed the default (`klangk-workspace`) in `enterShell` with the `${KLANGKD_IMAGE_NAME:-...}` pattern, so an externally exported value survives into the shell.
- A `devenv.local.nix` `env.*` override still wins (it is exported before `enterShell` runs).
- No script changes needed — `build-workspace-image.sh`, `build-host-image.sh`, `dist-smoke-test.sh`, and `trivy-workspace.sh` already read `${KLANGKD_IMAGE_NAME:-klangk-workspace}`.

## Verified

- `KLANGKD_IMAGE_NAME=klangk-workspace-fips devenv shell -- sh -c 'echo $KLANGKD_IMAGE_NAME'` → `klangk-workspace-fips`; no export → `klangk-workspace`.
- Full `test-all` (unit + sidecar + server e2e + client e2e) against the FIPS image: all green (two client-e2e latency flakes re-ran clean in isolation).
