### PR TITLE
feat(auth): gate resend-verification credential check on login lockout (#2618)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,11 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Login timing equalization (#2618).** Login and resend-verification
+  now burn one full password verify even when the account is unknown or
+  OIDC-only, so response timing no longer reveals whether an account
+  exists.
+
 - **OIDC state cookie hardening (#2573).** The OIDC callback no longer
   trusts the `redirect_uri` stored in the unsigned state cookie when
   exchanging the authorization code with the IdP; it now re-derives the
@@ -63,6 +68,12 @@ operators or integrators to act when upgrading.
   the web flow.
 
 ### Added
+
+- **Resend-verification lockout (#2618).** Failed password checks on
+  `POST /auth/resend-verification` now count toward the login lockout
+  (`KLANGKD_LOGIN_LOCKOUT_*`), keyed like login on the account's email.
+  A locked-out account gets `429` there too; a correct check clears the
+  counter. The 60s per-email resend cooldown is unchanged.
 
 - **Last successful login time (#2583).** Every login (password,
   SSO, no-auth, and the auto-login after register/verify/reset/invite

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -72,8 +72,9 @@ operators or integrators to act when upgrading.
 - **Resend-verification lockout (#2618).** Failed password checks on
   `POST /auth/resend-verification` now count toward the login lockout
   (`KLANGKD_LOGIN_LOCKOUT_*`), keyed like login on the account's email.
-  A locked-out account gets `429` there too; a correct check clears the
-  counter. The 60s per-email resend cooldown is unchanged.
+  A locked-out account gets `429` there too; a correct check on an
+  unverified account clears the counter, matching login semantics.
+  The 60s per-email resend cooldown is unchanged.
 
 - **Last successful login time (#2583).** Every login (password,
   SSO, no-auth, and the auto-login after register/verify/reset/invite

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -106,8 +106,13 @@ returned to your original URL after logging in.
 ## Brute-force protection
 
 By default, Klangk locks accounts after repeated failed login
-attempts (5 failures within the counting window). To tune or
-disable it, set:
+attempts (5 failures within the counting window). The same lockout
+covers the credential check on `POST /auth/resend-verification` —
+failed password guesses there count against the account's login
+counter, and a locked-out account cannot use it either. Failed
+credential checks cost the same whether or not the account exists,
+so response timing cannot be used to enumerate accounts. To tune or
+disable the lockout, set:
 
 | Variable                         | Default | Description                              |
 | -------------------------------- | ------- | ---------------------------------------- |

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -218,10 +218,12 @@ async def resend_verification(
     # account. Both verify against the dummy hash so the failure path
     # costs one full password verify either way — response timing
     # cannot enumerate accounts (#2618). Authorization still requires
-    # a real hash to have matched.
-    password_hash = (
-        user.get("password_hash") if user else None
-    ) or auth.dummy_verify_hash()
+    # a real hash to have matched. The dummy hash is minted off the
+    # event loop too — the one-time PBKDF2 cost must never block
+    # request handling (functools.cache makes later calls free).
+    password_hash = (user.get("password_hash") if user else None) or (
+        await asyncio.to_thread(auth.dummy_verify_hash)
+    )
     password_ok = await asyncio.to_thread(
         auth.verify_password, req.password, password_hash
     )

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -206,18 +206,31 @@ async def resend_verification(
 ):
     """Resend verification email. Requires email+password to prevent abuse."""
     user = await app.state.model.users.get_user_by_email(req.email)
-    # OIDC-only users have no password hash; treat that as invalid
-    # credentials rather than letting verify_password crash on None.
-    if (
-        user is None
-        or not user.get("password_hash")
-        or not await asyncio.to_thread(
-            auth.verify_password, req.password, user["password_hash"]
-        )
-    ):
+    # Same lockout accounting as login (#2618): key on the resolved
+    # user's canonical email (raw input for unknown addresses), check
+    # before the expensive verify, and record failures on a bad
+    # password. Without this the endpoint accepted unlimited password
+    # guesses — the 60s cooldown below only bounds email sending and
+    # only applies after the check succeeds.
+    lockout_key = user["email"] if user else req.email
+    attempt_info = await app.state.auth.check_login_lockout(lockout_key)
+    # OIDC-only users have no password hash; unknown users have no
+    # account. Both verify against the dummy hash so the failure path
+    # costs one full password verify either way — response timing
+    # cannot enumerate accounts (#2618). Authorization still requires
+    # a real hash to have matched.
+    password_hash = (
+        user.get("password_hash") if user else None
+    ) or auth.dummy_verify_hash()
+    password_ok = await asyncio.to_thread(
+        auth.verify_password, req.password, password_hash
+    )
+    if user is None or not user.get("password_hash") or not password_ok:
+        await app.state.auth.record_login_failure(lockout_key, attempt_info)
         raise HTTPException(status_code=401, detail="Invalid credentials")
     if user.get("verified"):
         raise HTTPException(status_code=400, detail="Account already verified")
+    await app.state.auth.clear_login_failures(lockout_key)
 
     # Rate limit: one resend per email per minute
     now = time.time()

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -10,6 +10,7 @@ dependency callables (``get_current_user`` etc.) stay module-level.
 
 import asyncio
 import base64
+import functools
 import hashlib
 import hmac
 import logging
@@ -164,6 +165,18 @@ def verify_password(password: str, hashed: str) -> bool:
         return False
     digest = hashlib.pbkdf2_hmac("sha512", encoded, salt, iterations)
     return hmac.compare_digest(digest, expected)
+
+
+# Equalizes the cost of failing on an unknown (or OIDC-only) account with
+# failing on a wrong password: login and resend-verification verify against
+# this hash when there is no real one, so both paths burn one full password
+# verify and response timing cannot enumerate accounts (#2618). The
+# preimage is random per process, so no submitted password can ever match
+# it — a match is still treated as invalid credentials by the callers.
+# Computed lazily (and once) so importing the module costs no PBKDF2 work.
+@functools.cache
+def dummy_verify_hash() -> str:
+    return hash_password(secrets.token_urlsafe(32))
 
 
 class RegisterRequest(BaseModel):
@@ -465,6 +478,67 @@ class Auth:
         return (
             datetime.now(timezone.utc) - first_dt
         ).total_seconds() > self.login_lockout_window
+
+    # --- lockout accounting (shared by login and resend-verification) ---
+
+    async def check_login_lockout(self, lockout_key: str) -> dict | None:
+        """Raise 429 if *lockout_key* is currently locked out.
+
+        Returns the pre-verify ``attempt_info`` (``None`` when lockout
+        is disabled) for the caller to hand to
+        :meth:`record_login_failure`, which needs it to apply the
+        sliding-window reset.
+        """
+        if self.login_lockout_failures <= 0:
+            return None
+        attempt_info = (
+            await self.app.state.model.login_attempts.get_login_attempt_info(
+                lockout_key
+            )
+        )
+        is_locked, msg = is_locked_out(attempt_info)
+        if is_locked:
+            raise HTTPException(status_code=429, detail=msg)
+        return attempt_info
+
+    async def record_login_failure(
+        self, lockout_key: str, attempt_info: dict | None
+    ) -> None:
+        """Record a failed credential check against *lockout_key*.
+
+        Applies the sliding-window reset (old failures stop counting
+        toward the threshold) and raises 429 when this failure is the
+        one that triggers the lockout.
+        """
+        if self.login_lockout_failures <= 0:
+            return
+        reset = self.window_elapsed(attempt_info)
+        await self.app.state.model.login_attempts.record_failed_login(
+            lockout_key, reset=reset
+        )
+        updated_info = (
+            await self.app.state.model.login_attempts.get_login_attempt_info(
+                lockout_key
+            )
+        )
+        if self.should_lockout(updated_info):
+            locked_until = datetime.now(timezone.utc) + timedelta(
+                seconds=self.login_lockout_duration
+            )
+            await self.app.state.model.login_attempts.set_login_lockout(
+                lockout_key, locked_until.isoformat()
+            )
+            raise HTTPException(
+                status_code=429,
+                detail=f"Too many failed attempts. Locked out for {self.login_lockout_duration // 60} minutes.",
+            )
+
+    async def clear_login_failures(self, lockout_key: str) -> None:
+        """Clear failure counters after a successful credential check."""
+        if self.login_lockout_failures > 0:
+            await self.app.state.model.login_attempts.clear_login_attempts(
+                lockout_key
+            )
 
     # --- access tokens ---
 
@@ -778,49 +852,21 @@ class Auth:
         # Check if locked out before doing any expensive work (the only
         # expensive step below is verify_password's PBKDF2, run in a
         # worker thread so the event loop is not blocked).
-        if self.login_lockout_failures > 0:
-            attempt_info = await self.app.state.model.login_attempts.get_login_attempt_info(
-                lockout_key
-            )
-            is_locked, msg = is_locked_out(attempt_info)
-            if is_locked:
-                raise HTTPException(status_code=429, detail=msg)
+        attempt_info = await self.check_login_lockout(lockout_key)
 
-        # OIDC-only users have no password hash; treat that as invalid
-        # credentials rather than letting verify_password crash on None.
-        if (
-            user is None
-            or not user.get("password_hash")
-            or not await asyncio.to_thread(
-                verify_password, req.password, user["password_hash"]
-            )
-        ):
-            if self.login_lockout_failures > 0:
-                # Reuse the attempt_info fetched up front for the lockout
-                # check to decide whether the sliding window has elapsed —
-                # if so, reset the count instead of incrementing, so old
-                # failures stop counting toward the threshold.
-                reset = self.window_elapsed(attempt_info)
-                await self.app.state.model.login_attempts.record_failed_login(
-                    lockout_key, reset=reset
-                )
-                # Check if this attempt triggered a lockout
-                updated_info = await self.app.state.model.login_attempts.get_login_attempt_info(
-                    lockout_key
-                )
-                if self.should_lockout(updated_info):
-                    locked_until = datetime.now(timezone.utc) + timedelta(
-                        seconds=self.login_lockout_duration
-                    )
-                    await (
-                        self.app.state.model.login_attempts.set_login_lockout(
-                            lockout_key, locked_until.isoformat()
-                        )
-                    )
-                    raise HTTPException(
-                        status_code=429,
-                        detail=f"Too many failed attempts. Locked out for {self.login_lockout_duration // 60} minutes.",
-                    )
+        # OIDC-only users have no password hash; unknown users have no
+        # account. Both verify against the dummy hash so the failure
+        # path costs one full password verify either way — response
+        # timing cannot enumerate accounts (#2618). Authorization
+        # still requires a real hash to have matched.
+        password_hash = (
+            user.get("password_hash") if user else None
+        ) or dummy_verify_hash()
+        password_ok = await asyncio.to_thread(
+            verify_password, req.password, password_hash
+        )
+        if user is None or not user.get("password_hash") or not password_ok:
+            await self.record_login_failure(lockout_key, attempt_info)
             raise HTTPException(status_code=401, detail="Invalid credentials")
         if not user.get("verified"):
             raise HTTPException(
@@ -828,10 +874,7 @@ class Auth:
                 detail="Account not verified. Check your email.",
             )
 
-        if self.login_lockout_failures > 0:
-            await self.app.state.model.login_attempts.clear_login_attempts(
-                lockout_key
-            )
+        await self.clear_login_failures(lockout_key)
         token = await self.issue_token(
             user["id"],
             user["email"],

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -44,6 +44,13 @@ MAX_PASSWORD_BYTES = 72
 # PBKDF2-HMAC-SHA512 recommendation (210k) for margin. Tests patch
 # ``PBKDF2_ITERATIONS`` down for suite speed; the stored format embeds the
 # iteration count, so hashes made under any value still verify.
+#
+# Timing-equalization coupling (#2618): ``dummy_verify_hash`` embeds the
+# *current* value while stored hashes keep their creation-time count.
+# Raising this constant therefore re-opens a small per-login timing gap
+# for accounts hashed under the old count (their verifies stay cheaper
+# than the dummy's until their password next changes). Re-baseline the
+# dummy when bumping, or accept the gap for pre-bump accounts.
 PBKDF2_ITERATIONS = 600_000
 _HASH_SCHEME = "pbkdf2_sha512"
 _SALT_BYTES = 16
@@ -174,6 +181,13 @@ def verify_password(password: str, hashed: str) -> bool:
 # preimage is random per process, so no submitted password can ever match
 # it — a match is still treated as invalid credentials by the callers.
 # Computed lazily (and once) so importing the module costs no PBKDF2 work.
+#
+# Residual gap, accepted: a stored hash that is malformed or not the
+# current scheme makes ``verify_password`` return False *before* any
+# PBKDF2 work, so such an account fails faster than an unknown one. All
+# deployments store current-scheme hashes (there are no legacy bcrypt
+# rows), so the gap is unreachable today; see the note at
+# ``PBKDF2_ITERATIONS`` for the bump-time coupling.
 @functools.cache
 def dummy_verify_hash() -> str:
     return hash_password(secrets.token_urlsafe(32))
@@ -858,10 +872,13 @@ class Auth:
         # account. Both verify against the dummy hash so the failure
         # path costs one full password verify either way — response
         # timing cannot enumerate accounts (#2618). Authorization
-        # still requires a real hash to have matched.
-        password_hash = (
-            user.get("password_hash") if user else None
-        ) or dummy_verify_hash()
+        # still requires a real hash to have matched. The dummy hash is
+        # minted off the event loop too — the one-time PBKDF2 cost must
+        # never block request handling (functools.cache makes later
+        # calls free).
+        password_hash = (user.get("password_hash") if user else None) or (
+            await asyncio.to_thread(dummy_verify_hash)
+        )
         password_ok = await asyncio.to_thread(
             verify_password, req.password, password_hash
         )

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1342,10 +1342,12 @@ class TestResendVerificationLockout:
         )
         assert resp.status_code == 429
 
-    async def test_unknown_email_also_rate_limited(self, client, db):
+    async def test_unknown_email_also_rate_limited(
+        self, client, db, app_state
+    ):
         """Guesses against a made-up address are counted under the raw
         input, so unknown accounts get the same lockout protection."""
-        failures = 5  # settings default (the client app has no app_state)
+        failures = app_state.state.settings.login_lockout_failures
         for i in range(failures):
             resp = await self._post(client, "ghost@example.com", "guess")
             assert resp.status_code == (401 if i < failures - 1 else 429)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1293,6 +1293,116 @@ class TestResendVerification:
         api.resend_timestamps.clear()
 
 
+class TestResendVerificationLockout:
+    """Failed credential checks against resend-verification count toward
+    the login lockout (#2618).
+
+    Without this the endpoint is an unthrottled password-guessing oracle:
+    the 60s per-email cooldown only bounds email sending, and only applies
+    after the credential check succeeds. Failures share the login counter
+    (keyed on the resolved user's canonical email, raw input for unknown
+    addresses)."""
+
+    async def _create_unverified_user(self, app_state):
+        password_hash = auth_mod.hash_password("testpass")
+        await app_state.state.model.users.create_user(
+            "unverified@example.com", password_hash, verified=False
+        )
+
+    async def _post(self, client, email, password):
+        return await client.post(
+            "/api/v1/auth/resend-verification",
+            json={"email": email, "password": password},
+        )
+
+    async def test_lockout_after_max_attempts(self, client, db, app_state):
+        """N-1 wrong passwords 401; the Nth triggers the 429 lockout, and
+        even the correct password is then rejected before the verify."""
+        await self._create_unverified_user(app_state)
+        failures = app_state.state.settings.login_lockout_failures
+        for i in range(failures):
+            resp = await self._post(client, "unverified@example.com", "wrong")
+            assert resp.status_code == (401 if i < failures - 1 else 429)
+        resp = await self._post(client, "unverified@example.com", "testpass")
+        assert resp.status_code == 429
+
+    async def test_lockout_shared_with_login(self, client, db, app_state):
+        """Resend failures key the same counter as login, so exhausting
+        the threshold via resend locks the account's login too."""
+        await self._create_unverified_user(app_state)
+        failures = app_state.state.settings.login_lockout_failures
+        for _ in range(failures):
+            await self._post(client, "unverified@example.com", "wrong")
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "unverified@example.com",
+                "password": "testpass",
+            },
+        )
+        assert resp.status_code == 429
+
+    async def test_unknown_email_also_rate_limited(self, client, db):
+        """Guesses against a made-up address are counted under the raw
+        input, so unknown accounts get the same lockout protection."""
+        failures = 5  # settings default (the client app has no app_state)
+        for i in range(failures):
+            resp = await self._post(client, "ghost@example.com", "guess")
+            assert resp.status_code == (401 if i < failures - 1 else 429)
+
+    async def test_success_clears_attempts(self, client, db, app_state):
+        """A correct credential check clears the counter, like a
+        successful login does."""
+        await self._create_unverified_user(app_state)
+        attempts = app_state.state.model.login_attempts
+        for _ in range(2):
+            await self._post(client, "unverified@example.com", "wrong")
+        info = await attempts.get_login_attempt_info("unverified@example.com")
+        assert info["attempt_count"] == 2
+        api.resend_timestamps.pop("unverified@example.com", None)
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_verification_email",
+            new_callable=AsyncMock,
+        ):
+            resp = await self._post(
+                client, "unverified@example.com", "testpass"
+            )
+        assert resp.status_code == 200
+        assert (
+            await attempts.get_login_attempt_info("unverified@example.com")
+            is None
+        )
+        api.resend_timestamps.pop("unverified@example.com", None)
+
+    async def test_window_reset_not_lockout(self, client, db, app_state):
+        """A near-threshold count whose first failure predates the window
+        resets instead of locking: old failures stop counting."""
+        from datetime import datetime, timedelta, timezone
+
+        await self._create_unverified_user(app_state)
+        old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        async with app_state.state.db.transaction() as raw_db:
+            await raw_db.execute(
+                "INSERT INTO login_attempts"
+                " (email, attempt_count, first_attempt_at)"
+                " VALUES (?, ?, ?)",
+                (
+                    "unverified@example.com",
+                    app_state.state.settings.login_lockout_failures - 1,
+                    old,
+                ),
+            )
+        resp = await self._post(client, "unverified@example.com", "wrong")
+        assert resp.status_code == 401  # reset, not 429
+        info = (
+            await app_state.state.model.login_attempts.get_login_attempt_info(
+                "unverified@example.com"
+            )
+        )
+        assert info["attempt_count"] == 1
+
+
 class TestForgotPassword:
     async def _create_user(self, app_state):
         password_hash = auth_mod.hash_password("oldpass")

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -698,7 +698,7 @@ class TestLoginRateLimit:
         assert auth.is_locked_out(no_lock) == (False, None)
         assert auth.is_locked_out(None) == (False, None)
 
-    async def test_login_lockout_disabled_when_zero(self, db):
+    async def test_login_lockout_disabled_when_zero(self, db, user):
         """With login_lockout_failures=0, no rate limiting occurs."""
         a = _auth({"KLANGKD_LOGIN_LOCKOUT_FAILURES": "0"})
         for _ in range(20):
@@ -709,6 +709,14 @@ class TestLoginRateLimit:
                     )
                 )
             assert exc_info.value.status_code == 401
+        # The success path's counter clear is a guarded no-op, not a
+        # crash, when lockout is disabled.
+        result = await a.login(
+            auth.LoginRequest(
+                identifier="testuser@example.com", password="testpass"
+            )
+        )
+        assert result.access_token
 
     async def test_login_nonexistent_user_also_rate_limited(self, db):
         """Nonexistent users are also rate-limited to prevent enumeration."""
@@ -723,6 +731,27 @@ class TestLoginRateLimit:
                 assert exc_info.value.status_code == 401
             else:
                 assert exc_info.value.status_code == 429
+
+    async def test_unknown_user_still_burns_a_verify(self, db, monkeypatch):
+        """The unknown-identifier path runs one full verify against the
+        dummy hash, so its response timing matches the wrong-password
+        path and accounts can't be enumerated by timing (#2618)."""
+        calls: list[str] = []
+        real = auth.verify_password
+
+        def counting(password, hashed):
+            calls.append(hashed)
+            return real(password, hashed)
+
+        monkeypatch.setattr(auth, "verify_password", counting)
+        with pytest.raises(HTTPException) as exc_info:
+            await _auth().login(
+                auth.LoginRequest(
+                    identifier="noone@example.com", password="guess"
+                )
+            )
+        assert exc_info.value.status_code == 401
+        assert calls == [auth.dummy_verify_hash()]
 
     async def test_login_clears_attempts(self, db, user, app_state):
         """Successful login clears failed attempt counts."""


### PR DESCRIPTION
Closes #2618.

## What

- **`POST /auth/resend-verification` now routes its email+password
  credential check through the login lockout machinery** (`Auth.check_login_lockout` /
  `record_login_failure` / `clear_login_failures`, extracted from
  `Auth.login` so both endpoints share one implementation). Keyed on the
  resolved user's canonical email (raw input for unknown addresses),
  checked before the expensive PBKDF2 verify; failures count toward
  `KLANGKD_LOGIN_LOCKOUT_*`, a locked-out account gets `429`, and a
  correct check clears the counter. The 60s per-email resend cooldown is
  unchanged — it bounds email sending, not guessing.
- **Account-enumeration timing gap closed** (secondary note in the issue):
  when the account is unknown or OIDC-only, login and
  resend-verification verify the submitted password against a per-process
  dummy hash (`dummy_verify_hash()`, lazily computed, random preimage), so
  both paths cost one full PBKDF2 verify end-to-end and response timing
  cannot reveal whether an account exists. Authorization still requires a
  real hash to have matched.

## Tests

- `TestResendVerificationLockout` (5): 429 after threshold (and stays 429
  with the right password), counter shared with login, unknown-email
  rate limit, success clears, window-reset-not-lockout.
- `test_unknown_user_still_burns_a_verify`: the unknown-identifier path
  performs exactly one verify against the dummy hash.
- Disabled-lockout (`0`) path now also covers the clear no-op.

Full suite: 5197 passed, 100% coverage.
