### PR TITLE
fix(devenv): provision registries.conf so short image names resolve

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -299,6 +299,23 @@ in
     else
       config.devenv.state + "/klangk/podman/policy.json"
   );
+  # Same story for registries.conf (#286): rootless podman from nix ships
+  # none, so any build whose Dockerfile uses a short image name (alpine:3.21,
+  # python:3.13-slim, debian:trixie-slim, node:26-slim) fails with "short-name
+  # ... did not resolve to an alias and no containers-registries-conf(5) was
+  # found". Unlike the policy, podman DOES read this env var directly (no CLI
+  # flag needed), so every podman invocation in the shell — including ones
+  # that don't go through scripts/_podman_common.sh — picks it up. enterShell
+  # seeds the file; _podman_common.sh re-creates it as a safety net for direct
+  # script invocation (podman hard-fails when the var points at a missing
+  # file). On macOS podman builds inside its VM, which ships its own
+  # registries.conf, so leave this empty there.
+  env.CONTAINERS_REGISTRIES_CONF = lib.mkOverride 1500 (
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      ""
+    else
+      config.devenv.state + "/klangk/podman/registries.conf"
+  );
   env.KLANGKD_VERSION_FILE = versionFile;
   # state_dir / frontend_dir live in klangkd.yaml (cmd:-indirected to
   # $DEVENV_STATE / $DEVENV_ROOT) — see klangkd.yaml.devenv. IMAGE_NAME and
@@ -682,6 +699,10 @@ in
     if [ ! -f "$_PODMAN_CONF/policy.json" ]; then
       echo '{"default": [{"type": "insecureAcceptAnything"}]}' \
         > "$_PODMAN_CONF/policy.json"
+    fi
+    if [ ! -f "$_PODMAN_CONF/registries.conf" ]; then
+      echo 'unqualified-search-registries = ["docker.io"]' \
+        > "$_PODMAN_CONF/registries.conf"
     fi
 
     # On macOS, podman requires a VM; init and start it if needed.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1148,6 +1148,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Short image names resolve in fresh checkouts (#286).** devenv now
+  exports `CONTAINERS_REGISTRIES_CONF` and seeds a
+  `registries.conf` (`unqualified-search-registries = ["docker.io"]`)
+  next to the podman signature policy, so image builds that reference
+  short names (`alpine:3.21`, `python:3.13-slim`, …) no longer fail with
+  `short-name ... did not resolve to an alias and no
+containers-registries.conf(5) was found`.
+
 - **Workspace Restart button after a server restart (#2674).** Clicking
   Restart while the browser sat on the container-stopped overlay during a
   host shutdown/restart used to spin forever: the WebSocket had given up

--- a/docs/reference/podman.md
+++ b/docs/reference/podman.md
@@ -59,6 +59,27 @@ Alternatively, create it system-wide at `/etc/containers/policy.json`.
 Without this file, podman operations fail with confusing errors about
 missing signatures or policies.
 
+## Short Image Names (registries.conf)
+
+Podman also needs a `containers-registries.conf(5)` to resolve a short
+image name like `alpine:3.21` to a registry. The devenv shell creates one
+automatically (`unqualified-search-registries = ["docker.io"]`, exported
+via `CONTAINERS_REGISTRIES_CONF`), but outside of devenv you need to
+create it yourself:
+
+```bash
+mkdir -p ~/.config/containers
+cat > ~/.config/containers/registries.conf <<'EOF'
+unqualified-search-registries = ["docker.io"]
+EOF
+```
+
+Without this file, builds referencing a short name fail with `short-name
+"alpine:3.21" did not resolve to an alias and no
+containers-registries.conf(5) was found`. Alternatively, use a
+fully-qualified image reference (`docker.io/library/alpine:3.21`) in the
+Dockerfile, which skips resolution entirely.
+
 ## Configuring Storage
 
 By default, podman stores images and runtime state under

--- a/scripts/_podman_common.sh
+++ b/scripts/_podman_common.sh
@@ -3,7 +3,9 @@
 #   build-workspace-image.sh, build-base-image.sh, pull-base-image.sh
 #
 # Sets SIG_POLICY_ARGS, expanded into every `podman build` / `podman pull`
-# invocation via "${SIG_POLICY_ARGS[@]}".
+# invocation via "${SIG_POLICY_ARGS[@]}", and ensures the registries.conf
+# named by CONTAINERS_REGISTRIES_CONF exists (#286) so short image names
+# resolve.
 #
 # Rootless podman from Nix ships no default /etc/containers/policy.json, so a
 # build/pull that verifies image signatures fails in a fresh environment
@@ -40,6 +42,22 @@ if [ -n "${CONTAINERS_SIGNATURE_POLICY:-}" ]; then
       >"$CONTAINERS_SIGNATURE_POLICY"
   fi
   SIG_POLICY_ARGS=(--signature-policy "$CONTAINERS_SIGNATURE_POLICY")
+fi
+
+# Rootless podman from nix ships no registries.conf either, so short image
+# names in our Dockerfiles (alpine:3.21, python:3.13-slim, …) fail to resolve
+# (#286). Unlike the policy, podman reads CONTAINERS_REGISTRIES_CONF
+# directly, so no flag is passed — every podman call in the environment
+# inherits it. The scripts only ensure the file exists: podman hard-fails
+# with "loading registries configuration ... no such file or directory" when
+# the env var points at a missing path.
+if [ -n "${CONTAINERS_REGISTRIES_CONF:-}" ] &&
+  [ ! -f "$CONTAINERS_REGISTRIES_CONF" ]; then
+  mkdir -p "$(dirname "$CONTAINERS_REGISTRIES_CONF")"
+  # Same config as enterShell generates: every short name our Dockerfiles
+  # use lives on docker.io.
+  echo 'unqualified-search-registries = ["docker.io"]' \
+    >"$CONTAINERS_REGISTRIES_CONF"
 fi
 
 # --- Shared image-build helpers (build-workspace-image.sh,

--- a/scripts/tests/test_podman_registries_conf.py
+++ b/scripts/tests/test_podman_registries_conf.py
@@ -1,0 +1,126 @@
+"""Contract tests for the registries.conf provisioning (#286).
+
+Rootless podman from nix ships no ``containers-registries.conf(5)``, so any
+image build whose Dockerfile references a short image name
+(``alpine:3.21``, ``python:3.13-slim``, ``debian:trixie-slim``,
+``node:26-slim``) fails with:
+
+    Error: creating build container: short-name "alpine:3.21" did not
+    resolve to an alias and no containers-registries.conf(5) was found
+
+The fix has two halves, both pinned here (grep-style contract tests in the
+spirit of ``test_build_script_remote_guard.py`` — a future edit that drops
+one silently is loud):
+
+1. ``devenv.nix`` exports ``CONTAINERS_REGISTRIES_CONF`` (empty on macOS,
+   where builds run inside the podman VM) and enterShell seeds the file.
+   Unlike the signature policy (which podman only honors via the
+   ``--signature-policy`` flag), podman reads this env var directly, so no
+   CLI flag is threaded through the build scripts.
+2. ``scripts/_podman_common.sh`` — sourced by every build/pull script —
+   re-creates the file when the env var is set but the file is missing
+   (direct script invocation outside the devenv shell). This matters more
+   than the policy safety net: podman hard-fails with "loading registries
+   configuration ... no such file or directory" when the env var points at
+   a nonexistent path.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Make sure the scripts directory is importable.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEVENV_NIX = _REPO_ROOT / "devenv.nix"
+_PODMAN_COMMON = _REPO_ROOT / "scripts" / "_podman_common.sh"
+# Scripts with their own `podman build`/`pull`/`push` that must source the
+# shared helper (dist-smoke-test.sh is exempt: its Dockerfile uses the
+# fully-qualified docker.io/library/node:22-slim precisely to sidestep
+# short-name resolution).
+_HELPER_CONSUMER_SCRIPTS = [
+    "build-workspace-image.sh",
+    "build-network-sidecar.sh",
+    "build-base-image.sh",
+    "build-fips-image.sh",
+    "pull-base-image.sh",
+    "pull-fips-image.sh",
+]
+
+
+def test_build_pull_scripts_source_the_helper():
+    """Every build/pull script must source _podman_common.sh.
+
+    The registries.conf (and signature-policy) provisioning lives in the
+    shared helper; a script that drops the source line misses it.
+    """
+    for name in _HELPER_CONSUMER_SCRIPTS:
+        text = (_REPO_ROOT / "scripts" / name).read_text()
+        assert 'source "$SCRIPT_DIR/_podman_common.sh"' in text, (
+            f"{name} no longer sources _podman_common.sh — it misses the "
+            f"registries.conf/signature-policy provisioning (#286)"
+        )
+
+
+def test_devenv_exports_registries_conf():
+    """devenv.nix must export CONTAINERS_REGISTRIES_CONF on Linux.
+
+    Without the export, every podman invocation inside the shell (including
+    ones that don't source _podman_common.sh) resolves short names against
+    a config that does not exist on nix-rootless podman.
+    """
+    text = _DEVENV_NIX.read_text()
+    assert "CONTAINERS_REGISTRIES_CONF" in text, (
+        "devenv.nix no longer exports CONTAINERS_REGISTRIES_CONF — short "
+        "image names fail to resolve (#286)"
+    )
+    # The export must be gated off on macOS (podman builds run inside the
+    # VM, which ships its own registries.conf).
+    m = re.search(
+        r"env\.CONTAINERS_REGISTRIES_CONF.*?if pkgs\.stdenv\.hostPlatform\.isDarwin",
+        text,
+        re.DOTALL,
+    )
+    assert m, (
+        "CONTAINERS_REGISTRIES_CONF must be empty on Darwin (the podman VM "
+        "has its own registries.conf) — the isDarwin gate is gone (#286)"
+    )
+
+
+def test_enter_shell_seeds_registries_conf():
+    """enterShell must seed the registries.conf next to policy.json.
+
+    The env var pointing at a missing file is worse than no env var at all:
+    podman hard-fails with "loading registries configuration ... no such
+    file or directory" instead of falling back to defaults.
+    """
+    text = _DEVENV_NIX.read_text()
+    assert 'unqualified-search-registries = ["docker.io"]' in text, (
+        "enterShell no longer seeds a registries.conf with docker.io in "
+        "unqualified-search-registries (#286)"
+    )
+    assert "$_PODMAN_CONF/registries.conf" in text, (
+        "enterShell must write registries.conf into the same state dir as "
+        "policy.json ($_PODMAN_CONF) — the seeding block is gone (#286)"
+    )
+
+
+def test_podman_common_recreates_missing_file():
+    """_podman_common.sh must recreate the file when the env var is set.
+
+    Covers direct script invocation outside the devenv shell, where
+    enterShell never ran. Mirrors the policy.json safety net.
+    """
+    text = _PODMAN_COMMON.read_text()
+    assert re.search(r'\[ -n "\$\{CONTAINERS_REGISTRIES_CONF:-\}" \]', text), (
+        "_podman_common.sh no longer checks CONTAINERS_REGISTRIES_CONF — "
+        "direct invocation outside devenv fails on short names (#286)"
+    )
+    assert 'unqualified-search-registries = ["docker.io"]' in text, (
+        "_podman_common.sh must write the same docker.io unqualified-search "
+        "config as enterShell (#286)"
+    )


### PR DESCRIPTION
## Summary

Fixes #286.

Rootless podman from nix ships no `containers-registries.conf(5)`, so in a fresh checkout every image build whose Dockerfile references a short image name (`alpine:3.21`, `python:3.13-slim`, `debian:trixie-slim`, `node:26-slim`) fails with:

```
Error: creating build container: short-name "alpine:3.21" did not resolve to an alias and no containers-registries.conf(5) was found
```

The signature-policy half of this problem was already solved (`CONTAINERS_SIGNATURE_POLICY` + `--signature-policy` in `scripts/_podman_common.sh`, #1230); this adds the missing registries.conf half.

## Changes

- **`devenv.nix`** — export `CONTAINERS_REGISTRIES_CONF` pointing at `<state>/klangk/podman/registries.conf` (empty on macOS, where builds run inside the podman VM). Unlike the signature policy, podman reads this env var directly — no CLI flag needed, so every podman invocation in the shell picks it up. `enterShell` seeds the file next to `policy.json`.
- **`scripts/_podman_common.sh`** — safety net: recreate the file when the env var is set but missing (direct script invocation outside devenv). This matters more than the policy safety net: podman hard-fails with `loading registries configuration ... no such file or directory` when the var points at a nonexistent path.
- **`scripts/tests/test_podman_registries_conf.py`** — contract tests pinning both halves (devenv export + isDarwin gate, enterShell seeding, helper recreate, consumers keep sourcing the helper).
- **`docs/reference/podman.md`** — document the manual equivalent outside devenv.

## Verification

- Reproduced the failure (`CONTAINERS_REGISTRIES_CONF` at a missing path → `short-name "alpine:3.21" did not resolve`), then verified the fix end-to-end in the worktree shell: `FROM alpine:3.21` builds successfully.
- `pytest scripts/tests` — 63 passed.
- shellcheck / shfmt / nixfmt / markdownlint clean; pre-commit hooks pass.
- Backend suite left to CI per request.
