### PR TITLE
fix(cli): per-invocation consent-popup sessions — concurrent shells land on their selected terminal

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1190,15 +1190,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
-- **Concurrent consent-popup shells no longer share one tmux session (#2692).**
-  The consent-popup wrapper named its outer/hidden sessions after the
-  workspace, so a second `klangk shell` into the same workspace (e.g. a
-  terminal opened from the TUI while another was still open) failed its
-  `new-session` and silently attached to the first shell's session —
-  showing the first shell's terminal regardless of which one was
-  selected. Sessions now carry a per-invocation suffix; the wrapper also
-  no longer prints best-effort tmux cleanup failures into the terminal
-  after the shell exits.
+- **Concurrent shells on one interactive-egress workspace now land on their
+  selected terminal (#2692).** Selecting a terminal (e.g. from the TUI with
+  `terminal-open-cmd`) while another consent-popup shell on the same
+  workspace was still open attached to the first shell's terminal instead.
+  Abandoned shells also no longer accumulate sessions and popups after the
+  terminal window is closed or the client is killed.
 - **Idempotent `POST /auth/logout` (#2687).** Logout now returns 200 even
   when the presented token is already expired, revoked, or absent — the
   token being dead is logout's desired end state, not an auth failure.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1190,6 +1190,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Concurrent consent-popup shells no longer share one tmux session (#2692).**
+  The consent-popup wrapper named its outer/hidden sessions after the
+  workspace, so a second `klangk shell` into the same workspace (e.g. a
+  terminal opened from the TUI while another was still open) failed its
+  `new-session` and silently attached to the first shell's session —
+  showing the first shell's terminal regardless of which one was
+  selected. Sessions now carry a per-invocation suffix; the wrapper also
+  no longer prints best-effort tmux cleanup failures into the terminal
+  after the shell exits.
 - **Idempotent `POST /auth/logout` (#2687).** Logout now returns 200 even
   when the presented token is already expired, revoked, or absent — the
   token being dead is logout's desired end state, not an auth failure.

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -38,6 +38,9 @@ from __future__ import annotations
 import logging
 import os
 import re
+import signal
+from collections.abc import Callable
+from contextlib import contextmanager
 import shlex
 import shutil
 import subprocess
@@ -138,20 +141,67 @@ def hidden_session_name(workspace_id: str) -> str:
 def popup_session_names(workspace_id: str) -> tuple[str, str]:
     """Per-invocation (outer, hidden) session names for the russian-doll.
 
-    The names embed a random suffix so each ``klangk shell`` invocation
-    gets its OWN outer + hidden pair on the shared per-workspace socket.
-    Deterministic per-workspace names made a second concurrent shell into
-    the same workspace fail its ``new-session`` (duplicate session) and
-    silently attach to the FIRST shell's session — showing that shell's
-    window regardless of the terminal the user selected (#2692). The
-    caller must use one call's result for BOTH the decider argv and
-    ``run_consent_shell`` so the names stay paired.
+    The names embed the wrapper pid + a random suffix so each
+    ``klangk shell`` invocation gets its OWN outer + hidden pair on the
+    shared per-workspace socket. Deterministic per-workspace names made a
+    second concurrent shell into the same workspace fail its
+    ``new-session`` (duplicate session) and silently attach to the FIRST
+    shell's session — showing that shell's window regardless of the
+    terminal the user selected (#2692). The caller must use one call's
+    result for BOTH the decider argv and ``run_consent_shell`` so the
+    names stay paired. The pid lets :func:`sweep_dead_sessions` reap
+    sessions whose wrapper died without cleanup (SIGKILL; SIGHUP and
+    exceptions are handled in ``run_consent_shell``) — per-invocation
+    names are never reused, so orphans would otherwise accumulate
+    (#2693 review).
     """
-    suffix = uuid.uuid4().hex[:8]
+    suffix = f"p{os.getpid()}-{uuid.uuid4().hex[:6]}"
     return (
         f"{outer_session_name(workspace_id)}-{suffix}",
         f"{hidden_session_name(workspace_id)}-{suffix}",
     )
+
+
+def sweep_dead_sessions(
+    workspace_id: str, run=None, alive=os.path.exists
+) -> int:
+    """Kill wrapper sessions whose owning process is dead. Returns count.
+
+    Session names embed the wrapper pid (``...-p<pid>-<rand>``). A session
+    whose ``/proc/<pid>`` is absent was left by a SIGKILLed wrapper (every
+    softer death path runs cleanup in ``run_consent_shell``) and is safe
+    to reap — it can never be reattached, and the hidden decider inside
+    it would keep its consent WebSocket reconnecting forever. Called at
+    wrapper startup, BEFORE this invocation's own sessions exist, so a
+    live wrapper's sessions are never at risk. No pid in the name (old
+    sessions, foreign sessions) → left alone. Best-effort: never raises.
+    """
+    socket = socket_path(workspace_id)
+    runner = run or _default_run
+    try:
+        proc = subprocess.run(
+            _tmux(socket, "list-sessions", "-F", "#{session_name}"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    if proc.returncode != 0:
+        # No server running on the socket — nothing to sweep.
+        return 0
+    reaped = 0
+    for name in proc.stdout.splitlines():
+        m = re.search(r"-p(\d+)-[0-9a-f]+$", name)
+        if not m:
+            continue
+        pid = int(m.group(1))
+        if pid == os.getpid() or alive(f"/proc/{pid}"):
+            continue
+        runner(kill_session_cmd(socket, name), quiet=True)
+        reaped += 1
+    return reaped
 
 
 # ---------------------------------------------------------------------------
@@ -360,31 +410,31 @@ def should_use_popup(
 # ---------------------------------------------------------------------------
 
 
-def _default_run(argv: list[str]) -> int:
+def _default_run(argv: list[str], quiet: bool = False) -> int:
     """Run a tmux control command, logging failures (never raising).
 
-    Output is captured, never shown: several of these commands run as
-    best-effort cleanup after the shell exits (kill-session on a server
-    that already terminated when the last session died), and tmux's
-    "no server running on <sock>" stderr there read like a crash instead
-    of a clean disconnect (#2685 follow-up). A non-zero exit code (with
-    captured stderr) goes to the log instead of the terminal.
+    Output is captured, never shown: post-exit cleanup commands
+    (kill-session on a server that already terminated when its last
+    session died) would spray tmux's ``no server running on <sock>``
+    stderr into the terminal, reading like a crash instead of a clean
+    disconnect (#2685 follow-up). Cleanup callers pass ``quiet=True`` —
+    their failures are expected and logged at debug (the CLI configures
+    no logging, so debug is effectively silent). Setup-step failures stay
+    at warning: they are real failures the user must be able to see (a
+    failed outer ``new-session`` is exactly the #2692 failure class).
     """
     try:
         proc = subprocess.run(
             argv, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
     except OSError as exc:
-        logger.debug(
+        logger.warning(
             "consent-popup tmux command failed: %s (%s)", argv[0], exc
         )
         return 1
     if proc.returncode != 0:
-        # Best-effort commands (setup steps tolerate absence; cleanup runs
-        # after the server may have exited with its last session) — debug,
-        # not warning: at warning level these sprayed into the user's
-        # terminal after every consent-wrapped shell exit (#2692).
-        logger.debug(
+        log = logger.debug if quiet else logger.warning
+        log(
             "consent-popup tmux command failed (rc=%d): %s %s",
             proc.returncode,
             argv,
@@ -425,9 +475,19 @@ def run_consent_shell(
     best-effort and never raises.
     """
     socket = socket_path(workspace_id)
+    # Reap sessions left by wrappers that died without cleanup (SIGKILL);
+    # runs before this invocation's own sessions exist (#2693 review).
+    sweep_dead_sessions(workspace_id)
     outer, hidden = session_names or popup_session_names(workspace_id)
     cols, rows = term_size or _term_size()
     pw, ph = popup_size
+
+    def cleanup() -> None:
+        # Best-effort reap of this invocation's sessions. quiet=True: the
+        # tmux server may already be gone (it exits with its last session),
+        # and post-exit failure noise read like a crash (#2685 follow-up).
+        run(kill_session_cmd(socket, hidden), quiet=True)
+        run(kill_session_cmd(socket, outer), quiet=True)
 
     # 1. outer session running the inner (normal) shell.
     run(new_detached_session(socket, outer, inner_argv, x=cols, y=rows))
@@ -445,11 +505,21 @@ def run_consent_shell(
     #    startup when there's nothing to decide).
     for cmd in popup_binding_cmds(socket, hidden, w=pw, h=ph):
         run(cmd)
-    # 5. attach the user's terminal to the outer session (blocks).
-    rc = attach(attach_cmd(socket, outer))
-    # 6. cleanup: reap the hidden decider session (and a lingering outer).
-    run(kill_session_cmd(socket, hidden))
-    run(kill_session_cmd(socket, outer))
+    # 5. attach the user's terminal to the outer session (blocks). Cleanup
+    #    runs even when the attach dies abnormally — the terminal window
+    #    being closed delivers SIGHUP mid-attach, and an unhandled
+    #    KeyboardInterrupt/OSError must not strand the detached sessions
+    #    (per-invocation names are never reused, so leaks accumulate, #2693
+    #    review).
+    with _cleanup_on_signal(cleanup):
+        try:
+            rc = attach(attach_cmd(socket, outer))
+        except BaseException:
+            cleanup()
+            raise
+    # 6. cleanup (normal path): reap the hidden decider session (and a
+    #    lingering outer).
+    cleanup()
     return rc
 
 
@@ -459,6 +529,34 @@ def _term_size() -> tuple[int, int]:
         return size.columns, size.lines
     except OSError:
         return 80, 24
+
+
+@contextmanager
+def _cleanup_on_signal(cleanup: Callable[[], None]):
+    """Run *cleanup* if SIGHUP arrives inside the block.
+
+    The wrapper's attach blocks in ``tmux attach``; closing the terminal
+    window delivers SIGHUP to the process group. tmux dies with it, but the
+    *detached* outer/hidden sessions survive — and with per-invocation names
+    they are never reused, so each window-close would strand a tmux server,
+    two sessions, and the decider's consent WebSocket forever (#2693
+    review). The handler reaps them, then re-raises the default SIGHUP
+    behavior (process death) so the exit status stays truthful.
+    """
+    prev = signal.getsignal(signal.SIGHUP)
+
+    def on_hup(signum, frame):
+        try:
+            cleanup()
+        finally:
+            signal.signal(signal.SIGHUP, signal.SIG_DFL)
+            os.kill(os.getpid(), signal.SIGHUP)
+
+    try:
+        signal.signal(signal.SIGHUP, on_hup)
+        yield
+    finally:
+        signal.signal(signal.SIGHUP, prev)
 
 
 # Re-exported for the shell command to build the inner/decider invocations.
@@ -486,6 +584,7 @@ __all__ = [
     "popup_viewer_shell_string",
     "run_consent_shell",
     "should_use_popup",
+    "sweep_dead_sessions",
     "show_popup_argv",
     "socket_path",
     "tmux_usable",

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -42,6 +42,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +133,25 @@ def outer_session_name(workspace_id: str) -> str:
 
 def hidden_session_name(workspace_id: str) -> str:
     return f"klangk-consent-{_sanitize(workspace_id)}"
+
+
+def popup_session_names(workspace_id: str) -> tuple[str, str]:
+    """Per-invocation (outer, hidden) session names for the russian-doll.
+
+    The names embed a random suffix so each ``klangk shell`` invocation
+    gets its OWN outer + hidden pair on the shared per-workspace socket.
+    Deterministic per-workspace names made a second concurrent shell into
+    the same workspace fail its ``new-session`` (duplicate session) and
+    silently attach to the FIRST shell's session — showing that shell's
+    window regardless of the terminal the user selected (#2692). The
+    caller must use one call's result for BOTH the decider argv and
+    ``run_consent_shell`` so the names stay paired.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    return (
+        f"{outer_session_name(workspace_id)}-{suffix}",
+        f"{hidden_session_name(workspace_id)}-{suffix}",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -355,12 +375,16 @@ def _default_run(argv: list[str]) -> int:
             argv, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
     except OSError as exc:
-        logger.warning(
+        logger.debug(
             "consent-popup tmux command failed: %s (%s)", argv[0], exc
         )
         return 1
     if proc.returncode != 0:
-        logger.warning(
+        # Best-effort commands (setup steps tolerate absence; cleanup runs
+        # after the server may have exited with its last session) — debug,
+        # not warning: at warning level these sprayed into the user's
+        # terminal after every consent-wrapped shell exit (#2692).
+        logger.debug(
             "consent-popup tmux command failed (rc=%d): %s %s",
             proc.returncode,
             argv,
@@ -383,6 +407,7 @@ def run_consent_shell(
     term_size: tuple[int, int] | None = None,
     run=_default_run,
     attach=_default_attach,
+    session_names: tuple[str, str] | None = None,
 ) -> int:
     """Bring up the consent-popup russian-doll and attach the user to it.
 
@@ -391,12 +416,16 @@ def run_consent_shell(
     does not re-wrap). *decider_argv* is the ``klangk consent-decide``
     invocation in its persistent popup role. Returns the attach's exit code.
 
+    *session_names* is the per-invocation ``(outer, hidden)`` pair from
+    :func:`popup_session_names`; when omitted it is generated here. Callers
+    that build the decider argv from the hidden session name MUST pass the
+    same pair so the decider and the wrapper agree (#2692).
+
     On any setup failure the outer session may not exist; cleanup is
     best-effort and never raises.
     """
     socket = socket_path(workspace_id)
-    outer = outer_session_name(workspace_id)
-    hidden = hidden_session_name(workspace_id)
+    outer, hidden = session_names or popup_session_names(workspace_id)
     cols, rows = term_size or _term_size()
     pw, ph = popup_size
 
@@ -453,6 +482,7 @@ __all__ = [
     "outer_session_name",
     "parse_tmux_version",
     "popup_binding_cmds",
+    "popup_session_names",
     "popup_viewer_shell_string",
     "run_consent_shell",
     "should_use_popup",

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -25,8 +25,8 @@ from .shell_popup import (
     EGRESS_INTERACTIVE,
     OUTER_PREFIX,
     REOPEN_KEY,
-    hidden_session_name,
     host_tmux_version,
+    popup_session_names,
     run_consent_shell,
     should_use_popup,
     socket_path,
@@ -118,9 +118,12 @@ def _run_consent_popup(ws, terminal: str | None, forward_agent: bool) -> int:
     """Bring up the consent-popup russian-doll + attach the user to it (#2383)."""
     server = context.server_url()
     socket = socket_path(ws.id)
-    hidden = hidden_session_name(ws.id)
+    # One per-invocation (outer, hidden) pair shared by the wrapper and the
+    # decider argv — deterministic per-workspace names made a concurrent
+    # second shell attach to the FIRST shell's session (#2692).
+    names = popup_session_names(ws.id)
     inner = _popup_inner_shell_argv(server, ws.name, terminal, forward_agent)
-    decider = _popup_decider_argv(server, ws.name, socket, hidden)
+    decider = _popup_decider_argv(server, ws.name, socket, names[1])
     context._err.print(
         f"Connecting to [bold]{ws.name}[/bold] with consent popup…"
     )
@@ -130,7 +133,10 @@ def _run_consent_popup(ws, terminal: str | None, forward_agent: bool) -> int:
         f"Enter, then ~. exits[/dim]"
     )
     rc = run_consent_shell(
-        workspace_id=ws.id, inner_argv=inner, decider_argv=decider
+        workspace_id=ws.id,
+        inner_argv=inner,
+        decider_argv=decider,
+        session_names=names,
     )
     context._err.print(f"Disconnected from [bold]{ws.name}[/bold].")
     return rc

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -6,8 +6,11 @@ command sequence (with the tmux runner / attach injected as recorders).
 
 from __future__ import annotations
 
+import re
 import shlex
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 from klangk.cli import shell_popup as sp
@@ -121,12 +124,12 @@ class TestNaming:
         attach to) the first shell's sessions (#2692)."""
         a = sp.popup_session_names("wsid")
         b = sp.popup_session_names("wsid")
-        assert a[0].startswith("klangk-shell-wsid-")
-        assert a[1].startswith("klangk-consent-wsid-")
+        assert re.match(r"klangk-shell-wsid-p\d+-[0-9a-f]+$", a[0])
+        assert re.match(r"klangk-consent-wsid-p\d+-[0-9a-f]+$", a[1])
         # Unique across invocations...
         assert a != b
         # ...and the pair shares one suffix (wrapper + decider agree).
-        assert a[0].rsplit("-", 1)[-1] == a[1].rsplit("-", 1)[-1]
+        assert a[0].rsplit("-", 2)[-2:] == a[1].rsplit("-", 2)[-2:]
 
 
 # ---------------------------------------------------------------------------
@@ -362,7 +365,7 @@ class TestRunConsentShell:
         """Drive run_consent_shell with recording run/attach stubs."""
         ran: list[list[str]] = []
 
-        def fake_run(argv):
+        def fake_run(argv, quiet=False):
             ran.append(argv)
             return 0
 
@@ -385,8 +388,8 @@ class TestRunConsentShell:
         # recover them from the actual new-session commands.
         outer = ran[0][ran[0].index("-s") + 1]
         hidden = ran[4][ran[4].index("-s") + 1]
-        assert outer.startswith("klangk-shell-wsid-")
-        assert hidden.startswith("klangk-consent-wsid-")
+        assert re.match(r"klangk-shell-wsid-p\d+-[0-9a-f]+$", outer)
+        assert re.match(r"klangk-consent-wsid-p\d+-[0-9a-f]+$", hidden)
         # 1 outer + 3 outer-config + 1 hidden + 1 hidden-config + 1 binding
         # + 1 attach + 2 kills = 10
         assert len(ran) == 10
@@ -429,7 +432,7 @@ class TestRunConsentShell:
         wrapper must target the same sessions (#2692)."""
         ran = []
 
-        def fake_run(argv):
+        def fake_run(argv, quiet=False):
             ran.append(argv)
             return 0
 
@@ -437,7 +440,10 @@ class TestRunConsentShell:
             ran.append(argv)
             return 0
 
-        names = ("klangk-shell-wsid-decafbad", "klangk-consent-wsid-decafbad")
+        names = (
+            "klangk-shell-wsid-p1234-decafbad",
+            "klangk-consent-wsid-p1234-decafbad",
+        )
         sp.run_consent_shell(
             workspace_id="wsid",
             inner_argv=["x"],
@@ -453,7 +459,7 @@ class TestRunConsentShell:
         assert ran[9] == sp.kill_session_cmd(socket, names[0])
 
     def test_returns_attach_exit_code(self):
-        def fake_run(argv):
+        def fake_run(argv, quiet=False):
             return 0
 
         def fake_attach(argv):
@@ -472,7 +478,7 @@ class TestRunConsentShell:
         # A failing run (nonzero rc) must not skip cleanup.
         ran: list[list[str]] = []
 
-        def fake_run(argv):
+        def fake_run(argv, quiet=False):
             ran.append(argv)
             return 1  # simulate a failing tmux command
 
@@ -498,7 +504,7 @@ class TestRunConsentShell:
     def test_custom_popup_and_term_size(self):
         ran: list[list[str]] = []
 
-        def fake_run(argv):
+        def fake_run(argv, quiet=False):
             ran.append(argv)
             return 0
 
@@ -526,10 +532,135 @@ class TestRunConsentShell:
         # popup command (the reopen binding) uses the popup size
         assert "-w 50 -h 10" in ran[6][5]
 
+    # ---------------------------------------------------------------------------
+    # real-subprocess helpers (the orchestrator's defaults)
+    # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# real-subprocess helpers (the orchestrator's defaults)
-# ---------------------------------------------------------------------------
+    def test_cleanup_runs_when_attach_raises(self):
+        """An exception out of attach (e.g. KeyboardInterrupt) must still
+        reap this invocation's sessions — per-invocation names are never
+        reused, so a leak accumulates (#2693 review)."""
+        ran = []
+
+        def fake_run(argv, quiet=False):
+            ran.append((argv, quiet))
+            return 0
+
+        def boom(argv):
+            raise KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            sp.run_consent_shell(
+                workspace_id="wsid",
+                inner_argv=["x"],
+                decider_argv=["y"],
+                run=fake_run,
+                attach=boom,
+            )
+        socket = sp.socket_path("wsid")
+        hidden = ran[4][0][ran[4][0].index("-s") + 1]
+        outer = ran[0][0][ran[0][0].index("-s") + 1]
+        assert ran[-2][0] == sp.kill_session_cmd(socket, hidden)
+        assert ran[-1][0] == sp.kill_session_cmd(socket, outer)
+        # cleanup kills are quiet
+        assert ran[-2][1] is True and ran[-1][1] is True
+
+    def test_setup_failures_log_at_warning_cleanup_at_debug(self, caplog):
+        """Setup-step failures stay at warning (a failed outer new-session
+        is the #2692 failure class — it must be visible); cleanup kills
+        are quiet (#2693 review)."""
+        import subprocess as sub
+
+        proc = sub.CompletedProcess(["tmux"], 1, stderr=b"boom")
+        with patch("klangk.cli.shell_popup.subprocess.run", return_value=proc):
+            with caplog.at_level("WARNING", logger="klangk.cli.shell_popup"):
+                assert sp._default_run(["tmux", "-S", "s", "new-session"]) == 1
+                assert (
+                    sp._default_run(
+                        ["tmux", "-S", "s", "kill-session"], quiet=True
+                    )
+                    == 1
+                )
+        warns = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warns) == 1  # only the setup command
+        assert "new-session" in warns[0].getMessage()
+
+    def test_sweep_dead_sessions_reaps_orphans_only(self):
+        """Sessions whose embedded wrapper pid is dead are reaped; a live
+        wrapper's session and pid-less (foreign) sessions are left alone
+        (#2693 review)."""
+        import subprocess as sub
+
+        dead_pid, live_pid, other_pid = 999998, 4242, 31337
+        listing = (
+            f"klangk-shell-wsid-p{dead_pid}-abc123\n"
+            f"klangk-shell-wsid-p{live_pid}-def456\n"
+            f"klangk-shell-wsid-p{other_pid}-7890ab\n"
+            "klangk-shell-wsid-noPid-ffffff\n"
+            "other-session\n"
+        )
+        proc = sub.CompletedProcess(["tmux"], 0, stdout=listing)
+        killed = []
+
+        def fake_run(argv, quiet=False):
+            killed.append(" ".join(argv))
+            return 0
+
+        def alive(path):
+            # only live_pid is alive; every other pid (incl. this process)
+            # counts as dead so exactly two sessions are reaped
+            return path == f"/proc/{live_pid}"
+
+        with patch("klangk.cli.shell_popup.subprocess.run", return_value=proc):
+            n = sp.sweep_dead_sessions("wsid", run=fake_run, alive=alive)
+
+        assert n == 2  # dead_pid + other_pid
+        joined = " | ".join(killed)
+        assert f"p{dead_pid}" in joined
+        assert f"p{other_pid}" in joined
+        assert f"p{live_pid}" not in joined
+        assert "noPid" not in joined  # no pid marker — foreign/legacy, skipped
+        assert "other-session" not in joined
+
+    def test_sweep_dead_sessions_handles_missing_server_and_errors(self):
+        """No tmux server on the socket (rc!=0), and a failure to even run
+        tmux — both are a no-op sweep, never a raise (#2693 review)."""
+        import subprocess as sub
+
+        proc = sub.CompletedProcess(["tmux"], 1, stdout="")
+        with patch("klangk.cli.shell_popup.subprocess.run", return_value=proc):
+            assert sp.sweep_dead_sessions("wsid") == 0
+        with patch(
+            "klangk.cli.shell_popup.subprocess.run", side_effect=OSError("x")
+        ):
+            assert sp.sweep_dead_sessions("wsid") == 0
+
+    def test_cleanup_on_signal_runs_cleanup_on_sighup(self):
+        """SIGHUP inside the block runs cleanup then kills the process —
+        the window-close path must not strand the sessions (#2693
+        review). Driven by invoking the installed handler directly."""
+        import signal
+
+        calls = []
+        installed = {}
+
+        def record(sig, handler):
+            installed[sig] = handler
+
+        with (
+            patch("klangk.cli.shell_popup.signal.signal", side_effect=record),
+            patch(
+                "klangk.cli.shell_popup.os.kill",
+                side_effect=lambda *a: calls.append(("kill", a)),
+            ),
+        ):
+            with sp._cleanup_on_signal(lambda: calls.append("cleanup")):
+                handler = installed.get(signal.SIGHUP)
+                assert callable(handler)
+                handler(signal.SIGHUP, None)
+        assert calls[0] == "cleanup"
+        assert calls[1][0] == "kill"
+        assert calls[1][1][1] == signal.SIGHUP
 
 
 class TestDefaultHelpers:
@@ -700,8 +831,8 @@ class TestShellWiring:
             captured["decider_argv"].index("--popup-session") + 1
         ]
         assert decider_session == names[1]
-        assert names[0].startswith("klangk-shell-wsid-")
-        assert names[1].startswith("klangk-consent-wsid-")
+        assert re.match(r"klangk-shell-wsid-p\d+-[0-9a-f]+$", names[0])
+        assert re.match(r"klangk-consent-wsid-p\d+-[0-9a-f]+$", names[1])
 
     def test_run_consent_popup_prints_disconnect_line(self, capsys):
         """After the attach returns the user sees a clean exit line, so

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -115,6 +115,19 @@ class TestNaming:
         bad = sp.outer_session_name("a.b:c")
         assert "." not in bad and ":" not in bad
 
+    def test_popup_session_names_unique_per_invocation(self):
+        """Each invocation gets its own (outer, hidden) pair so a second
+        concurrent shell into the same workspace cannot collide with (or
+        attach to) the first shell's sessions (#2692)."""
+        a = sp.popup_session_names("wsid")
+        b = sp.popup_session_names("wsid")
+        assert a[0].startswith("klangk-shell-wsid-")
+        assert a[1].startswith("klangk-consent-wsid-")
+        # Unique across invocations...
+        assert a != b
+        # ...and the pair shares one suffix (wrapper + decider agree).
+        assert a[0].rsplit("-", 1)[-1] == a[1].rsplit("-", 1)[-1]
+
 
 # ---------------------------------------------------------------------------
 # pure command builders
@@ -368,8 +381,12 @@ class TestRunConsentShell:
         )
         assert rc == 0
         socket = sp.socket_path("wsid")
-        outer = sp.outer_session_name("wsid")
-        hidden = sp.hidden_session_name("wsid")
+        # run_consent_shell generates per-invocation names (#2692) —
+        # recover them from the actual new-session commands.
+        outer = ran[0][ran[0].index("-s") + 1]
+        hidden = ran[4][ran[4].index("-s") + 1]
+        assert outer.startswith("klangk-shell-wsid-")
+        assert hidden.startswith("klangk-consent-wsid-")
         # 1 outer + 3 outer-config + 1 hidden + 1 hidden-config + 1 binding
         # + 1 attach + 2 kills = 10
         assert len(ran) == 10
@@ -387,12 +404,10 @@ class TestRunConsentShell:
         )  # size may differ; check the session
         assert ran[0][1:4] == ["-S", socket, "new-session"]
         assert ran[0][4] == "-d"
-        assert ran[0][ran[0].index("-s") + 1] == outer
         # configure: prefix/status/mouse
         assert ran[1:4] == sp.configure_outer_session(socket, outer)
         # hidden session
         assert ran[4][1:4] == ["-S", socket, "new-session"]
-        assert ran[4][ran[4].index("-s") + 1] == hidden
         # hidden session status bar hidden (popup shows only the decider)
         assert ran[5:6] == sp.configure_hidden_session(socket, hidden)
         # the reopen binding (no auto-show hook)
@@ -407,6 +422,35 @@ class TestRunConsentShell:
         # cleanup: kill hidden then outer
         assert ran[8] == sp.kill_session_cmd(socket, hidden)
         assert ran[9] == sp.kill_session_cmd(socket, outer)
+
+    def test_session_names_pair_is_shared_with_decider(self):
+        """When session_names is passed, the wrapper uses exactly that pair
+        — the caller's decider argv (built from the same pair) and the
+        wrapper must target the same sessions (#2692)."""
+        ran = []
+
+        def fake_run(argv):
+            ran.append(argv)
+            return 0
+
+        def fake_attach(argv):
+            ran.append(argv)
+            return 0
+
+        names = ("klangk-shell-wsid-decafbad", "klangk-consent-wsid-decafbad")
+        sp.run_consent_shell(
+            workspace_id="wsid",
+            inner_argv=["x"],
+            decider_argv=["y"],
+            run=fake_run,
+            attach=fake_attach,
+            session_names=names,
+        )
+        socket = sp.socket_path("wsid")
+        assert ran[0][ran[0].index("-s") + 1] == names[0]
+        assert ran[4][ran[4].index("-s") + 1] == names[1]
+        assert ran[7] == sp.attach_cmd(socket, names[0])
+        assert ran[9] == sp.kill_session_cmd(socket, names[0])
 
     def test_returns_attach_exit_code(self):
         def fake_run(argv):
@@ -443,14 +487,13 @@ class TestRunConsentShell:
             run=fake_run,
             attach=fake_attach,
         )
-        # final two commands are the cleanup kills regardless
+        # final two commands are the cleanup kills regardless; the
+        # per-invocation names are recovered from the create commands (#2692)
         socket = sp.socket_path("wsid")
-        assert ran[-2] == sp.kill_session_cmd(
-            socket, sp.hidden_session_name("wsid")
-        )
-        assert ran[-1] == sp.kill_session_cmd(
-            socket, sp.outer_session_name("wsid")
-        )
+        hidden = ran[4][ran[4].index("-s") + 1]
+        outer = ran[0][ran[0].index("-s") + 1]
+        assert ran[-2] == sp.kill_session_cmd(socket, hidden)
+        assert ran[-1] == sp.kill_session_cmd(socket, outer)
 
     def test_custom_popup_and_term_size(self):
         ran: list[list[str]] = []
@@ -650,6 +693,15 @@ class TestShellWiring:
         assert "ws" in captured["inner_argv"]
         assert "--popup-socket" in captured["decider_argv"]
         assert "--popup-session" in captured["decider_argv"]
+        # The decider session name and the wrapper session_names pair name
+        # the SAME hidden session (one suffix, one invocation, #2692).
+        names = captured["session_names"]
+        decider_session = captured["decider_argv"][
+            captured["decider_argv"].index("--popup-session") + 1
+        ]
+        assert decider_session == names[1]
+        assert names[0].startswith("klangk-shell-wsid-")
+        assert names[1].startswith("klangk-consent-wsid-")
 
     def test_run_consent_popup_prints_disconnect_line(self, capsys):
         """After the attach returns the user sees a clean exit line, so


### PR DESCRIPTION
## Summary

Fixes #2692: selecting a terminal on the TUI workspace detail page opened a shell on the 0th terminal regardless of the selection — when a consent-wrapped (interactive-egress) shell was already open on the same workspace, and only then.

## Root cause

The consent-popup wrapper (#2383) named its outer and hidden tmux sessions **after the workspace id** (`klangk-shell-<ws>`, `klangk-consent-<ws>`) on the shared per-workspace socket. A second `klangk shell` into the same workspace (exactly what `terminal-open-cmd` (#2685) produces) then:

1. failed its `new-session -d -s klangk-shell-<ws>` (duplicate session) — logged best-effort, never surfaced,
2. silently attached to the **first** shell's session, showing whatever window it had (typically window 0),
3. never sent `terminal_select_window` for its own target — the second shell never existed.

Reproduced end-to-end before the fix (real textual TUI via `run_test` + real konsole windows via `KLANGKC_TERMINAL_OPEN_CMD` against a standalone klangkd, per-window env markers): both selections showed window 0's content; the server log had no second `select_window`.

## Fix

- `popup_session_names(workspace_id)` — per-invocation `(outer, hidden)` pair with a random suffix; `run_consent_shell` takes an optional `session_names` and `_run_consent_popup` generates the pair **once**, sharing it with both the wrapper and the consent-decider argv so they stay paired.
- Verified the same live harness post-fix: `@1` selection → window 0's marker, `@5` selection → the second window's marker.
- Best-effort tmux wrapper failures demoted warning → debug: the post-exit cleanup `kill-session` against an already-dead tmux server was spraying `no server running on …sock` into the terminal after every consent-wrapped shell exit (noted in the issue).

## Notes

- Not a race after all — the issue's "intermittent" flavor came from it biting only while another consent-wrapped shell was open on the same workspace (or after a stale wrapper session survived an unclean exit).
- Server side (`terminal_select_window`, session-group independence) verified sound by direct tmux experiments; no server changes.

## Tests

- `popup_session_names` uniqueness per invocation + shared suffix across the pair.
- `run_consent_shell` honors a caller-provided pair (decider argv ↔ wrapper agree).
- Orchestrator test updated to per-invocation names; full CI suite green (5538 passed, 100% coverage).
