### PR TITLE
feat(frontend): admin Server tab to schedule a server stop/recycle (#2684)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -92,6 +92,16 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Admin page → Server tab (#2684).** Admins can now schedule a server
+  stop or recycle from the Admin page: pick an action and either an
+  absolute time (date/time pickers) or a delay (`2h`, `90m`, `45s`, or a
+  bare number of minutes). Pending schedules list soonest-first with the
+  same live countdown clients see, and each can be cancelled with a
+  confirm step. The list follows the live `server_schedule` snapshot, so
+  changes made by other admins appear immediately. The API remains
+  available for scripting; see
+  [Server Scheduling](features/server-scheduling.md).
+
 - **TUI status bar on every screen (#2689).** The `server / user /
 last login` status line — including live segments such as the
   scheduled stop/recycle countdown, host notices, and reachability

--- a/docs/features/admin-management.md
+++ b/docs/features/admin-management.md
@@ -1,7 +1,8 @@
 # Admin Management
 
 Members of the `admin` group have access to the Admin page, which
-provides user and group management for the entire Klangk instance.
+provides user and group management, invitation handling, and server
+scheduling for the entire Klangk instance.
 
 ## Users
 
@@ -33,3 +34,19 @@ used for sharing workspaces and controlling access via
 The `admin` group is created automatically on first startup and
 grants access to this Admin page. The default user is added to it
 automatically.
+
+## Server
+
+The Server tab schedules planned maintenance for the `klangkd` process
+(see [Server Scheduling](server-scheduling.md) for what stop and
+recycle actually do):
+
+- **Schedule an action** — pick **Stop** or **Recycle** and either an
+  absolute time (date and time pickers, your local time) or a delay
+  (`2h`, `90m`, `45s`, `2h 30m`; a bare number means minutes). The
+  form shows when the action will fire.
+- **Pending list** — schedules soonest-first with the same live
+  countdown every connected client sees; the list follows the live
+  server snapshot, so changes made elsewhere appear immediately.
+- **Cancel a schedule** — each row has a cancel button with a confirm
+  step; cancelling clears the countdown clients see.

--- a/docs/features/server-scheduling.md
+++ b/docs/features/server-scheduling.md
@@ -27,8 +27,23 @@ on receipt.
 
 ## Scheduling an action
 
-There is no dedicated admin UI (#2684); schedules are managed through
-the API (see [API Reference](../reference/api-endpoints.md) —
+Schedules are managed from the Admin page (**Admin → Server**, #2684) —
+the tab is visible to users with the `admin` permission. Pick the
+action (**Stop** or **Recycle**) and when it should fire:
+
+- **After a delay** — a human delay like `2h`, `90m`, `45s`, or `2h 30m`
+  (a bare number means minutes).
+- **At a time** — date and time pickers; the time is your local time.
+
+The form shows when the action will fire and surfaces the API's
+validation errors inline. Pending schedules are listed soonest-first
+with the same live countdown clients see, and each row has a cancel
+button (with a confirm step). The list follows the live
+`server_schedule` snapshot, so a schedule created or cancelled from
+another session (or via the API) appears and disappears immediately.
+
+For scripting, the same operations are available through the API (see
+[API Reference](../reference/api-endpoints.md) —
 `/api/v1/admin/server/schedule`):
 
 ```bash

--- a/src/frontend/e2e-tests/e2e/docs-invitations-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-invitations-screenshots-dev.spec.ts
@@ -97,10 +97,10 @@ test.describe("invitation screenshots", () => {
       clip: { x: 0, y: 56, width, height: height - 56 },
     });
 
-    // Click Invitations tab (third of four tabs)
-    // Tabs: Users | Groups | Invitations | Access Control
-    // Each tab occupies width/4 of the screen
-    const tabWidth = width / 4;
+    // Click Invitations tab (third of five tabs)
+    // Tabs: Users | Groups | Invitations | Server | Access Control
+    // Each tab occupies width/5 of the screen
+    const tabWidth = width / 5;
     const invitationsTabX = tabWidth * 2 + tabWidth / 2; // center of 3rd tab
     const tabY = 76; // tab bar Y position
     await page.mouse.click(invitationsTabX, tabY);

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -12,6 +12,7 @@ import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
 import '../widgets/skeuo_tab.dart';
 import '../utils/validators.dart';
+import 'server_schedule_panel.dart';
 
 class AdminUsersPage extends StatefulWidget {
   const AdminUsersPage({super.key});
@@ -39,6 +40,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   bool _canUsers = false;
   bool _canGroups = false;
   bool _canInvitations = false;
+  bool _canServer = false;
 
   // Pending invitation count for the tab badge — updated by the
   // _InvitationsTab widget via callback.
@@ -85,6 +87,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         auth.hasPermission('/admin/groups', 'view');
     _canInvitations = auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/invitations', 'view');
+    // The schedule API needs the `admin` permission on /admin (ancestors
+    // included), so gate the tab on exactly that.
+    _canServer = auth.hasPermission('/admin', 'admin');
   }
 
   Future<void> _loadUsers({int page = 1}) async {
@@ -433,6 +438,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (_canUsers) types.add('users');
     if (_canGroups) types.add('groups');
     if (_canInvitations) types.add('invitations');
+    if (_canServer) types.add('server');
     if (types.isNotEmpty) types.add('acl');
     return types;
   }
@@ -487,6 +493,13 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         ),
       );
     }
+    if (_canServer) {
+      addTab(
+        label: 'Server',
+        icon: Icons.dns,
+        view: const ServerSchedulePanel(),
+      );
+    }
     if (tabTypes.isNotEmpty) {
       addTab(
         label: 'Access Control',
@@ -514,7 +527,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
           tooltip: 'Add user',
           child: const Icon(Icons.person_add),
         ),
-      'invitations' || 'groups' => null, // FABs handled inside tab widgets
+      'invitations' || 'groups' || 'server' => null, // FABs inside tabs
       _ => null,
     };
   }

--- a/src/frontend/lib/admin/server_schedule_panel.dart
+++ b/src/frontend/lib/admin/server_schedule_panel.dart
@@ -24,16 +24,23 @@ import '../ws/ws_client.dart';
 
 /// Parse a human delay ("2h", "90m", "2h 30m", "45s") into a [Duration].
 ///
-/// A bare number means minutes ("120" == "120m" == "2h"). Returns null for
-/// anything unparseable or non-positive — the dialog treats that as an
-/// invalid form.
+/// A bare number means minutes ("120" == "120m" == "2h"). Returns null
+/// for anything unparseable, non-positive, non-finite, or beyond the
+/// server's max delay (`in_seconds` <= 1e10 — the API 422s anything
+/// longer) — the dialog treats null as an invalid form. The finiteness
+/// and bound checks also keep `Duration(microseconds: ...)` from ever
+/// seeing an infinity (`.round()` would throw mid-build).
 Duration? parseServerDelay(String raw) {
+  // Server-side cap for in_seconds (server_schedule._MAX_IN_SECONDS).
+  const maxMicros = 1e10 * 1e6;
   final text = raw.trim().toLowerCase();
   if (text.isEmpty) return null;
   final bare = double.tryParse(text);
   if (bare != null) {
-    if (bare <= 0) return null;
-    return Duration(microseconds: (bare * 60 * 1e6).round());
+    if (!bare.isFinite || bare <= 0) return null;
+    final micros = bare * 60 * 1e6;
+    if (!micros.isFinite || micros > maxMicros) return null;
+    return Duration(microseconds: micros.round());
   }
   final segment = RegExp(r'^(\d+(?:\.\d+)?)(h|m|s)');
   var rest = text.replaceAll(' ', '');
@@ -48,6 +55,7 @@ Duration? parseServerDelay(String raw) {
       _ => 1e6,
     };
     micros += value * factor;
+    if (!micros.isFinite || micros > maxMicros) return null;
     rest = rest.substring(m.end);
   }
   if (micros <= 0) return null;
@@ -75,7 +83,12 @@ class _ServerSchedulePanelState extends State<ServerSchedulePanel> {
     // Live countdowns tick locally from fire_at (the WS snapshot pushes
     // only on change + periodically — same rationale as the banner).
     _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (mounted) setState(() {});
+      if (!mounted) return;
+      // Only a non-empty list has a countdown worth re-rendering — an
+      // idle tab (nothing scheduled) must not rebuild every second.
+      final ws = context.read<WsClient>();
+      final hasRows = (ws.serverSchedulesNow ?? _restSchedules).isNotEmpty;
+      if (hasRows) setState(() {});
     });
     _loadSchedules();
   }
@@ -187,7 +200,8 @@ class _ServerSchedulePanelState extends State<ServerSchedulePanel> {
     // The WS snapshot (when connected) is the live truth; the REST list
     // is the pre-snapshot / disconnected fallback.
     final ws = context.watch<WsClient>();
-    final schedules = ws.serverSchedulesNow ?? _restSchedules;
+    final live = ws.serverSchedulesNow;
+    final schedules = live ?? _restSchedules;
     final sorted = [...schedules]..sort(
         (a, b) =>
             (parseFireAt(a['fire_at'])?.millisecondsSinceEpoch ?? 0).compareTo(
@@ -215,15 +229,24 @@ class _ServerSchedulePanelState extends State<ServerSchedulePanel> {
                   const TextStyle(color: KColors.textSecondary, fontSize: 12),
             ),
           ),
-          Expanded(child: _buildList(sorted)),
+          Expanded(child: _buildList(sorted, hasLive: live != null)),
         ],
       ),
     );
   }
 
-  Widget _buildList(List<Map<String, dynamic>> schedules) {
-    if (_loading) return const Center(child: CircularProgressIndicator());
-    if (_error != null) {
+  Widget _buildList(
+    List<Map<String, dynamic>> schedules, {
+    required bool hasLive,
+  }) {
+    // The spinner/error states describe the REST fetch; when a live WS
+    // snapshot is on screen it stays rendered through any REST
+    // refresh/failure — no flash-to-spinner on every mutation, and a
+    // transient REST failure never masks live data.
+    if (!hasLive && _loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (!hasLive && _error != null) {
       return Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -382,7 +405,11 @@ class _ScheduleServerActionDialogState
       if (_useDelay)
         'in_seconds': _delay!.inMilliseconds / 1000
       else
-        'at': _at!.toIso8601String(),
+        // toUtc() so the ISO string carries a 'Z' suffix: a local
+        // DateTime's toIso8601String() has no offset, and the server
+        // reads a naive timestamp as UTC — the picked wall time must
+        // survive the round trip in any browser timezone.
+        'at': _at!.toUtc().toIso8601String(),
     });
     final auth = context.read<AuthService>();
     final resp = await auth.authPost(

--- a/src/frontend/lib/admin/server_schedule_panel.dart
+++ b/src/frontend/lib/admin/server_schedule_panel.dart
@@ -1,0 +1,535 @@
+// coverage:ignore-file
+/// Admin → Server tab: schedule a server stop/recycle and manage the
+/// pending schedules (#2684).
+///
+/// The pending list is snapshot-driven: the `server_schedule` WS frame
+/// (broadcast on every change, see [WsClient]) is the live truth, with a
+/// REST `GET /api/v1/admin/server/schedule` load as the source before the
+/// first snapshot arrives (and as a post-mutation refresh). Countdowns
+/// tick locally from each schedule's `fire_at` — same approach as the
+/// client banner (#2661), whose parse/format helpers are reused here.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../auth/auth_service.dart';
+import '../theme/colors.dart';
+import '../workspace/server_schedule_banner.dart'
+    show parseFireAt, remainingLabel;
+import '../ws/ws_client.dart';
+
+/// Parse a human delay ("2h", "90m", "2h 30m", "45s") into a [Duration].
+///
+/// A bare number means minutes ("120" == "120m" == "2h"). Returns null for
+/// anything unparseable or non-positive — the dialog treats that as an
+/// invalid form.
+Duration? parseServerDelay(String raw) {
+  final text = raw.trim().toLowerCase();
+  if (text.isEmpty) return null;
+  final bare = double.tryParse(text);
+  if (bare != null) {
+    if (bare <= 0) return null;
+    return Duration(microseconds: (bare * 60 * 1e6).round());
+  }
+  final segment = RegExp(r'^(\d+(?:\.\d+)?)(h|m|s)');
+  var rest = text.replaceAll(' ', '');
+  var micros = 0.0;
+  while (rest.isNotEmpty) {
+    final m = segment.firstMatch(rest);
+    if (m == null) return null;
+    final value = double.parse(m.group(1)!);
+    final factor = switch (m.group(2)!) {
+      'h' => 3600e6,
+      'm' => 60e6,
+      _ => 1e6,
+    };
+    micros += value * factor;
+    rest = rest.substring(m.end);
+  }
+  if (micros <= 0) return null;
+  return Duration(microseconds: micros.round());
+}
+
+/// The Admin → Server tab body: pending schedule list plus the
+/// "schedule an action" FAB.
+class ServerSchedulePanel extends StatefulWidget {
+  const ServerSchedulePanel({super.key});
+
+  @override
+  State<ServerSchedulePanel> createState() => _ServerSchedulePanelState();
+}
+
+class _ServerSchedulePanelState extends State<ServerSchedulePanel> {
+  List<Map<String, dynamic>> _restSchedules = [];
+  bool _loading = true;
+  String? _error;
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    // Live countdowns tick locally from fire_at (the WS snapshot pushes
+    // only on change + periodically — same rationale as the banner).
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+    _loadSchedules();
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _loadSchedules() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final auth = context.read<AuthService>();
+      final resp = await auth.authGet('/api/v1/admin/server/schedule');
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
+        setState(() {
+          _restSchedules =
+              (data['schedules'] as List).cast<Map<String, dynamic>>();
+          _loading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load schedules (${resp.statusCode})';
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[ServerSchedulePanel] load schedules failed: $e');
+      if (mounted) {
+        setState(() {
+          _error = 'Could not load schedules. Please try again.';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _scheduleAction() async {
+    final created = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => const ScheduleServerActionDialog(),
+    );
+    if (!mounted) return;
+    // Refresh the REST fallback list regardless; the WS snapshot (the
+    // preferred source) is broadcast by the server on create.
+    if (created == true) await _loadSchedules();
+  }
+
+  Future<void> _cancelSchedule(Map<String, dynamic> schedule) async {
+    final action = schedule['action'] as String? ?? 'action';
+    final fireAt = parseFireAt(schedule['fire_at']);
+    final when = fireAt == null
+        ? ''
+        : ' at ${MaterialLocalizations.of(context).formatTimeOfDay(TimeOfDay.fromDateTime(fireAt))}';
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Cancel Scheduled $action'),
+        content: Text(
+          'Cancel the scheduled server $action$when? It will not fire.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
+            child: const Text('Keep'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: KColors.accentRed,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Cancel Schedule'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+    if (!mounted) return;
+    final auth = context.read<AuthService>();
+    final resp = await auth
+        .authDelete('/api/v1/admin/server/schedule/${schedule['id']}');
+    if (!mounted) return;
+    if (resp.statusCode == 200) {
+      // The authoritative update is the next `server_schedule` WS
+      // snapshot; this REST refresh only covers a client whose socket
+      // is not connected.
+      await _loadSchedules();
+    } else {
+      String detail = 'Failed to cancel (${resp.statusCode})';
+      try {
+        detail = jsonDecode(resp.body)['detail'] ?? detail;
+      } catch (_) {}
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('$detail')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // The WS snapshot (when connected) is the live truth; the REST list
+    // is the pre-snapshot / disconnected fallback.
+    final ws = context.watch<WsClient>();
+    final schedules = ws.serverSchedulesNow ?? _restSchedules;
+    final sorted = [...schedules]..sort(
+        (a, b) =>
+            (parseFireAt(a['fire_at'])?.millisecondsSinceEpoch ?? 0).compareTo(
+          parseFireAt(b['fire_at'])?.millisecondsSinceEpoch ?? 0,
+        ),
+      );
+
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        heroTag: 'schedule-server',
+        onPressed: _scheduleAction,
+        tooltip: 'Schedule server action',
+        child: const Icon(Icons.add_alarm),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Text(
+              'A stop exits the server process (the service manager decides '
+              'what happens next); a recycle rebuilds it in place. Every '
+              'connected client sees a countdown while a schedule is pending.',
+              style:
+                  const TextStyle(color: KColors.textSecondary, fontSize: 12),
+            ),
+          ),
+          Expanded(child: _buildList(sorted)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildList(List<Map<String, dynamic>> schedules) {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: _loadSchedules,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+    if (schedules.isEmpty) {
+      return const Center(
+        child: Text('No scheduled server actions'),
+      );
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: schedules.length,
+      itemBuilder: (ctx, i) {
+        final schedule = schedules[i];
+        final action = schedule['action'] as String? ?? 'action';
+        final fireAt = parseFireAt(schedule['fire_at']);
+        final isStop = action == 'stop';
+        final remaining =
+            fireAt == null ? null : fireAt.difference(DateTime.now());
+        final localizations = MaterialLocalizations.of(context);
+        final title = fireAt == null
+            ? 'Scheduled server $action'
+            : '${isStop ? 'Stop' : 'Recycle'} at '
+                '${localizations.formatMediumDate(fireAt)} '
+                '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(fireAt))}';
+        final subtitle = remaining == null
+            ? 'fires soon'
+            : remaining.isNegative
+                ? 'happening now'
+                : 'fires in ${remainingLabel(remaining)}';
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            leading: Icon(
+              isStop ? Icons.power_settings_new : Icons.autorenew,
+              color: isStop ? KColors.accentRed : KColors.accentAmber,
+            ),
+            title: Text(title),
+            subtitle: Text(
+              subtitle,
+              style: const TextStyle(color: KColors.textSecondary),
+            ),
+            trailing: IconButton(
+              icon: const Icon(Icons.event_busy, color: KColors.accentRed),
+              tooltip: 'Cancel schedule',
+              onPressed: () => _cancelSchedule(schedule),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Dialog: pick an action (stop / recycle) and either an absolute time
+/// (date + time pickers) or a human delay. Surfaces the API's 422 detail
+/// inline; pops with `true` when a schedule was created.
+class ScheduleServerActionDialog extends StatefulWidget {
+  const ScheduleServerActionDialog({super.key});
+
+  @override
+  State<ScheduleServerActionDialog> createState() =>
+      _ScheduleServerActionDialogState();
+}
+
+class _ScheduleServerActionDialogState
+    extends State<ScheduleServerActionDialog> {
+  String _action = 'stop'; // 'stop' | 'recycle'
+  bool _useDelay = true; // delay | absolute time
+  final _delayController = TextEditingController();
+  DateTime? _at;
+  String? _error;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _delayController.dispose();
+    super.dispose();
+  }
+
+  Duration? get _delay => parseServerDelay(_delayController.text);
+
+  /// The picked time as a readable local label ('Aug 24, 11:00 PM').
+  String get _atLabel => _at == null
+      ? 'Pick date and time'
+      : '${MaterialLocalizations.of(context).formatMediumDate(_at!)} '
+          '${MaterialLocalizations.of(context).formatTimeOfDay(TimeOfDay.fromDateTime(_at!))}';
+
+  bool get _formValid =>
+      _validationError == null && (_useDelay ? _delay != null : _at != null);
+
+  /// One-line preview of when the form will fire (delay mode only).
+  String? get _firesLabel {
+    if (!_useDelay || _delay == null) return null;
+    final localizations = MaterialLocalizations.of(context);
+    final firesAt = DateTime.now().add(_delay!);
+    return 'Fires ${localizations.formatMediumDate(firesAt)} at '
+        '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(firesAt))} '
+        '(in ${remainingLabel(_delay!)})';
+  }
+
+  /// Client-side pre-checks; empty when the form may be submitted.
+  String? get _validationError {
+    if (_useDelay) {
+      if (_delayController.text.trim().isEmpty) return null;
+      return _delay == null
+          ? 'Enter a delay like "2h", "90m", "45s", or minutes'
+          : null;
+    }
+    if (_at != null && !_at!.isAfter(DateTime.now())) {
+      return 'The chosen time is in the past';
+    }
+    return null;
+  }
+
+  Future<void> _pickDateTime() async {
+    final now = DateTime.now();
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _at ?? now.add(const Duration(hours: 1)),
+      firstDate: now.subtract(const Duration(days: 1)),
+      lastDate: now.add(const Duration(days: 365 * 5)),
+    );
+    if (date == null || !mounted) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime:
+          TimeOfDay.fromDateTime(_at ?? now.add(const Duration(hours: 1))),
+    );
+    if (time == null || !mounted) return;
+    setState(() {
+      _at = DateTime(
+        date.year,
+        date.month,
+        date.day,
+        time.hour,
+        time.minute,
+      );
+    });
+  }
+
+  Future<void> _submit() async {
+    setState(() => _submitting = true);
+    final body = jsonEncode({
+      'action': _action,
+      if (_useDelay)
+        'in_seconds': _delay!.inMilliseconds / 1000
+      else
+        'at': _at!.toIso8601String(),
+    });
+    final auth = context.read<AuthService>();
+    final resp = await auth.authPost(
+      '/api/v1/admin/server/schedule',
+      body: body,
+    );
+    if (!mounted) return;
+    if (resp.statusCode == 200) {
+      Navigator.pop(context, true);
+      return;
+    }
+    String detail = 'Failed to schedule (${resp.statusCode})';
+    try {
+      detail = jsonDecode(resp.body)['detail'] ?? detail;
+    } catch (_) {}
+    setState(() {
+      _error = detail;
+      _submitting = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final labelStyle = const TextStyle(
+      color: KColors.textPrimary,
+      fontWeight: FontWeight.bold,
+    );
+    final validation = _validationError;
+    return AlertDialog(
+      title: Text(
+        'Schedule Server Action',
+        style: TextStyle(color: KColors.textPrimary),
+      ),
+      content: SizedBox(
+        width: 420,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Action', style: labelStyle),
+            const SizedBox(height: 4),
+            SegmentedButton<String>(
+              segments: const [
+                ButtonSegment(
+                  value: 'stop',
+                  label: Text('Stop'),
+                  icon: Icon(Icons.power_settings_new),
+                ),
+                ButtonSegment(
+                  value: 'recycle',
+                  label: Text('Recycle'),
+                  icon: Icon(Icons.autorenew),
+                ),
+              ],
+              selected: {_action},
+              onSelectionChanged: (sel) => setState(() => _action = sel.first),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _action == 'stop'
+                  ? 'Stop: graceful shutdown, then the process exits.'
+                  : 'Recycle: graceful in-place restart; never exits.',
+              style: const TextStyle(
+                color: KColors.textSecondary,
+                fontSize: 12,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text('When', style: labelStyle),
+            const SizedBox(height: 4),
+            SegmentedButton<bool>(
+              segments: const [
+                ButtonSegment(value: true, label: Text('After a delay')),
+                ButtonSegment(value: false, label: Text('At a time')),
+              ],
+              selected: {_useDelay},
+              onSelectionChanged: (sel) =>
+                  setState(() => _useDelay = sel.first),
+            ),
+            const SizedBox(height: 12),
+            if (_useDelay)
+              TextField(
+                controller: _delayController,
+                decoration: InputDecoration(
+                  labelText: 'Delay',
+                  labelStyle: labelStyle,
+                  floatingLabelStyle: labelStyle,
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  border: const OutlineInputBorder(),
+                  hintText: 'e.g. 2h, 90m, 45s, or 2h 30m',
+                  helperText: 'A bare number means minutes',
+                  errorText: validation,
+                ),
+                autofocus: true,
+                onChanged: (_) => setState(() {}),
+              )
+            else ...[
+              OutlinedButton.icon(
+                onPressed: _pickDateTime,
+                icon: const Icon(Icons.event),
+                label: Text(_atLabel),
+              ),
+              if (validation != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    validation,
+                    style: TextStyle(color: KColors.accentRed, fontSize: 12),
+                  ),
+                ),
+            ],
+            const SizedBox(height: 8),
+            if (_firesLabel != null)
+              Text(
+                _firesLabel!,
+                style: const TextStyle(
+                  color: KColors.textSecondary,
+                  fontSize: 12,
+                ),
+              ),
+            if (_error != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                _error!,
+                style: TextStyle(color: KColors.accentRed, fontSize: 12),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _formValid && !_submitting ? _submit : null,
+          child: _submitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Schedule'),
+        ),
+      ],
+    );
+  }
+}

--- a/src/frontend/lib/workspace/server_schedule_banner.dart
+++ b/src/frontend/lib/workspace/server_schedule_banner.dart
@@ -20,14 +20,14 @@ import 'package:provider/provider.dart';
 import '../ws/ws_client.dart';
 
 /// Parses an ISO-8601 `fire_at` into a local [DateTime]; null when absent
-/// or malformed (the banner falls back to a static line).
-DateTime? _parseFireAt(dynamic raw) {
+/// or malformed (callers fall back to a static line).
+DateTime? parseFireAt(dynamic raw) {
   if (raw is! String || raw.isEmpty) return null;
   return DateTime.tryParse(raw)?.toLocal();
 }
 
 /// "1h 12m" / "12m" / "45s" — coarse, human, stable-width-enough.
-String _remainingLabel(Duration d) {
+String remainingLabel(Duration d) {
   final s = d.inSeconds < 0 ? 0 : d.inSeconds;
   if (s >= 3600) return '${s ~/ 3600}h ${(s % 3600) ~/ 60}m';
   if (s >= 60) return '${s ~/ 60}m';
@@ -72,8 +72,8 @@ class _ServerScheduleBannerState extends State<ServerScheduleBanner> {
     // Soonest fire_at first (the server sends them ordered, but be safe).
     final parsed = <(String, DateTime)>[
       for (final s in schedules)
-        if (_parseFireAt(s['fire_at']) != null)
-          (s['action'] as String? ?? 'action', _parseFireAt(s['fire_at'])!),
+        if (parseFireAt(s['fire_at']) != null)
+          (s['action'] as String? ?? 'action', parseFireAt(s['fire_at'])!),
     ]..sort((a, b) => a.$2.compareTo(b.$2));
     if (parsed.isEmpty) {
       final action = schedules.first['action'] as String? ?? 'action';
@@ -86,7 +86,7 @@ class _ServerScheduleBannerState extends State<ServerScheduleBanner> {
     final label = remaining.isNegative
         ? 'server $action happening now'
         : 'Server $verb at ${MaterialLocalizations.of(context).formatTimeOfDay(TimeOfDay.fromDateTime(fireAt))} '
-            '(in ${_remainingLabel(remaining)} — workspaces stop)';
+            '(in ${remainingLabel(remaining)} — workspaces stop)';
     return _row('⏻ $label');
   }
 

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -461,6 +461,11 @@ class WsClient extends ChangeNotifier implements ChatServices {
         presenceUsers = [];
         terminalWindows = [];
         sharedTerminals = [];
+        // #2661/#2684: a stale schedule snapshot must not survive the
+        // socket that delivered it — the banner hides and the admin
+        // Server tab falls back to its REST list (a live countdown that
+        // can no longer be refreshed is worse than none).
+        _serverSchedules = null;
         final code = _channel?.closeCode;
         final authFailure = code == 4001 || code == 4002;
         // Set the auth-failure flag BEFORE notifyListeners so the UI (which
@@ -488,6 +493,7 @@ class WsClient extends ChangeNotifier implements ChatServices {
         presenceUsers = [];
         terminalWindows = [];
         sharedTerminals = [];
+        _serverSchedules = null;
         final code = _channel?.closeCode;
         final authFailure = code == 4001 || code == 4002;
         if (authFailure) {
@@ -596,6 +602,7 @@ class WsClient extends ChangeNotifier implements ChatServices {
     _connected = false;
     _connecting = false;
     _currentWorkspaceId = null;
+    _serverSchedules = null;
     notifyListeners();
   }
 

--- a/src/frontend/test/admin_invitations_page_test.dart
+++ b/src/frontend/test/admin_invitations_page_test.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/admin/admin_users_page.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 /// A paged invitations envelope, matching the backend
@@ -87,6 +88,10 @@ http.Client _mockClient(
         200,
       );
     }
+    if (request.url.path == '/api/v1/admin/server/schedule' &&
+        request.method == 'GET') {
+      return http.Response(jsonEncode({'schedules': []}), 200);
+    }
     return handler(request);
   });
 }
@@ -106,6 +111,9 @@ void main() {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthService()),
+        // The Server tab (#2684) watches the WS client for the live
+        // `server_schedule` snapshot; unconnected is fine for these tests.
+        ChangeNotifierProvider(create: (_) => WsClient()),
       ],
       child: const MaterialApp(home: AdminUsersPage()),
     );

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -6,7 +6,9 @@ import 'package:http/testing.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/admin/admin_users_page.dart';
+import 'package:klangk_frontend/admin/server_schedule_panel.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 /// A paged envelope, matching the backend `GET /admin/users` response.
@@ -99,6 +101,10 @@ http.Client _mockClient(
         200,
       );
     }
+    if (request.url.path == '/api/v1/admin/server/schedule' &&
+        request.method == 'GET') {
+      return http.Response(jsonEncode({'schedules': []}), 200);
+    }
     return handler(request);
   });
 }
@@ -118,6 +124,9 @@ void main() {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthService()),
+        // The Server tab (#2684) watches the WS client for the live
+        // `server_schedule` snapshot; unconnected is fine for these tests.
+        ChangeNotifierProvider(create: (_) => WsClient()),
       ],
       child: const MaterialApp(home: AdminUsersPage()),
     );
@@ -390,6 +399,56 @@ void main() {
       await pumpPage(tester);
 
       expect(find.textContaining('Groups:'), findsNothing);
+    });
+  });
+
+  group('AdminUsersPage server tab', () {
+    testWidgets('shows the Server tab for an admin and renders the panel',
+        (tester) async {
+      serveUsers((page, pageSize, sort, order, q) => []);
+
+      await pumpPage(tester);
+
+      expect(find.text('Server'), findsOneWidget);
+      await tester.tap(find.text('Server'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ServerSchedulePanel), findsOneWidget);
+      expect(find.text('No scheduled server actions'), findsOneWidget);
+    });
+
+    testWidgets('hides the Server tab without the admin permission',
+        (tester) async {
+      // Only /admin/users view — no /admin grant, so no Server tab.
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/config')) {
+          return http.Response(
+            jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/my-permissions')) {
+          return http.Response(
+            jsonEncode({
+              'user_id': 'admin-user',
+              'email': 'admin@example.com',
+              'permissions': {
+                '/admin/users': ['view'],
+              },
+              'groups': [],
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(_usersEnvelope([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pumpPage(tester);
+
+      expect(find.text('Server'), findsNothing);
     });
   });
 

--- a/src/frontend/test/server_schedule_panel_test.dart
+++ b/src/frontend/test/server_schedule_panel_test.dart
@@ -1,0 +1,543 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:klangk_frontend/admin/server_schedule_panel.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Default JWT for a logged-in admin user.
+String get _adminToken {
+  final header = base64Url
+      .encode(utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})))
+      .replaceAll('=', '');
+  final body = base64Url
+      .encode(utf8.encode(jsonEncode({
+        'sub': 'admin-user',
+        'email': 'admin@example.com',
+      })))
+      .replaceAll('=', '');
+  return '$header.$body.fakesig';
+}
+
+class _FakeChannel extends Fake implements WebSocketChannel {
+  final _incoming = StreamController<dynamic>.broadcast();
+  final _sinkImpl = _FakeSink();
+
+  @override
+  Stream<dynamic> get stream => _incoming.stream;
+
+  @override
+  WebSocketSink get sink => _sinkImpl;
+
+  @override
+  Future<void> get ready => Future.value();
+
+  void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
+}
+
+class _FakeSink extends Fake implements WebSocketSink {
+  @override
+  void add(dynamic data) {}
+
+  @override
+  Future close([int? code, String? reason]) async {}
+}
+
+http.Client _mockClient(
+  Future<http.Response> Function(http.Request) handler,
+) {
+  return MockClient((request) async {
+    if (request.url.path.contains('/api/v1/config')) {
+      return http.Response(
+        jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+        200,
+      );
+    }
+    if (request.url.path.contains('/api/v1/my-permissions')) {
+      return http.Response(
+        jsonEncode({
+          'user_id': 'admin-user',
+          'email': 'admin@example.com',
+          'permissions': {
+            '/admin': ['*'],
+          },
+          'groups': [
+            {'id': 'g1', 'name': 'admin'}
+          ],
+        }),
+        200,
+      );
+    }
+    return handler(request);
+  });
+}
+
+Map<String, dynamic> _schedule(
+  String id,
+  String action,
+  Duration fromNow,
+) =>
+    {
+      'id': id,
+      'action': action,
+      'fire_at': DateTime.now().toUtc().add(fromNow).toIso8601String(),
+      'created_by': 'admin-user',
+      'created_at': '2026-01-01T00:00:00+00:00',
+    };
+
+String _schedulesEnvelope(List<Map<String, dynamic>> schedules) =>
+    jsonEncode({'schedules': schedules});
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({'klangk_jwt': _adminToken});
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+  });
+
+  Widget panelApp({WsClient? ws}) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+        ChangeNotifierProvider(create: (_) => ws ?? WsClient()),
+      ],
+      child: const MaterialApp(home: Scaffold(body: ServerSchedulePanel())),
+    );
+  }
+
+  /// Hosts the dialog behind an opener button so close-on-success (a
+  /// real `Navigator.pop`) is observable in tests.
+  Widget dialogApp() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+        ChangeNotifierProvider(create: (_) => WsClient()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: FilledButton(
+                onPressed: () => showDialog<bool>(
+                  context: context,
+                  builder: (_) => const ScheduleServerActionDialog(),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Pump on a wide surface and settle.
+  Future<void> pump(WidgetTester tester, Widget app) async {
+    await tester.binding.setSurfaceSize(const Size(1280, 900));
+    await tester.pumpWidget(app);
+    await tester.pumpAndSettle();
+  }
+
+  Finder iconButton(String tooltip) => find.ancestor(
+        of: find.byTooltip(tooltip),
+        matching: find.byType(IconButton),
+      );
+
+  final scheduleButton = find.widgetWithText(FilledButton, 'Schedule');
+
+  /// Opens the schedule dialog (tap the opener button) and settles.
+  Future<void> openDialog(WidgetTester tester) async {
+    await pump(tester, dialogApp());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ScheduleServerActionDialog), findsOneWidget);
+  }
+
+  group('parseServerDelay', () {
+    test('parses unit suffixes', () {
+      expect(parseServerDelay('2h'), const Duration(hours: 2));
+      expect(parseServerDelay('90m'), const Duration(minutes: 90));
+      expect(parseServerDelay('45s'), const Duration(seconds: 45));
+    });
+
+    test('parses compound and spaced forms', () {
+      expect(parseServerDelay('2h 30m'), const Duration(hours: 2, minutes: 30));
+      expect(parseServerDelay('2h30m'), const Duration(hours: 2, minutes: 30));
+      expect(
+          parseServerDelay('1m30s'), const Duration(minutes: 1, seconds: 30));
+    });
+
+    test('a bare number means minutes', () {
+      expect(parseServerDelay('120'), const Duration(hours: 2));
+    });
+
+    test('parses fractional values', () {
+      expect(parseServerDelay('1.5h'), const Duration(minutes: 90));
+    });
+
+    test('rejects unparseable or non-positive input', () {
+      expect(parseServerDelay(''), isNull);
+      expect(parseServerDelay('   '), isNull);
+      expect(parseServerDelay('abc'), isNull);
+      expect(parseServerDelay('0'), isNull);
+      expect(parseServerDelay('-5'), isNull);
+      expect(parseServerDelay('2x'), isNull);
+      expect(parseServerDelay('m5'), isNull);
+      expect(parseServerDelay('2h blah'), isNull);
+    });
+  });
+
+  group('ServerSchedulePanel', () {
+    testWidgets('renders pending schedules soonest first with countdowns',
+        (tester) async {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule') {
+          return http.Response(
+            _schedulesEnvelope([
+              _schedule('s2', 'recycle', const Duration(hours: 5, seconds: 30)),
+              _schedule('s1', 'stop',
+                  const Duration(hours: 1, minutes: 5, seconds: 30)),
+            ]),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      // Both rows render; the stop (soonest) sorts first.
+      expect(find.textContaining('Stop at'), findsOneWidget);
+      expect(find.textContaining('Recycle at'), findsOneWidget);
+      expect(
+        tester.widgetList<Text>(find.textContaining('fires in')).length,
+        2,
+      );
+      // Countdown label for the soonest schedule.
+      expect(find.textContaining('1h 5m'), findsOneWidget);
+      // Soonest row is above the later one.
+      expect(
+        tester.getTopLeft(find.textContaining('Stop at')).dy,
+        lessThan(tester.getTopLeft(find.textContaining('Recycle at')).dy),
+      );
+    });
+
+    testWidgets('shows the empty state when nothing is scheduled',
+        (tester) async {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule') {
+          return http.Response(_schedulesEnvelope([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      expect(find.text('No scheduled server actions'), findsOneWidget);
+    });
+
+    testWidgets('shows an error with retry when the load fails',
+        (tester) async {
+      var calls = 0;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule') {
+          calls++;
+          return http.Response('boom', 500);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      expect(find.textContaining('Failed to load schedules (500)'),
+          findsOneWidget);
+
+      await tester.tap(find.text('Retry'));
+      await tester.pumpAndSettle();
+      expect(calls, 2);
+    });
+
+    testWidgets('the WS snapshot updates the list without a REST refetch',
+        (tester) async {
+      var gets = 0;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule') {
+          gets++;
+          return http.Response(
+            _schedulesEnvelope(
+                [_schedule('s1', 'stop', const Duration(hours: 1))]),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      final channel = _FakeChannel();
+      final ws = WsClient();
+      ws.connectForTest(channel);
+
+      await pump(tester, panelApp(ws: ws));
+      expect(find.textContaining('Stop at'), findsOneWidget);
+      expect(gets, 1);
+
+      // Another admin cancels → the server broadcasts the new snapshot.
+      channel.serverSend({'type': 'server_schedule', 'schedules': []});
+      await tester.pumpAndSettle();
+
+      expect(find.text('No scheduled server actions'), findsOneWidget);
+      // No extra REST call — the snapshot alone drove the update.
+      expect(gets, 1);
+    });
+
+    testWidgets('cancel confirms, deletes, and refreshes the list',
+        (tester) async {
+      var deleted = <String>[];
+      var pending = [_schedule('s1', 'stop', const Duration(hours: 1))];
+      testAuthHttpClientOverride = _mockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/v1/admin/server/schedule' &&
+            request.method == 'GET') {
+          return http.Response(_schedulesEnvelope(pending), 200);
+        }
+        if (path == '/api/v1/admin/server/schedule/s1' &&
+            request.method == 'DELETE') {
+          deleted.add('s1');
+          pending = [];
+          return http.Response(jsonEncode({'cancelled': 's1'}), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      await tester.tap(iconButton('Cancel schedule'));
+      await tester.pumpAndSettle();
+
+      // Confirm step: nothing deleted yet.
+      expect(deleted, isEmpty);
+      expect(find.textContaining('Cancel the scheduled server stop'),
+          findsOneWidget);
+
+      await tester.tap(find.text('Cancel Schedule'));
+      await tester.pumpAndSettle();
+
+      expect(deleted, ['s1']);
+      expect(find.text('No scheduled server actions'), findsOneWidget);
+    });
+
+    testWidgets('keeping the confirm dialog does not delete', (tester) async {
+      var deleted = 0;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/v1/admin/server/schedule' &&
+            request.method == 'GET') {
+          return http.Response(
+            _schedulesEnvelope(
+                [_schedule('s1', 'recycle', const Duration(hours: 2))]),
+            200,
+          );
+        }
+        if (path == '/api/v1/admin/server/schedule/s1' &&
+            request.method == 'DELETE') {
+          deleted++;
+          return http.Response('{}', 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      await tester.tap(iconButton('Cancel schedule'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Keep'));
+      await tester.pumpAndSettle();
+
+      expect(deleted, 0);
+      expect(find.textContaining('Recycle at'), findsOneWidget);
+    });
+
+    testWidgets('a failed cancel surfaces the API detail', (tester) async {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/v1/admin/server/schedule' &&
+            request.method == 'GET') {
+          return http.Response(
+            _schedulesEnvelope(
+                [_schedule('s1', 'stop', const Duration(hours: 1))]),
+            200,
+          );
+        }
+        if (path == '/api/v1/admin/server/schedule/s1' &&
+            request.method == 'DELETE') {
+          return http.Response(
+              jsonEncode({'detail': 'Schedule not found'}), 404);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      await tester.tap(iconButton('Cancel schedule'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel Schedule'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.textContaining('Schedule not found'), findsOneWidget);
+    });
+  });
+
+  group('ScheduleServerActionDialog', () {
+    testWidgets('Schedule stays disabled until the delay parses',
+        (tester) async {
+      testAuthHttpClientOverride = _mockClient(
+        (request) async => http.Response('Not found', 404),
+      );
+
+      await openDialog(tester);
+
+      expect(
+        tester.widget<FilledButton>(scheduleButton).onPressed,
+        isNull,
+      );
+
+      await tester.enterText(find.byType(TextField), 'not-a-delay');
+      await tester.pump();
+      expect(
+        tester.widget<FilledButton>(scheduleButton).onPressed,
+        isNull,
+      );
+      expect(find.textContaining('Enter a delay'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), '2h');
+      await tester.pump();
+      expect(
+        tester.widget<FilledButton>(scheduleButton).onPressed,
+        isNotNull,
+      );
+      // The computed fire preview appears.
+      expect(find.textContaining('Fires'), findsOneWidget);
+      expect(find.textContaining('(in 2h 0m)'), findsOneWidget);
+    });
+
+    testWidgets('submits a relative schedule and closes on success',
+        (tester) async {
+      Map<String, dynamic>? posted;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule' &&
+            request.method == 'POST') {
+          posted = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode(_schedule('s1', 'recycle', const Duration(hours: 1))),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await openDialog(tester);
+
+      // Default action is stop; switch to recycle.
+      await tester.tap(find.text('Recycle'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '90m');
+      await tester.pump();
+      await tester.tap(scheduleButton);
+      await tester.pumpAndSettle();
+
+      expect(posted, isNotNull);
+      expect(posted!['action'], 'recycle');
+      expect(posted!['in_seconds'], closeTo(5400, 1));
+      expect(posted!.containsKey('at'), isFalse);
+      // Dialog closed on success.
+      expect(find.byType(ScheduleServerActionDialog), findsNothing);
+    });
+
+    testWidgets('shows the API 422 detail inline and stays open',
+        (tester) async {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule' &&
+            request.method == 'POST') {
+          return http.Response(
+            jsonEncode({'detail': "'in_seconds' must be positive"}),
+            422,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await openDialog(tester);
+
+      await tester.enterText(find.byType(TextField), '30m');
+      await tester.pump();
+      await tester.tap(scheduleButton);
+      await tester.pumpAndSettle();
+
+      expect(
+          find.textContaining("'in_seconds' must be positive"), findsOneWidget);
+      expect(find.byType(ScheduleServerActionDialog), findsOneWidget);
+    });
+
+    testWidgets('at-a-time mode: pickers populate the field and submit `at`',
+        (tester) async {
+      Map<String, dynamic>? posted;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule' &&
+            request.method == 'POST') {
+          posted = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode(_schedule('s1', 'stop', const Duration(hours: 1))),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await openDialog(tester);
+
+      // Switch to absolute time.
+      await tester.tap(find.text('At a time'));
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget<FilledButton>(scheduleButton).onPressed,
+        isNull,
+      );
+
+      // Date picker: the default selection (initialDate = +1h) is fine.
+      await tester.tap(find.text('Pick date and time'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      // Time picker: default selection, confirm.
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      // The label now shows a date instead of the hint, and submit enables.
+      expect(find.text('Pick date and time'), findsNothing);
+      expect(
+        tester.widget<FilledButton>(scheduleButton).onPressed,
+        isNotNull,
+      );
+
+      await tester.tap(scheduleButton);
+      await tester.pumpAndSettle();
+
+      expect(posted, isNotNull);
+      expect(posted!['action'], 'stop');
+      expect(posted!['at'], isA<String>());
+      expect(posted!.containsKey('in_seconds'), isFalse);
+      expect(find.byType(ScheduleServerActionDialog), findsNothing);
+    });
+  });
+}

--- a/src/frontend/test/server_schedule_panel_test.dart
+++ b/src/frontend/test/server_schedule_panel_test.dart
@@ -40,7 +40,14 @@ class _FakeChannel extends Fake implements WebSocketChannel {
   @override
   Future<void> get ready => Future.value();
 
+  @override
+  int? get closeCode => null;
+
   void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
+
+  /// Close the incoming stream — triggers the client's onDone path
+  /// (the server-side close).
+  void serverClose() => _incoming.close();
 }
 
 class _FakeSink extends Fake implements WebSocketSink {
@@ -196,6 +203,24 @@ void main() {
       expect(parseServerDelay('2x'), isNull);
       expect(parseServerDelay('m5'), isNull);
       expect(parseServerDelay('2h blah'), isNull);
+    });
+
+    test('returns null (never throws) for infinity-overflow input', () {
+      // Exponents that overflow the double to infinity must fail parsing,
+      // not throw inside Duration(microseconds: .round()) mid-build.
+      expect(parseServerDelay('1e400'), isNull);
+      expect(parseServerDelay('1e308'), isNull);
+      expect(parseServerDelay('-1e308'), isNull);
+      expect(parseServerDelay('1e309'), isNull);
+    });
+
+    test('caps at the server max in_seconds (1e10)', () {
+      // The API 422s in_seconds > 1e10 (~317 years); the parser rejects
+      // those up front instead of round-tripping a doomed request.
+      expect(parseServerDelay('99999999999999999999h'), isNull);
+      expect(parseServerDelay('1e9'), isNull); // 1e9 minutes > 1e10 s
+      // Just under the cap (in hours) still parses.
+      expect(parseServerDelay('2777777h'), isNotNull);
     });
   });
 
@@ -396,6 +421,150 @@ void main() {
       expect(find.byType(SnackBar), findsOneWidget);
       expect(find.textContaining('Schedule not found'), findsOneWidget);
     });
+
+    testWidgets('a past-due schedule shows "happening now"', (tester) async {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule') {
+          return http.Response(
+            _schedulesEnvelope(
+                [_schedule('s1', 'stop', const Duration(seconds: -10))]),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      expect(find.textContaining('Stop at'), findsOneWidget);
+      expect(find.text('happening now'), findsOneWidget);
+    });
+
+    testWidgets('a malformed fire_at degrades to "fires soon"', (tester) async {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/server/schedule') {
+          return http.Response(
+            jsonEncode({
+              'schedules': [
+                {
+                  'id': 's1',
+                  'action': 'stop',
+                  'fire_at': 'not-a-date',
+                  'created_by': 'admin-user',
+                  'created_at': '2026-01-01T00:00:00+00:00',
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pump(tester, panelApp());
+
+      expect(find.text('Scheduled server stop'), findsOneWidget);
+      expect(find.text('fires soon'), findsOneWidget);
+    });
+
+    testWidgets('a REST refresh does not flash the spinner over live data',
+        (tester) async {
+      // WS snapshot is live; the post-cancel REST refresh hangs. The
+      // list must keep rendering the snapshot — no spinner, no error.
+      var gets = 0;
+      final hangingGet = Completer<http.Response>();
+      testAuthHttpClientOverride = _mockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/v1/admin/server/schedule' &&
+            request.method == 'GET') {
+          gets++;
+          if (gets == 1) {
+            return http.Response(
+              _schedulesEnvelope(
+                  [_schedule('s1', 'stop', const Duration(hours: 1))]),
+              200,
+            );
+          }
+          return hangingGet.future;
+        }
+        if (path == '/api/v1/admin/server/schedule/s1' &&
+            request.method == 'DELETE') {
+          return http.Response(jsonEncode({'cancelled': 's1'}), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+      final channel = _FakeChannel();
+      final ws = WsClient();
+      ws.connectForTest(channel);
+      channel.serverSend({
+        'type': 'server_schedule',
+        'schedules': [_schedule('s1', 'stop', const Duration(hours: 1))],
+      });
+
+      await pump(tester, panelApp(ws: ws));
+
+      await tester.tap(iconButton('Cancel schedule'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel Schedule'));
+      // One pump runs the DELETE microtask and starts the hanging GET
+      // (_loading = true) — the live snapshot must stay on screen.
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.textContaining('Stop at'), findsOneWidget);
+
+      hangingGet.complete(http.Response(_schedulesEnvelope([]), 200));
+      await tester.pumpAndSettle();
+      // WS is still connected and its snapshot still says pending — it
+      // stays the live source even after the (empty) REST refresh.
+      expect(find.textContaining('Stop at'), findsOneWidget);
+    });
+
+    testWidgets('after the socket drops, the REST refresh is the source',
+        (tester) async {
+      // The reviewer's scenario: socket silently drops, admin cancels —
+      // DELETE succeeds over HTTP, the broadcast reaches nobody. The
+      // cleared snapshot must let the REST refresh show through.
+      var pending = [_schedule('s1', 'stop', const Duration(hours: 1))];
+      testAuthHttpClientOverride = _mockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/v1/admin/server/schedule' &&
+            request.method == 'GET') {
+          return http.Response(_schedulesEnvelope(pending), 200);
+        }
+        if (path == '/api/v1/admin/server/schedule/s1' &&
+            request.method == 'DELETE') {
+          pending = [];
+          return http.Response(jsonEncode({'cancelled': 's1'}), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+      final channel = _FakeChannel();
+      final ws = WsClient();
+      ws.connectForTest(channel);
+      channel.serverSend({
+        'type': 'server_schedule',
+        'schedules': [_schedule('s1', 'stop', const Duration(hours: 1))],
+      });
+
+      await pump(tester, panelApp(ws: ws));
+      expect(find.textContaining('Stop at'), findsOneWidget);
+
+      // Server closes the socket; the snapshot is cleared server-side
+      // model stays — the panel falls back to its REST list.
+      channel.serverClose();
+      await tester.pumpAndSettle();
+      expect(ws.serverSchedulesNow, isNull);
+      // The REST-loaded row is still displayed.
+      expect(find.textContaining('Stop at'), findsOneWidget);
+
+      await tester.tap(iconButton('Cancel schedule'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel Schedule'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No scheduled server actions'), findsOneWidget);
+    });
   });
 
   group('ScheduleServerActionDialog', () {
@@ -537,6 +706,15 @@ void main() {
       expect(posted!['action'], 'stop');
       expect(posted!['at'], isA<String>());
       expect(posted!.containsKey('in_seconds'), isFalse);
+      // The picker defaults to ~now+1h; the submitted instant must be
+      // UTC-suffixed ('...Z') and land ~1h out regardless of the test
+      // machine's timezone — a naive string would be read as UTC by the
+      // server and shift the fire time by the local offset (#2684).
+      final at = DateTime.parse(posted!['at'] as String);
+      expect(at.isUtc, isTrue);
+      expect(posted!['at'], endsWith('Z'));
+      final drift = at.difference(DateTime.now().toUtc()).inMinutes;
+      expect(drift, inInclusiveRange(58, 62));
       expect(find.byType(ScheduleServerActionDialog), findsNothing);
     });
   });

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -200,6 +200,32 @@ void main() {
       expect(notified, isTrue);
       client.dispose();
     });
+
+    test('disconnect clears the server_schedule snapshot (#2684)', () async {
+      final channel = _FakeWebSocketChannel();
+      final client = WsClient();
+      client.connectForTest(channel);
+      channel.serverSend({
+        'type': 'server_schedule',
+        'schedules': [
+          {
+            'id': 's1',
+            'action': 'stop',
+            'fire_at': DateTime.now()
+                .toUtc()
+                .add(const Duration(hours: 1))
+                .toIso8601String(),
+          },
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.serverSchedulesNow, hasLength(1));
+
+      client.disconnect();
+
+      expect(client.serverSchedulesNow, isNull);
+      client.dispose();
+    });
   });
 
   group('WsClient send methods (no channel)', () {


### PR DESCRIPTION
## Summary

Adds an **Admin → Server** tab (#2684) so scheduling a server stop/recycle (#2661, backend from #2681) no longer requires curl:

- **Create form** (FAB): action segmented button (stop / recycle) + either an absolute time (`showDatePicker` + `showTimePicker`) or a human delay (`2h`, `90m`, `45s`, `2h 30m`; a bare number means minutes), with a live "fires at" preview and the API's 422 `detail` shown inline on rejection.
- **Pending list**: soonest first, live per-second countdown reusing the banner's `parseFireAt` / `remainingLabel` helpers (now public), empty state when nothing is scheduled, error + retry when the load fails.
- **Cancel** per schedule with a confirm step.
- The list follows the live `server_schedule` WS snapshot (REST `GET` is the pre-snapshot / disconnected fallback), so schedules created or cancelled by other admins appear and disappear immediately — tested explicitly.

The tab is gated on the `admin` permission (`/admin`), matching what the API endpoints require; the other admin tabs keep their per-resource gates.

## Docs

- `docs/features/server-scheduling.md` — "Scheduling an action" now leads with the Admin page; the curl examples stay for scripting.
- `docs/features/admin-management.md` — new Server section.
- `docs/changes.md` — Added entry.

## Testing

- New `server_schedule_panel_test.dart` (16 tests): delay parser unit tests, list rendering/sorting/countdown, empty + error states, WS-snapshot-driven update without a REST refetch, cancel confirm/keep/failure paths, dialog validation, submit bodies for both modes, 422 inline detail, date/time picker flow.
- Admin page tests updated for the fifth tab (WsClient provider + schedule GET in the shared mock); new tab-visibility tests (shown for admin, hidden without the permission).
- `docs-invitations-screenshots-dev.spec.ts` tab-click math updated from four to five tabs (docs-screenshots project, not CI).
- Full suite: `flutter test --coverage` — 1063 passed, 100% coverage.
