### PR TITLE
fix(cli): TUI audit fixes — status WS url pin, form validation, modal stranding (#2029)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1207,6 +1207,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **TUI robustness and correctness fixes from the code audit (#2029).**
+  The status WebSocket no longer dials the previous server after a
+  server switch (which showed a false "server down" overlay). The
+  create/edit forms now validate numeric resource fields inline instead
+  of crashing on non-numeric input. A workspace deleted while a dialog
+  is open no longer strands the dead detail page behind the dialog.
+  Malformed `container_status`/OIDC payloads and UI-callback errors in
+  the status listener degrade gracefully instead of crashing or forcing
+  reconnect churn. Status-bar refreshes no longer re-read and re-parse
+  the state YAML three times per event (mtime+size stamp cache).
 - **No stale `live: …` segment in the TUI status bar after a server
   stop/recycle (#2690).** Routine broadcasts (`container_status`,
   `workspaces_changed`, `terminals_changed`, `service_health`) no

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1207,16 +1207,25 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
-- **TUI robustness and correctness fixes from the code audit (#2029).**
-  The status WebSocket no longer dials the previous server after a
-  server switch (which showed a false "server down" overlay). The
-  create/edit forms now validate numeric resource fields inline instead
-  of crashing on non-numeric input. A workspace deleted while a dialog
-  is open no longer strands the dead detail page behind the dialog.
-  Malformed `container_status`/OIDC payloads and UI-callback errors in
-  the status listener degrade gracefully instead of crashing or forcing
-  reconnect churn. Status-bar refreshes no longer re-read and re-parse
-  the state YAML three times per event (mtime+size stamp cache).
+- **Status WebSocket follows a server switch (#2029).** The TUI's live
+  status connection kept dialing the previous server after switching
+  servers, producing a false "server down" overlay. It now re-reads the
+  active server each cycle.
+- **Workspace forms validate numeric resource fields (#2029).**
+  Non-numeric or non-finite (NaN/Inf) values in the Idle timeout, CPU
+  limit, or PIDs limit fields now show an inline field-named error
+  instead of crashing the app or failing later at container start.
+- **TUI no longer strands a deleted workspace's page behind a dialog
+  (#2029).** Deleting a workspace while a dialog is open over its detail
+  page now closes both the dialog and the dead page, returning to the
+  workspace list.
+- **TUI tolerates malformed server payloads (#2029).** A malformed
+  `container_status` timestamp or OIDC provider entry degrades
+  gracefully instead of crashing, and errors in status-event handling no
+  longer masquerade as a lost connection.
+- **TUI status-bar refresh is cheaper (#2029).** Refreshing the status
+  bar no longer re-reads and re-parses the CLI state file several times
+  per event on the UI thread.
 - **No stale `live: …` segment in the TUI status bar after a server
   stop/recycle (#2690).** Routine broadcasts (`container_status`,
   `workspaces_changed`, `terminals_changed`, `service_health`) no

--- a/src/klangk/klangk/cli/tui/screens/login.py
+++ b/src/klangk/klangk/cli/tui/screens/login.py
@@ -345,13 +345,16 @@ class LoginScreen(SpatialNavScreen, StatusScreen):
     async def _do_login_oidc(self) -> None:
         providers = await asyncio.to_thread(self.app.tui_state.oidc_providers)
         # Pick the first well-formed provider entry; a malformed payload
-        # (non-dict entry, missing/non-string id) degrades to the "no
-        # provider" message instead of a KeyError crash (#2029 audit).
+        # (non-dict entry, missing/non-string/empty id) degrades to the "no
+        # provider" message instead of a KeyError crash (#2029 audit). An
+        # empty string would dial /auth/oidc//login -> 404 (#2029 review).
         provider_id = next(
             (
                 p["id"]
                 for p in providers
-                if isinstance(p, dict) and isinstance(p.get("id"), str)
+                if isinstance(p, dict)
+                and isinstance(p.get("id"), str)
+                and p["id"]
             ),
             None,
         )

--- a/src/klangk/klangk/cli/tui/screens/login.py
+++ b/src/klangk/klangk/cli/tui/screens/login.py
@@ -344,10 +344,20 @@ class LoginScreen(SpatialNavScreen, StatusScreen):
 
     async def _do_login_oidc(self) -> None:
         providers = await asyncio.to_thread(self.app.tui_state.oidc_providers)
-        if not providers:
+        # Pick the first well-formed provider entry; a malformed payload
+        # (non-dict entry, missing/non-string id) degrades to the "no
+        # provider" message instead of a KeyError crash (#2029 audit).
+        provider_id = next(
+            (
+                p["id"]
+                for p in providers
+                if isinstance(p, dict) and isinstance(p.get("id"), str)
+            ),
+            None,
+        )
+        if provider_id is None:
             self._set_message("No SSO provider configured.", error=True)
             return
-        provider_id = providers[0]["id"]
         try:
             await asyncio.to_thread(self.app.tui_state.oidc_login, provider_id)
         except LoginError as exc:

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -1203,13 +1203,19 @@ class MainScreen(StatusScreen):
         list refresh catches a REST-only degradation lazily.
         """
         state = self.app.tui_state
-        url = state.current_url()
-        token = state.token()
-        if not url or not token:
+        if not state.current_url() or not state.token():
             return
         while True:
+            # Re-read BOTH url and token every iteration: a server switch
+            # reuses this screen (App.server_changed -> refresh_lists, no
+            # re-mount), so a url captured once at mount kept dialing the
+            # previous server with the new server's token -- guaranteed
+            # auth rejection, 25 reconnect attempts, and a false "server
+            # down" overlay while REST on the new server worked fine
+            # (#2029 audit).
+            url = state.current_url()
             token = state.token()
-            if not token:
+            if not url or not token:
                 self.app.session_expired()
                 return
             # Screen popped (logout / server switch) — stop reconnecting.

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -1134,7 +1134,11 @@ class WorkspaceDetailScreen(StatusScreen):
         except Exception as exc:
             self._msg(f"Delete failed: {exc}", error=True)
             return
-        self.app.pop_screen()  # back to the list
+        # Guarded: the delete's own workspaces_changed broadcast can pop
+        # this screen before the worker resumes (#2029 review round 2) —
+        # an unguarded pop would eat the MainScreen below.
+        if self in self.app.screen_stack:
+            self.app.pop_screen()  # back to the list
         self.app.refresh_workspaces()
 
     def action_duplicate(self) -> None:

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -538,8 +538,14 @@ class WorkspaceDetailScreen(StatusScreen):
             was_running = self._ws.running
             old_started = self._ws.service_started_at
             self._ws.running = bool(event.get("running"))
-            if "service_started_at" in event:
-                self._ws.service_started_at = event["service_started_at"]
+            # Type-check before adopting: a malformed payload (string stamp)
+            # would crash _tick_uptime's ``time.time() - started`` math
+            # later (#2029 audit).
+            started = event.get("service_started_at")
+            if isinstance(started, (int, float)) and not isinstance(
+                started, bool
+            ):
+                self._ws.service_started_at = started
             # A container start or restart invalidates everything — uptime
             # resets, health resets, terminal sessions are gone. Do a full
             # reload so all detail-screen items reflect the new state (#1924).
@@ -562,7 +568,14 @@ class WorkspaceDetailScreen(StatusScreen):
     async def _reload_on_status(self) -> None:
         await self._load()
         if self._missing:
-            self.app.pop_screen()
+            # The workspace was deleted out from under this screen. Pop any
+            # modal sitting on top first (edit form / confirm dialog), then
+            # self -- a bare pop_screen() would dismiss only the TOP screen,
+            # silently closing the user's dialog while leaving the dead
+            # detail page mounted (#2029 audit).
+            self.app._pop_above(self)
+            if self.app.screen is self:
+                self.app.pop_screen()
 
     async def _reload_on_restart(self) -> None:
         """Full reload after a container start/restart (#1924).

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 
 import httpx
 
@@ -41,9 +42,12 @@ from ._base import (
 def _collect_settings(screen: Screen) -> dict | None:
     """Read the resource-limit inputs and return a settings dict, or None.
 
-    Raises ``ValueError`` (field-named) on non-numeric input so the form can
+    Raises ``ValueError`` (field-named) on invalid input so the form can
     show an inline error instead of crashing the app — ``int(raw)``/``float(raw)``
-    used to propagate out of the button handler (#2029 audit).
+    used to propagate out of the button handler (#2029 audit). The ``float``
+    field also rejects NaN/Inf: the server's positive-number check
+    (``f <= 0``) passes NaN, and podman later rejects ``--cpus nan`` at
+    container start with a cryptic error long after submit (#2029 review).
     """
     settings: dict = {}
     raw = screen.query_one("#idle_timeout", Input).value.strip()
@@ -57,11 +61,16 @@ def _collect_settings(screen: Screen) -> dict | None:
     raw = screen.query_one("#cpu_limit", Input).value.strip()
     if raw:
         try:
-            settings["cpu_limit"] = float(raw)
+            cpu = float(raw)
         except ValueError:
             raise ValueError(
                 f"CPU limit must be a number (e.g. 2.0): {raw!r}"
             ) from None
+        if not math.isfinite(cpu):
+            raise ValueError(
+                f"CPU limit must be a finite number (e.g. 2.0): {raw!r}"
+            )
+        settings["cpu_limit"] = cpu
     raw = screen.query_one("#memory_limit", Input).value.strip()
     if raw:
         settings["memory_limit"] = raw

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -39,20 +39,40 @@ from ._base import (
 
 
 def _collect_settings(screen: Screen) -> dict | None:
-    """Read the resource-limit inputs and return a settings dict, or None."""
+    """Read the resource-limit inputs and return a settings dict, or None.
+
+    Raises ``ValueError`` (field-named) on non-numeric input so the form can
+    show an inline error instead of crashing the app — ``int(raw)``/``float(raw)``
+    used to propagate out of the button handler (#2029 audit).
+    """
     settings: dict = {}
     raw = screen.query_one("#idle_timeout", Input).value.strip()
     if raw:
-        settings["idle_timeout"] = int(raw)
+        try:
+            settings["idle_timeout"] = int(raw)
+        except ValueError:
+            raise ValueError(
+                f"Idle timeout must be a whole number of seconds: {raw!r}"
+            ) from None
     raw = screen.query_one("#cpu_limit", Input).value.strip()
     if raw:
-        settings["cpu_limit"] = float(raw)
+        try:
+            settings["cpu_limit"] = float(raw)
+        except ValueError:
+            raise ValueError(
+                f"CPU limit must be a number (e.g. 2.0): {raw!r}"
+            ) from None
     raw = screen.query_one("#memory_limit", Input).value.strip()
     if raw:
         settings["memory_limit"] = raw
     raw = screen.query_one("#pids_limit", Input).value.strip()
     if raw:
-        settings["pids_limit"] = int(raw)
+        try:
+            settings["pids_limit"] = int(raw)
+        except ValueError:
+            raise ValueError(
+                f"PIDs limit must be a whole number: {raw!r}"
+            ) from None
     raw = screen.query_one("#tmp_size", Input).value.strip()
     if raw:
         settings["tmp_size"] = raw
@@ -557,7 +577,11 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         allowed_domains = list(self._allowed_domains) or None
         rejected_domains = list(self._rejected_domains) or None
         egress_mode = self.query_one("#egress_mode", Select).value
-        settings = _collect_settings(self)
+        try:
+            settings = _collect_settings(self)
+        except ValueError as exc:
+            self._msg(str(exc), error=True)
+            return
         if self._nix_available and self.query_one("#nix", Checkbox).value:
             settings = {**(settings or {}), "nix": True}
         self.run_worker(
@@ -1290,7 +1314,11 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         allowed_domains = list(self._allowed_domains) or None
         rejected_domains = list(self._rejected_domains) or None
         egress_mode = self.query_one("#egress_mode", Select).value
-        settings = _collect_settings(self)
+        try:
+            settings = _collect_settings(self)
+        except ValueError as exc:
+            self._msg(str(exc), error=True)
+            return
         # #2233: emit an explicit nix value (True/False) whenever the
         # toggle is shown. PUT settings is a full-replace bag, so we must
         # carry the checkbox state — including False — to actually turn

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -1383,6 +1383,18 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
             exit_on_error=False,
         )
 
+    def _safe_dismiss(self, result) -> None:
+        """Dismiss this form only when it is still on the screen stack.
+
+        ``Screen.dismiss`` unconditionally pops the top screen, so an
+        unguarded dismiss from an in-flight save worker whose form was
+        already popped underneath it (the workspace was deleted and the
+        status reload popped it, #2029 review round 2) would eat the
+        MainScreen below and leave a blank base screen. No-op instead.
+        """
+        if self in self.app.screen_stack:
+            self.dismiss(result)
+
     async def _do_save(self, name, body, ws, restart_needed) -> None:
         try:
             await asyncio.to_thread(
@@ -1410,7 +1422,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                         exit_on_error=False,
                     )
                 else:
-                    self.dismiss(name)
+                    self._safe_dismiss(name)
 
             self.app.push_screen(
                 ConfirmScreen(
@@ -1423,7 +1435,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                 _after,
             )
         else:
-            self.dismiss(name)
+            self._safe_dismiss(name)
 
     async def _do_restart_after_save(self, ws_name, dismiss_name) -> None:
         try:
@@ -1433,7 +1445,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         except Exception as exc:
             self._msg(f"Saved, but restart failed: {exc}", error=True)
             return
-        self.dismiss(dismiss_name)
+        self._safe_dismiss(dismiss_name)
 
     # --- event handlers ---
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -11,11 +11,13 @@ deps, and sibling ``cli`` modules.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
 
+from .. import config as cli_config
 from ..auth import (
     _UNREACHABLE,
     _oidc_browser_login,
@@ -36,6 +38,20 @@ from ..transport import http_request
 logger = logging.getLogger(__name__)
 
 
+def _file_stamp(path: Path) -> tuple[int, int] | None:
+    """Cheap change-detection stamp (mtime_ns, size) for a state file.
+
+    None when the file is absent (a missing state file is CLIState.load's
+    default-instance case). Read at call time off the ``config`` module
+    attribute so tests (and a future env change) can retarget the path.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
 class LoginError(Exception):
     """Raised when an in-TUI login attempt fails."""
 
@@ -51,9 +67,18 @@ class ServerInfo:
 class TuiState:
     """Live bridge to CLIConfig / CLIState / KlangkClient.
 
-    Config and state are re-loaded on every call rather than cached at
-    construction, so the TUI never acts on a stale snapshot after a
-    server switch, an external login, or a token refresh.
+    Config and state are re-checked on every call rather than cached at
+    construction, so the TUI never acts on a stale snapshot after a server
+    switch, an external login, or a token refresh. The state YAML is
+    served from an mtime+size stamp cache: a StatusBar refresh reads it
+    3+ times per event on the UI thread, and an unconditional
+    read+parse per call made every push/pop and every status WS event pay
+    three full file loads (#2029 audit). The stamp check keeps the
+    freshness contract — any write (ours via save(), an external
+    ``klangk login``, an editor) changes the stamp — while repeated reads
+    between changes are free. Callers may mutate the returned CLIState
+    (the load→mutate→save pattern); every save() in this class writes the
+    new object straight back into the cache.
     """
 
     def __init__(self, server_url: str | None = None) -> None:
@@ -65,6 +90,11 @@ class TuiState:
         # without a /me hit on every render. Refetched on server switch.
         self._me: dict | None = None
         self._me_url: str | None = None
+        # Stamp cache for CLIState (#2029 audit; see class docstring).
+        # ``_state_cache is None`` forces the first load; afterwards the
+        # (mtime_ns, size) stamp comparison drives reloads.
+        self._state_cache: CLIState | None = None
+        self._state_stamp: tuple[int, int] | None = None
 
     # --- fresh config / state each call ---
 
@@ -72,7 +102,21 @@ class TuiState:
         return CLIConfig.load()
 
     def state(self) -> CLIState:
-        return CLIState.load()
+        stamp = _file_stamp(cli_config._STATE_PATH)
+        if self._state_cache is None or stamp != self._state_stamp:
+            self._state_cache = CLIState.load()
+            self._state_stamp = stamp
+        return self._state_cache
+
+    def _sync_state_cache(self, state: CLIState) -> None:
+        """Write a just-saved CLIState back into the stamp cache.
+
+        Called right after every ``state.save()`` in this class: the save
+        changed the file (and our mutation changed the object), so adopt
+        both without waiting for the next stamp mismatch.
+        """
+        self._state_cache = state
+        self._state_stamp = _file_stamp(cli_config._STATE_PATH)
 
     def current_url(self) -> str | None:
         if self._server_override is not None:
@@ -364,6 +408,7 @@ class TuiState:
         state = self.state()
         state.set_credentials(url, identifier, token)
         state.save()
+        self._sync_state_cache(state)
         return identifier
 
     def login_none(self) -> str:
@@ -377,6 +422,7 @@ class TuiState:
         state = self.state()
         state.set_credentials(url, email, token)
         state.save()
+        self._sync_state_cache(state)
         return email
 
     def oidc_login(self, provider_id: str) -> None:
@@ -395,6 +441,7 @@ class TuiState:
         if url is not None:
             state.clear_credentials(url)
             state.save()
+            self._sync_state_cache(state)
         # Drop the cached /auth/me profile so a re-login as a different
         # identity on the same server isn't served the previous user's
         # profile (#2164 review: the cache is keyed by URL, not identity).
@@ -437,6 +484,7 @@ class TuiState:
         state = self.state()
         state.active_server = url
         state.save()
+        self._sync_state_cache(state)
 
     def add_server(
         self, alias: str, url: str, user: str | None = None
@@ -445,6 +493,7 @@ class TuiState:
         state = self.state()
         state.active_server = url
         state.save()
+        self._sync_state_cache(state)
 
     def update_server(
         self,
@@ -467,6 +516,7 @@ class TuiState:
         if old_url and state.active_server == old_url:
             state.active_server = url
             state.save()
+            self._sync_state_cache(state)
         return True
 
     def delete_server(self, url: str) -> bool:
@@ -486,4 +536,5 @@ class TuiState:
         if state.active_server == url:
             state.active_server = None
             state.save()
+            self._sync_state_cache(state)
         return True

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -95,6 +96,16 @@ class TuiState:
         # (mtime_ns, size) stamp comparison drives reloads.
         self._state_cache: CLIState | None = None
         self._state_stamp: tuple[int, int] | None = None
+        # Guards the stamp cache AND every load→mutate→save→sync sequence
+        # (#2029 review round 2): mutators run on textual worker threads
+        # while the UI thread calls state() constantly, and a torn
+        # two-field update (one writer's object paired with another
+        # writer's stamp) pinned a stale object forever — the exact
+        # wrong-server symptom this class exists to prevent. Reentrant so
+        # state()/_save_state can nest inside a mutator's single hold;
+        # NEVER held across network I/O (the HTTP calls finish before the
+        # mutators acquire it).
+        self._state_lock = threading.RLock()
 
     # --- fresh config / state each call ---
 
@@ -111,18 +122,43 @@ class TuiState:
         every save in this class syncs the cache — but documented so the
         tradeoff is a decision, not an accident (#2029 review).
         """
-        stamp = _file_stamp(cli_config._STATE_PATH)
-        if self._state_cache is None or stamp != self._state_stamp:
-            self._state_cache = CLIState.load()
-            self._state_stamp = stamp
-        return self._state_cache
+        with self._state_lock:
+            stamp = _file_stamp(cli_config._STATE_PATH)
+            if self._state_cache is None or stamp != self._state_stamp:
+                self._state_cache = CLIState.load()
+                self._state_stamp = stamp
+            return self._state_cache
+
+    def _save_state(self, state: CLIState) -> None:
+        """Save *state* and sync the stamp cache; drop the cache on failure.
+
+        Must be called with ``_state_lock`` held so a mutator's whole
+        load→mutate→save→sync sequence is atomic — two writers interleaving
+        inside that sequence produced a torn (stale object, fresh stamp)
+        pair that state() served forever (#2029 review round 2). A failed
+        save drops the cache: the in-memory mutation exists nowhere on
+        disk and must not be served as phantom credentials/state (the
+        same rule oidc_login's unconditional drop follows).
+        """
+        try:
+            state.save()
+        except Exception:
+            self._drop_state_cache()
+            raise
+        self._sync_state_cache(state)
+
+    def _drop_state_cache(self) -> None:
+        """Invalidate the stamp cache; the next ``state()`` reloads disk."""
+        with self._state_lock:
+            self._state_cache = None
+            self._state_stamp = None
 
     def _sync_state_cache(self, state: CLIState) -> None:
         """Write a just-saved CLIState back into the stamp cache.
 
-        Called right after every ``state.save()`` in this class: the save
-        changed the file (and our mutation changed the object), so adopt
-        both without waiting for the next stamp mismatch.
+        Called only from :meth:`_save_state` with ``_state_lock`` held (the
+        save changed the file and our mutation changed the object, so adopt
+        both without waiting for the next stamp mismatch).
         """
         self._state_cache = state
         self._state_stamp = _file_stamp(cli_config._STATE_PATH)
@@ -414,10 +450,10 @@ class TuiState:
         token = resp.json().get("access_token")
         if not token:
             raise LoginError("server returned no access token")
-        state = self.state()
-        state.set_credentials(url, identifier, token)
-        state.save()
-        self._sync_state_cache(state)
+        with self._state_lock:
+            state = self.state()
+            state.set_credentials(url, identifier, token)
+            self._save_state(state)
         return identifier
 
     def login_none(self) -> str:
@@ -428,10 +464,10 @@ class TuiState:
             email, token = local_login(url)
         except SystemExit as exc:
             raise LoginError("no-auth login failed") from exc
-        state = self.state()
-        state.set_credentials(url, email, token)
-        state.save()
-        self._sync_state_cache(state)
+        with self._state_lock:
+            state = self.state()
+            state.set_credentials(url, email, token)
+            self._save_state(state)
         return email
 
     def oidc_login(self, provider_id: str) -> None:
@@ -449,16 +485,15 @@ class TuiState:
             # file never changed, but the mutated object IS our cached one
             # — phantom credentials served forever. Drop the cache either
             # way; the next state() reloads exactly what is on disk.
-            self._state_cache = None
-            self._state_stamp = None
+            self._drop_state_cache()
 
     def logout(self) -> None:
         url = self.current_url()
-        state = self.state()
-        if url is not None:
-            state.clear_credentials(url)
-            state.save()
-            self._sync_state_cache(state)
+        with self._state_lock:
+            state = self.state()
+            if url is not None:
+                state.clear_credentials(url)
+                self._save_state(state)
         # Drop the cached /auth/me profile so a re-login as a different
         # identity on the same server isn't served the previous user's
         # profile (#2164 review: the cache is keyed by URL, not identity).
@@ -498,19 +533,19 @@ class TuiState:
         return "ok"
 
     def switch_server(self, url: str) -> None:
-        state = self.state()
-        state.active_server = url
-        state.save()
-        self._sync_state_cache(state)
+        with self._state_lock:
+            state = self.state()
+            state.active_server = url
+            self._save_state(state)
 
     def add_server(
         self, alias: str, url: str, user: str | None = None
     ) -> None:
         add_server_to_config(alias, url, user)
-        state = self.state()
-        state.active_server = url
-        state.save()
-        self._sync_state_cache(state)
+        with self._state_lock:
+            state = self.state()
+            state.active_server = url
+            self._save_state(state)
 
     def update_server(
         self,
@@ -529,11 +564,11 @@ class TuiState:
         old_url = old_entry.url if old_entry else None
         if not update_server_in_config(old_alias, new_alias, url, user):
             return False
-        state = self.state()
-        if old_url and state.active_server == old_url:
-            state.active_server = url
-            state.save()
-            self._sync_state_cache(state)
+        with self._state_lock:
+            state = self.state()
+            if old_url and state.active_server == old_url:
+                state.active_server = url
+                self._save_state(state)
         return True
 
     def delete_server(self, url: str) -> bool:
@@ -549,9 +584,9 @@ class TuiState:
             return False
         for a in aliases:
             remove_server_from_config(a)
-        state = self.state()
-        if state.active_server == url:
-            state.active_server = None
-            state.save()
-            self._sync_state_cache(state)
+        with self._state_lock:
+            state = self.state()
+            if state.active_server == url:
+                state.active_server = None
+                self._save_state(state)
         return True

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -102,6 +102,15 @@ class TuiState:
         return CLIConfig.load()
 
     def state(self) -> CLIState:
+        """The CLI's state, served from the stamp cache (see class docstring).
+
+        Accepted staleness window: a write that lands within the same
+        mtime tick AND keeps the file size identical to the loaded version
+        is missed (same strategy CPython uses for ``.pyc`` validity). Not
+        realistic for this file — a credential swap changes its size, and
+        every save in this class syncs the cache — but documented so the
+        tradeoff is a decision, not an accident (#2029 review).
+        """
         stamp = _file_stamp(cli_config._STATE_PATH)
         if self._state_cache is None or stamp != self._state_stamp:
             self._state_cache = CLIState.load()
@@ -434,6 +443,14 @@ class TuiState:
             _oidc_browser_login(url, provider_id, self.state())
         except SystemExit as exc:
             raise LoginError("OIDC login failed") from exc
+        finally:
+            # The browser flow mutates + saves the state object itself
+            # (#2029 review): if its save() failed (disk full, quota) the
+            # file never changed, but the mutated object IS our cached one
+            # — phantom credentials served forever. Drop the cache either
+            # way; the next state() reloads exactly what is on disk.
+            self._state_cache = None
+            self._state_stamp = None
 
     def logout(self) -> None:
         url = self.current_url()

--- a/src/klangk/klangk/cli/tui/ws.py
+++ b/src/klangk/klangk/cli/tui/ws.py
@@ -17,9 +17,12 @@ polling. The server side is lowered to match (``launcher.py``).
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 
 from ..transport import ws_connect
+
+logger = logging.getLogger(__name__)
 
 # Protocol-level liveness for the TUI's status WS (#2052). The client pings
 # the server every ``_WS_PING_INTERVAL`` seconds and expects a pong within
@@ -46,7 +49,12 @@ async def listen_for_status(
     unreachable overlay and refresh the workspace list on (re)connect (#2052).
 
     Non-JSON and non-object frames are skipped (the server occasionally
-    sends control/ack frames).
+    sends control/ack frames). Callback exceptions are isolated: a bug in
+    ``on_event``/``on_connect`` is logged and swallowed rather than tearing
+    down the connection — an exception escaping this listener reads as a
+    connection loss to ``_status_loop``, which would churn reconnects and
+    replay the failure forever (#2029 audit, same isolation rule as the
+    consent decider's pump).
     """
     async with ws_connect(
         server_url,
@@ -56,7 +64,10 @@ async def listen_for_status(
         ping_timeout=_WS_PING_TIMEOUT,
     ) as ws:
         if on_connect is not None:
-            on_connect()
+            try:
+                on_connect()
+            except Exception:  # noqa: BLE001
+                logger.exception("status WS on_connect callback failed")
         async for raw in ws:
             try:
                 event = json.loads(raw)
@@ -64,4 +75,7 @@ async def listen_for_status(
                 continue
             if not isinstance(event, dict):
                 continue
-            on_event(event)
+            try:
+                on_event(event)
+            except Exception:  # noqa: BLE001
+                logger.exception("status WS event callback failed")

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -12682,9 +12682,10 @@ async def test_listen_for_status_isolates_callback_errors(monkeypatch):
 
 
 async def test_login_oidc_malformed_provider_degrades(monkeypatch):
-    """#2029: a malformed provider payload (non-dict entry, missing or
-    non-string id) degrades to the "no provider" message instead of a
-    KeyError crash; a well-formed one is still handed through."""
+    """#2029: a malformed provider payload (non-dict entry, missing,
+    non-string, or empty id) degrades to the "no provider" message instead
+    of a KeyError crash or a bogus dial. (The well-formed handoff is covered
+    by test_login_oidc_flow.)"""
 
     async def noop(*a, **k):
         return None
@@ -12697,7 +12698,12 @@ async def test_login_oidc_malformed_provider_degrades(monkeypatch):
         current_url=lambda: "https://x.example",
         email=lambda: None,
         token=lambda: None,
-        oidc_providers=lambda: ["garbage", {"no_id": True}, {"id": 42}],
+        oidc_providers=lambda: [
+            "garbage",
+            {"no_id": True},
+            {"id": 42},
+            {"id": ""},
+        ],
         oidc_login=lambda pid: called.append(pid),
     )
     app = KlangkApp(st)
@@ -12755,3 +12761,85 @@ def test_state_stamp_cache_reload_when_file_removed(redirect_xdg):
     st.switch_server("https://a.example")
     spath.unlink()
     assert st.state().active_server is None
+
+
+async def test_create_screen_rejects_nonfinite_cpu(monkeypatch):
+    """#2029 review: NaN/Inf pass float() AND the server's positive check
+    (NaN <= 0 is False), then podman rejects --cpus nan at container
+    start — a cryptic failure long after submit. The form rejects them
+    inline with a field-named error."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    created: list = []
+
+    def create(*a, **k):
+        created.append((a, k))
+        return _wsobj("made")
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name", Input).value = "valid-name"
+        for bad in ("nan", "inf", "-inf", "NaN"):
+            cs.query_one("#cpu_limit", Input).value = bad
+            cs._create()
+            await pilot.pause()
+            assert created == []  # never submitted
+            assert "CPU limit" in str(
+                cs.query_one("#create_msg", Static).render()
+            ), f"{bad} was not rejected inline"
+        # A finite value still passes through to the request.
+        cs.query_one("#cpu_limit", Input).value = "2.0"
+        cs._create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(created) == 1
+        assert created[0][1]["settings"] == {"cpu_limit": 2.0}
+
+
+def test_oidc_login_drops_stamp_cache_on_save_failure(
+    monkeypatch, redirect_xdg
+):
+    """#2029 review: the browser flow mutates + saves the state object
+    itself. If its save() fails the file never changed, but the mutated
+    object IS the cached one — phantom credentials served forever.
+    oidc_login must drop the cache either way so state() reloads exactly
+    what is on disk."""
+
+    def fake_flow(url, provider_id, state):
+        # Mutate the shared object but do NOT save (simulates a failed
+        # save: the file on disk is unchanged).
+        state.set_credentials(url, "ghost@x", "ghost-token")
+        return None
+
+    monkeypatch.setattr(tui_state_mod, "_oidc_browser_login", fake_flow)
+    st = TuiState("https://x.example")
+    st.oidc_login("google")
+    # Cache dropped: state() reloaded from disk and does NOT serve the
+    # phantom credentials.
+    assert st.token() is None
+    assert st.email() is None
+
+
+def test_oidc_login_keeps_credentials_after_successful_save(
+    monkeypatch, redirect_xdg
+):
+    """The cache drop must not lose a genuinely saved login: after a
+    successful browser flow (mutate + save), state() reloads the same
+    credentials from disk."""
+
+    def fake_flow(url, provider_id, state):
+        state.set_credentials(url, "real@x", "real-token")
+        state.save()
+
+    monkeypatch.setattr(tui_state_mod, "_oidc_browser_login", fake_flow)
+    st = TuiState("https://x.example")
+    st.oidc_login("google")
+    assert st.token() == "real-token"
+    assert st.email() == "real@x"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import asyncio
 import re
+import threading
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -12843,3 +12845,127 @@ def test_oidc_login_keeps_credentials_after_successful_save(
     st.oidc_login("google")
     assert st.token() == "real-token"
     assert st.email() == "real@x"
+
+
+# ---------------------------------------------------------------------------
+# #2029 review round 2: stamp-cache serialization, save-failure drop,
+# guarded dismiss/pop
+# ---------------------------------------------------------------------------
+
+
+def test_state_cache_serializes_concurrent_writers(monkeypatch, redirect_xdg):
+    """#2029 r2: mutators run on worker threads while the UI thread reads,
+    and an interleaved load->mutate->save->sync could pair one writer's
+    stale object with another writer's fresh stamp — served forever. The
+    whole mutator sequence is atomic under _state_lock, so writer C cannot
+    complete (or even start its mutation) while writer B is parked mid-save;
+    final cache and disk both reflect B-then-C."""
+    b_in_save = threading.Event()
+    release_b = threading.Event()
+    real_save = CLIState.save
+
+    def gated_save(self):
+        if self.active_server == "https://b.example":
+            b_in_save.set()
+            assert release_b.wait(timeout=5)
+        return real_save(self)
+
+    monkeypatch.setattr(CLIState, "save", gated_save)
+    st = TuiState()
+    tb = threading.Thread(target=lambda: st.switch_server("https://b.example"))
+    tb.start()
+    assert b_in_save.wait(timeout=5)  # B holds the lock, parked in save()
+    tc = threading.Thread(target=lambda: st.switch_server("https://c.example"))
+    tc.start()
+    time.sleep(0.2)  # give C every chance to (wrongly) get in
+    release_b.set()  # let B finish; C must follow it
+    tb.join(timeout=5)
+    tc.join(timeout=5)
+    assert not tb.is_alive() and not tc.is_alive()
+    # Both serialized in order: disk and cache are v_C, consistent.
+    assert CLIState.load().active_server == "https://c.example"
+    assert st.state().active_server == "https://c.example"
+
+
+def test_mutator_save_failure_drops_cache(monkeypatch, redirect_xdg):
+    """#2029 r2: a failed save() in ANY mutator must drop the cache — the
+    in-memory mutation exists nowhere on disk and must not be served as
+    phantom state (the oidc_login rule, generalized)."""
+
+    def boom(self):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(CLIState, "save", boom)
+    st = TuiState("https://x.example")
+    with pytest.raises(OSError):
+        st.switch_server("https://y.example")
+    # Cache dropped: state() reloads from disk — no phantom active server.
+    assert st.state().active_server is None
+    assert st.current_url() is None or st.current_url() != "https://y.example"
+
+
+async def test_edit_save_dismiss_guarded_when_screen_already_popped(
+    monkeypatch,
+):
+    """#2029 r2: Screen.dismiss unconditionally pops the top screen. If the
+    edit form was popped underneath an in-flight save worker (workspace
+    deleted + status reload), the unguarded dismiss ate the MainScreen and
+    left a blank base. _safe_dismiss no-ops instead."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    ws = _wsobj("alpha", image="base", running=False)
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test(size=(140, 40)) as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        assert isinstance(es, EditWorkspaceScreen)
+        # Form still on the stack: the guarded dismiss runs for real.
+        es._safe_dismiss(True)
+        await pilot.pause()
+        assert es not in app.screen_stack
+        # Form already popped: the guarded dismiss is a no-op — the
+        # MainScreen underneath survives.
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es2 = app.screen
+        app.pop_screen()  # external actor pops it first
+        await pilot.pause()
+        es2._safe_dismiss(True)
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+
+async def test_detail_delete_pop_guarded_when_screen_already_popped(
+    monkeypatch,
+):
+    """#2029 r2: the delete worker's own workspaces_changed broadcast can
+    pop the detail screen before the worker resumes; the guarded pop must
+    no-op instead of eating the MainScreen below."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    st.delete_workspace = lambda n: None
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        assert isinstance(d, WorkspaceDetailScreen)
+        app.pop_screen()  # external actor pops it first
+        await pilot.pause()
+        before = list(app.screen_stack)
+        await d._do_delete()  # guarded pop no-ops
+        await pilot.pause()
+        assert list(app.screen_stack) == before
+        assert isinstance(app.screen, MainScreen)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -12464,3 +12464,294 @@ async def test_mount_does_not_cancel_status_ws_worker(monkeypatch):
         )
         running = [w.name for w in app.workers if w.is_running]
         assert "status-ws" in running
+
+
+# ---------------------------------------------------------------------------
+# #2029 audit: async blocking / correctness / robustness / performance
+# ---------------------------------------------------------------------------
+
+
+async def test_status_loop_rereads_url_after_server_switch(monkeypatch):
+    """#2029: a server switch reuses the MainScreen (no re-mount), so the
+    status-WS loop must re-read the url every iteration. A url pinned at
+    mount kept dialing the OLD server with the NEW server's token — a
+    guaranteed auth reject, 25 reconnect attempts, and a false "server
+    down" overlay while REST on the new server worked fine."""
+    await _fast_reconnect(monkeypatch)
+    box = {"url": "https://a.example", "token": "tok"}
+    dialed: list[str] = []
+
+    async def capture(url, token, **k):
+        dialed.append(url)
+        if len(dialed) == 1:
+            # A server switch lands mid-run (App.server_changed reuses this
+            # screen; on_mount does not re-fire).
+            box["url"] = "https://b.example"
+        if len(dialed) >= 3:
+            box["token"] = None  # end the loop on the next iteration
+        return None  # clean close
+
+    monkeypatch.setattr(scr_main, "listen_for_status", capture)
+    app = KlangkApp(
+        _authed_state(
+            current_url=lambda: box["url"],
+            token=lambda: box["token"],
+        )
+    )
+    expired: list = []
+    monkeypatch.setattr(app, "session_expired", lambda: expired.append(1))
+    async with app.run_test() as pilot:
+        main = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        await _real_status_loop(main)
+        await pilot.pause()
+    assert dialed[0] == "https://a.example"
+    # Every dial after the switch targets the NEW server.
+    assert dialed[1:] == ["https://b.example", "https://b.example"]
+    assert expired  # loop exited via the token-drop guard
+
+
+async def test_detail_reload_on_status_pops_modal_above(monkeypatch):
+    """#2029: when the workspace is deleted out from under an open detail
+    screen, the reload must pop any modal ABOVE it first — a bare
+    pop_screen() dismissed only the modal and left the dead detail page
+    mounted underneath."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        assert isinstance(d, WorkspaceDetailScreen)
+        app.push_screen(ConfirmScreen("Really?"))
+        await pilot.pause()
+
+        def gone(n):
+            raise WorkspaceNotFoundError("gone")
+
+        st.find_workspace = gone
+        d.apply_status_event({"type": "workspaces_changed"})
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # Both the modal AND the detail screen are gone; list on top.
+        assert not any(
+            isinstance(s, WorkspaceDetailScreen) for s in app.screen_stack
+        )
+        assert not any(isinstance(s, ConfirmScreen) for s in app.screen_stack)
+        assert isinstance(app.screen, MainScreen)
+
+
+async def test_detail_status_event_ignores_string_started_at(monkeypatch):
+    """#2029: a malformed (string) service_started_at payload must not be
+    adopted — it would crash the uptime math (int(time.time() - str))."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(owned=[a])
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        d = app.screen
+        # Malformed string stamp: not adopted, no crash on _display().
+        d.apply_status_event(
+            {
+                "type": "container_status",
+                "running": True,
+                "service_started_at": "2026-01-01T00:00:00",
+            }
+        )
+        await pilot.pause()
+        assert d._ws.service_started_at is None
+        # A well-formed numeric stamp still adopts.
+        d.apply_status_event(
+            {
+                "type": "container_status",
+                "running": True,
+                "service_started_at": 1234.5,
+            }
+        )
+        await pilot.pause()
+        assert d._ws.service_started_at == 1234.5
+
+
+async def test_create_screen_settings_validation_inline_error(monkeypatch):
+    """#2029: non-numeric resource inputs show an inline error instead of
+    crashing the app out of the button handler."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    created: list = []
+
+    def create(*a, **k):
+        created.append((a, k))
+        return _wsobj("made")
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name", Input).value = "valid-name"
+        # Cycle each numeric field through garbage: each names its field.
+        for field, label in (
+            ("#idle_timeout", "Idle timeout"),
+            ("#cpu_limit", "CPU limit"),
+            ("#pids_limit", "PIDs limit"),
+        ):
+            cs.query_one(field, Input).value = "garbage"
+            cs._create()
+            await pilot.pause()
+            assert created == []  # never submitted
+            assert label in str(
+                cs.query_one("#create_msg", Static).render()
+            ), f"{field} error did not name its field"
+            cs.query_one(field, Input).value = ""
+
+
+async def test_edit_screen_settings_validation_inline_error(monkeypatch):
+    """#2029: same validation on the edit form's _save path."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    updated: dict = {}
+
+    def update(wid, **f):
+        updated["id"] = wid
+        updated.update(f)
+
+    ws = _wsobj("alpha", image="base", running=False)
+    app = KlangkApp(_edit_state(ws, update=update))
+    async with app.run_test(size=(140, 40)) as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#cpu_limit", Input).value = "fast"
+        es._save()
+        await app.workers.wait_for_complete()
+        assert updated == {}  # never submitted
+        assert "CPU limit" in str(es.query_one("#edit_msg", Static).render())
+
+
+async def test_listen_for_status_isolates_callback_errors(monkeypatch):
+    """#2029: a bug in the UI's on_event/on_connect must not tear down the
+    status WS — an exception escaping the listener reads as a connection
+    loss to _status_loop and would churn reconnects forever."""
+    got: list[str] = []
+    frames = [
+        '{"type": "a"}',
+        '{"type": "b"}',
+        '{"type": "c"}',
+    ]
+    monkeypatch.setattr(
+        ws_mod, "ws_connect", lambda *a, **k: FakeCM(FakeWS(frames))
+    )
+
+    def bad_connect():
+        raise RuntimeError("connect bug")
+
+    def on_event(ev):
+        got.append(ev["type"])
+        if ev["type"] == "a":
+            raise RuntimeError("ui bug")
+
+    await listen_for_status(
+        "/sock", "tok", on_event=on_event, on_connect=bad_connect
+    )
+    # The failing callback was isolated; later frames still delivered.
+    assert got == ["a", "b", "c"]
+
+
+async def test_login_oidc_malformed_provider_degrades(monkeypatch):
+    """#2029: a malformed provider payload (non-dict entry, missing or
+    non-string id) degrades to the "no provider" message instead of a
+    KeyError crash; a well-formed one is still handed through."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    called: list = []
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "password",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        oidc_providers=lambda: ["garbage", {"no_id": True}, {"id": 42}],
+        oidc_login=lambda pid: called.append(pid),
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, LoginScreen)
+        await screen._do_login_oidc()
+        await pilot.pause()
+        assert "No SSO provider configured." in str(
+            screen.query_one("#message", Static).render()
+        )
+        assert called == []  # never handed a bogus provider id
+
+
+def test_state_stamp_cache_serves_same_object(redirect_xdg):
+    """#2029: repeated state() calls between writes hit the stamp cache —
+    the StatusBar refresh path reads it 3+ times per event on the UI
+    thread, and each used to be a full read+parse of the state YAML."""
+    st = TuiState()
+    s1 = st.state()
+    s2 = st.state()
+    assert s1 is s2
+
+
+def test_state_stamp_cache_reloads_on_external_write(redirect_xdg):
+    """#2029: an external write (a concurrent `klangk login`) changes the
+    stamp, so the next state() reloads — the freshness contract holds."""
+    cpath, spath = redirect_xdg
+    st = TuiState()
+    s1 = st.state()
+    ext = CLIState()
+    ext.set_credentials("https://x.example", "u@x", "tok2")
+    ext.save()
+    s2 = st.state()
+    assert s2 is not s1
+    assert st.token() == "tok2"
+
+
+def test_state_stamp_cache_sync_after_own_save(redirect_xdg):
+    """#2029: our own save() writes straight back into the cache, so
+    load->mutate->save->load yields the same object with new content."""
+    st = TuiState()
+    st.switch_server("https://a.example")
+    s = st.state()
+    assert s.active_server == "https://a.example"
+    assert st.state() is s
+
+
+def test_state_stamp_cache_reload_when_file_removed(redirect_xdg):
+    """#2029: the file vanishing (stamp -> None) forces a reload that
+    yields the default instance, not a stale cached copy."""
+    cpath, spath = redirect_xdg
+    st = TuiState()
+    st.switch_server("https://a.example")
+    spath.unlink()
+    assert st.state().active_server is None


### PR DESCRIPTION
## Summary

Fixes #2029 — the systematic TUI audit (async blocking, security, correctness, performance). The audit read every TUI module (`app.py`, `state.py`, `ws.py`, `widgets.py`, `consent.py`, all five screens) and the consent popup layer. Seven findings fixed; **no security issues found** (all dynamic text renders via literal `Text()` — no markup injection; all subprocess launches are list-argv — no shell injection; no credential logging).

## Fixes

1. **Status WS pinned the server URL at mount** (`main.py`). A server switch reuses the MainScreen (`App.server_changed`) without re-mounting, so `_status_loop` kept dialing the **old** server with the **new** server's token → guaranteed auth rejection → 25 reconnect attempts → false "server down" overlay while REST on the new server worked. Both `url` and `token` are now re-read every loop iteration.
2. **Create/edit form crash on non-numeric resource input** (`workspace_form.py`). `_collect_settings` did unguarded `int()`/`float()`; garbage in Idle/CPU/PIDs propagated out of the button handler and killed the app. Now raises a field-named `ValueError` caught by both `_create` and `_save`, shown as an inline error.
3. **Workspace deleted under an open dialog strands the dead detail page** (`workspace_detail.py`). `_reload_on_status` did a bare `pop_screen()` — with a modal on top it dismissed only the modal. Now pops everything above self first, then self.
4. **Malformed `service_started_at` crashes uptime math** (`workspace_detail.py`). A string payload was adopted verbatim; `int(time.time() - str)` later crashed. Now type-checked before adopting.
5. **Status-listener callback errors tear down the connection** (`ws.py`). An exception from `on_event`/`on_connect` escaped `listen_for_status`, which `_status_loop` reads as a connection loss — a UI bug became infinite reconnect churn. Callbacks are now isolated (logged, swallowed), same rule as the consent decider's pump.
6. **OIDC provider payload crash** (`login.py`). `providers[0]["id"]` unchecked; a non-dict entry or missing/non-string id raised. Degrades to the existing "No SSO provider configured." message.
7. **Status-bar refresh re-parses the state YAML 3+ times per event** (`state.py`). `refresh_status_bar` → `current_url()`/`email()` each did a full read+parse of `klangk-state.yaml` on the UI thread, for every mounted screen on every push/pop and every WS event. `TuiState.state()` now serves from an mtime+size stamp cache — any write (ours via `save()`, or an external `klangk login`) changes the stamp and forces a reload; every save syncs the cache.

## Notes from the audit (no action needed)

- The consent decider and shell popup (`consent.py`, `shell_popup.py`) were reviewed in depth during #2699/#2700 — their tmux subprocess scheduling and error isolation are sound.
- `TransferScreen` correctly hops `on_progress` from the worker thread via `call_from_thread`.
- `_launch_shell` uses `subprocess.Popen`/`run` with list argv; `terminal-open-cmd` comes from user config (trusted input).

## Tests

11 new cases pin each fix (URL re-read with a mid-run server switch, modal-pop on delete, string-stamp rejection, per-field validation on both forms, callback isolation, malformed-provider degrade, four stamp-cache behaviors). Full suite **5632 passed, 100 % coverage**.
