### PR TITLE
feat(auth): display last successful login time to users

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -64,6 +64,13 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Last successful login time (#2583).** Every login (password,
+  SSO, no-auth, and the auto-login after register/verify/reset/invite
+  acceptance) now stamps a `last_login_at` timestamp on the user.
+  `GET /auth/me` reports it, the TUI main-screen status bar shows it,
+  and `klangk account show` prints it — so users can spot unexpected
+  access to their account. Applied as schema migration 0002.
+
 - **Schema migrations (#30).** Schema changes are now applied as
   ordered, once-only migrations recorded in a new `schema_migrations`
   table at startup, instead of ad-hoc `CREATE TABLE IF NOT EXISTS`

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -159,6 +159,7 @@ async def verify_email(token: str, request: Request):
         raise HTTPException(status_code=404, detail="User not found")
     user = await request.app.state.model.users.get_user_by_id(user_id)
     access_token = request.app.state.auth.create_token(user_id, user["email"])
+    await request.app.state.model.users.record_login(user_id)
     return {"status": "verified", "access_token": access_token}
 
 
@@ -307,6 +308,7 @@ async def reset_password(req: ResetPasswordRequest, request: Request):
     if user is None:  # pragma: no cover
         raise HTTPException(status_code=404, detail="User not found")
     token = request.app.state.auth.create_token(user_id, user["email"])
+    await request.app.state.model.users.record_login(user_id)
     return {"status": "reset", "access_token": token}
 
 
@@ -369,6 +371,7 @@ async def local_login(request: Request):
             detail="Default user is not seeded",
         )
     token = request.app.state.auth.create_token(user["id"], user["email"])
+    await request.app.state.model.users.record_login(user["id"])
     return LocalLoginResponse(access_token=token, email=user["email"])
 
 
@@ -520,7 +523,12 @@ async def get_me(
     full = await app.state.model.users.get_user_by_id(user["id"])
     if full is None:  # pragma: no cover — race between auth and lookup
         raise HTTPException(status_code=404, detail="User not found")
-    return {"id": full["id"], "email": full["email"], "handle": full["handle"]}
+    return {
+        "id": full["id"],
+        "email": full["email"],
+        "handle": full["handle"],
+        "last_login_at": full.get("last_login_at"),
+    }
 
 
 @router.post("/auth/logout")
@@ -627,4 +635,5 @@ async def accept_invite(req: AcceptInviteRequest, request: Request):
     access_token = request.app.state.auth.create_token(
         user["id"], user["email"]
     )
+    await request.app.state.model.users.record_login(user["id"])
     return {"status": "accepted", "access_token": access_token}

--- a/src/klangk/klangk/api/oidc_auth.py
+++ b/src/klangk/klangk/api/oidc_auth.py
@@ -335,6 +335,7 @@ async def oidc_callback(
         await request.app.state.oidc.sync_oidc_groups(user["id"], hook_groups)
 
     access_token = request.app.state.auth.create_token(user["id"], email)
+    await request.app.state.model.users.record_login(user["id"])
     return _build_redirect_response(
         request, provider_id, access_token, cookie_data
     )

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -637,8 +637,10 @@ class Auth:
             await self.app.state.model.login_attempts.clear_login_attempts(
                 lockout_key
             )
-        await self.app.state.model.users.record_login(user["id"])
         token = self.create_token(user["id"], user["email"])
+        # Stamp after minting, matching every other session-issuing site
+        # (#2583): if minting fails, no login is recorded.
+        await self.app.state.model.users.record_login(user["id"])
         return TokenResponse(access_token=token)
 
     async def refresh_token(self, token: str) -> TokenResponse:

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -566,6 +566,7 @@ class Auth:
         token = None
         if verified:
             token = self.create_token(user["id"], user["email"])
+            await self.app.state.model.users.record_login(user["id"])
         return RegisterResult(
             user_id=user["id"], email=user["email"], access_token=token
         )
@@ -636,6 +637,7 @@ class Auth:
             await self.app.state.model.login_attempts.clear_login_attempts(
                 lockout_key
             )
+        await self.app.state.model.users.record_login(user["id"])
         token = self.create_token(user["id"], user["email"])
         return TokenResponse(access_token=token)
 

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -9,6 +9,7 @@ single-responsibility modules, all imported back into
 from __future__ import annotations
 
 import sys
+from datetime import datetime
 from pathlib import Path
 
 import httpx
@@ -138,9 +139,30 @@ def account_show() -> None:
     me = context._client().get_me()
     handle = me.get("handle") or "(none)"
     email = me.get("email") or "(unknown)"
-    Console().print(
-        f"Email:  [bold]{email}[/bold]\nHandle: [bold]@{handle}[/bold]"
-    )
+    last_login = _fmt_last_login(me.get("last_login_at"))
+    lines = [
+        f"Email:  [bold]{email}[/bold]",
+        f"Handle: [bold]@{handle}[/bold]",
+    ]
+    if last_login:
+        lines.append(f"Last login: [bold]{last_login}[/bold]")
+    Console().print("\n".join(lines))
+
+
+def _fmt_last_login(iso: str | None) -> str | None:
+    """Render a UTC ISO login timestamp in the local timezone (#2583).
+
+    Returns None for a missing or unparseable timestamp so callers can
+    omit the line entirely.
+    """
+    if not iso:
+        return None
+    try:
+        return (
+            datetime.fromisoformat(iso).astimezone().strftime("%Y-%m-%d %H:%M")
+        )
+    except ValueError:
+        return None
 
 
 @account_app.command("passwd")

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -161,7 +161,7 @@ def _fmt_last_login(iso: str | None) -> str | None:
         return (
             datetime.fromisoformat(iso).astimezone().strftime("%Y-%m-%d %H:%M")
         )
-    except ValueError:
+    except (ValueError, TypeError):
         return None
 
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -319,6 +319,9 @@ class KlangkApp(App):
             return
         self._pop_above(main)
         main.refresh_lists()
+        # The reused screen still shows the previous server's last-login
+        # stamp; drop it and re-fetch for the new identity (#2583).
+        main.reload_last_login()
 
     def server_changed_needs_login(self) -> None:
         """Switch server then show LoginScreen (invalid/missing creds)."""

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -262,6 +262,11 @@ class MainScreen(Screen):
         # it would drop a pending entry for a workspace that hasn't appeared
         # in any fetch yet.)
         self._running_overlay: dict[str, bool] = {}
+        # The user's last successful login, rendered for the status bar
+        # (#2583). Fetched once on mount by ``_load_last_login`` (a
+        # blocking /auth/me hit, so it runs in a worker) and None until
+        # that returns.
+        self._last_login: str | None = None
         self.query_one("#filter_bar").display = False
         self._refresh_action_hints()
         # One-time list load. There is no reachability heartbeat and no REST
@@ -272,6 +277,21 @@ class MainScreen(Screen):
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
             self.app.run_worker(self._token_refresh_loop, name="token-refresh")
+            self.app.run_worker(
+                self._load_last_login, name="last-login", exit_on_error=False
+            )
+
+    async def _load_last_login(self) -> None:
+        """Fetch the user's last successful login once for the status
+        bar (#2583).
+
+        ``TuiState.last_login_at`` does a blocking ``/auth/me`` round
+        trip, so it runs on a thread.
+        """
+        iso = await asyncio.to_thread(self.app.tui_state.last_login_at)
+        if iso:
+            self._last_login = self._fmt_login_ts(iso)
+            self._refresh_status()
 
     def on_tabbed_content_tab_activated(self, event) -> None:
         """Focus the first workspace row when switching tabs (#1792)."""
@@ -998,6 +1018,18 @@ class MainScreen(Screen):
             return []
 
     @staticmethod
+    def _fmt_login_ts(iso: str) -> str:
+        """Render a UTC ISO login timestamp in the local timezone."""
+        try:
+            return (
+                datetime.datetime.fromisoformat(iso)
+                .astimezone()
+                .strftime("%Y-%m-%d %H:%M")
+            )
+        except (ValueError, TypeError):
+            return ""
+
+    @staticmethod
     def _compact_date(raw: str) -> str:
         """Format a created_at timestamp as a compact date string."""
         try:
@@ -1061,6 +1093,7 @@ class MainScreen(Screen):
                 server=state.current_url(),
                 user=state.email() or "(unknown)",
                 extra=self.app.live_extra,
+                last_login=self._last_login,
             )
         except NoMatches:
             pass  # Widget not mounted yet; status will refresh on mount.

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -265,7 +265,10 @@ class MainScreen(Screen):
         # The user's last successful login, rendered for the status bar
         # (#2583). Fetched once on mount by ``_load_last_login`` (a
         # blocking /auth/me hit, so it runs in a worker) and None until
-        # that returns.
+        # that returns. Re-fetched by ``reload_last_login`` after a
+        # server switch — the App reuses this screen there, so on_mount
+        # does not re-run and the old server's value would linger next
+        # to the new identity.
         self._last_login: str | None = None
         self.query_one("#filter_bar").display = False
         self._refresh_action_hints()
@@ -278,7 +281,30 @@ class MainScreen(Screen):
             self.app.run_worker(self._status_loop, name="status-ws")
             self.app.run_worker(self._token_refresh_loop, name="token-refresh")
             self.app.run_worker(
-                self._load_last_login, name="last-login", exit_on_error=False
+                self._load_last_login,
+                name="last-login",
+                exclusive=True,
+                exit_on_error=False,
+            )
+
+    def reload_last_login(self) -> None:
+        """Drop the shown last login and re-fetch it (#2583).
+
+        Called by ``App.server_changed``: that path reuses this screen,
+        so without this the status bar would keep showing the previous
+        server's (possibly another user's) login time beside the new
+        server/user identity. Exclusive, so a still-running on-mount
+        fetch for the old server is cancelled rather than racing this
+        one.
+        """
+        self._last_login = None
+        self._refresh_status()
+        if self.app.tui_state.is_authenticated():
+            self.app.run_worker(
+                self._load_last_login,
+                name="last-login",
+                exclusive=True,
+                exit_on_error=False,
             )
 
     async def _load_last_login(self) -> None:

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -59,11 +59,12 @@ class TuiState:
     def __init__(self, server_url: str | None = None) -> None:
         # ``--server`` override; otherwise the active server from state.
         self._server_override = server_url
-        # Cached /auth/me user id for the active server, so the detail
+        # Cached /auth/me profile for the active server, so the detail
         # screen can filter a user's own shared windows out of the shared
-        # list without a /me hit on every render. Refetched on server switch.
-        self._user_id: str | None = None
-        self._user_id_url: str | None = None
+        # list and the main screen can show the last login (#2583)
+        # without a /me hit on every render. Refetched on server switch.
+        self._me: dict | None = None
+        self._me_url: str | None = None
 
     # --- fresh config / state each call ---
 
@@ -110,18 +111,20 @@ class TuiState:
             return None
         return self.state().get_email(url)
 
-    def current_user_id(self) -> str | None:
-        """The authenticated user's id for the active server (cached).
+    def _me_profile(self) -> dict | None:
+        """The active server's ``GET /auth/me`` profile (cached).
 
-        Fetched once via /auth/me; refetched if the active server changes.
-        Returns None if it can't be resolved (no token, unreachable) so
-        callers can degrade (e.g. skip filtering).
+        Fetched once per active server (cached like the old
+        ``current_user_id`` fetch, #2164: keyed by URL, cleared on logout
+        so a re-login as a different identity isn't served the previous
+        user's profile). Returns None if it can't be resolved (no token,
+        unreachable) so callers can degrade (e.g. skip filtering).
         """
         url = self.current_url()
         if url is None:
             return None
-        if self._user_id is not None and self._user_id_url == url:
-            return self._user_id
+        if self._me is not None and self._me_url == url:
+            return self._me
         token = self.token()
         if token is None:
             return None
@@ -138,12 +141,23 @@ class TuiState:
         if resp.status_code != 200:
             return None
         data = resp.json()
-        uid = data.get("id") if isinstance(data, dict) else None
-        if isinstance(uid, str):
-            self._user_id = uid
-            self._user_id_url = url
-            return uid
+        if isinstance(data, dict) and isinstance(data.get("id"), str):
+            self._me = data
+            self._me_url = url
+            return data
         return None
+
+    def current_user_id(self) -> str | None:
+        """The authenticated user's id for the active server (cached)."""
+        me = self._me_profile()
+        return me["id"] if me is not None else None
+
+    def last_login_at(self) -> str | None:
+        """The user's last successful login (UTC ISO) for the active
+        server, or None when unknown (#2583)."""
+        me = self._me_profile()
+        value = me.get("last_login_at") if me is not None else None
+        return value if isinstance(value, str) else None
 
     def is_authenticated(self) -> bool:
         url = self.current_url()
@@ -381,11 +395,11 @@ class TuiState:
         if url is not None:
             state.clear_credentials(url)
             state.save()
-        # Drop the cached /auth/me id so a re-login as a different identity
-        # on the same server isn't served the previous user's id (#2164
-        # review: the cache is keyed by URL, not identity).
-        self._user_id = None
-        self._user_id_url = None
+        # Drop the cached /auth/me profile so a re-login as a different
+        # identity on the same server isn't served the previous user's
+        # profile (#2164 review: the cache is keyed by URL, not identity).
+        self._me = None
+        self._me_url = None
 
     # --- server switching / adding ---
 

--- a/src/klangk/klangk/cli/tui/widgets.py
+++ b/src/klangk/klangk/cli/tui/widgets.py
@@ -26,11 +26,14 @@ class StatusBar(Static):
         server: str | None,
         user: str | None,
         extra: str = "",
+        last_login: str | None = None,
     ) -> None:
         text = (
             f"server: {server or '(none)'}"
             f"   |   user: {user or '(not logged in)'}"
         )
+        if last_login:
+            text += f"   |   last login: {last_login}"
         if extra:
             text += f"   |   {extra}"
         # Render literally — server URL / user / live `extra` may contain

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -49,6 +49,7 @@ Rules for contributors
 import logging
 
 from klangk.model.migrations import m0001_password_history
+from klangk.model.migrations import m0002_last_login_at
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -58,6 +59,7 @@ logger = logging.getLogger(__name__)
 
 MIGRATIONS: list[Migration] = [
     m0001_password_history.migration,
+    m0002_last_login_at.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0002_last_login_at.py
+++ b/src/klangk/klangk/model/migrations/m0002_last_login_at.py
@@ -1,0 +1,16 @@
+"""Migration 0002: users.last_login_at (#2583).
+
+Stamped by ``UsersModel.record_login`` on every successful login and
+shown back to the user via ``GET /auth/me`` (the TUI main screen and
+``klangk account show`` display it). Nullable — NULL means the user has
+not logged in since the column was introduced.
+"""
+
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    await db.execute("ALTER TABLE users ADD COLUMN last_login_at TEXT")
+
+
+migration = Migration(2, "0002_last_login_at", apply)

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -3,6 +3,7 @@
 import hashlib
 import re
 import uuid
+from datetime import datetime, timezone
 
 
 # Agent identity
@@ -783,9 +784,24 @@ class UsersModel:
         )
         return None if row is None else row["password_hash"]
 
+    async def record_login(self, user_id: str) -> None:
+        """Stamp the user's most recent successful login (#2583).
+
+        Called from every session-minting auth path (password login, the
+        OIDC callback, no-auth local login, and the auto-login after
+        register/verify/reset/invite-accept). Token refreshes continue a
+        session rather than establish one and do not stamp. Stored as a
+        UTC ISO-8601 string; displayed to the user via ``GET /auth/me``.
+        """
+        async with self.app.state.db.transaction() as db:
+            await db.execute(
+                "UPDATE users SET last_login_at = ? WHERE id = ?",
+                (datetime.now(timezone.utc).isoformat(), user_id),
+            )
+
     async def get_user_by_id(self, user_id: str) -> dict | None:
         row = await self.app.state.db.fetchone(
-            "SELECT id, email, handle FROM users WHERE id = ?",
+            "SELECT id, email, handle, last_login_at FROM users WHERE id = ?",
             (user_id,),
         )
         if row is None:
@@ -794,6 +810,7 @@ class UsersModel:
             "id": row["id"],
             "email": row["email"],
             "handle": row["handle"],
+            "last_login_at": row["last_login_at"],
         }
 
     async def search_users(self, query: str, limit: int = 10) -> list[dict]:

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5416,6 +5416,7 @@ class TestAccountCommands:
             "id": "u1",
             "email": "me@x.example",
             "handle": "me",
+            "last_login_at": "2026-08-20T10:00:00+00:00",
         }
         monkeypatch.setattr(context_mod, "_client", lambda: client)
         result = CliRunner().invoke(main.app, ["account", "show"])
@@ -5423,6 +5424,32 @@ class TestAccountCommands:
         out = result.output
         assert "me@x.example" in out
         assert "@me" in out
+        # Last login renders in the local timezone (#2583).
+        assert "Last login: " in out
+        assert "2026-08-20" in out
+
+    def test_account_show_no_last_login(self, logged_in_cfg, monkeypatch):
+        """A user who never logged in since the column shipped omits the
+        line; so does an unparseable timestamp (#2583)."""
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        client.get_me.return_value = {
+            "id": "u1",
+            "email": "me@x.example",
+            "handle": "me",
+            "last_login_at": None,
+        }
+        monkeypatch.setattr(context_mod, "_client", lambda: client)
+        result = CliRunner().invoke(main.app, ["account", "show"])
+        assert result.exit_code == 0
+        assert "Last login" not in result.output
+
+        client.get_me.return_value["last_login_at"] = "not-a-timestamp"
+        result = CliRunner().invoke(main.app, ["account", "show"])
+        assert result.exit_code == 0
+        assert "Last login" not in result.output
 
     def test_account_passwd_success(self, logged_in_cfg, monkeypatch):
         from klangk.cli import account, main
@@ -5435,7 +5462,12 @@ class TestAccountCommands:
             "password_policy",
             lambda url: account.PasswordPolicy(
                 min_length=4,
-                requirements={"upper": 0, "lower": 0, "digit": 0, "special": 0},
+                requirements={
+                    "upper": 0,
+                    "lower": 0,
+                    "digit": 0,
+                    "special": 0,
+                },
             ),
         )
         answers = iter(["oldpw", "newpw12", "newpw12"])
@@ -5471,7 +5503,12 @@ class TestAccountCommands:
             "password_policy",
             lambda url: account.PasswordPolicy(
                 min_length=12,
-                requirements={"upper": 0, "lower": 0, "digit": 0, "special": 0},
+                requirements={
+                    "upper": 0,
+                    "lower": 0,
+                    "digit": 0,
+                    "special": 0,
+                },
             ),
         )
         answers = iter(["oldpw", "short", "short"])
@@ -5495,7 +5532,12 @@ class TestAccountCommands:
             "password_policy",
             lambda url: account.PasswordPolicy(
                 min_length=4,
-                requirements={"upper": 1, "lower": 1, "digit": 1, "special": 1},
+                requirements={
+                    "upper": 1,
+                    "lower": 1,
+                    "digit": 1,
+                    "special": 1,
+                },
             ),
         )
         answers = iter(["oldpw", "newpw12", "newpw12"])
@@ -5524,7 +5566,12 @@ class TestAccountCommands:
             "password_policy",
             lambda url: account.PasswordPolicy(
                 min_length=4,
-                requirements={"upper": 0, "lower": 0, "digit": 0, "special": 0},
+                requirements={
+                    "upper": 0,
+                    "lower": 0,
+                    "digit": 0,
+                    "special": 0,
+                },
             ),
         )
         answers = iter(["oldpw", "newpw12", "newpw12"])

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5451,6 +5451,13 @@ class TestAccountCommands:
         assert result.exit_code == 0
         assert "Last login" not in result.output
 
+        # A non-string value raises TypeError, not ValueError — the
+        # command must not crash on it (#2583 review).
+        client.get_me.return_value["last_login_at"] = 42
+        result = CliRunner().invoke(main.app, ["account", "show"])
+        assert result.exit_code == 0
+        assert "Last login" not in result.output
+
     def test_account_passwd_success(self, logged_in_cfg, monkeypatch):
         from klangk.cli import account, main
         from typer.testing import CliRunner

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -264,24 +264,28 @@ async def _async_empty(*a, **k):
 _real_run_token_refresh_loop = scr_main.run_token_refresh_loop
 _real_status_loop = MainScreen._status_loop
 _real_token_refresh_loop = MainScreen._token_refresh_loop
+_real_load_last_login = MainScreen._load_last_login
 
 
 @pytest.fixture(autouse=True)
 def _stub_tui_bg_workers(monkeypatch):
-    """Stub MainScreen's on-mount bg workers (status-WS + token-refresh loops)
-    to no-ops for every TUI test.
+    """Stub MainScreen's on-mount bg workers (status-WS + token-refresh
+    loops + the one-shot last-login fetch) to no-ops for every TUI test.
 
-    on_mount spawns two workers — ``self._status_loop`` and
+    on_mount spawns workers — ``self._status_loop`` and
     ``self._token_refresh_loop``. Left real, the status loop reconnects up to
     4× (max_retries=3) with a 2s sleep whenever its ``listen_for_status``
     returns cleanly, costing ~8s per mounted MainScreen — which dominated TUI
     test runtime (#1989). The old fixture stubbed the *leaf*
     ``listen_for_status`` function, but that still ran the loop body and its
     real reconnect sleeps; stubbing the loop *methods* instead makes the
-    workers complete instantly. Tests exercising the real loop logic call the
-    saved ``_real_status_loop`` / ``_real_token_refresh_loop`` /
-    ``_real_run_token_refresh_loop`` directly (they stub the leaf functions
-    themselves as needed).
+    workers complete instantly. ``_load_last_login`` (#2583) is stubbed for
+    the same reason: on fakes it would call the real ``TuiState`` method,
+    consuming side-effecting ``token()`` stubs (and timing out on a real
+    HTTP hit to the fake server URL). Tests exercising the real loop logic
+    call the saved ``_real_status_loop`` / ``_real_token_refresh_loop`` /
+    ``_real_run_token_refresh_loop`` / ``_real_load_last_login`` directly
+    (they stub the leaf functions themselves as needed).
     """
 
     async def _noop(*a, **k):
@@ -289,6 +293,7 @@ def _stub_tui_bg_workers(monkeypatch):
 
     monkeypatch.setattr(MainScreen, "_status_loop", _noop)
     monkeypatch.setattr(MainScreen, "_token_refresh_loop", _noop)
+    monkeypatch.setattr(MainScreen, "_load_last_login", _noop)
 
 
 # ---------------------------------------------------------------------------
@@ -552,6 +557,64 @@ def test_current_user_id_refetch_on_server_switch(monkeypatch, redirect_xdg):
     # Different active server -> cache miss -> refetch.
     assert t.current_user_id() == "id-https://b.example"
     assert len(seen) == 2
+
+
+def test_last_login_at_from_profile(monkeypatch, redirect_xdg):
+    """last_login_at reads the cached /auth/me profile (#2583)."""
+    from unittest.mock import MagicMock
+
+    add_server_to_config("srv", "https://srv.example")
+    st = CLIState()
+    st.set_credentials("https://srv.example", "me@x", "tok123")
+    st.save()
+    t = TuiState()
+    calls = []
+
+    def fake_req(url, method, path, **k):
+        calls.append(url)
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {
+            "id": "user-123",
+            "last_login_at": "2026-08-20T10:00:00+00:00",
+        }
+        return r
+
+    monkeypatch.setattr(tui_state_mod, "http_request", fake_req)
+    assert t.last_login_at() == "2026-08-20T10:00:00+00:00"
+    # Shares the profile cache — no second fetch.
+    assert t.last_login_at() == "2026-08-20T10:00:00+00:00"
+    assert len(calls) == 1
+
+
+def test_last_login_at_missing_or_non_string(monkeypatch, redirect_xdg):
+    """A profile without last_login_at (or with a non-string value)
+    degrades to None (#2583)."""
+    from unittest.mock import MagicMock
+
+    add_server_to_config("srv", "https://srv.example")
+    st = CLIState()
+    st.set_credentials("https://srv.example", "me@x", "tok123")
+    st.save()
+
+    def mk(body):
+        def fake_req(url, method, path, **k):
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = body
+            return r
+
+        return fake_req
+
+    t = TuiState()
+    monkeypatch.setattr(tui_state_mod, "http_request", mk({"id": "user-123"}))
+    assert t.last_login_at() is None
+    monkeypatch.setattr(
+        tui_state_mod,
+        "http_request",
+        mk({"id": "user-123", "last_login_at": 42}),
+    )
+    assert TuiState().last_login_at() is None
 
 
 def test_current_user_id_cleared_on_logout(monkeypatch, redirect_xdg):
@@ -6831,6 +6894,87 @@ async def test_status_bar_markup_safe(monkeypatch):
         app.screen._refresh_status()
         await pilot.pause()
         assert "foo[/]bar" in str(app.screen.query_one("#status").render())
+
+
+async def test_status_bar_last_login_segment(monkeypatch):
+    """set_state renders the last-login segment when present and omits
+    it otherwise (#2583). Widgets need an active app to update, so this
+    drives a mounted StatusBar."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    app = KlangkApp(_ws(last_login_at=lambda: None))
+    async with app.run_test() as pilot:
+        status = app.screen.query_one("#status", StatusBar)
+        status.set_state(
+            server="https://x", user="me@x", last_login="2026-08-20 10:00"
+        )
+        await pilot.pause()
+        assert "last login: 2026-08-20 10:00" in str(status.render())
+        # Without a last login the segment is absent.
+        status.set_state(server="https://x", user="me@x")
+        await pilot.pause()
+        assert "last login" not in str(status.render())
+
+
+def test_fmt_login_ts_invalid():
+    """Unparseable timestamps render empty (#2583)."""
+    assert MainScreen._fmt_login_ts("not-a-date") == ""
+    assert MainScreen._fmt_login_ts("") == ""
+
+
+def test_fmt_login_ts_localizes():
+    from datetime import datetime
+
+    iso = "2026-08-20T10:00:00+00:00"
+    expected = (
+        datetime.fromisoformat(iso).astimezone().strftime("%Y-%m-%d %H:%M")
+    )
+    assert MainScreen._fmt_login_ts(iso) == expected
+
+
+async def test_main_screen_shows_last_login(monkeypatch):
+    """The main screen fetches the last login once on mount and shows it
+    in the status bar (#2583)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    # The autouse fixture stubs _load_last_login; this test covers it.
+    monkeypatch.setattr(MainScreen, "_load_last_login", _real_load_last_login)
+    iso = "2026-08-20T10:00:00+00:00"
+    st = _ws(owned=[_wsobj("alpha")], last_login_at=lambda: iso)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = str(app.screen.query_one("#status", StatusBar).render())
+        assert "last login:" in rendered
+        assert MainScreen._fmt_login_ts(iso) in rendered
+
+
+async def test_main_screen_last_login_none_omitted(monkeypatch):
+    """A server that reports no last login shows no segment (#2583)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    # The autouse fixture stubs _load_last_login; this test covers it.
+    monkeypatch.setattr(MainScreen, "_load_last_login", _real_load_last_login)
+    st = _ws(owned=[_wsobj("alpha")], last_login_at=lambda: None)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "last login" not in str(
+            app.screen.query_one("#status", StatusBar).render()
+        )
 
 
 async def test_main_screen_auth_expired_shows_overlay(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -6926,13 +6926,15 @@ def test_fmt_login_ts_invalid():
 
 
 def test_fmt_login_ts_localizes():
-    from datetime import datetime
+    """A UTC ISO timestamp renders in the local timezone, not UTC —
+    computed via the local offset rather than the implementation's own
+    expression (#2583)."""
+    from datetime import datetime, timezone
 
-    iso = "2026-08-20T10:00:00+00:00"
-    expected = (
-        datetime.fromisoformat(iso).astimezone().strftime("%Y-%m-%d %H:%M")
-    )
-    assert MainScreen._fmt_login_ts(iso) == expected
+    utc_naive = datetime(2026, 8, 20, 10)
+    local = utc_naive.replace(tzinfo=timezone.utc).astimezone()
+    expected = (utc_naive + local.utcoffset()).strftime("%Y-%m-%d %H:%M")
+    assert MainScreen._fmt_login_ts("2026-08-20T10:00:00+00:00") == expected
 
 
 async def test_main_screen_shows_last_login(monkeypatch):
@@ -6975,6 +6977,39 @@ async def test_main_screen_last_login_none_omitted(monkeypatch):
         assert "last login" not in str(
             app.screen.query_one("#status", StatusBar).render()
         )
+
+
+async def test_reload_last_login_refetches_after_server_switch(monkeypatch):
+    """reload_last_login re-fetches the stamp, so a server switch
+    doesn't keep the previous server's (possibly another user's) login
+    time beside the new identity (#2583)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setattr(scr_main, "run_token_refresh_loop", noop)
+    monkeypatch.setattr(MainScreen, "_load_last_login", _real_load_last_login)
+    iso_a = "2026-08-20T10:00:00+00:00"
+    iso_b = "2026-08-21T12:00:00+00:00"
+    current = {"iso": iso_a}
+    st = _ws(owned=[_wsobj("alpha")], last_login_at=lambda: current["iso"])
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = str(app.screen.query_one("#status", StatusBar).render())
+        assert MainScreen._fmt_login_ts(iso_a) in rendered
+
+        # "Switch servers": the state now reports the new identity's
+        # (different) stamp; the reload replaces the shown one.
+        current["iso"] = iso_b
+        app.screen.reload_last_login()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = str(app.screen.query_one("#status", StatusBar).render())
+        assert MainScreen._fmt_login_ts(iso_b) in rendered
+        assert MainScreen._fmt_login_ts(iso_a) not in rendered
 
 
 async def test_main_screen_auth_expired_shows_overlay(monkeypatch):
@@ -11031,6 +11066,10 @@ async def test_server_changed_pops_to_main_and_refreshes(monkeypatch):
     monkeypatch.setattr(
         MainScreen, "refresh_lists", lambda self: refreshed.append(True)
     )
+    reloaded = []
+    monkeypatch.setattr(
+        MainScreen, "reload_last_login", lambda self: reloaded.append(True)
+    )
     app = KlangkApp(_authed_state())
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -11044,6 +11083,7 @@ async def test_server_changed_pops_to_main_and_refreshes(monkeypatch):
             isinstance(s, ServerSwitchScreen) for s in app.screen_stack
         )
         assert refreshed  # MainScreen refreshed after the switch
+        assert reloaded  # last-login stamp re-fetched for the new identity
 
 
 async def test_server_changed_clears_stack_when_main_absent(monkeypatch):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1031,6 +1031,9 @@ class TestLocalLogin:
         )
         assert resp.status_code == 200
         assert resp.json()["email"] == "local@example.com"
+        # The no-auth login minted a session, so /auth/me reports it
+        # (#2583).
+        assert resp.json()["last_login_at"] is not None
 
     async def test_disabled_when_not_none_mode(
         self, client, app, db, monkeypatch
@@ -9787,6 +9790,9 @@ class TestOIDCCallback:
         assert user["provider"] == "test"
         assert user["external_id"] == "oidc-sub-123"
         assert user["password_hash"] is None
+        # The SSO login minted a session and stamps last_login_at (#2583).
+        by_id = await app_state.state.model.users.get_user_by_id(user["id"])
+        assert by_id["last_login_at"] is not None
 
     async def test_callback_syncs_groups_via_hook(
         self, client, app, monkeypatch, db, app_state

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -268,7 +268,8 @@ class TestRegister:
         assert result.access_token is None  # unverified, no token
 
     async def test_register_verified(self, db):
-        result = await _auth().register(
+        a = _auth()
+        result = await a.register(
             auth.RegisterRequest(
                 email="verified@example.com", password="pass1234"
             ),
@@ -276,6 +277,10 @@ class TestRegister:
         )
         assert result.access_token
         assert result.email == "verified@example.com"
+        # Auto-verify mints a session: that first session is a login
+        # and stamps last_login_at (#2583).
+        row = await a.app.state.model.users.get_user_by_id(result.user_id)
+        assert row["last_login_at"] is not None
 
     async def test_register_duplicate_email(self, db):
         await _auth().register(
@@ -350,13 +355,29 @@ class TestRegister:
 
 class TestLogin:
     async def test_login_success(self, user):
-        result = await _auth().login(
+        a = _auth()
+        result = await a.login(
             auth.LoginRequest(
                 identifier="testuser@example.com", password="testpass"
             )
         )
         assert result.access_token
         assert result.token_type == "bearer"
+        # A successful login stamps last_login_at (#2583).
+        row = await a.app.state.model.users.get_user_by_id(user["id"])
+        assert row["last_login_at"] is not None
+
+    async def test_login_failure_does_not_stamp(self, user):
+        """Only successful logins stamp last_login_at (#2583)."""
+        a = _auth()
+        with pytest.raises(HTTPException):
+            await a.login(
+                auth.LoginRequest(
+                    identifier="testuser@example.com", password="wrong"
+                )
+            )
+        row = await a.app.state.model.users.get_user_by_id(user["id"])
+        assert row["last_login_at"] is None
 
     async def test_login_success_by_handle(self, user):
         """Login accepts a handle as well as an email (#616)."""

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -1,7 +1,8 @@
 """Ordered schema-migration runner tests (#30).
 
 Covers the runner contract (fresh DB, replay no-op, failure semantics,
-validation) and migration 0001's shape (password_history + cascade).
+validation) and migration 0001's shape (password_history + cascade) and
+0002's shape (users.last_login_at).
 """
 
 import aiosqlite
@@ -41,17 +42,27 @@ class TestRunner:
         records it; a second init_db is a no-op."""
         await app_state.state.model.init_db()
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
-            assert await _recorded(db) == [(1, "0001_password_history")]
+            assert await _recorded(db) == [
+                (1, "0001_password_history"),
+                (2, "0002_last_login_at"),
+            ]
             # Migration 0001 created its table (not the baseline pile).
             cursor = await db.execute(
                 "SELECT name FROM sqlite_master"
                 " WHERE type='table' AND name='password_history'"
             )
             assert await cursor.fetchone() is not None
+            # Migration 0002 added its column to the baseline users table.
+            info = await db.execute("PRAGMA table_info(users)")
+            cols = {r[1] for r in await info.fetchall()}
+            assert "last_login_at" in cols
 
-            # Re-run: nothing new applied, still exactly one record.
+            # Re-run: nothing new applied, still exactly two records.
             await app_state.state.model.init_db()
-            assert await _recorded(db) == [(1, "0001_password_history")]
+            assert await _recorded(db) == [
+                (1, "0001_password_history"),
+                (2, "0002_last_login_at"),
+            ]
 
     async def test_old_db_without_migrations_table(
         self, temp_data_dir, app_state
@@ -79,7 +90,10 @@ class TestRunner:
 
         await app_state.state.model.init_db()
         async with aiosqlite.connect(str(db_path)) as db:
-            assert await _recorded(db) == [(1, "0001_password_history")]
+            assert await _recorded(db) == [
+                (1, "0001_password_history"),
+                (2, "0002_last_login_at"),
+            ]
 
     async def test_pending_only(self, tmp_path):
         """Only unrecorded migrations run; recorded ones are skipped."""

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -29,8 +29,25 @@ async def test_create_and_get_user(users):
     assert by_email["id"] == u["id"]
     by_id = await users.get_user_by_id(u["id"])
     assert by_id["handle"] == u["handle"]
+    # Never logged in: the column exists and reads NULL (#2583).
+    assert by_id["last_login_at"] is None
     assert await users.get_user_by_id("nope") is None
     assert await users.get_user_by_email("missing@x.com") is None
+
+
+async def test_record_login(users):
+    """record_login stamps a UTC ISO timestamp readable via
+    get_user_by_id (#2583)."""
+    from datetime import datetime
+
+    u = await users.create_user("login@x.com", "hash", verified=True)
+    await users.record_login(u["id"])
+    by_id = await users.get_user_by_id(u["id"])
+    stamped = by_id["last_login_at"]
+    assert stamped is not None
+    # Round-trips as a timezone-aware ISO-8601 timestamp.
+    dt = datetime.fromisoformat(stamped)
+    assert dt.tzinfo is not None
 
 
 async def test_get_user_by_handle_and_handle(users):


### PR DESCRIPTION
## Summary

Users can now see when their account was last logged into (#2583).

- **Server:** every session-minting auth path — password login, OIDC
  callback, no-auth local login, and the auto-login after register /
  email-verify / password-reset / invite acceptance — stamps a
  `last_login_at` timestamp on the user (schema migration
  `0002_last_login_at`; nullable, so pre-existing users read as
  "never"). Token refreshes don't stamp (they continue a session).
  `GET /auth/me` reports the timestamp.
- **TUI:** the main-screen status bar shows `last login: …`, localized
  to the user's timezone. Fetched once on mount in a background
  worker; omitted when unknown.
- **CLI:** `klangk account show` prints `Last login: …` (localized,
  omitted when unknown or unparseable).

## Testing

- Unit tests for the model (`record_login` / NULL default), all stamping
  auth paths, a failed-login no-stamp case, migration 0002 shape, the
  `/auth/me` field, the TUI status-bar segment + on-mount worker, and
  `account show` rendering.
- The autouse TUI fixture now also stubs the new `_load_last_login`
  on-mount worker (same #1989 pattern), with the real method saved for
  direct-coverage tests.
- Full backend suite green: 5112 passed, 100% coverage.

Closes #2583.
