### PR TITLE
fix(frontend): stale post-login redirect no longer leaks across sessions

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1156,6 +1156,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   `short-name ... did not resolve to an alias and no
 containers-registries.conf(5) was found`.
 
+- **Post-login redirect no longer leaks across sessions (#2670).** The
+  "return to where you were" URL stashed when a logged-out user hits a
+  protected route is now cleared on logout (and on any 401 that ends the
+  session), so it can never outlive its session. It is also checked
+  against the new session: a non-admin logging in on a browser where an
+  admin previously logged out now lands on `/workspaces`, not the admin
+  page the previous session was viewing.
+
 - **Workspace Restart button after a server restart (#2674).** Clicking
   Restart while the browser sat on the container-stopped overlay during a
   host shutdown/restart used to spin forever: the WebSocket had given up

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -113,11 +113,15 @@ export async function registerUser(
 }
 
 /** Type email + password into the Flutter login form and click Login.
- *  Returns once the response is received (does not wait for Workspaces). */
-export async function loginViaUI(page: Page, email: string, password: string) {
-  await page.goto("/");
-  await waitForFlutter(page);
-
+ *  Use when the app is already showing the login form and a page load
+ *  must be avoided — e.g. the pendingRedirect tests (#2670), whose
+ *  in-memory stash would not survive a reload. Does not wait for
+ *  Workspaces; callers assert on the outcome. */
+export async function loginOnCurrentPage(
+  page: Page,
+  email: string,
+  password: string,
+) {
   const { width, height } = vp(page);
   const cx = width / 2;
   const f = fv(page);
@@ -133,6 +137,15 @@ export async function loginViaUI(page: Page, email: string, password: string) {
   await page.keyboard.type(password);
 
   await f.click({ position: { x: cx, y: height * 0.64 }, force: true });
+}
+
+/** Load the app fresh, log in via the Flutter login form, and wait for
+ *  the Workspaces page. */
+export async function loginViaUI(page: Page, email: string, password: string) {
+  await page.goto("/");
+  await waitForFlutter(page);
+  await loginOnCurrentPage(page, email, password);
+
   await expect(page).toHaveTitle(/Workspaces/i, { timeout: 10_000 });
 }
 

--- a/src/frontend/e2e-tests/e2e/pending-redirect.spec.ts
+++ b/src/frontend/e2e-tests/e2e/pending-redirect.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+import {
+  TEST_PASSWORD,
+  registerUser,
+  loginViaUI,
+  loginOnCurrentPage,
+  waitForFlutter,
+  flutterClick,
+  vp,
+} from "./helpers";
+
+// Regression tests for #2670: the post-login "next URL" (pendingRedirect)
+// must never outlive its session. A URL stashed while logged out must not
+// redirect a different — possibly non-admin — user to an admin page after
+// login; the new session falls back to /workspaces instead.
+//
+// pendingRedirect is an in-memory global, so the stash must happen inside
+// the same page instance that then logs in — never reload between the two
+// (loginOnCurrentPage exists for exactly that reason).
+test.describe("post-login redirect (pendingRedirect, #2670)", () => {
+  test("non-admin login does not inherit a stashed admin URL", async ({
+    page,
+    request,
+  }) => {
+    // A genuine non-admin — the stashed target (/admin/users) is off
+    // limits to this session.
+    const email = `stale-redir-${Date.now()}@test.example.com`;
+    await registerUser(request, email, { admin: false });
+
+    // Visit a protected admin route while logged out: the app stashes the
+    // destination and shows the login form.
+    await page.goto("/#/admin/users");
+    await waitForFlutter(page);
+    await expect(page).toHaveURL(/#\/login/, { timeout: 10_000 });
+
+    // Log in as the non-admin user on the already-rendered form (no
+    // reload — it would reset the in-memory stash under test).
+    await loginOnCurrentPage(page, email, TEST_PASSWORD);
+
+    // The new session must land on /workspaces, not /admin/users.
+    await expect(page).toHaveTitle(/Workspaces/i, { timeout: 10_000 });
+    await expect(page).toHaveURL(/#\/workspaces/, { timeout: 10_000 });
+  });
+
+  test("logout discards the previous session's destination", async ({
+    page,
+    request,
+  }) => {
+    const adminEmail = `stale-admin-${Date.now()}@test.example.com`;
+    const userEmail = `stale-user-${Date.now()}@test.example.com`;
+    await registerUser(request, adminEmail);
+    await registerUser(request, userEmail, { admin: false });
+
+    // Admin session browsing an admin page.
+    await loginViaUI(page, adminEmail, TEST_PASSWORD);
+    await page.goto("/#/admin/users");
+    await waitForFlutter(page);
+    await expect(page).toHaveURL(/#\/admin\/users/, { timeout: 10_000 });
+
+    // Log out from the app bar (rightmost icon).
+    const { width } = vp(page);
+    await flutterClick(page, width - 25, 28);
+    await expect(page).toHaveURL(/#\/login/, { timeout: 30_000 });
+
+    // While logged out, hit the protected route again — the app stashes
+    // it (fresh page instance, so the reload is fine here) and asks for
+    // login.
+    await page.goto("/#/admin/users");
+    await waitForFlutter(page);
+    await expect(page).toHaveURL(/#\/login/, { timeout: 10_000 });
+
+    // A different, non-admin user logs in on the same browser: the
+    // previous session's destination must not carry over.
+    await loginOnCurrentPage(page, userEmail, TEST_PASSWORD);
+    await expect(page).toHaveTitle(/Workspaces/i, { timeout: 10_000 });
+    await expect(page).toHaveURL(/#\/workspaces/, { timeout: 10_000 });
+  });
+});

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
       name: "chromium",
       testMatch: [
         "klangk.spec.ts",
+        "pending-redirect.spec.ts",
         "terminal-keymap.spec.ts",
         "per-user-home.spec.ts",
         "terminal-tabs.spec.ts",

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -85,6 +85,7 @@ class _KlangkAppState extends State<KlangkApp> {
           currentUri: state.uri.toString(),
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: auth.isAdmin,
         );
       },
       routes: [

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -74,15 +74,27 @@ String? guardAuth({
 /// Feature routes are excluded: they are public but a logged-in user may
 /// legitimately navigate to them.
 ///
+/// The pending redirect is **consume-once**: it is cleared as soon as
+/// this guard uses it, so a stash from one login can never leak into a
+/// later session (#2670). The target is also permission-checked against
+/// the *current* session: an `/admin`-prefixed target (e.g. stashed by
+/// an admin's logout or expiry, then inherited by whoever logs in next
+/// on this browser) falls back to `/workspaces` unless [isAdmin].
+///
 /// Returns the redirect target, or null to allow.
 String? guardLoggedInPublicRoute({
   required bool isLoggedIn,
   required String loc,
   required Set<String> publicRoutes,
   required Set<String> featurePaths,
+  required bool isAdmin,
 }) {
   if (isLoggedIn && publicRoutes.contains(loc) && !featurePaths.contains(loc)) {
-    return pendingRedirect ?? '/workspaces';
+    final target = pendingRedirect;
+    pendingRedirect = null;
+    if (target == null) return '/workspaces';
+    if (target.startsWith('/admin') && !isAdmin) return '/workspaces';
+    return target;
   }
   return null;
 }
@@ -115,6 +127,7 @@ String? evaluateGuards({
   required String currentUri,
   required Set<String> publicRoutes,
   required Set<String> featurePaths,
+  required bool isAdmin,
 }) {
   if (bannerRequired) {
     return guardBanner(bannerRequired: true, loc: loc);
@@ -131,6 +144,7 @@ String? evaluateGuards({
         loc: loc,
         publicRoutes: publicRoutes,
         featurePaths: featurePaths,
+        isAdmin: isAdmin,
       ) ??
       guardRoot(isLoggedIn: isLoggedIn, loc: loc);
 }

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -74,12 +74,19 @@ String? guardAuth({
 /// Feature routes are excluded: they are public but a logged-in user may
 /// legitimately navigate to them.
 ///
-/// The pending redirect is **consume-once**: it is cleared as soon as
-/// this guard uses it, so a stash from one login can never leak into a
-/// later session (#2670). The target is also permission-checked against
-/// the *current* session: an `/admin`-prefixed target (e.g. stashed by
-/// an admin's logout or expiry, then inherited by whoever logs in next
-/// on this browser) falls back to `/workspaces` unless [isAdmin].
+/// The target is permission-checked against the *current* session: an
+/// `/admin`-prefixed target (e.g. stashed by an admin's logout or expiry,
+/// then inherited by whoever logs in next on this browser) falls back to
+/// `/workspaces` unless [isAdmin] (#2670).
+///
+/// The stash is deliberately NOT consumed here. GoRouter re-parses the
+/// *committed* location on every refreshListenable notification, and
+/// AuthService.login() fires two notifications in quick succession
+/// (saveToken's, then its finally-block's). Consuming on the first
+/// evaluation made the second — still re-parsing `/login` — see a null
+/// stash and win the navigation with the `/workspaces` fallback (#2670).
+/// The cross-session leak is instead cut where it originates:
+/// `_clearToken()` clears the stash on logout / any session-ending 401.
 ///
 /// Returns the redirect target, or null to allow.
 String? guardLoggedInPublicRoute({
@@ -91,7 +98,6 @@ String? guardLoggedInPublicRoute({
 }) {
   if (isLoggedIn && publicRoutes.contains(loc) && !featurePaths.contains(loc)) {
     final target = pendingRedirect;
-    pendingRedirect = null;
     if (target == null) return '/workspaces';
     if (target.startsWith('/admin') && !isAdmin) return '/workspaces';
     return target;

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../branding.dart';
 import 'password_policy.dart';
+import 'pending_redirect.dart';
 
 /// Override for testing — set to intercept all HTTP calls in AuthService.
 http.Client? testAuthHttpClientOverride;
@@ -259,6 +260,12 @@ class AuthService extends ChangeNotifier {
     _token = null;
     _permissions = {};
     _groups = [];
+    // The pending redirect belongs to the session being cleared; drop it
+    // so the next login can never inherit the old session's destination
+    // (#2670). If the user was on a protected page, guardAuth re-stashes
+    // the current URI on the redirect that follows, preserving the
+    // same-user "resume where you were" behavior after a token expiry.
+    pendingRedirect = null;
     _stopPermissionRefresh();
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_tokenKey);

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -181,48 +181,48 @@ void main() {
       );
     });
 
-    test('consumes the pending redirect (consume-once, #2670)', () {
+    test('guard is idempotent across repeated evaluations (#2670)', () {
+      // GoRouter re-parses the committed location on every refreshListenable
+      // notification, and login() notifies twice in quick succession — the
+      // guard must give both evaluations the same answer. It therefore must
+      // NOT consume the stash; see the guard's doc comment.
       pendingRedirect = '/workspace/abc';
-      expect(
-        guardLoggedInPublicRoute(
-          isLoggedIn: true,
-          loc: '/login',
-          publicRoutes: routes,
-          featurePaths: featurePaths,
-          isAdmin: false,
-        ),
-        '/workspace/abc',
+      final first = guardLoggedInPublicRoute(
+        isLoggedIn: true,
+        loc: '/login',
+        publicRoutes: routes,
+        featurePaths: featurePaths,
+        isAdmin: false,
       );
-      // A later login (or a logged-in visit to /login) must not inherit
-      // the consumed target.
-      expect(pendingRedirect, isNull);
-      expect(
-        guardLoggedInPublicRoute(
-          isLoggedIn: true,
-          loc: '/login',
-          publicRoutes: routes,
-          featurePaths: featurePaths,
-          isAdmin: false,
-        ),
-        '/workspaces',
+      final second = guardLoggedInPublicRoute(
+        isLoggedIn: true,
+        loc: '/login',
+        publicRoutes: routes,
+        featurePaths: featurePaths,
+        isAdmin: false,
       );
+      expect(first, '/workspace/abc');
+      expect(second, '/workspace/abc');
     });
 
-    test('does not leave a stale redirect when consuming with a fallback', () {
-      // Even when the guard falls back to /workspaces (no stash or
-      // permission-rejected target), the stash must not survive.
+    test('admin-target rejection is stable across evaluations (#2670)', () {
+      // A rejected target must yield the same fallback on every
+      // evaluation — clearing it here would re-introduce the double-
+      // notify race (the second evaluation would fall back while the
+      // first had already bounced the user).
       pendingRedirect = '/admin/users';
-      expect(
-        guardLoggedInPublicRoute(
-          isLoggedIn: true,
-          loc: '/login',
-          publicRoutes: routes,
-          featurePaths: featurePaths,
-          isAdmin: false,
-        ),
-        '/workspaces',
-      );
-      expect(pendingRedirect, isNull);
+      for (var i = 0; i < 2; i++) {
+        expect(
+          guardLoggedInPublicRoute(
+            isLoggedIn: true,
+            loc: '/login',
+            publicRoutes: routes,
+            featurePaths: featurePaths,
+            isAdmin: false,
+          ),
+          '/workspaces',
+        );
+      }
     });
 
     test('rejects an admin target for a non-admin session (#2670)', () {
@@ -389,8 +389,10 @@ void main() {
         ),
         '/workspaces',
       );
-      // And the stale target is consumed, not left for the next bounce.
-      expect(pendingRedirect, isNull);
+      // The rejected stash is not consumed here — clearing happens on
+      // session end (_clearToken). Idempotence is what makes the
+      // double-notify race harmless.
+      expect(pendingRedirect, '/admin/users');
     });
 
     test('logged-in admin on /login with admin target -> target', () {
@@ -407,7 +409,6 @@ void main() {
         ),
         '/admin/users',
       );
-      expect(pendingRedirect, isNull);
     });
 
     test('logged-in on / -> /workspaces (root, not public-route guard)', () {

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -123,6 +123,7 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/workspace/abc',
       );
@@ -135,6 +136,7 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/workspaces',
       );
@@ -147,6 +149,7 @@ void main() {
           loc: '/celebrate',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         isNull,
       );
@@ -159,6 +162,7 @@ void main() {
           loc: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         isNull,
       );
@@ -171,8 +175,96 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         isNull,
+      );
+    });
+
+    test('consumes the pending redirect (consume-once, #2670)', () {
+      pendingRedirect = '/workspace/abc';
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/workspace/abc',
+      );
+      // A later login (or a logged-in visit to /login) must not inherit
+      // the consumed target.
+      expect(pendingRedirect, isNull);
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/workspaces',
+      );
+    });
+
+    test('does not leave a stale redirect when consuming with a fallback', () {
+      // Even when the guard falls back to /workspaces (no stash or
+      // permission-rejected target), the stash must not survive.
+      pendingRedirect = '/admin/users';
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/workspaces',
+      );
+      expect(pendingRedirect, isNull);
+    });
+
+    test('rejects an admin target for a non-admin session (#2670)', () {
+      // Stashed by a previous (admin) session's logout or expiry.
+      pendingRedirect = '/admin/users';
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/workspaces',
+      );
+    });
+
+    test('allows an admin target for an admin session', () {
+      pendingRedirect = '/admin/users';
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: true,
+        ),
+        '/admin/users',
+      );
+    });
+
+    test('allows non-admin targets for a non-admin session', () {
+      pendingRedirect = '/workspace/abc?file=main.dart';
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/workspace/abc?file=main.dart',
       );
     });
   });
@@ -206,6 +298,7 @@ void main() {
           currentUri: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/consent',
       );
@@ -225,6 +318,7 @@ void main() {
           currentUri: '/consent',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         isNull,
       );
@@ -239,6 +333,7 @@ void main() {
           currentUri: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/consent',
       );
@@ -253,6 +348,7 @@ void main() {
           currentUri: '/workspace/abc?x=1',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/login',
       );
@@ -269,9 +365,49 @@ void main() {
           currentUri: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/workspace/zzz',
       );
+    });
+
+    test(
+        'logged-in non-admin on /login with stale admin target -> '
+        '/workspaces (#2670)', () {
+      // The repro from #2670: an admin session stashed /admin/users (via
+      // logout or expiry), and a non-admin logs in on the same browser.
+      pendingRedirect = '/admin/users';
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/login',
+          currentUri: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/workspaces',
+      );
+      // And the stale target is consumed, not left for the next bounce.
+      expect(pendingRedirect, isNull);
+    });
+
+    test('logged-in admin on /login with admin target -> target', () {
+      pendingRedirect = '/admin/users';
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/login',
+          currentUri: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: true,
+        ),
+        '/admin/users',
+      );
+      expect(pendingRedirect, isNull);
     });
 
     test('logged-in on / -> /workspaces (root, not public-route guard)', () {
@@ -285,6 +421,7 @@ void main() {
           currentUri: '/',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/workspaces',
       );
@@ -299,6 +436,7 @@ void main() {
           currentUri: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         isNull,
       );
@@ -313,6 +451,7 @@ void main() {
           currentUri: '/celebrate',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         isNull,
       );
@@ -327,6 +466,7 @@ void main() {
           currentUri: '/consent',
           publicRoutes: routes,
           featurePaths: featurePaths,
+          isAdmin: false,
         ),
         '/login',
       );

--- a/src/frontend/test/app_redirect_test.dart
+++ b/src/frontend/test/app_redirect_test.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:klangk_frontend/app.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/auth/login_page.dart';
+import 'package:klangk_frontend/workspace/host_services.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// App-level redirect tests that drive the real GoRouter (built by
+/// KlangkApp._createRouter) through the real AuthService login flow.
+///
+/// These pin the interaction between the router guards and AuthService's
+/// notifyListeners calls — something the pure guard unit tests cannot see,
+/// because GoRouter re-parses the *committed* location on every
+/// refreshListenable notification, and login() fires two notifications in
+/// quick succession (saveToken's, then the finally-block's).
+class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
+  final _incoming = StreamController<dynamic>.broadcast();
+  final _sink = _FakeSink();
+
+  @override
+  Stream<dynamic> get stream => _incoming.stream;
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  Future<void> get ready => Future.value();
+}
+
+class _FakeSink extends Fake implements WebSocketSink {
+  @override
+  void add(dynamic data) {}
+
+  @override
+  Future close([int? closeCode, String? closeReason]) async {}
+}
+
+void main() {
+  String makeJwt(Map<String, dynamic> payload) {
+    final header = base64Url
+        .encode(utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})))
+        .replaceAll('=', '');
+    final body =
+        base64Url.encode(utf8.encode(jsonEncode(payload))).replaceAll('=', '');
+    return '$header.$body.fakesig';
+  }
+
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({});
+    testAuthHttpClientOverride = null;
+    testConfigHttpClientOverride = null;
+    // The workspace page mounts a WorkspaceConnector on arrival; without a
+    // channel factory it would parse a ws:// URL derived from Uri.base,
+    // which is meaningless in a widget test.
+    WsClient.testChannelFactory = (_) => _FakeWebSocketChannel();
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+    testConfigHttpClientOverride = null;
+    WsClient.testChannelFactory = null;
+  });
+
+  // All HTTP the app issues during this flow: config (login page +
+  // AuthService), login, my-permissions, and the workspace lookups the
+  // workspace page performs after landing (answered with 404/empty so the
+  // page settles into its error state instead of connecting anything).
+  void installMocks(String token) {
+    testConfigHttpClientOverride = MockClient((request) async {
+      return http.Response(
+        jsonEncode({
+          'registration_enabled': true,
+          'login_banner_title': '',
+          'login_banner': '',
+          'oidc_providers': [],
+          'auth_modes': 'password',
+        }),
+        200,
+      );
+    });
+    testAuthHttpClientOverride = MockClient((request) async {
+      final path = request.url.path;
+      if (path.contains('/api/v1/auth/login')) {
+        return http.Response(
+          jsonEncode({'access_token': token}),
+          200,
+        );
+      }
+      if (path.contains('/api/v1/my-permissions')) {
+        return http.Response(
+          jsonEncode({
+            'user_id': 'u1',
+            'email': 'user@example.com',
+            'permissions': <String, List<String>>{},
+            'groups': <Map<String, dynamic>>[],
+          }),
+          200,
+        );
+      }
+      if (path.contains('/api/v1/config')) {
+        return http.Response(
+          jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+          200,
+        );
+      }
+      // Workspace list / shared list / per-resource permissions lookups.
+      if (path.contains('/api/v1/workspaces')) {
+        return http.Response(jsonEncode([]), 200);
+      }
+      return http.Response('Not found', 404);
+    });
+  }
+
+  Widget buildApp() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+        ChangeNotifierProxyProvider<AuthService, WsClient>(
+          create: (_) => WsClient(),
+          update: (_, auth, client) => client!..updateAuth(auth),
+        ),
+        Provider<WorkspaceServices>(
+          create: (ctx) => HostWorkspaceServices(
+            ctx.read<WsClient>(),
+            ctx.read<AuthService>(),
+          ),
+        ),
+      ],
+      child: const KlangkApp(initialLocation: '/workspace/test-ws-123'),
+    );
+  }
+
+  Future<String> currentLocation(WidgetTester tester) async {
+    // The Router's internal Navigator sits below InheritedGoRouter, so its
+    // context can resolve GoRouter.of (the builder-wrapped StaleBuildBanner
+    // is above the Router and cannot).
+    final ctx = tester.element(find.byType(Navigator).first);
+    final router = GoRouter.of(ctx);
+    return router.routerDelegate.currentConfiguration.uri.toString();
+  }
+
+  testWidgets(
+      'deep-link login lands on the stashed workspace, not /workspaces (#2670)',
+      (tester) async {
+    // No exp claim -> no token-refresh timer for the test to fight with.
+    installMocks(makeJwt({'sub': 'user-1', 'email': 'user@example.com'}));
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(find.text('Log In'), findsWidgets);
+    expect(await currentLocation(tester), '/login');
+
+    // Log in through the real form — this exercises the real login()
+    // double notifyListeners (saveToken + finally), which is exactly what
+    // the E2E deep-link test drives.
+    final fields = find.byType(TextField);
+    await tester.enterText(fields.first, 'user@example.com');
+    await tester.enterText(fields.last, 'password');
+    await tester.tap(find.widgetWithText(FilledButton, 'Log In'));
+
+    // Bounded pumps: process the notify -> re-parse -> redirect chain
+    // without pumpAndSettle (the workspace page's connector retries on
+    // timers that never quiesce in a test).
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+    }
+
+    expect(await currentLocation(tester), '/workspace/test-ws-123');
+  });
+}

--- a/src/frontend/test/app_redirect_test.dart
+++ b/src/frontend/test/app_redirect_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -8,44 +7,30 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:klangk_frontend/app.dart';
+import 'package:klangk_frontend/app_guards.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_frontend/auth/login_page.dart';
-import 'package:klangk_frontend/workspace/host_services.dart';
-import 'package:klangk_frontend/ws/ws_client.dart';
+import 'package:klangk_frontend/auth/pending_redirect.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
-/// App-level redirect tests that drive the real GoRouter (built by
-/// KlangkApp._createRouter) through the real AuthService login flow.
+/// App-level redirect tests that drive a real GoRouter through the real
+/// AuthService login flow.
 ///
-/// These pin the interaction between the router guards and AuthService's
-/// notifyListeners calls — something the pure guard unit tests cannot see,
-/// because GoRouter re-parses the *committed* location on every
-/// refreshListenable notification, and login() fires two notifications in
-/// quick succession (saveToken's, then the finally-block's).
-class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
-  final _incoming = StreamController<dynamic>.broadcast();
-  final _sink = _FakeSink();
-
-  @override
-  Stream<dynamic> get stream => _incoming.stream;
-
-  @override
-  WebSocketSink get sink => _sink;
-
-  @override
-  Future<void> get ready => Future.value();
-}
-
-class _FakeSink extends Fake implements WebSocketSink {
-  @override
-  void add(dynamic data) {}
-
-  @override
-  Future close([int? closeCode, String? closeReason]) async {}
-}
-
+/// The router here mirrors KlangkApp._createRouter's redirect wiring
+/// (evaluateGuards over publicRoutes + featurePaths, refreshListenable on
+/// auth) but mounts dummy builders — deliberately NOT the real KlangkApp:
+/// importing app.dart would transitively load every page module into the
+/// test isolate, and dart coverage reports all *loaded* files, so the
+/// pages that have no dedicated unit tests would surface as uncovered and
+/// collapse the 100% gate.
+///
+/// What these pin that the pure guard unit tests cannot: GoRouter
+/// re-parses the *committed* location on every refreshListenable
+/// notification, and login() fires two notifications back-to-back
+/// (saveToken's notifyListeners, then the finally-block's microtasks
+/// later). A guard that answers those evaluations differently (the
+/// consume-once bug, #2670 review) sends the deep-link login to
+/// /workspaces.
 void main() {
   String makeJwt(Map<String, dynamic> payload) {
     final header = base64Url
@@ -61,24 +46,21 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     testAuthHttpClientOverride = null;
     testConfigHttpClientOverride = null;
-    // The workspace page mounts a WorkspaceConnector on arrival; without a
-    // channel factory it would parse a ws:// URL derived from Uri.base,
-    // which is meaningless in a widget test.
-    WsClient.testChannelFactory = (_) => _FakeWebSocketChannel();
+    pendingRedirect = null;
   });
 
   tearDown(() {
     testBaseUrlOverride = null;
     testAuthHttpClientOverride = null;
     testConfigHttpClientOverride = null;
-    WsClient.testChannelFactory = null;
+    pendingRedirect = null;
   });
 
   // All HTTP the app issues during this flow: config (login page +
-  // AuthService), login, my-permissions, and the workspace lookups the
-  // workspace page performs after landing (answered with 404/empty so the
-  // page settles into its error state instead of connecting anything).
-  void installMocks(String token) {
+  // AuthService), login, and my-permissions. No token exp claim -> no
+  // refresh timer for the test to fight with.
+  String installMocks() {
+    final token = makeJwt({'sub': 'user-1', 'email': 'user@example.com'});
     testConfigHttpClientOverride = MockClient((request) async {
       return http.Response(
         jsonEncode({
@@ -94,10 +76,7 @@ void main() {
     testAuthHttpClientOverride = MockClient((request) async {
       final path = request.url.path;
       if (path.contains('/api/v1/auth/login')) {
-        return http.Response(
-          jsonEncode({'access_token': token}),
-          200,
-        );
+        return http.Response(jsonEncode({'access_token': token}), 200);
       }
       if (path.contains('/api/v1/my-permissions')) {
         return http.Response(
@@ -116,52 +95,66 @@ void main() {
           200,
         );
       }
-      // Workspace list / shared list / per-resource permissions lookups.
-      if (path.contains('/api/v1/workspaces')) {
-        return http.Response(jsonEncode([]), 200);
-      }
       return http.Response('Not found', 404);
     });
+    return token;
   }
 
-  Widget buildApp() {
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider(create: (_) => AuthService()),
-        ChangeNotifierProxyProvider<AuthService, WsClient>(
-          create: (_) => WsClient(),
-          update: (_, auth, client) => client!..updateAuth(auth),
+  GoRouter buildRouter(AuthService auth, String initialLocation) {
+    const featurePaths = <String>{};
+    return GoRouter(
+      initialLocation: initialLocation,
+      refreshListenable: auth,
+      redirect: (context, state) {
+        final loc = state.matchedLocation;
+        final routes = {...publicRoutes, ...featurePaths};
+        return evaluateGuards(
+          isLoggedIn: auth.isLoggedIn,
+          bannerRequired: auth.bannerRequired,
+          loc: loc,
+          currentUri: state.uri.toString(),
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: auth.isAdmin,
+        );
+      },
+      routes: [
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const LoginPage(),
         ),
-        Provider<WorkspaceServices>(
-          create: (ctx) => HostWorkspaceServices(
-            ctx.read<WsClient>(),
-            ctx.read<AuthService>(),
+        GoRoute(
+          path: '/workspaces',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('workspaces-list'))),
+        ),
+        GoRoute(
+          path: '/workspace/:id',
+          builder: (context, state) => Scaffold(
+            body:
+                Center(child: Text('workspace-${state.pathParameters['id']}')),
           ),
         ),
       ],
-      child: const KlangkApp(initialLocation: '/workspace/test-ws-123'),
     );
-  }
-
-  Future<String> currentLocation(WidgetTester tester) async {
-    // The Router's internal Navigator sits below InheritedGoRouter, so its
-    // context can resolve GoRouter.of (the builder-wrapped StaleBuildBanner
-    // is above the Router and cannot).
-    final ctx = tester.element(find.byType(Navigator).first);
-    final router = GoRouter.of(ctx);
-    return router.routerDelegate.currentConfiguration.uri.toString();
   }
 
   testWidgets(
       'deep-link login lands on the stashed workspace, not /workspaces (#2670)',
       (tester) async {
-    // No exp claim -> no token-refresh timer for the test to fight with.
-    installMocks(makeJwt({'sub': 'user-1', 'email': 'user@example.com'}));
+    installMocks();
 
-    await tester.pumpWidget(buildApp());
+    final auth = AuthService();
+    final router = buildRouter(auth, '/workspace/test-ws-123');
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: auth,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.text('Log In'), findsWidgets);
-    expect(await currentLocation(tester), '/login');
+    expect(pendingRedirect, '/workspace/test-ws-123');
 
     // Log in through the real form — this exercises the real login()
     // double notifyListeners (saveToken + finally), which is exactly what
@@ -170,14 +163,39 @@ void main() {
     await tester.enterText(fields.first, 'user@example.com');
     await tester.enterText(fields.last, 'password');
     await tester.tap(find.widgetWithText(FilledButton, 'Log In'));
+    await tester.pumpAndSettle();
 
-    // Bounded pumps: process the notify -> re-parse -> redirect chain
-    // without pumpAndSettle (the workspace page's connector retries on
-    // timers that never quiesce in a test).
-    for (var i = 0; i < 10; i++) {
-      await tester.pump(const Duration(milliseconds: 10));
-    }
+    expect(
+      router.routerDelegate.currentConfiguration.uri.toString(),
+      '/workspace/test-ws-123',
+    );
+    expect(find.text('workspace-test-ws-123'), findsOneWidget);
+  });
 
-    expect(await currentLocation(tester), '/workspace/test-ws-123');
+  testWidgets('plain login (no stash) lands on /workspaces', (tester) async {
+    installMocks();
+
+    final auth = AuthService();
+    final router = buildRouter(auth, '/login');
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: auth,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(pendingRedirect, isNull);
+
+    final fields = find.byType(TextField);
+    await tester.enterText(fields.first, 'user@example.com');
+    await tester.enterText(fields.last, 'password');
+    await tester.tap(find.widgetWithText(FilledButton, 'Log In'));
+    await tester.pumpAndSettle();
+
+    expect(
+      router.routerDelegate.currentConfiguration.uri.toString(),
+      '/workspaces',
+    );
+    expect(find.text('workspaces-list'), findsOneWidget);
   });
 }

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/auth/pending_redirect.dart';
 import 'package:klangk_frontend/branding.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
@@ -610,6 +611,39 @@ void main() {
 
       await service.logout();
       expect(service.isLoggedIn, isFalse);
+    });
+
+    test('clears pendingRedirect on logout (#2670)', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        return http.Response('', 200);
+      });
+
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'my-token'});
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+
+      pendingRedirect = '/admin/users';
+      await service.logout();
+      expect(pendingRedirect, isNull);
+    });
+
+    test('clears pendingRedirect when a 401 clears the token (#2670)',
+        () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/logout')) {
+          return http.Response('', 200);
+        }
+        return http.Response('Unauthorized', 401);
+      });
+
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'my-token'});
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+
+      pendingRedirect = '/admin/users';
+      await service.authGet('/api/v1/workspaces');
+      expect(service.isLoggedIn, isFalse);
+      expect(pendingRedirect, isNull);
     });
   });
 

--- a/src/frontend/test/login_page_test.dart
+++ b/src/frontend/test/login_page_test.dart
@@ -135,6 +135,33 @@ void main() {
       expect(find.text('Please log in to continue.'), findsNothing);
     });
 
+    testWidgets('failed login keeps the pending redirect (#2670)',
+        (tester) async {
+      // The stash may only be consumed by the router guard after a
+      // successful login; a failed attempt must not drop it, or the
+      // user would lose their return destination on a typo'd password.
+      pendingRedirect = '/workspace/abc123';
+      testAuthHttpClientOverride = MockClient((request) async {
+        return http.Response(
+          jsonEncode({'detail': 'Invalid credentials'}),
+          401,
+        );
+      });
+
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      final fields = find.byType(TextField);
+      await tester.enterText(fields.first, 'user@example.com');
+      await tester.enterText(fields.last, 'wrongpass');
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Log In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invalid credentials'), findsOneWidget);
+      expect(pendingRedirect, '/workspace/abc123');
+    });
+
     testWidgets('login mode rejects an invalid identifier', (tester) async {
       await tester.pumpWidget(buildLoginPage());
       await tester.pumpAndSettle();


### PR DESCRIPTION
Fixes #2670.

The post-login "next URL" (`pendingRedirect`, a top-level global stashed by
`guardAuth` when a logged-out user hits a protected route and consumed after
login) was never cleared on logout and never checked against the new session.
A URL stashed during an admin session (logout or token expiry on an admin
page) survived into the next login, sending a non-admin user to e.g.
`/admin/users`.

Two complementary fixes, per the issue's suggestions:

- **Clear on session end** — `AuthService._clearToken()` (logout, any 401 that
  ends the session, token refresh failure) resets `pendingRedirect`, so the
  stash can never outlive its session. The same-user token-expiry "resume
  where you were" flow is preserved: `guardAuth` re-stashes the current URI
  on the logout transition itself when the user was on a protected page.
- **Permission-check the target** — the redirect target is validated against
  the *current* session: an `/admin`-prefixed target falls back to
  `/workspaces` unless the new session is admin, defending against the same
  symptom from any other stale source.

**Not** consume-once in the guard: the first push had that and it broke the
deep-link E2E deterministically. GoRouter's `refreshListenable` re-parses the
*committed* location on every auth notification, and `login()` fires two
notifications back-to-back (`_saveToken`'s and the `finally`-block's,
microtasks apart). The first evaluation consumed the stash and emitted the
workspace URL; the second — still re-parsing `/login` — saw `null` and won
the navigation with the `/workspaces` fallback. The guard must answer every
evaluation identically; the leak is cut where it originates (`_clearToken`)
instead. A new app-level regression test (`app_redirect_test.dart`) pumps the
real router through the real login double-notify and pins the deep-link
landing.

## Testing

- `devenv ... flutter test --coverage` — all 1013 frontend tests pass,
  including new tests: clear-on-logout, clear-on-401, failed-login keeps the
  stash, guard idempotence, admin-target rejection/fallback, and the
  app-level deep-link redirect test.
