### PR TITLE
docs: shared-home rollout sweep (#2169 chunk 6, #2724)

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -75,8 +75,9 @@ password change requires your current password. Validation is enforced the
 same way on every surface (and again, authoritatively, on the server):
 
 - **handle** — lowercase, `[a-z0-9._-]+`, at most 32 characters. Changing
-  it affects your terminal home directory and how others see you,
-  so the TUI and CLI confirm before applying it.
+  it affects how others see you — and, on per-handle-home workspaces,
+  your terminal home directory (`/home/<handle>`, see
+  [Handles](handles.md)) — so the TUI and CLI confirm before applying it.
 - **email** — must be a well-formed address. The account is marked
   unverified and a verification email is sent to the new address; verify it
   to fully activate the change. The address must not already be in use.

--- a/docs/features/handles.md
+++ b/docs/features/handles.md
@@ -3,7 +3,9 @@
 Every Klangk user has a unique handle (e.g., `@alice`). Handles are
 used throughout the platform:
 
-- **Terminal** — your `$HOME` directory is `/home/<handle>/`
+- **Terminal** — under the per-handle home layout, your `$HOME`
+  directory is `/home/<handle>/` (see
+  [Workspaces](workspaces.md#home-directory-layout))
 - **Shared terminals** — shared tabs are prefixed with the owner's
   handle (e.g., `alice:build`)
 
@@ -19,14 +21,19 @@ dashes, and underscores.
 
 ## Handle and HOME directory
 
-Your handle determines your home directory path inside workspace
-containers. When you open a terminal, `$HOME` is set to
-`/home/<handle>/`, which is a symlink to `.users/<user-id>/` on the
-host filesystem.
+How your handle relates to your home directory depends on the
+workspace's [home layout](workspaces.md#home-directory-layout), chosen
+when the workspace is created:
 
-If you change your handle, your `$HOME` path changes on your next
-terminal session — but the underlying directory (keyed by user ID)
-stays the same. Your files, dotfiles, and history are preserved.
+- **Shared home** (the default) — every member's `$HOME` is the single
+  `/home/klangk`. Your handle does not affect your home directory path.
+- **Per-handle home** — your `$HOME` is `/home/<handle>/`, a symlink to
+  `.users/<user-id>/` on the host filesystem.
+
+On a per-handle workspace, changing your handle changes your `$HOME`
+path on your next terminal session — but the underlying directory
+(keyed by user ID) stays the same. Your files, dotfiles, and history
+are preserved.
 
 ## Changing your handle
 

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -92,16 +92,23 @@ sandbox:
   setup-timeout: 300
 ```
 
-| Field           | Required | Default  | Description                                                                                                |
-| --------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `mount-at`      | no       | `~/work` | Where the sandbox root is mounted inside the container. `~` expands to `/home/{handle}`.                   |
-| `setup`         | no       | (none)   | Script to run inside the container after creation. Relative to `mount-at`, or absolute if starts with `/`. |
-| `setup-timeout` | no       | `300`    | Maximum seconds the setup script may run before being killed. Set to `0` to disable.                       |
+| Field           | Required | Default  | Description                                                                                                   |
+| --------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `mount-at`      | no       | `~/work` | Where the sandbox root is mounted inside the container. `~` expands to `/home/{handle}` — see the note below. |
+| `setup`         | no       | (none)   | Script to run inside the container after creation. Relative to `mount-at`, or absolute if starts with `/`.    |
+| `setup-timeout` | no       | `300`    | Maximum seconds the setup script may run before being killed. Set to `0` to disable.                          |
 
 The setup script runs once — on workspace creation, not on
 reconnect. It runs as the `klangk` user inside the container. If
 `KLANGKD_ALLOW_SUDO` is enabled on the server, the script can use
 `sudo` for system-level setup (installing packages, etc.).
+
+> **`~` and the home layout:** In `mount-at`, `copy` destinations,
+> and `mounts` destinations, `~` always expands to `/home/{handle}` —
+> your home under the per-handle layout. On a **shared-home**
+> workspace (the default) your `$HOME` is `/home/klangk`, so a `~`
+> destination mounts outside your home; use an explicit absolute
+> path (e.g. `mount-at: /home/klangk/work`) there.
 
 ### `copy`
 
@@ -114,7 +121,7 @@ copy:
 Files copied from the host into the container home directory. Uses the
 same `source:destination` format as mounts. Tilde on the left expands
 to the host user's home; tilde on the right expands to the container
-user's home (`/home/{handle}`).
+user's home (`/home/{handle}` — see the `~` note above).
 
 Copies happen once during workspace creation, after the default home
 skeleton is populated but before the setup script runs. The copied
@@ -137,8 +144,8 @@ Bind mounts from the host into the container. Format:
 - **Source**: host path. Absolute, or relative to the sandbox root.
   Tilde expands to the host user's home.
 - **Destination**: container path. Tilde expands to
-  `/home/{handle}`. Relative paths (no `~` or `/` prefix) are
-  resolved relative to `mount-at`.
+  `/home/{handle}` (see the `~` note above). Relative paths (no `~`
+  or `/` prefix) are resolved relative to `mount-at`.
 - **Options**: optional, comma-separated. Common options: `ro`
   (read-only), `rw` (read-write, default).
 
@@ -308,7 +315,7 @@ export HOME="${KLANGKWS_AGENT_HOME:-/home/klangk}"
 # Now ~/.profile, ~/.local/bin, etc. resolve into the shared home.
 ```
 
-> Under the default per-handle layout the owner does **not** get tools
+> Under the per-handle layout the owner does **not** get tools
 > installed by a sandbox on their own PATH. Sandbox-installed services
 > are operated through the Service tab — that is the supported way to
 > manage them (e.g. `openclaw onboard`, restarting a gateway). Don't

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -32,30 +32,35 @@ By running everything as a single UNIX user, Klangk sidesteps all of
 this. Every workspace member can read and write every file without
 fighting permissions. Collaboration just works.
 
-### Per-user home directories
+### Home directory layouts
 
-Even though everyone shares the same UNIX user, each workspace member
-gets their own `$HOME` directory. When you open a terminal, `$HOME` is
-set to `/home/<handle>/` — a symlink that points to
-`.users/<user-id>/` on the bind-mounted home volume.
+Even though everyone shares the same UNIX user, a workspace controls
+who sees whose files via its **home layout** — a setting chosen when
+the workspace is created (see
+[Workspaces](workspaces.md#home-directory-layout)):
 
-This means:
+- **Shared home** (the default) — every member's shell, exec session,
+  and the service share the single `/home/klangk` as `$HOME`, with one
+  `.bash_history` and one set of dotfiles. What one member installs or
+  configures (`.profile`, `~/.local/bin`, nix profiles) is immediately
+  on every member's `PATH` — the point of the default.
+- **Per-handle home** — each member gets a private `$HOME` at
+  `/home/<handle>/` — a symlink to `.users/<user-id>/` on the
+  bind-mounted home volume. This means:
+  - Your dotfiles (`.bashrc`, `.gitconfig`, `.vimrc`) are yours alone
+  - Your bash history is separate from other members'
+  - Your AI agent config (`.pi/agent/`, `.claude/`) is per-user
 
-- Your dotfiles (`.bashrc`, `.gitconfig`, `.vimrc`) are yours alone
-- Your bash history is separate from other members'
-- Your AI agent config (`.pi/agent/`, `.claude/`) is per-user
-- Your project files live directly in your home (`~`); there is no
-  separate shared project directory
+Under both layouts your project files live directly in your home
+(`~`) — there is no separate shared project directory — and `/home/klangk`
+(the shared home) is created and populated from the image skeleton
+when the container is first created, on every start path (including
+[auto-start](auto-start.md) on server boot).
 
-A separate directory, `/home/klangk`, is the **shared home**. It is
-created and populated from the image skeleton when the container is
-first created (on every start path, including server boot). The
-[service command](service-command.md) session always runs with
+The [service command](service-command.md) session always runs with
 `HOME=/home/klangk` — under both layouts — so environment setup that
-must reach the service goes in `/home/klangk/.profile`. Workspaces
-created with `per_handle_home=false` use the shared home for
-_everything_: every member's shell, exec sessions, and the service all
-share the one `/home/klangk` (and its `.bash_history`).
+must reach the service goes in `/home/klangk/.profile` (see
+[Sandbox setup](sandbox.md) for the recipe).
 
 See [Handles](handles.md) for how handles are assigned and how they
 relate to your home directory path.
@@ -107,11 +112,11 @@ See [Health Check](health-check.md).
 
 ### Convention
 
-| File                                        | Purpose                                                                                                          | Sourced by                                                                           |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `/etc/profile.d/klangk-*.sh`                | system-wide defaults (klangk `PATH`, `EDITOR`)                                                                   | every login shell                                                                    |
-| `~/.profile`                                | **per-user environment exports** (PATH additions, tool homes, nvm/asdf) — anything login-shell commands must see | login shells: interactive terminals, the service command, `klangk exec` (`bash -lc`) |
-| `~/.bashrc` (below the interactivity guard) | interactive niceties (aliases, prompt)                                                                           | interactive non-login bash shells; also chained from `~/.profile` for login shells   |
+| File                                        | Purpose                                                                                                 | Sourced by                                                                           |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `/etc/profile.d/klangk-*.sh`                | system-wide defaults (klangk `PATH`, `EDITOR`)                                                          | every login shell                                                                    |
+| `~/.profile`                                | **environment exports** (PATH additions, tool homes, nvm/asdf) — anything login-shell commands must see | login shells: interactive terminals, the service command, `klangk exec` (`bash -lc`) |
+| `~/.bashrc` (below the interactivity guard) | interactive niceties (aliases, prompt)                                                                  | interactive non-login bash shells; also chained from `~/.profile` for login shells   |
 
 **Rule of thumb:** if a login-shell command (`klangk exec`, a setup
 script, the service command) needs it, it goes in `~/.profile`. If it

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -91,15 +91,18 @@ is already running by the time any user connects.
 
 Each workspace runs in its own container with:
 
-- A persistent home directory at `/home/<handle>/` (survives container
-  restarts)
-- A shared `work/` directory for project files
+- A persistent home directory (survives container restarts) — the
+  shared `/home/klangk` under the default layout, or your private
+  `/home/<handle>/` under per-handle (see
+  [Home directory layout](#home-directory-layout) above)
 - Pre-installed tools and AI agents (see
   [Container Packages](container-packages.md) and
   [AI Coding Harnesses](ai-coding-harnesses.md))
 
-Your dotfiles (`.bashrc`, `.gitconfig`, etc.), bash history, and Pi
-sessions all persist across container restarts.
+Project files live directly in the home directory — there is no
+separate project subdirectory. Your dotfiles (`.bashrc`, `.gitconfig`,
+etc.), bash history, and Pi sessions all persist across container
+restarts.
 
 ## Sharing workspaces
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,9 +42,9 @@ with full terminal access, confined to the workspace.
 
 ### Multi-User Collaboration
 
-Share workspaces with teammates. Everyone gets their own home directory
-inside the container, and shared terminals let you pair-program in
-real time.
+Share workspaces with teammates. Workspaces share one home directory
+by default (per-member homes are a creation-time option), and shared
+terminals let you pair-program in real time.
 
 - [Role-based access](features/authorization.md): owners, coders,
   collaborators, spectators

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1316,11 +1316,16 @@ are created automatically.
   "image": "klangk-workspace:latest",
   "service_command": "/bin/bash",
   "mounts": ["my-volume:/home/user/data"],
-  "env": { "MY_VAR": "value" }
+  "env": { "MY_VAR": "value" },
+  "per_handle_home": true
 }
 ```
 
-All fields except `name` are optional.
+All fields except `name` are optional. `per_handle_home` selects the
+[home layout](../features/workspaces.md#home-directory-layout): `true`
+gives each member a private `/home/<handle>`, `false` (the server
+default, `KLANGKD_PER_HANDLE_HOME`) shares one `/home/klangk`. Omit it
+to inherit the server default.
 
 ```json
 {
@@ -1646,9 +1651,14 @@ command, volume mounts, environment variables). All fields optional.
   "image": "klangk-workspace:latest",
   "service_command": "/bin/bash",
   "mounts": ["vol:/data"],
-  "env": { "KEY": "VALUE" }
+  "env": { "KEY": "VALUE" },
+  "per_handle_home": false
 }
 ```
+
+`per_handle_home` may be flipped here too; the new layout applies from
+the workspace's next connect/start (open terminals keep their layout
+until they end).
 
 ```json
 { "status": "updated" }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -239,30 +239,32 @@ klangk ls --sort name --order asc       # sort by name, ascending
 klangk ls --filter gamma                # substring filter on name
 klangk create my-project                # create a workspace
 klangk create my-project --auto-start   # create with auto-start on server boot
-klangk create my-project --mount ~/src:/home/klangk/work/src          # with bind mount
+klangk create my-project --mount ~/src:/home/klangk/src          # with bind mount
 klangk create my-project --mount nix-store:/nix           # with named volume
 klangk create my-project --env FOO=bar                      # with env vars
 klangk create my-project --health-check 'curl -sf http://localhost:8080/health'  # with a service health check
 klangk create my-project --command 'npm run dev'  # with a service command
 klangk create my-project -c 'npm run dev'         # short form of --command
+klangk create my-project --per-handle-home       # per-member private homes (default: shared /home/klangk)
 klangk create my-project --allow github.com:443 --allow pypi.org  # with egress allowlist
 klangk edit my-project                  # interactive edit (name, image, command, health check, mounts, env, allowed domains)
 klangk edit my-project --auto-start     # enable auto-start on server boot
 klangk edit my-project --no-auto-start  # disable auto-start
 klangk edit my-project --env FOO=bar    # set env var via flag
 klangk edit my-project --allow github.com:443     # set allowed egress domain via flag
+klangk edit my-project --shared-home             # switch layout (applies from next connect/start)
 klangk dup my-project my-copy           # duplicate a workspace
 klangk shell my-project                 # drop into bash inside the container
 klangk shell my-project debug           # attach to the "debug" terminal window (created if it doesn't exist)
 klangk sandbox myws                     # create workspace from .klangk-sandbox.yaml
 klangk sandbox myws ~/projects/myapp    # specify sandbox root explicitly
 klangk sandbox myws --force             # re-apply config and re-run setup on existing workspace
-klangk exec my-project ls /home/klangk/work         # run a command in the container (login shell: sources ~/.profile)
+klangk exec my-project ls /home/klangk           # run a command in the container (login shell: sources ~/.profile)
 klangk exec --raw my-project rsync --server ...      # raw argv, no shell (for transports like rsync)
 klangk monitor                                        # stream all server events as JSON
 klangk monitor --type service_health | jq .           # pretty-print health transitions
 klangk monitor --type service_health -- sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'  # alert with the failure reason
-klangk sync ~/src my-project:/home/klangk/work      # sync files to/from the container
+klangk sync ~/src my-project:/home/klangk/src      # sync files to/from the container
 klangk rm my-project                # delete a workspace
 klangk stop my-project              # stop the container for a workspace
 klangk start my-project             # start the container for a workspace


### PR DESCRIPTION
Part 6 of 6 (final chunk) of #2169 — the docs closeout for the shared-home rollout. Chunks 1–5 landed as #2733, #2735, #2736, #2737, #2739 (+ #2741 removing `/home/work`, and the default flip to shared). Each chunk updated the pages it touched directly; this sweep fixes every remaining page that still presented per-handle homes as the unconditional layout.

## What changed

- **`docs/features/handles.md`** — HOME now depends on the workspace's home layout; under the default shared layout everyone's `$HOME` is `/home/klangk`. Handle-change semantics qualified to per-handle workspaces.
- **`docs/features/the-shell.md`** — "Per-user home directories" restructured into "Home directory layouts", leading with the shared default (one `~`, one `.bash_history`, installs shared on every member's `PATH`); per-handle described as the opt-in.
- **`docs/features/sandbox.md`** — documented that `~` in `mount-at`/`copy`/`mounts` destinations always expands to `/home/{handle}` (current CLI behavior), with a callout that on shared-home workspaces (the default) that lands outside `$HOME` — use an explicit absolute path there. Removed the stale "default per-handle layout" claim (the default is shared since #2741's flip landing).
- **`docs/features/workspaces.md`** — "What's inside" no longer promises `/home/<handle>/` unconditionally; dropped the removed shared `work/` directory (#2725) and noted project files live directly in the home.
- **`docs/index.md`**, **`docs/features/authentication.md`** — landing page and handle-change blurb no longer promise everyone a private home.
- **`docs/reference/cli.md`** — example paths moved off the removed `/home/klangk/work` subtree; added `--per-handle-home/--shared-home` examples for `klangk create`/`klangk edit`.
- **`docs/reference/api-endpoints.md`** — `per_handle_home` documented on `POST /workspaces` and `PUT /workspaces/{id}` (semantics, server default, next-connect/start application).

Docs-only: `test-push` selects nothing to run; the zensical docs build reports the same 10 pre-existing warnings as `main` (all in `changes.md`/`fips.md`/`environment.md`) and no new ones.

## Known follow-up (not addressed here)

While documenting `~` expansion I confirmed that `expand_container_path` in `src/klangk/klangk/cli/sandbox.py` expands `~` → `/home/{handle}` unconditionally — on a shared-home workspace (the default) a `klangk sandbox` with the default `mount-at: ~/work` mounts the sandbox root at `/home/<handle>/work`, outside the member's actual `$HOME` (`/home/klangk`). Functional but awkward; the docs state the current behavior and the workaround (absolute `mount-at`). A follow-up could make `klangk sandbox` layout-aware or pass `per_handle_home` explicitly.

Closes #2724. With all six chunks plus the siblings (#2716, #2717, #2718) landed, this completes the #2169 rollout.
