### PR TITLE
fix(tests): sweep mkdtemp scratch dirs at process exit (#2662)

### DIFF
--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -11,7 +11,6 @@ Run with: devenv shell -- test-backend-e2e
 import logging
 import os
 import subprocess
-import tempfile
 import time
 from pathlib import Path
 
@@ -27,7 +26,7 @@ sys.path.insert(
     ),
 )
 from _e2e_env import clean_env
-from _e2e_server import start_server, stop_server
+from _e2e_server import start_server, stop_server, tracked_mkdtemp
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +80,7 @@ def _stop_server(server, data_dir=None):
 @pytest.fixture(scope="session")
 def server():
     """Start a real Klangk server for the test session."""
-    data_dir = tempfile.mkdtemp(prefix="klangk-cli-e2e-")
+    data_dir = tracked_mkdtemp("klangk-cli-e2e-")
     port = str(free_port())
     proc, base_url = _start_server(data_dir, port)
     yield {
@@ -644,7 +643,7 @@ class TestAutoStart:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def autostart_server(tmp_path_factory, request):
-        data_dir = tempfile.mkdtemp(prefix="klangk-autostart-")
+        data_dir = tracked_mkdtemp("klangk-autostart-")
         proc, base_url = _start_server(
             data_dir,
             str(free_port()),
@@ -762,7 +761,7 @@ class TestSandboxAutoStartServiceCommand:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def autostart_server(tmp_path_factory, request):
-        data_dir = tempfile.mkdtemp(prefix="klangk-sandbox-defcmd-")
+        data_dir = tracked_mkdtemp("klangk-sandbox-defcmd-")
         proc, base_url = _start_server(
             data_dir,
             TestSandboxAutoStartServiceCommand.PORT,
@@ -1435,7 +1434,7 @@ class TestAllowedMountRoots:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def restricted_server(tmp_path_factory, request):
-        data_dir = tempfile.mkdtemp(prefix="klangk-mount-roots-")
+        data_dir = tracked_mkdtemp("klangk-mount-roots-")
         proc, base_url = _start_server(
             data_dir,
             str(free_port()),
@@ -1507,7 +1506,7 @@ class TestVolumeUserIsolation:
     def two_user_server(tmp_path_factory, request):
         import httpx
 
-        data_dir = tempfile.mkdtemp(prefix="klangk-vol-iso-")
+        data_dir = tracked_mkdtemp("klangk-vol-iso-")
         proc, base_url = _start_server(data_dir, str(free_port()))
 
         # Register a second user via the API
@@ -1658,7 +1657,7 @@ class TestTerminalSharing:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def _dedicated_server(tmp_path_factory, request):
-        data_dir = tempfile.mkdtemp(prefix="klangk-terminal-sharing-")
+        data_dir = tracked_mkdtemp("klangk-terminal-sharing-")
         proc, base_url = _start_server(data_dir, str(free_port()))
         config_dir = tmp_path_factory.mktemp("klangk-terminal-sharing-config")
         env = clean_env(HOME=str(config_dir))
@@ -1949,7 +1948,7 @@ class TestWorkspaceSharing:
 @pytest.fixture(scope="module")
 def short_token_server():
     """Start a server with very short token lifetime (~7 seconds)."""
-    data_dir = tempfile.mkdtemp(prefix="klangk-refresh-e2e-")
+    data_dir = tracked_mkdtemp("klangk-refresh-e2e-")
     proc, base_url = _start_server(
         data_dir,
         str(free_port()),

--- a/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
@@ -28,7 +28,6 @@ import asyncio
 import json
 import os
 import subprocess
-import tempfile
 import time
 
 import httpx
@@ -44,7 +43,7 @@ sys.path.insert(
     ),
 )
 from _e2e_env import clean_env
-from _e2e_server import start_server, stop_server
+from _e2e_server import start_server, stop_server, tracked_mkdtemp
 
 
 # --- server / auth / cli-config fixtures (self-contained, per repo convention) ---
@@ -84,7 +83,7 @@ def _stop_server(server, data_dir=None):
 @pytest.fixture(scope="module")
 def server():
     """Start a real Klangk server with a fast health-check interval."""
-    data_dir = tempfile.mkdtemp(prefix="klangk-monitor-e2e-")
+    data_dir = tracked_mkdtemp("klangk-monitor-e2e-")
     server, base_url = _start_server(data_dir)
     yield {"url": base_url, "data_dir": data_dir}
     _stop_server(server)

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -17,7 +17,6 @@ import json
 import logging
 import os
 import subprocess
-import tempfile
 
 import httpx
 import pytest
@@ -33,7 +32,7 @@ sys.path.insert(
     ),
 )
 from _e2e_env import clean_env
-from _e2e_server import start_server, stop_server
+from _e2e_server import start_server, stop_server, tracked_mkdtemp
 
 logger = logging.getLogger(__name__)
 
@@ -342,7 +341,7 @@ class TestTerminalWindows:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def _dedicated_server(tmp_path_factory, request):
-        data_dir = tempfile.mkdtemp(prefix="klangk-tw-e2e-")
+        data_dir = tracked_mkdtemp("klangk-tw-e2e-")
         proc, base_url = _start_server(data_dir)
         config_dir = tmp_path_factory.mktemp("klangk-tw-config")
         env = clean_env(HOME=str(config_dir))

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -9,7 +9,6 @@ Run with: devenv shell -- test-cli-e2e -k TestTuiE2E
 
 import os
 import sys
-import tempfile
 import time
 
 import asyncio
@@ -25,7 +24,7 @@ sys.path.insert(
         os.path.dirname(__file__), "..", "..", "klangkd-tests", "e2e-tests"
     ),
 )
-from _e2e_server import start_server, stop_server  # noqa: E402
+from _e2e_server import start_server, stop_server, tracked_mkdtemp  # noqa: E402
 
 from klangk.cli.tui.app import KlangkApp  # noqa: E402
 from klangk.cli.tui.screens import (  # noqa: E402
@@ -102,7 +101,7 @@ async def _wait_for_workspace_loaded(app, pilot, timeout=30.0):
 
 @pytest.fixture(scope="module")
 def server():
-    data_dir = tempfile.mkdtemp(prefix="klangk-tui-e2e-")
+    data_dir = tracked_mkdtemp("klangk-tui-e2e-")
     log_path = os.path.join(data_dir, "server.log")
     srv = start_server(
         uds=False,

--- a/src/klangk/klangkc-tests/tests/_helpers.py
+++ b/src/klangk/klangkc-tests/tests/_helpers.py
@@ -1,0 +1,36 @@
+"""Shared helpers for the CLI unit-test suite.
+
+Mirrors the daemon suite's ``klangkd-tests/tests/_helpers.py`` helper of the
+same name (kept separate: the two suites share no imports, #2662).
+"""
+
+from __future__ import annotations
+
+import atexit
+import shutil
+import tempfile
+
+_mktemp_registry: list[str] = []
+
+
+def rmtree_registered_temps() -> None:
+    """Remove every dir :func:`tracked_mkdtemp` made (process exit, #2662)."""
+    for path in _mktemp_registry:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def tracked_mkdtemp(prefix: str) -> str:
+    """``tempfile.mkdtemp`` whose dir is removed at process exit (#2662).
+
+    Prefer pytest's ``tmp_path`` for ordinary per-test scratch. Use this only
+    where ``tmp_path`` can't serve: the short AF_UNIX socket paths macOS
+    needs (#1983 — pytest tmp paths resolve through ``/private/var`` and can
+    exceed the 104-char ``sun_path`` limit). The atexit sweep is the safety
+    net for paths that skip fixture teardown (crashed runs); explicit
+    ``shutil.rmtree`` teardown stays authoritative where one exists.
+    """
+    if not _mktemp_registry:
+        atexit.register(rmtree_registered_temps)
+    path = tempfile.mkdtemp(prefix=prefix)
+    _mktemp_registry.append(path)
+    return path

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1,6 +1,8 @@
 """Tests for klangk CLI commands (main.py)."""
 
 import json
+
+from _helpers import tracked_mkdtemp
 import klangk.cli.execsync
 import os
 import types
@@ -287,7 +289,6 @@ class TestMainCLI:
     def test_server_url_falls_back_to_default_uds(self, tmp_path, monkeypatch):
         """When the default klangkd UDS exists, server_url() uses it (#1676)."""
         import socket as _socket
-        import tempfile
         from pathlib import Path
 
         from klangk.cli import main
@@ -300,7 +301,7 @@ class TestMainCLI:
         CLIState().save()  # no active server, no --server
         # Use a short temp dir so the socket path stays under the 104-char
         # AF_UNIX sun_path limit on macOS (#1983).
-        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        short_tmp = Path(tracked_mkdtemp("ks-"))
         monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
         monkeypatch.delenv("KLANGK_STATE_DIR", raising=False)
         sock_dir = short_tmp / "klangkd"
@@ -318,7 +319,6 @@ class TestMainCLI:
     ):
         """KLANGK_STATE_DIR relocates the default UDS (#1676)."""
         import socket as _socket
-        import tempfile
         from pathlib import Path
 
         from klangk.cli import main
@@ -331,7 +331,7 @@ class TestMainCLI:
         CLIState().save()
         # Use a short temp dir so the socket path stays under the 104-char
         # AF_UNIX sun_path limit on macOS (#1983).
-        custom_state = Path(tempfile.mkdtemp(prefix="ks-"))
+        custom_state = Path(tracked_mkdtemp("ks-"))
         monkeypatch.setenv("KLANGK_STATE_DIR", str(custom_state))
         sock_path = custom_state / "klangk.sock"
         srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -384,7 +384,6 @@ class TestMainCLI:
     ):
         """A plain absolute KLANGK_SOCKET is used when it exists (#1676)."""
         import socket as _socket
-        import tempfile
         from pathlib import Path
 
         from klangk.cli import main
@@ -397,7 +396,7 @@ class TestMainCLI:
         CLIState().save()
         # Use a short temp dir so the socket path stays under the 104-char
         # AF_UNIX sun_path limit on macOS (#1983).
-        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        short_tmp = Path(tracked_mkdtemp("ks-"))
         monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
         sock_path = short_tmp / "relocated.sock"
         srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -413,7 +412,6 @@ class TestMainCLI:
     ):
         """active-server wins even when the default UDS exists."""
         import socket as _socket
-        import tempfile
         from pathlib import Path
 
         from klangk.cli import main
@@ -425,7 +423,7 @@ class TestMainCLI:
         config_path.write_text("")
         # Use a short temp dir so the socket path stays under the 104-char
         # AF_UNIX sun_path limit on macOS (#1983).
-        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        short_tmp = Path(tracked_mkdtemp("ks-"))
         monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
         sock_dir = short_tmp / "klangkd"
         sock_dir.mkdir()
@@ -443,7 +441,6 @@ class TestMainCLI:
     ):
         """--server override wins even when the default UDS exists."""
         import socket as _socket
-        import tempfile
         from pathlib import Path
 
         from klangk.cli import main
@@ -456,7 +453,7 @@ class TestMainCLI:
         CLIState().save()
         # Use a short temp dir so the socket path stays under the 104-char
         # AF_UNIX sun_path limit on macOS (#1983).
-        short_tmp = Path(tempfile.mkdtemp(prefix="ks-"))
+        short_tmp = Path(tracked_mkdtemp("ks-"))
         monkeypatch.setenv("XDG_STATE_HOME", str(short_tmp))
         sock_dir = short_tmp / "klangkd"
         sock_dir.mkdir()

--- a/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
@@ -51,10 +51,11 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
+
+from _e2e_server import tracked_mkdtemp
 
 # The default network-sidecar image has python3 + dnspython + openssl (the
 # proxy's deps), so a single image serves as both the DNS forwarder and the
@@ -343,7 +344,7 @@ class ControlledDns:
         """Bring up the target + dns containers and publish an empty map."""
         if self._p.target:
             return  # already started
-        d = tempfile.mkdtemp(prefix="ctrl-dns-")
+        d = tracked_mkdtemp("ctrl-dns-")
         self._p.dir = d
         self._p.map_path = os.path.join(d, "map.json")
         self._write_map()

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -28,6 +28,7 @@ Every server's env is built via :func:`_e2e_env.clean_env` (hermetic; no
 
 from __future__ import annotations
 
+import atexit
 import os
 import shutil
 import subprocess
@@ -55,6 +56,30 @@ BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
 FRONTEND_DIR = os.path.normpath(
     os.path.join(BACKEND_DIR, "..", "..", "frontend", "build", "web")
 )
+
+_mktemp_registry: list[str] = []
+
+
+def rmtree_registered_temps() -> None:
+    """Remove every dir :func:`tracked_mkdtemp` made (process exit, #2662)."""
+    for path in _mktemp_registry:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def tracked_mkdtemp(prefix: str) -> str:
+    """``tempfile.mkdtemp`` whose dir is removed at process exit (#2662).
+
+    ``start_server``'s explicit ``stop_server`` teardown stays authoritative;
+    this sweep is the safety net for dirs whose run never reaches it (a
+    readiness timeout, a crashed test session) — they used to orphan in
+    ``/tmp`` by the tens of thousands.
+    """
+    if not _mktemp_registry:
+        atexit.register(rmtree_registered_temps)
+    path = tempfile.mkdtemp(prefix=prefix)
+    _mktemp_registry.append(path)
+    return path
+
 
 # A dummy host for UDS clients: the UDS transport ignores it for the
 # connection, but httpx/websockets still need a syntactically valid URL
@@ -218,11 +243,9 @@ def start_server(
     :func:`ws_connect`. Pass the handle to :func:`stop_server` for teardown.
     """
     if data_dir is None:
-        data_dir = os.path.realpath(tempfile.mkdtemp(prefix="klangk-e2e-"))
+        data_dir = os.path.realpath(tracked_mkdtemp("klangk-e2e-"))
     if state_dir is None:
-        state_dir = os.path.realpath(
-            tempfile.mkdtemp(prefix="klangk-e2e-state-")
-        )
+        state_dir = os.path.realpath(tracked_mkdtemp("klangk-e2e-state-"))
     # Default to a file-streamed log inside the data dir so the failure
     # hooks in ``_e2e_logs`` can attach what the server said (#2623); a
     # captured pipe is only drainable at process exit and vanishes with

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -47,7 +47,7 @@ if _HERE not in sys.path:
 
 import httpx  # noqa: E402
 
-from _e2e_server import start_server, stop_server, ws_connect  # noqa: E402
+from _e2e_server import start_server, stop_server, tracked_mkdtemp, ws_connect  # noqa: E402
 
 from _controlled_dns import (  # noqa: E402
     ControlledDns,
@@ -1324,11 +1324,10 @@ class SmokeTest:
         subprocess) puts them on the shared ``podman`` bridge instead. No-op if
         the ambient CONTAINERS_CONF already sets a netns.
         """
-        import tempfile
 
         if os.environ.get("CONTAINERS_CONF"):
             return  # operator supplied their own; respect it
-        d = tempfile.mkdtemp(prefix="klangk-smoke-cc-")
+        d = tracked_mkdtemp("klangk-smoke-cc-")
         path = os.path.join(d, "containers.conf")
         with open(path, "w") as f:
             f.write('[containers]\nnetns = "bridge"\n')

--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -8,12 +8,16 @@ Run with: devenv shell -- test-backend-e2e test_api_e2e.py
 
 import shutil
 import subprocess
-import tempfile
 import uuid
 
 import pytest
 
-from _e2e_server import httpx_client, start_server, stop_server
+from _e2e_server import (
+    httpx_client,
+    start_server,
+    stop_server,
+    tracked_mkdtemp,
+)
 from pathlib import Path
 
 
@@ -1014,7 +1018,7 @@ class TestAutoStartWithServiceCommand:
     @staticmethod
     def autostart_server(request):
         server = start_server(
-            data_dir=tempfile.mkdtemp(prefix="klangk-autostart-e2e-"),
+            data_dir=tracked_mkdtemp("klangk-autostart-e2e-"),
             KLANGKD_JWT_SECRET="autostart-e2e-secret",
             KLANGKD_DEFAULT_USER="admin@example.com",
             KLANGKD_DEFAULT_PASSWORD="adminpass",

--- a/src/klangk/klangkd-tests/e2e-tests/test_caddy_lifecycle_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_caddy_lifecycle_e2e.py
@@ -19,7 +19,6 @@ Run with: devenv shell -- test-backend-e2e test_caddy_lifecycle_e2e.py
 import os
 import signal
 import subprocess
-import tempfile
 import time
 
 import httpx
@@ -27,6 +26,7 @@ import pytest
 
 from klangk.model import free_port
 from _e2e_env import clean_env, close_popen_pipes
+from _e2e_server import tracked_mkdtemp
 
 BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
 
@@ -60,7 +60,7 @@ def _port_listening(port):
 
 def _start_klangkd():
     """Start a klangkd process with the Caddy proxy engine, return (proc, port)."""
-    data_dir = tempfile.mkdtemp(prefix="klangk-caddy-lifecycle-")
+    data_dir = tracked_mkdtemp("klangk-caddy-lifecycle-")
     egress_port = str(free_port())
 
     env = clean_env(

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_prune_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_prune_e2e.py
@@ -26,13 +26,12 @@ Run: devenv shell -- test-backend-e2e -k TestConsentPruneE2E
 import os
 import sqlite3
 import subprocess
-import tempfile
 import time
 
 import pytest
 
 from _e2e_env import close_popen_pipes
-from _e2e_server import start_server, stop_server
+from _e2e_server import start_server, stop_server, tracked_mkdtemp
 
 # Common server config: TCP via the proxy (the sidecar's WS back to klangkd
 # needs the egress listener), password auth, test mode.
@@ -259,8 +258,8 @@ def _relaunch(server: dict, **env: str) -> dict:
 
 
 def _fresh_dirs() -> tuple[str, str]:
-    data_dir = os.path.realpath(tempfile.mkdtemp(prefix="prune-e2e-data-"))
-    state_dir = os.path.realpath(tempfile.mkdtemp(prefix="prune-e2e-state-"))
+    data_dir = os.path.realpath(tracked_mkdtemp("prune-e2e-data-"))
+    state_dir = os.path.realpath(tracked_mkdtemp("prune-e2e-state-"))
     return data_dir, state_dir
 
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -39,11 +39,12 @@ import platform
 import shutil
 import socket
 import subprocess
-import tempfile
 import time
 import uuid
 
 import pytest
+
+from _e2e_server import tracked_mkdtemp
 
 # The network sidecar image source (entrypoint.sh + Dockerfile), relative to
 # this e2e-tests dir. The proxy itself arrives as the klangksidecar wheel
@@ -292,7 +293,7 @@ def env():
     # the named context the Dockerfile consumes (COPY --from=sidecar). The
     # image pip-installs the wheel rather than a hand-copied proxy.py, so the
     # package can grow multifile without the build changing.
-    wheel_dir = tempfile.mkdtemp(prefix="netc-e2e-whl-")
+    wheel_dir = tracked_mkdtemp("netc-e2e-whl-")
     uv = subprocess.run(
         [
             "uv",
@@ -320,7 +321,7 @@ def env():
         timeout=300,
     )
     assert build.returncode == 0, build.stderr
-    tmp = tempfile.mkdtemp(prefix="netc-e2e-")
+    tmp = tracked_mkdtemp("netc-e2e-")
     fu = os.path.join(tmp, "fake_upstream.py")
     wq = os.path.join(tmp, "ws_query.py")
     sm = os.path.join(tmp, "somark_probe.py")
@@ -911,7 +912,7 @@ def consent_stack(env):
     (WS) + the sidecar pointed at it. Yields a dict with the container names +
     the trigger script path + image."""
     _require_platform()
-    tmp = tempfile.mkdtemp(prefix="consent-e2e-")
+    tmp = tracked_mkdtemp("consent-e2e-")
     fu = os.path.join(tmp, "consent_upstream.py")
     ver = os.path.join(tmp, "consent_verifier.py")
     trig = os.path.join(tmp, "consent_trigger.py")

--- a/src/klangk/klangkd-tests/e2e-tests/test_sighup_restart_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_sighup_restart_e2e.py
@@ -28,14 +28,18 @@ import asyncio
 import json
 import os
 import subprocess
-import tempfile
 import time
 
 import httpx
 import pytest
 import websockets
 
-from _e2e_server import start_server, stop_server, ws_connect as _ws_dial
+from _e2e_server import (
+    start_server,
+    stop_server,
+    tracked_mkdtemp,
+    ws_connect as _ws_dial,
+)
 
 
 @pytest.fixture(scope="module")
@@ -258,8 +262,8 @@ def test_config_reload_via_sighup():
     """
     import yaml
 
-    data_dir = tempfile.mkdtemp(prefix="klangk-reload-e2e-")
-    state_dir = tempfile.mkdtemp(prefix="klangk-reload-e2e-state-")
+    data_dir = tracked_mkdtemp("klangk-reload-e2e-")
+    state_dir = tracked_mkdtemp("klangk-reload-e2e-state-")
 
     config_path = os.path.join(state_dir, "klangk.yaml")
     with open(config_path, "w") as f:

--- a/src/klangk/klangkd-tests/tests/_helpers.py
+++ b/src/klangk/klangkd-tests/tests/_helpers.py
@@ -8,11 +8,41 @@ yet available.
 
 from __future__ import annotations
 
+import atexit
 import os
+import shutil
 import sys
 import tempfile
 
 from klangk.settings import KlangkSettings
+
+# Per-test DB holder (#1578). The autouse ``temp_data_dir`` fixture builds a
+_mktemp_registry: list[str] = []
+
+
+def rmtree_registered_temps() -> None:
+    """Remove every dir :func:`tracked_mkdtemp` made (process exit, #2662)."""
+    for path in _mktemp_registry:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def tracked_mkdtemp(prefix: str) -> str:
+    """``tempfile.mkdtemp`` whose dir is removed at process exit (#2662).
+
+    Prefer pytest's ``tmp_path`` for ordinary per-test scratch. Use this only
+    where ``tmp_path`` can't serve: settings built at module import time
+    (before fixtures set ``KLANGKD_*_DIR``) and the short AF_UNIX socket paths
+    macOS needs (#1983 — pytest tmp paths resolve through ``/private/var``
+    and can exceed the 104-char ``sun_path`` limit). The atexit sweep is the
+    safety net for paths that skip fixture teardown (crashed runs); explicit
+    ``shutil.rmtree`` teardown stays authoritative where one exists.
+    """
+    if not _mktemp_registry:
+        atexit.register(rmtree_registered_temps)
+    path = tempfile.mkdtemp(prefix=prefix)
+    _mktemp_registry.append(path)
+    return path
+
 
 # Per-test DB holder (#1578). The autouse ``temp_data_dir`` fixture builds a
 # DB from the per-test settings and stashes it here (``set_test_db``); the
@@ -54,24 +84,24 @@ def make_settings(
     value in ``env`` to override.
     """
     env = dict(env or {})
-    # Fall back to os.environ (set by the autouse temp_data_dir fixture) before
-    # creating orphan mkdtemp dirs that are never cleaned up.
+    # Fall back to os.environ (set by the autouse temp_data_dir fixture)
+    # before creating temp dirs. Tracked so module-import-time call sites
+    # (which run before any fixture) can't orphan them (#2662).
     env.setdefault(
         "KLANGKD_STATE_DIR",
         os.environ.get("KLANGKD_STATE_DIR")
-        or tempfile.mkdtemp(prefix="klangk-state-"),
+        or tracked_mkdtemp("klangk-state-"),
     )
     env.setdefault(
         "KLANGKD_DATA_DIR",
-        os.environ.get("KLANGKD_DATA_DIR")
-        or tempfile.mkdtemp(prefix="klangk-data-"),
+        os.environ.get("KLANGKD_DATA_DIR") or tracked_mkdtemp("klangk-data-"),
     )
     # On macOS the default socket paths derived from state_dir may exceed the
     # 104-char AF_UNIX sun_path limit because tempfile paths resolve through
     # /private/var/folders/... Set short socket paths so the settings
     # validator passes (#1983).
     if sys.platform == "darwin":
-        _sock_dir = tempfile.mkdtemp(prefix="ks-")
+        _sock_dir = tracked_mkdtemp("ks-")
         env.setdefault("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
         env.setdefault(
             "KLANGKD_CADDY_ADMIN_SOCKET",

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import tempfile
 
 # Must be set before coverage.py initialises in each xdist worker so that
 # code executed inside SQLAlchemy's greenlet context is tracked.
@@ -14,7 +13,7 @@ import pytest
 
 from klangk.settings import KlangkSettings
 
-from _helpers import make_settings
+from _helpers import make_settings, tracked_mkdtemp
 
 # Speed every hash in the suite up by dropping PBKDF2 to 1k iterations
 # (production default is 600k). The stored format embeds the iteration
@@ -50,9 +49,10 @@ def temp_data_dir(tmp_path, monkeypatch):
     # On macOS the default socket paths derived from tmp_path may exceed the
     # 104-char AF_UNIX sun_path limit because pytest tmp paths resolve
     # through /private/var/folders/... Set short socket paths so the
-    # settings validator passes (#1983).
+    # settings validator passes (#1983). Tracked so the dir can't orphan
+    # (#2662).
     if sys.platform == "darwin":
-        _sock_dir = tempfile.mkdtemp(prefix="ks-")
+        _sock_dir = tracked_mkdtemp("ks-")
         monkeypatch.setenv("KLANGKD_SOCKET", os.path.join(_sock_dir, "k.sock"))
         monkeypatch.setenv(
             "KLANGKD_CADDY_ADMIN_SOCKET",

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -32,7 +32,7 @@ from klangk.caddy import (
     tcp_upstream,
     uds_upstream,
 )
-from _helpers import make_settings
+from _helpers import make_settings, tracked_mkdtemp
 
 
 def _renderer(settings):
@@ -468,7 +468,6 @@ class TestLlmBlockCaddyAdapt:
         """Run `caddy adapt --adapter caddyfile` on a rendered config; return JSON."""
         import json
         import subprocess
-        import tempfile
 
         with tempfile.NamedTemporaryFile(
             "w", suffix=".Caddyfile", delete=False
@@ -727,7 +726,7 @@ class TestWatchdogPaths:
         # which can exceed the 104-byte AF_UNIX sun_path limit. Use a short
         # temp dir so the socket path passes the settings validator (#1983).
         if sys.platform == "darwin":
-            state = tempfile.mkdtemp(prefix="ks-")
+            state = tracked_mkdtemp("ks-")
             sock = os.path.join(state, "caddy-admin.sock")
             s = make_settings(
                 {
@@ -760,7 +759,7 @@ class TestWatchdogPaths:
         suffix (that's version-fragile — #1709; mode enforced via os.chmod).
         The bare path (admin_socket) is what httpx dials."""
         if sys.platform == "darwin":
-            state = tempfile.mkdtemp(prefix="ks-")
+            state = tracked_mkdtemp("ks-")
             sock = os.path.join(state, "caddy-admin.sock")
             s = make_settings(
                 {
@@ -877,7 +876,7 @@ class TestWatchdogStart:
         # On macOS, pytest tmp_path can exceed the AF_UNIX sun_path limit;
         # use a short temp dir for the state + socket (#1983).
         if sys.platform == "darwin":
-            state = tempfile.mkdtemp(prefix="ks-")
+            state = tracked_mkdtemp("ks-")
         else:
             state = str(tmp_path)
         s = make_settings(


### PR DESCRIPTION
## Summary

Fixes #2662. Every `tempfile.mkdtemp` in the test trees orphaned its directory: unit tests had no teardown at all, and e2e helpers only cleaned up on the happy path — interrupted runs accumulated **~355,000 `klangk-*` dirs (1.4 GB)** in `/tmp` here.

## Approach

A `tracked_mkdtemp()` helper — `mkdtemp` whose dir is registered and swept by an `atexit` handler — added to the three helper hubs:

- `klangkd-tests/tests/_helpers.py` (unit tests; also covers the `make_settings()` module-import-time fallbacks and the darwin socket dirs)
- `klangkc-tests/tests/_helpers.py` (new; CLI unit tests, mirrors the daemon suite — the suites share no imports)
- `klangkd-tests/e2e-tests/_e2e_server.py` (shared by both e2e suites and the smoketest)

Every `mkdtemp` site across 14 test files now goes through it. Explicit `stop_server`/`rmtree` teardown stays authoritative; the atexit sweep is the safety net for paths that skip teardown (readiness timeouts, crashed sessions). `tmp_path` is unchanged wherever it was already used — tracked dirs remain necessary for the short AF_UNIX socket paths (#1983) and module-import-time settings.

Not touched: `scripts/fuzz-*` / `import_dart_features` / `update_features` — operator-invoked tools whose temp dirs are deliberate artifacts (fuzz logs are post-mortem evidence).

## Verification

- Full CI-style suite: `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — **5444 passed, 100% coverage, no warnings**
- Leak check: that full run left **zero** new `klangk-*` entries in `/tmp` (previously hundreds per run)
- E2E files validated via `--collect-only` (127 tests collect; servers not run locally per repo policy)
