### PR TITLE
feat: gate per-handle home machinery on per_handle_home — shared path serves /home/klangk (#2169 chunk 2)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -155,6 +155,15 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`per_handle_home` now selects the home layout at runtime (#2720).**
+  A workspace created with `per_handle_home=false` (see
+  `KLANGKD_PER_HANDLE_HOME`, #2719) now actually serves the shared
+  layout: every connection — and exec sessions, the health-check probe,
+  and the `service` tmux session — uses the single shared `/home/klangk`
+  (the container user's own home), with no `/home/{handle}` →
+  `.users/{user_id}` symlinks and no per-user skeleton population.
+  Changing your handle no longer re-links a home on this layout. The
+  default (`true`, per-handle homes) is unchanged.
 - **`KLANGKD_PER_HANDLE_HOME` (#2719).** Deploy-wide default for the home
   layout of **new** workspaces: `true` (default) = per-handle homes, the
   current behavior; `false` = a shared klangk home. Overridable per

--- a/src/klangk/klangk/container/__init__.py
+++ b/src/klangk/klangk/container/__init__.py
@@ -57,5 +57,8 @@ from .registry import (
     _reap_sort_key as _reap_sort_key,
 )
 from .sidecar import NetworkSidecarMixin as NetworkSidecarMixin
-from .spec import ContainerStartSpec as ContainerStartSpec
+from .spec import (
+    ContainerStartSpec as ContainerStartSpec,
+    SHARED_HOME as SHARED_HOME,
+)
 from .state import ContainerState as ContainerState

--- a/src/klangk/klangk/container/health.py
+++ b/src/klangk/klangk/container/health.py
@@ -9,6 +9,7 @@ import logging
 import time
 
 from .. import podman
+from .spec import SHARED_HOME
 from .state import ContainerState
 
 logger = logging.getLogger(__name__)
@@ -123,17 +124,23 @@ class HealthMonitor:
         owner_id = state.owner_id
         if owner_id is None:
             return "unhealthy", "no owner recorded for workspace"
-        handle = await self.app.state.model.users.get_user_handle(owner_id)
-        if not handle:
-            return "unhealthy", f"owner {owner_id} has no handle"
-        # Resolve the owner's container home the same way
-        # start_workspace does, so the check runs in the right
-        # HOME rather than as root in /.
-        ws = self.app.state.workspaces
-        ws_home = ws.home_path(state.workspace_id)
-        user_home, _created = await ws.ensure_home_symlink(
-            ws_home, handle, owner_id
-        )
+        if state.per_handle_home:
+            handle = await self.app.state.model.users.get_user_handle(owner_id)
+            if not handle:
+                return "unhealthy", f"owner {owner_id} has no handle"
+            # Resolve the owner's container home the same way
+            # start_workspace does, so the check runs in the right
+            # HOME rather than as root in /.
+            ws = self.app.state.workspaces
+            ws_home = ws.home_path(state.workspace_id)
+            user_home, _created = await ws.ensure_home_symlink(
+                ws_home, handle, owner_id
+            )
+        else:
+            # Shared layout (#2169 chunk 2, #2720): one home for every
+            # connection — the check probes the workspace's shared
+            # /home/klangk; no per-owner symlink to resolve.
+            user_home = SHARED_HOME
         cid_short = state.container_id[:12]
         logger.debug(
             "Health check: container %s (workspace %s) running %r",

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -419,6 +419,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         health_check: str | None = None,
         owner_id: str | None = None,
         setup_state: str | None = None,
+        per_handle_home: bool | None = None,
     ) -> None:
         state = self.states.get(workspace_id)
         was_new = state is None
@@ -439,6 +440,8 @@ class ContainerRegistry(NetworkSidecarMixin):
             state.owner_id = owner_id
         if setup_state is not None:
             state.setup_state = setup_state
+        if per_handle_home is not None:
+            state.per_handle_home = per_handle_home
         if was_new:
             self._notify_status_changed(workspace_id, True)
 
@@ -686,6 +689,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         health_check: str | None = None,
         owner_id: str | None = None,
         setup_state: str | None = None,
+        per_handle_home: bool = True,
     ) -> tuple[str, str] | None:
         """Check an existing container and reuse/remove it.
 
@@ -722,6 +726,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                 health_check=health_check,
                 owner_id=owner_id,
                 setup_state=setup_state,
+                per_handle_home=per_handle_home,
             )
             if adopted is not None:
                 return adopted
@@ -743,6 +748,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                 health_check=health_check,
                 owner_id=owner_id,
                 setup_state=setup_state,
+                per_handle_home=per_handle_home,
             )
             logger.info(
                 "workspace-open: DONE — container was already running, "
@@ -770,6 +776,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         health_check: str | None = None,
         owner_id: str | None = None,
         setup_state: str | None = None,
+        per_handle_home: bool = True,
     ) -> tuple[str, str] | None:
         """Adopt a live workspace container found by label (#2676).
 
@@ -829,6 +836,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                 health_check=health_check,
                 owner_id=owner_id,
                 setup_state=setup_state,
+                per_handle_home=per_handle_home,
             )
             logger.info(
                 "workspace-open: DONE — adopted running labeled container "
@@ -885,6 +893,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         health_check: str | None = None,
         owner_id: str | None = None,
         setup_state: str | None = None,
+        per_handle_home: bool = True,
     ) -> str:
         """Create the container, persist it, start it, and configure it.
 
@@ -908,6 +917,7 @@ class ContainerRegistry(NetworkSidecarMixin):
             health_check=health_check,
             owner_id=owner_id,
             setup_state=setup_state,
+            per_handle_home=per_handle_home,
         )
         # --hooks-dir is a podman global flag that must be present on the
         # start invocation — podman does not persist it from create. No
@@ -1206,6 +1216,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                 health_check=health_check,
                 owner_id=user_id,
                 setup_state=setup_state,
+                per_handle_home=spec.per_handle_home,
             )
             if result is not None:
                 # Re-track a sidecar'd workspace's network sidecar on reconnect.
@@ -1487,6 +1498,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                     health_check=health_check,
                     owner_id=user_id,
                     setup_state=setup_state,
+                    per_handle_home=spec.per_handle_home,
                 )
             )
         except BaseException:

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -26,6 +26,16 @@ from .ports import CONTAINER_PORT_START, DEFAULT_PORTS_PER_WORKSPACE
 
 logger = logging.getLogger(__name__)
 
+# The single home every connection shares when a workspace has
+# ``per_handle_home = false`` (#2169 chunk 2, #2720): the container
+# user's own home (the image's ``-d /home/klangk``), which under the
+# shared layout is also where the ``service`` tmux session runs
+# (``ensure_agent_home`` materializes + populates it at every fresh
+# container create, under both layouts). Lives here — the container
+# filesystem-layout module — so ``workspaces``/``wshandler``/``health``
+# can import it without a cycle through the ``container`` package.
+SHARED_HOME = "/home/klangk"
+
 _VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
 
 
@@ -79,6 +89,11 @@ class ContainerStartSpec:
     rejected_domains: list[str] | None = None
     workspace_settings: dict | None = None
     egress_mode: str = "static"
+    # Home layout (#2169 chunk 2, #2720): True -> per-handle
+    # /home/{handle} symlinks; False -> the single shared /home/klangk.
+    # Traveled on the spec so ContainerState carries it for the health
+    # monitor (same pattern as health_check/owner_id/setup_state).
+    per_handle_home: bool = True
 
 
 def image_pull_policy(app) -> str:

--- a/src/klangk/klangk/container/state.py
+++ b/src/klangk/klangk/container/state.py
@@ -31,6 +31,11 @@ class ContainerState:
         self.health_check: str | None = None  # shell command, None = disabled
         self.owner_id: str | None = None
         self.setup_state: str | None = None
+        # Home layout (#2169 chunk 2, #2720): the health check resolves
+        # the owner's per-handle HOME only when this is True; False means
+        # the shared /home/klangk. Default True (the pre-#2720 layout and
+        # the safe fallback if a start path forgets to set it).
+        self.per_handle_home: bool = True
         # Anchor for the startup grace window
         # (HEALTH_CHECK_STARTUP_GRACE_SECONDS): the moment the monitored
         # service began starting.  Defaults to now (container-state

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -595,6 +595,7 @@ class Workspaces:
                 egress_mode=ws.get(
                     "egress_mode", model.EGRESS_MODE_INTERACTIVE
                 ),
+                per_handle_home=ws.get("per_handle_home", True),
             )
         )
         return cid, status

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from .. import container, model
+from ..container.spec import SHARED_HOME
 from ..exceptions import NodeDrainingError
 from ..terminal import TerminalSession
 from ..podman import ExecSession, PodmanError
@@ -242,19 +243,30 @@ class Connection:
             self.app.state.workspaces.get_config_host_path(workspace_id)
         )
 
-        # Ensure the per-user home symlink exists BEFORE starting the
-        # container, because mounts under /home/{handle}/ need the
-        # symlink in place so podman doesn't auto-create a real dir.
-        handle = await self.app.state.model.users.get_user_handle(
-            self.user["id"]
-        )
-        workspace_home = self.app.state.workspaces.home_path(workspace_id)
-        (
-            self._user_home,
-            self._home_created,
-        ) = await self.app.state.workspaces.ensure_home_symlink(
-            workspace_home, handle, self.user["id"]
-        )
+        # Home layout (#2169 chunk 2, #2720). Per-handle (the default):
+        # ensure the /home/{handle} -> .users/{user_id} symlink exists
+        # BEFORE starting the container, because mounts under
+        # /home/{handle}/ need the symlink in place so podman doesn't
+        # auto-create a real dir. Shared: every connection (and the
+        # ``service`` session) uses the one shared /home/klangk — no
+        # per-user symlink, no .users/{uid} dirs, no per-user skel
+        # (``ensure_agent_home`` populates /home/klangk at every fresh
+        # container create, under both layouts), and no handle lookup
+        # (the handle is irrelevant on this path).
+        if workspace.get("per_handle_home", True):
+            handle = await self.app.state.model.users.get_user_handle(
+                self.user["id"]
+            )
+            workspace_home = self.app.state.workspaces.home_path(workspace_id)
+            (
+                self._user_home,
+                self._home_created,
+            ) = await self.app.state.workspaces.ensure_home_symlink(
+                workspace_home, handle, self.user["id"]
+            )
+        else:
+            self._user_home = SHARED_HOME
+            self._home_created = False
 
         hosting_hostname, hosting_proto, hosting_base_path = (
             self.app.state.util.derive_hosting_info(
@@ -291,6 +303,7 @@ class Connection:
                 egress_mode=workspace.get(
                     "egress_mode", model.EGRESS_MODE_INTERACTIVE
                 ),
+                per_handle_home=workspace.get("per_handle_home", True),
             )
         )
         self.container_status = container_status
@@ -618,9 +631,11 @@ class Connection:
             await self.app.state.model.users.set_user_handle(
                 self.user["id"], handle
             )
-            # Update the per-workspace symlink.
+            # Update the per-workspace symlink (per-handle layout only;
+            # the shared layout has no per-user symlink and its home is
+            # the constant SHARED_HOME — nothing to refresh, #2720).
             workspace = self.workspace
-            if workspace:
+            if workspace and workspace.get("per_handle_home", True):
                 workspace_home = self.app.state.workspaces.home_path(
                     self.workspace_id
                 )

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -253,6 +253,19 @@ class TestActivityTracking:
         self.registry.track_activity("cid-1", "ws-1")
         assert self.registry.states["ws-1"].container_id == "cid-1"
 
+    def test_track_activity_threads_per_handle_home(self):
+        # The home-layout flag rides track_activity onto ContainerState
+        # (#2720) the same way health_check/owner_id/setup_state do, so
+        # the health monitor can branch without a DB lookup per tick.
+        self.registry.track_activity("cid-1", "ws-1")
+        assert self.registry.states["ws-1"].per_handle_home is True  # default
+        self.registry.track_activity("cid-1", "ws-1", per_handle_home=False)
+        assert self.registry.states["ws-1"].per_handle_home is False
+        # Untouched when not passed (e.g. test harness call sites) — the
+        # previous value survives, mirroring owner_id/setup_state.
+        self.registry.track_activity("cid-1", "ws-1")
+        assert self.registry.states["ws-1"].per_handle_home is False
+
     def test_track_activity_fires_status_changed_on_new(self):
         calls = []
         self.registry.set_on_container_status_changed(
@@ -310,6 +323,9 @@ class TestActivityTracking:
         assert state.health_check == ("curl -sf http://localhost:8080/health")
         assert state.owner_id == "uid-owner"
         assert state.setup_state == "complete"
+        # The home layout rides along too (#2720); default True (the
+        # pre-#2720 layout) when a caller doesn't pass it.
+        assert state.per_handle_home is True
 
 
 def _noop_callback(ws):
@@ -652,6 +668,28 @@ class TestStartContainer:
         assert status == "created"
         p.start_container.assert_awaited_once_with("new-cid", hooks_dir=None)
         assert workspace["id"] in self.registry.states
+
+    async def test_spec_threads_per_handle_home_onto_state(self, workspace):
+        # #2720: the layout rides the spec through every start path
+        # (create / reuse / adopt) onto ContainerState, so the health
+        # monitor can branch without a DB lookup per poll. Default True.
+        with patch_podman(self.registry):
+            await self.registry.start_container(
+                container.ContainerStartSpec(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
+            )
+        assert self.registry.states[workspace["id"]].per_handle_home is True
+        with patch_podman(self.registry):
+            await self.registry.start_container(
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    per_handle_home=False,
+                )
+            )
+        assert self.registry.states[workspace["id"]].per_handle_home is False
 
     async def test_egress_filter_no_domains_is_noop(self, workspace):
         # No allowed_domains -> no annotation or hooks-dir; the container
@@ -5966,6 +6004,36 @@ class TestHealthMonitorRunOne:
         assert status == "unhealthy"
         assert "handle" in message
         exec_mock.assert_not_called()
+
+    async def test_shared_layout_probes_shared_home(self, app_state):
+        # per_handle_home=False (#2720): the check probes the workspace's
+        # single shared /home/klangk — no owner handle lookup, no
+        # per-user symlink — and runs with that HOME.
+        monitor = _health_registry().health
+        st = _health_state()
+        st.per_handle_home = False
+        exec_mock = AsyncMock(return_value=(0, "", ""))
+        with (
+            patch.object(
+                monitor.app.state.podman, "exec_container", exec_mock
+            ),
+            patch.object(
+                monitor.app.state.model.users,
+                "get_user_handle",
+                AsyncMock(),
+            ) as handle_mock,
+            patch.object(
+                monitor.app.state.workspaces,
+                "ensure_home_symlink",
+                new_callable=AsyncMock,
+            ) as symlink_mock,
+        ):
+            assert await monitor._run_one(st) == ("healthy", "")
+        handle_mock.assert_not_awaited()
+        symlink_mock.assert_not_awaited()
+        assert exec_mock.call_args.kwargs["extra_env"] == {
+            "HOME": container.SHARED_HOME
+        }
 
 
 class TestHealthMonitorCheckWorkspace:

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2132,6 +2132,170 @@ class TestStartWorkspaceContainer:
         registry.states.pop(workspace["id"], None)
 
 
+# --- home layout (per_handle_home gate, #2169 chunk 2 / #2720) ---
+
+
+class TestSharedHomeLayout:
+    """Both layouts through the WS connect / handle-set / exec seams.
+
+    per_handle_home=False workspaces serve the single shared
+    /home/klangk for every connection; per-handle workspaces keep the
+    symlink machinery byte-identical (the default path above).
+    """
+
+    async def test_connect_shared_layout_skips_symlink(self, user, app_state):
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        sock = _mock_sock(headers={"host": "localhost:8997"})
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        workspace = await app_state.state.workspaces.create_workspace(
+            user["id"], "shared-ws", per_handle_home=False
+        )
+        captured = {}
+
+        async def fake_start(spec):
+            captured["spec"] = spec
+            registry.track_activity("cid-sh", workspace["id"])
+            return ("cid-sh", "created")
+
+        with (
+            patch.object(registry, "start_container", side_effect=fake_start),
+            patch("glob.glob", return_value=[]),
+            patch.object(
+                app_state.state.workspaces,
+                "ensure_home_symlink",
+                new_callable=AsyncMock,
+            ) as symlink_mock,
+            patch.object(
+                app_state.state.model.users,
+                "get_user_handle",
+                new_callable=AsyncMock,
+            ) as handle_mock,
+        ):
+            await conn.start_workspace_container(workspace["id"], workspace)
+
+        # No per-user machinery on the shared path: no handle lookup,
+        # no /home/{handle} -> .users/{uid} symlink, no per-user skel.
+        handle_mock.assert_not_awaited()
+        symlink_mock.assert_not_awaited()
+        assert conn._user_home == container.SHARED_HOME
+        assert conn._home_created is False
+        # The layout rides the start spec (health-monitor branch, same
+        # pattern as health_check/owner_id; the spec→ContainerState
+        # threading is covered in TestStartContainer).
+        assert captured["spec"].per_handle_home is False
+
+        sockets.sessions.pop(workspace["id"], None)
+        registry.states.pop(workspace["id"], None)
+
+    async def test_connect_per_handle_layout_keeps_symlink(
+        self, user, app_state
+    ):
+        # Explicit counterpart: the default layout is unchanged.
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        sock = _mock_sock(headers={"host": "localhost:8997"})
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        workspace = await app_state.state.workspaces.create_workspace(
+            user["id"], "per-handle-ws"
+        )
+        captured = {}
+
+        async def fake_start(spec):
+            captured["spec"] = spec
+            registry.track_activity("cid-ph", workspace["id"])
+            return ("cid-ph", "created")
+
+        with (
+            patch.object(registry, "start_container", side_effect=fake_start),
+            patch("glob.glob", return_value=[]),
+        ):
+            await conn.start_workspace_container(workspace["id"], workspace)
+
+        assert conn._user_home == f"/home/{user['handle']}"
+        assert conn._home_created is True  # fresh user dir → skel populate
+        assert captured["spec"].per_handle_home is True
+
+        sockets.sessions.pop(workspace["id"], None)
+        registry.states.pop(workspace["id"], None)
+
+    async def test_set_handle_shared_layout_skips_symlink(
+        self, user, app_state
+    ):
+        sock = _mock_sock()
+        conn = _base_conn(
+            user={"id": user["id"], "email": user["email"]}, ws=sock
+        )
+        conn.workspace_id = "ws-shared"
+        conn.workspace = {"user_id": user["id"], "per_handle_home": False}
+        conn.container_id = "cid"
+        conn._user_home = container.SHARED_HOME
+
+        with (
+            patch.object(
+                conn.app.state.workspaces,
+                "ensure_home_symlink",
+                new_callable=AsyncMock,
+            ) as symlink_mock,
+            patch(
+                "klangk.workspaces.populate_home_skel",
+                new_callable=AsyncMock,
+            ) as skel_mock,
+        ):
+            await conn.handle_set_handle({"handle": "alice"})
+        symlink_mock.assert_not_awaited()
+        skel_mock.assert_not_awaited()
+        # The handle still updates in the DB and the reply reports the
+        # (constant) shared home — nothing per-handle to refresh.
+        sent = sock.send_json.call_args_list
+        assert any(
+            call.args[0].get("type") == "handle_set"
+            and call.args[0].get("handle") == "alice"
+            and call.args[0].get("home") == container.SHARED_HOME
+            for call in sent
+        )
+        assert conn._user_home == container.SHARED_HOME
+
+    async def test_exec_shared_home_sets_env_and_work_dir(self, app_state):
+        # The exec path reads the connection's home; under the shared
+        # layout that is /home/klangk, so HOME and the cwd both point
+        # there (#2169 decision: exec cwd is /home/klangk, not
+        # /home/work).
+        app_state = _make_app_state()
+        registry = app_state.state.container_registry
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.container_id = "cid"
+        conn._user_home = container.SHARED_HOME
+        mock_session = AsyncMock()
+
+        async def empty_output():
+            return
+            yield  # pragma: no cover
+
+        mock_session.output = empty_output
+        mock_session.returncode = 0
+        with (
+            patch(
+                "klangk.wshandler.controllers.ExecSession",
+                return_value=mock_session,
+            ) as session_cls,
+            patch.object(registry, "record_activity"),
+            patch.object(conn, "_has_perm", new=AsyncMock(return_value=True)),
+        ):
+            await conn.handle_exec_start({"command": ["ls"]})
+        kwargs = session_cls.call_args.kwargs
+        assert f"HOME={container.SHARED_HOME}" in kwargs["env"]
+        assert kwargs["work_dir"] == container.SHARED_HOME
+        conn.exec_task.cancel()
+        try:
+            await conn.exec_task
+        except asyncio.CancelledError:
+            pass
+
+
 # --- handle_websocket dispatch branches ---
 
 


### PR DESCRIPTION
Closes #2720 (chunk 2 of #2169). **Stacked on #2733** — review/merge that first; this branch is based on its head and its PR targets `i2719-feat-per-u`, not `main`.

## What changed

The `per_handle_home` flag added in chunk 1 (#2733) is now armed: a `per_handle_home=false` workspace serves the single shared `/home/klangk`; `true` (the default) keeps per-handle homes byte-identical. No user-visible change unless a workspace is created with the flag off.

- **`wshandler/connection.py`** — `start_workspace_container` skips the `ensure_home_symlink` computation *and the handle DB lookup* when `per_handle_home=false`; `_user_home` is the constant `SHARED_HOME` (`/home/klangk`), `_home_created` is `False` (no per-user skel — the agent-home provisioning at every fresh container create populates `/home/klangk` under both layouts). `handle_set_handle` still updates the handle in the DB but skips the symlink refresh.
- **exec / terminal / service session** — no code change: they read `_conn._user_home`, which is now `/home/klangk`, so exec `HOME` **and cwd** are `/home/klangk` (#2169 decision: exec cwd is `/home/klangk`, not `/home/work`), terminals get `-e HOME=/home/klangk`, and the `service` session already runs under `/home/klangk` under both layouts (fixed agent handle, #2718). No override shim — decided in #2169.
- **health check** — `ContainerState` carries `per_handle_home`, threaded via `ContainerStartSpec` → the create/reuse/adopt paths → `track_activity` (same pattern as `health_check`/`owner_id`/`setup_state`); a shared-layout probe runs with `HOME=/home/klangk` and resolves no per-owner symlink or handle.
- **`workspaces.start_workspace`** (API start + boot autostart) threads the flag from the workspace dict, same as the WS path.
- **`SHARED_HOME`** lives in `container/spec.py` (the container filesystem-layout module) to avoid the `workspaces → container/__init__ → health → workspaces` import cycle.

## Coordination with #2717

#2717 (service session HOME constant + populate-before-first-shell) shares this seam. The shared-layout populate-before-first-shell already holds here via `ensure_agent_home` at the single create choke point (`_bringup`) — it materializes + skel-populates `/home/klangk` on every fresh container create, under both layouts, including the autostart boot path. #2717 remains for deleting the agent-home provisioning special-casing and making that guarantee explicit/first-class.

## Tests

- Both layouts through the WS connect seam (`TestSharedHomeLayout`): shared skips handle lookup + symlink + skel and threads the flag on the start spec; per-handle counterpart unchanged (`_user_home == /home/{handle}`, skel on fresh dir).
- `handle_set` under shared: no symlink/skel, DB handle still updates, reply reports the constant home.
- Exec under shared: `HOME=/home/klangk` env + `work_dir=/home/klangk`.
- Health `_run_one` under shared: no handle/symlink resolution, `extra_env HOME=/home/klangk`.
- Spec→`track_activity`→`ContainerState` threading through the real `start_container` (create path) + `track_activity` unit tests.
- Existing per-handle tests untouched. Full suite green: **5500 passed, 100% coverage** (`-n auto`).
