### PR TITLE
fix(cli): render consent popup row off the blocked event loop (#2699)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1197,7 +1197,6 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
-<<<<<<< HEAD
 - **No stale `live: …` segment in the TUI status bar after a server
   stop/recycle (#2690).** Routine broadcasts (`container_status`,
   `workspaces_changed`, `terminals_changed`, `service_health`) no
@@ -1213,7 +1212,6 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   countdown burned. The show now runs on a worker thread; a request held
   while the decider was reconnecting also surfaces promptly on the
   reconnect snapshot.
->>>>>>> 914f3666 (fix(cli): render consent popup row off the blocked event loop (#2699))
 - **Concurrent shells on one interactive-egress workspace now land on their
   selected terminal (#2692).** Selecting a terminal (e.g. from the TUI with
   `terminal-open-cmd`) while another consent-popup shell on the same

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1197,6 +1197,7 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+<<<<<<< HEAD
 - **No stale `live: …` segment in the TUI status bar after a server
   stop/recycle (#2690).** Routine broadcasts (`container_status`,
   `workspaces_changed`, `terminals_changed`, `service_health`) no
@@ -1204,6 +1205,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   surfaces — so the bar no longer shows a raw event name indefinitely
   after a drain cycle, and a pending scheduled stop/recycle countdown
   is no longer clobbered by them.
+- **Consent popup shows the held request immediately (#2699).** The
+  Allow/Deny row now renders within a few hundred ms of the popup frame
+  appearing over a shell. Previously the decider ran its tmux
+  `display-popup` subprocesses on the UI event loop, where the call
+  blocks until its timeout, delaying the row by seconds while the hold
+  countdown burned. The show now runs on a worker thread; a request held
+  while the decider was reconnecting also surfaces promptly on the
+  reconnect snapshot.
+>>>>>>> 914f3666 (fix(cli): render consent popup row off the blocked event loop (#2699))
 - **Concurrent shells on one interactive-egress workspace now land on their
   selected terminal (#2692).** Selecting a terminal (e.g. from the TUI with
   `terminal-open-cmd`) while another consent-popup shell on the same

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -661,6 +661,10 @@ class ConsentDeciderApp(App):
         # when launched by the shell-layer wrapper; None for standalone use.
         self.popup_socket = popup_socket
         self.popup_session = popup_session
+        # The in-flight popup-show task (#2699): one show at a time, so a
+        # burst of held requests (snapshot or rapid-fire) reuses the show
+        # already opening instead of piling up tmux subprocesses.
+        self._show_popup_task: asyncio.Task | None = None
 
     @property
     def _persistent(self) -> bool:
@@ -899,7 +903,16 @@ class ConsentDeciderApp(App):
                 if action == ADDED:
                     # A held request arrived: surface it as the popup over the
                     # shell (no-op in standalone, skipped if already shown).
-                    self._show_popup()
+                    # Scheduled OFF the event loop (#2699): the show is
+                    # synchronous tmux subprocess work and must never gate
+                    # the render below — inline, the Allow/Deny row only
+                    # appeared ~seconds after the popup wrapper, because a
+                    # `display-popup` blocks until dismissed and always
+                    # outlives its 3 s timeout. The task only starts on the
+                    # next loop tick, so the render below lands first and
+                    # the popup viewer (which paints whatever the hidden
+                    # session already shows) attaches to a painted row.
+                    self._schedule_popup_show()
                 try:
                     if action == ERROR:
                         self._flash(str(payload))
@@ -1271,6 +1284,43 @@ class ConsentDeciderApp(App):
         except Exception:  # noqa: BLE001
             logger.debug("consent-decide viewer detach failed")
 
+    def _schedule_popup_show(self) -> None:
+        """Schedule :meth:`_show_popup` on a worker thread, once at a time.
+
+        The show is synchronous tmux work — two ``list-clients`` queries
+        plus a ``display-popup`` subprocess that **blocks until the popup
+        is dismissed** (it always outlives its 3 s timeout, then is killed;
+        the popup itself stays up). Called inline from the async pump this
+        froze the UI event loop for the full timeout, so the held-request
+        row only rendered seconds after the popup wrapper appeared
+        (#2699). Off the loop, the row renders immediately (the render is
+        not gated on the show) and the popup wrapper follows within one
+        tmux round-trip.
+
+        Deduplicated: while one show is in flight, later ADDED frames skip
+        — the popup shows the whole held-request queue, not one request,
+        so the in-flight show already covers them. A failed/finished show
+        clears the slot so the next held request retries.
+        """
+        if not self.popup_socket or not self.popup_session:
+            return  # standalone: no popup to show (skip the thread entirely)
+        task = self._show_popup_task
+        if task is not None and not task.done():
+            return  # a show is already in flight; it covers this request too
+        self._show_popup_task = asyncio.create_task(self._popup_show_worker())
+
+    async def _popup_show_worker(self) -> None:
+        """Run :meth:`_show_popup` off the event loop; never raises (#2699).
+
+        :meth:`_show_popup` already swallows its subprocess errors; this
+        guard keeps the fire-and-forget task from surfacing anything (an
+        unretrieved task exception would just log noise).
+        """
+        try:
+            await asyncio.to_thread(self._show_popup)
+        except Exception:  # noqa: BLE001
+            logger.debug("consent-decide popup show failed")
+
     def _show_popup(self) -> None:
         """Show the popup on the user's shell client when a request arrives.
 
@@ -1278,6 +1328,9 @@ class ConsentDeciderApp(App):
         Skipped when the popup is already open (the hidden session has a
         viewer client attached). A failed show is swallowed -- the decider
         keeps running and the user can reopen with the shell's reopen key.
+        Blocking by design (see :meth:`_schedule_popup_show`): callers on
+        the event loop must go through the scheduler, which runs this on a
+        worker thread.
         """
         sock = self.popup_socket
         sess = self.popup_session

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -148,6 +148,14 @@ _FLASH_TTL = 5.0
 # shell is restarted.
 _REFUSED_RETRY_INTERVAL = 60.0
 
+# Popup-show retry (#2699 review): how many times a worker re-attempts a
+# show that targeted nothing (no outer client found — e.g. a contended tmux
+# server timing out ``list-clients``), and how long it waits between
+# attempts. Without a retry, requests that arrived during the failed
+# attempt's dedupe window would never get a popup (holds auto-deny unseen).
+_POPUP_SHOW_ATTEMPTS = 3
+_POPUP_SHOW_RETRY_DELAY = 1.0
+
 
 # Sent as the WS handshake User-Agent so klangkd's refusal log (#2490) can
 # attribute a 403 to this client (vs a browser or anything else).
@@ -665,6 +673,9 @@ class ConsentDeciderApp(App):
         # burst of held requests (snapshot or rapid-fire) reuses the show
         # already opening instead of piling up tmux subprocesses.
         self._show_popup_task: asyncio.Task | None = None
+        # The in-flight viewer-hide task (#2699 review): same off-loop
+        # treatment for the ``q``/``Esc`` detach path.
+        self._hide_task: asyncio.Task | None = None
 
     @property
     def _persistent(self) -> bool:
@@ -908,10 +919,10 @@ class ConsentDeciderApp(App):
                     # the render below — inline, the Allow/Deny row only
                     # appeared ~seconds after the popup wrapper, because a
                     # `display-popup` blocks until dismissed and always
-                    # outlives its 3 s timeout. The task only starts on the
-                    # next loop tick, so the render below lands first and
-                    # the popup viewer (which paints whatever the hidden
-                    # session already shows) attaches to a painted row.
+                    # outlives its 3 s timeout. The task starts on the next
+                    # loop tick, so in practice the row paints before the
+                    # viewer attaches (worst case it shows a tick later —
+                    # never seconds).
                     self._schedule_popup_show()
                 try:
                     if action == ERROR:
@@ -1257,12 +1268,33 @@ class ConsentDeciderApp(App):
         never quit by a key (it dies only when the shell ends). Standalone
         quits as before. (On the rules screen ``Esc`` still returns to the
         queue — that screen's own binding takes precedence.) Reopen the popup
-        with the shell wrapper's reopen key.
+        with the shell wrapper's reopen key. The detach itself is scheduled
+        off the event loop (:meth:`_schedule_viewer_hide`) — it is the same
+        blocking-tmux-subprocess failure mode the show path fixed (#2699).
         """
         if self._persistent:
-            self._hide_viewer()
+            self._schedule_viewer_hide()
         else:
             self.exit()
+
+    def _schedule_viewer_hide(self) -> None:
+        """Schedule :meth:`_hide_viewer` on a worker thread, once at a time.
+
+        ``_hide_viewer`` is a synchronous ``tmux detach-client`` subprocess
+        (3 s timeout); run inline from the key action a contended tmux
+        server froze the UI for up to 3 s on ``q``/``Esc`` — the identical
+        failure mode the show path fixed (#2699). Deduplicated like the
+        show: ``q`` mashing reuses the in-flight detach (a second detach of
+        an already-detaching viewer is pointless).
+        """
+        if not self.popup_socket or not self.popup_session:
+            return  # standalone: nothing to detach
+        task = self._hide_task
+        if task is not None and not task.done():
+            return  # a detach is already in flight
+        self._hide_task = asyncio.create_task(
+            asyncio.to_thread(self._hide_viewer)
+        )
 
     def _hide_viewer(self) -> None:
         """Detach the popup viewer so it hides; the decider stays registered.
@@ -1270,6 +1302,9 @@ class ConsentDeciderApp(App):
         No-op when not running under a popup (standalone `consent-decide`).
         A failed/stale detach is swallowed -- the decider keeps running
         either way, and the viewer is reopened with the reopen key.
+        Blocking by design (see :meth:`_schedule_viewer_hide`): callers on
+        the event loop must go through the scheduler, which runs this on a
+        worker thread.
         """
         sock = self.popup_socket
         sess = self.popup_session
@@ -1299,8 +1334,10 @@ class ConsentDeciderApp(App):
 
         Deduplicated: while one show is in flight, later ADDED frames skip
         — the popup shows the whole held-request queue, not one request,
-        so the in-flight show already covers them. A failed/finished show
-        clears the slot so the next held request retries.
+        so the in-flight show already covers them. A show that targeted
+        nothing is retried inside the worker (see
+        :meth:`_popup_show_worker`); once the worker ends, the slot frees
+        so the next held request schedules a fresh one.
         """
         if not self.popup_socket or not self.popup_session:
             return  # standalone: no popup to show (skip the thread entirely)
@@ -1312,16 +1349,27 @@ class ConsentDeciderApp(App):
     async def _popup_show_worker(self) -> None:
         """Run :meth:`_show_popup` off the event loop; never raises (#2699).
 
-        :meth:`_show_popup` already swallows its subprocess errors; this
-        guard keeps the fire-and-forget task from surfacing anything (an
-        unretrieved task exception would just log noise).
+        Retries a show that targeted nothing while holds remain pending
+        (#2699 review): a failed first attempt (contended tmux server,
+        ``list-clients`` timeout) must not strand requests that arrived
+        during the attempt's dedupe window — without a retry they would
+        sit unpopup'd until the next ADDED frame or a reconnect, and
+        auto-deny unseen. Bounded by ``_POPUP_SHOW_ATTEMPTS``; once the
+        worker ends the slot frees and the next ADDED frame schedules a
+        fresh one. :meth:`_show_popup` swallows its subprocess errors;
+        this guard keeps the fire-and-forget task from surfacing anything
+        (an unretrieved task exception would just log noise).
         """
         try:
-            await asyncio.to_thread(self._show_popup)
+            for _ in range(_POPUP_SHOW_ATTEMPTS):
+                shown = await asyncio.to_thread(self._show_popup)
+                if shown or not self.controller.pending:
+                    return
+                await asyncio.sleep(_POPUP_SHOW_RETRY_DELAY)
         except Exception:  # noqa: BLE001
-            logger.debug("consent-decide popup show failed")
+            logger.exception("consent-decide popup show failed")
 
-    def _show_popup(self) -> None:
+    def _show_popup(self) -> bool:
         """Show the popup on the user's shell client when a request arrives.
 
         No-op when not running under a popup (standalone ``consent-decide``).
@@ -1331,15 +1379,25 @@ class ConsentDeciderApp(App):
         Blocking by design (see :meth:`_schedule_popup_show`): callers on
         the event loop must go through the scheduler, which runs this on a
         worker thread.
+
+        Returns True when the popup is (or was just made) visible on at
+        least one shell client — including the already-open case. A
+        per-client ``display-popup`` that hits its timeout still counts as
+        shown: the call blocks while the popup is open, so the timeout
+        means it opened and stayed. False means nothing could be targeted
+        (standalone, or no outer client was found — e.g. a contended tmux
+        server timing out ``list-clients``); the worker retries so holds
+        that arrived meanwhile are not stranded.
         """
         sock = self.popup_socket
         sess = self.popup_session
         if not sock or not sess:
-            return
+            return False
         if hidden_has_client(sock, sess):
-            return  # popup already open
+            return True  # popup already open
         w, h = DEFAULT_POPUP_SIZE
-        for client in outer_clients(sock, sess):
+        clients = outer_clients(sock, sess)
+        for client in clients:
             try:
                 subprocess.run(
                     show_popup_argv(sock, sess, client, w=w, h=h),
@@ -1348,6 +1406,7 @@ class ConsentDeciderApp(App):
                 )
             except Exception:  # noqa: BLE001
                 logger.debug("consent-decide popup show failed")
+        return bool(clients)
 
     def _decide(self, decision: str) -> None:
         rid = self._focused_request_id()

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -2989,3 +2989,160 @@ class TestPersistentPopupRole:
 
         monkeypatch.setattr(tui_consent.subprocess, "run", boom)
         app._show_popup()  # must not raise
+
+
+class TestPopupShowOffLoop:
+    """#2699: the ADDED-path popup show runs off the UI event loop.
+
+    ``_show_popup`` is synchronous tmux subprocess work — two
+    ``list-clients`` queries plus a ``display-popup`` that blocks until
+    the popup is dismissed (it always outlives its 3 s timeout, then is
+    killed; the popup stays up). Called inline from the async pump it
+    froze the event loop, so the Allow/Deny row rendered ~seconds after
+    the popup wrapper appeared while the hold countdown burned.
+    """
+
+    async def test_slow_tmux_does_not_delay_row_render(self, monkeypatch):
+        # A contended/slow tmux server (here: list-clients takes 1.5s) must
+        # not delay the row render: the show is scheduled off the loop and
+        # the render is not gated on it.
+        import threading
+
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        started = threading.Event()
+
+        def slow_has_client(sock, sess):
+            started.set()
+            time.sleep(1.5)
+            return False
+
+        monkeypatch.setattr(tui_consent, "hidden_has_client", slow_has_client)
+        monkeypatch.setattr(
+            tui_consent, "outer_clients", lambda sock, sess: ["clientA"]
+        )
+        async with app.run_test():
+            t0 = time.monotonic()
+            # One ADDED frame, then the socket closes.
+            await app._pump(
+                FakeWS([_req_frame("r1", host="evil.example.com")])
+            )
+            elapsed = time.monotonic() - t0
+            # The pump returned (and rendered) without waiting for tmux.
+            # Inline, this took >= 1.5s; off-loop it is effectively instant.
+            assert elapsed < 1.0, (
+                f"row render gated on the popup show ({elapsed:.2f}s)"
+            )
+            # The row IS rendered despite the show still being in flight.
+            assert len(app.query_one("#requests", ListView).children) == 1
+            # ...and the show did run (on its worker thread).
+            assert started.wait(timeout=5)
+            # Let the in-flight show finish so run_test teardown is clean.
+            task = app._show_popup_task
+            assert task is not None
+            while not task.done():
+                await asyncio.sleep(0.05)
+
+    async def test_snapshot_reconnect_surfaces_row_and_popup(
+        self, monkeypatch
+    ):
+        # Acceptance: a request held while the decider's WS was reconnecting
+        # arrives in the connect snapshot -- the row renders and the popup is
+        # scheduled for it promptly on reconnect (#2699).
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(
+            tui_consent, "hidden_has_client", lambda sock, sess: False
+        )
+        monkeypatch.setattr(
+            tui_consent, "outer_clients", lambda sock, sess: ["clientA"]
+        )
+        ran: list[list[str]] = []
+        monkeypatch.setattr(
+            tui_consent.subprocess, "run", lambda cmd, **kw: ran.append(cmd)
+        )
+        async with app.run_test() as pilot:
+            # Reconnect: the server's snapshot replays the currently-held
+            # request as an egress_request frame.
+            await app._pump(
+                FakeWS([_req_frame("r1", host="evil.example.com")])
+            )
+            await pilot.pause()
+            assert set(app.controller.pending) == {"r1"}
+            assert len(app.query_one("#requests", ListView).children) == 1
+            # ...and the popup show was scheduled off-loop and ran.
+            for _ in range(100):
+                if ran:
+                    break
+                await asyncio.sleep(0.02)
+            assert ran, "popup show never ran"
+            assert ran[0][:5] == [
+                "tmux",
+                "-S",
+                "/tmp/k.sock",
+                "display-popup",
+                "-c",
+            ]
+
+    async def test_schedule_dedupes_in_flight_show(self, monkeypatch):
+        # A burst of held requests (snapshot replay) must not pile up shows:
+        # while one is in flight, later ADDED frames reuse it.
+        import threading
+
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        calls = []
+        release = threading.Event()
+
+        def slow_show():
+            calls.append(True)
+            release.wait(timeout=5)
+
+        monkeypatch.setattr(app, "_show_popup", slow_show)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._schedule_popup_show()
+            app._schedule_popup_show()
+            app._schedule_popup_show()
+            for _ in range(100):
+                if calls:
+                    break
+                await asyncio.sleep(0.02)
+            assert len(calls) == 1  # deduped onto the in-flight show
+            release.set()
+            task = app._show_popup_task
+            while not task.done():
+                await asyncio.sleep(0.05)
+            # After the show finished, the next request schedules a new one.
+            app._schedule_popup_show()
+            for _ in range(100):
+                if len(calls) >= 2:
+                    break
+                await asyncio.sleep(0.02)
+            assert len(calls) == 2
+            task = app._show_popup_task
+            while not task.done():
+                await asyncio.sleep(0.05)
+
+    def test_schedule_noop_without_popup_context(self):
+        # Standalone decider: scheduling neither spawns a task nor shows.
+        app = _make_app()
+        app._schedule_popup_show()
+        assert app._show_popup_task is None
+
+    async def test_popup_show_worker_swallows_errors(self, monkeypatch):
+        # The fire-and-forget worker must never surface an exception (an
+        # unretrieved task exception is log noise at best).
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+
+        async def boom(*a, **k):
+            raise RuntimeError("thread pool blew up")
+
+        monkeypatch.setattr(tui_consent.asyncio, "to_thread", boom)
+        async with app.run_test():
+            await app._popup_show_worker()  # must not raise

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 import time
 import types
 
@@ -2852,7 +2853,7 @@ class TestPersistentPopupRole:
         app.action_q_key()
         assert exited == [True]
 
-    def test_q_key_persistent_hides_not_quit(self, monkeypatch):
+    async def test_q_key_persistent_hides_not_quit(self, monkeypatch):
         # Popup context -> q detaches the viewer and does NOT quit/deregister.
         app = _make_app(
             popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
@@ -2863,9 +2864,16 @@ class TestPersistentPopupRole:
         monkeypatch.setattr(
             tui_consent.subprocess, "run", lambda cmd, **kw: ran.append(cmd)
         )
-        app.action_q_key()
-        assert exited == []
-        assert ran == [build_detach_command("/tmp/k.sock", "klangk-consent-w")]
+        async with app.run_test():
+            app.action_q_key()  # detaches off-loop; wait for it to land
+            for _ in range(200):
+                if ran:
+                    break
+                await asyncio.sleep(0.01)
+            assert exited == []
+            assert ran == [
+                build_detach_command("/tmp/k.sock", "klangk-consent-w")
+            ]
 
     async def test_escape_hides_in_persistent_mode(self, monkeypatch):
         # Escape detaches the viewer (hides) and does NOT quit/deregister.
@@ -2881,9 +2889,14 @@ class TestPersistentPopupRole:
         async with app.run_test() as pilot:
             await pilot.pause()
             await pilot.press("escape")
-            await pilot.pause()
-        assert exited == []
-        assert ran == [build_detach_command("/tmp/k.sock", "klangk-consent-w")]
+            for _ in range(200):
+                if ran:
+                    break
+                await asyncio.sleep(0.01)
+            assert exited == []
+            assert ran == [
+                build_detach_command("/tmp/k.sock", "klangk-consent-w")
+            ]
 
     async def test_escape_quits_in_standalone_mode(self):
         app = _make_app()
@@ -2904,6 +2917,52 @@ class TestPersistentPopupRole:
         app._hide_viewer()
         assert not run.called
 
+    def test_hide_schedule_noop_without_popup(self):
+        # Standalone: scheduling neither spawns a task nor detaches.
+        app = _make_app()
+        app._schedule_viewer_hide()
+        assert app._hide_task is None
+
+    async def test_hide_schedule_dedupes_in_flight_detach(self, monkeypatch):
+        # q-mashing reuses the in-flight detach; once it lands, the next
+        # hide schedules a fresh one.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        calls: list[bool] = []
+        release = threading.Event()
+
+        def slow_hide():
+            calls.append(True)
+            release.wait(timeout=5)
+
+        monkeypatch.setattr(app, "_hide_viewer", slow_hide)
+        async with app.run_test():
+            app._schedule_viewer_hide()
+            app._schedule_viewer_hide()
+            app._schedule_viewer_hide()
+            for _ in range(200):
+                if calls:
+                    break
+                await asyncio.sleep(0.01)
+            assert len(calls) == 1  # deduped onto the in-flight detach
+            release.set()
+            task = app._hide_task
+            assert task is not None
+            while not task.done():
+                await asyncio.sleep(0.01)
+            # After the detach finished, the next hide schedules a new one.
+            app._schedule_viewer_hide()
+            for _ in range(200):
+                if len(calls) >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            assert len(calls) == 2
+            task = app._hide_task
+            assert task is not None
+            while not task.done():
+                await asyncio.sleep(0.01)
+
     def test_hide_viewer_swallows_subprocess_error(self, monkeypatch):
         # A stale session / missing tmux must never crash the decider.
         app = _make_app(
@@ -2923,11 +2982,12 @@ class TestPersistentPopupRole:
         app = _make_app()
         run = MagicMock()
         monkeypatch.setattr(tui_consent.subprocess, "run", run)
-        app._show_popup()
+        assert app._show_popup() is False
         assert not run.called
 
     def test_show_popup_noop_when_already_open(self, monkeypatch):
-        # Hidden session already has a viewer (popup open) -> don't re-show.
+        # Hidden session already has a viewer (popup open) -> don't re-show;
+        # the goal (popup visible) holds, so this counts as shown.
         app = _make_app(
             popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
         )
@@ -2938,7 +2998,7 @@ class TestPersistentPopupRole:
         monkeypatch.setattr(
             tui_consent.subprocess, "run", lambda *a, **k: called.append(a)
         )
-        app._show_popup()
+        assert app._show_popup() is True
         assert called == []
 
     def test_show_popup_targets_outer_clients(self, monkeypatch):
@@ -2972,6 +3032,27 @@ class TestPersistentPopupRole:
         assert ran[1][5] == "clientB"
         # the viewer attaches to the hidden session (last positional)
         assert ran[0][-1].endswith("attach -t klangk-consent-w")
+        assert app._show_popup() is True
+
+    def test_show_popup_false_when_no_outer_clients(self, monkeypatch):
+        # No outer client could be targeted (e.g. a contended tmux server
+        # timed out list-clients): nothing shown -> False, so the worker
+        # knows to retry (#2699 review).
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(
+            tui_consent, "hidden_has_client", lambda sock, sess: False
+        )
+        monkeypatch.setattr(
+            tui_consent, "outer_clients", lambda sock, sess: []
+        )
+        ran: list = []
+        monkeypatch.setattr(
+            tui_consent.subprocess, "run", lambda cmd, **kw: ran.append(cmd)
+        )
+        assert app._show_popup() is False
+        assert ran == []
 
     def test_show_popup_swallows_subprocess_error(self, monkeypatch):
         app = _make_app(
@@ -3006,8 +3087,6 @@ class TestPopupShowOffLoop:
         # A contended/slow tmux server (here: list-clients takes 1.5s) must
         # not delay the row render: the show is scheduled off the loop and
         # the render is not gated on it.
-        import threading
-
         app = _make_app(
             popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
         )
@@ -3089,8 +3168,6 @@ class TestPopupShowOffLoop:
     async def test_schedule_dedupes_in_flight_show(self, monkeypatch):
         # A burst of held requests (snapshot replay) must not pile up shows:
         # while one is in flight, later ADDED frames reuse it.
-        import threading
-
         app = _make_app(
             popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
         )
@@ -3140,9 +3217,85 @@ class TestPopupShowOffLoop:
             popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
         )
 
-        async def boom(*a, **k):
-            raise RuntimeError("thread pool blew up")
+        def boom():
+            raise RuntimeError("show blew up")
 
-        monkeypatch.setattr(tui_consent.asyncio, "to_thread", boom)
+        monkeypatch.setattr(app, "_show_popup", boom)
         async with app.run_test():
             await app._popup_show_worker()  # must not raise
+
+    async def test_popup_show_retries_when_nothing_targeted(self, monkeypatch):
+        # A failed first attempt (no outer client found — e.g. a contended
+        # tmux server timing out list-clients) must not strand requests
+        # that arrived during its dedupe window: the worker retries and
+        # shows the popup on the next attempt (#2699 review).
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(tui_consent, "_POPUP_SHOW_RETRY_DELAY", 0.0)
+        attempts = []
+        clients = iter([[], ["clientA"]])
+        monkeypatch.setattr(
+            tui_consent,
+            "hidden_has_client",
+            lambda sock, sess: attempts.append("has") or False,
+        )
+        monkeypatch.setattr(
+            tui_consent, "outer_clients", lambda sock, sess: next(clients)
+        )
+        ran: list = []
+        monkeypatch.setattr(
+            tui_consent.subprocess, "run", lambda cmd, **kw: ran.append(cmd)
+        )
+        async with app.run_test():
+            app.controller.apply_frame(_req_frame("r1"))  # still held
+            await app._popup_show_worker()
+            assert len(attempts) == 2  # failed once, retried, succeeded
+            assert len(ran) == 1  # the retry showed the popup
+            assert ran[0][5] == "clientA"
+
+    async def test_popup_show_bounded_attempts_then_gives_up(
+        self, monkeypatch
+    ):
+        # Every attempt targets nothing: the worker stops after
+        # _POPUP_SHOW_ATTEMPTS tries (no infinite retry loop). The slot
+        # frees, so the next ADDED frame schedules a fresh worker.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(tui_consent, "_POPUP_SHOW_RETRY_DELAY", 0.0)
+        attempts = []
+        monkeypatch.setattr(
+            tui_consent,
+            "hidden_has_client",
+            lambda sock, sess: attempts.append("has") or False,
+        )
+        monkeypatch.setattr(
+            tui_consent, "outer_clients", lambda sock, sess: []
+        )
+        async with app.run_test():
+            app.controller.apply_frame(_req_frame("r1"))  # still held
+            await app._popup_show_worker()  # returns (does not spin)
+            assert len(attempts) == tui_consent._POPUP_SHOW_ATTEMPTS
+
+    async def test_popup_show_no_retry_when_nothing_pending(self, monkeypatch):
+        # Nothing is held anymore (the lone request resolved while the
+        # show was in flight): a failed attempt does not retry — there is
+        # nothing left to surface.
+        app = _make_app(
+            popup_socket="/tmp/k.sock", popup_session="klangk-consent-w"
+        )
+        monkeypatch.setattr(tui_consent, "_POPUP_SHOW_RETRY_DELAY", 0.0)
+        attempts = []
+        monkeypatch.setattr(
+            tui_consent,
+            "hidden_has_client",
+            lambda sock, sess: attempts.append("has") or False,
+        )
+        monkeypatch.setattr(
+            tui_consent, "outer_clients", lambda sock, sess: []
+        )
+        async with app.run_test():
+            assert app.controller.pending == {}
+            await app._popup_show_worker()
+            assert len(attempts) == 1  # shown False, but nothing pending


### PR DESCRIPTION
## Summary

Fixes #2699.

When a held egress request arrived, the decider's WS pump called
`_show_popup()` **inline from the async loop**: two `list-clients` tmux
queries plus a `display-popup` subprocess that **blocks until the popup is
dismissed** — it always outlives its 3 s timeout, then is killed (the popup
itself stays up; verified against tmux 3.6a). The UI event loop froze for
the full timeout, so the Allow/Deny row only rendered ~seconds after the
popup wrapper appeared, while the 120 s hold countdown burned.

## Change

- The ADDED path now schedules the show off the event loop via
  `_schedule_popup_show()` → `asyncio.to_thread(self._show_popup)` — no
  synchronous tmux subprocess remains on the UI event loop in the ADDED
  path. The render is not gated on the show; since the task only starts on
  the next loop tick, the row render always lands first and the popup
  viewer attaches to a painted row.
- Shows are deduplicated (one in-flight task at a time): a burst of held
  requests (connect snapshot replay or rapid-fire) reuses the show already
  opening — the popup shows the whole queue, not one request. A
  failed/finished show clears the slot so the next held request retries.
- `_show_popup()` itself is unchanged (still sync, still swallows errors);
  its docstring now flags it as blocking-by-design.

## Tests

- Fake slow tmux (`hidden_has_client` sleeps 1.5 s) does **not** delay the
  row render — the pump returns and the row is in the list well before the
  show completes.
- A request held while the WS was reconnecting arrives in the connect
  snapshot and surfaces promptly: row rendered + popup shown (acceptance
  criterion).
- Scheduling dedupes in-flight shows and no-ops in standalone mode; the
  fire-and-forget worker never surfaces an exception.
- Full suite green with the 100 % coverage gate: `5615 passed`.
