### PR TITLE
ci: retry devenv-evaluating steps once on the "path … is not valid" eval flake

### DIFF
--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -60,11 +60,14 @@ runs:
       shell: bash
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-        devenv shell -- true
+        # Retry wrapper: devenv 2.2.x's embedded Nix intermittently fails eval
+        # with "path ... is not valid" (UAF, #2774 / cachix/devenv#3064) - a
+        # per-eval coin flip, so one retry converts it to noise (#2775).
+        "$GITHUB_ACTION_PATH/scripts/retry-on-invalid-path.sh" devenv shell -- true
 
     - name: Build
       if: inputs.build-tasks != ''
       shell: bash
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-        devenv tasks run ${{ inputs.build-tasks }}
+        "$GITHUB_ACTION_PATH/scripts/retry-on-invalid-path.sh" devenv tasks run ${{ inputs.build-tasks }}

--- a/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh
+++ b/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Retry-once wrapper for devenv-evaluating steps in the devenv-setup action.
+#
+# devenv 2.2.x evaluates through an embedded Nix whose libexpr-c has a
+# readOnlyMode use-after-free (upstream cachix/devenv#3064, analyzed and
+# reproduced deterministically in #2774). The failure is a per-eval coin
+# flip inside the devenv binary and matches exactly:
+#
+#     error: path '/nix/store/<hash>-<name>' is not valid
+#
+# A single retry converts it to noise. Only this signature is retried;
+# every other failure passes through with its original exit code.
+#
+# Usage: retry-on-invalid-path.sh <command> [args...]
+#
+# Remove this script once the bootstrap pins a devenv release embedding the
+# fixed nix 2.35 line (tracked in #2774).
+set -uo pipefail
+
+signature_re="error: path '/nix/store/[^']*' is not valid"
+retry_annotation="devenv eval flake (#2774 / cachix/devenv#3064): 'path ... is not valid' - retrying once"
+
+strip_ansi() {
+  # nix colorizes output when it thinks stderr is a terminal; strip SGR
+  # sequences so the match does not depend on that.
+  sed 's/\x1b\[[0-9;]*m//g' "$1"
+}
+
+attempt=1
+while true; do
+  log=$(mktemp)
+  "$@" 2>&1 | tee "$log"
+  rc=${PIPESTATUS[0]}
+
+  if [ "$rc" -eq 0 ]; then
+    rm -f "$log"
+    exit 0
+  fi
+
+  if [ "$attempt" -eq 1 ] && strip_ansi "$log" | grep -Eq "$signature_re"; then
+    echo "::warning::${retry_annotation}"
+    attempt=2
+    rm -f "$log"
+    continue
+  fi
+
+  rm -f "$log"
+  exit "$rc"
+done

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -43,14 +43,17 @@ runs:
       shell: bash
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
-        devenv shell -- true
+        # Retry wrapper for the devenv 2.2.x embedded-Nix UAF (#2774 / cachix/devenv#3064, #2775)
+        retry="$GITHUB_WORKSPACE/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh"
+        "$retry" devenv shell -- true
 
     - name: Build images
       if: inputs.run == 'true'
       shell: bash
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
-        devenv tasks run ${{ inputs.build-tasks }}
+        retry="$GITHUB_WORKSPACE/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh"
+        "$retry" devenv tasks run ${{ inputs.build-tasks }}
 
     - name: Obtain FIPS image (pull, capped-build fallback)
       # #2631: the FIPS workspace image is published by image-workspace-
@@ -64,11 +67,14 @@ runs:
       shell: bash
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
-        if devenv shell -- bash scripts/pull-fips-image.sh "${{ inputs.fips-image }}"; then
+        retry="$GITHUB_WORKSPACE/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh"
+        # Wrapped so a UAF flake (#2774) is not misread as a pull failure
+        # and answered with an unnecessary capped local FIPS build.
+        if "$retry" devenv shell -- bash scripts/pull-fips-image.sh "${{ inputs.fips-image }}"; then
           echo "FIPS image pulled from ${{ inputs.fips-image }}"
         else
           echo "Pull failed — building FIPS image locally (compile capped to 2 jobs, #2631)"
-          KLANGKBUILD_FIPS_BUILD_JOBS=2 devenv shell -- devenv tasks run klangk:build-fips-image
+          KLANGKBUILD_FIPS_BUILD_JOBS=2 "$retry" devenv shell -- devenv tasks run klangk:build-fips-image
         fi
 
     - name: Clean leftover CI podman state
@@ -91,7 +97,8 @@ runs:
         KLANGK_E2E_VERBOSE_PODMAN: ${{ inputs.verbose-podman == 'true' && '1' || '' }}
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
-        devenv shell -- ${{ inputs.suite }}
+        retry="$GITHUB_WORKSPACE/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh"
+        "$retry" devenv shell -- ${{ inputs.suite }}
 
     - name: Skip notice
       if: inputs.run != 'true'


### PR DESCRIPTION
## Summary

devenv 2.2.x evaluates through an embedded Nix whose libexpr-c has a
`readOnlyMode` use-after-free (#2774 / upstream
[cachix/devenv#3064](https://github.com/cachix/devenv/issues/3064) — analyzed
and reproduced deterministically against the exact shipped libs). The failure
is a per-eval coin flip inside the devenv binary:

```
error: path '/nix/store/<hash>-<name>' is not valid
```

Nothing about the job influences it; reruns have succeeded every time. This PR
implements the interim mitigation from #2775: retry once, but only on that
exact signature.

## Changes

- **`devenv-setup/scripts/retry-on-invalid-path.sh`** (new): wraps a command,
  tees output, matches the signature on ANSI-stripped text, retries once with
  a `::warning::` citing both issues. Every other failure passes through with
  its original exit code — no retry, no masking.
- **`devenv-setup` action**: `Prepare klangk devenv` and `Build` wrapped.
- **`e2e-suite` action**: all five devenv invocations wrapped — `Prepare`,
  `Build images`, the FIPS **pull** (so a flake is not misread as a pull
  failure and answered with an unnecessary capped local FIPS build), the FIPS
  capped-build fallback, and `Run <suite>`.

Shared single script (e2e-suite reaches it via repo-relative path, valid on
both stock runners and the self-hosted nix runner since every workflow checks
out the repo first).

## Validation

- Functional tests of the wrapper: signature → retry + recover (rc 0);
  signature twice → rc 1 after exactly one retry; unrelated failure →
  original rc (42) with no retry; ANSI-colored signature still matches.
- `bash -n`, shellcheck, shfmt, yamllint, prettier (pre-commit) all pass.

## Follow-ups

- Remove the wrapper once the bootstrap pins a devenv release embedding the
  fixed nix 2.35 line (tracked in #2774); the script header says so.

Fixes #2775
