### PR TITLE
Key death teardown to the dead container id (#331, #1489)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1292,6 +1292,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Crash recovery no longer corrupts workspaces that reconnect
+  mid-death-detection (#331).** When the crash monitor was handling a
+  container's death while a user reconnect recreated the container, the
+  fresh container's registry state could be dropped and its network
+  sidecar torn down. Death teardown is now keyed to the dead container
+  id, so a workspace re-bound to a fresh container is left untouched.
 - **Status WebSocket follows a server switch (#2029).** The TUI's live
   status connection kept dialing the previous server after switching
   servers, producing a false "server down" overlay. It now re-reads the

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -696,7 +696,7 @@ async def stop_workspace(
     )
     if cid:
         await app.state.container_registry.notify_workspace_killed(
-            workspace_id
+            workspace_id, container_id=cid
         )
         await app.state.container_registry.stop_and_remove_container(
             cid, workspace_id=workspace_id

--- a/src/klangk/klangk/container/crash.py
+++ b/src/klangk/klangk/container/crash.py
@@ -403,6 +403,22 @@ class CrashRecoveryMonitor:
         if epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch:
             return  # a stop began and completed during detection
         memory_limit = await self._effective_memory_limit(ws_id)
+        # Re-validate after the await (#331): a user-driven reconnect
+        # (start_container -> _handle_existing_container removes the dead
+        # container with a direct podman rm -- no ``stopping`` marker, no
+        # epoch bump -- then _create_and_start re-binds the state to a
+        # fresh container) can complete entirely while the limit read is
+        # in flight. The entry guards above ran before that await; acting
+        # on the post-await state would tear down the freshly-started
+        # container's registry state and network sidecar.
+        if registry.states.get(ws_id) is not state:
+            return  # state replaced/removed (a user start re-bound it)
+        if state.container_id != container_id:
+            return  # rebound to a fresh container — not our death
+        if ws_id in registry.stopping:
+            return  # an expected stop is now in flight
+        if epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch:
+            return  # a stop began and completed during the limit read
         cause, message = classify_death(info, memory_limit)
         tracker = self.trackers.get(ws_id) or RestartTracker()
         tracker.last_cause = message
@@ -416,7 +432,9 @@ class CrashRecoveryMonitor:
         )
         # The service_health death frame carries the cause so consumers
         # can tell an OOM kill from a crash from external removal.
-        await registry.notify_workspace_killed(ws_id, cause=message)
+        await registry.notify_workspace_killed(
+            ws_id, cause=message, container_id=container_id
+        )
         # Teardown under the expected-stop marker (this stop is on
         # purpose — the restart, if any, is scheduled after it).
         await registry.stop_and_remove_container(

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -456,7 +456,9 @@ class MemoryPressureEvictor:
             victim.workspace_id,
             reason="host memory pressure",
         )
-        await registry.notify_workspace_killed(victim.workspace_id)
+        await registry.notify_workspace_killed(
+            victim.workspace_id, container_id=victim.container_id
+        )
         await registry.stop_and_remove_container(
             victim.container_id, workspace_id=victim.workspace_id
         )

--- a/src/klangk/klangk/container/idle.py
+++ b/src/klangk/klangk/container/idle.py
@@ -106,7 +106,7 @@ class IdleMonitor:
                             await cb(wid)
                         except Exception as e:
                             logger.error("Idle callback error: %s", e)
-                await registry.notify_workspace_killed(wid)
+                await registry.notify_workspace_killed(wid, container_id=cid)
                 await registry.stop_and_remove_container(cid)
 
             # Periodic orphan sidecar-token sweep (#2309): reclaim

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -482,7 +482,9 @@ class ContainerRegistry(NetworkSidecarMixin):
             started_at = state.service_started_at if state else None
             self.on_container_status_changed(workspace_id, running, started_at)
 
-    async def remove_state(self, workspace_id: str) -> None:
+    async def remove_state(
+        self, workspace_id: str, *, expect_container_id: str | None = None
+    ) -> None:
         """Remove tracked state for a workspace.
 
         Serialized under the per-workspace lock (the same one
@@ -490,8 +492,32 @@ class ContainerRegistry(NetworkSidecarMixin):
         half-cleaned registry (#1258). The per-workspace lock entry is
         deliberately *not* removed here -- see :meth:`stop_and_remove_container`
         for why popping it would reopen the race.
+
+        *expect_container_id* is the re-bind guard (#331): when the caller
+        names the container whose state it believes it is removing (a
+        death/stop teardown keyed to a specific dead container), the state
+        is popped only if it still belongs to that container. A racing
+        user-driven start may have removed the dead container and
+        re-bound the workspace to a fresh one (``start_container`` ->
+        ``_handle_existing_container`` removes a stopped container with a
+        direct ``podman rm`` -- never marking ``stopping`` or bumping the
+        stop epoch -- then ``track_activity`` re-binds the state) while
+        this teardown was between its guard checks and the lock; popping
+        the fresh state would orphan a RUNNING container. The check runs
+        under the workspace lock, so it is authoritative against
+        ``start_container``'s re-track: whichever side acquires the lock
+        first completes atomically.
         """
         async with self._get_workspace_lock(workspace_id):
+            state = self.states.get(workspace_id)
+            if (
+                expect_container_id is not None
+                and state is not None
+                and state.container_id != expect_container_id
+            ):
+                # Re-bound to a fresh container by a racing start: the
+                # live state is not ours to remove.
+                return
             state = self.states.pop(workspace_id, None)
             if state:
                 self._cid_to_wsid.pop(state.container_id, None)
@@ -1667,7 +1693,11 @@ class ContainerRegistry(NetworkSidecarMixin):
                 self.crash.on_expected_stop(ws_id)
 
     async def notify_workspace_killed(
-        self, workspace_id: str, *, cause: str | None = None
+        self,
+        workspace_id: str,
+        *,
+        cause: str | None = None,
+        container_id: str | None = None,
     ) -> None:
         """Call the on_workspace_killed callback, logging any errors.
 
@@ -1678,18 +1708,44 @@ class ContainerRegistry(NetworkSidecarMixin):
         limit"); it rides the death frame's ``message`` field so
         consumers can tell an OOM kill from a crash from external
         removal.
+
+        *container_id* (#331) is the re-bind guard: the id of the
+        container the caller believes died. When the workspace is now
+        tracked under a DIFFERENT container (a racing user-driven start
+        removed the dead one and re-bound the workspace), this death is
+        not ours to act on -- no terminal death frame for the live
+        container, no spurious ``running=False`` status, and the reset
+        chain carries the expected id down to :meth:`remove_state`, which
+        re-checks authoritatively under the workspace lock. Callers that
+        know the dead container (crash monitor, idle stop, eviction,
+        /stop, drain, logout) always have it at hand.
         """
+        state = self.states.get(workspace_id)
+        if (
+            container_id is not None
+            and state is not None
+            and state.container_id != container_id
+        ):
+            # Re-bound to a fresh container by a racing start: the
+            # workspace is live; a death teardown would corrupt it.
+            logger.info(
+                "Workspace %s: killed-container teardown skipped — "
+                "re-bound to %s (dead was %s)",
+                workspace_id,
+                state.container_id[:12],
+                container_id[:12],
+            )
+            return
         self._notify_status_changed(workspace_id, False)
         # Close the container-death hole (#1175 item 2): emit a terminal
         # ``running=False`` frame so consumers watching only service_health
         # learn the service is down.  Only health-checked workspaces ever
         # appeared on the stream, so only those get a terminal frame.
-        state = self.states.get(workspace_id)
         if state is not None and state.health_check is not None:
             self.health.broadcast_death(state, message=cause)
         if self.on_workspace_killed:
             try:
-                await self.on_workspace_killed(workspace_id)
+                await self.on_workspace_killed(workspace_id, container_id)
             except Exception as e:
                 logger.error(
                     "Workspace killed callback error for %s: %s",
@@ -1704,7 +1760,9 @@ class ContainerRegistry(NetworkSidecarMixin):
         )
         for ws in workspaces:
             if ws["container_id"]:
-                await self.notify_workspace_killed(ws["id"])
+                await self.notify_workspace_killed(
+                    ws["id"], container_id=ws["container_id"]
+                )
                 await self.stop_and_remove_container(
                     ws["container_id"], workspace_id=ws["id"]
                 )
@@ -1757,7 +1815,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         """
 
         async def drain_one(ws_id: str, cid: str) -> bool:
-            await self.notify_workspace_killed(ws_id)
+            await self.notify_workspace_killed(ws_id, container_id=cid)
             ok = await self.stop_and_remove_container(cid, workspace_id=ws_id)
             if not ok:
                 logger.warning(

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -1055,8 +1055,10 @@ async def lifespan(app: FastAPI):
         raise
     registry = app.state.container_registry
 
-    async def _on_workspace_killed(ws_id):
-        await wshandler.reset_workspace_state(app.state.sockets, ws_id)
+    async def _on_workspace_killed(ws_id, container_id=None):
+        await wshandler.reset_workspace_state(
+            app.state.sockets, ws_id, expected_container_id=container_id
+        )
 
     registry.set_on_workspace_killed(_on_workspace_killed)
     registry.set_on_container_status_changed(

--- a/src/klangk/klangk/wshandler/helpers.py
+++ b/src/klangk/klangk/wshandler/helpers.py
@@ -14,10 +14,19 @@ logger = logging.getLogger(__name__)
 
 
 async def reset_workspace_state(
-    sockets: WebSocketState, workspace_id: str
+    sockets: WebSocketState,
+    workspace_id: str,
+    expected_container_id: str | None = None,
 ) -> None:
-    """Thin wrapper for backward compatibility with external callers."""
-    await sockets.reset_workspace(workspace_id)
+    """Thin wrapper for backward compatibility with external callers.
+
+    *expected_container_id* (#331) is the dead container id threading
+    through to ``remove_state``'s re-bind guard: a racing user-driven
+    start that re-bound the workspace keeps its fresh registry state.
+    """
+    await sockets.reset_workspace(
+        workspace_id, expected_container_id=expected_container_id
+    )
 
 
 async def disconnect_all_websockets(sockets: WebSocketState) -> None:

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -628,14 +628,22 @@ class WorkspaceSession:
                 request_id, None
             )
 
-    async def full_reset(self) -> None:
+    async def full_reset(
+        self, expected_container_id: str | None = None
+    ) -> None:
         """Clean up all shared state for this workspace.
 
         Called when a container is killed externally (idle timeout,
         manual stop) so the next workspace_connect starts fresh.
+        *expected_container_id* (#331) threads the dead container id
+        down to :meth:`container_registry.remove_state`'s re-bind guard:
+        a racing user-driven start may have re-bound the workspace to a
+        fresh container, in which case the fresh registry state survives.
         """
         await self.app.state.sockets.remove_session(self.workspace_id)
-        await self.app.state.container_registry.remove_state(self.workspace_id)
+        await self.app.state.container_registry.remove_state(
+            self.workspace_id, expect_container_id=expected_container_id
+        )
         logger.info("Reset workspace state for %s", self.workspace_id)
 
 
@@ -768,18 +776,26 @@ class WebSocketState:
                 logger.debug("Error closing socket for user %s", user_id)
         return len(socks)
 
-    async def reset_workspace(self, workspace_id: str) -> None:
+    async def reset_workspace(
+        self, workspace_id: str, *, expected_container_id: str | None = None
+    ) -> None:
         """Clean up shared state for a workspace.
 
         Called when a container is killed externally (idle timeout,
         manual stop) so the next workspace_connect starts fresh.
         Delegates to WorkspaceSession.full_reset if a session exists.
+        *expected_container_id* (#331) is the dead container id; it
+        guards ``remove_state`` against a racing re-bind.
         """
         session = self.get_session(workspace_id)
         if session:
-            await session.full_reset()
+            await session.full_reset(
+                expected_container_id=expected_container_id
+            )
         else:
-            await self.app.state.container_registry.remove_state(workspace_id)
+            await self.app.state.container_registry.remove_state(
+                workspace_id, expect_container_id=expected_container_id
+            )
             logger.info("Reset workspace state for %s", workspace_id)
 
     def notify_container_status(

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1747,9 +1747,6 @@ class TestTerminalSharing:
 class TestContainerReplace:
     """Verify podman --replace handles stale/crashed containers."""
 
-    @pytest.mark.skip(
-        reason="Flaky: Server disconnected race condition (#331)"
-    )
     def test_exec_after_external_stop(self, cli_config):
         """Kill a workspace container externally, then exec again.
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2732,7 +2732,7 @@ class TestWorkspaceRoutes:
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "stopped"
-        mock_killed.assert_awaited_once_with(ws_id)
+        mock_killed.assert_awaited_once_with(ws_id, container_id="cid-stop")
         mock_stop.assert_awaited_once_with("cid-stop", workspace_id=ws_id)
         # Re-homed from the retired WS shutdown_container handler: REST /stop
         # broadcasts container_stopped so live viewers show "stopped".

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -4670,7 +4670,7 @@ class TestStopUserContainers:
         with patch_podman(self.registry):
             await self.registry.stop_user_containers(user["id"])
 
-        killed_cb.assert_awaited_once_with(workspace["id"])
+        killed_cb.assert_awaited_once_with(workspace["id"], "cid")
         self.registry.on_workspace_killed = old_cb
 
     async def test_stop_user_no_containers(self, user):
@@ -4808,7 +4808,7 @@ class TestCleanupIdleContainers:
             except asyncio.CancelledError:
                 pass
 
-        killed_cb.assert_awaited_once_with("ws-killed")
+        killed_cb.assert_awaited_once_with("ws-killed", "cid")
         self.registry.on_workspace_killed = old_cb
 
     async def test_idle_workspace_killed_callback_error(self):
@@ -6299,7 +6299,7 @@ class TestHealthMonitorDeath:
         reg.states[st.workspace_id] = st
         seen_state_present = []
 
-        async def on_killed(wid):
+        async def on_killed(wid, container_id=None):
             # The state must still be present when the callback runs --
             # death emission happens first, before removal.
             seen_state_present.append(wid in reg.states)

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -502,6 +502,142 @@ class TestHandleDeathEntryGuards:
         pm.remove_container.assert_not_awaited()
         assert monitor.pending == {}
 
+    @pytest.mark.parametrize(
+        "interleave",
+        ["rebind_in_place", "state_replaced", "stop_in_flight", "epoch"],
+    )
+    async def test_race_reconnect_during_memory_limit_read(
+        self, crash_env, interleave
+    ):
+        """#331: a user-driven reconnect completing between death
+        handling's entry guards and its memory-limit read must win.
+
+        Choreography: the container was stopped externally; the sweep's
+        handle_death passes its entry guards and parks inside
+        ``_effective_memory_limit`` (its first await). Meanwhile the
+        user's ``klangk exec`` reconnect runs ``start_container`` —
+        ``_handle_existing_container`` removes the dead container with a
+        direct podman rm (never marking ``stopping`` nor bumping the
+        epoch) and ``track_activity`` re-binds the SAME state object to a
+        fresh container (in-place mutation). Death handling resumes: the
+        re-validation must bail before any teardown — the old code tore
+        down the fresh container's registry state, killed its network
+        sidecar via ``stop_and_remove``'s untracked branch, and scheduled
+        a spurious restart.
+        """
+        app_state = make_app_state(crash_env)
+        reg = app_state.state.container_registry
+        monitor = reg.crash
+        dead_state(reg)
+        epoch0 = reg.stop_epoch.get("ws-crash", 0)
+        limit_read_started = asyncio.Event()
+        reconnect_done = asyncio.Event()
+
+        async def parked_limit_read(ws_id):
+            limit_read_started.set()
+            await reconnect_done.wait()
+            return None
+
+        killed_cb = AsyncMock()
+        reg.set_on_workspace_killed(killed_cb)
+        start_mock = AsyncMock(return_value=("new-cid", "created"))
+        with patch_podman_methods(app_state, inspect_dead()) as pm:
+            with patch.object(
+                monitor, "_effective_memory_limit", parked_limit_read
+            ):
+                with patch.object(
+                    app_state.state.workspaces,
+                    "start_workspace",
+                    start_mock,
+                ):
+                    death = asyncio.create_task(
+                        monitor.handle_death(
+                            "ws-crash",
+                            "cid-crash",
+                            inspect_dead(),
+                            epoch=epoch0,
+                        )
+                    )
+                    await limit_read_started.wait()
+                    # The user action completes while death handling is
+                    # parked (all four interleave shapes the re-validation
+                    # guards must catch):
+                    if interleave == "rebind_in_place":
+                        # The reconnect's _handle_existing_container rm +
+                        # track_activity re-bind (state mutated in place).
+                        await pm.remove_container("cid-crash")
+                        reg.track_activity("cid-fresh", "ws-crash")
+                    elif interleave == "state_replaced":
+                        # The state object was swapped outright (state
+                        # removal followed by a fresh track).
+                        reg.states.pop("ws-crash", None)
+                        reg._cid_to_wsid.pop("cid-crash", None)
+                        dead_state(reg, cid="cid-fresh")
+                    elif interleave == "stop_in_flight":
+                        # An expected /stop began and is still running.
+                        reg.stopping.add("ws-crash")
+                    else:  # epoch
+                        # An expected stop began AND completed (epoch bump
+                        # without the marker lingering).
+                        reg.stop_epoch["ws-crash"] = epoch0 + 1
+                    reconnect_done.set()
+                    await death
+        # Death handling bailed at the re-validation: no killed callback,
+        # no teardown remove, no restart.
+        killed_cb.assert_not_awaited()
+        # No post-resume teardown remove (the rebind_in_place shape made
+        # one explicit rm for the dead container; others made none).
+        assert pm.remove_container.await_count <= 1
+        if interleave == "rebind_in_place":
+            assert reg.states["ws-crash"].container_id == "cid-fresh"
+        elif interleave == "state_replaced":
+            assert reg.states["ws-crash"].container_id == "cid-fresh"
+        elif interleave == "stop_in_flight":
+            reg.stopping.discard("ws-crash")
+        start_mock.assert_not_awaited()
+        assert monitor.pending == {}
+        assert monitor.status("ws-crash") is None
+
+    async def test_notify_killed_skips_rebound_workspace(self, crash_env):
+        """#331: notify_workspace_killed names the dead container; a
+        workspace re-bound to a fresh one gets no death teardown."""
+        app_state = make_app_state(crash_env)
+        reg = app_state.state.container_registry
+        dead_state(reg, cid="cid-dead")
+        reg.track_activity("cid-fresh", "ws-crash")  # re-bind in place
+        killed_cb = AsyncMock()
+        reg.set_on_workspace_killed(killed_cb)
+        with patch_podman_methods(app_state, inspect_dead()) as pm:
+            await reg.notify_workspace_killed(
+                "ws-crash", container_id="cid-dead"
+            )
+        killed_cb.assert_not_awaited()
+        pm.remove_container.assert_not_awaited()
+        assert reg.states["ws-crash"].container_id == "cid-fresh"
+
+    async def test_notify_killed_matching_container_proceeds(self, crash_env):
+        app_state = make_app_state(crash_env)
+        reg = app_state.state.container_registry
+        dead_state(reg, cid="cid-dead")
+        killed_cb = AsyncMock()
+        reg.set_on_workspace_killed(killed_cb)
+        await reg.notify_workspace_killed("ws-crash", container_id="cid-dead")
+        killed_cb.assert_awaited_once_with("ws-crash", "cid-dead")
+
+    async def test_remove_state_expect_container_guard(self, crash_env):
+        """#331: remove_state pops only the named container's state."""
+        app_state = make_app_state(crash_env)
+        reg = app_state.state.container_registry
+        dead_state(reg, cid="cid-a")
+        await reg.remove_state("ws-crash", expect_container_id="cid-b")
+        assert "ws-crash" in reg.states  # re-bound: fresh state survives
+        await reg.remove_state("ws-crash", expect_container_id="cid-a")
+        assert "ws-crash" not in reg.states
+        # No-kwarg (legacy) form still pops unconditionally.
+        reg.track_activity("cid-c", "ws-crash")
+        await reg.remove_state("ws-crash")
+        assert "ws-crash" not in reg.states
+
 
 class TestHandleDeathDisabled:
     """With restart off: classify + events + teardown, no restart task."""
@@ -513,7 +649,7 @@ class TestHandleDeathDisabled:
         dead_state(reg, health_check="true")
         notified = []
 
-        async def fake_notify(ws_id, *, cause=None):
+        async def fake_notify(ws_id, *, cause=None, container_id=None):
             notified.append((ws_id, cause))
 
         session = MagicMock()

--- a/src/klangk/klangkd-tests/tests/test_draining.py
+++ b/src/klangk/klangkd-tests/tests/test_draining.py
@@ -433,7 +433,7 @@ class TestDrain:
         self._stub_sweep(app_state)
         killed = []
 
-        async def on_killed(ws_id):
+        async def on_killed(ws_id, container_id=None):
             killed.append(ws_id)
 
         registry.on_workspace_killed = on_killed

--- a/src/klangk/klangkd-tests/tests/test_eviction.py
+++ b/src/klangk/klangkd-tests/tests/test_eviction.py
@@ -377,8 +377,9 @@ class TestEvictOne:
 
         assert await evictor.evict_one(0.03) is True
         # Victim is the idle-longest workspace; kill notification precedes
-        # the stop (the death frame needs live registry state).
-        killed.assert_awaited_once_with("ws-old")
+        # the stop (the death frame needs live registry state). The
+        # notification names the dead container (#331 re-bind guard).
+        killed.assert_awaited_once_with("ws-old", container_id="cid-old")
         stopped.assert_awaited_once_with("cid-old", workspace_id="ws-old")
         assert killed.await_count == stopped.await_count == 1
 

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -998,7 +998,9 @@ class TestLifespan:
                 # into reset_workspace_state: (sockets, workspace_id).
                 assert registry.on_workspace_killed is not None
                 await registry.on_workspace_killed("ws-killed")
-        mock_reset.assert_awaited_once_with(app.state.sockets, "ws-killed")
+        mock_reset.assert_awaited_once_with(
+            app.state.sockets, "ws-killed", expected_container_id=None
+        )
 
     async def test_lifespan_refuses_if_pid_alive(self, db, app_state):
 

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -4403,6 +4403,37 @@ class TestResetWorkspaceState:
             sockets.sessions.pop("ws-reset-empty", None)
             registry.states.pop("ws-reset-empty", None)
 
+    async def test_expected_container_id_guards_state(self, app_state):
+        """#331: the reset chain threads the dead container id down to
+        remove_state's re-bind guard — a workspace whose state was
+        re-bound to a fresh container keeps it."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        sockets.get_or_create_session("ws-reset-guard", app_state)
+        registry.track_activity("cid-fresh", "ws-reset-guard")
+        try:
+            await reset_workspace_state(
+                sockets,
+                "ws-reset-guard",
+                expected_container_id="cid-dead",
+            )
+            # Re-bound: the fresh container's state survives; the session
+            # was still removed (a fresh workspace_connect recreates it).
+            assert registry.states["ws-reset-guard"].container_id == (
+                "cid-fresh"
+            )
+            # Matching id: the state is removed.
+            await reset_workspace_state(
+                sockets,
+                "ws-reset-guard",
+                expected_container_id="cid-fresh",
+            )
+            assert "ws-reset-guard" not in registry.states
+        finally:
+            sockets.sessions.pop("ws-reset-guard", None)
+            registry.states.pop("ws-reset-guard", None)
+
     async def test_remove_session_skips_if_subscribers_reappear(
         self, app_state
     ):


### PR DESCRIPTION
## Summary

From the #2740 umbrella: the **#331** exec-after-external-stop race (and the **#1489** skipped-test gap it caused).

### Root cause

When a container is stopped externally (crash, `podman stop`), two actors race:

- the **crash monitor** — its sweep detects the dead container and `handle_death` tears the workspace down;
- a **user reconnect** (`klangk exec`, page reload) — `start_container` → `_handle_existing_container` removes the stopped container with a *direct* `podman rm` (never marking `stopping`, never bumping the stop epoch) and `track_activity` re-binds the **same state object** to the fresh container.

`handle_death` validated its guards only at entry, **before its first await** (`_effective_memory_limit`). A reconnect completing during that await was invisible to the guards, and the death teardown then acted on the *live* workspace:

- `full_reset` → `remove_state` popped the **fresh container's registry state** (keyed by workspace id only) — the workspace became untracked while running;
- `stop_and_remove_container`'s under-lock rebind guard was defeated (`current is None` after the pop) → **the live container's network sidecar was torn down**;
- the post-teardown restart-suppression guard also passed → a **spurious crash restart** was scheduled (the #933 `rc=125 no container found` class).

This matches the #331 symptom: the second exec's output arrives, then the connection dies as the workspace's server-side state is ripped out mid-session.

### Fix — death teardown is keyed to the dead container id

- **`handle_death`** re-validates its guards (state identity + container id, `stopping`, epoch) after the memory-limit await, before any teardown.
- **`notify_workspace_killed(..., container_id=)`** — new re-bind guard: when the workspace is tracked under a *different* container, there are no death frames, no `running=false` status, and no reset callback.
- **`remove_state(..., expect_container_id=)`** — the authoritative pop-guard, checked under the same per-workspace lock `start_container` holds; threaded through `full_reset` / `reset_workspace` / `reset_workspace_state`.
- All callers (crash monitor, idle stop, eviction, `/stop`, drain, logout) pass their dead container id.

### #1489 — unskip the CLI e2e test

`TestContainerReplace::test_exec_after_external_stop` is unskipped: the race class now has deterministic unit coverage, and the unskipped test keeps the recovery path exercised on every CI run. 13 consecutive local runs green.

## Testing

- New parametrized race test (4 interleavings: in-place re-bind, state replacement, stop-in-flight, epoch bump) parking `handle_death` at its await while the user action completes underneath.
- New tests: notify skips/ proceeds by container match; `remove_state` expect-id guard; the `reset_workspace_state` chain threading.
- Existing tests updated for the 2-arg killed callback.
- Full backend suite CI-style: 5523 passed, 100% coverage. pre-commit clean.

Closes #1489. Fixes the #331 entry of #2740 (the race's registry corruption; the flake itself could not be reproduced deterministically — 13/13 local runs passed even pre-fix — so CI will adjudicate on the unskipped test).
