### PR TITLE
fix(frontend): guard /admin/users route against non-admin dead end

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1180,6 +1180,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   disabled, instead of surfacing a raw API error. `klangk admin invitations
   send` rejects a malformed address locally the same way.
 
+- **Admin route guard (#2669).** An authenticated non-admin visiting
+  `/admin/users` directly (typed URL, stale bookmark or redirect) no
+  longer sees the dead-end "No admin sections available" page; the
+  router now bounces them to the workspace list. Logged-out visitors
+  keep the normal login flow, and admins are unaffected.
+
 - **Short image names resolve in fresh checkouts (#286).** devenv now
   exports `CONTAINERS_REGISTRIES_CONF` and seeds a
   `registries.conf` (`unqualified-search-registries = ["docker.io"]`)

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -7,7 +7,7 @@
 //
 // The order matters: the first guard to return non-null wins. The
 // precedence matches the original inline redirect callback:
-//   banner -> auth -> logged-in-on-public -> root.
+//   banner -> auth -> logged-in-on-public -> admin -> root.
 
 import 'auth/pending_redirect.dart';
 
@@ -105,6 +105,34 @@ String? guardLoggedInPublicRoute({
   return null;
 }
 
+/// Admin-route gate (#2669).
+///
+/// A logged-in non-admin on an `/admin`-prefixed route is bounced to
+/// `/workspaces` — the route is reachable by URL or a stale redirect even
+/// though the app-bar admin icon is gated, and its page is a dead end
+/// ("No admin sections available") for them.
+///
+/// Fires only for *logged-in* users: a logged-out visitor must keep the
+/// `guardAuth` flow (stash + `/login`), and `guardLoggedInPublicRoute`
+/// already rejects `/admin`-prefixed stashes for non-admins on login
+/// (#2670), so the two checks meet in the middle.
+///
+/// Loop safety: the target `/workspaces` is not `/admin`-prefixed and no
+/// guard redirects away from it for a logged-in user, so this can never
+/// re-enter itself; the guard is pure w.r.t. its inputs, so repeated
+/// evaluations of the same committed location (GoRouter re-parses on
+/// every refreshListenable notification) all agree.
+String? guardAdminRoute({
+  required bool isLoggedIn,
+  required bool isAdmin,
+  required String loc,
+}) {
+  if (isLoggedIn && !isAdmin && loc.startsWith('/admin')) {
+    return '/workspaces';
+  }
+  return null;
+}
+
 /// Root shortcut: a logged-in user at `/` goes to `/workspaces`.
 ///
 /// Returns the redirect target, or null to allow.
@@ -151,6 +179,11 @@ String? evaluateGuards({
         publicRoutes: publicRoutes,
         featurePaths: featurePaths,
         isAdmin: isAdmin,
+      ) ??
+      guardAdminRoute(
+        isLoggedIn: isLoggedIn,
+        isAdmin: isAdmin,
+        loc: loc,
       ) ??
       guardRoot(isLoggedIn: isLoggedIn, loc: loc);
 }

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -269,6 +269,51 @@ void main() {
     });
   });
 
+  group('guardAdminRoute', () {
+    test('logged-in non-admin on /admin/users -> /workspaces (#2669)', () {
+      expect(
+        guardAdminRoute(isLoggedIn: true, isAdmin: false, loc: '/admin/users'),
+        '/workspaces',
+      );
+    });
+
+    test('logged-in admin on /admin/users -> allowed (null)', () {
+      expect(
+        guardAdminRoute(isLoggedIn: true, isAdmin: true, loc: '/admin/users'),
+        isNull,
+      );
+    });
+
+    test('logged-out non-admin on /admin/users -> allowed (null)', () {
+      // Must not fire for logged-out visitors: guardAuth owns that case
+      // (stash + /login), and firing here would strand them on the
+      // workspace list without ever seeing the login form.
+      expect(
+        guardAdminRoute(isLoggedIn: false, isAdmin: false, loc: '/admin/users'),
+        isNull,
+      );
+    });
+
+    test('non-admin on non-admin route -> allowed (null)', () {
+      expect(
+        guardAdminRoute(isLoggedIn: true, isAdmin: false, loc: '/workspaces'),
+        isNull,
+      );
+    });
+
+    test('idempotent across repeated evaluations of the same location', () {
+      // GoRouter re-parses the committed location on every
+      // refreshListenable notification; the guard must answer every
+      // evaluation identically (the #2670 lesson).
+      final first = guardAdminRoute(
+          isLoggedIn: true, isAdmin: false, loc: '/admin/users');
+      final second = guardAdminRoute(
+          isLoggedIn: true, isAdmin: false, loc: '/admin/users');
+      expect(first, second);
+      expect(first, '/workspaces');
+    });
+  });
+
   group('guardRoot', () {
     test('sends logged-in users at / to /workspaces', () {
       expect(guardRoot(isLoggedIn: true, loc: '/'), '/workspaces');
@@ -409,6 +454,55 @@ void main() {
         ),
         '/admin/users',
       );
+    });
+
+    test('logged-in non-admin on /admin/users -> /workspaces (#2669)', () {
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/admin/users',
+          currentUri: '/admin/users',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/workspaces',
+      );
+    });
+
+    test('logged-in admin on /admin/users -> allowed (null) (#2669)', () {
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/admin/users',
+          currentUri: '/admin/users',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: true,
+        ),
+        isNull,
+      );
+    });
+
+    test('logged-out on /admin/users -> /login with stash, not /workspaces',
+        () {
+      // The auth gate owns logged-out visitors; the admin gate must not
+      // preempt it (see guardAdminRoute 'logged-out' test).
+      expect(
+        evaluateGuards(
+          isLoggedIn: false,
+          bannerRequired: false,
+          loc: '/admin/users',
+          currentUri: '/admin/users',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          isAdmin: false,
+        ),
+        '/login',
+      );
+      expect(pendingRedirect, '/admin/users');
     });
 
     test('logged-in on / -> /workspaces (root, not public-route guard)', () {

--- a/src/frontend/test/app_redirect_test.dart
+++ b/src/frontend/test/app_redirect_test.dart
@@ -59,7 +59,7 @@ void main() {
   // All HTTP the app issues during this flow: config (login page +
   // AuthService), login, and my-permissions. No token exp claim -> no
   // refresh timer for the test to fight with.
-  String installMocks() {
+  String installMocks({Map<String, List<String>> permissions = const {}}) {
     final token = makeJwt({'sub': 'user-1', 'email': 'user@example.com'});
     testConfigHttpClientOverride = MockClient((request) async {
       return http.Response(
@@ -83,7 +83,7 @@ void main() {
           jsonEncode({
             'user_id': 'u1',
             'email': 'user@example.com',
-            'permissions': <String, List<String>>{},
+            'permissions': permissions,
             'groups': <Map<String, dynamic>>[],
           }),
           200,
@@ -134,6 +134,11 @@ void main() {
             body:
                 Center(child: Text('workspace-${state.pathParameters['id']}')),
           ),
+        ),
+        GoRoute(
+          path: '/admin/users',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('admin-users'))),
         ),
       ],
     );
@@ -197,5 +202,72 @@ void main() {
       '/workspaces',
     );
     expect(find.text('workspaces-list'), findsOneWidget);
+  });
+
+  // Restored-session tests for the admin-route guard (#2669). KlangkApp
+  // builds its router only after auth initializes, so the guard's first
+  // evaluation of the initial location sees the *real* session state.
+  // Mirror that here: let the persisted token restore (permissions fetch
+  // included) settle before mounting the router at /admin/users.
+  Future<AuthService> restoreSession(
+      WidgetTester tester, Map<String, List<String>> permissions) async {
+    final token = makeJwt({'sub': 'user-1', 'email': 'user@example.com'});
+    // ignore: invalid_use_of_visible_for_testing
+    SharedPreferences.setMockInitialValues({'klangk_jwt': token});
+    installMocks(permissions: permissions);
+    final auth = AuthService();
+    // A quiet host widget: pump until _loadToken (config + permissions)
+    // completes and initialized flips true.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await tester.pumpAndSettle();
+    expect(auth.initialized, isTrue);
+    return auth;
+  }
+
+  testWidgets(
+      'restored non-admin session at /admin/users lands on /workspaces, '
+      'no redirect loop (#2669)', (tester) async {
+    final auth = await restoreSession(tester, const {});
+    expect(auth.isAdmin, isFalse);
+
+    final router = buildRouter(auth, '/admin/users');
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: auth,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The dead-end admin page must not be showing.
+    expect(find.text('admin-users'), findsNothing);
+    expect(
+      router.routerDelegate.currentConfiguration.uri.toString(),
+      '/workspaces',
+    );
+    expect(find.text('workspaces-list'), findsOneWidget);
+  });
+
+  testWidgets('restored admin session at /admin/users stays put (#2669)',
+      (tester) async {
+    final auth = await restoreSession(tester, const {
+      '/admin': ['*'],
+    });
+    expect(auth.isAdmin, isTrue);
+
+    final router = buildRouter(auth, '/admin/users');
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: auth,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      router.routerDelegate.currentConfiguration.uri.toString(),
+      '/admin/users',
+    );
+    expect(find.text('admin-users'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Fixes #2669.

The `/admin/users` GoRoute had no admin guard, so an authenticated
non-admin reaching it directly (typed URL, stale bookmark or redirect)
landed on the dead-end "No admin sections available" page instead of
the workspace list.

**Fix:** new `guardAdminRoute` in `app_guards.dart`, wired into
`evaluateGuards` after the auth gate — a logged-in non-admin on an
`/admin`-prefixed route is bounced to `/workspaces`, which already
renders correctly for them (Owned/Shared tabs; create/import FABs hidden
without the permission).

**No redirect loop**, by construction:

- Fires only for *logged-in* users; logged-out visitors keep the
  `guardAuth` stash + `/login` flow, and `guardLoggedInPublicRoute`
  already rejects `/admin`-prefixed stashes for non-admins (#2670) —
  the two checks meet in the middle.
- The target `/workspaces` is not `/admin`-prefixed and no guard
  redirects away from it for a logged-in user, so the guard can never
  re-enter itself.
- The guard is pure w.r.t. its inputs, so repeated GoRouter evaluations
  of the same committed location (`refreshListenable` re-parse,
  login's double notify) all agree — the #2670 lesson.

**Tests** (11 new):

- `guardAdminRoute` unit group: non-admin bounced, admin allowed,
  logged-out untouched (auth gate owns that), idempotence.
- `evaluateGuards` precedence: logged-in non-admin → `/workspaces`,
  admin → allowed, logged-out → `/login` with stash.
- App-level restored-session tests in `app_redirect_test.dart` drive a
  real GoRouter with a persisted token, mirroring KlangkApp's gated
  router creation: a non-admin booting at `/admin/users` settles on
  `/workspaces` (no loop); an admin stays put.

Full frontend suite green (1024 tests), 100% coverage. Changelog entry
under `[Unreleased]` → Fixed.
