### PR TITLE
fix: point setup-time hosted URLs at the browser listener (#2732)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1337,6 +1337,18 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   Frontend e2e tests running four Playwright workers on one runner
   could exceed the 120s container bring-up budget under contention;
   the budget now doubles to 240s on CI (local runs keep 120s).
+- **Hosted-app URLs derived without a request now name the browser listener
+  (#2732).** The hostname floor used when no browser request is in hand
+  (sandbox setup starts, autostart) was a bare `localhost` — implying port
+  80 — and `sandboxes/openclaw/setup.sh` fell back to `localhost:8995`, the
+  container-egress port, which serves no `/hosted/` routes. The synthetic
+  loopback hostname now carries the configured `KLANGKD_PORT`, so the URL
+  printed at the end of a sandbox install is followable as-is.
+  `KLANGKD_HOSTING_HOSTNAME` pins and trusted `X-Forwarded-Host` values are
+  still used verbatim. Headless servers (no `KLANGKD_PORT`) no longer
+  inject `KLANGKWS_PORT_MAPPINGS` / `KLANGKWS_HOSTING_*` at all — setup
+  prints a pointer to the workspace page instead of a dead URL, and
+  `klangk-hosted-url` errors cleanly.
 - **Crash recovery no longer corrupts workspaces that reconnect
   mid-death-detection (#331).** When the crash monitor was handling a
   container's death while a user reconnect recreated the container, the

--- a/docs/features/hosted-apps.md
+++ b/docs/features/hosted-apps.md
@@ -35,12 +35,20 @@ WebSocket connections are supported — tools like Jupyter and Marimo work out o
 
 ## Environment variables inside containers
 
-| Variable                    | Example                   | Description                                   |
-| --------------------------- | ------------------------- | --------------------------------------------- |
-| `KLANGKWS_PORT_MAPPINGS`    | `8000:9000,8001:9001,...` | Container-to-host port mapping (CSV)          |
-| `KLANGKD_HOSTING_HOSTNAME`  | `localhost:8997`          | Hostname for constructing hosted app URLs     |
-| `KLANGKD_HOSTING_PROTO`     | `http`                    | Protocol for hosted app URLs                  |
-| `KLANGKD_HOSTING_BASE_PATH` | `/klangk`                 | Base path prefix (empty for root deployments) |
+| Variable                     | Example                   | Description                                   |
+| ---------------------------- | ------------------------- | --------------------------------------------- |
+| `KLANGKWS_PORT_MAPPINGS`     | `8000:9000,8001:9001,...` | Container-to-host port mapping (CSV)          |
+| `KLANGKWS_HOSTING_HOSTNAME`  | `localhost:8997`          | Hostname for constructing hosted app URLs     |
+| `KLANGKWS_HOSTING_PROTO`     | `http`                    | Protocol for hosted app URLs                  |
+| `KLANGKWS_HOSTING_BASE_PATH` | `/klangk`                 | Base path prefix (empty for root deployments) |
+
+These are injected at container start. `KLANGKWS_HOSTING_HOSTNAME` names the
+browser listener (`KLANGKD_PORT`): with no `KLANGKD_HOSTING_HOSTNAME` override,
+any synthetic port-less loopback hostname — the setup-time start with no
+request in hand, or a `Host: localhost` arriving from a CLI connected over the
+backend socket — automatically carries the browser-listener port. The whole
+block is omitted in headless deployments (`KLANGKD_PORT` unset) and
+when hosting is disabled — the same clean-error outcome as below.
 
 Extensions and scripts inside the container can use these to construct correct URLs for their hosted apps. Pi's built-in `get_hosted_url` tool does this automatically.
 
@@ -55,7 +63,7 @@ http://localhost:8997/hosted/abc123/9000/
 ```
 
 Pass the **container port** (8000-8004); it resolves the mapped host port via
-`KLANGKWS_PORT_MAPPINGS` and combines it with the `KLANGKD_HOSTING_*` and
+`KLANGKWS_PORT_MAPPINGS` and combines it with the `KLANGKWS_HOSTING_*` and
 `KLANGKWS_WORKSPACE_ID` env vars to print the full URL. Use it from `setup.sh`,
 your `service_command`, a `health_check`, or interactively. Pi's
 `get_hosted_url` tool delegates to this same script, so the URL logic lives in
@@ -99,8 +107,10 @@ server-wide. This is a single knob that doubles as the count configuration:
 - **No ports are allocated** — not at workspace creation, not on container
   start. Existing workspaces release their allocations on their next start.
 - **No hosting env in containers** — `KLANGKWS_PORT_MAPPINGS` and the
-  `KLANGKD_HOSTING_*` vars are not injected, so `klangk-hosted-url` and the
-  agent's `get_hosted_url` tool error out cleanly.
+  `KLANGKWS_HOSTING_*` vars are not injected, so `klangk-hosted-url` and the
+  agent's `get_hosted_url` tool error out cleanly. The same happens in
+  headless deployments (`KLANGKD_PORT` unset): `/hosted/` is served by the
+  browser listener, which headless mode does not render (#2732).
 - **`/hosted/<ws>/<port>/` returns 404** — the proxy locations are
   collapsed to a single `return 404` block.
 

--- a/docs/sandboxes/openclaw.md
+++ b/docs/sandboxes/openclaw.md
@@ -23,7 +23,9 @@ klangk sandbox openclaw
 
 First run installs Node.js 24 (via nvm), openclaw, writes a config
 pointing at the Klangk LLM proxy, and runs a non-interactive onboard.
-The setup script prints the hosted app URL at the end.
+The setup script prints the hosted app URL at the end (on servers that
+serve hosted apps; on a headless server it instead points you at the
+workspace page in the Klangk UI, since no direct URL exists).
 
 The gateway starts automatically in the Service terminal tab (it runs as
 the workspace's agent identity in a dedicated `service` tmux session, not

--- a/sandboxes/openclaw/setup.sh
+++ b/sandboxes/openclaw/setup.sh
@@ -16,7 +16,7 @@ INSTALL_DIR="/openclaw"
 # the WS exec that runs this script); the `:-` fallback defends against an
 # unset var. With HOME repointed, the existing ~/.profile appends below
 # land in the agent's ~/.profile unchanged.
-export HOME="${KLANGKWS_AGENT_HOME:-/home/clanker}"
+export HOME="${KLANGKWS_AGENT_HOME:-/home/klangk}"
 
 # Persist every env export the service_command depends on to ~/.profile
 # UP FRONT, before any long-running install step.
@@ -40,7 +40,7 @@ export HOME="${KLANGKWS_AGENT_HOME:-/home/clanker}"
 #   - NVM_DIR + nvm.sh source (so nvm/node load in new shells)
 #   - /openclaw/bin on PATH (so the `openclaw` binary is found)
 #   - OPENCLAW_HOME (so openclaw locates its config; the agent's
-#     $HOME is /home/clanker, not /openclaw, so without this openclaw
+#     $HOME is /home/klangk, not /openclaw, so without this openclaw
 #     looks in the wrong place and reports "Missing config" -- #1039)
 # These used to be appended at three separate points in setup, so a
 # mid-setup pane inherited PATH but not OPENCLAW_HOME. Each line is
@@ -174,16 +174,17 @@ cfg['models']['providers']['llm-proxy']['request'] = {'allowPrivateNetwork': Tru
 cfg['gateway']['bind'] = 'lan'
 cfg['gateway']['http'] = {'endpoints': {'chatCompletions': {'enabled': True}}}
 # Trust the Klangk reverse proxy and allow the hosted origin for
-# WebSocket connections (required since openclaw v2026.2.26).
+# WebSocket connections (required since openclaw v2026.2.26). The
+# KLANGKWS_HOSTING_* block is injected only when the server actually
+# serves hosted apps (#2732); when absent there is no working browser
+# origin to allow, so only the direct localhost origins are listed.
 hosting_proto = os.environ.get('KLANGKWS_HOSTING_PROTO', 'http')
-hosting_hostname = os.environ.get('KLANGKWS_HOSTING_HOSTNAME', 'localhost:8995')
-hosted_origin = f'{hosting_proto}://{hosting_hostname}'
+hosting_hostname = os.environ.get('KLANGKWS_HOSTING_HOSTNAME', '')
+allowed_origins = ['http://localhost:8000', 'http://127.0.0.1:8000']
+if hosting_hostname:
+    allowed_origins.insert(0, f'{hosting_proto}://{hosting_hostname}')
 cfg['gateway']['controlUi'] = cfg.get('gateway', {}).get('controlUi', {})
-cfg['gateway']['controlUi']['allowedOrigins'] = [
-    hosted_origin,
-    'http://localhost:8000',
-    'http://127.0.0.1:8000',
-]
+cfg['gateway']['controlUi']['allowedOrigins'] = allowed_origins
 cfg['gateway']['trustedProxies'] = ['0.0.0.0/0']
 cfg['secrets'] = {
     'providers': {
@@ -200,13 +201,18 @@ with open(cfg_path, 'w') as f:
 
 # Derive the hosted app URL from Klangk env vars.
 # Container port 8000 maps to the first host port in KLANGKWS_PORT_MAPPINGS.
+# The backend injects the KLANGKWS_HOSTING_* block only when it serves
+# /hosted/ (KLANGKD_PORT set, #2732) — KLANGKWS_HOSTING_HOSTNAME then names
+# the browser listener the URL is served on. When the block is absent the
+# server serves no hosted-app URL at all, so print a pointer to the UI
+# instead of guessing a host:port that cannot work.
 host_port=""
 if [ -n "${KLANGKWS_PORT_MAPPINGS:-}" ]; then
   # Format: 8000:9000,8001:9001,...
   host_port=$(echo "$KLANGKWS_PORT_MAPPINGS" | cut -d, -f1 | cut -d: -f2)
 fi
 proto="${KLANGKWS_HOSTING_PROTO:-http}"
-hostname="${KLANGKWS_HOSTING_HOSTNAME:-localhost:8995}"
+hostname="${KLANGKWS_HOSTING_HOSTNAME:-}"
 base_path="${KLANGKWS_HOSTING_BASE_PATH:-}"
 workspace_id="${KLANGKWS_WORKSPACE_ID:-}"
 
@@ -216,8 +222,12 @@ echo "openclaw: $(openclaw --version)"
 echo ""
 echo "Setup complete."
 echo "The gateway will start automatically via service-command."
-if [ -n "$host_port" ] && [ -n "$workspace_id" ]; then
+if [ -n "$host_port" ] && [ -n "$hostname" ] && [ -n "$workspace_id" ]; then
   echo ""
   echo "Open the UI at:"
   echo "  ${proto}://${hostname}${base_path}/hosted/${workspace_id}/${host_port}/"
+else
+  echo ""
+  echo "Hosted UI: open it from the workspace page in the Klangk UI"
+  echo "(this server serves no direct hosted-app URLs)."
 fi

--- a/sandboxes/tests/hermes/test_hermes_setup_e2e.py
+++ b/sandboxes/tests/hermes/test_hermes_setup_e2e.py
@@ -77,10 +77,6 @@ SANDBOX_DIR = os.path.join(REPO_ROOT, "sandboxes", "hermes")
 WS = "e2e-hermes-setup"
 EMAIL = "test@example.com"
 PASSWORD = "testpass"
-# The agent's user id (klangk.model.AGENT_USER_ID). setup.sh
-# repoints HOME at the agent's home (#1171) so the ~/.profile exports
-# land in the agent's home, not the owner's; the test reads that profile.
-AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
 # Real install (clone NousResearch/hermes-agent + uv sync .[all] + managed
 # Node) can take several minutes, especially on CI. The installer's own
 # estimate is 1-5 min for deps; the clone + Node add to that.
@@ -217,19 +213,19 @@ def _health_status(base_url, token, ws_id):
 def _agent_profile(data_dir, ws_id):
     """Path to the AGENT's ~/.profile on the host for *ws_id*.
 
-    setup.sh repoints HOME at the agent's home (#1171), so the
-    HERMES_HOME / PATH exports it writes land in the agent's home
-    (``.users/<AGENT_USER_ID>``), not the owner's. Since #1295
-    workspace storage is keyed by workspace_id, so the home tree
-    is ``<data>/workspaces/<ws_id>/home/.users/``.
+    setup.sh repoints HOME at the agent's home (#1171). Since #2718/#2720
+    the agent's handle is fixed: KLANGKWS_AGENT_HOME is always the shared
+    /home/klangk, whose host-side tree lives directly under the
+    workspace's home (``<data>/workspaces/<ws>/home/klangk``) — the old
+    ``.users/<AGENT_USER_ID>`` path is gone. (Same repair the openclaw
+    suite received in #2746.)
     """
     return os.path.join(
         data_dir,
         "workspaces",
         ws_id,
         "home",
-        ".users",
-        AGENT_USER_ID,
+        "klangk",
         ".profile",
     )
 

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -109,10 +109,6 @@ WS2 = "e2e-openclaw-setup-2"
 WS3 = "e2e-openclaw-setup-3"
 EMAIL = "test@example.com"
 PASSWORD = "testpass"
-# The agent's user id (klangk.model.AGENT_USER_ID). setup.sh
-# repoints HOME at the agent's home (#1171) so the ~/.profile exports
-# land in the agent's home, not the owner's; the tests read that profile.
-AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
 # Real npm install of openclaw (nvm + node + global package) can take a
 # while, especially on CI.
 SETUP_TIMEOUT = 900
@@ -249,19 +245,18 @@ def _health_status(base_url, token, ws_id):
 def _agent_profile(data_dir, ws_id):
     """Path to the AGENT's ~/.profile on the host for *ws_id*.
 
-    setup.sh repoints HOME at the agent's home (#1171), so the
-    OPENCLAW_HOME / PATH / NVM_DIR exports it writes land in the agent's
-    home (``.users/<AGENT_USER_ID>``), not the owner's. Since #1295
-    workspace storage is keyed by workspace_id, so the home tree
-    is ``<data>/workspaces/<ws_id>/home/.users/``.
+    setup.sh repoints HOME at the agent's home (#1171). Since #2718/#2720
+    the agent's handle is fixed: KLANGKWS_AGENT_HOME is always the shared
+    /home/klangk, whose host-side tree lives directly under the
+    workspace's home (``<data>/workspaces/<ws>/home/klangk``) — the old
+    ``.users/<AGENT_USER_ID>`` path is gone.
     """
     return os.path.join(
         data_dir,
         "workspaces",
         ws_id,
         "home",
-        ".users",
-        AGENT_USER_ID,
+        "klangk",
         ".profile",
     )
 

--- a/src/containers/workspace/agent-context.md
+++ b/src/containers/workspace/agent-context.md
@@ -80,10 +80,13 @@ You are an expert coding agent working within a container.
 
 ## Hosted Apps and Ports
 
-This container has mapped ports for serving apps to the user's
-browser. The `$KLANGKWS_PORT_MAPPINGS` env var lists container_port:host_port
-pairs (e.g., "8000:9000,8001:9001,..."). Only these mapped container ports are
-reachable from outside the container.
+When this server serves hosted apps, this container has mapped ports for
+serving apps to the user's browser. The `$KLANGKWS_PORT_MAPPINGS` env var
+lists container_port:host_port pairs (e.g., "8000:9000,8001:9001,...").
+Only these mapped container ports are reachable from outside the container.
+On a headless server the variable is absent entirely (no hosted-app URLs
+exist) — `get_hosted_url` will error, and apps are reachable only from
+inside the container.
 
 - Always configure apps to listen on one of the mapped container ports
   (8000, 8001, 8002, etc.). Never hardcode arbitrary ports like 3000 or 5000

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -220,12 +220,16 @@ def build_env(
     env_vars.append("PI_SKIP_VERSION_CHECK=1")
     logger.info("Container LLM proxy: %s", proxy_url)
 
-    # Hosted-app serving env. Omit entirely when the workspace has
+    # Hosted-app serving env. Omitted entirely when the workspace has
     # no host ports (KLANGKD_HOSTED_PORTS_PER_WORKSPACE=0, or a
     # per-workspace value of 0): KLANGKWS_PORT_MAPPINGS absent makes
     # klangk-hosted-url / get_hosted_url error out cleanly, and the
     # KLANGKWS_HOSTING_* vars are meaningless without hosting. #1237
-    if host_ports:
+    # Also omitted in headless deployments (KLANGKD_PORT unset, #2732):
+    # /hosted/ is served by the browser listener, which headless mode
+    # does not render, so any hosted URL baked now would be dead on
+    # arrival — the same clean-error outcome as the cap-0 case.
+    if host_ports and app.state.settings.port is not None:
         mappings = [
             f"{CONTAINER_PORT_START + i}:{hp}"
             for i, hp in enumerate(host_ports)

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -197,6 +197,59 @@ def scan_free_ports(start: int, count: int, used: set[int]) -> list[int]:
     return ports
 
 
+def authority_has_port(authority: str) -> bool:
+    """True if a ``host[:port]`` authority names an explicit port.
+
+    Used by :meth:`Util.browser_listener_hostname` (#2732) to tell a
+    port-less hostname (``localhost``, an outer proxy's standard-port
+    authority) from one that already carries its port. IPv6 literals
+    arrive bracketed per RFC 3986, so the colon inside ``[::1]`` is not
+    a port separator; ``[::1]:8997`` is. A bare (unbracketed) IPv6
+    literal is indistinguishable from ``host:port`` by suffix alone, so
+    it reports True — callers treat it as already-ported and leave it
+    alone, which is the safe outcome for a form no supported client
+    sends.
+    """
+    if authority.startswith("["):
+        return not authority.endswith("]")
+    _host, sep, port = authority.rpartition(":")
+    return bool(sep) and port.isdigit()
+
+
+def is_portless_loopback_host(authority: str) -> bool:
+    """True if *authority* is a port-less loopback hostname (#2732).
+
+    The synthetic local values :meth:`Util.browser_listener_hostname`
+    retargets at the browser listener: the no-request floor
+    ``localhost`` and the ``Host: localhost`` / ``Host: 127.x`` a CLI
+    handshake sends. Case-insensitive (Host is case-insensitive per RFC
+    7230) and covers 127.0.0.0/8 dotted-quad + bracketed ``::1``.
+    Port-bearing authorities and non-loopback hosts (remote intent;
+    never rewritten) are False. Any unbracketed colon-bearing form —
+    every bare IPv6 literal, including v4-mapped loopback like
+    ``::ffff:127.0.0.1`` — is left alone: appending ``:<port>`` to it
+    would emit an authority no URL parser accepts, and bracketing is
+    not this helper's job. Shorthand like ``127.1`` (rejected by
+    ``ipaddress``) and the FQDN dot form ``localhost.`` are also left
+    alone — value-noise edges no supported client sends.
+    """
+    if not authority or authority_has_port(authority):
+        return False
+    candidate = authority.lower()
+    if ":" in candidate:
+        # Bracketed form only; a bare IPv6 literal (``::1``, ``::ffff:..``)
+        # cannot take a bare :port append.
+        if not (candidate.startswith("[") and candidate.endswith("]")):
+            return False
+        candidate = candidate[1:-1]
+    if candidate == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
+
+
 # Loopback addresses used by ``Util.client_is_loopback`` (the none-mode
 # /auth/local self-defense). This is the *real* loopback range
 # (127.0.0.0/8 + ::1), not the three-string allowlist the startup bind
@@ -546,10 +599,20 @@ class Util:
         no request in hand (e.g. ``start_workspace`` at boot). With no
         headers the request branches are skipped and the env vars are the
         sole source, falling back to bare ``localhost`` / ``http`` / ``""``.
+
+        #2732: a loopback hostname that was NOT taken from the env pin or
+        a trusted ``X-Forwarded-Host`` is a synthetic local value (a UDS
+        CLI handshake sends ``Host: localhost``; the no-request floor is
+        bare ``localhost``). Every URL this resolver feeds is
+        browser-facing, and browsers reach the deployment through the
+        browser listener (``KLANGKD_PORT``), so the configured browser port
+        is appended — see :meth:`browser_listener_hostname`.
         """
         hostname = self.app.state.settings.hosting_hostname
         proto = self.app.state.settings.hosting_proto
         base_path = self.app.state.settings.hosting_base_path
+        pinned = bool(hostname)
+        forwarded = False
         trust = (
             (not self.reject_proxy_headers())
             and self.connection_peer_is_trusted(client_host)
@@ -560,10 +623,13 @@ class Util:
                 forwarded_host = headers.get("x-forwarded-host")
                 if forwarded_host:
                     hostname = forwarded_host
+                    forwarded = True
             if not hostname:
                 hostname = headers.get("host") or "localhost"
         if not hostname:
             hostname = "localhost"
+        if not pinned and not forwarded:
+            hostname = self.browser_listener_hostname(hostname)
         if not proto:
             if headers is not None and trust:
                 proto = headers.get("x-forwarded-proto") or "http"
@@ -576,11 +642,36 @@ class Util:
                 base_path = ""
         return hostname, proto, base_path
 
+    def browser_listener_hostname(self, hostname: str) -> str:
+        """Point a synthetic loopback hostname at the browser listener (#2732).
+
+        ``/hosted/`` and every other browser-facing surface live on the
+        browser listener (``KLANGKD_PORT``), never on the container-egress
+        listener or the backend UDS. The synthetic loopback values this
+        resolver produces when no operator intent is available (the
+        no-request floor ``localhost``, and the ``Host: localhost`` a CLI
+        sends over the backend UDS) name port 80 — a URL no deployment
+        serves. When a browser listener is configured, append its port.
+
+        No-op otherwise: a hostname that already carries a port (a direct
+        browser request to the browser listener), a non-loopback hostname
+        (carries remote intent; never rewritten), or headless mode
+        (``KLANGKD_PORT`` unset — no browser listener exists to point at).
+        The loopback test is :func:`is_portless_loopback_host` —
+        case-insensitive, whole 127.0.0.0/8 range, ``::1`` bracketed.
+        """
+        port = self.app.state.settings.port
+        if not port or not is_portless_loopback_host(hostname):
+            return hostname
+        return f"{hostname}:{port}"
+
     def cors_origins(self) -> list[str]:
         """Build the CORS allowed-origins list.
 
         Priority: KLANGKD_CORS_ORIGINS (comma-separated) > derived from the
-        hosting env vars > bare localhost.
+        hosting env vars > the derived localhost authority (bare in headless
+        mode, ``localhost:<KLANGKD_PORT>`` when a browser listener exists,
+        #2732).
 
         Consistent with hosted-app URL construction: the port comes from
         KLANGKD_HOSTING_HOSTNAME (which carries host[:port]); it is never

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -3304,7 +3304,8 @@ class TestStartContainer:
         binds = p.create_container.call_args.kwargs["binds"]
         assert "/tmp/home:/home" in binds
 
-    async def test_hosting_env_vars(self, workspace):
+    async def test_hosting_env_vars(self, workspace, monkeypatch):
+        monkeypatch.setattr(self.registry.app.state.settings, "port", "8997")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 container.ContainerStartSpec(
@@ -3320,17 +3321,21 @@ class TestStartContainer:
         assert "KLANGKWS_HOSTING_PROTO=https" in env
         assert "KLANGKWS_HOSTING_BASE_PATH=/klangk" in env
 
-    async def test_hosting_env_vars_default_is_bare_localhost(self, workspace):
-        """Omitted hosting_* resolves to bare localhost (#1240).
+    async def test_hosting_env_vars_default_gains_browser_port(
+        self, workspace, monkeypatch
+    ):
+        """Omitted hosting_* resolves through derive_hosting_info (#1240, #2732).
 
         This is the path ``eager_start_workspace`` takes (autostart /
-        workspace create have no request to derive from). Before the fix
-        the defaults were a bare ``localhost`` with no port anyway, but
-        *bypassed* ``derive_hosting_info`` entirely — so a deployer who set
-        ``KLANGKD_HOSTING_HOSTNAME`` saw it ignored on every eager start.
-        Now the choke point resolves it, and no port is synthesized from
-        ``KLANGKD_EGRESS_PORT`` (the port must live in HOSTING_HOSTNAME).
+        workspace create have no request to derive from). Before #1240 the
+        eager path bypassed ``derive_hosting_info`` entirely, so a deployer
+        who set ``KLANGKD_HOSTING_HOSTNAME`` saw it ignored. #2732: the
+        synthetic loopback floor now carries the browser-listener port, so
+        the hosted URL baked at setup names the listener that actually
+        serves ``/hosted/`` — never the egress port (#1240) and never bare
+        port-80 localhost.
         """
+        monkeypatch.setattr(self.registry.app.state.settings, "port", "8997")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 container.ContainerStartSpec(
@@ -3339,9 +3344,33 @@ class TestStartContainer:
                 )
             )
         env = p.create_container.call_args.kwargs["env"]
-        assert "KLANGKWS_HOSTING_HOSTNAME=localhost" in env
+        assert "KLANGKWS_HOSTING_HOSTNAME=localhost:8997" in env
         assert "KLANGKWS_HOSTING_PROTO=http" in env
         assert "KLANGKWS_HOSTING_BASE_PATH=" in env
+
+    async def test_headless_omits_hosting_env(self, workspace):
+        """Headless (KLANGKD_PORT unset) suppresses the hosting env (#2732).
+
+        ``/hosted/`` is served by the browser listener, which headless mode
+        does not render — any hosted URL baked now would be dead on arrival.
+        Same clean-error outcome as the cap-0 case: klangk-hosted-url /
+        get_hosted_url error out, non-hosting env is untouched.
+        """
+        # Fixture settings are headless by default (no KLANGKD_PORT).
+        assert self.registry.app.state.settings.port is None
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                container.ContainerStartSpec(
+                    workspace["id"],
+                    "/tmp/home",
+                    num_ports=5,
+                )
+            )
+        env = p.create_container.call_args.kwargs["env"]
+        assert not any(e.startswith("KLANGKWS_PORT_MAPPINGS=") for e in env)
+        assert not any(e.startswith("KLANGKWS_HOSTING_") for e in env)
+        assert any(e.startswith("KLANGKWS_WORKSPACE_ID=") for e in env)
+        assert any(e.startswith("KLANGKWS_LLM_PROXY_URL=") for e in env)
 
     async def test_terminal_banner_default_empty(self, workspace):
         """Default terminal banner is empty, so env var is not passed."""
@@ -3539,8 +3568,11 @@ class TestStartContainer:
         await self.registry.allocate_ports(workspace["id"], 5)
         assert await self.registry.get_workspace_ports(workspace["id"]) == []
 
-    async def test_hosting_env_present_when_enabled(self, workspace):
-        """Sanity: with the default cap, hosting env is injected as before."""
+    async def test_hosting_env_present_when_enabled(
+        self, workspace, monkeypatch
+    ):
+        """Sanity: with the default cap and a browser listener, hosting env is injected."""
+        monkeypatch.setattr(self.registry.app.state.settings, "port", "8997")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 container.ContainerStartSpec(

--- a/src/klangk/klangkd-tests/tests/test_util.py
+++ b/src/klangk/klangkd-tests/tests/test_util.py
@@ -8,7 +8,9 @@ from klangk.settings import resolve_dynamic_config
 from klangk.util import (
     MAX_PORT,
     Util,
+    authority_has_port,
     free_port,
+    is_portless_loopback_host,
     port_in_use,
     read_file_value,
     run_cmd_value,
@@ -373,6 +375,27 @@ class TestCorsOrigins:
         u = _util({"KLANGKD_EGRESS_PORT": "9000"})
         assert u.cors_origins() == ["http://localhost"]
 
+    def test_browser_listener_port_in_origin(self):
+        """Full mode without a pin: origin is the browser listener (#2732).
+
+        cors_origins derives through derive_hosting_info(None, None), so
+        the synthetic loopback floor carries KLANGKD_PORT — the origin
+        browsers actually load the UI from. Headless stays bare (no
+        browser listener to name).
+        """
+        u = _util({"KLANGKD_PORT": "8997"})
+        assert u.cors_origins() == ["http://localhost:8997"]
+
+    def test_hosting_hostname_pin_wins_over_browser_port(self):
+        """The env pin is used verbatim even in full mode."""
+        u = _util(
+            {
+                "KLANGKD_PORT": "8997",
+                "KLANGKD_HOSTING_HOSTNAME": "klangk.example.com",
+            }
+        )
+        assert u.cors_origins() == ["http://klangk.example.com"]
+
     def test_hosting_hostname_carries_port(self):
         u = _util({"KLANGKD_HOSTING_HOSTNAME": "localhost:8996"})
         assert u.cors_origins() == ["http://localhost:8996"]
@@ -661,6 +684,161 @@ class TestDeriveHostingInfo:
         assert h == "localhost"
         assert p == "http"
         assert b == ""
+
+    # --- #2732: the synthetic loopback floor carries the browser port ---
+
+    def test_no_headers_loopback_floor_gains_browser_port(self):
+        """No env, no request, browser listener set -> localhost:<KLANGKD_PORT>.
+
+        This is the value baked into KLANGKWS_HOSTING_HOSTNAME for the
+        setup-time container start (the sandbox hosted-URL path): /hosted/
+        is served on the browser listener, so the URL must name it.
+        """
+        u = _util({"KLANGKD_PORT": "8997"})
+        h, p, b = u.derive_hosting_info(None, None)
+        assert h == "localhost:8997"
+        assert p == "http"
+        assert b == ""
+
+    def test_uds_host_localhost_gains_browser_port(self):
+        """Host: localhost from a CLI-over-UDS handshake gains the port too."""
+        u = _util({"KLANGKD_PORT": "8997"})
+        h, p, b = u.derive_hosting_info({"host": "localhost"}, None)
+        assert h == "localhost:8997"
+
+    def test_host_with_port_unchanged(self):
+        """A Host that already carries its port is never rewritten."""
+        u = _util({"KLANGKD_PORT": "8997"})
+        h, _, _ = u.derive_hosting_info({"host": "localhost:8997"}, None)
+        assert h == "localhost:8997"
+
+    def test_loopback_host_forms_gains_browser_port(self):
+        """Case, 127.0.0.0/8, and bracketed ::1 do not dodge the retarget.
+
+        Host is case-insensitive per RFC 7230 and every 127.x is a local
+        synthetic value — all of them name port 80 without the append.
+        ``[::1]`` is the only IPv6 form whose append is parseable.
+        """
+        u = _util({"KLANGKD_PORT": "8997"})
+        for host in ("LOCALHOST", "LocalHost", "127.0.0.2", "[::1]"):
+            h, _, _ = u.derive_hosting_info({"host": host}, None)
+            assert h == f"{host}:8997", host
+
+    def test_bare_ipv6_host_left_alone(self):
+        """Bare (unbracketed) IPv6 Hosts are never appended (#2732 review).
+
+        ``::1`` parses as port-bearing; ``::ffff:127.0.0.1`` (v4-mapped
+        loopback) parses as a port-less loopback — either way a bare
+        ``:port`` append would emit an unparseable authority, so both
+        pass through untouched.
+        """
+        u = _util({"KLANGKD_PORT": "8997"})
+        for host in ("::1", "::ffff:127.0.0.1"):
+            h, _, _ = u.derive_hosting_info({"host": host}, None)
+            assert h == host, host
+
+    def test_untrusted_portless_host_unchanged(self):
+        """A non-loopback port-less Host carries remote intent; untouched.
+
+        Same anti-phishing posture as the forwarded-header gate: an
+        untrusted peer's Host is already suspect, and rewriting it with a
+        local port would only launder it.
+        """
+        u = _util({"KLANGKD_PORT": "8997"})
+        h, _, _ = u.derive_hosting_info(
+            {"host": "evil.com", "x-forwarded-host": "evil.com"},
+            "203.0.113.7",
+        )
+        assert h == "evil.com"
+
+    def test_forwarded_host_not_port_appended(self):
+        """A trusted X-Forwarded-Host passes through verbatim (#2732).
+
+        An outer proxy on a standard port is a deliberate deployment —
+        appending the local browser port would break it.
+        """
+        u = _util({"KLANGKD_PORT": "8997"})
+        h, _, _ = u.derive_hosting_info(
+            {"x-forwarded-host": "example.com"}, "127.0.0.1"
+        )
+        assert h == "example.com"
+
+    def test_env_pin_not_port_appended(self):
+        """The KLANGKD_HOSTING_HOSTNAME pin wins verbatim, port or not."""
+        u = _util(
+            {
+                "KLANGKD_PORT": "8997",
+                "KLANGKD_HOSTING_HOSTNAME": "klangk.example.com",
+            }
+        )
+        h, _, _ = u.derive_hosting_info({"host": "localhost"}, None)
+        assert h == "klangk.example.com"
+
+    def test_headless_floor_stays_bare(self):
+        """Headless (no KLANGKD_PORT): nothing to point at, floor bare."""
+        u = _util({})
+        h, _, _ = u.derive_hosting_info(None, None)
+        assert h == "localhost"
+
+
+class TestAuthorityHasPort:
+    """host[:port] authority parsing for browser_listener_hostname (#2732)."""
+
+    def test_portless_names(self):
+        assert not authority_has_port("localhost")
+        assert not authority_has_port("example.com")
+        assert not authority_has_port("[::1]")
+
+    def test_ported_names(self):
+        assert authority_has_port("localhost:8997")
+        assert authority_has_port("example.com:80")
+        assert authority_has_port("[::1]:8997")
+
+    def test_non_numeric_suffix_is_not_a_port(self):
+        assert not authority_has_port("host:notaport")
+
+    def test_bare_ipv6_reports_ported(self):
+        """A bare unbracketed IPv6 literal is indistinguishable from host:port.
+
+        Documented-intentional: callers leave such an authority alone
+        (no supported client sends it), which is the safe outcome.
+        """
+        assert authority_has_port("::1")
+
+
+class TestIsPortlessLoopbackHost:
+    """The synthetic-local gate for browser_listener_hostname (#2732)."""
+
+    def test_loopback_names(self):
+        assert is_portless_loopback_host("localhost")
+        assert is_portless_loopback_host("LOCALHOST")
+        assert is_portless_loopback_host("LocalHost")
+        assert is_portless_loopback_host("127.0.0.1")
+        assert is_portless_loopback_host("127.0.0.2")
+        assert is_portless_loopback_host("[::1]")
+
+    def test_ported_loopback_is_not_portless(self):
+        assert not is_portless_loopback_host("localhost:8997")
+        assert not is_portless_loopback_host("[::1]:8997")
+
+    def test_remote_and_garbage_are_false(self):
+        assert not is_portless_loopback_host("example.com")
+        assert not is_portless_loopback_host("evil.com")
+        assert not is_portless_loopback_host("")
+        assert not is_portless_loopback_host("not-an-ip:xyz")
+
+    def test_bare_ipv6_forms_left_alone(self):
+        """No bare (unbracketed) IPv6 is ever retargeted (#2732 review).
+
+        A v4-mapped loopback like ``::ffff:127.0.0.1`` slips past the
+        port check (its last colon-suffix is not digits) yet parses as
+        loopback — appending ``:port`` would emit an authority no URL
+        parser accepts. Every colon-bearing unbracketed form is False.
+        """
+        assert not is_portless_loopback_host("::1")
+        assert not is_portless_loopback_host("::ffff:127.0.0.1")
+        # The safe append exists only for the bracketed form.
+        assert is_portless_loopback_host("[::1]")
 
 
 # --- effective_client_ip (#2586: workstation identity for the ---


### PR DESCRIPTION
## Summary

Fixes #2732.

The hosted-app URL printed at the end of `klangk sandbox openclaw` was never followable. `/hosted/<ws>/<port>/` is served by the **browser listener** (`KLANGKD_PORT`), but the printed URL pointed elsewhere:

- `derive_hosting_info`'s no-request floor returned bare `localhost` (port 80 implied). The sandbox setup start has no browser request in hand, and the CLI's UDS handshake sends `Host: localhost`, so no header ever carried the real port.
- `setup.sh`'s own fallback hardcoded `localhost:8995` — the container-egress port, which serves no `/hosted/` routes.

## Changes

- **`util.py`** — `derive_hosting_info` now appends the configured browser-listener port to a synthetic port-less **loopback** hostname — one that came neither from the `KLANGKD_HOSTING_HOSTNAME` env pin nor a trusted `X-Forwarded-Host` (both pass through verbatim). A hostname that already carries a port or is non-loopback is never rewritten, preserving the anti-phishing posture. New `Util.browser_listener_hostname` + `authority_has_port` helpers.
- **`container/spec.py`** — headless deployments (`KLANGKD_PORT` unset) render no browser listener, so no hosted URL can work: `build_env` omits the `KLANGKWS_PORT_MAPPINGS` / `KLANGKWS_HOSTING_*` block entirely (same clean-error outcome as cap-0, so `klangk-hosted-url` / `get_hosted_url` fail cleanly).
- **`sandboxes/openclaw/setup.sh`** — drops the `localhost:8995` fallback; prints a URL only when the hosting env block was injected, otherwise a port-neutral pointer to the workspace page.
- **Docs** — `hosted-apps.md` names the in-container `KLANGKWS_HOSTING_*` vars correctly (was `KLANGKD_*`) and documents the headless omission; `openclaw.md` notes the fallback pointer; changelog entry under Fixed.
- **Suite repair** — `sandboxes/tests/openclaw`'s `_agent_profile` still read the pre-#2720 `.users/<AGENT_USER_ID>` path, but `KLANGKWS_AGENT_HOME` is now always the shared `/home/klangk` — the suite failed on current main. Fixed to the real path (verified locally: 4/4 pass after a full real install).

## Verification

- Full unit suite: 5546 passed, 100% coverage (`-n auto`, as CI runs it).
- Temporary e2e test (removed before this PR): real `klangkd` in browser mode → `klangk sandbox` → real install → the printed URL `http://localhost:<KLANGKD_PORT>/hosted/<ws>/<port>/` followed end-to-end returned **200** from the openclaw gateway through Caddy's `/hosted/` proxy. Under the old code the same URL pointed at the egress listener (connection refused / wrong server).
