### PR TITLE
fix(e2e): pass admin:false for tests that assert non-admin 403

### DIFF
--- a/src/frontend/e2e-tests/e2e/api.spec.ts
+++ b/src/frontend/e2e-tests/e2e/api.spec.ts
@@ -357,10 +357,11 @@ test.describe("API", () => {
     const adminToken = (await loginResp.json()).access_token;
     const adminHeaders = { Authorization: `Bearer ${adminToken}` };
 
-    // Create a test user via test mode
+    // Create a non-admin test user via test mode (#2643).
     const { token: userToken, headers: userHeaders } = await registerUser(
       request,
       "admin-test@test.example.com",
+      { admin: false },
     );
 
     // Admin can list users
@@ -1037,6 +1038,7 @@ test.describe("API", () => {
     const { headers: userHeaders } = await registerUser(
       request,
       `export-nonadmin-${Date.now()}@test.example.com`,
+      { admin: false },
     );
 
     // Create workspace as regular user
@@ -1115,6 +1117,7 @@ test.describe("API", () => {
     const { headers: userHeaders } = await registerUser(
       request,
       `acl-denied-${Date.now()}@test.example.com`,
+      { admin: false },
     );
 
     const resp = await request.get(

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -88,11 +88,14 @@ async function makeUserAdmin(
 }
 
 /** Register a new user via API (test mode allows unauthenticated registration).
- *  The user is added to the admin group so they can create workspaces (#2569).
+ *  By default the user is added to the admin group so they can create
+ *  workspaces (#2569).  Pass `admin: false` for tests that need a genuine
+ *  non-admin user (#2643).
  *  Returns { token, headers }. */
 export async function registerUser(
   request: APIRequestContext,
   email: string,
+  { admin = true }: { admin?: boolean } = {},
 ): Promise<{ token: string; headers: Record<string, string> }> {
   const data = await postJsonWithRetry(
     request,
@@ -103,7 +106,7 @@ export async function registerUser(
   const token = data.access_token;
   const headers = { Authorization: `Bearer ${token}` };
   // #2569: workspace creation requires admin group membership.
-  if (data.user_id) {
+  if (admin && data.user_id) {
     await makeUserAdmin(request, data.user_id);
   }
   return { token, headers };


### PR DESCRIPTION
## Summary

- Add an `admin` option (default `true`) to `registerUser()` in the E2E helpers so tests can create genuine non-admin users
- Pass `{ admin: false }` in three tests that assert 403 for non-admin access: user listing, workspace export, and ACL browser

The `registerUser()` helper unconditionally called `makeUserAdmin()` (added for #2569), so these tests were creating admin users and then expecting 403 — which always returned 200.

Closes #2643

## Test plan

- [ ] CI E2E suite passes — the three previously-failing tests should now get 403 as expected