### PR TITLE
ci(fips): publish FIPS image to GHCR; e2e pulls instead of compiling per-run

### DIFF
--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -15,6 +15,14 @@ inputs:
   build-tasks:
     description: "Space-separated devenv tasks for the build step"
     default: "klangk:build-workspace-image klangk:build-network-sidecar"
+  fips-image:
+    description: >-
+      Pull this published FIPS image (retagged klangk-workspace-fips:latest)
+      instead of compiling it per-run (#2631). On pull failure, falls back
+      to a local build with the compile parallelism capped
+      (KLANGKBUILD_FIPS_BUILD_JOBS=2) so a shared host is not starved.
+      Empty = no FIPS image handling.
+    default: ""
   verbose-podman:
     description: "Set KLANGK_E2E_VERBOSE_PODMAN=1 (pytest plugin surfacing podman stderr of failed calls)"
     default: "false"
@@ -33,6 +41,24 @@ runs:
       if: inputs.run == 'true'
       shell: bash
       run: devenv tasks run ${{ inputs.build-tasks }}
+
+    - name: Obtain FIPS image (pull, capped-build fallback)
+      # #2631: the FIPS workspace image is published by image-workspace-
+      # fips.yml on GitHub-hosted runners; pulling it here replaces a
+      # per-run `make -j$(nproc)` OpenSSL compile on the shared self-hosted
+      # host, which starved sibling e2e suites' podman execs. If the pull
+      # fails (package not yet published/flipped public, network), fall
+      # back to building locally with the compile capped to 2 jobs —
+      # slower, but bounded blast radius.
+      if: inputs.run == 'true' && inputs.fips-image != ''
+      shell: bash
+      run: |
+        if devenv shell -- bash scripts/pull-fips-image.sh "${{ inputs.fips-image }}"; then
+          echo "FIPS image pulled from ${{ inputs.fips-image }}"
+        else
+          echo "Pull failed — building FIPS image locally (compile capped to 2 jobs, #2631)"
+          KLANGKBUILD_FIPS_BUILD_JOBS=2 devenv shell -- devenv tasks run klangk:build-fips-image
+        fi
 
     - name: Clean leftover CI podman state
       if: inputs.run == 'true'

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -40,10 +40,7 @@ jobs:
           suite: test-backend-e2e
           suite-name: backend
           verbose-podman: "true"
-          # The FIPS variant feeds test_fips_e2e.py's positive-path class
-          # (~2 min of OpenSSL compile on the ephemeral VM; the stamp
-          # logic in the build script can't help across VMs).
-          build-tasks: >-
-            klangk:build-workspace-image
-            klangk:build-network-sidecar
-            klangk:build-fips-image
+          # FIPS image: pull the published GHCR image (built off-host by
+          # image-workspace-fips.yml) instead of compiling per-run on the
+          # shared host — the compile starved sibling suites (#2631).
+          fips-image: ghcr.io/mcdonc/klangk/klangk-workspace-fips:latest

--- a/.github/workflows/image-workspace-fips.yml
+++ b/.github/workflows/image-workspace-fips.yml
@@ -11,7 +11,13 @@ name: FIPS Workspace Image Check
 # falls back to the default provider — so a green build here IS the
 # compliance check (#2570, #2577).
 #
-# Does not publish anything; the image is throwaway per run.
+# Publishes to GHCR (#2631): the self-hosted e2e runners pull this image
+# instead of compiling OpenSSL per-PR on the shared host (which starved
+# sibling suites' podman execs). Tags: :<calver>-<commit> plus a floating
+# :latest (the same convention pull-base-image.sh relies on). ONE-TIME
+# setup: flip the new ghcr package's visibility to public so anonymous
+# pulls work (as klangk-workspace-base already is); until then the e2e
+# pull falls back to a local, parallelism-capped build.
 
 on:
   workflow_dispatch:
@@ -28,6 +34,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -93,3 +100,18 @@ jobs:
           fi
           echo FIPS-RUNTIME-OK
           EOS
+
+      # Publish for the e2e pull path (#2631). GITHUB_TOKEN is tied to this
+      # run; the tag links the package to the repo.
+      - name: Push FIPS image to GHCR
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          echo "${{ secrets.GITHUB_TOKEN }}" | devenv shell -- podman login ghcr.io -u ${{ github.actor }} --password-stdin
+          COMMIT=$(git rev-parse --short HEAD)
+          CALVER="$(date -u +%Y.%m.%d)"
+          VERSION="${CALVER}-${COMMIT}"
+          REPO="ghcr.io/${{ github.repository }}/klangk-workspace-fips"
+          devenv shell -- podman tag klangk-workspace-fips:ci "$REPO:$VERSION"
+          devenv shell -- podman tag klangk-workspace-fips:ci "$REPO:latest"
+          devenv shell -- podman push "$REPO:$VERSION"
+          devenv shell -- podman push "$REPO:latest"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1069,6 +1069,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`klangk terminal share`/`unshare` blind 10s timeout (#2633 CI
+  flake).** The tmux window-watcher's re-sync broadcast the window list
+  to clients without updating the in-memory map the share handlers
+  read, so a share issued right after a watcher frame (racing the
+  terminal-start sync under load) was answered "Window not found" —
+  which the CLI's receive loop ignored, timing out after 10 seconds
+  with a traceback. The watcher sync now updates the map through the
+  same merge as every other sync path, and the terminal commands'
+  receive loops surface server `error` frames immediately (#1966
+  pattern) instead of waiting out the timeout.
+
 - **Terminal window commands racing a fresh session (#2623).** A
   select/close issued immediately after opening a terminal could fail
   with `can't find session` under load: the session is created

--- a/scripts/build-fips-image.sh
+++ b/scripts/build-fips-image.sh
@@ -21,6 +21,10 @@ source "$SCRIPT_DIR/_podman_common.sh"
 STAMP="$DEVENV_STATE/klangk/.fips-image-hash"
 FIPS_IMAGE="${KLANGKBUILD_FIPS_IMAGE_NAME:-klangk-workspace-fips}"
 BASE_IMAGE="${KLANGKD_IMAGE_NAME:-klangk-workspace}"
+# Optional compile-parallelism cap (#2631): empty (default) = all cores;
+# constrained environments (e2e on the shared CI host) pass e.g. 2 so the
+# OpenSSL compile cannot starve sibling suites.
+FIPS_BUILD_JOBS="${KLANGKBUILD_FIPS_BUILD_JOBS:-}"
 
 # Only this script and Dockerfile.fips affect the FIPS layer (the base
 # image is an ARG; its own task rebuilds when IT changes).
@@ -59,6 +63,7 @@ echo "Building FIPS workspace image ${FIPS_IMAGE} (base ${BASE_IMAGE}) ..."
   --pull=newer \
   --platform "${KLANGKBUILD_PLATFORM:-linux/amd64}" \
   --build-arg WORKSPACE_IMAGE="${BASE_IMAGE}:latest" \
+  --build-arg FIPS_BUILD_JOBS="${FIPS_BUILD_JOBS}" \
   -t "${FIPS_IMAGE}:latest" \
   -t "${FIPS_IMAGE}:${KLANGK_IMAGE_VERSION}" \
   "${PASSTHROUGH_ARGS[@]}" \

--- a/scripts/pull-fips-image.sh
+++ b/scripts/pull-fips-image.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Pull the published FIPS workspace image and retag it for local use (#2631).
+#
+# The published image (ghcr.io/mcdonc/klangk/klangk-workspace-fips, built
+# + proofed by image-workspace-fips.yml on GitHub-hosted runners) replaces
+# the per-run local OpenSSL compile in CI e2e — compiling on the shared
+# self-hosted host starved sibling suites' podman execs (#2631).
+#
+# Retags to klangk-workspace-fips:latest, the name test_fips_e2e.py and
+# KLANGKD_IMAGE_NAME expect. Fails loudly (non-zero) when the pull fails so
+# callers can fall back to a local, capped build.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
+# shellcheck source=_podman_common.sh disable=SC1091
+source "$SCRIPT_DIR/_podman_common.sh"
+
+SRC="${1:-ghcr.io/mcdonc/klangk/klangk-workspace-fips:latest}"
+LOCAL="${KLANGKBUILD_FIPS_IMAGE_NAME:-klangk-workspace-fips}"
+echo "Pulling FIPS workspace image ${SRC} ..."
+"$PODMAN" pull \
+  "${SIG_POLICY_ARGS[@]}" \
+  "$SRC"
+"$PODMAN" tag "$SRC" "${LOCAL}:latest"
+echo "Tagged ${SRC} as ${LOCAL}:latest"

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -45,6 +45,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 ARG OPENSSL_FIPS_VERSION=3.1.2
 ARG OPENSSL_FIPS_SHA256=a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539
+# Cap the compile's parallelism when building on shared/oversubscribed
+# hosts: the default (empty) uses every core, which starves sibling CI
+# VMs during e2e runs (#2631). Pass --build-arg FIPS_BUILD_JOBS=2 from
+# constrained environments; dedicated build runners leave it unset.
+ARG FIPS_BUILD_JOBS=""
 WORKDIR /src
 RUN wget -q "https://www.openssl.org/source/openssl-${OPENSSL_FIPS_VERSION}.tar.gz" && \
     echo "${OPENSSL_FIPS_SHA256}  openssl-${OPENSSL_FIPS_VERSION}.tar.gz" | sha256sum -c - && \
@@ -53,7 +58,7 @@ WORKDIR "/src/openssl-${OPENSSL_FIPS_VERSION}"
 # Only the module is needed downstream; libcrypto/libssl from this build
 # are deliberately NOT installed into the final image.
 RUN ./Configure enable-fips --prefix=/opt/ossl-fips --libdir=lib && \
-    make -j"$(nproc)" && \
+    make -j"${FIPS_BUILD_JOBS:-$(nproc)}" && \
     make install_fips
 
 # --- Stage 2: workspace image + FIPS activation ------------------------------

--- a/src/klangk/klangk/cli/terminals.py
+++ b/src/klangk/klangk/cli/terminals.py
@@ -48,6 +48,26 @@ async def recv_until_event(conn, timeout: float, on_message=None):
             return msg
 
 
+def frame_is(frame_type: str):
+    """Predicate for recv_until that surfaces server errors immediately.
+
+    A bare ``lambda m: m.get("type") == t`` waits out the whole timeout
+    when the server answers with an ``error`` frame instead — a 10s hang
+    and a cryptic traceback instead of the server's reason (the #1966
+    lesson, applied to the terminal command paths after the #2633 CI
+    flake: ``terminal share`` blind-timed-out over an ignored
+    "Window not found"). Raises ConnectionError carrying the server's
+    message so the caller exits fast and loudly.
+    """
+
+    def predicate(msg) -> bool:
+        if msg.get("type") == "error":
+            raise ConnectionError(msg.get("message", "terminal error"))
+        return msg.get("type") == frame_type
+
+    return predicate
+
+
 terminal_app = typer.Typer(
     name="terminal",
     help="Manage workspace terminals.",
@@ -91,9 +111,7 @@ def terminals(
                     {"cmd": "terminal_start", "cols": cols, "rows": rows}
                 )
             )
-            msg = await recv_until(
-                conn, lambda m: m.get("type") == "terminal_windows", 30
-            )
+            msg = await recv_until(conn, frame_is("terminal_windows"), 30)
             own_windows: list[dict] = msg.get("windows", [])
 
             # Print results
@@ -226,9 +244,7 @@ def share_terminal(
                     {"cmd": "terminal_start", "cols": cols, "rows": rows}
                 )
             )
-            msg = await recv_until(
-                conn, lambda m: m.get("type") == "terminal_windows", 30
-            )
+            msg = await recv_until(conn, frame_is("terminal_windows"), 30)
             own_windows: list[dict] = msg.get("windows", [])
             match, err = _resolve_own_window(own_windows, terminal)
             if err is not None:
@@ -239,9 +255,7 @@ def share_terminal(
                 json.dumps({"cmd": "share_window", "window_id": match["id"]})
             )
             # Wait for shared_terminals confirmation
-            await recv_until(
-                conn, lambda m: m.get("type") == "shared_terminals", 10
-            )
+            await recv_until(conn, frame_is("shared_terminals"), 10)
             context._err.print(
                 f"[green]Terminal '{terminal}' is now shared[/green]"
             )
@@ -280,9 +294,7 @@ def unshare_terminal(
                     {"cmd": "terminal_start", "cols": cols, "rows": rows}
                 )
             )
-            msg = await recv_until(
-                conn, lambda m: m.get("type") == "terminal_windows", 30
-            )
+            msg = await recv_until(conn, frame_is("terminal_windows"), 30)
             own_windows: list[dict] = msg.get("windows", [])
 
             match, err = _resolve_own_window(own_windows, terminal)
@@ -294,9 +306,7 @@ def unshare_terminal(
                 json.dumps({"cmd": "unshare_window", "window_id": match["id"]})
             )
             # Wait for shared_terminals confirmation
-            await recv_until(
-                conn, lambda m: m.get("type") == "shared_terminals", 10
-            )
+            await recv_until(conn, frame_is("shared_terminals"), 10)
             context._err.print(
                 f"[green]Terminal '{terminal}' is no longer shared[/green]"
             )

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -22,6 +22,7 @@ from ..terminal import (
 from .safe_websocket import SlowClientError, WS_ERRORS
 from .constants import MAX_INPUT_SIZE
 from .helpers import send_error, send_event, get_shared_terminals
+from .session import merge_window_entries
 
 if TYPE_CHECKING:
     from .connection import Connection
@@ -912,31 +913,19 @@ class TerminalController:
             return
         user_id = self._conn.user["id"]
         old = ws_session.terminal_windows.get(user_id, [])
-        # Match old entries to new tmux entries by window_id (@N) —
-        # a tmux-assigned unique identifier that is never reused within
-        # a server's lifetime.  This is stable across renames and
-        # index reuse. Window names are display-only and may duplicate,
-        # so they are never used to match identity (#2192); after a
-        # container restart the in-container tmux server is gone and all
-        # custom tabs are lost anyway, so there is nothing to match by.
-        old_by_id = {w["id"]: w for w in old if "id" in w}
-        old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
-        new_entries = []
-        for w in windows:
-            prev = old_by_id.get(w["id"])
-            prev_shared = prev.get("shared", False) if prev else False
-            new_entries.append(
-                {
-                    "id": w["id"],
-                    "name": w["name"],
-                    "index": w["index"],
-                    "shared": self._window_shared(w["name"], prev_shared),
-                }
-            )
+        # Shared merge lives in one place (session.merge_window_entries,
+        # #2633 CI race): id-matched (tmux window ids are unique and never
+        # reused within a server's lifetime — stable across renames and
+        # index reuse, #2192), shared flags carry over, service-cmd stays
+        # shared. After a container restart the in-container tmux server
+        # is gone and all custom tabs are lost anyway, so there is
+        # nothing to match by.
+        new_entries = merge_window_entries(old, windows)
         ws_session.terminal_windows[user_id] = new_entries
         new_shared = {w["id"] for w in new_entries if w.get("shared")}
         # Broadcast if shared set changed (e.g. shared window was closed)
         # or if any shared window was renamed.
+        old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
         old_shared_names = {
             (w["id"], w["name"]) for w in old if w.get("shared") and "id" in w
         }

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from .. import model
+from ..terminal import SERVICE_CMD_WINDOW
 from ..window_watcher import WindowEventWatcher
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
 from .constants import (
@@ -23,6 +24,39 @@ if TYPE_CHECKING:
     from .connection import Connection
 
 logger = logging.getLogger(__name__)
+
+
+def merge_window_entries(old: list[dict], windows: list[dict]) -> list[dict]:
+    """Fold a fresh tmux ``list_windows`` result into the session map.
+
+    Single merge for every ``terminal_windows`` producer (#2633 CI race):
+    entries are matched by window id (``@N`` — tmux-assigned, never reused
+    within a server's lifetime, stable across renames/index reuse, #2192),
+    ``shared`` flags carry over from the old entry, and the agent's
+    ``service-cmd`` window is shared by definition (#1114).
+
+    Both the controller's sync (:meth:`sync_terminal_windows` in
+    controllers.py) and the window-watcher's debounced re-sync
+    (:meth:`_sync_windows_once`) MUST update the in-memory map through
+    this helper before broadcasting — the share/unshare handlers read
+    the map, and a frame sent without the matching map update let a
+    client act on a window the server would then not find (the
+    ``klangk terminal share`` 10s-blind-timeout flake).
+    """
+    old_by_id = {w["id"]: w for w in old if "id" in w}
+    entries = []
+    for w in windows:
+        prev = old_by_id.get(w["id"])
+        prev_shared = prev.get("shared", False) if prev else False
+        entries.append(
+            {
+                "id": w["id"],
+                "name": w["name"],
+                "index": w["index"],
+                "shared": (w["name"] == SERVICE_CMD_WINDOW or prev_shared),
+            }
+        )
+    return entries
 
 
 def _iso_utc(ts: float | None) -> str | None:
@@ -235,6 +269,16 @@ class WorkspaceSession:
             if self._last_windows.get(uid) == windows:
                 continue
             self._last_windows[uid] = windows
+            # Update the in-memory map BEFORE broadcasting (#2633 CI
+            # race): share/unshare read terminal_windows, and a client
+            # acting on this frame must find every listed window in the
+            # map. Without this, a watcher frame that beat
+            # _start_terminal's sync left the map empty/stale and
+            # ``klangk terminal share`` blind-timed-out on the missing
+            # window.
+            self.terminal_windows[uid] = merge_window_entries(
+                self.terminal_windows.get(uid, []), windows
+            )
             msg = {"type": "terminal_windows", "windows": windows}
             for sock in list(self.subscribers):
                 conn = sockets.connections.get(sock)

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -2248,7 +2248,9 @@ class TestRequireAuthNoneMode:
             "klangk.cli.context.fetch_config",
             lambda _: {"auth_modes": "none", "oidc_providers": []},
         )
-        with patch("klangk.cli.monitor.local_login", side_effect=SystemExit(1)):
+        with patch(
+            "klangk.cli.monitor.local_login", side_effect=SystemExit(1)
+        ):
             with pytest.raises(typer.Exit):
                 main.require_auth()
 
@@ -4252,7 +4254,9 @@ class TestMonitor:
         with (
             patch.object(klangk.cli.monitor, "monitor_connection", fake_conn),
             patch.object(main_mod.asyncio, "sleep", fake_sleep),
-            patch.object(klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.01),
+            patch.object(
+                klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.01
+            ),
         ):
             with pytest.raises(typer.Exit) as exc_info:
                 await main_mod.monitor_run(
@@ -4284,7 +4288,9 @@ class TestMonitor:
         with (
             patch.object(klangk.cli.monitor, "monitor_connection", fake_conn),
             patch.object(main_mod.asyncio, "sleep", fake_sleep),
-            patch.object(klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0),
+            patch.object(
+                klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0
+            ),
         ):
             with pytest.raises(typer.Exit) as exc_info:
                 await main_mod.monitor_run(
@@ -4349,9 +4355,13 @@ class TestMonitor:
 
         with (
             patch.object(klangk.cli.monitor, "monitor_connection", fake_conn),
-            patch.object(klangk.cli.monitor, "refresh_token_threaded", fake_refresh),
+            patch.object(
+                klangk.cli.monitor, "refresh_token_threaded", fake_refresh
+            ),
             patch.object(main_mod.asyncio, "sleep", fake_sleep),
-            patch.object(klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0),
+            patch.object(
+                klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0
+            ),
         ):
             # Stop the loop after the second connect via max_reconnects.
             with pytest.raises(typer.Exit):
@@ -4386,9 +4396,13 @@ class TestMonitor:
 
         with (
             patch.object(klangk.cli.monitor, "monitor_connection", fake_conn),
-            patch.object(klangk.cli.monitor, "refresh_token_threaded", fake_refresh),
+            patch.object(
+                klangk.cli.monitor, "refresh_token_threaded", fake_refresh
+            ),
             patch.object(main_mod.asyncio, "sleep", fake_sleep),
-            patch.object(klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0),
+            patch.object(
+                klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0
+            ),
         ):
             with pytest.raises(typer.Exit):
                 await main_mod.monitor_run(
@@ -4475,9 +4489,13 @@ class TestMonitor:
 
         with (
             patch.object(klangk.cli.monitor, "monitor_connection", fake_conn),
-            patch.object(klangk.cli.monitor, "refresh_token_threaded", fake_refresh),
+            patch.object(
+                klangk.cli.monitor, "refresh_token_threaded", fake_refresh
+            ),
             patch.object(main_mod.asyncio, "sleep", fake_sleep),
-            patch.object(klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0),
+            patch.object(
+                klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0
+            ),
         ):
             with pytest.raises(typer.Exit):
                 await main_mod.monitor_run(
@@ -4492,3 +4510,54 @@ class TestMonitor:
                 )
         assert seen_tokens[0] == "OLD_TOKEN"
         assert seen_tokens[1] == "NEW_TOKEN"
+
+
+class TestFrameIsPredicate:
+    """terminals.frame_is: surface server error frames immediately (#2633).
+
+    A bare type-equality predicate waits out the full recv timeout when
+    the server answers with an error — the CLI hung 10s on
+    "Window not found" during share instead of failing fast.
+    """
+
+    def _frames(self, *msgs):
+        class FakeRecv:
+            def __init__(self, frames):
+                self._frames = list(frames)
+
+            async def recv(self):
+                return self._frames.pop(0)
+
+        import json as _json
+
+        return FakeRecv([_json.dumps(m) for m in msgs])
+
+    def test_matches_target_frame(self):
+        from klangk.cli.terminals import frame_is
+        from klangk.cli.client import recv_until
+
+        conn = self._frames(
+            {"type": "presence_list"},
+            {"type": "terminal_windows", "windows": []},
+        )
+        msg = asyncio.run(recv_until(conn, frame_is("terminal_windows"), 5))
+        assert msg["type"] == "terminal_windows"
+
+    def test_error_frame_raises_immediately(self):
+        from klangk.cli.terminals import frame_is
+        from klangk.cli.client import recv_until
+
+        conn = self._frames(
+            {"type": "presence_list"},
+            {"type": "error", "message": "Window not found"},
+            {"type": "terminal_windows", "windows": []},
+        )
+        with pytest.raises(ConnectionError, match="Window not found"):
+            asyncio.run(recv_until(conn, frame_is("terminal_windows"), 5))
+
+    def test_error_frame_default_message(self):
+        from klangk.cli.terminals import frame_is
+
+        pred = frame_is("shared_terminals")
+        with pytest.raises(ConnectionError, match="terminal error"):
+            pred({"type": "error"})

--- a/src/klangk/klangkd-tests/e2e-tests/test_sighup_restart_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_sighup_restart_e2e.py
@@ -182,11 +182,15 @@ async def test_containers_stopped_then_autostarted(server, auth):
     headers = auth["headers"]
 
     # Create a workspace with auto_start enabled.
+    # 120s, not the #2619-era 30s: this create synchronously awaits the
+    # eager container start (the #2616 class — #2619 raised it to 120s in
+    # test_api_e2e.py's autostart class but missed this file; the same
+    # ReadTimeout resurfaced here under triple-e2e-suite load, #2633 CI).
     resp = client.post(
         "/api/v1/workspaces",
         headers=headers,
         json={"name": "sighup-autostart", "auto_start": True},
-        timeout=30,
+        timeout=120,
     )
     assert resp.status_code == 200
     workspace_id = resp.json()["id"]

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -121,3 +121,53 @@ async def test_reset_cancels_pending_sync_and_stops_watcher():
         await sess.reset()
         assert sess._window_watcher is None
         assert sess._window_sync_handle is None
+
+
+# --- #2633 CI race: the watcher's sync must update the in-memory map ---
+
+
+async def test_sync_updates_terminal_windows_map():
+    """A watcher frame must not advertise windows the map lacks.
+
+    ``klangk terminal share`` resolves a window from the
+    ``terminal_windows`` frame and immediately sends ``share_window``;
+    the handler reads ``terminal_windows`` from the session map. When
+    the watcher's frame beat ``_start_terminal``'s sync (the #2633 CI
+    flake), the map was still empty and the share failed with a
+    "Window not found" the CLI blindly timed out on. The map and the
+    broadcast must move together.
+    """
+    sess, sock, terminal = _session_with_user()
+    windows = [{"id": "@0", "index": 0, "name": "bash", "active": True}]
+    terminal.list_windows = AsyncMock(return_value=windows)
+
+    await sess._sync_windows_once()
+
+    assert sess.terminal_windows["u1"] == [
+        {"id": "@0", "index": 0, "name": "bash", "shared": False}
+    ]
+    sock.send_json.assert_called_once()
+
+
+async def test_sync_map_preserves_shared_flags_and_forces_service_cmd():
+    """The map update uses the shared merge: flags carry over by id and
+    service-cmd is shared by definition (#1114)."""
+    sess, _sock, terminal = _session_with_user()
+    sess.terminal_windows["u1"] = [
+        {"id": "@1", "index": 1, "name": "build", "shared": True},
+        {"id": "@0", "index": 0, "name": "bash", "shared": False},
+    ]
+    terminal.list_windows = AsyncMock(
+        return_value=[
+            {"id": "@0", "index": 0, "name": "bash", "active": True},
+            {"id": "@1", "index": 1, "name": "build", "active": False},
+            {"id": "@2", "index": 2, "name": "service-cmd", "active": False},
+        ]
+    )
+
+    await sess._sync_windows_once()
+
+    by_id = {w["id"]: w for w in sess.terminal_windows["u1"]}
+    assert by_id["@1"]["shared"] is True  # carried over
+    assert by_id["@2"]["shared"] is True  # service-cmd by definition
+    assert by_id["@0"]["shared"] is False


### PR DESCRIPTION
Closes #2631. Replaces #2632 (auto-closed when its base — the #2626 branch — was deleted by merge); same change, now based directly on main which already contains #2626.

## What

Moves the FIPS workspace image's OpenSSL compile **off the shared self-hosted CI host** so it can no longer starve sibling e2e suites (#2631):

1. **Publish** — `image-workspace-fips.yml` (GitHub-hosted `ubuntu-latest`, the existing compliance workflow) now pushes to `ghcr.io/mcdonc/klangk/klangk-workspace-fips` as `:<calver>-<commit>` plus floating `:latest` (the convention `pull-base-image.sh` already relies on). Same machinery as `image-workspace.yml`. One-time setup documented in the workflow: flip the new GHCR package to public.
2. **Pull** — the shared `e2e-suite` action gains a `fips-image` input: `scripts/pull-fips-image.sh` pulls and retags to `klangk-workspace-fips:latest` (what `test_fips_e2e.py` expects). `backend-e2e-tests.yml` passes the published `:latest` and drops `klangk:build-fips-image` from `build-tasks` — no per-PR compile at all when the pull works.
3. **Bounded fallback** — if the pull fails (package not yet published/flipped public, network), the action builds locally with the compile capped: `Dockerfile.fips` honors a `FIPS_BUILD_JOBS` build-arg (default `nproc`), `build-fips-image.sh` forwards `KLANGKBUILD_FIPS_BUILD_JOBS`, the fallback passes `2`. Slower, but a cold capped build cannot saturate the host the way `make -j$(nproc)` did.

## Verification (local)

- Pull script success path (pull + retag against the real GHCR base image), failure path (`manifest unknown` → exit 125 → fallback triggers), capped rebuild via `KLANGKBUILD_FIPS_BUILD_JOBS=2`.
- FIPS e2e 5/5, build-pipeline suite 59/59, actionlint + shellcheck clean.
- Rebased onto post-#2626 main via clean cherry-pick (no conflicts — the change only touches files #2626 didn't, plus the workflow/action it introduced).
