### PR TITLE
fix(sidecar): swallow CancelledError from consent stop during teardown (#2657)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1108,6 +1108,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Clean sidecar shutdown when its consent WebSocket is down
+  (#2657).** Removing a workspace whose egress sidecar sat in the
+  consent reconnect backoff dumped a raw
+  `asyncio.exceptions.CancelledError` traceback to the journal and
+  aborted teardown mid-way (exit code 1). SIGTERM teardown now
+  swallows the cancelled reconnect task and completes every cleanup
+  step.
+
 - **Egress sidecar startup log noise on read-only `/proc/sys` (#2656).**
   The sidecar entrypoint's best-effort sysctl writes (disable IPv6,
   `rp_filter=0`) leaked alarming `Read-only file system` shell errors to

--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -51,7 +51,12 @@ async def _shutdown(
     if client is not None:
         try:
             await asyncio.wait_for(client.stop(), _SHUTDOWN_CLIENT_TIMEOUT)
-        except Exception:
+        except (asyncio.CancelledError, Exception):
+            # CancelledError widened in (#2657): stop() awaiting its cancelled
+            # _run task raises it through the wait_for, `except Exception`
+            # doesn't catch a BaseException (3.8+), and the escape aborted the
+            # rest of teardown -- the exact failure mode the sweep/sampler
+            # guards below already widen against.
             pass
     if sweep is not None:
         sweep.cancel()

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -100,7 +100,15 @@ class SidecarConsentClient:
             self._task.cancel()
             try:
                 await self._task
-            except Exception:
+            except (asyncio.CancelledError, Exception):
+                # CancelledError first (#2657): the cancel we just issued
+                # makes the awaited task raise it wherever it is parked
+                # (reconnect backoff, token-retry sleep), and it is a
+                # BaseException (3.8+) that `except Exception` alone let
+                # escape -- aborting _shutdown (nfq.unbind/sock.close
+                # skipped) and dumping a raw traceback on every workspace
+                # removal whose WS was down. Same guard shape _shutdown
+                # uses for its sweep/sampler awaits (app.py).
                 pass
         self._fail_close_pending()
 

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -3244,3 +3244,44 @@ class TestSigtermShutdown:
         assert elapsed < 1.0  # bounded well under the 5s window
         nfq.unbind.assert_called()  # teardown proceeded past the timed-out stop
         sock.close.assert_called()
+
+    async def test_stop_swallows_cancelled_backoff_task(self, proxy, tmp_path):
+        # Regression (#2657): stop() awaited its cancelled _run task behind an
+        # `except Exception`, but the CancelledError a cancelled task raises is
+        # a BaseException (3.8+), so a stop() issued while _run was parked in
+        # the token-retry / reconnect-backoff sleep escaped stop(), escaped
+        # _shutdown's `except Exception` around the wait_for, and dumped a raw
+        # traceback out of asyncio.run on every workspace removal whose WS was
+        # down (eviction e2e saw it via the evict-bystander container) --
+        # skipping nfq.unbind/sock.close and exiting 1. The guard now matches
+        # _shutdown's sweep/sampler pattern.
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "missing"), 5)
+        await c.start()
+        await asyncio.sleep(0.05)  # let _run park in the token-retry sleep
+        assert not c._task.done()
+        fut = asyncio.get_running_loop().create_future()
+        c._pending["lid"] = fut
+        await c.stop()  # must return, not raise CancelledError
+        assert c._task.done()
+        # Teardown continued past the guarded await: pending requests were
+        # fail-closed (deny) by _fail_close_pending.
+        assert fut.done() and fut.result() == ("deny", "once")
+
+    async def test_shutdown_survives_cancelled_error_from_client_stop(self, proxy):
+        # #2657 defense in depth: _shutdown's wait_for(client.stop()) guard is
+        # widened to (CancelledError, Exception) so no BaseException path out
+        # of the client can abort teardown -- the same widening its own
+        # sweep/sampler guards already have.
+        nfq = MagicMock()
+        nfq.get_fd = MagicMock(return_value=9)
+        sock = MagicMock()
+        sweep = asyncio.get_running_loop().create_task(asyncio.sleep(100))
+
+        class _RaisingClient:
+            async def stop(self):
+                raise asyncio.CancelledError()
+
+        await proxy._shutdown(_RaisingClient(), nfq, sock, sweep)
+        nfq.unbind.assert_called_once()  # teardown was NOT aborted
+        sock.close.assert_called_once()
+        assert sweep.cancelled()


### PR DESCRIPTION
Closes #2657.

## What

`SidecarConsentClient.stop()` awaited its cancelled `_run` task behind an
`except Exception`, but the `CancelledError` a cancelled task raises is a
`BaseException` (3.8+). A `stop()` issued while `_run` was parked in the
reconnect-backoff or token-retry sleep let it escape both `stop()` and
`_shutdown`'s `except Exception` around the `wait_for` — aborting teardown
(`nfq.unbind`/`sock.close` skipped, exit code 1) and dumping a raw
`asyncio.exceptions.CancelledError` traceback to the journal on every
workspace removal whose consent WS was down (the eviction e2e's
`evict-bystander` container hit it reliably).

## Changes

- `consent.py` `stop()`: guard widened to
  `except (asyncio.CancelledError, Exception)` — the same shape
  `_shutdown` already uses for its sweep/sampler awaits.
- `app.py` `_shutdown`: the `wait_for(client.stop(), …)` guard widened the
  same way, as defense in depth so no `BaseException` path out of the
  client can abort teardown.
- Two regression tests in `TestSigtermShutdown`: one drives a real client
  parked in the token-retry sleep through `stop()` (fails with
  `CancelledError` before the fix); one drives `_shutdown` with a client
  whose `stop()` raises `CancelledError` and asserts unbind/close still
  run.
- Changelog entry under `[Unreleased]` → Fixed.

## Testing

- `test-sidecar`: 189 passed (187 + 2 new).
- `test-backend`: 5503 passed.

The server package's own `await self._task` sites
(`inactivity.py`, `window_watcher.py`, `consent/egress.py`,
`eviction.py`) already catch `CancelledError`; the bug was isolated to the
sidecar.
