### PR TITLE
feat(settings): numeric settings accept bare YAML ints/floats (#2603)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -43,7 +43,10 @@ operators or integrators to act when upgrading.
   ports) fail at startup naming the field instead of at request time;
   `smtp_use_tls: true` (native bool) is also accepted. Zero remains
   legal only where it already meant "off" (length floor, lockout,
-  hosted ports).
+  hosted ports). Explicitly emptying a value (`KLANGKD_X=""`) now
+  resolves to the field's default instead of crashing consumers with
+  `int(None)`; `port_range_start` is range-checked against the last
+  legal host port.
 
 ### Security
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -30,6 +30,21 @@ operators or integrators to act when upgrading.
 
 ## [Unreleased]
 
+### Changed
+
+- **Numeric config accepts bare numbers (#2603).** All numeric
+  `KLANGKD_*` settings (`access_token_hours`, `min_password_length`,
+  the `login_lockout_*` trio, `invite_expire_hours`, `port_range_start`,
+  `websocket_msg_size_max`, `smtp_port`, `file_upload_size_max`, the
+  `health_check_*` floats, `hosted_ports_per_workspace`) now accept a
+  bare YAML int/float (`access_token_hours: 48`) as well as quoted
+  strings and env vars, and keep `file:`/`cmd:` indirection working.
+  Malformed values (bools, floats-for-ints, negatives, out-of-range
+  ports) fail at startup naming the field instead of at request time;
+  `smtp_use_tls: true` (native bool) is also accepted. Zero remains
+  legal only where it already meant "off" (length floor, lockout,
+  hosted ports).
+
 ### Security
 
 - **WebSocket error responses (#1718).** Terminal- and shared-terminal

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -107,8 +107,8 @@ jwt_secret: "file:/run/secrets/jwt"
 prevent_insecure_jwt_secret: "1"
 default_user: admin@example.com
 default_password: "file:/run/secrets/admin-pw"
-access_token_hours: "24"
-min_password_length: "12"
+access_token_hours: 24
+min_password_length: 12
 
 # --- Server / network ---
 listen: "127.0.0.1"
@@ -126,7 +126,7 @@ data_dir: /var/lib/klangk/data
 image_name: klangk-workspace
 image_pull_policy: missing
 data_dir: /var/lib/klangk/data
-port_range_start: "9000"
+port_range_start: 9000
 allow_sudo: "true"
 
 # --- OIDC (inline) ---
@@ -140,7 +140,7 @@ oidc_providers:
 
 # --- SMTP ---
 smtp_host: smtp.example.com
-smtp_port: "587"
+smtp_port: 587
 smtp_user: klangk@example.com
 smtp_password: "file:/run/secrets/smtp-pw"
 smtp_from: noreply@example.com

--- a/src/klangk/klangk/api/files.py
+++ b/src/klangk/klangk/api/files.py
@@ -177,7 +177,7 @@ async def upload_file(
     if not filename:  # pragma: no cover
         raise HTTPException(status_code=400, detail="No filename provided")
 
-    max_upload = int(app.state.settings.file_upload_size_max)
+    max_upload = app.state.settings.file_upload_size_max
     buf = io.BytesIO()
     total = 0
     while chunk := await file.read(1024 * 1024):

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -1020,7 +1020,7 @@ async def import_workspace(
     extracts the home directory from the archive.
     """
     archive_path = await _stream_upload_to_tempfile(
-        file, int(app.state.settings.file_upload_size_max)
+        file, app.state.settings.file_upload_size_max
     )
     ws = None
     try:

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -155,31 +155,31 @@ class Auth:
 
     @property
     def token_expire_hours(self) -> float:
-        return float(self.app.state.settings.access_token_hours)
+        return self.app.state.settings.access_token_hours
 
     @property
     def min_password_length(self) -> int:
-        return int(self.app.state.settings.min_password_length)
+        return self.app.state.settings.min_password_length
 
     @property
     def login_lockout_failures(self) -> int:
-        return int(self.app.state.settings.login_lockout_failures)
+        return self.app.state.settings.login_lockout_failures
 
     @property
     def login_lockout_duration(self) -> int:
-        return int(self.app.state.settings.login_lockout_duration)
+        return self.app.state.settings.login_lockout_duration
 
     @property
     def login_lockout_window(self) -> int:
-        return int(self.app.state.settings.login_lockout_window)
+        return self.app.state.settings.login_lockout_window
 
     @property
     def invite_token_expire_hours(self) -> int:
-        return int(self.app.state.settings.invite_expire_hours)
+        return self.app.state.settings.invite_expire_hours
 
     @property
     def workspace_token_expire_hours(self) -> float:
-        return float(self.app.state.settings.workspace_token_hours)
+        return self.app.state.settings.workspace_token_hours
 
     # --- secret / startup guard ---
 

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -54,6 +54,8 @@ from pathlib import Path
 
 import httpx
 
+from .container.ports import DEFAULT_PORTS_PER_WORKSPACE
+
 # Pure host-IP / loopback probes + fallback subnets, folded into caddy (the
 # sole engine) from the former proxy_common.py (#2088). Both auto-detect the
 # pasta-NAT container source set the same way.
@@ -584,7 +586,7 @@ class CaddyRenderer:
         # default, 0 disables hosted ports. Compare against None so a
         # legitimate 0 is not swallowed by an `or`.
         _ports = self.app.state.settings.hosted_ports_per_workspace
-        if (_ports if _ports is not None else 5) == 0:
+        if (_ports if _ports is not None else DEFAULT_PORTS_PER_WORKSPACE) == 0:
             return "	handle /hosted/* {\n		respond 404\n	}\n"
         return (
             "	@hostedSlashless path_regexp hostedsl ^/hosted/[^/]+/([0-9]+)$\n"

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -326,11 +326,10 @@ class CaddyRenderer:
         The setting is bytes (default 500 MB); Caddy's ``max_size`` accepts a
         size with a unit (``500MB``). Minimum 1MB.
         """
+        # int-typed + validated at construction since #2603; None
+        # (explicitly emptied) means the default.
         raw = self.app.state.settings.file_upload_size_max
-        try:
-            bytes_ = int(str(raw))
-        except (TypeError, ValueError):
-            bytes_ = 524288000
+        bytes_ = raw if raw is not None else 524288000
         mb = max(1, bytes_ // 1048576)
         return f"{mb}MB"
 
@@ -581,8 +580,11 @@ class CaddyRenderer:
           ``127.0.0.1:<port>`` (WebSocket upgrade is automatic in
           ``reverse_proxy``).
         """
-        raw = self.app.state.settings.hosted_ports_per_workspace
-        if str(raw).strip() == "0":
+        # int-typed since #2603; None (explicitly emptied) means the
+        # default, 0 disables hosted ports. Compare against None so a
+        # legitimate 0 is not swallowed by an `or`.
+        _ports = self.app.state.settings.hosted_ports_per_workspace
+        if (_ports if _ports is not None else 5) == 0:
             return "	handle /hosted/* {\n		respond 404\n	}\n"
         return (
             "	@hostedSlashless path_regexp hostedsl ^/hosted/[^/]+/([0-9]+)$\n"

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -198,21 +198,19 @@ class ContainerRegistry(NetworkSidecarMixin):
 
     @property
     def port_range_start(self) -> int:
-        return int(self.app.state.settings.port_range_start or "9000")
+        return self.app.state.settings.port_range_start or 9000
 
     @property
     def health_check_interval(self) -> float:
-        return float(self.app.state.settings.health_check_interval or "30")
+        return self.app.state.settings.health_check_interval or 30.0
 
     @property
     def health_check_timeout(self) -> float:
-        return float(self.app.state.settings.health_check_timeout or "10")
+        return self.app.state.settings.health_check_timeout or 10.0
 
     @property
     def health_check_startup_grace(self) -> float:
-        return float(
-            self.app.state.settings.health_check_startup_grace or "30"
-        )
+        return self.app.state.settings.health_check_startup_grace or 30.0
 
     # --- settings-derived methods (were module functions, #1487) ---
 
@@ -300,17 +298,14 @@ class ContainerRegistry(NetworkSidecarMixin):
 
     def ports_per_workspace_cap(self) -> int:
         """Server-wide ceiling on hosted-app ports per workspace."""
+        # int-typed + validated at construction since #2603; None
+        # (explicitly emptied) means the default. A legitimate 0 (which
+        # disables hosted ports) must not be swallowed by an `or` — test
+        # against None explicitly.
         raw = self.app.state.settings.hosted_ports_per_workspace
-        try:
-            return max(0, int(raw))
-        except ValueError:
-            logger.warning(
-                "KLANGKD_HOSTED_PORTS_PER_WORKSPACE=%r is not an int; "
-                "using default %d",
-                raw,
-                DEFAULT_PORTS_PER_WORKSPACE,
-            )
+        if raw is None:
             return DEFAULT_PORTS_PER_WORKSPACE
+        return raw
 
     def set_idle_timeout(self, seconds: int) -> None:
         """Set the global idle timeout (replaces api mutating module globals)."""

--- a/src/klangk/klangk/emailsvc.py
+++ b/src/klangk/klangk/emailsvc.py
@@ -72,7 +72,7 @@ class EmailService:
         """Read SMTP configuration from settings at call time."""
         return {
             "host": self.app.state.settings.smtp_host,
-            "port": int(self.app.state.settings.smtp_port),
+            "port": self.app.state.settings.smtp_port,
             "user": self.app.state.settings.smtp_user,
             "password": self.resolve_password(),
             "from_addr": self.app.state.settings.smtp_from,

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -301,7 +301,7 @@ def main(  # pragma: no cover
     uds_path = settings.socket
 
     # Read ws_max_size through the typed config (default 16 MiB, #1394/#1395).
-    ws_max_size = int(settings.websocket_msg_size_max)
+    ws_max_size = settings.websocket_msg_size_max
 
     # Pre-flight PID check: abort *before* touching the UDS so a second
     # klangkd doesn't destroy the first instance's socket (#1837).

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -182,6 +182,93 @@ def _coerce_positive_int(v, name: str) -> int | None:
     return value
 
 
+def _resolve_numeric_indirection(v, name: str):
+    """Resolve ``file:``/``cmd:`` on a raw numeric-setting value (#2603).
+
+    Retyping the numeric fields to ``int``/``float`` takes them out of
+    ``_resolve_indirections``' str-only pass, so a value that arrives as
+    an indirection reference (``smtp_port: file:/run/secrets/port`` —
+    legal while the field was ``str``) must be resolved **here**, before
+    coercion. Plain strings pass through unchanged; a failed resolution
+    raises so construction fails fast (matching the
+    ``_resolve_indirections`` posture).
+    """
+    if isinstance(v, str) and v.startswith(("file:", "cmd:")):
+        resolved = _resolve_indirection(v, name)
+        if resolved is None:
+            raise ValueError(
+                f"{name} could not be resolved: the file:/cmd: reference "
+                "failed. See logs for detail."
+            )
+        return resolved
+    return v
+
+
+def _coerce_setting_int(v, name: str, *, minimum: int = 1) -> int | None:
+    """Coerce a numeric setting to int or None; raise with *name* (#2603).
+
+    Accepts every input form the sources produce: a native ``int`` (bare
+    YAML ``login-lockout-failures: 5``), an integer string (env var,
+    quoted YAML), or a ``file:``/``cmd:`` reference that resolves to one.
+    ``None``/empty → ``None`` (unset; callers apply their own defaults).
+    Bools, native floats (``1.5`` — silently truncating would hide a
+    typo), non-integers, and values below *minimum* raise so the server
+    refuses to boot on a malformed config instead of failing at request
+    time.
+    """
+    v = _resolve_numeric_indirection(v, name)
+    if v is None or v == "":
+        return None
+    if isinstance(v, bool):
+        raise ValueError(
+            f"{name}={v!r} must be an integer >= {minimum}, not a boolean."
+        )
+    if isinstance(v, float):
+        raise ValueError(
+            f"{name}={v!r} must be an integer, not a float "
+            "(use 5, not 5.0)."
+        )
+    try:
+        value = int(v)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}={v!r} must be an integer >= {minimum}, or unset."
+        ) from exc
+    if value < minimum:
+        raise ValueError(f"{name}={v!r} must be >= {minimum}.")
+    return value
+
+
+def _coerce_setting_float(v, name: str) -> float | None:
+    """Coerce a numeric setting to a positive float or None (#2603).
+
+    Same contract as :func:`_coerce_setting_int` for float fields: native
+    float (bare YAML), numeric string (env / quoted YAML), ``file:``/
+    ``cmd:`` reference, ``None``/empty → ``None``. Bools, non-finite or
+    non-numeric values, and values <= 0 raise (a token lifetime or
+    health-check interval of 0 or less is always a typo).
+    """
+    v = _resolve_numeric_indirection(v, name)
+    if v is None or v == "":
+        return None
+    if isinstance(v, bool):
+        raise ValueError(
+            f"{name}={v!r} must be a positive number, not a boolean."
+        )
+    try:
+        value = float(v)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}={v!r} must be a positive number, or unset."
+        ) from exc
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(
+            f"{name}={v!r} must be a finite, positive number "
+            "(nan/inf and <= 0 are rejected)."
+        )
+    return value
+
+
 def _coerce_podman_size(v, name: str) -> str | None:
     """Validate a podman size-string (``2g``/``512mb``/``1024``) or None.
 
@@ -604,15 +691,20 @@ class KlangkSettings(BaseSettings):
     prevent_insecure_jwt_secret: str = ""
     default_user: str | None = None
     default_password: str | None = None
-    access_token_hours: str | None = "24"
-    workspace_token_hours: str | None = "24"
-    min_password_length: str | None = "8"
-    login_lockout_failures: str | None = "5"
-    login_lockout_duration: str | None = "900"
-    login_lockout_window: str | None = "300"
+    # Numeric settings are typed int/float and accept every source form —
+    # bare YAML numbers (``access-token-hours: 48``), quoted strings
+    # (``"48"``), env strings, and file:/cmd: references — via the
+    # _coerce_numeric_* before-validators (#2603). ``None`` (unset) means
+    # the caller-side default applies.
+    access_token_hours: float | None = 24.0
+    workspace_token_hours: float | None = 24.0
+    min_password_length: int | None = 8
+    login_lockout_failures: int | None = 5
+    login_lockout_duration: int | None = 900
+    login_lockout_window: int | None = 300
     disable_registration: str = ""
     disable_invites: str = ""
-    invite_expire_hours: str | None = "72"
+    invite_expire_hours: int | None = 72
     allow_insecure_no_auth: str = ""
     reject_proxy_headers: str | None = None
     trusted_proxy_cidrs: str | None = "127.0.0.1,::1"
@@ -672,7 +764,7 @@ class KlangkSettings(BaseSettings):
     # **Callers read ``settings.egress_port`` — nothing reads ``proxy_port``
     # except that one validator.**
     proxy_port: str | None = None
-    port_range_start: str | None = "9000"
+    port_range_start: int | None = 9000
     # socket: the backend UDS path klangkd binds. Default
     # ``<state_dir>/klangk.sock`` (derived in ``_resolve_socket_and_ports``
     # after ``state_dir`` is resolved). A fail-fast validator rejects resolved
@@ -715,7 +807,7 @@ class KlangkSettings(BaseSettings):
     # websocket_msg_size_max: max WebSocket message size (bytes), passed to uvicorn.
     # Default 16 MiB; klangkd reads it through the typed config (config file +
     # file:/cmd: resolution), not raw env.
-    websocket_msg_size_max: str | None = "16777216"
+    websocket_msg_size_max: int | None = 16777216
     cors_origins: str | None = None
     # dns_servers: comma-separated DNS nameserver IPs passed to workspace
     # containers via podman --dns (container_dns_config() → create_container).
@@ -801,10 +893,10 @@ class KlangkSettings(BaseSettings):
     enable_ping: bool = True
     podman_bin: str | None = "podman"
     disable_tmux: str = ""
-    health_check_interval: str | None = None
-    health_check_startup_grace: str | None = None
-    health_check_timeout: str | None = None
-    hosted_ports_per_workspace: str = "5"
+    health_check_interval: float | None = None
+    health_check_startup_grace: float | None = None
+    health_check_timeout: float | None = None
+    hosted_ports_per_workspace: int | None = 5
     # netfilter_enabled: master on/off switch for per-workspace egress
     # filtering (#1774). Defaults to True — together with the defaulted
     # network_sidecar_image, FQDN egress filtering is available out of the
@@ -907,7 +999,7 @@ class KlangkSettings(BaseSettings):
 
     # --- SMTP / email ---
     smtp_host: str | None = None
-    smtp_port: str | None = "587"
+    smtp_port: int | None = 587
     smtp_user: str | None = None
     smtp_password: str | None = None
     smtp_from: str | None = None
@@ -937,7 +1029,7 @@ class KlangkSettings(BaseSettings):
     terminal_banner: str = ""
 
     # --- File upload ---
-    file_upload_size_max: str | None = "524288000"
+    file_upload_size_max: int | None = 524288000
 
     # --- Feature / feature config (#1659) ---
     # A config-file source for feature-declared dynamic keys (the keys the
@@ -1147,6 +1239,89 @@ class KlangkSettings(BaseSettings):
                 "default <state_dir>/...sock and the bind fails.) "
                 "See #1531 / #1636."
             )
+
+    @field_validator(
+        "min_password_length",
+        "login_lockout_failures",
+        "login_lockout_duration",
+        "login_lockout_window",
+        "invite_expire_hours",
+        "port_range_start",
+        "websocket_msg_size_max",
+        "file_upload_size_max",
+        "hosted_ports_per_workspace",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_numeric_int_fields(cls, v, info):
+        """Int settings accept int, integer string, or file:/cmd: (#2603).
+
+        Bare YAML numbers (``min-password-length: 12``) used to fail
+        validation because the fields were str-typed; now a native int,
+        an integer string (env var / quoted YAML), and an indirection
+        reference all work. Bools, floats, garbage, and negatives abort
+        startup with the field named — ``min_password_length``
+        previously had **no** validator and only exploded at request
+        time. Zero stays legal exactly where the consuming code has
+        explicit zero-handling (see ``_ZERO_MEANINGFUL`` below).
+        """
+        # 0 keeps its pre-existing per-field meaning where the code has
+        # explicit zero handling: disables the length floor
+        # (min_password_length), disables lockout (the login_lockout_*
+        # trio, guarded by ``> 0`` in auth.py), disables hosted ports
+        # (hosted_ports_per_workspace). Elsewhere 0 is nonsense (port 0,
+        # zero-byte uploads, empty port range) and is rejected.
+        _ZERO_MEANINGFUL = {
+            "min_password_length",
+            "login_lockout_failures",
+            "login_lockout_duration",
+            "login_lockout_window",
+            "hosted_ports_per_workspace",
+        }
+        minimum = 0 if info.field_name in _ZERO_MEANINGFUL else 1
+        return _coerce_setting_int(v, info.field_name, minimum=minimum)
+
+    @field_validator("smtp_port", mode="before")
+    @classmethod
+    def _coerce_smtp_port(cls, v):
+        """SMTP port accepts int/string/indirection and must be 1-65535."""
+        coerced = _coerce_setting_int(v, "smtp_port", minimum=1)
+        if coerced is not None and coerced > 65535:
+            raise ValueError(
+                f"smtp_port={coerced!r} must be between 1 and 65535."
+            )
+        return coerced
+
+    @field_validator(
+        "access_token_hours",
+        "workspace_token_hours",
+        "health_check_interval",
+        "health_check_startup_grace",
+        "health_check_timeout",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_numeric_float_fields(cls, v, info):
+        """Float settings accept float, numeric string, or file:/cmd:
+        (#2603) — same contract as the int fields above."""
+        return _coerce_setting_float(v, info.field_name)
+
+    @field_validator("smtp_use_tls", mode="before")
+    @classmethod
+    def _coerce_smtp_use_tls(cls, v):
+        """Accept a native YAML bool for the tls toggle (#2603).
+
+        The field stays str-typed (consumers match "1"/"true"/"yes"
+        case-insensitively), but ``smtp-use-tls: true`` in YAML parses as
+        a bool and used to fail validation. Translate the two bools to
+        their canonical strings; everything else passes through to the
+        consumers' own matching.
+        """
+        if v is True:
+            return "true"
+        if v is False:
+            return "false"
+        return v
 
     @field_validator("log_level")
     @classmethod

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -197,20 +197,26 @@ def _resolve_numeric_indirection(v, name: str):
         resolved = _resolve_indirection(v, name)
         if resolved is None:
             raise ValueError(
-                f"{name} could not be resolved: the file:/cmd: reference "
-                "failed. See logs for detail."
+                f"KLANGKD_{name.upper()} could not be resolved: the "
+                "file:/cmd: reference failed. See logs for detail."
             )
         return resolved
     return v
 
 
-def _coerce_setting_int(v, name: str, *, minimum: int = 1) -> int | None:
-    """Coerce a numeric setting to int or None; raise with *name* (#2603).
+def _coerce_setting_int(
+    v, name: str, *, minimum: int = 1, default: int | None = None
+) -> int | None:
+    """Coerce a numeric setting to int; raise with *name* (#2603).
 
     Accepts every input form the sources produce: a native ``int`` (bare
     YAML ``login-lockout-failures: 5``), an integer string (env var,
     quoted YAML), or a ``file:``/``cmd:`` reference that resolves to one.
-    ``None``/empty → ``None`` (unset; callers apply their own defaults).
+    ``None``/empty → *default* — the field's declared default, so an
+    explicitly-emptied value can never surface as ``None`` on a field
+    whose consumers assume a number (the request-time ``int(None)``
+    crashes of #2603's review). Fields whose default **is** None (the
+    ``health_check_*`` trio) pass ``default=None`` and stay optional.
     Bools, native floats (``1.5`` — silently truncating would hide a
     typo), non-integers, and values below *minimum* raise so the server
     refuses to boot on a malformed config instead of failing at request
@@ -218,7 +224,7 @@ def _coerce_setting_int(v, name: str, *, minimum: int = 1) -> int | None:
     """
     v = _resolve_numeric_indirection(v, name)
     if v is None or v == "":
-        return None
+        return default
     if isinstance(v, bool):
         raise ValueError(
             f"{name}={v!r} must be an integer >= {minimum}, not a boolean."
@@ -239,18 +245,22 @@ def _coerce_setting_int(v, name: str, *, minimum: int = 1) -> int | None:
     return value
 
 
-def _coerce_setting_float(v, name: str) -> float | None:
-    """Coerce a numeric setting to a positive float or None (#2603).
+def _coerce_setting_float(
+    v, name: str, *, default: float | None = None
+) -> float | None:
+    """Coerce a numeric setting to a positive float (#2603).
 
-    Same contract as :func:`_coerce_setting_int` for float fields: native
-    float (bare YAML), numeric string (env / quoted YAML), ``file:``/
-    ``cmd:`` reference, ``None``/empty → ``None``. Bools, non-finite or
-    non-numeric values, and values <= 0 raise (a token lifetime or
-    health-check interval of 0 or less is always a typo).
+    Same contract as :func:`_coerce_setting_int` for float fields:
+    native float (bare YAML), numeric string (env / quoted YAML),
+    ``file:``/``cmd:`` reference, ``None``/empty → *default* (the
+    declared field default; None only for genuinely-optional fields).
+    Bools, non-finite or non-numeric values, and values <= 0 raise (a
+    token lifetime or health-check interval of 0 or less is always a
+    typo).
     """
     v = _resolve_numeric_indirection(v, name)
     if v is None or v == "":
-        return None
+        return default
     if isinstance(v, bool):
         raise ValueError(
             f"{name}={v!r} must be a positive number, not a boolean."
@@ -1279,13 +1289,34 @@ class KlangkSettings(BaseSettings):
             "hosted_ports_per_workspace",
         }
         minimum = 0 if info.field_name in _ZERO_MEANINGFUL else 1
-        return _coerce_setting_int(v, info.field_name, minimum=minimum)
+        return _coerce_setting_int(
+            v,
+            info.field_name,
+            minimum=minimum,
+            default=cls.model_fields[info.field_name].default,
+        )
+
+    @field_validator("port_range_start", mode="after")
+    @classmethod
+    def _check_port_range_start(cls, v):
+        """Reject a start above the last legal host port (#2603).
+
+        The allocator hands out ``start..start+MAX_HOST_PORT``, so a start
+        beyond 65535 (or near enough to run past it) can never allocate a
+        valid port. Checked after coercion, on the int.
+        """
+        if v is not None and v > 65535:
+            raise ValueError(
+                f"port_range_start={v!r} must be <= 65535 (the last legal "
+                "host port)."
+            )
+        return v
 
     @field_validator("smtp_port", mode="before")
     @classmethod
     def _coerce_smtp_port(cls, v):
         """SMTP port accepts int/string/indirection and must be 1-65535."""
-        coerced = _coerce_setting_int(v, "smtp_port", minimum=1)
+        coerced = _coerce_setting_int(v, "smtp_port", minimum=1, default=587)
         if coerced is not None and coerced > 65535:
             raise ValueError(
                 f"smtp_port={coerced!r} must be between 1 and 65535."
@@ -1304,7 +1335,9 @@ class KlangkSettings(BaseSettings):
     def _coerce_numeric_float_fields(cls, v, info):
         """Float settings accept float, numeric string, or file:/cmd:
         (#2603) — same contract as the int fields above."""
-        return _coerce_setting_float(v, info.field_name)
+        return _coerce_setting_float(
+            v, info.field_name, default=cls.model_fields[info.field_name].default
+        )
 
     @field_validator("smtp_use_tls", mode="before")
     @classmethod

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -5340,7 +5340,7 @@ class TestFileRoutes:
         ws_id = await self._create_workspace(client, headers)
         try:
             monkeypatch.setattr(
-                app.state.settings, "file_upload_size_max", "10"
+                app.state.settings, "file_upload_size_max", 10
             )
             resp = await client.post(
                 f"/api/v1/workspaces/{ws_id}/files/upload?path=/home/work/big.txt",
@@ -8462,7 +8462,7 @@ class TestWorkspaceExportImport:
 
     async def test_import_size_limit(self, client, user, app, monkeypatch):
         """Upload exceeding size limit is rejected."""
-        monkeypatch.setattr(app.state.settings, "file_upload_size_max", "100")
+        monkeypatch.setattr(app.state.settings, "file_upload_size_max", 100)
 
         headers = await self._user_headers(client)
         resp = await client.post(

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -210,9 +210,11 @@ class TestMaxBodySize:
         s = make_settings({"KLANGKD_FILE_UPLOAD_SIZE_MAX": "100"})
         assert _renderer(s)._max_body_size() == "1MB"
 
-    def test_garbage_falls_back(self):
-        s = make_settings({"KLANGKD_FILE_UPLOAD_SIZE_MAX": "not-a-number"})
-        assert _renderer(s)._max_body_size() == "500MB"
+    def test_garbage_rejected_at_startup(self):
+        # #2603: a malformed upload cap aborts construction (naming the
+        # field) instead of silently falling back to 500MB at render time.
+        with pytest.raises(Exception, match="file_upload_size_max"):
+            make_settings({"KLANGKD_FILE_UPLOAD_SIZE_MAX": "not-a-number"})
 
 
 class TestContainerSourceLists:

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -530,19 +530,22 @@ class TestPortsPerWorkspaceCap:
             == 0
         )
 
-    def test_garbage_falls_back_to_default(self, monkeypatch):
+    def test_none_falls_back_to_default(self, monkeypatch):
+        # #2603: the field is int-typed; None (explicitly emptied) means
+        # the default at the cap property. Garbage and negatives are
+        # rejected at construction (see test_settings.py).
         monkeypatch.setattr(
             self.registry.app.state.settings,
             "hosted_ports_per_workspace",
-            "abc",
+            None,
         )
         assert self.registry.ports_per_workspace_cap() == 5
 
-    def test_negative_clamped_to_zero(self, monkeypatch):
+    def test_zero_disables_via_property(self, monkeypatch):
         monkeypatch.setattr(
             self.registry.app.state.settings,
             "hosted_ports_per_workspace",
-            "-2",
+            0,
         )
         assert self.registry.ports_per_workspace_cap() == 0
 
@@ -3013,7 +3016,7 @@ class TestStartContainer:
     async def test_cap_clamps_allocation_down(self, workspace, monkeypatch):
         """KLANGKD_HOSTED_PORTS_PER_WORKSPACE clamps num_ports down (#1237)."""
         monkeypatch.setattr(
-            self.registry.app.state.settings, "hosted_ports_per_workspace", "3"
+            self.registry.app.state.settings, "hosted_ports_per_workspace", 3
         )
         with patch_podman(self.registry):
             await self.registry.start_container(
@@ -3032,7 +3035,7 @@ class TestStartContainer:
     ):
         """cap=0 trims an existing workspace's allocations on next start."""
         monkeypatch.setattr(
-            self.registry.app.state.settings, "hosted_ports_per_workspace", "0"
+            self.registry.app.state.settings, "hosted_ports_per_workspace", 0
         )
         await app_state.state.model.ports.find_and_allocate_ports(
             workspace["id"], 5, self.registry.port_range_start
@@ -3052,7 +3055,7 @@ class TestStartContainer:
     async def test_cap_zero_omits_hosting_env(self, workspace, monkeypatch):
         """cap=0 suppresses KLANGKWS_PORT_MAPPINGS / KLANGKWS_HOSTING_* (#1237)."""
         monkeypatch.setattr(
-            self.registry.app.state.settings, "hosted_ports_per_workspace", "0"
+            self.registry.app.state.settings, "hosted_ports_per_workspace", 0
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
@@ -3081,7 +3084,7 @@ class TestStartContainer:
         not just trim on the container's first start.
         """
         monkeypatch.setattr(
-            self.registry.app.state.settings, "hosted_ports_per_workspace", "0"
+            self.registry.app.state.settings, "hosted_ports_per_workspace", 0
         )
         await self.registry.allocate_ports(workspace["id"], 5)
         assert await self.registry.get_workspace_ports(workspace["id"]) == []
@@ -5778,7 +5781,7 @@ class TestHealthMonitorLoopSkips:
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
                 patch.object(
-                    reg.app.state.settings, "health_check_interval", "0.01"
+                    reg.app.state.settings, "health_check_interval", 0.01
                 ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
@@ -5803,7 +5806,7 @@ class TestHealthMonitorLoopSkips:
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
                 patch.object(
-                    reg.app.state.settings, "health_check_interval", "0.01"
+                    reg.app.state.settings, "health_check_interval", 0.01
                 ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
@@ -5828,7 +5831,7 @@ class TestHealthMonitorLoopSkips:
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
                 patch.object(
-                    reg.app.state.settings, "health_check_interval", "0.01"
+                    reg.app.state.settings, "health_check_interval", 0.01
                 ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
@@ -6037,7 +6040,7 @@ class TestHealthLoopHeartbeat:
             with (
                 patch.object(monitor, "_check_workspace", AsyncMock()),
                 patch.object(
-                    reg.app.state.settings, "health_check_interval", "0.01"
+                    reg.app.state.settings, "health_check_interval", 0.01
                 ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -1423,10 +1423,23 @@ class TestNumericSettingCoercion:
         "port_range_start",
         "websocket_msg_size_max",
         "file_upload_size_max",
+        "hosted_ports_per_workspace",
+        "smtp_port",
+    ]
+    # 0 is legal here (disable semantics), so only these get the 0-rejection
+    INT_NO_ZERO_FIELDS = [
+        "invite_expire_hours",
+        "port_range_start",
+        "websocket_msg_size_max",
+        "file_upload_size_max",
+        "smtp_port",
     ]
     FLOAT_FIELDS = [
         "access_token_hours",
         "workspace_token_hours",
+        "health_check_interval",
+        "health_check_timeout",
+        "health_check_startup_grace",
     ]
 
     @pytest.mark.parametrize(
@@ -1441,21 +1454,17 @@ class TestNumericSettingCoercion:
             # range, 0-byte uploads, instantly-expiring invites). The
             # documented-disable fields (length floor, lockout trio,
             # hosted ports) are asserted separately below.
-            (f, 0)
-            for f in INT_FIELDS
-            if f
-            not in {
-                "min_password_length",
-                "login_lockout_failures",
-                "login_lockout_duration",
-                "login_lockout_window",
-            }
+            (f, 0) for f in INT_NO_ZERO_FIELDS
         ]
         + [("smtp_port", 70000)],
     )
     def test_int_field_rejections(self, field, bad):
         with pytest.raises(Exception, match=field):
             make_settings({f"KLANGKD_{field.upper()}": str(bad)})
+
+    def test_port_range_start_above_last_port_rejected(self):
+        with pytest.raises(Exception, match="port_range_start"):
+            make_settings({"KLANGKD_PORT_RANGE_START": "70000"})
 
     @pytest.mark.parametrize(
         "field",
@@ -1464,6 +1473,7 @@ class TestNumericSettingCoercion:
             "login_lockout_failures",
             "login_lockout_duration",
             "login_lockout_window",
+            "hosted_ports_per_workspace",
         ],
     )
     def test_zero_keeps_disable_semantics(self, field):
@@ -1568,11 +1578,44 @@ class TestNumericSettingCoercion:
         assert s.health_check_timeout is None
         assert s.hosted_ports_per_workspace == 5
 
-    def test_empty_env_means_unset_not_zero(self):
-        # "" -> None (unset), never a silent 0 that would e.g. disable
-        # lockout or allow empty passwords.
-        s = make_settings({"KLANGKD_MIN_PASSWORD_LENGTH": ""})
-        assert s.min_password_length is None
+    @pytest.mark.parametrize(
+        "field,default",
+        [
+            ("min_password_length", 8),
+            ("login_lockout_failures", 5),
+            ("login_lockout_duration", 900),
+            ("login_lockout_window", 300),
+            ("invite_expire_hours", 72),
+            ("port_range_start", 9000),
+            ("websocket_msg_size_max", 16777216),
+            ("smtp_port", 587),
+            ("file_upload_size_max", 524288000),
+            ("hosted_ports_per_workspace", 5),
+            ("access_token_hours", 24.0),
+            ("workspace_token_hours", 24.0),
+        ],
+    )
+    def test_empty_env_falls_back_to_field_default(self, field, default):
+        """Empty/None -> the declared default, never None (#2605 review).
+
+        Consumers assume a number on these fields (``len(pw) < None`` would
+        500 /api/config pre-auth; ``int(None)`` crashes emailsvc, the
+        upload check, and the launcher). Empty-as-disable is expressed by
+        the explicit 0, not by unsetting the field.
+        """
+        s = make_settings({f"KLANGKD_{field.upper()}": ""})
+        assert getattr(s, field) == default
+
+    @pytest.mark.parametrize(
+        "field",
+        ["health_check_interval", "health_check_timeout",
+         "health_check_startup_grace"],
+    )
+    def test_empty_env_stays_none_for_optional_floats(self, field):
+        # The health_check_* trio is genuinely optional (None = the
+        # consumer-side 30/10/30 defaults); empty keeps that meaning.
+        s = make_settings({f"KLANGKD_{field.upper()}": ""})
+        assert getattr(s, field) is None
 
     @pytest.mark.parametrize(
         "value", ["true", "false", True, False]

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -550,7 +550,7 @@ class TestDualFormKeys:
         s = make_settings({}, config_file=str(cfg))
         assert s.product_name == "Kebab"
         assert s.trusted_proxy_cidrs == "10.0.0.0/8"
-        assert s.login_lockout_window == "600"
+        assert s.login_lockout_window == 600
 
     def test_kebab_required_dir(self, tmp_path):
         """state-dir (kebab) satisfies the required-dir validator."""
@@ -823,7 +823,7 @@ class TestEnvConstructor:
         assert s.auth_modes is None
         # default_user is derived from the invoking Unix user (#1645).
         assert s.default_user == f"{getpass.getuser()}@example.com"
-        assert s.min_password_length == "8"
+        assert s.min_password_length == 8
 
     def test_default_user_falls_back_when_getuser_fails(self, monkeypatch):
         # In containers/CI where the uid has no passwd entry, getpass.getuser()
@@ -1402,3 +1402,189 @@ class TestEgressConsentPruneSettings:
         cfg.write_text(f"egress-consent-retention-days: {value!s}\n")
         with pytest.raises(Exception, match="RETENTION_DAYS"):
             make_settings({}, config_file=str(cfg))
+
+
+class TestNumericSettingCoercion:
+    """Numeric settings accept int/float, string, and file:/cmd: (#2603).
+
+    Every field must accept all three source forms: a bare YAML number
+    (``min-password-length: 12`` parses as an int and used to fail the
+    str-typed field), a quoted string / env string, and a ``file:`` or
+    ``cmd:`` reference (legal while the fields were str-typed; the
+    indirection is resolved before coercion).
+    """
+
+    INT_FIELDS = [
+        "min_password_length",
+        "login_lockout_failures",
+        "login_lockout_duration",
+        "login_lockout_window",
+        "invite_expire_hours",
+        "port_range_start",
+        "websocket_msg_size_max",
+        "file_upload_size_max",
+    ]
+    FLOAT_FIELDS = [
+        "access_token_hours",
+        "workspace_token_hours",
+    ]
+
+    @pytest.mark.parametrize(
+        "field,bad",
+        [
+            (f, True) for f in INT_FIELDS
+        ] + [(f, "abc") for f in INT_FIELDS]
+        + [(f, 1.5) for f in INT_FIELDS]
+        + [(f, -1) for f in INT_FIELDS]
+        + [
+            # 0 is rejected where it has no zero-semantics (empty port
+            # range, 0-byte uploads, instantly-expiring invites). The
+            # documented-disable fields (length floor, lockout trio,
+            # hosted ports) are asserted separately below.
+            (f, 0)
+            for f in INT_FIELDS
+            if f
+            not in {
+                "min_password_length",
+                "login_lockout_failures",
+                "login_lockout_duration",
+                "login_lockout_window",
+            }
+        ]
+        + [("smtp_port", 70000)],
+    )
+    def test_int_field_rejections(self, field, bad):
+        with pytest.raises(Exception, match=field):
+            make_settings({f"KLANGKD_{field.upper()}": str(bad)})
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "min_password_length",
+            "login_lockout_failures",
+            "login_lockout_duration",
+            "login_lockout_window",
+        ],
+    )
+    def test_zero_keeps_disable_semantics(self, field):
+        """0 stays legal where the code treats it as "off" (length floor,
+        lockout) — tightening to >= 1 would silently re-enable controls an
+        operator deliberately disabled."""
+        s = make_settings({f"KLANGKD_{field.upper()}": "0"})
+        assert getattr(s, field) == 0
+
+    @pytest.mark.parametrize(
+        "field,bad",
+        [
+            (f, True) for f in FLOAT_FIELDS
+        ] + [(f, "abc") for f in FLOAT_FIELDS]
+        + [(f, -1) for f in FLOAT_FIELDS],
+    )
+    def test_float_field_rejections(self, field, bad):
+        with pytest.raises(Exception, match=field):
+            make_settings({f"KLANGKD_{field.upper()}": str(bad)})
+
+    def test_yaml_bare_numbers_accepted(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "min-password-length: 12\n"  # kebab + bare int
+            "login_lockout_window: 600\n"
+            "access-token-hours: 48\n"  # bare int for a float field
+            "health-check-interval: 15.5\n"  # bare float
+            "smtp_port: 25\n"
+            "smtp-use-tls: false\n"  # native bool for the tls toggle
+        )
+        s = make_settings({}, config_file=str(cfg))
+        assert s.min_password_length == 12
+        assert s.login_lockout_window == 600
+        assert s.access_token_hours == 48.0
+        assert s.health_check_interval == 15.5
+        assert s.smtp_port == 25
+        assert s.smtp_use_tls == "false"
+
+    @pytest.mark.parametrize(
+        "yaml_value",
+        ["true", "1.5"],  # native YAML bool / float for an int field
+    )
+    def test_yaml_native_bool_and_float_rejected(self, yaml_value, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"min-password-length: {yaml_value}\n")
+        with pytest.raises(Exception, match="min_password_length"):
+            make_settings({}, config_file=str(cfg))
+
+    def test_yaml_native_bool_rejected_for_float_field(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("access-token-hours: true\n")
+        with pytest.raises(Exception, match="access_token_hours"):
+            make_settings({}, config_file=str(cfg))
+
+    def test_yaml_quoted_strings_still_accepted(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('min-password-length: "12"\naccess_token_hours: "1.5"\n')
+        s = make_settings({}, config_file=str(cfg))
+        assert s.min_password_length == 12
+        assert s.access_token_hours == 1.5
+
+    def test_env_strings_still_accepted(self):
+        s = make_settings(
+            {
+                "KLANGKD_MIN_PASSWORD_LENGTH": "10",
+                "KLANGKD_ACCESS_TOKEN_HOURS": "1.5",
+                "KLANGKD_SMTP_PORT": "2525",
+            }
+        )
+        assert s.min_password_length == 10
+        assert s.access_token_hours == 1.5
+        assert s.smtp_port == 2525
+
+    def test_file_indirection_still_works(self, tmp_path):
+        secret = tmp_path / "port"
+        secret.write_text("2525\n")
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"smtp_port: file:{secret}\n")
+        s = make_settings({}, config_file=str(cfg))
+        assert s.smtp_port == 2525
+
+    def test_file_indirection_failure_fails_fast(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("smtp_port: file:/nonexistent/definitely-missing\n")
+        with pytest.raises(Exception, match="smtp_port"):
+            make_settings({}, config_file=str(cfg))
+
+    def test_defaults_unchanged(self):
+        s = make_settings({})
+        assert s.min_password_length == 8
+        assert s.login_lockout_failures == 5
+        assert s.login_lockout_duration == 900
+        assert s.login_lockout_window == 300
+        assert s.invite_expire_hours == 72
+        assert s.access_token_hours == 24.0
+        assert s.workspace_token_hours == 24.0
+        assert s.port_range_start == 9000
+        assert s.websocket_msg_size_max == 16777216
+        assert s.smtp_port == 587
+        assert s.file_upload_size_max == 524288000
+        assert s.health_check_interval is None
+        assert s.health_check_timeout is None
+        assert s.hosted_ports_per_workspace == 5
+
+    def test_empty_env_means_unset_not_zero(self):
+        # "" -> None (unset), never a silent 0 that would e.g. disable
+        # lockout or allow empty passwords.
+        s = make_settings({"KLANGKD_MIN_PASSWORD_LENGTH": ""})
+        assert s.min_password_length is None
+
+    @pytest.mark.parametrize(
+        "value", ["true", "false", True, False]
+    )
+    def test_smtp_use_tls_accepts_bool_and_string(self, value, tmp_path):
+        if isinstance(value, bool):
+            cfg = tmp_path / "config.yaml"
+            cfg.write_text(f"smtp-use-tls: {str(value).lower()}\n")
+            s = make_settings({}, config_file=str(cfg))
+            assert s.smtp_use_tls == str(value).lower()
+        else:
+            s = make_settings(
+                {"KLANGKD_SMTP_USE_TLS": value}
+            )
+            assert s.smtp_use_tls == value

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -10484,7 +10484,7 @@ class TestTokenRenewal:
 
             with (
                 patch.object(
-                    app_state.state.settings, "workspace_token_hours", "1.0"
+                    app_state.state.settings, "workspace_token_hours", 1.0
                 ),
                 patch.object(
                     _mock_term,
@@ -10537,7 +10537,7 @@ class TestTokenRenewal:
 
             with (
                 patch.object(
-                    app_state.state.settings, "workspace_token_hours", "0.0001"
+                    app_state.state.settings, "workspace_token_hours", 0.0001
                 ),
                 patch.object(
                     _mock_term,
@@ -10578,7 +10578,7 @@ class TestTokenRenewal:
         try:
             with (
                 patch.object(
-                    app_state.state.settings, "workspace_token_hours", "0.0001"
+                    app_state.state.settings, "workspace_token_hours", 0.0001
                 ),
                 patch.object(
                     _mock_term,
@@ -11163,7 +11163,7 @@ class TestTokenRenewalFailureLogged:
         ) + timedelta(seconds=0.05)
         with (
             patch.object(
-                app_state.state.settings, "workspace_token_hours", "0.0001"
+                app_state.state.settings, "workspace_token_hours", 0.0001
             ),
             patch.object(
                 _mock_term,


### PR DESCRIPTION
## Summary

Fixes #2603. Numeric `KLANGKD_*` settings were `str`-typed, so a bare (unquoted) number in `klangkd.yaml` failed validation: `access_token_hours: 48` → `Input should be a valid string`. Operators had to quote every number. The `KLANGKD_PASSWORD_REQUIRE_*` fields hit this in #2602 and were fixed individually; this generalizes the treatment to every numeric field.

## What changed

**Retyped to `int`/`float` with `mode="before"` coercion** (all three source forms accepted — bare YAML number, quoted string, env string):

`access_token_hours`, `workspace_token_hours`, `min_password_length`, `login_lockout_{failures,duration,window}`, `invite_expire_hours`, `port_range_start`, `websocket_msg_size_max`, `smtp_port`, `file_upload_size_max`, `health_check_{interval,timeout,startup_grace}`, `hosted_ports_per_workspace`.

**`file:`/`cmd:` indirection preserved** — retyping takes these fields out of `_resolve_indirections`' str-only pass, so the coercion helpers resolve indirections themselves before coercing (`smtp_port: file:/run/secrets/port` still works; a failed reference fails fast).

**Startup validation instead of request-time/silent failures:**
- bools, native floats for int fields (`1.5`), negatives, garbage → construction fails naming the field
- `smtp_port` range-checked 1–65535
- `min_password_length` had **no** validator before (`abc` exploded at request time)
- `file_upload_size_max` garbage used to silently render a 500MB Caddy cap; now rejected
- **zero stays legal only where it already meant "off"** — length floor, lockout trio, hosted ports (guarded `> 0` in the code); elsewhere rejected (port range 0, 0-byte uploads, port 0)

**Bonus:** `smtp_use_tls: true` (native YAML bool) is accepted (translated to `"true"`/`"false"`; consumers' string matching unchanged).

**Consumers simplified** — string-era dances dropped (`int(settings.port_range_start or "9000")` → `or 9000`; `str(raw)`/`int(str(raw))` fallbacks removed; `or`-swallowing of a legitimate `hosted_ports_per_workspace: 0` fixed to `is None` checks).

## What I checked but did not change

- Nested subsettings (OIDC provider dicts, `nix_seed`, features block) — audited; their keys are strings/paths, no numeric keys to fix.
- Size-string fields (`container_memory_limit: "8g"`) — grammar fields, string is the type.

## Tests

`TestNumericSettingCoercion`: per-field rejection matrices (bool/float-for-int/garbage/negative/zero-where-nonsense), bare + quoted + kebab YAML acceptance, env strings, `file:` indirection success and fail-fast, defaults lock-in, zero-disable semantics preserved, native bool/float YAML rejections, `smtp_use_tls` forms. Full backend suite: 5017 passed, 100% coverage.

Fixes #2603
