### PR TITLE
fix(wshandler): first terminal load — resize to current client size so the bash prompt is visible (#2671)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1148,6 +1148,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **First terminal load shows the bash prompt (#2671).** On the first
+  open of a workspace terminal (fresh container or browser refresh),
+  the prompt could be scrolled off the top of the viewport — only a
+  blinking cursor on a blank screen — until Enter was pressed. The
+  forced initial tmux redraw now uses the client's current terminal
+  size instead of a possibly stale start-time size, so the prompt is
+  visible immediately on attach.
+
 - **Clean sidecar shutdown when its consent WebSocket is down
   (#2657).** Removing a workspace whose egress sidecar sat in the
   consent reconnect backoff dumped a raw

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -185,10 +185,8 @@ class Connection:
     def _notify_user_terminal_windows(self, windows: list[dict]) -> None:
         self.terminal.notify_user_terminal_windows(windows)
 
-    async def activate_session(
-        self, session: TerminalSession, cols: int, rows: int
-    ) -> bool:
-        return await self.terminal.activate_session(session, cols, rows)
+    async def activate_session(self, session: TerminalSession) -> bool:
+        return await self.terminal.activate_session(session)
 
     async def stop_terminal(self) -> None:
         await self.terminal.stop()

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -778,7 +778,7 @@ class TerminalController:
                     await conn.app.state.terminal.attach_browser(
                         conn.container_id, browser_id
                     )
-                if not await conn.activate_session(session, cols, rows):
+                if not await conn.activate_session(session):
                     return
                 conn.sock.send_json({"type": "terminal_started"})
                 try:
@@ -1131,9 +1131,7 @@ class TerminalController:
         if session is not None:
             await session.stop()
 
-    async def activate_session(
-        self, session: TerminalSession, cols: int, rows: int
-    ) -> bool:
+    async def activate_session(self, session: TerminalSession) -> bool:
         """Wire up a started session for output forwarding.
 
         Checks the session is still current, creates the output task,
@@ -1154,7 +1152,19 @@ class TerminalController:
         # Resize to force tmux to redraw at the client's terminal size.
         # Without this, reattaching shows a blank screen because tmux
         # skips the redraw when the PTY size matches the default.
-        await session.resize(cols, rows)
+        #
+        # Resize to the controller's CURRENT dims (``self.cols``/
+        # ``self.rows``), not the dims captured when terminal_start was
+        # handled (#2671). The client can shrink between the two -- e.g.
+        # the tab strip appearing fires a terminal_resize before the
+        # attach exec's PTY exists, and ``TerminalSession.resize`` drops
+        # it while ``_shell`` is None. Forcing the stale start-time size
+        # then makes tmux repaint TALLER than the client grid (e.g. 29
+        # rows into 27), and the extra line-feeds scroll the prompt off
+        # the top of the (alternate-screen) viewport -- the "bash prompt
+        # invisible until Enter" first-load bug. Resizing to the latest
+        # client size makes the forced redraw match the real grid.
+        await session.resize(self.cols, self.rows)
         self._conn.app.state.container_registry.record_activity(
             self._conn.container_id
         )
@@ -1464,7 +1474,7 @@ class SharedTerminalController:
                     window_id,
                     conn.app.state.terminal,
                 )
-                if not await conn.activate_session(session, cols, rows):
+                if not await conn.activate_session(session):
                     return
                 conn.sock.send_json(
                     {

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -6415,7 +6415,7 @@ class TestTerminalController:
         stale = AsyncMock()
         # Controller's current session is a different object.
         ctrl.session = AsyncMock()
-        result = await ctrl.activate_session(stale, 80, 24)
+        result = await ctrl.activate_session(stale)
         assert result is False
         stale.stop.assert_awaited_once()
 
@@ -6426,11 +6426,38 @@ class TestTerminalController:
         session = _mock_terminal()
         ctrl.session = session
         with patch.object(registry, "record_activity") as rec:
-            result = await ctrl.activate_session(session, 80, 24)
+            result = await ctrl.activate_session(session)
         assert result is True
         assert ctrl.output_task is not None
         session.resize.assert_awaited_once_with(80, 24)
         rec.assert_called_once_with("cid")
+        ctrl.output_task.cancel()
+        try:
+            await ctrl.output_task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_activate_session_uses_current_client_size(self):
+        """activate_session resizes to the controller's CURRENT dims, not
+        the dims captured at terminal_start (#2671).
+
+        The client can shrink between terminal_start and activation (the
+        tab strip appearing fires a terminal_resize while the attach
+        exec's PTY doesn't exist yet, so TerminalSession.resize drops
+        it). If the forced redraw then used the stale start-time size,
+        tmux would repaint taller than the client grid and scroll the
+        prompt off the top of the viewport.
+        """
+        ctrl, _, _ = self._controller()
+        session = _mock_terminal()
+        ctrl.session = session
+        # terminal_start captured 100x30; the client has since resized
+        # to 100x27 (tab strip appearing).
+        ctrl.cols = 100
+        ctrl.rows = 27
+        result = await ctrl.activate_session(session)
+        assert result is True
+        session.resize.assert_awaited_once_with(100, 27)
         ctrl.output_task.cancel()
         try:
             await ctrl.output_task
@@ -6928,9 +6955,9 @@ class TestTerminalController:
         with patch.object(
             conn.terminal, "activate_session", new=AsyncMock(return_value=True)
         ) as m:
-            result = await conn.activate_session(session, 80, 24)
+            result = await conn.activate_session(session)
         assert result is True
-        m.assert_awaited_once_with(session, 80, 24)
+        m.assert_awaited_once_with(session)
 
     async def test_connection_stop_terminal_delegate(self):
         conn = _base_conn()


### PR DESCRIPTION
## Summary

On the first terminal load of a workspace, the bash prompt was invisible —
only a blinking cursor on a blank screen — until Enter was pressed. The
reporter's follow-up nailed the mechanism: the screen was scrolled one line
past the prompt.

## Root cause

Captured end-to-end (Playwright + the real backend, byte stream off the
WebSocket) and replayed through libghostty:

1. `terminal_start` carries the *pre-tab-strip* size (e.g. 127x29). The
   attach exec's PTY is created at that size.
2. The tab strip mounts and shrinks the terminal view; flterm fires
   `terminal_resize 127x27` — this lands at the server **before** the PTY
   exists, so `TerminalSession.resize` silently drops it (`_shell is None`).
3. `activate_session` then forces a redraw at the **stale start-time** size
   (127x29), re-resizing the PTY taller than the client's 27-row grid.
4. tmux's final repaint (29 rows) painted into the 27-row alternate-screen
   grid: the extra line-feeds scroll the prompt off the top. Enter repaints
   a prompt at the cursor — hence "press Enter to see it".

Replay of the production byte stream through libghostty at 127x27 shows no
prompt row anywhere; at 127x29 the prompt renders at row 0. This also
explains why it only reproduces right after server start / on the first
workspace view: that's when the terminal view's first layout (and the
tab-strip shrink race) coincides with session creation.

## Fix

`TerminalController.activate_session` now resizes the session to the
controller's **current** client-known dims (`self.cols`/`self.rows`) instead
of the dims captured when `terminal_start` was handled. The forced tmux
redraw then always matches the real client grid. The `cols`/`rows`
parameters are dropped (they were always at least as stale as the
controller state; the join path's `conn._terminal_cols` already proxies it).

## Testing

- New regression test: `activate_session` resizes to the current client
  size after a mid-start shrink (`test_activate_session_uses_current_client_size`).
- Full backend suite with `-n auto`: 5578 passed, 100% coverage.
- Frontend suite: 996 passed.
- End-to-end: the same Playwright capture that reproduced the blank prompt
  now shows `~$ ` with the cursor beside it on first attach; the captured
  stream's final tmux repaint is `1;27r` (matches the client grid) instead
  of `1;29r`.

Fixes #2671.
