### PR TITLE
fix(e2e): increase ws-connect-speed timeout from 10s to 30s

### DIFF
--- a/src/frontend/e2e-tests/e2e/ws-connect-speed.spec.ts
+++ b/src/frontend/e2e-tests/e2e/ws-connect-speed.spec.ts
@@ -47,13 +47,13 @@ test.describe("WebSocket connect speed", () => {
 
       await expect
         .poll(() => containerReady, {
-          timeout: 10_000,
-          message: "container_ready not received within 10s of navigation",
+          timeout: 30_000,
+          message: "container_ready not received within 30s of navigation",
         })
         .toBeTruthy();
 
       const elapsed = Date.now() - start;
-      expect(elapsed).toBeLessThan(10_000);
+      expect(elapsed).toBeLessThan(30_000);
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## Summary

- Increase the `container_ready` poll timeout and elapsed-time assertion from 10s to 30s in the first ws-connect-speed test, matching the 30s `containerTimeout` used elsewhere

The 10s timeout was too tight for initial container startup under CI load, causing intermittent failures.

Closes #2645

## Test plan

- [ ] CI E2E suite passes without the ws-connect-speed flake