### PR TITLE
Silence egress sidecar sysctl errors on read-only /proc/sys (#2656)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1108,6 +1108,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Egress sidecar startup log noise on read-only `/proc/sys` (#2656).**
+  The sidecar entrypoint's best-effort sysctl writes (disable IPv6,
+  `rp_filter=0`) leaked alarming `Read-only file system` shell errors to
+  journald on hosts that mount `/proc/sys` read-only in containers. Both
+  writes are now fully silent; the egress deny is unaffected (ip6tables
+  OUTPUT DROP remains the backstop).
+
 - **Terminal tab state no longer flaps old→new under load (#2653).**
   The window watcher's window-list refresh could land between a
   rename/new/close command and its confirmation, briefly reverting

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -31,23 +31,27 @@ $IPT6 -P OUTPUT DROP
 # the createContainer-hook sysctl that was dropped (it ran before pasta
 # configured the netns and broke pasta's v6 address setup), this runs in the
 # sidecar entrypoint — AFTER pasta has configured the netns — so it just
-# removes the v6 addresses rather than blocking setup. Best-effort: rootless
-# per-netns ipv6 sysctl writability isn't guaranteed, and a silent no-op is
-# fine because the ip6tables DROP above is the certain backstop. Written via
-# procfs so no extra package (sysctl is in Alpine's procps, not installed).
-if [ -w /proc/sys/net/ipv6/conf/all/disable_ipv6 ]; then
-  echo 1 >/proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null ||
-    echo "egress-sidecar: could not disable IPv6 stack (relying on ip6tables DROP)" >&2
-fi
+# removes the v6 addresses rather than blocking setup. Best-effort and fully
+# silent: rootless per-netns sysctl writability isn't guaranteed (a read-only
+# /proc/sys defeats [ -w ] too — access(2) checks mode bits, not the mount),
+# and a no-op is fine because the ip6tables DROP above is the certain
+# backstop. Redirections apply left-to-right, so 2>/dev/null must precede the
+# write target; placed after it, the shell leaks "can't create ..." to the
+# still-open stderr (#2656). Written via procfs so no extra package (sysctl
+# is in Alpine's procps, not installed).
+echo 1 2>/dev/null >/proc/sys/net/ipv6/conf/all/disable_ipv6 || :
 # Disable rp_filter (reverse-path) in this netns so the proxy's forged eager-deny
 # RST (#2345) is delivered: the RST is sourced from the denied host's IP and
 # looped back to the local stack so connect() gets ECONNREFUSED at once; a
 # foreign-source packet arriving on lo can trip rp_filter and be silently
 # dropped. This is a single-uplink isolated netns with no multipath asymmetry,
 # so disabling rp_filter is safe. Best-effort (rootless per-netns writability).
+# The 2>/dev/null sits on `done` so it also covers the write redirections
+# inside the loop (per-write `>"$f" 2>/dev/null` still leaks the shell's own
+# error message — #2656).
 for f in /proc/sys/net/ipv4/conf/*/rp_filter; do
-  echo 0 >"$f" 2>/dev/null || true
-done
+  echo 0 >"$f" || true
+done 2>/dev/null
 # Loopback by *destination* (not -o lo): REDIRECT keeps the packet's original
 # output interface, so -o lo misses the redirected :53 packet under a DROP policy.
 $IPT -A OUTPUT -d 127.0.0.0/8 -j ACCEPT


### PR DESCRIPTION
Fixes #2656.

## Problem

On hosts that mount `/proc/sys` read-only inside containers, every egress-sidecar startup logged five alarming lines to journald:

```
/entrypoint.sh: line 39: can't create /proc/sys/net/ipv6/conf/all/disable_ipv6: Read-only file system
egress-sidecar: could not disable IPv6 stack (relying on ip6tables DROP)
/entrypoint.sh: line 49: can't create /proc/sys/net/ipv4/conf/all/rp_filter: Read-only file system
... (one per interface)
```

The `2>/dev/null` guards were ineffective for two reasons:

- **Redirection order.** POSIX shells apply redirections left-to-right, so `echo 0 >"$f" 2>/dev/null` fails the `>"$f"` open *before* `2>/dev/null` is in place — the shell prints its own "can't create" message to the still-open stderr.
- **`[ -w ]` can't detect it.** `access(2)` checks mode bits, not the mount, so the `disable_ipv6` guard passes on read-only mounts and the write (plus the `||` fallback message) fires every time.

Both writes are explicitly best-effort (the ip6tables OUTPUT DROP is the authoritative deny), so the noise carried no signal — it just scared operators.

## Fix

- `disable_ipv6`: single silent best-effort write — `echo 1 2>/dev/null >/proc/... || :` (suppression before the target). The fallback message is dropped; the ip6tables DROP is the certain backstop.
- `rp_filter` loop: per-write suppression replaced by loop-level `done 2>/dev/null`, which covers the write redirections inside the body.

## Verification

- Reproduced the exact reported lines under Alpine busybox ash (the sidecar image's shell) in a container with read-only `/proc/sys`; the patched script is silent there.
- `sh -n` under busybox ash, `shellcheck`, `shfmt` clean (pre-commit).
- `scripts/tests` (build-pipeline contract tests): 59 passed.
- Full backend suite CI-style (`-n auto`, coverage): 5444 passed, 100% coverage.
