### PR TITLE
refactor: hoist allow-deferred-import sites to module scope

### DIFF
--- a/scripts/check_deferred_imports.py
+++ b/scripts/check_deferred_imports.py
@@ -22,6 +22,39 @@ def _is_top_level(node: ast.AST) -> bool:
     return isinstance(getattr(node, "_parent", None), ast.Module)
 
 
+def _is_type_checking(node: ast.AST) -> bool:
+    """Check if a node sits directly inside ``if TYPE_CHECKING:``.
+
+    That block is the canonical module-scope pattern for annotation-only
+    imports (erased at runtime), so its imports are exempt without a marker.
+    """
+    parent = getattr(node, "_parent", None)
+    if not isinstance(parent, ast.If):
+        return False
+    test = parent.test
+    return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+        isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+    )
+
+
+def _is_guarded_optional(node: ast.AST) -> bool:
+    """Check if a node is a module-scope ``try: import`` over ``ImportError``.
+
+    The guarded-optional-dependency pattern (import at module scope inside
+    ``try/except ImportError``) is also module-scope in spirit — the import
+    executes once at load, with a fallback for absent extras.
+    """
+    parent = getattr(node, "_parent", None)
+    if not (isinstance(parent, ast.Try) and _is_top_level(parent)):
+        return False
+    return any(
+        isinstance(h, ast.ExceptHandler)
+        and isinstance(h.type, ast.Name)
+        and h.type.id in ("ImportError", "ModuleNotFoundError")
+        for h in parent.handlers
+    )
+
+
 def _parse_file(filepath: Path):
     """Parse a file and annotate parent nodes. Returns (tree, lines) or None."""
     try:
@@ -41,12 +74,19 @@ def _line_has_comment(lines: list[str], lineno: int, comment: str) -> bool:
 
 def _is_marked(lines: list[str], lineno: int, comment: str) -> bool:
     """Is the import at *lineno* suppressed? The marker may sit on the
-    import line itself or on a comment line directly above it."""
+    import line itself, on a comment line directly above it, or — when
+    the import sits inside a nested block (``if``/``try``/…) — on any
+    consecutive comment line above it."""
     if _line_has_comment(lines, lineno, comment):
         return True
-    if lineno >= 2:
-        above = lines[lineno - 2].strip()
-        return above.startswith("#") and comment in above
+    i = lineno - 2  # 0-based index of the line above
+    while i >= 0:
+        stripped = lines[i].strip()
+        if not stripped.startswith("#"):
+            return False
+        if comment in stripped:
+            return True
+        i -= 1
     return False
 
 
@@ -71,7 +111,11 @@ def check_deferred_imports(package_dir: str) -> list[str]:
         for node in ast.walk(tree):
             if not isinstance(node, (ast.Import, ast.ImportFrom)):
                 continue
-            if _is_top_level(node):
+            if (
+                _is_top_level(node)
+                or _is_type_checking(node)
+                or _is_guarded_optional(node)
+            ):
                 continue
             if _is_marked(source_lines, node.lineno, "allow-deferred-import"):
                 continue

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -323,7 +323,8 @@ def consent_decide(
     ws = _resolve_workspace_for_consent(client, workspace)
     token = context.session_token()
     # Lazy import so the textual dep only loads on this command path.
-    from .tui.consent import ConsentDeciderApp  # allow-deferred-import
+    # allow-deferred-import (textual, this path only)
+    from .tui.consent import ConsentDeciderApp
 
     ConsentDeciderApp(
         context.server_url(),

--- a/src/klangk/klangk/cli/context.py
+++ b/src/klangk/klangk/cli/context.py
@@ -94,7 +94,8 @@ def resolve_or_exit(client, name: str):
     # Deferred: context is imported by every command module; this keeps
     # client.py's httpx/websockets import weight off commands that never
     # build a client (check_deferred_imports allowlist).
-    from .client import WorkspaceNotFoundError  # allow-deferred-import
+    # allow-deferred-import (httpx weight)
+    from .client import WorkspaceNotFoundError
 
     try:
         return client.resolve_workspace(name)

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -208,7 +208,7 @@ def _maybe_launch_tui(ctx: typer.Context) -> None:
     if not _is_interactive():
         typer.echo(ctx.get_help())
         raise typer.Exit(code=0)
-    from .tui import run_tui  # allow-deferred-import
+    from .tui import run_tui  # allow-deferred-import (textual, ~440ms)
 
     try:
         run_tui(server_url=context._server_override)

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -39,10 +39,13 @@ from ..ws import listen_for_status
 from ._base import (
     CheatsheetScreen,
     ConfirmScreen,
+    DuplicateScreen,
     InputScreen,
     TransferScreen,
     WorkspaceListView,
 )
+from .server import ServerSwitchScreen
+from .workspace_form import CreateWorkspaceScreen, EditWorkspaceScreen
 
 logger = logging.getLogger(__name__)
 
@@ -399,9 +402,6 @@ class MainScreen(Screen):
                     lv.index = 0
 
     def action_switch_server(self) -> None:
-        # allow-deferred-import
-        from .server import ServerSwitchScreen
-
         self.app.push_screen(ServerSwitchScreen())
 
     # --- per-workspace actions (act on the highlighted row, #1878) ---
@@ -549,9 +549,6 @@ class MainScreen(Screen):
         self._refresh_action_hints()
 
     def action_duplicate(self) -> None:
-        # allow-deferred-import
-        from ._base import DuplicateScreen
-
         name = self._require_highlighted()
         if not name:
             return
@@ -610,9 +607,6 @@ class MainScreen(Screen):
         self.run_worker(self._do_edit(name), exit_on_error=False)
 
     async def _do_edit(self, name: str) -> None:
-        # allow-deferred-import
-        from .workspace_form import EditWorkspaceScreen
-
         state = self.app.tui_state
         try:
             ws = await asyncio.to_thread(state.find_workspace, name)
@@ -747,9 +741,6 @@ class MainScreen(Screen):
             self.refresh_lists()
 
     async def _do_create(self) -> None:
-        # allow-deferred-import
-        from .workspace_form import CreateWorkspaceScreen
-
         state = self.app.tui_state
         try:
             data = await asyncio.to_thread(state.list_images)
@@ -797,6 +788,9 @@ class MainScreen(Screen):
 
         def _offer(open_it: bool) -> None:
             if open_it:
+                # Deferred: genuine cycle — workspace_detail imports
+                # MainScreen; see the other WorkspaceDetailScreen import
+                # in this module for the full note.
                 # allow-deferred-import
                 from .workspace_detail import WorkspaceDetailScreen
 
@@ -1072,6 +1066,9 @@ class MainScreen(Screen):
             pass  # Widget not mounted yet; status will refresh on mount.
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
+        # Deferred: genuine cycle (workspace_detail imports MainScreen;
+        # screens/__init__ imports main). Both modules load textual at
+        # module scope anyway, so this defers cycle resolution, not weight.
         # allow-deferred-import
         from .workspace_detail import WorkspaceDetailScreen
 
@@ -1217,6 +1214,9 @@ class MainScreen(Screen):
 
     def _forward_status_to_detail(self, event: dict) -> None:
         """Mirror a live status broadcast onto an open detail screen."""
+        # Deferred: genuine cycle (workspace_detail imports MainScreen;
+        # screens/__init__ imports main). Both modules load textual at
+        # module scope anyway, so this defers cycle resolution, not weight.
         # allow-deferred-import
         from .workspace_detail import WorkspaceDetailScreen
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -37,6 +37,7 @@ from ._base import (
     SpatialListView,
     TransferScreen,
 )
+from .workspace_form import EditWorkspaceScreen
 
 logger = logging.getLogger(__name__)
 
@@ -445,9 +446,6 @@ class WorkspaceDetailScreen(Screen):
         self.run_worker(self._do_edit, exit_on_error=False)
 
     async def _do_edit(self) -> None:
-        # allow-deferred-import
-        from .workspace_form import EditWorkspaceScreen
-
         state = self.app.tui_state
         try:
             data = await asyncio.to_thread(state.list_images)
@@ -485,8 +483,12 @@ class WorkspaceDetailScreen(Screen):
             self.run_worker(self._reload_after_edit, exit_on_error=False)
 
     async def _reload_after_edit(self) -> None:
-        # allow-deferred-import
-        from .main import MainScreen
+        # Deferred: main.py imports this module (push_screen on row select),
+        # so a module-scope ``from .main import MainScreen`` would execute
+        # while main is partially initialized depending on entry order —
+        # a genuine import cycle. Only this method needs the name, at call
+        # time, when both modules are fully loaded.
+        from .main import MainScreen  # allow-deferred-import
 
         await self._load()
         try:

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -370,7 +370,8 @@ def main(  # pragma: no cover
     # ``module:app`` string import). This avoids the module-level
     # ``app = build_app()`` global — there's one ``build_app(settings)`` call,
     # one registry, wired correctly (#1464, #1454).
-    from klangk.main import build_app  # allow-deferred-import
+    # allow-deferred-import (serve-time import)
+    from klangk.main import build_app
 
     asgi_app = build_app(settings)
     # Arm the UDS trust flag on the Util instance: over a UDS,
@@ -410,7 +411,8 @@ def doctor(  # pragma: no cover
     ),
 ) -> None:
     """Check for missing dependencies and common misconfigurations."""
-    from klangk.doctor import doctor_main  # allow-deferred-import
+    # allow-deferred-import (subcommand-scoped)
+    from klangk.doctor import doctor_main
 
     raise SystemExit(doctor_main(verbose=verbose))
 

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -746,7 +746,7 @@ def setup_logfire(app: FastAPI) -> bool:
     """Enable Logfire instrumentation if LOGFIRE_TOKEN is set."""
     if not os.environ.get("LOGFIRE_TOKEN"):
         return False
-    import logfire  # allow-deferred-import
+    import logfire  # allow-deferred-import (opt-in, ~440ms)
 
     base_url = os.environ.get("LOGFIRE_BASE_URL")
     environment = os.environ.get("LOGFIRE_ENVIRONMENT")

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -24,8 +24,8 @@ from .constants import MAX_INPUT_SIZE
 from .helpers import send_error, send_event, get_shared_terminals
 
 if TYPE_CHECKING:
-    from .connection import Connection  # allow-deferred-import
-    from .session import WorkspaceSession  # allow-deferred-import
+    from .connection import Connection
+    from .session import WorkspaceSession
 
 logger = logging.getLogger(__name__)
 

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -20,7 +20,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from .connection import Connection  # allow-deferred-import
+    from .connection import Connection
 
 logger = logging.getLogger(__name__)
 

--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -18,7 +18,7 @@ from .config import DEBUG, HOLD_TIMEOUT, LISTEN_PORT, UPSTREAM, WORKSPACE_TOKEN_
 from .state import _BG_TASKS
 
 if TYPE_CHECKING:
-    from .consent import SidecarConsentClient  # allow-deferred-import (annotation-only)
+    from .consent import SidecarConsentClient
 
 # Bound on the consent client's teardown during SIGTERM shutdown (#2400):
 # client.stop() closes the WS (close_timeout=5s), and during klangkd shutdown

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -12,6 +12,7 @@ import json
 import random
 import time
 import uuid
+import websockets
 
 from . import allowlist, rules
 from .config import ACTIVITY_GATE_S, DEBUG
@@ -104,8 +105,6 @@ class SidecarConsentClient:
         self._fail_close_pending()
 
     async def _run(self) -> None:
-        import websockets  # allow-deferred-import (sidecar-only dep; lazy so the module loads without it)
-
         backoff = 1.0
         while not self._stop:
             token = self._read_token()

--- a/src/klangksidecar/klangksidecar/nfqueue.py
+++ b/src/klangksidecar/klangksidecar/nfqueue.py
@@ -24,8 +24,17 @@ from .packets import parse_dest, parse_syn_tuple
 from .rules import _host_for
 from .state import _BG_TASKS, _INFLIGHT, _VERDICT_CACHE
 
+# netfilterqueue is a sidecar-only optional dep ([nfqueue] extra: it links
+# libnetfilter_queue, a C library, and may be absent in dev environments).
+# Guarded module-scope import: importing the module works everywhere, and
+# _setup_nfq_consumer reports the absence at bind time.
+try:
+    from netfilterqueue import NetfilterQueue
+except ImportError:  # the [nfqueue] extra is not installed
+    NetfilterQueue = None
+
 if TYPE_CHECKING:
-    from .consent import SidecarConsentClient  # allow-deferred-import (annotation-only)
+    from .consent import SidecarConsentClient
 
 
 def _setup_nfq_consumer(client: SidecarConsentClient | None):
@@ -44,18 +53,15 @@ def _setup_nfq_consumer(client: SidecarConsentClient | None):
     does NOT serialize others -- distinct flows are held concurrently
     (netfilterqueue supports deferred verdicts; outstanding packets count
     against the kernel queue size, and the iptables rate-limit bounds arrivals).
-    netfilterqueue is a sidecar-only dep, imported lazily so the module loads
-    without it. Returns the bound ``NetfilterQueue`` (so :func:`_shutdown` can
-    unbind it on SIGTERM, #2400) or ``None`` on failure.
+    netfilterqueue is optional ([nfqueue] extra). Returns the bound
+    ``NetfilterQueue`` (so :func:`_shutdown` can unbind it on SIGTERM,
+    #2400) or ``None`` on failure.
     """
-    try:
-        # allow-deferred-import (sidecar-only; lazy so the module loads without it)
-        from netfilterqueue import NetfilterQueue as _NFQ
-    except Exception as exc:
-        print(f"nfqueue: netfilterqueue unavailable ({exc})", flush=True)
+    if NetfilterQueue is None:
+        print("nfqueue: netfilterqueue not installed", flush=True)
         return None
     try:
-        nfq = _NFQ()
+        nfq = NetfilterQueue()
         nfq.bind(QUEUE_NUM, lambda pkt: _cb(pkt, client))
         loop = asyncio.get_running_loop()
         # When the netlink socket is readable, process all pending packets on

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -22,7 +22,7 @@ from .config import DEBUG, MARK, UPSTREAM
 from .rules import _fmt_ports, _learn_all
 
 if TYPE_CHECKING:
-    from .consent import SidecarConsentClient  # allow-deferred-import (annotation-only)
+    from .consent import SidecarConsentClient
 
 
 def query_name(wire: bytes) -> str:

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -1504,11 +1504,15 @@ class TestConsentForward:
 
     # --- _run_nfq_consumer: graceful no-op without netfilterqueue ---
 
-    def test_setup_nfq_consumer_noop_without_netfilterqueue(self, proxy, capsys):
-        # The server venv has no netfilterqueue -> lazy import fails -> logs +
+    def test_setup_nfq_consumer_noop_without_netfilterqueue(
+        self, proxy, monkeypatch, capsys
+    ):
+        # netfilterqueue absent (dev venv without the [nfqueue] extra) -> the
+        # guarded module-scope import left NetfilterQueue = None -> logs +
         # returns instead of raising (before touching the event loop).
+        monkeypatch.setattr(proxy.nfqueue, "NetfilterQueue", None)
         proxy._setup_nfq_consumer(None)
-        assert "netfilterqueue unavailable" in capsys.readouterr().out
+        assert "netfilterqueue not installed" in capsys.readouterr().out
 
 
 # --- helpers for the NFQUEUE callback + _handle_packet tests (#2311 half B) ---
@@ -3006,11 +3010,13 @@ class TestSigtermShutdown:
 
     async def test_setup_nfq_consumer_returns_nfq_for_unbind(self, proxy, monkeypatch):
         # _setup_nfq_consumer returns the bound NFQUEUE so _shutdown can unbind
-        # it on SIGTERM (clean PID-1 teardown, #2400).
+        # it on SIGTERM (clean PID-1 teardown, #2400). The import is a guarded
+        # module-scope one; patch the resolved symbol directly.
         nfq = MagicMock()
         nfq.get_fd = MagicMock(return_value=7)
-        fake_mod = types.SimpleNamespace(NetfilterQueue=MagicMock(return_value=nfq))
-        monkeypatch.setitem(sys.modules, "netfilterqueue", fake_mod)
+        monkeypatch.setattr(
+            proxy.nfqueue, "NetfilterQueue", MagicMock(return_value=nfq)
+        )
         loop = asyncio.get_running_loop()
         monkeypatch.setattr(loop, "add_reader", MagicMock())
         assert proxy._setup_nfq_consumer(None) is nfq
@@ -3019,10 +3025,11 @@ class TestSigtermShutdown:
     async def test_setup_nfq_consumer_bind_failure_returns_none(
         self, proxy, monkeypatch, capsys
     ):
-        fake_mod = types.SimpleNamespace(
-            NetfilterQueue=MagicMock(side_effect=RuntimeError("bind boom"))
+        monkeypatch.setattr(
+            proxy.nfqueue,
+            "NetfilterQueue",
+            MagicMock(side_effect=RuntimeError("bind boom")),
         )
-        monkeypatch.setitem(sys.modules, "netfilterqueue", fake_mod)
         assert proxy._setup_nfq_consumer(None) is None
         assert "nfqueue consumer failed" in capsys.readouterr().out
 


### PR DESCRIPTION
Closes #2600.

## Summary

Audit of all 23 `# allow-deferred-import` sites; 13 became module-scope, 10 keep their markers with justification. 23 → 10.

**Checker** (`scripts/check_deferred_imports.py`) now exempts two canonical module-scope patterns without needing a marker:
- `if TYPE_CHECKING:` blocks (annotation-only imports — the standard cycle-free pattern)
- module-scope `try: import / except ImportError` (guarded optional dependency)

`_is_marked` also walks consecutive comment lines above the import, so the marker works inside nested blocks (`if`/`try`) where a long inline comment would force ruff-format to split the statement.

**Hoisted**
- TUI screens: `main → server/_base/workspace_form` (no cycle) and `workspace_detail → workspace_form`. Net: 7 sites.
- Sidecar `websockets`: unconditional dep, imports in ~1 ms — the lazy comment claimed value it never had.

**Converted**
- Sidecar `netfilterqueue`: optional `[nfqueue]` extra → guarded module-scope import with `NetfilterQueue = None` fallback; `_setup_nfq_consumer` reports absence at bind time. Tests retargeted at the resolved symbol instead of `sys.modules` injection.

**Kept (with tightened inline reasons)**
- `main ↔ workspace_detail` cycle (3 sites): genuine cycle — `workspace_detail` imports `MainScreen`; both modules load textual at module scope anyway, so the deferral resolves the cycle, not weight. Rationale recorded at each site.
- CLI startup weight: `run_tui`, `ConsentDeciderApp` (textual ≈ 440 ms), `WorkspaceNotFoundError` (httpx).
- Launcher: `build_app` (serve-time), `doctor_main` (subcommand-scoped).
- `logfire` (opt-in, `LOGFIRE_TOKEN`-gated).

## Testing

- `check_deferred_imports.py`: passes on both packages; negative probes verified (unmarked deferred import fails; TYPE_CHECKING and guarded-try exempt; marker-above exempt).
- `ruff check` + `ruff format --check`: clean.
- pytest: backend + CLI + sidecar 5143 passed locally (`--no-cov`, xdist); CI runs the full gate.
