### PR TITLE
feat: gate the exec channel (klangk exec / sync) on a exec-and-sync permission

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -126,6 +126,22 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **`exec-and-sync` permission gates one-shot command execution and
+  `klangk sync` (#2706, #2712).** The one-shot exec channel — `klangk
+exec`, and the rsync transport `klangk sync` and `klangk sandbox`
+  ride on — now requires the new `exec-and-sync` permission on the
+  workspace, enforced server-side at `exec_start`. Both sync directions
+  are covered by the same gate: a member without `exec-and-sync` cannot
+  run one-shot commands or sync in either direction. Isolated terminals
+  still use `code-in-isolation` and are unaffected. Coders and
+  collaborators keep `exec-and-sync` (existing workspaces are backfilled
+  by migration), so revoking it is an admin choice — remove the
+  permission in the ACL editor to stop one-shot exec and bulk sync for a
+  member while keeping their terminal access. Custom ACEs that granted
+  `code-in-isolation` must add `exec-and-sync` explicitly to keep
+  one-shot exec working for those principals. `klangk exec`/`klangk
+sync` report a clear permission-denied error.
+
 - **Workspace creation restricted to administrators (#2569).** `POST
 /workspaces`, `POST /workspaces/import`, and workspace duplication
   now require the `create` permission on the `/workspaces` collection

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -166,6 +166,7 @@ handles of all current viewers.
 | `code-in-shared-terminals`     | \*     |        | yes           |            |
 | `spectate-on-shared-terminals` | \*     | yes    | yes           | yes        |
 | `files`                        | \*     | yes    | yes           |            |
+| `exec-and-sync`                | \*     | yes    | yes           |            |
 
 \* Owners have the wildcard (`*`) permission which implies all permissions.
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -101,6 +101,7 @@ When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/w
 | `files`          | Can browse/read files                                             |
 | `files-download` | Can download raw bytes via `/files/download` (needs `files` too)  |
 | `files-write`    | Can mutate files: upload, rename, delete (needs `files` too)      |
+| `exec-and-sync`  | Can run one-shot commands (`klangk exec`) and sync (`klangk sync`) against the workspace |
 | `edit`           | Can change workspace settings (name, image, command, mounts, env) |
 | `share`          | Can manage who has access (Sharing tab)                           |
 | `delete`         | Can delete the workspace                                          |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -264,7 +264,8 @@ klangk exec --raw my-project rsync --server ...      # raw argv, no shell (for t
 klangk monitor                                        # stream all server events as JSON
 klangk monitor --type service_health | jq .           # pretty-print health transitions
 klangk monitor --type service_health -- sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'  # alert with the failure reason
-klangk sync ~/src my-project:/home/klangk/src      # sync files to/from the container
+klangk sync ~/src my-project:/home/klangk/src      # push files to the container — needs the exec-and-sync permission
+klangk sync my-project:/home/klangk/src ~/src       # pull files out of the container — needs the exec-and-sync permission
 klangk rm my-project                # delete a workspace
 klangk stop my-project              # stop the container for a workspace
 klangk start my-project             # start the container for a workspace

--- a/sandboxes/tests/test_revoke_sync_e2e.py
+++ b/sandboxes/tests/test_revoke_sync_e2e.py
@@ -1,0 +1,324 @@
+"""E2E: revoking ``exec-and-sync`` blocks the exec channel (#2706).
+
+Proves the security property end-to-end against a real klangkd + real
+container: revoking ``exec-and-sync`` BEFORE the tool runs blocks every
+consumer of the exec channel for a regular (non-admin) member:
+
+1. admin creates a workspace and shares it with a second user as coder;
+2. the member's ``klangk exec`` works (coders seed ``exec-and-sync``);
+3. the ``exec-and-sync`` ACE is removed from the member's role group;
+4. ``klangk exec`` is rejected with the sync-permission error;
+5. ``klangk sync`` is rejected by the CLI preflight before rsync runs;
+6. ``klangk sandbox --force`` (re-apply + setup over the exec channel)
+   fails: the exec nack surfaces and setup_state flips to ``failed``;
+7. restoring the ACE makes ``klangk exec`` work again (the failure was
+   the permission, nothing else).
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+import httpx
+import pytest
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "src",
+        "klangk",
+        "klangkd-tests",
+        "e2e-tests",
+    ),
+)
+from _e2e_server import start_server, stop_server
+
+ADMIN_EMAIL = "test@example.com"
+ADMIN_PASSWORD = "testpass"
+MEMBER_EMAIL = "member@example.com"
+MEMBER_PASSWORD = "memberpass"
+WS = "e2e-revoke-sync"
+
+
+def _run(args, timeout=300, env=None, input=None):
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        input=input,
+        env=env,
+    )
+
+
+class TestRevokeSyncBlocksExec:
+    @pytest.fixture(autouse=True, scope="class")
+    @staticmethod
+    def server(tmp_path_factory, request):
+        data_dir = tempfile.mkdtemp(prefix="klangk-revoke-sync-e2e-")
+        log_path = os.path.join(data_dir, "server.log")
+        overrides = {
+            "KLANGKD_JWT_SECRET": "revoke-sync-e2e-test-secret",
+            "KLANGKD_PREVENT_INSECURE_JWT_SECRET": "",
+            "KLANGKD_DEFAULT_USER": ADMIN_EMAIL,
+            "KLANGKD_DEFAULT_PASSWORD": ADMIN_PASSWORD,
+            "KLANGKD_AUTH_MODES": "password",
+            "KLANGKD_TEST_MODE": "1",
+            "KLANGKD_IDLE_TIMEOUT_SECONDS": "300",
+            "LOGFIRE_TOKEN": "",
+            "log_path": log_path,
+        }
+        server = start_server(uds=False, data_dir=data_dir, **overrides)
+
+        def _login_env(email, password, home):
+            env = {**os.environ, "HOME": str(home)}
+            os.makedirs(home / ".config" / "klangk", exist_ok=True)
+            r = _run(
+                ["klangk", "login", server["url"], email, "--password-file", "-"],
+                input=password + "\n",
+                env=env,
+            )
+            assert r.returncode == 0, r.stderr
+            return env
+
+        admin_home = tmp_path_factory.mktemp("klangk-admin-home")
+        member_home = tmp_path_factory.mktemp("klangk-member-home")
+        admin_env = _login_env(ADMIN_EMAIL, ADMIN_PASSWORD, admin_home)
+        r = httpx.post(
+            f"{server['url']}/api/v1/auth/login",
+            json={"identifier": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            timeout=30,
+        )
+        r.raise_for_status()
+        admin_token = r.json()["access_token"]
+        request.cls._admin_headers = {"Authorization": f"Bearer {admin_token}"}
+        # Non-admin member (the site admin's '*' on '/' inherits sync
+        # everywhere, so the member is the population the gate targets).
+        r = httpx.post(
+            f"{server['url']}/api/v1/admin/users",
+            headers=request.cls._admin_headers,
+            json={"email": MEMBER_EMAIL, "password": MEMBER_PASSWORD},
+            timeout=30,
+        )
+        r.raise_for_status()
+        request.cls._member_env = _login_env(MEMBER_EMAIL, MEMBER_PASSWORD, member_home)
+        request.cls._base_url = server["url"]
+        request.cls._log_path = log_path
+        request.cls._admin_env = admin_env
+        yield
+        stop_server(server)
+
+    def _list_workspaces(self):
+        r = httpx.get(
+            f"{self._base_url}/api/v1/workspaces",
+            headers=self._admin_headers,
+            timeout=30,
+        )
+        r.raise_for_status()
+        items = r.json()
+        if isinstance(items, dict):
+            items = items.get("workspaces") or []
+        return items
+
+    def _ws_id(self):
+        for ws in self._list_workspaces():
+            if ws["name"] == WS:
+                return ws["id"]
+        raise LookupError(WS)
+
+    def _get_acl(self, ws_id):
+        r = httpx.get(
+            f"{self._base_url}/api/v1/workspaces/{ws_id}/acl",
+            headers=self._admin_headers,
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def _put_acl(self, ws_id, entries):
+        r = httpx.put(
+            f"{self._base_url}/api/v1/workspaces/{ws_id}/acl",
+            headers=self._admin_headers,
+            json=entries,
+            timeout=30,
+        )
+        r.raise_for_status()
+
+    def _member_id(self):
+        r = httpx.get(
+            f"{self._base_url}/api/v1/admin/users",
+            headers=self._admin_headers,
+            timeout=30,
+        )
+        r.raise_for_status()
+        users = r.json()
+        if isinstance(users, dict):
+            users = users.get("users") or []
+        for u in users:
+            if u.get("email") == MEMBER_EMAIL:
+                return u["id"]
+        raise LookupError(MEMBER_EMAIL)
+
+    def _acl_sans_sync(self, acl):
+        """The same ACL with every 'exec-and-sync' Allow ACE dropped, plus an
+        ``edit`` Allow for the member (sandbox --force's preamble needs
+        edit + terminal; coders hold terminal but not edit) — so the
+        ONLY effective permission removed is ``exec-and-sync``."""
+        member_id = self._member_id()
+        rebuilt = [
+            {
+                "action": e["action"],
+                "principal_type": e["principal_type"],
+                "permission": e["permission"],
+                "user_id": e.get("user_id"),
+                "group_id": e.get("group_id"),
+                "system_principal": e.get("system_principal"),
+            }
+            for e in acl
+            if e["permission"] != "exec-and-sync"
+        ]
+        assert len(rebuilt) < len(acl), "no exec-and-sync ACE found to revoke"
+        rebuilt.append(
+            {
+                "action": 1,
+                "principal_type": 1,
+                "permission": "edit",
+                "user_id": member_id,
+                "group_id": None,
+                "system_principal": None,
+            }
+        )
+        return rebuilt
+
+    def _plain_acl(self, acl):
+        rebuilt = [
+            {
+                "action": e["action"],
+                "principal_type": e["principal_type"],
+                "permission": e["permission"],
+                "user_id": e.get("user_id"),
+                "group_id": e.get("group_id"),
+                "system_principal": e.get("system_principal"),
+            }
+            for e in acl
+        ]
+        return rebuilt
+
+    def _setup_state(self, ws_id):
+        for ws in self._list_workspaces():
+            if ws["id"] == ws_id:
+                return ws.get("setup_state")
+        raise LookupError(ws_id)
+
+    def _container_running(self, ws_id):
+        """(running, container_id) from the status endpoint."""
+        r = httpx.get(
+            f"{self._base_url}/api/v1/workspaces/{ws_id}/status",
+            headers=self._admin_headers,
+            timeout=30,
+        )
+        r.raise_for_status()
+        body = r.json()
+        return bool(body.get("running")), body.get("container_id")
+
+    def test_revoking_sync_blocks_exec_sync_and_sandbox(self, tmp_path):
+        # 1. Admin creates the workspace, shares it with the member as
+        #    coder (coders seed sync), and boots the container.
+        r = _run(["klangk", "create", WS], env=self._admin_env)
+        assert r.returncode == 0, r.stdout + r.stderr
+        r = _run(
+            ["klangk", "share", WS, MEMBER_EMAIL, "--role=coder"],
+            env=self._admin_env,
+        )
+        assert r.returncode == 0, r.stdout + r.stderr
+        ws_id = self._ws_id()
+
+        # 2. The member can exec while their role group holds sync.
+        r = _run(["klangk", "exec", WS, "true"], env=self._member_env)
+        assert r.returncode == 0, (
+            "member exec should work before revocation:\n" + r.stdout + r.stderr
+        )
+
+        original_acl = self._get_acl(ws_id)
+
+        # 3. Revoke: drop the member's role group's sync ACE.
+        self._put_acl(ws_id, self._acl_sans_sync(original_acl))
+
+        # 4. klangk exec is rejected by the server-side gate. The CLI's
+        #    connect handshake waits for ``container_ready`` — which the
+        #    server sends only after the full create-choke-point bring-up
+        #    (entrypoint one-time setup, sudo config, workspace token,
+        #    FIPS gate) — so the very fact the denial (not a hang or a
+        #    silent no-op) arrived proves the creation hook had fired
+        #    before the exec was attempted; ExecController.start checks
+        #    container_id before the permission. Assert it directly too.
+        running, container_id = self._container_running(ws_id)
+        assert running and container_id, "precondition: container up"
+        r = _run(["klangk", "exec", WS, "echo", "hi"], env=self._member_env)
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert "exec-and-sync permission" in " ".join((r.stdout + r.stderr).split()), (
+            r.stdout + r.stderr
+        )
+        # The denial did not tear the (creation-hook-provided) container
+        # down — bring-up completed and only the member's exec was
+        # refused.
+        running, container_id_after = self._container_running(ws_id)
+        assert running and container_id_after == container_id, (
+            "container should still be the same, running instance after the denied exec"
+        )
+
+        # 5. klangk sync is rejected by the CLI preflight before rsync.
+        dest = tmp_path / "pull-dest"
+        dest.mkdir()
+        r = _run(
+            ["klangk", "sync", f"{WS}:/home/klangk", str(dest)],
+            env=self._member_env,
+        )
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert "requires the exec-and-sync permission" in " ".join(r.stderr.split()), (
+            r.stdout + r.stderr
+        )
+
+        # 6. klangk sandbox --force re-runs setup over the exec channel:
+        #    denied, and setup_state flips to 'failed'. (The member needs
+        #    edit + terminal for the re-apply preamble -- those stay
+        #    granted; only sync was revoked.)
+        root = tmp_path / "sbroot"
+        root.mkdir()
+        (root / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n  mount-at: /sbtest\n  setup: setup.sh\n"
+        )
+        (root / "setup.sh").write_text("#!/bin/sh\nexit 0\n")
+        r = _run(
+            ["klangk", "sandbox", WS, str(root), "--force"],
+            env=self._member_env,
+        )
+        combined = " ".join((r.stdout + r.stderr).split())
+        assert "exec-and-sync permission" in combined, combined
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline:
+            if self._setup_state(ws_id) == "failed":
+                break
+            time.sleep(2)
+        assert self._setup_state(ws_id) == "failed", (
+            f"setup_state={self._setup_state(ws_id)!r}, expected 'failed'"
+        )
+        # The sandbox's --force preamble restarted the container — the
+        # creation hook re-fired on that restart's bring-up — and the
+        # member's setup exec then hit the sync gate. The nack message
+        # itself proves the ordering: the CLI waits for ``container_ready``
+        # (sent only after bring-up) before sending ``exec_start``, and
+        # ``ExecController.start`` only reaches the permission check with
+        # a container_id — a pre-hook exec would hang or no-op, not be
+        # denied. The container being stopped afterwards is the sandbox
+        # CLI's normal post-setup behavior (#2404), not a hook failure.
+
+        # 7. Restore the ACL; the member's exec works again (causality).
+        self._put_acl(ws_id, self._plain_acl(original_acl))
+        r = _run(["klangk", "exec", WS, "true"], env=self._member_env)
+        assert r.returncode == 0, r.stdout + r.stderr

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -35,6 +35,7 @@ class AclEditorState extends State<AclEditor> {
     'files',
     'files-download',
     'files-write',
+    'exec-and-sync',
     'edit',
     'share',
     'delete',

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -278,6 +278,7 @@ ALL_PERMISSIONS = [
     "delete",
     "terminal",
     "code-in-isolation",
+    "exec-and-sync",
     "spectate-on-shared-terminals",
     "code-in-shared-terminals",
     "share-terminals",

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -1747,10 +1747,15 @@ class ExecSession(_ShellSession):
             elif data.get("type") == "exec_exit":
                 self.exit_code = data.get("code", 0)
                 break
-            elif data.get("type") == "error":  # pragma: no cover
-                logging.error(
-                    "Server error: %s",
-                    data.get("message", "unknown"),
+            elif data.get("type") == "error":
+                # Server-side nack (e.g. the #2706/#2712 exec-and-sync permission
+                # gate on exec_start). stderr, never stdout: stdout
+                # carries rsync's binary protocol when this session is
+                # the sync transport, and rsync relays transport stderr
+                # to the user's rsync output.
+                print(
+                    f"klangk: {data.get('message', 'unknown error')}",
+                    file=sys.stderr,
                 )
                 self.exit_code = 1
                 break

--- a/src/klangk/klangk/cli/execsync.py
+++ b/src/klangk/klangk/cli/execsync.py
@@ -9,6 +9,7 @@ single-responsibility modules, all imported back into
 from __future__ import annotations
 
 import asyncio
+import re
 import shutil
 import subprocess
 
@@ -17,9 +18,53 @@ import typer
 from rich.console import Console
 
 from .client import (
+    WorkspaceNotFoundError,
     ws_exec,
 )
 from . import context
+
+
+def remote_host(spec: str) -> str | None:
+    """The remote host when *spec* is a ``host:path`` spec, else None.
+
+    Mirrors rsync's own remote-path rule: a colon before any slash makes
+    the text before it the remote host (reached via the ``-e``
+    transport). A colon after a slash (``./a:b``) is a plain local
+    filename. Either side being remote means the sync rides the exec
+    channel of that workspace (#2706).
+    """
+    m = re.match(r"^([^/:]+):", spec)
+    return m.group(1) if m else None
+
+
+def sync_denied(client, host: str) -> bool:
+    """True when *host* is a workspace the user may not exec against.
+
+    #2706/#2712: ``klangk sync`` rides the one-shot exec channel (its
+    transport is ``klangk exec --raw``), which is gated server-side on
+    the ``exec-and-sync`` permission — so a denied member cannot sync in
+    either direction. This preflight exists only so the CLI can fail fast
+    with a clear message instead of rsync's transport-error noise.
+    Unknown hosts, API failures, and missing data return False — rsync
+    or the server reports those.
+    """
+    try:
+        ws = client.resolve_workspace(host)
+    except (WorkspaceNotFoundError, httpx.HTTPError):
+        return False
+    resource = f"/workspaces/{ws.id}"
+    try:
+        resp = client.get(
+            "/api/v1/my-permissions", params={"resource": resource}
+        )
+        perms = resp.json().get("permissions", {}).get(resource)
+    except (httpx.HTTPError, ValueError):
+        # ValueError: a non-JSON error body (e.g. an HTML 500 page from
+        # a proxy in front of klangkd) must not crash the preflight.
+        return False
+    if perms is None:
+        return False
+    return "exec-and-sync" not in perms
 
 
 @context.app.command(
@@ -126,6 +171,27 @@ def sync(
     rsync_bin = shutil.which("rsync")
     if not rsync_bin:
         context._err.print("[red]Cannot find rsync in PATH[/red]")
+        raise typer.Exit(code=1)
+
+    # #2706/#2712: sync rides the one-shot exec channel, gated on the
+    # ``exec-and-sync`` permission — a remote source or destination
+    # means the user needs it on that workspace (either direction).
+    # Fail fast with a clear permission error; the server still enforces
+    # when rsync gets that far.
+    client = context._client()
+    pull_host = remote_host(src)
+    if pull_host and sync_denied(client, pull_host):
+        context._err.print(
+            f"[red]Permission denied:[/red] syncing out of workspace"
+            f" '{pull_host}' requires the exec-and-sync permission"
+        )
+        raise typer.Exit(code=1)
+    push_host = remote_host(dest)
+    if push_host and sync_denied(client, push_host):
+        context._err.print(
+            f"[red]Permission denied:[/red] syncing into workspace"
+            f" '{push_host}' requires the exec-and-sync permission"
+        )
         raise typer.Exit(code=1)
 
     cmd = [

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -60,6 +60,7 @@ from klangk.model.migrations import m0009_per_handle_home
 from klangk.model.migrations import m0010_groups_source
 from klangk.model.migrations import m0011_files_download
 from klangk.model.migrations import m0012_files_write
+from klangk.model.migrations import m0013_exec_and_sync_permission
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -80,6 +81,7 @@ MIGRATIONS: list[Migration] = [
     m0010_groups_source.migration,
     m0011_files_download.migration,
     m0012_files_write.migration,
+    m0013_exec_and_sync_permission.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0013_exec_and_sync_permission.py
+++ b/src/klangk/klangk/model/migrations/m0013_exec_and_sync_permission.py
@@ -1,0 +1,72 @@
+"""Migration 0013: grant ``exec-and-sync`` to existing role groups.
+
+The one-shot exec channel is now gated on the dedicated ``exec-and-sync``
+permission (#2706/#2712) — enforced in ``ExecController.start`` for
+every exec session, which is also what ``klangk sync`` rides on (its
+rsync transport is ``klangk exec --raw``), so both sync directions are
+covered by the same gate. New workspaces seed the permission into their
+``coders``/``collaborators`` role groups via
+``_ROLE_GROUP_PERMISSIONS``; this migration backfills existing
+workspaces so the upgrade does not silently break ``klangk exec`` /
+``klangk sync`` / ``klangk sandbox`` for members who already had it
+(preserving prior behavior: revoking ``exec-and-sync`` is an admin
+choice, not
+the new default).
+
+For every ``coders-``/``collaborators-<workspace_id>`` role group, an
+``Allow`` ACE for ``exec-and-sync`` is appended at the end of that resource's
+ACL (max position + 1) unless one already exists. Owners need nothing
+(their seeded ACE is the ``*`` wildcard); spectators never had exec.
+Admins who granted ``code-in-isolation`` to other principals via custom
+ACEs must add ``exec-and-sync`` explicitly to preserve one-shot exec
+for them —
+terminals are unaffected.
+"""
+
+import re
+
+from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_GROUP
+from klangk.model.migrations.base import Migration
+
+_SYNC_ROLES = ("coders", "collaborators")
+_ROLE_GROUP_RE = re.compile(r"^(%s)-(.+)$" % "|".join(_SYNC_ROLES))
+
+
+async def apply(db) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM groups WHERE source = 'workspace-role'"
+    )
+    role_groups = [row[0] for row in await cursor.fetchall()]
+    for name in role_groups:
+        m = _ROLE_GROUP_RE.match(name)
+        if m is None:
+            continue  # owners/spectators (and unknown suffixes) untouched
+        ws_id = m.group(2)
+        resource = f"/workspaces/{ws_id}"
+        existing = await db.execute(
+            "SELECT 1 FROM acl_entries"
+            " WHERE resource = ? AND group_id = ("
+            "   SELECT id FROM groups WHERE name = ?)"
+            " AND permission = 'exec-and-sync' LIMIT 1",
+            (resource, name),
+        )
+        if await existing.fetchone() is not None:
+            continue
+        max_pos = await db.execute(
+            "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
+            " WHERE resource = ?",
+            (resource,),
+        )
+        pos = (await max_pos.fetchone())[0] + 1
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type,"
+            "  user_id, group_id, system_principal, permission)"
+            " VALUES (?, ?, ?, ?, NULL,"
+            "  (SELECT id FROM groups WHERE name = ?), NULL,"
+            "  'exec-and-sync')",
+            (resource, pos, ACTION_ALLOW, PRINCIPAL_GROUP, name),
+        )
+
+
+migration = Migration(13, "0013_exec_and_sync_permission", apply)

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -25,6 +25,7 @@ _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
     "coders": [
         "terminal",
         "code-in-isolation",
+        "exec-and-sync",
         "spectate-on-shared-terminals",
         "files",
         "files-download",
@@ -33,6 +34,7 @@ _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
     "collaborators": [
         "terminal",
         "code-in-isolation",
+        "exec-and-sync",
         "code-in-shared-terminals",
         "spectate-on-shared-terminals",
         "share-terminals",

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -382,10 +382,19 @@ class ExecController:
         container_id = self._conn.container_id
         if not container_id:
             return
-        if not await self._conn._has_perm("code-in-isolation"):
+        # #2706/#2712: the one-shot exec channel is a programmatic
+        # bulk-read/write path — and it is also what ``klangk sync``
+        # rides on (its rsync transport is ``klangk exec --raw``), so
+        # this gate is the enforcement point for both. It uses the
+        # dedicated ``exec-and-sync`` permission, separate from
+        # ``code-in-isolation`` (isolated terminals), so an admin can
+        # keep terminals available while stopping one-shot command
+        # execution and bulk sync — revoking ``exec-and-sync`` blocks
+        # both sync directions along with ``klangk exec``.
+        if not await self._conn._has_perm("exec-and-sync"):
             send_error(
                 self._conn.sock,
-                "exec requires code-in-isolation permission",
+                "exec requires the exec-and-sync permission",
             )
             return
         await self.stop()

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -4093,6 +4093,33 @@ class TestExecSessionRunClosedWs:
         assert exit_code == 0
 
 
+class TestExecSessionErrorFrame:
+    async def test_error_frame_sets_exit_code_and_prints_stderr(self, capsys):
+        """#2706/#2712: a server-side nack (e.g. the exec-and-sync
+        permission gate) is printed to stderr — never stdout, which
+        carries rsync's protocol when the session is a sync transport —
+        and exits 1."""
+        from klangk.cli.client import ExecSession
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+        ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "type": "error",
+                    "message": "exec requires the exec-and-sync permission",
+                }
+            )
+        )
+
+        session = ExecSession(ws, command=["rsync", "--server"], stdin=None)
+        exit_code = await session.run()
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "exec-and-sync permission" in captured.err
+        assert captured.out == ""
+
+
 class _FakeMonitorConn:
     """Async-iterator WS stub for ``klangk monitor``."""
 

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -3843,10 +3843,15 @@ class TestMainCLI:
         ctx.args = []
         mock_result = MagicMock()
         mock_result.returncode = 0
-        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
-            with patch("subprocess.run", return_value=mock_result) as mock_run:
-                with pytest.raises(typer.Exit) as exc_info:
-                    main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
+        client = MagicMock()
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("ws")
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
         assert exc_info.value.exit_code == 0
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == "/usr/bin/rsync"
@@ -3866,9 +3871,12 @@ class TestMainCLI:
 
         ctx = MagicMock()
         ctx.args = []
-        with patch("shutil.which", side_effect=which_no_rsync):
-            with pytest.raises(typer.Exit) as exc_info:
-                main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
+        client = MagicMock()
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("ws")
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=which_no_rsync):
+                with pytest.raises(typer.Exit) as exc_info:
+                    main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
         assert exc_info.value.exit_code == 1
 
     def test_sync_passes_extra_args(self, logged_in_cfg):
@@ -3878,10 +3886,15 @@ class TestMainCLI:
         ctx.args = ["--delete", "--exclude=.git"]
         mock_result = MagicMock()
         mock_result.returncode = 0
-        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
-            with patch("subprocess.run", return_value=mock_result) as mock_run:
-                with pytest.raises(typer.Exit):
-                    main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
+        client = MagicMock()
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("ws")
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit):
+                        main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
         cmd = mock_run.call_args[0][0]
         assert "--delete" in cmd
         assert "--exclude=.git" in cmd
@@ -3893,11 +3906,239 @@ class TestMainCLI:
         ctx.args = []
         mock_result = MagicMock()
         mock_result.returncode = 23
-        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
-            with patch("subprocess.run", return_value=mock_result):
-                with pytest.raises(typer.Exit) as exc_info:
-                    main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
+        client = MagicMock()
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("ws")
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch("subprocess.run", return_value=mock_result):
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="/tmp/foo", dest="ws:/work/foo")
         assert exc_info.value.exit_code == 23
+
+    def _perm_client(self, perms, ws_id="ws1" + "0" * 52):
+        """A mock client whose my-permissions response carries *perms*."""
+        client = MagicMock()
+        client.resolve_workspace.return_value = Workspace(
+            id=ws_id, name="my-ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client.get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={"permissions": {f"/workspaces/{ws_id}": perms}}
+            ),
+        )
+        return client
+
+    def test_sync_pull_denied_fails_before_rsync(self, logged_in_cfg):
+        """#2706: a remote source (workspace→local pull) without the
+        exec permission exits 1 before rsync ever runs."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client(["terminal", "files"])
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch("subprocess.run") as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="my-ws:/work/out", dest="/tmp/out")
+        assert exc_info.value.exit_code == 1
+        mock_run.assert_not_called()
+        client.get.assert_called_once()
+
+    def test_sync_pull_allowed_runs_rsync(self, logged_in_cfg):
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client(["terminal", "files", "exec-and-sync"])
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="my-ws:/work/out", dest="/tmp/out")
+        assert exc_info.value.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_sync_push_denied_fails_before_rsync(self, logged_in_cfg):
+        """#2706: a remote destination (local→workspace push) without
+        the exec-and-sync permission exits 1 before rsync ever runs."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client(["terminal", "files"])
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch("subprocess.run") as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="/tmp/foo", dest="my-ws:/work/foo")
+        assert exc_info.value.exit_code == 1
+        mock_run.assert_not_called()
+        client.get.assert_called_once()
+
+    def test_sync_push_allowed_runs_rsync(self, logged_in_cfg):
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client(["terminal", "files", "exec-and-sync"])
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="/tmp/foo", dest="my-ws:/work/foo")
+        assert exc_info.value.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_sync_ws_to_ws_requires_exec(self, logged_in_cfg):
+        """A workspace→workspace sync checks exec-and-sync on each remote side;
+        lacking it on the source is enough to stop the transfer."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client(["terminal", "files"])
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch("subprocess.run") as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="my-ws:/a", dest="my-ws:/b")
+        assert exc_info.value.exit_code == 1
+        mock_run.assert_not_called()
+
+    def test_sync_pull_unknown_host_proceeds(self, logged_in_cfg):
+        """A remote source that is not a klangk workspace (e.g. a real
+        ssh host via a custom --rsh) is left to rsync to report."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = MagicMock()
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("nope")
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="nope:/x", dest="/tmp/out")
+        assert exc_info.value.exit_code == 0
+        mock_run.assert_called_once()
+        client.get.assert_not_called()
+
+    def test_sync_pull_api_error_proceeds(self, logged_in_cfg):
+        """A failed preflight lookup is not fatal — the server still
+        enforces the gate on the exec channel."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client([])
+        client.get.side_effect = httpx.ConnectError("boom")
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="my-ws:/x", dest="/tmp/out")
+        assert exc_info.value.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_sync_pull_empty_permission_data_proceeds(self, logged_in_cfg):
+        """my-permissions omits resources with no granted permissions —
+        treat missing data as "cannot preflight" (rsync proceeds; the
+        server's exec-channel gate still enforces)."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client([])
+        client.get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"permissions": {}}),
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="my-ws:/x", dest="/tmp/out")
+        assert exc_info.value.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_sync_push_resolve_error_proceeds(self, logged_in_cfg):
+        """A resolve failure on the push side (network down) is not
+        fatal — the server still enforces the gate on the exec
+        channel."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = MagicMock()
+        client.resolve_workspace.side_effect = httpx.ConnectError("boom")
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="/tmp/foo", dest="my-ws:/x")
+        assert exc_info.value.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_sync_preflight_non_json_error_body_proceeds(self, logged_in_cfg):
+        """A preflight response that is not JSON (e.g. an HTML 500 page
+        from a proxy in front of klangkd) must not crash the CLI — the
+        preflight is best-effort and the server still enforces the
+        exec gate."""
+        from klangk.cli import main
+
+        ctx = MagicMock()
+        ctx.args = []
+        client = self._perm_client([])
+        client.get.return_value = MagicMock(
+            status_code=500,
+            json=MagicMock(side_effect=ValueError("Expecting value")),
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+                with patch(
+                    "subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        main.sync(ctx, src="my-ws:/x", dest="/tmp/out")
+        assert exc_info.value.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_remote_host(self):
+        from klangk.cli.execsync import remote_host
+
+        assert remote_host("ws:/work/out") == "ws"
+        assert remote_host("ws:/a/b:c") == "ws"
+        assert remote_host("/tmp/local") is None
+        assert remote_host("./rel:ative") is None
+        assert remote_host("") is None
 
 
 class TestVolumes:

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -291,3 +291,18 @@ class TestSubmoduleStructure:
             "SUPPORT_EMAIL",
         ):
             assert not hasattr(api_init, name), f"api still defines {name}"
+
+
+def test_all_permissions_single_source():
+    """``ALL_PERMISSIONS`` must have exactly one definition. It is
+    load-bearing for /my-permissions and the klangk sync preflight
+    (#2706); a second hand-maintained copy in api/admin.py drifted
+    silently, so #2765 removed it — keep it removed."""
+    import klangk.api.admin as api_admin
+
+    assert not hasattr(api_admin, "ALL_PERMISSIONS")
+    # The exec-and-sync permission gate (#2706/#2712) depends on
+    # "exec-and-sync" being reportable via /my-permissions.
+    assert "exec-and-sync" in api.ALL_PERMISSIONS
+    # #2765's transfer permissions must be present too.
+    assert {"files-download", "files-write"} <= set(api.ALL_PERMISSIONS)

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -61,6 +61,7 @@ class TestRunner:
             (10, "0010_groups_source"),
             (11, "0011_files_download"),
             (12, "0012_files_write"),
+            (13, "0013_exec_and_sync_permission"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -139,6 +140,7 @@ class TestRunner:
                 (10, "0010_groups_source"),
                 (11, "0011_files_download"),
                 (12, "0012_files_write"),
+                (13, "0013_exec_and_sync_permission"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -727,6 +729,141 @@ class TestM0012FilesUpload:
             assert ("u-kept", "files-write") in perms
             assert ("u-trimmed", "files-download") not in perms
             assert ("u-trimmed", "files-write") not in perms
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0013ExecAndSyncPermission:
+    """m0013: backfill ``exec-and-sync`` onto existing role groups (#2706/#2712).
+
+    Exercised against a hand-built post-m0010 schema (groups with the
+    ``source`` marker, minimal ``acl_entries``) by calling ``apply``
+    directly, mirroring the m0010 pattern.
+    """
+
+    WS_ID = "11111111-2222-3333-4444-555555555555"
+    RESOURCE = f"/workspaces/{WS_ID}"
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0013.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT, source TEXT)"
+        )
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT)"
+        )
+        for role in ("owners", "coders", "collaborators", "spectators"):
+            await db.execute(
+                "INSERT INTO groups (id, name, source) VALUES (?, ?, ?)",
+                (f"g-{role}", f"{role}-{self.WS_ID}", "workspace-role"),
+            )
+        await db.execute(
+            "INSERT INTO groups (id, name, source) VALUES (?, ?, ?)",
+            ("g-human", "human", "manual"),
+        )
+        # A pre-#2706 seeded ACL: owner wildcard + one ACE per role group.
+        for resource, pos, gid, perm in (
+            (self.RESOURCE, 0, "g-owners", "*"),
+            (self.RESOURCE, 1, "g-coders", "terminal"),
+            (self.RESOURCE, 2, "g-collaborators", "terminal"),
+            (self.RESOURCE, 3, "g-spectators", "terminal"),
+        ):
+            await db.execute(
+                "INSERT INTO acl_entries (resource, position, action,"
+                " principal_type, group_id, permission)"
+                " VALUES (?, ?, 1, 2, ?, ?)",
+                (resource, pos, gid, perm),
+            )
+        return db
+
+    async def _exec_aces(self, db) -> dict[str, int]:
+        """group_id -> count of exec-and-sync Allow ACEs."""
+        cursor = await db.execute(
+            "SELECT group_id, COUNT(*) FROM acl_entries"
+            " WHERE permission = 'exec-and-sync' AND action = 1"
+            " GROUP BY group_id"
+        )
+        return {row[0]: row[1] for row in await cursor.fetchall()}
+
+    async def test_backfill_grants_exec_and_sync_roles_only(self, tmp_path):
+        from klangk.model.migrations import m0013_exec_and_sync_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await m0013_exec_and_sync_permission.migration.apply(db)
+            assert await self._exec_aces(db) == {
+                "g-coders": 1,
+                "g-collaborators": 1,
+            }
+            # Appended after the seeded entries, not interleaved.
+            cursor = await db.execute(
+                "SELECT position FROM acl_entries"
+                " WHERE permission = 'exec-and-sync' AND group_id = 'g-coders'"
+            )
+            assert (await cursor.fetchone())[0] == 4
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_idempotent(self, tmp_path):
+        from klangk.model.migrations import m0013_exec_and_sync_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await m0013_exec_and_sync_permission.migration.apply(db)
+            await m0013_exec_and_sync_permission.migration.apply(db)
+            assert await self._exec_aces(db) == {
+                "g-coders": 1,
+                "g-collaborators": 1,
+            }
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_skips_manual_groups(self, tmp_path):
+        """A manual group named like a role group is untouched — the
+        backfill matches on the workspace-role source marker."""
+        from klangk.model.migrations import m0013_exec_and_sync_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO groups (id, name, source) VALUES (?, ?, ?)",
+                ("g-lookalike", f"coders-{self.WS_ID}-lookalike", "manual"),
+            )
+            await m0013_exec_and_sync_permission.migration.apply(db)
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM acl_entries WHERE group_id ="
+                " 'g-lookalike'"
+            )
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_empty_groups_table(self, tmp_path):
+        """No groups: nothing raises, nothing is written."""
+        from klangk.model.migrations import m0013_exec_and_sync_permission
+
+        db = aiosqlite.connect(str(tmp_path / "m0013-empty.db"))
+        db = await db.__aenter__()
+        try:
+            await db.execute(
+                "CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT,"
+                " source TEXT)"
+            )
+            await db.execute(
+                "CREATE TABLE acl_entries ("
+                " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                " resource TEXT, position INTEGER, action INTEGER,"
+                " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+                " system_principal INTEGER, permission TEXT)"
+            )
+            await m0013_exec_and_sync_permission.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
         finally:
             await db.__aexit__(None, None, None)
 

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -198,10 +198,12 @@ async def test_create_workspace_with_acl_seeds_owner_and_role_groups(
     # Position counter is global across all groups (no collisions).
     positions = sorted(e["position"] for e in entries)
     assert positions == list(range(len(entries)))
-    # 1 owner ACE + 1 + 6 + 8 + 2 group ACEs (coders/collaborators carry
-    # `files-download` and `files-write` alongside `files`, #2705).
-    assert len(entries) == 1 + 1 + 6 + 8 + 2
-    # Coder/collaborator grants include both transfer permissions.
+    # 1 owner ACE + 1 + 7 + 9 + 2 group ACEs (coders/collaborators carry
+    # `files-download`/`files-write` alongside `files` (#2705) and
+    # `exec-and-sync` (#2706/#2712)).
+    assert len(entries) == 1 + 1 + 7 + 9 + 2
+    # Coder/collaborator grants include both transfer permissions and
+    # the exec-channel permission.
     for suffix in ["coders", "collaborators"]:
         group = await app_state.state.model.users.get_group_by_name(
             f"{suffix}-{ws['id']}"
@@ -212,7 +214,12 @@ async def test_create_workspace_with_acl_seeds_owner_and_role_groups(
             if e["principal_type"] == model.PRINCIPAL_GROUP
             and e["group_id"] == group["id"]
         }
-        assert {"files", "files-download", "files-write"} <= perms
+        assert {
+            "files",
+            "files-download",
+            "files-write",
+            "exec-and-sync",
+        } <= perms
 
 
 async def test_create_workspace_with_acl_rollback_on_seeding_failure(

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2654,9 +2654,9 @@ class TestExecHandlers:
         ):
             await conn.handle_exec_start({"command": ["ls"]})
         sock.send_json.assert_called()
-        assert "code-in-isolation" in sock.send_json.call_args[0][0].get(
-            "message", ""
-        )
+        assert "exec-and-sync permission" in sock.send_json.call_args[0][
+            0
+        ].get("message", "")
         assert conn.exec_session is None
 
     async def test_exec_start_no_command(self):
@@ -2667,6 +2667,71 @@ class TestExecHandlers:
             await conn.handle_exec_start({"command": []})
         sock.send_json.assert_called()
         assert "command" in sock.send_json.call_args[0][0].get("message", "")
+
+    async def test_exec_start_requires_exec_permission(self):
+        """#2706/#2712: the one-shot exec channel — which ``klangk sync``
+        rides on — is gated on the dedicated ``exec-and-sync`` permission, not on
+        ``code-in-isolation``: a member who may open isolated terminals
+        but lacks ``exec-and-sync`` gets no exec session (and thus no sync
+        in either direction)."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        with patch.object(
+            conn,
+            "_has_perm",
+            new=AsyncMock(side_effect=lambda p: p == "code-in-isolation"),
+        ):
+            await conn.handle_exec_start(
+                {
+                    "command": [
+                        "rsync",
+                        "--server",
+                        "--sender",
+                        "-vlogDtprz",
+                        ".",
+                        "/src",
+                    ]
+                }
+            )
+        sent = sock.send_json.call_args[0][0]
+        assert "exec-and-sync permission" in sent.get("message", "")
+        assert conn.exec_session is None
+
+    async def test_exec_start_with_exec_and_sync_permission_runs(
+        self, app_state
+    ):
+        """``exec-and-sync`` alone authorizes the session — the gate replaced the
+        old ``code-in-isolation`` check on this path, it does not stack
+        on top of it (terminals keep using ``code-in-isolation``)."""
+        app_state = _make_app_state()
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.container_id = "cid"
+        mock_session = AsyncMock()
+
+        async def empty_output():
+            return
+            yield  # pragma: no cover
+
+        mock_session.output = empty_output
+        mock_session.returncode = 0
+        with patch(
+            "klangk.wshandler.controllers.ExecSession",
+            return_value=mock_session,
+        ):
+            with patch.object(
+                conn,
+                "_has_perm",
+                new=AsyncMock(side_effect=lambda p: p == "exec-and-sync"),
+            ):
+                await conn.handle_exec_start({"command": ["ls"]})
+        assert conn.exec_session is mock_session
+        conn.exec_task.cancel()
+        try:
+            await conn.exec_task
+        except asyncio.CancelledError:
+            pass
 
     async def test_exec_start_success(self, app_state):
         app_state = _make_app_state()
@@ -2916,7 +2981,7 @@ class TestExecController:
         await ctrl.start({"command": ["ls"]})
         msg = sock.send_json.call_args[0][0]
         assert msg["type"] == "error"
-        assert "code-in-isolation" in msg["message"]
+        assert "exec-and-sync permission" in msg["message"]
         assert ctrl.session is None
 
     async def test_start_no_command_sends_error(self):


### PR DESCRIPTION
## Summary

Exfil-avenue hardening for #2589: the one-shot exec channel — `klangk
exec`, and the rsync transport that `klangk sync` (and `klangk
sandbox`'s copy/setup path) rides on — is now gated on a single new
**`exec-and-sync`** permission on `/workspaces/{id}`. A member without
`exec-and-sync` cannot run one-shot commands or sync in either
direction; isolated terminals still use `code-in-isolation` and are
unaffected.

Closes #2706. Closes #2712 (the exec-gating companion).

## How it works

- **Server-side enforcement**: `ExecController.start` requires
  `exec-and-sync` for every exec session (this replaced the old
  `code-in-isolation` check on that path — it is not stacked on top of
  it). Since `klangk sync`'s transport is `klangk exec --raw <ws>
  rsync --server …`, blocking exec blocks both sync directions with the
  same gate — and, unlike the earlier argv-shape detector in this PR
  (withdrawn after the adversarial review showed it was bypassable with
  a custom `-e` wrapper), this gate cannot be routed around, because
  there is no exec session to ride at all.
- **Role defaults**: `coders` and `collaborators` seed
  `exec-and-sync` (preserving today's behavior for everyone who could
  already exec); `spectators` don't get it; owners hold the `*`
  wildcard. Migration `0013_exec_and_sync_permission` backfills
  existing workspaces' role groups so the upgrade does not break
  `klangk exec`/`sync`/`sandbox`. Custom ACEs that granted
  `code-in-isolation` to other principals must add `exec-and-sync`
  explicitly to keep one-shot exec working for them (changelog calls
  this out).
- **CLI UX**: `klangk sync` preflights each remote side via
  `/api/v1/my-permissions` and exits 1 with a clear permission-denied
  message before rsync ever runs. Preflight failures (unknown host,
  API error, non-JSON error body) are non-fatal — the server-side gate
  still enforces. Server error frames on exec sessions now print to
  stderr (stdout carries rsync's binary protocol when the session is
  the sync transport, so rsync relays the message).
- **Ordering guarantee**: the sandbox/exec client waits for
  `container_ready` — which the server sends only after the full
  create-choke-point bring-up (entrypoint setup, sudo config, workspace
  token, FIPS gate) — before sending `exec_start`, so the creation hook
  always fires before any (possibly denied) exec.

## Review fixes included

The adversarial review (posted as a PR comment) flagged: (1) the
argv-shape rsync detector was bypassable and the claims overstated —
solved structurally by gating the whole exec channel instead; (2) the
preflight crashed on non-JSON error bodies — fixed (`ValueError`
caught); (3) the two hand-maintained `ALL_PERMISSIONS` copies could
drift — pinned equal by a test that also asserts `exec-and-sync` is
present.

## Testing

- Backend: full suite with `-n auto` at 100% coverage (5618 passed).
- Frontend: `flutter test` green (ACL editor permission list).
- Sandbox e2e (real klangkd + real container):
  - `sandboxes/tests/openclaw` — 3 passed: full `klangk sandbox`
    install of openclaw (Node 24 via nvm + real npm install), shared
    -mount reuse, and gateway health turning **healthy** via
    service-command.
  - `sandboxes/tests/test_revoke_sync_e2e.py` — the security property:
    a non-admin coder loses `klangk exec` (server nack), `klangk sync`
    (CLI preflight), and `klangk sandbox --force` (setup exec denied →
    `setup_state=failed`) the moment their role group's
    `exec-and-sync` ACE is removed; restoring the ACE brings exec
    back. Also asserts the creation hook (bring-up) fired before the
    denied exec — same running container across the denial.
