### PR TITLE
fix(e2e): de-flake autostart create timeout + sidecar teardown hang

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -993,7 +993,12 @@ class TestAutoStartWithServiceCommand:
 
     @pytest.fixture()
     def api(self):
-        with httpx_client(self._server, timeout=10.0) as client:
+        # POST /workspaces with auto_start=true synchronously awaits the
+        # eager container start (api/workspaces.py eager-start block, #1244),
+        # so the response time includes full container bring-up. 10 s was too
+        # tight on loaded CI runners (#2616); this class only keeps the strict
+        # 10 s default everywhere else.
+        with httpx_client(self._server, timeout=120.0) as client:
             yield client
 
     @pytest.fixture()

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -217,6 +217,63 @@ def _podman(*args, check=True, timeout=120):
     )
 
 
+def _podman_exists(kind, name):
+    """Exit-code probe: is the podman object still there?"""
+    try:
+        return (
+            _podman(kind, "exists", name, check=False, timeout=10).returncode
+            == 0
+        )
+    except subprocess.TimeoutExpired:
+        # Probe itself wedged: assume present so the caller keeps trying.
+        return True
+
+
+def _podman_cleanup(kind, *targets, attempts=3, timeout=10):
+    """Best-effort teardown: state-checked, sleep-free (#2616).
+
+    Fixed sleeps are this suite's main source of flakes, so none remain
+    here, including podman's own:
+
+    - ``rm -f -t 0``: podman's default stop sequence SIGTERMs the container
+      and waits up to 10 s before SIGKILL. ``-t 0`` goes straight to
+      SIGKILL, removing that hidden fixed wait from every teardown.
+    - A wedged invocation is killed by the subprocess timeout and retried
+      immediately — a fresh podman start carries its own latency, which is
+      all the spacing a retry needs.
+    - Progress is measured against actual state, not the clock: after each
+      attempt ``podman <kind> exists`` decides whether to try again.
+
+    A target that survives every attempt only warns: all teardown names
+    here are uuid-suffixed, so leftovers cannot collide with later runs,
+    and the CI VM is ephemeral. Worst case is attempts x timeout per
+    target, so even a multi-container teardown stays well under the 300 s
+    per-test timeout stamp.
+    """
+    verb = {
+        "container": ("rm", "-f", "-t", "0"),
+        "network": ("network", "rm"),
+        "image": ("rmi", "-f"),
+    }[kind]
+    for target in targets:
+        for attempt in range(1, attempts + 1):
+            try:
+                _podman(*verb, target, check=False, timeout=timeout)
+            except subprocess.TimeoutExpired:
+                print(
+                    f"podman {' '.join(verb)} {target} timed out after "
+                    f"{timeout}s (attempt {attempt}/{attempts})"
+                )
+            if not _podman_exists(kind, target):
+                break
+        else:
+            print(
+                f"WARNING: podman {' '.join(verb)} {target} still present "
+                f"after {attempts} attempts; leaving it (uuid-suffixed "
+                "leftover, ephemeral CI VM)"
+            )
+
+
 def _require_platform():
     if shutil.which("podman") is None:
         pytest.skip("podman not on PATH")
@@ -279,7 +336,7 @@ def env():
         "ws_query": wq,
         "somark_probe": sm,
     }
-    _podman("rmi", "-f", tag, check=False, timeout=60)
+    _podman_cleanup("image", tag, timeout=30)
     shutil.rmtree(tmp, ignore_errors=True)
     shutil.rmtree(wheel_dir, ignore_errors=True)
 
@@ -388,9 +445,8 @@ def stack(env):
         _wait_ready(nc)
         yield upstream_ip, nc
     finally:
-        for c in (nc, fu):
-            _podman("rm", "-f", c, check=False, timeout=60)
-        _podman("network", "rm", net, check=False, timeout=60)
+        _podman_cleanup("container", nc, fu)
+        _podman_cleanup("network", net)
 
 
 def _query(env, stack, name, server=None):
@@ -592,8 +648,8 @@ class TestNetworkSidecarE2E:
                 f"{_podman('logs', nc, check=False).stdout}"
             )
         finally:
-            _podman("rm", "-f", nc, check=False, timeout=60)
-            _podman("network", "rm", net, check=False, timeout=60)
+            _podman_cleanup("container", nc)
+            _podman_cleanup("network", net)
 
     def test_somark_bypass_blocked_under_production_userns(self, env, stack):
         # Review #1 of the egress stack: a filtered workspace launches in its
@@ -721,8 +777,8 @@ class TestNetworkSidecarE2E:
                 f"workspace's host ports (#2267)."
             )
         finally:
-            _podman("rm", "-f", ws, nc, check=False, timeout=60)
-            _podman("network", "rm", net, check=False, timeout=60)
+            _podman_cleanup("container", ws, nc)
+            _podman_cleanup("network", net)
 
 
 # ---------------------------------------------------------------------------
@@ -919,9 +975,8 @@ def consent_stack(env):
             "image": env["image"],
         }
     finally:
-        for c in (nc, ver_c, fu_c):
-            _podman("rm", "-f", c, check=False, timeout=60)
-        _podman("network", "rm", net, check=False, timeout=60)
+        _podman_cleanup("container", nc, ver_c, fu_c)
+        _podman_cleanup("network", net)
         shutil.rmtree(tmp, ignore_errors=True)
 
 
@@ -959,4 +1014,4 @@ class TestConsentConcurrentFlows:
             _wait_log(stub, "EGRESS repoze.test", timeout=30)
             _wait_log(stub, "EGRESS ford.test", timeout=30)
         finally:
-            _podman("rm", "-f", trig_c, check=False, timeout=60)
+            _podman_cleanup("container", trig_c)


### PR DESCRIPTION
## Summary

Fixes #2616 — both flakes from the `test-backend-e2e` run on PR #2615.

### Flake 1: `TestAutoStartWithServiceCommand::test_create_with_auto_start_and_service_command` — `httpx.ReadTimeout`

`POST /workspaces` with `auto_start: true` synchronously awaits the eager container start (api/workspaces.py, #1244), so response time includes full container bring-up. The class's `api` fixture used a 10 s read timeout — too tight on loaded CI runners. Raised to 120 s **for that class only**; the strict 10 s default stays everywhere else, so real deadlock regressions elsewhere still fail fast.

### Flake 2: `TestNetworkSidecarE2E::test_allowed_domain_resolves` — teardown ERROR, `podman rm -f netc-fu-*` timed out after 60 s

Single-shot teardown `podman` calls are replaced by a state-checked, **sleep-free** cleanup helper (`_podman_cleanup`), used at every `rm` / `rmi` / `network rm` call site in the suite:

- **`rm -f -t 0`** — podman's `--time` defaults to a 10 s SIGTERM-grace wait before SIGKILL; `-t 0` removes that hidden fixed wait from every teardown (the actual source of most "hangs").
- **No `time.sleep` between retries** — a wedged invocation is killed by the short subprocess timeout and a fresh podman process retried immediately; podman's own startup latency is all the spacing a retry needs.
- **Progress measured against actual state, not the clock** — `podman <kind> exists` decides whether another attempt is needed.
- **Exhausted attempts warn instead of erroring** — all teardown names are uuid-suffixed so leftovers cannot collide with later runs, and the CI VM is ephemeral.

Smoke-tested against real podman 5.8.6: running container removed in 0.28 s, idempotent re-run, network removal OK.

## Testing

- `test-backend`: 5163 passed, 100% coverage.
- E2E suites left to CI per repo policy.
