### PR TITLE
fix(wshandler): keep shared_terminals in sync when the window watcher applies renames

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1108,6 +1108,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Terminal tab state no longer flaps old→new under load (#2653).**
+  The window watcher's window-list refresh could land between a
+  rename/new/close command and its confirmation, briefly reverting
+  the tab strip and shared-terminal list to the pre-command state
+  (new → old → new) before the next event re-corrected it. Stale
+  in-flight watcher snapshots are now discarded instead of applied.
+
 - **Shared-terminal tab list not updating on rename under load
   (#2651).** Renaming a shared terminal could leave other users' tab
   lists showing the old name indefinitely: the window-watcher's

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1114,11 +1114,8 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   debounced re-sync could apply the renamed window list to the session
   state before the rename command's own sync, erasing the change the
   sync's broadcast decision relies on — so the `shared_terminals`
-  update was never sent to other workspace members (visible as the
-  e2e rename test timing out under CI load). Both sync paths now
-  detect and broadcast shared-window changes through one shared
-  merge, so the update is sent exactly once regardless of which path
-  applies it first.
+  update was never sent to other workspace members. The update is now
+  sent exactly once regardless of which path applies it first.
 
 - **`klangk terminal share`/`unshare` blind 10s timeout (#2633 CI
   flake).** The tmux window-watcher's re-sync broadcast the window list

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1108,6 +1108,18 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Shared-terminal tab list not updating on rename under load
+  (#2651).** Renaming a shared terminal could leave other users' tab
+  lists showing the old name indefinitely: the window-watcher's
+  debounced re-sync could apply the renamed window list to the session
+  state before the rename command's own sync, erasing the change the
+  sync's broadcast decision relies on — so the `shared_terminals`
+  update was never sent to other workspace members (visible as the
+  e2e rename test timing out under CI load). Both sync paths now
+  detect and broadcast shared-window changes through one shared
+  merge, so the update is sent exactly once regardless of which path
+  applies it first.
+
 - **`klangk terminal share`/`unshare` blind 10s timeout (#2633 CI
   flake).** The tmux window-watcher's re-sync broadcast the window list
   to clients without updating the in-memory map the share handlers

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -22,7 +22,6 @@ from ..terminal import (
 from .safe_websocket import SlowClientError, WS_ERRORS
 from .constants import MAX_INPUT_SIZE
 from .helpers import send_error, send_event, get_shared_terminals
-from .session import merge_window_entries
 
 if TYPE_CHECKING:
     from .connection import Connection
@@ -912,28 +911,19 @@ class TerminalController:
         if not ws_session:
             return
         user_id = self._conn.user["id"]
-        old = ws_session.terminal_windows.get(user_id, [])
-        # Shared merge lives in one place (session.merge_window_entries,
-        # #2633 CI race): id-matched (tmux window ids are unique and never
-        # reused within a server's lifetime — stable across renames and
-        # index reuse, #2192), shared flags carry over, service-cmd stays
-        # shared. After a container restart the in-container tmux server
-        # is gone and all custom tabs are lost anyway, so there is
-        # nothing to match by.
-        new_entries = merge_window_entries(old, windows)
-        ws_session.terminal_windows[user_id] = new_entries
-        new_shared = {w["id"] for w in new_entries if w.get("shared")}
-        # Broadcast if shared set changed (e.g. shared window was closed)
-        # or if any shared window was renamed.
-        old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
-        old_shared_names = {
-            (w["id"], w["name"]) for w in old if w.get("shared") and "id" in w
-        }
-        new_shared_names = {
-            (w["id"], w["name"]) for w in new_entries if w.get("shared")
-        }
-        if old_shared != new_shared or old_shared_names != new_shared_names:
-            self._conn.broadcast_shared_terminals(ws_session)
+        # Shared merge and delta detection live in one place
+        # (WorkspaceSession.apply_window_list, #2633 CI race + #2651):
+        # entries are matched by tmux window id
+        # (unique and never reused within a server's lifetime — stable
+        # across renames and index reuse, #2192), shared flags carry
+        # over, service-cmd stays shared. The window-watcher sync uses
+        # the same method, so whichever path applies a shared-window
+        # rename first is also the one that broadcasts it — a watcher
+        # re-sync landing between the rename and this handler's
+        # list_windows used to erase the delta and the coadmin's
+        # shared_terminals frame was never sent (#2651).
+        if ws_session.apply_window_list(user_id, windows):
+            ws_session.broadcast_shared_terminals()
 
     def _merge_service_windows(self, ws_session, windows: list[dict]) -> None:
         """Merge the agent's ``service`` session windows into the map.
@@ -1528,12 +1518,7 @@ class SharedTerminalController:
 
     def broadcast_shared_terminals(self, ws_session) -> None:
         """Broadcast the current shared terminal list to all subscribers."""
-        terminals = get_shared_terminals(
-            ws_session, self._conn.app.state.sockets
-        )
-        ws_session.broadcast(
-            {"type": "shared_terminals", "terminals": terminals}
-        )
+        ws_session.broadcast_shared_terminals()
 
     # Keep old handler name for backwards compat with existing E2E tests
     async def create_shared_terminal(self, msg: dict) -> None:

--- a/src/klangk/klangk/wshandler/helpers.py
+++ b/src/klangk/klangk/wshandler/helpers.py
@@ -6,7 +6,10 @@ from .. import model
 from ..container import _workspace_container_name, _workspace_name_slug
 from .safe_websocket import SafeWebSocket
 from .constants import log_ws_msg
-from .session import WebSocketState
+from .session import (
+    WebSocketState,
+    get_shared_terminals as get_shared_terminals,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,59 +46,6 @@ async def get_presence_list(
             }
         )
     return users
-
-
-def get_shared_terminals(ws_session, sockets: WebSocketState) -> list[dict]:
-    """Collect all shared windows across all users in a workspace."""
-    # Build viewer map: (owner_user_id, window_id) -> [{user_id, email}]
-    viewer_map: dict[tuple[str, str], list[dict]] = {}
-    for sock in ws_session.subscribers:
-        conn = sockets.connections.get(sock)
-        if not conn or not conn.viewing_shared:
-            continue
-        key = (
-            conn.viewing_shared["user_id"],
-            conn.viewing_shared["window_id"],
-        )
-        viewer_map.setdefault(key, []).append(
-            {"user_id": conn.user["id"], "email": conn.user.get("email", "")}
-        )
-
-    terminals = []
-    for user_id, windows in ws_session.terminal_windows.items():
-        # Look up the user's handle from any active connection. The
-        # agent (AGENT_USER_ID) has no WS connection, so its handle is
-        # the cached ``agent_handle`` populated by ``_sync_service_windows``
-        # -- the agent is always attributable, never "offline" (#1133).
-        handle = None
-        if user_id == model.AGENT_USER_ID:
-            handle = ws_session.agent_handle
-        else:
-            for sock in ws_session.subscribers:
-                conn = sockets.connections.get(sock)
-                if conn and conn.user.get("id") == user_id:
-                    handle = conn.user.get("handle")
-                    break
-        if not handle:
-            continue
-        for w in windows:
-            if w.get("shared"):
-                wid = w.get("id", "")
-                viewers = viewer_map.get((user_id, wid), [])
-                terminals.append(
-                    {
-                        "user_id": user_id,
-                        "handle": handle,
-                        "window_name": w["name"],
-                        "window_id": wid,
-                        "viewers": viewers,
-                        # The agent's shared windows live in the standalone
-                        # ``service`` tmux session (#1158); flag them so the
-                        # UI can present the service tab distinctly (#1159).
-                        "is_service": user_id == model.AGENT_USER_ID,
-                    }
-                )
-    return terminals
 
 
 async def reset_workspace_state(

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -197,6 +197,15 @@ class WorkspaceSession:
         # list_windows snapshot per user_id, so we re-broadcast only on a
         # real change (#2161 / #2171).
         self._last_windows: dict[str, list] = {}
+        # Monotonic per-user generation of the applied window list
+        # (#2653). Bumped by every apply_window_list; the debounced
+        # watcher stamps it before starting its list_windows exec and
+        # discards a snapshot that returns to a moved counter — a podman
+        # exec that started before a tmux rename/new/close committed can
+        # land after the command handler applied the newer list, and
+        # applying it would transiently revert the map, the baseline,
+        # and the broadcasts (new → old → new flap).
+        self._window_generations: dict[str, int] = {}
         self._window_watcher: WindowEventWatcher | None = None
         self._window_sync_handle: asyncio.TimerHandle | None = None
 
@@ -224,6 +233,7 @@ class WorkspaceSession:
         if watcher is not None:
             asyncio.create_task(watcher.stop())  # pragma: no cover
         self._last_windows.clear()
+        self._window_generations.clear()
 
     async def add_subscriber(
         self,
@@ -280,10 +290,20 @@ class WorkspaceSession:
         reused within a tmux server's lifetime, stable across renames
         and index reuse, #2192) and ``shared`` flags carry over; the
         agent's ``service-cmd`` window is shared by definition (#1114).
+
+        Applying also bumps the per-user window generation so the
+        watcher can tell a stale in-flight snapshot from a current one
+        (#2653).
         """
         old = self.terminal_windows.get(user_id, [])
         new_entries = merge_window_entries(old, windows)
         self.terminal_windows[user_id] = new_entries
+        # This list is now the newest applied state for the user (#2653):
+        # a watcher list_windows exec still in flight predates it, and
+        # its snapshot must be discarded instead of applied over it.
+        self._window_generations[user_id] = (
+            self._window_generations.get(user_id, 0) + 1
+        )
         # Broadcast-worthy delta: shared set changed (a shared window
         # was added or closed) or any shared window was renamed.
         old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
@@ -356,9 +376,22 @@ class WorkspaceSession:
             if uid and uid != model.AGENT_USER_ID:
                 user_ids.add(uid)
         for uid in user_ids:
+            # Stamp the apply generation before the exec (#2653): the
+            # list_windows below is a podman round-trip that can straddle
+            # a command handler's tmux mutation and its apply. If the
+            # counter moved by the time the exec returns, a newer list
+            # was applied while we were in flight and this snapshot is
+            # stale — applying it would revert the map, the baseline,
+            # and the client frames to the pre-mutation state.
+            generation = self._window_generations.get(uid, 0)
             try:
                 windows = await terminal.list_windows(self.container_id, uid)
             except Exception:  # pragma: no cover - container mid-restart
+                continue
+            if self._window_generations.get(uid, 0) != generation:
+                # Stale in-flight snapshot (#2653): the newer applied
+                # list already updated the map, the baseline, and the
+                # broadcasts; drop ours instead of reverting them.
                 continue
             if self._last_windows.get(uid) == windows:
                 continue

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -38,7 +38,8 @@ def merge_window_entries(old: list[dict], windows: list[dict]) -> list[dict]:
     Both the controller's sync (:meth:`sync_terminal_windows` in
     controllers.py) and the window-watcher's debounced re-sync
     (:meth:`_sync_windows_once`) MUST update the in-memory map through
-    this helper before broadcasting — the share/unshare handlers read
+    :meth:`WorkspaceSession.apply_window_list` (which wraps this helper)
+    before broadcasting — the share/unshare handlers read
     the map, and a frame sent without the matching map update let a
     client act on a window the server would then not find (the
     ``klangk terminal share`` 10s-blind-timeout flake).
@@ -57,6 +58,59 @@ def merge_window_entries(old: list[dict], windows: list[dict]) -> list[dict]:
             }
         )
     return entries
+
+
+def get_shared_terminals(ws_session, sockets) -> list[dict]:
+    """Collect all shared windows across all users in a workspace."""
+    # Build viewer map: (owner_user_id, window_id) -> [{user_id, email}]
+    viewer_map: dict[tuple[str, str], list[dict]] = {}
+    for sock in ws_session.subscribers:
+        conn = sockets.connections.get(sock)
+        if not conn or not conn.viewing_shared:
+            continue
+        key = (
+            conn.viewing_shared["user_id"],
+            conn.viewing_shared["window_id"],
+        )
+        viewer_map.setdefault(key, []).append(
+            {"user_id": conn.user["id"], "email": conn.user.get("email", "")}
+        )
+
+    terminals = []
+    for user_id, windows in ws_session.terminal_windows.items():
+        # Look up the user's handle from any active connection. The
+        # agent (AGENT_USER_ID) has no WS connection, so its handle is
+        # the cached ``agent_handle`` populated by ``_sync_service_windows``
+        # -- the agent is always attributable, never "offline" (#1133).
+        handle = None
+        if user_id == model.AGENT_USER_ID:
+            handle = ws_session.agent_handle
+        else:
+            for sock in ws_session.subscribers:
+                conn = sockets.connections.get(sock)
+                if conn and conn.user.get("id") == user_id:
+                    handle = conn.user.get("handle")
+                    break
+        if not handle:
+            continue
+        for w in windows:
+            if w.get("shared"):
+                wid = w.get("id", "")
+                viewers = viewer_map.get((user_id, wid), [])
+                terminals.append(
+                    {
+                        "user_id": user_id,
+                        "handle": handle,
+                        "window_name": w["name"],
+                        "window_id": wid,
+                        "viewers": viewers,
+                        # The agent's shared windows live in the standalone
+                        # ``service`` tmux session (#1158); flag them so the
+                        # UI can present the service tab distinctly (#1159).
+                        "is_service": user_id == model.AGENT_USER_ID,
+                    }
+                )
+    return terminals
 
 
 def _iso_utc(ts: float | None) -> str | None:
@@ -209,6 +263,46 @@ class WorkspaceSession:
         """Send message to all subscribers, removing dead ones."""
         return broadcast_to_set(self.subscribers, message)
 
+    def apply_window_list(self, user_id: str, windows: list[dict]) -> bool:
+        """Fold a fresh tmux ``list_windows`` result into the session map.
+
+        Returns True when the shared-window set or any shared window name
+        changed — the signal that ``shared_terminals`` viewers need a
+        re-broadcast. Both window-list producers (the terminal command
+        handlers and the debounced window-watcher sync) MUST go through
+        this method so a shared rename is detected exactly once, by
+        whichever path applies it first (#2651: the watcher merged
+        renamed entries into the map without broadcasting, erasing the
+        delta the rename handler's own broadcast relied on, so other
+        users' shared-terminal tab lists never updated).
+
+        Entries are matched by window id (``@N`` — unique and never
+        reused within a tmux server's lifetime, stable across renames
+        and index reuse, #2192) and ``shared`` flags carry over; the
+        agent's ``service-cmd`` window is shared by definition (#1114).
+        """
+        old = self.terminal_windows.get(user_id, [])
+        new_entries = merge_window_entries(old, windows)
+        self.terminal_windows[user_id] = new_entries
+        # Broadcast-worthy delta: shared set changed (a shared window
+        # was added or closed) or any shared window was renamed.
+        old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
+        new_shared = {w["id"] for w in new_entries if w.get("shared")}
+        old_shared_names = {
+            (w["id"], w["name"]) for w in old if w.get("shared") and "id" in w
+        }
+        new_shared_names = {
+            (w["id"], w["name"]) for w in new_entries if w.get("shared")
+        }
+        return old_shared != new_shared or old_shared_names != new_shared_names
+
+    def broadcast_shared_terminals(self) -> None:
+        """Send the current shared-terminal list to all subscribers."""
+        if self.app is None:  # pragma: no cover - bare sessions in tests
+            return
+        terminals = get_shared_terminals(self, self.app.state.sockets)
+        self.broadcast({"type": "shared_terminals", "terminals": terminals})
+
     def start_token_renewal(self, expiry: datetime) -> None:
         """Schedule periodic workspace token renewal.
 
@@ -276,9 +370,7 @@ class WorkspaceSession:
             # _start_terminal's sync left the map empty/stale and
             # ``klangk terminal share`` blind-timed-out on the missing
             # window.
-            self.terminal_windows[uid] = merge_window_entries(
-                self.terminal_windows.get(uid, []), windows
-            )
+            shared_changed = self.apply_window_list(uid, windows)
             msg = {"type": "terminal_windows", "windows": windows}
             for sock in list(self.subscribers):
                 conn = sockets.connections.get(sock)
@@ -287,6 +379,13 @@ class WorkspaceSession:
                         sock.send_json(msg)
                     except WS_ERRORS:
                         pass
+            # A rename/close/add that touched a shared window must also
+            # reach shared-terminal viewers: this path can be the first
+            # to apply the change (under load its list_windows exec can
+            # beat the command handler's), and the handler's own delta
+            # check would then see no change (#2651).
+            if shared_changed:
+                self.broadcast_shared_terminals()
 
     async def _token_renewal_loop(self) -> None:
         """Periodically renew the workspace token before it expires."""

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -60,7 +60,7 @@ def merge_window_entries(old: list[dict], windows: list[dict]) -> list[dict]:
     return entries
 
 
-def get_shared_terminals(ws_session, sockets) -> list[dict]:
+def get_shared_terminals(ws_session, sockets: "WebSocketState") -> list[dict]:
     """Collect all shared windows across all users in a workspace."""
     # Build viewer map: (owner_user_id, window_id) -> [{user_id, email}]
     viewer_map: dict[tuple[str, str], list[dict]] = {}
@@ -298,7 +298,7 @@ class WorkspaceSession:
 
     def broadcast_shared_terminals(self) -> None:
         """Send the current shared-terminal list to all subscribers."""
-        if self.app is None:  # pragma: no cover - bare sessions in tests
+        if self.app is None:
             return
         terminals = get_shared_terminals(self, self.app.state.sockets)
         self.broadcast({"type": "shared_terminals", "terminals": terminals})
@@ -654,7 +654,13 @@ class WebSocketState:
         try:
             return self.sessions[workspace_id]
         except KeyError:
-            session = WorkspaceSession(workspace_id, app=app)
+            # Fall back to the state object's own app when a caller
+            # omits it: a session built with ``app=None`` would silently
+            # skip every ``shared_terminals`` broadcast
+            # (WorkspaceSession.broadcast_shared_terminals guards on
+            # ``self.app``), with no error to surface the mistake (#2652
+            # review).
+            session = WorkspaceSession(workspace_id, app=app or self.app)
             return self.sessions.setdefault(workspace_id, session)
 
     async def remove_session(self, workspace_id: str) -> None:

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -3,7 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from klangk.wshandler.session import WorkspaceSession
+from klangk.wshandler.session import WorkspaceSession, WebSocketState
 
 
 def _session_with_user(user_id: str = "u1", handle: str | None = None):
@@ -289,3 +289,52 @@ def test_apply_window_list_reports_shared_deltas():
     assert sess.terminal_windows["u1"] == [
         {"id": "@1", "index": 0, "name": "aux", "shared": False}
     ]
+
+
+# --- #2652 review follow-ups ---
+
+
+def test_get_or_create_session_falls_back_to_state_app():
+    """Omitting ``app`` still yields a session wired to the state's app.
+
+    A session built with ``app=None`` silently skips every
+    ``shared_terminals`` broadcast (the guard in
+    ``broadcast_shared_terminals``), so the factory must never produce
+    one even when a caller forgets the argument (#2652 review).
+    """
+    app = MagicMock()
+    sockets = WebSocketState(app=app)
+
+    sess = sockets.get_or_create_session("ws")
+
+    assert sess.app is app
+
+
+def test_get_or_create_session_explicit_app_wins():
+    """An explicitly passed ``app`` is honored over the state's own."""
+    sockets = WebSocketState(app=MagicMock())
+    other = MagicMock()
+
+    sess = sockets.get_or_create_session("ws", other)
+
+    assert sess.app is other
+
+
+def test_broadcast_shared_terminals_noop_without_app():
+    """A bare session (``app=None``) broadcasts nothing.
+
+    Covers the defensive guard instead of hiding it behind a pragma —
+    with the ``get_or_create_session`` fallback this is unreachable in
+    production, but the constructor still permits it.
+    """
+    sock = MagicMock()
+    sock.send_json = MagicMock()
+    sess = WorkspaceSession("ws")
+    sess.subscribers.add(sock)
+    sess.terminal_windows["u1"] = [
+        {"id": "@0", "index": 0, "name": "bash", "shared": True}
+    ]
+
+    sess.broadcast_shared_terminals()
+
+    sock.send_json.assert_not_called()

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -291,6 +291,86 @@ def test_apply_window_list_reports_shared_deltas():
     ]
 
 
+# --- #2653: stale in-flight watcher snapshots must be discarded ---
+
+
+async def test_sync_discards_stale_inflight_snapshot():
+    """A watcher snapshot racing a command-handler apply is dropped.
+
+    The watcher's ``list_windows`` is a podman exec round-trip: under
+    load it can start before a tmux rename commits and return after
+    the rename handler already applied and broadcast the renamed
+    list. Applying the stale pre-rename snapshot would revert the map,
+    the baseline, and the client frames (new → old → new flap,
+    #2653). The generation stamped before the exec must discard it.
+    """
+    sess, sock, terminal = _session_with_user()
+    # Seeded shared: the concurrent apply below must report a shared
+    # rename delta — the issue's worst case (a revert broadcast to
+    # shared_terminals viewers), and what the recorded-delta assert
+    # at the end checks for.
+    sess.terminal_windows["u1"] = [
+        {"id": "@0", "index": 0, "name": "bash", "shared": True}
+    ]
+    stale = [{"id": "@0", "index": 0, "name": "bash", "active": True}]
+    renamed = [{"id": "@0", "index": 0, "name": "my-build", "active": True}]
+    deltas: list[bool] = []
+
+    async def straddling_exec(container_id, uid):
+        # While the watcher's exec is in flight, the rename handler
+        # commits and applies (and would broadcast) the renamed list.
+        # A real handler's notify_user_terminal_windows also refreshes
+        # the watcher's baseline. The apply's return value is recorded
+        # rather than asserted here — this coroutine runs inside
+        # _sync_windows_once's except-Exception guard, which would
+        # swallow an AssertionError and turn the failure into a
+        # baffling KeyError on _last_windows below.
+        deltas.append(sess.apply_window_list("u1", renamed))
+        sess._last_windows["u1"] = renamed
+        return stale  # our exec queried tmux before the rename committed
+
+    terminal.list_windows = AsyncMock(side_effect=straddling_exec)
+
+    await sess._sync_windows_once()
+
+    # The concurrent handler's apply did see (and broadcast) the
+    # shared rename — and the watcher's stale snapshot was discarded
+    # after it: the map and the baseline still hold the renamed list
+    # and no frame was broadcast for the revert.
+    assert deltas == [True]
+    assert sess.terminal_windows["u1"][0]["name"] == "my-build"
+    assert sess._last_windows["u1"] == renamed
+    sock.send_json.assert_not_called()
+
+
+async def test_sync_applies_change_when_generation_unmoved():
+    """A genuine tmux-side change (no concurrent command-handler apply)
+    still passes the generation check and broadcasts (#2653 guard must
+    not eat real watcher deltas — e.g. a rename typed inside tmux)."""
+    sess, sock, terminal = _session_with_user()
+    terminal.list_windows = AsyncMock(
+        return_value=[{"id": "@0", "index": 0, "name": "dev", "active": True}]
+    )
+
+    await sess._sync_windows_once()
+
+    assert sess.terminal_windows["u1"][0]["name"] == "dev"
+    sock.send_json.assert_called_once()
+
+
+def test_apply_window_list_bumps_generation():
+    """Every apply is the newest applied state: the per-user generation
+    advances on each apply_window_list call (#2653)."""
+    sess, _sock, _terminal = _session_with_user()
+    windows = [{"id": "@0", "index": 0, "name": "bash", "active": True}]
+
+    assert sess._window_generations.get("u1", 0) == 0
+    sess.apply_window_list("u1", windows)
+    assert sess._window_generations["u1"] == 1
+    sess.apply_window_list("u1", windows)
+    assert sess._window_generations["u1"] == 2
+
+
 # --- #2652 review follow-ups ---
 
 

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -6,11 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from klangk.wshandler.session import WorkspaceSession
 
 
-def _session_with_user(user_id: str = "u1"):
+def _session_with_user(user_id: str = "u1", handle: str | None = None):
     sock = MagicMock()
     sock.send_json = MagicMock()
     conn = MagicMock()
     conn.user = {"id": user_id}
+    if handle is not None:
+        conn.user["handle"] = handle
     sockets = MagicMock()
     sockets.connections = {sock: conn}
     terminal = MagicMock()
@@ -171,3 +173,119 @@ async def test_sync_map_preserves_shared_flags_and_forces_service_cmd():
     assert by_id["@1"]["shared"] is True  # carried over
     assert by_id["@2"]["shared"] is True  # service-cmd by definition
     assert by_id["@0"]["shared"] is False
+
+
+# --- #2651: the watcher's sync must broadcast shared_terminals too ---
+
+
+async def test_sync_broadcasts_shared_terminals_on_shared_rename():
+    """A shared window renamed in tmux must reach shared-terminal viewers
+    even when the watcher's re-sync is the path that applies it.
+
+    The rename command handler broadcasts ``shared_terminals`` only when
+    its merge sees the old→new name delta; under load this debounced
+    re-sync can apply the renamed list to the session map first and
+    erase that delta. The watcher must then broadcast the shared list
+    itself — otherwise other users' tab lists never update (the e2e
+    rename test's recvUntil starved exactly this way, #2651).
+    """
+    sess, sock, terminal = _session_with_user(handle="alice")
+    sess.terminal_windows["u1"] = [
+        {"id": "@0", "index": 0, "name": "bash", "shared": True}
+    ]
+    terminal.list_windows = AsyncMock(
+        return_value=[
+            {"id": "@0", "index": 0, "name": "my-build", "active": True}
+        ]
+    )
+
+    await sess._sync_windows_once()
+
+    calls = [c[0][0] for c in sock.send_json.call_args_list]
+    shared = [m for m in calls if m.get("type") == "shared_terminals"]
+    assert len(shared) == 1
+    assert [t["window_name"] for t in shared[0]["terminals"]] == ["my-build"]
+
+
+async def test_sync_shared_rename_broadcast_fires_exactly_once():
+    """Whichever path applies a shared rename first broadcasts it; the
+    second apply finds no delta and stays quiet (#2651).
+
+    Simulates the CI race: the watcher's re-sync lands between the tmux
+    rename and the rename handler's own list_windows, so the handler's
+    sync_terminal_windows sees an unchanged shared set.
+    """
+    sess, sock, terminal = _session_with_user(handle="alice")
+    sess.terminal_windows["u1"] = [
+        {"id": "@0", "index": 0, "name": "bash", "shared": True}
+    ]
+    renamed = [{"id": "@0", "index": 0, "name": "my-build", "active": True}]
+    terminal.list_windows = AsyncMock(return_value=renamed)
+
+    await sess._sync_windows_once()  # watcher applies the rename first
+    # The rename handler's own sync with the same list: no second delta.
+    assert sess.apply_window_list("u1", renamed) is False
+
+    calls = [c[0][0] for c in sock.send_json.call_args_list]
+    shared = [m for m in calls if m.get("type") == "shared_terminals"]
+    assert len(shared) == 1
+
+
+async def test_sync_no_shared_broadcast_without_shared_delta():
+    """A rename of a non-shared window updates terminal_windows only."""
+    sess, sock, terminal = _session_with_user(handle="alice")
+    sess.terminal_windows["u1"] = [
+        {"id": "@0", "index": 0, "name": "bash", "shared": False}
+    ]
+    terminal.list_windows = AsyncMock(
+        return_value=[{"id": "@0", "index": 0, "name": "dev", "active": True}]
+    )
+
+    await sess._sync_windows_once()
+
+    calls = [c[0][0] for c in sock.send_json.call_args_list]
+    assert [m for m in calls if m.get("type") == "shared_terminals"] == []
+
+
+def test_apply_window_list_reports_shared_deltas():
+    """apply_window_list flags exactly the changes viewers must hear
+    about: a shared window added/closed, or any shared rename."""
+    sess, _sock, _terminal = _session_with_user()
+    sess.terminal_windows["u1"] = [
+        {"id": "@0", "index": 0, "name": "bash", "shared": True},
+        {"id": "@1", "index": 1, "name": "aux", "shared": False},
+    ]
+
+    # Same windows (active flag aside) → no delta.
+    assert (
+        sess.apply_window_list(
+            "u1",
+            [
+                {"id": "@0", "index": 0, "name": "bash", "active": True},
+                {"id": "@1", "index": 1, "name": "aux", "active": False},
+            ],
+        )
+        is False
+    )
+    # Shared window renamed → delta.
+    assert (
+        sess.apply_window_list(
+            "u1",
+            [
+                {"id": "@0", "index": 0, "name": "my-build", "active": True},
+                {"id": "@1", "index": 1, "name": "aux", "active": False},
+            ],
+        )
+        is True
+    )
+    # Shared window closed → delta.
+    assert (
+        sess.apply_window_list(
+            "u1", [{"id": "@1", "index": 0, "name": "aux", "active": True}]
+        )
+        is True
+    )
+    # Map reflects the last applied list, shared flags carried by id.
+    assert sess.terminal_windows["u1"] == [
+        {"id": "@1", "index": 0, "name": "aux", "shared": False}
+    ]

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -5911,6 +5911,96 @@ class TestTerminalWindowHandlers:
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "error"
 
+    async def test_rename_shared_window_broadcasts_shared_terminals(
+        self, user, app_state
+    ):
+        """Renaming a shared window updates other users' shared list.
+
+        The broadcast comes from the handler's sync when it is the path
+        that applies the rename (controller-first ordering of the #2651
+        race).
+        """
+        async with _conn_in_workspace(
+            user, "ws-1", user_home="/home/admin"
+        ) as (sock, conn, session, app_state):
+            session.terminal_windows[user["id"]] = [
+                {"name": "bash", "index": 0, "id": "@0", "shared": True}
+            ]
+            with (
+                patch.object(_mock_term, "rename_window"),
+                patch.object(
+                    _mock_term,
+                    "list_windows",
+                    return_value=[
+                        {
+                            "id": "@0",
+                            "index": 0,
+                            "name": "my-build",
+                            "active": True,
+                        }
+                    ],
+                ),
+            ):
+                await conn.handle_terminal_rename_window(
+                    {"index": 0, "name": "my-build"}
+                )
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            shared = [c for c in calls if c.get("type") == "shared_terminals"]
+            assert len(shared) == 1
+            assert [t["window_name"] for t in shared[0]["terminals"]] == [
+                "my-build"
+            ]
+
+    async def test_rename_shared_window_after_watcher_applied(
+        self, user, app_state
+    ):
+        """No duplicate shared broadcast when the watcher applied first.
+
+        Watcher-first ordering of the #2651 race: the debounced window
+        sync already merged the renamed list into the session map (and
+        broadcast the shared update itself — covered in
+        test_session_sync.py), so the handler's sync finds no delta and
+        must not broadcast again. The rename still reaches the client as
+        a terminal_windows frame.
+        """
+        async with _conn_in_workspace(
+            user, "ws-1", user_home="/home/admin"
+        ) as (sock, conn, session, app_state):
+            renamed = [
+                {
+                    "id": "@0",
+                    "index": 0,
+                    "name": "my-build",
+                    "active": True,
+                }
+            ]
+            # State as the watcher's re-sync left it: map merged,
+            # baseline current.
+            session.terminal_windows[user["id"]] = [
+                {"name": "my-build", "index": 0, "id": "@0", "shared": True}
+            ]
+            session._last_windows[user["id"]] = renamed
+            with (
+                patch.object(_mock_term, "rename_window"),
+                patch.object(
+                    _mock_term,
+                    "list_windows",
+                    return_value=renamed,
+                ),
+            ):
+                await conn.handle_terminal_rename_window(
+                    {"index": 0, "name": "my-build"}
+                )
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            assert [
+                c for c in calls if c.get("type") == "shared_terminals"
+            ] == []
+            assert any(
+                c.get("type") == "terminal_windows"
+                and any(w["name"] == "my-build" for w in c["windows"])
+                for c in calls
+            )
+
     async def test_list_windows(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)


### PR DESCRIPTION
## Summary

Fixes #2651.

The e2e flake was not a tight test budget — the `shared_terminals` frame
was structurally lost in a server-side race between the two producers of
the `terminal_windows` session map:

- **Direct path**: the `terminal_rename_window` handler runs tmux rename,
  then its own `list_windows`, then `sync_terminal_windows`, which
  broadcasts `shared_terminals` **only if the shared names differ from the
  map's current state**.
- **Watcher path**: the debounced control-mode re-sync
  (`_sync_windows_once`, 0.15 s after `%unlinked-window-renamed`) runs its
  own `list_windows` and merges the renamed entries into the **same map**
  — but never broadcast `shared_terminals`.

Under CI-VM load the podman exec order is a coin flip. When the watcher's
list lands first it erases the old→new name delta the handler relies on,
so the handler's delta check sees "no shared change" and skips the
broadcast. The admin still gets `terminal_windows` (both paths send it);
the coadmin never gets `shared_terminals` → `recv timed out`, and the
Playwright retry fails the same way whenever it loses the same race.

## Changes

- `WorkspaceSession.apply_window_list(user_id, windows)`: single merge +
  shared-delta detection point (wraps `merge_window_entries`; returns
  whether the shared set or any shared name changed).
- Both producers now broadcast `shared_terminals` when the merge detects a
  shared-window change, so the update fires exactly once regardless of
  which path applies it first:
  - `TerminalController.sync_terminal_windows` (command handlers)
  - `WorkspaceSession._sync_windows_once` (window watcher)
- `WorkspaceSession.broadcast_shared_terminals()` owns the broadcast;
  `SharedTerminalController.broadcast_shared_terminals` delegates to it.
- `get_shared_terminals` moved from `helpers.py` to `session.py`
  (re-exported from helpers for existing importers) so the session can
  call it without an import cycle.

This also fixes the same gap for watcher-visible closes/adds of shared
windows (previously only the command-handler path told shared-terminal
viewers).

## Testing

- New regression tests in `test_session_sync.py`: watcher sync broadcasts
  `shared_terminals` on a shared rename; exactly one broadcast across both
  paths in the CI-race ordering; no broadcast on non-shared renames;
  `apply_window_list` delta semantics.
- New tests in `test_wshandler.py`: rename of a shared window broadcasts
  the updated list (controller-first ordering); no duplicate broadcast
  when the watcher already applied the rename (watcher-first ordering).
- Full CI suite: `pytest src/klangk/klangkd-tests/tests
  src/klangk/klangkc-tests/tests -v -n auto` → 5438 passed, 100 % coverage.
