### PR TITLE
fix: restart reuses live container; sidecar clear handles dependents (#2676)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1164,6 +1164,14 @@ containers-registries.conf(5) was found`.
   admin previously logged out now lands on `/workspaces`, not the admin
   page the previous session was viewing.
 
+- **Restart button with a still-running container (#2676).** Pressing
+  Restart after an unclean host shutdown/restart no longer fails with a
+  raw `dependent containers` podman error and a dropped WebSocket: the
+  restart now always reads the workspace fresh from the database (so a
+  live container is reused, like a reconnect does), a create-path start
+  whose lingering network sidecar is pinned by a dependent removes the
+  dependent first, and any remaining start failure is reported as an
+  error frame with a clear message while the session stays connected.
 - **Workspace Restart button after a server restart (#2674).** Clicking
   Restart while the browser sat on the container-stopped overlay during a
   host shutdown/restart used to spin forever: the WebSocket had given up

--- a/src/frontend/lib/workspace/workspace_connector.dart
+++ b/src/frontend/lib/workspace/workspace_connector.dart
@@ -30,6 +30,13 @@ class WorkspaceConnector {
   /// Called when a permission/auth error arrives.
   final void Function(String error) onPermissionError;
 
+  /// Called when a non-permission error arrives while a restart is in
+  /// flight (#2676): the server now refuses a failed container restart
+  /// with an `error` frame instead of dropping the socket, so the page
+  /// must clear its restart spinner on this callback. May fire for
+  /// unrelated errors too — the owner filters by its own state.
+  final void Function(String error)? onRestartError;
+
   BrowserDelegate? _browserDelegate;
   StreamSubscription<Map<String, dynamic>>? _customEventSub;
   StreamSubscription<String>? _errorSub;
@@ -43,6 +50,7 @@ class WorkspaceConnector {
     required this.onContainerEvent,
     required this.onSharedTerminalDeleted,
     required this.onPermissionError,
+    this.onRestartError,
   });
 
   /// Whether [connect] has been called and subscriptions are active.
@@ -130,6 +138,10 @@ class WorkspaceConnector {
       final lower = error.toLowerCase();
       if (lower.contains('permission') || lower.contains('denied')) {
         onPermissionError(error);
+      } else {
+        // #2676: anything else (e.g. a refused container restart) goes to
+        // the optional restart-error hook; the owner decides relevance.
+        onRestartError?.call(error);
       }
     });
 

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -246,6 +246,22 @@ class _WorkspacePageState extends State<WorkspacePage> {
           });
         }
       },
+      // #2676: the server refuses a failed restart with an error frame
+      // (instead of dropping the socket), so the spinner must clear here —
+      // no container_ready ever arrives for it.
+      onRestartError: (error) {
+        if (!mounted || !_restarting) return;
+        setState(() => _restarting = false);
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text('Restart failed: $error'),
+              duration: const Duration(seconds: 6),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      },
       onSharedTerminalDeleted: (msg) {
         if (!mounted) return;
         final deletedUserId = msg['user_id'] as String? ?? '';

--- a/src/frontend/test/workspace_connector_test.dart
+++ b/src/frontend/test/workspace_connector_test.dart
@@ -243,6 +243,62 @@ void main() {
       ws.close();
     });
 
+    test('forwards non-permission errors to onRestartError (#2676)', () async {
+      final ws = _MockWsClient();
+      final restartErrors = <String>[];
+
+      final connector = WorkspaceConnector(
+        wsClient: ws,
+        workspaceId: 'ws-1',
+        featureRegistry: ToolPluginRegistry(),
+        onConnected: ({required connected, error}) {},
+        onContainerEvent: (_, __) {},
+        onSharedTerminalDeleted: (_) {},
+        onPermissionError: (_) {},
+        onRestartError: (e) => restartErrors.add(e),
+      );
+
+      await connector.connect();
+
+      // A refused restart (server sends an error frame instead of dropping
+      // the socket) reaches the hook…
+      ws.emitError('Container restart failed: dependent containers');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(restartErrors, ['Container restart failed: dependent containers']);
+
+      // …but permission errors do not (they stay on onPermissionError).
+      ws.emitError('Permission denied');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(restartErrors, hasLength(1));
+
+      connector.dispose();
+      ws.close();
+    });
+
+    test('onRestartError absent: non-permission errors are dropped', () async {
+      final ws = _MockWsClient();
+
+      final connector = WorkspaceConnector(
+        wsClient: ws,
+        workspaceId: 'ws-1',
+        featureRegistry: ToolPluginRegistry(),
+        onConnected: ({required connected, error}) {},
+        onContainerEvent: (_, __) {},
+        onSharedTerminalDeleted: (_) {},
+        onPermissionError: (_) {},
+      );
+
+      await connector.connect();
+
+      ws.emitError('Connection timeout');
+      await Future<void>.delayed(Duration.zero);
+
+      connector.dispose();
+      ws.close();
+    });
+
     test('reconnect disposes old subscriptions and reconnects', () async {
       final ws = _MockWsClient();
       int connectedCount = 0;

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -687,6 +687,24 @@ class ContainerRegistry(NetworkSidecarMixin):
                 "Could not find container %s, creating new one",
                 existing_container_id,
             )
+            # #2676: the id can be stale (an unclean host shutdown/restart,
+            # or another connection recreated the container without this
+            # caller's DB snapshot updating). Reconcile against live podman
+            # state by label before creating: a running workspace container
+            # is adopted exactly like a matching id above (this is the path
+            # a reconnect takes and why it self-heals), and a stopped one is
+            # removed. Without this, the create path would race the live
+            # pair — the sidecar pre-remove is refused with "dependent
+            # containers" while its workspace container is attached.
+            adopted = await self._adopt_labeled_container(
+                workspace_id,
+                t_start,
+                health_check=health_check,
+                owner_id=owner_id,
+                setup_state=setup_state,
+            )
+            if adopted is not None:
+                return adopted
             return None
         if info["State"]["Running"]:
             # FIPS gate on adoption (#2626 review): a container started
@@ -722,6 +740,84 @@ class ContainerRegistry(NetworkSidecarMixin):
             existing_container_id,
             workspace_id,
         )
+        return None
+
+    async def _adopt_labeled_container(
+        self,
+        workspace_id: str,
+        t_start: float,
+        *,
+        health_check: str | None = None,
+        owner_id: str | None = None,
+        setup_state: str | None = None,
+    ) -> tuple[str, str] | None:
+        """Adopt a live workspace container found by label (#2676).
+
+        The id passed to :meth:`start_container` can be stale (an unclean
+        host shutdown/restart, or another connection recreated the container
+        without the caller's snapshot updating). This reconcile step looks
+        up the workspace's container by its ``klangk.workspace`` label —
+        the same identity the reaper and sidecar sweeps key on — and:
+
+        - running  -> adopt it: same semantics as the matching-id branch of
+          :meth:`_handle_existing_container` (FIPS gate, re-track), plus the
+          DB ``container_id`` is re-persisted so the staleness heals for
+          every later caller;
+        - stopped  -> remove it (so the create path's sidecar pre-remove
+          can't be refused for a still-attached dependent), then fall
+          through to create.
+
+        Returns ``(container_id, "connected")`` on adoption, or ``None``
+        when no labeled container exists (a plain fresh create).
+        """
+        try:
+            containers = await self.app.state.podman.list_containers(
+                f"klangk.workspace={workspace_id}"
+            )
+        except (podman.PodmanError, OSError, ValueError):
+            # Best-effort reconcile: a failed ps must not break a start
+            # that may legitimately create a fresh container.
+            return None
+        for c in containers:
+            labels = c.get("Labels") or {}
+            if labels.get("klangk.role") != "workspace":
+                continue  # the network sidecar shares the workspace label
+            ident = container_ident(c)
+            if not ident:
+                continue
+            running = str(c.get("State", "")).lower() == "running"
+            if not running:
+                await self.app.state.podman.remove_container(ident)
+                logger.info(
+                    "workspace-open: removed stopped labeled container %s "
+                    "for workspace %s, will recreate",
+                    ident[:12],
+                    workspace_id[:8],
+                )
+                continue
+            # Adopt the running container — this is exactly what a fresh
+            # connect does with a current id, and why a reconnect after a
+            # failed restart self-heals today (#2676).
+            if self.app.state.settings.fips_mode:
+                await self._fips_gate(workspace_id, ident)
+            await self.app.state.model.workspaces.update_workspace_container(
+                workspace_id, ident
+            )
+            self.track_activity(
+                ident,
+                workspace_id,
+                health_check=health_check,
+                owner_id=owner_id,
+                setup_state=setup_state,
+            )
+            logger.info(
+                "workspace-open: DONE — adopted running labeled container "
+                "%s for stale-id workspace %s: %.3fs",
+                ident[:12],
+                workspace_id[:8],
+                time.monotonic() - t_start,
+            )
+            return ident, "connected"
         return None
 
     async def _reconcile_ports(

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -285,8 +285,25 @@ class NetworkSidecarMixin:
         # differ from a prior generation's (a rename) and can't be
         # reconstructed from the id alone. The instance reaper is the
         # backstop for orphans; this just keeps a restart from deadlocking.
-        await self._remove_network_sidecar(workspace_id)
+        # #2676: when the clear fails — a container is still joined to the
+        # old sidecar's netns (podman's "dependent containers" refusal) or
+        # podman otherwise refuses the removal — refuse here with a clear
+        # error instead of swallowing it and letting create_container's
+        # --replace collide with the same refusal (a raw 500 + traceback at
+        # the caller, guaranteed whenever the dependent survives). Inside
+        # the try so the fail-closed warning below logs it like any other
+        # sidecar start failure.
         try:
+            if not await self._remove_network_sidecar(workspace_id):
+                raise podman.PodmanError(
+                    500,
+                    "cannot remove the existing network sidecar for "
+                    f"workspace {workspace_id[:8]}: a container is still "
+                    "joined to its network namespace (podman's dependent "
+                    "containers refusal) or podman refused the removal; "
+                    "stop or remove the workspace's containers before "
+                    "starting it again",
+                )
             # NET_RAW lets the proxy forge the eager-deny RST directly from
             # the NFQUEUE callback (#2345) so a denied connect() gets
             # ECONNREFUSED at once, independent of the conntrack/retransmit
@@ -364,7 +381,7 @@ class NetworkSidecarMixin:
             return
         await self._remove_network_sidecar(workspace_id)
 
-    async def _remove_network_sidecar(self, workspace_id: str) -> None:
+    async def _remove_network_sidecar(self, workspace_id: str) -> bool:
         """Best-effort remove this workspace's network sidecar by label (#2286).
 
         Keyed on ``klangk.workspace=<workspace_id>`` +
@@ -374,20 +391,29 @@ class NetworkSidecarMixin:
         restart (the in-memory set is gone). Label-based removal finds the
         sidecar regardless, leaves the workspace container (role=workspace)
         untouched, and is 404-tolerant.
+
+        Returns True when no same-label sidecar remains — none existed, all
+        were removed, or the state is unknowable (a list failure keeps the
+        old proceed-anyway semantics). Returns False when a labeled sidecar
+        survived removal (#2676): the create path that calls this before
+        ``create_container --replace`` refuses to collide with it (podman's
+        rm does not override the dependent-containers check), and the stop
+        paths log it and fall back to the reaper.
+
+        #2676: a sidecar whose workspace container is still joined to its
+        netns (``--network container:<sidecar>``) cannot be removed — podman
+        refuses with "has dependent containers" and ``rm -f`` does not
+        override that check (the same lesson as the reapers'
+        dependents-first ordering, #2476). On that refusal the dependent
+        workspace containers of *this* workspace (label-matched, so a
+        foreign container joined to the netns is never touched) are removed
+        first and the sidecar removal retried once — the create path that
+        called this is about to replace those containers anyway.
         """
-        try:
-            containers = await self.app.state.podman.list_containers(
-                f"klangk.workspace={workspace_id}"
-            )
-        except (podman.PodmanError, OSError, ValueError) as exc:
-            # ValueError: corrupted ps JSON (json.loads in list_containers) —
-            # best-effort removal must never raise into the caller.
-            logger.warning(
-                "cannot list containers to remove network sidecar for %s: %s",
-                workspace_id[:8],
-                exc,
-            )
-            return
+        containers = await self._list_workspace_containers(workspace_id)
+        if containers is None:
+            return True
+        failures: list[tuple[str, podman.PodmanError]] = []
         for c in containers:
             labels = c.get("Labels") or {}
             if labels.get("klangk.role") != "network-sidecar":
@@ -395,12 +421,124 @@ class NetworkSidecarMixin:
             ident = container_ident(c)
             if not ident:
                 continue
+            exc = await self._force_remove_sidecar(workspace_id, ident)
+            if exc is not None:
+                failures.append((ident, exc))
+        if not failures:
+            return True
+        # A removal refused. Re-list: the error may be a benign race (the
+        # container vanished between list and rm — "no such container");
+        # only a sidecar that is still present can collide with the create
+        # that follows, so judge by observable state, not the error text.
+        remaining = await self._list_workspace_containers(workspace_id)
+        if remaining is None:
+            return True
+        remaining_sidecars = {
+            container_ident(c)
+            for c in remaining
+            if (c.get("Labels") or {}).get("klangk.role") == "network-sidecar"
+        }
+        blocked = [(i, e) for i, e in failures if i in remaining_sidecars]
+        for ident, exc in blocked:
+            logger.warning(
+                "network sidecar %s for %s could not be removed: %s",
+                ident[:12],
+                workspace_id[:8],
+                exc,
+            )
+        return not blocked
+
+    async def _list_workspace_containers(
+        self, workspace_id: str
+    ) -> list[dict] | None:
+        """List this workspace's labeled containers, or None when unknowable.
+
+        Best-effort callers must never raise into their caller (#2286):
+        podman errors, OSError, and corrupted ps JSON (``json.loads`` in
+        ``list_containers`` — ValueError) all map to None so the caller can
+        proceed as before.
+        """
+        try:
+            return await self.app.state.podman.list_containers(
+                f"klangk.workspace={workspace_id}"
+            )
+        except (podman.PodmanError, OSError, ValueError) as exc:
+            logger.warning(
+                "cannot list containers for network sidecar of %s: %s",
+                workspace_id[:8],
+                exc,
+            )
+            return None
+
+    async def _force_remove_sidecar(
+        self, workspace_id: str, ident: str
+    ) -> podman.PodmanError | None:
+        """Force-remove one sidecar container; None on success (#2676).
+
+        On podman's dependent-containers refusal, first remove this
+        workspace's own labeled workspace containers (the dependents) and
+        retry the sidecar removal once. Returns the final error (if any)
+        for the caller to classify against a fresh listing; never raises.
+        """
+        try:
+            await self.app.state.podman.remove_container(ident, force=True)
+        except podman.PodmanError as exc:
+            if "dependent containers" not in str(exc):
+                return exc  # already gone / transient — caller re-lists
+            logger.info(
+                "sidecar %s for %s has dependent containers; removing the "
+                "workspace's own containers to free it (#2676)",
+                ident[:12],
+                workspace_id[:8],
+            )
+            await self._remove_dependent_workspace_containers(workspace_id)
+            try:
+                await self.app.state.podman.remove_container(ident, force=True)
+            except podman.PodmanError as retry_exc:
+                return retry_exc
+        logger.info(
+            "network sidecar removed for %s: %s",
+            workspace_id[:8],
+            ident[:12],
+        )
+        return None
+
+    async def _remove_dependent_workspace_containers(
+        self, workspace_id: str
+    ) -> None:
+        """Remove this workspace's labeled workspace (dependent) containers.
+
+        Called only when podman refuses to remove a sidecar because a
+        dependent container is still joined to its netns (#2676). Only
+        containers carrying both ``klangk.workspace=<id>`` and
+        ``klangk.role=workspace`` are touched — ours — so a foreign
+        dependent stays put and the sidecar refusal surfaces to the caller
+        instead. Best-effort: each removal's failure is logged and
+        swallowed so one stuck container never aborts the loop.
+        """
+        containers = await self._list_workspace_containers(workspace_id)
+        if containers is None:
+            return
+        for c in containers:
+            labels = c.get("Labels") or {}
+            if labels.get("klangk.role") != "workspace":
+                continue
+            ident = container_ident(c)
+            if not ident:
+                continue
             try:
                 await self.app.state.podman.remove_container(ident, force=True)
                 logger.info(
-                    "network sidecar removed for %s: %s",
-                    workspace_id[:8],
+                    "removed dependent workspace container %s to free the "
+                    "network sidecar for %s",
                     ident[:12],
+                    workspace_id[:8],
                 )
-            except podman.PodmanError:
-                pass  # already gone — expected
+            except podman.PodmanError as exc:
+                logger.warning(
+                    "could not remove dependent workspace container %s for "
+                    "%s: %s",
+                    ident[:12],
+                    workspace_id[:8],
+                    exc,
+                )

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from .. import container, model
 from ..exceptions import NodeDrainingError
 from ..terminal import TerminalSession
-from ..podman import ExecSession
+from ..podman import ExecSession, PodmanError
 from .constants import (
     agent_conversations,
     agent_tasks,
@@ -533,8 +533,6 @@ class Connection:
 
         # Save before cleanup — cleanup clears state fields.
         workspace_id = self.workspace_id
-        user = self.user
-        workspace = self.workspace
 
         send_event(self.sock, "container_restart", "Restarting container...")
 
@@ -543,10 +541,16 @@ class Connection:
         except WS_ERRORS as e:
             logger.warning("Cleanup error during restart: %s", e)
 
-        if workspace is None:
-            workspace = await self.app.state.workspaces.get_workspace(
-                workspace_id, user["id"]
-            )
+        # Always read the workspace fresh from the DB (#2676): the cached
+        # self.workspace dict can carry a stale container_id (an unclean
+        # host shutdown/restart can leave the running container under a new
+        # id), which sends the restart down the create path into a network
+        # sidecar collision instead of the reuse path a reconnect takes.
+        # Like handle_workspace_connect, read without the owner filter —
+        # access is already gated by the terminal-permission ACL check
+        # above, and an owner-only read would break restart for shared
+        # workspaces' non-owner members.
+        workspace = await self.app.state.workspaces.get_workspace(workspace_id)
         if workspace is None:
             send_error(self.sock, "Workspace not found")
             return
@@ -557,6 +561,12 @@ class Connection:
             # Draining node (#2527) — same clear refusal on the WS restart
             # path as the API's 503.
             send_error(self.sock, str(exc))
+            return
+        except (PodmanError, ValueError) as exc:
+            # A failed (re)start must not drop the whole WebSocket with a
+            # traceback (#2676) — the user's session survives and can retry;
+            # the error frame surfaces the actionable podman message.
+            send_error(self.sock, f"Container restart failed: {exc}")
             return
         self.app.state.container_registry.record_activity(self.container_id)
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -2805,6 +2805,183 @@ class TestStartContainer:
         p.start_container.assert_not_awaited()
         p.create_container.assert_not_awaited()
 
+    async def test_stale_id_adopts_running_labeled_container(
+        self, workspace, user
+    ):
+        # #2676: after an unclean host restart the id carried by the
+        # caller's snapshot can be stale while a (differently-id'd)
+        # workspace container is actually running. The start path must
+        # reconcile against live podman state by label — adopting the
+        # running container exactly like a matching-id reconnect —
+        # instead of racing the create path into the live pair.
+        ws_id = workspace["id"]
+        live = {
+            "Id": "live-cid",
+            "Names": ["klangk-ws"],
+            "State": "running",
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            inspect_container=AsyncMock(return_value=None),
+            list_containers=AsyncMock(return_value=[live]),
+        ) as p:
+            cid, status = await self.registry.start_container(
+                container.ContainerStartSpec(
+                    ws_id,
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="stale-cid",
+                )
+            )
+        assert cid == "live-cid"
+        assert status == "connected"
+        p.create_container.assert_not_awaited()
+        p.start_container.assert_not_awaited()
+        p.remove_container.assert_not_awaited()
+        # The DB id is re-persisted so the staleness heals for every
+        # later caller (restart, API start, reconnect).
+        fresh = await self.registry.app.state.model.workspaces.get_workspace(
+            ws_id, user["id"]
+        )
+        assert fresh["container_id"] == "live-cid"
+
+    async def test_stale_id_adopt_skips_unidentifiable_entries(
+        self, workspace
+    ):
+        # #2676: a ps entry with no usable ident (no Id/ID/Names) is
+        # skipped, not crashed on.
+        ws_id = workspace["id"]
+        identless = {
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+            # no Id / ID / Names
+        }
+        with patch_podman(
+            self.registry,
+            inspect_container=AsyncMock(return_value=None),
+            list_containers=AsyncMock(return_value=[identless]),
+        ) as p:
+            cid, status = await self.registry.start_container(
+                container.ContainerStartSpec(
+                    ws_id,
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="stale-cid",
+                )
+            )
+        # Nothing to adopt — a fresh container was created.
+        assert cid == "new-cid"
+        assert status == "created"
+        p.remove_container.assert_not_awaited()
+
+    async def test_stale_id_adopt_runs_fips_gate(self, workspace, monkeypatch):
+        # #2676: adoption is the _handle_existing_container running branch
+        # — the FIPS gate (#2626) must run on the label-adopted container
+        # too, not only on a matching-id adopt.
+        ws_id = workspace["id"]
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "fips_mode", True
+        )
+        live = {
+            "Id": "live-cid",
+            "State": "running",
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+        gate = AsyncMock()
+        with (
+            patch_podman(
+                self.registry,
+                inspect_container=AsyncMock(return_value=None),
+                list_containers=AsyncMock(return_value=[live]),
+            ),
+            patch.object(self.registry, "_fips_gate", gate),
+        ):
+            await self.registry.start_container(
+                container.ContainerStartSpec(
+                    ws_id,
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="stale-cid",
+                )
+            )
+        gate.assert_awaited_once_with(ws_id, "live-cid")
+
+    async def test_stale_id_removes_stopped_labeled_container(self, workspace):
+        # #2676: a STOPPED labeled container found by the reconcile scan is
+        # removed before the create proceeds — a present dependent would
+        # make the sidecar pre-remove's rm fail with "dependent containers".
+        ws_id = workspace["id"]
+        stopped = {
+            "Id": "stopped-cid",
+            "Names": ["klangk-ws"],
+            "State": "exited",
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+        sidecar = {
+            "Id": "sidecar-cid",
+            "Names": ["klangk-net"],
+            "State": "exited",
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            inspect_container=AsyncMock(return_value=None),
+            list_containers=AsyncMock(return_value=[stopped, sidecar]),
+        ) as p:
+            cid, status = await self.registry.start_container(
+                container.ContainerStartSpec(
+                    ws_id,
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="stale-cid",
+                )
+            )
+        assert cid == "new-cid"
+        assert status == "created"
+        # Only the workspace container was removed — the scan's role
+        # filter leaves the sidecar to the sidecar paths.
+        assert p.remove_container.await_args_list[0].args == ("stopped-cid",)
+        assert len(p.remove_container.await_args_list) == 1
+
+    async def test_stale_id_scan_failure_falls_through_to_create(
+        self, workspace
+    ):
+        # #2676: the label reconcile is best-effort — a failed `podman ps`
+        # must not break a start that would legitimately create a fresh
+        # container.
+        with patch_podman(
+            self.registry,
+            inspect_container=AsyncMock(return_value=None),
+            list_containers=AsyncMock(
+                side_effect=podman.PodmanError(500, "ps failed")
+            ),
+        ):
+            cid, status = await self.registry.start_container(
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    existing_container_id="stale-cid",
+                )
+            )
+        assert cid == "new-cid"
+        assert status == "created"
+
     async def test_reuse_running_filtered_container_retracks_sidecar(
         self, workspace, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1023,9 +1023,10 @@ class TestStartContainer:
         self, monkeypatch
     ):
         # #2265 + #2286: the pre-create removal of a lingering sidecar is
-        # best-effort -- if the per-container remove errors (the id is already
-        # gone, or podman hiccups), _remove_network_sidecar swallows it and
-        # the create proceeds normally.
+        # best-effort -- if the per-container remove errors, the state is
+        # judged by a re-list (#2676): the rm error here is the already-gone
+        # race (list saw it, rm 404s, the re-list no longer does), so the
+        # create proceeds normally.
         ws_id = "abcdef1234567890"
         monkeypatch.setattr(
             self.registry.app.state.settings,
@@ -1045,7 +1046,9 @@ class TestStartContainer:
         }
         with patch_podman(
             self.registry,
-            list_containers=AsyncMock(return_value=[stale]),
+            # First list (the clear) sees the stale sidecar; the post-failure
+            # re-list no longer does — the already-gone race.
+            list_containers=AsyncMock(side_effect=[[stale], []]),
             remove_container=AsyncMock(
                 side_effect=podman.PodmanError(500, "not found")
             ),
@@ -1057,6 +1060,214 @@ class TestStartContainer:
             cid == "new-cid"
         )  # create still happened despite the remove error
         assert p.create_container.await_count == 1
+
+    async def test_start_network_sidecar_clears_dependents_then_creates(
+        self, monkeypatch
+    ):
+        # #2676: podman refuses to rm -f a sidecar whose workspace container
+        # is still joined to its netns ("has dependent containers"). The
+        # clear removes THIS workspace's own role=workspace containers (the
+        # dependents) and retries the sidecar removal, so a create-path start
+        # against a stale live container+sidecar pair succeeds instead of
+        # dying on the raw dependent-containers refusal.
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        from klangk import netfilter as _nf
+
+        monkeypatch.setattr(_nf, "_detect_host_resolvers", lambda: ["8.8.8.8"])
+        sidecar = {
+            "Id": "sidecar-cid",
+            "Names": ["klangk-net-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        ws_container = {
+            "Id": "ws-cid",
+            "Names": ["klangk-ws-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+
+        async def remove(ident, force=True):
+            if ident == "sidecar-cid":
+                # First sidecar rm: refused (dependent). Retry after the
+                # dependent was removed: succeeds.
+                if remove.sidecar_calls == 0:
+                    remove.sidecar_calls += 1
+                    raise podman.PodmanError(
+                        500,
+                        "container sidecar-cid has dependent containers "
+                        "which must be removed before it: ws-cid",
+                    )
+                return
+
+        remove.sidecar_calls = 0
+
+        with patch_podman(
+            self.registry,
+            # 1) the clear's list (sees pair), 2) the dependent listing
+            # (sees pair), 3) would be the survivor re-list — never reached
+            # because the retry removes the sidecar.
+            list_containers=AsyncMock(
+                side_effect=[[sidecar, ws_container]] * 3
+            ),
+            remove_container=AsyncMock(side_effect=remove),
+        ) as p:
+            cid = await self.registry._start_network_sidecar(
+                ws_id, ["github.com:443"]
+            )
+        assert cid == "new-cid"
+        removed = [c.args[0] for c in p.remove_container.call_args_list]
+        # Dependent (this workspace's container) removed before the sidecar
+        # retry, never the other way around.
+        assert removed == ["sidecar-cid", "ws-cid", "sidecar-cid"]
+        assert p.create_container.await_count == 1
+
+    async def test_start_network_sidecar_clean_error_when_sidecar_survives(
+        self, monkeypatch
+    ):
+        # #2676: when the dependent can't be removed (here: the rm keeps
+        # refusing — e.g. a foreign container joined to the netns), the
+        # create path refuses with a clear, actionable error instead of
+        # swallowing the refusal and letting create_container --replace hit
+        # podman's raw dependent-containers 500.
+        ws_id = "abcdef1234567890"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        sidecar = {
+            "Id": "sidecar-cid",
+            "Names": ["klangk-net-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        ws_container = {
+            "Id": "ws-cid",
+            "Names": ["klangk-ws-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+        dep_refusal = podman.PodmanError(
+            500,
+            "container sidecar-cid has dependent containers which must "
+            "be removed before it: foreign-cid",
+        )
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                side_effect=[[sidecar, ws_container]] * 4
+            ),
+            remove_container=AsyncMock(side_effect=dep_refusal),
+        ) as p:
+            with pytest.raises(podman.PodmanError) as excinfo:
+                await self.registry._start_network_sidecar(
+                    ws_id, ["github.com:443"]
+                )
+        assert "cannot remove the existing network sidecar" in str(
+            excinfo.value
+        )
+        assert "dependent" in str(excinfo.value)
+        # The create never ran — no collision attempt against the survivor.
+        p.create_container.assert_not_awaited()
+
+    async def test_remove_network_sidecar_true_when_clear(self, monkeypatch):
+        # #2676: the bool contract — nothing to remove means cleared.
+        ws_id = "abcdef1234567890"
+        with patch_podman(self.registry) as p:
+            assert await self.registry._remove_network_sidecar(ws_id) is True
+        p.remove_container.assert_not_awaited()
+
+    async def test_remove_network_sidecar_survivor_relist_error_proceeds(
+        self, monkeypatch
+    ):
+        # #2676: when the survivor re-list itself errors after a refused
+        # removal, the state is unknowable — proceed (the old best-effort
+        # semantics) instead of refusing the create on a podman hiccup.
+        ws_id = "abcdef1234567890"
+        sidecar = {
+            "Id": "sidecar-cid",
+            "Names": ["klangk-net-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                side_effect=[
+                    [sidecar],
+                    podman.PodmanError(500, "podman down"),
+                ]
+            ),
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(500, "refused")
+            ),
+        ):
+            assert await self.registry._remove_network_sidecar(ws_id) is True
+
+    async def test_remove_dependents_only_own_workspace_role(
+        self, monkeypatch
+    ):
+        # #2676: the dependent sweep touches only containers carrying both
+        # this workspace's label and role=workspace — a sidecar (or any
+        # other role) in the same listing is skipped — and an unknowable
+        # listing (podman down) is a quiet no-op.
+        ws_id = "abcdef1234567890"
+        ws_container = {
+            "Id": "ws-cid",
+            "Names": ["klangk-ws-abcdef12"],
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+        sidecar = {
+            "Id": "sidecar-cid",
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "network-sidecar",
+            },
+        }
+        # role=workspace but no id/name at all — skipped, not removed.
+        nameless = {
+            "Labels": {
+                "klangk.workspace": ws_id,
+                "klangk.role": "workspace",
+            },
+        }
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[sidecar, nameless, ws_container]
+            ),
+        ) as p:
+            await self.registry._remove_dependent_workspace_containers(ws_id)
+        p.remove_container.assert_awaited_once_with("ws-cid", force=True)
+
+        # Unknowable listing: no removals, no raise.
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                side_effect=podman.PodmanError(500, "podman down")
+            ),
+        ) as p:
+            await self.registry._remove_dependent_workspace_containers(ws_id)
+        p.remove_container.assert_not_awaited()
 
     async def test_start_network_sidecar_failure_raises(self, monkeypatch):
         # #2254 review B2: a network sidecar that can't start must surface the failure

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -5400,6 +5400,107 @@ class TestHandleRestartContainer:
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("not found" in str(c) for c in calls)
 
+    async def test_restart_reads_workspace_fresh_from_db(
+        self, user, app_state
+    ):
+        """#2676: restart must not trust the connection's cached workspace
+        dict. After an unclean host restart the cached container_id can be
+        stale, sending the restart down the create path (sidecar collision)
+        instead of the reuse path a reconnect takes 3 seconds later. The
+        DB row is the source of truth for container_id."""
+        app_state = _make_app_state()
+        sock = _mock_sock(headers={"host": "localhost:8997"})
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "restart-fresh"
+        )
+        fresh = {**workspace, "container_id": "cid-fresh"}
+        stale = {**workspace, "container_id": "cid-stale"}
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        conn.workspace_id = workspace["id"]
+        conn.container_id = "cid-stale"
+        conn.workspace = stale
+        conn._has_perm = AsyncMock(return_value=True)
+
+        started: list[tuple[str, dict]] = []
+
+        async def fake_start(wid, ws_obj):
+            started.append((wid, ws_obj))
+            conn.container_id = "cid-fresh"
+            conn.workspace_id = wid
+
+        with (
+            patch.object(
+                app_state.state.workspaces,
+                "get_workspace",
+                AsyncMock(return_value=fresh),
+            ) as mock_get,
+            patch.object(
+                Connection,
+                "start_workspace_container",
+                side_effect=fake_start,
+            ),
+            patch.object(Connection, "cleanup", new_callable=AsyncMock),
+            patch.object(
+                app_state.state.container_registry, "record_activity"
+            ),
+            patch.object(
+                app_state.state.container_registry,
+                "get_workspace_ports",
+                return_value=[],
+            ),
+        ):
+            await conn.handle_restart_container()
+
+        # Read fresh (not the cached stale dict) and started with it.
+        mock_get.assert_awaited_once_with(workspace["id"])
+        assert started == [(workspace["id"], fresh)]
+
+    async def test_restart_podman_error_sends_error_frame(
+        self, user, app_state
+    ):
+        """#2676: a failed (re)start must not drop the WebSocket with a
+        traceback — the error frame keeps the session alive and surfaces
+        the actionable podman message."""
+        from klangk.podman import PodmanError
+
+        app_state = _make_app_state()
+        sock = _mock_sock(headers={"host": "localhost:8997"})
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "restart-podman-err"
+        )
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        conn.workspace_id = workspace["id"]
+        conn.container_id = "cid-old"
+        conn.workspace = workspace
+        conn._has_perm = AsyncMock(return_value=True)
+
+        with (
+            patch.object(Connection, "cleanup", new_callable=AsyncMock),
+            patch.object(
+                Connection,
+                "start_workspace_container",
+                AsyncMock(
+                    side_effect=PodmanError(
+                        500,
+                        "cannot remove the existing network sidecar "
+                        "for workspace abcd1234",
+                    )
+                ),
+            ),
+        ):
+            # Must not raise (which would drop the WS in dispatch).
+            await conn.handle_restart_container()
+
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        errors = [
+            c
+            for c in calls
+            if isinstance(c, dict) and c.get("type") == "error"
+        ]
+        assert len(errors) == 1
+        assert "Container restart failed" in errors[0]["message"]
+        assert "network sidecar" in errors[0]["message"]
+
     async def test_restart_fractional_timeout(
         self, user, monkeypatch, app_state
     ):
@@ -11590,9 +11691,14 @@ class TestDrainingStartPaths:
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-c"
-        conn.workspace = {"id": "ws-c"}
+        conn.workspace = {"id": "ws-c", "name": "c"}
         with (
             patch.object(conn, "_has_perm", new=AsyncMock(return_value=True)),
+            patch.object(
+                app_state.state.workspaces,
+                "get_workspace",
+                new=AsyncMock(return_value={"id": "ws-c", "name": "c"}),
+            ),
             patch.object(
                 Connection,
                 "cleanup",


### PR DESCRIPTION
## Summary

Fixes #2676.

After an unclean host shutdown/restart, pressing the workspace Restart button with the container still (or again) running could fail with a raw podman `dependent containers` 500 plus a WebSocket-dropping traceback, then silently self-heal 3s later when the client's auto-reconnect took the reuse path. Two defects, both fixed:

**1. `handle_restart_container` restarted from a stale snapshot.** It used the connection's cached `self.workspace` dict (reading the DB only as a fallback). After an unclean host restart that cached `container_id` can be stale, sending the restart down the *create* path instead of the *reuse* path a reconnect takes. It now always reads the workspace fresh from the DB, like `handle_workspace_connect` (also without the owner filter — access is already gated by the terminal-permission ACL check, and an owner-only read would break restart for shared-workspace members).

**2. `_remove_network_sidecar` swallowed a refusal it could never survive.** Podman refuses to `rm -f` a sidecar whose workspace container is joined to its netns (`--network container:`), and the old code swallowed that error and let `create_container --replace` collide with the identical refusal (guaranteed whenever the dependent survives — same lesson as the reapers' dependents-first ordering, #2476). Now:

- On the dependent-containers refusal, the clear removes **this workspace's own** labeled `role=workspace` containers (the dependents — the create path that called it is about to replace them anyway) and retries the sidecar removal once.
- If a same-label sidecar still survives, the create path refuses up front with a clear, actionable error instead of podman's raw 500.
- Survival is judged by a fresh re-list (state, not error text), so benign races (already-gone between list and rm) still proceed.

**Plus:** a failed restart start (`PodmanError`/`ValueError`) now sends an `error` frame instead of dropping the whole WebSocket with a traceback, and the frontend (`WorkspaceConnector.onRestartError` + workspace page) clears the restart spinner and shows a failure snackbar when that error frame arrives — previously the spinner could spin forever with no `container_ready` coming.

## Testing

- Python suite: `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 5526 passed, 100% coverage.
- Frontend suite: `flutter test --coverage` — 1004 passed.
- New tests: restart reads workspace fresh from DB (ignores stale cache); restart failure sends error frame instead of raising; sidecar clear removes dependents-then-sidecar on the refusal; clean refusal when the sidecar survives; bool contract and defensive branches of the removal helpers; connector forwards non-permission errors to `onRestartError`.
