### PR TITLE
feat(ops): cordon/drain mode for klangkd (#2527)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -92,6 +92,17 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Cordon/drain mode (#2527).** New operator controls for clean
+  host maintenance: `klangk admin cordon` refuses new workspace starts
+  (API returns 503, WebSocket start paths send an error frame, boot
+  auto-start and crash-recovery restarts are suppressed) while existing
+  workspaces keep running; `klangk admin drain` cordons and then
+  gracefully stops all running workspaces (clients see terminal stop
+  frames, not a dropped connection). The cordon flag is persisted in
+  the database, so it survives klangkd restarts — a crash-looping
+  service stays cordoned instead of re-starting user workspaces.
+  Docs: [Cordon & Drain](deployment/cordon-drain.md) (systemd
+  `ExecStop` and docker upgrade workflows included).
 - **Decommissioning guide (#2593).** New [deployment chapter](../deployment/decommissioning.md)
   documenting the decommissioning notification chain (users, admins, integrators,
   infrastructure owners) and the shutdown sequence: workspace export, graceful

--- a/docs/deployment/cordon-drain.md
+++ b/docs/deployment/cordon-drain.md
@@ -1,0 +1,124 @@
+# Cordon & drain (operator maintenance workflow)
+
+The k8s cordon/drain pair for klangkd (#2527): quiesce a host before an
+upgrade, reboot, or maintenance window without dirty container deaths.
+
+- **Cordon** — the node refuses _new_ workspace starts. Existing
+  workspaces keep running. Every start path honors it: the API start /
+  restart endpoints (503 with a clear message), WebSocket connects (an
+  error frame), eager starts on create, boot auto-start on a klangkd
+  restart, and crash-recovery restarts.
+- **Drain** — gracefully stop every running workspace through the same
+  path as logout / idle timeout: connected clients receive terminal
+  status frames and a `container_stopped` event carrying the reason, so
+  the UI shows a clean shutdown instead of a dropped WebSocket.
+
+The cordon flag is persisted in the database (`server_state` table), so
+it survives klangkd restarts: a crash-looping service that comes back up
+stays cordoned and does **not** re-start user workspaces — mirroring
+k8s's cordon-on-boot. This is deliberate: an operator investigating a
+sick host wants the quiesce to hold.
+
+## Commands (admin)
+
+```bash
+klangk admin cordon          # refuse new starts
+klangk admin drain           # cordon + stop all running workspaces
+klangk admin cordon-status   # show the flag
+klangk admin uncordon        # re-enable starts
+```
+
+`drain` cordons first by default so nothing restarts behind the drain's
+back; `--no-cordon` skips that (users may restart workspaces
+mid-drain), and `--uncordon` uncordons afterwards for scripted
+maintenance windows that end automatically. The exit status reflects
+API failures, so wrappers can wait on completion; `drain` reports the
+number of workspaces stopped.
+
+The HTTP surface behind them (if you script against the API directly):
+
+| Method | Path                   | Effect                                        |
+| ------ | ---------------------- | --------------------------------------------- |
+| GET    | `/api/v1/admin/cordon` | Read the flag                                 |
+| PUT    | `/api/v1/admin/cordon` | Set/clear (`{"cordoned": true}`)              |
+| POST   | `/api/v1/admin/drain`  | Stop all running workspaces, `{"stopped": n}` |
+
+Authenticated clients also see `cordoned` in `GET /api/v1/config` (the
+web UI can badge the state); the pre-auth payload does not include it.
+
+## systemd deployment (system Python)
+
+For hosts running klangkd under systemd with the system Python
+(Ubuntu/Arch `pip install klangk` + a unit file), the full upgrade
+cycle is:
+
+```bash
+# 1. Quiesce: no new starts, then stop everything gracefully.
+klangk admin cordon
+klangk admin drain
+
+# 2. Upgrade (unit restart / host reboot / pip install of the new version).
+sudo systemctl restart klangkd      # or: reboot
+
+# 3. Resume.
+klangk admin uncordon
+```
+
+Because drain already quiesced every workspace, the unit stop cannot
+kill containers mid-flight (klangkd's own SIGTERM path stops
+containers too, but with drain you choose _when_ it happens, and
+clients saw clean stop frames).
+
+A unit can also wire the drain into its stop:
+
+```ini
+[Service]
+ExecStart=/usr/local/bin/klangkd --config /etc/klangk/klangkd.yaml
+ExecStop=/usr/bin/klangk admin drain --uncordon
+```
+
+`ExecStop` runs on `systemctl stop`/reboot, giving a graceful drain
+before the process goes away. The `--uncordon` there is a policy
+choice: it assumes the _next_ start (after upgrade or reboot) should
+serve traffic again. Omit it to stay cordoned across the restart and
+uncordon by hand once you've verified the upgrade — the safer default
+when a human is watching the window.
+
+The klangkd package does not ship unit files; the snippet above is the
+shape that matters (`ExecStop` = drain), adapted to wherever your
+`klangk`/`klangkd` binaries live.
+
+## Docker deployment (host container)
+
+The docker host-container deployment gets the same protection from the
+volume-mounted database (`/home/klangk/data` carries the cordon flag
+across container replacements):
+
+```bash
+# 1. Quiesce.
+klangk admin cordon
+klangk admin drain
+
+# 2. Replace the container (drain already stopped the nested workspace
+#    containers, so docker's SIGTERM -> SIGKILL window has nothing
+#    left to kill mid-flight).
+docker stop klangk && docker rm klangk
+docker run ... ghcr.io/mcdonc/klangk/klangk-host:<version>
+
+# 3. Resume.
+klangk admin uncordon
+```
+
+Docker has no `ExecStop` equivalent; run the drain explicitly before
+`docker stop` as shown. A crash-looping container restarted by a docker
+restart policy reads the persisted flag and stays cordoned — no
+auto-started workspaces until an operator uncordons.
+
+## What cordon does NOT do
+
+- It does not disconnect connected clients — terminals to _running_
+  workspaces keep working between cordon and drain.
+- It does not evict users or block the API otherwise; only workspace
+  _starts_ are refused.
+- Drain does not delete workspaces — everything restarts on the next
+  start (or boot auto-start, once uncordoned).

--- a/docs/deployment/cordon-drain.md
+++ b/docs/deployment/cordon-drain.md
@@ -43,8 +43,10 @@ The HTTP surface behind them (if you script against the API directly):
 | PUT    | `/api/v1/admin/cordon` | Set/clear (`{"cordoned": true}`)              |
 | POST   | `/api/v1/admin/drain`  | Stop all running workspaces, `{"stopped": n}` |
 
-Authenticated clients also see `cordoned` in `GET /api/v1/config` (the
-web UI can badge the state); the pre-auth payload does not include it.
+Authenticated clients also see `cordoned` in `GET /api/v1/config`, and
+every connected WebSocket receives a `node_cordon` event on change —
+forward API surface for a future UI badge (no client consumes it yet);
+the pre-auth payload does not include it.
 
 ## systemd deployment (system Python)
 
@@ -78,7 +80,14 @@ ExecStop=/usr/bin/klangk admin drain --uncordon
 ```
 
 `ExecStop` runs on `systemctl stop`/reboot, giving a graceful drain
-before the process goes away. The `--uncordon` there is a policy
+before the process goes away. Raise the unit's stop deadline to match
+the drain's worst case — the default `TimeoutStopSec=90` can SIGKILL a
+drain on a host with many workspaces, leaving `--uncordon` unrun and
+the node cordoned after the upgrade:
+
+````ini
+TimeoutStopSec=600
+``` The `--uncordon` there is a policy
 choice: it assumes the _next_ start (after upgrade or reboot) should
 serve traffic again. Omit it to stay cordoned across the restart and
 uncordon by hand once you've verified the upgrade — the safer default
@@ -107,7 +116,7 @@ docker run ... ghcr.io/mcdonc/klangk/klangk-host:<version>
 
 # 3. Resume.
 klangk admin uncordon
-```
+````
 
 Docker has no `ExecStop` equivalent; run the drain explicitly before
 `docker stop` as shown. A crash-looping container restarted by a docker

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -20,7 +20,10 @@ What happens, in order:
 5. Dispose the database engine and remove the PID file.
 
 Net effect: a _full_ stop. Workspaces go away; on the next start,
-`auto_start` brings back any that are configured for it.
+`auto_start` brings back any that are configured for it. To control
+_when_ that happens (and give clients clean stop frames first), see
+[Cordon & Drain](cordon-drain.md) — drain before the stop, and cordon
+keeps a restarting/crash-looping klangkd from re-starting workspaces.
 
 ## SIGHUP — reload configuration + graceful runtime restart (#1212, #1587)
 

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -538,6 +538,10 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
     ("GET", f"{P}/admin/acl/by-principal/group/{{group_id}}", None, None),
     ("GET", f"{P}/admin/acl/resource", None, {"resource": "string"}),
     ("PUT", f"{P}/admin/acl/resource", {"entries": "value"}, None),
+    # Cordon / drain (#2527)
+    ("GET", f"{P}/admin/cordon", None, None),
+    ("PUT", f"{P}/admin/cordon", {"cordoned": "bool"}, None),
+    ("POST", f"{P}/admin/drain", None, None),
     # Browser delegate
     ("POST", f"{P}/browser-delegate", {"action": "string", "data": "value"}, None),
     (
@@ -905,7 +909,9 @@ async def run_fuzz(
     ) as client:
         while time.monotonic() < deadline:
             # Pick a random endpoint
-            method, path_template, body_schema, query_schema = rng.choice(ENDPOINTS)
+            method, path_template, body_schema, query_schema = rng.choice(
+                _fuzzable_endpoints()
+            )
 
             # Fill in path parameters
             path = path_template
@@ -1011,6 +1017,24 @@ async def run_fuzz(
 # ---------------------------------------------------------------------------
 # Endpoint drift check (--check mode)
 # ---------------------------------------------------------------------------
+
+
+# State-mutating operator routes (#2527). They stay in ENDPOINTS so the
+# --check parity gate covers them, but the randomized loop skips them:
+# a fuzzed {"cordoned": true} (the wrong-type generator can yield a real
+# bool) would cordon the fuzzed server and turn every later start's
+# legitimate 503 into a flagged "5xx anomaly"; a fuzzed drain adds nothing
+# the endpoints' input validation hasn't already seen. GET cordon is safe
+# and IS fuzzed.
+NO_FUZZ: set[tuple[str, str]] = {
+    ("PUT", f"{P}/admin/cordon"),
+    ("POST", f"{P}/admin/drain"),
+}
+
+
+def _fuzzable_endpoints() -> list[tuple]:
+    """ENDPOINTS minus NO_FUZZ — what the randomized loop draws from."""
+    return [(m, p, b, q) for m, p, b, q in ENDPOINTS if (m, p) not in NO_FUZZ]
 
 
 def _fuzzed_routes() -> set[tuple[str, str]]:

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -243,6 +243,10 @@ async def get_config(
             app.state.netfilter.default_domains()
         )
         config["netfilter_enabled"] = app.state.netfilter.enabled()
+        # Cordon state (#2527): authenticated clients learn the node is
+        # cordoned (starts will be refused) so the UI can badge it. Like
+        # the netfilter block: not on the pre-auth payload.
+        config["cordoned"] = await app.state.model.server_state.is_cordoned()
     config.update(app.state.features.frontend_config())
     # Whether the clanker agent is on for this deploy (#1977): the chat
     # feature active AND KLANGKWS_FEATURE_CHAT_AGENT_ENABLED set. A bool so

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -789,6 +789,71 @@ async def replace_resource_acl(
     return await app.state.model.acl.get_acl_entries_resolved(resource)
 
 
+# --- Node maintenance: cordon / drain (#2527) -------------------------------
+
+
+class CordonRequest(BaseModel):
+    cordoned: bool
+
+
+@router.get("/admin/cordon")
+async def get_cordon(
+    admin: dict = Depends(acl.has_permission("admin", admin_resource)),
+    app=Depends(get_app_dep),
+):
+    """Report the node's cordon state (admin only).
+
+    The flag is persisted in the DB (``server_state``), so it survives
+    klangkd restarts — a crash-looping service stays cordoned and keeps
+    suppressing boot auto-start until an operator uncordons.
+    """
+    return {"cordoned": await app.state.model.server_state.is_cordoned()}
+
+
+@router.put("/admin/cordon")
+async def set_cordon(
+    body: CordonRequest,
+    admin: dict = Depends(acl.has_permission("admin", admin_resource)),
+    app=Depends(get_app_dep),
+):
+    """Set or clear the cordon flag (admin only).
+
+    Cordon refuses *new* workspace starts (API/WS/eager-create/boot
+    auto-start/crash restart) while existing workspaces keep running —
+    the k8s pre-upgrade posture. Broadcast to every connected client so
+    the UI can badge the state.
+    """
+    await app.state.model.server_state.set_cordoned(body.cordoned)
+    word = "Cordoned" if body.cordoned else "Uncordoned"
+    logger.info("%s by %s", word, admin.get("email") or admin.get("id"))
+    app.state.sockets.notify_node_cordoned(body.cordoned)
+    return {"cordoned": body.cordoned}
+
+
+@router.post("/admin/drain")
+async def drain_node(
+    admin: dict = Depends(acl.has_permission("admin", admin_resource)),
+    app=Depends(get_app_dep),
+):
+    """Gracefully stop every running workspace (admin only).
+
+    Same path as logout/idle stop — terminal status frames reach
+    connected clients (clean "stopped", not a dropped WebSocket), and
+    each container stops with the deploy's podman stop grace. Idempotent
+    on an already-drained node (0 stopped). Typically preceded by
+    cordon; the CLI ``drain`` command does cordon-then-drain by default.
+    """
+    stopped = await app.state.container_registry.drain_all_containers(
+        reason="node drain (operator)"
+    )
+    logger.info(
+        "Node drained by %s: %d workspace(s) stopped",
+        admin.get("email") or admin.get("id"),
+        stopped,
+    )
+    return {"stopped": stopped}
+
+
 STATIC_RESOURCES = [
     "/",
     "/workspaces",

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -617,7 +617,18 @@ async def restart_workspace(
     fresh one with the same workspace config (#1244). The service
     command re-fires at the create choke point, so a service workspace
     recovers to healthy.
+
+    #2527: a cordoned node refuses the restart up front — checking
+    *before* the stop keeps a running workspace running (the cordon
+    posture promises existing workspaces survive until drain), instead
+    of stopping it and then failing the start.
     """
+    if await app.state.model.server_state.is_cordoned():
+        raise HTTPException(
+            status_code=503,
+            detail="node is cordoned: new workspace starts are disabled "
+            "(an operator is preparing this host; uncordon to resume)",
+        )
     workspace = await app.state.model.workspaces.get_workspace(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -31,6 +31,7 @@ from .. import (
     netfilter as netfilter_mod,
     wshandler,
 )
+from ..exceptions import NodeCordonedError
 from ..workspace_settings import (
     validate_settings,
     validate_settings_patch,
@@ -340,6 +341,15 @@ async def create_workspace(
     if body.auto_start:
         try:
             await app.state.workspaces.start_workspace(ws)
+        except NodeCordonedError:
+            # Cordon raced the create (#2527): the workspace row exists
+            # but no container may start. Not worth failing the create —
+            # it simply won't run until uncordon (a start then succeeds).
+            logger.warning(
+                "Node cordoned mid-create: workspace %s created but not "
+                "started",
+                ws["id"],
+            )
         except Exception:
             logger.warning(
                 "Eager start failed for workspace %s",
@@ -626,6 +636,10 @@ async def restart_workspace(
     # create choke point in start_container.
     try:
         await app.state.workspaces.start_workspace(workspace)
+    except NodeCordonedError as exc:
+        # Cordoned nodes refuse fresh starts (#2527); the stop above
+        # already happened, so the workspace is simply left stopped.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     except ValueError as exc:
         # User-config error (e.g. a bind-mount source path that doesn't
         # exist) — surface as a 400, not an unhandled 500 (#2157).
@@ -703,6 +717,10 @@ async def start_workspace(
         return {"status": "already_running"}
     try:
         await app.state.workspaces.start_workspace(workspace)
+    except NodeCordonedError as exc:
+        # Cordoned node (#2527): clear 503 so clients/CLI can distinguish
+        # "temporarily disabled by an operator" from a config error.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     except ValueError as exc:
         # User-config error (e.g. a bind-mount source path that doesn't
         # exist) — surface as a 400, not an unhandled 500 (#2157). The WS

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -282,7 +282,12 @@ def admin_drain(
         if resp.status_code != 200:
             _admin_error(resp)
         console.print("[yellow]Cordoned.[/yellow]")
-    resp = client.post("/api/v1/admin/drain")
+    # A drain is sequential server-side (podman stop per workspace, ~6-8s
+    # each); the client default 60s timeout would abort and blindly retry
+    # mid-drain on busy hosts (#2527 review). One long request, no retry
+    # storm: the server is idempotent, but a concurrent second drain's
+    # count would misreport.
+    resp = client.post("/api/v1/admin/drain", timeout=600.0)
     client.check_auth(resp)
     if resp.status_code != 200:
         _admin_error(resp)

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -211,6 +211,107 @@ def admin_invitations_ls() -> None:
     console.print(table)
 
 
+@admin_app.command("cordon")
+def admin_cordon() -> None:
+    """Cordon the node: refuse new workspace starts (admin only).
+
+    The k8s cordon posture (#2527): existing workspaces keep running,
+    but starts, restarts, eager starts, and boot auto-start are refused
+    until uncordon. The flag is persisted, so it survives klangkd
+    restarts — a crash-looping service stays cordoned.
+    """
+    context.require_auth()
+    client = context._client()
+    resp = client.put("/api/v1/admin/cordon", json={"cordoned": True})
+    client.check_auth(resp)
+    if resp.status_code != 200:
+        _admin_error(resp)
+    Console().print(
+        "[yellow]Node cordoned.[/yellow] New workspace starts are "
+        "refused until uncordon. Run [bold]klangk admin drain[/bold] "
+        "to stop running workspaces."
+    )
+
+
+@admin_app.command("uncordon")
+def admin_uncordon() -> None:
+    """Uncordon the node: re-enable workspace starts (admin only)."""
+    context.require_auth()
+    client = context._client()
+    resp = client.put("/api/v1/admin/cordon", json={"cordoned": False})
+    client.check_auth(resp)
+    if resp.status_code != 200:
+        _admin_error(resp)
+    Console().print(
+        "[green]Node uncordoned.[/green] Workspace starts re-enabled."
+    )
+
+
+@admin_app.command("drain")
+def admin_drain(
+    no_cordon: bool = typer.Option(
+        False,
+        "--no-cordon",
+        help="Drain without cordoning first (stopped workspaces may be "
+        "restarted by users mid-drain).",
+    ),
+    uncordon_after: bool = typer.Option(
+        False,
+        "--uncordon",
+        help="Uncordon the node after draining (for scripted maintenance "
+        "windows that end automatically).",
+    ),
+) -> None:
+    """Cordon + gracefully stop all running workspaces (admin only).
+
+    The k8s drain posture (#2527): cordons first (so nothing restarts
+    behind the drain's back), then stops every running workspace via
+    the graceful logout/idle path — connected clients see a clean
+    "stopped" frame, not a dropped connection. Use before upgrades,
+    reboots, or host maintenance; typically followed by uncordon once
+    the maintenance completes.
+    """
+    context.require_auth()
+    client = context._client()
+    console = Console()
+    if no_cordon:
+        console.print("Skipping cordon (--no-cordon).")
+    else:
+        resp = client.put("/api/v1/admin/cordon", json={"cordoned": True})
+        client.check_auth(resp)
+        if resp.status_code != 200:
+            _admin_error(resp)
+        console.print("[yellow]Cordoned.[/yellow]")
+    resp = client.post("/api/v1/admin/drain")
+    client.check_auth(resp)
+    if resp.status_code != 200:
+        _admin_error(resp)
+    stopped = resp.json().get("stopped", 0)
+    console.print(f"Drained: {stopped} workspace(s) stopped.")
+    if uncordon_after:
+        resp = client.put("/api/v1/admin/cordon", json={"cordoned": False})
+        client.check_auth(resp)
+        if resp.status_code != 200:
+            _admin_error(resp)
+        console.print("[green]Uncordoned.[/green]")
+
+
+@admin_app.command("cordon-status")
+def admin_cordon_status() -> None:
+    """Show the node's cordon state (admin only)."""
+    context.require_auth()
+    client = context._client()
+    resp = client.get("/api/v1/admin/cordon")
+    client.check_auth(resp)
+    if resp.status_code != 200:
+        _admin_error(resp)
+    cordoned = resp.json().get("cordoned", False)
+    if cordoned:
+        Console().print("[yellow]CORDONED[/yellow] — new starts refused.")
+    else:
+        Console().print("[green]Ready[/green] — not cordoned.")
+
+
 @vol_app.command("ls")
 def volumes_list(
     plain: bool = typer.Option(False, "--plain", help="Plain text output"),

--- a/src/klangk/klangk/container/crash.py
+++ b/src/klangk/klangk/container/crash.py
@@ -520,6 +520,15 @@ class CrashRecoveryMonitor:
             if not self.enabled:
                 tracker.next_attempt_at = None
                 return
+            # Cordoned node (#2527): a drain's stopped state must stick —
+            # crash recovery would otherwise undo the operator's quiesce.
+            if await self.app.state.model.server_state.is_cordoned():
+                tracker.next_attempt_at = None
+                logger.info(
+                    "Workspace %s: restart suppressed (node cordoned)",
+                    ws_id,
+                )
+                return
             ws = None
             try:
                 ws = await self.app.state.model.workspaces.get_workspace_by_id(

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -17,6 +17,7 @@ import time
 
 from .. import podman
 from .. import fips as fips_mod
+from ..exceptions import NodeCordonedError
 from ..model.workspaces import EGRESS_MODE_ALLOW, EGRESS_MODE_INTERACTIVE
 from ..podman import PodmanError
 from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST
@@ -1083,6 +1084,20 @@ class ContainerRegistry(NetworkSidecarMixin):
                     self._ws_with_network_sidecar.add(workspace_id)
                 return result
 
+        # Cordon gate (#2527): a cordoned node refuses every *new* container
+        # creation. Placed after the existing-container reuse above so a
+        # client connecting to a still-running workspace keeps working
+        # between cordon and drain (existing workspaces keep running — only
+        # fresh starts are blocked). The flag is read from the DB at start
+        # time, so it survives restarts and applies immediately across all
+        # start paths (API start/restart, WS connect, create eager start,
+        # boot auto-start, crash-recovery restart).
+        if await self.app.state.model.server_state.is_cordoned():
+            raise NodeCordonedError(
+                "node is cordoned: new workspace starts are disabled "
+                "(an operator is preparing this host; uncordon to resume)"
+            )
+
         # A fresh container (re)start means no `restart`-duration consent
         # verdict can still be in effect -- the sidecar's in-memory rules
         # (learned ACCEPT for an allow, REJECT for a deny) died with the
@@ -1518,6 +1533,46 @@ class ContainerRegistry(NetworkSidecarMixin):
                 await self.stop_and_remove_container(
                     ws["container_id"], workspace_id=ws["id"]
                 )
+
+    async def drain_all_containers(self, *, reason: str = "node drain") -> int:
+        """Gracefully stop every running workspace (#2527 drain).
+
+        The k8s ``drain`` half: same path as logout's
+        :meth:`stop_user_containers` and the idle-timeout cleanup —
+        :meth:`notify_workspace_killed` emits the terminal
+        status/service-death frames so connected clients see a clean
+        "stopped" instead of a dropped WebSocket, then
+        :meth:`stop_and_remove_container` runs the graceful podman stop
+        with the deploy's stop grace. The container_stopped broadcast
+        carries the drain reason so the UI shows it.
+
+        Iterates a snapshot (list(...) of states) so a container exiting
+        mid-loop cannot mutate the dict under us. Returns the number of
+        workspaces stopped.
+        """
+        stopped = 0
+        for ws_id, state in list(self.states.items()):
+            cid = state.container_id
+            if not cid:
+                continue
+            await self.notify_workspace_killed(ws_id)
+            await self.stop_and_remove_container(cid, workspace_id=ws_id)
+            # Same "stopped on purpose" broadcast as the /stop endpoint:
+            # clients re-render as stopped, not disconnected.
+            session = self.app.state.sockets.get_session(ws_id)
+            if session:
+                session.broadcast(
+                    {
+                        "type": "event",
+                        "event": {
+                            "type": "CUSTOM",
+                            "name": "container_stopped",
+                            "value": {"reason": reason},
+                        },
+                    }
+                )
+            stopped += 1
+        return stopped
 
     # --- Pre-warm ---
 

--- a/src/klangk/klangk/exceptions.py
+++ b/src/klangk/klangk/exceptions.py
@@ -22,3 +22,14 @@ class ContainerGoneError(TerminalError):
 
 class SendmailError(RuntimeError):
     """The sendmail subprocess exited with a non-zero status."""
+
+
+class NodeCordonedError(RuntimeError):
+    """The node is cordoned: new workspace starts are refused (#2527).
+
+    Raised at the container-start choke point when the persisted cordon
+    flag is set. Existing workspaces keep running; only fresh container
+    creation is blocked. The API layer translates it to a 503 with a
+    clear detail, the WS start paths send an error frame, and the crash
+    restart loop abandons quietly.
+    """

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -53,6 +53,7 @@ from klangk.model.migrations import m0002_last_login_at
 from klangk.model.migrations import m0003_user_sessions
 from klangk.model.migrations import m0004_user_sessions_workstation
 from klangk.model.migrations import m0005_user_inactivity
+from klangk.model.migrations import m0006_server_state
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -66,6 +67,7 @@ MIGRATIONS: list[Migration] = [
     m0003_user_sessions.migration,
     m0004_user_sessions_workstation.migration,
     m0005_user_inactivity.migration,
+    m0006_server_state.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0006_server_state.py
+++ b/src/klangk/klangk/model/migrations/m0006_server_state.py
@@ -1,0 +1,24 @@
+"""Migration 0006: the ``server_state`` key-value table (#2527).
+
+Node-level operator state that must survive a klangkd restart — today
+the cordon flag (k8s cordon/drain, #2527): a cordoned node refuses new
+workspace starts and suppresses boot auto-start, and a crash-looping
+service must not silently un-cordon itself, so the flag lives in the
+DB rather than process memory.
+"""
+
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    await db.execute(
+        """
+        CREATE TABLE server_state (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
+
+
+migration = Migration(6, "0006_server_state", apply)

--- a/src/klangk/klangk/model/model.py
+++ b/src/klangk/klangk/model/model.py
@@ -22,6 +22,7 @@ from .acl import ACLModel
 from .chat import ChatModel
 from .egress_consent import EgressConsentModel
 from .ports import PortsModel
+from .server_state import ServerStateModel
 from .sessions import SessionsModel
 from .tokens import TokensModel
 from .login_attempts import LoginAttemptsModel
@@ -52,6 +53,7 @@ class Model:
         self.workspaces = WorkspacesModel(app)
         self.chat = ChatModel(app)
         self.egress_consent = EgressConsentModel(app)
+        self.server_state = ServerStateModel(app)
 
     def reconfigure(self, app) -> None:
         self.app = app
@@ -66,6 +68,7 @@ class Model:
             self.workspaces,
             self.chat,
             self.egress_consent,
+            self.server_state,
         ):
             sub.reconfigure(app)
 

--- a/src/klangk/klangk/model/server_state.py
+++ b/src/klangk/klangk/model/server_state.py
@@ -1,0 +1,60 @@
+"""Node-level operator state persisted in the ``server_state`` table.
+
+The k8s cordon/drain pair for klangkd (#2527): the cordon flag must
+survive a klangkd restart (a crash-looping service must not silently
+un-cordon itself and re-start user workspaces while an operator
+investigates), so it lives in the DB, not process memory.
+
+The table is a generic key-value store (``key TEXT PRIMARY KEY``,
+``value TEXT NOT NULL``) so future node-level state slots in without
+another migration. Only the cordon key exists today.
+
+:class:`ServerStateModel` is the ``app_state``-owned form reached via
+``app.state.model.server_state``. The flag is read at container-start
+time (not cached at boot), so a cordon set by one request path is
+honored immediately by every other path, across SIGHUP restarts, and
+after crashes.
+"""
+
+from __future__ import annotations
+
+CORDON_KEY = "cordoned"
+
+
+class ServerStateModel:
+    """Persisted node-level state, resolved through ``app_state.db``."""
+
+    def __init__(self, app):
+        self.app = app
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    async def get(self, key: str, default: str | None = None) -> str | None:
+        """Return the stored value for *key*, or *default*."""
+        row = await self.app.state.db.fetchone(
+            "SELECT value FROM server_state WHERE key = ?", (key,)
+        )
+        return row[0] if row else default
+
+    async def set(self, key: str, value: str) -> None:
+        """Upsert *key* = *value*."""
+        async with self.app.state.db.transaction() as db:
+            await db.execute(
+                """
+                INSERT INTO server_state (key, value)
+                VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """,
+                (key, value),
+            )
+
+    # --- Cordon (#2527) ---
+
+    async def is_cordoned(self) -> bool:
+        """True when the node is cordoned (new starts refused)."""
+        return (await self.get(CORDON_KEY)) == "1"
+
+    async def set_cordoned(self, cordoned: bool) -> None:
+        """Set/clear the cordon flag."""
+        await self.set(CORDON_KEY, "1" if cordoned else "0")

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -556,6 +556,17 @@ class Workspaces:
         if not self.app.state.settings.allow_autostart:
             return 0
 
+        # Cordon check (#2527): a cordoned node suppresses boot auto-start
+        # entirely. The start choke point would refuse each workspace anyway
+        # (NodeCordonedError), but checking up front gives one clear log line
+        # instead of N per-workspace failure warnings.
+        if await self.app.state.model.server_state.is_cordoned():
+            logger.info(
+                "Node is cordoned: suppressing boot auto-start "
+                "(uncordon and restart, or run drain --uncordon, to resume)"
+            )
+            return 0
+
         ws_list = (
             await self.app.state.model.workspaces.list_auto_start_workspaces()
         )

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from .. import container, model
+from ..exceptions import NodeCordonedError
 from ..terminal import TerminalSession
 from ..podman import ExecSession
 from .constants import (
@@ -443,6 +444,11 @@ class Connection:
         except ValueError as exc:
             send_error(self.sock, str(exc))
             return
+        except NodeCordonedError as exc:
+            # Cordoned node (#2527): an operator has disabled new starts;
+            # existing workspaces keep running. Error frame, not a drop.
+            send_error(self.sock, str(exc))
+            return
         logger.info(
             "workspace-open: start or reuse container "
             "(see breakdown above): %.3fs",
@@ -546,7 +552,13 @@ class Connection:
             send_error(self.sock, "Workspace not found")
             return
 
-        await self.start_workspace_container(workspace_id, workspace)
+        try:
+            await self.start_workspace_container(workspace_id, workspace)
+        except NodeCordonedError as exc:
+            # Cordoned node (#2527) — same clear refusal on the WS restart
+            # path as the API's 503.
+            send_error(self.sock, str(exc))
+            return
         self.app.state.container_registry.record_activity(self.container_id)
 
         # Update container_id on ALL connections to this workspace

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -799,6 +799,28 @@ class WebSocketState:
         for sock, _ in dead:
             self.connections.pop(sock, None)
 
+    def notify_node_cordoned(self, cordoned: bool) -> None:
+        """Broadcast a node-cordon event to all connections (#2527).
+
+        Fanned out to every authenticated connection like
+        :meth:`notify_workspace_evicted` so clients can badge the state
+        (new starts will be refused while cordoned).
+        """
+        message: dict = {
+            "type": "node_cordon",
+            "cordoned": cordoned,
+        }
+        dead = []
+        for sock, conn in self.connections.items():
+            if conn.user.get("id") is None:
+                continue
+            try:
+                sock.send_json(message)
+            except WS_ERRORS:
+                dead.append((sock, conn))
+        for sock, _ in dead:
+            self.connections.pop(sock, None)
+
     def notify_service_health(
         self,
         workspace_id: str,

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5922,3 +5922,189 @@ class TestConsentDecideCommand:
         assert app.popup_socket == "/tmp/klangk.sock"
         assert app.popup_session == "klangk-consent-wsid"
         assert app._persistent
+
+
+class TestCordonDrainCommands:
+    """`klangk admin cordon/uncordon/drain/cordon-status` (#2527)."""
+
+    def _invoke(self, argv, client):
+        from klangk.cli import main
+
+        with patch.object(context_mod, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            return runner.invoke(main.app, argv)
+
+    @staticmethod
+    def _client(responses):
+        """A MagicMock client whose get/put/post replay *responses* keyed
+        by (method, path)."""
+        client = MagicMock()
+
+        def route(method, path, payload):
+            def handler(p, *args, **kwargs):
+                if p == path:
+                    return MagicMock(
+                        status_code=200,
+                        json=MagicMock(return_value=payload),
+                    )
+                return MagicMock(status_code=500)
+
+            getattr(client, method).side_effect = handler
+
+        for (method, path), payload in responses.items():
+            route(method, path, payload)
+        return client
+
+    def test_cordon(self, logged_in_cfg):
+        client = self._client({("put", "/api/v1/admin/cordon"): True})
+        result = self._invoke(["admin", "cordon"], client)
+        assert result.exit_code == 0
+        assert "cordoned" in result.stdout.lower()
+
+    def test_uncordon(self, logged_in_cfg):
+        client = self._client({("put", "/api/v1/admin/cordon"): False})
+        result = self._invoke(["admin", "uncordon"], client)
+        assert result.exit_code == 0
+        assert "uncordoned" in result.stdout.lower()
+
+    def test_cordon_status(self, logged_in_cfg):
+        client = self._client(
+            {("get", "/api/v1/admin/cordon"): {"cordoned": True}}
+        )
+        result = self._invoke(["admin", "cordon-status"], client)
+        assert result.exit_code == 0
+        assert "CORDONED" in result.stdout
+
+    def test_drain(self, logged_in_cfg):
+        client = self._client(
+            {
+                ("put", "/api/v1/admin/cordon"): True,
+                ("post", "/api/v1/admin/drain"): {"stopped": 2},
+            }
+        )
+        result = self._invoke(["admin", "drain"], client)
+        assert result.exit_code == 0
+        assert "2" in result.stdout
+
+    def test_drain_no_cordon(self, logged_in_cfg):
+        client = self._client(
+            {
+                ("post", "/api/v1/admin/drain"): {"stopped": 0},
+            }
+        )
+        result = self._invoke(["admin", "drain", "--no-cordon"], client)
+        assert result.exit_code == 0
+        # no cordon PUT happened
+        client.put.assert_not_called()
+
+    def test_drain_uncordon_flag(self, logged_in_cfg):
+        client = self._client(
+            {
+                ("put", "/api/v1/admin/cordon"): True,
+                ("post", "/api/v1/admin/drain"): {"stopped": 1},
+            }
+        )
+        result = self._invoke(["admin", "drain", "--uncordon"], client)
+        assert result.exit_code == 0
+        assert client.put.call_count == 2  # cordon, then uncordon
+
+    def test_cordon_error_exits(self, logged_in_cfg):
+        client = MagicMock()
+        resp = MagicMock(
+            status_code=403,
+            headers={},
+            json=MagicMock(return_value={"detail": "Permission denied"}),
+        )
+        client.put.return_value = resp
+        result = self._invoke(["admin", "cordon"], client)
+        assert result.exit_code == 1
+
+    def test_drain_cordon_put_fails(self, logged_in_cfg):
+        """Drain's cordon step failing exits non-zero."""
+        client = MagicMock()
+        bad = MagicMock(
+            status_code=500,
+            headers={"content-type": "application/json"},
+            json=MagicMock(return_value={"detail": "boom"}),
+        )
+        client.put.return_value = bad
+        result = self._invoke(["admin", "drain"], client)
+        assert result.exit_code == 1
+
+    def test_drain_post_fails(self, logged_in_cfg):
+        client = MagicMock()
+        ok_put = MagicMock(status_code=200, json=MagicMock(return_value=True))
+        bad_post = MagicMock(
+            status_code=500,
+            headers={"content-type": "application/json"},
+            json=MagicMock(return_value={"detail": "boom"}),
+        )
+        client.put.return_value = ok_put
+        client.post.return_value = bad_post
+        result = self._invoke(["admin", "drain"], client)
+        assert result.exit_code == 1
+
+    def test_drain_uncordon_put_fails(self, logged_in_cfg):
+        client = MagicMock()
+        ok = MagicMock(status_code=200, json=MagicMock(return_value=True))
+        drain_ok = MagicMock(
+            status_code=200, json=MagicMock(return_value={"stopped": 1})
+        )
+        client.put.return_value = ok
+        client.post.return_value = drain_ok
+        result = self._invoke(["admin", "drain", "--uncordon"], client)
+        # cordon ok, drain ok, uncordon ok (same ok response)
+        assert result.exit_code == 0
+
+    def test_cordon_status_not_cordoned(self, logged_in_cfg):
+        client = self._client(
+            {("get", "/api/v1/admin/cordon"): {"cordoned": False}}
+        )
+        result = self._invoke(["admin", "cordon-status"], client)
+        assert result.exit_code == 0
+        assert "Ready" in result.stdout
+
+    def test_cordon_status_error(self, logged_in_cfg):
+        client = MagicMock()
+        client.get.return_value = MagicMock(
+            status_code=500,
+            headers={},
+            json=MagicMock(return_value={}),
+        )
+        result = self._invoke(["admin", "cordon-status"], client)
+        assert result.exit_code == 1
+
+    def test_uncordon_error_exits(self, logged_in_cfg):
+        client = MagicMock()
+        client.put.return_value = MagicMock(
+            status_code=500,
+            headers={"content-type": "application/json"},
+            json=MagicMock(return_value={"detail": "boom"}),
+        )
+        result = self._invoke(["admin", "uncordon"], client)
+        assert result.exit_code == 1
+
+    def test_drain_uncodon_put_fails_exits(self, logged_in_cfg):
+        """drain --uncordon whose uncordon PUT fails exits non-zero."""
+        client = MagicMock()
+
+        def put_handler(p, *a, **k):
+            if k.get("json", {}).get("cordoned") is False:
+                # the uncordon PUT (drain's --uncordon step) fails
+                return MagicMock(
+                    status_code=500,
+                    headers={"content-type": "application/json"},
+                    json=MagicMock(return_value={"detail": "boom"}),
+                )
+            return MagicMock(
+                status_code=200, json=MagicMock(return_value=True)
+            )
+
+        client.put.side_effect = put_handler
+        client.post.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"stopped": 1})
+        )
+        result = self._invoke(["admin", "drain", "--uncordon"], client)
+        assert result.exit_code == 1

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -6046,18 +6046,6 @@ class TestCordonDrainCommands:
         result = self._invoke(["admin", "drain"], client)
         assert result.exit_code == 1
 
-    def test_drain_uncordon_put_fails(self, logged_in_cfg):
-        client = MagicMock()
-        ok = MagicMock(status_code=200, json=MagicMock(return_value=True))
-        drain_ok = MagicMock(
-            status_code=200, json=MagicMock(return_value={"stopped": 1})
-        )
-        client.put.return_value = ok
-        client.post.return_value = drain_ok
-        result = self._invoke(["admin", "drain", "--uncordon"], client)
-        # cordon ok, drain ok, uncordon ok (same ok response)
-        assert result.exit_code == 0
-
     def test_cordon_status_not_cordoned(self, logged_in_cfg):
         client = self._client(
             {("get", "/api/v1/admin/cordon"): {"cordoned": False}}
@@ -6086,7 +6074,7 @@ class TestCordonDrainCommands:
         result = self._invoke(["admin", "uncordon"], client)
         assert result.exit_code == 1
 
-    def test_drain_uncodon_put_fails_exits(self, logged_in_cfg):
+    def test_drain_uncordon_put_fails_exits(self, logged_in_cfg):
         """drain --uncordon whose uncordon PUT fails exits non-zero."""
         client = MagicMock()
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -11558,3 +11558,122 @@ class TestInactivityDisable:
         assert kicked == 2
         assert closed[-1] == (4001, "Account disabled")
         app.state.sockets.connections.clear()
+
+
+# --- Cordon / drain (#2527) ---
+
+
+class TestCordonDrainApi:
+    async def _admin_headers(self, client):
+        return await _admin_login(client)
+
+    async def _user_headers(self, client):
+        return await _auth_headers(client)
+
+    async def test_cordon_get_put_roundtrip(
+        self, client, admin_user, app_state
+    ):
+        headers = await self._admin_headers(client)
+        resp = await client.get("/api/v1/admin/cordon", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json() == {"cordoned": False}
+
+        resp = await client.put(
+            "/api/v1/admin/cordon", headers=headers, json={"cordoned": True}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"cordoned": True}
+        # Persisted (DB-backed), not just echoed.
+        assert await app_state.state.model.server_state.is_cordoned() is True
+
+    async def test_cordon_requires_admin(self, client, user):
+        headers = await self._user_headers(client)
+        resp = await client.put(
+            "/api/v1/admin/cordon", headers=headers, json={"cordoned": True}
+        )
+        assert resp.status_code == 403
+
+    async def test_start_refused_503_while_cordoned(
+        self, client, app, user, registry, ws_admin
+    ):
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "cw"}
+        )
+        assert create_resp.status_code == 200, create_resp.text
+        ws_id = create_resp.json()["id"]
+        await app.state.model.server_state.set_cordoned(True)
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/start", headers=headers
+        )
+        assert resp.status_code == 503
+        assert "cordoned" in resp.json()["detail"].lower()
+
+    async def test_restart_refused_503_while_cordoned(
+        self, client, app, user, registry, ws_admin
+    ):
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "cw2"}
+        )
+        assert create_resp.status_code == 200, create_resp.text
+        ws_id = create_resp.json()["id"]
+        await app.state.model.server_state.set_cordoned(True)
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/restart", headers=headers
+        )
+        assert resp.status_code == 503
+        assert "cordoned" in resp.json()["detail"].lower()
+
+    async def test_drain_reports_count(self, client, app, admin_user):
+        from klangk.container.state import ContainerState
+
+        registry = app.state.container_registry
+        for i in range(2):
+            registry.states[f"ws-{i}"] = ContainerState(
+                f"ws-{i}", f"cid-{i}", app
+            )
+        headers = await self._admin_headers(client)
+        with (
+            patch.object(registry, "stop_and_remove_container", AsyncMock()),
+            patch.object(registry, "notify_workspace_killed", AsyncMock()),
+        ):
+            resp = await client.post("/api/v1/admin/drain", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json() == {"stopped": 2}
+
+    async def test_drain_requires_admin(self, client, user):
+        headers = await self._user_headers(client)
+        resp = await client.post("/api/v1/admin/drain", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_config_carries_cordon_for_authed_only(
+        self, client, app, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        await app.state.model.server_state.set_cordoned(True)
+        resp = await client.get("/api/v1/config", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["cordoned"] is True
+
+        # Anonymous (pre-auth) config must not leak the flag.
+        resp = await client.get("/api/v1/config")
+        assert resp.status_code == 200
+        assert "cordoned" not in resp.json()
+
+    async def test_create_with_autostart_cordoned_mid_create(
+        self, client, app, user, ws_admin, registry
+    ):
+        """#2527: cordon racing a create leaves the workspace row intact
+        and does not fail the create — an eager start refusal is a
+        warning, not an error."""
+        headers = await _auth_headers(client)
+        app.state.settings.allow_autostart = "1"
+        await app.state.model.server_state.set_cordoned(True)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "cordoned-create", "auto_start": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"]

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -11625,6 +11625,54 @@ class TestCordonDrainApi:
         assert resp.status_code == 503
         assert "cordoned" in resp.json()["detail"].lower()
 
+    async def test_restart_refusal_leaves_running_workspace_alone(
+        self, client, app, user, registry, ws_admin
+    ):
+        """#2527 review: the cordon check fires BEFORE the stop, so a
+        running workspace survives a restart attempt on a cordoned node
+        (cordon's documented posture — drain is the stopping half)."""
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "cw3"}
+        )
+        ws_id = create_resp.json()["id"]
+        # Simulate a running container.
+        registry.track_activity("cid-cw3", ws_id)
+        await app.state.model.server_state.set_cordoned(True)
+        with patch.object(
+            registry, "stop_and_remove_container", AsyncMock()
+        ) as mock_stop:
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/restart", headers=headers
+            )
+        assert resp.status_code == 503
+        mock_stop.assert_not_awaited()
+
+    async def test_restart_cordon_race_between_check_and_start(
+        self, client, app, user, ws_admin
+    ):
+        """Cordon lands between restart's up-front check and the start:
+        the inner NodeCordonedError handler still maps to 503 (the
+        workspace is left stopped — the stop already happened)."""
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "cw4"}
+        )
+        ws_id = create_resp.json()["id"]
+        answers = iter([False, True])
+
+        async def flapping():
+            return next(answers, True)
+
+        with patch.object(
+            app.state.model.server_state, "is_cordoned", flapping
+        ):
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/restart", headers=headers
+            )
+        assert resp.status_code == 503
+        assert "cordoned" in resp.json()["detail"].lower()
+
     async def test_drain_reports_count(self, client, app, admin_user):
         from klangk.container.state import ContainerState
 

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -35,11 +35,11 @@ api_auth = sys.modules["klangk.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 94
+EXPECTED_ROUTE_COUNT = 97
 
-# Per-domain submodules and the number of routes each owns.  89 sub-routes
+# Per-domain submodules and the number of routes each owns.  92 sub-routes
 # + 3 routes defined directly on the main router (version, config,
-# my-permissions) + 2 on the root router (health, empty) == 94.
+# my-permissions) + 2 on the root router (health, empty) == 97.
 SUBMODULE_ROUTES = {
     "auth": 15,
     "oidc_auth": 2,
@@ -48,7 +48,7 @@ SUBMODULE_ROUTES = {
     "images": 4,
     "browser_delegate": 2,
     "chat": 1,
-    "admin": 30,
+    "admin": 33,
     "llm_proxy": 2,
 }
 

--- a/src/klangk/klangkd-tests/tests/test_cordon.py
+++ b/src/klangk/klangkd-tests/tests/test_cordon.py
@@ -269,6 +269,36 @@ class TestDrain:
         assert n == 0
         mock_stop.assert_not_awaited()
 
+    async def test_drain_fires_kill_callback_per_workspace(
+        self, app_state, db
+    ):
+        """Drain's session/agent reset rides the on_workspace_killed
+        callback (wired in main.py) — assert it fires per workspace, so
+        a wiring change cannot silently leave stale sessions (#2527
+        review: the /stop endpoint calls reset_workspace_state itself,
+        drain relies on this callback)."""
+        registry = app_state.state.container_registry
+        from klangk.wshandler.session import WebSocketState
+
+        app_state.state.sockets = WebSocketState(app_state)
+        self._track(app_state, registry, 2)
+        killed = []
+
+        async def on_killed(ws_id):
+            killed.append(ws_id)
+
+        registry.on_workspace_killed = on_killed
+
+        async def fake_stop(cid, workspace_id=None):
+            pass
+
+        # No patch on notify_workspace_killed — the real wrapper is the
+        # code under test (it invokes the callback above).
+        with patch.object(registry, "stop_and_remove_container", fake_stop):
+            n = await registry.drain_all_containers()
+        assert n == 2
+        assert sorted(killed) == ["ws-0", "ws-1"]
+
     async def test_drain_idempotent(self, app_state):
         registry = app_state.state.container_registry
         with (

--- a/src/klangk/klangkd-tests/tests/test_cordon.py
+++ b/src/klangk/klangkd-tests/tests/test_cordon.py
@@ -1,0 +1,279 @@
+"""Cordon/drain operator controls (#2527) — model + registry level.
+
+Cordon: a persisted flag (``server_state`` table) that makes the
+container-start choke point refuse new starts everywhere — API start /
+restart, WS connect/restart, create's eager start, boot auto-start, and
+crash-recovery restart. Existing workspaces keep running.
+
+Drain: stop every running workspace via the graceful logout/idle path,
+with terminal frames and a container_stopped reason broadcast.
+
+HTTP-surface tests (routes, auth, 503 mapping) live in test_api.py's
+TestCordonDrainApi.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from klangk.exceptions import NodeCordonedError
+
+
+class TestServerStateModel:
+    async def test_flag_roundtrip_and_default(self, app_state, db):
+        """Default uncordoned; set/clear round-trips through the DB."""
+        m = app_state.state.model.server_state
+        assert await m.is_cordoned() is False
+        await m.set_cordoned(True)
+        assert await m.is_cordoned() is True
+        await m.set_cordoned(False)
+        assert await m.is_cordoned() is False
+
+    async def test_generic_kv_roundtrip(self, app_state, db):
+        """The table is a generic KV store; upsert replaces."""
+        m = app_state.state.model.server_state
+        await m.set("k", "v1")
+        await m.set("k", "v2")
+        assert await m.get("k") == "v2"
+        assert await m.get("missing") is None
+        assert await m.get("missing", "d") == "d"
+
+
+class TestCordonGate:
+    async def test_registry_choke_point_raises(self, app_state, db):
+        """The single start choke point raises NodeCordonedError — the
+        error every start path (WS, auto-start, crash restart) funnels
+        through."""
+        from klangk.container import ContainerStartSpec
+
+        registry = app_state.state.container_registry
+        await app_state.state.model.server_state.set_cordoned(True)
+        with pytest.raises(NodeCordonedError):
+            await registry.start_container(
+                ContainerStartSpec(
+                    workspace_id="ws-x",
+                    host_path="/tmp/x",
+                    home_path="/tmp/x/home",
+                )
+            )
+
+    async def test_gate_opens_after_uncordon(self, app_state, db):
+        """After uncordon the same start proceeds past the gate (it may
+        still fail later on podman — that is not the gate's business)."""
+        from klangk.container import ContainerStartSpec
+
+        registry = app_state.state.container_registry
+        await app_state.state.model.server_state.set_cordoned(False)
+        try:
+            await registry.start_container(
+                ContainerStartSpec(
+                    workspace_id="ws-x",
+                    host_path="/tmp/x",
+                    home_path="/tmp/x/home",
+                )
+            )
+        except NodeCordonedError:  # pragma: no cover — gate must be open
+            pytest.fail("gate still closed after uncordon")
+        except Exception:
+            pass  # later failure (podman etc.) is fine — gate let it pass
+
+    async def test_existing_workspace_untouched(self, app_state, db):
+        """Cordon does not stop running workspaces: state present in the
+        registry survives cordon (drain is the stopping half)."""
+        from klangk.container.state import ContainerState
+
+        registry = app_state.state.container_registry
+        state = ContainerState("ws-live", "cid-live", app_state)
+        registry.states["ws-live"] = state
+        await app_state.state.model.server_state.set_cordoned(True)
+        assert registry.states.get("ws-live") is state
+
+
+class TestAutostartSuppressed:
+    async def test_boot_autostart_skipped_when_cordoned(self, app_state, db):
+        """auto_start_workspaces returns 0 and starts nothing while
+        cordoned, even with allow_autostart on."""
+        settings = app_state.state.settings
+        with (
+            patch.object(settings, "allow_autostart", "1"),
+            patch.object(
+                app_state.state.model.workspaces,
+                "list_auto_start_workspaces",
+                AsyncMock(return_value=[{"id": "ws-a", "name": "a"}]),
+            ),
+            patch.object(
+                app_state.state.workspaces,
+                "start_workspace",
+                AsyncMock(side_effect=AssertionError("must not start")),
+            ),
+        ):
+            await app_state.state.model.server_state.set_cordoned(True)
+            n = await app_state.state.workspaces.auto_start_workspaces()
+            assert n == 0
+
+    async def test_boot_autostart_runs_when_uncordoned(self, app_state, db):
+        settings = app_state.state.settings
+        with (
+            patch.object(settings, "allow_autostart", "1"),
+            patch.object(
+                app_state.state.model.workspaces,
+                "list_auto_start_workspaces",
+                AsyncMock(return_value=[{"id": "ws-a", "name": "a"}]),
+            ),
+            patch.object(
+                app_state.state.workspaces,
+                "start_workspace",
+                AsyncMock(return_value=("cid-a", "created")),
+            ),
+        ):
+            n = await app_state.state.workspaces.auto_start_workspaces()
+            assert n == 1
+
+
+class TestCrashRestartSuppressed:
+    async def test_restart_loop_abandons_when_cordoned(self, app_state, db):
+        """A pending crash-restart does not fire while cordoned — a
+        drain's stopped state must stick (#2527). Restart must be
+        ENABLED so the cordon check (not the enabled check) is what
+        stops the attempt."""
+        from klangk.container.crash import RestartTracker
+
+        monitor = app_state.state.container_registry.crash
+        tracker = RestartTracker()
+        started = []
+
+        async def fake_start(ws):
+            started.append(ws["id"])
+            return "new-cid", "created"
+
+        async def fake_ws(ws_id):
+            return {"id": ws_id, "name": "ws", "settings": {}}
+
+        with (
+            patch.object(
+                app_state.state.settings, "container_restart_enabled", True
+            ),
+            patch.object(
+                app_state.state.model.server_state,
+                "is_cordoned",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(
+                app_state.state.model.workspaces,
+                "get_workspace_by_id",
+                AsyncMock(side_effect=fake_ws),
+            ),
+            patch.object(
+                app_state.state.workspaces,
+                "start_workspace",
+                fake_start,
+            ),
+        ):
+            monitor.trackers["ws-c"] = tracker
+            await monitor.delayed_restart("ws-c", tracker)
+        assert started == []
+        assert tracker.next_attempt_at is None
+
+
+class TestDrain:
+    def _track(self, app_state, registry, n):
+        from klangk.container.state import ContainerState
+
+        for i in range(n):
+            ws_id = f"ws-{i}"
+            registry.states[ws_id] = ContainerState(
+                ws_id, f"cid-{i}", app_state
+            )
+
+    async def test_drain_stops_everything(self, app_state, db):
+        from klangk.wshandler.session import WebSocketState
+
+        registry = app_state.state.container_registry
+        app_state.state.sockets = WebSocketState(app_state)
+        self._track(app_state, registry, 3)
+        stopped = []
+
+        async def fake_stop(cid, workspace_id=None):
+            stopped.append(workspace_id)
+
+        with (
+            patch.object(registry, "stop_and_remove_container", fake_stop),
+            patch.object(registry, "notify_workspace_killed", AsyncMock()),
+        ):
+            n = await registry.drain_all_containers()
+        assert n == 3
+        assert sorted(stopped) == ["ws-0", "ws-1", "ws-2"]
+
+    async def test_drain_broadcasts_reason(self, app_state):
+        """Connected clients get a container_stopped frame carrying the
+        drain reason (clean 'stopped', not a dropped WebSocket)."""
+        from klangk.wshandler.session import WebSocketState
+
+        registry = app_state.state.container_registry
+        app_state.state.sockets = WebSocketState(app_state)
+        self._track(app_state, registry, 1)
+        broadcast = []
+
+        class FakeSession:
+            def broadcast(self, message):
+                broadcast.append(message)
+
+        with (
+            patch.object(
+                app_state.state.sockets,
+                "get_session",
+                return_value=FakeSession(),
+            ),
+            patch.object(registry, "stop_and_remove_container", AsyncMock()),
+            patch.object(registry, "notify_workspace_killed", AsyncMock()),
+        ):
+            n = await registry.drain_all_containers()
+        assert n == 1
+        assert broadcast, "expected a container_stopped broadcast"
+        event = broadcast[0]["event"]
+        assert event["name"] == "container_stopped"
+        assert "drain" in event["value"]["reason"]
+
+    async def test_drain_skips_broadcast_without_session(self, app_state):
+        """No connected clients (get_session -> None) — drain still
+        completes and simply skips the broadcast."""
+        from klangk.wshandler.session import WebSocketState
+
+        registry = app_state.state.container_registry
+        app_state.state.sockets = WebSocketState(app_state)
+        self._track(app_state, registry, 1)
+        with (
+            patch.object(registry, "stop_and_remove_container", AsyncMock()),
+            patch.object(registry, "notify_workspace_killed", AsyncMock()),
+        ):
+            n = await registry.drain_all_containers()
+        assert n == 1
+
+    async def test_drain_skips_cidless_state(self, app_state, db):
+        """A tracked state with no container id is skipped, not stopped."""
+        from klangk.container.state import ContainerState
+
+        registry = app_state.state.container_registry
+        from klangk.wshandler.session import WebSocketState
+
+        app_state.state.sockets = WebSocketState(app_state)
+        state = ContainerState("ws-nocid", None, app_state)
+        registry.states["ws-nocid"] = state
+        with (
+            patch.object(
+                registry, "stop_and_remove_container", AsyncMock()
+            ) as mock_stop,
+            patch.object(registry, "notify_workspace_killed", AsyncMock()),
+        ):
+            n = await registry.drain_all_containers()
+        assert n == 0
+        mock_stop.assert_not_awaited()
+
+    async def test_drain_idempotent(self, app_state):
+        registry = app_state.state.container_registry
+        with (
+            patch.object(registry, "stop_and_remove_container", AsyncMock()),
+            patch.object(registry, "notify_workspace_killed", AsyncMock()),
+        ):
+            n = await registry.drain_all_containers()
+        assert n == 0

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -39,6 +39,12 @@ def make_app_state(env=None):
 
     app_state.state.util = util_mod.Util(app_state)
     wire_db_and_model(app_state)
+    # #2527: the crash loop consults the cordon flag on every restart
+    # attempt; these tests exercise restart mechanics, not cordon (which
+    # has its own tests), so pin it uncordoned without a schema-bearing DB.
+    app_state.state.model.server_state.is_cordoned = AsyncMock(
+        return_value=False
+    )
     return app_state
 
 

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -49,6 +49,7 @@ class TestRunner:
             (3, "0003_user_sessions"),
             (4, "0004_user_sessions_workstation"),
             (5, "0005_user_inactivity"),
+            (6, "0006_server_state"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -109,6 +110,7 @@ class TestRunner:
                 (3, "0003_user_sessions"),
                 (4, "0004_user_sessions_workstation"),
                 (5, "0005_user_inactivity"),
+                (6, "0006_server_state"),
             ]
 
     async def test_pending_only(self, tmp_path):

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -26,7 +26,11 @@ from klangk import (
     container,
     workspaces as ws_mod,
 )
-from klangk.exceptions import ContainerGoneError, TerminalError
+from klangk.exceptions import (
+    ContainerGoneError,
+    NodeCordonedError,
+    TerminalError,
+)
 from klangk.podman import PodmanError
 from klangk.model.chat import ChatModel
 from _helpers import make_settings
@@ -11422,3 +11426,103 @@ class TestFormatContainerInfo:
         name, ports_str = format_container_info(ws_id, [], iid, "!!!")
         assert name == f"klangk-{iid}-{ws_id[:8]}"
         assert ports_str == ""
+
+
+class TestCordonedStartPaths:
+    """#2527: WS connect/restart on a cordoned node send an error frame
+    (the node refuses new container starts)."""
+
+    async def test_connect_refused_while_cordoned(self, user, app_state):
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        with (
+            patch.object(
+                conn.app.state.acl,
+                "get_principals",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                conn.app.state.acl,
+                "check_permission",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                conn.app.state.workspaces,
+                "get_workspace",
+                new=AsyncMock(return_value={"id": "ws-c", "name": "c"}),
+            ),
+            patch.object(
+                Connection,
+                "start_workspace_container",
+                new=AsyncMock(
+                    side_effect=NodeCordonedError(
+                        "node is cordoned: new workspace starts are disabled"
+                    )
+                ),
+            ),
+            patch.object(conn, "handle_workspace_disconnect", new=AsyncMock()),
+        ):
+            await conn.handle_workspace_connect({"workspaceId": "ws-c"})
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            isinstance(m, dict) and "cordoned" in m.get("message", "")
+            for m in sent
+        )
+
+    async def test_restart_refused_while_cordoned(self, user, app_state):
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        conn.workspace_id = "ws-c"
+        conn.workspace = {"id": "ws-c"}
+        with (
+            patch.object(conn, "_has_perm", new=AsyncMock(return_value=True)),
+            patch.object(
+                Connection,
+                "cleanup",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                Connection,
+                "start_workspace_container",
+                new=AsyncMock(
+                    side_effect=NodeCordonedError(
+                        "node is cordoned: new workspace starts are disabled"
+                    )
+                ),
+            ),
+        ):
+            await conn.handle_restart_container()
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            isinstance(m, dict) and "cordoned" in m.get("message", "")
+            for m in sent
+        )
+
+
+class TestNotifyNodeCordoned:
+    def _sockets_with(self, sockets, entries):
+        sockets.connections.clear()
+        for sock, conn in entries:
+            sockets.connections[sock] = conn
+        return sockets
+
+    def test_broadcast_reaches_authed_and_drops_dead(self):
+        sockets = _make_app_state().state.sockets
+        live = _mock_sock()
+        anon = _mock_sock()
+        dead = _mock_sock()
+        dead.send_json.side_effect = RuntimeError("closed")
+        self._sockets_with(
+            sockets,
+            [
+                (live, types.SimpleNamespace(user={"id": "u1"})),
+                (anon, types.SimpleNamespace(user={})),
+                (dead, types.SimpleNamespace(user={"id": "u2"})),
+            ],
+        )
+        sockets.notify_node_cordoned(True)
+        sent = [c[0][0] for c in live.send_json.call_args_list]
+        assert sent == [{"type": "node_cordon", "cordoned": True}]
+        anon.send_json.assert_not_called()
+        assert dead not in sockets.connections
+        sockets.connections.clear()

--- a/zensical.toml
+++ b/zensical.toml
@@ -52,6 +52,7 @@ nav = [
     { "Behind a Reverse Proxy" = "deployment/behind-a-proxy.md" },
     { "Customizing" = "deployment/customizing.md" },
     { "FIPS 140-3 Mode" = "deployment/fips.md" },
+    { "Cordon & Drain" = "deployment/cordon-drain.md" },
     { "Process Signals" = "deployment/signals.md" },
     { "Decommissioning" = "deployment/decommissioning.md" },
     { "Podman" = "reference/podman.md" },


### PR DESCRIPTION
Closes #2527.

## What

**Cordon** — persisted flag (new `server_state` table, migration 0006) that makes the single container-start choke point raise `NodeCordonedError`:

- API `POST /workspaces/{id}/start` and `/restart` → **503** with a clear detail
- WS connect / restart-container paths → error frame (connection stays up)
- create's eager auto-start start → logged warning, create still succeeds
- boot auto-start → suppressed entirely with one log line
- crash-recovery restart loop → abandons, so a drain's stopped state sticks
- existing workspaces keep running (gate sits after the running-container reuse)

The flag is **DB-persisted**, so it survives klangkd restarts: a crash-looping service (systemd or docker restart policy) stays cordoned instead of re-starting user workspaces — k8s's cordon-on-boot semantics.

**Drain** — `registry.drain_all_containers()` stops every running workspace through the same graceful path as logout/idle stop: terminal status frames + a `container_stopped` event carrying the reason (clients see clean "stopped", not a dropped WebSocket), and the deploy's podman stop grace. Returns the count; idempotent.

**Surface:**

- API: `GET/PUT /api/v1/admin/cordon`, `POST /api/v1/admin/drain` (admin permission); authenticated `GET /config` carries `cordoned` (pre-auth payload does not); `node_cordon` WS broadcast for badge-able client state.
- CLI: `klangk admin cordon | uncordon | drain [--no-cordon] [--uncordon] | cordon-status`.
- Docs: new [Cordon & Drain](../blob/issue-2527-cordo/docs/deployment/cordon-drain.md) chapter with the **systemd `ExecStop` = drain** example for the system-Python (Ubuntu/Arch) deployment and the **docker host-container** upgrade flow (the flag rides the `/home/klangk/data` volume across container replacements); signals.md cross-link; changelog entry.

## Acceptance criteria

- [x] Cordon flag persisted across restarts; start API and boot auto-start honor it with clear errors/logging
- [x] Drain stops all running workspaces via the graceful path and reports completion (count in the response; CLI exit status reflects API failures so wrappers can wait)
- [x] `klangk` CLI commands to cordon/uncordon/drain (TUI left as a follow-up — operator/script surface, CLI covers the workflow)
- [x] Documented in the deployment docs (systemd upgrade workflow + docker)

## Tests

Full CI suite green after rebase: **5470 passed, 100% coverage**. New coverage: model round-trip, choke-point refusal + uncordon, autostart suppression, crash-restart abandonment, drain (count/broadcast/idempotent/skip-cidless), HTTP routes (auth, 503 mapping, config exposure), WS error frames, `node_cordon` broadcast, CLI commands incl. error paths.
