### PR TITLE
fix(oidc): re-derive redirect_uri at callback instead of trusting the state cookie

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,13 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **OIDC state cookie hardening (#2573).** The OIDC callback no longer
+  trusts the `redirect_uri` stored in the unsigned state cookie when
+  exchanging the authorization code with the IdP; it now re-derives the
+  value from hosting configuration the same way the login endpoint does.
+  The cookie now carries only `state`, `verifier`, and `cli_redirect`.
+  Defense-in-depth — not exploitable against a conforming IdP.
+
 - **WebSocket error responses (#1718).** Terminal- and shared-terminal
   failure frames sent over the workspace WebSocket no longer include raw
   exception text (which could leak backend paths, image names, or

--- a/src/klangk/klangk/api/oidc_auth.py
+++ b/src/klangk/klangk/api/oidc_auth.py
@@ -83,22 +83,21 @@ async def oidc_login(
     verifier, challenge = oidc.generate_pkce()
     state = secrets.token_urlsafe(32)
 
-    hostname, proto, base_path = request.app.state.util.derive_hosting_info(
-        request.headers, request.client.host if request.client else None
-    )
-    redirect_uri = f"{proto}://{hostname}{base_path}{API_PREFIX}/auth/oidc/{provider_id}/callback"
+    redirect_uri = _derive_redirect_uri(request, provider_id)
 
     auth_url = await oidc_inst.build_auth_url(
         provider, redirect_uri, state, challenge
     )
 
     response = RedirectResponse(url=auth_url, status_code=302)
-    # Store state + verifier + cli_redirect in a cookie
+    # Store state + verifier + cli_redirect in a cookie.  The
+    # redirect_uri is deliberately NOT stored: the cookie is unsigned
+    # and client-controlled, so the callback re-derives it from hosting
+    # info instead of trusting a round-tripped copy (#2573).
     cookie_value = json.dumps(
         {
             "state": state,
             "verifier": verifier,
-            "redirect_uri": redirect_uri,
             "cli_redirect": cli_redirect,
         }
     )
@@ -112,6 +111,20 @@ async def oidc_login(
         path="/",
     )
     return response
+
+
+def _derive_redirect_uri(request: Request, provider_id: str) -> str:
+    """Derive the OAuth2 ``redirect_uri`` from hosting info.
+
+    Derived identically at login and callback time (hosting env vars,
+    then trusted forwarded headers).  The unsigned state cookie must
+    never carry it: a client-controlled ``redirect_uri`` would be fed
+    verbatim to the IdP token endpoint (#2573).
+    """
+    hostname, proto, base_path = request.app.state.util.derive_hosting_info(
+        request.headers, request.client.host if request.client else None
+    )
+    return f"{proto}://{hostname}{base_path}{API_PREFIX}/auth/oidc/{provider_id}/callback"
 
 
 def _validate_state_cookie(
@@ -135,21 +148,32 @@ def _validate_state_cookie(
     if not isinstance(cookie_data, dict) or cookie_data.get("state") != state:
         raise HTTPException(status_code=400, detail="State mismatch")
 
+    # The PKCE verifier is required downstream; a cookie missing it
+    # must 400, not KeyError-500.
+    verifier = cookie_data.get("verifier")
+    if not isinstance(verifier, str) or not verifier:
+        raise HTTPException(
+            status_code=400, detail="Invalid OIDC state cookie"
+        )
+
     return cookie_data
 
 
-async def _exchange_and_validate_token(oidc_inst, provider, code, cookie_data):
+async def _exchange_and_validate_token(
+    oidc_inst, provider, code, redirect_uri, verifier
+):
     """Exchange the authorization code for tokens and validate the ID token.
 
     Returns ``(claims, tokens)`` where *claims* contains at least ``sub``
-    and ``email``.
+    and ``email``.  *redirect_uri* is the server-derived callback URL —
+    never a value read back from the unsigned state cookie (#2573).
     """
     try:
         tokens = await oidc_inst.exchange_code(
             provider,
             code,
-            cookie_data["redirect_uri"],
-            cookie_data["verifier"],
+            redirect_uri,
+            verifier,
         )
     except httpx.HTTPStatusError as exc:
         logger.error("OIDC token exchange failed: %s", exc.response.text)
@@ -267,7 +291,11 @@ async def oidc_callback(
 
     cookie_data = _validate_state_cookie(request, provider_id, state)
     claims, tokens = await _exchange_and_validate_token(
-        request.app.state.oidc, provider, code, cookie_data
+        request.app.state.oidc,
+        provider,
+        code,
+        _derive_redirect_uri(request, provider_id),
+        cookie_data["verifier"],
     )
 
     email = claims["email"]

--- a/src/klangk/klangk/api/oidc_auth.py
+++ b/src/klangk/klangk/api/oidc_auth.py
@@ -120,6 +120,12 @@ def _derive_redirect_uri(request: Request, provider_id: str) -> str:
     then trusted forwarded headers).  The unsigned state cookie must
     never carry it: a client-controlled ``redirect_uri`` would be fed
     verbatim to the IdP token endpoint (#2573).
+
+    Because the value is derived per request, a hosting-config reload
+    (SIGHUP) between login and callback — or a fleet with differing
+    proxy-trust settings — can make the two derivations disagree; the
+    IdP then rejects the exchange and the login fails loudly with a
+    502.  In-flight logins only; retrying after the reload succeeds.
     """
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -9537,13 +9537,20 @@ class TestOIDCLogin:
             app.state.oidc, "oidc_login_allowed", lambda *args: True
         )
         monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
-        monkeypatch.setattr(
-            app.state.oidc,
-            "build_auth_url",
-            AsyncMock(return_value="https://idp.example.com/auth?x=1"),
+        build_auth_url = AsyncMock(
+            return_value="https://idp.example.com/auth?x=1"
         )
+        monkeypatch.setattr(app.state.oidc, "build_auth_url", build_auth_url)
         resp = await client.get(
             "/api/v1/auth/oidc/test/login", follow_redirects=False
+        )
+        # End-to-end consistency: the URI login hands to the IdP must
+        # equal the URI the callback later sends to the token exchange
+        # (pinned in TestOIDCCallback.test_callback_redirect_uri_
+        # rederived_not_from_cookie) — both derive it from hosting info
+        # (#2573).
+        assert build_auth_url.call_args[0][1] == (
+            "http://test/api/v1/auth/oidc/test/callback"
         )
         from http.cookies import SimpleCookie
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -9516,6 +9516,42 @@ class TestOIDCLogin:
         )
         assert "oidc_test" in resp.headers.get("set-cookie", "")
 
+    async def test_login_cookie_omits_redirect_uri(
+        self, client, app, monkeypatch
+    ):
+        """The state cookie carries only state, verifier, cli_redirect.
+
+        redirect_uri is never round-tripped through the unsigned cookie —
+        it is re-derived from hosting info at callback time (#2573).
+        """
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(
+            app.state.oidc, "oidc_login_allowed", lambda *args: True
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            app.state.oidc,
+            "build_auth_url",
+            AsyncMock(return_value="https://idp.example.com/auth?x=1"),
+        )
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/login", follow_redirects=False
+        )
+        from http.cookies import SimpleCookie
+
+        sc = SimpleCookie()
+        sc.load(resp.headers["set-cookie"])
+        data = json_mod.loads(sc["oidc_test"].value)
+        assert set(data) == {"state", "verifier", "cli_redirect"}
+
 
 class TestOIDCCallback:
     async def _setup_callback(self, client, app, monkeypatch, db, claims=None):
@@ -9557,7 +9593,6 @@ class TestOIDCCallback:
             {
                 "state": "test-state",
                 "verifier": "test-verifier",
-                "redirect_uri": "https://klangk.example.com/auth/oidc/test/callback",
                 "cli_redirect": None,
             }
         )
@@ -9730,7 +9765,6 @@ class TestOIDCCallback:
             {
                 "state": "s",
                 "verifier": "v",
-                "redirect_uri": "https://klangk.example.com/cb",
                 "cli_redirect": "http://localhost:12345/callback",
             }
         )
@@ -9784,7 +9818,6 @@ class TestOIDCCallback:
             {
                 "state": "s",
                 "verifier": "v",
-                "redirect_uri": "https://klangk.example.com/cb",
                 "cli_redirect": "https://evil.com/steal",
             }
         )
@@ -9849,7 +9882,6 @@ class TestOIDCCallback:
                 {
                     "state": "s",
                     "verifier": "v",
-                    "redirect_uri": "https://klangk.example.com/cb",
                     "cli_redirect": payload,
                 }
             )
@@ -9867,6 +9899,87 @@ class TestOIDCCallback:
             assert "oidc-complete" in location, payload
             assert "token=" in location, payload
             client.cookies.delete("oidc_test")
+
+    async def test_callback_redirect_uri_rederived_not_from_cookie(
+        self, client, app, monkeypatch, db
+    ):
+        """A tampered redirect_uri in the unsigned state cookie must be
+        ignored — the token exchange uses the hosting-derived URI.
+
+        Regression test for #2573: the cookie value used to be fed
+        verbatim to the IdP token endpoint.  The exchange must receive
+        the redirect_uri re-derived via derive_hosting_info (host
+        ``test`` from the test client's base_url), never the cookie's
+        attacker-influenced copy.
+        """
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
+        exchange = AsyncMock(
+            return_value={"id_token": "idt", "access_token": "at"}
+        )
+        monkeypatch.setattr(app.state.oidc, "exchange_code", exchange)
+        monkeypatch.setattr(
+            app.state.oidc,
+            "validate_id_token",
+            AsyncMock(
+                return_value={
+                    "sub": "rd-sub",
+                    "email": "rd@example.com",
+                    "email_verified": True,
+                }
+            ),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://attacker.example/steal",
+                "cli_redirect": None,
+            }
+        )
+        client.cookies.set("oidc_test", cookie_data)
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        exchange.assert_awaited_once()
+        redirect_uri = exchange.call_args[0][2]
+        assert redirect_uri == ("http://test/api/v1/auth/oidc/test/callback")
+        assert "attacker.example" not in redirect_uri
+
+    async def test_callback_missing_verifier_cookie(
+        self, client, app, monkeypatch, db
+    ):
+        """A dict cookie with matching state but no verifier is 400,
+        not a KeyError-500."""
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
+        cookie_data = json_mod.dumps({"state": "s", "cli_redirect": None})
+        client.cookies.set("oidc_test", cookie_data)
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+        )
+        assert resp.status_code == 400
+        assert "Invalid OIDC state cookie" in resp.json()["detail"]
 
     async def test_callback_token_exchange_failure(
         self, client, app, monkeypatch, db
@@ -9898,7 +10011,6 @@ class TestOIDCCallback:
             {
                 "state": "s",
                 "verifier": "v",
-                "redirect_uri": "https://cb",
                 "cli_redirect": None,
             }
         )
@@ -9929,7 +10041,6 @@ class TestOIDCCallback:
             {
                 "state": "s",
                 "verifier": "v",
-                "redirect_uri": "https://cb",
                 "cli_redirect": None,
             }
         )
@@ -9968,7 +10079,6 @@ class TestOIDCCallback:
             {
                 "state": "s",
                 "verifier": "v",
-                "redirect_uri": "https://cb",
                 "cli_redirect": None,
             }
         )
@@ -10005,7 +10115,6 @@ class TestOIDCCallback:
             {
                 "state": "s",
                 "verifier": "v",
-                "redirect_uri": "https://cb",
                 "cli_redirect": None,
             }
         )
@@ -10252,7 +10361,6 @@ class TestOIDCCallbackAgentGuard:
             {
                 "state": "test-state",
                 "verifier": "test-verifier",
-                "redirect_uri": "https://klangk.example.com/auth/oidc/test/callback",
                 "cli_redirect": None,
             }
         )


### PR DESCRIPTION
## Summary

- The OIDC callback no longer trusts the `redirect_uri` stored in the unsigned, client-controlled state cookie when exchanging the authorization code with the IdP. It now re-derives the value via `derive_hosting_info()` exactly as `oidc_login` does, so the cookie carries only `state`, `verifier`, and `cli_redirect` (all of which are re-validated or state-bound at callback time).
- Hardened `_validate_state_cookie`: a dict cookie with matching state but a missing/empty PKCE `verifier` now returns 400 instead of a KeyError-500.
- Regression tests: a tampered `redirect_uri` in the cookie is ignored (the exchange receives the hosting-derived URI), the login cookie payload omits `redirect_uri`, and a missing-verifier cookie is rejected cleanly.
- Changelog entry under `[Unreleased]` → Security.

Closes #2573.

## Testing

- `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` → 5102 passed, coverage 100% (CI invocation).
