### PR TITLE
Rename KLANGKD_QUIESCE_TIMEOUT and respect it on TERM/INT shutdown

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -92,26 +92,27 @@ operators or integrators to act when upgrading.
 
 ### Added
 
-- **Graceful stop on SIGTERM/SIGINT (#2527).** TERM/INT shutdown now
-  broadcasts a `host_shutdown` WebSocket event (so clients render
+- **Graceful stop on SIGTERM/SIGINT (#2527, #2664).** TERM/INT shutdown
+  now broadcasts a `host_shutdown` WebSocket event (so clients render
   "server went away" instead of reconnect-looping), refuses new
-  workspace starts, and drains every running workspace through the
-  same graceful path as SIGHUP (terminal stop frames +
-  `container_stopped` with reason `host shutdown`) before uvicorn's
-  exit sequence runs. A drain failure is logged and never blocks the
-  exit; a SIGHUP arriving during shutdown is ignored. Clients surface
-  `host_shutdown` / `host_restart` / `host_started` as transient,
-  non-blocking notices (web UI snackbar, TUI status line + toast) —
-  auto-reconnect is never visually impeded. Docs:
+  workspace starts, waits up to `KLANGKD_QUIESCE_TIMEOUT` seconds
+  (default 15) for in-flight HTTP requests to finish, and drains every
+  running workspace through the same graceful path as SIGHUP (terminal
+  stop frames + `container_stopped` with reason `host shutdown`)
+  before uvicorn's exit sequence runs. A drain failure is logged and
+  never blocks the exit; a SIGHUP arriving during shutdown is ignored.
+  Clients surface `host_shutdown` / `host_restart` / `host_started` as
+  transient, non-blocking notices (web UI snackbar, TUI status line +
+  toast) — auto-reconnect is never visually impeded. Docs:
   [Signals](deployment/signals.md).
-- **Graceful SIGHUP restart + `KLANGKD_RESTART_INFLIGHT_TIMEOUT` (#2527).**
-  SIGHUP is now a full graceful restart: new workspace starts are
-  refused, in-flight HTTP requests get
-  `KLANGKD_RESTART_INFLIGHT_TIMEOUT` seconds (default 15) to finish,
-  running workspaces are stopped gracefully (concurrently per
-  workspace, each with a 5s podman stop grace); the reloaded config is
-  applied, and the runtime recycles (drained
-  workspaces are not restarted — only `auto_start` ones return).
+- **Graceful SIGHUP restart + `KLANGKD_QUIESCE_TIMEOUT` (#2527,
+  #2664).** SIGHUP is now a full graceful restart: new workspace
+  starts are refused, in-flight HTTP requests get
+  `KLANGKD_QUIESCE_TIMEOUT` seconds (default 15) to finish, running
+  workspaces are stopped gracefully (concurrently per workspace, each
+  with a 5s podman stop grace); the reloaded config is applied, and
+  the runtime recycles (drained workspaces are not restarted — only
+  `auto_start` ones return).
   Clients get `host_restart` events with a `phase` field and a final
   `host_started` broadcast; each phase is logged. Starts stay refused
   until the post-restart container reaps finish, and a failed restart

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -35,8 +35,8 @@ What happens, in order:
    arriving after the signal is ignored (the runtime is being torn
    down; a restart would race the exit).
 5. Accept no new requests, close every WebSocket client (uvicorn's own
-   exit sequence). A second Ctrl-C during the drain skips the rest of
-   the graceful work and forces the exit immediately.
+   exit sequence). A second Ctrl-C during the quiesce or drain skips the
+   rest of the graceful work and forces the exit immediately.
 6. Tear down chat-agent subprocesses and cancel in-flight agent runs.
 7. Dispose the database engine and remove the PID file.
 
@@ -46,10 +46,12 @@ that are configured for it. For a config reload with the same drain
 treatment while keeping the listener up, use SIGHUP (below).
 
 A drain failure is logged and never blocks the exit — the process always
-terminates. Budget the drain inside your service manager's stop
-deadline (`TimeoutStopSec` under systemd; the drain is bounded by the
-per-workspace stop grace, but a host with many workspaces takes
-proportionally longer).
+terminates. Budget the quiesce + drain inside your service manager's
+stop deadline (`TimeoutStopSec` under systemd): up to
+`KLANGKD_QUIESCE_TIMEOUT` seconds (default 15) of request quiesce, plus
+one per-workspace stop grace (5s; stops run concurrently across
+workspaces). Raising `KLANGKD_QUIESCE_TIMEOUT` past ~85s blows the
+default 90s `TimeoutStopSec`.
 
 ## SIGHUP — graceful restart (#1212, #1587, #2527)
 

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -21,17 +21,24 @@ What happens, in order:
    auto-start, crash-restart) return a clear 503/error frame for the
    rest of the process's life; a start racing the shutdown is refused
    rather than killed mid-create.
-3. **Drain** — stop every running workspace through the same graceful
+3. **Quiesce** (#2664) — wait up to `KLANGKD_QUIESCE_TIMEOUT` seconds
+   (default 15) for in-flight HTTP requests to finish, so an upload or
+   terminal snapshot in progress isn't cut off by the drain below.
+   Stragglers at expiry are logged (WARNING) and left to finish against
+   the exiting process (uvicorn's own in-flight wait only starts after
+   this phase, when the containers are already stopped, so the wait
+   has to happen here to buy them anything).
+4. **Drain** — stop every running workspace through the same graceful
    path as SIGHUP's drain (concurrently per workspace, 5s podman stop
    grace): clients get terminal stop frames and a `container_stopped`
    event with reason `host shutdown`, not a bare socket drop. A SIGHUP
    arriving after the signal is ignored (the runtime is being torn
    down; a restart would race the exit).
-4. Accept no new requests, close every WebSocket client (uvicorn's own
+5. Accept no new requests, close every WebSocket client (uvicorn's own
    exit sequence). A second Ctrl-C during the drain skips the rest of
    the graceful work and forces the exit immediately.
-5. Tear down chat-agent subprocesses and cancel in-flight agent runs.
-6. Dispose the database engine and remove the PID file.
+6. Tear down chat-agent subprocesses and cancel in-flight agent runs.
+7. Dispose the database engine and remove the PID file.
 
 Net effect: a _full_ stop with clean client-visible shutdown frames.
 Workspaces go away; on the next start, `auto_start` brings back any
@@ -69,7 +76,7 @@ authenticated WebSocket clients receive a `host_restart` event with a
    crash-recovery restart) refuses with a clear error until the restart
    completes. This flag is never persisted — a crashed restart
    cannot leave the node refusing starts.
-3. **Quiesce** — wait up to `KLANGKD_RESTART_INFLIGHT_TIMEOUT` seconds
+3. **Quiesce** — wait up to `KLANGKD_QUIESCE_TIMEOUT` seconds
    (default 15) for in-flight HTTP requests to finish. Requests still
    running at expiry are logged (WARNING); ordinary requests finish
    against the recycling runtime, but a long-lived streaming response

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -317,7 +317,7 @@ port: "8997"
 | `container_restart_enabled`         | `false`                         | `KLANGKD_CONTAINER_RESTART_ENABLED`         |
 | `container_restart_max_retries`     | `5`                             | `KLANGKD_CONTAINER_RESTART_MAX_RETRIES`     |
 | `container_restart_backoff_seconds` | `5.0`                           | `KLANGKD_CONTAINER_RESTART_BACKOFF_SECONDS` |
-| `restart_inflight_timeout`          | `15.0`                          | `KLANGKD_RESTART_INFLIGHT_TIMEOUT`          |
+| `quiesce_timeout`                   | `15.0`                          | `KLANGKD_QUIESCE_TIMEOUT`                   |
 | `fips_mode`                         | `false`                         | `KLANGKD_FIPS_MODE`                         |
 | `health_check_interval`             |                                 | `KLANGKD_HEALTH_CHECK_INTERVAL`             |
 | `health_check_startup_grace`        |                                 | `KLANGKD_HEALTH_CHECK_STARTUP_GRACE`        |

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -431,12 +431,14 @@ def _make_graceful_exit_server(app):
     deferred to the hook's done-callback and should_exit is still
     unset — #2527 review).
     """
-    import contextlib
-    import signal as signal_mod
-    import threading
+    import contextlib  # allow-deferred-import (serve-time import)
+    import signal as signal_mod  # allow-deferred-import (serve-time)
+    import threading  # allow-deferred-import (serve-time import)
 
-    import uvicorn
-    from uvicorn.server import HANDLED_SIGNALS
+    import uvicorn  # allow-deferred-import (serve-time import)
+    from uvicorn.server import (  # allow-deferred-import (serve-time)
+        HANDLED_SIGNALS,
+    )
 
     @contextlib.contextmanager
     def capture_signals(self):

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -778,11 +778,12 @@ class Lifecycle:
         state.sockets.notify_host_shutdown()
         logger.info("%s: phase: draining (refusing new starts)", name)
         registry.draining = True
+        # #2664: same bounded quiesce as the SIGHUP restart path, so
+        # in-flight requests finish before their containers are
+        # stopped. Read from the LIVE settings (no reload happens on
+        # the exit path). Own try block: a quiesce failure must be
+        # labeled truthfully and must not skip the drain below.
         try:
-            # #2664: same bounded quiesce as the SIGHUP restart path, so
-            # in-flight requests finish before their containers are
-            # stopped. Read from the LIVE settings (no reload happens
-            # on the exit path).
             timeout = state.settings.quiesce_timeout
             logger.info(
                 "%s: phase: quiesce (waiting up to %.1fs for in-flight "
@@ -800,6 +801,11 @@ class Lifecycle:
                     inflight.count,
                     timeout,
                 )
+        except Exception as exc:  # noqa: BLE001 — never block the exit
+            logger.warning(
+                "%s: quiesce failed (proceeding with shutdown): %s", name, exc
+            )
+        try:
             logger.info("%s: phase: drain (stopping workspaces)", name)
             stopped = await registry.drain_all_containers(
                 reason="host shutdown"

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -491,7 +491,7 @@ class Lifecycle:
            container-start path refuses new starts (the single start
            choke point; the flag is never persisted, so a crashed
            restart cannot leave the node refusing starts).
-        3. **quiesce** — wait up to ``restart_inflight_timeout`` seconds
+        3. **quiesce** — wait up to ``quiesce_timeout`` seconds
            (default 15) for in-flight HTTP requests to finish; stragglers
            at expiry are logged and left to finish against the recycling
            runtime.
@@ -547,7 +547,7 @@ class Lifecycle:
             try:
                 # #2527 review: read the timeout from the NEW settings so
                 # a reload takes effect on THIS restart, not the next.
-                timeout = new_settings.restart_inflight_timeout
+                timeout = new_settings.quiesce_timeout
                 logger.info(
                     "SIGHUP: phase: quiesce (waiting up to %.1fs for "
                     "in-flight requests)",
@@ -737,7 +737,7 @@ class Lifecycle:
 
     async def graceful_shutdown(self, *, signal_num: int) -> None:
         """Graceful pre-exit work for TERM/INT (#2527): broadcast, refuse,
-        drain, then hand off to uvicorn's own exit.
+        quiesce, drain, then hand off to uvicorn's own exit.
 
         Runs at signal-receipt time (uvicorn closes every WebSocket before
         the lifespan teardown, so waiting for teardown would mean the
@@ -748,30 +748,58 @@ class Lifecycle:
         2. Refuse new container starts (the in-memory drain flag — same
            gate as the SIGHUP restart; a start racing the shutdown gets
            a 503 instead of being killed by the process exit).
-        3. Gracefully drain every running workspace — clients get
+        3. Quiesce — wait up to ``quiesce_timeout`` seconds (read from
+           the live settings; default 15) for in-flight HTTP requests
+           to finish, so a file upload or terminal snapshot isn't cut
+           off by the drain below (#2664). Stragglers at expiry are
+           logged (WARNING) and left to finish against the exiting
+           process — uvicorn's own in-flight wait only starts after
+           this hook, when the containers are already stopped, so the
+           wait has to happen here to buy them anything.
+        4. Gracefully drain every running workspace — clients get
            terminal stop frames + ``container_stopped`` with reason
            ``host shutdown``, then uvicorn's 1012/exit drop lands on
            already-stopped sessions. Also denies a concurrent SIGHUP
            restart (``shutting_down`` is checked in ``on_sighup``).
-        4. Call the uvicorn exit callback handed to the hook — uvicorn's
+        5. Call the uvicorn exit callback handed to the hook — uvicorn's
            listener stop / connection drain / lifespan teardown (which
            runs ``runtime_shutdown`` + ``process_shutdown``) takes over.
 
         Time-bounded by the deploy's service manager: the hook's own
-        budget is the drain's per-workspace 5s podman grace (bounded by
-        the 15s ``restart_inflight_timeout``-style budgets upstream); a
-        second TERM/INT during the hook bypasses it straight to uvicorn.
+        budget is the ``quiesce_timeout`` wait (default 15s) plus the
+        drain's concurrent per-workspace 5s podman grace — inside
+        systemd's default 90s ``TimeoutStopSec``; a second TERM/INT
+        during the hook bypasses it straight to uvicorn.
         """
-        import signal as signal_mod
-
         state = self.app.state
         registry = state.container_registry
-        name = signal_mod.Signals(signal_num).name
+        name = signal.Signals(signal_num).name
         logger.info("%s: graceful shutdown beginning (phase: notify)", name)
         state.sockets.notify_host_shutdown()
         logger.info("%s: phase: draining (refusing new starts)", name)
         registry.draining = True
         try:
+            # #2664: same bounded quiesce as the SIGHUP restart path, so
+            # in-flight requests finish before their containers are
+            # stopped. Read from the LIVE settings (no reload happens
+            # on the exit path).
+            timeout = state.settings.quiesce_timeout
+            logger.info(
+                "%s: phase: quiesce (waiting up to %.1fs for in-flight "
+                "requests)",
+                name,
+                timeout,
+            )
+            inflight = state.inflight_requests
+            idle = await inflight.wait_for_idle(timeout)
+            if not idle:
+                logger.warning(
+                    "%s: %d request(s) still in flight after %.1fs; "
+                    "proceeding with the shutdown",
+                    name,
+                    inflight.count,
+                    timeout,
+                )
             logger.info("%s: phase: drain (stopping workspaces)", name)
             stopped = await registry.drain_all_containers(
                 reason="host shutdown"
@@ -1127,11 +1155,12 @@ class LiveCORSMiddleware:
 
 
 class InFlightRequests:
-    """In-flight HTTP request counter (#2527 graceful restart).
+    """In-flight HTTP request counter (#2527 graceful restart/shutdown).
 
-    Backs the SIGHUP quiesce phase: after new container starts are
-    refused, :meth:`wait_for_idle` waits for the request count to reach
-    zero before the containers are drained. Not an owned subsystem —
+    Backs the quiesce phase of both the SIGHUP restart and the
+    TERM/INT shutdown: after new container starts are refused,
+    :meth:`wait_for_idle` waits for the request count to reach zero
+    before the containers are drained. Not an owned subsystem —
     a plain counter with no app dependency.
     """
 
@@ -1166,8 +1195,8 @@ class InFlightMiddleware:
 
     ``http`` scopes only — a WebSocket connection never "completes", so
     counting it would block the drain quiesce forever. The counter is
-    shared via ``app.state.inflight_requests`` so the SIGHUP restart path
-    can wait on it.
+    shared via ``app.state.inflight_requests`` so the SIGHUP restart
+    and TERM/INT shutdown paths can wait on it.
     """
 
     def __init__(self, app_asgi, counter: InFlightRequests) -> None:

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -1073,14 +1073,16 @@ class KlangkSettings(BaseSettings):
     container_restart_enabled: bool = False
     container_restart_max_retries: int = 5
     container_restart_backoff_seconds: float = 5.0
-    # Graceful SIGHUP restart (#2527): after new container starts are
-    # refused, the restart waits this many seconds for in-flight HTTP
-    # requests to finish before draining the containers. Requests still
-    # running at expiry are logged and left to finish against the
-    # recycling runtime (streaming responses may be interrupted). Read
-    # from the freshly-reloaded settings, so a change takes effect on
-    # the very restart that re-reads it.
-    restart_inflight_timeout: float = 15.0
+    # Graceful SIGHUP restart and TERM/INT shutdown (#2527, #2664):
+    # after new container starts are refused, the restart/shutdown waits
+    # this many seconds for in-flight HTTP requests to finish before
+    # draining the containers. Requests still running at expiry are
+    # logged and left to finish against the recycling/exiting runtime
+    # (streaming responses may be interrupted). The restart path reads
+    # it from the freshly-reloaded settings, so a change takes effect
+    # on the very restart that re-reads it; the shutdown path reads it
+    # from the live settings.
+    quiesce_timeout: float = 15.0
     # FIPS mode (#2570, #2591, #2628): when enabled, every workspace
     # container must prove an actively-enforcing OpenSSL FIPS provider
     # at start (fail closed — the container is removed and the start
@@ -1479,7 +1481,7 @@ class KlangkSettings(BaseSettings):
         "memory_eviction_threshold_percent",
         "memory_eviction_recovery_percent",
         "memory_eviction_poll_interval",
-        "restart_inflight_timeout",
+        "quiesce_timeout",
         mode="before",
     )
     @classmethod

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1147,8 +1147,8 @@ class TestGracefulShutdown:
         ):
             await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
         assert order == ["notify", "quiesce", "drain:host shutdown"]
-        # The shutdown reads the timeout from the LIVE settings (no
-        # reload happens on the exit path).
+        # The shutdown reads the timeout from the live settings (the
+        # app's own settings object — no reload happens on this path).
         mock_wait.assert_awaited_once_with(
             app_state.state.settings.quiesce_timeout
         )
@@ -1184,7 +1184,41 @@ class TestGracefulShutdown:
             caplog.at_level("WARNING"),
         ):
             await lc.graceful_shutdown(signal_num=signal_mod.SIGINT)
-        assert any("still in flight" in r.message for r in caplog.records)
+        assert any(
+            "still in flight" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+        mock_drain.assert_awaited_once_with(reason="host shutdown")
+
+    async def test_shutdown_quiesce_failure_still_drains(
+        self, app_state, caplog
+    ):
+        """A quiesce-phase exception is labeled truthfully (not as a
+        drain failure) and never skips the drain — the exit path must
+        always stop the containers (#2664 review)."""
+        import signal as signal_mod
+
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        with (
+            patch.object(
+                app_state.state.inflight_requests,
+                "wait_for_idle",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("counter exploded"),
+            ),
+            patch.object(
+                app_state.state.container_registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                return_value=1,
+            ) as mock_drain,
+            patch.object(app_state.state.sockets, "notify_host_shutdown"),
+            caplog.at_level("WARNING"),
+        ):
+            await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
+        assert any("quiesce failed" in r.message for r in caplog.records)
+        assert not any("drain failed" in r.message for r in caplog.records)
         mock_drain.assert_awaited_once_with(reason="host shutdown")
 
     async def test_drain_failure_does_not_block_exit(self, app_state, caplog):
@@ -1865,7 +1899,10 @@ class TestStartupShutdownRestart:
         ):
             with caplog.at_level("WARNING"):
                 await lc.restart_runtime()
-        assert any("still in flight" in r.message for r in caplog.records)
+        assert any(
+            "still in flight" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        )
         assert app_state.state.container_registry.draining is False
 
     async def test_restart_failure_clears_draining(self, app_state):

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1110,11 +1110,13 @@ class TestInFlightRequests:
 class TestGracefulShutdown:
     """TERM/INT graceful shutdown hook (#2527)."""
 
-    async def test_sequence_notify_refuse_drain_handoff(
+    async def test_sequence_notify_refuse_quiesce_drain_handoff(
         self, app_state, caplog
     ):
-        """The hook broadcasts host_shutdown, refuses starts, drains
-        with reason 'host shutdown', and logs each phase."""
+        """The hook broadcasts host_shutdown, refuses starts, quiesces
+        in-flight requests (bounded by the live settings' timeout,
+        #2664), drains with reason 'host shutdown', and logs each
+        phase."""
         import signal as signal_mod
 
         app_state = _make_app_state()
@@ -1128,6 +1130,12 @@ class TestGracefulShutdown:
                 side_effect=lambda: order.append("notify"),
             ),
             patch.object(
+                app_state.state.inflight_requests,
+                "wait_for_idle",
+                new_callable=AsyncMock,
+                side_effect=lambda timeout: order.append("quiesce") or True,
+            ) as mock_wait,
+            patch.object(
                 registry,
                 "drain_all_containers",
                 new_callable=AsyncMock,
@@ -1138,12 +1146,46 @@ class TestGracefulShutdown:
             caplog.at_level("INFO"),
         ):
             await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
-        assert order == ["notify", "drain:host shutdown"]
+        assert order == ["notify", "quiesce", "drain:host shutdown"]
+        # The shutdown reads the timeout from the LIVE settings (no
+        # reload happens on the exit path).
+        mock_wait.assert_awaited_once_with(
+            app_state.state.settings.quiesce_timeout
+        )
         # The drain flag stays set: nothing comes back after a shutdown.
         assert registry.draining is True
         assert any(
             "graceful shutdown beginning" in r.message for r in caplog.records
         )
+
+    async def test_shutdown_quiesce_timeout_proceeds(self, app_state, caplog):
+        """Straggler requests at quiesce expiry are logged (WARNING) and
+        the shutdown proceeds to the drain anyway — the exit is never
+        blocked by a stuck request."""
+        import signal as signal_mod
+
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        app_state.state.inflight_requests.increment()
+        with (
+            patch.object(
+                app_state.state.inflight_requests,
+                "wait_for_idle",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                app_state.state.container_registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_drain,
+            patch.object(app_state.state.sockets, "notify_host_shutdown"),
+            caplog.at_level("WARNING"),
+        ):
+            await lc.graceful_shutdown(signal_num=signal_mod.SIGINT)
+        assert any("still in flight" in r.message for r in caplog.records)
+        mock_drain.assert_awaited_once_with(reason="host shutdown")
 
     async def test_drain_failure_does_not_block_exit(self, app_state, caplog):
         """A drain exception is logged and the hook completes — the
@@ -1686,9 +1728,7 @@ class TestStartupShutdownRestart:
         mock_drain.assert_awaited_once_with(reason="host restart")
         # The quiesce timeout comes from the RELOADED settings, so a
         # change takes effect on this restart (#2527 review).
-        mock_wait.assert_awaited_once_with(
-            new_settings.restart_inflight_timeout
-        )
+        mock_wait.assert_awaited_once_with(new_settings.quiesce_timeout)
         # The flag never survives the restart.
         assert registry.draining is False
 
@@ -1789,7 +1829,7 @@ class TestStartupShutdownRestart:
             "autostart(draining=False)",
         ]
 
-    async def test_restart_inflight_timeout_proceeds(self, app_state, caplog):
+    async def test_restart_quiesce_timeout_proceeds(self, app_state, caplog):
         """Straggler requests at timeout expiry are logged; the restart
         proceeds anyway."""
         app_state = _make_app_state()
@@ -1894,9 +1934,7 @@ class TestStartupShutdownRestart:
                 lc, "runtime_shutdown", new_callable=AsyncMock
             ) as mock_down,
             patch.object(lc, "startup", new_callable=AsyncMock) as mock_up,
-            patch.object(
-                app_state.state.sockets, "notify_host_restart"
-            ) as mock_notify,
+            patch.object(app_state.state.sockets, "notify_host_restart"),
         ):
             await lc.restart_runtime()
         assert order == ["drain"]

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -1442,7 +1442,7 @@ class TestNumericSettingCoercion:
         "health_check_interval",
         "health_check_timeout",
         "health_check_startup_grace",
-        "restart_inflight_timeout",
+        "quiesce_timeout",
     ]
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Renames `KLANGKD_RESTART_INFLIGHT_TIMEOUT` → `KLANGKD_QUIESCE_TIMEOUT` (`restart_inflight_timeout` → `quiesce_timeout`) and makes the TERM/INT graceful shutdown respect it (#2664).

The `RESTART_` prefix was wrong once the setting covers the shutdown path too — both graceful sequences log a "quiesce" phase, so the name describes the phase, not the trigger. Free to rename while #2655 is unreleased.

`graceful_shutdown` now runs the same bounded quiesce as the SIGHUP restart: after refusing new starts it waits up to `quiesce_timeout` (read from the **live** settings; default 15s) on `InFlightRequests.wait_for_idle` before draining containers, logging stragglers at WARNING. Uvicorn's own in-flight wait only starts *after* the hook — when the containers are already stopped — so the wait has to happen here to buy a mid-flight upload or terminal snapshot anything. Budget stays inside systemd's default 90s `TimeoutStopSec` (15s quiesce + concurrent 5s podman stops); second-Ctrl-C force-exit unchanged.

## Changes

- `settings.py`: field renamed (env derives as `KLANGKD_QUIESCE_TIMEOUT`), validator list + comment updated
- `main.py`: quiesce phase added to `graceful_shutdown`; docstrings cover both paths; redundant local `signal` import dropped (module scope already imports it)
- `launcher.py`: `allow-deferred-import` markers on the serve-time imports #2527 landed unmarked (unblocks pre-commit)
- Docs: `klangkd-config.md` table row, `signals.md` TERM/INT + SIGHUP sections, unreleased changelog entries renamed in place
- Tests: shutdown sequence asserts `notify → quiesce → drain` with the live-settings timeout; new shutdown straggler-proceeds test; settings float-coercion list renamed

## Testing

`python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 5511 passed, 100% coverage. Pre-commit fully green.

Stacked on #2655 (base `issue-2527-hup-graceful-restart`, head 9fba4492) — merge that first.

Closes #2664.
