### PR TITLE
feat(cli): terminal-open-cmd opens TUI shell launches in a new terminal

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -92,6 +92,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`terminal-open-cmd` / `KLANGKC_TERMINAL_OPEN_CMD` (#2685).** New CLI
+  setting (klangk.yaml or envvar) that names the command used to open a
+  new terminal window, e.g. `konsole --hold -e`. When set, selecting a
+  terminal in the TUI spawns `klangk shell` in a new terminal window
+  instead of suspending the TUI and taking over the current terminal;
+  the TUI stays running. If the command can't be launched, the TUI shows
+  an error and falls back to the previous inline behavior. See
+  [CLI reference](reference/cli.md).
 - **`EX_CONFIG` exit status 78 for deterministic config errors (#2666).**
   When `klangkd` refuses to boot over bad configuration — e.g. a
   `KLANGKD_DEFAULT_PASSWORD` that violates the password policy, password

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -94,11 +94,13 @@ operators or integrators to act when upgrading.
 
 - **`terminal-open-cmd` / `KLANGKC_TERMINAL_OPEN_CMD` (#2685).** New CLI
   setting (klangk.yaml or envvar) that names the command used to open a
-  new terminal window, e.g. `konsole --hold -e`. When set, selecting a
+  new terminal window, e.g. `konsole -e`. When set, selecting a
   terminal in the TUI spawns `klangk shell` in a new terminal window
   instead of suspending the TUI and taking over the current terminal;
-  the TUI stays running. If the command can't be launched, the TUI shows
-  an error and falls back to the previous inline behavior. See
+  the TUI stays running, and the window closes on its own when the shell
+  disconnects (a holding flag like `--hold` keeps it open if wanted). If
+  the command can't be launched, the TUI shows an error and falls back
+  to the previous inline behavior. See
   [CLI reference](reference/cli.md).
 - **Clearer shell exit (#2685).** `klangk shell` now says how to exit
   ("Exit this shell: press Enter, then ~.") and prints

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -100,6 +100,12 @@ operators or integrators to act when upgrading.
   the TUI stays running. If the command can't be launched, the TUI shows
   an error and falls back to the previous inline behavior. See
   [CLI reference](reference/cli.md).
+- **Clearer shell exit (#2685).** `klangk shell` now says how to exit
+  ("Exit this shell: press Enter, then ~.") and prints
+  `Disconnected from <workspace>.` after a clean disconnect, so tmux's
+  `[exited]` line reads as a normal exit instead of a crash. The
+  consent-popup wrapper's cleanup no longer sprays
+  `no server running on …sock` into the terminal after the shell ends.
 - **`EX_CONFIG` exit status 78 for deterministic config errors (#2666).**
   When `klangkd` refuses to boot over bad configuration — e.g. a
   `KLANGKD_DEFAULT_PASSWORD` that violates the password policy, password

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -177,7 +177,11 @@ left pending forever.
 - **`klangk shell`** — shelling into an interactive workspace wraps the
   shell in a local tmux that floats the decider over it as a popup: a
   held request pops up without leaving the shell (`C-a p` reopens it;
-  skip the wrapper with `--no-consent-popup`) (#2383).
+  skip the wrapper with `--no-consent-popup`) (#2383). Disconnect with
+  the SSH-style escape — press **Enter**, then **~**, then **.** — after
+  which the CLI prints `Disconnected from <workspace>.` and the wrapper
+  cleans up; the `[exited]` line that may follow is tmux confirming the
+  outer session ended, not an error.
 - **Web UI** — the workspace page shows a consent banner with per-row
   allow/deny split buttons: a bare click uses the default duration
   (until restart), and the attached ▾ menu sends the verdict with any

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -144,6 +144,18 @@ that in the string form the value is shell-split, so backslashes (as in
 Windows paths) need the list form. When unset, behavior is unchanged
 from before.
 
+#### Exiting an external-terminal shell
+
+Disconnect from the remote shell itself with the SSH-style escape —
+press **Enter**, then **~**, then **.** (period). Typing `exit` or
+**Ctrl+D** only ends the inner shell; klangk respawns it. After the
+escape the CLI prints `Disconnected from <workspace>.` (a following
+`[exited]` line is tmux confirming the outer session ended — not an
+error). The terminal window itself then closes unless your configured
+command holds it open: with `konsole --hold -e` the window stays so you
+can read the final messages — close it with the window's normal close
+button; without `--hold` it closes on its own.
+
 ### klangk-state.yaml
 
 Auto-managed. Stores the active server, active user per server, and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,14 +85,60 @@ freely after the initial creation.
 
 #### Settings
 
-| Setting         | Scope            | Default  | Description                                       |
-| --------------- | ---------------- | -------- | ------------------------------------------------- |
-| `forward-agent` | global or server | `true`   | Forward local SSH agent into containers           |
-| `ws-max-size`   | global or server | 16777216 | Maximum WebSocket message size in bytes           |
-| `user`          | server only      |          | Default user (email or handle) for `klangk login` |
-| `url`           | server only      |          | Server URL (required for each server entry)       |
+| Setting             | Scope            | Default  | Description                                       |
+| ------------------- | ---------------- | -------- | ------------------------------------------------- |
+| `forward-agent`     | global or server | `true`   | Forward local SSH agent into containers           |
+| `ws-max-size`       | global or server | 16777216 | Maximum WebSocket message size in bytes           |
+| `user`              | server only      |          | Default user (email or handle) for `klangk login` |
+| `url`               | server only      |          | Server URL (required for each server entry)       |
+| `terminal-open-cmd` | global           |          | Open TUI shell launches in a new terminal window  |
 
 Per-server settings override global settings. CLI flags override both.
+
+#### Opening shells in a new terminal (`terminal-open-cmd`)
+
+By default, selecting a terminal in the TUI suspends the TUI and runs
+`klangk shell` in the same terminal. With `terminal-open-cmd` set, each
+selection instead spawns `klangk shell` in a **new terminal window** via
+the configured command, and the TUI stays running (#2685).
+
+The value is the command that opens a terminal; the `klangk shell`
+invocation is appended as trailing arguments (most terminals take the
+command to run after `-e` / `--`):
+
+```yaml
+# kitty
+# terminal-open-cmd: kitty
+
+# konsole (--hold keeps the window open after the shell exits so error
+# messages stay readable)
+terminal-open-cmd: konsole --hold -e
+
+# wezterm
+terminal-open-cmd: wezterm cli spawn --
+```
+
+A list form is also accepted (no shell quoting to worry about):
+
+```yaml
+terminal-open-cmd:
+  - alacritty
+  - -T
+  - klangk shell
+  - -e
+```
+
+The environment variable `KLANGKC_TERMINAL_OPEN_CMD` overrides the file
+value (same syntax as the string form):
+
+```bash
+export KLANGKC_TERMINAL_OPEN_CMD="konsole --hold -e"
+```
+
+If the configured command cannot be launched (not installed, no
+`DISPLAY`), the TUI shows an inline error and falls back to running the
+shell in the current terminal. When unset, behavior is unchanged from
+before.
 
 ### klangk-state.yaml
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -135,10 +135,14 @@ value (same syntax as the string form):
 export KLANGKC_TERMINAL_OPEN_CMD="konsole --hold -e"
 ```
 
-If the configured command cannot be launched (not installed, no
-`DISPLAY`), the TUI shows an inline error and falls back to running the
-shell in the current terminal. When unset, behavior is unchanged from
-before.
+If the configured command cannot be executed (not installed, not
+executable), the TUI shows an inline error and falls back to running the
+shell in the current terminal. A command that starts but then fails on
+its own (e.g. `wezterm cli spawn` with no wezterm GUI running) does not
+trigger the fallback — prefer simple `terminal -e` style commands. Note
+that in the string form the value is shell-split, so backslashes (as in
+Windows paths) need the list form. When unset, behavior is unchanged
+from before.
 
 ### klangk-state.yaml
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -110,13 +110,17 @@ command to run after `-e` / `--`):
 # kitty
 # terminal-open-cmd: kitty
 
-# konsole (--hold keeps the window open after the shell exits so error
-# messages stay readable)
-terminal-open-cmd: konsole --hold -e
+# konsole — the window closes on its own when the shell disconnects
+terminal-open-cmd: konsole -e
 
 # wezterm
 terminal-open-cmd: wezterm cli spawn --
 ```
+
+Add `--hold` (konsole) or your terminal's equivalent **only** when you
+want the window to remain open after the shell exits — e.g. to read
+connect errors or final output. Without it the window closes itself,
+which is usually what you want.
 
 A list form is also accepted (no shell quoting to worry about):
 
@@ -132,7 +136,7 @@ The environment variable `KLANGKC_TERMINAL_OPEN_CMD` overrides the file
 value (same syntax as the string form):
 
 ```bash
-export KLANGKC_TERMINAL_OPEN_CMD="konsole --hold -e"
+export KLANGKC_TERMINAL_OPEN_CMD="konsole -e"
 ```
 
 If the configured command cannot be executed (not installed, not
@@ -151,10 +155,10 @@ press **Enter**, then **~**, then **.** (period). Typing `exit` or
 **Ctrl+D** only ends the inner shell; klangk respawns it. After the
 escape the CLI prints `Disconnected from <workspace>.` (a following
 `[exited]` line is tmux confirming the outer session ended — not an
-error). The terminal window itself then closes unless your configured
-command holds it open: with `konsole --hold -e` the window stays so you
-can read the final messages — close it with the window's normal close
-button; without `--hold` it closes on its own.
+error). The terminal window then closes on its own. If you configured a
+holding variant (e.g. `konsole --hold -e`) because you want the window
+to remain open — say, to read final messages — close it with the
+window's normal close button when you're done.
 
 ### klangk-state.yaml
 

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -102,17 +102,31 @@ def default_server_uds_path() -> str:
     return os.path.join(state_dir, _SOCKET_NAME)
 
 
+def _split_terminal_cmd(text: str) -> list[str] | None:
+    """shlex-split a terminal command string, ignoring syntax errors.
+
+    An unbalanced quote raises ``ValueError`` out of ``shlex.split`` — a
+    one-character typo in klangk.yaml / the envvar must not crash every
+    CLI command that loads the config (or the TUI mid-message-handler),
+    so the value degrades to None (inline shell) instead (#2686 review).
+    """
+    try:
+        return shlex.split(text)
+    except ValueError:
+        return None
+
+
 def _parse_terminal_open_cmd(value) -> list[str] | None:
     """Normalize a ``terminal-open-cmd`` yaml value to an argv list.
 
     Accepts a shell string (``"konsole --hold -e"``, split with shlex) or
-    a list of strings (``[konsole, --hold, -e]``). Empty and wrong-typed
-    values are ignored (None) so a bad edit degrades to the inline shell
-    instead of crashing the TUI (#2685).
+    a list of strings (``[konsole, --hold, -e]``). Empty, wrong-typed, and
+    unparseable values are ignored (None) so a bad edit degrades to the
+    inline shell instead of crashing the CLI/TUI (#2685).
     """
     if isinstance(value, str):
         value = value.strip()
-        return shlex.split(value) if value else None
+        return _split_terminal_cmd(value) if value else None
     if isinstance(value, list) and all(isinstance(v, str) for v in value):
         return list(value) if value else None
     return None
@@ -200,7 +214,7 @@ class CLIConfig:
         """
         env = os.environ.get(TERMINAL_OPEN_CMD_ENV, "").strip()
         if env:
-            return shlex.split(env)
+            return _split_terminal_cmd(env)
         return self.terminal_open_cmd
 
 

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 
 import os
+import shlex
 import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -53,6 +54,11 @@ _STATE_PATH = _xdg_state_home() / _CLI_SUBDIR / "klangk-state.yaml"
 
 
 _DEFAULT_WS_MAX_SIZE = 2**24  # 16 MB
+
+
+# Envvar override for ``terminal-open-cmd`` — ``KLANGKC_<FIELD>``
+# convention (#2685). Set (non-empty) it wins over the yaml value.
+TERMINAL_OPEN_CMD_ENV = "KLANGKC_TERMINAL_OPEN_CMD"
 
 
 # Server-side XDG subdir + socket filename, mirrored from
@@ -96,6 +102,22 @@ def default_server_uds_path() -> str:
     return os.path.join(state_dir, _SOCKET_NAME)
 
 
+def _parse_terminal_open_cmd(value) -> list[str] | None:
+    """Normalize a ``terminal-open-cmd`` yaml value to an argv list.
+
+    Accepts a shell string (``"konsole --hold -e"``, split with shlex) or
+    a list of strings (``[konsole, --hold, -e]``). Empty and wrong-typed
+    values are ignored (None) so a bad edit degrades to the inline shell
+    instead of crashing the TUI (#2685).
+    """
+    if isinstance(value, str):
+        value = value.strip()
+        return shlex.split(value) if value else None
+    if isinstance(value, list) and all(isinstance(v, str) for v in value):
+        return list(value) if value else None
+    return None
+
+
 @dataclass
 class ServerEntry:
     """A named server in klangk.yaml."""
@@ -112,6 +134,7 @@ class CLIConfig:
 
     forward_agent: bool | None = None
     ws_max_size: int | None = None
+    terminal_open_cmd: list[str] | None = None
     servers: dict[str, ServerEntry] = field(default_factory=dict)
 
     @classmethod
@@ -133,6 +156,9 @@ class CLIConfig:
         return cls(
             forward_agent=data.get("forward-agent"),
             ws_max_size=data.get("ws-max-size"),
+            terminal_open_cmd=_parse_terminal_open_cmd(
+                data.get("terminal-open-cmd")
+            ),
             servers=servers,
         )
 
@@ -162,6 +188,20 @@ class CLIConfig:
             if entry.url == server_url and entry.ws_max_size is not None:
                 return entry.ws_max_size
         return self.ws_max_size or _DEFAULT_WS_MAX_SIZE
+
+    def get_terminal_open_cmd(self) -> list[str] | None:
+        """Return the argv that opens a new terminal window, or None.
+
+        ``KLANGKC_TERMINAL_OPEN_CMD`` (a shell string) wins over the yaml
+        ``terminal-open-cmd`` value, so a single ``export`` redirects TUI
+        shell launches without editing klangk.yaml (#2685). An empty or
+        unset envvar falls through to the file value; None means "not
+        configured" — launch the shell inline (current behavior).
+        """
+        env = os.environ.get(TERMINAL_OPEN_CMD_ENV, "").strip()
+        if env:
+            return shlex.split(env)
+        return self.terminal_open_cmd
 
 
 def ensure_config() -> None:

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -341,14 +341,32 @@ def should_use_popup(
 
 
 def _default_run(argv: list[str]) -> int:
-    """Run a tmux control command, logging failures (never raising)."""
+    """Run a tmux control command, logging failures (never raising).
+
+    Output is captured, never shown: several of these commands run as
+    best-effort cleanup after the shell exits (kill-session on a server
+    that already terminated when the last session died), and tmux's
+    "no server running on <sock>" stderr there read like a crash instead
+    of a clean disconnect (#2685 follow-up). A non-zero exit code (with
+    captured stderr) goes to the log instead of the terminal.
+    """
     try:
-        return subprocess.run(argv, check=False).returncode
+        proc = subprocess.run(
+            argv, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
     except OSError as exc:
         logger.warning(
             "consent-popup tmux command failed: %s (%s)", argv[0], exc
         )
         return 1
+    if proc.returncode != 0:
+        logger.warning(
+            "consent-popup tmux command failed (rc=%d): %s %s",
+            proc.returncode,
+            argv,
+            proc.stderr.decode(errors="replace").strip(),
+        )
+    return proc.returncode
 
 
 def _default_attach(argv: list[str]) -> int:

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -126,11 +126,14 @@ def _run_consent_popup(ws, terminal: str | None, forward_agent: bool) -> int:
     )
     context._err.print(
         f"[dim]A consent popup appears when an egress request is held; "
-        f"{OUTER_PREFIX} {REOPEN_KEY} reopens  ·  q/Q hides[/dim]"
+        f"{OUTER_PREFIX} {REOPEN_KEY} reopens  ·  q/Q hides  ·  "
+        f"Enter, then ~. exits[/dim]"
     )
-    return run_consent_shell(
+    rc = run_consent_shell(
         workspace_id=ws.id, inner_argv=inner, decider_argv=decider
     )
+    context._err.print(f"Disconnected from [bold]{ws.name}[/bold].")
+    return rc
 
 
 @context.app.command()
@@ -203,7 +206,9 @@ def shell(
             ws = workspaces[idx]
 
     context._err.print(f"Connecting to [bold]{ws.name}[/bold]...")
-    context._err.print("[dim]Escape: Enter, then ~.[/dim]")
+    context._err.print(
+        "[dim]Exit this shell: press Enter, then ~. (like ssh).[/dim]"
+    )
     forward_agent = resolve_forward_agent(
         forward_agent,
         config_default=context._cfg().get_forward_agent(context.server_url())
@@ -226,6 +231,7 @@ def shell(
                 max_size=context.ws_max_size(),
             )
         )
+        context._err.print(f"Disconnected from [bold]{ws.name}[/bold].")
     except websockets.InvalidStatus as e:
         reset_terminal()
         drain_stdin()

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -693,7 +693,10 @@ class WorkspaceDetailScreen(Screen):
         return self.app.tui_state.current_user_id()
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
-        """Suspend the TUI and spawn ``klangk shell`` for the selected terminal."""
+        """Spawn ``klangk shell`` for the selected terminal.
+
+        Inline in this terminal (TUI suspended) by default, or in a new
+        terminal window when ``terminal-open-cmd`` is configured (#2685)."""
         if event.control.id == "shared_term_list":
             self._launch_shared_terminal(event)
             return
@@ -714,26 +717,60 @@ class WorkspaceDetailScreen(Screen):
             )
             self.run_worker(self._load_terminals, exit_on_error=False)
             return
-        cmd = [sys.executable, "-m", "klangk.cli.main"]
-        server = self.app.tui_state.current_url()
-        if server:
-            cmd += ["--server", server]
-        cmd += ["shell", self._name, target]
-        with self.app.suspend():
-            # suspend() restored the primary screen buffer, which still
-            # shows whatever was on screen before the TUI launched. Clear
-            # it so that stale content never flashes before `klangk shell`
-            # attaches (#2010). No connecting line — klangk shell prints
-            # its own on attach.
-            sys.stdout.write("\033[2J\033[H")
-            sys.stdout.flush()
-            completed = subprocess.run(cmd)
-        if completed.returncode != 0:
+        completed = self._launch_shell(self._shell_argv(target))
+        if completed is not None and completed.returncode != 0:
             # The shell exited non-zero — most likely the window was
             # deleted server-side between list refresh and selection.
             # Refresh so the dead row self-heals instead of failing
             # identically on every re-select (#1955 review).
             self.run_worker(self._load_terminals, exit_on_error=False)
+
+    def _shell_argv(self, target: str) -> list[str]:
+        """The ``klangk shell`` argv for a terminal target on this workspace."""
+        cmd = [sys.executable, "-m", "klangk.cli.main"]
+        server = self.app.tui_state.current_url()
+        if server:
+            cmd += ["--server", server]
+        return cmd + ["shell", self._name, target]
+
+    def _launch_shell(
+        self, cmd: list[str]
+    ) -> subprocess.CompletedProcess | None:
+        """Run the ``klangk shell`` argv, externally when configured.
+
+        With a terminal-open command configured (#2685: ``terminal-open-cmd``
+        in klangk.yaml or ``KLANGKC_TERMINAL_OPEN_CMD``), spawn the shell in
+        a new terminal window via the configured argv (``term_cmd + cmd`` —
+        terminal emulators like konsole take the command as trailing args
+        after ``-e``). The TUI stays up — no suspend. Returns None on that
+        path: launchers like konsole always exit 0 and return immediately
+        (or when the window closes), so there is no exit code worth acting
+        on. A spawn failure (command missing, no DISPLAY) shows an inline
+        message and falls through to the inline path, so the selection
+        still works.
+
+        Unset — current behavior: suspend the TUI, clear the primary
+        screen buffer (which still shows whatever was there before the
+        TUI launched, #2010), run inline, return the CompletedProcess so
+        the caller can act on a non-zero exit.
+        """
+        term_cmd = self.app.tui_state.cfg().get_terminal_open_cmd()
+        if term_cmd:
+            try:
+                # Own session so the new window outlives the TUI / this
+                # command's process group.
+                subprocess.Popen([*term_cmd, *cmd], start_new_session=True)
+                return None
+            except OSError as exc:
+                self._msg(
+                    f"terminal-open-cmd failed ({exc}) —"
+                    " opening in this terminal instead.",
+                    error=True,
+                )
+        with self.app.suspend():
+            sys.stdout.write("\033[2J\033[H")
+            sys.stdout.flush()
+            return subprocess.run(cmd)
 
     def _launch_shared_terminal(self, event: ListView.Selected) -> None:
         """Join the selected shared terminal via ``klangk shell <ws> <handle>:<win>``.
@@ -751,16 +788,8 @@ class WorkspaceDetailScreen(Screen):
             self._msg("Invalid shared terminal — refreshing.", error=True)
             self.run_worker(self._load_shared_terminals, exit_on_error=False)
             return
-        cmd = [sys.executable, "-m", "klangk.cli.main"]
-        server = self.app.tui_state.current_url()
-        if server:
-            cmd += ["--server", server]
-        cmd += ["shell", self._name, target]
-        with self.app.suspend():
-            sys.stdout.write("\033[2J\033[H")
-            sys.stdout.flush()
-            completed = subprocess.run(cmd)
-        if completed.returncode != 0:
+        completed = self._launch_shell(self._shell_argv(target))
+        if completed is not None and completed.returncode != 0:
             # The shared window may have been unshared/closed server-side
             # between refresh and selection — refresh the shared list.
             self.run_worker(self._load_shared_terminals, exit_on_error=False)

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -745,9 +745,13 @@ class WorkspaceDetailScreen(Screen):
         after ``-e``). The TUI stays up — no suspend. Returns None on that
         path: launchers like konsole always exit 0 and return immediately
         (or when the window closes), so there is no exit code worth acting
-        on. A spawn failure (command missing, no DISPLAY) shows an inline
-        message and falls through to the inline path, so the selection
-        still works.
+        on. Output is discarded — the launcher runs in its own window, and
+        a launcher that fails after exec'ing (e.g. no DISPLAY server) would
+        otherwise spray its abort message across the TUI's screen. Only an
+        ``OSError`` from Popen itself (command missing / not executable)
+        triggers the fallback: the error is shown inline and the inline
+        launch is deferred via ``set_timer`` so the message paints before
+        suspend() blanks the screen (#2686 review).
 
         Unset — current behavior: suspend the TUI, clear the primary
         screen buffer (which still shows whatever was there before the
@@ -759,7 +763,12 @@ class WorkspaceDetailScreen(Screen):
             try:
                 # Own session so the new window outlives the TUI / this
                 # command's process group.
-                subprocess.Popen([*term_cmd, *cmd], start_new_session=True)
+                subprocess.Popen(
+                    [*term_cmd, *cmd],
+                    start_new_session=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
                 return None
             except OSError as exc:
                 self._msg(
@@ -767,6 +776,16 @@ class WorkspaceDetailScreen(Screen):
                     " opening in this terminal instead.",
                     error=True,
                 )
+                # Defer one refresh cycle so the message above renders
+                # before suspend() takes over the screen.
+                self.call_after_refresh(lambda: self._launch_shell_inline(cmd))
+                return None
+        return self._launch_shell_inline(cmd)
+
+    def _launch_shell_inline(
+        self, cmd: list[str]
+    ) -> subprocess.CompletedProcess:
+        """Suspend the TUI and run the shell argv in this terminal."""
         with self.app.suspend():
             sys.stdout.write("\033[2J\033[H")
             sys.stdout.flush()

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -216,6 +216,76 @@ class TestCLIConfig:
         cfg = CLIConfig.load()
         assert cfg.servers["prod"].user == "admin@prod.com"
 
+    # --- terminal-open-cmd (#2685) ---
+
+    def test_terminal_open_cmd_absent(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text("forward-agent: true\n")
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        monkeypatch.delenv("KLANGKC_TERMINAL_OPEN_CMD", raising=False)
+        cfg = CLIConfig.load()
+        assert cfg.terminal_open_cmd is None
+        assert cfg.get_terminal_open_cmd() is None
+
+    def test_terminal_open_cmd_string_form(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text('terminal-open-cmd: "konsole --hold -e"\n')
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        monkeypatch.delenv("KLANGKC_TERMINAL_OPEN_CMD", raising=False)
+        cfg = CLIConfig.load()
+        assert cfg.get_terminal_open_cmd() == ["konsole", "--hold", "-e"]
+
+    def test_terminal_open_cmd_list_form(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text(
+            "terminal-open-cmd:\n  - kitty\n  - --class\n  - klangk shell\n"
+        )
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        monkeypatch.delenv("KLANGKC_TERMINAL_OPEN_CMD", raising=False)
+        cfg = CLIConfig.load()
+        assert cfg.get_terminal_open_cmd() == [
+            "kitty",
+            "--class",
+            "klangk shell",
+        ]
+
+    def test_terminal_open_cmd_invalid_values_ignored(
+        self, tmp_path, monkeypatch
+    ):
+        """Empty / wrong-typed values degrade to None (inline shell), not a
+        crash of every CLIConfig.load() caller."""
+        import klangk.cli.config as cfgmod
+
+        assert cfgmod._parse_terminal_open_cmd("") is None
+        assert cfgmod._parse_terminal_open_cmd("   ") is None
+        assert cfgmod._parse_terminal_open_cmd([]) is None
+        assert cfgmod._parse_terminal_open_cmd(42) is None
+        assert cfgmod._parse_terminal_open_cmd({"a": 1}) is None
+        assert cfgmod._parse_terminal_open_cmd(["a", 2]) is None
+        # Quoted args survive shlex splitting in the string form.
+        assert cfgmod._parse_terminal_open_cmd(
+            'alacritty -T "klangk shell" -e'
+        ) == ["alacritty", "-T", "klangk shell", "-e"]
+
+    def test_terminal_open_cmd_envvar_wins(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text('terminal-open-cmd: "kitty"\n')
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        monkeypatch.setenv("KLANGKC_TERMINAL_OPEN_CMD", "konsole --hold -e")
+        cfg = CLIConfig.load()
+        # The envvar overrides the file value.
+        assert cfg.get_terminal_open_cmd() == ["konsole", "--hold", "-e"]
+
+    def test_terminal_open_cmd_envvar_empty_falls_back_to_file(
+        self, tmp_path, monkeypatch
+    ):
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text('terminal-open-cmd: "kitty"\n')
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        monkeypatch.setenv("KLANGKC_TERMINAL_OPEN_CMD", "   ")
+        cfg = CLIConfig.load()
+        assert cfg.get_terminal_open_cmd() == ["kitty"]
+
 
 # --- seed_config tests ---
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -266,6 +266,23 @@ class TestCLIConfig:
         assert cfgmod._parse_terminal_open_cmd(
             'alacritty -T "klangk shell" -e'
         ) == ["alacritty", "-T", "klangk shell", "-e"]
+        # An unbalanced quote raises ValueError out of shlex.split — it
+        # must degrade to None (one yaml typo must not crash every CLI
+        # command that loads the config, #2686 review).
+        assert cfgmod._parse_terminal_open_cmd('konsole "-e') is None
+
+    def test_terminal_open_cmd_envvar_unbalanced_quote_no_crash(
+        self, tmp_path, monkeypatch
+    ):
+        """A typo'd envvar must not raise from get_terminal_open_cmd — the
+        TUI calls it inside a message handler, where an exception is a
+        crash screen (#2686 review)."""
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text("forward-agent: true\n")
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        monkeypatch.setenv("KLANGKC_TERMINAL_OPEN_CMD", "konsole '-e")
+        cfg = CLIConfig.load()
+        assert cfg.get_terminal_open_cmd() is None
 
     def test_terminal_open_cmd_envvar_wins(self, tmp_path, monkeypatch):
         config_path = tmp_path / "klangk.yaml"

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -507,6 +507,19 @@ class TestDefaultHelpers:
         ):
             assert sp._default_run(["tmux"]) == 7
 
+    def test_default_run_captures_output(self):
+        """Best-effort tmux commands must never spray stderr into the
+        user's terminal — the post-exit kill-session against an
+        already-dead server read like a crash (#2685 follow-up)."""
+        proc = MagicMock(returncode=1, stderr=b"no server running on /x.sock")
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run", return_value=proc
+        ) as fake_run:
+            assert sp._default_run(["tmux"]) == 1
+        kwargs = fake_run.call_args.kwargs
+        assert kwargs["stdout"] is sp.subprocess.PIPE
+        assert kwargs["stderr"] is sp.subprocess.PIPE
+
     def test_default_run_oserror_returns_1(self):
         with patch(
             "klangk.cli.shell_popup.subprocess.run",
@@ -598,7 +611,9 @@ class TestShellWiring:
         ws = SimpleNamespace(egress_mode="interactive")
         with (
             patch("klangk.cli.main.sys.stdin.isatty", return_value=True),
-            patch("klangk.cli.shellcmd.host_tmux_version", return_value=(3, 6)),
+            patch(
+                "klangk.cli.shellcmd.host_tmux_version", return_value=(3, 6)
+            ),
         ):
             assert cli_main._consent_popup_enabled(ws, False) is True
 
@@ -606,7 +621,9 @@ class TestShellWiring:
         ws = SimpleNamespace(egress_mode="interactive")
         with (
             patch("klangk.cli.main.sys.stdin.isatty", return_value=True),
-            patch("klangk.cli.shellcmd.host_tmux_version", return_value=(3, 1)),
+            patch(
+                "klangk.cli.shellcmd.host_tmux_version", return_value=(3, 1)
+            ),
         ):
             assert cli_main._consent_popup_enabled(ws, False) is False
 
@@ -619,8 +636,12 @@ class TestShellWiring:
             return 7
 
         with (
-            patch("klangk.cli.shellcmd.run_consent_shell", side_effect=fake_run),
-            patch("klangk.cli.context.server_url", return_value="http://server"),
+            patch(
+                "klangk.cli.shellcmd.run_consent_shell", side_effect=fake_run
+            ),
+            patch(
+                "klangk.cli.context.server_url", return_value="http://server"
+            ),
         ):
             rc = cli_main._run_consent_popup(ws, "@1", True)
         assert rc == 7
@@ -629,3 +650,25 @@ class TestShellWiring:
         assert "ws" in captured["inner_argv"]
         assert "--popup-socket" in captured["decider_argv"]
         assert "--popup-session" in captured["decider_argv"]
+
+    def test_run_consent_popup_prints_disconnect_line(self, capsys):
+        """After the attach returns the user sees a clean exit line, so
+        tmux's own `[exited]` (and the returned-to dead screen) reads as
+        a clean disconnect, not a crash (#2685 follow-up)."""
+        ws = SimpleNamespace(id="wsid", name="mork")
+
+        def fake_run(**kwargs):
+            return 0
+
+        with (
+            patch(
+                "klangk.cli.shellcmd.run_consent_shell", side_effect=fake_run
+            ),
+            patch(
+                "klangk.cli.context.server_url", return_value="http://server"
+            ),
+        ):
+            rc = cli_main._run_consent_popup(ws, "@1", True)
+        assert rc == 0
+        out = capsys.readouterr()
+        assert "Disconnected from mork" in out.err

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -6473,7 +6473,9 @@ async def test_detail_terminal_select_external_terminal(monkeypatch):
         await pilot.pause()
         app.screen.on_list_view_selected(FakeSelected("0"))
         # Spawned via Popen with the configured terminal command prefixed,
-        # in its own session so the window outlives the TUI.
+        # in its own session so the window outlives the TUI, and with
+        # launcher output discarded so a post-exec failure can't trash
+        # the TUI's screen (#2686 review).
         assert len(popped) == 1
         argv, kwargs = popped[0]
         assert argv[:3] == ["konsole", "--hold", "-e"]
@@ -6488,6 +6490,8 @@ async def test_detail_terminal_select_external_terminal(monkeypatch):
             "@0",
         ]
         assert kwargs.get("start_new_session") is True
+        assert kwargs.get("stdout") == scr_detail.subprocess.DEVNULL
+        assert kwargs.get("stderr") == scr_detail.subprocess.DEVNULL
         # Not run inline — the TUI stays up, no suspend.
         assert ran == []
 
@@ -6543,14 +6547,18 @@ async def test_detail_terminal_select_external_failure_falls_back(
         await pilot.pause()
         monkeypatch.setattr(app, "suspend", fake_suspend)
         app.screen.on_list_view_selected(FakeSelected("0"))
-        # Fell back to the inline path.
-        assert len(spawned) == 1
-        assert spawned[0][-3:] == ["shell", "alpha", "@0"]
-        # The failure is surfaced inline.
+        # The inline fallback is deferred (call_after_refresh) so the error message
+        # paints before suspend() blanks the screen — not launched yet.
+        assert spawned == []
         msg = str(
             app.screen.query_one("#detail_msg", scr_detail.Static).render()
         )
         assert "terminal-open-cmd failed" in msg
+        # Let the timer fire, then the deferred inline launch runs.
+        await pilot.pause()
+        await pilot.pause()
+        assert len(spawned) == 1
+        assert spawned[0][-3:] == ["shell", "alpha", "@0"]
 
 
 async def test_detail_shared_terminal_select_external_terminal(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -6431,6 +6431,173 @@ async def test_detail_terminal_select_spawns_shell(monkeypatch):
         assert "Connecting to alpha" not in captured[0]
 
 
+async def test_detail_terminal_select_external_terminal(monkeypatch):
+    """With terminal-open-cmd configured, the shell spawns in a new
+    terminal window via Popen (argv appended after the configured command)
+    and the TUI is not suspended (#2685)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setenv("KLANGKC_TERMINAL_OPEN_CMD", "konsole --hold -e")
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+
+    class FakeProc:
+        returncode = 0
+
+    popped = []
+
+    def fake_popen(argv, **k):
+        popped.append((argv, k))
+        return FakeProc()
+
+    monkeypatch.setattr(scr_detail.subprocess, "Popen", fake_popen)
+    ran = []
+    monkeypatch.setattr(
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: (
+            ran.append(cmd) or scr_detail.subprocess.CompletedProcess(cmd, 0)
+        ),
+    )
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        app.screen.on_list_view_selected(FakeSelected("0"))
+        # Spawned via Popen with the configured terminal command prefixed,
+        # in its own session so the window outlives the TUI.
+        assert len(popped) == 1
+        argv, kwargs = popped[0]
+        assert argv[:3] == ["konsole", "--hold", "-e"]
+        assert argv[3:] == [
+            scr_detail.sys.executable,
+            "-m",
+            "klangk.cli.main",
+            "--server",
+            "https://x.example",
+            "shell",
+            "alpha",
+            "@0",
+        ]
+        assert kwargs.get("start_new_session") is True
+        # Not run inline — the TUI stays up, no suspend.
+        assert ran == []
+
+
+async def test_detail_terminal_select_external_failure_falls_back(
+    monkeypatch,
+):
+    """A broken terminal-open-cmd (command missing) shows an inline error
+    and falls back to the inline suspend-and-run path (#2685)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setenv("KLANGKC_TERMINAL_OPEN_CMD", "no-such-terminal -e")
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+
+    def boom(argv, **k):
+        raise FileNotFoundError("no-such-terminal not found")
+
+    monkeypatch.setattr(scr_detail.subprocess, "Popen", boom)
+    spawned = []
+    monkeypatch.setattr(
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: (
+            spawned.append(cmd)
+            or scr_detail.subprocess.CompletedProcess(cmd, 0)
+        ),
+    )
+
+    import io
+    import sys
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_suspend():
+        saved = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            yield
+        finally:
+            sys.stdout = saved
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        monkeypatch.setattr(app, "suspend", fake_suspend)
+        app.screen.on_list_view_selected(FakeSelected("0"))
+        # Fell back to the inline path.
+        assert len(spawned) == 1
+        assert spawned[0][-3:] == ["shell", "alpha", "@0"]
+        # The failure is surfaced inline.
+        msg = str(
+            app.screen.query_one("#detail_msg", scr_detail.Static).render()
+        )
+        assert "terminal-open-cmd failed" in msg
+
+
+async def test_detail_shared_terminal_select_external_terminal(monkeypatch):
+    """Shared-terminal joins honor terminal-open-cmd too (#2685)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    monkeypatch.setenv("KLANGKC_TERMINAL_OPEN_CMD", "konsole --hold -e")
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_shared_terminals=_async_shared)
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+
+    class FakeProc:
+        returncode = 0
+
+    popped = []
+
+    def fake_popen(argv, **k):
+        popped.append(argv)
+        return FakeProc()
+
+    monkeypatch.setattr(scr_detail.subprocess, "Popen", fake_popen)
+    ran = []
+    monkeypatch.setattr(
+        scr_detail.subprocess,
+        "run",
+        lambda cmd, **k: (
+            ran.append(cmd) or scr_detail.subprocess.CompletedProcess(cmd, 0)
+        ),
+    )
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        app.screen.on_list_view_selected(
+            FakeSelected("alice:build", control_id="shared_term_list")
+        )
+        assert len(popped) == 1
+        assert popped[0][-3:] == ["shell", "alpha", "alice:build"]
+        assert popped[0][:3] == ["konsole", "--hold", "-e"]
+        assert ran == []
+
+
 async def test_detail_terminal_select_refuses_when_id_unresolvable(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Adds a `terminal-open-cmd` CLI setting (klangk.yaml or `KLANGKC_TERMINAL_OPEN_CMD` envvar) that names the command used to open a new terminal window (e.g. `konsole --hold -e`). When set, selecting a terminal (own or shared) on the TUI workspace detail screen spawns `klangk shell` in a **new terminal window** via the configured command — the TUI stays running, no suspend. When unset, behavior is unchanged. If the configured command can't be launched (missing binary, no `DISPLAY`), the TUI shows an inline error and falls back to the inline suspend-and-run path.

Closes #2685.

## Changes

- **`cli/config.py`** — `CLIConfig.terminal_open_cmd` parsed from `terminal-open-cmd` (string form is shlex-split; list form accepted), `get_terminal_open_cmd()` applies the `KLANGKC_TERMINAL_OPEN_CMD` override (empty envvar falls through to the file value). Invalid values (wrong type, empty) degrade to unset rather than crash.
- **`cli/tui/screens/workspace_detail.py`** — the two spawn sites (own + shared terminal selection) now go through `_shell_argv()` / `_launch_shell()`. With a terminal command configured: `Popen([*term_cmd, *shell_argv], start_new_session=True)` — argv appended after the configured command (terminals take the command as trailing args after `-e`/`--`), own session so the window outlives the TUI. The external path returns no exit-code signal (launchers like konsole always exit 0 / return at window close), so the stale-row refresh stays tied to the inline path only.
- **Tests** — 7 config tests (parsing, precedence, invalid values) + 3 TUI tests (external spawn for own and shared lists, spawn-failure fallback), all under the existing harness.
- **Docs** — `docs/reference/cli.md` settings table row + "Opening shells in a new terminal" section (kitty / konsole / wezterm / alacritty examples); changelog entry.

## Notes

- Konsole specifics verified empirically (issue #2685): env forwarding works per-window, `-e` must be last, `--hold` keeps error output readable, exit code is always 0 — hence `FileNotFoundError`/`OSError` detection instead of exit codes.
- Per-server override deliberately omitted (global preference only) — can add if wanted.
