### PR TITLE
Fix service-command fire loss and E2E budget flakes (#2740)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1298,6 +1298,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   fresh container's registry state could be dropped and its network
   sidecar torn down. Death teardown is now keyed to the dead container
   id, so a workspace re-bound to a fresh container is left untouched.
+- **Service commands now recover from interrupted startup (#2740).**
+  A podman exec killed by CPU load (or a client disconnect) during the
+  service-command fire could leave a half-created `service-cmd` tmux
+  window that silently suppressed the workspace's service command until
+  the container was recreated. Any such half-fire is now cleaned up and
+  retried on the next terminal start.
 - **Status WebSocket follows a server switch (#2029).** The TUI's live
   status connection kept dialing the previous server after switching
   servers, producing a false "server down" overlay. It now re-reads the

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -146,7 +146,9 @@ export async function loginViaUI(page: Page, email: string, password: string) {
   await waitForFlutter(page);
   await loginOnCurrentPage(page, email, password);
 
-  await expect(page).toHaveTitle(/Workspaces/i, { timeout: 10_000 });
+  // 30s: slow CI runners exceed 10s between click and the Workspaces
+  // title flip; the flake class is load, not logic (#485/#469, #2740).
+  await expect(page).toHaveTitle(/Workspaces/i, { timeout: 30_000 });
 }
 
 /** Like loginViaUI but does not wait for Workspaces — use when

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -182,6 +182,11 @@ class ContainerRegistry(NetworkSidecarMixin):
         self.draining: bool = False
         self._workspace_locks: dict[str, asyncio.Lock] = {}
         self._service_session_locks: dict[str, asyncio.Lock] = {}
+        # Containers whose service-command fire half-completed and whose
+        # cleanup ALSO failed, leaving a command-less ``service-cmd``
+        # window behind (#2740). Keyed like the locks above; cleared on
+        # successful fire/retry, cleanup, and container teardown.
+        self._service_fire_pending: set[str] = set()
         self.on_workspace_killed = None
         self.on_container_status_changed = None
 
@@ -390,6 +395,27 @@ class ContainerRegistry(NetworkSidecarMixin):
             del self._service_session_locks[cid]
         return len(stale)
 
+    def mark_service_fire_pending(self, container_id: str) -> None:
+        """Record a half-completed service-command fire (#2740).
+
+        Set when the ``service-cmd`` window exists but the command may
+        never have been typed into it (killed/timed-out send-keys whose
+        kill-window cleanup also failed, or a cancellation mid-sequence).
+        The next :meth:`terminal.ensure_service_session` call sees the
+        window plus this flag and retries only the send, instead of
+        suppressing the fire forever on the window-exists check.
+        """
+        self._service_fire_pending.add(container_id)
+
+    def clear_service_fire_pending(self, container_id: str) -> None:
+        """Drop the pending-fire marker (fire/retry/cleanup succeeded,
+        or the container was torn down). Safe when not set."""
+        self._service_fire_pending.discard(container_id)
+
+    def service_fire_pending(self, container_id: str) -> bool:
+        """True if a service-command fire is awaiting a send retry."""
+        return container_id in self._service_fire_pending
+
     def _get_workspace_lock(self, workspace_id: str) -> asyncio.Lock:
         """Get or create a per-workspace lock for container operations."""
         if workspace_id not in self._workspace_locks:
@@ -524,6 +550,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                 # Drop the per-container service-firing lock (#1188), then
                 # sweep any other entries orphaned by container churn (#1351).
                 self.clear_service_session_lock(state.container_id)
+                self.clear_service_fire_pending(state.container_id)
                 self.prune_service_session_locks(set(self._cid_to_wsid))
 
     # --- Proxy: PortAllocator ---
@@ -1064,6 +1091,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                     self.states.pop(workspace_id, None)
                     self._cid_to_wsid.pop(cid, None)
                 self.clear_service_session_lock(cid)
+                self.clear_service_fire_pending(cid)
                 self._notify_status_changed(workspace_id, False)
             finally:
                 self.stopping.discard(workspace_id)
@@ -1679,6 +1707,7 @@ class ContainerRegistry(NetworkSidecarMixin):
             # re-bind that popped this container's mapping before teardown)
             # (#1351).
             self.clear_service_session_lock(container_id)
+            self.clear_service_fire_pending(container_id)
             self.prune_service_session_locks(set(self._cid_to_wsid))
             # Gone via this call AND (untracked, or our registry state torn
             # down — i.e. not left alone by the rebind guard).

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -9,6 +9,7 @@ podman with ``SIGWINCH`` so it resizes the container PTY.
 
 import asyncio
 import codecs
+import contextlib
 import fcntl
 import re
 import logging
@@ -94,6 +95,17 @@ SERVICE_CMD_WINDOW = "service-cmd"
 # ``pi --mode rpc`` subprocess lifecycle (it survives the agent process
 # dying because it is just a tmux session) (#1133 D6).
 SERVICE_SESSION = "service"
+
+# Per-exec budget for the tmux control-plane calls in the service-command
+# fire sequence (has-session / list-windows / new-window / send-keys /
+# kill-window). These are cheap when the host is healthy (0.1-0.2s) but
+# pure control-plane -- nothing user-visible blocks on them being fast --
+# so the old 5s budget only ever fired as a false kill under runner CPU
+# saturation (a killed exec returns rc=-1 from ``Podman.run``, the
+# container side may or may not have completed). 15s keeps a bound on a
+# wedged runtime while leaving headroom for concurrent E2E jobs on a
+# shared host (#2740).
+SERVICE_EXEC_TIMEOUT = 15.0
 
 
 def should_fire_service_command(
@@ -311,7 +323,7 @@ class Terminal:
                 container_id,
                 ["tmux", "has-session", "-t", session_name],
                 user=CONTAINER_USER,
-                timeout=5,
+                timeout=SERVICE_EXEC_TIMEOUT,
             )
         except Exception:
             return False
@@ -319,8 +331,8 @@ class Terminal:
 
     async def service_cmd_window_exists(
         self, container_id: str, session_name: str
-    ) -> bool:
-        """Return True if the ``service-cmd`` window exists in *session_name*.
+    ) -> bool | None:
+        """Return whether the ``service-cmd`` window exists in *session_name*.
 
         This is the ephemeral "has the service command already fired in
         THIS container" check (#1033). Unlike ``setup_state`` it is
@@ -328,6 +340,14 @@ class Terminal:
         re-fires the service command for an already-``complete`` workspace.
         tmux allows duplicate window names, so we must inspect the list
         rather than rely on ``new-window`` failing.
+
+        Tri-state (#2740): ``True``/``False`` when tmux answered (rc=0),
+        ``None`` when the check itself failed (exec killed under load,
+        launch failure). A killed exec is NOT evidence the window is
+        absent -- assuming "absent" fired a duplicate ``service-cmd``
+        window and re-sent the command into a service that may already be
+        running. Callers treat ``None`` as "unknown, skip this round" and
+        retry on the next terminal_start/reconnect.
         """
         try:
             rc, stdout, _ = await self.podman.exec_container(
@@ -341,12 +361,12 @@ class Terminal:
                     "#{window_name}",
                 ],
                 user=CONTAINER_USER,
-                timeout=5,
+                timeout=SERVICE_EXEC_TIMEOUT,
             )
         except Exception:
-            return False
+            return None
         if rc != 0:
-            return False
+            return None
         return SERVICE_CMD_WINDOW in {
             line.strip() for line in stdout.splitlines() if line.strip()
         }
@@ -451,6 +471,58 @@ class Terminal:
                 container_id,
             )
 
+    async def kill_service_cmd_window(self, container_id: str) -> bool:
+        """Kill the ``service:service-cmd`` window; True iff it died.
+
+        The #1186 cleanup, factored out so every failure mode in the fire
+        sequence (failed new-window, failed send-keys, cancellation) shares
+        it. Best-effort: returns False on a failed/killed exec or launch
+        error, leaving the caller to mark the fire pending (#2740).
+        """
+        try:
+            rc, _, _ = await self.podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "kill-window",
+                    "-t",
+                    f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
+                ],
+                user=CONTAINER_USER,
+                timeout=SERVICE_EXEC_TIMEOUT,
+            )
+        except Exception:
+            return False
+        return rc == 0
+
+    async def _send_service_command(
+        self, container_id: str, service_command: str
+    ) -> bool:
+        """send-keys the service command into ``service:service-cmd``.
+
+        Shared by the fresh-fire path (window just created) and the
+        pending-retry path (window survived a failed fire). Returns True
+        only on a clean rc=0 exec -- a killed exec (rc=-1 under the
+        #2740 load budget) means the send state is UNKNOWN, not OK.
+        """
+        try:
+            rc, _, _ = await self.podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "send-keys",
+                    "-t",
+                    f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
+                    service_command,
+                    "Enter",
+                ],
+                user=CONTAINER_USER,
+                timeout=SERVICE_EXEC_TIMEOUT,
+            )
+        except Exception:
+            return False
+        return rc == 0
+
     async def ensure_service_session(
         self,
         container_id: str,
@@ -489,6 +561,26 @@ class Terminal:
         existence check before either created the window, producing two
         duplicate-named ``service-cmd`` windows (tmux allows duplicate
         names), leaving later ``send-keys -t service:service-cmd`` ambiguous.
+
+        Recovery (#2740): ``Podman.exec_container`` runs ``check=False``, so
+        a timed-out exec returns ``rc=-1`` instead of raising -- the old
+        ``except Exception`` guards never fired for timeouts, and a killed
+        ``send-keys`` was mistaken for success (window exists, command never
+        typed -> every later fire suppressed forever). Every step now checks
+        rc, and any failure lands in a recoverable state:
+
+        - failed new-window or send-keys: kill the half-created window so
+          the next ``terminal_start`` re-runs the whole sequence (#1186's
+          cleanup extended to the earlier steps).
+        - cleanup kill-window also fails: mark the fire pending on the
+          registry; the next call sees the window + pending flag and
+          retries ONLY the send into the surviving window.
+        - unknown window-exists (killed list-windows): skip this round;
+          the next ``terminal_start`` retries the check.
+        - cancellation (client WS drop) mid-sequence: mark pending, run
+          the cleanup, re-raise. A re-run of an already-typed command is
+          possible on the retry path; that is the accepted cost versus
+          permanently suppressing the service.
         """
         # Hold the per-container lock across the entire read-modify-write so
         # a concurrent caller (boot vs first terminal_start, owner vs
@@ -499,85 +591,128 @@ class Terminal:
             await self._ensure_tmux_session(
                 container_id, SERVICE_SESSION, user_home=SHARED_HOME
             )
-            if not (
-                should_fire_service_command(service_command, setup_state)
-            ) or await self.service_cmd_window_exists(
+            if not should_fire_service_command(service_command, setup_state):
+                return
+            exists = await self.service_cmd_window_exists(
                 container_id, SERVICE_SESSION
-            ):
-                return
-            try:
-                await self.podman.exec_container(
+            )
+            if exists is None:
+                # The check itself failed (killed exec under load): the
+                # window state is UNKNOWN. Firing here could duplicate the
+                # window and re-send into a running service; skipping keeps
+                # the exactly-once invariant and the next terminal_start
+                # retries the check (#2740).
+                logger.debug(
+                    "service-cmd window state unknown for %s; "
+                    "deferring fire to next terminal_start",
                     container_id,
-                    [
-                        "tmux",
-                        "new-window",
-                        "-d",
-                        "-t",
-                        SERVICE_SESSION,
-                        "-n",
-                        SERVICE_CMD_WINDOW,
-                    ],
-                    user=CONTAINER_USER,
-                    timeout=5,
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to create %s window in %s",
-                    SERVICE_CMD_WINDOW,
-                    SERVICE_SESSION,
                 )
                 return
-            # The new window's shell needs a moment to source .profile / .bashrc
-            # before it can resolve PATH-dependent commands (nvm, openclaw, ...).
-            # Same race as #1030.
-            await asyncio.sleep(1)
+            if exists:
+                if self.registry.service_fire_pending(container_id):
+                    # A previous fire half-completed and its cleanup failed:
+                    # the window exists but the command was (probably)
+                    # never typed. Retry only the send -- recreating the
+                    # window would lose the settled shell (#2740).
+                    if await self._send_service_command(
+                        container_id, service_command
+                    ):
+                        self.registry.clear_service_fire_pending(container_id)
+                        self.registry.mark_service_started(container_id)
+                    else:
+                        logger.warning(
+                            "Service command retry failed for %s; "
+                            "will retry on next terminal_start",
+                            container_id,
+                        )
+                return
+            # Fresh fire. Any stale pending flag (e.g. the window died some
+            # other way) is moot once this sequence runs.
+            self.registry.clear_service_fire_pending(container_id)
             try:
-                await self.podman.exec_container(
-                    container_id,
-                    [
-                        "tmux",
-                        "send-keys",
-                        "-t",
-                        f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
-                        service_command,
-                        "Enter",
-                    ],
-                    user=CONTAINER_USER,
-                    timeout=5,
-                )
-                # The service command just fired -- reset the health-check
-                # startup-grace anchor so the monitor gives the service time
-                # to boot before a failing poll can flag it unhealthy (e.g.
-                # a gateway that isn't accepting connections yet).  Set only
-                # on a successful send-keys; the except path below never
-                # launched the command, so it must not start the grace
-                # window.
-                self.registry.mark_service_started(container_id)
-            except Exception:
-                logger.warning(
-                    "Failed to send service command to %s", SERVICE_SESSION
-                )
-                # The window was created above but we never typed the command
-                # into it. Kill it so the next fire re-runs the whole sequence
-                # instead of no-op'ing forever on the half-created window (#1186).
                 try:
-                    await self.podman.exec_container(
+                    rc, _, _ = await self.podman.exec_container(
                         container_id,
                         [
                             "tmux",
-                            "kill-window",
+                            "new-window",
+                            "-d",
                             "-t",
-                            f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
+                            SERVICE_SESSION,
+                            "-n",
+                            SERVICE_CMD_WINDOW,
                         ],
                         user=CONTAINER_USER,
-                        timeout=5,
+                        timeout=SERVICE_EXEC_TIMEOUT,
                     )
                 except Exception:
+                    rc = -1
+                if rc != 0:
                     logger.warning(
-                        "Failed to clean up %s window in %s",
+                        "Failed to create %s window in %s",
                         SERVICE_CMD_WINDOW,
                         SERVICE_SESSION,
                     )
+                    # The exec may have been killed client-side while the
+                    # container side created the window -- clean it up so
+                    # the next fire re-runs the whole sequence instead of
+                    # suppressing on a command-less window (#2740).
+                    self.registry.mark_service_fire_pending(container_id)
+                    if await self.kill_service_cmd_window(container_id):
+                        self.registry.clear_service_fire_pending(container_id)
+                    else:
+                        logger.warning(
+                            "Failed to clean up %s window in %s",
+                            SERVICE_CMD_WINDOW,
+                            SERVICE_SESSION,
+                        )
+                    return
+                # The new window's shell needs a moment to source
+                # .profile / .bashrc before it can resolve PATH-dependent
+                # commands (nvm, openclaw, ...). Same race as #1030.
+                await asyncio.sleep(1)
+                if await self._send_service_command(
+                    container_id, service_command
+                ):
+                    # The service command just fired -- reset the
+                    # health-check startup-grace anchor so the monitor
+                    # gives the service time to boot before a failing poll
+                    # can flag it unhealthy (e.g. a gateway that isn't
+                    # accepting connections yet). Only on a clean send:
+                    # the failure paths never launched the command, so they
+                    # must not start the grace window.
+                    self.registry.mark_service_started(container_id)
+                    return
+                logger.warning(
+                    "Failed to send service command to %s", SERVICE_SESSION
+                )
+                # The window was created above but the command never
+                # landed in it. Kill it so the next fire re-runs the whole
+                # sequence instead of no-op'ing forever on the
+                # half-created window (#1186). If the cleanup itself
+                # fails, leave the fire pending so the next call retries
+                # the send into the surviving window (#2740).
+                self.registry.mark_service_fire_pending(container_id)
+                if await self.kill_service_cmd_window(container_id):
+                    self.registry.clear_service_fire_pending(container_id)
+                else:
+                    logger.warning(
+                        "Failed to clean up %s window in %s; "
+                        "fire marked pending",
+                        SERVICE_CMD_WINDOW,
+                        SERVICE_SESSION,
+                    )
+            except asyncio.CancelledError:
+                # The caller (e.g. the _start_terminal task on a client WS
+                # drop) went away mid-sequence. The synchronous pending
+                # flag lands BEFORE the cleanup await, so even a second
+                # cancellation during cleanup leaves a recoverable state:
+                # the next terminal_start sees window + pending and retries
+                # the send (#2740).
+                self.registry.mark_service_fire_pending(container_id)
+                with contextlib.suppress(Exception):
+                    await self.kill_service_cmd_window(container_id)
+                raise
 
     # --- container-side helpers ---
 

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -256,12 +256,23 @@ class TestTuiE2E:
             ).value = "tuiuser@example.com"
             app.screen.query_one("#password", Input).value = "wrongpass"
             app.screen._attempt_password()
-            # Wait for async HTTP login attempt to complete.
-            await asyncio.sleep(2)
-            await pilot.pause()
+            # Wait for the async login round-trip to land. Server-side
+            # login ALWAYS pays a full PBKDF2-HMAC-SHA512 (600k iters —
+            # dummy_verify_hash for unknown users, timing-leak defense),
+            # which stretches well past 2s on a loaded CI runner (two
+            # xdist workers + podman churn; #2740 flake family). Poll for
+            # the message instead of a fixed sleep, bounded by the
+            # client's own 15s HTTP budget.
+            msg = ""
+            deadline = asyncio.get_event_loop().time() + 15.0
+            while asyncio.get_event_loop().time() < deadline:
+                await pilot.pause()
+                await asyncio.sleep(0.1)
+                msg = str(app.screen.query_one("#message").render())
+                if msg:
+                    break
             # Should still be on login screen with an error message.
             assert isinstance(app.screen, LoginScreen)
-            msg = str(app.screen.query_one("#message").render())
             assert msg  # error message shown
 
     async def test_login_empty_fields(self, base_url, tmp_path, monkeypatch):

--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -77,8 +77,14 @@ def _ws_name(prefix: str) -> str:
 
 @pytest.fixture(scope="module")
 def api(server):
-    """httpx client pointing at the test server (over its UDS)."""
-    with httpx_client(server, timeout=10.0) as client:
+    """httpx client pointing at the test server (over its UDS).
+
+    30s budget (#2740): register/login are PBKDF2-HMAC-SHA512 CPU work via
+    ``asyncio.to_thread``, so a runner starved by a concurrent xdist worker
+    (e.g. a local FIPS image build) stretches them well past 10s; a
+    fixture-level ReadTimeout then errors the whole module.
+    """
+    with httpx_client(server, timeout=30.0) as client:
         yield client
 
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_concurrent_logon_audit_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_concurrent_logon_audit_e2e.py
@@ -39,7 +39,9 @@ def server(tmp_path_factory):
 
 @pytest.fixture(scope="module")
 def api(server):
-    with httpx_client(server, timeout=10.0) as client:
+    # 30s budget: login is PBKDF2 CPU work that stretches past 10s on a
+    # CI runner starved by concurrent xdist workers (#2740).
+    with httpx_client(server, timeout=30.0) as client:
         yield client
 
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -6499,6 +6499,36 @@ class TestRegistryServiceSessionLocks:
         finally:
             held.release()
 
+
+class TestRegistryServiceFirePending:
+    """The registry's per-container pending-fire set (#2740): the marker
+    that a service-command fire half-completed (window exists, command
+    never typed) so the next ensure_service_session retries the send."""
+
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.state.container_registry
+        self.registry._service_fire_pending.clear()
+
+    def teardown_method(self):
+        self.registry._service_fire_pending.clear()
+
+    def test_mark_and_query_pending(self):
+        reg = self.registry
+        assert reg.service_fire_pending("cid") is False
+        reg.mark_service_fire_pending("cid")
+        assert reg.service_fire_pending("cid") is True
+
+    def test_clear_pending(self):
+        reg = self.registry
+        reg.mark_service_fire_pending("cid")
+        reg.clear_service_fire_pending("cid")
+        assert reg.service_fire_pending("cid") is False
+
+    def test_clear_pending_is_noop_for_unknown_container(self):
+        # Must not raise for a container that never fired.
+        self.registry.clear_service_fire_pending("never-seen")
+
     def test_prune_noop_when_all_tracked(self):
         reg = self.registry
         reg.get_service_session_lock("a")

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -36,6 +36,11 @@ _mock_pod = MagicMock()
 _mock_registry = MagicMock()
 _mock_registry.get_service_session_lock.return_value = asyncio.Lock()
 _mock_registry.mark_service_started = MagicMock()
+# Default: no pending service-command fire. Tests exercising the #2740
+# pending-retry path override this per-test.
+_mock_registry.service_fire_pending.return_value = False
+_mock_registry.mark_service_fire_pending = MagicMock()
+_mock_registry.clear_service_fire_pending = MagicMock()
 
 # These are rebuilt per-test by the _fresh_terminal fixture so a value a
 # test writes onto settings (e.g. disable_tmux) can't leak into the next
@@ -1448,8 +1453,9 @@ class TestSetWorkspaceName:
 
 
 class TestServiceCmdWindowExists:
-    async def test_service_cmd_window_exists_exception_returns_false(self):
-        """service_cmd_window_exists returns False if list-windows raises."""
+    async def test_service_cmd_window_exists_exception_returns_none(self):
+        """service_cmd_window_exists returns None (unknown) if
+        list-windows raises (#2740)."""
 
         with patch.object(
             _mock_pod,
@@ -1460,10 +1466,11 @@ class TestServiceCmdWindowExists:
             result = await _terminal.service_cmd_window_exists(
                 "cid", "my-session"
             )
-        assert result is False
+        assert result is None
 
-    async def test_service_cmd_window_exists_rc_nonzero_returns_false(self):
-        """service_cmd_window_exists returns False if list-windows fails."""
+    async def test_service_cmd_window_exists_rc_nonzero_returns_none(self):
+        """service_cmd_window_exists returns None (unknown) if
+        list-windows fails or is killed under load (#2740)."""
 
         with patch.object(
             _mock_pod,
@@ -1474,7 +1481,7 @@ class TestServiceCmdWindowExists:
             result = await _terminal.service_cmd_window_exists(
                 "cid", "my-session"
             )
-        assert result is False
+        assert result is None
 
     async def test_has_tmux_session_exception_returns_false(self):
         """has_tmux_session returns False if has-session raises."""
@@ -1502,6 +1509,9 @@ class TestEnsureServiceSession:
         _mock_registry.reset_mock()
         _mock_registry.get_service_session_lock.return_value = asyncio.Lock()
         _mock_registry.mark_service_started = MagicMock()
+        _mock_registry.service_fire_pending.return_value = False
+        _mock_registry.mark_service_fire_pending = MagicMock()
+        _mock_registry.clear_service_fire_pending = MagicMock()
 
     async def test_creates_window_and_sends_command(self):
         """A fresh service session fires the service command in its
@@ -1999,6 +2009,260 @@ class TestEnsureServiceSession:
         # Both the send-keys failure and the cleanup failure are warned.
         assert mock_logger.warning.call_count == 2
 
+    async def test_send_keys_timeout_is_failure_not_success(self):
+        """#2740 core: a killed send-keys exec returns rc=-1 WITHOUT
+        raising (exec_container is check=False), and must NOT be mistaken
+        for a successful fire -- the old code called mark_service_started
+        on it, leaving a command-less window that suppressed every later
+        fire. Now: warning, cleanup kill-window, no grace reset."""
+        with (
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                new=AsyncMock(
+                    side_effect=[
+                        (0, "", ""),  # new-window succeeds
+                        (-1, "", "podman exec timed out"),  # send-keys KILLED
+                        (0, "", ""),  # kill-window cleanup succeeds
+                    ]
+                ),
+            ) as mock_exec,
+            patch("klangk.terminal.logger") as mock_logger,
+        ):
+            await _terminal.ensure_service_session("cid", "cmd")
+        _mock_registry.mark_service_started.assert_not_called()
+        mock_logger.warning.assert_called()
+        # Cleanup ran and succeeded -> pending marked then cleared.
+        _mock_registry.mark_service_fire_pending.assert_called_with("cid")
+        _mock_registry.clear_service_fire_pending.assert_called_with("cid")
+        argv = mock_exec.call_args_list[2].args[1]
+        assert "kill-window" in argv and "service:service-cmd" in argv
+
+    async def test_send_keys_failure_cleanup_failure_keeps_pending(self):
+        """#2740: if the kill-window cleanup ALSO fails, the fire stays
+        pending so the next terminal_start retries the send into the
+        surviving window instead of suppressing forever."""
+        with (
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                new=AsyncMock(
+                    side_effect=[
+                        (0, "", ""),  # new-window succeeds
+                        (-1, "", ""),  # send-keys killed
+                        (-1, "", ""),  # kill-window cleanup killed too
+                    ]
+                ),
+            ),
+            patch("klangk.terminal.logger"),
+        ):
+            await _terminal.ensure_service_session("cid", "cmd")
+        # The pending flag survived: it was marked AFTER the fresh-path
+        # pre-clear and never cleared again (cleanup failed).
+        _mock_registry.mark_service_fire_pending.assert_called_with("cid")
+        names = [
+            name
+            for name, _args, _kw in _mock_registry.mock_calls
+            if name
+            in ("mark_service_fire_pending", "clear_service_fire_pending")
+        ]
+        assert names == [
+            "clear_service_fire_pending",
+            "mark_service_fire_pending",
+        ]
+
+    async def test_pending_fire_retries_send_into_existing_window(self):
+        """#2740: window exists + pending flag -> retry ONLY the send-keys
+        (no new-window: recreating the window would lose the settled
+        shell), then clear pending and reset the grace anchor."""
+        _mock_registry.service_fire_pending.return_value = True
+        with (
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                new=AsyncMock(return_value=(0, "", "")),
+            ) as mock_exec,
+        ):
+            await _terminal.ensure_service_session("cid", "cmd")
+        cmds = [c.args[1] for c in mock_exec.call_args_list]
+        assert len(cmds) == 1  # exactly one exec: the send-keys retry
+        assert "send-keys" in cmds[0]
+        assert "service:service-cmd" in cmds[0]
+        assert "cmd" in cmds[0]
+        assert not any("new-window" in c for c in cmds)
+        _mock_registry.clear_service_fire_pending.assert_called_with("cid")
+        _mock_registry.mark_service_started.assert_called_once_with("cid")
+
+    async def test_pending_fire_retry_failure_keeps_pending(self):
+        """#2740: a failed retry logs a warning and keeps the pending flag
+        so the next terminal_start tries again."""
+        _mock_registry.service_fire_pending.return_value = True
+        with (
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                new=AsyncMock(return_value=(-1, "", "")),
+            ),
+            patch("klangk.terminal.logger") as mock_logger,
+        ):
+            await _terminal.ensure_service_session("cid", "cmd")
+        mock_logger.warning.assert_called()
+        _mock_registry.clear_service_fire_pending.assert_not_called()
+        _mock_registry.mark_service_started.assert_not_called()
+
+    async def test_new_window_timeout_cleans_up_half_created_window(self):
+        """#2740: a killed new-window exec may still have created the
+        window container-side -- clean it up so the next fire re-runs the
+        whole sequence instead of suppressing on a command-less window."""
+        with (
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                new=AsyncMock(
+                    side_effect=[
+                        (-1, "", ""),  # new-window KILLED (may have landed)
+                        (0, "", ""),  # kill-window cleanup succeeds
+                    ]
+                ),
+            ) as mock_exec,
+            patch("klangk.terminal.logger") as mock_logger,
+        ):
+            await _terminal.ensure_service_session("cid", "cmd")
+        mock_logger.warning.assert_called()
+        _mock_registry.mark_service_started.assert_not_called()
+        _mock_registry.clear_service_fire_pending.assert_called_with("cid")
+        argv = mock_exec.call_args_list[1].args[1]
+        assert "kill-window" in argv and "service:service-cmd" in argv
+
+    async def test_unknown_window_state_defers_fire(self):
+        """#2740: a killed list-windows exec means the window state is
+        UNKNOWN. Firing blind could duplicate the window and re-send into
+        a running service, so the fire is deferred to the next
+        terminal_start."""
+        with (
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                new=AsyncMock(),
+            ) as mock_exec,
+            patch("klangk.terminal.logger") as mock_logger,
+        ):
+            await _terminal.ensure_service_session("cid", "cmd")
+        cmds = [c.args[1] for c in mock_exec.call_args_list]
+        assert not any("new-window" in c or "send-keys" in c for c in cmds)
+        mock_logger.debug.assert_called()
+
+    async def test_cancellation_mid_fire_marks_pending_and_cleans_up(self):
+        """#2740: a WS drop cancelling the caller mid-sequence (the exact
+        CLI-E2E flake) must not leave a half-created window with no
+        recovery: the pending flag is marked synchronously BEFORE the
+        cleanup await, the kill-window cleanup runs, and the
+        CancelledError still propagates."""
+        send_started = asyncio.Event()
+        real_sleep = asyncio.sleep
+
+        async def fake_exec(cid, argv, **kwargs):
+            if "send-keys" in argv:
+                # Cancel the caller's task while the send await is in
+                # flight -- the flake's exact window.
+                send_started.set()
+                await real_sleep(3600)
+            return (0, "", "")
+
+        async def canceller(task: asyncio.Task):
+            await send_started.wait()
+            task.cancel()
+
+        with (
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch.object(
+                _mock_pod,
+                "exec_container",
+                side_effect=fake_exec,
+            ) as mock_exec,
+            patch("klangk.terminal.asyncio.sleep", new=AsyncMock()),
+        ):
+            fire = asyncio.create_task(
+                _terminal.ensure_service_session("cid", "cmd")
+            )
+            await asyncio.gather(canceller(fire), return_exceptions=True)
+            with pytest.raises(asyncio.CancelledError):
+                await fire
+
+        _mock_registry.mark_service_fire_pending.assert_called_with("cid")
+        cmds = [c.args[1] for c in mock_exec.call_args_list]
+        # The cancellation cleanup ran a kill-window.
+        assert any("kill-window" in c for c in cmds)
+
 
 class TestServiceSessionHelpers:
     """Direct coverage for the firing-predicate helpers used by
@@ -2028,6 +2292,33 @@ class TestServiceSessionHelpers:
             assert (
                 await _terminal.service_cmd_window_exists("cid", "service")
                 is False
+            )
+
+    async def test_service_cmd_window_exists_none_when_check_fails(self):
+        """#2740: a killed/non-zero list-windows exec means UNKNOWN
+        (None), not absent -- the caller must defer the fire rather than
+        risk a duplicate window."""
+        with patch.object(
+            _mock_pod,
+            "exec_container",
+            new_callable=AsyncMock,
+            return_value=(-1, "", "podman exec timed out"),
+        ):
+            assert (
+                await _terminal.service_cmd_window_exists("cid", "service")
+                is None
+            )
+
+    async def test_service_cmd_window_exists_none_on_exception(self):
+        with patch.object(
+            _mock_pod,
+            "exec_container",
+            new_callable=AsyncMock,
+            side_effect=OSError("boom"),
+        ):
+            assert (
+                await _terminal.service_cmd_window_exists("cid", "service")
+                is None
             )
 
     def test_should_fire_returns_false_without_service_command(self):


### PR DESCRIPTION
## Summary

First tranche of #2740 (umbrella CI/E2E flake tracker): fixes both acceptance-criteria flakes plus the one-line `loginViaUI` budget from the consolidated list.

### Flake 1 — service-cmd fire lost to the 5s podman exec budget (CLI E2E)

Root cause: `Podman.exec_container` runs `check=False`, so a timed-out exec returns `rc=-1` **without raising**. The `except Exception` guards in `ensure_service_session` therefore never fired for timeouts:

- a killed `send-keys` was mistaken for success — `mark_service_started` ran, and the window-exists check then permanently suppressed every later fire (the exact `test_service_command_runs_only_after_setup` flake: no "Failed to create/send" warning, marker never written);
- a client WS drop cancelling `_start_terminal` between new-window and send-keys left a half-created `service-cmd` window with no cleanup — same permanent suppression.

Fix — every failure mode now lands in a recoverable state:

| failure | recovery |
|---|---|
| killed/failed `new-window` | kill the half-created window (a client-side kill may have landed container-side); next `terminal_start` re-runs the sequence |
| killed/failed `send-keys` | existing #1186 kill-window cleanup |
| cleanup `kill-window` also fails | fire marked pending on the registry; the next call retries **only** the send into the surviving window |
| killed `list-windows` (state unknown) | `service_cmd_window_exists` is now tri-state (`None` = unknown): defer instead of firing blind into a possibly-running service; next `terminal_start` retries |
| cancellation mid-sequence | pending flag marked synchronously **before** the cleanup await, kill-window best-effort, `CancelledError` re-raised — even a double-cancel leaves a recoverable state |

Also loosens the tmux control-plane exec budgets 5s → 15s (`SERVICE_EXEC_TIMEOUT`) — they are 0.1–0.2s when healthy and nothing user-visible depends on them being fast; 5s only ever fired as a false kill under runner saturation.

### Flake 2 — `nonadmin_user` fixture ReadTimeout (backend E2E)

Register/login is PBKDF2-HMAC-SHA512 CPU work via `asyncio.to_thread`; on a runner where a concurrent xdist worker is compiling a FIPS image it stretches past the module `api` fixture's 10s httpx budget, erroring the whole module at setup. Bumped to 30s in `test_api_e2e.py` and `test_concurrent_logon_audit_e2e.py`.

### Consolidated-list fix

- **#485/#469** — `loginViaUI` 10s Workspaces title check → 30s (the PR #470 one-liner, unmerged).

Remaining consolidated items (#468, #245, #405, #1491, #933, #331, #392, #1720) stay tracked under the umbrella — each needs its own debugging or is environmental.

## Testing

- New unit tests for every recovery path (send-keys timeout ≠ success, cleanup-failure → pending retry, retry failure → stays pending, new-window timeout cleanup, unknown-state deferral, mid-fire cancellation) plus tri-state `service_cmd_window_exists` and the registry pending API.
- Full backend suite CI-style: 5527 passed, 100% coverage.
- pre-commit (ruff, markdownlint, prettier, trufflehog) clean.

Closes the acceptance criteria of #2740 (remaining consolidated flakes stay open there).
