### PR TITLE
fix: surface files listing errors and heal unlistable home volume roots (#2766)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1373,6 +1373,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Files tab: a directory listing failure no longer renders as an
+  empty directory (#2766).** Listing an unreadable directory (e.g. a
+  home volume root created without world `r-x` under a restrictive
+  umask) now returns an error with the underlying message (403 for
+  permission denied, 500 otherwise) shown in the viewer, and workspace
+  start heals the home volume root to a listable mode.
+
 - **`GET /api/v1/groups` no longer silently truncates at 200 rows
   (#2750).** The endpoint previously fetched a single 200-row page and
   returned it as a bare list; deployments with more groups (easy to hit

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -180,6 +180,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       if (cached != null) {
         setState(() {
           _entries = cached.entries;
+          _listError = null;
           _loading = false;
         });
         return;
@@ -213,16 +214,29 @@ class FileViewerPanelState extends State<FileViewerPanel> {
           if (body is Map && body['detail'] is String) {
             detail = body['detail'] as String;
           }
-        } catch (_) {
+        } on FormatException {
           // Non-JSON body — keep the status-line detail.
         }
         debugPrint('File listing failed: ${response.statusCode}');
-        if (mounted) setState(() => _listError = detail);
+        // Clear the entries too: they belong to the previous directory
+        // and would otherwise feed FileDropZone's overwrite check with
+        // the wrong names (#2769 review).
+        if (mounted) {
+          setState(() {
+            _entries = [];
+            _listError = detail;
+          });
+        }
       }
     } catch (e) {
       if (generation != _loadGeneration) return;
       debugPrint('File listing error: $e');
-      if (mounted) setState(() => _listError = '$e');
+      if (mounted) {
+        setState(() {
+          _entries = [];
+          _listError = '$e';
+        });
+      }
     } finally {
       if (generation == _loadGeneration && mounted) {
         setState(() => _loading = false);

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -93,6 +93,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
   bool _loading = false;
   int _loadGeneration = 0;
   late final FileRendererRegistry _registry;
+  String? _listError;
 
   /// Refresh the file list for the current directory, bypassing the cache
   /// (manual refresh, or after a mutation that changed this directory).
@@ -185,7 +186,10 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       }
     }
     final requestedPath = _currentPath;
-    setState(() => _loading = true);
+    setState(() {
+      _loading = true;
+      _listError = null;
+    });
     try {
       final response = await _client.get(
         Uri.parse(
@@ -200,11 +204,25 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         _fileListCache.put(widget.workspaceId, requestedPath, entries);
         if (mounted) setState(() => _entries = entries);
       } else {
+        // Surface the failure instead of silently keeping the previous
+        // directory's entries (#2766): a permission-denied directory must
+        // not look like an empty one.
+        var detail = 'HTTP ${response.statusCode}';
+        try {
+          final body = jsonDecode(response.body);
+          if (body is Map && body['detail'] is String) {
+            detail = body['detail'] as String;
+          }
+        } catch (_) {
+          // Non-JSON body — keep the status-line detail.
+        }
         debugPrint('File listing failed: ${response.statusCode}');
+        if (mounted) setState(() => _listError = detail);
       }
     } catch (e) {
       if (generation != _loadGeneration) return;
       debugPrint('File listing error: $e');
+      if (mounted) setState(() => _listError = '$e');
     } finally {
       if (generation == _loadGeneration && mounted) {
         setState(() => _loading = false);
@@ -732,6 +750,20 @@ class FileViewerPanelState extends State<FileViewerPanel> {
   Widget _buildFileList() {
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
+    }
+    if (_listError != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            'Cannot list this directory:\n$_listError',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.error,
+            ),
+          ),
+        ),
+      );
     }
     if (_entries.isEmpty) {
       return Align(

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -115,6 +115,34 @@ void main() {
       client.close();
     });
 
+    testWidgets('shows error when listing fails', (tester) async {
+      // #2766: a permission-denied directory must not render as empty.
+      testHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/files') &&
+            !request.url.path.contains('/content')) {
+          return http.Response(
+            jsonEncode({"detail": "find: '/home': Permission denied"}),
+            403,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      final client = _MockWsClient();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: buildPanel(wsClient: client),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Cannot list this directory'), findsOneWidget);
+      expect(find.textContaining('Permission denied'), findsOneWidget);
+      client.close();
+    });
+
     testWidgets('shows file entries from mock', (tester) async {
       testHttpClientOverride = MockClient((request) async {
         if (request.url.path.contains('/files')) {

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -143,6 +143,60 @@ void main() {
       client.close();
     });
 
+    testWidgets('cached listing replaces a stale error on navigate-back',
+        (tester) async {
+      // #2769 review: browse a cached dir, enter an erroring one, go
+      // back — the cached entries must show, not the old error.
+      testHttpClientOverride = MockClient((request) async {
+        if (!request.url.path.contains('/files') ||
+            request.url.path.contains('/content')) {
+          return http.Response('Not found', 404);
+        }
+        final path = request.url.queryParameters['path'] ?? '/home/tester';
+        if (path == '/denied') {
+          return http.Response(
+            jsonEncode({"detail": "find: '/denied': Permission denied"}),
+            403,
+          );
+        }
+        return http.Response(
+          jsonEncode([
+            {
+              'name': 'hello.txt',
+              'path': '/home/tester/hello.txt',
+              'is_dir': false,
+              'size': 11
+            },
+          ]),
+          200,
+        );
+      });
+
+      final client = _MockWsClient();
+      final key = GlobalKey<FileViewerPanelState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: buildPanel(key: key, wsClient: client),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('hello.txt'), findsOneWidget);
+
+      // Enter the erroring directory.
+      key.currentState!.openDir('/denied');
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Cannot list this directory'), findsOneWidget);
+
+      // Back to the cached directory: entries, no stale error.
+      key.currentState!.openDir('/home/tester');
+      await tester.pumpAndSettle();
+      expect(find.text('hello.txt'), findsOneWidget);
+      expect(find.textContaining('Cannot list this directory'), findsNothing);
+      client.close();
+    });
+
     testWidgets('shows file entries from mock', (tester) async {
       testHttpClientOverride = MockClient((request) async {
         if (request.url.path.contains('/files')) {

--- a/src/klangk/klangk/api/files.py
+++ b/src/klangk/klangk/api/files.py
@@ -58,6 +58,8 @@ def _files_http_error(
         return HTTPException(
             status_code=409, detail="Destination already exists"
         )
+    if isinstance(e, PermissionError):
+        return HTTPException(status_code=403, detail=str(e))
     return HTTPException(status_code=500, detail=str(e))
 
 
@@ -71,8 +73,8 @@ async def list_files(
     cid = _require_container(workspace_id, app.state.container_registry)
     try:
         return await app.state.files.list_files(cid, path)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except (ValueError, FileNotFoundError, PermissionError, OSError) as e:
+        raise _files_http_error(e) from None
 
 
 @router.get("/workspaces/{workspace_id}/files/content")

--- a/src/klangk/klangk/api/files.py
+++ b/src/klangk/klangk/api/files.py
@@ -73,7 +73,7 @@ async def list_files(
     cid = _require_container(workspace_id, app.state.container_registry)
     try:
         return await app.state.files.list_files(cid, path)
-    except (ValueError, FileNotFoundError, PermissionError, OSError) as e:
+    except (ValueError, OSError) as e:
         raise _files_http_error(e) from None
 
 

--- a/src/klangk/klangk/files.py
+++ b/src/klangk/klangk/files.py
@@ -14,10 +14,13 @@ every call. ``validate_path`` is a pure path-normalization helper with
 no podman/settings dependency, so it stays module-level.
 """
 
+import logging
 import posixpath
 from collections.abc import AsyncGenerator
 
 EXEC_USER = "klangk"
+
+logger = logging.getLogger(__name__)
 
 # 255 is the common Linux NAME_MAX; reading at import time is fine.
 NAME_MAX = 255
@@ -69,7 +72,7 @@ class Files:
     ) -> list[dict]:
         """List files and directories at the given path inside the container."""
         path = validate_path(path)
-        rc, out, _err = await self.app.state.podman.exec_container(
+        rc, out, err = await self.app.state.podman.exec_container(
             container_id,
             [
                 "find",
@@ -85,7 +88,23 @@ class Files:
             user=EXEC_USER,
         )
         if rc != 0:
-            return []
+            # At -maxdepth 1 a non-zero find means the start point itself
+            # failed. ENOENT lists as empty (a missing directory is not an
+            # error — matches stat_path/read_file); everything else — a
+            # permission-denied volume root rendered as a mysterious
+            # "Empty directory" (#2766) — is surfaced, not swallowed.
+            message = " ".join(err.split()) or f"find exited with status {rc}"
+            if "No such file or directory" in message:
+                return []
+            logger.warning(
+                "list_files failed for %s in container %s: %s",
+                path,
+                container_id,
+                message,
+            )
+            if "Permission denied" in message:
+                raise PermissionError(message)
+            raise OSError(message)
         entries = []
         for line in out.strip().splitlines():
             parts = line.split("\t")

--- a/src/klangk/klangk/files.py
+++ b/src/klangk/klangk/files.py
@@ -16,11 +16,18 @@ no podman/settings dependency, so it stays module-level.
 
 import logging
 import posixpath
+import re
 from collections.abc import AsyncGenerator
 
 EXEC_USER = "klangk"
 
 logger = logging.getLogger(__name__)
+
+# find's stderr diagnostics name the path they failed on:
+# ``find: '<path>': <reason>``. Used to tell a start-point failure
+# (whole listing fails) from a child-entry failure (one unreadable
+# entry; the rest of the listing is still good).
+_FIND_ERROR_PATH_RE = re.compile(r"^find: '(.*)': ")
 
 # 255 is the common Linux NAME_MAX; reading at import time is fine.
 NAME_MAX = 255
@@ -86,25 +93,59 @@ class Files:
                 r"%f\t%Y\t%s\t%T@\t%C@\n",
             ],
             user=EXEC_USER,
+            # C locale keeps find's diagnostics in the exact
+            # ``find: '<path>': <reason>`` form regardless of the
+            # container's or a workspace env override's locale — the
+            # classification below depends on it (#2769 review).
+            extra_env={"LC_ALL": "C"},
         )
         if rc != 0:
-            # At -maxdepth 1 a non-zero find means the start point itself
-            # failed. ENOENT lists as empty (a missing directory is not an
-            # error — matches stat_path/read_file); everything else — a
-            # permission-denied volume root rendered as a mysterious
-            # "Empty directory" (#2766) — is surfaced, not swallowed.
-            message = " ".join(err.split()) or f"find exited with status {rc}"
-            if "No such file or directory" in message:
-                return []
-            logger.warning(
-                "list_files failed for %s in container %s: %s",
-                path,
-                container_id,
-                message,
-            )
-            if "Permission denied" in message:
-                raise PermissionError(message)
-            raise OSError(message)
+            # find exits 1 for BOTH start-point failures and individual
+            # child-entry failures (a stat-denied entry — e.g. a symlink
+            # into a 0700 dir — a raced-away file, ELOOP), and still
+            # prints the readable entries on stdout. Only a start-point
+            # failure fails the listing; child failures degrade to a
+            # logged warning plus the surviving entries (#2769 review).
+            start_errors = []
+            child_errors = []
+            for line in err.splitlines():
+                if not line.strip():
+                    continue
+                m = _FIND_ERROR_PATH_RE.match(line)
+                if m and m.group(1) == path:
+                    start_errors.append(line)
+                else:
+                    child_errors.append(line)
+            if child_errors:
+                logger.warning(
+                    "list_files: skipped unreadable entries under %s in "
+                    "container %s: %s",
+                    path,
+                    container_id,
+                    " | ".join(child_errors),
+                )
+            if start_errors:
+                message = " ".join(" ".join(start_errors).split())
+                if "No such file or directory" in message:
+                    # ENOENT lists as empty (a missing directory is not
+                    # an error — matches stat_path/read_file).
+                    return []
+                logger.warning(
+                    "list_files failed for %s in container %s: %s",
+                    path,
+                    container_id,
+                    message,
+                )
+                if "Permission denied" in message:
+                    # A permission-denied volume root rendered as a
+                    # mysterious "Empty directory" (#2766) — surfaced,
+                    # not swallowed.
+                    raise PermissionError(message)
+                raise OSError(message)
+            if not child_errors:
+                # rc != 0 with no diagnostics at all: cannot classify —
+                # surface it rather than guess.
+                raise OSError(f"find exited with status {rc}")
         entries = []
         for line in out.strip().splitlines():
             parts = line.split("\t")

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 import shutil
+import stat
 import tempfile
 from pathlib import Path
 
@@ -38,6 +39,42 @@ def rmtree(path: Path | str, label: str = "") -> None:
     shutil.rmtree(path, onexc=_on_error)
 
 
+def ensure_listable(path: Path) -> None:
+    """Ensure a home-volume directory is listable by the container user.
+
+    mkdir modes are umask-filtered: a restrictive daemon umask yields a
+    volume root of 0711 — traversable, so listing /home/klangk works,
+    but unlistable, so the Files tab shows /home as empty (#2766).
+    ORs group/world r-x in (owner bits untouched). Both a heal and a
+    failed heal log LOUDLY — a restrictive root is evidence of the
+    underlying creation bug recurring, and the original trigger was
+    never reconstructed (#2766). A root the daemon cannot chmod
+    (foreign uid) stays broken but visible: the files API surfaces
+    the listing error instead.
+    """
+    try:
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        if mode & 0o0555 != 0o0555:
+            healed = mode | 0o0555
+            os.chmod(path, healed)
+            logger.warning(
+                "#2766: home volume dir %s was NOT listable by the "
+                "container user (mode %04o — restrictive umask at "
+                "creation, or a foreign-uid root); healed to %04o. "
+                "If this recurs, find what created it.",
+                path,
+                mode,
+                healed,
+            )
+    except OSError as e:
+        logger.warning(
+            "#2766: cannot make %s listable (%s) — Files tab listings "
+            "of it will fail until an operator chmods it",
+            path,
+            e,
+        )
+
+
 def _ensure_shared_home_dir_sync(
     workspace_home: Path,
     name: str,
@@ -68,6 +105,11 @@ def _ensure_shared_home_dir_sync(
     # top dir may not exist yet (no in-tree caller mkdir'd it), and
     # unlike the old work/ helper this must not assume it does.
     shared_dir.mkdir(parents=True, exist_ok=True)
+    # #2766: mkdir modes are umask-tainted (0711 → unlistable /home) and
+    # exist_ok never fixes an existing root — chmod both here, the one
+    # choke point every start path funnels through.
+    ensure_listable(workspace_home)
+    ensure_listable(shared_dir)
     return created or not any(shared_dir.iterdir())
 
 

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -136,6 +136,12 @@ def _ensure_home_symlink_sync(
     user_dir = users_dir / user_id
     created = not user_dir.exists()
     user_dir.mkdir(exist_ok=True)
+    # #2766: same umask-tainted-mkdir hazard as the volume root — the
+    # per-handle home (/home/<handle> resolves through .users/<uid>)
+    # must stay listable by the container's fixed exec user. Before the
+    # fast-path return so every connection heals, not just renames.
+    ensure_listable(users_dir)
+    ensure_listable(user_dir)
 
     symlink = workspace_home / handle
     target = f".users/{user_id}"

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6177,6 +6177,49 @@ class TestFileRoutes:
         finally:
             self._cleanup(ws_id)
 
+    async def test_list_files_permission_denied_returns_403(
+        self, client, user
+    ):
+        """#2766: an unreadable directory is an error, not an empty list."""
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            with patch.object(
+                _mock_pod,
+                "exec_container",
+                new_callable=AsyncMock,
+                return_value=(1, "", "find: '/home': Permission denied"),
+            ):
+                resp = await client.get(
+                    f"/api/v1/workspaces/{ws_id}/files?path=/home",
+                    headers=headers,
+                )
+            assert resp.status_code == 403
+            assert "Permission denied" in resp.json()["detail"]
+        finally:
+            self._cleanup(ws_id)
+
+    async def test_list_files_find_error_returns_500(self, client, user):
+        """A non-permission find failure maps to 500 with the stderr text
+        (#2766)."""
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            with patch.object(
+                _mock_pod,
+                "exec_container",
+                new_callable=AsyncMock,
+                return_value=(1, "", "find: '/deep': Too many levels"),
+            ):
+                resp = await client.get(
+                    f"/api/v1/workspaces/{ws_id}/files?path=/deep",
+                    headers=headers,
+                )
+            assert resp.status_code == 500
+            assert "Too many levels" in resp.json()["detail"]
+        finally:
+            self._cleanup(ws_id)
+
     async def test_list_files_no_container_returns_409(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6220,6 +6220,34 @@ class TestFileRoutes:
         finally:
             self._cleanup(ws_id)
 
+    async def test_list_files_nonexistent_dir_returns_empty_list(
+        self, client, user
+    ):
+        """#2766/#2769: a missing directory is NOT an error — the route
+        returns 200 + [] (statWorkspacePath leans on this to classify
+        paths by listing the parent)."""
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            with patch.object(
+                _mock_pod,
+                "exec_container",
+                new_callable=AsyncMock,
+                return_value=(
+                    1,
+                    "",
+                    "find: '/no/such/dir': No such file or directory",
+                ),
+            ):
+                resp = await client.get(
+                    f"/api/v1/workspaces/{ws_id}/files?path=/no/such/dir",
+                    headers=headers,
+                )
+            assert resp.status_code == 200
+            assert resp.json() == []
+        finally:
+            self._cleanup(ws_id)
+
     async def test_list_files_no_container_returns_409(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(

--- a/src/klangk/klangkd-tests/tests/test_files.py
+++ b/src/klangk/klangkd-tests/tests/test_files.py
@@ -166,7 +166,8 @@ class TestListFiles:
                 await files_inst.list_files(CID, "/home")
 
     async def test_list_other_find_error_raises(self, files_inst):
-        """Any other find failure surfaces as a plain OSError (#2766)."""
+        """Any other START-POINT find failure surfaces as a plain OSError
+        (#2766)."""
         with patch.object(
             _mock_pod,
             EXEC,
@@ -176,6 +177,56 @@ class TestListFiles:
             with pytest.raises(OSError, match="Too many levels") as excinfo:
                 await files_inst.list_files(CID, "/deep")
         assert not isinstance(excinfo.value, PermissionError)
+
+    async def test_list_child_error_returns_entries(self, files_inst):
+        """#2769 review: find exits 1 for an unreadable CHILD entry too
+        (e.g. a symlink into a 0700 dir) while still printing the rest —
+        one bad entry must not 403/500 a readable directory."""
+        find_output = "a.txt\tf\t10\t0.0\t0.0\npeek\tN\t0\t0.0\t0.0\n"
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(
+                1,
+                find_output,
+                "find: '/home/klangk/peek': Permission denied\n\n",
+            ),
+        ):
+            entries = await files_inst.list_files(CID, "/home/klangk")
+
+        assert [e["name"] for e in entries] == ["a.txt", "peek"]
+
+    async def test_list_child_enoent_race_returns_entries(self, files_inst):
+        """A child deleted between readdir and stat is a child diagnostic,
+        not an empty-directory signal — the surviving entries list."""
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(
+                1,
+                "a.txt\tf\t10\t0.0\t0.0\n",
+                "find: '/home/klangk/gone': No such file or directory",
+            ),
+        ):
+            entries = await files_inst.list_files(CID, "/home/klangk")
+
+        assert [e["name"] for e in entries] == ["a.txt"]
+
+    async def test_list_exec_pins_c_locale(self, files_inst):
+        """find's diagnostics must stay in the parseable English form —
+        the classification keys on the quoted-path message format
+        (#2769 review)."""
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),
+        ) as mock:
+            await files_inst.list_files(CID, "/home/klangk")
+
+        assert mock.call_args.kwargs["extra_env"] == {"LC_ALL": "C"}
 
     async def test_list_error_without_stderr_raises(self, files_inst):
         """A non-zero exit with no stderr still raises, not empty."""

--- a/src/klangk/klangkd-tests/tests/test_files.py
+++ b/src/klangk/klangkd-tests/tests/test_files.py
@@ -144,11 +144,49 @@ class TestListFiles:
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
-            return_value=(1, "", "No such file"),
+            return_value=(
+                1,
+                "",
+                "find: '/no/such/dir': No such file or directory",
+            ),
         ):
             entries = await files_inst.list_files(CID, "/no/such/dir")
 
         assert entries == []
+
+    async def test_list_permission_denied_raises(self, files_inst):
+        """#2766: an unreadable directory must not render as empty."""
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(1, "", "find: '/home': Permission denied"),
+        ):
+            with pytest.raises(PermissionError, match="Permission denied"):
+                await files_inst.list_files(CID, "/home")
+
+    async def test_list_other_find_error_raises(self, files_inst):
+        """Any other find failure surfaces as a plain OSError (#2766)."""
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(1, "", "find: '/deep': Too many levels"),
+        ):
+            with pytest.raises(OSError, match="Too many levels") as excinfo:
+                await files_inst.list_files(CID, "/deep")
+        assert not isinstance(excinfo.value, PermissionError)
+
+    async def test_list_error_without_stderr_raises(self, files_inst):
+        """A non-zero exit with no stderr still raises, not empty."""
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(1, "", ""),
+        ):
+            with pytest.raises(OSError, match="status 1"):
+                await files_inst.list_files(CID, "/home")
 
     async def test_list_sorted(self, files_inst):
         find_output = (

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -1,6 +1,8 @@
 """Tests for workspaces: workspace lifecycle, directory management, port allocation."""
 
+import logging
 import os
+import stat
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -905,4 +907,79 @@ class TestEnsureSharedHome:
         assert dangling.is_dir()
         skel_mock.assert_awaited_once_with(
             "cid", model.AGENT_USER_ID, home="/home/klangk"
+        )
+
+    async def test_heals_unlistable_volume_root_mode(
+        self, user, app_state, caplog
+    ):
+        """#2766: a volume root without group/world r-x (umask-tainted
+        mkdir, or an inherited volume mode) is traversable but not
+        listable by the container user — the Files tab showed /home as
+        empty. The start choke point ORs r-x back in; owner bits keep."""
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "shared-home-mode-ws"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "klangk").mkdir(exist_ok=True)
+        os.chmod(home, 0o0711)
+        os.chmod(home / "klangk", 0o0711)
+
+        with patch(
+            "klangk.workspaces.Workspaces.populate_home_skel",
+            new_callable=AsyncMock,
+        ):
+            with caplog.at_level(logging.WARNING, logger="klangk.workspaces"):
+                await app_state.state.workspaces.ensure_shared_home(
+                    ws["id"], "cid"
+                )
+
+        for healed in (home, home / "klangk"):
+            mode = stat.S_IMODE(os.stat(healed).st_mode)
+            assert mode & 0o0555 == 0o0555
+            assert mode & 0o700 == 0o700
+        # The heal is loud (#2766): a restrictive root is evidence of
+        # the creation bug recurring and must leave a trace.
+        healed_logs = [r for r in caplog.records if "#2766" in r.message]
+        assert len(healed_logs) == 2
+        assert all("NOT listable" in r.message for r in healed_logs)
+        assert any(str(home) in r.message for r in healed_logs)
+        assert any("0711" in r.message for r in healed_logs)
+        assert any("0755" in r.message for r in healed_logs)
+
+    async def test_unchmoddable_volume_root_does_not_crash(
+        self, user, app_state, caplog
+    ):
+        """A root the daemon can't chmod (foreign uid) is skipped with a
+        warning — container start must not fail; the listing error
+        surfaces via the files API instead (#2766)."""
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "shared-home-unfixable-ws"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        os.chmod(home, 0o0711)
+
+        with (
+            patch(
+                "klangk.workspaces.os.chmod",
+                side_effect=PermissionError(1, "Operation not permitted"),
+            ),
+            patch(
+                "klangk.workspaces.Workspaces.populate_home_skel",
+                new_callable=AsyncMock,
+            ) as skel_mock,
+        ):
+            # Must not raise.
+            with caplog.at_level(logging.WARNING, logger="klangk.workspaces"):
+                await app_state.state.workspaces.ensure_shared_home(
+                    ws["id"], "cid"
+                )
+        skel_mock.assert_awaited_once_with(
+            "cid", model.AGENT_USER_ID, home="/home/klangk"
+        )
+        # The failed heal is equally loud (#2766).
+        assert any(
+            "cannot make" in r.message and str(home) in r.message
+            for r in caplog.records
         )

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -402,6 +402,32 @@ class TestEnsureHomeSymlink:
         assert os.readlink(symlink) == ".users/uid-1"
         assert (home / ".users" / "uid-1").is_dir()
 
+    async def test_heals_unlistable_users_dirs(self, user, app_state, caplog):
+        """#2766/#2769: .users and the per-handle home have the same
+        umask-tainted-mkdir hazard as the volume root — the per-handle
+        home resolves through them, so an unlistable .users/<uid> breaks
+        the Files tab one level down. Healed loudly on every connect."""
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "symlink-mode-ws"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        users = home / ".users"
+        users.mkdir(parents=True, exist_ok=True)
+        (users / "uid-1").mkdir(exist_ok=True)
+        os.chmod(users, 0o0711)
+        os.chmod(users / "uid-1", 0o0711)
+
+        with caplog.at_level(logging.WARNING, logger="klangk.workspaces"):
+            await app_state.state.workspaces.ensure_home_symlink(
+                home, "carol", "uid-1"
+            )
+
+        for healed in (users, users / "uid-1"):
+            mode = stat.S_IMODE(os.stat(healed).st_mode)
+            assert mode & 0o0555 == 0o0555
+            assert mode & 0o700 == 0o700
+        assert len([r for r in caplog.records if "#2766" in r.message]) == 2
+
     async def test_idempotent(self, user, app_state):
         ws = await app_state.state.workspaces.create_workspace(
             user["id"], "symlink-ws2"


### PR DESCRIPTION

## Review follow-ups (second commit)

A fresh-eyes adversarial review (0f9057ff) tightened three things:

- **Child-entry find errors** no longer fail the whole listing: `find` exits 1 for a stat-denied *child* (e.g. a symlink into a `0700` dir), a raced-away file, or ELOOP, while still printing the readable entries. Diagnostics are now classified per line — only a diagnostic naming the start point fails the listing (ENOENT → `[]`, permission → 403, else 500); child diagnostics log a warning and the surviving entries are returned. The find exec also pins `LC_ALL=C` so the message-form classification is locale-proof.
- **The heal now covers the per-handle layout too**: `.users/` and `.users/<uid>` get the same `ensure_listable` treatment at the `ensure_home_symlink` choke point.
- **Frontend stale-state bug fixed**: a cached listing no longer renders under a stale error on navigate-back, and a failed listing clears the previous directory's entries (which were feeding the drop-zone overwrite check the wrong names).

Also: API-layer test pinning the ENOENT → 200 `[]` contract, and the route's except-tuple simplified.
