### PR TITLE
Double frontend E2E container-readiness budget on CI (#245)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1292,6 +1292,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **E2E container-readiness budget tolerates CI load (#245).**
+  Frontend e2e tests running four Playwright workers on one runner
+  could exceed the 120s container bring-up budget under contention;
+  the budget now doubles to 240s on CI (local runs keep 120s).
 - **Crash recovery no longer corrupts workspaces that reconnect
   mid-death-detection (#331).** When the crash monitor was handling a
   container's death while a user reconnect recreated the container, the

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -387,6 +387,16 @@ export async function createWorkspace(
   };
 }
 
+/** Default budget for waiting on container (and terminal) readiness.
+ *
+ *  240s (#245): the file-viewer specs run 4 Playwright workers on one
+ *  runner VM, and under that contention podman create/start + sidecar +
+ *  shared-home provisioning can exceed the old 120s — the failing test
+ *  then burned its retry on the same starved bring-up. 120s stays the
+ *  local-dev default via the explicit override; CI inherits the
+ *  load-tolerant budget. */
+const CONTAINER_READY_TIMEOUT = process.env.CI ? 240_000 : 120_000;
+
 /** Open a workspace in the browser and wait for the container to be ready. */
 export async function openWorkspace(
   page: Page,
@@ -394,7 +404,7 @@ export async function openWorkspace(
   workspaceId: string,
   {
     waitForTerminal = false,
-    containerTimeout = 120_000,
+    containerTimeout = CONTAINER_READY_TIMEOUT,
   }: { waitForTerminal?: boolean; containerTimeout?: number } = {},
 ) {
   // Set up WebSocket listener before login so we catch all WebSocket
@@ -505,7 +515,7 @@ export function dockerContainersForWorkspace(workspaceId: string): string[] {
 export async function connectContainer(
   workspaceId: string,
   token: string,
-  timeout = 120_000,
+  timeout = CONTAINER_READY_TIMEOUT,
 ): Promise<void> {
   const wsBase = API_BASE.replace(/^http/, "ws");
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
## Summary

From the #2740 umbrella audit: **#245** — the markdown file-viewer spec intermittently failed with `Container did not become ready within 120s` under CI load.

### Root cause

A budget problem, not a logic bug: the file-viewer specs (and the rest of the frontend suite) run **4 Playwright workers on one runner VM** (`fullyParallel: true`, default workers 4). Under that contention a fresh workspace's bring-up — podman create/start, network sidecar, shared-home provisioning — can exceed the helpers' fixed 120s `containerTimeout`; the spec's single CI retry then re-runs the same starved bring-up and fails again.

### Fix

- `openWorkspace` / `createAndOpenWorkspace` (and the API-only sibling `connectContainer`, same failure mode) now default to **240s when `process.env.CI` is set** (Playwright sets it in test runners); local dev keeps the snappier 120s.
- Explicit `containerTimeout`/`timeout` args still win everywhere — callers that already pin a budget (e.g. klangk.spec.ts) are unchanged.
- One shared constant (`CONTAINER_READY_TIMEOUT`) documents the rationale (#245).

Chose the budget bump over retry-in-helper (bring-up already has server-side recovery paths; a second overlapping create risks the 409 name-conflict race the helper's `goto`-based navigation deliberately avoids) and over reduced parallelism (would slow every run to fix a tail flake).

## Testing

- `npx playwright test --list` parses the full suite (194 tests / 30 files) with the change.
- prettier/pre-commit clean.
- E2E suites run in CI on this PR; the spec list + markdown file-viewer specs are the exercise path (frontend e2e is not run locally per AGENTS.md).
