### PR TITLE
fix(frontend): validate email format in admin user/invite dialogs

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1173,6 +1173,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   web client also no longer sends a logout request once its token is
   already cleared.
 
+- **Admin dialogs validate email format before submitting (#2668).** The
+  Add User, Edit User, and Invite User dialogs now check the address
+  client-side against the same rule the server applies: a malformed value
+  shows an inline "Enter a valid email" error and keeps the confirm button
+  disabled, instead of surfacing a raw API error. `klangk admin invitations
+  send` rejects a malformed address locally the same way.
+
 - **Short image names resolve in fresh checkouts (#286).** devenv now
   exports `CONTAINERS_REGISTRIES_CONF` and seeds a
   `registries.conf` (`unqualified-search-registries = ["docker.io"]`)

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -11,6 +11,7 @@ import '../widgets/acl_editor.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
 import '../widgets/skeuo_tab.dart';
+import '../utils/validators.dart';
 
 class AdminUsersPage extends StatefulWidget {
   const AdminUsersPage({super.key});
@@ -1341,8 +1342,13 @@ class _AddUserDialogState extends State<_AddUserDialog> {
     final passwordValid =
         password.isNotEmpty && policyError == null && password == confirm;
     final email = _emailController.text.trim();
-    final canAdd =
-        email.isNotEmpty && (_sendVerificationEmail || passwordValid);
+    // Flag a malformed address as soon as it's typed, mirroring how the
+    // password fields surface policy errors (blank stays quiet).
+    final emailError =
+        email.isEmpty || isValidEmail(email) ? null : 'Enter a valid email';
+    final canAdd = email.isNotEmpty &&
+        emailError == null &&
+        (_sendVerificationEmail || passwordValid);
     return AlertDialog(
       title: Text('Add User', style: TextStyle(color: KColors.textPrimary)),
       content: SizedBox(
@@ -1358,6 +1364,7 @@ class _AddUserDialogState extends State<_AddUserDialog> {
                 floatingLabelStyle: labelStyle,
                 floatingLabelBehavior: FloatingLabelBehavior.always,
                 border: const OutlineInputBorder(),
+                errorText: emailError,
               ),
               autofocus: true,
               onChanged: (_) => setState(() {}),
@@ -1432,9 +1439,9 @@ class _AddUserDialogState extends State<_AddUserDialog> {
           child: const Text('Cancel'),
         ),
         FilledButton(
-          // Disabled until the form is valid: email present, and either the
-          // verification-email path is chosen or the password meets the
-          // minimum length and matches its confirmation.
+          // Disabled until the form is valid: a syntactically valid email,
+          // and either the verification-email path is chosen or the password
+          // meets the minimum length and matches its confirmation.
           onPressed: canAdd
               ? () {
                   if (_sendVerificationEmail) {
@@ -1513,7 +1520,10 @@ class _EditUserDialogState extends State<_EditUserDialog> {
     final passwordValid =
         !settingPassword || (policyError == null && password == confirm);
     final email = _emailController.text.trim();
-    final canSave = email.isNotEmpty && passwordValid;
+    // Same as the add dialog: only flag a malformed address once typed.
+    final emailError =
+        email.isEmpty || isValidEmail(email) ? null : 'Enter a valid email';
+    final canSave = email.isNotEmpty && emailError == null && passwordValid;
     return AlertDialog(
       title: Text('Edit User', style: TextStyle(color: KColors.textPrimary)),
       content: SizedBox(
@@ -1529,6 +1539,7 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                 floatingLabelStyle: labelStyle,
                 floatingLabelBehavior: FloatingLabelBehavior.always,
                 border: const OutlineInputBorder(),
+                errorText: emailError,
               ),
               autofocus: true,
               onChanged: (_) => setState(() {}),
@@ -1603,9 +1614,9 @@ class _EditUserDialogState extends State<_EditUserDialog> {
           child: const Text('Cancel'),
         ),
         FilledButton(
-          // Disabled until valid: email present, and either no password is
-          // being set or the new password meets the minimum length and matches
-          // its confirmation.
+          // Disabled until valid: a syntactically valid email, and either
+          // no password is being set or the new password meets the minimum
+          // length and matches its confirmation.
           onPressed: canSave
               ? () {
                   final handle = _handleController.text.trim();
@@ -1642,6 +1653,10 @@ class _InviteUserDialogState extends State<_InviteUserDialog> {
       color: KColors.textPrimary,
       fontWeight: FontWeight.bold,
     );
+    final email = _emailController.text.trim();
+    final emailError =
+        email.isEmpty || isValidEmail(email) ? null : 'Enter a valid email';
+    final canInvite = emailError == null && email.isNotEmpty;
     return AlertDialog(
       title: Text('Invite User', style: TextStyle(color: KColors.textPrimary)),
       content: SizedBox(
@@ -1661,11 +1676,12 @@ class _InviteUserDialogState extends State<_InviteUserDialog> {
                 floatingLabelStyle: labelStyle,
                 floatingLabelBehavior: FloatingLabelBehavior.always,
                 border: const OutlineInputBorder(),
+                errorText: emailError,
               ),
               autofocus: true,
+              onChanged: (_) => setState(() {}),
               onSubmitted: (_) {
-                final email = _emailController.text.trim();
-                if (email.isNotEmpty) Navigator.pop(context, email);
+                if (canInvite) Navigator.pop(context, email);
               },
             ),
           ],
@@ -1678,11 +1694,7 @@ class _InviteUserDialogState extends State<_InviteUserDialog> {
           child: const Text('Cancel'),
         ),
         FilledButton(
-          onPressed: () {
-            final email = _emailController.text.trim();
-            if (email.isEmpty) return;
-            Navigator.pop(context, email);
-          },
+          onPressed: canInvite ? () => Navigator.pop(context, email) : null,
           child: const Text('Send Invitation'),
         ),
       ],

--- a/src/frontend/lib/auth/forgot_password_page.dart
+++ b/src/frontend/lib/auth/forgot_password_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'auth_service.dart';
 import '../utils/page_title.dart';
+import '../utils/validators.dart';
 import '../widgets/klangk_logo.dart';
 
 class ForgotPasswordPage extends StatefulWidget {
@@ -138,7 +139,7 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
             ),
             validator: (v) {
               if (v == null || v.trim().isEmpty) return 'Required';
-              if (!RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$').hasMatch(v.trim())) {
+              if (!isValidEmail(v)) {
                 return 'Enter a valid email address';
               }
               return null;

--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -221,9 +221,7 @@ class _LoginPageState extends State<LoginPage> {
           }
           // Login also accepts a handle (#616); registration requires
           // an email (a deliverable address is needed for verification).
-          if (!_isRegister &&
-              RegExp(r'^[a-z0-9._-]+$').hasMatch(value) &&
-              value.length <= 32) {
+          if (!_isRegister && isValidHandleChars(value) && value.length <= 32) {
             return null;
           }
           return _isRegister

--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -8,6 +8,7 @@ import 'auth_service.dart';
 import 'pending_redirect.dart';
 import '../branding.dart';
 import '../utils/page_title.dart';
+import '../utils/validators.dart';
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../widgets/klangk_logo.dart';
@@ -215,7 +216,7 @@ class _LoginPageState extends State<LoginPage> {
         validator: (v) {
           if (v == null || v.trim().isEmpty) return 'Required';
           final value = v.trim();
-          if (RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$').hasMatch(value)) {
+          if (isValidEmail(value)) {
             return null;
           }
           // Login also accepts a handle (#616); registration requires

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'auth_service.dart';
 import '../utils/page_title.dart';
+import '../utils/validators.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
 
@@ -591,7 +592,7 @@ class _EmailSectionState extends State<_EmailSection> {
             ),
             validator: (v) {
               if (v == null || v.trim().isEmpty) return 'Required';
-              if (!RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$').hasMatch(v.trim())) {
+              if (!isValidEmail(v)) {
                 return 'Enter a valid email address';
               }
               return null;

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -438,7 +438,7 @@ class _HandleSectionState extends State<_HandleSection> {
             validator: (v) {
               if (v == null || v.trim().isEmpty) return 'Required';
               if (v != v.toLowerCase()) return 'Must be lowercase';
-              if (!RegExp(r'^[a-z0-9._-]+$').hasMatch(v)) {
+              if (!isValidHandleChars(v)) {
                 return 'Only lowercase letters, numbers, dots, hyphens, underscores';
               }
               return null;

--- a/src/frontend/lib/utils/validators.dart
+++ b/src/frontend/lib/utils/validators.dart
@@ -1,0 +1,10 @@
+/// Shared client-side format validators.
+///
+/// These mirror the server-side rules (`klangk.auth._EMAIL_RE`) and exist
+/// only to give immediate inline feedback; the server stays authoritative.
+
+final RegExp _emailRe = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+
+/// Whether [value] is a syntactically valid email address —
+/// `local@domain.tld`, no whitespace, single `@`.
+bool isValidEmail(String value) => _emailRe.hasMatch(value.trim());

--- a/src/frontend/lib/utils/validators.dart
+++ b/src/frontend/lib/utils/validators.dart
@@ -1,10 +1,19 @@
 /// Shared client-side format validators.
 ///
-/// These mirror the server-side rules (`klangk.auth._EMAIL_RE`) and exist
-/// only to give immediate inline feedback; the server stays authoritative.
+/// These mirror the server-side rules (`klangk.auth._EMAIL_RE`,
+/// `klangk.model.users.HANDLE_RE`) and exist only to give immediate inline
+/// feedback; the server stays authoritative.
 
-final RegExp _emailRe = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+/// `local@domain.tld` — no whitespace, a single `@`, a dot in the domain.
+final RegExp emailRe = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
 
-/// Whether [value] is a syntactically valid email address —
-/// `local@domain.tld`, no whitespace, single `@`.
-bool isValidEmail(String value) => _emailRe.hasMatch(value.trim());
+/// Handle charset: lowercase letters, digits, dots, hyphens, underscores.
+final RegExp handleRe = RegExp(r'^[a-z0-9._-]+$');
+
+/// Whether [value] is a syntactically valid email address.
+bool isValidEmail(String value) => emailRe.hasMatch(value.trim());
+
+/// Whether [value] uses only handle characters. Call sites layer their own
+/// policy on top (length cap, lowercase, reserved names) — this predicate
+/// covers just the charset.
+bool isValidHandleChars(String value) => handleRe.hasMatch(value.trim());

--- a/src/frontend/test/admin_invitations_page_test.dart
+++ b/src/frontend/test/admin_invitations_page_test.dart
@@ -370,4 +370,90 @@ void main() {
       expect(capturedQ, 'needle');
     });
   });
+
+  group('AdminUsersPage invite dialog', () {
+    /// Finder for a TextField whose labelText matches [label].
+    Finder fieldLabeled(String label) => find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField && widget.decoration?.labelText == label,
+        );
+
+    /// Serves the invitations list and captures any POST (invite) body into
+    /// [posts].
+    void serveInvitationsCapturePosts(List<Map<String, dynamic>> posts) {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/invitations') {
+          if (request.method == 'POST') {
+            posts.add(jsonDecode(request.body) as Map<String, dynamic>);
+            return http.Response(
+              jsonEncode(_invitation('new@example.com')),
+              200,
+            );
+          }
+          return http.Response(
+            _invitationsEnvelope([], total: 0, pendingCount: 0),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(
+            jsonEncode({
+              'users': <Map<String, dynamic>>[],
+              'page': 1,
+              'page_size': 10,
+              'total': 0,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/admin/groups') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+    }
+
+    testWidgets(
+        'invalid email shows inline error and keeps Send Invitation disabled',
+        (tester) async {
+      final posts = <Map<String, dynamic>>[];
+      serveInvitationsCapturePosts(posts);
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Invite user'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(fieldLabeled('Email'), 'notanemail');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(fieldLabeled('Email')).decoration?.errorText,
+        'Enter a valid email',
+      );
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.widgetWithText(FilledButton, 'Send Invitation'),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(posts, isEmpty);
+
+      // Correcting the address clears the error, enables the button, and
+      // submits (#2668).
+      await tester.enterText(fieldLabeled('Email'), 'new@example.com');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(fieldLabeled('Email')).decoration?.errorText,
+        isNull,
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Send Invitation'));
+      await tester.pumpAndSettle();
+
+      expect(posts.single['email'], 'new@example.com');
+      expect(find.text('Invitation sent to new@example.com'), findsOneWidget);
+    });
+  });
 }

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -702,6 +702,59 @@ void main() {
       expect(isPrimaryEnabled(tester, 'Add'), isFalse);
     });
 
+    testWidgets('Add: invalid email shows inline error and disables Add',
+        (tester) async {
+      final writes = <Map<String, dynamic>>[];
+      serveUsersCaptureWrite(writes, (_p, _ps, _s, _o, _q) => [], total: 0);
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Add user'));
+      await tester.pumpAndSettle();
+
+      // A malformed address is flagged inline even when everything else is
+      // valid, and Add stays disabled (#2668).
+      await tester.enterText(fieldLabeled('Email'), 'notanemail');
+      await tester.enterText(fieldLabeled('Password'), 'longenough');
+      await tester.pumpAndSettle();
+      await tester.enterText(fieldLabeled('Confirm Password'), 'longenough');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(fieldLabeled('Email')).decoration?.errorText,
+        'Enter a valid email',
+      );
+      expect(isPrimaryEnabled(tester, 'Add'), isFalse);
+      expect(writes, isEmpty);
+
+      // Correcting the address clears the error and enables Add.
+      await tester.enterText(fieldLabeled('Email'), 'new@example.com');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(fieldLabeled('Email')).decoration?.errorText,
+        isNull,
+      );
+      expect(isPrimaryEnabled(tester, 'Add'), isTrue);
+    });
+
+    testWidgets('Add: verification-email path also requires a valid email',
+        (tester) async {
+      final writes = <Map<String, dynamic>>[];
+      serveUsersCaptureWrite(writes, (_p, _ps, _s, _o, _q) => [], total: 0);
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Add user'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Send verification email'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(fieldLabeled('Email'), 'foo@');
+      await tester.pumpAndSettle();
+
+      expect(isPrimaryEnabled(tester, 'Add'), isFalse);
+      expect(writes, isEmpty);
+    });
+
     testWidgets('Add: sends email + password when valid', (tester) async {
       final writes = <Map<String, dynamic>>[];
       serveUsersCaptureWrite(writes, (_p, _ps, _s, _o, _q) => [], total: 0);
@@ -795,6 +848,41 @@ void main() {
 
       expect(find.byType(AlertDialog), findsNothing);
       expect(writes, isEmpty);
+    });
+
+    testWidgets('Edit: invalid email shows inline error and disables Save',
+        (tester) async {
+      final writes = <Map<String, dynamic>>[];
+      serveUsersCaptureWrite(
+        writes,
+        (_p, _ps, _s, _o, _q) => [_user('alice@example.com', id: 'u1')],
+        total: 1,
+      );
+      await pumpPage(tester);
+      await tester.tap(find.text('alice@example.com'));
+      await tester.pumpAndSettle();
+
+      // Replacing the prefilled valid address with a malformed one flags
+      // the field and keeps Save disabled (#2668).
+      await tester.enterText(fieldLabeled('Email'), 'a b@c.com');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(fieldLabeled('Email')).decoration?.errorText,
+        'Enter a valid email',
+      );
+      expect(isPrimaryEnabled(tester, 'Save'), isFalse);
+      expect(writes, isEmpty);
+
+      // Restoring a valid address re-enables Save.
+      await tester.enterText(fieldLabeled('Email'), 'alice2@example.com');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(fieldLabeled('Email')).decoration?.errorText,
+        isNull,
+      );
+      expect(isPrimaryEnabled(tester, 'Save'), isTrue);
     });
 
     testWidgets('Edit: blank password keeps Save enabled and sends email only',

--- a/src/frontend/test/validators_test.dart
+++ b/src/frontend/test/validators_test.dart
@@ -19,4 +19,19 @@ void main() {
       expect(isValidEmail('a@b@c.com'), isFalse);
     });
   });
+
+  group('isValidHandleChars', () {
+    test('accepts handle characters', () {
+      expect(isValidHandleChars('hero'), isTrue);
+      expect(isValidHandleChars('first.last_2-x'), isTrue);
+      expect(isValidHandleChars('  padded  '), isTrue);
+    });
+
+    test('rejects non-handle characters', () {
+      expect(isValidHandleChars(''), isFalse);
+      expect(isValidHandleChars('Upper'), isFalse);
+      expect(isValidHandleChars('has space'), isFalse);
+      expect(isValidHandleChars('a@b.com'), isFalse);
+    });
+  });
 }

--- a/src/frontend/test/validators_test.dart
+++ b/src/frontend/test/validators_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/utils/validators.dart';
+
+void main() {
+  group('isValidEmail', () {
+    test('accepts valid addresses', () {
+      expect(isValidEmail('user@example.com'), isTrue);
+      expect(isValidEmail('first.last+tag@sub.domain.org'), isTrue);
+      // Surrounding whitespace is trimmed before the format check.
+      expect(isValidEmail('  padded@example.com  '), isTrue);
+    });
+
+    test('rejects malformed addresses', () {
+      expect(isValidEmail(''), isFalse);
+      expect(isValidEmail('foo'), isFalse);
+      expect(isValidEmail('foo@'), isFalse);
+      expect(isValidEmail('a@b'), isFalse);
+      expect(isValidEmail('a b@c.com'), isFalse);
+      expect(isValidEmail('a@b@c.com'), isFalse);
+    });
+  });
+}

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -16,6 +16,7 @@ from rich.table import Table
 from .client import KlangkClient
 from rich.prompt import Prompt
 
+from . import account
 from . import context
 
 
@@ -173,6 +174,12 @@ def admin_invitations_send(
     ),
 ) -> None:
     """Send an invitation email (admin only)."""
+    # Same format check the server applies (#2668) — fail fast locally
+    # instead of surfacing the API error after the round-trip.
+    err = account.validate_email(email)
+    if err:
+        context._err.print(f"[red]{err}[/red]")
+        raise typer.Exit(code=1)
     context.require_auth()
     client = context._client()
     resp = client.post("/api/v1/admin/invitations", json={"email": email})

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -3970,6 +3970,25 @@ class TestInviteCLI:
         assert result.exit_code == 0
         assert "a@b.com" in result.stdout
 
+    def test_invite_invalid_email_rejected_locally(
+        self, logged_in_cfg, monkeypatch
+    ):
+        """A malformed address fails fast client-side (#2668) — no POST."""
+        from klangk.cli import main
+
+        client = MagicMock()
+        monkeypatch.setattr(context_mod, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app, ["admin", "invitations", "send", "notanemail"]
+        )
+        assert result.exit_code == 1
+        assert "Enter a valid email address" in result.output
+        client.post.assert_not_called()
+
     def test_invite_error(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main
 


### PR DESCRIPTION
## Summary

- The admin **Add User**, **Edit User**, and **Invite User** dialogs enabled their confirm button on any non-empty email; a malformed address was submitted and only rejected server-side with a raw API error snackbar. All three now validate the format client-side with the same regex the server applies (`klangk.auth._EMAIL_RE`): a malformed value shows an inline "Enter a valid email" error and keeps the button disabled (#2668).
- New shared `utils/validators.dart` (`isValidEmail`); the login, forgot-password, and settings pages now reuse it instead of their three private copies of the same regex.
- The Invite dialog also gained live `onChanged` state tracking (its button was previously always enabled and just no-oped on empty input), and `onSubmitted` now only submits a valid address.
- `klangk admin invitations send` rejects a malformed address locally before the HTTP round-trip, reusing `account.validate_email`.
- Server-side validation remains authoritative; this is purely client-side UX.

## Testing

- Widget tests: Add (invalid email error + disabled Add, incl. the verification-email path; clears on correction), Edit (same on Save), Invite (inline error, disabled button, submits on correction).
- New `validators_test.dart` unit tests; CLI test asserting local rejection with no POST.
- Full suites green the CI way: `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` (5520 passed, 100% coverage) and `flutter test --coverage` (1020 passed, 100% coverage).

Closes #2668.
