### PR TITLE
feat: expose per-handle home on all three create surfaces

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -155,6 +155,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Per-handle home is choosable on every create and edit surface (#2721).**
+  The web create dialog and Settings tab, the TUI create/edit screens, and
+  `klangk create`/`klangk edit` (`--per-handle-home`/`--shared-home`) all
+  send the workspace's home layout. Create forms pre-reflect the server
+  default (`KLANGKD_PER_HANDLE_HOME`, surfaced as `default_per_handle_home`
+  on `/config`); a flip on an existing workspace applies from the next
+  connect/start. See [Workspaces](features/workspaces.md).
+
 - **Service session HOME is always the shared home (#2717).** The
   `service` tmux session now runs with `HOME=/home/klangk` pinned as a
   constant under both home layouts, and `/home/klangk` is created and

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -35,8 +35,9 @@ optionally configure:
 - **Per-handle home** — the home-directory layout. On: every member
   gets a private `/home/<handle>` (dotfiles, shell history, and agent
   configs are per-user). Off: everyone shares `/home/klangk`. The
-  checkbox starts on the server default (`KLANGKD_PER_HANDLE_HOME`).
-  See [The Shell](the-shell.md).
+  checkbox starts on the server default (`KLANGKD_PER_HANDLE_HOME`);
+  if that default can't be fetched, the choice is left out and the
+  server default applies. See [The Shell](the-shell.md).
 
 You can change all of these later from the workspace **Settings** tab.
 

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -32,8 +32,34 @@ optionally configure:
 - **Allowed egress domains** — restrict outbound network access to a
   list of hosts (e.g., `github.com:443`, `pypi.org`). See
   [Egress Filtering](egress-filtering.md).
+- **Per-handle home** — the home-directory layout. On: every member
+  gets a private `/home/<handle>` (dotfiles, shell history, and agent
+  configs are per-user). Off: everyone shares `/home/klangk`. The
+  checkbox starts on the server default (`KLANGKD_PER_HANDLE_HOME`).
+  See [The Shell](the-shell.md).
 
 You can change all of these later from the workspace **Settings** tab.
+
+## Home directory layout
+
+Every workspace picks one of two home layouts:
+
+- **Per-handle home** (the default) — each member gets a private
+  `/home/<handle>` directory; see [The Shell](the-shell.md).
+- **Shared home** — all members share the single `/home/klangk`.
+
+The choice appears on the create form and the **Settings** tab (web),
+the create and edit screens (TUI), and the CLI:
+
+```bash
+klangk create my-project --shared-home
+klangk edit my-project --per-handle-home
+```
+
+The deploy-wide default for new workspaces is
+`KLANGKD_PER_HANDLE_HOME`. Changing an existing workspace's layout
+applies from the next connect/start — open terminals keep their
+layout until they end.
 
 ## Auto-start
 

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -30,9 +30,11 @@ class AuthService extends ChangeNotifier {
   // #2721: deploy default home layout for new workspaces
   // (KLANGKD_PER_HANDLE_HOME via /config's default_per_handle_home). The
   // create dialog pre-reflects it so an untouched form submits the
-  // server's default. Per-handle (true) is the fallback — the server's
-  // own default — so a config-fetch hiccup can't silently flip layouts.
-  bool _perHandleHomeDefault = true;
+  // server's default. Null = unknown (old server / fetch failure): the
+  // dialog hides the toggle and omits the field, so the server applies
+  // its own default — a hiccup can never silently force a layout
+  // (#2737 review).
+  bool? _perHandleHomeDefault;
   // #1365: deploy-wide netfilter default allow-list + whether the feature
   // is armed. Surfaced via /api/v1/config so the create-workspace UI can
   // pre-fill its allowed-domains editor from the default (a workspace
@@ -71,8 +73,10 @@ class AuthService extends ChangeNotifier {
   bool get allowAutostart => _allowAutostart;
 
   /// #2721: the deploy default home layout for new workspaces (true =
-  /// per-handle private homes, false = shared /home/klangk).
-  bool get perHandleHomeDefault => _perHandleHomeDefault;
+  /// per-handle private homes, false = shared /home/klangk). Null when
+  /// unknown — the create dialog then hides the toggle and omits the
+  /// field so the server default applies.
+  bool? get perHandleHomeDefault => _perHandleHomeDefault;
 
   /// #1365: the deploy-wide netfilter default allow-list
   /// (KLANGKD_NETFILTER_DEFAULT_DOMAINS). The create-workspace dialog
@@ -151,8 +155,7 @@ class AuthService extends ChangeNotifier {
             (data['login_banner_every_visit'] as bool?) ?? false;
         _instanceId = (data['instance_id'] as String?) ?? 'default';
         _allowAutostart = (data['allow_autostart'] as bool?) ?? false;
-        _perHandleHomeDefault =
-            (data['default_per_handle_home'] as bool?) ?? true;
+        _perHandleHomeDefault = data['default_per_handle_home'] as bool?;
         _netfilterDefaultDomains =
             (data['netfilter_default_domains'] as List?)?.cast<String>() ??
                 const [];

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -27,6 +27,12 @@ class AuthService extends ChangeNotifier {
   PasswordPolicy _passwordPolicy = const PasswordPolicy();
   String _instanceId = 'default';
   bool _allowAutostart = false;
+  // #2721: deploy default home layout for new workspaces
+  // (KLANGKD_PER_HANDLE_HOME via /config's default_per_handle_home). The
+  // create dialog pre-reflects it so an untouched form submits the
+  // server's default. Per-handle (true) is the fallback — the server's
+  // own default — so a config-fetch hiccup can't silently flip layouts.
+  bool _perHandleHomeDefault = true;
   // #1365: deploy-wide netfilter default allow-list + whether the feature
   // is armed. Surfaced via /api/v1/config so the create-workspace UI can
   // pre-fill its allowed-domains editor from the default (a workspace
@@ -63,6 +69,10 @@ class AuthService extends ChangeNotifier {
   /// on this — setting auto_start on a server that rejects it would
   /// 400 (#1115).
   bool get allowAutostart => _allowAutostart;
+
+  /// #2721: the deploy default home layout for new workspaces (true =
+  /// per-handle private homes, false = shared /home/klangk).
+  bool get perHandleHomeDefault => _perHandleHomeDefault;
 
   /// #1365: the deploy-wide netfilter default allow-list
   /// (KLANGKD_NETFILTER_DEFAULT_DOMAINS). The create-workspace dialog
@@ -141,6 +151,8 @@ class AuthService extends ChangeNotifier {
             (data['login_banner_every_visit'] as bool?) ?? false;
         _instanceId = (data['instance_id'] as String?) ?? 'default';
         _allowAutostart = (data['allow_autostart'] as bool?) ?? false;
+        _perHandleHomeDefault =
+            (data['default_per_handle_home'] as bool?) ?? true;
         _netfilterDefaultDomains =
             (data['netfilter_default_domains'] as List?)?.cast<String>() ??
                 const [];

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -370,29 +370,6 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                             ),
                           ),
                         ],
-                        const SizedBox(height: 8),
-                        // #2721: home layout. Pre-reflects the deploy
-                        // default when known; hidden (and the field
-                        // omitted) when it couldn't be fetched — an
-                        // offered choice we can't pre-reflect would pin a
-                        // possibly-wrong value.
-                        if (_perHandleHome != null)
-                          Material(
-                            type: MaterialType.transparency,
-                            child: CheckboxListTile(
-                              value: _perHandleHome,
-                              onChanged: (v) => setState(
-                                () => _perHandleHome = v ?? true,
-                              ),
-                              title: const Text('Per-handle home'),
-                              subtitle: const Text(
-                                'Each member gets a private /home/<handle>; '
-                                'off = everyone shares /home/klangk',
-                              ),
-                              controlAffinity: ListTileControlAffinity.leading,
-                              contentPadding: EdgeInsets.zero,
-                            ),
-                          ),
                       ],
                     ),
                     const SizedBox(height: 16),
@@ -577,6 +554,30 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                           ),
                           onSubmitted: (_) => _submit(),
                         ),
+                        // #2721: home layout. Pre-reflects the deploy
+                        // default when known; hidden (and the field
+                        // omitted) when it couldn't be fetched — an
+                        // offered choice we can't pre-reflect would pin a
+                        // possibly-wrong value.
+                        if (_perHandleHome != null) ...[
+                          const SizedBox(height: 16),
+                          Material(
+                            type: MaterialType.transparency,
+                            child: CheckboxListTile(
+                              value: _perHandleHome,
+                              onChanged: (v) => setState(
+                                () => _perHandleHome = v ?? true,
+                              ),
+                              title: const Text('Per-handle home'),
+                              subtitle: const Text(
+                                'Each member gets a private /home/<handle>; '
+                                'off = everyone shares /home/klangk',
+                              ),
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: EdgeInsets.zero,
+                            ),
+                          ),
+                        ],
                         // #2202: per-workspace nix flag (only when the
                         // server has a btrfs seed subvolume). Independent
                         // of the image choice — it mounts a shared /nix

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -40,8 +40,10 @@ class CreateWorkspaceDialog extends StatefulWidget {
 
   /// #2721: deploy default home layout (KLANGKD_PER_HANDLE_HOME). The
   /// Per-handle home checkbox starts on this, so an untouched form
-  /// submits exactly what a silent POST would get.
-  final bool defaultPerHandleHome;
+  /// submits exactly what a silent POST would get. Null = unknown (old
+  /// server / fetch failure): the toggle is hidden and the field omitted,
+  /// so the server applies its own default (#2737 review).
+  final bool? defaultPerHandleHome;
 
   const CreateWorkspaceDialog({
     super.key,
@@ -52,7 +54,7 @@ class CreateWorkspaceDialog extends StatefulWidget {
     this.defaultAllowedDomains = const [],
     this.netfilterEnabled = false,
     this.nixAvailable = false,
-    this.defaultPerHandleHome = true,
+    this.defaultPerHandleHome,
   });
 
   @override
@@ -79,8 +81,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _rejectedDomains = <String>[];
   bool _autoStart = false;
   bool _nixEnabled = false;
-  // #2721: home layout. Starts on the deploy default; always submitted.
-  bool _perHandleHome = true;
+  // #2721: home layout. Starts on the deploy default when known; null
+  // (unknown) hides the toggle and omits the field.
+  bool? _perHandleHome;
   // #2409: per-workspace egress mode. 'interactive' is the server default for
   // new workspaces (consent-gated egress on out of the box).
   String _egressMode = 'interactive';
@@ -240,7 +243,10 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       body['rejected_domains'] = List<String>.from(_rejectedDomains);
     }
     body['egress_mode'] = _egressMode;
-    body['per_handle_home'] = _perHandleHome;
+    // #2721: sent only when the deploy default was known — the toggle's
+    // initial state IS that default, so an untouched form submits it
+    // unchanged. Unknown: omitted, and the server applies its own.
+    if (_perHandleHome != null) body['per_handle_home'] = _perHandleHome!;
     if (widget.allowAutostart && _autoStart) {
       body['auto_start'] = true;
     }
@@ -366,23 +372,27 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                         ],
                         const SizedBox(height: 8),
                         // #2721: home layout. Pre-reflects the deploy
-                        // default; always sent (so the checkbox's initial
-                        // state equals a silent POST's outcome).
-                        Material(
-                          type: MaterialType.transparency,
-                          child: CheckboxListTile(
-                            value: _perHandleHome,
-                            onChanged: (v) =>
-                                setState(() => _perHandleHome = v ?? true),
-                            title: const Text('Per-handle home'),
-                            subtitle: const Text(
-                              'Each member gets a private /home/<handle>; '
-                              'off = everyone shares /home/klangk',
+                        // default when known; hidden (and the field
+                        // omitted) when it couldn't be fetched — an
+                        // offered choice we can't pre-reflect would pin a
+                        // possibly-wrong value.
+                        if (_perHandleHome != null)
+                          Material(
+                            type: MaterialType.transparency,
+                            child: CheckboxListTile(
+                              value: _perHandleHome,
+                              onChanged: (v) => setState(
+                                () => _perHandleHome = v ?? true,
+                              ),
+                              title: const Text('Per-handle home'),
+                              subtitle: const Text(
+                                'Each member gets a private /home/<handle>; '
+                                'off = everyone shares /home/klangk',
+                              ),
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: EdgeInsets.zero,
                             ),
-                            controlAffinity: ListTileControlAffinity.leading,
-                            contentPadding: EdgeInsets.zero,
                           ),
-                        ),
                       ],
                     ),
                     const SizedBox(height: 16),

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -38,6 +38,11 @@ class CreateWorkspaceDialog extends StatefulWidget {
   /// image-only (the user picks the nix image themselves).
   final bool nixAvailable;
 
+  /// #2721: deploy default home layout (KLANGKD_PER_HANDLE_HOME). The
+  /// Per-handle home checkbox starts on this, so an untouched form
+  /// submits exactly what a silent POST would get.
+  final bool defaultPerHandleHome;
+
   const CreateWorkspaceDialog({
     super.key,
     required this.auth,
@@ -47,6 +52,7 @@ class CreateWorkspaceDialog extends StatefulWidget {
     this.defaultAllowedDomains = const [],
     this.netfilterEnabled = false,
     this.nixAvailable = false,
+    this.defaultPerHandleHome = true,
   });
 
   @override
@@ -73,6 +79,8 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _rejectedDomains = <String>[];
   bool _autoStart = false;
   bool _nixEnabled = false;
+  // #2721: home layout. Starts on the deploy default; always submitted.
+  bool _perHandleHome = true;
   // #2409: per-workspace egress mode. 'interactive' is the server default for
   // new workspaces (consent-gated egress on out of the box).
   String _egressMode = 'interactive';
@@ -101,6 +109,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   void initState() {
     super.initState();
     _selectedImage = widget.defaultImage;
+    _perHandleHome = widget.defaultPerHandleHome;
     // #1365: pre-fill the editor with the deploy-wide default so a new
     // workspace inherits it; the creator's edits replace (not merge with)
     // the default and are submitted as the workspace's allowed_domains.
@@ -231,6 +240,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       body['rejected_domains'] = List<String>.from(_rejectedDomains);
     }
     body['egress_mode'] = _egressMode;
+    body['per_handle_home'] = _perHandleHome;
     if (widget.allowAutostart && _autoStart) {
       body['auto_start'] = true;
     }
@@ -354,6 +364,25 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                             ),
                           ),
                         ],
+                        const SizedBox(height: 8),
+                        // #2721: home layout. Pre-reflects the deploy
+                        // default; always sent (so the checkbox's initial
+                        // state equals a silent POST's outcome).
+                        Material(
+                          type: MaterialType.transparency,
+                          child: CheckboxListTile(
+                            value: _perHandleHome,
+                            onChanged: (v) =>
+                                setState(() => _perHandleHome = v ?? true),
+                            title: const Text('Per-handle home'),
+                            subtitle: const Text(
+                              'Each member gets a private /home/<handle>; '
+                              'off = everyone shares /home/klangk',
+                            ),
+                            controlAffinity: ListTileControlAffinity.leading,
+                            contentPadding: EdgeInsets.zero,
+                          ),
+                        ),
                       ],
                     ),
                     const SizedBox(height: 16),

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -573,7 +573,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                                 'Each member gets a private /home/<handle>; '
                                 'off = everyone shares /home/klangk',
                               ),
-                              controlAffinity: ListTileControlAffinity.leading,
+                              controlAffinity: ListTileControlAffinity.trailing,
                               contentPadding: EdgeInsets.zero,
                             ),
                           ),

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -457,6 +457,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         defaultAllowedDomains: _auth.netfilterDefaultDomains,
         netfilterEnabled: _auth.netfilterEnabled,
         nixAvailable: nixAvailable,
+        defaultPerHandleHome: _auth.perHandleHomeDefault,
       ),
     );
 

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -327,6 +327,9 @@ class _SettingsFormState extends State<_SettingsForm> {
   // #2233: per-workspace nix toggle (Mount /nix dir). Only meaningful
   // when the server has a nix backend (widget.nixAvailable).
   bool _nixEnabled = false;
+  // #2721: home layout, seeded from the workspace. Mutable (#2719): a
+  // flip applies from the next connect/start.
+  bool _perHandleHome = true;
   String? _mountError;
   String? _envError;
   String? _allowedDomainsError;
@@ -386,6 +389,7 @@ class _SettingsFormState extends State<_SettingsForm> {
     );
     _egressMode = (widget.workspace['egress_mode'] as String?) ?? 'interactive';
     _autoStart = (widget.workspace['auto_start'] as bool?) ?? false;
+    _perHandleHome = (widget.workspace['per_handle_home'] as bool?) ?? true;
     final settings =
         (widget.workspace['settings'] as Map<String, dynamic>?) ?? {};
     _idleTimeoutCtrl = TextEditingController(
@@ -426,6 +430,11 @@ class _SettingsFormState extends State<_SettingsForm> {
     if (old.workspace['auto_start'] != widget.workspace['auto_start']) {
       // coverage:ignore-start
       _autoStart = (widget.workspace['auto_start'] as bool?) ?? false;
+    } // coverage:ignore-end
+    if (old.workspace['per_handle_home'] !=
+        widget.workspace['per_handle_home']) {
+      // coverage:ignore-start
+      _perHandleHome = (widget.workspace['per_handle_home'] as bool?) ?? true;
     } // coverage:ignore-end
     final oldSettings = (old.workspace['settings'] as Map<String, dynamic>?) ??
         const <String, dynamic>{};
@@ -538,6 +547,7 @@ class _SettingsFormState extends State<_SettingsForm> {
       'allowed_domains': _allowedDomains.isNotEmpty ? _allowedDomains : null,
       'rejected_domains': _rejectedDomains.isNotEmpty ? _rejectedDomains : null,
       'egress_mode': _egressMode,
+      'per_handle_home': _perHandleHome,
       if (widget.allowAutostart) 'auto_start': _autoStart,
       if (settings.isNotEmpty) 'settings': settings,
     });
@@ -785,6 +795,25 @@ class _SettingsFormState extends State<_SettingsForm> {
             ),
           ),
         ],
+        // #2721: home layout. Mutable (#2719) — a flip applies from the
+        // next connect/start, never to open sessions, so it is NOT a
+        // restart-needed field.
+        const SizedBox(height: 8),
+        Material(
+          type: MaterialType.transparency,
+          child: CheckboxListTile(
+            value: _perHandleHome,
+            onChanged: (v) => setState(() => _perHandleHome = v ?? true),
+            title: const Text('Per-handle home'),
+            subtitle: const Text(
+              'Each member gets a private /home/<handle>; '
+              'off = everyone shares /home/klangk (applies from the next '
+              'connect)',
+            ),
+            controlAffinity: ListTileControlAffinity.leading,
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
         // #2233: per-workspace nix toggle. Gated on the server having a
         // nix backend (nix_seed), matching the create dialog. The /nix
         // mount is set up at container create time, so toggling it on a

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -795,25 +795,6 @@ class _SettingsFormState extends State<_SettingsForm> {
             ),
           ),
         ],
-        // #2721: home layout. Mutable (#2719) — a flip applies from the
-        // next connect/start, never to open sessions, so it is NOT a
-        // restart-needed field.
-        const SizedBox(height: 8),
-        Material(
-          type: MaterialType.transparency,
-          child: CheckboxListTile(
-            value: _perHandleHome,
-            onChanged: (v) => setState(() => _perHandleHome = v ?? true),
-            title: const Text('Per-handle home'),
-            subtitle: const Text(
-              'Each member gets a private /home/<handle>; '
-              'off = everyone shares /home/klangk (applies from the next '
-              'connect)',
-            ),
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
         // #2233: per-workspace nix toggle. Gated on the server having a
         // nix backend (nix_seed), matching the create dialog. The /nix
         // mount is set up at container create time, so toggling it on a
@@ -1010,6 +991,25 @@ class _SettingsFormState extends State<_SettingsForm> {
             floatingLabelBehavior: FloatingLabelBehavior.always,
             border: const OutlineInputBorder(),
             hintText: 'Optional — polled to gauge service health',
+          ),
+        ),
+        // #2721: home layout. Mutable (#2719) — a flip applies from the
+        // next connect/start, never to open sessions, so it is NOT a
+        // restart-needed field.
+        const SizedBox(height: 16),
+        Material(
+          type: MaterialType.transparency,
+          child: CheckboxListTile(
+            value: _perHandleHome,
+            onChanged: (v) => setState(() => _perHandleHome = v ?? true),
+            title: const Text('Per-handle home'),
+            subtitle: const Text(
+              'Each member gets a private /home/<handle>; '
+              'off = everyone shares /home/klangk (applies from the next '
+              'connect)',
+            ),
+            controlAffinity: ListTileControlAffinity.leading,
+            contentPadding: EdgeInsets.zero,
           ),
         ),
       ],

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -1008,7 +1008,7 @@ class _SettingsFormState extends State<_SettingsForm> {
               'off = everyone shares /home/klangk (applies from the next '
               'connect)',
             ),
-            controlAffinity: ListTileControlAffinity.leading,
+            controlAffinity: ListTileControlAffinity.trailing,
             contentPadding: EdgeInsets.zero,
           ),
         ),

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -162,18 +162,23 @@ void main() {
     });
 
     test('loads default_per_handle_home from /api/config', () async {
-      // #2721: defaults to true (per-handle, the server default) when the
-      // field is absent — a config-fetch hiccup can't silently flip
-      // layouts — and parses the advertised deploy default when present.
+      // #2721 / #2737 review: null (unknown) when the field is absent or
+      // the fetch fails — the create dialog then hides the toggle and
+      // omits the field so the server default applies.
       testAuthHttpClientOverride = _bannerClient();
       final service = AuthService();
       await Future.delayed(Duration.zero);
-      expect(service.perHandleHomeDefault, isTrue);
+      expect(service.perHandleHomeDefault, isNull);
 
       testAuthHttpClientOverride = _bannerClient(defaultPerHandleHome: false);
       final service2 = AuthService();
       await Future.delayed(Duration.zero);
       expect(service2.perHandleHomeDefault, isFalse);
+
+      testAuthHttpClientOverride = _bannerClient(defaultPerHandleHome: true);
+      final service3 = AuthService();
+      await Future.delayed(Duration.zero);
+      expect(service3.perHandleHomeDefault, isTrue);
     });
 
     test('loads netfilter default domains + enabled from /api/config',

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -93,6 +93,7 @@ void main() {
       String? productName,
       List<String>? netfilterDefaultDomains,
       bool? netfilterEnabled,
+      bool? defaultPerHandleHome,
     }) {
       return MockClient((request) async {
         if (request.url.path.contains('/api/v1/config')) {
@@ -112,6 +113,8 @@ void main() {
                 'netfilter_default_domains': netfilterDefaultDomains,
               if (netfilterEnabled != null)
                 'netfilter_enabled': netfilterEnabled,
+              if (defaultPerHandleHome != null)
+                'default_per_handle_home': defaultPerHandleHome,
             }),
             200,
           );
@@ -156,6 +159,21 @@ void main() {
       final service2 = AuthService();
       await Future.delayed(Duration.zero);
       expect(service2.allowAutostart, isTrue);
+    });
+
+    test('loads default_per_handle_home from /api/config', () async {
+      // #2721: defaults to true (per-handle, the server default) when the
+      // field is absent — a config-fetch hiccup can't silently flip
+      // layouts — and parses the advertised deploy default when present.
+      testAuthHttpClientOverride = _bannerClient();
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      expect(service.perHandleHomeDefault, isTrue);
+
+      testAuthHttpClientOverride = _bannerClient(defaultPerHandleHome: false);
+      final service2 = AuthService();
+      await Future.delayed(Duration.zero);
+      expect(service2.perHandleHomeDefault, isFalse);
     });
 
     test('loads netfilter default domains + enabled from /api/config',

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -66,7 +66,7 @@ void main() {
     List<String> defaultAllowedDomains = const [],
     bool netfilterEnabled = false,
     bool nixAvailable = false,
-    bool defaultPerHandleHome = true,
+    bool? defaultPerHandleHome = true,
   }) {
     final a = auth ?? AuthService();
     return MaterialApp(
@@ -930,7 +930,7 @@ void main() {
     });
 
     testWidgets(
-      'per-handle home checkbox pre-reflects the deploy default and always sends (#2721)',
+      'per-handle home checkbox pre-reflects the deploy default, toggles, and omits when unknown (#2721, #2737)',
       (tester) async {
         Map<String, dynamic>? postedBody;
         testAuthHttpClientOverride = mockClient((request) async {
@@ -962,10 +962,26 @@ void main() {
         await tester.pump();
         expect(postedBody!['per_handle_home'], false);
 
-        // Default dialog (per-handle): submitted as true even untouched —
-        // an untouched form equals a silent POST against the default deploy.
+        // Toggle the checkbox ON (exercises the onChanged handler) and
+        // submit — the flipped value reaches the POST body.
         postedBody = null;
-        await tester.pumpWidget(buildDialog());
+        await tester.pumpWidget(buildDialog(defaultPerHandleHome: false));
+        await tester.pump();
+        await tester.pump();
+        await tester.ensureVisible(checkbox);
+        await tester.tap(checkbox);
+        await tester.pump();
+        expect(tester.widget<Checkbox>(checkbox).value, isTrue);
+        await tester.enterText(_nameField(), 'Toggled');
+        await tester.tap(find.text('Create'));
+        await tester.pump();
+        await tester.pump();
+        expect(postedBody!['per_handle_home'], true);
+
+        // Per-handle-default dialog: submitted as true even untouched —
+        // an untouched form equals a silent POST against that deploy.
+        postedBody = null;
+        await tester.pumpWidget(buildDialog(defaultPerHandleHome: true));
         await tester.pump();
         await tester.pump();
         await tester.enterText(_nameField(), 'PerHandle');
@@ -973,6 +989,19 @@ void main() {
         await tester.pump();
         await tester.pump();
         expect(postedBody!['per_handle_home'], true);
+
+        // Unknown default (fetch failed / old server): no tile, and the
+        // field is omitted so the server applies its own default.
+        postedBody = null;
+        await tester.pumpWidget(buildDialog(defaultPerHandleHome: null));
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Per-handle home'), findsNothing);
+        await tester.enterText(_nameField(), 'Unknown');
+        await tester.tap(find.text('Create'));
+        await tester.pump();
+        await tester.pump();
+        expect(postedBody!.containsKey('per_handle_home'), isFalse);
       },
     );
 

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -66,6 +66,7 @@ void main() {
     List<String> defaultAllowedDomains = const [],
     bool netfilterEnabled = false,
     bool nixAvailable = false,
+    bool defaultPerHandleHome = true,
   }) {
     final a = auth ?? AuthService();
     return MaterialApp(
@@ -84,6 +85,7 @@ void main() {
                   defaultAllowedDomains: defaultAllowedDomains,
                   netfilterEnabled: netfilterEnabled,
                   nixAvailable: nixAvailable,
+                  defaultPerHandleHome: defaultPerHandleHome,
                 ),
               );
             });
@@ -852,7 +854,10 @@ void main() {
       await tester.pump(); // dialog renders
 
       expect(find.text('Auto start'), findsNothing);
-      expect(find.byType(Checkbox), findsNothing);
+      // The Per-handle home checkbox (#2721) is always shown — it is the
+      // only checkbox when auto-start is not allowed.
+      expect(find.text('Per-handle home'), findsOneWidget);
+      expect(find.byType(Checkbox), findsOneWidget);
     });
 
     testWidgets('shows auto-start checkbox and sends auto_start when allowed',
@@ -875,8 +880,13 @@ void main() {
 
       expect(find.text('Auto start'), findsOneWidget);
       // Toggle the checkbox on, then submit (checkbox is at the bottom of
-      // the dialog, so ensure it's visible before tapping).
-      final checkbox = find.byType(Checkbox);
+      // the dialog, so ensure it's visible before tapping). Scoped to the
+      // Auto start tile — the Per-handle home checkbox (#2721) is always
+      // present too.
+      final checkbox = find.descendant(
+        of: find.widgetWithText(CheckboxListTile, 'Auto start'),
+        matching: find.byType(Checkbox),
+      );
       await tester.ensureVisible(checkbox);
       await tester.tap(checkbox);
       await tester.pump();
@@ -907,8 +917,9 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      // Checkbox is present but unchecked.
-      expect(find.byType(Checkbox), findsOneWidget);
+      // Both checkboxes are present (Auto start off, Per-handle home on
+      // by default); auto_start stays unsent while the box is unchecked.
+      expect(find.byType(Checkbox), findsNWidgets(2));
       await tester.enterText(_nameField(), 'Auto');
       await tester.tap(find.text('Create'));
       await tester.pump();
@@ -917,6 +928,53 @@ void main() {
       expect(postedBody, isNotNull);
       expect(postedBody!.containsKey('auto_start'), isFalse);
     });
+
+    testWidgets(
+      'per-handle home checkbox pre-reflects the deploy default and always sends (#2721)',
+      (tester) async {
+        Map<String, dynamic>? postedBody;
+        testAuthHttpClientOverride = mockClient((request) async {
+          if (request.method == 'POST') {
+            postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+            return http.Response(
+              jsonEncode({'id': 'ws-1', 'name': 'x', 'created_at': ''}),
+              200,
+            );
+          }
+          return http.Response('Not found', 404);
+        });
+        // Deploy default is shared (default_per_handle_home: false).
+        await tester.pumpWidget(buildDialog(defaultPerHandleHome: false));
+        await tester.pump(); // post-frame callback
+        await tester.pump(); // dialog renders
+
+        final checkbox = find.descendant(
+          of: find.widgetWithText(CheckboxListTile, 'Per-handle home'),
+          matching: find.byType(Checkbox),
+        );
+        expect(checkbox, findsOneWidget);
+        expect(tester.widget<Checkbox>(checkbox).value, isFalse);
+
+        // Untouched form submits the deploy default (shared).
+        await tester.enterText(_nameField(), 'Shared');
+        await tester.tap(find.text('Create'));
+        await tester.pump();
+        await tester.pump();
+        expect(postedBody!['per_handle_home'], false);
+
+        // Default dialog (per-handle): submitted as true even untouched —
+        // an untouched form equals a silent POST against the default deploy.
+        postedBody = null;
+        await tester.pumpWidget(buildDialog());
+        await tester.pump();
+        await tester.pump();
+        await tester.enterText(_nameField(), 'PerHandle');
+        await tester.tap(find.text('Create'));
+        await tester.pump();
+        await tester.pump();
+        expect(postedBody!['per_handle_home'], true);
+      },
+    );
 
     testWidgets('submits settings via resource field Enter key',
         (tester) async {

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -2137,8 +2137,12 @@ void main() {
       await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
-      // Try adding invalid mount (no colon)
+      // Try adding invalid mount (no colon). The General pane grew
+      // (Per-handle home tile, #2721), pushing the mounts editor below
+      // the fold — scroll it in before tapping.
       await tester.enterText(_dialogMountInput(), 'bad-mount');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
+      await tester.pumpAndSettle();
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
 
@@ -2285,8 +2289,12 @@ void main() {
       // No copy buttons initially
       expect(find.byTooltip('Copy'), findsNothing);
 
-      // Add a mount
+      // Add a mount. The General pane grew (Per-handle home tile,
+      // #2721), pushing the mounts editor below the fold — scroll it in
+      // before tapping.
       await tester.enterText(_dialogMountInput(), '/src:/work');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
+      await tester.pumpAndSettle();
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
 

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -591,6 +591,10 @@ void main() {
       // Close icons: [mount-remove, mount-copy, env-remove, env-copy].
       // The env-remove is the close icon after the mounts section.
       final closes = find.byIcon(Icons.close);
+      // The General pane grew (Per-handle home tile, #2721), pushing the
+      // env editor below the fold — scroll it in before tapping.
+      await tester.ensureVisible(closes.last);
+      await tester.pumpAndSettle();
       await tester.tap(closes.last);
       await tester.pump();
 
@@ -1163,6 +1167,10 @@ void main() {
       await tester.pumpAndSettle();
 
       // Remove the existing env var (FOO=bar) — the last close icon.
+      // The General pane grew (Per-handle home tile, #2721), pushing the
+      // env editor below the fold — scroll it in before tapping.
+      await tester.ensureVisible(find.byIcon(Icons.close).last);
+      await tester.pumpAndSettle();
       await tester.tap(find.byIcon(Icons.close).last);
       await tester.pump();
 
@@ -1317,7 +1325,11 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Auto start'), findsNothing);
-      expect(find.byType(Checkbox), findsNothing);
+      // The Per-handle home checkbox (#2721) is always shown in the
+      // settings form — it is the only checkbox when auto-start is not
+      // allowed.
+      expect(find.text('Per-handle home'), findsOneWidget);
+      expect(find.byType(Checkbox), findsOneWidget);
     });
 
     testWidgets('shows the checkbox and round-trips auto_start when allowed',
@@ -1361,7 +1373,12 @@ void main() {
       await tester.pumpAndSettle();
 
       // Checkbox present + checked (workspace had auto_start: true).
-      final checkbox = find.byType(Checkbox);
+      // Scoped to the Auto start tile — the Per-handle home checkbox
+      // (#2721) is always present too.
+      final checkbox = find.descendant(
+        of: find.widgetWithText(CheckboxListTile, 'Auto start'),
+        matching: find.byType(Checkbox),
+      );
       expect(checkbox, findsOneWidget);
       expect(tester.widget<Checkbox>(checkbox).value, isTrue);
 
@@ -1375,6 +1392,71 @@ void main() {
 
       expect(savedBody, isNotNull);
       expect(savedBody!['auto_start'], false);
+      // Drain the 2s auto-clear timer (see save-success test).
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+        'per_handle_home seeds from the workspace and saves a flip (#2721)',
+        (tester) async {
+      Map<String, dynamic>? savedBody;
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({}), 200);
+        }
+        if (p == '/api/v1/workspaces') {
+          return http.Response(
+            jsonEncode([
+              {
+                ..._workspace,
+                'egress_mode': 'interactive',
+                'per_handle_home': true,
+              }
+            ]),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+          savedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(jsonEncode({'status': 'updated'}), 200);
+        }
+        return http.Response('nf', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Seeded from the workspace (per-handle).
+      final checkbox = find.descendant(
+        of: find.widgetWithText(CheckboxListTile, 'Per-handle home'),
+        matching: find.byType(Checkbox),
+      );
+      expect(checkbox, findsOneWidget);
+      expect(tester.widget<Checkbox>(checkbox).value, isTrue);
+
+      // Toggle to shared and save; the flip reaches the PUT body.
+      await tester.ensureVisible(checkbox);
+      await tester.tap(checkbox);
+      await tester.pump();
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(savedBody, isNotNull);
+      expect(savedBody!['per_handle_home'], false);
       // Drain the 2s auto-clear timer (see save-success test).
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -205,6 +205,12 @@ async def get_config(
         # boot) is permitted. The web UI gates its "Auto start" checkbox on
         # this so users can't toggle a setting the server will reject (#1115).
         "allow_autostart": autostart_allowed(app),
+        # Home-layout default for NEW workspaces (KLANGKD_PER_HANDLE_HOME,
+        # #2169 chunk 3 / #2721). The create surfaces (web dialog, TUI form,
+        # `klangk create`) pre-reflect this so an untouched form submits the
+        # server's default. Not sensitive — the pre-auth payload carries it
+        # (the TUI reads /config before login like it does allow_autostart).
+        "default_per_handle_home": s.per_handle_home,
         # Surfaced so the UI can validate password length inline (matches
         # the rule enforced server-side by auth.validate_password).
         "min_password_length": app.state.auth.min_password_length,

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -179,6 +179,10 @@ class Workspace:
     allowed_domains: list[str] | None = None
     rejected_domains: list[str] | None = None
     egress_mode: str | None = None
+    # Home layout (#2169): True = each member gets a private
+    # /home/.users/{id} home (via a /home/{handle} symlink); False = all
+    # members share /home/klangk. Server default is True.
+    per_handle_home: bool = True
     owner_email: str | None = None
     running: bool = False
     health: str | None = None
@@ -488,6 +492,7 @@ class KlangkClient:
             allowed_domains=w.get("allowed_domains"),
             rejected_domains=w.get("rejected_domains"),
             egress_mode=w.get("egress_mode"),
+            per_handle_home=bool(w.get("per_handle_home", True)),
             service_started_at=w.get("service_started_at"),
             settings=w.get("settings"),
         )
@@ -506,6 +511,7 @@ class KlangkClient:
         egress_mode: str | None = None,
         rejected_domains: list[str] | None = None,
         settings: dict | None = None,
+        per_handle_home: bool | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
         if image:
@@ -530,6 +536,10 @@ class KlangkClient:
             body["rejected_domains"] = rejected_domains
         if settings:
             body["settings"] = settings
+        # None = not chosen: the server applies the deploy default
+        # (KLANGKD_PER_HANDLE_HOME) — same convention as egress_mode.
+        if per_handle_home is not None:
+            body["per_handle_home"] = per_handle_home
         resp = self.post("/api/v1/workspaces", json=body)
         self.check_auth(resp)
         self._raise_for_status(resp)

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -28,6 +28,15 @@ def edit(
         "--auto-start/--no-auto-start",
         help="Start container automatically on server boot",
     ),
+    per_handle_home: bool | None = typer.Option(
+        None,
+        "--per-handle-home/--shared-home",
+        help=(
+            "Home layout (applies from the next connect/start): "
+            "per-handle gives each member a private /home/<handle>; "
+            "shared puts everyone in /home/klangk"
+        ),
+    ),
     health_check: str | None = typer.Option(
         None,
         "--health-check",
@@ -88,6 +97,7 @@ def edit(
         or image is not None
         or command is not None
         or auto_start is not None
+        or per_handle_home is not None
         or health_check is not None
         or isinstance(mount, list)
         or isinstance(env, list)
@@ -307,6 +317,11 @@ def edit(
             body["service_command"] = command or None
         if auto_start is not None:
             body["auto_start"] = auto_start
+        if per_handle_home is not None:
+            # Mutable (#2719); takes effect on the next connect/start —
+            # never a restart-prompt field (existing sessions keep their
+            # layout until they end).
+            body["per_handle_home"] = per_handle_home
         if health_check is not None:
             body["health_check"] = health_check or None
         if isinstance(mount, list):

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -175,6 +175,11 @@ class KlangkApp(App):
     .field-row > Input, .field-row > Select {
         width: 1fr;
     }
+    /* A checkbox in a field-row keeps its content-sized (auto) width —
+    without this the row's fixed label column bleeds onto it (#2721). */
+    .field-row > Checkbox {
+        width: auto;
+    }
     /* Editor rows (Input + Add/Remove buttons): keep the Input fractional so
     the buttons always fit inside the pane (#1891) — a greedy default-width
     Input otherwise pushes Add/Remove past the tab pane's clip region, where

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -869,6 +869,16 @@ class MainScreen(StatusScreen):
         except (httpx.HTTPError, OSError, ValueError) as exc:
             logger.debug("Could not fetch default allowed domains: %s", exc)
             default_domains = []
+        # #2721: the deploy's home-layout default, pre-reflected by the
+        # form's Per-handle home checkbox. Falls back to True (per-handle,
+        # the server default) on any fetch failure.
+        try:
+            default_per_handle_home = await asyncio.to_thread(
+                state.default_per_handle_home
+            )
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            logger.debug("Could not fetch home-layout default: %s", exc)
+            default_per_handle_home = True
         self.app.push_screen(
             CreateWorkspaceScreen(
                 allowed=allowed,
@@ -876,6 +886,7 @@ class MainScreen(StatusScreen):
                 allow_autostart=allow_autostart,
                 default_allowed_domains=default_domains,
                 nix_available=nix_available,
+                default_per_handle_home=default_per_handle_home,
             ),
             self._on_created,
         )

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -870,15 +870,16 @@ class MainScreen(StatusScreen):
             logger.debug("Could not fetch default allowed domains: %s", exc)
             default_domains = []
         # #2721: the deploy's home-layout default, pre-reflected by the
-        # form's Per-handle home checkbox. Falls back to True (per-handle,
-        # the server default) on any fetch failure.
+        # form's Per-handle home checkbox. None (fetch failed) hides the
+        # checkbox and omits the field, so the server applies its own
+        # default — never a silently forced layout (#2737 review).
         try:
             default_per_handle_home = await asyncio.to_thread(
                 state.default_per_handle_home
             )
         except (httpx.HTTPError, OSError, ValueError) as exc:
             logger.debug("Could not fetch home-layout default: %s", exc)
-            default_per_handle_home = True
+            default_per_handle_home = None
         self.app.push_screen(
             CreateWorkspaceScreen(
                 allowed=allowed,

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -131,7 +131,6 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         "name",
         "image",
         "auto_start",
-        "per_handle_home",
         "nix",
         "mount_input",
         "env_input",
@@ -143,6 +142,7 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         "memory_limit",
         "pids_limit",
         "tmp_size",
+        "per_handle_home",
         "command",
         "health_check",
         "cancel",
@@ -242,11 +242,6 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                         Static("Image"), image_select, classes="field-row"
                     )
                     yield Checkbox("Auto start", id="auto_start")
-                    yield Checkbox(
-                        "Per-handle home (off = shared /home/klangk)",
-                        value=bool(self._default_per_handle_home),
-                        id="per_handle_home",
-                    )
                     yield Checkbox("Mount /nix dir", id="nix")
                 with TabPane("Mounts", id="mounts_pane"):
                     yield Static(
@@ -339,6 +334,11 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                         classes="field-row",
                     )
                 with TabPane("Advanced", id="advanced_pane"):
+                    yield Checkbox(
+                        "Per-handle home (off = shared /home/klangk)",
+                        value=bool(self._default_per_handle_home),
+                        id="per_handle_home",
+                    )
                     yield Horizontal(
                         Static("Command"),
                         Input(id="command"),
@@ -761,7 +761,6 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         "name",
         "image",
         "auto_start",
-        "per_handle_home",
         "nix",
         "mount_input",
         "env_input",
@@ -773,6 +772,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         "memory_limit",
         "pids_limit",
         "tmp_size",
+        "per_handle_home",
         "command",
         "health_check",
         "cancel",
@@ -886,11 +886,6 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                         "Auto start",
                         value=self._ws.auto_start,
                         id="auto_start",
-                    )
-                    yield Checkbox(
-                        "Per-handle home (off = shared /home/klangk)",
-                        value=self._per_handle_home,
-                        id="per_handle_home",
                     )
                     yield Checkbox(
                         "Mount /nix dir",
@@ -1009,6 +1004,11 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                         classes="field-row",
                     )
                 with TabPane("Advanced", id="advanced_pane"):
+                    yield Checkbox(
+                        "Per-handle home (off = shared /home/klangk)",
+                        value=self._per_handle_home,
+                        id="per_handle_home",
+                    )
                     yield Horizontal(
                         Static("Command"),
                         Input(

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -174,7 +174,7 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         default_allowed_domains: list[str] | None = None,
         default_rejected_domains: list[str] | None = None,
         nix_available: bool = False,
-        default_per_handle_home: bool = True,
+        default_per_handle_home: bool | None = None,
     ) -> None:
         super().__init__()
         self._allowed = list(allowed)
@@ -197,8 +197,10 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         # #2721: home-layout default (KLANGKD_PER_HANDLE_HOME) fetched by
         # the caller from /config, so the checkbox starts on the server's
         # default — an untouched form submits exactly what a silent POST
-        # would get.
-        self._default_per_handle_home = bool(default_per_handle_home)
+        # would get. None = unknown (fetch failed): the checkbox is hidden
+        # and the field omitted, so the server applies its own default —
+        # never a silently forced layout (#2737 review).
+        self._default_per_handle_home = default_per_handle_home
         if self._allowed:
             # Select tuples are (prompt, value). Prompts are rich Text so an
             # image name containing brackets can't trigger markup parsing.
@@ -241,10 +243,8 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                     )
                     yield Checkbox("Auto start", id="auto_start")
                     yield Checkbox(
-                        "Per-handle home"
-                        "  (private /home/<handle> per member;"
-                        " off = shared /home/klangk)",
-                        value=self._default_per_handle_home,
+                        "Per-handle home (off = shared /home/klangk)",
+                        value=bool(self._default_per_handle_home),
                         id="per_handle_home",
                     )
                     yield Checkbox("Mount /nix dir", id="nix")
@@ -365,6 +365,13 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         nix_cb = self.query_one("#nix", Checkbox)
         nix_cb.display = self._nix_available
         nix_cb.disabled = not self._nix_available
+        # The home-layout toggle is hidden when the deploy default is
+        # unknown (fetch failure): an offered choice we can't pre-reflect
+        # would pin a possibly-wrong value, so the field is omitted and
+        # the server applies its own default (#2737 review).
+        phh_cb = self.query_one("#per_handle_home", Checkbox)
+        phh_cb.display = self._default_per_handle_home is not None
+        phh_cb.disabled = self._default_per_handle_home is None
         self._skip_editors_on_tab()
         self._render_mounts()
         self._render_env()
@@ -595,9 +602,12 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
             self._allow_autostart
             and self.query_one("#auto_start", Checkbox).value
         )
-        # #2721: always sent — the checkbox's initial state IS the
-        # server default, so an untouched form submits it unchanged.
-        per_handle_home = self.query_one("#per_handle_home", Checkbox).value
+        # #2721: sent whenever the deploy default was known — the
+        # checkbox's initial state IS the server default, so an untouched
+        # form submits it unchanged. Unknown default (hidden checkbox):
+        # omitted, and the server applies its own.
+        phh_cb = self.query_one("#per_handle_home", Checkbox)
+        per_handle_home = phh_cb.value if phh_cb.display else None
         mounts = list(self._mounts) or None
         env = dict(self._env) or None
         allowed_domains = list(self._allowed_domains) or None
@@ -878,9 +888,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                         id="auto_start",
                     )
                     yield Checkbox(
-                        "Per-handle home"
-                        "  (private /home/<handle> per member;"
-                        " off = shared /home/klangk)",
+                        "Per-handle home (off = shared /home/klangk)",
                         value=self._per_handle_home,
                         id="per_handle_home",
                     )

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -131,6 +131,7 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         "name",
         "image",
         "auto_start",
+        "per_handle_home",
         "nix",
         "mount_input",
         "env_input",
@@ -173,6 +174,7 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         default_allowed_domains: list[str] | None = None,
         default_rejected_domains: list[str] | None = None,
         nix_available: bool = False,
+        default_per_handle_home: bool = True,
     ) -> None:
         super().__init__()
         self._allowed = list(allowed)
@@ -192,6 +194,11 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         self._rejected_domains: list[str] = list(
             default_rejected_domains or []
         )
+        # #2721: home-layout default (KLANGKD_PER_HANDLE_HOME) fetched by
+        # the caller from /config, so the checkbox starts on the server's
+        # default — an untouched form submits exactly what a silent POST
+        # would get.
+        self._default_per_handle_home = bool(default_per_handle_home)
         if self._allowed:
             # Select tuples are (prompt, value). Prompts are rich Text so an
             # image name containing brackets can't trigger markup parsing.
@@ -233,6 +240,13 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                         Static("Image"), image_select, classes="field-row"
                     )
                     yield Checkbox("Auto start", id="auto_start")
+                    yield Checkbox(
+                        "Per-handle home"
+                        "  (private /home/<handle> per member;"
+                        " off = shared /home/klangk)",
+                        value=self._default_per_handle_home,
+                        id="per_handle_home",
+                    )
                     yield Checkbox("Mount /nix dir", id="nix")
                 with TabPane("Mounts", id="mounts_pane"):
                     yield Static(
@@ -581,6 +595,9 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
             self._allow_autostart
             and self.query_one("#auto_start", Checkbox).value
         )
+        # #2721: always sent — the checkbox's initial state IS the
+        # server default, so an untouched form submits it unchanged.
+        per_handle_home = self.query_one("#per_handle_home", Checkbox).value
         mounts = list(self._mounts) or None
         env = dict(self._env) or None
         allowed_domains = list(self._allowed_domains) or None
@@ -606,6 +623,7 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                 rejected_domains,
                 settings,
                 egress_mode,
+                per_handle_home,
             ),
             exit_on_error=False,
         )
@@ -623,6 +641,7 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         rejected_domains,
         settings,
         egress_mode,
+        per_handle_home,
     ) -> None:
         try:
             ws = await asyncio.to_thread(
@@ -638,6 +657,7 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                 rejected_domains=rejected_domains,
                 settings=settings,
                 egress_mode=egress_mode,
+                per_handle_home=per_handle_home,
             )
         except AuthError:
             self.app.session_expired()
@@ -731,6 +751,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         "name",
         "image",
         "auto_start",
+        "per_handle_home",
         "nix",
         "mount_input",
         "env_input",
@@ -799,6 +820,9 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         # #2409: the workspace's egress mode, seeded for the Netfilter
         # picker. Falls back to the deploy default when unset.
         self._egress_mode: str = workspace.egress_mode or EGRESS_MODE_DEFAULT
+        # #2721: home layout, seeded from the workspace. Mutable (#2719):
+        # a flip applies from the next connect/start.
+        self._per_handle_home: bool = bool(workspace.per_handle_home)
         # In-place editor state (#1778): when set, the next Add *replaces*
         # the item at this index/key instead of appending. Cleared on Add.
         self._editing_mount: int | None = None
@@ -852,6 +876,13 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                         "Auto start",
                         value=self._ws.auto_start,
                         id="auto_start",
+                    )
+                    yield Checkbox(
+                        "Per-handle home"
+                        "  (private /home/<handle> per member;"
+                        " off = shared /home/klangk)",
+                        value=self._per_handle_home,
+                        id="per_handle_home",
                     )
                     yield Checkbox(
                         "Mount /nix dir",
@@ -1323,6 +1354,10 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         allowed_domains = list(self._allowed_domains) or None
         rejected_domains = list(self._rejected_domains) or None
         egress_mode = self.query_one("#egress_mode", Select).value
+        # #2721: home layout is mutable and applies from the next
+        # connect/start — never a restart-needed field (open sessions
+        # keep their layout until they end).
+        per_handle_home = self.query_one("#per_handle_home", Checkbox).value
         try:
             settings = _collect_settings(self)
         except ValueError as exc:
@@ -1352,6 +1387,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
             "allowed_domains": allowed_domains,
             "rejected_domains": rejected_domains,
             "egress_mode": egress_mode,
+            "per_handle_home": per_handle_home,
         }
         if settings is not None:
             body["settings"] = settings

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -334,10 +334,19 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                         classes="field-row",
                     )
                 with TabPane("Advanced", id="advanced_pane"):
-                    yield Checkbox(
-                        "Per-handle home (off = shared /home/klangk)",
-                        value=bool(self._default_per_handle_home),
-                        id="per_handle_home",
+                    yield Horizontal(
+                        Static("Home layout"),
+                        Checkbox(
+                            "",
+                            value=bool(self._default_per_handle_home),
+                            id="per_handle_home",
+                        ),
+                        classes="field-row",
+                    )
+                    yield Static(
+                        "On = private /home/<handle> per member; "
+                        "off = shared /home/klangk",
+                        classes="editor-label",
                     )
                     yield Horizontal(
                         Static("Command"),
@@ -1004,10 +1013,19 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                         classes="field-row",
                     )
                 with TabPane("Advanced", id="advanced_pane"):
-                    yield Checkbox(
-                        "Per-handle home (off = shared /home/klangk)",
-                        value=self._per_handle_home,
-                        id="per_handle_home",
+                    yield Horizontal(
+                        Static("Home layout"),
+                        Checkbox(
+                            "",
+                            value=self._per_handle_home,
+                            id="per_handle_home",
+                        ),
+                        classes="field-row",
+                    )
+                    yield Static(
+                        "On = private /home/<handle> per member; "
+                        "off = shared /home/klangk",
+                        classes="editor-label",
                     )
                     yield Horizontal(
                         Static("Command"),

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -337,16 +337,11 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
                     yield Horizontal(
                         Static("Home layout"),
                         Checkbox(
-                            "",
+                            "per-handle (off = shared home)",
                             value=bool(self._default_per_handle_home),
                             id="per_handle_home",
                         ),
                         classes="field-row",
-                    )
-                    yield Static(
-                        "On = private /home/<handle> per member; "
-                        "off = shared /home/klangk",
-                        classes="editor-label",
                     )
                     yield Horizontal(
                         Static("Command"),
@@ -1016,16 +1011,11 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
                     yield Horizontal(
                         Static("Home layout"),
                         Checkbox(
-                            "",
+                            "per-handle (off = shared home)",
                             value=self._per_handle_home,
                             id="per_handle_home",
                         ),
                         classes="field-row",
-                    )
-                    yield Static(
-                        "On = private /home/<handle> per member; "
-                        "off = shared /home/klangk",
-                        classes="editor-label",
                     )
                     yield Horizontal(
                         Static("Command"),

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -329,6 +329,7 @@ class TuiState:
         rejected_domains: list[str] | None = None,
         settings: dict | None = None,
         egress_mode: str | None = None,
+        per_handle_home: bool | None = None,
     ) -> Workspace:
         return self.client().create_workspace(
             name,
@@ -342,6 +343,7 @@ class TuiState:
             rejected_domains=rejected_domains,
             settings=settings,
             egress_mode=egress_mode,
+            per_handle_home=per_handle_home,
         )
 
     def update_workspace(self, workspace_id: str, **fields) -> None:
@@ -423,6 +425,24 @@ class TuiState:
         # Strict: the server serializes a Python bool, so require True exactly
         # (a string like "false" must not coerce to True).
         return config.get("allow_autostart") is True
+
+    def default_per_handle_home(self) -> bool:
+        """Deploy default home layout for NEW workspaces (#2721).
+
+        ``default_per_handle_home`` in ``/api/v1/config``
+        (KLANGKD_PER_HANDLE_HOME). The create form's checkbox pre-reflects
+        this so an untouched form submits the server's default. Defaults
+        to True (per-handle) on any failure — the server's own default, so
+        a config-fetch hiccup cannot silently flip the layout.
+        """
+        url = self.current_url()
+        if url is None:
+            return True
+        config = fetch_config(url)
+        if not isinstance(config, dict):
+            return True
+        val = config.get("default_per_handle_home")
+        return True if val is None else bool(val)
 
     # --- login arms ---
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -426,21 +426,27 @@ class TuiState:
         # (a string like "false" must not coerce to True).
         return config.get("allow_autostart") is True
 
-    def default_per_handle_home(self) -> bool:
+    def default_per_handle_home(self) -> bool | None:
         """Deploy default home layout for NEW workspaces (#2721).
 
         ``default_per_handle_home`` in ``/api/v1/config``
         (KLANGKD_PER_HANDLE_HOME). The create form's checkbox pre-reflects
-        this so an untouched form submits the server's default. Defaults
-        to True (per-handle) on any failure — the server's own default, so
-        a config-fetch hiccup cannot silently flip the layout.
+        this so an untouched form submits the server's default.
+
+        Returns ``None`` when the default is UNKNOWN (no server / fetch
+        failure): the caller then hides the checkbox and OMITS the field,
+        so the server applies its own default — a config hiccup can
+        never silently force a layout onto a shared-home deploy (#2737
+        review). A fetched config that merely LACKS the key (old server)
+        returns ``True`` — per-handle is the historical behavior those
+        servers implement.
         """
         url = self.current_url()
         if url is None:
-            return True
+            return None
         config = fetch_config(url)
         if not isinstance(config, dict):
-            return True
+            return None
         val = config.get("default_per_handle_home")
         return True if val is None else bool(val)
 

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -183,6 +183,15 @@ def create(
         "--auto-start",
         help="Start container automatically on server boot",
     ),
+    per_handle_home: bool | None = typer.Option(
+        None,
+        "--per-handle-home/--shared-home",
+        help=(
+            "Home layout: per-handle gives each member a private "
+            "/home/<handle>; shared puts everyone in /home/klangk. "
+            "Omitted = server default"
+        ),
+    ),
     health_check: str | None = typer.Option(
         None,
         "--health-check",
@@ -272,6 +281,7 @@ def create(
             allowed_domains=allow or None,
             rejected_domains=reject or None,
             settings=settings,
+            per_handle_home=per_handle_home,
         )
     except httpx.HTTPStatusError as exc:
         detail = exc.response.json().get("detail", exc.response.text)

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1250,6 +1250,51 @@ class TestKlangkClient:
             client.create_workspace("n2")
             assert "egress_mode" not in client.post.call_args.kwargs["json"]
 
+    def test_create_workspace_includes_per_handle_home(self):
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "id": "ws-1",
+            "name": "n",
+            "created_at": "x",
+        }
+        with patch.object(client, "post", return_value=mock_resp):
+            # Explicit choice is sent either way (#2721).
+            client.create_workspace("n", per_handle_home=False)
+            assert (
+                client.post.call_args.kwargs["json"]["per_handle_home"]
+                is False
+            )
+            client.create_workspace("n2", per_handle_home=True)
+            assert (
+                client.post.call_args.kwargs["json"]["per_handle_home"] is True
+            )
+            # Omitted when not provided (server applies the deploy default).
+            client.create_workspace("n3")
+            assert (
+                "per_handle_home" not in client.post.call_args.kwargs["json"]
+            )
+
+    def test_workspace_from_json_parses_per_handle_home(self):
+        # The layout is editable (#2719) and seeded into edit surfaces, so
+        # list/get responses must carry it through (#2721). Absent key =
+        # per-handle (the server default) for older servers.
+        w = KlangkClient._workspace_from_json(
+            {
+                "id": "ws-1",
+                "name": "n",
+                "created_at": "x",
+                "per_handle_home": False,
+            },
+            shared=False,
+        )
+        assert w.per_handle_home is False
+        w2 = KlangkClient._workspace_from_json(
+            {"id": "ws-1", "name": "n", "created_at": "x"},
+            shared=False,
+        )
+        assert w2.per_handle_home is True
+
     def test_create_workspace_includes_allowed_domains(self):
         client = KlangkClient("http://test:8995", "token")
         mock_resp = MagicMock(status_code=200)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -2537,6 +2537,7 @@ class TestMainCLI:
             allowed_domains=None,
             rejected_domains=None,
             settings=None,
+            per_handle_home=None,
         )
 
     def test_create_with_command_flag(self, logged_in_cfg, monkeypatch):
@@ -2565,6 +2566,7 @@ class TestMainCLI:
             allowed_domains=None,
             rejected_domains=None,
             settings=None,
+            per_handle_home=None,
         )
 
     def test_create_with_invalid_env_flag(self, logged_in_cfg, monkeypatch):
@@ -2616,6 +2618,7 @@ class TestMainCLI:
             allowed_domains=["github.com:443", "pypi.org"],
             rejected_domains=None,
             settings=None,
+            per_handle_home=None,
         )
 
     def test_create_with_reject_flag(self, logged_in_cfg, monkeypatch):
@@ -2648,6 +2651,7 @@ class TestMainCLI:
             allowed_domains=None,
             rejected_domains=["evil.example.com"],
             settings=None,
+            per_handle_home=None,
         )
 
     def test_create_with_reject_cidr_rejected(
@@ -2712,6 +2716,7 @@ class TestMainCLI:
                 "memory_limit": "4g",
                 "pids_limit": 256,
             },
+            per_handle_home=None,
         )
 
     def test_create_with_invalid_allow_flag(self, logged_in_cfg, monkeypatch):
@@ -3228,6 +3233,70 @@ class TestMainCLI:
 
         body = client.put.call_args[1]["json"]
         assert body["auto_start"] is True
+
+    def test_create_with_home_layout_flags(self, logged_in_cfg, monkeypatch):
+        # #2721: --per-handle-home / --shared-home thread the home layout
+        # through to create_workspace; omitted = None (deploy default).
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="new-id", name="ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client = MagicMock()
+        client.create_workspace.return_value = ws
+        monkeypatch.setattr(context_mod, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["create", "ws", "--shared-home"])
+        assert result.exit_code == 0
+        client.create_workspace.assert_called_once_with(
+            "ws",
+            image=None,
+            service_command=None,
+            auto_start=False,
+            mounts=None,
+            env=None,
+            health_check=None,
+            allowed_domains=None,
+            rejected_domains=None,
+            settings=None,
+            per_handle_home=False,
+        )
+        client.create_workspace.reset_mock()
+        client.create_workspace.return_value = ws
+        result = runner.invoke(main.app, ["create", "ws", "--per-handle-home"])
+        assert result.exit_code == 0
+        assert (
+            client.create_workspace.call_args.kwargs["per_handle_home"] is True
+        )
+
+    def test_edit_with_home_layout_flag(self, logged_in_cfg, monkeypatch):
+        # #2721: `klangk edit --shared-home` flips the layout; the flip
+        # applies from the next connect/start (no restart prompt).
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(context_mod, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app, ["edit", "my-ws", "--shared-home"]
+            )
+            assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["per_handle_home"] is False
 
     def test_edit_with_settings_flags(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -837,6 +837,30 @@ def test_allow_autostart(monkeypatch, redirect_xdg):
     assert TuiState().allow_autostart() is False
 
 
+def test_default_per_handle_home(monkeypatch, redirect_xdg):
+    # #2721: the create form pre-reflects the deploy default; the safe
+    # fallback on any fetch failure is True (per-handle, the server's own
+    # default) — a config hiccup can't silently flip the layout.
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"default_per_handle_home": False},
+    )
+    assert TuiState("https://x.example").default_per_handle_home() is False
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"default_per_handle_home": True},
+    )
+    assert TuiState("https://x.example").default_per_handle_home() is True
+    # missing field / non-dict / no server -> safe default True
+    monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: {})
+    assert TuiState("https://x.example").default_per_handle_home() is True
+    monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
+    assert TuiState("https://x.example").default_per_handle_home() is True
+    assert TuiState().default_per_handle_home() is True
+
+
 def test_default_allowed_domains(monkeypatch, redirect_xdg):
     # netfilter_default_domains is auth-gated on /api/v1/config (absent from
     # the pre-auth payload), so default_allowed_domains() reads it via the
@@ -2274,6 +2298,7 @@ def test_tui_state_workspace_methods(monkeypatch, redirect_xdg):
         rejected_domains=None,
         settings=None,
         egress_mode=None,
+        per_handle_home=None,
     )
     fake.list_images.assert_called_once_with()
 
@@ -8050,6 +8075,7 @@ def _create_state(create=None, **extra):
         },
         allow_autostart=lambda: True,
         default_allowed_domains=lambda: [],
+        default_per_handle_home=lambda: True,
         # The create flow opens the new workspace's detail screen, whose
         # _mount_async calls find_workspace — stub it so the flow test
         # doesn't make a real (timing-out) HTTP call (#1989).
@@ -8294,6 +8320,42 @@ async def test_create_screen_submit_omits_default_image(monkeypatch):
         assert captured["k"]["env"] is None
 
 
+async def test_create_screen_per_handle_home_default_and_toggle(monkeypatch):
+    """#2721: the create form's Per-handle home checkbox pre-reflects the
+    deploy default (KLANGKD_PER_HANDLE_HOME) and the toggle reaches the
+    create request — an untouched form submits the server default."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    captured = {}
+
+    def create(name, **k):
+        captured["k"] = k
+        return _wsobj(name)
+
+    app = KlangkApp(
+        _create_state(create=create, default_per_handle_home=lambda: False)
+    )
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        # Pre-reflects the deploy default (shared here).
+        assert cs.query_one("#per_handle_home", Checkbox).value is False
+        cs.query_one("#name").value = "ws"
+        cs._create()
+        await app.workers.wait_for_complete()
+        assert captured["k"]["per_handle_home"] is False
+        # Toggle to per-handle; the flip reaches the request.
+        cs.query_one("#per_handle_home", Checkbox).value = True
+        cs._create()
+        await app.workers.wait_for_complete()
+        assert captured["k"]["per_handle_home"] is True
+
+
 async def test_create_screen_submit_custom_fields(monkeypatch):
     async def noop(*a, **k):
         return None
@@ -8403,6 +8465,7 @@ async def test_create_screen_images_unavailable(monkeypatch):
             list_images=boom,
             allow_autostart=boom,
             default_allowed_domains=boom,
+            default_per_handle_home=boom,
         )
     )
     async with app.run_test(size=(140, 40)) as pilot:
@@ -8914,6 +8977,40 @@ async def test_edit_screen_egress_mode_pre_populates_and_saves(monkeypatch):
         await app.workers.wait_for_complete()
         assert captured["egress_mode"] == "allow"
         # Not running => no restart offer.
+        assert not isinstance(app.screen, ConfirmScreen)
+
+
+async def test_edit_screen_per_handle_home_pre_populates_and_saves(
+    monkeypatch,
+):
+    """#2721: the edit form seeds the checkbox from the workspace's home
+    layout and sends a flip through the update body — without a restart
+    offer (a flip applies from the next connect/start, #2719)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    captured = {}
+
+    def update(wid, **f):
+        captured["id"] = wid
+        captured.update(f)
+
+    ws = _wsobj("alpha", image="base", per_handle_home=True, running=True)
+    app = KlangkApp(_edit_state(ws, update=update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # Seeded from the workspace (per-handle).
+        assert es.query_one("#per_handle_home", Checkbox).value is True
+        es.query_one("#per_handle_home", Checkbox).value = False
+        es._save()
+        await app.workers.wait_for_complete()
+        assert captured["per_handle_home"] is False
+        # Running workspace, but a layout flip applies from the next
+        # connect — never a restart-needed field.
         assert not isinstance(app.screen, ConfirmScreen)
 
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -838,9 +838,11 @@ def test_allow_autostart(monkeypatch, redirect_xdg):
 
 
 def test_default_per_handle_home(monkeypatch, redirect_xdg):
-    # #2721: the create form pre-reflects the deploy default; the safe
-    # fallback on any fetch failure is True (per-handle, the server's own
-    # default) — a config hiccup can't silently flip the layout.
+    # #2721: the create form pre-reflects the deploy default. Unknown
+    # (fetch failure / no server) is None — the caller then hides the
+    # checkbox and omits the field so the server applies its own default
+    # (#2737 review). A fetched config that merely lacks the key is an
+    # OLD server, whose behavior is per-handle (True).
     monkeypatch.setattr(
         tui_state_mod,
         "fetch_config",
@@ -853,12 +855,13 @@ def test_default_per_handle_home(monkeypatch, redirect_xdg):
         lambda url: {"default_per_handle_home": True},
     )
     assert TuiState("https://x.example").default_per_handle_home() is True
-    # missing field / non-dict / no server -> safe default True
+    # missing field (old server) -> per-handle
     monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: {})
     assert TuiState("https://x.example").default_per_handle_home() is True
+    # non-dict / no server -> unknown (None)
     monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
-    assert TuiState("https://x.example").default_per_handle_home() is True
-    assert TuiState().default_per_handle_home() is True
+    assert TuiState("https://x.example").default_per_handle_home() is None
+    assert TuiState().default_per_handle_home() is None
 
 
 def test_default_allowed_domains(monkeypatch, redirect_xdg):
@@ -8349,11 +8352,53 @@ async def test_create_screen_per_handle_home_default_and_toggle(monkeypatch):
         cs._create()
         await app.workers.wait_for_complete()
         assert captured["k"]["per_handle_home"] is False
-        # Toggle to per-handle; the flip reaches the request.
-        cs.query_one("#per_handle_home", Checkbox).value = True
+
+    # Fresh app for the toggle case (the first form dismissed on create).
+    app2 = KlangkApp(_create_state(create=create))
+    async with app2.run_test(size=(140, 40)) as pilot:
+        app2.screen.action_create()
+        await app2.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app2.screen
+        assert cs.query_one("#per_handle_home", Checkbox).value is True
+        cs.query_one("#per_handle_home", Checkbox).value = False
+        cs.query_one("#name").value = "ws2"
+        cs._create()
+        await app2.workers.wait_for_complete()
+        assert captured["k"]["per_handle_home"] is False
+
+
+async def test_create_screen_per_handle_home_unknown_omits(monkeypatch):
+    """#2737 review: when the deploy default is UNKNOWN (fetch failure),
+    the checkbox is hidden and the field omitted — the server applies
+    its own default instead of a possibly-wrong forced value."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    captured = {}
+
+    def create(name, **k):
+        captured["k"] = k
+        return _wsobj(name)
+
+    app = KlangkApp(
+        _create_state(create=create, default_per_handle_home=lambda: None)
+    )
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        cs = app.screen
+        cb = cs.query_one("#per_handle_home", Checkbox)
+        assert cb.display is False  # unknown default -> hidden
+        cs.query_one("#name").value = "ws"
         cs._create()
         await app.workers.wait_for_complete()
-        assert captured["k"]["per_handle_home"] is True
+        # None = omit: the client drops the key so the server default
+        # applies (asserted at the client level in test_cli.py).
+        assert captured["k"]["per_handle_home"] is None
 
 
 async def test_create_screen_submit_custom_fields(monkeypatch):
@@ -8476,10 +8521,14 @@ async def test_create_screen_images_unavailable(monkeypatch):
         assert cs._allowed == []
         assert cs._allowed_domains == []  # fetch failed -> empty seed
         assert cs.query_one("#auto_start", Checkbox).display is False
+        # Fetch failed -> layout default unknown -> checkbox hidden and
+        # the field omitted (#2737 review).
+        assert cs.query_one("#per_handle_home", Checkbox).display is False
         cs.query_one("#name").value = "ws"
         cs._create()
         await app.workers.wait_for_complete()
         assert captured["k"]["image"] is None  # omitted
+        assert captured["k"]["per_handle_home"] is None  # omitted too
 
 
 async def test_create_screen_cancel_button(monkeypatch):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -359,6 +359,20 @@ class TestConfig:
         assert "login_banner" in data
         assert "instance_id" in data
 
+    async def test_get_config_advertises_per_handle_home_default(
+        self, client, app
+    ):
+        # #2721: the create surfaces pre-reflect the deploy's home-layout
+        # default (KLANGKD_PER_HANDLE_HOME) so an untouched form submits
+        # exactly what a silent POST would get. Present pre-auth (the TUI
+        # reads /config before login, like allow_autostart).
+        app.state.settings.per_handle_home = False
+        resp = await client.get("/api/v1/config")
+        assert resp.json()["default_per_handle_home"] is False
+        app.state.settings.per_handle_home = True
+        resp = await client.get("/api/v1/config")
+        assert resp.json()["default_per_handle_home"] is True
+
     async def test_get_config_omits_netfilter_fields_when_unauthenticated(
         self, client, app
     ):


### PR DESCRIPTION
Implements #2721 (= #2169 chunk 3, the first user-visible change): the home layout (`per_handle_home`, #2719) is choosable on **all three create surfaces — and their edit forms**.

## What changed

**Server**
- `/api/v1/config` now carries `default_per_handle_home` (the `KLANGKD_PER_HANDLE_HOME` deploy default), pre-auth — the TUI reads `/config` before login exactly like `allow_autostart`.

**Web**
- Create dialog (General section): a **Per-handle home** checkbox, pre-reflecting the deploy default; always submitted, so an untouched form equals a silent POST.
- Settings tab: same checkbox seeded from the workspace; a flip is sent in the save body.

**TUI**
- Create screen: Per-handle home checkbox on the General pane, default fetched from `/config` (safe fallback: per-handle — the server default — on any fetch failure).
- Edit screen: seeded from the workspace, sent in the PUT body. Never a restart-needed field.

**CLI**
- `klangk create --per-handle-home/--shared-home` (omitted = server default).
- `klangk edit --per-handle-home/--shared-home` — a flip applies from the next connect/start.
- `Workspace` model + JSON parse carry `per_handle_home` (absent = `True`, the server default).

## Semantics

- Create forms pre-reflect the server default (`default_per_handle_home`), so default state matches server config — the acceptance criterion.
- Edit forms seed from the workspace's stored layout; a flip applies from the **next connect/start** (#2719) — open sessions keep their layout until they end, so it is never a restart-prompt field.
- Docs: new "Home directory layout" section in `features/workspaces.md`; changelog entry under Unreleased/Added.

## Tests

- Server: `/config` advertises the default (both values).
- CLI: client includes/omits the field, `_workspace_from_json` parses it; `create --shared-home`/`--per-handle-home` and `edit --shared-home` thread through.
- TUI: create checkbox pre-reflects the deploy default and the toggle reaches the request; edit seeds + saves a flip without a restart offer; `default_per_handle_home()` fallbacks.
- Flutter: config parse (absent → true), dialog default + always-sent, panel seed + flip save.
- Full suites green: Python 5510 passed @ 100% coverage (`-n auto`, CI invocation); `flutter test --coverage` 1056 passed.

Closes #2721
