### PR TITLE
Frontend: adopt groups source filter + pagination (#2752)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -186,6 +186,16 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **De-noised group lists in the UI (#2752).** The admin Groups tab
+  defaults to `source=manual`, with a "Workspace role groups" filter
+  chip to include the seeded per-workspace groups. The ACL editor's
+  add-entry picker offers manual groups plus the groups already
+  referenced by the resource's ACEs — other workspaces' role groups are
+  omitted — and the entries table is unchanged. Group (and picker user)
+  fetches now walk every page of the paged envelope instead of silently
+  truncating at 200 rows, and the picker dropdowns ellipsize long names
+  (e.g. UUID-suffixed role groups) instead of overflowing.
+
 - **Group `source` marker and filtering (#2750).** Groups now carry a
   `source` column: `manual` for human-managed groups,
   `workspace-role` for the four role groups seeded per workspace.

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -589,6 +589,14 @@ class _GroupsTabState extends State<_GroupsTab> {
   String _groupsSort = 'name';
   String _groupsOrder = 'asc';
   String _groupsQuery = '';
+
+  // Source filter (#2752): the browser defaults to manual-only — the
+  // seeded role-group flood hides where it hurts most — with a chip to
+  // include workspace role groups. Null sends no filter (show all);
+  // the API default stays show-all.
+  bool _showWorkspaceRoles = false;
+  String? get _groupsSource => _showWorkspaceRoles ? null : 'manual';
+
   final TextEditingController _groupSearchController = TextEditingController();
   Timer? _groupsQueryDebounce;
 
@@ -640,6 +648,8 @@ class _GroupsTabState extends State<_GroupsTab> {
       };
       final q = _groupsQuery.trim();
       if (q.isNotEmpty) query['q'] = q;
+      final source = _groupsSource;
+      if (source != null) query['source'] = source;
       final resp = await auth.authGet(
         '/api/v1/admin/groups?${_encodeQuery(query)}',
       );
@@ -767,6 +777,13 @@ class _GroupsTabState extends State<_GroupsTab> {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
   }
 
+  /// Toggle the workspace-role filter chip: off shows manual groups only,
+  /// on includes the seeded workspace role groups (#2752).
+  void _toggleWorkspaceRoles(bool value) {
+    setState(() => _showWorkspaceRoles = value);
+    _loadGroups(page: 1);
+  }
+
   Future<void> _changeGroupsSort(String sortKey) async {
     if (_groupsSort == sortKey) {
       setState(() => _groupsOrder = _groupsOrder == 'asc' ? 'desc' : 'asc');
@@ -853,6 +870,12 @@ class _GroupsTabState extends State<_GroupsTab> {
             pageSize: _groupsPageSize,
             total: _groupsTotal,
             onPage: (p) => _loadGroups(page: p),
+            filter: FilterChip(
+              label: const Text('Workspace role groups'),
+              selected: _showWorkspaceRoles,
+              onSelected: _toggleWorkspaceRoles,
+              tooltip: 'Include the seeded per-workspace role groups (#2752)',
+            ),
           ),
           Expanded(child: _buildGroupsList()),
         ],
@@ -1919,6 +1942,10 @@ class _AdminListToolbar extends StatelessWidget {
   final int total;
   final ValueChanged<int> onPage; // requested page number
 
+  /// Optional filter control rendered between the sort chips and the
+  /// search field (e.g. the groups-tab source chip, #2752).
+  final Widget? filter;
+
   const _AdminListToolbar({
     super.key,
     required this.columns,
@@ -1931,6 +1958,7 @@ class _AdminListToolbar extends StatelessWidget {
     required this.pageSize,
     required this.total,
     required this.onPage,
+    this.filter,
   });
 
   Widget _sortChip(String label, String sortKey) {
@@ -1955,6 +1983,7 @@ class _AdminListToolbar extends StatelessWidget {
         crossAxisAlignment: WrapCrossAlignment.center,
         children: [
           for (final (label, key) in columns) _sortChip(label, key),
+          if (filter != null) filter!,
           const SizedBox(width: 12),
           SizedBox(
             width: 220,

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -96,6 +96,72 @@ class AclEditorState extends State<AclEditor> {
     setState(() => _entries.removeAt(index));
   }
 
+  /// Fetch every page of a paged list endpoint (``{items, total}``
+  /// envelope), not just the first — the old single ``?page_size=200``
+  /// shot silently truncated at 200 rows (#2752). The server caps
+  /// ``page_size`` at 200, so this walks pages until ``total`` rows are
+  /// collected. ``_pickerMaxPages`` guards against a server that reports
+  /// a ``total`` that never shrinks.
+  static const _pickerPageSize = 200;
+  static const _pickerMaxPages = 50;
+
+  Future<List<Map<String, dynamic>>> _fetchEnvelopeAll(
+    AuthService auth,
+    String path,
+    String itemsKey, {
+    Map<String, String> query = const {},
+  }) async {
+    final rows = <Map<String, dynamic>>[];
+    for (var page = 1; page <= _pickerMaxPages; page++) {
+      final resp = await auth.authGet(
+        '$path?${Uri(queryParameters: {
+              ...query,
+              'page': '$page',
+              'page_size': '$_pickerPageSize',
+            }).query}',
+      );
+      if (resp.statusCode != 200) return rows;
+      final body = jsonDecode(resp.body) as Map<String, dynamic>;
+      final items = (body[itemsKey] as List? ?? const [])
+          .map((e) => Map<String, dynamic>.from(e as Map))
+          .toList();
+      rows.addAll(items);
+      final total = (body['total'] as num?)?.toInt() ?? 0;
+      if (items.isEmpty || rows.length >= total) return rows;
+    }
+    return rows;
+  }
+
+  /// Load the groups selectable in the add-entry picker: manual groups
+  /// (`source=manual`, all pages) unioned with the groups already
+  /// referenced by the loaded entries, deduped by id. Other workspaces'
+  /// seeded role groups are omitted (#2752); this resource's own role
+  /// groups stay selectable because they already hold ACEs (and remain
+  /// visible in the entries table, which is untouched by design).
+  Future<List<Map<String, dynamic>>> _loadPickerGroups(AuthService auth) async {
+    final groups = await _fetchEnvelopeAll(
+      auth,
+      '/api/v1/admin/groups',
+      'groups',
+      query: const {'source': 'manual'},
+    );
+    final seenIds = groups.map((g) => g['id']).toSet();
+    for (final entry in _entries) {
+      if (entry['principal_type'] != 2) continue;
+      final id = entry['group_id'] as String?;
+      if (id == null || id.isEmpty || seenIds.contains(id)) continue;
+      seenIds.add(id);
+      groups.add({
+        'id': id,
+        'name': entry['principal'] as String? ?? id,
+      });
+    }
+    groups.sort(
+      (a, b) => (a['name'] as String).compareTo(b['name'] as String),
+    );
+    return groups;
+  }
+
   Future<void> _addEntry() async {
     final auth = context.read<AuthService>();
 
@@ -103,28 +169,12 @@ class AclEditorState extends State<AclEditor> {
     List<Map<String, dynamic>> users = [];
     List<Map<String, dynamic>> groups = [];
     try {
-      final uResp = await auth.authGet(
-        '/api/v1/admin/users?page_size=200',
-      );
-      if (uResp.statusCode == 200) {
-        final body = jsonDecode(uResp.body) as Map<String, dynamic>;
-        users = (body['users'] as List)
-            .map((e) => Map<String, dynamic>.from(e as Map))
-            .toList();
-      }
+      users = await _fetchEnvelopeAll(auth, '/api/v1/admin/users', 'users');
     } catch (e) {
       debugPrint('[AclEditor] fetch users failed: $e');
     }
     try {
-      final gResp = await auth.authGet(
-        '/api/v1/admin/groups?page_size=200',
-      );
-      if (gResp.statusCode == 200) {
-        final body = jsonDecode(gResp.body) as Map<String, dynamic>;
-        groups = (body['groups'] as List)
-            .map((e) => Map<String, dynamic>.from(e as Map))
-            .toList();
-      }
+      groups = await _loadPickerGroups(auth);
     } catch (e) {
       debugPrint('[AclEditor] fetch groups failed: $e');
     }
@@ -181,6 +231,7 @@ class AclEditorState extends State<AclEditor> {
                 const SizedBox(height: 12),
                 if (principalType == 1 && users.isNotEmpty)
                   DropdownButtonFormField<String>(
+                    isExpanded: true,
                     initialValue: selectedUserId,
                     decoration: const InputDecoration(
                       labelText: 'User',
@@ -189,12 +240,17 @@ class AclEditorState extends State<AclEditor> {
                     items: users
                         .map((u) => DropdownMenuItem(
                             value: u['id'] as String,
-                            child: Text(u['email'] as String)))
+                            child: Text(
+                              u['email'] as String,
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                            )))
                         .toList(),
                     onChanged: (v) => setDialogState(() => selectedUserId = v),
                   ),
                 if (principalType == 2 && groups.isNotEmpty)
                   DropdownButtonFormField<String>(
+                    isExpanded: true,
                     initialValue: selectedGroupId,
                     decoration: const InputDecoration(
                       labelText: 'Group',
@@ -203,7 +259,11 @@ class AclEditorState extends State<AclEditor> {
                     items: groups
                         .map((g) => DropdownMenuItem(
                             value: g['id'] as String,
-                            child: Text(g['name'] as String)))
+                            child: Text(
+                              g['name'] as String,
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                            )))
                         .toList(),
                     onChanged: (v) => setDialogState(() => selectedGroupId = v),
                   ),
@@ -224,13 +284,20 @@ class AclEditorState extends State<AclEditor> {
                 ],
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String>(
+                  isExpanded: true,
                   initialValue: selectedPermission,
                   decoration: const InputDecoration(
                     labelText: 'Permission',
                     border: OutlineInputBorder(),
                   ),
                   items: _permissions
-                      .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                      .map((p) => DropdownMenuItem(
+                          value: p,
+                          child: Text(
+                            p,
+                            overflow: TextOverflow.ellipsis,
+                            maxLines: 1,
+                          )))
                       .toList(),
                   onChanged: (v) =>
                       setDialogState(() => selectedPermission = v ?? 'view'),

--- a/src/frontend/test/acl_editor_test.dart
+++ b/src/frontend/test/acl_editor_test.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/widgets/acl_editor.dart';
+
+/// Default JWT for a logged-in admin user.
+String get _adminToken {
+  final header = base64Url
+      .encode(utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})))
+      .replaceAll('=', '');
+  final body = base64Url
+      .encode(utf8.encode(jsonEncode({
+        'sub': 'admin-user',
+        'email': 'admin@example.com',
+      })))
+      .replaceAll('=', '');
+  return '$header.$body.fakesig';
+}
+
+/// ACE rows as served by `GET /api/v1/workspaces/{id}/acl`: one entry for
+/// this workspace's own role group, one for a manual group (also present
+/// in the manual groups list — exercises the dedupe), and one user entry.
+List<Map<String, dynamic>> _entries() => [
+      {
+        'id': 1,
+        'action': 1,
+        'principal_type': 2,
+        'permission': 'view',
+        'group_id': 'g-role-owners',
+        'principal': 'owners-abc-123',
+      },
+      {
+        'id': 2,
+        'action': 1,
+        'principal_type': 2,
+        'permission': 'edit',
+        'group_id': 'g-manual-alpha',
+        'principal': 'aa-manual-alpha',
+      },
+      {
+        'id': 3,
+        'action': 1,
+        'principal_type': 1,
+        'permission': '*',
+        'user_id': 'u1',
+        'principal': 'alice@example.com',
+      },
+    ];
+
+Map<String, dynamic> _group(String id, String name) => {
+      'id': id,
+      'name': name,
+      'description': '',
+      'source': 'manual',
+      'created_at': '2026-01-01T00:00:00',
+    };
+
+Map<String, dynamic> _user(String email) => {
+      'id': email,
+      'email': email,
+      'handle': '',
+      'verified': true,
+      'provider': 'local',
+      'created_at': '2026-01-01T00:00:00',
+    };
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({'klangk_jwt': _adminToken});
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+  });
+
+  Widget buildEditor() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+      ],
+      child: const MaterialApp(
+          home: Scaffold(body: AclEditor(resource: '/workspaces/ws1'))),
+    );
+  }
+
+  testWidgets('picker offers manual ∪ referenced groups, all pages',
+      (tester) async {
+    final requestedGroupPages = <int>[];
+    String? capturedSource;
+    testAuthHttpClientOverride = MockClient((request) async {
+      final path = request.url.path;
+      if (path == '/api/v1/workspaces/ws1/acl') {
+        return http.Response(jsonEncode(_entries()), 200);
+      }
+      if (path == '/api/v1/admin/users') {
+        return http.Response(
+          jsonEncode({
+            'users': [_user('alice@example.com')],
+            'page': 1,
+            'page_size': 200,
+            'total': 1,
+          }),
+          200,
+        );
+      }
+      if (path == '/api/v1/admin/groups') {
+        final page = int.parse(request.url.queryParameters['page'] ?? '1');
+        requestedGroupPages.add(page);
+        capturedSource = request.url.queryParameters['source'];
+        // 201 manual groups: a full first page (200) plus one straggler on
+        // page 2 — the picker must walk both pages (#2752).
+        final rows = page == 1
+            ? [
+                _group('g-manual-alpha', 'aa-manual-alpha'),
+                for (var i = 0; i < 199; i++)
+                  _group('g-filler-$i', 'zz-filler-$i'),
+              ]
+            : [_group('g-page2', 'aa-from-page-2')];
+        return http.Response(
+          jsonEncode({
+            'groups': rows,
+            'page': page,
+            'page_size': 200,
+            'total': 201,
+          }),
+          200,
+        );
+      }
+      return http.Response('Not found', 404);
+    });
+
+    await tester.pumpWidget(buildEditor());
+    await tester.pumpAndSettle();
+
+    // The entries table is unchanged by design: this workspace's own role
+    // group stays visible as an existing ACE (#2752).
+    expect(find.text('owners-abc-123'), findsOneWidget);
+    expect(find.text('aa-manual-alpha'), findsOneWidget);
+
+    // Open the add-entry dialog.
+    await tester.tap(find.widgetWithIcon(TextButton, Icons.add));
+    await tester.pumpAndSettle();
+
+    // Switch the principal type to Group (dropdown menu item).
+    final principalField = find.byWidgetPredicate(
+      (widget) =>
+          widget is DropdownButtonFormField<int> &&
+          widget.decoration?.labelText == 'Principal Type',
+    );
+    await tester.tap(principalField);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Group'));
+    await tester.pumpAndSettle();
+
+    // The picker asked for manual groups only, and walked every page.
+    expect(capturedSource, 'manual');
+    expect(requestedGroupPages, [1, 2]);
+
+    // Open the group dropdown: manual groups from both pages are offered.
+    final groupField = find.byWidgetPredicate(
+      (widget) =>
+          widget is DropdownButtonFormField<String> &&
+          widget.decoration?.labelText == 'Group',
+    );
+    await tester.tap(groupField);
+    await tester.pumpAndSettle();
+
+    // Page-2 straggler: proves all pages were loaded, not just the first.
+    // (It appears only in the menu — nothing else carries this name.)
+    expect(find.text('aa-from-page-2'), findsOneWidget);
+    // Referenced-only group (this workspace's role group) is unioned in:
+    // once in the untouched entries table, once in the picker menu.
+    expect(find.text('owners-abc-123'), findsNWidgets(2));
+    // A group that is both manual and referenced appears exactly once in
+    // the menu (dedupe by id): table + menu = 2, not 3.
+    expect(find.text('aa-manual-alpha'), findsNWidgets(2));
+  });
+}

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -583,6 +583,85 @@ void main() {
       expect(inGroupsToolbar(find.text('Created ▲')), findsOneWidget);
     });
 
+    testWidgets('defaults the groups browser to manual-only', (tester) async {
+      String? capturedSource;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(_usersEnvelope([]), 200);
+        }
+        if (request.url.path == '/api/v1/admin/invitations') {
+          return http.Response(emptyInvitationsEnvelope(), 200);
+        }
+        if (request.url.path == '/api/v1/admin/groups') {
+          capturedSource = request.url.queryParameters['source'];
+          return http.Response(
+            _groupsEnvelope([_group('admins')], total: 1),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pumpGroupsTab(tester);
+
+      // The seeded workspace role groups are de-noised away by default
+      // (#2752); the chip is unselected.
+      expect(capturedSource, 'manual');
+      final chip = tester.widget<FilterChip>(
+        inGroupsToolbar(find.byType(FilterChip)),
+      );
+      expect(chip.selected, isFalse);
+      expect(
+          inGroupsToolbar(find.text('Workspace role groups')), findsOneWidget);
+    });
+
+    testWidgets('workspace-role chip includes the seeded role groups',
+        (tester) async {
+      final capturedSources = <String?>[];
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(_usersEnvelope([]), 200);
+        }
+        if (request.url.path == '/api/v1/admin/invitations') {
+          return http.Response(emptyInvitationsEnvelope(), 200);
+        }
+        if (request.url.path == '/api/v1/admin/groups') {
+          capturedSources.add(request.url.queryParameters['source']);
+          // No filter (show all): the manual group plus a seeded role
+          // group both come back.
+          final all = request.url.queryParameters['source'] == null;
+          return http.Response(
+            _groupsEnvelope(
+              all
+                  ? [_group('admins'), _group('owners-1f0c')]
+                  : [_group('admins')],
+              total: all ? 2 : 1,
+            ),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pumpGroupsTab(tester);
+
+      // Default load hides the role groups.
+      expect(capturedSources.single, 'manual');
+      expect(find.text('owners-1f0c', skipOffstage: false), findsNothing);
+
+      // Toggling the chip re-queries with no filter (show all) and the
+      // seeded role group becomes visible.
+      await tester.tap(inGroupsToolbar(find.text('Workspace role groups')));
+      await tester.pumpAndSettle();
+
+      expect(capturedSources, ['manual', null]);
+      expect(find.text('owners-1f0c', skipOffstage: false), findsOneWidget);
+      final chip = tester.widget<FilterChip>(
+        inGroupsToolbar(find.byType(FilterChip)),
+      );
+      expect(chip.selected, isTrue);
+    });
+
     testWidgets('sends name filter query live (debounced)', (tester) async {
       String? capturedQ;
       testAuthHttpClientOverride = _mockClient((request) async {


### PR DESCRIPTION
# Frontend: adopt groups source filter + pagination

Closes #2752. Builds on #2756 (backend half of #2750 — the `groups.source` column, list filters, and paged envelope), which has landed in `main`; this branch is rebased on top of it.

## What changes

**Admin groups browser** (`admin_users_page.dart`): the Groups tab now defaults to `source=manual`, hiding the machine-generated `owners-<uuid>`/`coders-<uuid>`/… role groups. A "Workspace role groups" filter chip in the toolbar re-includes them (no filter = show all; the API default is unchanged).

**ACL editor add-entry picker** (`acl_editor.dart`): instead of fetching every group with a single `?page_size=200` shot, the picker now:

- fetches `?source=manual` only,
- unions in the groups already referenced by the loaded ACEs (each entry carries `group_id` + principal name), deduped by id,
- walks **every page** of the paged envelope, so nothing silently truncates at 200 rows.

Result: manual ∪ this resource's referenced groups are selectable; other workspaces' role groups are omitted. The entries table is untouched by design — the workspace's own role groups remain visible as ACEs.

**Picker dropdown robustness**: on Flutter 3.41 a closed `DropdownButtonFormField` lays out *all* menu items in an IndexedStack sized to the widest one, so the long permission names (and now the UUID-suffixed role-group names the union reintroduces) overflowed the 350px dialog by ~158px. The user/group/permission dropdowns get `isExpanded` + ellipsized item text.

## Tests

- `acl_editor_test.dart` (new): picker requests `source=manual`, walks both pages of a 201-row envelope, offers the page-2 straggler + the referenced-only role group, dedupes a group that is both manual and referenced, and confirms the entries table still shows the role-group ACE.
- `admin_users_page_test.dart`: groups browser defaults to `source=manual` with the chip unselected; toggling the chip re-queries unfiltered and the seeded role group becomes visible.
