### PR TITLE
fix(devenv): seed a policy-compliant default_password in klangkd.yaml.devenv

### DIFF
--- a/klangkd.yaml.devenv
+++ b/klangkd.yaml.devenv
@@ -28,7 +28,7 @@ auth_modes: password
 # --- Auth / identity ---
 jwt_secret: secret-change-in-production
 default_user: admin@example.com
-default_password: admin
+default_password: admin123abc
 
 # --- Storage ---
 # state_dir/data_dir are required (no defaults, #1461). In dev these resolve


### PR DESCRIPTION
Since #2581, the backend fails fast at startup when `KLANGKD_DEFAULT_PASSWORD` violates the password policy (`min_password_length=8` by default). The devenv template still seeds `default_password: admin` (5 chars), so every fresh checkout or worktree that runs `devenv processes up` for the first time crashes during `seed_default_user` and the backend never boots.

Change the template to `admin123abc`, which satisfies the default policy. `klangkd.yaml.devenv` is dev-only (copied to the gitignored `klangkd.yaml` on first shell entry), so no operator action and no changelog entry.
