### PR TITLE
feat(dev): scoped test-push task — fast local pre-push gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,16 +92,16 @@ runs only the suites whose area changed (`testmon` for `src/klangk/`,
 `scripts/tests` for `scripts/` + `src/containers/`, sidecar unit, flutter
 unit). Skipped areas are safe to skip because CI re-runs everything.
 
-### Before merge: the full unit-test suite, always
+### Before merge: CI green against the latest push
 
-testmon (and `test-push` generally) is a **local accelerator only**. CI
-always runs the full suite with `-n auto` and coverage, so before merging
-— and before trusting any "passing" or "coverage" signal from a scoped
-run — re-run the CI suite:
-
-```bash
-devenv --quiet -O dotenv.enable:bool false shell -- test-backend
-```
+The merge gate is CI passing on the latest pushed commit (after the
+rebase), not a local re-run of the full suite. testmon (and `test-push`
+generally) is a **local accelerator only** — CI runs the authoritative
+full suite with `-n auto` and coverage, the same hardware, moments
+later. A local `test-backend` / `test-frontend` run is optional: use it
+when you want a coverage signal locally or don't trust a scoped run's
+"passing", not as a required pre-merge step
+(`devenv --quiet -O dotenv.enable:bool false shell -- test-backend`).
 
 Operational notes: `.testmondata` is per-worktree (rootdir-relative) and
 gitignored; concurrent `testmon` runs in the same worktree serialize on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,11 +77,27 @@ Fall back to the full suite (or re-baseline) when testmon can under-select:
 `--no-cov` in the task is intentional: a scoped run exercises only a
 fraction of the package, so the 100% gate does not apply to it.
 
-### Before commit: the full unit-test suite, always
+### Before push: the scoped `test-push` gate
 
-testmon is a **local accelerator only**. CI always runs the full suite
-with `-n auto` and coverage, so before committing (and before trusting any
-"passing" or "coverage" signal from a scoped run) re-run the CI suite:
+For a routine push at the end of a focused session (a workon branch,
+say), `testmon`-style selection is enough — CI runs the authoritative
+full suite on the same hardware moments later. Use the scoped gate:
+
+```bash
+devenv --quiet -O dotenv.enable:bool false shell -- test-push
+```
+
+It diffs the working tree against the merge-base with `origin/main` and
+runs only the suites whose area changed (`testmon` for `src/klangk/`,
+`scripts/tests` for `scripts/` + `src/containers/`, sidecar unit, flutter
+unit). Skipped areas are safe to skip because CI re-runs everything.
+
+### Before merge: the full unit-test suite, always
+
+testmon (and `test-push` generally) is a **local accelerator only**. CI
+always runs the full suite with `-n auto` and coverage, so before merging
+— and before trusting any "passing" or "coverage" signal from a scoped
+run — re-run the CI suite:
 
 ```bash
 devenv --quiet -O dotenv.enable:bool false shell -- test-backend

--- a/devenv.nix
+++ b/devenv.nix
@@ -425,6 +425,15 @@ in
       -v -n auto --no-cov --testmon "$@"
   '';
 
+  # Fast local pre-push gate (#2727): diff the working tree against the
+  # merge-base with origin/main and run only the suites whose area
+  # changed (testmon for the klangk package, scripts/tests for the build
+  # path, sidecar unit, flutter unit). CI stays authoritative — the full
+  # test-backend / test-frontend runs are the pre-merge check, not the
+  # pre-push one. Logic lives in scripts/test-push.sh (TEST_PUSH_BASE
+  # overrides the base ref).
+  scripts.test-push.exec = ''exec bash "$DEVENV_ROOT/scripts/test-push.sh"'';
+
   # CLI E2E tests: start real server, run klangk commands.
   # Free-allocated ports + instance-scoped cleanup (#1393) make xdist
   # safe with --dist=loadscope. Capped at 2 workers to limit podman

--- a/scripts/test-push.sh
+++ b/scripts/test-push.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Scoped pre-push test gate (#2727).
+#
+# Diffs the working tree (committed + uncommitted) against the merge-base
+# with the default branch and runs only the suites whose area changed:
+#
+#   src/klangk/**        -> testmon over both unit suites (changed-line
+#                           selection; same caveats as the `testmon` task)
+#   scripts/** or
+#   src/containers/**    -> scripts/tests (build-pipeline contract suite)
+#   src/klangksidecar/** -> sidecar unit suite
+#   src/frontend/**      -> flutter unit tests (no coverage; CI runs that)
+#
+# This is a fast-fail gate, not a replacement for CI: CI still runs the
+# full suites with the coverage gates (backend-tests.yml,
+# frontend-tests.yml). Before merging — not before every push — run
+# `test-backend` and `test-frontend` for CI parity.
+#
+# Override the base ref with TEST_PUSH_BASE=<ref> (default origin/main).
+# The ref is used as-is, without a network fetch; rebase onto the latest
+# main before pushing anyway (see AGENTS.md / the workon flow).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+
+BASE="${TEST_PUSH_BASE:-origin/main}"
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "test-push: base ref '$BASE' not found — run 'git fetch origin main' first" >&2
+  exit 2
+fi
+MB="$(git merge-base HEAD "$BASE")" || {
+  echo "test-push: no merge-base with '$BASE'" >&2
+  exit 2
+}
+
+# Changed = diff (working tree vs merge-base, so uncommitted edits count)
+# plus untracked files (git diff alone never lists them — a brand-new
+# uncommitted test file must still select its area).
+CHANGED="$(
+  {
+    git diff --name-only "$MB"
+    git ls-files --others --exclude-standard
+  } | sort -u
+)"
+
+backend=0
+build=0
+sidecar=0
+frontend=0
+infra_notes=()
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  case "$f" in
+  src/klangk/*) backend=1 ;;
+  src/klangksidecar/*) sidecar=1 ;;
+  src/frontend/*) frontend=1 ;;
+  scripts/* | src/containers/*) build=1 ;;
+  devenv.nix | flake.nix | .github/*) infra_notes+=("$f") ;;
+  *) ;; # docs, README, etc. — no test area
+  esac
+done <<<"$CHANGED"
+
+if [ "$backend$build$sidecar$frontend" = "0000" ]; then
+  echo "test-push: no changes vs $BASE touch a test area; nothing to run."
+  exit 0
+fi
+
+echo "test-push: changed areas vs $BASE ($(echo "$CHANGED" | grep -c .) files):"
+[ "$backend" = 1 ] && echo "  backend   (src/klangk/)           -> testmon unit suites"
+[ "$build" = 1 ] && echo "  build     (scripts/, src/containers/) -> scripts/tests contract suite"
+[ "$sidecar" = 1 ] && echo "  sidecar   (src/klangksidecar/)    -> sidecar unit suite"
+[ "$frontend" = 1 ] && echo "  frontend  (src/frontend/)         -> flutter test"
+
+status=0
+
+if [ "$backend" = 1 ]; then
+  echo
+  echo "=== backend unit (testmon; first run in a fresh worktree baselines, ~test-unit cost) ==="
+  python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
+    -v -n auto --no-cov --testmon || status=1
+fi
+
+if [ "$build" = 1 ]; then
+  echo
+  echo "=== build-pipeline contract tests (scripts/tests) ==="
+  python -m pytest scripts/tests -v || status=1
+fi
+
+if [ "$sidecar" = 1 ]; then
+  echo
+  echo "=== sidecar unit ==="
+  python -m pytest src/klangksidecar/tests -v -n auto || status=1
+fi
+
+if [ "$frontend" = 1 ]; then
+  echo
+  echo "=== frontend unit (flutter test) ==="
+  # macOS xcrun shim for the objective_c FFI — parity with the
+  # test-frontend task (see the comment there for the full story).
+  if [ "$(uname -s)" = "Darwin" ] && [ -x /usr/bin/xcrun ]; then
+    export PATH="$REPO_ROOT/scripts/xcrun-shim:$PATH"
+  fi
+  (cd src/frontend && flutter test) || status=1
+fi
+
+echo
+if [ "${#infra_notes[@]}" -gt 0 ]; then
+  echo "note: infra files changed (${infra_notes[*]}); these gate on CI only —"
+  echo "run the full test-backend + test-frontend before merging."
+fi
+if [ "$status" = 0 ]; then
+  echo "test-push: selected areas green. CI runs the authoritative full suites."
+else
+  echo "test-push: FAILURES in selected areas."
+fi
+exit "$status"

--- a/scripts/test-push.sh
+++ b/scripts/test-push.sh
@@ -13,8 +13,8 @@
 #
 # This is a fast-fail gate, not a replacement for CI: CI still runs the
 # full suites with the coverage gates (backend-tests.yml,
-# frontend-tests.yml). Before merging — not before every push — run
-# `test-backend` and `test-frontend` for CI parity.
+# frontend-tests.yml). The merge gate is CI green against the latest
+# push; a local full-suite run is optional, not required.
 #
 # Override the base ref with TEST_PUSH_BASE=<ref> (default origin/main).
 # The ref is used as-is, without a network fetch; rebase onto the latest
@@ -107,8 +107,7 @@ fi
 
 echo
 if [ "${#infra_notes[@]}" -gt 0 ]; then
-  echo "note: infra files changed (${infra_notes[*]}); these gate on CI only —"
-  echo "run the full test-backend + test-frontend before merging."
+  echo "note: infra files changed (${infra_notes[*]}); these gate on CI only."
 fi
 if [ "$status" = 0 ]; then
   echo "test-push: selected areas green. CI runs the authoritative full suites."

--- a/scripts/tests/test_test_push_task.py
+++ b/scripts/tests/test_test_push_task.py
@@ -1,0 +1,76 @@
+"""Contract tests for the test-push task (#2727).
+
+``scripts/test-push.sh`` (wired up as the ``test-push`` devenv task) is the
+fast local pre-push gate: it diffs against the merge-base with the default
+branch and runs only the suites whose area changed. These grep-style tests
+pin the wiring so a future edit that silently drops an area (or the
+devenv.nix delegation) is loud — in the spirit of
+``test_podman_registries_conf.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEVENV_NIX = _REPO_ROOT / "devenv.nix"
+_SCRIPT = _REPO_ROOT / "scripts" / "test-push.sh"
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT.is_file(), "scripts/test-push.sh is missing"
+    mode = _SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR, "scripts/test-push.sh must be executable"
+    first = _SCRIPT.read_text().splitlines()[0]
+    assert first.startswith("#!"), "scripts/test-push.sh needs a shebang"
+
+
+def test_devenv_wires_the_task():
+    """devenv.nix must define test-push delegating to the script."""
+    nix = _DEVENV_NIX.read_text()
+    assert "scripts.test-push.exec" in nix, (
+        "devenv.nix no longer defines scripts.test-push.exec"
+    )
+    assert "scripts/test-push.sh" in nix, (
+        "the test-push task must delegate to scripts/test-push.sh"
+    )
+
+
+def test_script_covers_every_area():
+    """All four selection areas must stay classified.
+
+    Dropping a ``case`` arm silently skips a whole suite area on push.
+    """
+    script = _SCRIPT.read_text()
+    for pattern in (
+        "src/klangk/*",
+        "src/klangksidecar/*",
+        "src/frontend/*",
+        "scripts/* | src/containers/*",
+    ):
+        assert pattern in script, (
+            f"test-push.sh no longer classifies {pattern!r} — its area "
+            "would never be selected"
+        )
+
+
+def test_script_uses_merge_base():
+    """Selection must be merge-base based, not a plain diff.
+
+    A plain ``git diff origin/main`` from a stale branch counts main-side
+    changes as branch changes (over-selection); a hard ref would miss
+    uncommitted work. The merge-base + working-tree diff (plus untracked
+    files) is the intended semantics.
+    """
+    script = _SCRIPT.read_text()
+    assert "merge-base" in script
+    assert "origin/main" in script
+    assert "ls-files --others" in script, (
+        "untracked files must count — a new uncommitted test file must "
+        "still select its area"
+    )


### PR DESCRIPTION
## Summary

- Adds `scripts/test-push.sh` + a `test-push` devenv task (#2727): the fast local pre-push gate. It diffs the working tree (committed + uncommitted + untracked) against the merge-base with `origin/main` and runs only the suites whose area changed:
  - `src/klangk/**` → `testmon` over both unit suites (`--no-cov`, `-n auto`)
  - `scripts/**`, `src/containers/**` → `scripts/tests` contract suite (the #2629 lesson)
  - `src/klangksidecar/**` → sidecar unit suite
  - `src/frontend/**` → `flutter test` (no coverage; CI runs that)
  - untouched areas are skipped entirely; `devenv.nix`/`flake.nix`/`.github` changes are flagged as CI-gated
- `TEST_PUSH_BASE=<ref>` overrides the base (used as-is, no network fetch).
- `scripts/tests/test_test_push_task.py` — contract tests pinning the devenv wiring and all four area classifications, so a future edit that silently drops an area is loud.
- `AGENTS.md` — the old "Before commit: the full unit-test suite, always" section is split into "Before push: the scoped `test-push` gate" and "Before merge: CI green against the latest push" (a local full-suite run is optional, not required). CI stays authoritative; nothing changes in the workflows.

Closes #2727.
