### PR TITLE
fix(ws): catch-all websocket fallback before StaticFiles mount

### DIFF
--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -1087,6 +1087,15 @@ def build_app(settings: KlangkSettings) -> FastAPI:
         # fanout lands with #2244, the sidecar kernel hold in a follow-up.
         await handle_egress_sidecar(ws, app)
 
+    # #2322: catch-all websocket fallback — must be registered after specific
+    # ws routes but before the StaticFiles mount, which otherwise swallows ws
+    # scopes and crashes with ``assert scope["type"] == "http"``.
+    @app.websocket("/{path:path}")
+    async def ws_fallback(ws: WebSocket, path: str):  # pragma: no cover
+        await ws.accept()
+        logger.warning("unhandled ws path: /%s", path)
+        await ws.close(code=4044, reason=f"no websocket route at /{path}")
+
     # Frontend UI dir, resolved from settings (#1456, #1600). Mounted only
     # when it exists; a packaged/installed klangkd ships the UI inside the
     # wheel (klangk/frontend) so this is the common case. When the dir is

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -2290,6 +2290,26 @@ class TestBuildApp:
         }
         assert "/ws" in ws_paths
 
+    def test_build_app_has_ws_fallback(self, tmp_path):
+        """#2322: a catch-all ws fallback is registered before the StaticFiles
+        mount so unmatched WS upgrades get a clear close instead of the
+        StaticFiles ``assert scope["type"] == "http"`` crash."""
+        (tmp_path / "index.html").write_text("<html></html>")
+        settings = make_settings({"KLANGKD_FRONTEND_DIR": str(tmp_path)})
+        app = main.build_app(settings)
+        fallback_idx = None
+        static_idx = None
+        for i, r in enumerate(app.routes):
+            if getattr(r, "path", None) == "/{path:path}":
+                fallback_idx = i
+            if getattr(r, "name", None) == "frontend":
+                static_idx = i
+        assert fallback_idx is not None, "ws fallback route missing"
+        assert static_idx is not None, "static mount missing"
+        assert fallback_idx < static_idx, (
+            "ws fallback must be registered before the StaticFiles mount"
+        )
+
     def test_build_app_registers_exception_handlers(self):
         app = main.build_app(make_settings({}))
         assert model.AgentPrincipalError in app.exception_handlers


### PR DESCRIPTION
## Summary

- Register a `/{path:path}` websocket fallback route after the specific ws routes but before the `StaticFiles` mount, so unmatched WS upgrades get a clear warning log and close code 4044 instead of the cryptic `assert scope["type"] == "http"` crash from StaticFiles.

Closes #2322

## Test plan

- [x] New test verifies fallback route exists and is ordered before the static mount
- [x] Full backend suite passes (5491 tests)