### PR TITLE
feat: service session HOME is always /home/klangk — drop agent-home provisioning, populate before first shell

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -155,6 +155,19 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Service session HOME is always the shared home (#2717).** The
+  `service` tmux session now runs with `HOME=/home/klangk` pinned as a
+  constant under both home layouts, and `/home/klangk` is created and
+  populated from the image skeleton before the session's first login
+  shell — including on the server-boot auto-start path, where no user
+  ever connects first. This gives the service environment parity with
+  member setup: exports written to `/home/klangk/.profile` reach the
+  service (with the shared-mutable-state consequence that typed
+  commands land in the shared `.bash_history`). The agent-private home
+  provisioning is gone; `KLANGKWS_AGENT_HOME` remains baked as the
+  constant `/home/klangk`, so sandbox `setup.sh` scripts using
+  `export HOME="${KLANGKWS_AGENT_HOME}"` keep working (a no-op on
+  shared-home workspaces).
 - **`per_handle_home` now selects the home layout at runtime (#2720).**
   A workspace created with `per_handle_home=false` (see
   `KLANGKD_PER_HANDLE_HOME`, #2719) now actually serves the shared

--- a/docs/features/auto-start.md
+++ b/docs/features/auto-start.md
@@ -58,12 +58,13 @@ When the Klangk server starts, after initializing the database and
 cleaning up orphaned containers, it queries all workspaces with
 auto-start enabled and starts their containers. The shared home
 (`/home/klangk`) is created and populated from the image skeleton
-before anything else runs in the container, so a brand-new workspace
-boots correctly with no user ever having connected. If a workspace
-also has a [service command](service-command.md), the command runs in
-the workspace's `service-cmd` terminal window — so the service is
-already running by the time any user connects. Auto-started containers
-are pinned alive (they do not idle out between connections).
+before the service command's first login shell — and before any
+member's shell — so a brand-new workspace boots correctly with no user
+ever having connected. If a workspace also
+has a [service command](service-command.md), the command runs in the
+workspace's `service-cmd` terminal window — so the service is already
+running by the time any user connects. Auto-started containers are
+pinned alive (they do not idle out between connections).
 
 Users connect later with `klangk shell` and see the service output in
 the `service-cmd` tab. They can open another tab for a shell alongside

--- a/docs/features/auto-start.md
+++ b/docs/features/auto-start.md
@@ -56,11 +56,14 @@ workspace:
 
 When the Klangk server starts, after initializing the database and
 cleaning up orphaned containers, it queries all workspaces with
-auto-start enabled and starts their containers. If a workspace also
-has a [service command](service-command.md), the command runs in the
-workspace's `service-cmd` terminal window — so the service is already
-running by the time any user connects. Auto-started containers are
-pinned alive (they do not idle out between connections).
+auto-start enabled and starts their containers. The shared home
+(`/home/klangk`) is created and populated from the image skeleton
+before anything else runs in the container, so a brand-new workspace
+boots correctly with no user ever having connected. If a workspace
+also has a [service command](service-command.md), the command runs in
+the workspace's `service-cmd` terminal window — so the service is
+already running by the time any user connects. Auto-started containers
+are pinned alive (they do not idle out between connections).
 
 Users connect later with `klangk shell` and see the service output in
 the `service-cmd` tab. They can open another tab for a shell alongside

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -275,43 +275,45 @@ in the server's `.env` file.
 ### Where the service command runs (and how to install for it)
 
 A `service-command` does **not** run in the workspace owner's shell.
-It runs as the workspace's **agent** identity, in a dedicated
-`service` tmux session whose `$HOME` is the agent's home
-(`/home/klangk` — the fixed agent identity, #2718 — exposed as `$KLANGKWS_AGENT_HOME`) — not
-the owner's. The owner interacts with it through the **Service**
+It runs in a dedicated `service` tmux session whose `$HOME` is
+**always `/home/klangk`** — the shared home, under both home layouts
+(exposed as the constant `$KLANGKWS_AGENT_HOME`) — not the owner's
+per-handle home. The owner interacts with it through the **Service**
 terminal tab in the web UI.
 
 This matters for setup scripts: anything the service command needs at
 runtime — env exports in `~/.profile`, binaries installed under
-`~/.local/bin`, config it reads from `$HOME` — must land in the
-**agent's** home, because that's the home whose `~/.profile` the
-service session sources. If you write to `~/.profile` while `$HOME`
-is still the owner's home (the default when the setup script starts),
-the service command will never see those exports.
+`~/.local/bin`, config it reads from `$HOME` — must land in
+`/home/klangk`, because that's the home whose `~/.profile` the service
+session sources. If you write to `~/.profile` while `$HOME` is still
+the owner's home (the default when the setup script starts under the
+per-handle layout), the service command will never see those exports.
 
-The simplest fix is to repoint `HOME` at the agent home at the top of
+The simplest fix is to repoint `HOME` at the shared home at the top of
 your setup script. After that, every home-relative write in the
 script — `~/.profile` appends, `~/.local/bin` links, `~/.pi` config —
-lands in the agent's home, which is exactly where the service command
-will look:
+lands in `/home/klangk`, which is exactly where the service command
+will look. (On a shared-home workspace — `per_handle_home=false` — the
+export is a no-op: `$HOME` already is `/home/klangk`.)
 
 ```bash
 #!/bin/bash
 set -euo pipefail
 
-# Run the rest of setup as the agent identity: the service command
-# runs in the agent's service session ($KLANGKWS_AGENT_HOME), so install
-# everything the service command depends on into THAT home.
+# Run the rest of setup against the shared home: the service command
+# runs in the service session with HOME=/home/klangk ($KLANGKWS_AGENT_HOME),
+# so install everything the service command depends on into THAT home.
 export HOME="${KLANGKWS_AGENT_HOME:-/home/klangk}"
 
-# Now ~/.profile, ~/.local/bin, etc. resolve into the agent's home.
+# Now ~/.profile, ~/.local/bin, etc. resolve into the shared home.
 ```
 
-> The owner does **not** get tools installed by a sandbox on their own
-> PATH. Sandbox-installed services are owned and operated by the agent
-> through the Service tab — that is the supported way to manage them
-> (e.g. `openclaw onboard`, restarting a gateway). Don't also write
-> the same exports to the owner's `~/.profile`; it's not a consumer.
+> Under the default per-handle layout the owner does **not** get tools
+> installed by a sandbox on their own PATH. Sandbox-installed services
+> are operated through the Service tab — that is the supported way to
+> manage them (e.g. `openclaw onboard`, restarting a gateway). Don't
+> also write the same exports to the owner's `~/.profile`; it's not a
+> consumer.
 
 ### Example: install nix and devenv
 
@@ -407,10 +409,10 @@ And a setup script:
 # setup.sh
 set -euo pipefail
 
-# Run the rest of setup as the agent identity: the service command
-# runs in the agent's service session ($KLANGKWS_AGENT_HOME), so install
-# everything it depends on into THAT home. See
-# "Where the service command runs" in sandbox.md.
+# Run the rest of setup against the shared home: the service command
+# runs in the service session with HOME=/home/klangk
+# ($KLANGKWS_AGENT_HOME), so install everything it depends on into
+# THAT home. See "Where the service command runs" in sandbox.md.
 export HOME="${KLANGKWS_AGENT_HOME:-/home/klangk}"
 
 # Install nix (single-user, no daemon needed in containers).
@@ -426,12 +428,12 @@ mkdir -p ~/.config/nix
 grep -q experimental-features ~/.config/nix/nix.conf 2>/dev/null \
   || echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
-# Source nix in every login shell of the agent -- the service command
-# (running in the service session) sources the agent's ~/.profile.
-# Writing this to ~/.bashrc instead would hide it from non-interactive
-# login shells (its interactivity guard returns early). (The health
-# check is NOT a ~/.profile consumer -- it runs as a non-login bash -c;
-# see health-check.md.) See the-shell.md#startup-files.
+# Source nix in every login shell of the shared home -- the service
+# command (running in the service session) sources /home/klangk's
+# ~/.profile. Writing this to ~/.bashrc instead would hide it from
+# non-interactive login shells (its interactivity guard returns early).
+# (The health check is NOT a ~/.profile consumer -- it runs as a
+# non-login bash -c; see health-check.md.) See the-shell.md#startup-files.
 # shellcheck disable=SC2016
 grep -q nix-profile ~/.profile 2>/dev/null \
   || echo '. "$HOME/.nix-profile/etc/profile.d/nix.sh"' >> ~/.profile

--- a/docs/features/service-command.md
+++ b/docs/features/service-command.md
@@ -12,10 +12,27 @@ running whenever the workspace is in use.
 
 The service command runs as a **per-workspace singleton** — like a
 global service. It starts exactly once, in a dedicated `service-cmd`
-tmux window that lives in the **workspace owner's** terminal session,
-and is **never** re-run for other users who open the workspace.
+window that lives in a standalone `service` tmux session owned by the
+workspace's agent identity (not any user's session), and is **never**
+re-run for other users who open the workspace.
 
-The command is sent as keystrokes into a bash login shell, so:
+The session's `$HOME` is **always `/home/klangk`** — the shared home,
+under both home layouts — and its shell is a bash login shell, so it
+sources `/home/klangk/.profile`. That directory is populated from the
+image skeleton before the session is created, on every fresh container
+(including server boot for auto-start workspaces, before any user
+connects). Environment setup a member writes to `/home/klangk/.profile`
+therefore reaches the service — but note that under the default
+per-handle layout a member's interactive shell reads _their own_
+home's `.profile`, not the shared one; see
+[The Shell](the-shell.md) for the distinction.
+
+Because the service session and (under the shared home layout) every
+member share one `/home/klangk`, they also share its mutable state: a
+command typed into the service tab lands in the shared `.bash_history`,
+and shell state (environment, cwd history) is visible across sessions.
+
+The command is sent as keystrokes into the bash login shell, so:
 
 - **Ctrl+C** stops the process and returns to the bash prompt
 - **Up-arrow + Enter** restarts it
@@ -28,15 +45,16 @@ If no service command is set, no `service-cmd` window is created.
 
 Because the command is a shared workspace service:
 
-- The **owner** sees `service-cmd` as one of their own terminal tabs.
-- Other users granted a workspace role (**coders** / **collaborators**)
-  see it as a **shared terminal** they can open and join.
+- Every member sees `service-cmd` in the shared terminal list (the
+  owner and users granted a workspace role alike — **coders** /
+  **collaborators**).
   [Read-only spectators](terminal.md#shared-terminals) can view it.
-- The window is **shared by definition**: the owner never has to reshare
-  it manually, and it remains visible even after the owner disconnects.
+- The window is **shared by definition**: nobody has to reshare
+  it manually, and it remains visible even after every member
+  disconnects.
 
-Anyone who can write to the shared window (the owner, plus users with
-the `code-in-shared-terminals` permission) can stop or restart the
+Anyone who can write to the shared window (members with the
+`code-in-shared-terminals` permission) can stop or restart the
 service via Ctrl+C / up-arrow / Enter — everyone joined sees the same
 output.
 

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -46,6 +46,16 @@ This means:
 - Your AI agent config (`.pi/agent/`, `.claude/`) is per-user
 - The shared project directory at `/home/work/` is accessible to everyone
 
+A separate directory, `/home/klangk`, is the **shared home**. It is
+created and populated from the image skeleton when the container is
+first created (on every start path, including server boot). The
+[service command](service-command.md) session always runs with
+`HOME=/home/klangk` — under both layouts — so environment setup that
+must reach the service goes in `/home/klangk/.profile`. Workspaces
+created with `per_handle_home=false` use the shared home for
+_everything_: every member's shell, exec sessions, and the service all
+share the one `/home/klangk` (and its `.bash_history`).
+
 See [Handles](handles.md) for how handles are assigned and how they
 relate to your home directory path.
 
@@ -112,8 +122,8 @@ health check is not a `~/.profile` consumer — see
 
 | In-container command                         | How Klangk runs it                            | Sources `~/.profile`?                                                                      |
 | -------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes                                                                                        |
-| `service_command` (the `service-cmd` window) | login shell (tmux window 0)                   | yes                                                                                        |
+| Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes — your own home's, or `/home/klangk/.profile` under the shared layout                  |
+| `service_command` (the `service-cmd` window) | login shell (tmux window 0)                   | yes — always `/home/klangk/.profile` (the shared home), under both layouts                 |
 | Workspace health check                       | `bash -c` (a **non-login** shell)             | no — the probe is deterministic; uses absolute paths (see [Health Check](health-check.md)) |
 | `klangk exec` (default)                      | `bash -lc` (a login shell)                    | yes                                                                                        |
 | `klangk exec --raw` / `klangk sync`          | raw command (no shell)                        | no — programmatic transports (rsync) must not source startup files                         |

--- a/src/containers/workspace/agent-context.md
+++ b/src/containers/workspace/agent-context.md
@@ -135,8 +135,9 @@ stale the instant it was written.
 
 - Discover the workspace's environment with `env | grep KLANGKWS_`. Notable vars:
   `KLANGKWS_LLM_PROXY_URL`, `KLANGKWS_PORT_MAPPINGS`,
-  `KLANGKWS_WORKSPACE_ID`, and `KLANGKWS_AGENT_HOME` (your own home directory,
-  `/home/<agent_handle>`, injected at container start). (Do not treat this
+  `KLANGKWS_WORKSPACE_ID`, and `KLANGKWS_AGENT_HOME` (the shared home,
+  `/home/klangk`, injected at container start — also the `$HOME` of the
+  `service` session). (Do not treat this
   list as exhaustive — re-run the command to see what is actually set.)
 - Decide **your own mechanism** for a task based on what you observe. For
   example, to restart a service you might send Ctrl-C to a foreground process,

--- a/src/containers/workspace/klangk-setup-pi.py
+++ b/src/containers/workspace/klangk-setup-pi.py
@@ -11,7 +11,6 @@ Skips setup if $HOME/.pi/agent/settings.json already exists.
 import json
 import os
 import subprocess
-import sys
 import traceback
 from pathlib import Path
 
@@ -153,11 +152,7 @@ def main():
     if not home or home == Path("/home"):
         return  # don't init for the system user
 
-    force = "--force" in sys.argv
-
     agent = _agent_dir()
-    if force:
-        (agent / "settings.json").unlink(missing_ok=True)
 
     if (agent / "settings.json").exists():
         # Already initialized — refresh models.json (token may have

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -18,7 +18,6 @@ import time
 from .. import podman
 from .. import fips as fips_mod
 from ..exceptions import NodeDrainingError
-from ..model import AGENT_USER_ID
 from ..model.workspaces import EGRESS_MODE_ALLOW, EGRESS_MODE_INTERACTIVE
 from ..podman import PodmanError
 from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST
@@ -594,22 +593,26 @@ class ContainerRegistry(NetworkSidecarMixin):
         service_command: str | None,
         setup_state: str | None,
     ) -> None:
-        """Materialize the agent home and fire the service command.
+        """Populate the shared home and fire the service command.
 
         Called at the single choke point: every freshly-created container
         (the tail of :meth:`start_container`).
 
-        The agent identity never connects over the WebSocket, so nothing
-        else would materialize its home (``/home/klangk``) — yet the sandbox
-        ``setup.sh`` contract repoints ``HOME`` at ``$KLANGKWS_AGENT_HOME``
-        and appends to ``~/.profile`` under ``set -euo pipefail``, and the
-        ``service`` tmux session runs with that same ``HOME``. So the home
-        is ensured here on every fresh create: a plain real directory on
-        the workspace home mount (no ``.users/{uid}`` indirection — the
-        agent's handle is fixed, #2718), populated with /etc/skel on first
-        creation so it has a ``.profile``. Only the chat-agent Pi-config
-        provisioning (``klangk-setup-pi --force``) died with the chat
-        feature (#2716).
+        The shared home (``/home/klangk``) is ensured + populated HERE,
+        under both layouts (#2717): the home volume mounts at ``/home``,
+        shadowing the image's ``/home/klangk`` content, so a fresh
+        workspace has no ``.profile``/``.bashrc`` there until this writes
+        them. Sequenced BEFORE ``ensure_service_session`` -- the service
+        session's login shell sources ``/home/klangk/.profile`` (#2169's
+        environment-parity motivation) -- and before any user's first
+        shell, including on the boot/autostart path where no user ever
+        connects first. For pre-#2718 per-user volumes this materializes
+        ``/home/klangk`` where it never existed; orphaned
+        ``.users/{AGENT_USER_ID}`` agent dirs are simply abandoned. No
+        layout provisions an agent-private home anymore. The sandbox
+        ``setup.sh`` contract (``KLANGKWS_AGENT_HOME``, baked as the same
+        constant in :meth:`.spec.build_env`) keeps working under both
+        layouts and is a no-op under shared.
 
         The service command itself is idempotent via
         :meth:`terminal.ensure_service_session` (per-container lock +
@@ -620,19 +623,13 @@ class ContainerRegistry(NetworkSidecarMixin):
         ``"pending"`` at create, and the fire lands later once setup
         completes and the WS connect path runs.
         """
-        (
-            agent_home,
-            created,
-        ) = await self.app.state.workspaces.ensure_agent_home(workspace_id)
-        if created:
-            await self.app.state.workspaces.populate_home_skel(
-                container_id, AGENT_USER_ID, home=agent_home
-            )
+        await self.app.state.workspaces.ensure_shared_home(
+            workspace_id, container_id
+        )
         if not service_command:
             return
         await self.app.state.terminal.ensure_service_session(
             container_id,
-            agent_home,
             service_command,
             setup_state=setup_state,
         )

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -599,20 +599,22 @@ class ContainerRegistry(NetworkSidecarMixin):
         (the tail of :meth:`start_container`).
 
         The shared home (``/home/klangk``) is ensured + populated HERE,
-        under both layouts (#2717): the home volume mounts at ``/home``,
-        shadowing the image's ``/home/klangk`` content, so a fresh
-        workspace has no ``.profile``/``.bashrc`` there until this writes
-        them. Sequenced BEFORE ``ensure_service_session`` -- the service
-        session's login shell sources ``/home/klangk/.profile`` (#2169's
-        environment-parity motivation) -- and before any user's first
-        shell, including on the boot/autostart path where no user ever
-        connects first. For pre-#2718 per-user volumes this materializes
-        ``/home/klangk`` where it never existed; orphaned
-        ``.users/{AGENT_USER_ID}`` agent dirs are simply abandoned. No
-        layout provisions an agent-private home anymore. The sandbox
-        ``setup.sh`` contract (``KLANGKWS_AGENT_HOME``, baked as the same
-        constant in :meth:`.spec.build_env`) keeps working under both
-        layouts and is a no-op under shared.
+        under both layouts (#2717): the image has no ``/home/klangk``
+        (uid 1000's passwd home is ``/home`` itself), and the home volume
+        mounts at ``/home`` shadowing the image's own content — so a
+        fresh volume has nothing at ``/home/klangk`` (no
+        ``.profile``/``.bashrc``) until this writes it. Sequenced BEFORE
+        ``ensure_service_session`` -- the service session's login shell
+        sources ``/home/klangk/.profile`` (#2169's environment-parity
+        motivation) -- and before any user's first shell, including on
+        the boot/autostart path where no user ever connects first. For
+        pre-#2718 per-user volumes this materializes ``/home/klangk``
+        where it never existed; orphaned ``.users/{AGENT_USER_ID}``
+        agent dirs are simply abandoned. No layout provisions an
+        agent-private home anymore. The sandbox ``setup.sh`` contract
+        (``KLANGKWS_AGENT_HOME``, baked as the same constant in
+        :meth:`.spec.build_env`) keeps working under both layouts and is
+        a no-op under shared.
 
         The service command itself is idempotent via
         :meth:`terminal.ensure_service_session` (per-container lock +

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -30,9 +30,10 @@ logger = logging.getLogger(__name__)
 # ``per_handle_home = false`` (#2169 chunk 2, #2720), and the HOME the
 # ``service`` tmux session is pinned to under BOTH layouts (#2717):
 # ``/home/klangk``, materialized + populated from /etc/skel at every
-# fresh container create by ``ensure_shared_home`` (the home volume
-# mounts at ``/home``, shadowing the image's own ``/home/klangk``,
-# which is why the skel copy is needed at all). Lives here — the container
+# fresh container create by ``ensure_shared_home`` (the image has no
+# ``/home/klangk`` — uid 1000's passwd home is ``/home`` itself, and the
+# home volume mounts at ``/home`` shadowing that image content, which
+# is why the skel copy is needed at all). Lives here — the container
 # filesystem-layout module — so ``workspaces``/``wshandler``/``health``
 # can import it without a cycle through the ``container`` package.
 #

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -27,11 +27,12 @@ from .ports import CONTAINER_PORT_START, DEFAULT_PORTS_PER_WORKSPACE
 logger = logging.getLogger(__name__)
 
 # The single home every connection shares when a workspace has
-# ``per_handle_home = false`` (#2169 chunk 2, #2720): the container
-# user's own home (the image's ``-d /home/klangk``), which under the
-# shared layout is also where the ``service`` tmux session runs
-# (``ensure_agent_home`` materializes + populates it at every fresh
-# container create, under both layouts). Lives here — the container
+# ``per_handle_home = false`` (#2169 chunk 2, #2720), and the HOME the
+# ``service`` tmux session is pinned to under BOTH layouts (#2717):
+# ``/home/klangk``, materialized + populated from /etc/skel at every
+# fresh container create by ``ensure_shared_home`` (the home volume
+# mounts at ``/home``, shadowing the image's own ``/home/klangk``,
+# which is why the skel copy is needed at all). Lives here — the container
 # filesystem-layout module — so ``workspaces``/``wshandler``/``health``
 # can import it without a cycle through the ``container`` package.
 #

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -21,6 +21,7 @@ import termios
 import tty
 from collections.abc import AsyncGenerator
 
+from .container.spec import SHARED_HOME
 from .podman import Podman, classify, subprocess_env
 from .exceptions import ContainerGoneError, TerminalError
 from .model.workspaces import SETUP_STATE_COMPLETE
@@ -453,7 +454,6 @@ class Terminal:
     async def ensure_service_session(
         self,
         container_id: str,
-        agent_home: str,
         service_command: str,
         setup_state: str = SETUP_STATE_COMPLETE,
     ) -> None:
@@ -467,11 +467,17 @@ class Terminal:
         lifecycle -- it survives the agent subprocess dying/restarting
         because it is just a tmux session (#1133 D6).
 
-        *agent_home* (the fixed ``/home/klangk``, #2718) is the session's HOME. The
-        service command fires iff the predicate holds (configured AND setup
-        complete) AND the ``service-cmd`` window doesn't already exist
-        (exactly-once-per-container). Idempotent: safe to call from every
-        ``terminal_start`` (#1033) and the boot path alike -- the
+        The session's HOME is **always** ``/home/klangk`` -- the shared
+        home, under both layouts (#2717) -- pinned explicitly via the
+        tmux ``-e HOME`` flag: the image's uid-1000 passwd home is
+        ``/home`` (the mount point), so the podman-exec default is not
+        the shared home. No ``per_handle_home`` branch exists on this
+        path.
+
+        The service command fires iff the predicate holds (configured AND
+        setup complete) AND the ``service-cmd`` window doesn't already
+        exist (exactly-once-per-container). Idempotent: safe to call from
+        every ``terminal_start`` (#1033) and the boot path alike -- the
         window-exists check makes it a no-op after the first fire.
 
         The window-exists -> new-window -> send-keys sequence is serialized
@@ -488,7 +494,7 @@ class Terminal:
         # window from #1186.
         async with self.registry.get_service_session_lock(container_id):
             await self._ensure_tmux_session(
-                container_id, SERVICE_SESSION, agent_home
+                container_id, SERVICE_SESSION, user_home=SHARED_HOME
             )
             if not (
                 should_fire_service_command(service_command, setup_state)

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -472,7 +472,10 @@ class Terminal:
         tmux ``-e HOME`` flag: the image's uid-1000 passwd home is
         ``/home`` (the mount point), so the podman-exec default is not
         the shared home. No ``per_handle_home`` branch exists on this
-        path.
+        path. The pin applies only at session creation; a ``service``
+        session that already exists (its container outliving a daemon
+        upgrade) keeps whatever HOME it was created with for the
+        remainder of that container's life.
 
         The service command fires iff the predicate holds (configured AND
         setup complete) AND the ``service-cmd`` window doesn't already

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -44,16 +44,28 @@ def _ensure_shared_home_dir_sync(
 ) -> bool:
     """Synchronous ``ensure_shared_home`` implementation (see #1262).
 
-    Creates ``workspace_home / name`` when missing and reports whether
-    it was created. A legacy ``klangk`` symlink (chat-era provisioning,
-    pointing at ``.users/{AGENT_USER_ID}``) or a pre-#2718 per-user
-    volume's absent directory are both handled: the symlink resolves and
-    is adopted as-is; the absent directory is materialized fresh.
+    Returns whether the shared home should be populated with /etc/skel:
+    True when it is empty — freshly created, left empty by a failed
+    populate on an earlier create, or a legacy symlink whose target
+    never had content. A non-empty home (user content present) is never
+    re-populated, so customizations survive container recreates.
+
+    Edge cases: a legacy ``klangk`` symlink (chat-era provisioning,
+    pointing at ``.users/{AGENT_USER_ID}``) that *resolves* is adopted
+    as-is; one that *dangles* (target deleted) is removed and replaced
+    with a real directory — the abandoned target stays orphaned
+    (#2717). ``Path.mkdir(exist_ok=True)`` alone would re-raise
+    ``FileExistsError`` on the dangling symlink (``exist_ok`` only
+    suppresses when the path is a directory), crashing container
+    create after the container is already running — and ``_bringup``
+    never runs again for that container.
     """
     shared_dir = workspace_home / name
+    if shared_dir.is_symlink() and not shared_dir.exists():
+        shared_dir.unlink()
     created = not shared_dir.exists()
     shared_dir.mkdir(exist_ok=True)
-    return created
+    return created or not any(shared_dir.iterdir())
 
 
 async def _async_rmtree(path: Path | str, label: str = "") -> None:
@@ -521,9 +533,11 @@ class Workspaces:
 
         Under both home layouts (#2169) the ``service`` tmux session and
         (shared layout) every login shell runs with ``HOME=/home/klangk``.
-        The home volume mounts at ``/home``, shadowing the image's
-        ``/home/klangk`` content, so a fresh workspace has no
-        ``.profile``/``.bashrc`` there until this writes them (#2717).
+        The image has no ``/home/klangk`` at all — uid 1000's passwd home
+        is ``/home`` itself (``useradd -d /home``, populated by ``-m``
+        from /etc/skel) — and the home volume mounts at ``/home``,
+        shadowing that image content. So nothing at ``/home/klangk``
+        exists on a fresh volume until this creates it (#2717).
         Called at the container-create choke point (``_bringup``) —
         before ``ensure_service_session`` and before any user's first
         shell — including the boot/autostart path where no user ever
@@ -531,20 +545,22 @@ class Workspaces:
         ``/home/klangk`` where it never existed; orphaned
         ``.users/{AGENT_USER_ID}`` agent dirs are simply abandoned.
 
-        One-time and idempotent: the ``/etc/skel`` copy runs only when
-        the directory is freshly created on the mount, so user
-        customizations are never clobbered by a later container
-        recreate. Restart-safe by the same exactly-once key.
+        Self-healing and idempotent: the /etc/skel copy runs whenever the
+        home is EMPTY — freshly created, left empty by a failed populate
+        on an earlier create (the exec failure is swallowed, so the
+        emptiness gate is what makes the next create retry), or a legacy
+        symlink adopted onto an empty target. A home with any content is
+        never re-populated, so user customizations are never clobbered.
 
         The blocking filesystem work runs in a worker thread via
         ``asyncio.to_thread`` so the container-create path does not stall
         the event loop on disk latency (#1262).
         """
         workspace_home = self.home_path(workspace_id)
-        created = await asyncio.to_thread(
+        needs_populate = await asyncio.to_thread(
             _ensure_shared_home_dir_sync, workspace_home, SHARED_HOME_NAME
         )
-        if created:
+        if needs_populate:
             await self.populate_home_skel(
                 container_id, model.AGENT_USER_ID, home=SHARED_HOME
             )

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 
 from . import container, model
-from .container.spec import SHARED_HOME_NAME
+from .container.spec import SHARED_HOME, SHARED_HOME_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -38,15 +38,22 @@ def rmtree(path: Path | str, label: str = "") -> None:
     shutil.rmtree(path, onexc=_on_error)
 
 
-def _ensure_agent_home_dir_sync(
+def _ensure_shared_home_dir_sync(
     workspace_home: Path,
-    handle: str,
-) -> tuple[str, bool]:
-    """Synchronous ``ensure_agent_home`` implementation (see #1262)."""
-    agent_dir = workspace_home / handle
-    created = not agent_dir.exists()
-    agent_dir.mkdir(exist_ok=True)
-    return f"/home/{handle}", created
+    name: str,
+) -> bool:
+    """Synchronous ``ensure_shared_home`` implementation (see #1262).
+
+    Creates ``workspace_home / name`` when missing and reports whether
+    it was created. A legacy ``klangk`` symlink (chat-era provisioning,
+    pointing at ``.users/{AGENT_USER_ID}``) or a pre-#2718 per-user
+    volume's absent directory are both handled: the symlink resolves and
+    is adopted as-is; the absent directory is materialized fresh.
+    """
+    shared_dir = workspace_home / name
+    created = not shared_dir.exists()
+    shared_dir.mkdir(exist_ok=True)
+    return created
 
 
 async def _async_rmtree(path: Path | str, label: str = "") -> None:
@@ -507,33 +514,40 @@ class Workspaces:
             _ensure_home_symlink_sync, workspace_home, handle, user_id
         )
 
-    async def ensure_agent_home(self, workspace_id: str) -> tuple[str, bool]:
-        """Ensure the agent identity's home directory exists on the mount.
+    async def ensure_shared_home(
+        self, workspace_id: str, container_id: str
+    ) -> None:
+        """Ensure the shared home ``/home/klangk`` exists and is populated.
 
-        Unlike human users (whose handle can change, hence the
-        ``.users/{user_id}`` dir + handle symlink indirection), the agent
-        identity is fixed (#2718: handle ``klangk``, reserved name), so its
-        home is a plain real directory on the workspace home mount — no
-        symlink, no indirection. A legacy ``klangk`` symlink left by the
-        old chat-era provisioning still resolves and is adopted as-is.
+        Under both home layouts (#2169) the ``service`` tmux session and
+        (shared layout) every login shell runs with ``HOME=/home/klangk``.
+        The home volume mounts at ``/home``, shadowing the image's
+        ``/home/klangk`` content, so a fresh workspace has no
+        ``.profile``/``.bashrc`` there until this writes them (#2717).
+        Called at the container-create choke point (``_bringup``) —
+        before ``ensure_service_session`` and before any user's first
+        shell — including the boot/autostart path where no user ever
+        connects first. For pre-#2718 per-user volumes this materializes
+        ``/home/klangk`` where it never existed; orphaned
+        ``.users/{AGENT_USER_ID}`` agent dirs are simply abandoned.
 
-        The directory name is the :data:`SHARED_HOME_NAME` constant (not a
-        DB ``agent_handle()`` lookup): the handle is immutable, and the
-        agent home *is* the shared home under both layouts (#2720) — one
-        constant keeps them provably the same path.
+        One-time and idempotent: the ``/etc/skel`` copy runs only when
+        the directory is freshly created on the mount, so user
+        customizations are never clobbered by a later container
+        recreate. Restart-safe by the same exactly-once key.
 
         The blocking filesystem work runs in a worker thread via
         ``asyncio.to_thread`` so the container-create path does not stall
         the event loop on disk latency (#1262).
-
-        Returns ``(container_home_path, created)`` where *created* is True
-        when a new directory was created (caller should populate it with
-        skeleton files).
         """
         workspace_home = self.home_path(workspace_id)
-        return await asyncio.to_thread(
-            _ensure_agent_home_dir_sync, workspace_home, SHARED_HOME_NAME
+        created = await asyncio.to_thread(
+            _ensure_shared_home_dir_sync, workspace_home, SHARED_HOME_NAME
         )
+        if created:
+            await self.populate_home_skel(
+                container_id, model.AGENT_USER_ID, home=SHARED_HOME
+            )
 
     async def populate_home_skel(
         self,

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -250,7 +250,7 @@ class Connection:
         # auto-create a real dir. Shared: every connection (and the
         # ``service`` session) uses the one shared /home/klangk — no
         # per-user symlink, no .users/{uid} dirs, no per-user skel
-        # (``ensure_agent_home`` populates /home/klangk at every fresh
+        # (``ensure_shared_home`` populates /home/klangk at every fresh
         # container create, under both layouts), and no handle lookup
         # (the handle is irrelevant on this path).
         if workspace.get("per_handle_home", True):

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 from fastapi import WebSocketDisconnect
 
 from .. import model
-from ..container.spec import SHARED_HOME
 from ..exceptions import ContainerGoneError, TerminalError
 from ..podman import ExecSession
 from ..terminal import (
@@ -612,14 +611,11 @@ class TerminalController:
         # time, but by terminal_start (after setup.sh returns) the DB
         # holds 'complete' (#1033).
         setup_state = await self._setup_state_for_workspace()
-        # The agent home is eagerly provisioned at container create
-        # (#1157) and persists in the bind-mount volume; it is the
-        # constant shared home (#2720 — the agent's handle is fixed,
-        # #2718), so no DB resolution is needed here.
-        agent_home = SHARED_HOME
+        # The service session's HOME is pinned to the constant shared
+        # home (/home/klangk, under both layouts) inside
+        # ensure_service_session (#2717) -- nothing to resolve here.
         await self._conn.app.state.terminal.ensure_service_session(
             self._conn.container_id,
-            agent_home,
             service_command,
             setup_state=setup_state,
         )

--- a/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
@@ -205,14 +205,15 @@ class TestAgentHomeE2E:
 
     @pytest.mark.asyncio
     async def test_agent_home_materialized_eagerly(self, server, auth):
-        """The agent home exists immediately after a container is brought
+        """The shared home exists immediately after a container is brought
         up via start_workspace — with NO WS connection preceding the check.
 
-        The agent identity never connects over the WebSocket, so the only
-        thing that materializes its home is the create choke point
-        (``_bringup`` → ``ensure_agent_home``): a plain ``/home/klangk``
-        directory populated with /etc/skel (so ``~/.profile`` exists for
-        the sandbox ``setup.sh`` contract and the ``service`` session).
+        Nothing but the create choke point (``_bringup`` →
+        ``ensure_shared_home``) materializes ``/home/klangk`` — the home
+        volume mounts at ``/home`` and shadows the image's own content —
+        so a populated ``/home/klangk`` (with ``.profile``) must be there
+        before the ``service`` session's first login shell, including on
+        the boot path where no user ever connects (#2717).
         auto_start=True routes creation through start_workspace, so the
         container is up by the time the POST returned; we inspect the
         filesystem directly via podman exec as root, independent of any

--- a/src/klangk/klangkd-tests/tests/test_bringup.py
+++ b/src/klangk/klangkd-tests/tests/test_bringup.py
@@ -1,27 +1,23 @@
 """Tests for the create choke-point orchestrator (#1244).
 
 ``ContainerRegistry._bringup`` runs inside ``start_container`` for every
-fresh container. It materializes the agent identity's home (the agent
-never connects over the WebSocket, so nothing else would — yet the sandbox
-``setup.sh`` contract and the ``service`` tmux session both need
-``/home/klangk`` to exist) and fires the service command. The underlying
-primitives (``Workspaces.ensure_agent_home`` / ``populate_home_skel``,
+fresh container. It ensures the shared home (``/home/klangk`` — needed
+under both layouts by the ``service`` tmux session and, under the shared
+layout, every login shell) and fires the service command. The underlying
+primitives (``Workspaces.ensure_shared_home`` /
 ``Terminal.ensure_service_session``) have their own coverage; these tests
 pin the orchestration: that each is called with the right args, in the
-right cases.
+right cases, in the right order (#2717: shared-home population before
+the service session).
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 from klangk.container import ContainerRegistry
-from klangk.model import AGENT_USER_ID
 
 _app_state = MagicMock()
 _app_state.state.terminal.ensure_service_session = AsyncMock()
-_app_state.state.workspaces.ensure_agent_home = AsyncMock(
-    return_value=("/home/klangk", False)
-)
-_app_state.state.workspaces.populate_home_skel = AsyncMock()
+_app_state.state.workspaces.ensure_shared_home = AsyncMock()
 
 
 def _registry():
@@ -40,58 +36,57 @@ def _registry():
 class TestBringup:
     def setup_method(self):
         _app_state.state.terminal.ensure_service_session.reset_mock()
-        _app_state.state.workspaces.ensure_agent_home.reset_mock()
-        _app_state.state.workspaces.ensure_agent_home.return_value = (
-            "/home/klangk",
-            False,
-        )
-        _app_state.state.workspaces.populate_home_skel.reset_mock()
+        _app_state.state.workspaces.ensure_shared_home.reset_mock()
 
-    async def test_ensures_agent_home_then_fires_service_command(self):
-        """A configured service command fires with the resolved agent home."""
-        await _registry()._bringup(
-            "ws-id",
-            "cid",
-            "openclaw gateway",
-            setup_state="complete",
+    async def test_populates_shared_home_then_fires_service_command(self):
+        """A configured service command fires after the shared home is
+        ensured; the service session itself carries no home parameter
+        (HOME is pinned to the constant inside it, #2717)."""
+        calls: list[str] = []
+
+        async def shared_home(workspace_id, container_id):
+            calls.append("shared_home")
+
+        async def service_session(
+            container_id, service_command, setup_state=None
+        ):
+            calls.append("service_session")
+
+        _app_state.state.workspaces.ensure_shared_home.side_effect = (
+            shared_home
         )
-        _app_state.state.workspaces.ensure_agent_home.assert_awaited_once_with(
-            "ws-id"
+        _app_state.state.terminal.ensure_service_session.side_effect = (
+            service_session
+        )
+        try:
+            await _registry()._bringup(
+                "ws-id",
+                "cid",
+                "openclaw gateway",
+                setup_state="complete",
+            )
+        finally:
+            _app_state.state.workspaces.ensure_shared_home.side_effect = None
+            _app_state.state.terminal.ensure_service_session.side_effect = None
+        _app_state.state.workspaces.ensure_shared_home.assert_awaited_once_with(
+            "ws-id", "cid"
         )
         _app_state.state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
-            "/home/klangk",
             "openclaw gateway",
             setup_state="complete",
         )
+        # Sequencing: the shared home is populated BEFORE the service
+        # session is ensured, so the session's login shell finds a
+        # populated /home/klangk/.profile (#2717).
+        assert calls == ["shared_home", "service_session"]
 
-    async def test_populates_skel_only_on_first_creation(self):
-        """``created=True`` from ensure_agent_home triggers the skel copy
-        into the agent's own home path; an already-existing home does not."""
-        _app_state.state.workspaces.ensure_agent_home.return_value = (
-            "/home/klangk",
-            True,
-        )
+    async def test_ensures_shared_home_even_without_service_command(self):
+        """No service_command → the shared home is still ensured (login
+        shells under the shared layout need it), but nothing is fired."""
         await _registry()._bringup("ws-id", "cid", None, "complete")
-        _app_state.state.workspaces.populate_home_skel.assert_awaited_once_with(
-            "cid", AGENT_USER_ID, home="/home/klangk"
-        )
-
-        # Second bringup: home exists → no skel copy.
-        _app_state.state.workspaces.ensure_agent_home.return_value = (
-            "/home/klangk",
-            False,
-        )
-        _app_state.state.workspaces.populate_home_skel.reset_mock()
-        await _registry()._bringup("ws-id", "cid", None, "complete")
-        _app_state.state.workspaces.populate_home_skel.assert_not_awaited()
-
-    async def test_ensures_home_even_without_service_command(self):
-        """No service_command → the home is still ensured (the sandbox
-        setup.sh contract needs it), but nothing is fired."""
-        await _registry()._bringup("ws-id", "cid", None, "complete")
-        _app_state.state.workspaces.ensure_agent_home.assert_awaited_once_with(
-            "ws-id"
+        _app_state.state.workspaces.ensure_shared_home.assert_awaited_once_with(
+            "ws-id", "cid"
         )
         _app_state.state.terminal.ensure_service_session.assert_not_awaited()
 
@@ -115,7 +110,6 @@ class TestBringup:
         )
         _app_state.state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
-            "/home/klangk",
             "openclaw gateway",
             setup_state="pending",
         )
@@ -130,7 +124,6 @@ class TestBringup:
         )
         _app_state.state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
-            "/home/klangk",
             "openclaw gateway",
             setup_state=None,
         )

--- a/src/klangk/klangkd-tests/tests/test_setup_pi.py
+++ b/src/klangk/klangkd-tests/tests/test_setup_pi.py
@@ -224,20 +224,6 @@ class TestMain:
         assert "prompts" in settings
         assert settings["extensions"] == ["/e"]  # preserved
 
-    def test_force_rewrites_settings(self, fake_home, monkeypatch):
-        monkeypatch.setenv("KLANGKWS_LLM_MODEL", "m")
-        monkeypatch.setenv("KLANGKWS_LLM_PROXY_URL", "http://x")
-        monkeypatch.setattr("sys.argv", ["setup-pi", "--force"])
-        agent = fake_home / ".pi" / "agent"
-        agent.mkdir(parents=True)
-        (agent / "settings.json").write_text(json.dumps({"old": True}))
-
-        sc.main()
-
-        settings = json.loads((agent / "settings.json").read_text())
-        assert "old" not in settings
-        assert settings["defaultProvider"] == "llm-proxy"
-
     def test_skips_system_user(self, fake_home, monkeypatch):
         monkeypatch.setenv("HOME", "/home")
         monkeypatch.setattr("sys.argv", ["setup-pi"])

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -1567,6 +1567,40 @@ class TestEnsureServiceSession:
             "cid", SERVICE_SESSION, user_home="/home/klangk"
         )
 
+    async def test_service_session_argv_pins_home(self):
+        """The service session is created via a real tmux argv (not via a
+        mocked _ensure_tmux_session) whose ``-e HOME`` flag pins the
+        shared home — the argv-level contract, not just the kwarg
+        boundary (#2717)."""
+        with (
+            patch.object(
+                _terminal,
+                "has_tmux_session",
+                new=AsyncMock(return_value=False),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                new=AsyncMock(
+                    side_effect=[
+                        (0, "", ""),  # tmux new-session -d -s service ...
+                        (0, "service-cmd\n", ""),  # window exists → noop
+                    ]
+                ),
+            ) as mock_exec,
+        ):
+            await _terminal.ensure_service_session("cid", "openclaw gateway")
+        new_session_argv = mock_exec.call_args_list[0].args[1]
+        assert "-s" in new_session_argv and "service" in new_session_argv
+        home_flags = [
+            a for a in new_session_argv if a == "-e" or a.startswith("HOME=")
+        ]
+        assert "-e" in new_session_argv
+        assert "HOME=/home/klangk" in new_session_argv
+        assert (
+            home_flags.index("-e") == home_flags.index("HOME=/home/klangk") - 1
+        )
+
     async def test_skips_when_window_already_exists(self):
         """Exactly-once: no new-window/send-keys if service-cmd exists."""
 

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -1526,7 +1526,6 @@ class TestEnsureServiceSession:
         ):
             await _terminal.ensure_service_session(
                 "cid",
-                "/home/klangk",
                 "openclaw gateway",
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
@@ -1543,9 +1542,10 @@ class TestEnsureServiceSession:
             for c in cmds
         )
 
-    async def test_ensures_service_session_with_agent_home(self):
-        """The service session is ensured with the constant name and the
-        agent home as its HOME."""
+    async def test_ensures_service_session_with_pinned_home(self):
+        """The service session is ensured with the constant name and HOME
+        pinned to the shared home (/home/klangk) under both layouts
+        (#2717) — no caller-threaded home parameter."""
 
         with (
             patch.object(
@@ -1561,11 +1561,10 @@ class TestEnsureServiceSession:
         ):
             await _terminal.ensure_service_session(
                 "cid",
-                "/home/klangk",
                 "openclaw gateway",
             )
         mock_ensure.assert_awaited_once_with(
-            "cid", SERVICE_SESSION, "/home/klangk"
+            "cid", SERVICE_SESSION, user_home="/home/klangk"
         )
 
     async def test_skips_when_window_already_exists(self):
@@ -1590,7 +1589,6 @@ class TestEnsureServiceSession:
         ):
             await _terminal.ensure_service_session(
                 "cid",
-                "/home/klangk",
                 "openclaw gateway",
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
@@ -1619,7 +1617,6 @@ class TestEnsureServiceSession:
         ):
             await _terminal.ensure_service_session(
                 "cid",
-                "/home/klangk",
                 "openclaw gateway",
                 setup_state="pending",
             )
@@ -1648,9 +1645,7 @@ class TestEnsureServiceSession:
             ),
             patch("klangk.terminal.logger") as mock_logger,
         ):
-            await _terminal.ensure_service_session(
-                "cid", "/home/klangk", "cmd"
-            )
+            await _terminal.ensure_service_session("cid", "cmd")
         mock_logger.warning.assert_called()
 
     async def test_send_keys_failure_logs_warning(self):
@@ -1680,9 +1675,7 @@ class TestEnsureServiceSession:
             ),
             patch("klangk.terminal.logger") as mock_logger,
         ):
-            await _terminal.ensure_service_session(
-                "cid", "/home/klangk", "cmd"
-            )
+            await _terminal.ensure_service_session("cid", "cmd")
         mock_logger.warning.assert_called()
 
     async def test_firing_resets_health_grace_anchor(self):
@@ -1708,7 +1701,6 @@ class TestEnsureServiceSession:
         ):
             await _terminal.ensure_service_session(
                 "cid",
-                "/home/klangk",
                 "openclaw gateway",
             )
         _mock_registry.mark_service_started.assert_called_once_with("cid")
@@ -1740,7 +1732,6 @@ class TestEnsureServiceSession:
         ):
             await _terminal.ensure_service_session(
                 "cid",
-                "/home/klangk",
                 "openclaw gateway",
             )
         mock_registry.mark_service_started.assert_not_called()
@@ -1776,11 +1767,7 @@ class TestEnsureServiceSession:
                 ),
             ),
         ):
-            await _terminal.ensure_service_session(
-                "cid",
-                "/home/klangk",
-                "cmd",
-            )
+            await _terminal.ensure_service_session("cid", "cmd")
         mock_registry.mark_service_started.assert_not_called()
 
     async def test_concurrent_fires_create_window_exactly_once(self):
@@ -1845,12 +1832,10 @@ class TestEnsureServiceSession:
             await asyncio.gather(
                 _terminal.ensure_service_session(
                     "cid",
-                    "/home/klangk",
                     "openclaw gateway",
                 ),
                 _terminal.ensure_service_session(
                     "cid",
-                    "/home/klangk",
                     "openclaw gateway",
                 ),
             )
@@ -1900,16 +1885,8 @@ class TestEnsureServiceSession:
             patch("klangk.terminal.asyncio.sleep", new=AsyncMock()),
         ):
             await asyncio.gather(
-                _terminal.ensure_service_session(
-                    "cid-a",
-                    "/home/klangk",
-                    "cmd-a",
-                ),
-                _terminal.ensure_service_session(
-                    "cid-b",
-                    "/home/klangk",
-                    "cmd-b",
-                ),
+                _terminal.ensure_service_session("cid-a", "cmd-a"),
+                _terminal.ensure_service_session("cid-b", "cmd-b"),
             )
 
         # Each container fired exactly once -- the per-container lock did not
@@ -1946,9 +1923,7 @@ class TestEnsureServiceSession:
             ) as mock_exec,
             patch("klangk.terminal.logger"),
         ):
-            await _terminal.ensure_service_session(
-                "cid", "/home/klangk", "cmd"
-            )
+            await _terminal.ensure_service_session("cid", "cmd")
 
         # The third exec call must be the kill-window cleanup targeting
         # the service-cmd window we just created.
@@ -1986,9 +1961,7 @@ class TestEnsureServiceSession:
             ),
             patch("klangk.terminal.logger") as mock_logger,
         ):
-            await _terminal.ensure_service_session(
-                "cid", "/home/klangk", "cmd"
-            )
+            await _terminal.ensure_service_session("cid", "cmd")
         # Both the send-keys failure and the cleanup failure are warned.
         assert mock_logger.warning.call_count == 2
 

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -749,13 +749,43 @@ class TestEnsureSharedHome:
             assert shared_dir.is_dir()
             assert not shared_dir.is_symlink()
 
-            # Idempotent: second call does not re-populate (user
-            # customizations must never be clobbered by a recreate).
+            # Idempotent: once the home has content (the skel copy), a
+            # later create never re-populates (customizations must not
+            # be clobbered).
+            (shared_dir / ".profile").write_text("# populated\n")
             skel_mock.reset_mock()
             await app_state.state.workspaces.ensure_shared_home(
                 ws["id"], "cid"
             )
             skel_mock.assert_not_awaited()
+
+    async def test_failed_populate_retries_on_next_create(
+        self, user, app_state
+    ):
+        """The skel exec failure is swallowed, so a failed populate leaves
+        the home EMPTY — and emptiness is what gates the retry: the next
+        create re-populates instead of leaving the workspace profile-less
+        forever (the #2717 acceptance criterion is not best-effort)."""
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "shared-home-retry-ws"
+        )
+
+        with patch(
+            "klangk.workspaces.Workspaces.populate_home_skel",
+            new_callable=AsyncMock,
+        ) as skel_mock:
+            # First create: populate "fails" (mock does nothing) — the
+            # directory stays empty.
+            await app_state.state.workspaces.ensure_shared_home(
+                ws["id"], "cid"
+            )
+            assert skel_mock.await_count == 1
+            # Second create (container recreate): still empty → retried.
+            await app_state.state.workspaces.ensure_shared_home(
+                ws["id"], "cid-2"
+            )
+            assert skel_mock.await_count == 2
+            assert skel_mock.await_args.kwargs["home"] == "/home/klangk"
 
     async def test_populate_skel_home_override(self):
         """populate_home_skel(home=...) threads the override through; the
@@ -785,8 +815,9 @@ class TestEnsureSharedHome:
 
     async def test_adopts_legacy_chat_era_symlink(self, user, app_state):
         """A ``klangk`` symlink left by the chat-era provisioning (pointing
-        at ``.users/{AGENT_USER_ID}``) is adopted as-is — no removal, no
-        restructuring of existing volumes, and no skel re-population."""
+        at a non-empty ``.users/{AGENT_USER_ID}``) is adopted as-is — no
+        removal, no restructuring of existing volumes, and no skel
+        re-population."""
         from klangk.model import AGENT_USER_ID
 
         ws = await app_state.state.workspaces.create_workspace(
@@ -795,6 +826,7 @@ class TestEnsureSharedHome:
         home = app_state.state.workspaces.home_path(ws["id"])
         users = home / ".users" / AGENT_USER_ID
         users.mkdir(parents=True, exist_ok=True)
+        (users / ".profile").write_text("# legacy\n")  # non-empty target
         legacy = home / "klangk"
         legacy.symlink_to(f".users/{AGENT_USER_ID}")
 
@@ -805,7 +837,68 @@ class TestEnsureSharedHome:
             await app_state.state.workspaces.ensure_shared_home(
                 ws["id"], "cid"
             )
-        # A symlink already exists at the path: leave it be, no skel.
+        # A resolving symlink with content: leave it be, no skel.
         skel_mock.assert_not_awaited()
         assert legacy.is_symlink()
         assert os.readlink(legacy) == f".users/{AGENT_USER_ID}"
+
+    async def test_empty_adopted_symlink_target_gets_skel(
+        self, user, app_state
+    ):
+        """A legacy symlink onto an EMPTY target (the chat-era agent dir
+        never had content) is adopted but still populated through the
+        symlink — the service session's login shell needs a .profile
+        there."""
+        from klangk.model import AGENT_USER_ID
+
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "shared-home-empty-legacy-ws"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        (home / ".users" / AGENT_USER_ID).mkdir(parents=True, exist_ok=True)
+        legacy = home / "klangk"
+        legacy.symlink_to(f".users/{AGENT_USER_ID}")
+
+        with patch(
+            "klangk.workspaces.Workspaces.populate_home_skel",
+            new_callable=AsyncMock,
+        ) as skel_mock:
+            await app_state.state.workspaces.ensure_shared_home(
+                ws["id"], "cid"
+            )
+        skel_mock.assert_awaited_once_with(
+            "cid", model.AGENT_USER_ID, home="/home/klangk"
+        )
+        assert legacy.is_symlink()  # still adopted, not replaced
+
+    async def test_dangling_legacy_symlink_replaced_by_real_dir(
+        self, user, app_state
+    ):
+        """A DANGLING ``klangk`` symlink (chat-era target deleted) must not
+        crash create: ``mkdir(exist_ok=True)`` re-raises FileExistsError
+        on a dangling symlink, which would fail ``_bringup`` after the
+        container is already running (and it never runs again for that
+        container). The broken link is removed and a real directory
+        materialized instead (#2717)."""
+        from klangk.model import AGENT_USER_ID
+
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "shared-home-dangling-ws"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        dangling = home / "klangk"
+        dangling.symlink_to(f".users/{AGENT_USER_ID}")  # target absent
+
+        with patch(
+            "klangk.workspaces.Workspaces.populate_home_skel",
+            new_callable=AsyncMock,
+        ) as skel_mock:
+            # Must not raise.
+            await app_state.state.workspaces.ensure_shared_home(
+                ws["id"], "cid"
+            )
+        assert not dangling.is_symlink()
+        assert dangling.is_dir()
+        skel_mock.assert_awaited_once_with(
+            "cid", model.AGENT_USER_ID, home="/home/klangk"
+        )

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from klangk import container
+from klangk import model
 from klangk import workspaces as ws_mod
 
 
@@ -718,32 +719,43 @@ async def test_idle_timeout_zero_pins_alive(user, app_state):
         registry.states.pop("ws-zero", None)
 
 
-class TestEnsureAgentHome:
-    """The agent identity's home: a plain real directory (#2716), no
-    ``.users/{uid}`` symlink indirection (the handle is fixed, #2718)."""
+class TestEnsureSharedHome:
+    """The shared home ``/home/klangk``: a plain real directory on the
+    home mount (#2717), no ``.users/{uid}`` symlink indirection, ensured
+    + populated under both layouts before the first login shell."""
 
-    async def test_creates_plain_dir_and_reports_created(
-        self, user, agent_user, app_state
+    async def test_creates_plain_dir_and_populates_skel_once(
+        self, user, app_state
     ):
         ws = await app_state.state.workspaces.create_workspace(
-            user["id"], "agent-home-ws"
+            user["id"], "shared-home-ws"
         )
         home = app_state.state.workspaces.home_path(ws["id"])
 
-        result, created = await app_state.state.workspaces.ensure_agent_home(
-            ws["id"]
-        )
-        assert result == "/home/klangk"
-        assert created is True
-        agent_dir = home / "klangk"
-        assert agent_dir.is_dir()
-        assert not agent_dir.is_symlink()
-        # Idempotent: second call does not report creation.
-        result2, created2 = await app_state.state.workspaces.ensure_agent_home(
-            ws["id"]
-        )
-        assert result2 == "/home/klangk"
-        assert created2 is False
+        with patch(
+            "klangk.workspaces.Workspaces.populate_home_skel",
+            new_callable=AsyncMock,
+        ) as skel_mock:
+            await app_state.state.workspaces.ensure_shared_home(
+                ws["id"], "cid"
+            )
+            # Freshly created → exactly-one skel copy into the shared
+            # home path.
+            skel_mock.assert_awaited_once_with(
+                "cid", model.AGENT_USER_ID, home="/home/klangk"
+            )
+
+            shared_dir = home / "klangk"
+            assert shared_dir.is_dir()
+            assert not shared_dir.is_symlink()
+
+            # Idempotent: second call does not re-populate (user
+            # customizations must never be clobbered by a recreate).
+            skel_mock.reset_mock()
+            await app_state.state.workspaces.ensure_shared_home(
+                ws["id"], "cid"
+            )
+            skel_mock.assert_not_awaited()
 
     async def test_populate_skel_home_override(self):
         """populate_home_skel(home=...) threads the override through; the
@@ -771,16 +783,14 @@ class TestEnsureAgentHome:
                 "cid", "uid-9", podman, home="/home/klangk"
             )
 
-    async def test_adopts_legacy_chat_era_symlink(
-        self, user, agent_user, app_state
-    ):
+    async def test_adopts_legacy_chat_era_symlink(self, user, app_state):
         """A ``klangk`` symlink left by the chat-era provisioning (pointing
         at ``.users/{AGENT_USER_ID}``) is adopted as-is — no removal, no
-        restructuring of existing volumes."""
+        restructuring of existing volumes, and no skel re-population."""
         from klangk.model import AGENT_USER_ID
 
         ws = await app_state.state.workspaces.create_workspace(
-            user["id"], "agent-home-legacy-ws"
+            user["id"], "shared-home-legacy-ws"
         )
         home = app_state.state.workspaces.home_path(ws["id"])
         users = home / ".users" / AGENT_USER_ID
@@ -788,11 +798,14 @@ class TestEnsureAgentHome:
         legacy = home / "klangk"
         legacy.symlink_to(f".users/{AGENT_USER_ID}")
 
-        result, created = await app_state.state.workspaces.ensure_agent_home(
-            ws["id"]
-        )
-        assert result == "/home/klangk"
-        # A symlink already exists at the path: leave it be.
-        assert created is False
+        with patch(
+            "klangk.workspaces.Workspaces.populate_home_skel",
+            new_callable=AsyncMock,
+        ) as skel_mock:
+            await app_state.state.workspaces.ensure_shared_home(
+                ws["id"], "cid"
+            )
+        # A symlink already exists at the path: leave it be, no skel.
+        skel_mock.assert_not_awaited()
         assert legacy.is_symlink()
         assert os.readlink(legacy) == f".users/{AGENT_USER_ID}"

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -840,11 +840,11 @@ class TestHandleTerminalStart:
             await conn.handle_terminal_start({"cols": 80, "rows": 24})
             await asyncio.sleep(0)
 
-        # Fired in the service session with the agent home, not threaded
-        # into the user's TerminalSession (no service_command kwarg).
+        # Fired in the service session (HOME pinned inside it, #2717),
+        # not threaded into the user's TerminalSession (no
+        # service_command kwarg).
         mock_ess.assert_awaited_once_with(
             "cid",
-            "/home/klangk",
             "./serve",
             setup_state="complete",
         )
@@ -1389,7 +1389,6 @@ class TestHandleTerminalStart:
         )
         mock_ess.assert_awaited_once_with(
             "cid",
-            "/home/klangk",
             "pi",
             setup_state="complete",
         )
@@ -6945,8 +6944,9 @@ class TestTerminalController:
     async def test_fire_service_command_invokes_ensure_service_session(
         self, app_state
     ):
-        """_fire_service_command reads fresh setup_state from the DB,
-        resolves the agent home, and targets the service session (#1133)."""
+        """_fire_service_command reads fresh setup_state from the DB and
+        targets the service session (#1133); the session HOME is pinned
+        inside ensure_service_session, so no home argument (#2717)."""
         ctrl, _, conn = self._controller()
         conn._service_command = "./run.sh"
         with (
@@ -6969,7 +6969,6 @@ class TestTerminalController:
             await ctrl._fire_service_command()
         mock_ess.assert_awaited_once_with(
             "cid",
-            "/home/klangk",
             "./run.sh",
             setup_state="complete",
         )


### PR DESCRIPTION
## Summary

Implements #2717 — the `service` tmux session's HOME is **always** the shared home `/home/klangk` under both home layouts, and the shared home is materialized + populated before the first login shell on every start path.

- **`ensure_service_session` no longer threads an `agent_home`.** HOME is pinned to the `SHARED_HOME` constant inside the method (the image's uid-1000 passwd home is `/home` — the mount point — so the podman-exec default is not the shared home). No `per_handle_home` branch on this path. Callers (`_bringup`, `_fire_service_command`) drop the argument.
- **`Workspaces.ensure_agent_home` → `ensure_shared_home`.** One method ensures `/home/klangk` exists on the home mount and populates it from `/etc/skel` exactly once (created-flag keyed on directory existence — restart-safe, never clobbers user customizations). Sequenced in `_bringup` **before** `ensure_service_session`, so the service session's login shell finds a populated `~/.profile` — including on the boot/autostart path where no user ever connects first. For pre-#2718 per-user volumes this materializes `/home/klangk` where it never existed; orphaned `.users/{AGENT_USER_ID}` dirs are abandoned; chat-era `klangk` symlinks are adopted as-is.
- **`KLANGKWS_AGENT_HOME` stays baked** as the constant `/home/klangk` (unchanged), so sandbox `setup.sh` scripts using `export HOME="${KLANGKWS_AGENT_HOME}"` keep working under both layouts (a no-op on shared-home workspaces).
- **`klangk-setup-pi --force` removed** — the backend caller died with chat (#2716); the tool itself stays.

Untouched, per the issue: session/window names, the per-container service lock + exactly-once window check, agent identity rows/ACL, `_sync_service_windows` merge, health check.

## Docs

`service-command.md` (session ownership + HOME + shared-`.bash_history` consequence; also fixed the stale "owner's session" description), `sandbox.md` ("Where the service command runs"), `auto-start.md` (boot-path population), `the-shell.md` (shared home + startup-files table), in-container `agent-context.md`, changelog entry.

## Testing

- Full CI suite: `5498 passed`, 100% coverage (`-n auto`).
- Build-pipeline contract tests: `71 passed`.
- pre-commit (ruff, markdownlint, prettier, …): clean.
- E2E (`test_agent_home_e2e.py`): unchanged assertions still lock the contract — `KLANGKWS_AGENT_HOME=/home/klangk` baked and `/home/klangk` materialized eagerly with `.profile` on autostart, no WS connection needed.

Closes #2717
