### PR TITLE
feat(auth): audit concurrent logons from different workstations (#2586)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -71,6 +71,16 @@ operators or integrators to act when upgrading.
   and `klangk account show` prints it — so users can spot unexpected
   access to their account. Applied as schema migration 0002.
 
+- **Concurrent-logon audit records (#2586).** Each session now records
+  the workstation it was established from (effective client IP +
+  user agent; applied as schema migration 0004). When a login is
+  concurrent with an active session from a different workstation,
+  klangkd writes an audit record to the server log — the signal to
+  review for shared or stolen credentials. The new
+  `GET /api/v1/admin/users/{id}/sessions` endpoint lists a user's
+  active sessions with their workstations. See
+  [Authentication](docs/features/authentication.md).
+
 - **`KLANGKD_MAX_SESSIONS_PER_USER` (#2585).** New setting that caps
   how many concurrent login sessions a user may have (default `0` = no
   limit). When a new login pushes a user past the cap, the oldest session

--- a/docs/deployment/behind-a-proxy.md
+++ b/docs/deployment/behind-a-proxy.md
@@ -60,11 +60,16 @@ trusted-proxy-cidrs: "127.0.0.1,::1,10.0.0.0/24"
 Use a comma-separated list. Each entry is an IP address or a CIDR range.
 Only the immediate TCP peer is checked against this list.
 
-If you do not set this correctly, three things break:
+If you do not set this correctly, four things break:
 
 1. **Hosted app URLs** use `localhost` instead of the public hostname.
 2. **OIDC callbacks** use `http` instead of `https`.
 3. **Login links** (password reset, verification) point to the wrong host.
+4. **Concurrent-logon audit records** never fire — every session records
+   the proxy's address as its workstation, so different workstations are
+   never detected. See
+   [Concurrent-logon auditing depends on the proxy chain](#concurrent-logon-auditing-depends-on-the-proxy-chain)
+   for how to verify the setup.
 
 ### Browser port
 
@@ -202,6 +207,79 @@ to start unless you set `KLANGKD_ALLOW_INSECURE_NO_AUTH=1`. Do not use
 `none` mode in production with network-reachable deployments. Use
 `password`, `oidc`, or `both` instead.
 
+## Concurrent-logon auditing depends on the proxy chain
+
+klangk records the workstation of every login session: the effective
+client IP plus the user agent. When one account holds concurrent
+sessions from different workstations, klangkd writes an audit record to
+the server log (see
+[Authentication](../features/authentication.md#concurrent-logon-auditing)).
+
+This works only when the proxy chain preserves the real client IP.
+The backend resolves the effective client IP from `X-Real-IP` (or the
+first hop of `X-Forwarded-For`) **and only when the immediate peer is
+trusted**. When the chain is misconfigured, every session records the
+proxy's address instead of the client's.
+
+### Consequences of a misconfigured proxy chain
+
+**Too little trust** (headers missing, `trusted-proxy-cidrs` wrong,
+or `reject-proxy-headers: true`):
+
+- **No audit records are ever written.** All logins appear to come
+  from one workstation (the proxy's address), so concurrent logons
+  from different workstations are never detected. This is exactly the
+  event the feature exists to catch — an attacker using stolen
+  credentials from a second machine leaves no trace.
+- **The admin session list is misleading.**
+  `GET /api/v1/admin/users/{id}/sessions` shows the proxy's address
+  for every session. An operator cannot tell workstations apart, and
+  account sharing looks the same as normal use.
+- **The failure is silent.** Nothing errors, no warning is logged, and
+  the deployment looks healthy. The only symptom is an audit trail
+  that stays empty — which is easy to miss until you need it, and by
+  then the missed events cannot be reconstructed (the workstation was
+  never recorded).
+
+Note that the **session limit is not affected**: it counts sessions,
+not IP addresses, so `KLANGKD_MAX_SESSIONS_PER_USER` still works.
+Only the audit signal is lost.
+
+**Too much trust** (a trust list wider than your actual proxies):
+
+- **The audit trail can be forged.** Any client whose forwarded
+  headers are honored can claim any `X-Real-IP` — a stolen-credential
+  login can be made to appear as the victim's own workstation, or a
+  fake "different workstation" record can be planted to distract an
+  investigation.
+
+### Checklist for a correct setup
+
+1. The outer proxy must send `X-Real-IP` (or `X-Forwarded-For`) set to
+   the real client address — see the nginx and Caddy examples above.
+2. `trusted-proxy-cidrs` must contain the outer proxy's IP or subnet.
+   With a wrong list, klangk's Caddy and the backend ignore the
+   forwarded headers.
+3. `reject-proxy-headers` must be off (the default). It disables all
+   forwarded-header trust, which also disables the workstation audit.
+4. The trust list must contain **only** your actual proxies (see the
+   too-much-trust consequence above).
+
+### Verify it works
+
+1. Log in as a test user from workstation A.
+2. Log in as the same user from a different network (workstation B —
+   for example, a phone hotspot).
+3. As admin, call `GET /api/v1/admin/users/{id}/sessions`. The two
+   sessions must show different `source_ip` values, and each must be
+   the real client address — not the proxy's.
+4. The klangkd log must contain
+   `audit: concurrent logon from different workstations`.
+
+If every session's `source_ip` is the proxy's address or `127.0.0.1`,
+forwarded headers are dropped or ignored. Fix the outer proxy headers
+or `trusted-proxy-cidrs`, then repeat the check.
+
 ## Reject all forwarded headers
 
 To ignore all forwarded headers unconditionally:
@@ -234,3 +312,5 @@ you add an outer proxy.
   reference.
 - [Auth Modes](../features/auth-modes.md) — `none`, `password`, `oidc`,
   `both`.
+- [Authentication](../features/authentication.md#concurrent-logon-auditing)
+  — what the workstation audit records and how to read them.

--- a/docs/deployment/behind-a-proxy.md
+++ b/docs/deployment/behind-a-proxy.md
@@ -255,8 +255,17 @@ Only the audit signal is lost.
 
 ### Checklist for a correct setup
 
-1. The outer proxy must send `X-Real-IP` (or `X-Forwarded-For`) set to
-   the real client address — see the nginx and Caddy examples above.
+1. The outer proxy must **overwrite** a client-IP header with the
+   address it actually saw: `X-Real-IP $remote_addr;` (nginx) or
+   Caddy's automatic `X-Forwarded-For` semantics. Do **not** rely on
+   an outer proxy that only _appends_ to `X-Forwarded-For` — the
+   leftmost entry is then client-controlled, and a client can forge
+   its workstation identity (mask a stolen-credential login as the
+   victim's machine, or plant fake "different workstation" records).
+   klangk validates that the forwarded value parses as an IP and
+   ignores garbage, but a syntactically valid forged IP from an
+   append-style chain is still honored. See the nginx and Caddy
+   examples above for the safe forms.
 2. `trusted-proxy-cidrs` must contain the outer proxy's IP or subnet.
    With a wrong list, klangk's Caddy and the backend ignore the
    forwarded headers.

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -125,6 +125,38 @@ rejected with code `4001`, logging that client out. Sessions whose
 token has already
 expired are purged lazily and never count toward the cap.
 
+## Concurrent-logon auditing
+
+Every session records the workstation it was established from: the
+effective client IP (behind a trusted reverse proxy this is the real
+client from `X-Real-IP`/`X-Forwarded-For`; a direct caller cannot
+spoof it) and the `User-Agent` string. When a login is concurrent
+with an active session from a **different** workstation, klangkd
+writes an audit record to the server log:
+
+```text
+audit: concurrent logon from different workstations: user=<id> email=<email> new session from 198.51.100.9; concurrent with session(s) from 203.0.113.7
+```
+
+This is the signal to review when credentials may be shared with (or
+stolen by) a second machine — especially useful when no session cap
+is configured. Sessions with an unknown IP (created before the
+feature, or from clients whose address cannot be resolved) are never
+reported as different, and a user logging in twice from the same
+machine is not audited.
+
+Admins can query a user's active sessions at any time — see
+[`GET /api/v1/admin/users/{id}/sessions`](../reference/api-endpoints.md#get-apiv1adminusersidsessions)
+in the API reference. Each row shows when the session was established,
+when it expires, and the workstation it came from.
+
+Behind a reverse proxy, the workstation audit works only when the proxy
+chain forwards the real client IP (`X-Real-IP` / `X-Forwarded-For` plus
+`KLANGKD_TRUSTED_PROXY_CIDRS`). If that is misconfigured, every session
+records the proxy's address and no audit records are ever written — see
+[Behind a Reverse Proxy: concurrent-logon auditing](../deployment/behind-a-proxy.md#concurrent-logon-auditing-depends-on-the-proxy-chain)
+for how to verify the setup.
+
 ## Consent banner
 
 If `KLANGKD_LOGIN_BANNER` is set, users see a consent page before

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -85,6 +85,34 @@ No request body.
 
 ---
 
+### GET `/api/v1/admin/users/{id}/sessions`
+
+List a user's active sessions with their workstation identity — the
+queryable half of concurrent-logon auditing. One item per unexpired
+session, oldest first; `source_ip` is the effective client IP the
+session was established from (null = unknown, e.g. sessions created
+before the audit feature), `user_agent` is the client's User-Agent
+string (null = none was sent). Expired sessions are excluded.
+
+**Auth:** JWT required. User must have `admin` permission on `/`.
+
+No request body.
+
+```json
+{
+  "items": [
+    {
+      "created_at": "2026-08-20 18:03:41",
+      "expires_at": "2026-08-21 18:03:41.862671+00:00",
+      "source_ip": "203.0.113.7",
+      "user_agent": "klangk-cli/1.0"
+    }
+  ]
+}
+```
+
+---
+
 ### GET `/api/v1/admin/acl/by-principal/group/{id}`
 
 List all ACL entries granted to a specific group across all resources.

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -501,6 +501,7 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
         {"limit": "int", "offset": "int"},
     ),
     ("POST", f"{P}/admin/users/{{user_id}}/unlockout", None, None),
+    ("GET", f"{P}/admin/users/{{user_id}}/sessions", None, None),
     ("GET", f"{P}/admin/groups", None, None),
     (
         "POST",

--- a/src/klangk/klangk/api/_common.py
+++ b/src/klangk/klangk/api/_common.py
@@ -35,6 +35,21 @@ async def workspace_resource(request: Request, user: dict) -> str:
     return f"/workspaces/{workspace_id}"
 
 
+def workstation(request: Request) -> tuple[str | None, str | None]:
+    """The ``(source_ip, user_agent)`` a session is established from (#2586).
+
+    The IP is the effective client address, resolved proxy-trust-aware
+    (``X-Real-IP``/``X-Forwarded-For`` honored only behind a trusted
+    proxy), so a workstation identity cannot be spoofed by a direct
+    caller. Both values may be ``None`` (unknown) — the audit layer
+    treats unknown as never-different, never same.
+    """
+    ip = request.app.state.util.effective_client_ip(
+        request.headers, request.client.host if request.client else None
+    )
+    return ip, request.headers.get("user-agent") or None
+
+
 async def admin_resource(request: Request, user: dict) -> str:  # noqa: ARG001
     """Resource function for admin operations (always checks /admin)."""
     return "/admin"

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -357,6 +357,39 @@ async def unlock_user(
     return {"status": "unlocked"}
 
 
+@router.get("/admin/users/{user_id}/sessions")
+async def list_user_sessions(
+    user_id: str,
+    admin: dict = Depends(acl.has_permission("admin")),
+    app=Depends(get_app_dep),
+):
+    """List a user's active sessions with workstation identity (#2586).
+
+    The queryable half of concurrent-logon auditing: one row per
+    unexpired session, oldest first, carrying when it was established,
+    when it expires, and the effective client IP / user agent it came
+    from. The logon-time audit record (server log) fires when a new
+    login is concurrent with a session from a different workstation;
+    this endpoint is how an operator reviews the trail afterwards.
+    """
+    user = await app.state.model.users.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    await app.state.model.sessions.purge_expired()
+    rows = await app.state.model.sessions.list_sessions(user_id)
+    return {
+        "items": [
+            {
+                "created_at": row["created_at"],
+                "expires_at": row["expires_at"],
+                "source_ip": row["source_ip"],
+                "user_agent": row["user_agent"],
+            }
+            for row in rows
+        ]
+    }
+
+
 # --- Group management endpoints ---
 
 

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -23,6 +23,7 @@ from .. import (
 from ._common import get_app_dep
 from ._common import (
     send_email,
+    workstation,
 )
 
 logger = logging.getLogger(__name__)
@@ -92,7 +93,13 @@ async def register(
         )
     if request.app.state.settings.test_mode:
         # Test mode: auto-verify so E2E tests get immediate access
-        result = await request.app.state.auth.register(req, verified=True)
+        source_ip, user_agent = workstation(request)
+        result = await request.app.state.auth.register(
+            req,
+            verified=True,
+            source_ip=source_ip,
+            user_agent=user_agent,
+        )
         return result
 
     logger.info("Registering user: %s", req.email)
@@ -158,8 +165,12 @@ async def verify_email(token: str, request: Request):
     if not updated:
         raise HTTPException(status_code=404, detail="User not found")
     user = await request.app.state.model.users.get_user_by_id(user_id)
+    source_ip, user_agent = workstation(request)
     access_token = await request.app.state.auth.issue_token(
-        user_id, user["email"]
+        user_id,
+        user["email"],
+        source_ip=source_ip,
+        user_agent=user_agent,
     )
     await request.app.state.model.users.record_login(user_id)
     return {"status": "verified", "access_token": access_token}
@@ -309,7 +320,13 @@ async def reset_password(req: ResetPasswordRequest, request: Request):
     user = await request.app.state.model.users.get_user_by_id(user_id)
     if user is None:  # pragma: no cover
         raise HTTPException(status_code=404, detail="User not found")
-    token = await request.app.state.auth.issue_token(user_id, user["email"])
+    source_ip, user_agent = workstation(request)
+    token = await request.app.state.auth.issue_token(
+        user_id,
+        user["email"],
+        source_ip=source_ip,
+        user_agent=user_agent,
+    )
     await request.app.state.model.users.record_login(user_id)
     return {"status": "reset", "access_token": token}
 
@@ -323,7 +340,10 @@ async def login(
         raise HTTPException(
             status_code=403, detail="Password login is disabled"
         )
-    return await request.app.state.auth.login(req)
+    source_ip, user_agent = workstation(request)
+    return await request.app.state.auth.login(
+        req, source_ip=source_ip, user_agent=user_agent
+    )
 
 
 class LocalLoginResponse(BaseModel):
@@ -372,7 +392,13 @@ async def local_login(request: Request):
             status_code=500,
             detail="Default user is not seeded",
         )
-    token = await request.app.state.auth.issue_token(user["id"], user["email"])
+    source_ip, user_agent = workstation(request)
+    token = await request.app.state.auth.issue_token(
+        user["id"],
+        user["email"],
+        source_ip=source_ip,
+        user_agent=user_agent,
+    )
     await request.app.state.model.users.record_login(user["id"])
     return LocalLoginResponse(access_token=token, email=user["email"])
 
@@ -634,8 +660,12 @@ async def accept_invite(req: AcceptInviteRequest, request: Request):
         invitation_id
     )
 
+    source_ip, user_agent = workstation(request)
     access_token = await request.app.state.auth.issue_token(
-        user["id"], user["email"]
+        user["id"],
+        user["email"],
+        source_ip=source_ip,
+        user_agent=user_agent,
     )
     await request.app.state.model.users.record_login(user["id"])
     return {"status": "accepted", "access_token": access_token}

--- a/src/klangk/klangk/api/oidc_auth.py
+++ b/src/klangk/klangk/api/oidc_auth.py
@@ -21,6 +21,7 @@ from .. import (
     oidc,
 )
 from ..util import API_PREFIX
+from ._common import workstation
 
 logger = logging.getLogger(__name__)
 
@@ -334,7 +335,13 @@ async def oidc_callback(
     if hook_groups is not None:
         await request.app.state.oidc.sync_oidc_groups(user["id"], hook_groups)
 
-    access_token = await request.app.state.auth.issue_token(user["id"], email)
+    source_ip, user_agent = workstation(request)
+    access_token = await request.app.state.auth.issue_token(
+        user["id"],
+        email,
+        source_ip=source_ip,
+        user_agent=user_agent,
+    )
     await request.app.state.model.users.record_login(user["id"])
     return _build_redirect_response(
         request, provider_id, access_token, cookie_data

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -425,13 +425,24 @@ class Auth:
         }
         return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
-    async def issue_token(self, user_id: str, email: str) -> str:
+    async def issue_token(
+        self,
+        user_id: str,
+        email: str,
+        *,
+        source_ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> str:
         """Mint an access token AND register it as a session (#2585).
 
         Every interactive issuance path (password login, registration,
         email verification, password-reset auto-login, invite acceptance,
         OIDC callback, ``none``-mode local login) goes through here so the
-        server-side session registry stays complete. Then
+        server-side session registry stays complete. The session row
+        records the workstation it was established from (*source_ip* /
+        *user_agent*, #2586) and :meth:`_audit_concurrent_logons`
+        generates an audit record when the logon is concurrent with
+        sessions from other workstations. Then
         :meth:`_enforce_session_limit` revokes the user's oldest sessions
         past ``KLANGKD_MAX_SESSIONS_PER_USER`` (0 = unlimited; the table
         is still purged of expired rows so it stays bounded).
@@ -442,10 +453,57 @@ class Auth:
             payload["exp"], tz=timezone.utc
         ).isoformat()
         await self.app.state.model.sessions.record_session(
-            user_id, payload["jti"], expires_at
+            user_id,
+            payload["jti"],
+            expires_at,
+            source_ip=source_ip,
+            user_agent=user_agent,
         )
+        await self._audit_concurrent_logons(user_id, email, source_ip)
         await self._enforce_session_limit(user_id)
         return token
+
+    async def _audit_concurrent_logons(
+        self, user_id: str, email: str, source_ip: str | None
+    ) -> None:
+        """Audit concurrent logons from different workstations (#2586).
+
+        A "workstation" is the effective client IP the session was
+        established from. When this logon (from *source_ip*) is
+        concurrent with an active session established from a different,
+        known IP, an audit record is written to the server log — the
+        signal an operator reviews to spot credentials shared with (or
+        stolen by) a second machine. Sessions with an unknown IP
+        (pre-#2586 rows, unresolvable clients) are never reported as
+        different; expired rows are purged first so dead sessions
+        don't generate records. Runs BEFORE the session limit so an
+        about-to-be-evicted other-workstation session is still
+        audited — that eviction is exactly the event of interest.
+        """
+        if source_ip is None:
+            return
+        sessions = self.app.state.model.sessions
+        await sessions.purge_expired()
+        rows = await sessions.list_sessions(user_id)
+        others = sorted(
+            {
+                row["source_ip"]
+                for row in rows
+                if row["source_ip"] is not None
+                and row["source_ip"] != source_ip
+            }
+        )
+        if not others:
+            return
+        logger.info(
+            "audit: concurrent logon from different workstations:"
+            " user=%s email=%s new session from %s; concurrent with"
+            " session(s) from %s",
+            user_id,
+            email,
+            source_ip,
+            ", ".join(others),
+        )
 
     async def _enforce_session_limit(self, user_id: str) -> None:
         """Revoke the user's oldest sessions past the configured cap.
@@ -599,7 +657,12 @@ class Auth:
     # --- registration / login flows ---
 
     async def register(
-        self, req: RegisterRequest, verified: bool = False
+        self,
+        req: RegisterRequest,
+        verified: bool = False,
+        *,
+        source_ip: str | None = None,
+        user_agent: str | None = None,
     ) -> RegisterResult:
         if not self.registration_enabled():
             raise HTTPException(
@@ -627,13 +690,24 @@ class Auth:
             raise HTTPException(status_code=400, detail="Registration failed")
         token = None
         if verified:
-            token = await self.issue_token(user["id"], user["email"])
+            token = await self.issue_token(
+                user["id"],
+                user["email"],
+                source_ip=source_ip,
+                user_agent=user_agent,
+            )
             await self.app.state.model.users.record_login(user["id"])
         return RegisterResult(
             user_id=user["id"], email=user["email"], access_token=token
         )
 
-    async def login(self, req: LoginRequest) -> TokenResponse:
+    async def login(
+        self,
+        req: LoginRequest,
+        *,
+        source_ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> TokenResponse:
         # Resolve the user by email or handle (#616).
         user = await self.app.state.model.users.get_user_by_identifier(
             req.identifier
@@ -699,7 +773,12 @@ class Auth:
             await self.app.state.model.login_attempts.clear_login_attempts(
                 lockout_key
             )
-        token = await self.issue_token(user["id"], user["email"])
+        token = await self.issue_token(
+            user["id"],
+            user["email"],
+            source_ip=source_ip,
+            user_agent=user_agent,
+        )
         # Stamp after minting, matching every other session-issuing site
         # (#2583): if minting fails, no login is recorded.
         await self.app.state.model.users.record_login(user["id"])

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -51,6 +51,7 @@ import logging
 from klangk.model.migrations import m0001_password_history
 from klangk.model.migrations import m0002_last_login_at
 from klangk.model.migrations import m0003_user_sessions
+from klangk.model.migrations import m0004_user_sessions_workstation
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -62,6 +63,7 @@ MIGRATIONS: list[Migration] = [
     m0001_password_history.migration,
     m0002_last_login_at.migration,
     m0003_user_sessions.migration,
+    m0004_user_sessions_workstation.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0004_user_sessions_workstation.py
+++ b/src/klangk/klangk/model/migrations/m0004_user_sessions_workstation.py
@@ -1,0 +1,22 @@
+"""Migration 0004: workstation identity on user_sessions (#2586).
+
+Adds ``source_ip`` and ``user_agent`` columns so each active session
+records which workstation it was established from. That turns the
+session registry (#2585) into an auditable trail: concurrent sessions
+from different workstations can be detected at login time (an audit
+record is logged by ``Auth._audit_concurrent_logons``) and queried
+later via the admin sessions endpoint. Both columns are nullable —
+rows written before this migration (and issuances where the effective
+client IP could not be resolved) have an unknown workstation, which is
+never reported as "different".
+"""
+
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    await db.execute("ALTER TABLE user_sessions ADD COLUMN source_ip TEXT")
+    await db.execute("ALTER TABLE user_sessions ADD COLUMN user_agent TEXT")
+
+
+migration = Migration(4, "0004_user_sessions_workstation", apply)

--- a/src/klangk/klangk/model/sessions.py
+++ b/src/klangk/klangk/model/sessions.py
@@ -1,11 +1,15 @@
-"""Active-session registry for concurrent-session limiting (#2585).
+"""Active-session registry for concurrent-session limiting (#2585) and
+concurrent-logon auditing (#2586).
 
 Storage only; the limit *decision* (who to revoke, blocklisting the
 evicted JTIs) lives in :mod:`klangk.auth`. A row exists per issued
 access-token JTI; it is inserted at issuance, replaced on refresh (the
 old JTI is blocklisted), deleted on logout, and lazily purged once the
 token's ``exp`` has passed — so ``user_sessions`` never tracks a token
-that is already dead.
+that is already dead. Each row also records the workstation the
+session was established from (effective client IP + user agent), so
+concurrent sessions from different workstations can be detected at
+login and audited later.
 """
 
 from datetime import datetime, timezone
@@ -26,20 +30,28 @@ class SessionsModel:
         self.app = app
 
     async def record_session(
-        self, user_id: str, jti: str, expires_at: str
+        self,
+        user_id: str,
+        jti: str,
+        expires_at: str,
+        source_ip: str | None = None,
+        user_agent: str | None = None,
     ) -> None:
         """Insert a session row for a freshly issued token.
 
         ``expires_at`` is the token's ``exp`` as a UTC ISO string (the
         same form the token blocklist stores), used by
         :meth:`purge_expired` and handed back for blocklisting on
-        eviction.
+        eviction. ``source_ip``/``user_agent`` record the workstation
+        the session was established from (#2586); ``None`` means
+        unknown (never reported as a *different* workstation).
         """
         async with self.app.state.db.transaction() as db:
             await db.execute(
                 "INSERT OR REPLACE INTO user_sessions"
-                " (jti, user_id, expires_at) VALUES (?, ?, ?)",
-                (jti, user_id, expires_at),
+                " (jti, user_id, expires_at, source_ip, user_agent)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (jti, user_id, expires_at, source_ip, user_agent),
             )
 
     async def replace_session(
@@ -113,13 +125,25 @@ class SessionsModel:
 
         ``rowid`` breaks ``created_at`` ties (datetime('now') has
         second granularity; burst logins would otherwise tie) with the
-        later insert ordering as the newer session.
+        later insert ordering as the newer session. Each row carries
+        the workstation identity (``source_ip``/``user_agent``) for
+        concurrent-logon auditing (#2586).
         """
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
-                "SELECT jti, expires_at FROM user_sessions"
-                " WHERE user_id = ? ORDER BY created_at, rowid",
+                "SELECT jti, expires_at, source_ip, user_agent, created_at"
+                " FROM user_sessions WHERE user_id = ?"
+                " ORDER BY created_at, rowid",
                 (user_id,),
             )
             rows = await cursor.fetchall()
-            return [{"jti": row[0], "expires_at": row[1]} for row in rows]
+            return [
+                {
+                    "jti": row[0],
+                    "expires_at": row[1],
+                    "source_ip": row[2],
+                    "user_agent": row[3],
+                    "created_at": row[4],
+                }
+                for row in rows
+            ]

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -470,8 +470,12 @@ class Util:
         is a trusted proxy and ``KLANGKD_REJECT_PROXY_HEADERS`` is off —
         the same trust gate :meth:`client_is_loopback` and
         :meth:`derive_hosting_info` use, so a direct caller cannot
-        spoof a workstation identity (#2586). Returns the peer address
-        otherwise, or ``None`` when there is no client at all.
+        spoof a workstation identity (#2586). The header value must
+        parse as an IP address; a garbage or forged-unparseable value
+        falls back to the peer rather than being persisted, logged,
+        or served as a workstation identity. Returns the canonical
+        (``str()``-normalized) address, or ``None`` when there is no
+        client at all.
         """
         candidate = client_host
         trust = (
@@ -485,8 +489,20 @@ class Util:
                 xff = headers.get("x-forwarded-for") or ""
                 real_ip = xff.split(",")[0].strip() if xff else ""
             if real_ip:
-                candidate = real_ip
-        return candidate
+                try:
+                    return str(ipaddress.ip_address(real_ip))
+                except ValueError:
+                    # A trusted peer forwarded a value that is not an
+                    # IP (garbage, or a proxy chain appending
+                    # client-controlled text). Fall back to the peer
+                    # instead of trusting an unvalidated string.
+                    pass
+        if candidate is None:
+            return None
+        try:
+            return str(ipaddress.ip_address(candidate))
+        except ValueError:
+            return candidate
 
     def client_is_loopback(
         self, headers=None, client_host: str | None = None

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -460,6 +460,34 @@ class Util:
             client_host is None and self.uds_mode
         )
 
+    def effective_client_ip(
+        self, headers=None, client_host: str | None = None
+    ) -> str | None:
+        """The effective client IP of a request, proxy-trust-aware.
+
+        Forwarded headers (``X-Real-IP``, then the first hop of
+        ``X-Forwarded-For``) are honored only when the immediate peer
+        is a trusted proxy and ``KLANGKD_REJECT_PROXY_HEADERS`` is off —
+        the same trust gate :meth:`client_is_loopback` and
+        :meth:`derive_hosting_info` use, so a direct caller cannot
+        spoof a workstation identity (#2586). Returns the peer address
+        otherwise, or ``None`` when there is no client at all.
+        """
+        candidate = client_host
+        trust = (
+            (not self.reject_proxy_headers())
+            and self.connection_peer_is_trusted(client_host)
+            and headers is not None
+        )
+        if trust:
+            real_ip = headers.get("x-real-ip") or ""
+            if not real_ip:
+                xff = headers.get("x-forwarded-for") or ""
+                real_ip = xff.split(",")[0].strip() if xff else ""
+            if real_ip:
+                candidate = real_ip
+        return candidate
+
     def client_is_loopback(
         self, headers=None, client_host: str | None = None
     ) -> bool:
@@ -479,19 +507,7 @@ class Util:
         an unparseable IP, rejects. Over a UDS a ``None`` client is treated
         as the trusted reverse proxy (same-uid socket access).
         """
-        candidate = client_host
-        trust = (
-            (not self.reject_proxy_headers())
-            and self.connection_peer_is_trusted(client_host)
-            and headers is not None
-        )
-        if trust:
-            real_ip = headers.get("x-real-ip") or ""
-            if not real_ip:
-                xff = headers.get("x-forwarded-for") or ""
-                real_ip = xff.split(",")[0].strip() if xff else ""
-            if real_ip:
-                candidate = real_ip
+        candidate = self.effective_client_ip(headers, client_host)
         if candidate is None and self.uds_mode:
             return True
         try:

--- a/src/klangk/klangkd-tests/e2e-tests/test_concurrent_logon_audit_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_concurrent_logon_audit_e2e.py
@@ -1,0 +1,155 @@
+"""Concurrent-logon audit E2E against a real klangkd (#2586).
+
+Boots one server (UDS-direct) and simulates two workstations by sending
+different ``X-Real-IP`` headers on the auth endpoints — over the UDS the
+None peer is the trusted same-uid proxy hop, so the backend honors the
+forwarded header as the effective client IP. Verifies the logon-time
+audit record in the server log and the admin query endpoint.
+
+Run with: devenv shell -- test-backend-e2e test_concurrent_logon_audit_e2e.py
+"""
+
+import uuid
+
+import pytest
+
+from _e2e_server import httpx_client, start_server, stop_server
+
+WS_A = "203.0.113.7"
+WS_B = "198.51.100.9"
+
+
+@pytest.fixture(scope="module")
+def server(tmp_path_factory):
+    """A real klangkd logging to a file (the audit record lands there)."""
+    log_path = tmp_path_factory.mktemp("audit") / "klangkd.log"
+    server = start_server(
+        KLANGKD_JWT_SECRET="logon-audit-e2e-secret",
+        KLANGKD_DEFAULT_USER="admin@example.com",
+        KLANGKD_DEFAULT_PASSWORD="adminpass",
+        KLANGKD_TEST_MODE="1",
+        KLANGKD_IDLE_TIMEOUT_SECONDS="300",
+        LOGFIRE_TOKEN="",
+        log_path=str(log_path),
+    )
+    server["audit_log"] = str(log_path)
+    yield server
+    stop_server(server)
+
+
+@pytest.fixture(scope="module")
+def api(server):
+    with httpx_client(server, timeout=10.0) as client:
+        yield client
+
+
+def _log(server) -> str:
+    with open(server["audit_log"]) as fh:
+        return fh.read()
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _audit_records(server) -> list[str]:
+    return [
+        line
+        for line in _log(server).splitlines()
+        if "concurrent logon from different workstations" in line
+    ]
+
+
+def _register(api, source_ip: str) -> tuple[str, str]:
+    """Register a unique auto-verified user from *source_ip*; return
+    (email, session-1 token)."""
+    email = f"cla-{uuid.uuid4().hex[:8]}@example.com"
+    resp = api.post(
+        "/api/v1/auth/register",
+        json={"email": email, "password": "testpass"},
+        headers={"X-Real-IP": source_ip},
+    )
+    assert resp.status_code == 200, resp.text
+    return email, resp.json()["access_token"]
+
+
+def _login(api, email: str, source_ip: str, password: str = "testpass") -> str:
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": email, "password": password},
+        headers={"X-Real-IP": source_ip},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+class TestConcurrentLogonAudit:
+    def test_different_workstation_audited(self, api, server):
+        """A login concurrent with an active session from another
+        workstation writes an audit record naming both."""
+        email, first = _register(api, WS_A)
+        assert _audit_records(server) == []
+
+        second = _login(api, email, WS_B)
+        records = _audit_records(server)
+        assert len(records) == 1
+        assert WS_A in records[0] and WS_B in records[0]
+        assert email in records[0]
+
+        # Both sessions are live (no limit configured — audit only).
+        assert (
+            api.get("/api/v1/auth/me", headers=_bearer(first)).status_code
+            == 200
+        )
+        assert (
+            api.get("/api/v1/auth/me", headers=_bearer(second)).status_code
+            == 200
+        )
+
+    def test_same_workstation_not_audited(self, api, server):
+        """Logins from one workstation (two browsers on one machine) are
+        concurrent but not from different workstations: no record."""
+        email, _ = _register(api, WS_A)
+        before = len(_audit_records(server))
+        _login(api, email, WS_A)
+        _login(api, email, WS_A)
+        assert len(_audit_records(server)) == before
+
+    def test_admin_can_query_session_workstations(self, api, server):
+        """The admin sessions endpoint lists the user's active sessions
+        with their workstation identity — the queryable audit trail."""
+        email, _ = _register(api, WS_A)
+        token = _login(api, email, WS_B)
+        user_id = api.get("/api/v1/auth/me", headers=_bearer(token)).json()[
+            "id"
+        ]
+
+        admin = _login(api, "admin@example.com", "127.0.0.1", "adminpass")
+        resp = api.get(
+            f"/api/v1/admin/users/{user_id}/sessions",
+            headers=_bearer(admin),
+        )
+        assert resp.status_code == 200, resp.text
+        ips = {item["source_ip"] for item in resp.json()["items"]}
+        assert ips == {WS_A, WS_B}
+        # Every row carries the full workstation identity shape.
+        for item in resp.json()["items"]:
+            assert set(item) == {
+                "created_at",
+                "expires_at",
+                "source_ip",
+                "user_agent",
+            }
+
+    def test_sessions_endpoint_requires_admin(self, api):
+        """A non-admin user cannot query another user's sessions."""
+        email, _ = _register(api, WS_A)
+        token = _login(api, email, WS_B)
+        user_id = api.get("/api/v1/auth/me", headers=_bearer(token)).json()[
+            "id"
+        ]
+        resp = api.get(
+            f"/api/v1/admin/users/{user_id}/sessions",
+            headers=_bearer(token),
+        )
+        assert resp.status_code == 403

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6690,6 +6690,118 @@ class TestAdminEndpoints:
         assert resp.status_code == 403
 
 
+class TestUserSessionsAudit:
+    """Admin query for a user's active sessions with workstation identity
+    (#2586), plus the login path threading X-Real-IP into the registry."""
+
+    async def _admin_headers(self, client):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
+        )
+        return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+    async def test_login_threads_workstation_into_registry(
+        self, client, user, app_state
+    ):
+        """A login carrying X-Real-IP (behind the trusted loopback test
+        peer) records that IP on the session row."""
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
+            headers={"X-Real-IP": "203.0.113.7"},
+        )
+        assert resp.status_code == 200
+        rows = await app_state.state.model.sessions.list_sessions(user["id"])
+        assert len(rows) == 1
+        assert rows[0]["source_ip"] == "203.0.113.7"
+
+    async def test_admin_lists_sessions_with_workstations(
+        self, client, admin_user, user, app_state
+    ):
+        headers = await self._admin_headers(client)
+        for ip in ("203.0.113.7", "198.51.100.9"):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={
+                    "identifier": "testuser@example.com",
+                    "password": "testpass",
+                },
+                headers={
+                    "X-Real-IP": ip,
+                    "User-Agent": f"ua-{ip}",
+                },
+            )
+            assert resp.status_code == 200
+        resp = await client.get(
+            f"/api/v1/admin/users/{user['id']}/sessions", headers=headers
+        )
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert {i["source_ip"] for i in items} == {
+            "203.0.113.7",
+            "198.51.100.9",
+        }
+        assert {i["user_agent"] for i in items} == {
+            "ua-203.0.113.7",
+            "ua-198.51.100.9",
+        }
+        # Oldest first: the workstation-A session was established first.
+        assert items[0]["source_ip"] == "203.0.113.7"
+
+    async def test_admin_sessions_peer_fallback_workstation(
+        self, client, admin_user, user, app_state
+    ):
+        """A login with no forwarded headers (direct loopback client)
+        records the peer as the workstation; an empty User-Agent is
+        stored as null (unknown), never as an empty string."""
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
+            headers={"User-Agent": ""},
+        )
+        assert resp.status_code == 200
+        headers = await self._admin_headers(client)
+        resp = await client.get(
+            f"/api/v1/admin/users/{user['id']}/sessions", headers=headers
+        )
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["source_ip"] == "127.0.0.1"
+        assert items[0]["user_agent"] is None
+
+    async def test_admin_sessions_404_unknown_user(self, client, admin_user):
+        headers = await self._admin_headers(client)
+        resp = await client.get(
+            "/api/v1/admin/users/no-such-user/sessions", headers=headers
+        )
+        assert resp.status_code == 404
+
+    async def test_admin_sessions_requires_admin(self, client, user):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
+        )
+        headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+        resp = await client.get(
+            f"/api/v1/admin/users/{user['id']}/sessions", headers=headers
+        )
+        assert resp.status_code == 403
+
+
 class TestGroupEndpoints:
     async def _admin_headers(self, client):
         resp = await client.post(

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -35,11 +35,11 @@ api_auth = sys.modules["klangk.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 93
+EXPECTED_ROUTE_COUNT = 94
 
-# Per-domain submodules and the number of routes each owns.  88 sub-routes
+# Per-domain submodules and the number of routes each owns.  89 sub-routes
 # + 3 routes defined directly on the main router (version, config,
-# my-permissions) + 2 on the root router (health, empty) == 93.
+# my-permissions) + 2 on the root router (health, empty) == 94.
 SUBMODULE_ROUTES = {
     "auth": 15,
     "oidc_auth": 2,
@@ -48,7 +48,7 @@ SUBMODULE_ROUTES = {
     "images": 4,
     "browser_delegate": 2,
     "chat": 1,
-    "admin": 29,
+    "admin": 30,
     "llm_proxy": 2,
 }
 
@@ -248,14 +248,14 @@ class TestSubmoduleStructure:
         )
 
     def test_submodule_route_counts_sum_to_subtotal(self):
-        """The 9 sub-routers together account for 88 of the 93 routes."""
+        """The 9 sub-routers together account for 89 of the 94 routes."""
         from importlib import import_module
 
         total = 0
         for submod in SUBMODULE_ROUTES:
             total += len(import_module(f"klangk.api.{submod}").router.routes)
         # 88 sub-routes + 3 direct (version/config/my-permissions) + 2
-        # root (health/empty) == 93.
+        # root (health/empty) == 94.
         assert total == EXPECTED_ROUTE_COUNT - 3 - 2
 
     def test_common_module_has_no_router(self):

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1455,7 +1455,10 @@ class TestConcurrentLogonAudit:
         await self._login()  # unknown workstation
         with caplog.at_level(logging.INFO, logger="klangk.auth"):
             await self._login(source_ip="203.0.113.7")
-        await self._login()  # unknown again, now concurrent with a known one
+            # Unknown again, now concurrent with a known one — inside the
+            # capture context so the no-record assertion actually observes
+            # this login too (review nit).
+            await self._login()
         assert not any(
             "concurrent logon" in r.getMessage() for r in caplog.records
         )

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1379,3 +1379,153 @@ class TestSessionLimit:
             result.user_id
         )
         assert len(rows) == 1
+
+
+class TestConcurrentLogonAudit:
+    """Audit records for concurrent logons from different workstations
+    (#2586). A workstation is the effective client IP a session was
+    established from; when a login is concurrent with an active session
+    from a different, known IP, an audit record is written to the
+    klangk.auth logger.
+    """
+
+    def _login_req(self):
+        return auth.LoginRequest(
+            identifier="testuser@example.com", password="testpass"
+        )
+
+    async def _login(self, source_ip=None, user_agent=None, env=None):
+        return await _auth(env).login(
+            self._login_req(),
+            source_ip=source_ip,
+            user_agent=user_agent,
+        )
+
+    async def test_session_row_records_workstation(self, user, app_state):
+        await self._login(source_ip="203.0.113.7", user_agent="klangk-cli/1.0")
+        rows = await app_state.state.model.sessions.list_sessions(user["id"])
+        assert len(rows) == 1
+        assert rows[0]["source_ip"] == "203.0.113.7"
+        assert rows[0]["user_agent"] == "klangk-cli/1.0"
+
+    async def test_workstation_defaults_to_unknown(self, user, app_state):
+        """Issuance without request info (tests, internal paths) records
+        NULL workstation columns — unknown, never 'different'."""
+        await self._login()
+        rows = await app_state.state.model.sessions.list_sessions(user["id"])
+        assert rows[0]["source_ip"] is None
+        assert rows[0]["user_agent"] is None
+
+    async def test_different_workstation_audited(
+        self, user, app_state, caplog
+    ):
+        """A login concurrent with an active session from another IP
+        generates an audit record naming both workstations."""
+        import logging
+
+        await self._login(source_ip="203.0.113.7")
+        with caplog.at_level(logging.INFO, logger="klangk.auth"):
+            await self._login(source_ip="198.51.100.9")
+        assert any(
+            "concurrent logon from different workstations" in r.getMessage()
+            and "203.0.113.7" in r.getMessage()
+            and "198.51.100.9" in r.getMessage()
+            for r in caplog.records
+        )
+
+    async def test_same_workstation_not_audited(self, user, app_state, caplog):
+        """Two sessions from the same IP (two browsers on one machine)
+        are concurrent but not from different workstations: no record."""
+        import logging
+
+        await self._login(source_ip="203.0.113.7", user_agent="ua-one")
+        with caplog.at_level(logging.INFO, logger="klangk.auth"):
+            await self._login(source_ip="203.0.113.7", user_agent="ua-two")
+        assert not any(
+            "concurrent logon" in r.getMessage() for r in caplog.records
+        )
+
+    async def test_unknown_workstation_not_audited(
+        self, user, app_state, caplog
+    ):
+        """A session with an unknown IP never compares as 'different':
+        neither direction (known→unknown nor unknown→known) audits."""
+        import logging
+
+        await self._login()  # unknown workstation
+        with caplog.at_level(logging.INFO, logger="klangk.auth"):
+            await self._login(source_ip="203.0.113.7")
+        await self._login()  # unknown again, now concurrent with a known one
+        assert not any(
+            "concurrent logon" in r.getMessage() for r in caplog.records
+        )
+
+    async def test_expired_other_workstation_not_audited(
+        self, user, app_state, caplog
+    ):
+        """Dead sessions are purged before the audit check, so a login
+        after another workstation's session expired generates nothing."""
+        import logging
+
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        await app_state.state.model.sessions.record_session(
+            user["id"], "jti-dead", past, source_ip="203.0.113.7"
+        )
+        with caplog.at_level(logging.INFO, logger="klangk.auth"):
+            await self._login(source_ip="198.51.100.9")
+        assert not any(
+            "concurrent logon" in r.getMessage() for r in caplog.records
+        )
+
+    async def test_audit_runs_before_session_limit_eviction(
+        self, user, app_state, caplog
+    ):
+        """A cap-evicting login is still audited: the other-workstation
+        session it is about to revoke was concurrent at logon time."""
+        import logging
+
+        env = {"KLANGKD_MAX_SESSIONS_PER_USER": "1"}
+        await self._login(source_ip="203.0.113.7", env=env)
+        with caplog.at_level(logging.INFO, logger="klangk.auth"):
+            await self._login(source_ip="198.51.100.9", env=env)
+        assert any(
+            "concurrent logon from different workstations" in r.getMessage()
+            for r in caplog.records
+        )
+
+    async def test_register_records_workstation_refresh_keeps_it(
+        self, user, app_state, caplog
+    ):
+        """The verified-register path records the workstation on its
+        session row, and a token refresh (the same session continuing)
+        neither audits nor rewrites the workstation columns."""
+        import logging
+
+        result = await _auth().register(
+            auth.RegisterRequest(
+                email="fresh@example.com", password="longenough1"
+            ),
+            verified=True,
+            source_ip="198.51.100.9",
+            user_agent="ua-register",
+        )
+        rows = await app_state.state.model.sessions.list_sessions(
+            result.user_id
+        )
+        assert rows[0]["source_ip"] == "198.51.100.9"
+        assert rows[0]["user_agent"] == "ua-register"
+
+        # Refresh continues a session; it is not a new logon (no audit
+        # record) and the row keeps the logon-time workstation identity.
+        with caplog.at_level(logging.INFO, logger="klangk.auth"):
+            refreshed = await _auth().refresh_token(result.access_token)
+        assert not any(
+            "concurrent logon" in r.getMessage() for r in caplog.records
+        )
+        rows = await app_state.state.model.sessions.list_sessions(
+            result.user_id
+        )
+        new_jti = _auth().decode_token(refreshed.access_token)["jti"]
+        assert [r["jti"] for r in rows] == [new_jti]
+        assert rows[0]["source_ip"] == "198.51.100.9"
+        assert rows[0]["user_agent"] == "ua-register"

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -2,8 +2,8 @@
 
 Covers the runner contract (fresh DB, replay no-op, failure semantics,
 validation), migration 0001's shape (password_history + cascade),
-0002's (users.last_login_at), and 0003's (user_sessions + cascade,
-#2585).
+0002's (users.last_login_at), 0003's (user_sessions + cascade,
+#2585), and 0004's (workstation columns on user_sessions, #2586).
 """
 
 import aiosqlite
@@ -46,6 +46,7 @@ class TestRunner:
             (1, "0001_password_history"),
             (2, "0002_last_login_at"),
             (3, "0003_user_sessions"),
+            (4, "0004_user_sessions_workstation"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -61,8 +62,12 @@ class TestRunner:
             info = await db.execute("PRAGMA table_info(users)")
             cols = {r[1] for r in await info.fetchall()}
             assert "last_login_at" in cols
+            # Migration 0004 added the workstation columns (#2586).
+            info = await db.execute("PRAGMA table_info(user_sessions)")
+            cols = {r[1] for r in await info.fetchall()}
+            assert {"source_ip", "user_agent"} <= cols
 
-            # Re-run: nothing new applied, still exactly three records.
+            # Re-run: nothing new applied, still exactly four records.
             await app_state.state.model.init_db()
             assert await _recorded(db) == expected
 
@@ -96,6 +101,7 @@ class TestRunner:
                 (1, "0001_password_history"),
                 (2, "0002_last_login_at"),
                 (3, "0003_user_sessions"),
+                (4, "0004_user_sessions_workstation"),
             ]
 
     async def test_pending_only(self, tmp_path):
@@ -270,6 +276,41 @@ class TestValidation:
         migrations_mod._validate_migrations(
             [Migration(1, "a", None), Migration(2, "b", None)]  # noqa: ARG005
         )
+
+
+class TestUserSessionsWorkstation:
+    async def test_upgrade_from_0003_schema_adds_columns(
+        self, temp_data_dir, app_state
+    ):
+        """A database last booted on #2585's schema (user_sessions without
+        workstation columns) gets them added by migration 0004, and the
+        pre-existing rows read back with an unknown (NULL) workstation.
+        """
+        from _helpers import get_test_db
+
+        db_path = get_test_db().db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        async with aiosqlite.connect(str(db_path)) as db:
+            await db.execute("""
+                CREATE TABLE user_sessions (
+                    jti TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    expires_at TEXT NOT NULL
+                )
+            """)
+            await db.execute(
+                "INSERT INTO user_sessions (jti, user_id, expires_at)"
+                " VALUES ('jti-old', ?, '2099-01-01T00:00:00+00:00')",
+                ("user-x",),
+            )
+            await db.commit()
+
+        await app_state.state.model.init_db()
+        rows = await app_state.state.db.fetchall(
+            "SELECT jti, source_ip, user_agent FROM user_sessions"
+        )
+        assert [(r[0], r[1], r[2]) for r in rows] == [("jti-old", None, None)]
 
 
 class TestPasswordHistory:

--- a/src/klangk/klangkd-tests/tests/test_util.py
+++ b/src/klangk/klangkd-tests/tests/test_util.py
@@ -693,6 +693,25 @@ class TestEffectiveClientIp:
         h = self._hdr(**{"x-real-ip": "203.0.113.7"})
         assert u.effective_client_ip(h, "10.89.0.5") == "10.89.0.5"
 
+    def test_garbage_forwarded_value_falls_back_to_peer(self):
+        """A trusted peer forwarding a non-IP value (garbage, or an
+        append-style XFF chain where the leftmost hop is client-
+        controlled text) must not become a workstation identity: the
+        resolver falls back to the peer (#2586 review)."""
+        u = _util({})
+        for garbage in ("not-an-ip", "1.2.3.4, 5.6.7.8, evil"):
+            h = self._hdr(**{"x-real-ip": garbage})
+            assert u.effective_client_ip(h, "127.0.0.1") == "127.0.0.1"
+        h = self._hdr(**{"x-forwarded-for": "definitely-not-an-ip"})
+        assert u.effective_client_ip(h, "127.0.0.1") == "127.0.0.1"
+
+    def test_result_is_canonicalized(self):
+        """The returned address is str()-normalized, so the same IPv6
+        host written two ways compares as one workstation."""
+        u = _util({})
+        h = self._hdr(**{"x-real-ip": "0:0:0:0:0:0:0:1"})
+        assert u.effective_client_ip(h, "127.0.0.1") == "::1"
+
     def test_reject_proxy_headers_forces_peer_only(self):
         u = _util({"KLANGKD_REJECT_PROXY_HEADERS": "1"})
         h = self._hdr(**{"x-real-ip": "203.0.113.7"})

--- a/src/klangk/klangkd-tests/tests/test_util.py
+++ b/src/klangk/klangkd-tests/tests/test_util.py
@@ -663,6 +663,54 @@ class TestDeriveHostingInfo:
         assert b == ""
 
 
+# --- effective_client_ip (#2586: workstation identity for the ---
+# --- session registry) ---
+# Same proxy-trust gate as client_is_loopback: forwarded headers count
+# only behind a trusted peer, so a workstation identity cannot be spoofed
+# by a direct caller.
+
+
+class TestEffectiveClientIp:
+    def _hdr(self, **kw):
+        return kw
+
+    def test_direct_peer_is_the_client(self):
+        u = _util({})
+        assert u.effective_client_ip(self._hdr(), "10.89.0.5") == "10.89.0.5"
+
+    def test_real_ip_behind_trusted_proxy(self):
+        u = _util({})
+        h = self._hdr(**{"x-real-ip": "203.0.113.7"})
+        assert u.effective_client_ip(h, "127.0.0.1") == "203.0.113.7"
+
+    def test_forwarded_for_first_hop(self):
+        u = _util({})
+        h = self._hdr(**{"x-forwarded-for": "203.0.113.7, 10.0.0.1"})
+        assert u.effective_client_ip(h, "127.0.0.1") == "203.0.113.7"
+
+    def test_spoofed_header_from_untrusted_peer_ignored(self):
+        u = _util({})
+        h = self._hdr(**{"x-real-ip": "203.0.113.7"})
+        assert u.effective_client_ip(h, "10.89.0.5") == "10.89.0.5"
+
+    def test_reject_proxy_headers_forces_peer_only(self):
+        u = _util({"KLANGKD_REJECT_PROXY_HEADERS": "1"})
+        h = self._hdr(**{"x-real-ip": "203.0.113.7"})
+        assert u.effective_client_ip(h, "127.0.0.1") == "127.0.0.1"
+
+    def test_no_client_is_none(self):
+        u = _util({})
+        assert u.effective_client_ip(self._hdr(), None) is None
+
+    def test_uds_mode_none_peer_still_resolves_via_headers(self):
+        """Over a UDS the None peer is the trusted proxy hop, so its
+        X-Real-IP resolves the real workstation."""
+        u = _util({})
+        u.set_uds_mode(True)
+        h = self._hdr(**{"x-real-ip": "203.0.113.7"})
+        assert u.effective_client_ip(h, None) == "203.0.113.7"
+
+
 # --- client_is_loopback (moved from test_wshandler.py, #1503) ---
 # Powers the none-mode /auth/local self-defense (#1374). Must admit a real
 # loopback browser, admit a request proxied by the proxy (peer loopback, real


### PR DESCRIPTION
Closes #2586.

## What

Audit records for concurrent logons from different workstations, built
on the `user_sessions` registry from #2585.

- **Migration 0004** adds nullable `source_ip` / `user_agent` columns
  to `user_sessions` (NULL = unknown workstation — never reported as
  "different").
- **Every issuance path records the workstation** the session was
  established from: password login, registration, verification,
  password-reset auto-login, invite acceptance, OIDC callback, and
  `none`-mode local login. The IP is the *effective* client address,
  resolved by the new `Util.effective_client_ip` — proxy-trust-aware
  (`X-Real-IP` / `X-Forwarded-For` honored only behind a trusted
  peer), extracted from the existing `client_is_loopback` logic so the
  two cannot drift. Refresh keeps the logon-time identity (a refresh
  is the same session continuing).
- **`Auth._audit_concurrent_logons`** fires on every issuance: when
  the logon is concurrent with an active session from a different,
  known workstation, it writes
  `audit: concurrent logon from different workstations: user=… email=… new session from A; concurrent with session(s) from B`
  to the server log. Runs **before** session-cap enforcement so a
  cap-evicting login is still audited (that eviction is exactly the
  event of interest). Expired rows are purged first; unknown IPs
  never compare as different; same-IP second logins (two browsers on
  one machine) never audit.
- **`GET /api/v1/admin/users/{id}/sessions`** (admin permission) —
  the queryable half: a user's unexpired sessions, oldest first, with
  `created_at`, `expires_at`, `source_ip`, `user_agent`.

## Proxy-chain dependency + docs

The audit silently degrades if the proxy chain does not preserve the
real client IP: every session then records the proxy's address, all
logins look like one workstation, and no records are ever written.
`docs/deployment/behind-a-proxy.md` gains a section covering the
failure mode, the consequences of too little trust (empty audit trail,
missed events unrecoverable) and too much trust (forgeable audit
trail), plus a step-by-step verification checklist.
`trusted-proxy-cidrs`'s breakage list gains the audit as item 4.

## Tests

- Unit: audit fire/no-fire matrix (different / same / unknown /
  expired / pre-eviction workstations), workstation recording and
  refresh-keeps-it, migration 0004 (fresh + upgrade from the 0003
  shape), `effective_client_ip` (incl. spoof + UDS), API endpoint
  (admin list, ordering, 404, 403, login threading). Route-parity
  counts updated (93 → 94).
- E2E: `test_concurrent_logon_audit_e2e.py` drives a real klangkd over
  its UDS with two simulated workstations (`X-Real-IP`) — audit record
  in the server log, no record for same-workstation, admin query,
  non-admin 403.

Full unit suite (CI invocation): 5184 passed, 100% coverage.
