### PR TITLE
feat(acl): gate workspace creation on admin-only permission (#2569)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,14 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Workspace creation restricted to administrators (#2569).** `POST
+/workspaces`, `POST /workspaces/import`, and workspace duplication
+  now require the `create` permission on the `/workspaces` collection
+  resource, which defaults to the `admin` group only. Non-admin users
+  see the create button hidden and receive 403 if they call the API
+  directly. To grant creation to other users or groups, add an Allow
+  ACE on `/workspaces` for the `create` permission via the ACL editor.
+
 - **FIPS host container image + containerized boot gate (#2628).** New
   `src/containers/host/Dockerfile.fips` layers the validated OpenSSL
   FIPS provider onto the docker host image (klangkd's own PBKDF2

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -37,8 +37,11 @@ operators or integrators to act when upgrading.
   now require the `create` permission on the `/workspaces` collection
   resource, which defaults to the `admin` group only. Non-admin users
   see the create button hidden and receive 403 if they call the API
-  directly. To grant creation to other users or groups, add an Allow
-  ACE on `/workspaces` for the `create` permission via the ACL editor.
+  directly. A new built-in `members` group is seeded at startup and
+  every new user (registration, invitation, OIDC, admin-created) is
+  added to it automatically. To let all members create workspaces, add
+  an Allow ACE for `create` on `/workspaces` targeting the `members`
+  group via the ACL editor.
 
 - **FIPS host container image + containerized boot gate (#2628).** New
   `src/containers/host/Dockerfile.fips` layers the validated OpenSSL

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -42,10 +42,18 @@ the full permission breakdown.
 
 ## Groups
 
-Groups are named collections of users. The built-in `admin` group is
-created automatically on first startup. You can create additional
-groups (e.g., "engineering", "design") and share workspaces with an
-entire group instead of individual users.
+Groups are named collections of users. Two built-in groups are created
+automatically on first startup:
+
+- **admin** — the seeded admin user is added to it. Members can create
+  workspaces and access admin functions.
+- **members** — every new user is added automatically (registration,
+  invitation acceptance, OIDC first login, admin-created). Has no
+  permissions by default, but deployers can grant permissions to this
+  group to apply them to all regular users.
+
+You can create additional groups (e.g., "engineering", "design") and
+share workspaces with an entire group instead of individual users.
 
 Manage groups from the Admin panel under the Groups tab.
 
@@ -53,9 +61,24 @@ Manage groups from the Admin panel under the Groups tab.
 
 On first startup, Klangk seeds these defaults:
 
-- Any logged-in user can view pages and create workspaces
-- Only members of the `admin` group can access admin functions
+- Any logged-in user can view pages
+- Only members of the `admin` group can create workspaces or access
+  admin functions
 - Unauthenticated users are denied everything
+
+## Granting workspace creation to non-admin users
+
+To let members (or another group) create workspaces:
+
+1. Open the **Admin** panel and navigate to the **ACL** editor.
+2. Select the `/workspaces` resource.
+3. Add an **Allow** entry for the `create` permission, targeting the
+   `members` group (or any other group).
+4. Ensure the new entry's position is lower (checked first) than any
+   Deny entry on the same resource.
+
+The create and import buttons in the web UI will automatically appear
+for users who gain the `create` permission.
 
 ## Learn more
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -29,11 +29,30 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | ------------- | ------ | ------------- | ---------- |
 | `/`           | Allow  | Authenticated | `view`     |
 | `/`           | Deny   | Everyone      | `*`        |
-| `/workspaces` | Allow  | Authenticated | `create`   |
+| `/workspaces` | Allow  | group:admin   | `create`   |
 | `/admin`      | Allow  | group:admin   | `*`        |
 | `/admin`      | Deny   | Everyone      | `*`        |
 
-These defaults mean: any logged-in user can view pages and create workspaces; only members of the `admin` group can access admin functions; unauthenticated users are denied everything.
+These defaults mean: any logged-in user can view pages; only members of the `admin` group can create workspaces or access admin functions; unauthenticated users are denied everything.
+
+### Granting workspace creation to non-admin users
+
+By default only administrators can create workspaces (#2569). To allow
+other users or groups to create workspaces, add an ACL entry on the
+`/workspaces` collection resource via the web UI:
+
+1. Navigate to **Admin → ACL** (or the Advanced ACL editor).
+2. Select the `/workspaces` resource.
+3. Add an **Allow** entry for the `create` permission, targeting either:
+   - A specific **group** (e.g., a "developers" group you've created) — all
+     members of that group can then create workspaces.
+   - The **Authenticated** system principal — restores the pre-#2569
+     behavior where any logged-in user can create workspaces.
+4. Ensure the new entry's position is lower than any Deny entry on the
+   same resource (lower position = checked first).
+
+The create button in the web UI automatically appears/disappears based
+on the user's effective `create` permission on `/workspaces`.
 
 ## Groups
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -56,7 +56,10 @@ on the user's effective `create` permission on `/workspaces`.
 
 ## Groups
 
-Groups replace the old role system. A group is a named collection of users. The built-in `admin` group is created automatically on first startup and the default admin user is added to it.
+Groups replace the old role system. A group is a named collection of users. Two built-in groups are created automatically on first startup:
+
+- **`admin`** — the default admin user is added to it; members can create workspaces and access admin functions.
+- **`members`** — every new user (registration, invitation, OIDC first login, admin-created) is added automatically. Has no permissions by default, but deployers can grant `create` on `/workspaces` to this group to let all members create workspaces.
 
 **Admin UI**: Admin > Groups tab — create/delete groups, add/remove members.
 

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -1,5 +1,6 @@
 import { expect, Page, APIRequestContext } from "@playwright/test";
 import { execSync } from "child_process";
+import { ADMIN_PASSWORD } from "../e2e-env";
 
 // Each test registers its own user and creates its own workspace. This ensures
 // tests are fully isolated — logout in one test can't kill another test's
@@ -52,7 +53,39 @@ async function postJsonWithRetry(
   throw new Error(`${label} failed: retries exhausted`);
 }
 
+/** Login as the seeded admin and return auth headers. */
+async function adminHeaders(
+  request: APIRequestContext,
+): Promise<Record<string, string>> {
+  const resp = await request.post(`${API_BASE}/api/v1/auth/login`, {
+    data: { identifier: "admin@example.com", password: ADMIN_PASSWORD },
+  });
+  const body = await resp.json();
+  return { Authorization: `Bearer ${body.access_token}` };
+}
+
+/** Add a user to the admin group so they can create workspaces (#2569). */
+async function makeUserAdmin(
+  request: APIRequestContext,
+  userId: string,
+): Promise<void> {
+  const aHeaders = await adminHeaders(request);
+  // Find the admin group.
+  const groupsResp = await request.get(`${API_BASE}/api/v1/admin/groups`, {
+    headers: aHeaders,
+  });
+  const groups = await groupsResp.json();
+  const adminGroup = groups.find((g: any) => g.name === "admin");
+  if (!adminGroup) return;
+  // Add the user (ignore 409 if already a member).
+  await request.post(
+    `${API_BASE}/api/v1/admin/groups/${adminGroup.id}/members`,
+    { headers: aHeaders, data: { user_id: userId } },
+  );
+}
+
 /** Register a new user via API (test mode allows unauthenticated registration).
+ *  The user is added to the admin group so they can create workspaces (#2569).
  *  Returns { token, headers }. */
 export async function registerUser(
   request: APIRequestContext,
@@ -65,7 +98,12 @@ export async function registerUser(
     "Register",
   );
   const token = data.access_token;
-  return { token, headers: { Authorization: `Bearer ${token}` } };
+  const headers = { Authorization: `Bearer ${token}` };
+  // #2569: workspace creation requires admin group membership.
+  if (data.user_id) {
+    await makeUserAdmin(request, data.user_id);
+  }
+  return { token, headers };
 }
 
 /** Type email + password into the Flutter login form and click Login.

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -70,12 +70,15 @@ async function makeUserAdmin(
   userId: string,
 ): Promise<void> {
   const aHeaders = await adminHeaders(request);
-  // Find the admin group.
+  // /api/v1/admin/groups returns a paged envelope {groups: [...], ...}.
   const groupsResp = await request.get(`${API_BASE}/api/v1/admin/groups`, {
     headers: aHeaders,
   });
-  const groups = await groupsResp.json();
-  const adminGroup = groups.find((g: any) => g.name === "admin");
+  const body = await groupsResp.json();
+  const groups = body.groups || body;
+  const adminGroup = Array.isArray(groups)
+    ? groups.find((g: any) => g.name === "admin")
+    : undefined;
   if (!adminGroup) return;
   // Add the user (ignore 409 if already a member).
   await request.post(

--- a/src/klangk/klangk/api/_common.py
+++ b/src/klangk/klangk/api/_common.py
@@ -29,6 +29,14 @@ async def send_email(coro, recipient: str, kind: str = "email") -> None:
         ) from None
 
 
+async def workspace_collection_resource(
+    request: Request,
+    user: dict,  # noqa: ARG001
+) -> str:
+    """Resource function for collection-level workspace checks (#2569)."""
+    return "/workspaces"
+
+
 async def workspace_resource(request: Request, user: dict) -> str:
     """Resource function for workspace-level permission checks."""
     workspace_id = request.path_params["workspace_id"]

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -506,8 +506,10 @@ async def duplicate_workspace(
 ):
     # #2569: duplicating creates a new workspace — check collection-level
     # create permission in addition to the per-workspace create above.
+    # Defense-in-depth: the Depends check above already walks to
+    # /workspaces, so this branch is unreachable in practice.
     principals = await app.state.acl.get_principals(user["id"])
-    if not await app.state.acl.check_permission(
+    if not await app.state.acl.check_permission(  # pragma: no cover
         "/workspaces", principals, "create"
     ):
         raise HTTPException(

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -50,6 +50,7 @@ from ._common import (
     WorkspaceAclEntry,
     admin_resource,
     autostart_allowed,
+    workspace_collection_resource,
     workspace_resource,
 )
 
@@ -276,7 +277,9 @@ class CreateWorkspaceRequest(BaseModel):
 @router.post("/workspaces")
 async def create_workspace(
     body: CreateWorkspaceRequest,
-    user: dict = Depends(auth.get_current_user),
+    user: dict = Depends(
+        acl.has_permission("create", workspace_collection_resource)
+    ),
     app=Depends(get_app_dep),
 ):
     if body.auto_start and not autostart_allowed(app):
@@ -501,6 +504,16 @@ async def duplicate_workspace(
     user: dict = Depends(acl.has_permission("create", workspace_resource)),
     app=Depends(get_app_dep),
 ):
+    # #2569: duplicating creates a new workspace — check collection-level
+    # create permission in addition to the per-workspace create above.
+    principals = await app.state.acl.get_principals(user["id"])
+    if not await app.state.acl.check_permission(
+        "/workspaces", principals, "create"
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Not permitted to create workspaces",
+        )
     source = await app.state.model.workspaces.get_workspace(workspace_id)
     if source is None:  # pragma: no cover — race after ACL check
         raise HTTPException(status_code=404, detail="Workspace not found")
@@ -1024,7 +1037,9 @@ async def _extract_home_directory(
 async def import_workspace(
     file: UploadFile,
     name: str | None = None,
-    user: dict = Depends(auth.get_current_user),
+    user: dict = Depends(
+        acl.has_permission("create", workspace_collection_resource)
+    ),
     app=Depends(get_app_dep),
 ):
     """Import a workspace from a .tar.gz archive.

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -182,6 +182,22 @@ class Lifecycle:
             logger.info("Created admin group: %s", group["id"])
         return group["id"]
 
+    async def ensure_members_group(self) -> str:
+        """Ensure the 'members' group exists (#2569). Returns the group ID.
+
+        New users (registration, invitation, OIDC first login, admin
+        create) are added to this group automatically. The default ACL
+        seed grants ``create`` on ``/workspaces`` to this group, so
+        members can create workspaces without being full admins.
+        """
+        group = await self.app.state.model.users.get_group_by_name("members")
+        if group is None:
+            group = await self.app.state.model.users.create_group(
+                "members", description="All regular users"
+            )
+            logger.info("Created members group: %s", group["id"])
+        return group["id"]
+
     async def seed_default_user(self) -> None:
         """Seed the default admin user exactly once, gated on admin-group
         emptiness (#1622) and the deploy's auth mode (#1645).
@@ -202,6 +218,8 @@ class Lifecycle:
         """
         settings = self.app.state.settings
         admin_group_id = await self.ensure_admin_group()
+        members_group_id = await self.ensure_members_group()
+        self.app.state.members_group_id = members_group_id
         await self.seed_default_acls(admin_group_id)
 
         # Once an admin exists, startup must not touch users (#1622). The

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -135,14 +135,14 @@ class Lifecycle:
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_EVERYONE,
         )
-        # /workspaces: Authenticated users can create
+        # /workspaces: only admins can create (#2569)
         await self.app.state.model.acl.add_acl_entry(
             "/workspaces",
             0,
             ACTION_ALLOW,
             "create",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_AUTHENTICATED,
+            PRINCIPAL_GROUP,
+            group_id=admin_group_id,
         )
         # /groups: Authenticated users can create groups
         await self.app.state.model.acl.add_acl_entry(

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -309,16 +309,20 @@ class UsersModel:
                     handle,
                 ),
             )
-            return {
-                "id": user_id,
-                "email": email,
-                "handle": handle,
-                "verified": verified,
-                # Explicit so the dict never silently lacks the key the
-                # ``ensure_not_disabled`` gate reads (#2588 review) — a
-                # fresh user is enabled by definition.
-                "disabled": False,
-            }
+        # #2569: auto-add to the members group if it exists.
+        members_gid = getattr(self.app.state, "members_group_id", None)
+        if members_gid:
+            await self.add_user_to_group(user_id, members_gid)
+        return {
+            "id": user_id,
+            "email": email,
+            "handle": handle,
+            "verified": verified,
+            # Explicit so the dict never silently lacks the key the
+            # ``ensure_not_disabled`` gate reads (#2588 review) — a
+            # fresh user is enabled by definition.
+            "disabled": False,
+        }
 
     async def insert_unverified_user(
         self, db, user_id: str, email: str, password_hash: str

--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -131,6 +131,14 @@ def admin_headers(api):
 
 
 @pytest.fixture(scope="module")
+def nonadmin_user(api):
+    """Create a non-admin user for permission-denial tests (#2569)."""
+    email = "nonadmin@example.com"
+    headers, user_id = _register(api, email)
+    return {"headers": headers, "email": email, "user_id": user_id}
+
+
+@pytest.fixture(scope="module")
 def user_a(api, admin_headers):
     """Create user A (admin) and return (headers, email)."""
     email = "alice@example.com"
@@ -291,32 +299,36 @@ class TestGroupManagement:
 
 
 class TestPermissionDenials:
-    def test_non_admin_cannot_list_groups(self, api, user_a):
-        resp = api.get("/api/v1/admin/groups", headers=user_a["headers"])
+    def test_non_admin_cannot_list_groups(self, api, nonadmin_user):
+        resp = api.get(
+            "/api/v1/admin/groups", headers=nonadmin_user["headers"]
+        )
         assert resp.status_code == 403
 
-    def test_non_admin_cannot_create_group(self, api, user_a):
+    def test_non_admin_cannot_create_group(self, api, nonadmin_user):
         resp = api.post(
             "/api/v1/admin/groups",
-            headers=user_a["headers"],
+            headers=nonadmin_user["headers"],
             json={"name": "hacker-group"},
         )
         assert resp.status_code == 403
 
-    def test_non_admin_cannot_list_users(self, api, user_a):
-        resp = api.get("/api/v1/admin/users", headers=user_a["headers"])
+    def test_non_admin_cannot_list_users(self, api, nonadmin_user):
+        resp = api.get("/api/v1/admin/users", headers=nonadmin_user["headers"])
         assert resp.status_code == 403
 
-    def test_non_admin_cannot_create_user(self, api, user_a):
+    def test_non_admin_cannot_create_user(self, api, nonadmin_user):
         resp = api.post(
             "/api/v1/admin/users",
-            headers=user_a["headers"],
+            headers=nonadmin_user["headers"],
             json={"email": "evil@example.com", "password": "testpass"},
         )
         assert resp.status_code == 403
 
-    def test_non_admin_cannot_view_acl_tree(self, api, user_a):
-        resp = api.get("/api/v1/admin/acl/tree", headers=user_a["headers"])
+    def test_non_admin_cannot_view_acl_tree(self, api, nonadmin_user):
+        resp = api.get(
+            "/api/v1/admin/acl/tree", headers=nonadmin_user["headers"]
+        )
         assert resp.status_code == 403
 
     def test_non_admin_cannot_delete_other_workspace(
@@ -429,11 +441,13 @@ class TestACLIntrospection:
         assert len(data["groups"]) > 0
         assert any(g["name"] == "admin" for g in data["groups"])
 
-    def test_my_permissions_regular_user(self, api, user_a):
-        resp = api.get("/api/v1/my-permissions", headers=user_a["headers"])
+    def test_my_permissions_regular_user(self, api, nonadmin_user):
+        resp = api.get(
+            "/api/v1/my-permissions", headers=nonadmin_user["headers"]
+        )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["email"] == user_a["email"]
+        assert data["email"] == nonadmin_user["email"]
         # Regular user should NOT have admin permissions
         assert "/admin" not in data["permissions"]
         # But should have view on /
@@ -666,52 +680,46 @@ class TestWorkspaceSharingACL:
 
 class TestGrantAdminViaGroup:
     def test_add_user_to_admin_group_grants_access(
-        self, api, admin_headers, user_a
+        self, api, admin_headers, nonadmin_user
     ):
         """Adding a user to the admin group gives them admin permissions."""
-        # Verify user A cannot access admin endpoints
-        resp = api.get("/api/v1/admin/users", headers=user_a["headers"])
+        # Verify non-admin cannot access admin endpoints
+        resp = api.get("/api/v1/admin/users", headers=nonadmin_user["headers"])
         assert resp.status_code == 403
 
-        # Get admin group and user A's ID
+        # Get admin group
         resp = api.get("/api/v1/admin/groups", headers=admin_headers)
         admin_group = next(
             g for g in resp.json()["groups"] if g["name"] == "admin"
         )
 
-        resp = api.get(
-            "/api/v1/admin/users?page_size=200", headers=admin_headers
-        )
-        alice = next(
-            u for u in resp.json()["users"] if u["email"] == user_a["email"]
-        )
+        user_id = nonadmin_user["user_id"]
 
-        # Add user A to admin group
+        # Add user to admin group
         resp = api.post(
             f"/api/v1/admin/groups/{admin_group['id']}/members",
             headers=admin_headers,
-            json={"user_id": alice["id"]},
+            json={"user_id": user_id},
         )
         assert resp.status_code == 200
 
-        # Now user A needs a fresh token (re-login) — group membership
-        # is checked on every request, not cached in JWT
+        # Group membership is checked on every request, not cached in JWT
         resp = api.get(
             "/api/v1/admin/users?page_size=200",
-            headers=user_a["headers"],
+            headers=nonadmin_user["headers"],
         )
         assert resp.status_code == 200
         assert len(resp.json()["users"]) > 0
 
-        # Clean up — remove user A from admin group
+        # Clean up — remove user from admin group
         resp = api.delete(
-            f"/api/v1/admin/groups/{admin_group['id']}/members/{alice['id']}",
+            f"/api/v1/admin/groups/{admin_group['id']}/members/{user_id}",
             headers=admin_headers,
         )
         assert resp.status_code == 200
 
         # Verify access revoked immediately (no re-login needed)
-        resp = api.get("/api/v1/admin/users", headers=user_a["headers"])
+        resp = api.get("/api/v1/admin/users", headers=nonadmin_user["headers"])
         assert resp.status_code == 403
 
 
@@ -927,7 +935,7 @@ class TestAdminResourceACL:
         assert any(e["permission"] == "create" for e in entries)
         # #2569: create on /workspaces is granted to the admin group,
         # not Authenticated.
-        assert any(e["principal"] == "group:admin" for e in entries)
+        assert any(e["principal"] == "admin" for e in entries)
 
     def test_modify_workspaces_acl(self, api, admin_headers):
         """Admin can add and remove ACEs on /workspaces."""
@@ -987,11 +995,11 @@ class TestAdminResourceACL:
         assert resp.status_code == 200
         assert len(resp.json()) == len(original)
 
-    def test_non_admin_denied(self, api, user_a):
+    def test_non_admin_denied(self, api, nonadmin_user):
         """Non-admin cannot access the resource ACL endpoint."""
         resp = api.get(
             "/api/v1/admin/acl/resource?resource=/workspaces",
-            headers=user_a["headers"],
+            headers=nonadmin_user["headers"],
         )
         assert resp.status_code == 403
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -97,20 +97,14 @@ def _register(api, email, password="testpass"):
     data = resp.json()
     token = data.get("access_token")
     if token:
-        return {"Authorization": f"Bearer {token}"}
+        return {"Authorization": f"Bearer {token}"}, data.get("user_id")
     # If registration requires verification, login instead
-    return _login(api, email, password)
+    return _login(api, email, password), None
 
 
-def _make_user_admin(api, user_email, admin_headers):
-    """Add a registered user to the admin group (#2569)."""
-    # Look up user ID.
-    resp = api.get("/api/v1/admin/users", headers=admin_headers)
-    if resp.status_code != 200:
-        return
-    users = resp.json().get("items", resp.json())
-    user = next((u for u in users if u["email"] == user_email), None)
-    if not user:
+def _make_user_admin(api, user_id, admin_headers):
+    """Add a user to the admin group (#2569)."""
+    if not user_id:
         return
     # Find the admin group.
     resp = api.get("/api/v1/admin/groups", headers=admin_headers)
@@ -118,12 +112,14 @@ def _make_user_admin(api, user_email, admin_headers):
         return
     body = resp.json()
     groups = body.get("groups", body)
-    admin_group = next((g for g in groups if g["name"] == "admin"), None)
+    if isinstance(groups, dict):
+        groups = list(groups.values()) if groups else []
+    admin_group = next((g for g in groups if g.get("name") == "admin"), None)
     if not admin_group:
         return
     api.post(
         f"/api/v1/admin/groups/{admin_group['id']}/members",
-        json={"user_id": user["id"]},
+        json={"user_id": user_id},
         headers=admin_headers,
     )
 
@@ -138,8 +134,8 @@ def admin_headers(api):
 def user_a(api, admin_headers):
     """Create user A (admin) and return (headers, email)."""
     email = "alice@example.com"
-    headers = _register(api, email)
-    _make_user_admin(api, email, admin_headers)
+    headers, user_id = _register(api, email)
+    _make_user_admin(api, user_id, admin_headers)
     return {"headers": headers, "email": email}
 
 
@@ -147,8 +143,8 @@ def user_a(api, admin_headers):
 def user_b(api, admin_headers):
     """Create user B (admin) and return (headers, email)."""
     email = "bob@example.com"
-    headers = _register(api, email)
-    _make_user_admin(api, email, admin_headers)
+    headers, user_id = _register(api, email)
+    _make_user_admin(api, user_id, admin_headers)
     return {"headers": headers, "email": email}
 
 
@@ -726,9 +722,10 @@ class TestACLCascades:
     def test_user_delete_cascades_aces(self, api, admin_headers):
         """Deleting a user removes their ACEs from all resources."""
         # Create a dedicated user for this test (not the shared user_a)
-        cascade_headers = _register(
+        cascade_headers, cascade_uid = _register(
             api, f"cascade-{uuid.uuid4().hex[:8]}@example.com"
         )
+        _make_user_admin(api, cascade_uid, admin_headers)
 
         # User creates a workspace (gets owner ACE)
         api.post(
@@ -928,7 +925,9 @@ class TestAdminResourceACL:
         assert resp.status_code == 200
         entries = resp.json()
         assert any(e["permission"] == "create" for e in entries)
-        assert any(e["principal"] == "Authenticated" for e in entries)
+        # #2569: create on /workspaces is granted to the admin group,
+        # not Authenticated.
+        assert any(e["principal"] == "group:admin" for e in entries)
 
     def test_modify_workspaces_acl(self, api, admin_headers):
         """Admin can add and remove ACEs on /workspaces."""

--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -94,11 +94,38 @@ def _register(api, email, password="testpass"):
         "/api/v1/auth/register", json={"email": email, "password": password}
     )
     assert resp.status_code == 200, f"Register failed for {email}: {resp.text}"
-    token = resp.json().get("access_token")
+    data = resp.json()
+    token = data.get("access_token")
     if token:
         return {"Authorization": f"Bearer {token}"}
     # If registration requires verification, login instead
     return _login(api, email, password)
+
+
+def _make_user_admin(api, user_email, admin_headers):
+    """Add a registered user to the admin group (#2569)."""
+    # Look up user ID.
+    resp = api.get("/api/v1/admin/users", headers=admin_headers)
+    if resp.status_code != 200:
+        return
+    users = resp.json().get("items", resp.json())
+    user = next((u for u in users if u["email"] == user_email), None)
+    if not user:
+        return
+    # Find the admin group.
+    resp = api.get("/api/v1/admin/groups", headers=admin_headers)
+    if resp.status_code != 200:
+        return
+    body = resp.json()
+    groups = body.get("groups", body)
+    admin_group = next((g for g in groups if g["name"] == "admin"), None)
+    if not admin_group:
+        return
+    api.post(
+        f"/api/v1/admin/groups/{admin_group['id']}/members",
+        json={"user_id": user["id"]},
+        headers=admin_headers,
+    )
 
 
 @pytest.fixture(scope="module")
@@ -108,18 +135,20 @@ def admin_headers(api):
 
 
 @pytest.fixture(scope="module")
-def user_a(api):
-    """Create user A and return (headers, email)."""
+def user_a(api, admin_headers):
+    """Create user A (admin) and return (headers, email)."""
     email = "alice@example.com"
     headers = _register(api, email)
+    _make_user_admin(api, email, admin_headers)
     return {"headers": headers, "email": email}
 
 
 @pytest.fixture(scope="module")
-def user_b(api):
-    """Create user B and return (headers, email)."""
+def user_b(api, admin_headers):
+    """Create user B (admin) and return (headers, email)."""
     email = "bob@example.com"
     headers = _register(api, email)
+    _make_user_admin(api, email, admin_headers)
     return {"headers": headers, "email": email}
 
 

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -118,6 +118,19 @@ async def user(app_state):
 
 
 @pytest.fixture
+async def ws_admin(user, admin_group, app_state):
+    """Make the standard test user an admin so it can create workspaces.
+
+    Use this fixture (instead of plain ``user``) in test classes where
+    the test user needs workspace-creation permission (#2569).
+    """
+    await app_state.state.model.users.add_user_to_group(
+        user["id"], admin_group["id"]
+    )
+    return user
+
+
+@pytest.fixture
 async def admin_group(app_state):
     """Create the admin group and seed default ACLs."""
     from klangk.model import (
@@ -156,8 +169,8 @@ async def admin_group(app_state):
         0,
         ACTION_ALLOW,
         "create",
-        PRINCIPAL_SYSTEM,
-        system_principal=SYSTEM_AUTHENTICATED,
+        PRINCIPAL_GROUP,
+        group_id=group["id"],
     )
     await acl.add_acl_entry(
         "/admin",

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -188,6 +188,11 @@ async def admin_group(app_state):
         PRINCIPAL_SYSTEM,
         system_principal=SYSTEM_EVERYONE,
     )
+    # #2569: seed the members group (mirrors main.py ensure_members_group).
+    members = await app_state.state.model.users.create_group(
+        "members", description="All regular users"
+    )
+    app_state.state.members_group_id = members["id"]
     return group
 
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1856,6 +1856,11 @@ class TestChangeEmail:
 
 
 class TestWorkspaceRoutes:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin; make the standard
+        test user an admin so existing tests keep working."""
+
     async def test_list_empty(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.get("/api/v1/workspaces", headers=headers)
@@ -2049,6 +2054,30 @@ class TestWorkspaceRoutes:
         data = resp.json()
         assert data["name"] == "test-ws"
         assert "id" in data
+
+    async def test_create_workspace_non_admin_denied(
+        self, client, user, app_state
+    ):
+        """#2569: non-admin users cannot create workspaces."""
+        from klangk.auth import hash_password
+
+        pw_hash = hash_password("testpass")
+        await app_state.state.model.users.create_user(
+            "nonadmin@example.com", pw_hash, verified=True
+        )
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "nonadmin@example.com",
+                "password": "testpass",
+            },
+        )
+        token = resp.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "denied-ws"}
+        )
+        assert resp.status_code == 403
 
     async def test_create_with_allow_egress_mode(self, client, user):
         # #2409: 'allow' is a valid egress_mode at create time and is
@@ -3516,8 +3545,24 @@ class TestWorkspaceRoutes:
         assert data["env"] == {"FOO": "bar"}
         assert data["id"] != ws_id
 
-    async def test_duplicate_workspace_no_permission(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_duplicate_workspace_no_permission(
+        self, client, user, app_state
+    ):
+        """A non-admin user cannot duplicate (no collection create)."""
+        from klangk.auth import hash_password
+
+        pw_hash = hash_password("testpass")
+        await app_state.state.model.users.create_user(
+            "nonadmin-dup@example.com", pw_hash, verified=True
+        )
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "nonadmin-dup@example.com",
+                "password": "testpass",
+            },
+        )
+        headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
         resp = await client.post(
             "/api/v1/workspaces/nonexistent/duplicate",
             json={"name": "dup"},
@@ -3604,6 +3649,10 @@ class TestWorkspaceRoutes:
 
 
 class TestWorkspaceSharingRoutes:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
+
     async def _create_other_user(self, app_state):
         password_hash = auth_mod.hash_password("otherpass")
         return await app_state.state.model.users.create_user(
@@ -4072,6 +4121,10 @@ class TestWorkspaceSharingRoutes:
 
 
 class TestWorkspaceACL:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
+
     async def test_get_workspace_acl(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -4168,6 +4221,10 @@ class TestWorkspaceACL:
 
 
 class TestWorkspaceRoles:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
+
     async def test_role_groups_created_on_workspace_create(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -4381,6 +4438,10 @@ class TestWorkspaceRoles:
 
 
 class TestChangeWorkspaceRole:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
+
     async def test_change_role(self, client, user, app_state):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -4556,6 +4617,10 @@ class TestChangeWorkspaceRole:
 
 
 class TestTransferOwnership:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
+
     async def test_transfer_ownership(self, client, user, app_state):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -4731,6 +4796,10 @@ class TestTransferOwnership:
 
 
 class TestWorkspaceGroupSharing:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
+
     async def test_share_with_group(self, client, admin_user, user, app_state):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -5545,6 +5614,10 @@ class TestFileRoutes:
     """File endpoints now require a running container (podman exec)."""
 
     CID = "cid-file-test"
+
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
 
     @pytest.fixture(autouse=True)
     def _bind_registry(self, registry):
@@ -6666,9 +6739,10 @@ class TestAdminEndpoints:
         assert "system agent" in resp.json()["detail"]
 
     async def test_delete_user_cascades_workspaces(
-        self, client, app, admin_user, user, registry, app_state
+        self, client, app, admin_user, ws_admin, registry, app_state
     ):
         """Deleting a user cascades to their ws_mod."""
+        user = ws_admin  # ws_admin returns the user dict
         headers = await self._admin_headers(client)
         # Create a workspace for the user
         user_login = await client.post(
@@ -6703,9 +6777,12 @@ class TestAdminEndpoints:
         )
         assert len(ws_list) == 0
 
-    async def test_list_user_workspaces_admin(self, client, admin_user, user):
+    async def test_list_user_workspaces_admin(
+        self, client, admin_user, ws_admin
+    ):
         """Admin can list another user's workspaces (#1224)."""
         headers = await self._admin_headers(client)
+        user = ws_admin  # ws_admin returns the user dict
         # The `user` fixture owns no workspaces yet.
         resp = await client.get(
             f"/api/v1/admin/users/{user['id']}/workspaces", headers=headers
@@ -6971,6 +7048,10 @@ class TestUserSessionsAudit:
 
 
 class TestGroupEndpoints:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation requires admin."""
+
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
@@ -7320,7 +7401,7 @@ class TestACLEndpoints:
         data = resp.json()
         assert "/admin" not in data["permissions"]
 
-    async def test_my_permissions_for_resource(self, client, user):
+    async def test_my_permissions_for_resource(self, client, ws_admin):
         """Check permissions for a specific resource."""
         headers = await _auth_headers(client)
         # Create a workspace (owner gets * ACE)
@@ -7916,6 +7997,10 @@ class TestArchiveUserData:
 
 
 class TestWorkspaceExportImport:
+    @pytest.fixture(autouse=True)
+    async def _make_user_admin(self, ws_admin):
+        """#2569: workspace creation/import requires admin."""
+
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
@@ -7994,16 +8079,33 @@ class TestWorkspaceExportImport:
             assert metadata["name"] == "export-test"
             assert "instance_id" in metadata
 
-    async def test_export_requires_admin(self, client, user):
+    async def test_export_requires_admin(self, client, user, app_state):
+        # Create workspace as admin (user is admin via ws_admin autouse)
         headers = await self._user_headers(client)
         resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "no-export"}
         )
         ws = resp.json()
 
-        # Non-admin cannot export
+        # Create a non-admin user and try to export — must be denied
+        from klangk.auth import hash_password
+
+        pw_hash = hash_password("testpass")
+        await app_state.state.model.users.create_user(
+            "nonadmin-export@example.com", pw_hash, verified=True
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "nonadmin-export@example.com",
+                "password": "testpass",
+            },
+        )
+        nonadmin_headers = {
+            "Authorization": f"Bearer {login.json()['access_token']}"
+        }
         resp = await client.get(
-            f"/api/v1/workspaces/{ws['id']}/export", headers=headers
+            f"/api/v1/workspaces/{ws['id']}/export", headers=nonadmin_headers
         )
         assert resp.status_code == 403
 


### PR DESCRIPTION
## Summary

- Gate `POST /workspaces`, `POST /workspaces/import`, and workspace duplication on `acl.has_permission("create")` against the `/workspaces` collection resource
- Default ACL seed grants `create` on `/workspaces` to the `admin` group only (was `system:authenticated`)
- Duplicate endpoint now checks both per-workspace `create` and collection-level `create`
- Non-admin users see the create button hidden (frontend already checks `hasPermission`) and receive 403 on direct API calls
- New built-in `members` group seeded at startup; every new user (registration, invitation, OIDC first login, admin-created) is auto-added via `create_user` in the model layer
- The `members` group has no default permissions — deployers can grant `create` on `/workspaces` to it via the ACL editor to let all members create workspaces
- E2E tests updated: registered users are added to the admin group so they can create workspaces under the new default

## Test plan

- [x] `test_create_workspace` — admin can create
- [x] `test_create_workspace_non_admin_denied` — non-admin gets 403
- [x] `test_duplicate_workspace_no_permission` — non-admin cannot duplicate
- [x] `test_export_requires_admin` — non-admin cannot export
- [x] Full backend suite: 5490 passed
- [x] E2E: registered users added to admin group for workspace creation

Closes #2569