### PR TITLE
fix(wshandler): discard stale in-flight watcher window snapshots (#2653)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1108,6 +1108,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Terminal tab state no longer flaps old→new under load (#2653).**
+  The window watcher's window-list refresh could land between a
+  rename/new/close command and its confirmation, briefly reverting
+  the tab strip and shared-terminal list to the pre-command state
+  (new → old → new) before the next event re-corrected it. Stale
+  in-flight watcher snapshots are now discarded instead of applied.
+
 - **Shared-terminal tab list not updating on rename under load
   (#2651).** Renaming a shared terminal could leave other users' tab
   lists showing the old name indefinitely: the window-watcher's

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -197,6 +197,15 @@ class WorkspaceSession:
         # list_windows snapshot per user_id, so we re-broadcast only on a
         # real change (#2161 / #2171).
         self._last_windows: dict[str, list] = {}
+        # Monotonic per-user generation of the applied window list
+        # (#2653). Bumped by every apply_window_list; the debounced
+        # watcher stamps it before starting its list_windows exec and
+        # discards a snapshot that returns to a moved counter — a podman
+        # exec that started before a tmux rename/new/close committed can
+        # land after the command handler applied the newer list, and
+        # applying it would transiently revert the map, the baseline,
+        # and the broadcasts (new → old → new flap).
+        self._window_generations: dict[str, int] = {}
         self._window_watcher: WindowEventWatcher | None = None
         self._window_sync_handle: asyncio.TimerHandle | None = None
 
@@ -224,6 +233,7 @@ class WorkspaceSession:
         if watcher is not None:
             asyncio.create_task(watcher.stop())  # pragma: no cover
         self._last_windows.clear()
+        self._window_generations.clear()
 
     async def add_subscriber(
         self,
@@ -280,10 +290,20 @@ class WorkspaceSession:
         reused within a tmux server's lifetime, stable across renames
         and index reuse, #2192) and ``shared`` flags carry over; the
         agent's ``service-cmd`` window is shared by definition (#1114).
+
+        Applying also bumps the per-user window generation so the
+        watcher can tell a stale in-flight snapshot from a current one
+        (#2653).
         """
         old = self.terminal_windows.get(user_id, [])
         new_entries = merge_window_entries(old, windows)
         self.terminal_windows[user_id] = new_entries
+        # This list is now the newest applied state for the user (#2653):
+        # a watcher list_windows exec still in flight predates it, and
+        # its snapshot must be discarded instead of applied over it.
+        self._window_generations[user_id] = (
+            self._window_generations.get(user_id, 0) + 1
+        )
         # Broadcast-worthy delta: shared set changed (a shared window
         # was added or closed) or any shared window was renamed.
         old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
@@ -356,9 +376,22 @@ class WorkspaceSession:
             if uid and uid != model.AGENT_USER_ID:
                 user_ids.add(uid)
         for uid in user_ids:
+            # Stamp the apply generation before the exec (#2653): the
+            # list_windows below is a podman round-trip that can straddle
+            # a command handler's tmux mutation and its apply. If the
+            # counter moved by the time the exec returns, a newer list
+            # was applied while we were in flight and this snapshot is
+            # stale — applying it would revert the map, the baseline,
+            # and the client frames to the pre-mutation state.
+            generation = self._window_generations.get(uid, 0)
             try:
                 windows = await terminal.list_windows(self.container_id, uid)
             except Exception:  # pragma: no cover - container mid-restart
+                continue
+            if self._window_generations.get(uid, 0) != generation:
+                # Stale in-flight snapshot (#2653): the newer applied
+                # list already updated the map, the baseline, and the
+                # broadcasts; drop ours instead of reverting them.
                 continue
             if self._last_windows.get(uid) == windows:
                 continue

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -305,18 +305,27 @@ async def test_sync_discards_stale_inflight_snapshot():
     #2653). The generation stamped before the exec must discard it.
     """
     sess, sock, terminal = _session_with_user()
+    # Seeded shared: the concurrent apply below must report a shared
+    # rename delta — the issue's worst case (a revert broadcast to
+    # shared_terminals viewers), and what the recorded-delta assert
+    # at the end checks for.
     sess.terminal_windows["u1"] = [
         {"id": "@0", "index": 0, "name": "bash", "shared": True}
     ]
     stale = [{"id": "@0", "index": 0, "name": "bash", "active": True}]
     renamed = [{"id": "@0", "index": 0, "name": "my-build", "active": True}]
+    deltas: list[bool] = []
 
     async def straddling_exec(container_id, uid):
         # While the watcher's exec is in flight, the rename handler
         # commits and applies (and would broadcast) the renamed list.
         # A real handler's notify_user_terminal_windows also refreshes
-        # the watcher's baseline.
-        assert sess.apply_window_list("u1", renamed) is True
+        # the watcher's baseline. The apply's return value is recorded
+        # rather than asserted here — this coroutine runs inside
+        # _sync_windows_once's except-Exception guard, which would
+        # swallow an AssertionError and turn the failure into a
+        # baffling KeyError on _last_windows below.
+        deltas.append(sess.apply_window_list("u1", renamed))
         sess._last_windows["u1"] = renamed
         return stale  # our exec queried tmux before the rename committed
 
@@ -324,8 +333,11 @@ async def test_sync_discards_stale_inflight_snapshot():
 
     await sess._sync_windows_once()
 
-    # The stale snapshot was discarded: the map and the baseline still
-    # hold the renamed list and no frame was broadcast.
+    # The concurrent handler's apply did see (and broadcast) the
+    # shared rename — and the watcher's stale snapshot was discarded
+    # after it: the map and the baseline still hold the renamed list
+    # and no frame was broadcast for the revert.
+    assert deltas == [True]
     assert sess.terminal_windows["u1"][0]["name"] == "my-build"
     assert sess._last_windows["u1"] == renamed
     sock.send_json.assert_not_called()

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -291,6 +291,74 @@ def test_apply_window_list_reports_shared_deltas():
     ]
 
 
+# --- #2653: stale in-flight watcher snapshots must be discarded ---
+
+
+async def test_sync_discards_stale_inflight_snapshot():
+    """A watcher snapshot racing a command-handler apply is dropped.
+
+    The watcher's ``list_windows`` is a podman exec round-trip: under
+    load it can start before a tmux rename commits and return after
+    the rename handler already applied and broadcast the renamed
+    list. Applying the stale pre-rename snapshot would revert the map,
+    the baseline, and the client frames (new → old → new flap,
+    #2653). The generation stamped before the exec must discard it.
+    """
+    sess, sock, terminal = _session_with_user()
+    sess.terminal_windows["u1"] = [
+        {"id": "@0", "index": 0, "name": "bash", "shared": True}
+    ]
+    stale = [{"id": "@0", "index": 0, "name": "bash", "active": True}]
+    renamed = [{"id": "@0", "index": 0, "name": "my-build", "active": True}]
+
+    async def straddling_exec(container_id, uid):
+        # While the watcher's exec is in flight, the rename handler
+        # commits and applies (and would broadcast) the renamed list.
+        # A real handler's notify_user_terminal_windows also refreshes
+        # the watcher's baseline.
+        assert sess.apply_window_list("u1", renamed) is True
+        sess._last_windows["u1"] = renamed
+        return stale  # our exec queried tmux before the rename committed
+
+    terminal.list_windows = AsyncMock(side_effect=straddling_exec)
+
+    await sess._sync_windows_once()
+
+    # The stale snapshot was discarded: the map and the baseline still
+    # hold the renamed list and no frame was broadcast.
+    assert sess.terminal_windows["u1"][0]["name"] == "my-build"
+    assert sess._last_windows["u1"] == renamed
+    sock.send_json.assert_not_called()
+
+
+async def test_sync_applies_change_when_generation_unmoved():
+    """A genuine tmux-side change (no concurrent command-handler apply)
+    still passes the generation check and broadcasts (#2653 guard must
+    not eat real watcher deltas — e.g. a rename typed inside tmux)."""
+    sess, sock, terminal = _session_with_user()
+    terminal.list_windows = AsyncMock(
+        return_value=[{"id": "@0", "index": 0, "name": "dev", "active": True}]
+    )
+
+    await sess._sync_windows_once()
+
+    assert sess.terminal_windows["u1"][0]["name"] == "dev"
+    sock.send_json.assert_called_once()
+
+
+def test_apply_window_list_bumps_generation():
+    """Every apply is the newest applied state: the per-user generation
+    advances on each apply_window_list call (#2653)."""
+    sess, _sock, _terminal = _session_with_user()
+    windows = [{"id": "@0", "index": 0, "name": "bash", "active": True}]
+
+    assert sess._window_generations.get("u1", 0) == 0
+    sess.apply_window_list("u1", windows)
+    assert sess._window_generations["u1"] == 1
+    sess.apply_window_list("u1", windows)
+    assert sess._window_generations["u1"] == 2
+
+
 # --- #2652 review follow-ups ---
 
 


### PR DESCRIPTION
## Summary

Fixes #2653 — **stacked on #2652** (base branch is its head; retarget to `main` after it merges).

The window watcher's debounced re-sync issues its own `list_windows`
podman exec. Under load that exec can start before a tmux
rename/new/close commits and return after the command handler already
applied and broadcast the newer list; applying the stale snapshot
briefly reverted `terminal_windows` / `_last_windows` and re-broadcast
the old state (new → old → new flap), including `shared_terminals` to
every viewer.

## Fix

Per-user apply-generation counter on `WorkspaceSession`
(`_window_generations`), per the issue's suggested direction:

- `apply_window_list` — the single choke point every fresh window list
  already passes through (#2633 / #2651) — bumps the generation on
  every apply, so both producers (command handlers and the watcher)
  advance it with no call-site changes.
- `_sync_windows_once` stamps the generation before starting its exec
  and discards the snapshot if the counter moved while the exec was in
  flight. The newer apply already updated the map, the baseline, and
  the broadcasts; dropping a stale snapshot can only skip a frame,
  never revert one. Any genuinely-newer tmux-side state lost to a
  discard is picked up by the next event-driven re-sync (every tmux
  change fires control-mode events → debounce → re-sync).
- A watcher snapshot landing *before* the handler's apply is unchanged
  by design: clients haven't seen the new state yet, so applying the
  old list is invisible and the handler's apply still lands last.

## Testing

- `test_sync_discards_stale_inflight_snapshot` — simulates the exact
  straddle (handler applies mid-exec; exec returns the pre-rename
  list): the map/baseline keep the renamed list, no frame broadcast.
- `test_sync_applies_change_when_generation_unmoved` — genuine
  tmux-side deltas (e.g. a rename typed inside the terminal) still
  broadcast; the guard doesn't eat real changes.
- `test_apply_window_list_bumps_generation` — the counter advances
  monotonically per apply.
- Full backend suite, CI-style (`-n auto`, coverage gate): 5444
  passed, 100%.
