### PR TITLE
fix(frontend): restart button reconnects when WebSocket gave up after host restart (#2674)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1148,6 +1148,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace Restart button after a server restart (#2674).** Clicking
+  Restart while the browser sat on the container-stopped overlay during a
+  host shutdown/restart used to spin forever: the WebSocket had given up
+  auto-reconnecting while the server was down, so the restart command was
+  silently dropped. The button now reconnects and rejoins the workspace,
+  which auto-starts the container, clears the spinner, and reattaches the
+  terminal. If the server is still unreachable, the Restart button is
+  restored so the user can retry.
+
 - **First terminal load shows the bash prompt (#2671).** On the first
   open of a workspace terminal (fresh container or browser refresh),
   the prompt could be scrolled off the top of the viewport — only a

--- a/src/frontend/lib/workspace/restart_flow.dart
+++ b/src/frontend/lib/workspace/restart_flow.dart
@@ -1,0 +1,49 @@
+/// Delivery logic for the workspace Restart button (#2674).
+///
+/// When the host shuts down gracefully, the drain broadcast leaves the
+/// container-stopped overlay on screen with its Restart button — and the
+/// WebSocket drops moments later when the server exits. After a bounded
+/// number of auto-reconnect attempts (far fewer than a host reboot takes)
+/// [WsClient] stops retrying, so a Restart press with the socket down
+/// would be silently dropped by `WsClient._send` and the "Restarting..."
+/// spinner would never clear.
+import '../ws/ws_client.dart';
+
+/// Outcome of a Restart-button press.
+enum RestartRequestResult {
+  /// `restart_container` was sent over the live WebSocket. The caller's
+  /// spinner clears on the `container_ready` event.
+  sent,
+
+  /// The socket was down, so a reconnect was performed instead. The
+  /// `workspace_connect` sent on reconnect auto-starts the container;
+  /// the `container_ready` event that follows clears the spinner and
+  /// reattaches the terminal.
+  reconnecting,
+
+  /// The socket was down and the reconnect attempt failed (server still
+  /// unreachable). Nothing was delivered; the caller should restore the
+  /// Restart button so the user can retry.
+  failed,
+}
+
+/// Deliver a container-restart request for [workspaceId] over [wsClient].
+Future<RestartRequestResult> requestContainerRestart({
+  required WsClient wsClient,
+  required String workspaceId,
+}) async {
+  if (wsClient.connected) {
+    wsClient.sendRestartContainer();
+    return RestartRequestResult.sent;
+  }
+  // Socket down (host restart): reconnect instead of sending into the
+  // void. Reconnecting also re-arms auto-reconnect (connectWorkspace
+  // sets the pending-workspace + auto-reconnect flags), so future drops
+  // retry again instead of staying given-up.
+  await wsClient.connect();
+  if (!wsClient.connected) {
+    return RestartRequestResult.failed;
+  }
+  wsClient.connectWorkspace(workspaceId);
+  return RestartRequestResult.reconnecting;
+}

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -17,6 +17,7 @@ import '../layout/ide_layout.dart';
 import '../terminal/ghostty_terminal.dart';
 import '../terminal/terminal_link.dart';
 import 'workspace_file_api.dart';
+import 'restart_flow.dart';
 import 'workspace_overlays.dart';
 import 'consent_banner.dart';
 import 'consent_decider_service.dart';
@@ -146,8 +147,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
   Future<void> _fetchWorkspaceName() async {
     final auth = context.read<AuthService>();
     try {
-      final ws =
-          await _findWorkspace(auth, '/api/v1/workspaces') ??
+      final ws = await _findWorkspace(auth, '/api/v1/workspaces') ??
           await _findWorkspace(auth, '/api/v1/workspaces/shared');
       if (ws != null && mounted) {
         final name = ws['name'] as String?;
@@ -251,8 +251,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
         final deletedUserId = msg['user_id'] as String? ?? '';
         final deletedWindow = msg['window_name'] as String? ?? '';
         final deletedWid = msg['window_id'] as String? ?? '';
-        final wasViewing =
-            _activeSharedTerminal != null &&
+        final wasViewing = _activeSharedTerminal != null &&
             _activeSharedTerminal!['user_id'] == deletedUserId &&
             _activeSharedTerminal!['window_id'] == deletedWid;
         if (wasViewing) {
@@ -352,17 +351,15 @@ class _WorkspacePageState extends State<WorkspacePage> {
       // Snapshot the previous window ids BEFORE reassigning, so we can tell a
       // switch to an existing window apart from a brand-new window becoming
       // active.
-      final prevWindowIds = _prevTerminalWindows
-          .map((w) => w['id'] as String?)
-          .toSet();
+      final prevWindowIds =
+          _prevTerminalWindows.map((w) => w['id'] as String?).toSet();
       _prevTerminalWindows = wsClient.terminalWindows;
       _prevSharedTerminals = wsClient.sharedTerminals;
       // Track selected own-window: initialize on first message, or
       // reset if the selected window was closed.
       if (wsClient.terminalWindows.isNotEmpty) {
-        final ids = wsClient.terminalWindows
-            .map((w) => w['id'] as String?)
-            .toSet();
+        final ids =
+            wsClient.terminalWindows.map((w) => w['id'] as String?).toSet();
         // Follow tmux's active window on a switch to an EXISTING window (or
         // the first load) so the Flutter tab matches the status-bar selection
         // (#2171) — but NOT when a brand-new window just became active. The
@@ -375,8 +372,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
             break;
           }
         }
-        final followActive =
-            activeId != null &&
+        final followActive = activeId != null &&
             (prevWindowIds.isEmpty || prevWindowIds.contains(activeId));
         if (followActive) {
           _selectedOwnWindowId = activeId;
@@ -410,10 +406,24 @@ class _WorkspacePageState extends State<WorkspacePage> {
     }
   }
 
-  void _restartContainer() {
+  Future<void> _restartContainer() async {
     setState(() => _restarting = true);
     final wsClient = context.read<WsClient>();
-    wsClient.sendRestartContainer();
+    // #2674: with the WebSocket down (host restarted while this page was
+    // open, auto-reconnect exhausted) a restart_container send would be
+    // silently dropped and the spinner would never clear — reconnect
+    // instead; the workspace_connect on reconnect auto-starts the
+    // container and container_ready clears the overlay.
+    final result = await requestContainerRestart(
+      wsClient: wsClient,
+      workspaceId: widget.workspaceId,
+    );
+    if (!mounted) return;
+    if (result == RestartRequestResult.failed) {
+      // Server still unreachable: restore the button so the user can
+      // retry rather than spinning forever.
+      setState(() => _restarting = false);
+    }
   }
 
   void _switchToIsolated(WsClient wsClient, String windowId) {
@@ -596,9 +606,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
       sharing: _hasPerm('share')
           ? WorkspaceSharingPanel(workspaceId: widget.workspaceId)
           : null,
-      consentRules: _consent != null
-          ? ConsentRulesPanel(service: _consent!)
-          : null,
+      consentRules:
+          _consent != null ? ConsentRulesPanel(service: _consent!) : null,
       terminalKey: _terminalKey,
       fileViewerKey: _fileViewerKey,
       initialFile: widget.initialFile,

--- a/src/frontend/test/restart_flow_test.dart
+++ b/src/frontend/test/restart_flow_test.dart
@@ -1,0 +1,80 @@
+/// Tests for the Restart-button delivery logic (#2674): a press with the
+/// WebSocket up sends `restart_container`; a press with the socket down
+/// (host restarted, auto-reconnect exhausted) reconnects instead of
+/// dropping the send; a failed reconnect restores the retryable state.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/workspace/restart_flow.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
+
+class _MockWsClient extends WsClient {
+  bool _connected = false;
+  bool connectCalled = false;
+  bool connectShouldSucceed = true;
+  bool restartSent = false;
+  String? connectedWorkspaceId;
+
+  @override
+  bool get connected => _connected;
+
+  @override
+  Future<void> connect() async {
+    connectCalled = true;
+    _connected = connectShouldSucceed;
+  }
+
+  @override
+  void connectWorkspace(String workspaceId) {
+    connectedWorkspaceId = workspaceId;
+  }
+
+  @override
+  void sendRestartContainer() {
+    restartSent = true;
+  }
+}
+
+void main() {
+  test('socket up: sends restart_container directly', () async {
+    final client = _MockWsClient().._connected = true;
+
+    final result = await requestContainerRestart(
+      wsClient: client,
+      workspaceId: 'ws-1',
+    );
+
+    expect(result, RestartRequestResult.sent);
+    expect(client.restartSent, isTrue);
+    expect(client.connectCalled, isFalse);
+    expect(client.connectedWorkspaceId, isNull);
+  });
+
+  test('socket down: reconnects and rejoins the workspace', () async {
+    final client = _MockWsClient();
+
+    final result = await requestContainerRestart(
+      wsClient: client,
+      workspaceId: 'ws-1',
+    );
+
+    expect(result, RestartRequestResult.reconnecting);
+    expect(client.connectCalled, isTrue);
+    expect(client.connectedWorkspaceId, 'ws-1');
+    // The restart command itself is not sent — the workspace_connect on
+    // reconnect auto-starts the container.
+    expect(client.restartSent, isFalse);
+  });
+
+  test('socket down and server unreachable: reports failure', () async {
+    final client = _MockWsClient()..connectShouldSucceed = false;
+
+    final result = await requestContainerRestart(
+      wsClient: client,
+      workspaceId: 'ws-1',
+    );
+
+    expect(result, RestartRequestResult.failed);
+    expect(client.connectCalled, isTrue);
+    expect(client.connectedWorkspaceId, isNull);
+    expect(client.restartSent, isFalse);
+  });
+}


### PR DESCRIPTION
Fixes #2674.

## Problem

After a host shutdown while a user sat on a workspace terminal, the graceful-drain `container_stopped` broadcast leaves the container-stopped overlay with its Restart button on screen, and the WebSocket drops moments later when the server exits. `WsClient`'s auto-reconnect gives up after 25 attempts — far fewer than a host reboot takes — so by the time the server is back the socket is dead until something explicitly reconnects.

Clicking Restart in that state called `sendRestartContainer()` into a dead socket: `WsClient._send` silently dropped the frame (channel is null), `_restarting` was never cleared (it only clears on the `container_ready` event that can no longer arrive), and the spinner spun forever.

## Fix

New `restart_flow.dart` helper (`requestContainerRestart`):

- **Socket up** → sends `restart_container` as before; spinner clears on `container_ready`.
- **Socket down** → explicitly `connect()`s and rejoins the workspace via `connectWorkspace`. The server auto-starts the container on `workspace_connect` (`handle_workspace_connect` → `start_workspace_container`), so the resulting `container_ready` clears the spinner, and the terminal widgets reattach on that same event (`sendTerminalStart`) — the terminal comes back too. Reconnecting also re-arms auto-reconnect (`connectWorkspace` sets the pending-workspace + auto-reconnect flags).
- **Reconnect failed** (server still unreachable) → returns failure and `_restartContainer` restores the Restart button so the user can retry instead of spinning forever.

## Tests

`restart_flow_test.dart`: three outcomes (direct send / reconnect-and-rejoin / failed reconnect). Full frontend suite passes (1002 tests).

## Changelog

`docs/changes.md` `[Unreleased]` → Fixed.
