### PR TITLE
fix(e2e): seed policy-compliant admin passwords

### DIFF
--- a/src/frontend/e2e-tests/demo/demo-helpers.ts
+++ b/src/frontend/e2e-tests/demo/demo-helpers.ts
@@ -45,7 +45,8 @@ export const DEMO_PASSWORD =
  *  cast of throwaway users.
  *
  *  NOTE: do NOT fall through to KLANGKD_DEFAULT_USER / KLANGKD_DEFAULT_PASSWORD
- *  — those are the BOOTSTRAP admin (admin@plope.com / "admin"), a DIFFERENT
+ *  — those are the BOOTSTRAP admin (admin@plope.com / "Admin123!",
+ *  the KLANGKD_DEFAULT_PASSWORD default), a DIFFERENT
  *  account used only by demo-seed.ts for destructive reset. The hero is its
  *  own account: admin@example.com / "adminpass". */
 export const DEMO_ADMIN_EMAIL =

--- a/src/frontend/e2e-tests/demo/demo-seed.ts
+++ b/src/frontend/e2e-tests/demo/demo-seed.ts
@@ -34,7 +34,9 @@ const DEMO_URL = process.env.KLANGKBUILD_TEST_URL || "http://localhost:8996";
 // reset and user/group management. MUST differ from the hero (you can't delete
 // yourself) and holds the `admin` permission to manage users + groups.
 const BOOTSTRAP_EMAIL = process.env.KLANGKD_DEFAULT_USER || "admin@plope.com";
-const BOOTSTRAP_PASSWORD = process.env.KLANGKD_DEFAULT_PASSWORD || "admin";
+// Must satisfy the boot-time password-policy gate (#2581, #2604);
+// keep in sync with run-demo-backend.sh DEMO_BOOTSTRAP_PASSWORD.
+const BOOTSTRAP_PASSWORD = process.env.KLANGKD_DEFAULT_PASSWORD || "Admin123!";
 
 // Hero = the on-camera admin. Created + promoted to the "admin" group by this
 // seed, so --reset can fully repave (delete -> recreate) for a clean slate.

--- a/src/frontend/e2e-tests/demo/run-demo-backend.sh
+++ b/src/frontend/e2e-tests/demo/run-demo-backend.sh
@@ -83,7 +83,9 @@ DEMO_OIDC_CONFIG="$_SCRIPT_DIR/demo-oidc.yaml"
 # this account to manage users + run the destructive reset. Must match the
 # seed's BOOTSTRAP_EMAIL / BOOTSTRAP_PASSWORD defaults (see demo-seed.ts).
 DEMO_BOOTSTRAP_EMAIL="${KLANGKD_DEFAULT_USER:-admin@plope.com}"
-DEMO_BOOTSTRAP_PASSWORD="${KLANGKD_DEFAULT_PASSWORD:-admin}"
+# Must satisfy the boot-time password-policy gate (#2581, #2604);
+# keep in sync with demo-seed.ts BOOTSTRAP_PASSWORD.
+DEMO_BOOTSTRAP_PASSWORD="${KLANGKD_DEFAULT_PASSWORD:-Admin123!}"
 # LLM provider the live-agent scenes (pi -p in scene 2, clanker in 6/8) call
 # via the /llm-proxy. Override with KLANGKBUILD_DEMO_LLM_* if you want a different
 # provider for the demo. Defaults to z.ai (glm-5.2); the API key uses the

--- a/src/frontend/e2e-tests/e2e/docs-chat-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-chat-screenshots-dev.spec.ts
@@ -5,9 +5,9 @@
  *     --project docs-screenshots -g "chat dev" --no-deps
  */
 import { test } from "@playwright/test";
+import { ADMIN_PASSWORD } from "../e2e-env";
 import { join } from "path";
 import { mkdirSync } from "fs";
-import { ADMIN_PASSWORD } from "../e2e-env";
 
 const SCREENSHOT_DIR = join(
   __dirname,

--- a/src/frontend/e2e-tests/e2e/docs-files-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-files-screenshots-dev.spec.ts
@@ -5,9 +5,9 @@
  *     --project docs-screenshots -g "files screenshots" --no-deps
  */
 import { test } from "@playwright/test";
+import { ADMIN_PASSWORD } from "../e2e-env";
 import { join } from "path";
 import { mkdirSync } from "fs";
-import { ADMIN_PASSWORD } from "../e2e-env";
 
 const SCREENSHOT_DIR = join(
   __dirname,

--- a/src/frontend/e2e-tests/e2e/docs-invitations-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-invitations-screenshots-dev.spec.ts
@@ -5,9 +5,9 @@
  *     --project docs-screenshots -g "invitation" --no-deps
  */
 import { test } from "@playwright/test";
+import { ADMIN_PASSWORD } from "../e2e-env";
 import { join } from "path";
 import { mkdirSync } from "fs";
-import { ADMIN_PASSWORD } from "../e2e-env";
 
 const SCREENSHOT_DIR = join(
   __dirname,

--- a/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
+++ b/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
@@ -59,8 +59,6 @@ const INSTALL_FSA_SHIM = `
 // Admin account provisioned by global-setup (KLANGKD_DEFAULT_USER / PASSWORD).
 // The export endpoint is admin-only (workspaces.py: has_permission("admin")).
 const ADMIN_EMAIL = "admin@example.com";
-// Re-exported from e2e-env: must stay in sync with global-setup's
-// KLANGKD_DEFAULT_PASSWORD (the policy-compliant seed, #2581).
 import { ADMIN_PASSWORD } from "../e2e-env";
 
 /** Poll the shim's window globals until the stream finishes (or errors).


### PR DESCRIPTION
Closes #2604.

## Summary

PR #2602's boot-time password-policy gate (#2581) refuses to start klangkd when the seeded `KLANGKD_DEFAULT_PASSWORD` is shorter than `KLANGKD_MIN_PASSWORD_LENGTH=8`. Two E2E suites seeded short passwords and died:

- **test-cli-e2e**: `test_tui_e2e.py` seeded `tuipass` (7) → `klangkd exited early` → 15 errors.
- **test-frontend-e2e**: `global-setup.ts` seeded `admin` (5) → server never came up → 10-minute startup timeout.

## Changes

- **`e2e-env.ts`**: new shared `ADMIN_PASSWORD = "Admin123!"` — 9 chars with all four character classes, so it also survives a future `KLANGKD_PASSWORD_REQUIRE_*` tightening rather than failing with another silent startup timeout. Documented at the constant.
- Frontend users switched to it: `global-setup.ts` (seed), `klangk.spec.ts` (respawn env — must match the seeded DB row), `workspace-export.spec.ts` (was a local `"admin"` literal), and the three `docs-*-dev` screenshot specs (typed + POSTed `"admin"`).
- **Demo tooling**: `demo-seed.ts` / `run-demo-backend.sh` bootstrap default `admin` → `Admin123!` (cross-referenced to stay in sync); stale `demo-helpers.ts` doc mention updated.
- **CLI TUI e2e**: `tuipass` → `Tuipass123!` (seed + login fixture).

All other `KLANGKD_DEFAULT_PASSWORD` sites already seed ≥8-char passwords (`testpass`, `adminpass`, `smokepass`, `prunepass`).

## Testing

- `tsc --noEmit` clean for e2e specs and demo tsconfig; pre-commit (prettier, shellcheck, shfmt, ruff) clean.
- Both new passwords verified against the policy shape from #2602 (length ≥ 8, upper/lower/digit/special all present).
- Merging this before #2602 un-bricks its CI; E2E proof comes from the suites themselves in CI.
