### PR TITLE
Exit EX_CONFIG (78) on deterministic config errors instead of restart-looping

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -92,6 +92,16 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`EX_CONFIG` exit status 78 for deterministic config errors (#2666).**
+  When `klangkd` refuses to boot over bad configuration — e.g. a
+  `KLANGKD_DEFAULT_PASSWORD` that violates the password policy, password
+  mode without a staged password, `auth_modes: none` on a non-loopback
+  bind, or a containerized FIPS backend with non-FIPS OpenSSL — it now
+  exits with status 78 instead of uvicorn's generic startup-failure
+  status, so a first-boot misconfiguration no longer presents as an
+  endless restart loop. Supervisors can stop retrying it (systemd:
+  `RestartPreventExitStatus=78`). See
+  [Process signals](deployment/signals.md) for the exit-status table.
 - **Decommissioning guide (#2593).** New [deployment chapter](../deployment/decommissioning.md)
   documenting the decommissioning notification chain (users, admins, integrators,
   infrastructure owners) and the shutdown sequence: workspace export, graceful

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -92,3 +92,30 @@ non-reloadable change needs a full `klangkd` restart:
 SIGHUP can be sent several times in quick succession. A second signal
 arriving mid-restart queues behind the first via an `asyncio.Lock`, so
 restarts never race — they run strictly one after another.
+
+## Exit statuses
+
+`klangkd`'s exit status tells a supervisor _why_ the process left — in
+particular, whether restarting can help (#2666):
+
+| Status | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0`    | Clean shutdown (SIGINT/SIGTERM).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `78`   | **Configuration error** (`EX_CONFIG`, sysexits.h). Startup was refused over bad configuration — e.g. a `KLANGKD_DEFAULT_PASSWORD` that violates the password policy, `auth_modes: password` without a staged password, an insecure JWT secret with prevention on, `auth_modes: none` on a non-loopback bind, a missing OIDC login hook, or a containerized FIPS backend whose OpenSSL is not FIPS-enforcing. **Restarting cannot fix this** — fix the config/image first. The refusal reason is logged at `ERROR` right before exit. |
+| `3`    | uvicorn startup failure that is _not_ a config refusal (e.g. an unusable database). Retrying makes sense once the underlying fault is repaired.                                                                                                                                                                                                                                                                                                                                                                                      |
+| `1`    | Launcher pre-flight refusals (another instance already running, a browser/egress port already owned) or a UDS bind failure.                                                                                                                                                                                                                                                                                                                                                                                                          |
+
+### Telling systemd not to restart-loop a config error
+
+A config refusal is permanent, so a supervisor that restarts on any
+failure will loop on it forever. With systemd, pin the status:
+
+```ini
+[Service]
+Restart=on-failure
+RestartPreventExitStatus=78
+```
+
+A bad password then stops the unit in a single failed attempt instead of
+burning CPU in a restart loop; `journalctl -u <unit>` shows the
+`ConfigurationError` naming the setting to fix.

--- a/src/klangk/klangk/exceptions.py
+++ b/src/klangk/klangk/exceptions.py
@@ -1,8 +1,23 @@
 """Domain-specific exceptions for the klangk backend."""
 
+#: Exit status for a deterministic configuration error (sysexits.h
+#: ``EX_CONFIG``). The klangkd launcher exits with this status — instead of
+#: uvicorn's generic startup-failure status (3) — when the lifespan refused
+#: to boot over bad config (e.g. a ``KLANGKD_DEFAULT_PASSWORD`` that violates
+#: the password policy). Restarting cannot fix it, so supervisors can treat
+#: it as permanent: systemd ``RestartPreventExitStatus=78`` stops the
+#: restart loop (#2666).
+EX_CONFIG = 78
+
 
 class ConfigurationError(RuntimeError):
-    """A required configuration value is missing, invalid, or insecure."""
+    """A required configuration value is missing, invalid, or insecure.
+
+    Raised by startup validation when the process must refuse to boot. The
+    klangkd launcher translates a ``ConfigurationError`` that escapes the
+    lifespan into exit status :data:`EX_CONFIG`, so a supervisor can tell
+    "config is wrong" apart from a crash (#2666).
+    """
 
 
 class TerminalError(RuntimeError):

--- a/src/klangk/klangk/fips.py
+++ b/src/klangk/klangk/fips.py
@@ -55,6 +55,8 @@ import os
 import ssl
 import subprocess
 
+from .exceptions import ConfigurationError
+
 logger = logging.getLogger(__name__)
 
 # A short sentinel payload for the digest probes.
@@ -351,7 +353,8 @@ def verify_process_fips(settings) -> None:
 
     - **Containerized backend** (``running_in_container()``): the
       process OpenSSL is the crypto boundary of an image *we* ship — a
-      failed probe raises :class:`SystemExit` and the boot aborts.
+      failed probe raises :class:`ConfigurationError` and the boot
+      aborts.
     - **Control host**: a failed probe logs a prominent warning and
       the boot continues — klangkd may legitimately run on a host
       whose OpenSSL is not the FIPS variant while every workspace it
@@ -384,7 +387,7 @@ def verify_process_fips(settings) -> None:
             version,
             detail,
         )
-        raise SystemExit(
+        raise ConfigurationError(
             "KLANGKD_FIPS_MODE: containerized backend's OpenSSL is not "
             f"FIPS-enforcing ({detail})"
         )

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -56,6 +56,7 @@ import uvicorn
 # instead of logging and exiting (#1993).
 import klangk.logger  # noqa: F401
 from klangk import first_run
+from klangk.exceptions import EX_CONFIG
 from klangk.settings import KlangkSettings
 
 logger = logging.getLogger(__name__)
@@ -218,6 +219,25 @@ def _check_port_preflight(host: str, port: int) -> bool:
         return False
     finally:
         sock.close()
+
+
+def config_error_exit_status(app_state) -> int | None:
+    """Return ``EX_CONFIG`` if the lifespan flagged a config refusal.
+
+    The lifespan records the first deterministic ``ConfigurationError`` it
+    hits during startup (password-policy-violating ``KLANGKD_DEFAULT_PASSWORD``,
+    missing password in password mode, insecure JWT secret with prevention
+    on, unsafe no-auth bind, …) on ``app.state.startup_config_error`` (#2666).
+    The launcher consults this when uvicorn exits with a startup failure:
+    uvicorn's own status (3) is indistinguishable between "config is wrong
+    forever" and "transient failure, try again", so a supervisor restart-loops
+    both. ``EX_CONFIG`` (78, sysexits.h) marks the permanent class — systemd
+    ``RestartPreventExitStatus=78`` stops the loop.
+    """
+    flagged = getattr(app_state, "startup_config_error", None)
+    if flagged is None:
+        return None
+    return EX_CONFIG
 
 
 def _prepend_gnubin_paths() -> None:  # pragma: no cover
@@ -402,6 +422,21 @@ def main(  # pragma: no cover
             "uvicorn failed to bind UDS at %s: %s — exiting", uds_path, exc
         )
         sys.exit(1)
+    except SystemExit:
+        # uvicorn exits STARTUP_FAILURE (3) for every startup failure. If the
+        # failure was a deterministic config error (flagged by the lifespan
+        # on app.state), translate to EX_CONFIG (78) so supervisors can stop
+        # restart-looping a config that cannot fix itself (#2666).
+        config_status = config_error_exit_status(asgi_app.state)
+        if config_status is None:
+            raise
+        logger.error(
+            "klangkd refused to start over a configuration error — exiting "
+            "with status %d (EX_CONFIG); restarting cannot fix this, fix "
+            "the config instead",
+            config_status,
+        )
+        raise SystemExit(config_status) from None
 
 
 @app.command()

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -39,6 +39,7 @@ from . import (
 )
 from .llm_router import LLMRouter
 from .auth import _PASSWORD_CLASSES, password_class_counts
+from .exceptions import ConfigurationError
 from .settings import KlangkSettings
 from .logger import configure as configure_logging
 from .api import root_router, router
@@ -249,7 +250,7 @@ class Lifecycle:
             # deployments (#1645).
             password = settings.default_password
             if password is None:
-                raise RuntimeError(
+                raise ConfigurationError(
                     f"auth_modes={auth_modes} requires KLANGKD_DEFAULT_PASSWORD "
                     "(set it in klangkd.yaml or the env). Refusing to boot "
                     "without a known admin password."
@@ -275,7 +276,7 @@ class Lifecycle:
                         f"(KLANGKD_PASSWORD_REQUIRE_{_key.upper()}={_need})"
                     )
             if _policy_errors:
-                raise RuntimeError(
+                raise ConfigurationError(
                     "KLANGKD_DEFAULT_PASSWORD violates the configured "
                     f"password policy: it {_policy_errors[0]}"
                     + (
@@ -685,7 +686,7 @@ def enforce_no_auth_bind_safety(app) -> None:
             host,
         )
         return
-    raise SystemExit(
+    raise ConfigurationError(
         "Refusing to start: KLANGKD_AUTH_MODES=none but KLANGKD_LISTEN=%r "
         "is not a loopback address. no-auth mode freely issues an admin "
         "token, so it must bind loopback (127.0.0.0/8, ::1, or localhost). "
@@ -739,19 +740,28 @@ async def lifespan(app: FastAPI):
     # and therefore before trust is applied.
     setup_logfire(app)
 
-    app.state.auth.require_secure_jwt_secret()
-    # #2570: with KLANGKD_FIPS_MODE on, audit klangkd's own OpenSSL (its
-    # password hashing + JWT signing) once at startup — verified, or a
-    # prominent warning (klangkd may legitimately run on a non-FIPS
-    # control host; workspace containers are the fail-closed gate).
-    fips_mod.verify_process_fips(app.state.settings)
-    # Features reads the build-emitted features.json at construction
-    # (Features(app) in build_app); no separate load() step (#1655).
-    app.state.oidc.init_providers()
-    enforce_no_auth_bind_safety(app)
-    app.state.oidc.load_login_hook()
-    await app.state.lifecycle.seed_default_user()
-    await app.state.lifecycle.seed_agent_user()
+    # Deterministic config validation + seeding. A ConfigurationError from
+    # this stretch is a config problem a restart cannot fix; flag it on
+    # app.state so the launcher can exit EX_CONFIG (78) instead of uvicorn's
+    # generic startup-failure status — without that, a supervisor
+    # restart-loops a bad password/secret/bind forever (#2666).
+    try:
+        app.state.auth.require_secure_jwt_secret()
+        # #2570: with KLANGKD_FIPS_MODE on, audit klangkd's own OpenSSL (its
+        # password hashing + JWT signing) once at startup — verified, or a
+        # prominent warning (klangkd may legitimately run on a non-FIPS
+        # control host; workspace containers are the fail-closed gate).
+        fips_mod.verify_process_fips(app.state.settings)
+        # Features reads the build-emitted features.json at construction
+        # (Features(app) in build_app); no separate load() step (#1655).
+        app.state.oidc.init_providers()
+        enforce_no_auth_bind_safety(app)
+        app.state.oidc.load_login_hook()
+        await app.state.lifecycle.seed_default_user()
+        await app.state.lifecycle.seed_agent_user()
+    except ConfigurationError as exc:
+        app.state.startup_config_error = str(exc)
+        raise
     registry = app.state.container_registry
 
     async def _on_workspace_killed(ws_id):

--- a/src/klangk/klangkd-tests/tests/test_fips.py
+++ b/src/klangk/klangkd-tests/tests/test_fips.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from klangk import fips
+from klangk.exceptions import ConfigurationError
 
 
 def _hashlib_stub(
@@ -374,7 +375,8 @@ class TestVerifyProcessFips:
         assert any("NOT FIPS-enforcing" in r.message for r in caplog.records)
 
     def test_on_not_verified_in_container_refuses_boot(self, caplog):
-        """Containerized backend + failed probe → SystemExit (#2628).
+        """Containerized backend + failed probe → ConfigurationError (#2628,
+        #2666 — a ConfigurationError so the launcher exits EX_CONFIG).
 
         Inside a container the process OpenSSL is the crypto boundary of
         an image we ship — the boot must abort, not warn.
@@ -386,7 +388,7 @@ class TestVerifyProcessFips:
             patch.object(fips, "running_in_container", return_value=True),
         ):
             with caplog.at_level(logging.ERROR):
-                with pytest.raises(SystemExit, match="FIPS-enforcing"):
+                with pytest.raises(ConfigurationError, match="FIPS-enforcing"):
                     fips.verify_process_fips(self._settings(True))
         assert any("refusing to start" in r.message for r in caplog.records)
 

--- a/src/klangk/klangkd-tests/tests/test_launcher.py
+++ b/src/klangk/klangkd-tests/tests/test_launcher.py
@@ -1,0 +1,38 @@
+"""Tests for klangk.launcher — config-error exit-status translation (#2666).
+
+The launcher turns uvicorn's generic STARTUP_FAILURE exit (3) into
+``EX_CONFIG`` (78) when the lifespan flagged a deterministic
+``ConfigurationError`` on ``app.state.startup_config_error``, so a
+supervisor can stop restart-looping a config that cannot fix itself.
+"""
+
+import types
+
+from klangk import launcher
+from klangk.exceptions import EX_CONFIG
+
+
+class TestConfigErrorExitStatus:
+    def test_flagged_config_error_maps_to_ex_config(self):
+        app_state = types.SimpleNamespace(
+            startup_config_error=(
+                "KLANGKD_DEFAULT_PASSWORD violates the configured "
+                "password policy"
+            )
+        )
+        assert launcher.config_error_exit_status(app_state) == EX_CONFIG
+
+    def test_unflagged_state_maps_to_none(self):
+        # No attribute at all (normal startup, non-config crash).
+        assert (
+            launcher.config_error_exit_status(types.SimpleNamespace()) is None
+        )
+
+    def test_none_flag_maps_to_none(self):
+        app_state = types.SimpleNamespace(startup_config_error=None)
+        assert launcher.config_error_exit_status(app_state) is None
+
+    def test_ex_config_is_78(self):
+        """sysexits.h EX_CONFIG — the value systemd configs will pin via
+        ``RestartPreventExitStatus=78``."""
+        assert EX_CONFIG == 78

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -34,6 +34,7 @@ from klangk import (
     workspaces,
 )
 from klangk.container import ContainerRegistry
+from klangk.exceptions import ConfigurationError
 from _helpers import make_settings
 from klangk.wshandler.session import WebSocketState
 
@@ -138,13 +139,29 @@ class TestSeedDefaultUser:
         user = await app_state.state.model.users.get_user_by_email("seed-test")
         assert user is not None
 
+    async def test_password_mode_without_default_password_fails_fast(
+        self, db, app_state
+    ):
+        """Password mode with no staged password is a config refusal
+        (#1645, and a ConfigurationError so the launcher exits EX_CONFIG
+        — #2666)."""
+        with pytest.raises(
+            ConfigurationError, match="requires KLANGKD_DEFAULT_PASSWORD"
+        ):
+            await _lifecycle(
+                make_settings(
+                    {
+                        "KLANGKD_AUTH_MODES": "password",
+                        "KLANGKD_DEFAULT_USER": "seed-test",
+                    }
+                )
+            ).seed_default_user()
+
     async def test_default_password_violating_policy_fails_fast(
         self, db, app_state
     ):
         """#2581: the seeded admin must satisfy the configured policy."""
-        import pytest as _pytest
-
-        with _pytest.raises(RuntimeError, match="DEFAULT_PASSWORD"):
+        with pytest.raises(ConfigurationError, match="DEFAULT_PASSWORD"):
             await _lifecycle(
                 make_settings(
                     {
@@ -160,9 +177,7 @@ class TestSeedDefaultUser:
         assert user is None
 
     async def test_default_password_too_short_fails_fast(self, db, app_state):
-        import pytest as _pytest
-
-        with _pytest.raises(RuntimeError, match="MIN_PASSWORD_LENGTH"):
+        with pytest.raises(ConfigurationError, match="MIN_PASSWORD_LENGTH"):
             await _lifecycle(
                 make_settings(
                     {
@@ -640,7 +655,7 @@ class TestNoAuthBindSafety:
     def test_refuses_ipv6_wildcard(self):
         """``::`` binds every interface (incl. IPv6) and is NOT loopback —
         must be refused even though it isn't ``0.0.0.0``."""
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(ConfigurationError) as exc_info:
             main.enforce_no_auth_bind_safety(
                 _bind_safety_app_state(auth_mode="none", listen="::")
             )
@@ -649,13 +664,13 @@ class TestNoAuthBindSafety:
     def test_refuses_non_loopback_hostname(self):
         """A bare hostname (other than ``localhost``) is not an IP literal and
         not a recognized loopback name — fail-closed (refuse)."""
-        with pytest.raises(SystemExit):
+        with pytest.raises(ConfigurationError):
             main.enforce_no_auth_bind_safety(
                 _bind_safety_app_state(auth_mode="none", listen="myhost")
             )
 
     def test_refuses_non_loopback_bind(self):
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(ConfigurationError) as exc_info:
             main.enforce_no_auth_bind_safety(
                 _bind_safety_app_state(auth_mode="none", listen="0.0.0.0")
             )
@@ -911,6 +926,8 @@ class TestLifespan:
                 mock_start.assert_called_once()
             mock_shutdown.assert_awaited_once()
             mock_remove.assert_called_once()
+        # A clean startup leaves no config-error flag for the launcher (#2666).
+        assert getattr(app.state, "startup_config_error", None) is None
 
     async def test_lifespan_workspace_killed_resets_state(self, db, app_state):
         """The workspace-killed callback threads app.state into
@@ -990,6 +1007,53 @@ class TestLifespan:
         ):
             async with main.lifespan(app):
                 pass  # pragma: no cover
+
+    async def test_lifespan_flags_config_error_for_launcher(
+        self, db, app_state
+    ):
+        """A ConfigurationError escaping startup is flagged on app.state so
+        the launcher can exit EX_CONFIG (78) instead of uvicorn's generic
+        startup-failure status — a supervisor restart-looping a bad config
+        cannot converge (#2666)."""
+        app = FastAPI()
+        app_state = _make_app_state()
+        app.state.container_registry = app_state.state.container_registry
+        app.state.sockets = app_state.state.sockets
+        app.state.settings = app_state.state.settings
+        app.state.ssl_trust = app_state.state.ssl_trust
+        app.state.db = app_state.state.db
+        app.state.model = app_state.state.model
+        app.state.oidc = oidc.OIDC(app)
+        app.state.util = util_mod.Util(app)
+        app.state.auth = auth_mod.Auth(app)
+        app.state.lifecycle = app_state.state.lifecycle
+        registry = app_state.state.container_registry
+        refusal = ConfigurationError(
+            "KLANGKD_DEFAULT_PASSWORD violates the configured password policy"
+        )
+        with (
+            patch.object(
+                registry, "reap_instance_containers", new_callable=AsyncMock
+            ),
+            patch.object(
+                registry, "reap_dead_owner_containers", new_callable=AsyncMock
+            ),
+            patch.object(registry, "start_cleanup_loop"),
+            patch.object(registry, "shutdown", new_callable=AsyncMock),
+            patch.object(util_mod.Util, "check_pid_file", return_value=None),
+            patch.object(util_mod.Util, "write_pid_file"),
+            patch.object(util_mod.Util, "remove_pid_file"),
+            patch.object(
+                app.state.lifecycle,
+                "seed_default_user",
+                new_callable=AsyncMock,
+                side_effect=refusal,
+            ),
+            pytest.raises(ConfigurationError, match="DEFAULT_PASSWORD"),
+        ):
+            async with main.lifespan(app):
+                pass  # pragma: no cover
+        assert app.state.startup_config_error == str(refusal)
 
 
 # --- SIGHUP runtime restart (#1212) ---


### PR DESCRIPTION
## Summary

Fixes #2666 (the "exit with distinguishable status" direction).

A first boot with a policy-violating `KLANGKD_DEFAULT_PASSWORD` crash-looped
under the supervisor: uvicorn exits `STARTUP_FAILURE` (3) for *every* startup
failure, so "config is wrong forever" and "transient fault, retry" are
indistinguishable — the supervisor restarts both forever.

`klangkd` now exits with **`EX_CONFIG` (78, sysexits.h)** when startup was
refused over deterministic bad configuration, so a supervisor can treat it as
permanent (systemd: `RestartPreventExitStatus=78`).

## How it works

- `exceptions.py`: new `EX_CONFIG = 78` constant; `ConfigurationError`
  (already the established type for deterministic config refusals —
  `require_secure_jwt_secret`, OIDC provider/login-hook validation) now
  documents the launcher contract.
- `main.py`: the two seed-path refusals (missing `KLANGKD_DEFAULT_PASSWORD`,
  password-policy violation, #2581) and the no-auth non-loopback bind refusal
  (#1374) raise `ConfigurationError` instead of `RuntimeError`/`SystemExit`.
  The lifespan flags the first `ConfigurationError` escaping the
  config-validation stretch on `app.state.startup_config_error` and re-raises
  (starlette/uvicorn still log the full traceback + message as before).
- `fips.py`: the containerized non-FIPS OpenSSL boot refusal (#2628) raises
  `ConfigurationError` too — same class: restart cannot fix a wrong image.
- `launcher.py`: after `uvicorn.run`, a `SystemExit` whose app carries the
  flag is translated to `SystemExit(EX_CONFIG)` with a one-line operator
  message; unflagged startup failures keep uvicorn's status 3 (retryable).
- Docs: exit-status table + systemd `RestartPreventExitStatus=78` snippet in
  `docs/deployment/signals.md`; changelog entry.

Verified end-to-end: booting `klangkd` against a scratch config with
`default_password: admin` exits **78** with the operator-facing ERROR line
(no behavior change to the logged refusal reason).

## Testing

- Existing #2581/#1374/#2628 refusal tests tightened to expect
  `ConfigurationError`; new test that the missing-password seed refusal
  raises it too.
- New lifespan test: a `ConfigurationError` during startup sets
  `app.state.startup_config_error` and propagates; a clean boot leaves it
  unset.
- New `test_launcher.py`: `config_error_exit_status()` maps a flagged state
  to 78 and an unflagged one to `None`.
- Full CI suite: `5450 passed`, 100% coverage on the `klangk` package.
