### PR TITLE
ci: path-filter E2E workflows to skip doc-only PRs (#2636, #2637, #2638)

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -5,6 +5,14 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths:
+      - "src/klangk/**"
+      - "src/containers/**"
+      - "scripts/**"
+      - "devenv.nix"
+      - "devenv.yaml"
+      - ".github/workflows/backend-e2e-tests.yml"
+      - ".github/actions/e2e-suite/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -27,8 +35,8 @@ jobs:
           filters: |
             e2e:
               - 'src/klangk/**'
-              - 'src/containers/workspace/**'
-              - 'src/containers/network/**'
+              - 'src/containers/**'
+              - 'scripts/**'
               - 'devenv.nix'
               - 'devenv.yaml'
               - '.github/workflows/backend-e2e-tests.yml'

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -5,6 +5,14 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths:
+      - "src/klangk/**"
+      - "src/containers/workspace/**"
+      - "src/containers/network/**"
+      - "devenv.nix"
+      - "devenv.yaml"
+      - ".github/workflows/cli-e2e-tests.yml"
+      - ".github/actions/e2e-suite/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -14,6 +14,16 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths:
+      - "src/klangk/**"
+      - "src/frontend/**"
+      - "src/containers/workspace/**"
+      - "src/containers/network/**"
+      - "features/**"
+      - "devenv.nix"
+      - "devenv.yaml"
+      - ".github/workflows/frontend-e2e-tests.yml"
+      - ".github/actions/e2e-suite/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary

Add `paths` filters to the `pull_request` trigger on all three E2E workflows so the jobs don't start at all for PRs that only touch docs or unrelated code:

- **CLI E2E** (`cli-e2e-tests.yml`): triggers on `src/klangk/**`, `src/containers/{workspace,network}/**`, `devenv.{nix,yaml}`, workflow files
- **Backend E2E** (`backend-e2e-tests.yml`): same plus `src/containers/**` and `scripts/**` (backend E2E starts real containers)
- **Frontend E2E** (`frontend-e2e-tests.yml`): same plus `src/frontend/**` and `features/**`

The existing `dorny/paths-filter` per-step check remains as a secondary guard. The `push` trigger on `release/**` branches and `workflow_dispatch` are unfiltered (release and manual runs always execute).

## Test plan

- [x] Verified path lists match the existing dorny filter in each workflow
- [x] actionlint passes

Closes #2636, closes #2637, closes #2638