### PR TITLE
refactor(model): use DB.fetchall instead of per-callsite transaction boilerplate (#2609)

### DIFF
--- a/src/klangk/klangk/model/acl.py
+++ b/src/klangk/klangk/model/acl.py
@@ -95,15 +95,14 @@ class ACLModel:
 
     async def get_acl_entries(self, resource: str) -> list[dict]:
         """Get ACL entries for a resource, ordered by position."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT id, resource, position, action, principal_type,"
-                " user_id, group_id, system_principal, permission"
-                " FROM acl_entries WHERE resource = ?"
-                " ORDER BY position",
-                (resource,),
-            )
-            return [row_to_acl_entry(row) for row in await cursor.fetchall()]
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            " FROM acl_entries WHERE resource = ?"
+            " ORDER BY position",
+            (resource,),
+        )
+        return [row_to_acl_entry(row) for row in rows]
 
     async def get_acl_entries_map(
         self,
@@ -122,62 +121,58 @@ class ACLModel:
         if not resources:
             return result
         placeholders = ",".join("?" for _ in resources)
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT id, resource, position, action, principal_type,"
-                " user_id, group_id, system_principal, permission"
-                " FROM acl_entries WHERE resource IN"
-                f" ({placeholders}) ORDER BY position",
-                tuple(resources),
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            " FROM acl_entries WHERE resource IN"
+            f" ({placeholders}) ORDER BY position",
+            tuple(resources),
+        )
+        for row in rows:
+            result.setdefault(row["resource"], []).append(
+                row_to_acl_entry(row)
             )
-            for row in await cursor.fetchall():
-                result.setdefault(row["resource"], []).append(
-                    row_to_acl_entry(row)
-                )
         return result
 
     async def get_acl_entries_resolved(self, resource: str) -> list[dict]:
         """Get ACL entries with resolved principal names."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT ae.id, ae.resource, ae.position, ae.action,"
-                " ae.principal_type, ae.user_id, ae.group_id,"
-                " ae.system_principal, ae.permission,"
-                " u.email AS user_email, g.name AS group_name"
-                " FROM acl_entries ae"
-                " LEFT JOIN users u ON ae.user_id = u.id"
-                " LEFT JOIN groups g ON ae.group_id = g.id"
-                " WHERE ae.resource = ?"
-                " ORDER BY ae.position",
-                (resource,),
-            )
-            results = []
-            for row in await cursor.fetchall():
-                entry = {
-                    "id": row["id"],
-                    "resource": row["resource"],
-                    "position": row["position"],
-                    "action": row["action"],
-                    "principal_type": row["principal_type"],
-                    "permission": row["permission"],
-                }
-                pt = row["principal_type"]
-                if pt == PRINCIPAL_SYSTEM:
-                    sp = row["system_principal"]
-                    entry["principal"] = (
-                        "Everyone"
-                        if sp == SYSTEM_EVERYONE
-                        else "Authenticated"
-                    )
-                    entry["system_principal"] = sp
-                elif pt == PRINCIPAL_USER:
-                    entry["principal"] = row["user_email"] or row["user_id"]
-                    entry["user_id"] = row["user_id"]
-                elif pt == PRINCIPAL_GROUP:
-                    entry["principal"] = row["group_name"] or row["group_id"]
-                    entry["group_id"] = row["group_id"]
-                results.append(entry)
-            return results
+        rows = await self.app.state.db.fetchall(
+            "SELECT ae.id, ae.resource, ae.position, ae.action,"
+            " ae.principal_type, ae.user_id, ae.group_id,"
+            " ae.system_principal, ae.permission,"
+            " u.email AS user_email, g.name AS group_name"
+            " FROM acl_entries ae"
+            " LEFT JOIN users u ON ae.user_id = u.id"
+            " LEFT JOIN groups g ON ae.group_id = g.id"
+            " WHERE ae.resource = ?"
+            " ORDER BY ae.position",
+            (resource,),
+        )
+        results = []
+        for row in rows:
+            entry = {
+                "id": row["id"],
+                "resource": row["resource"],
+                "position": row["position"],
+                "action": row["action"],
+                "principal_type": row["principal_type"],
+                "permission": row["permission"],
+            }
+            pt = row["principal_type"]
+            if pt == PRINCIPAL_SYSTEM:
+                sp = row["system_principal"]
+                entry["principal"] = (
+                    "Everyone" if sp == SYSTEM_EVERYONE else "Authenticated"
+                )
+                entry["system_principal"] = sp
+            elif pt == PRINCIPAL_USER:
+                entry["principal"] = row["user_email"] or row["user_id"]
+                entry["user_id"] = row["user_id"]
+            elif pt == PRINCIPAL_GROUP:
+                entry["principal"] = row["group_name"] or row["group_id"]
+                entry["group_id"] = row["group_id"]
+            results.append(entry)
+        return results
 
     async def replace_acl_entries(
         self, resource: str, entries: list[dict]
@@ -235,39 +230,36 @@ class ACLModel:
         self, user_id: str
     ) -> list[dict]:
         """Get all ACL entries referencing a specific user."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT id, resource, position, action, principal_type,"
-                " user_id, group_id, system_principal, permission"
-                " FROM acl_entries WHERE principal_type = ? AND user_id = ?"
-                " ORDER BY resource, position",
-                (PRINCIPAL_USER, user_id),
-            )
-            return [dict(row) for row in await cursor.fetchall()]
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            " FROM acl_entries WHERE principal_type = ? AND user_id = ?"
+            " ORDER BY resource, position",
+            (PRINCIPAL_USER, user_id),
+        )
+        return [dict(row) for row in rows]
 
     async def get_acl_entries_by_principal_group(
         self, group_id: str
     ) -> list[dict]:
         """Get all ACL entries referencing a specific group."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT id, resource, position, action, principal_type,"
-                " user_id, group_id, system_principal, permission"
-                " FROM acl_entries WHERE principal_type = ? AND group_id = ?"
-                " ORDER BY resource, position",
-                (PRINCIPAL_GROUP, group_id),
-            )
-            return [dict(row) for row in await cursor.fetchall()]
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            " FROM acl_entries WHERE principal_type = ? AND group_id = ?"
+            " ORDER BY resource, position",
+            (PRINCIPAL_GROUP, group_id),
+        )
+        return [dict(row) for row in rows]
 
     async def get_acl_tree_summary(self) -> list[dict]:
         """Get all distinct resources with their ACE counts."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT resource, COUNT(*) as ace_count"
-                " FROM acl_entries GROUP BY resource"
-                " ORDER BY resource"
-            )
-            return [
-                {"resource": row["resource"], "ace_count": row["ace_count"]}
-                for row in await cursor.fetchall()
-            ]
+        rows = await self.app.state.db.fetchall(
+            "SELECT resource, COUNT(*) as ace_count"
+            " FROM acl_entries GROUP BY resource"
+            " ORDER BY resource"
+        )
+        return [
+            {"resource": row["resource"], "ace_count": row["ace_count"]}
+            for row in rows
+        ]

--- a/src/klangk/klangk/model/chat.py
+++ b/src/klangk/klangk/model/chat.py
@@ -1,9 +1,7 @@
 """Chat messages and @handle mention resolution.
 
 ``ChatModel`` is the ``app_state``-owned form, reached via
-``app_state.model.chat`` (#1563 / #1576). The module-level free functions
-are the pre-existing ``_current_db`` ContextVar delegates, kept as the
-backstop until #1578 dissolves the ContextVar. The message-type constants
+``app_state.model.chat`` (#1563 / #1576). The message-type constants
 (``MSG_USER`` / ``MSG_AGENT`` / ``MSG_SYSTEM``) and the ``MENTION_RE``
 pattern stay module-level — they are imported as literal values by the
 ``wshandler`` package and ``api/chat.py``.
@@ -27,8 +25,7 @@ class ChatModel:
     """Chat data access, through ``app_state.db``.
 
     Reached via ``app_state.model.chat``. Reaches the DB through
-    ``self.app.state.db`` (the single DB instance for the whole app). The
-    method bodies mirror the module-level free functions below (backstop);
+    ``self.app.state.db`` (the single DB instance for the whole app);
     the message-type constants and ``MENTION_RE`` stay module-level.
     """
 
@@ -239,7 +236,7 @@ class ChatModel:
             mention_rows = await self.app.state.db.fetchall(
                 "SELECT message_id, user_id FROM chat_mentions"
                 " WHERE message_id IN (" + placeholders + ")",
-                msg_ids,
+                tuple(msg_ids),
             )
             mentions_by_msg: dict[str, list[str]] = {}
             for mr in mention_rows:

--- a/src/klangk/klangk/model/chat.py
+++ b/src/klangk/klangk/model/chat.py
@@ -156,110 +156,96 @@ class ChatModel:
         self, workspace_id: str, before_id: str, limit: int = 50
     ) -> list[dict]:
         """Get older chat messages before a given message ID."""
-        async with self.app.state.db.transaction() as db:
-            # Get the created_at and rowid of the anchor message
-            cursor = await db.execute(
-                "SELECT created_at, rowid FROM chat_messages WHERE id = ?",
-                (before_id,),
-            )
-            anchor = await cursor.fetchone()
-            if anchor is None:
-                return []
-            anchor_ts = anchor["created_at"]
-            anchor_rowid = anchor["rowid"]
+        # Get the created_at and rowid of the anchor message
+        anchor = await self.app.state.db.fetchone(
+            "SELECT created_at, rowid FROM chat_messages WHERE id = ?",
+            (before_id,),
+        )
+        if anchor is None:
+            return []
+        anchor_ts = anchor["created_at"]
+        anchor_rowid = anchor["rowid"]
 
-            cursor = await db.execute(
-                "SELECT c.id, c.workspace_id, c.user_id, c.user_email,"
-                " c.message, c.message_type, c.created_at,"
-                " u.handle AS user_handle"
-                " FROM chat_messages c LEFT JOIN users u ON c.user_id = u.id"
-                " WHERE c.workspace_id = ?"
-                " AND (c.created_at < ? OR (c.created_at = ? AND c.rowid < ?))"
-                " ORDER BY c.created_at DESC, c.rowid DESC LIMIT ?",
-                (workspace_id, anchor_ts, anchor_ts, anchor_rowid, limit),
+        rows = await self.app.state.db.fetchall(
+            "SELECT c.id, c.workspace_id, c.user_id, c.user_email,"
+            " c.message, c.message_type, c.created_at,"
+            " u.handle AS user_handle"
+            " FROM chat_messages c LEFT JOIN users u ON c.user_id = u.id"
+            " WHERE c.workspace_id = ?"
+            " AND (c.created_at < ? OR (c.created_at = ? AND c.rowid < ?))"
+            " ORDER BY c.created_at DESC, c.rowid DESC LIMIT ?",
+            (workspace_id, anchor_ts, anchor_ts, anchor_rowid, limit),
+        )
+        messages = list(
+            reversed(
+                [
+                    {
+                        "id": row["id"],
+                        "workspace_id": row["workspace_id"],
+                        "user_id": row["user_id"],
+                        "user_email": row["user_email"],
+                        "user_handle": row["user_handle"],
+                        "message": row["message"],
+                        "message_type": row["message_type"],
+                        "created_at": row["created_at"],
+                    }
+                    for row in rows
+                ]
             )
-            rows = await cursor.fetchall()
-            messages = list(
-                reversed(
-                    [
-                        {
-                            "id": row["id"],
-                            "workspace_id": row["workspace_id"],
-                            "user_id": row["user_id"],
-                            "user_email": row["user_email"],
-                            "user_handle": row["user_handle"],
-                            "message": row["message"],
-                            "message_type": row["message_type"],
-                            "created_at": row["created_at"],
-                        }
-                        for row in rows
-                    ]
-                )
-            )
-            if messages:
-                msg_ids = [m["id"] for m in messages]
-                placeholders = ",".join("?" for _ in msg_ids)
-                cursor = await db.execute(
-                    "SELECT message_id, user_id FROM chat_mentions"
-                    " WHERE message_id IN (" + placeholders + ")",
-                    msg_ids,
-                )
-                mention_rows = await cursor.fetchall()
-                mentions_by_msg: dict[str, list[str]] = {}
-                for mr in mention_rows:
-                    mentions_by_msg.setdefault(mr["message_id"], []).append(
-                        mr["user_id"]
-                    )
-                for m in messages:
-                    m["mentions"] = mentions_by_msg.get(m["id"], [])
-            return messages
+        )
+        return await self._attach_mentions(messages)
 
     async def get_chat_messages(
         self, workspace_id: str, limit: int = 50
     ) -> list[dict]:
         """Get the most recent chat messages for a workspace."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT c.id, c.workspace_id, c.user_id, c.user_email,"
-                " c.message, c.message_type, c.created_at,"
-                " u.handle AS user_handle"
-                " FROM chat_messages c LEFT JOIN users u ON c.user_id = u.id"
-                " WHERE c.workspace_id = ?"
-                " ORDER BY c.created_at DESC, c.rowid DESC LIMIT ?",
-                (workspace_id, limit),
+        rows = await self.app.state.db.fetchall(
+            "SELECT c.id, c.workspace_id, c.user_id, c.user_email,"
+            " c.message, c.message_type, c.created_at,"
+            " u.handle AS user_handle"
+            " FROM chat_messages c LEFT JOIN users u ON c.user_id = u.id"
+            " WHERE c.workspace_id = ?"
+            " ORDER BY c.created_at DESC, c.rowid DESC LIMIT ?",
+            (workspace_id, limit),
+        )
+        messages = list(
+            reversed(
+                [
+                    {
+                        "id": row["id"],
+                        "workspace_id": row["workspace_id"],
+                        "user_id": row["user_id"],
+                        "user_email": row["user_email"],
+                        "user_handle": row["user_handle"],
+                        "message": row["message"],
+                        "message_type": row["message_type"],
+                        "created_at": row["created_at"],
+                    }
+                    for row in rows
+                ]
             )
-            rows = await cursor.fetchall()
-            messages = list(
-                reversed(
-                    [
-                        {
-                            "id": row["id"],
-                            "workspace_id": row["workspace_id"],
-                            "user_id": row["user_id"],
-                            "user_email": row["user_email"],
-                            "user_handle": row["user_handle"],
-                            "message": row["message"],
-                            "message_type": row["message_type"],
-                            "created_at": row["created_at"],
-                        }
-                        for row in rows
-                    ]
-                )
+        )
+        return await self._attach_mentions(messages)
+
+    async def _attach_mentions(self, messages: list[dict]) -> list[dict]:
+        """Attach mention lists to mapped message dicts (in place).
+
+        Mentions are inserted atomically with their message, so the
+        follow-up read for already-fetched IDs needs no shared snapshot.
+        """
+        if messages:
+            msg_ids = [m["id"] for m in messages]
+            placeholders = ",".join("?" for _ in msg_ids)
+            mention_rows = await self.app.state.db.fetchall(
+                "SELECT message_id, user_id FROM chat_mentions"
+                " WHERE message_id IN (" + placeholders + ")",
+                msg_ids,
             )
-            if messages:
-                msg_ids = [m["id"] for m in messages]
-                placeholders = ",".join("?" for _ in msg_ids)
-                cursor = await db.execute(
-                    "SELECT message_id, user_id FROM chat_mentions"
-                    " WHERE message_id IN (" + placeholders + ")",
-                    msg_ids,
+            mentions_by_msg: dict[str, list[str]] = {}
+            for mr in mention_rows:
+                mentions_by_msg.setdefault(mr["message_id"], []).append(
+                    mr["user_id"]
                 )
-                mention_rows = await cursor.fetchall()
-                mentions_by_msg: dict[str, list[str]] = {}
-                for mr in mention_rows:
-                    mentions_by_msg.setdefault(mr["message_id"], []).append(
-                        mr["user_id"]
-                    )
-                for m in messages:
-                    m["mentions"] = mentions_by_msg.get(m["id"], [])
-            return messages
+            for m in messages:
+                m["mentions"] = mentions_by_msg.get(m["id"], [])
+        return messages

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -250,23 +250,21 @@ class EgressConsentModel:
         limit: int = 100,
     ) -> list[dict]:
         """List consent requests for a workspace, optionally filtered by decision."""
-        async with self.app.state.db.transaction() as db:
-            if decision is not None:
-                cursor = await db.execute(
-                    f"SELECT {_EC_COLUMNS} FROM egress_consent"
-                    " WHERE workspace_id = ? AND decision = ?"
-                    " ORDER BY requested_at DESC LIMIT ?",
-                    (workspace_id, decision, limit),
-                )
-            else:
-                cursor = await db.execute(
-                    f"SELECT {_EC_COLUMNS} FROM egress_consent"
-                    " WHERE workspace_id = ?"
-                    " ORDER BY requested_at DESC LIMIT ?",
-                    (workspace_id, limit),
-                )
-            rows = await cursor.fetchall()
-            return [_row_to_dict(row) for row in rows]
+        if decision is not None:
+            rows = await self.app.state.db.fetchall(
+                f"SELECT {_EC_COLUMNS} FROM egress_consent"
+                " WHERE workspace_id = ? AND decision = ?"
+                " ORDER BY requested_at DESC LIMIT ?",
+                (workspace_id, decision, limit),
+            )
+        else:
+            rows = await self.app.state.db.fetchall(
+                f"SELECT {_EC_COLUMNS} FROM egress_consent"
+                " WHERE workspace_id = ?"
+                " ORDER BY requested_at DESC LIMIT ?",
+                (workspace_id, limit),
+            )
+        return [_row_to_dict(row) for row in rows]
 
     # Duration string -> seconds, for the time-bounded in-effect window
     # (#2328). `once`/`tilrestart`/`forever` are not time-bounded (handled
@@ -329,9 +327,7 @@ class EgressConsentModel:
                 DECISION_DENIED,
             )
         now = time.time()
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(query, params)
-            rows = await cursor.fetchall()
+        rows = await self.app.state.db.fetchall(query, params)
         # Newest-first: return the first verdict still in effect. An elapsed
         # newer verdict (e.g. an expired timed allow) is skipped so it can't
         # hide an older in-effect deny -- the pause must keep blocking a host
@@ -369,15 +365,13 @@ class EgressConsentModel:
         never in effect.
         """
         now = time.time()
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                f"SELECT {_EC_COLUMNS} FROM egress_consent"
-                " WHERE workspace_id = ? AND decision IN (?, ?)"
-                " AND decided_by IS NOT NULL"
-                " ORDER BY decided_at DESC",
-                (workspace_id, DECISION_ALLOWED, DECISION_DENIED),
-            )
-            rows = await cursor.fetchall()
+        rows = await self.app.state.db.fetchall(
+            f"SELECT {_EC_COLUMNS} FROM egress_consent"
+            " WHERE workspace_id = ? AND decision IN (?, ?)"
+            " AND decided_by IS NOT NULL"
+            " ORDER BY decided_at DESC",
+            (workspace_id, DECISION_ALLOWED, DECISION_DENIED),
+        )
         out = []
         for row in rows:
             if self._duration_in_effect(
@@ -653,14 +647,12 @@ class EgressConsentModel:
 
         if retention_days > 0:
             cutoff = now - retention_days * 86400.0
-            async with self.app.state.db.transaction() as db:
-                cursor = await db.execute(
-                    "SELECT id, decision, duration, decided_at, decided_by"
-                    " FROM egress_consent"
-                    " WHERE COALESCE(revoked_at, decided_at, requested_at) < ?",
-                    (cutoff,),
-                )
-                rows = await cursor.fetchall()
+            rows = await self.app.state.db.fetchall(
+                "SELECT id, decision, duration, decided_at, decided_by"
+                " FROM egress_consent"
+                " WHERE COALESCE(revoked_at, decided_at, requested_at) < ?",
+                (cutoff,),
+            )
             # TOCTOU guard: the snapshot and the deletes run in separate
             # transactions, so a row snapshotted as pending may have been
             # decided in between -- deleting it would silently drop a fresh
@@ -687,25 +679,21 @@ class EgressConsentModel:
             deleted += await self._delete_ids(other_ids)
 
         if row_cap > 0:
-            async with self.app.state.db.transaction() as db:
-                cursor = await db.execute(
-                    "SELECT workspace_id, COUNT(*) AS cnt"
-                    " FROM egress_consent GROUP BY workspace_id HAVING cnt > ?",
-                    (row_cap,),
-                )
-                over = await cursor.fetchall()
+            over = await self.app.state.db.fetchall(
+                "SELECT workspace_id, COUNT(*) AS cnt"
+                " FROM egress_consent GROUP BY workspace_id HAVING cnt > ?",
+                (row_cap,),
+            )
             for entry in over:
                 excess = entry["cnt"] - row_cap
-                async with self.app.state.db.transaction() as db:
-                    cursor = await db.execute(
-                        "SELECT id, decision, duration, decided_at, decided_by"
-                        " FROM egress_consent"
-                        " WHERE workspace_id = ? AND decision != ?"
-                        " ORDER BY COALESCE(revoked_at, decided_at,"
-                        " requested_at) ASC",
-                        (entry["workspace_id"], DECISION_PENDING),
-                    )
-                    rows = await cursor.fetchall()
+                rows = await self.app.state.db.fetchall(
+                    "SELECT id, decision, duration, decided_at, decided_by"
+                    " FROM egress_consent"
+                    " WHERE workspace_id = ? AND decision != ?"
+                    " ORDER BY COALESCE(revoked_at, decided_at,"
+                    " requested_at) ASC",
+                    (entry["workspace_id"], DECISION_PENDING),
+                )
                 ids = []
                 for r in rows:
                     if excess <= 0:

--- a/src/klangk/klangk/model/invitations.py
+++ b/src/klangk/klangk/model/invitations.py
@@ -111,53 +111,54 @@ class InvitationsModel:
         page_size = max(1, min(page_size, 200))
         offset = (page - 1) * page_size
 
-        async with self.app.state.db.transaction() as db:
-            where_clause = ""
-            params: list = []
-            if q:
-                where_clause = " WHERE i.email LIKE ?"
-                params.append(f"%{q}%")
+        where_clause = ""
+        params: list = []
+        if q:
+            where_clause = " WHERE i.email LIKE ?"
+            params.append(f"%{q}%")
 
-            count_cursor = await db.execute(
+        total = (
+            await self.app.state.db.fetchone(
                 f"SELECT COUNT(*) AS c FROM invitations i{where_clause}",
                 params,
             )
-            total = (await count_cursor.fetchone())["c"]
+        )["c"]
 
-            pending_cursor = await db.execute(
+        pending_count = (
+            await self.app.state.db.fetchone(
                 "SELECT COUNT(*) AS c FROM invitations WHERE status = 'pending'"
             )
-            pending_count = (await pending_cursor.fetchone())["c"]
+        )["c"]
 
-            cursor = await db.execute(
-                "SELECT i.id, i.email, i.invited_by, i.status,"
-                " i.created_at, i.accepted_at, u.email AS invited_by_email"
-                " FROM invitations i"
-                " JOIN users u ON i.invited_by = u.id"
-                f"{where_clause}"
-                f" ORDER BY {sort_col} {direction}, i.id"
-                " LIMIT ? OFFSET ?",
-                (*params, page_size, offset),
-            )
-            invitations = [
-                {
-                    "id": row["id"],
-                    "email": row["email"],
-                    "invited_by": row["invited_by"],
-                    "invited_by_email": row["invited_by_email"],
-                    "status": row["status"],
-                    "created_at": row["created_at"],
-                    "accepted_at": row["accepted_at"],
-                }
-                for row in await cursor.fetchall()
-            ]
-            return {
-                "invitations": invitations,
-                "page": page,
-                "page_size": page_size,
-                "total": total,
-                "pending_count": pending_count,
+        rows = await self.app.state.db.fetchall(
+            "SELECT i.id, i.email, i.invited_by, i.status,"
+            " i.created_at, i.accepted_at, u.email AS invited_by_email"
+            " FROM invitations i"
+            " JOIN users u ON i.invited_by = u.id"
+            f"{where_clause}"
+            f" ORDER BY {sort_col} {direction}, i.id"
+            " LIMIT ? OFFSET ?",
+            (*params, page_size, offset),
+        )
+        invitations = [
+            {
+                "id": row["id"],
+                "email": row["email"],
+                "invited_by": row["invited_by"],
+                "invited_by_email": row["invited_by_email"],
+                "status": row["status"],
+                "created_at": row["created_at"],
+                "accepted_at": row["accepted_at"],
             }
+            for row in rows
+        ]
+        return {
+            "invitations": invitations,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "pending_count": pending_count,
+        }
 
     async def mark_invitation_accepted(self, invitation_id: str) -> bool:
         """Mark an invitation as accepted. Returns True if updated."""

--- a/src/klangk/klangk/model/invitations.py
+++ b/src/klangk/klangk/model/invitations.py
@@ -111,54 +111,56 @@ class InvitationsModel:
         page_size = max(1, min(page_size, 200))
         offset = (page - 1) * page_size
 
-        where_clause = ""
-        params: list = []
-        if q:
-            where_clause = " WHERE i.email LIKE ?"
-            params.append(f"%{q}%")
+        # The two counts and the page are dependent pagination reads —
+        # keep them on one snapshot so total/pending_count can't drift
+        # from the page under concurrent writes (issue #2609 rule).
+        async with self.app.state.db.transaction() as db:
+            where_clause = ""
+            params: list = []
+            if q:
+                where_clause = " WHERE i.email LIKE ?"
+                params.append(f"%{q}%")
 
-        total = (
-            await self.app.state.db.fetchone(
+            count_cursor = await db.execute(
                 f"SELECT COUNT(*) AS c FROM invitations i{where_clause}",
                 params,
             )
-        )["c"]
+            total = (await count_cursor.fetchone())["c"]
 
-        pending_count = (
-            await self.app.state.db.fetchone(
+            pending_cursor = await db.execute(
                 "SELECT COUNT(*) AS c FROM invitations WHERE status = 'pending'"
             )
-        )["c"]
+            pending_count = (await pending_cursor.fetchone())["c"]
 
-        rows = await self.app.state.db.fetchall(
-            "SELECT i.id, i.email, i.invited_by, i.status,"
-            " i.created_at, i.accepted_at, u.email AS invited_by_email"
-            " FROM invitations i"
-            " JOIN users u ON i.invited_by = u.id"
-            f"{where_clause}"
-            f" ORDER BY {sort_col} {direction}, i.id"
-            " LIMIT ? OFFSET ?",
-            (*params, page_size, offset),
-        )
-        invitations = [
-            {
-                "id": row["id"],
-                "email": row["email"],
-                "invited_by": row["invited_by"],
-                "invited_by_email": row["invited_by_email"],
-                "status": row["status"],
-                "created_at": row["created_at"],
-                "accepted_at": row["accepted_at"],
+            cursor = await db.execute(
+                "SELECT i.id, i.email, i.invited_by, i.status,"
+                " i.created_at, i.accepted_at, u.email AS invited_by_email"
+                " FROM invitations i"
+                " JOIN users u ON i.invited_by = u.id"
+                f"{where_clause}"
+                f" ORDER BY {sort_col} {direction}, i.id"
+                " LIMIT ? OFFSET ?",
+                (*params, page_size, offset),
+            )
+            invitations = [
+                {
+                    "id": row["id"],
+                    "email": row["email"],
+                    "invited_by": row["invited_by"],
+                    "invited_by_email": row["invited_by_email"],
+                    "status": row["status"],
+                    "created_at": row["created_at"],
+                    "accepted_at": row["accepted_at"],
+                }
+                for row in await cursor.fetchall()
+            ]
+            return {
+                "invitations": invitations,
+                "page": page,
+                "page_size": page_size,
+                "total": total,
+                "pending_count": pending_count,
             }
-            for row in rows
-        ]
-        return {
-            "invitations": invitations,
-            "page": page,
-            "page_size": page_size,
-            "total": total,
-            "pending_count": pending_count,
-        }
 
     async def mark_invitation_accepted(self, invitation_id: str) -> bool:
         """Mark an invitation as accepted. Returns True if updated."""

--- a/src/klangk/klangk/model/ports.py
+++ b/src/klangk/klangk/model/ports.py
@@ -97,17 +97,15 @@ class PortsModel:
 
     async def get_workspace_ports(self, workspace_id: str) -> list[int]:
         """Return all allocated ports for a workspace, sorted."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT port FROM port_allocations WHERE workspace_id = ? ORDER BY port",
-                (workspace_id,),
-            )
-            rows = await cursor.fetchall()
-            return [row["port"] for row in rows]
+        rows = await self.app.state.db.fetchall(
+            "SELECT port FROM port_allocations WHERE workspace_id = ? ORDER BY port",
+            (workspace_id,),
+        )
+        return [row["port"] for row in rows]
 
     async def get_all_allocated_ports(self) -> set[int]:
         """Return all allocated port numbers across all workspaces."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute("SELECT port FROM port_allocations")
-            rows = await cursor.fetchall()
-            return {row["port"] for row in rows}
+        rows = await self.app.state.db.fetchall(
+            "SELECT port FROM port_allocations"
+        )
+        return {row["port"] for row in rows}

--- a/src/klangk/klangk/model/sessions.py
+++ b/src/klangk/klangk/model/sessions.py
@@ -129,21 +129,19 @@ class SessionsModel:
         the workstation identity (``source_ip``/``user_agent``) for
         concurrent-logon auditing (#2586).
         """
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT jti, expires_at, source_ip, user_agent, created_at"
-                " FROM user_sessions WHERE user_id = ?"
-                " ORDER BY created_at, rowid",
-                (user_id,),
-            )
-            rows = await cursor.fetchall()
-            return [
-                {
-                    "jti": row[0],
-                    "expires_at": row[1],
-                    "source_ip": row[2],
-                    "user_agent": row[3],
-                    "created_at": row[4],
-                }
-                for row in rows
-            ]
+        rows = await self.app.state.db.fetchall(
+            "SELECT jti, expires_at, source_ip, user_agent, created_at"
+            " FROM user_sessions WHERE user_id = ?"
+            " ORDER BY created_at, rowid",
+            (user_id,),
+        )
+        return [
+            {
+                "jti": row[0],
+                "expires_at": row[1],
+                "source_ip": row[2],
+                "user_agent": row[3],
+                "created_at": row[4],
+            }
+            for row in rows
+        ]

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -313,12 +313,10 @@ class UsersModel:
 
     async def get_user_handle(self, user_id: str) -> str | None:
         """Return the handle for a user, or None if not found."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT handle FROM users WHERE id = ?", (user_id,)
-            )
-            row = await cursor.fetchone()
-            return row["handle"] if row else None
+        row = await self.app.state.db.fetchone(
+            "SELECT handle FROM users WHERE id = ?", (user_id,)
+        )
+        return row["handle"] if row else None
 
     async def set_user_handle(self, user_id: str, handle: str) -> None:
         """Update a user's handle. Raises ValueError on invalid or conflict."""
@@ -543,60 +541,56 @@ class UsersModel:
 
     async def get_group_members(self, group_id: str) -> list[dict]:
         """List users in a group."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT u.id, u.email, ug.source FROM users u"
-                " JOIN user_groups ug ON u.id = ug.user_id"
-                " WHERE ug.group_id = ?"
-                " ORDER BY u.email",
-                (group_id,),
-            )
-            return [
-                {
-                    "id": row["id"],
-                    "email": row["email"],
-                    "source": row["source"],
-                }
-                for row in await cursor.fetchall()
-            ]
+        rows = await self.app.state.db.fetchall(
+            "SELECT u.id, u.email, ug.source FROM users u"
+            " JOIN user_groups ug ON u.id = ug.user_id"
+            " WHERE ug.group_id = ?"
+            " ORDER BY u.email",
+            (group_id,),
+        )
+        return [
+            {
+                "id": row["id"],
+                "email": row["email"],
+                "source": row["source"],
+            }
+            for row in rows
+        ]
 
     async def get_user_group_ids(self, user_id: str) -> list[str]:
         """Get all group IDs for a user."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT group_id FROM user_groups WHERE user_id = ?",
-                (user_id,),
-            )
-            return [row["group_id"] for row in await cursor.fetchall()]
+        rows = await self.app.state.db.fetchall(
+            "SELECT group_id FROM user_groups WHERE user_id = ?",
+            (user_id,),
+        )
+        return [row["group_id"] for row in rows]
 
     async def get_user_oidc_sync_group_ids(self, user_id: str) -> list[str]:
         """Get group IDs where membership source is 'oidc_sync'."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT group_id FROM user_groups"
-                " WHERE user_id = ? AND source = 'oidc_sync'",
-                (user_id,),
-            )
-            return [row["group_id"] for row in await cursor.fetchall()]
+        rows = await self.app.state.db.fetchall(
+            "SELECT group_id FROM user_groups"
+            " WHERE user_id = ? AND source = 'oidc_sync'",
+            (user_id,),
+        )
+        return [row["group_id"] for row in rows]
 
     async def get_user_groups(self, user_id: str) -> list[dict]:
         """Get all groups a user belongs to."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT g.id, g.name, g.description FROM groups g"
-                " JOIN user_groups ug ON g.id = ug.group_id"
-                " WHERE ug.user_id = ?"
-                " ORDER BY g.name",
-                (user_id,),
-            )
-            return [
-                {
-                    "id": row["id"],
-                    "name": row["name"],
-                    "description": row["description"],
-                }
-                for row in await cursor.fetchall()
-            ]
+        rows = await self.app.state.db.fetchall(
+            "SELECT g.id, g.name, g.description FROM groups g"
+            " JOIN user_groups ug ON g.id = ug.group_id"
+            " WHERE ug.user_id = ?"
+            " ORDER BY g.name",
+            (user_id,),
+        )
+        return [
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "description": row["description"],
+            }
+            for row in rows
+        ]
 
     async def get_user_by_email(self, email: str) -> dict | None:
         row = await self.app.state.db.fetchone(
@@ -815,18 +809,17 @@ class UsersModel:
 
     async def search_users(self, query: str, limit: int = 10) -> list[dict]:
         """Search users by email or handle prefix (#616)."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT id, email, handle FROM users"
-                " WHERE email LIKE ? OR handle LIKE ?"
-                " ORDER BY email LIMIT ?",
-                (f"{query}%", f"{query}%", limit),
-            )
-            return [
-                {
-                    "id": row["id"],
-                    "email": row["email"],
-                    "handle": row["handle"],
-                }
-                for row in await cursor.fetchall()
-            ]
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, email, handle FROM users"
+            " WHERE email LIKE ? OR handle LIKE ?"
+            " ORDER BY email LIMIT ?",
+            (f"{query}%", f"{query}%", limit),
+        )
+        return [
+            {
+                "id": row["id"],
+                "email": row["email"],
+                "handle": row["handle"],
+            }
+            for row in rows
+        ]

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -593,9 +593,7 @@ class WorkspacesModel:
         _sweep_orphaned_sidecar_tokens`) to tell token files whose workspace
         still exists from orphans left by a deleted/crashed workspace (#2309).
         """
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute("SELECT id FROM workspaces")
-            rows = await cursor.fetchall()
+        rows = await self.app.state.db.fetchall("SELECT id FROM workspaces")
         return {row["id"] for row in rows}
 
     async def get_workspace_members(self, workspace_id: str) -> list[dict]:
@@ -604,29 +602,28 @@ class WorkspacesModel:
         Returns users with direct user-level ACEs on /workspaces/{id},
         excluding the workspace owner.
         """
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT DISTINCT u.id, u.email, u.handle FROM users u"
-                " JOIN acl_entries ae ON ae.user_id = u.id"
-                " JOIN workspaces w ON w.id = ?"
-                " WHERE ae.resource = ? AND ae.principal_type = ?"
-                "   AND ae.action = ? AND u.id != w.user_id"
-                " ORDER BY u.email",
-                (
-                    workspace_id,
-                    f"/workspaces/{workspace_id}",
-                    PRINCIPAL_USER,
-                    ACTION_ALLOW,
-                ),
-            )
-            return [
-                {
-                    "id": row["id"],
-                    "email": row["email"],
-                    "handle": row["handle"],
-                }
-                for row in await cursor.fetchall()
-            ]
+        rows = await self.app.state.db.fetchall(
+            "SELECT DISTINCT u.id, u.email, u.handle FROM users u"
+            " JOIN acl_entries ae ON ae.user_id = u.id"
+            " JOIN workspaces w ON w.id = ?"
+            " WHERE ae.resource = ? AND ae.principal_type = ?"
+            "   AND ae.action = ? AND u.id != w.user_id"
+            " ORDER BY u.email",
+            (
+                workspace_id,
+                f"/workspaces/{workspace_id}",
+                PRINCIPAL_USER,
+                ACTION_ALLOW,
+            ),
+        )
+        return [
+            {
+                "id": row["id"],
+                "email": row["email"],
+                "handle": row["handle"],
+            }
+            for row in rows
+        ]
 
     async def delete_workspace(self, workspace_id: str, user_id: str) -> bool:
         async with self.app.state.db.transaction() as db:
@@ -1062,28 +1059,21 @@ class WorkspacesModel:
     async def get_user_workspaces_with_containers(
         self, user_id: str
     ) -> list[dict]:
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT id, container_id FROM workspaces WHERE user_id = ? AND container_id IS NOT NULL",
-                (user_id,),
-            )
-            rows = await cursor.fetchall()
-            return [
-                {"id": row["id"], "container_id": row["container_id"]}
-                for row in rows
-            ]
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, container_id FROM workspaces WHERE user_id = ? AND container_id IS NOT NULL",
+            (user_id,),
+        )
+        return [
+            {"id": row["id"], "container_id": row["container_id"]}
+            for row in rows
+        ]
 
     async def list_auto_start_workspaces(self) -> list[dict]:
         """List all workspaces with auto_start enabled."""
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                _WORKSPACE_FULL_COLUMNS
-                + " FROM workspaces WHERE auto_start = 1",
-            )
-            rows = await cursor.fetchall()
-            # auto_start is pinned True by the WHERE clause; the mapper's
-            # bool() would also be True, but pass the explicit form so the
-            # query's intent stays readable at the call site.
-            return [
-                _workspace_row_to_dict(row, auto_start=True) for row in rows
-            ]
+        rows = await self.app.state.db.fetchall(
+            _WORKSPACE_FULL_COLUMNS + " FROM workspaces WHERE auto_start = 1",
+        )
+        # auto_start is pinned True by the WHERE clause; the mapper's
+        # bool() would also be True, but pass the explicit form so the
+        # query's intent stays readable at the call site.
+        return [_workspace_row_to_dict(row, auto_start=True) for row in rows]

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -412,51 +412,47 @@ class WorkspacesModel:
             where += " AND name LIKE '%' || ? || '%'"
             params.append(q)
         params.extend([limit + 1, offset])
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT id, name, container_id, image, service_command,"
-                " auto_start, setup_state, health_check, mounts, env,"
-                " allowed_domains, rejected_domains, settings, egress_mode, created_at"
-                " FROM workspaces"
-                f" {where} {order_by} LIMIT ? OFFSET ?",
-                tuple(params),
-            )
-            rows = await cursor.fetchall()
-            items = [
-                {
-                    "id": row["id"],
-                    "name": row["name"],
-                    "container_id": row["container_id"],
-                    "image": row["image"],
-                    "service_command": row["service_command"],
-                    "auto_start": bool(row["auto_start"]),
-                    "setup_state": row["setup_state"],
-                    "health_check": row["health_check"],
-                    "mounts": json.loads(row["mounts"])
-                    if row["mounts"]
-                    else None,
-                    "env": json.loads(row["env"]) if row["env"] else None,
-                    "allowed_domains": json.loads(row["allowed_domains"])
-                    if row["allowed_domains"]
-                    else None,
-                    "rejected_domains": json.loads(row["rejected_domains"])
-                    if row["rejected_domains"]
-                    else None,
-                    "settings": json.loads(row["settings"])
-                    if row["settings"]
-                    else None,
-                    "egress_mode": row["egress_mode"],
-                    "created_at": row["created_at"],
-                }
-                for row in rows
-            ]
-            has_more = len(items) > limit
-            items = items[:limit]
-            return {
-                "items": items,
-                "has_more": has_more,
-                "next_offset": offset + limit if has_more else None,
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, name, container_id, image, service_command,"
+            " auto_start, setup_state, health_check, mounts, env,"
+            " allowed_domains, rejected_domains, settings, egress_mode, created_at"
+            " FROM workspaces"
+            f" {where} {order_by} LIMIT ? OFFSET ?",
+            tuple(params),
+        )
+        items = [
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "container_id": row["container_id"],
+                "image": row["image"],
+                "service_command": row["service_command"],
+                "auto_start": bool(row["auto_start"]),
+                "setup_state": row["setup_state"],
+                "health_check": row["health_check"],
+                "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
+                "env": json.loads(row["env"]) if row["env"] else None,
+                "allowed_domains": json.loads(row["allowed_domains"])
+                if row["allowed_domains"]
+                else None,
+                "rejected_domains": json.loads(row["rejected_domains"])
+                if row["rejected_domains"]
+                else None,
+                "settings": json.loads(row["settings"])
+                if row["settings"]
+                else None,
+                "egress_mode": row["egress_mode"],
+                "created_at": row["created_at"],
             }
+            for row in rows
+        ]
+        has_more = len(items) > limit
+        items = items[:limit]
+        return {
+            "items": items,
+            "has_more": has_more,
+            "next_offset": offset + limit if has_more else None,
+        }
 
     async def list_shared_workspaces(
         self,
@@ -476,80 +472,79 @@ class WorkspacesModel:
         """
         order_by = sort_order_clause(sort, order, prefix="w")
         name_filter = " AND w.name LIKE '%' || ? || '%'" if q else ""
-        async with self.app.state.db.transaction() as db:
-            group_ids = await self.app.state.model.users.get_user_group_ids(
-                user_id
-            )
-            group_placeholders = ",".join("?" for _ in group_ids)
-            group_clause = (
-                f" OR (ae.principal_type = {PRINCIPAL_GROUP}"
-                f" AND ae.group_id IN ({group_placeholders}))"
-                if group_ids
-                else ""
-            )
-            cursor = await db.execute(
-                "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
-                " w.service_command, w.auto_start, w.setup_state,"
-                " w.health_check, w.mounts, w.env, w.allowed_domains, w.rejected_domains,"
-                " w.settings, w.egress_mode, w.created_at,"
-                " u.email AS owner_email"
-                " FROM workspaces w"
-                " JOIN acl_entries ae ON ae.resource = '/workspaces/' || w.id"
-                " JOIN users u ON w.user_id = u.id"
-                " WHERE ae.action = ? AND w.user_id != ?"
-                "   AND ("
-                f"    (ae.principal_type = {PRINCIPAL_USER} AND ae.user_id = ?)"
-                f"    {group_clause}"
-                "   )"
-                f"{name_filter}"
-                f" {order_by} LIMIT ? OFFSET ?",
-                (
-                    ACTION_ALLOW,
-                    user_id,
-                    user_id,
-                    *group_ids,
-                    *([q] if q else []),
-                    limit + 1,
-                    offset,
-                ),
-            )
-            rows = await cursor.fetchall()
-            items = [
-                {
-                    "id": row["id"],
-                    "name": row["name"],
-                    "container_id": row["container_id"],
-                    "image": row["image"],
-                    "service_command": row["service_command"],
-                    "auto_start": bool(row["auto_start"]),
-                    "setup_state": row["setup_state"],
-                    "health_check": row["health_check"],
-                    "mounts": json.loads(row["mounts"])
-                    if row["mounts"]
-                    else None,
-                    "env": json.loads(row["env"]) if row["env"] else None,
-                    "allowed_domains": json.loads(row["allowed_domains"])
-                    if row["allowed_domains"]
-                    else None,
-                    "rejected_domains": json.loads(row["rejected_domains"])
-                    if row["rejected_domains"]
-                    else None,
-                    "settings": json.loads(row["settings"])
-                    if row["settings"]
-                    else None,
-                    "egress_mode": row["egress_mode"],
-                    "created_at": row["created_at"],
-                    "owner_email": row["owner_email"],
-                }
-                for row in rows
-            ]
-            has_more = len(items) > limit
-            items = items[:limit]
-            return {
-                "items": items,
-                "has_more": has_more,
-                "next_offset": offset + limit if has_more else None,
+        # The group-ids read runs on its own connection (it did before
+        # the fetchall conversion too), so it never shared the page
+        # read's snapshot.
+        group_ids = await self.app.state.model.users.get_user_group_ids(
+            user_id
+        )
+        group_placeholders = ",".join("?" for _ in group_ids)
+        group_clause = (
+            f" OR (ae.principal_type = {PRINCIPAL_GROUP}"
+            f" AND ae.group_id IN ({group_placeholders}))"
+            if group_ids
+            else ""
+        )
+        rows = await self.app.state.db.fetchall(
+            "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
+            " w.service_command, w.auto_start, w.setup_state,"
+            " w.health_check, w.mounts, w.env, w.allowed_domains, w.rejected_domains,"
+            " w.settings, w.egress_mode, w.created_at,"
+            " u.email AS owner_email"
+            " FROM workspaces w"
+            " JOIN acl_entries ae ON ae.resource = '/workspaces/' || w.id"
+            " JOIN users u ON w.user_id = u.id"
+            " WHERE ae.action = ? AND w.user_id != ?"
+            "   AND ("
+            f"    (ae.principal_type = {PRINCIPAL_USER} AND ae.user_id = ?)"
+            f"    {group_clause}"
+            "   )"
+            f"{name_filter}"
+            f" {order_by} LIMIT ? OFFSET ?",
+            (
+                ACTION_ALLOW,
+                user_id,
+                user_id,
+                *group_ids,
+                *([q] if q else []),
+                limit + 1,
+                offset,
+            ),
+        )
+        items = [
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "container_id": row["container_id"],
+                "image": row["image"],
+                "service_command": row["service_command"],
+                "auto_start": bool(row["auto_start"]),
+                "setup_state": row["setup_state"],
+                "health_check": row["health_check"],
+                "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
+                "env": json.loads(row["env"]) if row["env"] else None,
+                "allowed_domains": json.loads(row["allowed_domains"])
+                if row["allowed_domains"]
+                else None,
+                "rejected_domains": json.loads(row["rejected_domains"])
+                if row["rejected_domains"]
+                else None,
+                "settings": json.loads(row["settings"])
+                if row["settings"]
+                else None,
+                "egress_mode": row["egress_mode"],
+                "created_at": row["created_at"],
+                "owner_email": row["owner_email"],
             }
+            for row in rows
+        ]
+        has_more = len(items) > limit
+        items = items[:limit]
+        return {
+            "items": items,
+            "has_more": has_more,
+            "next_offset": offset + limit if has_more else None,
+        }
 
     async def get_workspace(
         self, workspace_id: str, user_id: str | None = None


### PR DESCRIPTION
Closes #2609.

## What

Mechanical conversion of model methods that hand-rolled the
open-transaction / execute / `cursor.fetchall()` / map pattern for single
read-only SELECTs to the `DB.fetchall` / `DB.fetchone` wrappers (which open
their own short transaction per call):

- **ports**: `get_workspace_ports`, `get_all_allocated_ports`
- **workspaces**: `existing_workspace_ids`, `get_workspace_members`,
  `get_user_workspaces_with_containers`, `list_auto_start_workspaces`,
  `list_workspaces`, `list_shared_workspaces`
- **users**: `get_group_members`, `get_user_group_ids`,
  `get_user_oidc_sync_group_ids`, `get_user_groups`, `get_user_handle`,
  `search_users`
- **egress_consent**: pause-path verdict query, `list_requests`,
  `list_active`, retention/row-cap prune SELECTs
- **chat**: `get_chat_messages_before` (anchor via `fetchone`),
  `get_chat_messages`; the duplicated mention-attachment block is now one
  `_attach_mentions` helper
- **acl**: `get_acl_entries`, `get_acl_entries_map`, `get_acl_entries_resolved`,
  `get_acl_entries_by_principal_user`, `get_acl_entries_by_principal_group`,
  `get_acl_tree_summary`
- **sessions**: `list_sessions` — not in the issue's line list; found by an
  AST scan for remaining read-only `transaction()` blocks

## Kept explicit

Blocks that share a transaction with writes or need a consistent snapshot
(`find_and_allocate_ports`, `add_chat_message`, slug-fallback chains, the
prune DELETEs, `parse_mentions` inside the caller's tx) are untouched, per
the issue's rules. **`invitations`' admin listing keeps its explicit
transaction**: its two COUNTs and the page are dependent pagination reads
that rely on one snapshot (the same treatment as `users.list_users` /
`list_groups`). In `list_shared_workspaces`, the interleaved
`get_user_group_ids` read always ran on its own connection, so the outer
transaction never spanned it (commented in code).

An AST scan confirms no remaining single-SELECT read-only `transaction()`
block in `model/` (the flagged leftovers are the `fetchone`/`fetchall`
wrappers themselves and a DELETE whose SQL is built outside its block).

No behavior change. Full suite: 5197 passed, 100% coverage.
