### PR TITLE
fix(tui): drop old server's status WS on server switch (#2704)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1292,6 +1292,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **TUI server switch now drops the old server's status WebSocket
+  (#2704).** Switching servers in the TUI (`c`) left the status WS
+  connected to the previous server until that server closed it, so live
+  updates and the unreachable/reachability indicator kept tracking a
+  server the user had already left. The switch now tears that connection
+  down promptly, re-dials the new server immediately (also interrupting a
+  pending reconnect backoff), and restarts the status loop when it had
+  given up reconnecting — making the give-up screen's "switch server to
+  reconnect" promise real.
 - **E2E container-readiness budget tolerates CI load (#245).**
   Frontend e2e tests running four Playwright workers on one runner
   could exceed the 120s container bring-up budget under contention;

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1292,15 +1292,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
-- **TUI server switch now drops the old server's status WebSocket
-  (#2704).** Switching servers in the TUI (`c`) left the status WS
-  connected to the previous server until that server closed it, so live
-  updates and the unreachable/reachability indicator kept tracking a
+- **TUI server switch and logout now drop the old server's status
+  WebSocket (#2704).** Switching servers in the TUI (`c`) left the status
+  WS connected to the previous server until that server closed it, so
+  live updates and the unreachable/reachability indicator kept tracking a
   server the user had already left. The switch now tears that connection
   down promptly, re-dials the new server immediately (also interrupting a
   pending reconnect backoff), and restarts the status loop when it had
   given up reconnecting — making the give-up screen's "switch server to
-  reconnect" promise real.
+  reconnect" promise real. Logout and session expiry tear the connection
+  down too, so a logged-out TUI no longer keeps receiving the old
+  server's events and a re-login no longer runs two status connections.
 - **E2E container-readiness budget tolerates CI load (#245).**
   Frontend e2e tests running four Playwright workers on one runner
   could exceed the 120s container bring-up budget under contention;

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -313,6 +313,20 @@ class KlangkApp(App):
     def do_logout(self) -> None:
         async def _logout() -> None:
             await asyncio.to_thread(self.tui_state.logout)
+            # Logout clears the token; drop the parked status-WS listener
+            # so the loop wakes, sees no token, and exits instead of
+            # lingering on the old server's connection — a parked WS would
+            # keep firing events (toasts, live_extra) after logout, and a
+            # later re-login would spawn a second concurrent status WS
+            # (#2704). Sequence: drop AFTER logout (so the loop exits via
+            # the no-token branch rather than re-dialing), BEFORE the pop
+            # (so the screen is still in the stack if the loop checks).
+            main = next(
+                (s for s in self.screen_stack if isinstance(s, MainScreen)),
+                None,
+            )
+            if main is not None:
+                main.drop_status_connection()
             self.pop_screen()  # MainScreen
             self.live_extra = ""
             self.last_login = None
@@ -446,6 +460,19 @@ class KlangkApp(App):
         async def _expire() -> None:
             try:
                 await asyncio.to_thread(self.tui_state.logout)
+                # Same parked-listener teardown as ``do_logout`` (#2704):
+                # logout cleared the token, so the dropped loop exits via
+                # its no-token branch instead of re-dialing the old server.
+                main = next(
+                    (
+                        s
+                        for s in self.screen_stack
+                        if isinstance(s, MainScreen)
+                    ),
+                    None,
+                )
+                if main is not None:
+                    main.drop_status_connection()
                 # Clear every screen above the base, then show login.
                 # ``_pop_above`` pops a fixed snapshot, so the teardown is
                 # bounded regardless of what a concurrent worker does between

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -377,6 +377,14 @@ class KlangkApp(App):
             self.push_screen(MainScreen())
             return
         self._pop_above(main)
+        # The status-WS loop is parked inside its listener against the old
+        # server — without this drop it stays there until that server drops
+        # the connection itself, so reachability and live updates keep
+        # tracking the previous server (#2704). Also restarts the loop if it
+        # had given up reconnecting: the give-up overlay promises "switch
+        # server … to reconnect".
+        main.drop_status_connection()
+        main.ensure_status_ws_worker()
         main.refresh_lists()
         # The reused screen still shows the previous server's last-login
         # stamp; drop it and re-fetch for the new identity (#2583).
@@ -384,6 +392,16 @@ class KlangkApp(App):
 
     def server_changed_needs_login(self) -> None:
         """Switch server then show LoginScreen (invalid/missing creds)."""
+        # Same WS teardown as ``server_changed`` (#2704): the popped
+        # MainScreen's loop exits via its stack guard only *between*
+        # connections, so without this drop the old server's WS would stay
+        # open until the server closed it. No restart here — the login flow
+        # pushes a fresh MainScreen that mounts its own workers.
+        main = next(
+            (s for s in self.screen_stack if isinstance(s, MainScreen)), None
+        )
+        if main is not None:
+            main.drop_status_connection()
         # Tear down every screen above the base, then push login. The
         # ``target not in stack`` early return in ``_pop_above`` is what
         # prevents the ScreenStackError the old pop-until-MainScreen loop hit

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -1254,9 +1254,16 @@ class MainScreen(StatusScreen):
         reconnect backoff sleep, so a switch interrupts either (#2704).
         """
         waiter = asyncio.create_task(self._ws_drop.wait())
-        done, _ = await asyncio.wait(
-            {waiter, awaiting}, return_when=asyncio.FIRST_COMPLETED
-        )
+        try:
+            done, _ = await asyncio.wait(
+                {waiter, awaiting}, return_when=asyncio.FIRST_COMPLETED
+            )
+        except BaseException:
+            # The loop itself was cancelled while parked in the race (app
+            # shutdown): reap the waiter so it doesn't outlive this frame.
+            if not waiter.done():
+                waiter.cancel()
+            raise
         if waiter in done:
             if not awaiting.done():
                 awaiting.cancel()

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -286,6 +286,17 @@ class MainScreen(StatusScreen):
         self._server_unreachable = False
         self._reconnect_attempt = 0
         self._gave_up = False
+        # Server-switch teardown for the status WS (#2704): a switch sets
+        # this event so a parked status-loop iteration drops the old
+        # server's connection and re-dials the new one immediately. Sticky
+        # (stays set until the next loop iteration clears it), so a switch
+        # that lands between iterations is not lost.
+        self._ws_drop = asyncio.Event()
+        # The status-WS loop worker, or None when no loop is running (never
+        # started on an unauthenticated mount). Kept so
+        # ``ensure_status_ws_worker`` can restart the loop after it gave up
+        # and a server switch reuses this screen (#2704).
+        self._status_worker = None
         # True only while the status WS is actively connected (set in
         # ``_on_ws_connected``, cleared when the connection drops). Lets a
         # transport-failed REST list fetch distinguish a real outage (WS also
@@ -324,7 +335,9 @@ class MainScreen(StatusScreen):
         # broadcasts plus the WS reconnect keep the list fresh.
         self.refresh_lists()
         if self.app.tui_state.is_authenticated():
-            self.app.run_worker(self._status_loop, name="status-ws")
+            self._status_worker = self.app.run_worker(
+                self._status_loop, name="status-ws"
+            )
             self.app.run_worker(self._token_refresh_loop, name="token-refresh")
             self.app.run_worker(
                 self._load_last_login,
@@ -1203,6 +1216,59 @@ class MainScreen(StatusScreen):
         if name:
             self.app.push_screen(WorkspaceDetailScreen(name))
 
+    def drop_status_connection(self) -> None:
+        """Tear down the current status-WS connection promptly (#2704).
+
+        Called by ``App.server_changed`` / ``App.server_changed_needs_login``
+        after the active server changed: without this, the status loop stays
+        parked inside ``listen_for_status`` against the *old* server until
+        that server drops the connection on its own, so reachability and
+        live-update signaling (#2052) keep tracking a server the user has
+        already left. Setting the event makes the parked iteration cancel
+        its listener (closing the WS) and re-dial with the new URL/token.
+        """
+        self._ws_drop.set()
+
+    def ensure_status_ws_worker(self) -> None:
+        """(Re)start the status-WS loop worker (#2704).
+
+        The loop terminates itself once it exhausts
+        ``_MAX_RECONNECT_ATTEMPTS`` — the give-up overlay tells the user to
+        "switch server … to reconnect" — and a switch reuses this screen
+        (no re-mount, so ``on_mount`` doesn't run). Without a restart here
+        the switched-to server would get no live updates and no WS
+        reachability signal until the TUI is restarted.
+        """
+        if self._status_worker is None or self._status_worker.is_finished:
+            self._status_worker = self.app.run_worker(
+                self._status_loop, name="status-ws"
+            )
+
+    async def _wait_drop_or(self, awaiting: asyncio.Future) -> bool:
+        """Await ``awaiting`` unless a server-switch drop fires first.
+
+        Returns ``True`` when the drop won — ``awaiting`` is cancelled and
+        its outcome abandoned (the switch supersedes it) — and ``False``
+        when ``awaiting`` completed on its own (its outcome is then
+        inspected by the caller). Races both the listener task and the
+        reconnect backoff sleep, so a switch interrupts either (#2704).
+        """
+        waiter = asyncio.create_task(self._ws_drop.wait())
+        done, _ = await asyncio.wait(
+            {waiter, awaiting}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if waiter in done:
+            if not awaiting.done():
+                awaiting.cancel()
+            elif not awaiting.cancelled():
+                # Both finished on the same tick: retrieve (and discard)
+                # the outcome so asyncio doesn't warn it was never
+                # retrieved. The drop supersedes it either way.
+                awaiting.exception()
+            return True
+        waiter.cancel()
+        return False
+
     async def _status_loop(self) -> None:
         """Single reachability signal: maintain the status WS and drive the
         unreachable overlay from its lifecycle (#2052).
@@ -1213,6 +1279,10 @@ class MainScreen(StatusScreen):
         reachability poll — the WS protocol pings (lowered to 10 s / 10 s)
         detect a wedged / half-open connection, and a reconnect-triggered
         list refresh catches a REST-only degradation lazily.
+
+        A server switch interrupts the parked listener (and any backoff
+        sleep) via ``drop_status_connection`` so the next iteration re-dials
+        the new server immediately (#2704).
         """
         state = self.app.tui_state
         if not state.current_url() or not state.token():
@@ -1233,22 +1303,43 @@ class MainScreen(StatusScreen):
             # Screen popped (logout / server switch) — stop reconnecting.
             if self not in self.app.screen_stack:
                 return
-            try:
-                await listen_for_status(
+            # Consume any drop request still set from a previous iteration
+            # *after* the URL/token re-read above: a stale drop's only
+            # purpose was interruption, and the freshest config was just
+            # captured, so clearing it here keeps the new connection from
+            # being torn down the instant it is made.
+            self._ws_drop.clear()
+            listener = asyncio.create_task(
+                listen_for_status(
                     url,
                     token,
                     on_event=self._on_status_event,
                     on_connect=self._on_ws_connected,
                 )
-            except AuthError:
-                self.app.session_expired()
-                return
-            except Exception as exc:
-                logger.debug(
-                    "Status WS error (attempt %d): %s",
-                    self._reconnect_attempt + 1,
-                    exc,
-                )
+            )
+            try:
+                if await self._wait_drop_or(listener):
+                    # Server switch: the old connection is torn down
+                    # (#2704). Re-dial against the new server on the next
+                    # iteration — this is not an outage, so no attempt
+                    # accounting, no overlay, no backoff.
+                    self._ws_connected = False
+                    continue
+                exc = listener.exception()
+                if isinstance(exc, AuthError):
+                    self.app.session_expired()
+                    return
+                if exc is not None:
+                    logger.debug(
+                        "Status WS error (attempt %d): %s",
+                        self._reconnect_attempt + 1,
+                        exc,
+                    )
+            finally:
+                # Loop cancelled outright (app shutdown) with the listener
+                # still running: don't leave the WS dangling.
+                if not listener.done():
+                    listener.cancel()
             # The connection is over (clean close or error) — the backend is
             # no longer WS-reachable from this screen's point of view.
             self._ws_connected = False
@@ -1280,7 +1371,12 @@ class MainScreen(StatusScreen):
             else:
                 self._enter_unreachable()
                 self._refresh_unreachable_display()
-            await _reconnect_sleep(delay)
+            if await self._wait_drop_or(
+                asyncio.create_task(_reconnect_sleep(delay))
+            ):
+                # Switch during the backoff sleep: skip the rest of the
+                # delay and re-dial the new server now (#2704).
+                continue
 
     def _on_ws_connected(self) -> None:
         """The status WS (re)connected — the backend is reachable again.

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1523,6 +1523,311 @@ async def test_status_loop_resets_backoff_after_success(monkeypatch):
     assert seen[2] == 1
 
 
+# ---------------------------------------------------------------------------
+# Server switch tears down the old status WS (#2704)
+# ---------------------------------------------------------------------------
+
+
+async def test_server_switch_drops_old_ws_and_redials(monkeypatch):
+    """A server switch (``App.server_changed``) cancels the parked listener
+    to the old server and re-dials the new one immediately — not counted as
+    an outage, so no reconnect backoff and no "server down" flash (#2704)."""
+    await _fast_reconnect(monkeypatch)
+
+    # Spy on the backoff: the drop path must never reach it (a loss that
+    # went through the outage accounting would call it, and on_connect
+    # resetting the counter afterwards would hide that from
+    # _reconnect_attempt alone).
+    seen: list[int] = []
+    monkeypatch.setattr(
+        scr_main,
+        "_reconnect_backoff",
+        lambda attempt: (seen.append(attempt), 0.0)[1],
+    )
+
+    dialed: list[str] = []
+    cancelled: list[bool] = []
+    release = asyncio.Event()
+
+    async def park(url, token, on_event=None, on_connect=None, **k):
+        # An established connection: fires on_connect, then parks reading
+        # frames until the server drops it (or the loop cancels it).
+        dialed.append(url)
+        on_connect()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    monkeypatch.setattr(scr_main, "listen_for_status", park)
+
+    st = _authed_state()
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        screen = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        loop = asyncio.create_task(_real_status_loop(screen))
+        for _ in range(4):
+            await pilot.pause()
+        assert dialed == ["https://x.example"]  # parked on server A
+
+        # Switch the active server and fire the real App hook (the server
+        # screen's action does exactly this after updating state).
+        st.current_url = lambda: "https://y.example"
+        app.server_changed()
+        for _ in range(4):
+            await pilot.pause()
+
+        # The old connection was torn down promptly and the new server
+        # dialed — no outage accounting on the way (no backoff call).
+        assert cancelled == [True]
+        assert dialed[-1] == "https://y.example"
+        assert seen == []
+        assert screen._server_unreachable is False
+        assert not isinstance(app.screen, ServerDownScreen)
+
+        loop.cancel()  # end the driven loop; its finally cancels the parker
+        try:
+            await loop
+        except asyncio.CancelledError:
+            pass
+        await pilot.pause()
+
+
+async def test_server_switch_during_backoff_redials_immediately(monkeypatch):
+    """A switch that lands while the loop waits out a reconnect backoff
+    interrupts the delay and re-dials the new server at once (#2704)."""
+    # Deliberately NOT _fast_reconnect: the long backoff sleep is the thing
+    # that must get cut short.
+    monkeypatch.setattr(scr_main, "_reconnect_backoff", lambda attempt: 999.0)
+    _real_sleep = asyncio.sleep
+    sleep_cancelled: list[bool] = []
+
+    async def slow(t):
+        try:
+            await _real_sleep(999)
+        except asyncio.CancelledError:
+            sleep_cancelled.append(True)
+            raise
+
+    monkeypatch.setattr(scr_main, "_reconnect_sleep", slow)
+
+    dialed: list[str] = []
+    release = asyncio.Event()
+
+    async def script(url, token, on_event=None, on_connect=None, **k):
+        dialed.append(url)
+        if url == "https://x.example":
+            raise RuntimeError("ws refused")  # old server down -> backoff
+        on_connect()  # new server: connect, then park
+        await release.wait()
+
+    monkeypatch.setattr(scr_main, "listen_for_status", script)
+
+    st = _authed_state()
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        screen = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        loop = asyncio.create_task(_real_status_loop(screen))
+        for _ in range(4):
+            await pilot.pause()
+        # Attempt 1 failed and the loop is parked in the 999 s backoff.
+        assert dialed == ["https://x.example"]
+        assert screen._reconnect_attempt == 1
+
+        st.current_url = lambda: "https://y.example"
+        app.server_changed()
+        for _ in range(4):
+            await pilot.pause()
+
+        # The backoff was cut short and the new server dialed immediately —
+        # not after the remaining ~999 s.
+        assert sleep_cancelled == [True]
+        assert dialed == ["https://x.example", "https://y.example"]
+        assert screen._ws_connected is True
+
+        loop.cancel()
+        try:
+            await loop
+        except asyncio.CancelledError:
+            pass
+        await pilot.pause()
+
+
+async def test_switch_lands_same_tick_as_listener_end(monkeypatch):
+    """A drop that arrives in the same tick the listener finished still
+    wins the race: the listener's outcome is discarded and the loop re-dials
+    the new server rather than accounting a loss (#2704)."""
+    await _fast_reconnect(monkeypatch)
+
+    seen: list[int] = []
+    monkeypatch.setattr(
+        scr_main,
+        "_reconnect_backoff",
+        lambda attempt: (seen.append(attempt), 0.0)[1],
+    )
+
+    dialed: list[str] = []
+    holder: dict = {}
+    release_a = asyncio.Event()
+
+    async def script(url, token, on_event=None, on_connect=None, **k):
+        dialed.append(url)
+        on_connect()
+        if url == "https://x.example":
+            await release_a.wait()  # park like an established connection
+            # Server A closes cleanly at the same moment the user switches:
+            # the drop is set from inside the listener, so both futures are
+            # done when the loop's race resumes.
+            holder["screen"].drop_status_connection()
+            return None
+        release = asyncio.Event()
+        await release.wait()  # new server: connect, then park
+
+    monkeypatch.setattr(scr_main, "listen_for_status", script)
+
+    st = _authed_state()
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        screen = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        holder["screen"] = screen
+        loop = asyncio.create_task(_real_status_loop(screen))
+        for _ in range(4):
+            await pilot.pause()
+        assert dialed == ["https://x.example"]
+
+        st.current_url = lambda: "https://y.example"
+        release_a.set()  # clean close + drop land on the same tick
+        for _ in range(4):
+            await pilot.pause()
+
+        # The clean close was NOT treated as a loss (no backoff / attempt
+        # accounting): the drop re-dialed the new server directly.
+        assert dialed == ["https://x.example", "https://y.example"]
+        assert seen == []
+        assert screen._server_unreachable is False
+
+        loop.cancel()
+        try:
+            await loop
+        except asyncio.CancelledError:
+            pass
+        await pilot.pause()
+
+
+async def test_server_changed_needs_login_drops_old_ws(monkeypatch):
+    """``server_changed_needs_login`` tears the old server's WS down too —
+    the popped screen's loop would otherwise linger parked on it until the
+    server closed the connection (#2704)."""
+    await _fast_reconnect(monkeypatch)
+
+    dialed: list[str] = []
+    cancelled: list[bool] = []
+    release = asyncio.Event()
+
+    async def park(url, token, on_event=None, on_connect=None, **k):
+        dialed.append(url)
+        on_connect()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    monkeypatch.setattr(scr_main, "listen_for_status", park)
+
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        screen = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        loop = asyncio.create_task(_real_status_loop(screen))
+        for _ in range(4):
+            await pilot.pause()
+        assert dialed == ["https://x.example"]
+
+        app.server_changed_needs_login()
+        # The loop exits on its own via the stack guard once the listener
+        # is dropped — bounded so a regression fails instead of hanging.
+        await asyncio.wait_for(loop, 2)
+        await pilot.pause()
+
+        assert cancelled == [True]
+        assert dialed == ["https://x.example"]  # never re-dialed after pop
+        assert isinstance(app.screen, LoginScreen)
+
+
+async def test_server_switch_restarts_loop_after_gave_up(monkeypatch):
+    """After the reconnect loop gave up (its overlay promises "switch
+    server … to reconnect"), a server switch restarts the status-WS worker
+    on the reused screen and live updates resume (#2704)."""
+    # Run the real loop (undo the autouse stub) so give-up and the restart
+    # exercise actual worker lifecycle.
+    monkeypatch.setattr(MainScreen, "_status_loop", _real_status_loop)
+    monkeypatch.setattr(scr_main, "_MAX_RECONNECT_ATTEMPTS", 2)
+    await _fast_reconnect(monkeypatch)
+
+    dialed: list[str] = []
+    release = asyncio.Event()
+
+    async def script(url, token, on_event=None, on_connect=None, **k):
+        dialed.append(url)
+        if url == "https://x.example":
+            raise RuntimeError("ws refused")
+        on_connect()  # the new server accepts: connect, then park
+        await release.wait()
+
+    monkeypatch.setattr(scr_main, "listen_for_status", script)
+
+    st = _ws(
+        owned=[_wsobj("beta")],
+        list_owned_workspaces=lambda: [_wsobj("beta")],
+        list_shared_workspaces=lambda: [],
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()  # mount workers run to give-up
+        await pilot.pause()
+        main = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        assert main._gave_up is True
+        assert main._status_worker.is_finished is True
+        assert dialed == ["https://x.example"] * 3
+
+        # Switch to the (reachable) new server through the real App hook.
+        st.current_url = lambda: "https://y.example"
+        app.server_changed()
+        for _ in range(8):
+            await pilot.pause()
+
+        # The restarted worker re-dialed the new server and its connection
+        # cleared the give-up state.
+        assert "https://y.example" in dialed
+        assert main._gave_up is False
+        assert main._ws_connected is True
+        assert not isinstance(app.screen, ServerDownScreen)
+
+
+async def test_ensure_status_ws_worker_starts_when_missing(monkeypatch):
+    """``ensure_status_ws_worker`` also covers a screen whose loop never
+    started (unauthenticated mount): ``_status_worker`` is None (#2704)."""
+    st = _st(
+        is_authenticated=lambda: False,
+        current_url=lambda: None,
+        token=lambda: None,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(MainScreen())  # mounts without starting workers
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, MainScreen)
+        assert screen._status_worker is None
+
+        screen.ensure_status_ws_worker()
+        assert screen._status_worker is not None
+        await app.workers.wait_for_complete()  # the (stubbed) loop runs
+        await pilot.pause()
+
+
 async def test_login_password_flow_success(monkeypatch):
     async def noop(*a, **k):
         return None

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1806,6 +1806,100 @@ async def test_server_switch_restarts_loop_after_gave_up(monkeypatch):
         assert not isinstance(app.screen, ServerDownScreen)
 
 
+async def test_do_logout_drops_old_ws(monkeypatch):
+    """Logout drops the parked status-WS listener after the token clears,
+    so the loop exits via the no-token branch and never re-dials — no
+    lingering old-server events, no second concurrent WS after a re-login
+    (#2704)."""
+    await _fast_reconnect(monkeypatch)
+
+    dialed: list[str] = []
+    cancelled: list[bool] = []
+    release = asyncio.Event()
+
+    async def park(url, token, on_event=None, on_connect=None, **k):
+        dialed.append(url)
+        on_connect()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    monkeypatch.setattr(scr_main, "listen_for_status", park)
+
+    st = _authed_state()
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        screen = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        loop = asyncio.create_task(_real_status_loop(screen))
+        for _ in range(4):
+            await pilot.pause()
+        assert dialed == ["https://x.example"]
+
+        # Logout: token clears, then the real App hook runs. Reuse the
+        # app's worker (it is what production runs) and bound the wait so a
+        # regression fails instead of hanging.
+        def fake_logout():
+            st.token = lambda: None
+
+        st.logout = fake_logout
+        app.do_logout()
+        await asyncio.wait_for(asyncio.shield(asyncio.gather(loop)), 2)
+        await pilot.pause()
+
+        assert cancelled == [True]  # the parked listener was torn down
+        assert dialed == ["https://x.example"]  # never re-dialed
+        assert isinstance(app.screen, LoginScreen)
+
+
+async def test_confirm_session_expired_drops_old_ws(monkeypatch):
+    """Confirming the session-expired overlay drops the parked listener
+    too — same teardown as do_logout, on the expiry path (#2704)."""
+    await _fast_reconnect(monkeypatch)
+
+    dialed: list[str] = []
+    cancelled: list[bool] = []
+    release = asyncio.Event()
+
+    async def park(url, token, on_event=None, on_connect=None, **k):
+        dialed.append(url)
+        on_connect()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    monkeypatch.setattr(scr_main, "listen_for_status", park)
+
+    st = _authed_state()
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        screen = next(s for s in app.screen_stack if isinstance(s, MainScreen))
+        loop = asyncio.create_task(_real_status_loop(screen))
+        for _ in range(4):
+            await pilot.pause()
+        assert dialed == ["https://x.example"]
+
+        # The expiry flow requires the overlay to be up first.
+        app.session_expired()
+        await pilot.pause()
+        assert app._session_expired_screen is not None
+
+        def fake_logout():
+            st.token = lambda: None
+
+        st.logout = fake_logout
+        app.confirm_session_expired()
+        await asyncio.wait_for(asyncio.shield(asyncio.gather(loop)), 2)
+        await pilot.pause()
+
+        assert cancelled == [True]
+        assert dialed == ["https://x.example"]
+        assert isinstance(app.screen, LoginScreen)
+
+
 async def test_ensure_status_ws_worker_starts_when_missing(monkeypatch):
     """``ensure_status_ws_worker`` also covers a screen whose loop never
     started (unauthenticated mount): ``_status_worker`` is None (#2704)."""


### PR DESCRIPTION
## Summary

Fixes #2704.

A server switch in the TUI (`c` → pick server) reused the MainScreen but left the status-WS loop parked inside `listen_for_status` against the **old** server until that server dropped the connection itself. While parked, all reachability and live-update signaling (#2052 — the WS lifecycle is the single reachability signal) tracked the previous server.

- **`MainScreen.drop_status_connection()`** — sets a `_ws_drop` event; the status loop races the parked listener (and any pending reconnect-backoff sleep) against it via `_wait_drop_or`, so a switch interrupts either and re-dials the new server on the next iteration with zero outage accounting (no attempt increment, no overlay, no backoff — a switch is not an outage).
- **`App.server_changed` / `App.server_changed_needs_login`** call the drop; the needs-login variant drops without restarting (the fresh MainScreen mounts its own workers).
- **`MainScreen.ensure_status_ws_worker()`** — `server_changed` also restarts the loop when it had exhausted `_MAX_RECONNECT_ATTEMPTS`, making the give-up overlay's "switch server … to reconnect" promise real (the worker was one-shot and dead before; a switch reuses the screen, so `on_mount` never re-ran).
- The listener now runs as a task; exceptions are read via `task.exception()`, and outer cancellation (shutdown/loop death) still closes the WS via a `finally`-cancel. A drop landing the same tick the listener finished still wins the race and its outcome is discarded safely.

## Testing

- `test_server_switch_drops_old_ws_and_redials` — parked listener cancelled, new server dialed, no backoff/overlay
- `test_server_switch_during_backoff_redials_immediately` — 999 s backoff cut short, immediate re-dial
- `test_switch_lands_same_tick_as_listener_end` — drop + clean close on the same tick: no loss accounting
- `test_server_changed_needs_login_drops_old_ws` — drop on the needs-login path, no re-dial after pop
- `test_server_switch_restarts_loop_after_gave_up` — real worker lifecycle: give-up → switch → restarted worker connects to the new server
- `test_ensure_status_ws_worker_starts_when_missing` — `None`-worker (unauthenticated mount) case

Full suite CI-style: `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` → 5541 passed, 100% coverage. Changelog entry under `[Unreleased] → Fixed`.
