### PR TITLE
ci: default E2E workflows to stock runners, nix runner as opt-in

### DIFF
--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -1,6 +1,8 @@
-name: E2E suite on self-hosted NixOS runner
-description: Shared prepare/build/cleanup/run steps for the e2e suites on the
-  klangk-ci VM runners (label "nix")
+name: E2E suite (stock or self-hosted nix runner)
+description: Shared prepare/build/cleanup/run steps for the e2e suites. Works
+  on GitHub-hosted runners (after ./.github/actions/devenv-setup has installed
+  nix + devenv + podman) and on the self-hosted NixOS runner (label "nix",
+  klangk-ci VM) where the toolchain comes from the host config.
 
 inputs:
   run:
@@ -30,17 +32,25 @@ inputs:
 runs:
   using: composite
   steps:
-    # The JIT runner's .env file provides XDG_RUNTIME_DIR,
-    # DBUS_SESSION_BUS_ADDRESS, and XDG_CACHE_HOME to every step
-    # automatically — no per-step export needed.
+    # On GitHub-hosted runners devenv/nix only land on PATH after sourcing
+    # the nix profile (installed by devenv-setup); on the self-hosted nix
+    # runner the profile file also exists and sourcing it is a no-op.
     - name: Prepare klangk devenv
+      # Gated on the filter like the build/run steps: on stock runners
+      # devenv-setup is skipped when there is nothing to run, and devenv
+      # would not be on PATH here.
+      if: inputs.run == 'true'
       shell: bash
-      run: devenv shell -- true
+      run: |
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
+        devenv shell -- true
 
     - name: Build images
       if: inputs.run == 'true'
       shell: bash
-      run: devenv tasks run ${{ inputs.build-tasks }}
+      run: |
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
+        devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Obtain FIPS image (pull, capped-build fallback)
       # #2631: the FIPS workspace image is published by image-workspace-
@@ -53,6 +63,7 @@ runs:
       if: inputs.run == 'true' && inputs.fips-image != ''
       shell: bash
       run: |
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
         if devenv shell -- bash scripts/pull-fips-image.sh "${{ inputs.fips-image }}"; then
           echo "FIPS image pulled from ${{ inputs.fips-image }}"
         else
@@ -78,7 +89,9 @@ runs:
       shell: bash
       env:
         KLANGK_E2E_VERBOSE_PODMAN: ${{ inputs.verbose-podman == 'true' && '1' || '' }}
-      run: devenv shell -- ${{ inputs.suite }}
+      run: |
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
+        devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice
       if: inputs.run != 'true'

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -2,6 +2,12 @@ name: "E2E: Backend Tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
   push:
     branches: [release/**]
   pull_request:
@@ -20,11 +26,13 @@ concurrency:
 
 jobs:
   test-backend-e2e:
-    # Self-hosted NixOS runner (label "nix", klangk-ci VM). nix, devenv, git,
-    # and rootless podman (SUID newuidmap shims) come from the host config;
-    # the shared action handles devenv prep, image builds, cleanup, and the
+    # Defaults to stock GitHub-hosted runners; the self-hosted NixOS runner
+    # (label "nix", klangk-ci VM) is a workflow_dispatch opt-in (input
+    # runner: nix). On nix, devenv/git/rootless podman (SUID newuidmap shims)
+    # come from the host config; on stock runners devenv-setup installs them.
+    # The shared action handles devenv prep, image builds, cleanup, and the
     # suite itself.
-    runs-on: nix
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -41,6 +49,12 @@ jobs:
               - 'devenv.yaml'
               - '.github/workflows/backend-e2e-tests.yml'
               - '.github/actions/e2e-suite/**'
+
+      # Stock runners only: bootstrap nix + devenv + podman/uidmap. The nix
+      # runner already has the toolchain from its host config. Skipped when
+      # the paths filter found no e2e-relevant changes (nothing to run).
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix' && steps.filter.outputs.e2e == 'true'
 
       - uses: ./.github/actions/e2e-suite
         with:

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -33,7 +33,7 @@ jobs:
     # The shared action handles devenv prep, image builds, cleanup, and the
     # suite itself.
     runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
     # a workflow_dispatch opt-in (input runner: nix). See backend-e2e-tests.yml
     # for the provisioning split.
     runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -2,6 +2,12 @@ name: "E2E: CLI Tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
   push:
     branches: [release/**]
   pull_request:
@@ -20,7 +26,10 @@ concurrency:
 
 jobs:
   test-cli-e2e:
-    runs-on: nix
+    # Defaults to stock GitHub-hosted runners; the self-hosted nix runner is
+    # a workflow_dispatch opt-in (input runner: nix). See backend-e2e-tests.yml
+    # for the provisioning split.
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -37,6 +46,11 @@ jobs:
               - 'devenv.yaml'
               - '.github/workflows/cli-e2e-tests.yml'
               - '.github/actions/e2e-suite/**'
+
+      # Stock runners only (see backend-e2e-tests.yml); skipped when the
+      # paths filter found no e2e-relevant changes.
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix' && steps.filter.outputs.e2e == 'true'
 
       - uses: ./.github/actions/e2e-suite
         with:

--- a/.github/workflows/frontend-e2e-cross-browser.yml
+++ b/.github/workflows/frontend-e2e-cross-browser.yml
@@ -7,13 +7,26 @@ on:
   push:
     branches: [release/**]
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
 
 jobs:
   test-frontend-e2e-cross-browser:
-    runs-on: nix
+    # Defaults to stock GitHub-hosted runners (also for the scheduled runs);
+    # the self-hosted nix runner is a workflow_dispatch opt-in (input
+    # runner: nix). See backend-e2e-tests.yml for the provisioning split.
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
+
+      # Stock runners only (see backend-e2e-tests.yml).
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix'
 
       - uses: ./.github/actions/e2e-suite
         with:

--- a/.github/workflows/frontend-e2e-cross-browser.yml
+++ b/.github/workflows/frontend-e2e-cross-browser.yml
@@ -20,7 +20,7 @@ jobs:
     # the self-hosted nix runner is a workflow_dispatch opt-in (input
     # runner: nix). See backend-e2e-tests.yml for the provisioning split.
     runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -41,7 +41,7 @@ jobs:
     # a workflow_dispatch opt-in (input runner: nix). See backend-e2e-tests.yml
     # for the provisioning split.
     runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -3,6 +3,11 @@ name: "E2E: Frontend Tests"
 on:
   workflow_dispatch:
     inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
       project:
         description: "Playwright project (chromium|firefox|webkit); blank = all"
         required: false
@@ -32,7 +37,10 @@ concurrency:
 jobs:
   # Chromium + API tests — gates PR merges
   test-frontend-e2e:
-    runs-on: nix
+    # Defaults to stock GitHub-hosted runners; the self-hosted nix runner is
+    # a workflow_dispatch opt-in (input runner: nix). See backend-e2e-tests.yml
+    # for the provisioning split.
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -51,6 +59,11 @@ jobs:
               - 'devenv.yaml'
               - '.github/workflows/frontend-e2e-tests.yml'
               - '.github/actions/e2e-suite/**'
+
+      # Stock runners only (see backend-e2e-tests.yml); skipped when the
+      # paths filter found no e2e-relevant changes.
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix' && steps.filter.outputs.e2e == 'true'
 
       - uses: ./.github/actions/e2e-suite
         with:

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -2,6 +2,12 @@ name: "E2E: Sandbox Tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
   pull_request:
     paths:
       - "sandboxes/**"
@@ -13,12 +19,19 @@ concurrency:
 
 jobs:
   test-sandbox-e2e:
-    runs-on: nix
+    # Defaults to stock GitHub-hosted runners; the self-hosted nix runner is
+    # a workflow_dispatch opt-in (input runner: nix). See backend-e2e-tests.yml
+    # for the provisioning split.
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
     # openclaw + hermes both do real installs (npm/uv + git clone) that take
     # several minutes each; they run sequentially in one job.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
+
+      # Stock runners only (see backend-e2e-tests.yml).
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix'
 
       - uses: ./.github/actions/e2e-suite
         with:

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
     # openclaw + hermes both do real installs (npm/uv + git clone) that take
     # several minutes each; they run sequentially in one job.
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,16 @@ The flags: `--quiet` suppresses noisy devenv output; `-O dotenv.enable:bool fals
 
 A long-running interactive `devenv up` (backend + proxy + workspace image build) is a human-facing workflow; agents generally don't run it. If you need the backend up for something, ask.
 
+## CI runners (stock by default, nix opt-in)
+
+The five E2E workflows (backend, CLI, frontend, cross-browser, sandbox)
+default to **stock GitHub-hosted runners** (`ubuntu-latest`); on stock
+runners the `devenv-setup` action installs nix + devenv + podman/uidmap per
+run. To run a suite on the self-hosted NixOS runner (label `nix`, the
+klangk-ci VM — toolchain from the host config), trigger it via
+`workflow_dispatch` and set the `runner` input to `nix`; push/PR/schedule
+triggers always use the stock default (#2772).
+
 ## Running tests (match CI)
 
 Always run the test suites **the way CI runs them**. The exact invocations

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1781627264,
-        "narHash": "sha256-TPj5d5MUyvuQZjsfDAAoYJ0SB+tNNNBrdCpD8XL0WeU=",
+        "lastModified": 1787869093,
+        "narHash": "sha256-1VoofjgRU3IuyJM//vsqzJeTXXgPpw9fHykHtitUIEY=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0fe5629a2955141c336b95e384e2c793c01214fb",
+        "rev": "d1856d19d9568a40f6e7ec72adba891cafd3f14a",
         "type": "github"
       },
       "original": {
@@ -36,53 +36,31 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786313170,
-        "narHash": "sha256-9BG7OgUWdu0ONDO5X2q6+K4bsuBITkX/3W4nNJu1Ito=",
+        "lastModified": 1787753485,
+        "narHash": "sha256-BZWCi9ZRJiARTuKTbbtvFTj7t1TK4G3UEckT3HyNfRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d",
+        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Closes #2772.

## What changes

- **The five E2E workflows (backend, CLI, frontend, cross-browser, sandbox) now default to stock GitHub-hosted runners** (`ubuntu-latest`) on push/PR/schedule triggers, instead of the self-hosted `nix` VM. This PR's own CI runs are the first exercise of the new default.
- **The nix runner stays one click away**: each E2E workflow gained a `workflow_dispatch` input `runner` (choice `stock`/`nix`, default `stock`) mapped via `runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}`.
- **Provisioning split**: on stock runners, `./.github/actions/devenv-setup` (nix + devenv + podman/uidmap, the same action the other stock-runner workflows already use) runs before `e2e-suite`, gated on both "not nix" and (where a paths-filter exists) "suite will actually run". On `nix`, nothing changes — the toolchain comes from the host config.
- **`e2e-suite` is runner-agnostic**: every devenv-invoking step sources `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` defensively (no-op on the nix host), and the "Prepare klangk devenv" step is now gated on the filter so it doesn't fail on a stock runner whose bootstrap was skipped for a no-op run.
- **`devenv update`** run and the refreshed `devenv.lock` committed (nixpkgs, git-hooks; upstream inlined the `gitignore` input). devenv shell still evaluates and builds cleanly against it.
- **AGENTS.md** documents the default and the opt-in.

## Notes for review

- The FIPS image pull in backend E2E works anonymously from stock runners — the GHCR package was already flipped public for the #2631 pull path.
- Timeouts are bumped for the from-scratch stock-runner path (30→60 min for backend/cli/frontend, 60→90 for cross-browser/sandbox) so the nix/devenv bootstrap and image builds fit inside the budgets.
- Validation beyond pre-commit (actionlint/yamllint/prettier passed on both commits) is the CI on this branch — which now runs on the stock runners by design.

## Flake-omnibus context

Defaulting to ephemeral stock runners removes the single-shared-VM contention behind the flake families tracked in #2740/#2749; the nix opt-in remains for debugging.
