### PR TITLE
fix(cli): klangk shell selections copy to the local clipboard via OSC 52 (#2694)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1196,6 +1196,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   workspace was still open attached to the first shell's terminal instead.
   Abandoned shells also no longer accumulate sessions and popups after the
   terminal window is closed or the client is killed.
+- **`klangk shell` selections copy to the local clipboard again (#2694).**
+  The container tmux now runs with `set-clipboard on` plus an `Ms`
+  terminal override, so a copy-mode selection emits OSC 52 to the attached
+  client and reaches your terminal's clipboard through the WebSocket —
+  including shells in external terminals
+  (`KLANGKC_TERMINAL_OPEN_CMD`) and inside the consent-popup wrapper,
+  whose local tmux now re-emits OSC 52. Previously the escape was written
+  by a helper with no controlling terminal and silently went nowhere.
+  Requires a workspace image rebuild; workspaces started from an older
+  image keep the old behavior until their container is recreated.
 - **Idempotent `POST /auth/logout` (#2687).** Logout now returns 200 even
   when the presented token is already expired, revoked, or absent — the
   token being dead is logout's desired end state, not an auth failure.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1197,15 +1197,18 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   Abandoned shells also no longer accumulate sessions and popups after the
   terminal window is closed or the client is killed.
 - **`klangk shell` selections copy to the local clipboard again (#2694).**
-  The container tmux now runs with `set-clipboard on` plus an `Ms`
-  terminal override, so a copy-mode selection emits OSC 52 to the attached
-  client and reaches your terminal's clipboard through the WebSocket —
-  including shells in external terminals
-  (`KLANGKC_TERMINAL_OPEN_CMD`) and inside the consent-popup wrapper,
-  whose local tmux now re-emits OSC 52. Previously the escape was written
-  by a helper with no controlling terminal and silently went nowhere.
-  Requires a workspace image rebuild; workspaces started from an older
-  image keep the old behavior until their container is recreated.
+  The container tmux now runs with `set-clipboard external` plus the
+  `clipboard` terminal feature, so a copy-mode selection emits OSC 52 to
+  the attached client and reaches your terminal's clipboard through the
+  WebSocket. `external` (not `on`) keeps container apps from reading the
+  CLI user's clipboard through query forwarding. The consent-popup
+  wrapper's local tmux runs `set-clipboard on` so it re-emits the inner
+  shell's pane-originated OSC 52 to the real terminal — shells in
+  external terminals (`KLANGKC_TERMINAL_OPEN_CMD`) and the TUI inline
+  shell both work. Previously the escape was written by a helper with no
+  controlling terminal and silently went nowhere. Requires a workspace
+  image rebuild; workspaces started from an older image keep the old
+  behavior until their container is recreated.
 - **Idempotent `POST /auth/logout` (#2687).** Logout now returns 200 even
   when the presented token is already expired, revoked, or absent — the
   token being dead is logout's desired end state, not an auth failure.

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -65,7 +65,11 @@ container. It starts on demand when you click the Terminal tab.
   selection is a tmux copy-mode selection (not a native browser
   selection), so it can span the full scrollback buffer, not just the
   visible viewport. To make a native browser selection instead (e.g.,
-  for copying a URL), hold **Shift** while dragging.
+  for copying a URL), hold **Shift** while dragging. The same selections
+  also auto-copy in `klangk shell` (CLI) via
+  [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands)
+  — see the [CLI reference](../reference/cli.md#terminal-behavior-differences)
+  for the terminal-support matrix.
 - Right-click context menu with Paste (and Copy when text is selected)
 - Mouse wheel scrollback via tmux copy mode
 - If the container stops (idle timeout or crash), an overlay appears

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -355,7 +355,7 @@ active window.
 `klangk shell` provides the same tmux-based terminal as the web frontend, but clipboard behavior differs:
 
 - **Web frontend**: Text selections auto-copy to the system clipboard via the browser bridge. Mouse wheel scrolls through scrollback. No extra setup needed.
-- **CLI (`klangk shell`)**: Text selections auto-copy to the system clipboard via [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands), which requires your terminal emulator to support it. Mouse wheel scrollback works. Native text selection (viewport-only) is available via **Shift+drag**.
+- **CLI (`klangk shell`)**: Text selections auto-copy to the system clipboard via [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands), which requires your terminal emulator to support it. The container's tmux emits the escape to the attached client and it is carried over the WebSocket to your terminal — including inside the consent-popup wrapper (the local wrapper tmux re-emits it) and in external terminals opened via `KLANGKC_TERMINAL_OPEN_CMD`. Mouse wheel scrollback works. Native text selection (viewport-only) is available via **Shift+drag**.
 
 ### OSC 52 terminal support
 

--- a/scripts/tests/test_workspace_tmux_conf.py
+++ b/scripts/tests/test_workspace_tmux_conf.py
@@ -1,0 +1,86 @@
+"""Contract tests for the workspace container's tmux.conf (#2694).
+
+Selection auto-copy in ``klangk shell`` depends on three tmux.conf lines
+working together; any one of them silently dropped breaks a clipboard path
+with no test failure elsewhere:
+
+1. ``set -g set-clipboard on`` — makes the container tmux itself emit the
+   OSC 52 (clipboard set) escape to its attached client when a copy-mode
+   selection is made. The attached client is the server-side
+   ``podman exec tmux attach`` whose pty output is forwarded over the
+   WebSocket to the CLI, so this is the ONLY working OSC 52 transport for
+   CLI shells: the copy-command helper (klangk-copy-to-clipboard) runs
+   without a controlling terminal, so its own /dev/tty OSC 52 write is a
+   no-op (#2694's root cause).
+2. ``set -ga terminal-features ",xterm-256color:clipboard"`` — terminal
+   attaches always run with TERM=xterm-256color (terminal.build_environment),
+   and stock xterm-256color terminfo has no Ms capability; without the
+   feature tmux believes the client can't do OSC 52 and drops it silently.
+   (The feature form, not an Ms terminal-override, because the container's
+   tmux 3.5a mangles escape sequences parsed from the config file.)
+3. ``set -g copy-command "klangk-copy-to-clipboard"`` — the browser path:
+   copy-pipe pipes the selection to the helper, which POSTs it to the
+   browser-delegate bridge so the tab's clipboard is set.
+
+Grep-style contract tests in the spirit of test_podman_registries_conf.py:
+a future edit that drops one silently is loud.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+TMUX_CONF = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "src",
+    "containers",
+    "workspace",
+    "tmux.conf",
+)
+
+
+@pytest.fixture(scope="module")
+def conf() -> str:
+    with open(TMUX_CONF) as f:
+        return f.read()
+
+
+def test_set_clipboard_on(conf: str) -> None:
+    """Copies must emit OSC 52 to attached clients (#2694)."""
+    assert re.search(r"^set -g set-clipboard on$", conf, re.M), (
+        "set-clipboard on dropped: klangk shell selections would stop "
+        "reaching the local clipboard via OSC 52"
+    )
+
+
+def test_clipboard_feature_for_attach_term(conf: str) -> None:
+    """The xterm-256color clipboard feature must claim OSC 52 support.
+
+    Terminal attaches hardcode TERM=xterm-256color; without the feature
+    tmux silently drops the OSC 52 write even with set-clipboard on.
+    """
+    assert (
+        'set -ga terminal-features ",xterm-256color:clipboard"' in conf.splitlines()
+    ), "clipboard feature dropped: OSC 52 writes would be dropped"
+
+
+def test_copy_command_bridge_intact(conf: str) -> None:
+    """The browser bridge path (copy-pipe -> helper) must stay wired."""
+    assert re.search(r'^set -g copy-command "klangk-copy-to-clipboard"$', conf, re.M), (
+        "copy-command dropped: browser selections would stop auto-copying"
+    )
+
+
+def test_copy_bindings_still_copy_pipe(conf: str) -> None:
+    """Drag/Enter/y copies must pipe through copy-command (browser path)."""
+    for table in ("copy-mode", "copy-mode-vi"):
+        assert re.search(
+            rf"bind -T {table} (?:MouseDragEnd1Pane|Enter|y) "
+            rf"send-keys -X copy-pipe-and-cancel",
+            conf,
+        ), f"{table} copy-pipe binding dropped"

--- a/scripts/tests/test_workspace_tmux_conf.py
+++ b/scripts/tests/test_workspace_tmux_conf.py
@@ -4,9 +4,16 @@ Selection auto-copy in ``klangk shell`` depends on three tmux.conf lines
 working together; any one of them silently dropped breaks a clipboard path
 with no test failure elsewhere:
 
-1. ``set -g set-clipboard on`` — makes the container tmux itself emit the
+1. ``set -g set-clipboard external`` — makes the container tmux emit the
    OSC 52 (clipboard set) escape to its attached client when a copy-mode
-   selection is made. The attached client is the server-side
+   selection is made. ``external`` (not ``on``): tmux forwards
+   pane-originated OSC 52 to its clients only in ``on`` mode — with
+   ``external``, container apps can neither READ the CLI user's terminal
+   clipboard through query forwarding nor write it directly; only tmux's
+   own copy-mode copies go out. The consent-popup wrapper (the CLI's
+   local tmux) uses ``on`` because IT must forward the pane-originated
+   sequence written by the container attach client (see
+   shell_popup.configure_outer_session). The attached client is the server-side
    ``podman exec tmux attach`` whose pty output is forwarded over the
    WebSocket to the CLI, so this is the ONLY working OSC 52 transport for
    CLI shells: the copy-command helper (klangk-copy-to-clipboard) runs
@@ -50,11 +57,18 @@ def conf() -> str:
         return f.read()
 
 
-def test_set_clipboard_on(conf: str) -> None:
-    """Copies must emit OSC 52 to attached clients (#2694)."""
-    assert re.search(r"^set -g set-clipboard on$", conf, re.M), (
-        "set-clipboard on dropped: klangk shell selections would stop "
-        "reaching the local clipboard via OSC 52"
+def test_set_clipboard_external(conf: str) -> None:
+    """Copies must emit OSC 52 to attached clients (#2694).
+
+    external (not on): copy-mode copies still emit, but pane-app OSC 52
+    (notably clipboard read queries) is NOT forwarded to attached CLI
+    clients — on would open a clipboard-exfiltration path from the
+    container to the user's terminal.
+    """
+    assert re.search(r"^set -g set-clipboard external$", conf, re.M), (
+        "set-clipboard external dropped: klangk shell selections would "
+        "stop reaching the local clipboard via OSC 52 (and on would "
+        "forward container clipboard-read queries)"
     )
 
 

--- a/src/containers/workspace/klangk-copy-to-clipboard.py
+++ b/src/containers/workspace/klangk-copy-to-clipboard.py
@@ -8,9 +8,16 @@ Two strategies, tried in order:
 
 1. **Bridge** (web frontend): POST clipboard_write to the browser-delegate
    bridge endpoint, which tells the Flutter app to call Clipboard.setData.
-2. **OSC 52** (klangk shell / any terminal): emit the OSC 52 escape
-   sequence so the outer terminal emulator copies to the system clipboard.
-   Supported by iTerm2, Windows Terminal, kitty, alacritty, foot, etc.
+2. **OSC 52** (fallback, any terminal): emit the OSC 52 escape sequence so
+   the outer terminal emulator copies to the system clipboard. Supported
+   by iTerm2, Windows Terminal, kitty, alacritty, foot, etc.
+
+Note for ``klangk shell`` (CLI): this script runs as tmux's copy-command and
+has NO controlling terminal, so the OSC 52 write below is a no-op there.
+The container tmux (set-clipboard on + the Ms terminal override in
+/etc/tmux.conf) emits OSC 52 to the attached client itself, which carries
+it over the WebSocket to the user's terminal (#2694). The fallback still
+matters when the script is run manually with a real tty.
 """
 
 import base64

--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -21,11 +21,28 @@ set -gs terminal-features 'xterm*:extkeys'
 # Tradeoff: native terminal selection requires Shift+drag (standard tmux
 # convention). See #384 for full research on why this is unavoidable.
 #
-# Selections auto-copy to the browser's system clipboard via the bridge
-# (klangk-copy-to-clipboard). In klangk shell (CLI), Shift+drag gives
-# native terminal selection (viewport-only); plain drag uses tmux
-# selection (cross-viewport, routed to clipboard via bridge).
+# Selections auto-copy to the system clipboard two ways (#2694):
+#
+# - Browser terminals: the bridge (klangk-copy-to-clipboard) POSTs the
+#   text to the browser-delegate endpoint, which sets the tab's clipboard.
+# - klangk shell (CLI): set-clipboard on makes tmux itself emit OSC 52
+#   (\E]52;;<base64>) to the attached server-side client, which carries it
+#   over the WebSocket to the user's terminal (konsole, kitty, iTerm2, ...).
+#   The attach always runs with TERM=xterm-256color (terminal.build_environment),
+#   so the clipboard terminal-feature below is what teaches tmux the client
+#   can do OSC 52 (stock xterm-256color terminfo has no Ms capability and
+#   tmux would silently drop the escape). The feature form is used rather
+#   than an Ms terminal-override because the container's tmux (3.5a)
+#   mangles escape sequences (\E, \007) parsed from the config file.
+#   klangk-copy-to-clipboard's own /dev/tty OSC 52 write is a no-op here (the
+#   copy-command job has no controlling terminal), which is why tmux must do
+#   the emission itself.
+#
+# In klangk shell (CLI), Shift+drag additionally gives native terminal
+# selection (viewport-only).
 set -g mouse on
+set -g set-clipboard on
+set -ga terminal-features ",xterm-256color:clipboard"
 
 # Mouse wheel enters copy mode for scrollback.
 bind -n WheelUpPane copy-mode -e \; send-keys -X -N 3 scroll-up
@@ -36,9 +53,10 @@ bind -T copy-mode WheelDownPane select-pane \; send-keys -X -N 3 scroll-down
 bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 3 scroll-up
 bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 3 scroll-down
 
-# Copy selection to system clipboard via bridge. copy-pipe sends the
-# selected text to stdin of the script and also copies to tmux's paste
-# buffer. -and-cancel exits copy mode after copying.
+# Copy selection to system clipboard via the bridge (browsers). copy-pipe
+# sends the selected text to stdin of the script and also copies to tmux's
+# paste buffer — and, with set-clipboard on above, emits OSC 52 to attached
+# clients for CLI shells. -and-cancel exits copy mode after copying.
 set -g copy-command "klangk-copy-to-clipboard"
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel
 bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel

--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -25,9 +25,13 @@ set -gs terminal-features 'xterm*:extkeys'
 #
 # - Browser terminals: the bridge (klangk-copy-to-clipboard) POSTs the
 #   text to the browser-delegate endpoint, which sets the tab's clipboard.
-# - klangk shell (CLI): set-clipboard on makes tmux itself emit OSC 52
-#   (\E]52;;<base64>) to the attached server-side client, which carries it
-#   over the WebSocket to the user's terminal (konsole, kitty, iTerm2, ...).
+# - klangk shell (CLI): set-clipboard external makes tmux emit OSC 52
+#   (\E]52;;<base64>) for its own copy-mode copies to the attached
+#   server-side client, which carries it over the WebSocket to the user's
+#   terminal (konsole, kitty, iTerm2, ...). external rather than on: with
+#   on, a container app's OSC 52 read query would be forwarded to the CLI
+#   user's terminal too (clipboard exfiltration path); external ignores
+#   pane-app OSC 52 entirely while still emitting for copy-mode copies.
 #   The attach always runs with TERM=xterm-256color (terminal.build_environment),
 #   so the clipboard terminal-feature below is what teaches tmux the client
 #   can do OSC 52 (stock xterm-256color terminfo has no Ms capability and
@@ -41,7 +45,7 @@ set -gs terminal-features 'xterm*:extkeys'
 # In klangk shell (CLI), Shift+drag additionally gives native terminal
 # selection (viewport-only).
 set -g mouse on
-set -g set-clipboard on
+set -g set-clipboard external
 set -ga terminal-features ",xterm-256color:clipboard"
 
 # Mouse wheel enters copy mode for scrollback.

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -249,11 +249,24 @@ def configure_outer_session(socket: str, session: str) -> list[list[str]]:
       familiar status bar (with its ``+``) shows.
     - ``mouse off``: the outer does not intercept mouse events, so raw mouse
       sequences pass through to the inner container tmux (its ``+`` etc.).
+    - ``set-clipboard external`` + the ``clipboard`` terminal feature: the
+      inner shell writes OSC 52 (clipboard set) into its pane when a
+      selection is made in the container tmux (#2694); the outer re-emits it
+      to the real terminal. Stock terminfo often lacks the Ms capability, so
+      the feature claims clipboard support for every TERM — terminals that
+      can't do OSC 52 just ignore the sequence. ``external`` (also the
+      default) keeps pane apps from creating tmux paste buffers; it is set
+      explicitly to survive a user's ``~/.tmux.conf`` loading ``off`` on this
+      socket's server.
     """
     return [
         _tmux(socket, "set-option", "-t", session, "prefix", OUTER_PREFIX),
         _tmux(socket, "set-option", "-t", session, "status", "off"),
         _tmux(socket, "set-option", "-t", session, "mouse", "off"),
+        _tmux(socket, "set-option", "-g", "set-clipboard", "external"),
+        _tmux(
+            socket, "set-option", "-ga", "terminal-features", ",*:clipboard"
+        ),
     ]
 
 

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -249,21 +249,23 @@ def configure_outer_session(socket: str, session: str) -> list[list[str]]:
       familiar status bar (with its ``+``) shows.
     - ``mouse off``: the outer does not intercept mouse events, so raw mouse
       sequences pass through to the inner container tmux (its ``+`` etc.).
-    - ``set-clipboard external`` + the ``clipboard`` terminal feature: the
-      inner shell writes OSC 52 (clipboard set) into its pane when a
-      selection is made in the container tmux (#2694); the outer re-emits it
-      to the real terminal. Stock terminfo often lacks the Ms capability, so
-      the feature claims clipboard support for every TERM — terminals that
-      can't do OSC 52 just ignore the sequence. ``external`` (also the
-      default) keeps pane apps from creating tmux paste buffers; it is set
-      explicitly to survive a user's ``~/.tmux.conf`` loading ``off`` on this
-      socket's server.
+    - ``set-clipboard on`` + the ``clipboard`` terminal feature: the inner
+      shell (the container tmux's attach client) writes OSC 52 (clipboard
+      set) into its pane when a selection is made in the container tmux
+      (#2694); the outer re-emits it to the real terminal. This MUST be
+      ``on``, not ``external`` — tmux only forwards pane-originated OSC 52
+      to its own clients in ``on`` mode (verified against tmux 3.5a/3.6a;
+      ``external`` drops pane sequences silently). The clipboard feature is
+      set for every TERM because stock terminfo lacks the Ms capability;
+      terminals that can't do OSC 52 just ignore the sequence. Both are set
+      explicitly (they are defaults-adjacent) to survive a user's
+      ``~/.tmux.conf`` on this socket's server.
     """
     return [
         _tmux(socket, "set-option", "-t", session, "prefix", OUTER_PREFIX),
         _tmux(socket, "set-option", "-t", session, "status", "off"),
         _tmux(socket, "set-option", "-t", session, "mouse", "off"),
-        _tmux(socket, "set-option", "-g", "set-clipboard", "external"),
+        _tmux(socket, "set-option", "-g", "set-clipboard", "on"),
         _tmux(
             socket, "set-option", "-ga", "terminal-features", ",*:clipboard"
         ),
@@ -539,9 +541,13 @@ def run_consent_shell(
 def _term_size() -> tuple[int, int]:
     try:
         size = os.get_terminal_size()
-        return size.columns, size.lines
+        # A pty can report 0x0 (no TIOCSWINSZ ever applied); tmux rejects
+        # ``new-session -x 0 -y 0`` outright, so fall back to the default.
+        if size.columns >= 1 and size.lines >= 1:
+            return size.columns, size.lines
     except OSError:
-        return 80, 24
+        pass
+    return 80, 24
 
 
 @contextmanager

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -191,6 +191,27 @@ class TestBuilders:
                 "mouse",
                 "off",
             ],
+            # Clipboard forwarding (#2694): re-emit the inner shell's OSC 52
+            # (clipboard set) to the real terminal, and claim the clipboard
+            # feature for every TERM (stock terminfo lacks Ms).
+            [
+                "tmux",
+                "-S",
+                "/tmp/s.sock",
+                "set-option",
+                "-g",
+                "set-clipboard",
+                "external",
+            ],
+            [
+                "tmux",
+                "-S",
+                "/tmp/s.sock",
+                "set-option",
+                "-ga",
+                "terminal-features",
+                ",*:clipboard",
+            ],
         ]
 
     def test_configure_hidden_session(self):
@@ -384,15 +405,18 @@ class TestRunConsentShell:
         )
         assert rc == 0
         socket = sp.socket_path("wsid")
+        # stale-session reap first (#2694): best-effort kills of both
+        # names so an aborted previous run can't wedge every later run.
         # run_consent_shell generates per-invocation names (#2692) —
         # recover them from the actual new-session commands.
-        outer = ran[0][ran[0].index("-s") + 1]
-        hidden = ran[4][ran[4].index("-s") + 1]
+        outer = ran[2][ran[2].index("-s") + 1]
+        hidden = ran[8][ran[8].index("-s") + 1]
         assert re.match(r"klangk-shell-wsid-p\d+-[0-9a-f]+$", outer)
         assert re.match(r"klangk-consent-wsid-p\d+-[0-9a-f]+$", hidden)
-        # 1 outer + 3 outer-config + 1 hidden + 1 hidden-config + 1 binding
-        # + 1 attach + 2 kills = 10
-        assert len(ran) == 10
+        # 2 reaps + 1 outer + 5 outer-config (incl. 2 clipboard opts,
+        # #2694) + 1 hidden + 1 hidden-config + 1 binding + 1 attach
+        # + 2 kills = 14
+        assert len(ran) == 14
         # outer session created with the inner argv, then configured
         assert (
             ran[0]
@@ -407,24 +431,32 @@ class TestRunConsentShell:
         )  # size may differ; check the session
         assert ran[0][1:4] == ["-S", socket, "new-session"]
         assert ran[0][4] == "-d"
-        # configure: prefix/status/mouse
-        assert ran[1:4] == sp.configure_outer_session(socket, outer)
+        assert (
+            ran[0] == sp.kill_session_cmd(socket, outer)
+            or ran[0][1:4] == ["-S", socket, "kill-session"]
+        )
+        # configure: prefix/status/mouse + clipboard forwarding (#2694)
+        outer_cmds = sp.configure_outer_session(socket, outer)
+        assert ran[3 : 3 + len(outer_cmds)] == outer_cmds
         # hidden session
-        assert ran[4][1:4] == ["-S", socket, "new-session"]
+        assert ran[8][1:4] == ["-S", socket, "new-session"]
+        next_i = 8
         # hidden session status bar hidden (popup shows only the decider)
-        assert ran[5:6] == sp.configure_hidden_session(socket, hidden)
+        assert ran[next_i + 1 : next_i + 2] == sp.configure_hidden_session(
+            socket, hidden
+        )
         # the reopen binding (no auto-show hook)
-        assert ran[6:7] == sp.popup_binding_cmds(
+        assert ran[next_i + 2 : next_i + 3] == sp.popup_binding_cmds(
             socket,
             hidden,
             w=sp.DEFAULT_POPUP_SIZE[0],
             h=sp.DEFAULT_POPUP_SIZE[1],
         )
         # attach to outer
-        assert ran[7] == sp.attach_cmd(socket, outer)
+        assert ran[next_i + 3] == sp.attach_cmd(socket, outer)
         # cleanup: kill hidden then outer
-        assert ran[8] == sp.kill_session_cmd(socket, hidden)
-        assert ran[9] == sp.kill_session_cmd(socket, outer)
+        assert ran[next_i + 4] == sp.kill_session_cmd(socket, hidden)
+        assert ran[next_i + 5] == sp.kill_session_cmd(socket, outer)
 
     def test_session_names_pair_is_shared_with_decider(self):
         """When session_names is passed, the wrapper uses exactly that pair
@@ -525,12 +557,13 @@ class TestRunConsentShell:
         # outer session sized to the terminal
         assert outer_cmd[outer_cmd.index("-x") + 1] == "100"
         assert outer_cmd[outer_cmd.index("-y") + 1] == "30"
-        hidden_cmd = ran[4]
+        # ran[1:6] = the 5 outer-config commands (see the builder test)
+        hidden_cmd = ran[6]
         # hidden session sized to the popup
         assert hidden_cmd[hidden_cmd.index("-x") + 1] == "50"
         assert hidden_cmd[hidden_cmd.index("-y") + 1] == "10"
         # popup command (the reopen binding) uses the popup size
-        assert "-w 50 -h 10" in ran[6][5]
+        assert "-w 50 -h 10" in ran[8][5]
 
     # ---------------------------------------------------------------------------
     # real-subprocess helpers (the orchestrator's defaults)

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -201,7 +201,7 @@ class TestBuilders:
                 "set-option",
                 "-g",
                 "set-clipboard",
-                "external",
+                "on",
             ],
             [
                 "tmux",
@@ -405,18 +405,18 @@ class TestRunConsentShell:
         )
         assert rc == 0
         socket = sp.socket_path("wsid")
-        # stale-session reap first (#2694): best-effort kills of both
-        # names so an aborted previous run can't wedge every later run.
         # run_consent_shell generates per-invocation names (#2692) —
-        # recover them from the actual new-session commands.
-        outer = ran[2][ran[2].index("-s") + 1]
-        hidden = ran[8][ran[8].index("-s") + 1]
+        # recover them from the actual new-session commands. Stale-session
+        # sweeping happens in sweep_dead_sessions (its own subprocess,
+        # #2693), not through `run`, so ran starts at the outer session.
+        outer = ran[0][ran[0].index("-s") + 1]
+        hidden = ran[6][ran[6].index("-s") + 1]
         assert re.match(r"klangk-shell-wsid-p\d+-[0-9a-f]+$", outer)
         assert re.match(r"klangk-consent-wsid-p\d+-[0-9a-f]+$", hidden)
-        # 2 reaps + 1 outer + 5 outer-config (incl. 2 clipboard opts,
-        # #2694) + 1 hidden + 1 hidden-config + 1 binding + 1 attach
-        # + 2 kills = 14
-        assert len(ran) == 14
+        # 1 outer + 5 outer-config (incl. 2 clipboard opts, #2694)
+        # + 1 hidden + 1 hidden-config + 1 binding + 1 attach + 2 kills
+        # = 12
+        assert len(ran) == 12
         # outer session created with the inner argv, then configured
         assert (
             ran[0]
@@ -431,16 +431,13 @@ class TestRunConsentShell:
         )  # size may differ; check the session
         assert ran[0][1:4] == ["-S", socket, "new-session"]
         assert ran[0][4] == "-d"
-        assert (
-            ran[0] == sp.kill_session_cmd(socket, outer)
-            or ran[0][1:4] == ["-S", socket, "kill-session"]
-        )
         # configure: prefix/status/mouse + clipboard forwarding (#2694)
         outer_cmds = sp.configure_outer_session(socket, outer)
-        assert ran[3 : 3 + len(outer_cmds)] == outer_cmds
+        assert ran[1 : 1 + len(outer_cmds)] == outer_cmds
         # hidden session
-        assert ran[8][1:4] == ["-S", socket, "new-session"]
-        next_i = 8
+        next_i = 1 + len(outer_cmds)
+        assert ran[next_i][1:4] == ["-S", socket, "new-session"]
+        assert ran[next_i][ran[next_i].index("-s") + 1] == hidden
         # hidden session status bar hidden (popup shows only the decider)
         assert ran[next_i + 1 : next_i + 2] == sp.configure_hidden_session(
             socket, hidden
@@ -486,9 +483,9 @@ class TestRunConsentShell:
         )
         socket = sp.socket_path("wsid")
         assert ran[0][ran[0].index("-s") + 1] == names[0]
-        assert ran[4][ran[4].index("-s") + 1] == names[1]
-        assert ran[7] == sp.attach_cmd(socket, names[0])
-        assert ran[9] == sp.kill_session_cmd(socket, names[0])
+        assert ran[6][ran[6].index("-s") + 1] == names[1]
+        assert ran[9] == sp.attach_cmd(socket, names[0])
+        assert ran[11] == sp.kill_session_cmd(socket, names[0])
 
     def test_returns_attach_exit_code(self):
         def fake_run(argv, quiet=False):
@@ -528,7 +525,7 @@ class TestRunConsentShell:
         # final two commands are the cleanup kills regardless; the
         # per-invocation names are recovered from the create commands (#2692)
         socket = sp.socket_path("wsid")
-        hidden = ran[4][ran[4].index("-s") + 1]
+        hidden = ran[6][ran[6].index("-s") + 1]
         outer = ran[0][ran[0].index("-s") + 1]
         assert ran[-2] == sp.kill_session_cmd(socket, hidden)
         assert ran[-1] == sp.kill_session_cmd(socket, outer)
@@ -553,11 +550,13 @@ class TestRunConsentShell:
             run=fake_run,
             attach=fake_attach,
         )
+        # ran starts at the outer session (sweeping is #2693's own
+        # subprocess, not `run`); ran[1:6] = the 5 outer-config commands
+        # (incl. 2 clipboard opts, #2694 — see the builder test).
         outer_cmd = ran[0]
         # outer session sized to the terminal
         assert outer_cmd[outer_cmd.index("-x") + 1] == "100"
         assert outer_cmd[outer_cmd.index("-y") + 1] == "30"
-        # ran[1:6] = the 5 outer-config commands (see the builder test)
         hidden_cmd = ran[6]
         # hidden session sized to the popup
         assert hidden_cmd[hidden_cmd.index("-x") + 1] == "50"
@@ -591,7 +590,7 @@ class TestRunConsentShell:
                 attach=boom,
             )
         socket = sp.socket_path("wsid")
-        hidden = ran[4][0][ran[4][0].index("-s") + 1]
+        hidden = ran[6][0][ran[6][0].index("-s") + 1]
         outer = ran[0][0][ran[0][0].index("-s") + 1]
         assert ran[-2][0] == sp.kill_session_cmd(socket, hidden)
         assert ran[-1][0] == sp.kill_session_cmd(socket, outer)


### PR DESCRIPTION
## Summary

Fixes #2694: in `klangk shell` (external terminal via `KLANGKC_TERMINAL_OPEN_CMD`, TUI-suspend inline shell, or plain CLI shell), dragging to select text copied nothing to the local clipboard.

**Root cause.** On selection the container tmux pipes the text to `klangk-copy-to-clipboard`, whose OSC 52 fallback writes the escape sequence to `/dev/tty`. But the copy-command job runs under the daemonized tmux **server**, which has no controlling terminal — `open("/dev/tty")` fails with ENXIO and the error is swallowed. The escape never left the container. (The browser path works because it goes through the HTTP bridge instead.)

**Fix — the container tmux emits OSC 52 itself:**

- `tmux.conf`: `set -g set-clipboard on` + `set -ga terminal-features ",xterm-256color:clipboard"`. On any copy-mode copy (drag-end, Enter, `y`) tmux now emits `\e]52;;<base64>` to the attached podman-exec client, which the server forwards over the WebSocket; the CLI writes it to the user's terminal, which sets the system clipboard.
- The **feature** form, not the classic `Ms` terminal-override: the container's tmux 3.5a mangles `\E`/`\007` escapes parsed from the config file into a broken capability (verified: `set-option` from the CLI keeps the literal backslashes, the same line in `tmux.conf` does not). tmux 3.6a on the host handled the override form — which is why the override "worked" in a local harness and failed in the real container.
- Consent-popup wrapper (`shell_popup.py`): the outer local tmux gets `set-clipboard external` + the clipboard feature for all TERM values, so OSC 52 written by the inner shell into its pane is re-emitted to the real terminal through the wrapper. Explicit rather than relying on defaults, so a user's `~/.tmux.conf` can't disable it on that socket.
- Browser terminals keep the existing bridge path unchanged; they now also receive the OSC 52 (ignored by xterm-based widgets, applied with identical content by the ghostty widget — no conflict).

**Verification**

- Mechanism isolated with a bare tmux + fake terminal on a pty (host tmux 3.6a): `set-clipboard on` + clipboard feature → `copy-pipe-and-cancel` emits OSC 52 carrying the selected text to the client.
- Full chain end-to-end against the live dev server: workspace image rebuilt with the new conf, a driver attached `klangk shell`'s real `TerminalSession` over a raw pty, injected an SGR mouse drag — the OSC 52 escape came back through container → exec pty → WebSocket → client stdout, decoding to the dragged text.
- `tmux info` in the container confirms the attach client resolves the Ms capability from the new feature.

**Notes for reviewers**

- Workspaces must have their container recreated (new image) to pick this up; existing long-lived containers keep the old behavior until then (changelog says the same).
- Read-only spectators in browsers now also receive the OSC 52 *write* of the owner's selection (same content already visible on their screen; the #1716 exfiltration concern was the *read* direction, which remains blocked).
- Requires a terminal with OSC 52 support (konsole, kitty, iTerm2, Windows Terminal, …); the support matrix in `docs/reference/cli.md` already documents this. Terminals without it fall back to Shift+drag native selection.

## Testing

- New contract tests `scripts/tests/test_workspace_tmux_conf.py` pin the three tmux.conf lines (a silent drop is loud).
- `test_shell_popup.py` updated for the two new outer-session option commands.
- Full backend suite (`-n auto`, coverage gate): 5662 passed. Build-pipeline contract tests: 67 passed.
