### PR TITLE
feat(auth): enforce password character-class complexity (#2581)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -30,7 +30,6 @@ operators or integrators to act when upgrading.
 
 ## [Unreleased]
 
-<<<<<<< HEAD
 ### Changed
 
 - **Numeric config accepts bare numbers (#2603).** All numeric
@@ -48,18 +47,6 @@ operators or integrators to act when upgrading.
   resolves to the field's default instead of crashing consumers with
   `int(None)`; `port_range_start` is range-checked against the last
   legal host port.
-=======
-### Added
-
-- **`KLANGKD_PASSWORD_REQUIRE_{UPPER,LOWER,DIGIT,SPECIAL}` (#2581).**
-  Character-class complexity requirements for passwords: each setting is
-  the number of characters of that class a password must contain
-  (e.g. `2` = at least two uppercase letters), `0` (the default) = no
-  requirement. Enforced on registration, password change/reset, invite
-  acceptance, and admin set-password; advertised to clients via
-  `password_requirements` in `/api/v1/config` for inline validation in
-  the web UI and CLI.
->>>>>>> 78452048 (feat(auth): enforce password character-class complexity (#2581))
 
 ### Security
 
@@ -80,6 +67,15 @@ operators or integrators to act when upgrading.
   the web flow.
 
 ### Added
+
+- **`KLANGKD_PASSWORD_REQUIRE_{UPPER,LOWER,DIGIT,SPECIAL}` (#2581).**
+  Character-class complexity requirements for passwords: each setting is
+  the number of characters of that class a password must contain
+  (e.g. `2` = at least two uppercase letters), `0` (the default) = no
+  requirement. Enforced on registration, password change/reset, invite
+  acceptance, and admin set-password; advertised to clients via
+  `password_requirements` in `/api/v1/config` for inline validation in
+  the web UI and CLI.
 
 - **FIPS 140-3 workspace image (#2570, #2577).** New
   `src/containers/workspace/Dockerfile.fips` variant builds on the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -30,6 +30,7 @@ operators or integrators to act when upgrading.
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ### Changed
 
 - **Numeric config accepts bare numbers (#2603).** All numeric
@@ -47,6 +48,18 @@ operators or integrators to act when upgrading.
   resolves to the field's default instead of crashing consumers with
   `int(None)`; `port_range_start` is range-checked against the last
   legal host port.
+=======
+### Added
+
+- **`KLANGKD_PASSWORD_REQUIRE_{UPPER,LOWER,DIGIT,SPECIAL}` (#2581).**
+  Character-class complexity requirements for passwords: each setting is
+  the number of characters of that class a password must contain
+  (e.g. `2` = at least two uppercase letters), `0` (the default) = no
+  requirement. Enforced on registration, password change/reset, invite
+  acceptance, and admin set-password; advertised to clients via
+  `password_requirements` in `/api/v1/config` for inline validation in
+  the web UI and CLI.
+>>>>>>> 78452048 (feat(auth): enforce password character-class complexity (#2581))
 
 ### Security
 

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -109,6 +109,10 @@ default_user: admin@example.com
 default_password: "file:/run/secrets/admin-pw"
 access_token_hours: 24
 min_password_length: 12
+password_require_upper: 1
+password_require_lower: 1
+password_require_digit: 1
+password_require_special: 1
 
 # --- Server / network ---
 listen: "127.0.0.1"
@@ -238,6 +242,10 @@ port: "8997"
 | `access_token_hours`          | `24`                     | `KLANGKD_ACCESS_TOKEN_HOURS`          |
 | `workspace_token_hours`       | `24`                     | `KLANGKD_WORKSPACE_TOKEN_HOURS`       |
 | `min_password_length`         | `8`                      | `KLANGKD_MIN_PASSWORD_LENGTH`         |
+| `password_require_upper`      | `0`                      | `KLANGKD_PASSWORD_REQUIRE_UPPER`      |
+| `password_require_lower`      | `0`                      | `KLANGKD_PASSWORD_REQUIRE_LOWER`      |
+| `password_require_digit`      | `0`                      | `KLANGKD_PASSWORD_REQUIRE_DIGIT`      |
+| `password_require_special`    | `0`                      | `KLANGKD_PASSWORD_REQUIRE_SPECIAL`    |
 | `login_lockout_failures`      | `5`                      | `KLANGKD_LOGIN_LOCKOUT_FAILURES`      |
 | `login_lockout_duration`      | `900`                    | `KLANGKD_LOGIN_LOCKOUT_DURATION`      |
 | `login_lockout_window`        | `300`                    | `KLANGKD_LOGIN_LOCKOUT_WINDOW`        |

--- a/src/frontend/e2e-tests/e2e-env.ts
+++ b/src/frontend/e2e-tests/e2e-env.ts
@@ -20,6 +20,18 @@ const STRIP_PREFIXES = ["KLANGK", "_KLANGK", "KLANGKC", "LOGFIRE"];
 // a klangkd.yaml setting), so each env-only launcher sets it explicitly
 // (global-setup.ts, run-demo-backend.sh). Forwarding a stray ambient value
 // risks pointing at a stale/wrong build.
+/**
+ * The seeded admin password for E2E servers (KLANGKD_DEFAULT_PASSWORD).
+ *
+ * Must satisfy the boot-time password-policy gate (#2581): the daemon
+ * refuses to start when the seeded admin's password violates
+ * KLANGKD_MIN_PASSWORD_LENGTH (default 8) or any character-class count
+ * (KLANGKD_PASSWORD_REQUIRE_*). "Admin123!" clears the length minimum and
+ * all four classes, so it survives a policy tightening without a silent
+ * 10-minute startup timeout in global-setup.
+ */
+export const ADMIN_PASSWORD = "Admin123!";
+
 const INFRA_VARS = ["KLANGKD_IMAGE_NAME", "KLANGKD_VERSION_FILE"];
 
 export function cleanEnv(

--- a/src/frontend/e2e-tests/e2e/api.spec.ts
+++ b/src/frontend/e2e-tests/e2e/api.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { API_BASE, registerUser, connectContainer } from "./helpers";
+import { ADMIN_PASSWORD } from "../e2e-env";
 
 test.describe("API", () => {
   test("index.html has cache-busted flutter_bootstrap.js", async ({
@@ -350,7 +351,7 @@ test.describe("API", () => {
   }) => {
     // Login as the default admin user (seeded on startup)
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { identifier: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: ADMIN_PASSWORD },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminToken = (await loginResp.json()).access_token;
@@ -443,7 +444,7 @@ test.describe("API", () => {
     // Login as the default admin user via the API, then set the token
     // and navigate directly to the admin page.
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { identifier: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: ADMIN_PASSWORD },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminToken = (await loginResp.json()).access_token;
@@ -822,7 +823,7 @@ test.describe("API", () => {
   }) => {
     // Login as admin
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { identifier: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: ADMIN_PASSWORD },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminHeaders = {
@@ -914,7 +915,7 @@ test.describe("API", () => {
     request,
   }) => {
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { identifier: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: ADMIN_PASSWORD },
     });
     const adminHeaders = {
       Authorization: `Bearer ${(await loginResp.json()).access_token}`,
@@ -941,7 +942,7 @@ test.describe("API", () => {
   test("workspace export and import round-trip", async ({ request }) => {
     // Login as admin (export requires admin permission)
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { identifier: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: ADMIN_PASSWORD },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminToken = (await loginResp.json()).access_token;
@@ -1062,7 +1063,7 @@ test.describe("API", () => {
   test("workspace import with custom name", async ({ request }) => {
     // Login as admin
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { identifier: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: ADMIN_PASSWORD },
     });
     const adminHeaders = {
       Authorization: `Bearer ${(await loginResp.json()).access_token}`,

--- a/src/frontend/e2e-tests/e2e/docs-chat-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-chat-screenshots-dev.spec.ts
@@ -7,6 +7,7 @@
 import { test } from "@playwright/test";
 import { join } from "path";
 import { mkdirSync } from "fs";
+import { ADMIN_PASSWORD } from "../e2e-env";
 
 const SCREENSHOT_DIR = join(
   __dirname,
@@ -116,13 +117,13 @@ test.describe("chat dev server screenshots", () => {
     await page.keyboard.type("admin@plope.com");
     await f.click({ position: { x: cx, y: height * 0.56 }, force: true });
     await page.waitForTimeout(200);
-    await page.keyboard.type("admin");
+    await page.keyboard.type(ADMIN_PASSWORD);
     await f.click({ position: { x: cx, y: height * 0.64 }, force: true });
     await page.waitForTimeout(5000);
 
     // Find or create workspace via API
     const loginResp = await request.post(`${BASE_URL}/auth/login`, {
-      data: { identifier: "admin@plope.com", password: "admin" },
+      data: { identifier: "admin@plope.com", password: ADMIN_PASSWORD },
     });
     const { access_token: token } = await loginResp.json();
     const wsResp = await request.get(`${BASE_URL}/workspaces`, {

--- a/src/frontend/e2e-tests/e2e/docs-files-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-files-screenshots-dev.spec.ts
@@ -7,6 +7,7 @@
 import { test } from "@playwright/test";
 import { join } from "path";
 import { mkdirSync } from "fs";
+import { ADMIN_PASSWORD } from "../e2e-env";
 
 const SCREENSHOT_DIR = join(
   __dirname,
@@ -77,7 +78,7 @@ test.describe("files screenshots", () => {
       force: true,
     });
     await page.waitForTimeout(200);
-    await page.keyboard.type("admin");
+    await page.keyboard.type(ADMIN_PASSWORD);
     await f.click({
       position: { x: cx, y: height * 0.64 },
       force: true,
@@ -86,7 +87,7 @@ test.describe("files screenshots", () => {
 
     // Find or create workspace via API
     const loginResp = await request.post(`${BASE_URL}/auth/login`, {
-      data: { identifier: "admin@plope.com", password: "admin" },
+      data: { identifier: "admin@plope.com", password: ADMIN_PASSWORD },
     });
     const { access_token: token } = await loginResp.json();
     const headers = { Authorization: `Bearer ${token}` };

--- a/src/frontend/e2e-tests/e2e/docs-invitations-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-invitations-screenshots-dev.spec.ts
@@ -7,6 +7,7 @@
 import { test } from "@playwright/test";
 import { join } from "path";
 import { mkdirSync } from "fs";
+import { ADMIN_PASSWORD } from "../e2e-env";
 
 const SCREENSHOT_DIR = join(
   __dirname,
@@ -77,7 +78,7 @@ test.describe("invitation screenshots", () => {
       force: true,
     });
     await page.waitForTimeout(200);
-    await page.keyboard.type("admin");
+    await page.keyboard.type(ADMIN_PASSWORD);
     await f.click({
       position: { x: cx, y: height * 0.64 },
       force: true,

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { cleanEnv } from "../e2e-env";
+import { ADMIN_PASSWORD, cleanEnv } from "../e2e-env";
 import {
   API_BASE,
   TEST_PASSWORD,
@@ -608,7 +608,7 @@ test.describe("Klangk E2E", () => {
               ),
               KLANGKD_JWT_SECRET: "e2e-test-secret",
               KLANGKD_DEFAULT_USER: "admin@example.com",
-              KLANGKD_DEFAULT_PASSWORD: "admin",
+              KLANGKD_DEFAULT_PASSWORD: ADMIN_PASSWORD,
               KLANGKD_TEST_MODE: "1",
               KLANGKD_PORT_RANGE_START: "19200",
               LOGFIRE_TOKEN: "",

--- a/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
+++ b/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
@@ -59,7 +59,9 @@ const INSTALL_FSA_SHIM = `
 // Admin account provisioned by global-setup (KLANGKD_DEFAULT_USER / PASSWORD).
 // The export endpoint is admin-only (workspaces.py: has_permission("admin")).
 const ADMIN_EMAIL = "admin@example.com";
-const ADMIN_PASSWORD = "admin";
+// Re-exported from e2e-env: must stay in sync with global-setup's
+// KLANGKD_DEFAULT_PASSWORD (the policy-compliant seed, #2581).
+import { ADMIN_PASSWORD } from "../e2e-env";
 
 /** Poll the shim's window globals until the stream finishes (or errors).
  *  Returns only cheap status fields — the bytes themselves are retrieved

--- a/src/frontend/e2e-tests/global-setup.ts
+++ b/src/frontend/e2e-tests/global-setup.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, openSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { cleanEnv } from "./e2e-env";
+import { ADMIN_PASSWORD, cleanEnv } from "./e2e-env";
 
 async function globalSetup() {
   // When KLANGKBUILD_TEST_URL is set, skip server startup — tests run against
@@ -92,7 +92,7 @@ async function globalSetup() {
         KLANGKD_LOGIN_LOCKOUT_FAILURES: "5",
         KLANGKD_JWT_SECRET: "e2e-test-secret",
         KLANGKD_DEFAULT_USER: "admin@example.com",
-        KLANGKD_DEFAULT_PASSWORD: "admin",
+        KLANGKD_DEFAULT_PASSWORD: ADMIN_PASSWORD,
         // These tests exercise the password auth flow (login, register,
         // lockout); pin password mode explicitly — the production default
         // is `none` when unset (#1374), which disables all of that.

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -6,6 +6,7 @@ import '../theme/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
+import '../auth/password_policy.dart';
 import '../widgets/acl_editor.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
@@ -131,7 +132,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     final result = await showDialog<Map<String, dynamic>>(
       context: context,
       builder: (ctx) => _AddUserDialog(
-        minPasswordLength: auth.minPasswordLength,
+        passwordPolicy: auth.passwordPolicy,
       ),
     );
     if (result == null) return;
@@ -311,7 +312,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       builder: (ctx) => _EditUserDialog(
         currentEmail: user['email'] as String,
         currentHandle: user['handle'] as String? ?? '',
-        minPasswordLength: auth.minPasswordLength,
+        passwordPolicy: auth.passwordPolicy,
       ),
     );
     if (result == null) return;
@@ -1300,9 +1301,9 @@ class _InvitationsTabState extends State<_InvitationsTab> {
 // ---------------------------------------------------------------------------
 
 class _AddUserDialog extends StatefulWidget {
-  final int minPasswordLength;
+  final PasswordPolicy passwordPolicy;
 
-  const _AddUserDialog({this.minPasswordLength = 8});
+  const _AddUserDialog({this.passwordPolicy = const PasswordPolicy()});
 
   @override
   State<_AddUserDialog> createState() => _AddUserDialogState();
@@ -1330,14 +1331,15 @@ class _AddUserDialogState extends State<_AddUserDialog> {
       color: KColors.textPrimary,
       fontWeight: FontWeight.bold,
     );
-    final min = widget.minPasswordLength;
+    final policy = widget.passwordPolicy;
     final password = _passwordController.text;
     final confirm = _confirmController.text;
-    // Show length/mismatch errors only once the user has typed something, so
+    // Show policy/mismatch errors only once the user has typed something, so
     // an empty field isn't flagged before input begins.
-    final passwordTooShort = password.isNotEmpty && password.length < min;
+    final policyError = password.isEmpty ? null : policy.validate(password);
     final passwordsMismatch = confirm.isNotEmpty && confirm != password;
-    final passwordValid = password.length >= min && password == confirm;
+    final passwordValid =
+        password.isNotEmpty && policyError == null && password == confirm;
     final email = _emailController.text.trim();
     final canAdd =
         email.isNotEmpty && (_sendVerificationEmail || passwordValid);
@@ -1384,10 +1386,8 @@ class _AddUserDialogState extends State<_AddUserDialog> {
                   border: const OutlineInputBorder(),
                   // Make the rule discoverable before the first keystroke,
                   // and surface a violation as soon as it's typed.
-                  helperText: 'At least $min characters',
-                  errorText: passwordTooShort
-                      ? 'Password must be at least $min characters'
-                      : null,
+                  helperText: policy.helperText,
+                  errorText: policyError,
                   suffixIcon: IconButton(
                     icon: Icon(_obscurePassword
                         ? Icons.visibility_off
@@ -1460,12 +1460,12 @@ class _AddUserDialogState extends State<_AddUserDialog> {
 class _EditUserDialog extends StatefulWidget {
   final String currentEmail;
   final String currentHandle;
-  final int minPasswordLength;
+  final PasswordPolicy passwordPolicy;
 
   const _EditUserDialog({
     required this.currentEmail,
     required this.currentHandle,
-    this.minPasswordLength = 8,
+    this.passwordPolicy = const PasswordPolicy(),
   });
 
   @override
@@ -1502,16 +1502,16 @@ class _EditUserDialogState extends State<_EditUserDialog> {
       color: KColors.textPrimary,
       fontWeight: FontWeight.bold,
     );
-    final min = widget.minPasswordLength;
+    final policy = widget.passwordPolicy;
     final password = _passwordController.text;
     final confirm = _confirmController.text;
     // The password field is optional ("leave blank to keep current"), so the
-    // length/mismatch checks only apply once the admin starts typing one.
+    // policy/mismatch checks only apply once the admin starts typing one.
     final settingPassword = password.isNotEmpty;
-    final passwordTooShort = settingPassword && password.length < min;
+    final policyError = password.isEmpty ? null : policy.validate(password);
     final passwordsMismatch = confirm.isNotEmpty && confirm != password;
     final passwordValid =
-        !settingPassword || (password.length >= min && password == confirm);
+        !settingPassword || (policyError == null && password == confirm);
     final email = _emailController.text.trim();
     final canSave = email.isNotEmpty && passwordValid;
     return AlertDialog(
@@ -1553,10 +1553,8 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                 floatingLabelStyle: labelStyle,
                 floatingLabelBehavior: FloatingLabelBehavior.always,
                 hintText: 'Leave blank to keep current',
-                helperText: settingPassword ? 'At least $min characters' : null,
-                errorText: passwordTooShort
-                    ? 'Password must be at least $min characters'
-                    : null,
+                helperText: settingPassword ? policy.helperText : null,
+                errorText: policyError,
                 border: const OutlineInputBorder(),
                 suffixIcon: IconButton(
                   icon: Icon(_obscurePassword

--- a/src/frontend/lib/auth/accept_invite_page.dart
+++ b/src/frontend/lib/auth/accept_invite_page.dart
@@ -146,8 +146,10 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
                     obscureText: _obscurePassword,
                     validator: (v) {
                       if (v == null || v.isEmpty) return 'Required';
-                      if (v.length < 8) return 'Min 8 characters';
-                      return null;
+                      return context
+                          .read<AuthService>()
+                          .passwordPolicy
+                          .validate(v);
                     },
                   ),
                   const SizedBox(height: 16),

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../branding.dart';
+import 'password_policy.dart';
 
 /// Override for testing — set to intercept all HTTP calls in AuthService.
 http.Client? testAuthHttpClientOverride;
@@ -23,6 +24,7 @@ class AuthService extends ChangeNotifier {
   bool _bannerAccepted = false;
   bool _loginBannerEveryVisit = false;
   int _minPasswordLength = 8;
+  PasswordPolicy _passwordPolicy = const PasswordPolicy();
   String _instanceId = 'default';
   bool _allowAutostart = false;
   // #1365: deploy-wide netfilter default allow-list + whether the feature
@@ -54,6 +56,11 @@ class AuthService extends ChangeNotifier {
   /// to 8 when the server omits the field so client-side validation still works
   /// against older backends.
   int get minPasswordLength => _minPasswordLength;
+
+  /// Full password policy (length + character-class counts, #2581) parsed
+  /// from /config. Pages that validate inline should use
+  /// [passwordPolicy.validate] rather than the bare length getter.
+  PasswordPolicy get passwordPolicy => _passwordPolicy;
   String get instanceId => _instanceId;
 
   /// Whether the server permits per-workspace auto-start
@@ -145,6 +152,7 @@ class AuthService extends ChangeNotifier {
         _netfilterEnabled = (data['netfilter_enabled'] as bool?) ?? false;
         _minPasswordLength =
             (data['min_password_length'] as num?)?.toInt() ?? 8;
+        _passwordPolicy = PasswordPolicy.fromConfig(data);
         // White-label values — mirrored into the Branding helper so widgets
         // that don't have an AuthService context (e.g. the app-bar logo,
         // page title) can read them synchronously. Covers the product name

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -23,7 +23,6 @@ class AuthService extends ChangeNotifier {
   String _bannerText = '';
   bool _bannerAccepted = false;
   bool _loginBannerEveryVisit = false;
-  int _minPasswordLength = 8;
   PasswordPolicy _passwordPolicy = const PasswordPolicy();
   String _instanceId = 'default';
   bool _allowAutostart = false;
@@ -51,11 +50,6 @@ class AuthService extends ChangeNotifier {
   /// the banner text hash (#1544).
   bool get loginBannerEveryVisit => _loginBannerEveryVisit;
   bool get bannerRequired => _bannerText.isNotEmpty && !_bannerAccepted;
-
-  /// Minimum password length enforced by the server (from /config). Defaults
-  /// to 8 when the server omits the field so client-side validation still works
-  /// against older backends.
-  int get minPasswordLength => _minPasswordLength;
 
   /// Full password policy (length + character-class counts, #2581) parsed
   /// from /config. Pages that validate inline should use
@@ -150,8 +144,6 @@ class AuthService extends ChangeNotifier {
             (data['netfilter_default_domains'] as List?)?.cast<String>() ??
                 const [];
         _netfilterEnabled = (data['netfilter_enabled'] as bool?) ?? false;
-        _minPasswordLength =
-            (data['min_password_length'] as num?)?.toInt() ?? 8;
         _passwordPolicy = PasswordPolicy.fromConfig(data);
         // White-label values — mirrored into the Branding helper so widgets
         // that don't have an AuthService context (e.g. the app-bar logo,

--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -251,7 +251,7 @@ class _LoginPageState extends State<LoginPage> {
         obscureText: _obscurePassword,
         validator: (v) {
           if (v == null || v.isEmpty) return 'Required';
-          if (_isRegister && v.length < 8) return 'Min 8 characters';
+          if (_isRegister) return auth.passwordPolicy.validate(v);
           return null;
         },
         onFieldSubmitted: (_) => _submit(),

--- a/src/frontend/lib/auth/password_policy.dart
+++ b/src/frontend/lib/auth/password_policy.dart
@@ -68,7 +68,12 @@ class PasswordPolicy {
   /// or null when it satisfies every rule.
   String? validate(String? password) {
     if (password == null || password.isEmpty) return 'Required';
-    if (password.length < minLength) return 'Min $minLength characters';
+    // Runes (code points), not UTF-16 code units — the server counts code
+    // points, and an emoji-heavy password would otherwise be judged longer
+    // here than there.
+    if (password.runes.length < minLength) {
+      return 'Min $minLength characters';
+    }
     final counts = <String, int>{
       'uppercase letter': password.runes.where((r) => _isUpper(r)).length,
       'lowercase letter': password.runes.where((r) => _isLower(r)).length,

--- a/src/frontend/lib/auth/password_policy.dart
+++ b/src/frontend/lib/auth/password_policy.dart
@@ -1,0 +1,100 @@
+/// Server-advertised password policy helpers (#2581).
+///
+/// Mirrors the server's ``validate_password`` (length floor +
+/// character-class counts from ``/api/v1/config``'s
+/// ``password_requirements``). The server enforces authoritatively; this
+/// is inline client-side feedback only.
+class PasswordPolicy {
+  /// Minimum password length advertised by the server.
+  final int minLength;
+
+  /// Character-class counts: upper / lower / digit / special. ``0`` means
+  /// no requirement for that class.
+  final int requireUpper;
+  final int requireLower;
+  final int requireDigit;
+  final int requireSpecial;
+
+  const PasswordPolicy({
+    this.minLength = 8,
+    this.requireUpper = 0,
+    this.requireLower = 0,
+    this.requireDigit = 0,
+    this.requireSpecial = 0,
+  });
+
+  /// Parse from ``/api/v1/config`` fields. Missing/unparseable values fall
+  /// back to no-requirement defaults so the UI keeps working against older
+  /// backends that don't advertise the fields.
+  factory PasswordPolicy.fromConfig(Map<String, dynamic>? config) {
+    if (config == null) return const PasswordPolicy();
+    final reqs = config['password_requirements'];
+    int req(String key) {
+      if (reqs is! Map) return 0;
+      final v = reqs[key];
+      return v is num ? v.toInt() : 0;
+    }
+
+    final min = config['min_password_length'];
+    return PasswordPolicy(
+      minLength: min is num ? min.toInt() : 8,
+      requireUpper: req('upper'),
+      requireLower: req('lower'),
+      requireDigit: req('digit'),
+      requireSpecial: req('special'),
+    );
+  }
+
+  /// One-line description of the policy for helper text under password
+  /// fields, e.g. ``At least 12 characters, 1 uppercase letter, 1 digit``.
+  /// Empty when only the default length rule applies.
+  String get helperText {
+    final parts = <String>[
+      if (minLength > 0) 'at least $minLength characters',
+      if (requireUpper > 0)
+        '$requireUpper uppercase letter${requireUpper != 1 ? 's' : ''}',
+      if (requireLower > 0)
+        '$requireLower lowercase letter${requireLower != 1 ? 's' : ''}',
+      if (requireDigit > 0)
+        '$requireDigit digit${requireDigit != 1 ? 's' : ''}',
+      if (requireSpecial > 0)
+        '$requireSpecial special character${requireSpecial != 1 ? 's' : ''}',
+    ];
+    if (parts.isEmpty) return '';
+    return 'Password needs ${parts.join(', ')}';
+  }
+
+  /// Returns a human-readable error when [password] violates the policy,
+  /// or null when it satisfies every rule.
+  String? validate(String? password) {
+    if (password == null || password.isEmpty) return 'Required';
+    if (password.length < minLength) return 'Min $minLength characters';
+    final counts = <String, int>{
+      'uppercase letter': password.runes.where((r) => _isUpper(r)).length,
+      'lowercase letter': password.runes.where((r) => _isLower(r)).length,
+      'digit': password.runes.where((r) => _isDigit(r)).length,
+      'special character': password.runes
+          .where((r) => !_isUpper(r) && !_isLower(r) && !_isDigit(r))
+          .length,
+    };
+    final needed = <String, int>{
+      'uppercase letter': requireUpper,
+      'lowercase letter': requireLower,
+      'digit': requireDigit,
+      'special character': requireSpecial,
+    };
+    final unmet = <String>[
+      for (final e in needed.entries)
+        if (counts[e.key]! < e.value)
+          '${e.value} ${e.key}${e.value != 1 ? 's' : ''}',
+    ];
+    if (unmet.isNotEmpty) return 'Needs at least ${unmet.join(', ')}';
+    return null;
+  }
+
+  // Rune-class helpers (ASCII-oriented; matches the server's str methods
+  // closely enough for inline feedback).
+  static bool _isUpper(int r) => r >= 0x41 && r <= 0x5A;
+  static bool _isLower(int r) => r >= 0x61 && r <= 0x7A;
+  static bool _isDigit(int r) => r >= 0x30 && r <= 0x39;
+}

--- a/src/frontend/lib/auth/reset_password_page.dart
+++ b/src/frontend/lib/auth/reset_password_page.dart
@@ -141,8 +141,10 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
                     obscureText: _obscurePassword,
                     validator: (v) {
                       if (v == null || v.isEmpty) return 'Required';
-                      if (v.length < 8) return 'Min 8 characters';
-                      return null;
+                      return context
+                          .read<AuthService>()
+                          .passwordPolicy
+                          .validate(v);
                     },
                   ),
                   const SizedBox(height: 16),

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -242,13 +242,10 @@ class _PasswordSectionState extends State<_PasswordSection> {
             obscureText: _obscureNew,
             validator: (v) {
               if (v == null || v.isEmpty) return 'Required';
-              // Read the server-configured minimum (KLANGKD_MIN_PASSWORD_LENGTH,
-              // surfaced by AuthService from /api/v1/config) instead of
-              // hardcoding 8 — otherwise the client passes a password the
-              // server rejects when the deploy raised the floor (#1350).
-              final min = context.read<AuthService>().minPasswordLength;
-              if (v.length < min) return 'Min $min characters';
-              return null;
+              // Server-advertised policy (KLANGKD_MIN_PASSWORD_LENGTH +
+              // character-class counts, #2581/#1350) instead of hardcoded 8 —
+              // otherwise the client passes a password the server rejects.
+              return context.read<AuthService>().passwordPolicy.validate(v);
             },
           ),
           const SizedBox(height: 12),

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -653,7 +653,7 @@ void main() {
             .widget<TextField>(fieldLabeled('Password'))
             .decoration
             ?.errorText,
-        'Password must be at least 8 characters',
+        'Min 8 characters',
       );
       expect(isPrimaryEnabled(tester, 'Add'), isFalse);
       expect(writes, isEmpty);
@@ -843,7 +843,7 @@ void main() {
             .widget<TextField>(fieldLabeled('New Password'))
             .decoration
             ?.errorText,
-        'Password must be at least 8 characters',
+        'Min 8 characters',
       );
       expect(fieldLabeled('Confirm New Password'), findsOneWidget);
       expect(isPrimaryEnabled(tester, 'Save'), isFalse);

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -88,6 +88,7 @@ void main() {
       bool allowAutostart = false,
       bool loginBannerEveryVisit = false,
       int? minPasswordLength,
+      Map<String, dynamic>? passwordRequirements,
       String? productName,
       List<String>? netfilterDefaultDomains,
       bool? netfilterEnabled,
@@ -103,6 +104,8 @@ void main() {
               'login_banner_every_visit': loginBannerEveryVisit,
               if (minPasswordLength != null)
                 'min_password_length': minPasswordLength,
+              if (passwordRequirements != null)
+                'password_requirements': passwordRequirements,
               if (productName != null) 'product_name': productName,
               if (netfilterDefaultDomains != null)
                 'netfilter_default_domains': netfilterDefaultDomains,
@@ -190,6 +193,38 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(service.minPasswordLength, 8);
+    });
+
+    test('loads password_requirements from /api/config', () async {
+      // #2581: advertised class counts are surfaced verbatim.
+      testAuthHttpClientOverride = _bannerClient(
+        passwordRequirements: {
+          'upper': 1,
+          'lower': 1,
+          'digit': 2,
+          'special': 0,
+        },
+      );
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+
+      expect(service.passwordPolicy.requireUpper, 1);
+      expect(service.passwordPolicy.requireLower, 1);
+      expect(service.passwordPolicy.requireDigit, 2);
+      expect(service.passwordPolicy.requireSpecial, 0);
+    });
+
+    test('password_requirements defaults to no requirements when absent',
+        () async {
+      testAuthHttpClientOverride = _bannerClient();
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+
+      expect(service.passwordPolicy.requireUpper, 0);
+      expect(service.passwordPolicy.requireSpecial, 0);
+      expect(service.passwordPolicy.validate('aaaaaaaa'), isNull);
     });
 
     test('product_name is applied to Branding from /api/config', () async {

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -183,7 +183,7 @@ void main() {
       final service = AuthService();
       await Future.delayed(Duration.zero);
 
-      expect(service.minPasswordLength, 12);
+      expect(service.passwordPolicy.minLength, 12);
     });
 
     test('min_password_length defaults to 8 when absent', () async {
@@ -192,7 +192,7 @@ void main() {
       final service = AuthService();
       await Future.delayed(Duration.zero);
 
-      expect(service.minPasswordLength, 8);
+      expect(service.passwordPolicy.minLength, 8);
     });
 
     test('loads password_requirements from /api/config', () async {

--- a/src/frontend/test/password_policy_test.dart
+++ b/src/frontend/test/password_policy_test.dart
@@ -96,10 +96,25 @@ void main() {
       expect(two.validate('AB1!cdef'), isNull);
     });
 
-    test('non-ASCII runes count as special characters', () {
+    test('non-ASCII runes count as special characters, never letters or '
+        'digits', () {
       const spec = PasswordPolicy(minLength: 4, requireSpecial: 1);
       expect(spec.validate('abé!'), isNull);
       expect(spec.validate('ab1c'), contains('1 special character'));
+      // Parity with the server (ASCII classes): é is not a lowercase
+      // letter, ²/٣ are not digits.
+      const lower = PasswordPolicy(minLength: 4, requireLower: 1);
+      expect(lower.validate('éééé!'), contains('1 lowercase letter'));
+      const digit = PasswordPolicy(minLength: 4, requireDigit: 1);
+      expect(digit.validate('²٣!!'), contains('1 digit'));
+    });
+
+    test('length is counted in runes, not UTF-16 code units', () {
+      // 😀 is one code point but two UTF-16 units: runes.length == 2 here,
+      // String.length == 4. The floor is code points (server parity).
+      const p = PasswordPolicy(minLength: 3);
+      expect(p.validate('😀😀'), 'Min 3 characters');
+      expect(p.validate('😀😀😀'), isNull);
     });
 
     test('zero requirements never fail on classes', () {

--- a/src/frontend/test/password_policy_test.dart
+++ b/src/frontend/test/password_policy_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/auth/password_policy.dart';
+
+void main() {
+  group('PasswordPolicy.fromConfig', () {
+    test('null config falls back to defaults', () {
+      final p = PasswordPolicy.fromConfig(null);
+      expect(p.minLength, 8);
+      expect(p.requireUpper, 0);
+      expect(p.requireLower, 0);
+      expect(p.requireDigit, 0);
+      expect(p.requireSpecial, 0);
+    });
+
+    test('missing fields fall back to defaults', () {
+      final p = PasswordPolicy.fromConfig({});
+      expect(p.minLength, 8);
+      expect(p.requireUpper, 0);
+    });
+
+    test('parses advertised counts', () {
+      final p = PasswordPolicy.fromConfig({
+        'min_password_length': 12,
+        'password_requirements': {
+          'upper': 1,
+          'lower': 2,
+          'digit': 3,
+          'special': 4,
+        },
+      });
+      expect(p.minLength, 12);
+      expect(p.requireUpper, 1);
+      expect(p.requireLower, 2);
+      expect(p.requireDigit, 3);
+      expect(p.requireSpecial, 4);
+    });
+
+    test('non-numeric requirement values fall back to zero', () {
+      final p = PasswordPolicy.fromConfig({
+        'password_requirements': {'upper': 'many'},
+      });
+      expect(p.requireUpper, 0);
+    });
+
+    test('non-map password_requirements is ignored', () {
+      final p = PasswordPolicy.fromConfig({
+        'password_requirements': 'nope',
+      });
+      expect(p.requireUpper, 0);
+      expect(p.requireSpecial, 0);
+    });
+
+    test('non-numeric min_password_length falls back to 8', () {
+      final p = PasswordPolicy.fromConfig({
+        'min_password_length': 'twelve',
+      });
+      expect(p.minLength, 8);
+    });
+  });
+
+  group('PasswordPolicy.validate', () {
+    const policy = PasswordPolicy(
+      minLength: 8,
+      requireUpper: 1,
+      requireLower: 1,
+      requireDigit: 1,
+      requireSpecial: 1,
+    );
+
+    test('null and empty are required', () {
+      expect(policy.validate(null), 'Required');
+      expect(policy.validate(''), 'Required');
+    });
+
+    test('too short reports the floor', () {
+      expect(policy.validate('Aa1!'), 'Min 8 characters');
+    });
+
+    test('satisfying password returns null', () {
+      expect(policy.validate('Aa1!aaaa'), isNull);
+    });
+
+    test('missing classes are all reported', () {
+      final err = policy.validate('plainpassword');
+      expect(err, contains('1 uppercase letter'));
+      expect(err, contains('1 digit'));
+      expect(err, contains('1 special character'));
+    });
+
+    test('counts pluralize', () {
+      const two = PasswordPolicy(
+        minLength: 8,
+        requireUpper: 2,
+      );
+      expect(two.validate('ab1!cdef'), contains('2 uppercase letters'));
+      expect(two.validate('AB1!cdef'), isNull);
+    });
+
+    test('non-ASCII runes count as special characters', () {
+      const spec = PasswordPolicy(minLength: 4, requireSpecial: 1);
+      expect(spec.validate('abé!'), isNull);
+      expect(spec.validate('ab1c'), contains('1 special character'));
+    });
+
+    test('zero requirements never fail on classes', () {
+      const none = PasswordPolicy(minLength: 4);
+      expect(none.validate('aaaa'), isNull);
+    });
+  });
+
+  group('PasswordPolicy.helperText', () {
+    test('describes the length floor', () {
+      const p = PasswordPolicy(minLength: 12);
+      expect(p.helperText, 'Password needs at least 12 characters');
+    });
+
+    test('lists every class requirement', () {
+      const p = PasswordPolicy(
+        minLength: 8,
+        requireUpper: 1,
+        requireLower: 3,
+        requireDigit: 2,
+        requireSpecial: 1,
+      );
+      expect(
+        p.helperText,
+        'Password needs at least 8 characters, '
+        '1 uppercase letter, 3 lowercase letters, '
+        '2 digits, 1 special character',
+      );
+    });
+
+    test('empty when nothing is required', () {
+      const p = PasswordPolicy(minLength: 0);
+      expect(p.helperText, '');
+    });
+  });
+}

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -208,8 +208,11 @@ async def get_config(
         # this so users can't toggle a setting the server will reject (#1115).
         "allow_autostart": autostart_allowed(app),
         # Surfaced so the UI can validate password length inline (matches
-        # the rule enforced server-side by auth.validate_password_length).
+        # the rule enforced server-side by auth.validate_password).
         "min_password_length": app.state.auth.min_password_length,
+        # Character-class counts enforced by auth.validate_password_complexity
+        # (#2581); 0 = no requirement. Clients validate inline with these.
+        "password_requirements": app.state.auth.password_requirements,
         # Deployer logo override (KLANGKD_LOGO_URL). Empty when unset, in
         # which case the frontend renders the default KlangkLogo widget.
         # Supports file:/cmd: resolution like other secrets. See #1152.

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -256,7 +256,7 @@ async def admin_create_user(
             status_code=400,
             detail="Password is required when not sending verification email",
         )
-    app.state.auth.validate_password_length(req.password)
+    app.state.auth.validate_password(req.password)
     password_hash = auth.hash_password(req.password)
     user = await app.state.model.users.create_user(
         req.email, password_hash, verified=True
@@ -326,7 +326,7 @@ async def update_user(
     if req.email is not None:
         await app.state.model.users.update_email(user_id, req.email)
     if req.password is not None:
-        app.state.auth.validate_password_length(req.password)
+        app.state.auth.validate_password(req.password)
         password_hash = auth.hash_password(req.password)
         await app.state.model.users.update_password(user_id, password_hash)
     if req.handle is not None:

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -100,7 +100,7 @@ async def register(
     existing = await app.state.model.users.get_user_by_email(req.email)
     if existing is not None:
         raise HTTPException(status_code=400, detail="Registration failed")
-    request.app.state.auth.validate_password_length(req.password)
+    request.app.state.auth.validate_password(req.password)
 
     password_hash = auth.hash_password(req.password)
     user_id = str(uuid.uuid4())
@@ -291,7 +291,7 @@ async def reset_password(req: ResetPasswordRequest, request: Request):
         raise HTTPException(
             status_code=400, detail="Invalid or expired reset token"
         )
-    request.app.state.auth.validate_password_length(req.password)
+    request.app.state.auth.validate_password(req.password)
     if user_id == model.AGENT_USER_ID:
         raise HTTPException(
             status_code=400,
@@ -413,7 +413,7 @@ async def change_password(
         raise HTTPException(
             status_code=401, detail="Current password is incorrect"
         )
-    request.app.state.auth.validate_password_length(req.new_password)
+    request.app.state.auth.validate_password(req.new_password)
     password_hash = auth.hash_password(req.new_password)
     await request.app.state.model.users.update_password(
         user["id"], password_hash
@@ -602,7 +602,7 @@ async def accept_invite(req: AcceptInviteRequest, request: Request):
             status_code=400, detail="Invitation is no longer valid"
         )
 
-    request.app.state.auth.validate_password_length(req.password)
+    request.app.state.auth.validate_password(req.password)
 
     existing = await request.app.state.model.users.get_user_by_email(email)
     if existing is not None:

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -162,6 +162,36 @@ class Auth:
         return self.app.state.settings.min_password_length
 
     @property
+    def password_require_upper(self) -> int:
+        return int(self.app.state.settings.password_require_upper)
+
+    @property
+    def password_require_lower(self) -> int:
+        return int(self.app.state.settings.password_require_lower)
+
+    @property
+    def password_require_digit(self) -> int:
+        return int(self.app.state.settings.password_require_digit)
+
+    @property
+    def password_require_special(self) -> int:
+        return int(self.app.state.settings.password_require_special)
+
+    @property
+    def password_requirements(self) -> dict:
+        """Character-class counts a password must satisfy (#2581).
+
+        Surfaced verbatim by ``/api/v1/config`` so clients can validate
+        inline; ``0`` means "no requirement for this class".
+        """
+        return {
+            "upper": self.password_require_upper,
+            "lower": self.password_require_lower,
+            "digit": self.password_require_digit,
+            "special": self.password_require_special,
+        }
+
+    @property
     def login_lockout_failures(self) -> int:
         return self.app.state.settings.login_lockout_failures
 
@@ -230,6 +260,47 @@ class Auth:
                 status_code=400,
                 detail=f"Password must not exceed {MAX_PASSWORD_BYTES} bytes",
             )
+
+    def validate_password_complexity(self, password: str) -> None:
+        """Enforce the configured character-class counts (#2581).
+
+        Each class count (``KLANGKD_PASSWORD_REQUIRE_UPPER`` etc.) is the
+        minimum number of characters of that class; 0 disables that class.
+        Raises a single 400 listing every unmet requirement.
+        """
+        counts = {
+            "uppercase letter": (
+                sum(c.isupper() for c in password),
+                self.password_require_upper,
+            ),
+            "lowercase letter": (
+                sum(c.islower() for c in password),
+                self.password_require_lower,
+            ),
+            "digit": (
+                sum(c.isdigit() for c in password),
+                self.password_require_digit,
+            ),
+            "special character": (
+                sum(not c.isalnum() for c in password),
+                self.password_require_special,
+            ),
+        }
+        unmet = [
+            f"at least {need} {name}{'s' if need != 1 else ''}"
+            for name, (have, need) in counts.items()
+            if have < need
+        ]
+        if unmet:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Password must contain {', '.join(unmet)}",
+            )
+
+    def validate_password(self, password: str) -> None:
+        """Length + complexity — the one password gate every setter uses."""
+        self.validate_password_length(password)
+        self.validate_password_complexity(password)
 
     # --- lockout predicates (read lockout config) ---
 
@@ -406,7 +477,7 @@ class Auth:
         if existing is not None:
             raise HTTPException(status_code=400, detail="Registration failed")
         validate_email(req.email)
-        self.validate_password_length(req.password)
+        self.validate_password(req.password)
 
         password_hash = hash_password(req.password)
         # The duplicate-email pre-check above is not atomic with the

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -28,6 +28,38 @@ logger = logging.getLogger(__name__)
 # Maximum password length bcrypt will accept (its 72-byte limit).
 MAX_PASSWORD_BYTES = 72
 
+# Display names for the character classes, in requirement-message order.
+_PASSWORD_CLASSES = (
+    ("upper", "uppercase letter"),
+    ("lower", "lowercase letter"),
+    ("digit", "digit"),
+    ("special", "special character"),
+)
+
+
+def password_class_counts(password: str) -> dict[str, int]:
+    """ASCII character-class counts for the complexity policy (#2581).
+
+    Classes are defined in ASCII terms — ``A-Z``, ``a-z``, ``0-9``, and
+    everything else is "special" — so every non-ASCII character (``é``)
+    counts as special, never as a letter or digit. This is deliberate:
+    the Flutter UI's mirror (``PasswordPolicy``) and the CLI's mirror
+    (``cli/account.password_complexity_error``) classify the same way,
+    and Unicode's ``isupper``/``isdigit`` would accept things no operator
+    means by "a digit" (``٣``) or "uppercase" (``Ⅰ``) while disagreeing
+    with the clients. Server, web UI, and CLI must stay in sync.
+    """
+    upper = sum(1 for c in password if "A" <= c <= "Z")
+    lower = sum(1 for c in password if "a" <= c <= "z")
+    digit = sum(1 for c in password if "0" <= c <= "9")
+    return {
+        "upper": upper,
+        "lower": lower,
+        "digit": digit,
+        "special": len(password) - upper - lower - digit,
+    }
+
+
 security = HTTPBearer(auto_error=False)
 
 
@@ -268,28 +300,17 @@ class Auth:
         minimum number of characters of that class; 0 disables that class.
         Raises a single 400 listing every unmet requirement.
         """
-        counts = {
-            "uppercase letter": (
-                sum(c.isupper() for c in password),
-                self.password_require_upper,
-            ),
-            "lowercase letter": (
-                sum(c.islower() for c in password),
-                self.password_require_lower,
-            ),
-            "digit": (
-                sum(c.isdigit() for c in password),
-                self.password_require_digit,
-            ),
-            "special character": (
-                sum(not c.isalnum() for c in password),
-                self.password_require_special,
-            ),
+        counts = password_class_counts(password)
+        configured = {
+            "upper": self.password_require_upper,
+            "lower": self.password_require_lower,
+            "digit": self.password_require_digit,
+            "special": self.password_require_special,
         }
         unmet = [
             f"at least {need} {name}{'s' if need != 1 else ''}"
-            for name, (have, need) in counts.items()
-            if have < need
+            for key, name in _PASSWORD_CLASSES
+            if (need := configured[key]) > 0 and counts[key] < need
         ]
         if unmet:
             raise HTTPException(

--- a/src/klangk/klangk/cli/account.py
+++ b/src/klangk/klangk/cli/account.py
@@ -79,3 +79,65 @@ def password_min_length(server_url: str) -> int:
         except (TypeError, ValueError):
             return _DEFAULT_MIN_PASSWORD
     return _DEFAULT_MIN_PASSWORD
+
+
+def password_requirements(server_url: str) -> dict:
+    """Server-configured character-class counts (#2581).
+
+    Mirrors ``password_min_length``: reads ``/api/v1/config``'s
+    ``password_requirements`` (upper/lower/digit/special ints, 0 = no
+    requirement) and falls back to all-zero (no requirements) when the
+    server doesn't advertise them. The server enforces authoritatively.
+    """
+    config = fetch_config(server_url)
+    reqs = (
+        config.get("password_requirements")
+        if isinstance(config, dict)
+        else None
+    )
+    if not isinstance(reqs, dict):
+        return {"upper": 0, "lower": 0, "digit": 0, "special": 0}
+    out = {}
+    for key in ("upper", "lower", "digit", "special"):
+        try:
+            out[key] = int(reqs.get(key) or 0)
+        except (TypeError, ValueError):
+            out[key] = 0
+    return out
+
+
+def password_complexity_error(password: str, reqs: dict) -> str | None:
+    """Local mirror of the server's complexity rule (#2581).
+
+    Returns a human-readable error string when ``password`` fails the
+    character-class counts in ``reqs`` (as returned by
+    ``password_requirements``), else ``None``. Must stay in sync with
+    ``auth.validate_password_complexity`` on the server — duplication is
+    deliberate (CLI subpackage isolation; see AGENTS.md).
+    """
+    counts = {
+        "uppercase letter": (
+            sum(c.isupper() for c in password),
+            int(reqs.get("upper") or 0),
+        ),
+        "lowercase letter": (
+            sum(c.islower() for c in password),
+            int(reqs.get("lower") or 0),
+        ),
+        "digit": (
+            sum(c.isdigit() for c in password),
+            int(reqs.get("digit") or 0),
+        ),
+        "special character": (
+            sum(not c.isalnum() for c in password),
+            int(reqs.get("special") or 0),
+        ),
+    }
+    unmet = [
+        f"at least {need} {name}{'s' if need != 1 else ''}"
+        for name, (have, need) in counts.items()
+        if have < need
+    ]
+    if unmet:
+        return f"Password must contain {', '.join(unmet)}"
+    return None

--- a/src/klangk/klangk/cli/account.py
+++ b/src/klangk/klangk/cli/account.py
@@ -13,6 +13,7 @@ from the server package.
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 from .auth import fetch_config
 
@@ -63,81 +64,65 @@ def validate_email(email: str) -> str | None:
     return None
 
 
-def password_min_length(server_url: str) -> int:
-    """Server-configured minimum password length, from ``/api/v1/config``.
+class PasswordPolicy(NamedTuple):
+    """Server-advertised password policy (#2581): length + class counts."""
 
-    Falls back to ``_DEFAULT_MIN_PASSWORD`` (8) when the server doesn't
-    advertise one — an unreachable/old server, or an unparseable value.
-    The server still enforces its own floor authoritatively.
+    min_length: int
+    requirements: dict
+
+    def complexity_error(self, password: str) -> str | None:
+        """Local mirror of the server's complexity rule.
+
+        Returns a human-readable error string when ``password`` fails the
+        character-class counts, else ``None``. Must stay in sync with
+        ``auth.validate_password_complexity`` on the server — duplication
+        is deliberate (CLI subpackage isolation; see AGENTS.md). Classes
+        are ASCII (A-Z, a-z, 0-9, everything else special), matching the
+        server and the web UI.
+        """
+        upper = sum(1 for c in password if "A" <= c <= "Z")
+        lower = sum(1 for c in password if "a" <= c <= "z")
+        digit = sum(1 for c in password if "0" <= c <= "9")
+        special = len(password) - upper - lower - digit
+        counts = {
+            "uppercase letter": (upper, self.requirements.get("upper", 0)),
+            "lowercase letter": (lower, self.requirements.get("lower", 0)),
+            "digit": (digit, self.requirements.get("digit", 0)),
+            "special character": (special, self.requirements.get("special", 0)),
+        }
+        unmet = [
+            f"at least {need} {name}{'s' if need != 1 else ''}"
+            for name, (have, need) in counts.items()
+            if need > 0 and have < need
+        ]
+        if unmet:
+            return f"Password must contain {', '.join(unmet)}"
+        return None
+
+
+def password_policy(server_url: str) -> PasswordPolicy:
+    """Fetch the server's password policy from ``/api/v1/config``.
+
+    One fetch covers length + character-class counts. Falls back to
+    permissive defaults (length 8, no class requirements) when the
+    server is unreachable, old, or advertises unparseable values — the
+    server enforces its own policy authoritatively either way.
     """
     config = fetch_config(server_url)
+    min_length = _DEFAULT_MIN_PASSWORD
+    requirements = {"upper": 0, "lower": 0, "digit": 0, "special": 0}
     if isinstance(config, dict):
         try:
-            return int(
+            min_length = int(
                 config.get("min_password_length") or _DEFAULT_MIN_PASSWORD
             )
         except (TypeError, ValueError):
-            return _DEFAULT_MIN_PASSWORD
-    return _DEFAULT_MIN_PASSWORD
-
-
-def password_requirements(server_url: str) -> dict:
-    """Server-configured character-class counts (#2581).
-
-    Mirrors ``password_min_length``: reads ``/api/v1/config``'s
-    ``password_requirements`` (upper/lower/digit/special ints, 0 = no
-    requirement) and falls back to all-zero (no requirements) when the
-    server doesn't advertise them. The server enforces authoritatively.
-    """
-    config = fetch_config(server_url)
-    reqs = (
-        config.get("password_requirements")
-        if isinstance(config, dict)
-        else None
-    )
-    if not isinstance(reqs, dict):
-        return {"upper": 0, "lower": 0, "digit": 0, "special": 0}
-    out = {}
-    for key in ("upper", "lower", "digit", "special"):
-        try:
-            out[key] = int(reqs.get(key) or 0)
-        except (TypeError, ValueError):
-            out[key] = 0
-    return out
-
-
-def password_complexity_error(password: str, reqs: dict) -> str | None:
-    """Local mirror of the server's complexity rule (#2581).
-
-    Returns a human-readable error string when ``password`` fails the
-    character-class counts in ``reqs`` (as returned by
-    ``password_requirements``), else ``None``. Must stay in sync with
-    ``auth.validate_password_complexity`` on the server — duplication is
-    deliberate (CLI subpackage isolation; see AGENTS.md).
-    """
-    counts = {
-        "uppercase letter": (
-            sum(c.isupper() for c in password),
-            int(reqs.get("upper") or 0),
-        ),
-        "lowercase letter": (
-            sum(c.islower() for c in password),
-            int(reqs.get("lower") or 0),
-        ),
-        "digit": (
-            sum(c.isdigit() for c in password),
-            int(reqs.get("digit") or 0),
-        ),
-        "special character": (
-            sum(not c.isalnum() for c in password),
-            int(reqs.get("special") or 0),
-        ),
-    }
-    unmet = [
-        f"at least {need} {name}{'s' if need != 1 else ''}"
-        for name, (have, need) in counts.items()
-        if have < need
-    ]
-    if unmet:
-        return f"Password must contain {', '.join(unmet)}"
-    return None
+            pass
+        reqs = config.get("password_requirements")
+        if isinstance(reqs, dict):
+            for key in requirements:
+                try:
+                    requirements[key] = int(reqs.get(key) or 0)
+                except (TypeError, ValueError):
+                    pass
+    return PasswordPolicy(min_length, requirements)

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -161,6 +161,12 @@ def account_passwd() -> None:
             f"[red]Password must be at least {min_len} characters[/red]"
         )
         raise typer.Exit(code=1)
+    complexity_error = account.password_complexity_error(
+        new, account.password_requirements(url)
+    )
+    if complexity_error:
+        context._err.print(f"[red]{complexity_error}[/red]")
+        raise typer.Exit(code=1)
     try:
         client.change_password(current, new)
     except httpx.HTTPStatusError as exc:

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -155,15 +155,13 @@ def account_passwd() -> None:
     if new != confirm:
         context._err.print("[red]Passwords do not match[/red]")
         raise typer.Exit(code=1)
-    min_len = account.password_min_length(url)
-    if len(new) < min_len:
+    policy = account.password_policy(url)
+    if len(new) < policy.min_length:
         context._err.print(
-            f"[red]Password must be at least {min_len} characters[/red]"
+            f"[red]Password must be at least {policy.min_length} characters[/red]"
         )
         raise typer.Exit(code=1)
-    complexity_error = account.password_complexity_error(
-        new, account.password_requirements(url)
-    )
+    complexity_error = policy.complexity_error(new)
     if complexity_error:
         context._err.print(f"[red]{complexity_error}[/red]")
         raise typer.Exit(code=1)

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -37,6 +37,7 @@ from . import (
     wshandler,
 )
 from .llm_router import LLMRouter
+from .auth import _PASSWORD_CLASSES, password_class_counts
 from .settings import KlangkSettings
 from .logger import configure as configure_logging
 from .api import root_router, router
@@ -233,6 +234,38 @@ class Lifecycle:
                     f"auth_modes={auth_modes} requires KLANGKD_DEFAULT_PASSWORD "
                     "(set it in klangkd.yaml or the env). Refusing to boot "
                     "without a known admin password."
+                )
+            # The default admin password must satisfy the same policy every
+            # other password setter enforces (#2581). Fail fast at startup —
+            # seeding a non-compliant password and letting it fail at first
+            # change would strand deployments whose policy was tightened
+            # after the seed ran.
+            _policy_errors = []
+            min_len = int(settings.min_password_length or "8")
+            if len(password) < min_len:
+                _policy_errors.append(
+                    f"is shorter than KLANGKD_MIN_PASSWORD_LENGTH={min_len}"
+                )
+            _counts = password_class_counts(password)
+            for _key, _name in _PASSWORD_CLASSES:
+                _need = getattr(settings, f"password_require_{_key}")
+                if _need > 0 and _counts[_key] < _need:
+                    _policy_errors.append(
+                        f"lacks the {_need} required {_name}"
+                        f"{'s' if _need != 1 else ''} "
+                        f"(KLANGKD_PASSWORD_REQUIRE_{_key.upper()}={_need})"
+                    )
+            if _policy_errors:
+                raise RuntimeError(
+                    "KLANGKD_DEFAULT_PASSWORD violates the configured "
+                    f"password policy: it {_policy_errors[0]}"
+                    + (
+                        f" (and {len(_policy_errors) - 1} more issue(s))"
+                        if len(_policy_errors) > 1
+                        else ""
+                    )
+                    + ". Fix the password or loosen the policy; refusing to "
+                    "boot with a seeded admin that already violates it."
                 )
             password_hash = bcrypt.hashpw(
                 password.encode(), bcrypt.gensalt()

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -182,6 +182,13 @@ def _coerce_positive_int(v, name: str) -> int | None:
     return value
 
 
+# Sanity ceiling for the KLANGKD_PASSWORD_REQUIRE_* counts: bcrypt only
+# hashes the first 72 bytes (auth.MAX_PASSWORD_BYTES), so requiring more
+# than 72 of one class would make every password unsettable. Duplicated
+# here to avoid an import cycle with klangk.auth.
+_PASSWORD_REQUIRE_MAX = 72
+
+
 def _resolve_numeric_indirection(v, name: str):
     """Resolve ``file:``/``cmd:`` on a raw numeric-setting value (#2603).
 
@@ -231,8 +238,7 @@ def _coerce_setting_int(
         )
     if isinstance(v, float):
         raise ValueError(
-            f"{name}={v!r} must be an integer, not a float "
-            "(use 5, not 5.0)."
+            f"{name}={v!r} must be an integer, not a float (use 5, not 5.0)."
         )
     try:
         value = int(v)
@@ -1345,7 +1351,9 @@ class KlangkSettings(BaseSettings):
         """Float settings accept float, numeric string, or file:/cmd:
         (#2603) — same contract as the int fields above."""
         return _coerce_setting_float(
-            v, info.field_name, default=cls.model_fields[info.field_name].default
+            v,
+            info.field_name,
+            default=cls.model_fields[info.field_name].default,
         )
 
     @field_validator("smtp_use_tls", mode="before")
@@ -1590,16 +1598,21 @@ class KlangkSettings(BaseSettings):
         Integer string (env var), native int (YAML config file —
         ``password_require_upper: 2`` parses as an int, no quotes
         needed), or a ``file:``/``cmd:`` reference; ``None`` / empty ->
-        ``0`` (class not required). Negative or non-integer raises and
-        aborts startup, same posture as the other numeric settings
-        (``_coerce_setting_int`` with ``minimum=0``, #2603).
+        ``0`` (class not required). Negative, non-integer, or a count
+        above 72 (bcrypt's byte limit) raises and aborts startup, same
+        posture as the other numeric settings (``_coerce_setting_int``
+        with ``minimum=0``, #2603). Errors name the setting field
+        (``password_require_*``), which is unambiguous whichever source
+        (env or YAML) supplied it.
         """
-        return _coerce_setting_int(
-            v,
-            f"KLANGKD_{info.field_name.upper()}",
-            minimum=0,
-            default=0,
-        )
+        value = _coerce_setting_int(v, info.field_name, minimum=0, default=0)
+        if value is not None and value > _PASSWORD_REQUIRE_MAX:
+            raise ValueError(
+                f"{info.field_name}={v!r} must be <= "
+                f"{_PASSWORD_REQUIRE_MAX} — bcrypt hashes at most 72 "
+                "bytes, so a higher count can never be satisfied."
+            )
+        return value
 
     @field_validator("llm_models", mode="before")
     @classmethod

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -709,6 +709,13 @@ class KlangkSettings(BaseSettings):
     access_token_hours: float | None = 24.0
     workspace_token_hours: float | None = 24.0
     min_password_length: int | None = 8
+    # Character-class complexity counts (#2581). Each is the number of
+    # characters of that class a password must contain (0 = no requirement).
+    # KLANGKD_PASSWORD_REQUIRE_UPPER=2 demands two uppercase letters, etc.
+    password_require_upper: int | None = 0
+    password_require_lower: int | None = 0
+    password_require_digit: int | None = 0
+    password_require_special: int | None = 0
     login_lockout_failures: int | None = 5
     login_lockout_duration: int | None = 900
     login_lockout_window: int | None = 300

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -710,12 +710,14 @@ class KlangkSettings(BaseSettings):
     workspace_token_hours: float | None = 24.0
     min_password_length: int | None = 8
     # Character-class complexity counts (#2581). Each is the number of
-    # characters of that class a password must contain (0 = no requirement).
-    # KLANGKD_PASSWORD_REQUIRE_UPPER=2 demands two uppercase letters, etc.
-    password_require_upper: int | None = 0
-    password_require_lower: int | None = 0
-    password_require_digit: int | None = 0
-    password_require_special: int | None = 0
+    # characters of that class a password must contain; 0 (the default)
+    # disables that class. Ints (YAML) or integer strings (env) both work
+    # (``_coerce_setting_int``, minimum=0), e.g.
+    # KLANGKD_PASSWORD_REQUIRE_UPPER=2 demands two uppercase letters.
+    password_require_upper: int = 0
+    password_require_lower: int = 0
+    password_require_digit: int = 0
+    password_require_special: int = 0
     login_lockout_failures: int | None = 5
     login_lockout_duration: int | None = 900
     login_lockout_window: int | None = 300
@@ -1571,6 +1573,32 @@ class KlangkSettings(BaseSettings):
             v,
             "KLANGKD_EGRESS_CONSENT_ROW_CAP",
             default=2000,
+        )
+
+    @field_validator(
+        "password_require_upper",
+        "password_require_lower",
+        "password_require_digit",
+        "password_require_special",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_password_require_counts(cls, v, info):
+        """Coerce + validate the ``KLANGKD_PASSWORD_REQUIRE_*`` counts
+        (#2581).
+
+        Integer string (env var), native int (YAML config file —
+        ``password_require_upper: 2`` parses as an int, no quotes
+        needed), or a ``file:``/``cmd:`` reference; ``None`` / empty ->
+        ``0`` (class not required). Negative or non-integer raises and
+        aborts startup, same posture as the other numeric settings
+        (``_coerce_setting_int`` with ``minimum=0``, #2603).
+        """
+        return _coerce_setting_int(
+            v,
+            f"KLANGKD_{info.field_name.upper()}",
+            minimum=0,
+            default=0,
         )
 
     @field_validator("llm_models", mode="before")

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -110,7 +110,7 @@ def server():
         KLANGKD_JWT_SECRET="tui-e2e-secret",
         KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
         KLANGKD_DEFAULT_USER="tuiuser@example.com",
-        KLANGKD_DEFAULT_PASSWORD="tuipass",
+        KLANGKD_DEFAULT_PASSWORD="Tuipass1!",
         KLANGKD_TEST_MODE="1",
         KLANGKD_IDLE_TIMEOUT_SECONDS="300",
         LOGFIRE_TOKEN="",
@@ -129,7 +129,7 @@ def base_url(server):
 def token(base_url):
     r = httpx.post(
         f"{base_url}/api/v1/auth/login",
-        json={"identifier": "tuiuser@example.com", "password": "tuipass"},
+        json={"identifier": "tuiuser@example.com", "password": "Tuipass1!"},
         timeout=30,
     )
     r.raise_for_status()

--- a/src/klangk/klangkc-tests/tests/test_account.py
+++ b/src/klangk/klangkc-tests/tests/test_account.py
@@ -92,3 +92,86 @@ class TestPasswordMinLength:
             account, "fetch_config", lambda url: {"min_password_length": "abc"}
         )
         assert account.password_min_length("http://x") == 8
+
+
+class TestPasswordRequirements:
+    def test_reads_from_config(self, monkeypatch):
+        monkeypatch.setattr(
+            account,
+            "fetch_config",
+            lambda url: {
+                "password_requirements": {
+                    "upper": 1,
+                    "lower": 2,
+                    "digit": 3,
+                    "special": 4,
+                }
+            },
+        )
+        assert account.password_requirements("http://x") == {
+            "upper": 1,
+            "lower": 2,
+            "digit": 3,
+            "special": 4,
+        }
+
+    def test_defaults_when_missing(self, monkeypatch):
+        monkeypatch.setattr(account, "fetch_config", lambda url: {})
+        assert account.password_requirements("http://x") == {
+            "upper": 0,
+            "lower": 0,
+            "digit": 0,
+            "special": 0,
+        }
+
+    def test_defaults_when_unreachable(self, monkeypatch):
+        monkeypatch.setattr(account, "fetch_config", lambda url: "boom")
+        assert account.password_requirements("http://x") == {
+            "upper": 0,
+            "lower": 0,
+            "digit": 0,
+            "special": 0,
+        }
+
+    def test_defaults_when_not_a_dict(self, monkeypatch):
+        monkeypatch.setattr(
+            account,
+            "fetch_config",
+            lambda url: {"password_requirements": "nope"},
+        )
+        assert account.password_requirements("http://x")["upper"] == 0
+
+    def test_defaults_when_unparseable(self, monkeypatch):
+        monkeypatch.setattr(
+            account,
+            "fetch_config",
+            lambda url: {"password_requirements": {"upper": "x", "digit": 1}},
+        )
+        reqs = account.password_requirements("http://x")
+        assert reqs == {"upper": 0, "lower": 0, "digit": 1, "special": 0}
+
+
+class TestPasswordComplexityError:
+    _reqs = {"upper": 1, "lower": 1, "digit": 1, "special": 1}
+
+    def test_ok_password(self):
+        assert (
+            account.password_complexity_error("Aa1!aaaa", self._reqs) is None
+        )
+
+    def test_reports_every_unmet_class(self):
+        err = account.password_complexity_error("plain", self._reqs)
+        assert err is not None
+        assert "1 uppercase letter" in err
+        assert "1 digit" in err
+        assert "1 special character" in err
+
+    def test_pluralizes_counts(self):
+        err = account.password_complexity_error(
+            "Aa1!aaaa", {**self._reqs, "upper": 2}
+        )
+        assert "at least 2 uppercase letters" in err
+
+    def test_zero_requirements_never_fails(self):
+        zero = {"upper": 0, "lower": 0, "digit": 0, "special": 0}
+        assert account.password_complexity_error("", zero) is None

--- a/src/klangk/klangkc-tests/tests/test_account.py
+++ b/src/klangk/klangkc-tests/tests/test_account.py
@@ -68,110 +68,123 @@ class TestValidateEmail:
         assert account.validate_email(email) is not None
 
 
-class TestPasswordMinLength:
-    def test_reads_from_config(self, monkeypatch):
-        monkeypatch.setattr(
-            account, "fetch_config", lambda url: {"min_password_length": 12}
-        )
-        assert account.password_min_length("http://x") == 12
+class TestPasswordPolicy:
+    """The single-fetch /config policy parser (#2581)."""
 
-    def test_defaults_when_unreachable(self, monkeypatch):
-        monkeypatch.setattr(account, "fetch_config", lambda url: "unreachable")
-        assert account.password_min_length("http://x") == 8
+    def test_reads_both_fields_from_one_fetch(self, monkeypatch):
+        fetched = []
 
-    def test_defaults_when_none(self, monkeypatch):
-        monkeypatch.setattr(account, "fetch_config", lambda url: None)
-        assert account.password_min_length("http://x") == 8
-
-    def test_defaults_when_missing_field(self, monkeypatch):
-        monkeypatch.setattr(account, "fetch_config", lambda url: {})
-        assert account.password_min_length("http://x") == 8
-
-    def test_defaults_when_unparseable(self, monkeypatch):
-        monkeypatch.setattr(
-            account, "fetch_config", lambda url: {"min_password_length": "abc"}
-        )
-        assert account.password_min_length("http://x") == 8
-
-
-class TestPasswordRequirements:
-    def test_reads_from_config(self, monkeypatch):
-        monkeypatch.setattr(
-            account,
-            "fetch_config",
-            lambda url: {
+        def fake_fetch(url):
+            fetched.append(url)
+            return {
+                "min_password_length": 12,
                 "password_requirements": {
                     "upper": 1,
                     "lower": 2,
                     "digit": 3,
                     "special": 4,
-                }
-            },
-        )
-        assert account.password_requirements("http://x") == {
+                },
+            }
+
+        monkeypatch.setattr(account, "fetch_config", fake_fetch)
+        policy = account.password_policy("http://x")
+        assert policy.min_length == 12
+        assert policy.requirements == {
             "upper": 1,
             "lower": 2,
             "digit": 3,
             "special": 4,
         }
-
-    def test_defaults_when_missing(self, monkeypatch):
-        monkeypatch.setattr(account, "fetch_config", lambda url: {})
-        assert account.password_requirements("http://x") == {
-            "upper": 0,
-            "lower": 0,
-            "digit": 0,
-            "special": 0,
-        }
+        assert len(fetched) == 1  # one fetch for length + counts
 
     def test_defaults_when_unreachable(self, monkeypatch):
-        monkeypatch.setattr(account, "fetch_config", lambda url: "boom")
-        assert account.password_requirements("http://x") == {
+        monkeypatch.setattr(account, "fetch_config", lambda url: "unreachable")
+        policy = account.password_policy("http://x")
+        assert policy.min_length == 8
+        assert policy.requirements == {
             "upper": 0,
             "lower": 0,
             "digit": 0,
             "special": 0,
         }
 
-    def test_defaults_when_not_a_dict(self, monkeypatch):
-        monkeypatch.setattr(
-            account,
-            "fetch_config",
-            lambda url: {"password_requirements": "nope"},
-        )
-        assert account.password_requirements("http://x")["upper"] == 0
+    def test_defaults_when_none(self, monkeypatch):
+        monkeypatch.setattr(account, "fetch_config", lambda url: None)
+        policy = account.password_policy("http://x")
+        assert policy.min_length == 8
+        assert policy.requirements["upper"] == 0
+
+    def test_defaults_when_missing_fields(self, monkeypatch):
+        monkeypatch.setattr(account, "fetch_config", lambda url: {})
+        policy = account.password_policy("http://x")
+        assert policy.min_length == 8
+        assert policy.requirements["special"] == 0
 
     def test_defaults_when_unparseable(self, monkeypatch):
         monkeypatch.setattr(
             account,
             "fetch_config",
-            lambda url: {"password_requirements": {"upper": "x", "digit": 1}},
+            lambda url: {
+                "min_password_length": "abc",
+                "password_requirements": {"upper": "x", "digit": 1},
+            },
         )
-        reqs = account.password_requirements("http://x")
-        assert reqs == {"upper": 0, "lower": 0, "digit": 1, "special": 0}
+        policy = account.password_policy("http://x")
+        assert policy.min_length == 8
+        assert policy.requirements == {
+            "upper": 0,
+            "lower": 0,
+            "digit": 1,
+            "special": 0,
+        }
+
+    def test_defaults_when_requirements_not_a_dict(self, monkeypatch):
+        monkeypatch.setattr(
+            account,
+            "fetch_config",
+            lambda url: {"password_requirements": "nope"},
+        )
+        policy = account.password_policy("http://x")
+        assert policy.requirements["upper"] == 0
 
 
 class TestPasswordComplexityError:
+    """The ASCII mirror of the server rule (stays in sync with the server
+    and the Flutter PasswordPolicy — non-ASCII is special, never a letter
+    or digit)."""
+
     _reqs = {"upper": 1, "lower": 1, "digit": 1, "special": 1}
 
+    def _policy(self, reqs):
+        return account.PasswordPolicy(min_length=4, requirements=reqs)
+
     def test_ok_password(self):
-        assert (
-            account.password_complexity_error("Aa1!aaaa", self._reqs) is None
-        )
+        err = self._policy(self._reqs).complexity_error("Aa1!aaaa")
+        assert err is None
 
     def test_reports_every_unmet_class(self):
-        err = account.password_complexity_error("plain", self._reqs)
+        err = self._policy(self._reqs).complexity_error("plain")
         assert err is not None
         assert "1 uppercase letter" in err
         assert "1 digit" in err
         assert "1 special character" in err
 
     def test_pluralizes_counts(self):
-        err = account.password_complexity_error(
-            "Aa1!aaaa", {**self._reqs, "upper": 2}
-        )
+        reqs = {**self._reqs, "upper": 2}
+        err = self._policy(reqs).complexity_error("Aa1!aaaa")
         assert "at least 2 uppercase letters" in err
 
     def test_zero_requirements_never_fails(self):
         zero = {"upper": 0, "lower": 0, "digit": 0, "special": 0}
-        assert account.password_complexity_error("", zero) is None
+        assert self._policy(zero).complexity_error("") is None
+
+    def test_non_ascii_is_special_not_a_letter_or_digit(self):
+        # Parity with the server: é is special, not lowercase; ² and ٣
+        # are not digits.
+        assert self._policy(self._reqs).complexity_error("Aé1!a") is None
+        lower_only = {"upper": 0, "lower": 1, "digit": 0, "special": 0}
+        err = self._policy(lower_only).complexity_error("éééé")
+        assert "1 lowercase letter" in err
+        digit_only = {"upper": 0, "lower": 0, "digit": 1, "special": 0}
+        err = self._policy(digit_only).complexity_error("²٣")
+        assert "1 digit" in err

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5425,18 +5425,18 @@ class TestAccountCommands:
         assert "@me" in out
 
     def test_account_passwd_success(self, logged_in_cfg, monkeypatch):
-        from klangk.cli import main
+        from klangk.cli import account, main
         from typer.testing import CliRunner
 
         client = MagicMock()
         monkeypatch.setattr(context_mod, "_client", lambda: client)
         monkeypatch.setattr(
-            authcmds_mod.account, "password_min_length", lambda url: 4
-        )
-        monkeypatch.setattr(
             authcmds_mod.account,
-            "password_requirements",
-            lambda url: {"upper": 0, "lower": 0, "digit": 0, "special": 0},
+            "password_policy",
+            lambda url: account.PasswordPolicy(
+                min_length=4,
+                requirements={"upper": 0, "lower": 0, "digit": 0, "special": 0},
+            ),
         )
         answers = iter(["oldpw", "newpw12", "newpw12"])
         monkeypatch.setattr(
@@ -5461,18 +5461,18 @@ class TestAccountCommands:
         client.change_password.assert_not_called()
 
     def test_account_passwd_too_short(self, logged_in_cfg, monkeypatch):
-        from klangk.cli import main
+        from klangk.cli import account, main
         from typer.testing import CliRunner
 
         client = MagicMock()
         monkeypatch.setattr(context_mod, "_client", lambda: client)
         monkeypatch.setattr(
-            authcmds_mod.account, "password_min_length", lambda url: 12
-        )
-        monkeypatch.setattr(
             authcmds_mod.account,
-            "password_requirements",
-            lambda url: {"upper": 0, "lower": 0, "digit": 0, "special": 0},
+            "password_policy",
+            lambda url: account.PasswordPolicy(
+                min_length=12,
+                requirements={"upper": 0, "lower": 0, "digit": 0, "special": 0},
+            ),
         )
         answers = iter(["oldpw", "short", "short"])
         monkeypatch.setattr(
@@ -5485,18 +5485,18 @@ class TestAccountCommands:
     def test_account_passwd_complexity_rejected(
         self, logged_in_cfg, monkeypatch
     ):
-        from klangk.cli import main
+        from klangk.cli import account, main
         from typer.testing import CliRunner
 
         client = MagicMock()
         monkeypatch.setattr(context_mod, "_client", lambda: client)
         monkeypatch.setattr(
-            authcmds_mod.account, "password_min_length", lambda url: 4
-        )
-        monkeypatch.setattr(
             authcmds_mod.account,
-            "password_requirements",
-            lambda url: {"upper": 1, "lower": 1, "digit": 1, "special": 1},
+            "password_policy",
+            lambda url: account.PasswordPolicy(
+                min_length=4,
+                requirements={"upper": 1, "lower": 1, "digit": 1, "special": 1},
+            ),
         )
         answers = iter(["oldpw", "newpw12", "newpw12"])
         monkeypatch.setattr(
@@ -5509,7 +5509,7 @@ class TestAccountCommands:
     def test_account_passwd_backend_error(self, logged_in_cfg, monkeypatch):
         import httpx
 
-        from klangk.cli import main
+        from klangk.cli import account, main
         from typer.testing import CliRunner
 
         client = MagicMock()
@@ -5520,12 +5520,12 @@ class TestAccountCommands:
         )
         monkeypatch.setattr(context_mod, "_client", lambda: client)
         monkeypatch.setattr(
-            authcmds_mod.account, "password_min_length", lambda url: 4
-        )
-        monkeypatch.setattr(
             authcmds_mod.account,
-            "password_requirements",
-            lambda url: {"upper": 0, "lower": 0, "digit": 0, "special": 0},
+            "password_policy",
+            lambda url: account.PasswordPolicy(
+                min_length=4,
+                requirements={"upper": 0, "lower": 0, "digit": 0, "special": 0},
+            ),
         )
         answers = iter(["oldpw", "newpw12", "newpw12"])
         monkeypatch.setattr(

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1329,12 +1329,16 @@ class TestMainCLI:
 
         with patch.object(context_mod, "_client", return_value=client):
             with patch.object(
-                klangk.cli.shellcmd, "_consent_popup_enabled", return_value=True
+                klangk.cli.shellcmd,
+                "_consent_popup_enabled",
+                return_value=True,
             ):
                 with patch.object(
                     klangk.cli.shellcmd, "_run_consent_popup", return_value=0
                 ) as fake_popup:
-                    with patch.object(klangk.cli.shellcmd, "ws_shell") as fake_shell:
+                    with patch.object(
+                        klangk.cli.shellcmd, "ws_shell"
+                    ) as fake_shell:
                         with pytest.raises(typer.Exit) as exc:
                             main.shell("ws", "@1")
         assert exc.value.exit_code == 0
@@ -4254,7 +4258,9 @@ class TestSandboxCommand:
 
         with (
             patch.object(context_mod, "_client", return_value=client),
-            patch.object(klangk.cli.sandboxcmd, "sandbox_setup_only", fake_setup),
+            patch.object(
+                klangk.cli.sandboxcmd, "sandbox_setup_only", fake_setup
+            ),
         ):
             from typer.testing import CliRunner
 
@@ -4335,7 +4341,9 @@ class TestSandboxCommand:
 
         with (
             patch.object(context_mod, "_client", return_value=client),
-            patch.object(klangk.cli.sandboxcmd, "sandbox_setup_only", fake_setup),
+            patch.object(
+                klangk.cli.sandboxcmd, "sandbox_setup_only", fake_setup
+            ),
         ):
             from typer.testing import CliRunner
 
@@ -4376,7 +4384,9 @@ class TestSandboxCommand:
 
         with (
             patch.object(context_mod, "_client", return_value=client),
-            patch.object(klangk.cli.sandboxcmd, "sandbox_setup_only", failing_setup),
+            patch.object(
+                klangk.cli.sandboxcmd, "sandbox_setup_only", failing_setup
+            ),
         ):
             from typer.testing import CliRunner
 
@@ -4821,7 +4831,9 @@ class TestSandboxSetupOnly:
 
         ws = AsyncMock()
 
-        with patch("klangk.cli.sandboxcmd.exec_on_ws", AsyncMock(return_value=0)):
+        with patch(
+            "klangk.cli.sandboxcmd.exec_on_ws", AsyncMock(return_value=0)
+        ):
             await sandbox_setup(ws, config, tmp_path, "admin")
 
         # exec_on_ws should not have been called (file doesn't exist)
@@ -5418,7 +5430,14 @@ class TestAccountCommands:
 
         client = MagicMock()
         monkeypatch.setattr(context_mod, "_client", lambda: client)
-        monkeypatch.setattr(authcmds_mod.account, "password_min_length", lambda url: 4)
+        monkeypatch.setattr(
+            authcmds_mod.account, "password_min_length", lambda url: 4
+        )
+        monkeypatch.setattr(
+            authcmds_mod.account,
+            "password_requirements",
+            lambda url: {"upper": 0, "lower": 0, "digit": 0, "special": 0},
+        )
         answers = iter(["oldpw", "newpw12", "newpw12"])
         monkeypatch.setattr(
             "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
@@ -5450,7 +5469,36 @@ class TestAccountCommands:
         monkeypatch.setattr(
             authcmds_mod.account, "password_min_length", lambda url: 12
         )
+        monkeypatch.setattr(
+            authcmds_mod.account,
+            "password_requirements",
+            lambda url: {"upper": 0, "lower": 0, "digit": 0, "special": 0},
+        )
         answers = iter(["oldpw", "short", "short"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        result = CliRunner().invoke(main.app, ["account", "passwd"])
+        assert result.exit_code == 1
+        client.change_password.assert_not_called()
+
+    def test_account_passwd_complexity_rejected(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        monkeypatch.setattr(context_mod, "_client", lambda: client)
+        monkeypatch.setattr(
+            authcmds_mod.account, "password_min_length", lambda url: 4
+        )
+        monkeypatch.setattr(
+            authcmds_mod.account,
+            "password_requirements",
+            lambda url: {"upper": 1, "lower": 1, "digit": 1, "special": 1},
+        )
+        answers = iter(["oldpw", "newpw12", "newpw12"])
         monkeypatch.setattr(
             "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
         )
@@ -5471,7 +5519,14 @@ class TestAccountCommands:
             "401: Current password is incorrect", request=req, response=bad
         )
         monkeypatch.setattr(context_mod, "_client", lambda: client)
-        monkeypatch.setattr(authcmds_mod.account, "password_min_length", lambda url: 4)
+        monkeypatch.setattr(
+            authcmds_mod.account, "password_min_length", lambda url: 4
+        )
+        monkeypatch.setattr(
+            authcmds_mod.account,
+            "password_requirements",
+            lambda url: {"upper": 0, "lower": 0, "digit": 0, "special": 0},
+        )
         answers = iter(["oldpw", "newpw12", "newpw12"])
         monkeypatch.setattr(
             "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -131,6 +131,18 @@ async def _auth_headers(client):
     return {"Authorization": f"Bearer {token}"}
 
 
+async def _admin_login(client):
+    """Auth headers for the seeded admin (admin_user fixture)."""
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={
+            "identifier": "testadmin@example.com",
+            "password": "testpass",
+        },
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
 async def _oidc_user_headers(app_state, email="oidc@example.com"):
     """Auth headers for an OIDC-only user (password_hash is NULL).
 
@@ -5362,9 +5374,7 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            monkeypatch.setattr(
-                app.state.settings, "file_upload_size_max", 10
-            )
+            monkeypatch.setattr(app.state.settings, "file_upload_size_max", 10)
             resp = await client.post(
                 f"/api/v1/workspaces/{ws_id}/files/upload?path=/home/work/big.txt",
                 headers=headers,
@@ -10557,3 +10567,127 @@ class TestHandleEndpoints:
         assert data["id"] == user["id"]
         assert data["email"] == "testuser@example.com"
         assert "handle" in data
+
+
+class TestPasswordPolicyRouteEnforcement:
+    """Every password-setting route must enforce complexity (#2581).
+
+    Route-level wiring tests — not unit tests of
+    ``Auth.validate_password_complexity``. Each test drives the real
+    endpoint with a policy-violating password and asserts the 400, so a
+    refactor that reverts any call site back to
+    ``validate_password_length`` fails here instead of passing CI
+    silently.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _require_upper(self, app, monkeypatch):
+        """Arm REQUIRE_UPPER=1 for every test in this class."""
+        monkeypatch.setattr(app.state.settings, "password_require_upper", 1)
+
+    async def test_register_rejects_violating_password(
+        self, client, db, app_state
+    ):
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_verification_email",
+            new_callable=AsyncMock,
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "policy@example.com",
+                    "password": "alllowercase1!",
+                },
+            )
+        assert resp.status_code == 400
+        assert "uppercase letter" in resp.json()["detail"]
+        # Nothing was created.
+        assert (
+            await app_state.state.model.users.get_user_by_email(
+                "policy@example.com"
+            )
+            is None
+        )
+
+    async def test_change_password_rejects_violating_password(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": "testpass",
+                "new_password": "alllowercase1!",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "uppercase letter" in resp.json()["detail"]
+
+    async def test_reset_password_rejects_violating_password(
+        self, client, db, app_state
+    ):
+        password_hash = auth_mod.hash_password("oldpass")
+        created = await app_state.state.model.users.create_user(
+            "policyreset@example.com", password_hash, verified=True
+        )
+        token = _auth().create_password_reset_token(created["id"])
+        resp = await client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "password": "alllowercase1!"},
+        )
+        assert resp.status_code == 400
+        assert "uppercase letter" in resp.json()["detail"]
+
+    async def test_accept_invite_rejects_violating_password(
+        self, client, db, admin_user
+    ):
+        headers = await _admin_login(client)
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_invitation_email",
+            new_callable=AsyncMock,
+        ):
+            create_resp = await client.post(
+                "/api/v1/admin/invitations",
+                headers=headers,
+                json={"email": "policyinvite@example.com"},
+            )
+        inv_id = create_resp.json()["id"]
+        token = _auth().create_invitation_token(
+            inv_id, "policyinvite@example.com"
+        )
+        resp = await client.post(
+            "/api/v1/auth/accept-invite",
+            json={"token": token, "password": "alllowercase1!"},
+        )
+        assert resp.status_code == 400
+        assert "uppercase letter" in resp.json()["detail"]
+
+    async def test_admin_create_user_rejects_violating_password(
+        self, client, admin_user
+    ):
+        headers = await _admin_login(client)
+        resp = await client.post(
+            "/api/v1/admin/users",
+            headers=headers,
+            json={
+                "email": "policyadmin@example.com",
+                "password": "alllower1!",
+            },
+        )
+        assert resp.status_code == 400
+        assert "uppercase letter" in resp.json()["detail"]
+
+    async def test_admin_set_password_rejects_violating_password(
+        self, client, admin_user, user
+    ):
+        headers = await _admin_login(client)
+        resp = await client.patch(
+            f"/api/v1/admin/users/{user['id']}",
+            headers=headers,
+            json={"password": "alllowercase1!"},
+        )
+        assert resp.status_code == 400
+        assert "uppercase letter" in resp.json()["detail"]

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -609,11 +609,34 @@ class TestConfig:
 
     async def test_get_config_advertises_min_password_length(self, client):
         # Surfaced so the UI can validate password length inline; matches the
-        # rule enforced server-side by auth.validate_password_length.
+        # rule enforced server-side by auth.validate_password.
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         data = resp.json()
         assert data["min_password_length"] == _auth().min_password_length
+
+    async def test_get_config_advertises_password_requirements(
+        self, client, app, monkeypatch
+    ):
+        # Character-class counts (#2581), same contract as
+        # min_password_length: what the client validates inline is what the
+        # server enforces on every password setter.
+        for key, val in {
+            "password_require_upper": "1",
+            "password_require_lower": "1",
+            "password_require_digit": "2",
+            "password_require_special": "0",
+        }.items():
+            monkeypatch.setattr(app.state.settings, key, val)
+        resp = await client.get("/api/v1/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["password_requirements"] == {
+            "upper": 1,
+            "lower": 1,
+            "digit": 2,
+            "special": 0,
+        }
 
     async def test_get_config_logo_url_defaults_empty(self, client, app):
         # No KLANGKD_LOGO_URL set -> empty string (UI renders default widget).

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -108,6 +108,86 @@ class TestValidatePasswordLength:
         _auth().validate_password_length("goodpass")
 
 
+class TestValidatePasswordComplexity:
+    """Character-class counts (#2581). Defaults are all 0 (off)."""
+
+    def test_defaults_accept_anything(self):
+        a = _auth()
+        assert a.password_requirements == {
+            "upper": 0,
+            "lower": 0,
+            "digit": 0,
+            "special": 0,
+        }
+        a.validate_password_complexity("alllowercase")
+
+    def test_requirements_read_from_settings(self):
+        a = _auth(
+            {
+                "KLANGKD_PASSWORD_REQUIRE_UPPER": "1",
+                "KLANGKD_PASSWORD_REQUIRE_LOWER": "2",
+                "KLANGKD_PASSWORD_REQUIRE_DIGIT": "3",
+                "KLANGKD_PASSWORD_REQUIRE_SPECIAL": "4",
+            }
+        )
+        assert a.password_requirements == {
+            "upper": 1,
+            "lower": 2,
+            "digit": 3,
+            "special": 4,
+        }
+
+    def test_each_class_enforced(self):
+        good = "Aa1!"
+        cases = {
+            "KLANGKD_PASSWORD_REQUIRE_UPPER": "zaa1!",
+            "KLANGKD_PASSWORD_REQUIRE_LOWER": "ZAA1!",
+            "KLANGKD_PASSWORD_REQUIRE_DIGIT": "Zaaa!",
+            "KLANGKD_PASSWORD_REQUIRE_SPECIAL": "Zaa11",
+        }
+        for env, bad in cases.items():
+            a = _auth({env: "1"})
+            a.validate_password_complexity(good)
+            with pytest.raises(HTTPException) as exc_info:
+                a.validate_password_complexity(bad)
+            assert exc_info.value.status_code == 400
+
+    def test_count_greater_than_one(self):
+        a = _auth({"KLANGKD_PASSWORD_REQUIRE_UPPER": "2"})
+        a.validate_password_complexity("ABcdefg1")
+        with pytest.raises(HTTPException) as exc_info:
+            a.validate_password_complexity("Abcdefg1")
+        # 2 uppercase letters -> plural form in the message
+        assert "at least 2 uppercase letters" in exc_info.value.detail
+
+    def test_lists_every_unmet_requirement(self):
+        a = _auth(
+            {
+                "KLANGKD_PASSWORD_REQUIRE_UPPER": "1",
+                "KLANGKD_PASSWORD_REQUIRE_DIGIT": "1",
+            }
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            a.validate_password_complexity("plain")
+        detail = exc_info.value.detail
+        assert "1 uppercase letter" in detail
+        assert "1 digit" in detail
+
+    def test_special_counts_non_alnum(self):
+        a = _auth({"KLANGKD_PASSWORD_REQUIRE_SPECIAL": "1"})
+        a.validate_password_complexity("Password1!")
+        with pytest.raises(HTTPException):
+            a.validate_password_complexity("Password1")
+
+    def test_validate_password_runs_both_checks(self):
+        a = _auth({"KLANGKD_PASSWORD_REQUIRE_DIGIT": "1"})
+        # Long enough but no digit -> complexity rejects via the wrapper.
+        with pytest.raises(HTTPException) as exc_info:
+            a.validate_password("nodigitshere")
+        assert "digit" in exc_info.value.detail
+        a.validate_password("has1digit")
+
+
 class TestJWT:
     def test_create_and_decode_token(self):
         token = _auth().create_token("user-123", "alice@example.com")

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError as SAIntegrityError
 import types as _types
 
 from _helpers import make_settings
-from klangk.auth import Auth
+from klangk.auth import Auth, password_class_counts
 
 
 def _auth(env=None):
@@ -178,6 +178,50 @@ class TestValidatePasswordComplexity:
         a.validate_password_complexity("Password1!")
         with pytest.raises(HTTPException):
             a.validate_password_complexity("Password1")
+
+    def test_classes_are_ascii(self):
+        """Unicode letters/digits are special, not letters/digits (#2581).
+
+        Parity with the Flutter ``PasswordPolicy`` and the CLI mirror:
+        ``é`` is not a lowercase letter, ``²``/``٣`` are not digits,
+        ``Ⅰ`` is not uppercase — they all count as special characters.
+        """
+        # é is special, satisfies REQUIRE_SPECIAL but not REQUIRE_LOWER.
+        a = _auth(
+            {
+                "KLANGKD_PASSWORD_REQUIRE_LOWER": "1",
+                "KLANGKD_PASSWORD_REQUIRE_SPECIAL": "1",
+            }
+        )
+        a.validate_password_complexity("Aé1!aaaa")
+        with pytest.raises(HTTPException) as exc_info:
+            a.validate_password_complexity("A1!éééé")
+        assert "1 lowercase letter" in exc_info.value.detail
+
+        # ² and ٣ are not digits.
+        a = _auth({"KLANGKD_PASSWORD_REQUIRE_DIGIT": "1"})
+        with pytest.raises(HTTPException):
+            a.validate_password_complexity("ab²٣cd!")
+
+        # Ⅰ (Roman numeral) is not uppercase.
+        a = _auth({"KLANGKD_PASSWORD_REQUIRE_UPPER": "1"})
+        with pytest.raises(HTTPException):
+            a.validate_password_complexity("aⅠb1!cde")
+
+    def test_password_class_counts_helper(self):
+        """The shared counter used by validation and startup seeding."""
+        assert password_class_counts("") == {
+            "upper": 0,
+            "lower": 0,
+            "digit": 0,
+            "special": 0,
+        }
+        assert password_class_counts("Aa1!é²Ⅰ😀") == {
+            "upper": 1,
+            "lower": 1,
+            "digit": 1,
+            "special": 5,
+        }
 
     def test_validate_password_runs_both_checks(self):
         a = _auth({"KLANGKD_PASSWORD_REQUIRE_DIGIT": "1"})

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -136,6 +136,58 @@ class TestSeedDefaultUser:
         user = await app_state.state.model.users.get_user_by_email("seed-test")
         assert user is not None
 
+    async def test_default_password_violating_policy_fails_fast(
+        self, db, app_state
+    ):
+        """#2581: the seeded admin must satisfy the configured policy."""
+        import pytest as _pytest
+
+        with _pytest.raises(RuntimeError, match="DEFAULT_PASSWORD"):
+            await _lifecycle(
+                make_settings(
+                    {
+                        "KLANGKD_AUTH_MODES": "password",
+                        "KLANGKD_DEFAULT_USER": "seed-test",
+                        "KLANGKD_DEFAULT_PASSWORD": "alllowercase1!",
+                        "KLANGKD_PASSWORD_REQUIRE_UPPER": "1",
+                    }
+                )
+            ).seed_default_user()
+        # Nothing was seeded.
+        user = await app_state.state.model.users.get_user_by_email("seed-test")
+        assert user is None
+
+    async def test_default_password_too_short_fails_fast(self, db, app_state):
+        import pytest as _pytest
+
+        with _pytest.raises(RuntimeError, match="MIN_PASSWORD_LENGTH"):
+            await _lifecycle(
+                make_settings(
+                    {
+                        "KLANGKD_AUTH_MODES": "password",
+                        "KLANGKD_DEFAULT_USER": "seed-test",
+                        "KLANGKD_DEFAULT_PASSWORD": "ab",
+                        "KLANGKD_MIN_PASSWORD_LENGTH": "8",
+                    }
+                )
+            ).seed_default_user()
+
+    async def test_compliant_default_password_seeds(self, db, app_state):
+        """A policy-compliant password passes the new gate untouched."""
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGKD_AUTH_MODES": "password",
+                    "KLANGKD_DEFAULT_USER": "seed-test",
+                    "KLANGKD_DEFAULT_PASSWORD": "Seed-Pass1!",
+                    "KLANGKD_PASSWORD_REQUIRE_UPPER": "1",
+                    "KLANGKD_PASSWORD_REQUIRE_SPECIAL": "1",
+                }
+            )
+        ).seed_default_user()
+        user = await app_state.state.model.users.get_user_by_email("seed-test")
+        assert user is not None
+
     async def test_skips_existing_user(self, db, app_state):
         s = make_settings(
             {

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -1631,3 +1631,69 @@ class TestNumericSettingCoercion:
                 {"KLANGKD_SMTP_USE_TLS": value}
             )
             assert s.smtp_use_tls == value
+
+class TestPasswordRequireCounts:
+    """KLANGKD_PASSWORD_REQUIRE_* coercion (#2581).
+
+    Ints (YAML), integer strings (env), None/empty (-> 0) are accepted;
+    floats, bools, negatives, and non-integers abort startup.
+    """
+
+    def test_env_integer_strings(self):
+        s = make_settings(
+            {
+                "KLANGKD_PASSWORD_REQUIRE_UPPER": "2",
+                "KLANGKD_PASSWORD_REQUIRE_DIGIT": "1",
+            }
+        )
+        assert s.password_require_upper == 2
+        assert s.password_require_digit == 1
+        assert s.password_require_lower == 0
+
+    def test_env_empty_string_is_zero(self):
+        s = make_settings({"KLANGKD_PASSWORD_REQUIRE_UPPER": ""})
+        assert s.password_require_upper == 0
+
+    def test_defaults_are_zero(self):
+        s = make_settings({})
+        assert s.password_require_upper == 0
+        assert s.password_require_lower == 0
+        assert s.password_require_digit == 0
+        assert s.password_require_special == 0
+
+    def test_yaml_native_ints(self, tmp_path):
+        # The reported bug (#2602 review): ``password_require_upper: 2``
+        # parses as an int from YAML and must not hit the str-typed
+        # ValidationError.
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "password-require-upper: 2\n"
+            "password-require-lower: 1\n"
+            "password-require-digit: 1\n"
+            "password-require-special: 0\n"
+        )
+        s = make_settings({}, config_file=str(cfg))
+        assert s.password_require_upper == 2
+        assert s.password_require_lower == 1
+        assert s.password_require_digit == 1
+        assert s.password_require_special == 0
+
+    def test_yaml_quoted_string_also_accepted(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('password-require-upper: "3"\n')
+        s = make_settings({}, config_file=str(cfg))
+        assert s.password_require_upper == 3
+
+    @pytest.mark.parametrize("value", ["-1", "abc", "1.5"])
+    def test_malformed_env_rejected(self, value):
+        with pytest.raises(Exception, match="REQUIRE_UPPER"):
+            make_settings({"KLANGKD_PASSWORD_REQUIRE_UPPER": value})
+
+    @pytest.mark.parametrize("value", [-1, 0.5, True])
+    def test_malformed_yaml_rejected(self, value, tmp_path):
+        # Negative, native float, and bool (true -> 1 is a typo, not a
+        # window) all abort startup.
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"password-require-upper: {value!s}\n")
+        with pytest.raises(Exception, match="REQUIRE_UPPER"):
+            make_settings({}, config_file=str(cfg))

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -1444,9 +1444,8 @@ class TestNumericSettingCoercion:
 
     @pytest.mark.parametrize(
         "field,bad",
-        [
-            (f, True) for f in INT_FIELDS
-        ] + [(f, "abc") for f in INT_FIELDS]
+        [(f, True) for f in INT_FIELDS]
+        + [(f, "abc") for f in INT_FIELDS]
         + [(f, 1.5) for f in INT_FIELDS]
         + [(f, -1) for f in INT_FIELDS]
         + [
@@ -1454,7 +1453,8 @@ class TestNumericSettingCoercion:
             # range, 0-byte uploads, instantly-expiring invites). The
             # documented-disable fields (length floor, lockout trio,
             # hosted ports) are asserted separately below.
-            (f, 0) for f in INT_NO_ZERO_FIELDS
+            (f, 0)
+            for f in INT_NO_ZERO_FIELDS
         ]
         + [("smtp_port", 70000)],
     )
@@ -1485,9 +1485,8 @@ class TestNumericSettingCoercion:
 
     @pytest.mark.parametrize(
         "field,bad",
-        [
-            (f, True) for f in FLOAT_FIELDS
-        ] + [(f, "abc") for f in FLOAT_FIELDS]
+        [(f, True) for f in FLOAT_FIELDS]
+        + [(f, "abc") for f in FLOAT_FIELDS]
         + [(f, -1) for f in FLOAT_FIELDS],
     )
     def test_float_field_rejections(self, field, bad):
@@ -1530,7 +1529,9 @@ class TestNumericSettingCoercion:
 
     def test_yaml_quoted_strings_still_accepted(self, tmp_path):
         cfg = tmp_path / "config.yaml"
-        cfg.write_text('min-password-length: "12"\naccess_token_hours: "1.5"\n')
+        cfg.write_text(
+            'min-password-length: "12"\naccess_token_hours: "1.5"\n'
+        )
         s = make_settings({}, config_file=str(cfg))
         assert s.min_password_length == 12
         assert s.access_token_hours == 1.5
@@ -1608,8 +1609,11 @@ class TestNumericSettingCoercion:
 
     @pytest.mark.parametrize(
         "field",
-        ["health_check_interval", "health_check_timeout",
-         "health_check_startup_grace"],
+        [
+            "health_check_interval",
+            "health_check_timeout",
+            "health_check_startup_grace",
+        ],
     )
     def test_empty_env_stays_none_for_optional_floats(self, field):
         # The health_check_* trio is genuinely optional (None = the
@@ -1617,9 +1621,7 @@ class TestNumericSettingCoercion:
         s = make_settings({f"KLANGKD_{field.upper()}": ""})
         assert getattr(s, field) is None
 
-    @pytest.mark.parametrize(
-        "value", ["true", "false", True, False]
-    )
+    @pytest.mark.parametrize("value", ["true", "false", True, False])
     def test_smtp_use_tls_accepts_bool_and_string(self, value, tmp_path):
         if isinstance(value, bool):
             cfg = tmp_path / "config.yaml"
@@ -1627,10 +1629,9 @@ class TestNumericSettingCoercion:
             s = make_settings({}, config_file=str(cfg))
             assert s.smtp_use_tls == str(value).lower()
         else:
-            s = make_settings(
-                {"KLANGKD_SMTP_USE_TLS": value}
-            )
+            s = make_settings({"KLANGKD_SMTP_USE_TLS": value})
             assert s.smtp_use_tls == value
+
 
 class TestPasswordRequireCounts:
     """KLANGKD_PASSWORD_REQUIRE_* coercion (#2581).
@@ -1686,7 +1687,7 @@ class TestPasswordRequireCounts:
 
     @pytest.mark.parametrize("value", ["-1", "abc", "1.5"])
     def test_malformed_env_rejected(self, value):
-        with pytest.raises(Exception, match="REQUIRE_UPPER"):
+        with pytest.raises(Exception, match="password_require_upper"):
             make_settings({"KLANGKD_PASSWORD_REQUIRE_UPPER": value})
 
     @pytest.mark.parametrize("value", [-1, 0.5, True])
@@ -1695,5 +1696,11 @@ class TestPasswordRequireCounts:
         # window) all abort startup.
         cfg = tmp_path / "config.yaml"
         cfg.write_text(f"password-require-upper: {value!s}\n")
-        with pytest.raises(Exception, match="REQUIRE_UPPER"):
+        with pytest.raises(Exception, match="password_require_upper"):
             make_settings({}, config_file=str(cfg))
+
+    def test_count_above_bcrypt_limit_rejected(self):
+        # 73 of one class can never be satisfied (bcrypt caps at 72 bytes);
+        # startup aborts instead of making every password unsettable.
+        with pytest.raises(Exception, match="72"):
+            make_settings({"KLANGKD_PASSWORD_REQUIRE_SPECIAL": "73"})


### PR DESCRIPTION
## Summary

Implements #2581. Klangk enforced password **length** only; this adds configurable character-class complexity counts.

Per the issue discussion, the settings are **counts**, not booleans: `KLANGKD_PASSWORD_REQUIRE_UPPER=2` requires at least two uppercase letters. `0` (the default) disables that class — so existing deployments see no behavior change until an operator opts in.

## Server

- New settings: `KLANGKD_PASSWORD_REQUIRE_{UPPER,LOWER,DIGIT,SPECIAL}` (ints, default `0`).
- `Auth.validate_password_complexity()` counts each class and raises a single 400 listing every unmet requirement (pluralized: "at least 2 uppercase letters, 1 digit").
- `Auth.validate_password()` = length + complexity; every password setter uses it: register, change-password, reset-password, accept-invite, admin add-user, admin set-password.
- `/api/v1/config` advertises `password_requirements: {upper, lower, digit, special}` alongside `min_password_length`.

## Clients

- **Web UI:** new `PasswordPolicy` model parses the config fields; `AuthService.passwordPolicy` exposes it. Register/login, settings (change password), accept-invite, reset-password, and the admin add/edit-user dialogs all validate inline with the full policy and show a `Password needs ...` helper/error.
- **CLI:** `klangk account passwd` fetches `password_requirements` and rejects locally before hitting the server (server remains authoritative).

## Tests

- Server: complexity unit tests (per-class, counts>1, multi-error listing, settings plumbing, `validate_password` wrapper), `/api/v1/config` advertisement test.
- CLI: `password_requirements` fetch fallbacks, `password_complexity_error` mirror, passwd flow with/without requirements.
- Frontend: `password_policy_test.dart` (parse/validate/helperText, incl. pluralization and non-ASCII specials), auth-service config parsing, updated admin dialog expectations. `flutter test --coverage` passes at 100%.

Fixes #2581
