### PR TITLE
feat(acl): restrict group creation to administrators (#2770)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -142,6 +142,15 @@ exec`, and the rsync transport `klangk sync` and `klangk sandbox`
   one-shot exec working for those principals. `klangk exec`/`klangk
 sync` report a clear permission-denied error.
 
+- **Group creation restricted to administrators (#2770).** The default
+  ACL no longer grants `create` on `/groups` to every authenticated
+  user; it goes to the `admin` group instead, matching workspace
+  creation (#2569). Existing deployments carrying the untouched seeded
+  ACE are migrated automatically; if you deliberately loosened `/groups`,
+  remove the Allow `create` → Authenticated users entry via the ACL
+  editor. To re-open group creation, add an Allow ACE for `create` on
+  `/groups` targeting the `members` group.
+
 - **Workspace creation restricted to administrators (#2569).** `POST
 /workspaces`, `POST /workspaces/import`, and workspace duplication
   now require the `create` permission on the `/workspaces` collection

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -145,11 +145,12 @@ sync` report a clear permission-denied error.
 - **Group creation restricted to administrators (#2770).** The default
   ACL no longer grants `create` on `/groups` to every authenticated
   user; it goes to the `admin` group instead, matching workspace
-  creation (#2569). Existing deployments carrying the untouched seeded
-  ACE are migrated automatically; if you deliberately loosened `/groups`,
-  remove the Allow `create` → Authenticated users entry via the ACL
-  editor. To re-open group creation, add an Allow ACE for `create` on
-  `/groups` targeting the `members` group.
+  creation (#2569). Existing deployments whose `/groups` still carries
+  exactly the seeded ACE are migrated automatically; if your `/groups`
+  entries differ (deliberately loosened or customized), remove the
+  Allow `create` → Authenticated users entry via the ACL editor. To
+  re-open group creation, add an Allow ACE for `create` on `/groups`
+  targeting the `members` group.
 
 - **Workspace creation restricted to administrators (#2569).** `POST
 /workspaces`, `POST /workspaces/import`, and workspace duplication

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -60,8 +60,8 @@ only members of the `admin` group can create groups (the `/groups`
 resource grants `create` to the admin group). To let other users create
 groups, add an **Allow** entry for the `create` permission on the
 `/groups` resource targeting the `members` group (or any other group)
-via the ACL editor — the same recipe as [workspace creation](#granting-
-workspace-creation-to-non-admin-users).
+via the ACL editor — the same recipe as
+[workspace creation](#granting-workspace-creation-to-non-admin-users).
 
 ## Default access rules
 

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -55,15 +55,21 @@ automatically on first startup:
 You can create additional groups (e.g., "engineering", "design") and
 share workspaces with an entire group instead of individual users.
 
-Manage groups from the Admin panel under the Groups tab.
+Manage groups from the Admin panel under the Groups tab. By default,
+only members of the `admin` group can create groups (the `/groups`
+resource grants `create` to the admin group). To let other users create
+groups, add an **Allow** entry for the `create` permission on the
+`/groups` resource targeting the `members` group (or any other group)
+via the ACL editor — the same recipe as [workspace creation](#granting-
+workspace-creation-to-non-admin-users).
 
 ## Default access rules
 
 On first startup, Klangk seeds these defaults:
 
 - Any logged-in user can view pages
-- Only members of the `admin` group can create workspaces or access
-  admin functions
+- Only members of the `admin` group can create workspaces, create
+  groups, or access admin functions
 - Unauthenticated users are denied everything
 
 ## Granting workspace creation to non-admin users

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -30,10 +30,11 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/`           | Allow  | Authenticated | `view`     |
 | `/`           | Deny   | Everyone      | `*`        |
 | `/workspaces` | Allow  | group:admin   | `create`   |
+| `/groups`     | Allow  | group:admin   | `create`   |
 | `/admin`      | Allow  | group:admin   | `*`        |
 | `/admin`      | Deny   | Everyone      | `*`        |
 
-These defaults mean: any logged-in user can view pages; only members of the `admin` group can create workspaces or access admin functions; unauthenticated users are denied everything.
+These defaults mean: any logged-in user can view pages; only members of the `admin` group can create workspaces, create groups, or access admin functions; unauthenticated users are denied everything.
 
 ### Granting workspace creation to non-admin users
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1260,9 +1260,11 @@ Returns `StreamingResponse` (`application/x-ndjson`).
 
 ### POST `/api/v1/groups`
 
-Create a new group.
+Create a new group. The creator receives full (`*`) access to the new
+group.
 
-**Auth:** JWT required. User must have `create` permission on `/groups`.
+**Auth:** JWT required. User must have `create` permission on `/groups`
+(default: the `admin` group only).
 
 ```json
 { "name": "my-group", "description": "optional description" }

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -141,14 +141,18 @@ class Lifecycle:
             PRINCIPAL_GROUP,
             group_id=admin_group_id,
         )
-        # /groups: Authenticated users can create groups
+        # /groups: only admins can create (#2770). Group management
+        # otherwise runs through /admin/groups (admin permission).
+        # Deployers can loosen this per-deployment by adding an Allow
+        # `create` ACE on /groups targeting another group (the same
+        # recipe as /workspaces, #2569).
         await self.app.state.model.acl.add_acl_entry(
             "/groups",
             0,
             ACTION_ALLOW,
             "create",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_AUTHENTICATED,
+            PRINCIPAL_GROUP,
+            group_id=admin_group_id,
         )
         # /admin: admin group gets full access, deny everyone else
         await self.app.state.model.acl.add_acl_entry(

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -187,9 +187,10 @@ class Lifecycle:
         """Ensure the 'members' group exists (#2569). Returns the group ID.
 
         New users (registration, invitation, OIDC first login, admin
-        create) are added to this group automatically. The default ACL
-        seed grants ``create`` on ``/workspaces`` to this group, so
-        members can create workspaces without being full admins.
+        create) are added to this group automatically. It gets no
+        default permissions — the ``/workspaces`` ``create`` seed goes to
+        the admin group (#2569); deployers who want all members to
+        create workspaces grant it to this group via the ACL editor.
         """
         group = await self.app.state.model.users.get_group_by_name("members")
         if group is None:

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -61,6 +61,7 @@ from klangk.model.migrations import m0010_groups_source
 from klangk.model.migrations import m0011_files_download
 from klangk.model.migrations import m0012_files_write
 from klangk.model.migrations import m0013_exec_and_sync_permission
+from klangk.model.migrations import m0014_groups_create_admin
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -82,6 +83,7 @@ MIGRATIONS: list[Migration] = [
     m0011_files_download.migration,
     m0012_files_write.migration,
     m0013_exec_and_sync_permission.migration,
+    m0014_groups_create_admin.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
+++ b/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
@@ -1,0 +1,88 @@
+"""Migration 0014: tighten the seeded ``create`` ACE on ``/groups`` (#2770).
+
+``seed_default_acls`` used to grant ``Allow /groups create →
+system:authenticated``, so every logged-in user could create groups (and
+received a full ``*`` ACE on the new group, letting them add/remove any
+user as a member without that user's consent). Nothing in any client
+(frontend, CLI, TUI, e2e) relies on that default — group management runs
+through the admin-gated ``/admin/groups`` endpoints — and the documented
+permission model says groups are managed by admins. The seed now grants
+``create`` on ``/groups`` to the admin group instead, matching the
+``/workspaces`` tightening (#2569).
+
+Because ``seed_default_acls`` only runs on a database with **no** ACL
+entries at all, deployments that already carry the open ACE keep it
+across upgrades. This migration rewrites it to the tightened shape —
+but only when the ``/groups`` entry set is **exactly** the single seeded
+ACE (position 0, Allow, ``create``, system:authenticated). Any other
+shape means an operator customized the resource (loosened deliberately,
+added entries, reordered): the migration leaves it untouched, and the
+changelog documents the manual tightening step for that case.
+
+The replacement inserts an Allow ``create`` ACE for the ``admin`` group
+at position 0, so a migrated deployment's ``/groups`` ACL matches a
+freshly seeded one. If no ``admin`` group row exists (a pathological
+state — ``ensure_admin_group`` recreates it at boot), the seeded ACE is
+simply deleted with no replacement: admins manage groups through
+``/admin/groups`` regardless.
+"""
+
+from klangk.model.acl import (
+    ACTION_ALLOW,
+    PRINCIPAL_GROUP,
+    PRINCIPAL_SYSTEM,
+    SYSTEM_AUTHENTICATED,
+)
+from klangk.model.migrations.base import Migration
+
+_RESOURCE = "/groups"
+
+
+async def apply(db) -> None:
+    cursor = await db.execute(
+        "SELECT position, action, principal_type, user_id, group_id,"
+        " system_principal, permission FROM acl_entries"
+        " WHERE resource = ?",
+        (_RESOURCE,),
+    )
+    rows = await cursor.fetchall()
+    if not rows:
+        return  # nothing seeded on /groups — fresh/pre-seed deployment
+    seeded_shape = (
+        len(rows) == 1
+        and rows[0][0] == 0  # position
+        and rows[0][1] == ACTION_ALLOW
+        and rows[0][2] == PRINCIPAL_SYSTEM
+        and rows[0][3] is None  # user_id
+        and rows[0][4] is None  # group_id
+        and rows[0][5] == SYSTEM_AUTHENTICATED
+        and rows[0][6] == "create"
+    )
+    if not seeded_shape:
+        return  # operator-customized — leave for the manual step
+    await db.execute(
+        "DELETE FROM acl_entries WHERE resource = ?", (_RESOURCE,)
+    )
+    cursor = await db.execute("SELECT id FROM groups WHERE name = 'admin'")
+    row = await cursor.fetchone()
+    if row is None:
+        return
+    await db.execute(
+        "INSERT INTO acl_entries"
+        " (resource, position, action, principal_type, user_id,"
+        "  group_id, system_principal, permission)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            _RESOURCE,
+            0,
+            ACTION_ALLOW,
+            PRINCIPAL_GROUP,
+            None,
+            row[0],
+            None,
+            "create",
+        ),
+    )
+
+
+migration = Migration(14, "0014_groups_create_admin", apply)

--- a/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
+++ b/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
@@ -19,12 +19,15 @@ shape means an operator customized the resource (loosened deliberately,
 added entries, reordered): the migration leaves it untouched, and the
 changelog documents the manual tightening step for that case.
 
-The replacement inserts an Allow ``create`` ACE for the ``admin`` group
-at position 0, so a migrated deployment's ``/groups`` ACL matches a
-freshly seeded one. If no ``admin`` group row exists (a pathological
-state — ``ensure_admin_group`` recreates it at boot), the seeded ACE is
+The replacement inserts an Allow ``create`` ACE for the ``admin``
+group at position 0, so a migrated deployment's ``/groups`` ACL matches a
+freshly seeded one. If no ``admin`` group row exists, the seeded ACE is
 simply deleted with no replacement: admins manage groups through
-``/admin/groups`` regardless.
+``/admin/groups`` regardless. That state is reachable without anything
+pathological — the admin group can be renamed (``update_group`` has no
+admin guard), and this migration runs before ``ensure_admin_group``
+recreates the row — so the branch is a deliberate fallback, not a
+should-never-happen.
 """
 
 from klangk.model.acl import (

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -5426,6 +5426,39 @@ class TestUserGroupEndpoints:
             for e in entries
         )
 
+    async def test_create_group_default_seed_admin_only(
+        self, client, admin_user, user, admin_group, app_state
+    ):
+        """#2770: under the real seeded tree (not the fixture's
+        hand-built approximation), POST /groups is admin-only — the
+        conftest admin_group fixture seeds no /groups entry at all, so
+        this is the only test that exercises seed_default_acls' actual
+        /groups default end to end."""
+        from klangk.lifecycle import Lifecycle
+
+        # Replace the fixture's approximation with the real seed.
+        async with app_state.state.db.transaction() as db:
+            await db.execute("DELETE FROM acl_entries")
+        await Lifecycle(app_state).seed_default_acls(admin_group["id"])
+
+        admin_headers = await self._admin_login(client)
+        resp = await client.post(
+            "/api/v1/groups",
+            headers=admin_headers,
+            json={"name": "admin-made-group"},
+        )
+        assert resp.status_code == 200
+
+        # A plain authenticated user is denied: nothing on /groups
+        # matches, and the walk falls through to /'s Deny * → everyone.
+        user_headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/groups",
+            headers=user_headers,
+            json={"name": "user-made-group"},
+        )
+        assert resp.status_code == 403
+
     async def test_create_group_duplicate(
         self, client, admin_user, user, app_state
     ):

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -226,6 +226,26 @@ class TestSeedDefaultUser:
         assert admin_group["id"] in group_ids
 
 
+class TestSeedDefaultAcls:
+    """The tightened /groups seed (#2770): create goes to the admin
+    group, mirroring /workspaces (#2569) — not to system:authenticated."""
+
+    async def test_groups_create_seeded_for_admin_group(self, db, app_state):
+        lifecycle = _lifecycle(make_settings({}))
+        admin_group_id = await lifecycle.ensure_admin_group()
+        await lifecycle.seed_default_acls(admin_group_id)
+
+        entries = await app_state.state.model.acl.get_acl_entries("/groups")
+        assert len(entries) == 1
+        from klangk.model import ACTION_ALLOW, PRINCIPAL_GROUP
+
+        entry = entries[0]
+        assert entry["action"] == ACTION_ALLOW
+        assert entry["permission"] == "create"
+        assert entry["principal_type"] == PRINCIPAL_GROUP
+        assert entry["group_id"] == admin_group_id
+
+
 class TestSeedDefaultUserAuthModeGating:
     """#1645 Table A: password handling depends on auth_modes.
 

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -7,8 +7,10 @@ validation), migration 0001's shape (password_history + cascade),
 0005's (users.disabled + users.last_activity_at, #2588),
 0009's (workspaces.per_handle_home backfill, #2719),
 0010's (groups.source marker + name-pattern backfill, #2750),
-0011's (`files-download` mirror of Allow `files` ACEs, #2705), and
-0012's (`files-write` mirror of Allow `files-download` ACEs).
+0011's (`files-download` mirror of Allow `files` ACEs, #2705),
+0012's (`files-write` mirror of Allow `files-download` ACEs), and
+0013's (exec-and-sync role-group backfill, #2706/#2712), and
+0014's (/groups create ACE tightened to the admin group, #2770).
 """
 
 import aiosqlite
@@ -62,6 +64,7 @@ class TestRunner:
             (11, "0011_files_download"),
             (12, "0012_files_write"),
             (13, "0013_exec_and_sync_permission"),
+            (14, "0014_groups_create_admin"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -141,6 +144,7 @@ class TestRunner:
                 (11, "0011_files_download"),
                 (12, "0012_files_write"),
                 (13, "0013_exec_and_sync_permission"),
+                (14, "0014_groups_create_admin"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -864,6 +868,135 @@ class TestM0013ExecAndSyncPermission:
             await m0013_exec_and_sync_permission.migration.apply(db)
             cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
             assert (await cursor.fetchone())[0] == 0
+class TestM0014GroupsCreateAdmin:
+    """Migration 0014 tightens the seeded Allow-create→authenticated ACE
+    on /groups to the admin group (#2770)."""
+
+    async def _legacy_db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0013.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT NOT NULL, position INTEGER NOT NULL,"
+            " action INTEGER NOT NULL, principal_type INTEGER NOT NULL,"
+            " user_id TEXT, group_id TEXT, system_principal INTEGER,"
+            " permission TEXT NOT NULL,"
+            " UNIQUE(resource, position))"
+        )
+        await db.execute(
+            "CREATE TABLE groups ("
+            " id TEXT PRIMARY KEY, name TEXT UNIQUE NOT NULL,"
+            " description TEXT,"
+            " created_at TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        return db
+
+    async def _rows(self, db) -> list[tuple]:
+        cursor = await db.execute(
+            "SELECT position, action, principal_type, user_id, group_id,"
+            " system_principal, permission FROM acl_entries"
+            " WHERE resource = '/groups' ORDER BY position"
+        )
+        return await cursor.fetchall()
+
+    async def _seed_open_ace(self, db):
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type, user_id,"
+            "  group_id, system_principal, permission)"
+            " VALUES ('/groups', 0, 1, 0, NULL, NULL, 1, 'create')"
+        )
+
+    async def test_rewrites_seeded_ace_to_admin_group(self, tmp_path):
+        """The exact seeded shape is replaced with an Allow-create ACE
+        for the admin group."""
+        from klangk.model.migrations import m0014_groups_create_admin
+
+        db = await self._legacy_db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-admin', 'admin')"
+            )
+            await self._seed_open_ace(db)
+            await m0014_groups_create_admin.migration.apply(db)
+
+            assert await self._rows(db) == [
+                (0, 1, 2, None, "g-admin", None, "create")
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_no_groups_entries_noop(self, tmp_path):
+        """Fresh / pre-seed deployments (nothing on /groups) are
+        untouched — the new lifecycle seed covers them."""
+        from klangk.model.migrations import m0014_groups_create_admin
+
+        db = await self._legacy_db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-admin', 'admin')"
+            )
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, user_id,"
+                "  group_id, system_principal, permission)"
+                " VALUES ('/admin', 0, 1, 2, NULL, 'g-admin', NULL, '*')"
+            )
+            await m0014_groups_create_admin.migration.apply(db)
+
+            assert await self._rows(db) == []
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM acl_entries WHERE resource = '/admin'"
+            )
+            assert (await cursor.fetchone())[0] == 1
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_customized_resource_untouched(self, tmp_path):
+        """Any other /groups shape means an operator customized it —
+        extra entries, a different principal, a different permission —
+        and the migration must not clobber the operator's choice."""
+        from klangk.model.migrations import m0014_groups_create_admin
+
+        db = await self._legacy_db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-admin', 'admin')"
+            )
+            # Seeded shape + an operator-added loosening for members.
+            await self._seed_open_ace(db)
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-m', 'members')"
+            )
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, user_id,"
+                "  group_id, system_principal, permission)"
+                " VALUES ('/groups', 1, 1, 2, NULL, 'g-m', NULL, 'create')"
+            )
+            await m0014_groups_create_admin.migration.apply(db)
+
+            rows = await self._rows(db)
+            assert len(rows) == 2
+            assert (0, 1, 0, None, None, 1, "create") in rows
+            assert (1, 1, 2, None, "g-m", None, "create") in rows
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_seeded_shape_without_admin_group_deletes_only(
+        self, tmp_path
+    ):
+        """No 'admin' group row (ensure_admin_group recreates it at
+        boot): the seeded ACE is removed with no replacement."""
+        from klangk.model.migrations import m0014_groups_create_admin
+
+        db = await self._legacy_db(tmp_path)
+        try:
+            await self._seed_open_ace(db)
+            await m0014_groups_create_admin.migration.apply(db)
+
+            assert await self._rows(db) == []
         finally:
             await db.__aexit__(None, None, None)
 

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -868,6 +868,10 @@ class TestM0013ExecAndSyncPermission:
             await m0013_exec_and_sync_permission.migration.apply(db)
             cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
             assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+
 class TestM0014GroupsCreateAdmin:
     """Migration 0014 tightens the seeded Allow-create→authenticated ACE
     on /groups to the admin group (#2770)."""


### PR DESCRIPTION
## Summary

Closes #2770. Investigation outcome: **tighten** — the default ACL no longer grants `create` on `/groups` to every authenticated user; it goes to the `admin` group instead, matching the `/workspaces` tightening (#2569).

### Investigation findings

**Nothing depends on the open default.** No frontend page, CLI command, TUI screen, or e2e/demo flow calls `POST /groups` — every client manages groups through the admin-gated `/admin/groups` endpoints. OIDC group sync auto-creates groups server-side (model-layer call, no ACL check), so it is unaffected. The server tests for `POST /groups` seed their own ACE and don't rely on the default.

**Exposure was real but bounded.** Any authenticated user could create unlimited groups (polluting the listings other users and admins see), and a group's creator holds a `*` ACE on it — letting them add/remove *any* user as a member without that user's consent, with membership opaque to a workspace owner who later shares with the group. No path to escalate into the admin group or a seeded role group: `manage_members` checks walk `/groups/{id}` → `/groups` → `/` and inherit nothing, role-group names embed an unpredictable uuid4 workspace id (and `groups.name` is UNIQUE, so a pre-created collision would abort workspace creation, not hijack it), and the agent principal is refused group membership in the model layer.

## Changes

- `seed_default_acls`: `/groups` `create` → admin group (was `system:authenticated`).
- **Migration 0013** rewrites the seeded ACE on deployments that already carry it — but only when `/groups` holds exactly the single seeded entry. A customized resource is left untouched; the changelog documents the one-step manual tightening for that case.
- `POST /api/v1/groups` itself is unchanged (still permission-gated); admins were never using it — the admin panel uses `/admin/groups`.
- Docs: authorization page default rules + loosening recipe, API reference note, changelog Security entry.

## Testing

- New `TestM0013GroupsCreateAdmin` (4 cases: rewrite, noop, customized-untouched, no-admin-group) and `TestSeedDefaultAcls` pinning the new seed shape.
- Full Python suite the CI way: 5620 passed, 100% coverage.
