### PR TITLE
Remove the vestigial /home/.terminals directory creation

### DIFF
--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -436,8 +436,6 @@ class Workspaces:
         home.mkdir(parents=True, exist_ok=True)
         users_dir = home / ".users"
         users_dir.mkdir(exist_ok=True)
-        terminals_dir = home / ".terminals"
-        terminals_dir.mkdir(exist_ok=True)
         # Allocate ports at creation time so ranges are sequential
         try:
             await self.app.state.container_registry.allocate_ports(


### PR DESCRIPTION
## Summary

- Remove the vestigial `/home/.terminals` directory creation from
  `Workspaces.create_workspace` (`src/klangk/klangk/workspaces.py`).

Closes #2731.

## Context

The directory was the shared-terminal tmux **socket directory** from #319 —
each shared terminal ran as an independent tmux server with a named socket at
`/home/.terminals/<name>.sock`. That machinery was removed when sharing moved
to per-tab window promotion (`share_window`); the `mkdir` survived the
migration, but nothing in the backend, CLI, container image, or docs reads or
writes the directory anymore.

## Notes

- Existing mounts keep the empty directory as an inert leftover — no
  destructive cleanup (same posture as the chat tables in #2716).
- No test asserted its creation (swept `test_workspaces.py`,
  `test_model_workspaces.py`, and the whole tree for `.terminals` references).
- No changelog entry: the removed behavior is invisible to users (an empty,
  unused directory no longer appears in new workspaces).
