### PR TITLE
fix(security): scope workspace status broadcasts to workspace members (#1714)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -134,6 +134,18 @@ operators or integrators to act when upgrading.
   relay actions (e.g. git-credential prompts, browser fetch) to another
   workspace's browser tab if it learned that tab's browser ID — the
   token provided no workspace boundary on the relay.
+=======
+- **Workspace status broadcasts are now scoped to workspace members
+  (#1714).** `container_status`, `service_health` (including the
+  connect-time snapshot), and `workspace_evicted` WebSocket events
+  were previously fanned out to every authenticated connection, letting
+  any connected client enumerate every workspace's id, running state,
+  health, and the bounded `health_message` tail of another tenant's
+  service output. The server now delivers these frames only to
+  connections of users holding workspace access (the `terminal`
+  permission — owner, direct share, or role group). `klangk monitor`
+  and the workspace list page behave as before, seeing exactly the
+  workspaces the logged-in user can open.
 
 - **`exec-and-sync` permission gates one-shot command execution and
   `klangk sync` (#2706, #2712).** The one-shot exec channel — `klangk

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -133,17 +133,30 @@ operators or integrators to act when upgrading.
   otherwise. Previously a container holding workspace A's token could
   relay actions (e.g. git-credential prompts, browser fetch) to another
   workspace's browser tab if it learned that tab's browser ID — the
-  token provided no workspace boundary on the relay.- **Workspace status WebSocket broadcasts are now scoped to workspace
+  token provided no workspace boundary on the relay.
+
+- **New `monitor` permission gates health/status reception (#2783,
+  #1714).** Observing a workspace's health no longer requires
+  `terminal`: `GET /workspaces/{id}/status` and the member-scoped
+  `container_status` / `service_health` / `workspace_evicted`
+  WebSocket frames now check the dedicated `monitor` permission.
+  Every role and share that grants `terminal` also grants `monitor`
+  (existing deployments are backfilled by migration 0016), and
+  `monitor` can be granted alone for monitoring-only members who
+  should observe health without exec/attach access.
+
+- **Workspace status WebSocket broadcasts are now scoped to workspace
   members (#1714).** `container_status`, `service_health` (including
   the connect-time snapshot), and `workspace_evicted` frames were
   fanned out to every authenticated connection, letting any connected
   client enumerate every workspace's id, running state, health, and
   the bounded `health_message` tail of another tenant's service
-  output; they are now delivered only to users holding the `terminal`
-  permission on the workspace. A view-only grantee still sees status
-  in the workspace list (HTTP), but receives no live deltas; an admin
+  output; they are now delivered only to users holding `monitor` on
+  the workspace. A view-only grantee still sees status in the
+  workspace list (HTTP), but receives no live deltas; an admin
   watching other tenants' workspaces via `klangk monitor` now sees
   only their own workspaces — intended, and part of the fix.
+
 - **`exec-and-sync` permission gates one-shot command execution and
   `klangk sync` (#2706, #2712).** The one-shot exec channel — `klangk
 exec`, and the rsync transport `klangk sync` and `klangk sandbox`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -133,20 +133,17 @@ operators or integrators to act when upgrading.
   otherwise. Previously a container holding workspace A's token could
   relay actions (e.g. git-credential prompts, browser fetch) to another
   workspace's browser tab if it learned that tab's browser ID — the
-  token provided no workspace boundary on the relay.
-=======
-- **Workspace status broadcasts are now scoped to workspace members
-  (#1714).** `container_status`, `service_health` (including the
-  connect-time snapshot), and `workspace_evicted` WebSocket events
-  were previously fanned out to every authenticated connection, letting
-  any connected client enumerate every workspace's id, running state,
-  health, and the bounded `health_message` tail of another tenant's
-  service output. The server now delivers these frames only to
-  connections of users holding workspace access (the `terminal`
-  permission — owner, direct share, or role group). `klangk monitor`
-  and the workspace list page behave as before, seeing exactly the
-  workspaces the logged-in user can open.
-
+  token provided no workspace boundary on the relay.- **Workspace status WebSocket broadcasts are now scoped to workspace
+  members (#1714).** `container_status`, `service_health` (including
+  the connect-time snapshot), and `workspace_evicted` frames were
+  fanned out to every authenticated connection, letting any connected
+  client enumerate every workspace's id, running state, health, and
+  the bounded `health_message` tail of another tenant's service
+  output; they are now delivered only to users holding the `terminal`
+  permission on the workspace. A view-only grantee still sees status
+  in the workspace list (HTTP), but receives no live deltas; an admin
+  watching other tenants' workspaces via `klangk monitor` now sees
+  only their own workspaces — intended, and part of the fix.
 - **`exec-and-sync` permission gates one-shot command execution and
   `klangk sync` (#2706, #2712).** The one-shot exec channel — `klangk
 exec`, and the rsync transport `klangk sync` and `klangk sandbox`

--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -47,14 +47,15 @@ For each workspace with a health check configured:
    shared users, role groups) connected over WebSocket gets a
    `service_health` event so the UI can update in real time (#1714:
    the fan-out is scoped server-side — other tenants never see it).
-   Membership here means the `terminal` permission — the same gate as
-   connecting to the workspace — so a view-only grantee sees status in
-   the workspace list (via HTTP) but receives no live delta frames.
+   Membership here means the `monitor` permission — the dedicated
+   status-observation permission (#2783), granted alongside `terminal`
+   by every share path — so a monitoring-only grantee (no `terminal`)
+   receives live deltas, while a view-only grantee does not.
    Because the stream is deltas-only (it fires on transitions, not
    every poll), a client that connects to an _already_-unhealthy
    workspace also receives a one-time **snapshot** of the current
-   status of every health-checked workspace it can open immediately on
-   connect -- so a pure-WS consumer like `klangk monitor` sees
+   status of every health-checked workspace it can observe immediately
+   on connect -- so a pure-WS consumer like `klangk monitor` sees
    steady-state failures right away instead of being blind until the
    next transition (#1175).
    Each `service_health` frame also carries three additive fields:

--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -43,14 +43,17 @@ For each workspace with a health check configured:
    `HOME` set.
 2. **Exit code 0 = healthy.** Any non-zero exit code, a timeout, or an
    error counts as **unhealthy**.
-3. When the status changes, every connected client gets a
-   `service_health` event so the UI can update in real time. Because the
-   stream is deltas-only (it fires on transitions, not every poll), a
-   client that connects to an _already_-unhealthy workspace also
-   receives a one-time **snapshot** of every health-checked
-   workspace's current status immediately on connect -- so a pure-WS
-   consumer like `klangk monitor` sees steady-state failures right
-   away instead of being blind until the next transition (#1175).
+3. When the status changes, every **member of the workspace** (owner,
+   shared users, role groups) connected over WebSocket gets a
+   `service_health` event so the UI can update in real time (#1714:
+   the fan-out is scoped server-side — other tenants never see it).
+   Because the stream is deltas-only (it fires on transitions, not
+   every poll), a client that connects to an _already_-unhealthy
+   workspace also receives a one-time **snapshot** of the current
+   status of every health-checked workspace it can open immediately on
+   connect -- so a pure-WS consumer like `klangk monitor` sees
+   steady-state failures right away instead of being blind until the
+   next transition (#1175).
    Each `service_health` frame also carries three additive fields:
    `running` (`false` on the terminal **container-death** frame, so a
    consumer watching only this stream learns the service is down

--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -47,6 +47,9 @@ For each workspace with a health check configured:
    shared users, role groups) connected over WebSocket gets a
    `service_health` event so the UI can update in real time (#1714:
    the fan-out is scoped server-side — other tenants never see it).
+   Membership here means the `terminal` permission — the same gate as
+   connecting to the workspace — so a view-only grantee sees status in
+   the workspace list (via HTTP) but receives no live delta frames.
    Because the stream is deltas-only (it fires on transitions, not
    every poll), a client that connects to an _already_-unhealthy
    workspace also receives a one-time **snapshot** of the current

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -91,23 +91,24 @@ other resource) are rejected with a 400 error.
 
 When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/workspaces/{id}`. This grants full access: view, edit, delete, share, terminal, files, export.
 
-**Sharing**: the owner can share a workspace with users or groups. The simple sharing UI (Sharing tab) grants `view`, `terminal`, `files`, `files-download`, and `files-write`. For finer control, the Advanced ACL editor lets you add/remove/reorder individual ACEs.
+**Sharing**: the owner can share a workspace with users or groups. The simple sharing UI (Sharing tab) grants `view`, `monitor`, `terminal`, `files`, `files-download`, and `files-write`. For finer control, the Advanced ACL editor lets you add/remove/reorder individual ACEs.
 
 **Permissions checked on workspace resources**:
 
-| Permission       | Controls                                                          |
-| ---------------- | ----------------------------------------------------------------- |
-| `view`           | Can see the workspace exists                                      |
-| `terminal`       | Can open a terminal / exec commands                               |
-| `files`          | Can browse/read files                                             |
-| `files-download` | Can download raw bytes via `/files/download` (needs `files` too)  |
-| `files-write`    | Can mutate files: upload, rename, delete (needs `files` too)      |
-| `exec-and-sync`  | Can run one-shot commands (`klangk exec`) and sync (`klangk sync`) against the workspace |
-| `edit`           | Can change workspace settings (name, image, command, mounts, env) |
-| `share`          | Can manage who has access (Sharing tab)                           |
-| `delete`         | Can delete the workspace                                          |
-| `export`         | Can export the workspace as a `.tar.gz` archive (#2707)           |
-| `*`              | All of the above                                                  |
+| Permission       | Controls                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `view`           | Can see the workspace exists                                                                                                    |
+| `monitor`        | Can observe health/status: `GET /workspaces/{id}/status` and the `container_status` / `service_health` WebSocket frames (#2783) |
+| `terminal`       | Can open a terminal / exec commands                                                                                             |
+| `files`          | Can browse/read files                                                                                                           |
+| `files-download` | Can download raw bytes via `/files/download` (needs `files` too)                                                                |
+| `files-write`    | Can mutate files: upload, rename, delete (needs `files` too)                                                                    |
+| `exec-and-sync`  | Can run one-shot commands (`klangk exec`) and sync (`klangk sync`) against the workspace                                        |
+| `edit`           | Can change workspace settings (name, image, command, mounts, env)                                                               |
+| `share`          | Can manage who has access (Sharing tab)                                                                                         |
+| `delete`         | Can delete the workspace                                                                                                        |
+| `export`         | Can export the workspace as a `.tar.gz` archive (#2707)                                                                         |
+| `*`              | All of the above                                                                                                                |
 
 Withholding `files-download` keeps the in-app file viewer working for text
 files (read via `/files/content`) but hides every download affordance and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -261,8 +261,8 @@ klangk sandbox myws ~/projects/myapp    # specify sandbox root explicitly
 klangk sandbox myws --force             # re-apply config and re-run setup on existing workspace
 klangk exec my-project ls /home/klangk           # run a command in the container (login shell: sources ~/.profile)
 klangk exec --raw my-project rsync --server ...      # raw argv, no shell (for transports like rsync)
-klangk monitor                                        # stream all server events as JSON
-klangk monitor --type service_health | jq .           # pretty-print health transitions
+klangk monitor                                        # stream all server events you can see (scoped to your workspaces, #1714) as JSON
+klangk monitor --type service_health | jq .           # pretty-print health transitions for your workspaces
 klangk monitor --type service_health -- sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'  # alert with the failure reason
 klangk sync ~/src my-project:/home/klangk/src      # push files to the container — needs the exec-and-sync permission
 klangk sync my-project:/home/klangk/src ~/src       # pull files out of the container — needs the exec-and-sync permission

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -27,6 +27,7 @@ class AclEditorState extends State<AclEditor> {
   static const _principalTypeLabels = {0: 'System', 1: 'User', 2: 'Group'};
   static const _permissions = [
     'view',
+    'monitor',
     'terminal',
     'code-in-isolation',
     'spectate-on-shared-terminals',

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -290,6 +290,7 @@ STATIC_RESOURCES = [
 
 ALL_PERMISSIONS = [
     "view",
+    "monitor",
     "create",
     "edit",
     "delete",

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -796,7 +796,7 @@ async def start_workspace(
 @router.get("/workspaces/{workspace_id}/status")
 async def workspace_status(
     workspace_id: str,
-    user: dict = Depends(acl.has_permission("terminal", workspace_resource)),
+    user: dict = Depends(acl.has_permission("monitor", workspace_resource)),
     app=Depends(get_app_dep),
 ):
     """Return container status for a workspace.
@@ -1278,13 +1278,17 @@ async def add_workspace_member(
         raise HTTPException(
             status_code=400, detail="Cannot share with yourself"
         )
-    # Add ACL entries granting the target user view+terminal+files(+dl/ul)
-    # on this workspace, packed at the next available positions.
+    # Add ACL entries granting the target user view+monitor+terminal+
+    # files(+dl/ul) on this workspace, packed at the next available
+    # positions. ``monitor`` rides along with ``terminal`` (#2783) so a
+    # shared member keeps receiving health/status frames — it can also
+    # be granted alone for monitoring-only members.
     resource = f"/workspaces/{workspace_id}"
     existing = await app.state.model.acl.get_acl_entries(resource)
     next_pos = max((e["position"] for e in existing), default=-1) + 1
     for perm in (
         "view",
+        "monitor",
         "terminal",
         "files",
         "files-download",

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -452,7 +452,7 @@ class MemoryPressureEvictor:
         )
         sockets = self.app.state.sockets
         registry = self.app.state.container_registry
-        sockets.notify_workspace_evicted(
+        await sockets.notify_workspace_evicted(
             victim.workspace_id,
             reason="host memory pressure",
         )

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -401,11 +401,12 @@ class MemoryPressureEvictor:
         a stop path is excluded by the ``registry.stopping`` check
         (``stop_and_remove_container`` sets it synchronously at entry,
         before its first await). The remaining window is DURING this
-        method's two awaits: a concurrent idle-stop of the same victim
-        double-notifies and double-removes — benign (both stops are
-        state-tolerant, the remove 404-tolerant, and the death frame
-        deduplicates by state) — so no guard is needed and none would
-        be reachable.
+        method's awaits (the member-scoped ``workspace_evicted`` fan-out
+        plus the kill/stop calls — the fan-out became async with #1714):
+        a concurrent idle-stop of the same victim double-notifies and
+        double-removes — benign (both stops are state-tolerant, the
+        remove 404-tolerant, and the death frame deduplicates by state)
+        — so no guard is needed and none would be reachable.
         """
         candidates = self._evictable_workspaces()
         if not candidates:

--- a/src/klangk/klangk/container/health.py
+++ b/src/klangk/klangk/container/health.py
@@ -205,9 +205,9 @@ class HealthMonitor:
                 message,
             )
         if new_status != old_status:
-            self._broadcast(state, new_status, state.health_message)
+            await self._broadcast(state, new_status, state.health_message)
 
-    def _emit(
+    async def _emit(
         self,
         state: ContainerState,
         *,
@@ -223,7 +223,7 @@ class HealthMonitor:
         fields can never diverge between them again.
         """
         state.health_seq += 1
-        self.connections.notify_service_health(
+        await self.connections.notify_service_health(
             state.workspace_id,
             healthy=healthy,
             message=message,
@@ -232,20 +232,21 @@ class HealthMonitor:
             seq=state.health_seq,
         )
 
-    def _broadcast(
+    async def _broadcast(
         self,
         state: ContainerState,
         status: str,
         message: str | None = None,
     ) -> None:
-        """Emit a ``service_health`` transition event to all connections.
+        """Emit a ``service_health`` transition event to workspace members.
 
-        Fanned out via :meth:`WsState.notify_service_health` so the
-        workspace list page learns about health transitions for
-        auto-started services even when nobody is connected to the
-        workspace's terminal session (#1015).  The failure *reason*
-        rides along as ``health_message`` so operators can see *why*
-        it's unhealthy without digging through logs (#1088).
+        Fanned out via :meth:`WsState.notify_service_health` (scoped to
+        the workspace's members, #1714) so the workspace list page learns
+        about health transitions for auto-started services even when
+        nobody is connected to the workspace's terminal session (#1015).
+        The failure *reason* rides along as ``health_message`` so
+        operators can see *why* it's unhealthy without digging through
+        logs (#1088).
 
         Also forwards the additive contract fields (#1175):
         ``running=True`` (this is a live-container frame), the last
@@ -253,14 +254,14 @@ class HealthMonitor:
         ``seq`` (#1175 item 4) bumped on every emit so a reconnecting
         consumer can detect a missed transition.
         """
-        self._emit(
+        await self._emit(
             state,
             healthy=status == "healthy",
             message=message,
             running=True,
         )
 
-    def broadcast_death(
+    async def broadcast_death(
         self, state: ContainerState, *, message: str | None = None
     ) -> None:
         """Emit the terminal ``service_health`` frame for a dying container.
@@ -280,7 +281,7 @@ class HealthMonitor:
         "OOM-killed at 8g memory limit") when the death was detected by
         the crash monitor; expected stops leave it None.
         """
-        self._emit(
+        await self._emit(
             state,
             healthy=False,
             message=message,

--- a/src/klangk/klangk/container/health.py
+++ b/src/klangk/klangk/container/health.py
@@ -275,7 +275,10 @@ class HealthMonitor:
         container is gone (#1175 item 2).  This closes the hole by
         emitting one unambiguous terminal frame with ``running=False``
         and ``healthy=False`` *before* the state is dropped, so a single
-        stream is a single source of truth.
+        stream is a single source of truth.  (Relative wire order vs the
+        separately-scheduled ``container_status`` frame — see
+        ``lifecycle.broadcast_container_status`` — is not guaranteed;
+        consumers must not depend on it.)
 
         *message* (#2524) carries the classified death cause (e.g.
         "OOM-killed at 8g memory limit") when the death was detected by

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -1775,7 +1775,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         # learn the service is down.  Only health-checked workspaces ever
         # appeared on the stream, so only those get a terminal frame.
         if state is not None and state.health_check is not None:
-            self.health.broadcast_death(state, message=cause)
+            await self.health.broadcast_death(state, message=cause)
         if self.on_workspace_killed:
             try:
                 await self.on_workspace_killed(workspace_id, container_id)

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -44,6 +44,12 @@ from .model.users import AGENT_EMAIL, AGENT_HANDLE
 
 logger = logging.getLogger(__name__)
 
+# Strong references to in-flight container_status broadcast tasks (#1714
+# review): an unreferenced task is GC-eligible mid-execution — the same
+# hazard Lifecycle's own ``_recycle_tasks`` set guards against (#2527). The
+# done-callback discards from the set.
+_status_broadcast_tasks: set[asyncio.Task] = set()
+
 
 def broadcast_container_status(
     app, workspace_id: str, running: bool, started_at: float | None = None
@@ -74,7 +80,9 @@ def broadcast_container_status(
         loop = asyncio.get_running_loop()
     except RuntimeError:
         return
-    loop.create_task(_run())
+    task = loop.create_task(_run())
+    _status_broadcast_tasks.add(task)
+    task.add_done_callback(_status_broadcast_tasks.discard)
 
 
 # Settings that a SIGHUP reload re-resolves and validates but CANNOT apply

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -45,6 +45,38 @@ from .model.users import AGENT_EMAIL, AGENT_HANDLE
 logger = logging.getLogger(__name__)
 
 
+def broadcast_container_status(
+    app, workspace_id: str, running: bool, started_at: float | None = None
+) -> None:
+    """Schedule the member-scoped ``container_status`` broadcast (#1714).
+
+    Registered as the container registry's status-change callback. The
+    registry invokes it synchronously (from ``track_activity`` on a
+    container start and the stop paths), but the broadcast itself is
+    async: it ACL-checks each recipient for workspace membership.
+    Fire-and-forget on the running loop; outside a loop (sync test
+    harnesses driving the registry directly) there is nothing to
+    broadcast to.
+    """
+
+    async def _run() -> None:
+        try:
+            await app.state.sockets.notify_container_status(
+                workspace_id, running, started_at
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "container_status broadcast failed for workspace %s",
+                workspace_id,
+            )
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(_run())
+
+
 # Settings that a SIGHUP reload re-resolves and validates but CANNOT apply
 # without a full process restart: the HTTP listener is bound for the life of
 # the process, and the DB engine + on-disk state dir are already open/written.
@@ -1022,7 +1054,9 @@ async def lifespan(app: FastAPI):
 
     registry.set_on_workspace_killed(_on_workspace_killed)
     registry.set_on_container_status_changed(
-        app.state.sockets.notify_container_status
+        lambda ws_id, running, started_at=None: broadcast_container_status(
+            app, ws_id, running, started_at
+        )
     )
     await app.state.lifecycle.startup()
     # Reap orphaned pending consent rows from a prior run: the in-memory

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -63,6 +63,7 @@ from klangk.model.migrations import m0012_files_write
 from klangk.model.migrations import m0013_exec_and_sync_permission
 from klangk.model.migrations import m0014_groups_create_admin
 from klangk.model.migrations import m0015_classification_banner
+from klangk.model.migrations import m0016_monitor_permission
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -86,6 +87,7 @@ MIGRATIONS: list[Migration] = [
     m0013_exec_and_sync_permission.migration,
     m0014_groups_create_admin.migration,
     m0015_classification_banner.migration,
+    m0016_monitor_permission.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0016_monitor_permission.py
+++ b/src/klangk/klangk/model/migrations/m0016_monitor_permission.py
@@ -1,0 +1,83 @@
+"""Migration 0016: grant ``monitor`` to existing terminal holders (#2783).
+
+Health/status reception is now gated on the dedicated ``monitor``
+permission instead of ``terminal`` — enforced on the
+``GET /workspaces/{id}/status`` endpoint and on the member-scoped
+``container_status`` / ``service_health`` / ``workspace_evicted``
+WebSocket fan-outs (#1714). New workspaces seed ``monitor`` into every
+role group that has ``terminal`` via ``_ROLE_GROUP_PERMISSIONS``, and
+the member-share flow grants it alongside ``terminal``; this migration
+backfills existing deployments so the upgrade does not silently stop
+status delivery to principals who already receive it (preserving prior
+behavior: revoking ``monitor`` is an admin choice, not the new default).
+
+For every workspace resource, each principal (user, group, or system)
+holding an ``Allow`` ACE for ``terminal`` gets an ``Allow`` ACE for
+``monitor`` appended at the end of that resource's ACL (max position +
+1) unless it already has ``monitor`` or the ``*`` wildcard (owners need
+nothing). Every grant path that ever carried ``terminal`` is covered —
+role groups and direct user shares alike.
+"""
+
+from klangk.model.acl import ACTION_ALLOW
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    # Distinct principals holding an Allow terminal ACE, on any resource.
+    cursor = await db.execute(
+        "SELECT DISTINCT resource, principal_type, user_id, group_id,"
+        " system_principal FROM acl_entries"
+        " WHERE action = ? AND permission = 'terminal'",
+        (ACTION_ALLOW,),
+    )
+    holders = await cursor.fetchall()
+    for (
+        resource,
+        principal_type,
+        user_id,
+        group_id,
+        system_principal,
+    ) in holders:
+        # Already covered: an existing monitor (or wildcard) Allow ACE
+        # for the same principal on the same resource.
+        covered = await db.execute(
+            "SELECT 1 FROM acl_entries"
+            " WHERE resource = ? AND action = ? AND principal_type = ?"
+            " AND user_id IS ? AND group_id IS ? AND system_principal IS ?"
+            " AND permission IN ('monitor', '*') LIMIT 1",
+            (
+                resource,
+                ACTION_ALLOW,
+                principal_type,
+                user_id,
+                group_id,
+                system_principal,
+            ),
+        )
+        if await covered.fetchone() is not None:
+            continue
+        max_pos = await db.execute(
+            "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
+            " WHERE resource = ?",
+            (resource,),
+        )
+        pos = (await max_pos.fetchone())[0] + 1
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type,"
+            "  user_id, group_id, system_principal, permission)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, 'monitor')",
+            (
+                resource,
+                pos,
+                ACTION_ALLOW,
+                principal_type,
+                user_id,
+                group_id,
+                system_principal,
+            ),
+        )
+
+
+migration = Migration(16, "0016_monitor_permission", apply)

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -24,6 +24,7 @@ DEFAULT_PORTS_PER_WORKSPACE = 5
 _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
     "owners": ["*"],
     "coders": [
+        "monitor",
         "terminal",
         "code-in-isolation",
         "exec-and-sync",
@@ -33,6 +34,7 @@ _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
         "files-write",
     ],
     "collaborators": [
+        "monitor",
         "terminal",
         "code-in-isolation",
         "exec-and-sync",
@@ -44,6 +46,7 @@ _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
         "files-write",
     ],
     "spectators": [
+        "monitor",
         "terminal",
         "spectate-on-shared-terminals",
     ],

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -84,11 +84,12 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
     safe_ws.start_sender()
     conn = Connection(safe_ws, user, app)
     app.state.sockets.connections[safe_ws] = conn
-    # Replay current health of every health-checked workspace so a
-    # pure-WS consumer (e.g. ``klangk monitor``) sees steady-state
-    # status immediately instead of being blind until the next
-    # transition (#1175 item 1).
-    app.state.sockets.send_service_health_snapshot(safe_ws)
+    # Replay current health of every health-checked workspace the user
+    # can open so a pure-WS consumer (e.g. ``klangk monitor``) sees
+    # steady-state status immediately instead of being blind until the
+    # next transition (#1175 item 1). Scoped to the user's memberships
+    # (#1714).
+    await app.state.sockets.send_service_health_snapshot(safe_ws)
     # #2661: replay any pending server stop/recycle schedule so a
     # just-connected client can show the countdown immediately instead
     # of waiting for the scheduler's next periodic broadcast. Guarded:

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -84,21 +84,25 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
     safe_ws.start_sender()
     conn = Connection(safe_ws, user, app)
     app.state.sockets.connections[safe_ws] = conn
-    # Replay current health of every health-checked workspace the user
-    # can open so a pure-WS consumer (e.g. ``klangk monitor``) sees
-    # steady-state status immediately instead of being blind until the
-    # next transition (#1175 item 1). Scoped to the user's memberships
-    # (#1714).
-    await app.state.sockets.send_service_health_snapshot(safe_ws)
-    # #2661: replay any pending server stop/recycle schedule so a
-    # just-connected client can show the countdown immediately instead
-    # of waiting for the scheduler's next periodic broadcast. Guarded:
-    # minimal test apps may not wire the scheduler.
-    server_scheduler = getattr(app.state, "server_scheduler", None)
-    if server_scheduler is not None:
-        await server_scheduler.send_snapshot_to(safe_ws)
-
+    # Everything from here on is inside the try so a failure in the
+    # connect-time work below still runs the ``finally`` cleanup — the
+    # snapshot (#1714) awaits DB queries, and a raise there used to
+    # leak the sender task and skip conn.cleanup().
     try:
+        # Replay current health of every health-checked workspace the
+        # user can open so a pure-WS consumer (e.g. ``klangk monitor``)
+        # sees steady-state status immediately instead of being blind
+        # until the next transition (#1175 item 1). Scoped to the
+        # user's memberships (#1714).
+        await app.state.sockets.send_service_health_snapshot(safe_ws)
+        # #2661: replay any pending server stop/recycle schedule so a
+        # just-connected client can show the countdown immediately instead
+        # of waiting for the scheduler's next periodic broadcast. Guarded:
+        # minimal test apps may not wire the scheduler.
+        server_scheduler = getattr(app.state, "server_scheduler", None)
+        if server_scheduler is not None:
+            await server_scheduler.send_snapshot_to(safe_ws)
+
         while True:
             raw = await safe_ws.receive_text()
             try:

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from .. import model
+from ..acl import check_permission_inmemory, resource_ancestors
 from ..terminal import SERVICE_CMD_WINDOW
 from ..window_watcher import WindowEventWatcher
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
@@ -818,6 +819,13 @@ class WebSocketState:
         Sends to all of an allowed user's connections (a user with the
         workspace open in two tabs gets both). Dead sockets are pruned;
         dispatch.py owns cleanup on disconnect.
+
+        One ACE fetch for the whole fan-out: the entries for the
+        resource's ancestor paths are loaded once and each distinct
+        user is then evaluated in memory
+        (:func:`klangk.acl.check_permission_inmemory`, the same
+        preload-then-evaluate shape ``permissions_for_resources`` uses)
+        — a transition burst doesn't re-query identical paths per user.
         """
         by_user: dict[str, list[tuple[SafeWebSocket, "Connection"]]] = {}
         for sock, conn in self.connections.items():
@@ -825,14 +833,19 @@ class WebSocketState:
             if uid is None:
                 continue
             by_user.setdefault(uid, []).append((sock, conn))
+        if not by_user:
+            return
+        resource = f"/workspaces/{workspace_id}"
         acl = self.app.state.acl
+        entries = await self.app.state.model.acl.get_acl_entries_map(
+            resource_ancestors(resource)
+        )
         dead = []
         for uid, conns in by_user.items():
             principals = await acl.get_principals(uid)
-            allowed = await acl.check_permission(
-                f"/workspaces/{workspace_id}", principals, "terminal"
-            )
-            if not allowed:
+            if not check_permission_inmemory(
+                resource, principals, "terminal", entries
+            ):
                 continue
             for sock, _conn in conns:
                 try:
@@ -1027,29 +1040,48 @@ class WebSocketState:
 
         Mirrors :meth:`notify_service_health`'s frame shape.  Consumer-side
         the frame is applied idempotently, so a transition arriving just
-        after the snapshot is harmless.  Workspaces whose container has
-        died are absent from ``registry.states`` and thus skipped (the
-        container-death hole is #1175 item 2).
+        after the snapshot is harmless; a transition or death arriving
+        *during* the snapshot's ACL pass is detected (seq/state re-check)
+        and the stale replay frame is dropped rather than sent over the
+        newer delta.  Workspaces whose container has died are absent
+        from ``registry.states`` and thus skipped (the container-death
+        hole is #1175 item 2).
         """
         conn = self.connections.get(sock)
         user_id = conn.user.get("id") if conn else None
         if user_id is None:
             return
+        registry = self.app.state.container_registry
+        # Snapshot (state, seq) pairs: the ACL pass below awaits, and a
+        # container that dies or a health transition that fires in that
+        # window must not be overwritten by a stale replay frame — the
+        # per-workspace seq bumps on every emit and the state is dropped
+        # on death, so a mismatch means a newer frame already went out.
         candidates = [
-            cs
-            for cs in self.app.state.container_registry.states.values()
+            (cs, cs.health_seq)
+            for cs in registry.states.values()
             if cs.health_check is not None and cs.health_status is not None
         ]
         if not candidates:
             return
         acl = self.app.state.acl
         principals = await acl.get_principals(user_id)
-        resources = [f"/workspaces/{cs.workspace_id}" for cs in candidates]
+        resources = [f"/workspaces/{cs.workspace_id}" for cs, _ in candidates]
         allowed = await acl.permissions_for_resources(
             resources, principals, ["terminal"]
         )
-        for cs in candidates:
+        for cs, seq in candidates:
             if f"/workspaces/{cs.workspace_id}" not in allowed:
+                continue
+            if registry.states.get(cs.workspace_id) is not cs:
+                # Died (state removed) or was re-bound while the ACL
+                # pass was in flight — its terminal/death frame already
+                # went to this member; don't replay over it.
+                continue
+            if cs.health_seq != seq:
+                # A transition fired mid-snapshot; its delta frame
+                # already went out — replaying the older status over it
+                # would flip the client backwards.
                 continue
             try:
                 sock.send_json(

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -798,16 +798,62 @@ class WebSocketState:
             )
             logger.info("Reset workspace state for %s", workspace_id)
 
-    def notify_container_status(
+    async def _send_to_workspace_members(
+        self, workspace_id: str, message: dict
+    ) -> None:
+        """Send a per-workspace *message* to that workspace's members (#1714).
+
+        The pre-#1714 fan-outs iterated every authenticated connection
+        and left filtering to the client, which leaked every workspace's
+        id, running state, and health (including the bounded
+        ``health_message`` tail of another tenant's service output) to
+        anyone with a WebSocket. This scopes delivery server-side:
+        connections are grouped by user and each distinct user is
+        ACL-checked for ``terminal`` on ``/workspaces/{workspace_id}`` —
+        the permission every grant path carries (the owner's wildcard
+        ACE, a direct member share, and every role group), while the
+        deployment-wide ``view``-for-authenticated seed ACE at ``/`` is
+        deliberately too weak to count as membership.
+
+        Sends to all of an allowed user's connections (a user with the
+        workspace open in two tabs gets both). Dead sockets are pruned;
+        dispatch.py owns cleanup on disconnect.
+        """
+        by_user: dict[str, list[tuple[SafeWebSocket, "Connection"]]] = {}
+        for sock, conn in self.connections.items():
+            uid = conn.user.get("id")
+            if uid is None:
+                continue
+            by_user.setdefault(uid, []).append((sock, conn))
+        acl = self.app.state.acl
+        dead = []
+        for uid, conns in by_user.items():
+            principals = await acl.get_principals(uid)
+            allowed = await acl.check_permission(
+                f"/workspaces/{workspace_id}", principals, "terminal"
+            )
+            if not allowed:
+                continue
+            for sock, _conn in conns:
+                try:
+                    sock.send_json(message)
+                except WS_ERRORS:
+                    dead.append(sock)
+        for sock in dead:
+            self.connections.pop(sock, None)
+
+    async def notify_container_status(
         self,
         workspace_id: str,
         running: bool,
         service_started_at: float | None = None,
     ) -> None:
-        """Broadcast container running/stopped status to all connections.
+        """Broadcast container running/stopped status to workspace members.
 
         Sent when a workspace container starts or is killed so the
         workspace list page can update status icons in real time.
+        Scoped to members of *workspace_id* (#1714) via
+        :meth:`_send_to_workspace_members`.
         """
         message: dict = {
             "type": "container_status",
@@ -816,24 +862,15 @@ class WebSocketState:
         }
         if service_started_at is not None:
             message["service_started_at"] = service_started_at
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
-                continue
-            try:
-                sock.send_json(message)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        await self._send_to_workspace_members(workspace_id, message)
 
-    def notify_workspace_evicted(
+    async def notify_workspace_evicted(
         self, workspace_id: str, *, reason: str = "host memory pressure"
     ) -> None:
-        """Broadcast a workspace-evicted event to all connections (#2526).
+        """Broadcast a workspace-evicted event to workspace members (#2526).
 
-        Fanned out to every connection (like
-        :meth:`notify_container_status`) so workspace list pages and any
+        Scoped to members of *workspace_id* (#1714) like
+        :meth:`notify_container_status`, so workspace list pages and any
         client watching the workspace learn *why* it stopped — the
         eviction path's own analogue of the idle monitor's
         ``container_stopped``/idle-timeout event, kept distinct from it
@@ -846,16 +883,7 @@ class WebSocketState:
             "workspace_id": workspace_id,
             "reason": reason,
         }
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
-                continue
-            try:
-                sock.send_json(message)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        await self._send_to_workspace_members(workspace_id, message)
 
     def broadcast_to_all(self, message: dict) -> None:
         """Broadcast *message* to every authenticated connection.
@@ -941,7 +969,7 @@ class WebSocketState:
         for sock, _ in dead:
             self.connections.pop(sock, None)
 
-    def notify_service_health(
+    async def notify_service_health(
         self,
         workspace_id: str,
         *,
@@ -951,13 +979,13 @@ class WebSocketState:
         health_checked_at: float | None = None,
         seq: int = 0,
     ) -> None:
-        """Broadcast service-health status to all connections.
+        """Broadcast service-health status to workspace members.
 
-        Fanned out to every connection (like
-        :meth:`notify_container_status`) so the workspace list page can
-        reflect health transitions for auto-started services even when no
-        one is connected to that workspace's terminal session (#1015).
-        The frontend ignores events for workspaces it doesn't display.
+        Scoped to members of *workspace_id* (#1714) via
+        :meth:`_send_to_workspace_members`, so the workspace list page
+        still reflects health transitions for auto-started services even
+        when no one is connected to that workspace's terminal session
+        (#1015) — but other tenants no longer learn them.
 
         ``message`` carries the failure *reason* (a bounded tail of the
         check's stderr/stdout) so an unhealthy workspace isn't a black
@@ -978,19 +1006,10 @@ class WebSocketState:
             health_checked_at=health_checked_at,
             seq=seq,
         )
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
-                continue
-            try:
-                sock.send_json(message_dict)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        await self._send_to_workspace_members(workspace_id, message_dict)
 
-    def send_service_health_snapshot(self, sock: SafeWebSocket) -> None:
-        """Send the current health of every health-checked workspace.
+    async def send_service_health_snapshot(self, sock: SafeWebSocket) -> None:
+        """Send the current health of the member workspaces to one socket.
 
         The ``service_health`` stream is **deltas only**: it fires on a
         status transition, not every poll, so a steady-state unhealthy
@@ -1000,16 +1019,37 @@ class WebSocketState:
         checked (``health_check`` configured and at least one poll
         completed) to a single connection right after it registers.
 
-        Mirrors :meth:`notify_service_health`'s fan-out scope (every
-        workspace, consumer filters): server-side scoping is tracked
-        separately (#1175 item 5).  Consumer-side the frame is applied
-        idempotently, so a transition arriving just after the snapshot
-        is harmless.  Workspaces whose container has died are absent
-        from ``registry.states`` and thus skipped (the container-death
-        hole is #1175 item 2).
+        Scoped to the connection's user's memberships (#1714): the
+        allowed workspace set is resolved with one
+        ``permissions_for_resources`` pass (``terminal`` on each
+        candidate resource), so a connecting client learns the health
+        of workspaces it can open — never other tenants'.
+
+        Mirrors :meth:`notify_service_health`'s frame shape.  Consumer-side
+        the frame is applied idempotently, so a transition arriving just
+        after the snapshot is harmless.  Workspaces whose container has
+        died are absent from ``registry.states`` and thus skipped (the
+        container-death hole is #1175 item 2).
         """
-        for cs in list(self.app.state.container_registry.states.values()):
-            if cs.health_check is None or cs.health_status is None:
+        conn = self.connections.get(sock)
+        user_id = conn.user.get("id") if conn else None
+        if user_id is None:
+            return
+        candidates = [
+            cs
+            for cs in self.app.state.container_registry.states.values()
+            if cs.health_check is not None and cs.health_status is not None
+        ]
+        if not candidates:
+            return
+        acl = self.app.state.acl
+        principals = await acl.get_principals(user_id)
+        resources = [f"/workspaces/{cs.workspace_id}" for cs in candidates]
+        allowed = await acl.permissions_for_resources(
+            resources, principals, ["terminal"]
+        )
+        for cs in candidates:
+            if f"/workspaces/{cs.workspace_id}" not in allowed:
                 continue
             try:
                 sock.send_json(

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -810,11 +810,14 @@ class WebSocketState:
         ``health_message`` tail of another tenant's service output) to
         anyone with a WebSocket. This scopes delivery server-side:
         connections are grouped by user and each distinct user is
-        ACL-checked for ``terminal`` on ``/workspaces/{workspace_id}`` —
-        the permission every grant path carries (the owner's wildcard
-        ACE, a direct member share, and every role group), while the
-        deployment-wide ``view``-for-authenticated seed ACE at ``/`` is
-        deliberately too weak to count as membership.
+        ACL-checked for ``monitor`` on ``/workspaces/{workspace_id}`` —
+        the dedicated status-observation permission (#2783). Every
+        grant path that carries ``terminal`` also seeds ``monitor``
+        (the owner's wildcard ACE, a direct member share, and every
+        role group), and ``monitor`` can be granted alone for
+        monitoring-only members, while the deployment-wide
+        ``view``-for-authenticated seed ACE at ``/`` is deliberately
+        too weak to count as membership.
 
         Sends to all of an allowed user's connections (a user with the
         workspace open in two tabs gets both). Dead sockets are pruned;
@@ -844,7 +847,7 @@ class WebSocketState:
         for uid, conns in by_user.items():
             principals = await acl.get_principals(uid)
             if not check_permission_inmemory(
-                resource, principals, "terminal", entries
+                resource, principals, "monitor", entries
             ):
                 continue
             for sock, _conn in conns:
@@ -1034,9 +1037,10 @@ class WebSocketState:
 
         Scoped to the connection's user's memberships (#1714): the
         allowed workspace set is resolved with one
-        ``permissions_for_resources`` pass (``terminal`` on each
-        candidate resource), so a connecting client learns the health
-        of workspaces it can open — never other tenants'.
+        ``permissions_for_resources`` pass (``monitor`` on each
+        candidate resource — the dedicated status-observation
+        permission, #2783), so a connecting client learns the health
+        of workspaces it can observe — never other tenants'.
 
         Mirrors :meth:`notify_service_health`'s frame shape.  Consumer-side
         the frame is applied idempotently, so a transition arriving just
@@ -1068,7 +1072,7 @@ class WebSocketState:
         principals = await acl.get_principals(user_id)
         resources = [f"/workspaces/{cs.workspace_id}" for cs, _ in candidates]
         allowed = await acl.permissions_for_resources(
-            resources, principals, ["terminal"]
+            resources, principals, ["monitor"]
         )
         for cs, seq in candidates:
             if f"/workspaces/{cs.workspace_id}" not in allowed:

--- a/src/klangk/klangkd-tests/e2e-tests/test_event_fanout.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_event_fanout.py
@@ -90,8 +90,8 @@ async def ws_connect(server, auth, workspace_id):
     """Open a WebSocket, connect to workspace, return ws.
 
     Drains messages until ``container_ready`` arrives. A
-    ``container_status`` broadcast (sent to all authenticated
-    connections when a container starts) can land before the ready
+    ``container_status`` broadcast (sent to the workspace's members
+    when a container starts, #1714) can land before the ready
     response, because the container is started during the
     ``workspace_connect`` handshake.
     """

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2993,6 +2993,97 @@ class TestWorkspaceRoutes:
         finally:
             registry.crash.trackers.pop(ws_id, None)
 
+    async def test_workspace_status_monitor_only_member(
+        self, client, user, app_state
+    ):
+        """#2783: ``monitor`` alone (no ``terminal``) can read status —
+        health observation is decoupled from exec/attach."""
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "status-monitor-only"},
+        )
+        ws_id = create_resp.json()["id"]
+        other = await app_state.state.model.users.create_user(
+            "monitor@example.com",
+            auth_mod.hash_password("monpass"),
+            verified=True,
+        )
+        resource = f"/workspaces/{ws_id}"
+        seeded = await app_state.state.model.acl.get_acl_entries(resource)
+        pos = max((e["position"] for e in seeded), default=-1) + 1
+        await app_state.state.model.acl.add_acl_entry(
+            resource,
+            pos,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_USER,
+            user_id=other["id"],
+        )
+        await app_state.state.model.acl.add_acl_entry(
+            resource,
+            pos + 1,
+            model.ACTION_ALLOW,
+            "monitor",
+            model.PRINCIPAL_USER,
+            user_id=other["id"],
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"identifier": "monitor@example.com", "password": "monpass"},
+        )
+        other_headers = {
+            "Authorization": f"Bearer {login.json()['access_token']}"
+        }
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/status", headers=other_headers
+        )
+        assert resp.status_code == 200
+        assert resp.json()["running"] is False
+
+    async def test_workspace_status_view_only_member_denied(
+        self, client, user, app_state
+    ):
+        """``view`` alone does not grant status reads — ``monitor`` is the
+        gate (the deployment-wide view-for-authenticated seed stays too
+        weak)."""
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "status-view-only"},
+        )
+        ws_id = create_resp.json()["id"]
+        other = await app_state.state.model.users.create_user(
+            "viewer@example.com",
+            auth_mod.hash_password("viewpass"),
+            verified=True,
+        )
+        seeded = await app_state.state.model.acl.get_acl_entries(
+            f"/workspaces/{ws_id}"
+        )
+        pos = max((e["position"] for e in seeded), default=-1) + 1
+        await app_state.state.model.acl.add_acl_entry(
+            f"/workspaces/{ws_id}",
+            pos,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_USER,
+            user_id=other["id"],
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"identifier": "viewer@example.com", "password": "viewpass"},
+        )
+        other_headers = {
+            "Authorization": f"Bearer {login.json()['access_token']}"
+        }
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/status", headers=other_headers
+        )
+        assert resp.status_code == 403
+
     async def test_workspace_status_not_found(self, client, user, app_state):
         headers = await _auth_headers(client)
         fake_id = "fake-status-id"
@@ -3000,7 +3091,7 @@ class TestWorkspaceRoutes:
             f"/workspaces/{fake_id}",
             0,
             model.ACTION_ALLOW,
-            "terminal",
+            "monitor",
             model.PRINCIPAL_USER,
             user_id=user["id"],
         )
@@ -4400,6 +4491,7 @@ class TestWorkspaceSharingRoutes:
             "files",
             "files-download",
             "files-write",
+            "monitor",
             "terminal",
             "view",
         ]

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -306,3 +306,5 @@ def test_all_permissions_single_source():
     assert "exec-and-sync" in api.ALL_PERMISSIONS
     # #2765's transfer permissions must be present too.
     assert {"files-download", "files-write"} <= set(api.ALL_PERMISSIONS)
+    # #2783's health/status gate must be reportable the same way.
+    assert "monitor" in api.ALL_PERMISSIONS

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -6273,6 +6273,8 @@ class TestHealthMonitorStartupGrace:
             self.registry.states.pop(st.workspace_id, None)
             self.registry._cid_to_wsid.pop(st.container_id, None)
 
+
+class TestHealthMonitorBroadcast:
     """_broadcast fans out to workspace members, not just the session (#1714)."""
 
     async def test_fans_out_via_notify_service_health(self, app_state):

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -5772,6 +5772,36 @@ def _health_registry(ws_state=None):
     return app_state.state.container_registry
 
 
+async def _grant_health_member(reg, user_id: str, workspace_id: str) -> None:
+    """Seed a member ALLOW ACE for a health fan-out test (#1714).
+
+    The status fan-outs ACL-check each recipient for ``terminal`` on
+    ``/workspaces/{id}``; the per-test DB starts with no ACEs (default
+    deny), so tests that assert delivery must grant membership first.
+    """
+    from klangk import model
+
+    await reg.app.state.model.init_db()
+    # acl_entries.user_id has an FK to users(id): plant the principal row.
+    async with reg.app.state.db.transaction() as tx:
+        await tx.execute(
+            "INSERT OR IGNORE INTO users (id, email, verified)"
+            " VALUES (?, ?, 1)",
+            (user_id, f"{user_id}@test.example"),
+        )
+    resource = f"/workspaces/{workspace_id}"
+    entries = await reg.app.state.model.acl.get_acl_entries(resource)
+    position = max((e["position"] for e in entries), default=-1) + 1
+    await reg.app.state.model.acl.add_acl_entry(
+        resource,
+        position,
+        model.ACTION_ALLOW,
+        "terminal",
+        model.PRINCIPAL_USER,
+        user_id=user_id,
+    )
+
+
 def _health_state(
     *,
     workspace_id="ws-h",
@@ -6063,7 +6093,7 @@ class TestHealthMonitorCheckWorkspace:
                 "_run_one",
                 AsyncMock(return_value=("unhealthy", "connection refused")),
             ),
-            patch.object(monitor, "_broadcast") as bcast,
+            patch.object(monitor, "_broadcast", AsyncMock()) as bcast,
         ):
             await monitor._check_workspace(st)
         assert st.health_status == "unhealthy"
@@ -6078,7 +6108,7 @@ class TestHealthMonitorCheckWorkspace:
             patch.object(
                 monitor, "_run_one", AsyncMock(return_value=("healthy", ""))
             ),
-            patch.object(monitor, "_broadcast") as bcast,
+            patch.object(monitor, "_broadcast", AsyncMock()) as bcast,
         ):
             await monitor._check_workspace(st)
         assert st.health_status == "healthy"
@@ -6164,7 +6194,7 @@ class TestHealthMonitorStartupGrace:
                 "_run_one",
                 AsyncMock(return_value=("unhealthy", "connection refused")),
             ),
-            patch.object(monitor, "_broadcast") as bcast,
+            patch.object(monitor, "_broadcast", AsyncMock()) as bcast,
         ):
             await monitor._check_workspace(st)
         # Status, reason, and last-checked are all untouched: the grace
@@ -6184,7 +6214,7 @@ class TestHealthMonitorStartupGrace:
             patch.object(
                 monitor, "_run_one", AsyncMock(return_value=("healthy", ""))
             ),
-            patch.object(monitor, "_broadcast") as bcast,
+            patch.object(monitor, "_broadcast", AsyncMock()) as bcast,
         ):
             await monitor._check_workspace(st)
         assert st.health_status == "healthy"
@@ -6202,7 +6232,7 @@ class TestHealthMonitorStartupGrace:
                 "_run_one",
                 AsyncMock(return_value=("unhealthy", "connection refused")),
             ),
-            patch.object(monitor, "_broadcast") as bcast,
+            patch.object(monitor, "_broadcast", AsyncMock()) as bcast,
         ):
             await monitor._check_workspace(st)
         assert st.health_status == "unhealthy"
@@ -6243,9 +6273,9 @@ class TestHealthMonitorStartupGrace:
             self.registry.states.pop(st.workspace_id, None)
             self.registry._cid_to_wsid.pop(st.container_id, None)
 
-    """_broadcast fans out to ALL connections, not just the session."""
+    """_broadcast fans out to workspace members, not just the session (#1714)."""
 
-    def test_fans_out_via_notify_service_health(self, app_state):
+    async def test_fans_out_via_notify_service_health(self, app_state):
         reg = _health_registry()
         monitor = reg.health
         sock = _mock_sock_for_health()
@@ -6254,9 +6284,10 @@ class TestHealthMonitorStartupGrace:
             reg.app.state.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
+            await _grant_health_member(reg, "u1", st.workspace_id)
             # No WorkspaceSession registered for this workspace — yet
-            # the event must still reach the connection.
-            monitor._broadcast(st, "unhealthy", "connection refused")
+            # the event must still reach the member's connection.
+            await monitor._broadcast(st, "unhealthy", "connection refused")
         finally:
             reg.app.state.sockets.connections.pop(sock, None)
         sock.send_json.assert_called_once_with(
@@ -6271,6 +6302,28 @@ class TestHealthMonitorStartupGrace:
                 "seq": 1,
             }
         )
+
+    async def test_non_member_never_receives_health_frames(self, app_state):
+        """#1714: a connected user with no grant on the workspace is skipped."""
+        reg = _health_registry()
+        monitor = reg.health
+        member = _mock_sock_for_health()
+        stranger = _mock_sock_for_health()
+        st = _health_state(health_status="unhealthy")
+        try:
+            reg.app.state.sockets.connections[member] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            reg.app.state.sockets.connections[stranger] = SimpleNamespace(
+                user={"id": "u2", "email": "b@x"}
+            )
+            await _grant_health_member(reg, "u1", st.workspace_id)
+            await monitor._broadcast(st, "unhealthy", "connection refused")
+        finally:
+            reg.app.state.sockets.connections.pop(member, None)
+            reg.app.state.sockets.connections.pop(stranger, None)
+        member.send_json.assert_called_once()
+        stranger.send_json.assert_not_called()
 
 
 class TestHealthMonitorLoopSkips:
@@ -6359,7 +6412,7 @@ class TestHealthMonitorLoopSkips:
 class TestHealthMonitorBroadcastSeq:
     """_broadcast bumps per-workspace seq and forwards live fields."""
 
-    def test_bumps_seq_each_emit_and_forwards_fields(self, app_state):
+    async def test_bumps_seq_each_emit_and_forwards_fields(self, app_state):
         reg = _health_registry()
         monitor = reg.health
         sock = _mock_sock_for_health()
@@ -6369,8 +6422,9 @@ class TestHealthMonitorBroadcastSeq:
             reg.app.state.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
-            monitor._broadcast(st, "unhealthy", "connection refused")
-            monitor._broadcast(st, "unhealthy", "connection refused")
+            await _grant_health_member(reg, "u1", st.workspace_id)
+            await monitor._broadcast(st, "unhealthy", "connection refused")
+            await monitor._broadcast(st, "unhealthy", "connection refused")
         finally:
             reg.app.state.sockets.connections.pop(sock, None)
         frames = [c[0][0] for c in sock.send_json.call_args_list]
@@ -6394,7 +6448,7 @@ class TestHealthMonitorDeath:
         app_state = _make_app_state()
         self.registry = app_state.state.container_registry
 
-    def test_broadcast_death_emits_terminal_frame(self, app_state):
+    async def test_broadcast_death_emits_terminal_frame(self, app_state):
         reg = _health_registry()
         monitor = reg.health
         sock = _mock_sock_for_health()
@@ -6405,7 +6459,8 @@ class TestHealthMonitorDeath:
             reg.app.state.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
-            monitor.broadcast_death(st)
+            await _grant_health_member(reg, "u1", st.workspace_id)
+            await monitor.broadcast_death(st)
         finally:
             reg.app.state.sockets.connections.pop(sock, None)
         frame = sock.send_json.call_args[0][0]
@@ -6437,6 +6492,7 @@ class TestHealthMonitorDeath:
             reg.app.state.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
+            await _grant_health_member(reg, "u1", st.workspace_id)
             reg.set_on_workspace_killed(on_killed)
             await reg.notify_workspace_killed(st.workspace_id)
         finally:
@@ -6501,6 +6557,7 @@ class TestHealthMonitorDeath:
             reg.app.state.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
+            await _grant_health_member(reg, "u1", st.workspace_id)
             # Patch the registry that actually runs the cleanup loop
             # (``reg``), not ``self.registry`` -- otherwise the real
             # ``podman remove_container`` fires on a fake container id

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -5773,9 +5773,10 @@ def _health_registry(ws_state=None):
 
 
 async def _grant_health_member(reg, user_id: str, workspace_id: str) -> None:
-    """Seed a member ALLOW ACE for a health fan-out test (#1714).
+    """Seed a member ALLOW ``monitor`` ACE for a health fan-out test
+    (#1714/#2783).
 
-    The status fan-outs ACL-check each recipient for ``terminal`` on
+    The status fan-outs ACL-check each recipient for ``monitor`` on
     ``/workspaces/{id}``; the per-test DB starts with no ACEs (default
     deny), so tests that assert delivery must grant membership first.
     """
@@ -5796,7 +5797,7 @@ async def _grant_health_member(reg, user_id: str, workspace_id: str) -> None:
         resource,
         position,
         model.ACTION_ALLOW,
-        "terminal",
+        "monitor",
         model.PRINCIPAL_USER,
         user_id=user_id,
     )

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -1162,7 +1162,7 @@ class TestDeathFrameCarriesCause:
         dead_state(reg, health_check="true")
         frames = []
 
-        def fake_broadcast(state, *, message=None):
+        async def fake_broadcast(state, *, message=None):
             frames.append(message)
 
         with patch.object(reg.health, "broadcast_death", fake_broadcast):
@@ -1177,7 +1177,7 @@ class TestDeathFrameCarriesCause:
         dead_state(reg, health_check="true")
         frames = []
 
-        def fake_broadcast(state, *, message=None):
+        async def fake_broadcast(state, *, message=None):
             frames.append(message)
 
         with patch.object(reg.health, "broadcast_death", fake_broadcast):

--- a/src/klangk/klangkd-tests/tests/test_eviction.py
+++ b/src/klangk/klangkd-tests/tests/test_eviction.py
@@ -892,6 +892,7 @@ class TestNotifyWorkspaceEvicted:
         return conn
 
     async def _grant(self, app, user_id, workspace_id):
+        """Seed a member ALLOW ``monitor`` ACE (#1714/#2783)."""
         from klangk import model
 
         await app.state.model.init_db()
@@ -909,7 +910,7 @@ class TestNotifyWorkspaceEvicted:
             resource,
             position,
             model.ACTION_ALLOW,
-            "terminal",
+            "monitor",
             model.PRINCIPAL_USER,
             user_id=user_id,
         )

--- a/src/klangk/klangkd-tests/tests/test_eviction.py
+++ b/src/klangk/klangkd-tests/tests/test_eviction.py
@@ -49,10 +49,14 @@ def _make_app_state(env=None):
     app = types.SimpleNamespace(state=types.SimpleNamespace(settings=settings))
     from klangk.podman import Podman
     from klangk.wshandler.session import WebSocketState
+    from _helpers import wire_db_and_model
 
     app.state.podman = Podman(app)
     app.state.sockets = WebSocketState(app)
     app.state.container_registry = container.ContainerRegistry(app)
+    # #1714: the evicted broadcast ACL-checks recipients, so the eviction
+    # paths need the DB/model/acl wiring the real app has.
+    wire_db_and_model(app)
     return app
 
 
@@ -389,11 +393,11 @@ class TestEvictOne:
         self._tracked(registry, "ws-1", "cid-1", 100)
         registry.notify_workspace_killed = AsyncMock()
         registry.stop_and_remove_container = AsyncMock()
-        broadcast = MagicMock()
+        broadcast = AsyncMock()
         app.state.sockets.notify_workspace_evicted = broadcast
 
         await evictor.evict_one(0.03)
-        broadcast.assert_called_once_with(
+        broadcast.assert_awaited_once_with(
             "ws-1", reason="host memory pressure"
         )
 
@@ -877,21 +881,48 @@ class TestNotifyWorkspaceEvicted:
     def _sockets(self):
         app = _make_app_state()
         from klangk.wshandler.session import WebSocketState
+        from _helpers import wire_db_and_model
 
-        return WebSocketState(app)
+        wire_db_and_model(app)
+        return WebSocketState(app), app
 
     def _conn(self, user_id="u1"):
         conn = MagicMock()
         conn.user = {"id": user_id}
         return conn
 
-    def test_fans_out_to_all_connections(self):
-        sockets = self._sockets()
+    async def _grant(self, app, user_id, workspace_id):
+        from klangk import model
+
+        await app.state.model.init_db()
+        # acl_entries.user_id has an FK to users(id): plant the row.
+        async with app.state.db.transaction() as tx:
+            await tx.execute(
+                "INSERT OR IGNORE INTO users (id, email, verified)"
+                " VALUES (?, ?, 1)",
+                (user_id, f"{user_id}@test.example"),
+            )
+        resource = f"/workspaces/{workspace_id}"
+        entries = await app.state.model.acl.get_acl_entries(resource)
+        position = max((e["position"] for e in entries), default=-1) + 1
+        await app.state.model.acl.add_acl_entry(
+            resource,
+            position,
+            model.ACTION_ALLOW,
+            "terminal",
+            model.PRINCIPAL_USER,
+            user_id=user_id,
+        )
+
+    async def test_fans_out_to_members(self):
+        sockets, app = self._sockets()
         sock1, sock2 = MagicMock(), MagicMock()
         sockets.connections[sock1] = self._conn()
         sockets.connections[sock2] = self._conn("u2")
+        await self._grant(app, "u1", "ws-1")
+        await self._grant(app, "u2", "ws-1")
 
-        sockets.notify_workspace_evicted("ws-1")
+        await sockets.notify_workspace_evicted("ws-1")
 
         for sock in (sock1, sock2):
             sock.send_json.assert_called_once_with(
@@ -902,8 +933,21 @@ class TestNotifyWorkspaceEvicted:
                 }
             )
 
-    def test_dead_socket_popped_unauthenticated_skipped(self):
-        sockets = self._sockets()
+    async def test_non_member_receives_nothing(self):
+        """#1714: a connected user with no grant on the workspace is skipped."""
+        sockets, app = self._sockets()
+        member, stranger = MagicMock(), MagicMock()
+        sockets.connections[member] = self._conn()
+        sockets.connections[stranger] = self._conn("u2")
+        await self._grant(app, "u1", "ws-1")
+
+        await sockets.notify_workspace_evicted("ws-1")
+
+        member.send_json.assert_called_once()
+        stranger.send_json.assert_not_called()
+
+    async def test_dead_socket_popped_unauthenticated_skipped(self):
+        sockets, app = self._sockets()
         dead, alive, anon = MagicMock(), MagicMock(), MagicMock()
         dead.send_json.side_effect = WS_ERRORS[0](
             "sender stopped — cannot enqueue"
@@ -911,8 +955,9 @@ class TestNotifyWorkspaceEvicted:
         sockets.connections[dead] = self._conn()
         sockets.connections[alive] = self._conn()
         sockets.connections[anon] = self._conn(user_id=None)
+        await self._grant(app, "u1", "ws-1")
 
-        sockets.notify_workspace_evicted("ws-1", reason="other")
+        await sockets.notify_workspace_evicted("ws-1", reason="other")
 
         alive.send_json.assert_called_once()
         anon.send_json.assert_not_called()

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -35,6 +35,7 @@ from klangk import (
 )
 from klangk.container import ContainerRegistry
 from klangk.exceptions import ConfigurationError, EX_CONFIG
+from klangk.lifecycle import broadcast_container_status
 from _helpers import make_settings
 from klangk.wshandler.session import WebSocketState
 
@@ -1091,6 +1092,56 @@ class TestLifespan:
             async with main.lifespan(app):
                 pass  # pragma: no cover
         assert app.state.startup_config_error == str(refusal)
+
+
+class TestBroadcastContainerStatus:
+    """The registry status callback schedules the scoped broadcast (#1714).
+
+    The registry invokes its status-change callback synchronously (from
+    ``track_activity`` and the stop paths); the broadcast itself is
+    async because it ACL-checks every recipient, so the callback wraps
+    it in a fire-and-forget task.
+    """
+
+    def _app(self):
+        return types.SimpleNamespace(
+            state=types.SimpleNamespace(
+                sockets=types.SimpleNamespace(
+                    notify_container_status=AsyncMock()
+                )
+            )
+        )
+
+    async def test_schedules_scoped_broadcast(self):
+        app = self._app()
+        broadcast_container_status(app, "ws-1", True, 1000.0)
+        # Let the scheduled task run to completion.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        app.state.sockets.notify_container_status.assert_awaited_once_with(
+            "ws-1", True, 1000.0
+        )
+
+    async def test_broadcast_error_is_logged_not_raised(self, caplog):
+        app = self._app()
+        app.state.sockets.notify_container_status.side_effect = RuntimeError(
+            "acl unavailable"
+        )
+        with caplog.at_level("ERROR", logger="klangk.lifecycle"):
+            broadcast_container_status(app, "ws-2", False)
+            for _ in range(3):
+                await asyncio.sleep(0)
+        assert any(
+            "container_status broadcast failed" in r.message
+            for r in caplog.records
+        )
+
+    def test_no_running_loop_is_a_noop(self):
+        # Sync registry call paths (unit harnesses driving track_activity
+        # directly) have no loop to schedule on — nothing to broadcast to.
+        app = self._app()
+        broadcast_container_status(app, "ws-3", True)
+        app.state.sockets.notify_container_status.assert_not_called()
 
 
 # --- SIGHUP runtime restart (#1212) ---

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -67,6 +67,7 @@ class TestRunner:
             (13, "0013_exec_and_sync_permission"),
             (14, "0014_groups_create_admin"),
             (15, "0015_classification_banner"),
+            (16, "0016_monitor_permission"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -148,6 +149,7 @@ class TestRunner:
                 (13, "0013_exec_and_sync_permission"),
                 (14, "0014_groups_create_admin"),
                 (15, "0015_classification_banner"),
+                (16, "0016_monitor_permission"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -1206,3 +1208,133 @@ class TestClassificationBanner:
             "SELECT classification_banner FROM workspaces WHERE id = 'ws-old'"
         )
         assert rows[0][0] is None
+
+
+class TestM0016MonitorPermission:
+    """m0016: backfill ``monitor`` onto existing terminal holders (#2783).
+
+    Health/status reception moved from the ``terminal`` permission to
+    the dedicated ``monitor`` permission; this migration preserves
+    status delivery for every principal that already had ``terminal``
+    (role groups and direct user shares alike).
+    """
+
+    WS_ID = "11111111-2222-3333-4444-555555555555"
+    RESOURCE = f"/workspaces/{WS_ID}"
+
+    async def _db(self, tmp_path):
+        import aiosqlite
+
+        db = aiosqlite.connect(str(tmp_path / "m0016.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT)"
+        )
+        # A pre-#2783 workspace ACL: owner wildcard, role-group terminal
+        # ACEs, and a direct member share (user-principal terminal).
+        for resource, pos, principal_type, user_id, group_id, perm in (
+            (self.RESOURCE, 0, 1, "u-owner", None, "*"),
+            (self.RESOURCE, 1, 2, None, "g-coders", "terminal"),
+            (self.RESOURCE, 2, 2, None, "g-spectators", "terminal"),
+            (self.RESOURCE, 3, 1, "u-member", None, "terminal"),
+            (self.RESOURCE, 4, 1, "u-member", None, "view"),
+        ):
+            await db.execute(
+                "INSERT INTO acl_entries (resource, position, action,"
+                " principal_type, user_id, group_id, permission)"
+                " VALUES (?, ?, 1, ?, ?, ?, ?)",
+                (resource, pos, principal_type, user_id, group_id, perm),
+            )
+        return db
+
+    async def _monitor_aces(self, db) -> dict[tuple, int]:
+        cursor = await db.execute(
+            "SELECT user_id, group_id, COUNT(*) FROM acl_entries"
+            " WHERE permission = 'monitor' AND action = 1"
+            " GROUP BY user_id, group_id"
+        )
+        return {(row[0], row[1]): row[2] for row in await cursor.fetchall()}
+
+    async def test_backfill_covers_groups_and_direct_users(self, tmp_path):
+        from klangk.model.migrations import m0016_monitor_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await m0016_monitor_permission.migration.apply(db)
+            # Role groups and the direct member share are covered; the
+            # wildcard owner needs nothing.
+            assert await self._monitor_aces(db) == {
+                (None, "g-coders"): 1,
+                (None, "g-spectators"): 1,
+                ("u-member", None): 1,
+            }
+            # Appended after the seeded entries, not interleaved.
+            cursor = await db.execute(
+                "SELECT position FROM acl_entries"
+                " WHERE permission = 'monitor' AND group_id = 'g-coders'"
+            )
+            assert (await cursor.fetchone())[0] == 5
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_idempotent(self, tmp_path):
+        from klangk.model.migrations import m0016_monitor_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await m0016_monitor_permission.migration.apply(db)
+            await m0016_monitor_permission.migration.apply(db)
+            assert await self._monitor_aces(db) == {
+                (None, "g-coders"): 1,
+                (None, "g-spectators"): 1,
+                ("u-member", None): 1,
+            }
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_skips_deny_terminal(self, tmp_path):
+        """Only ``Allow`` terminal ACEs earn the backfill — a Deny row is\n        not a grant."""
+        from klangk.model.migrations import m0016_monitor_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries (resource, position, action,"
+                " principal_type, user_id, group_id, permission)"
+                " VALUES (?, 5, 0, 1, 'u-denied', NULL, 'terminal')",
+                (self.RESOURCE,),
+            )
+            await m0016_monitor_permission.migration.apply(db)
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM acl_entries"
+                " WHERE user_id = 'u-denied' AND permission = 'monitor'"
+            )
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_empty_table(self, tmp_path):
+        """No ACEs: nothing raises, nothing is written."""
+        import aiosqlite
+
+        from klangk.model.migrations import m0016_monitor_permission
+
+        db = aiosqlite.connect(str(tmp_path / "m0016-empty.db"))
+        db = await db.__aenter__()
+        try:
+            await db.execute(
+                "CREATE TABLE acl_entries ("
+                " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                " resource TEXT, position INTEGER, action INTEGER,"
+                " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+                " system_principal INTEGER, permission TEXT)"
+            )
+            await m0016_monitor_permission.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -200,10 +200,11 @@ async def test_create_workspace_with_acl_seeds_owner_and_role_groups(
     # Position counter is global across all groups (no collisions).
     positions = sorted(e["position"] for e in entries)
     assert positions == list(range(len(entries)))
-    # 1 owner ACE + 1 + 7 + 9 + 2 group ACEs (coders/collaborators carry
-    # `files-download`/`files-write` alongside `files` (#2705) and
-    # `exec-and-sync` (#2706/#2712)).
-    assert len(entries) == 1 + 1 + 7 + 9 + 2
+    # 1 owner ACE + 1 + 8 + 10 + 3 group ACEs (coders/collaborators carry
+    # `files-download`/`files-write` alongside `files` (#2705),
+    # `exec-and-sync` (#2706/#2712), and `monitor` (#2783) joins every
+    # role that has `terminal`, spectators included).
+    assert len(entries) == 1 + 1 + 8 + 10 + 3
     # Coder/collaborator grants include both transfer permissions and
     # the exec-channel permission.
     for suffix in ["coders", "collaborators"]:

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2608,6 +2608,27 @@ class TestHandleWebsocket:
 
         websocket.accept.assert_awaited_once()
 
+    async def test_snapshot_failure_still_runs_cleanup(self, user, app_state):
+        """#1714 review: the connect-time snapshot awaits DB queries inside
+        the handler's try — a raise there must run the ``finally`` cleanup
+        (sender stopped, connection unregistered), not leak them."""
+        app_state = _make_app_state()
+
+        token = _auth().create_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+
+        with patch.object(
+            app_state.state.sockets,
+            "send_service_health_snapshot",
+            AsyncMock(side_effect=RuntimeError("db unavailable")),
+        ):
+            await handle_websocket(websocket, app_state)
+
+        websocket.accept.assert_awaited_once()
+        # The finally block ran: the connection was unregistered.
+        assert not app_state.state.sockets.connections
+
     async def test_runtime_error_treated_as_disconnect(self, user, app_state):
         app_state = _make_app_state()
 
@@ -5182,6 +5203,87 @@ class TestServiceHealthSnapshot:
             registry.states.clear()
             self._register(sock, app_state)
             await sockets.send_service_health_snapshot(sock)
+        finally:
+            registry.states.clear()
+            registry.states.update(saved)
+            sockets.connections.pop(sock, None)
+        sock.send_json.assert_not_called()
+
+    async def test_state_dropped_during_acl_pass_is_not_replayed(
+        self, app_state
+    ):
+        """#1714 review: a container dying while the snapshot's ACL pass is
+        in flight must not be resurrected by a stale running=true frame —
+        its terminal death frame already went to this member."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        saved = dict(registry.states)
+        sock = _mock_sock()
+        real = app_state.state.acl.permissions_for_resources
+
+        async def dying_during_acl(resources, principals, permissions):
+            # The container dies between the candidate snapshot and the
+            # sends: remove_state pops the registry entry.
+            registry.states.pop("ws-1", None)
+            return await real(resources, principals, permissions)
+
+        try:
+            registry.states.clear()
+            registry.states["ws-1"] = self._state(
+                "ws-1",
+                registry=registry,
+                health_check="true",
+                health_status="healthy",
+            )
+            self._register(sock, app_state)
+            await _grant_terminal(app_state, "uid-1", "ws-1")
+            with patch.object(
+                app_state.state.acl,
+                "permissions_for_resources",
+                new=dying_during_acl,
+            ):
+                await sockets.send_service_health_snapshot(sock)
+        finally:
+            registry.states.clear()
+            registry.states.update(saved)
+            sockets.connections.pop(sock, None)
+        sock.send_json.assert_not_called()
+
+    async def test_transition_during_acl_pass_is_not_replayed(self, app_state):
+        """#1714 review: a health transition firing mid-snapshot bumps seq;
+        replaying the older status after the newer delta would flip the
+        client backwards, so the stale frame is dropped."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        saved = dict(registry.states)
+        sock = _mock_sock()
+        st = self._state(
+            "ws-1",
+            registry=registry,
+            health_check="true",
+            health_status="healthy",
+        )
+        real = app_state.state.acl.permissions_for_resources
+
+        async def transition_during_acl(resources, principals, permissions):
+            # A transition lands between the candidate snapshot and the
+            # sends: same state object, seq bumped.
+            st.health_seq += 1
+            return await real(resources, principals, permissions)
+
+        try:
+            registry.states.clear()
+            registry.states["ws-1"] = st
+            self._register(sock, app_state)
+            await _grant_terminal(app_state, "uid-1", "ws-1")
+            with patch.object(
+                app_state.state.acl,
+                "permissions_for_resources",
+                new=transition_during_acl,
+            ):
+                await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
             registry.states.update(saved)

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -131,10 +131,11 @@ def _auth():
     return auth_mod.Auth(state)
 
 
-async def _grant_terminal(app_state, user_id: str, workspace_id: str) -> None:
-    """Seed a member ALLOW ACE so a connection passes the #1714 scope.
+async def _grant_monitor(app_state, user_id: str, workspace_id: str) -> None:
+    """Seed a member ALLOW ``monitor`` ACE so a connection passes the
+    #1714/#2783 scope.
 
-    The status fan-outs ACL-check each recipient for ``terminal`` on
+    The status fan-outs ACL-check each recipient for ``monitor`` on
     ``/workspaces/{id}``; the per-test DB starts with no ACEs (default
     deny), so tests that assert delivery must grant membership first.
     """
@@ -153,7 +154,7 @@ async def _grant_terminal(app_state, user_id: str, workspace_id: str) -> None:
         resource,
         position,
         model.ACTION_ALLOW,
-        "terminal",
+        "monitor",
         model.PRINCIPAL_USER,
         user_id=user_id,
     )
@@ -4796,8 +4797,8 @@ class TestNotifyContainerStatus:
         try:
             self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
             self._register(sock_b, {"id": "uid-2", "email": "b@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-123")
-            await _grant_terminal(app_state, "uid-2", "ws-123")
+            await _grant_monitor(app_state, "uid-1", "ws-123")
+            await _grant_monitor(app_state, "uid-2", "ws-123")
             await sockets.notify_container_status("ws-123", True)
         finally:
             sockets.connections.pop(sock_a, None)
@@ -4821,7 +4822,7 @@ class TestNotifyContainerStatus:
             self._register(
                 stranger, {"id": "uid-2", "email": "b@x"}, app_state
             )
-            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await _grant_monitor(app_state, "uid-1", "ws-123")
             await sockets.notify_container_status("ws-123", True)
         finally:
             sockets.connections.pop(member, None)
@@ -4864,7 +4865,7 @@ class TestNotifyContainerStatus:
         try:
             self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
             self._register(sock_b, {"id": "uid-1", "email": "a@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await _grant_monitor(app_state, "uid-1", "ws-123")
             await sockets.notify_container_status("ws-123", True)
         finally:
             sockets.connections.pop(sock_a, None)
@@ -4878,7 +4879,7 @@ class TestNotifyContainerStatus:
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-789")
+            await _grant_monitor(app_state, "uid-1", "ws-789")
             await sockets.notify_container_status("ws-789", True, 1000.0)
         finally:
             sockets.connections.pop(sock, None)
@@ -4892,7 +4893,7 @@ class TestNotifyContainerStatus:
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-456")
+            await _grant_monitor(app_state, "uid-1", "ws-456")
             await sockets.notify_container_status("ws-456", False)
         finally:
             sockets.connections.pop(sock, None)
@@ -4920,7 +4921,7 @@ class TestNotifyContainerStatus:
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await _grant_monitor(app_state, "uid-1", "ws-1")
             await sockets.notify_container_status("ws-1", True)
             assert sock not in sockets.connections
         finally:
@@ -4943,8 +4944,8 @@ class TestNotifyServiceHealth:
         try:
             self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
             self._register(sock_b, {"id": "uid-2", "email": "b@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-123")
-            await _grant_terminal(app_state, "uid-2", "ws-123")
+            await _grant_monitor(app_state, "uid-1", "ws-123")
+            await _grant_monitor(app_state, "uid-2", "ws-123")
             await sockets.notify_service_health("ws-123", healthy=True)
         finally:
             sockets.connections.pop(sock_a, None)
@@ -4972,7 +4973,7 @@ class TestNotifyServiceHealth:
             self._register(
                 stranger, {"id": "uid-2", "email": "b@x"}, app_state
             )
-            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await _grant_monitor(app_state, "uid-1", "ws-123")
             await sockets.notify_service_health(
                 "ws-123", healthy=False, message="boom"
             )
@@ -4982,6 +4983,52 @@ class TestNotifyServiceHealth:
         member.send_json.assert_called_once()
         stranger.send_json.assert_not_called()
 
+    async def test_monitor_without_terminal_receives_frames(self, app_state):
+        """#2783: ``monitor`` alone — without ``terminal`` — is the status
+        gate; a monitoring-only member observes health without being
+        able to open a terminal."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            await _grant_monitor(app_state, "uid-1", "ws-123")
+            await sockets.notify_service_health("ws-123", healthy=False)
+        finally:
+            sockets.connections.pop(sock, None)
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "service_health"
+        assert msg["workspace_id"] == "ws-123"
+
+    async def test_terminal_without_monitor_receives_nothing(self, app_state):
+        """The two permissions are distinct: ``terminal`` alone no longer
+        grants status reception (grant ``monitor`` too, or rely on the
+        seeded/migrated pairing)."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            await app_state.state.model.init_db()
+            async with app_state.state.db.transaction() as tx:
+                await tx.execute(
+                    "INSERT OR IGNORE INTO users (id, email, verified)"
+                    " VALUES (?, ?, 1)",
+                    ("uid-1", "uid-1@test.example"),
+                )
+            await app_state.state.model.acl.add_acl_entry(
+                "/workspaces/ws-123",
+                0,
+                model.ACTION_ALLOW,
+                "terminal",
+                model.PRINCIPAL_USER,
+                user_id="uid-1",
+            )
+            await sockets.notify_service_health("ws-123", healthy=False)
+        finally:
+            sockets.connections.pop(sock, None)
+        sock.send_json.assert_not_called()
+
     async def test_sends_unhealthy_with_reason(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
@@ -4990,7 +5037,7 @@ class TestNotifyServiceHealth:
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-9")
+            await _grant_monitor(app_state, "uid-1", "ws-9")
             await sockets.notify_service_health(
                 "ws-9", healthy=False, message="curl: connection refused"
             )
@@ -5021,7 +5068,7 @@ class TestNotifyServiceHealth:
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await _grant_monitor(app_state, "uid-1", "ws-1")
             await sockets.notify_service_health("ws-1", healthy=True)
             assert sock not in sockets.connections
         finally:
@@ -5093,8 +5140,8 @@ class TestServiceHealthSnapshot:
                 health_status="healthy",
             )
             self._register(sock, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-healthy")
-            await _grant_terminal(app_state, "uid-1", "ws-sick")
+            await _grant_monitor(app_state, "uid-1", "ws-healthy")
+            await _grant_monitor(app_state, "uid-1", "ws-sick")
             await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
@@ -5151,7 +5198,7 @@ class TestServiceHealthSnapshot:
                 health_status="healthy",
             )
             self._register(sock, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await _grant_monitor(app_state, "uid-1", "ws-1")
             await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
@@ -5184,8 +5231,8 @@ class TestServiceHealthSnapshot:
                 health_status="unhealthy",
             )
             self._register(sock, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-1")
-            await _grant_terminal(app_state, "uid-1", "ws-2")
+            await _grant_monitor(app_state, "uid-1", "ws-1")
+            await _grant_monitor(app_state, "uid-1", "ws-2")
             # Must not raise; the dead socket ends the snapshot early.
             await sockets.send_service_health_snapshot(sock)
         finally:
@@ -5237,7 +5284,7 @@ class TestServiceHealthSnapshot:
                 health_status="healthy",
             )
             self._register(sock, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await _grant_monitor(app_state, "uid-1", "ws-1")
             with patch.object(
                 app_state.state.acl,
                 "permissions_for_resources",
@@ -5277,7 +5324,7 @@ class TestServiceHealthSnapshot:
             registry.states.clear()
             registry.states["ws-1"] = st
             self._register(sock, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await _grant_monitor(app_state, "uid-1", "ws-1")
             with patch.object(
                 app_state.state.acl,
                 "permissions_for_resources",
@@ -5354,7 +5401,7 @@ class TestNotifyServiceHealthForwarding:
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            await _grant_terminal(app_state, "uid-1", "ws-9")
+            await _grant_monitor(app_state, "uid-1", "ws-9")
             await sockets.notify_service_health(
                 "ws-9",
                 healthy=False,
@@ -5400,7 +5447,7 @@ class TestServiceHealthSnapshotFields:
                 app_state=app_state,
             )
             sockets.connections[sock] = conn
-            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await _grant_monitor(app_state, "uid-1", "ws-1")
             await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -131,6 +131,34 @@ def _auth():
     return auth_mod.Auth(state)
 
 
+async def _grant_terminal(app_state, user_id: str, workspace_id: str) -> None:
+    """Seed a member ALLOW ACE so a connection passes the #1714 scope.
+
+    The status fan-outs ACL-check each recipient for ``terminal`` on
+    ``/workspaces/{id}``; the per-test DB starts with no ACEs (default
+    deny), so tests that assert delivery must grant membership first.
+    """
+    await app_state.state.model.init_db()
+    # acl_entries.user_id has an FK to users(id): plant the principal row.
+    async with app_state.state.db.transaction() as tx:
+        await tx.execute(
+            "INSERT OR IGNORE INTO users (id, email, verified)"
+            " VALUES (?, ?, 1)",
+            (user_id, f"{user_id}@test.example"),
+        )
+    resource = f"/workspaces/{workspace_id}"
+    entries = await app_state.state.model.acl.get_acl_entries(resource)
+    position = max((e["position"] for e in entries), default=-1) + 1
+    await app_state.state.model.acl.add_acl_entry(
+        resource,
+        position,
+        model.ACTION_ALLOW,
+        "terminal",
+        model.PRINCIPAL_USER,
+        user_id=user_id,
+    )
+
+
 def _mock_sock(headers=None, query_params=None):
     """Create a mock SafeWebSocket for testing.
 
@@ -4732,14 +4760,14 @@ class TestNotifyUserTerminalsChanged:
 
 
 class TestNotifyContainerStatus:
-    """notify_container_status broadcasts to all authenticated connections."""
+    """notify_container_status broadcasts to workspace members only (#1714)."""
 
     def _register(self, sock, user, app_state):
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         app_state.state.sockets.connections[sock] = conn
         return conn
 
-    def test_sends_to_all_authenticated(self, app_state):
+    async def test_sends_to_members_of_both_users(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock_a = _mock_sock()
@@ -4747,7 +4775,9 @@ class TestNotifyContainerStatus:
         try:
             self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
             self._register(sock_b, {"id": "uid-2", "email": "b@x"}, app_state)
-            sockets.notify_container_status("ws-123", True)
+            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await _grant_terminal(app_state, "uid-2", "ws-123")
+            await sockets.notify_container_status("ws-123", True)
         finally:
             sockets.connections.pop(sock_a, None)
             sockets.connections.pop(sock_b, None)
@@ -4759,44 +4789,108 @@ class TestNotifyContainerStatus:
         sock_a.send_json.assert_called_once_with(expected)
         sock_b.send_json.assert_called_once_with(expected)
 
-    def test_includes_service_started_at(self, app_state):
+    async def test_non_member_receives_nothing(self, app_state):
+        """#1714: a connected user with no grant on the workspace is skipped."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        member = _mock_sock()
+        stranger = _mock_sock()
+        try:
+            self._register(member, {"id": "uid-1", "email": "a@x"}, app_state)
+            self._register(
+                stranger, {"id": "uid-2", "email": "b@x"}, app_state
+            )
+            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await sockets.notify_container_status("ws-123", True)
+        finally:
+            sockets.connections.pop(member, None)
+            sockets.connections.pop(stranger, None)
+        member.send_json.assert_called_once()
+        stranger.send_json.assert_not_called()
+
+    async def test_view_only_grant_is_not_membership(self, app_state):
+        """The ``/``-level view-for-authenticated ACE must not leak frames.
+
+        Seeds the deployment default (view at ``/`` for authenticated)
+        and asserts it still does not count as membership — only a real
+        grant on the workspace does.
+        """
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            sockets.notify_container_status("ws-789", True, 1000.0)
+            await app_state.state.model.init_db()
+            await app_state.state.model.acl.add_acl_entry(
+                "/",
+                0,
+                model.ACTION_ALLOW,
+                "view",
+                model.PRINCIPAL_SYSTEM,
+                system_principal=model.SYSTEM_AUTHENTICATED,
+            )
+            await sockets.notify_container_status("ws-123", True)
+        finally:
+            sockets.connections.pop(sock, None)
+        sock.send_json.assert_not_called()
+
+    async def test_same_users_two_connections_both_receive(self, app_state):
+        """All connections of an allowed user receive the frame."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock_a = _mock_sock()
+        sock_b = _mock_sock()
+        try:
+            self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
+            self._register(sock_b, {"id": "uid-1", "email": "a@x"}, app_state)
+            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await sockets.notify_container_status("ws-123", True)
+        finally:
+            sockets.connections.pop(sock_a, None)
+            sockets.connections.pop(sock_b, None)
+        sock_a.send_json.assert_called_once()
+        sock_b.send_json.assert_called_once()
+
+    async def test_includes_service_started_at(self, app_state):
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            await _grant_terminal(app_state, "uid-1", "ws-789")
+            await sockets.notify_container_status("ws-789", True, 1000.0)
         finally:
             sockets.connections.pop(sock, None)
         msg = sock.send_json.call_args[0][0]
         assert msg["service_started_at"] == 1000.0
         assert msg["running"] is True
 
-    def test_sends_stopped(self, app_state):
+    async def test_sends_stopped(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            sockets.notify_container_status("ws-456", False)
+            await _grant_terminal(app_state, "uid-1", "ws-456")
+            await sockets.notify_container_status("ws-456", False)
         finally:
             sockets.connections.pop(sock, None)
         msg = sock.send_json.call_args[0][0]
         assert msg["running"] is False
         assert msg["workspace_id"] == "ws-456"
 
-    def test_skips_unauthenticated(self, app_state):
+    async def test_skips_unauthenticated(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock = _mock_sock()
         try:
             self._register(sock, {"id": None, "email": ""}, app_state)
-            sockets.notify_container_status("ws-1", True)
+            await sockets.notify_container_status("ws-1", True)
         finally:
             sockets.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
-    def test_dead_socket_is_pruned(self, app_state):
+    async def test_dead_member_socket_is_pruned(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         from klangk.wshandler import WS_ERRORS
@@ -4805,21 +4899,22 @@ class TestNotifyContainerStatus:
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            sockets.notify_container_status("ws-1", True)
+            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await sockets.notify_container_status("ws-1", True)
             assert sock not in sockets.connections
         finally:
             sockets.connections.pop(sock, None)
 
 
 class TestNotifyServiceHealth:
-    """notify_service_health fans health events out to all connections."""
+    """notify_service_health fans health events out to workspace members."""
 
     def _register(self, sock, user, app_state):
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         app_state.state.sockets.connections[sock] = conn
         return conn
 
-    def test_sends_healthy_to_all_authenticated(self, app_state):
+    async def test_sends_healthy_to_members(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock_a = _mock_sock()
@@ -4827,7 +4922,9 @@ class TestNotifyServiceHealth:
         try:
             self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
             self._register(sock_b, {"id": "uid-2", "email": "b@x"}, app_state)
-            sockets.notify_service_health("ws-123", healthy=True)
+            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await _grant_terminal(app_state, "uid-2", "ws-123")
+            await sockets.notify_service_health("ws-123", healthy=True)
         finally:
             sockets.connections.pop(sock_a, None)
             sockets.connections.pop(sock_b, None)
@@ -4843,7 +4940,28 @@ class TestNotifyServiceHealth:
         sock_a.send_json.assert_called_once_with(expected)
         sock_b.send_json.assert_called_once_with(expected)
 
-    def test_sends_unhealthy_with_reason(self, app_state):
+    async def test_non_member_receives_nothing(self, app_state):
+        """#1714: another tenant never sees health frames."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        member = _mock_sock()
+        stranger = _mock_sock()
+        try:
+            self._register(member, {"id": "uid-1", "email": "a@x"}, app_state)
+            self._register(
+                stranger, {"id": "uid-2", "email": "b@x"}, app_state
+            )
+            await _grant_terminal(app_state, "uid-1", "ws-123")
+            await sockets.notify_service_health(
+                "ws-123", healthy=False, message="boom"
+            )
+        finally:
+            sockets.connections.pop(member, None)
+            sockets.connections.pop(stranger, None)
+        member.send_json.assert_called_once()
+        stranger.send_json.assert_not_called()
+
+    async def test_sends_unhealthy_with_reason(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         # The failure reason rides along on the broadcast so operators
@@ -4851,7 +4969,8 @@ class TestNotifyServiceHealth:
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            sockets.notify_service_health(
+            await _grant_terminal(app_state, "uid-1", "ws-9")
+            await sockets.notify_service_health(
                 "ws-9", healthy=False, message="curl: connection refused"
             )
         finally:
@@ -4861,18 +4980,18 @@ class TestNotifyServiceHealth:
         assert msg["type"] == "service_health"
         assert msg["health_message"] == "curl: connection refused"
 
-    def test_skips_unauthenticated(self, app_state):
+    async def test_skips_unauthenticated(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock = _mock_sock()
         try:
             self._register(sock, {"id": None, "email": ""}, app_state)
-            sockets.notify_service_health("ws-1", healthy=True)
+            await sockets.notify_service_health("ws-1", healthy=True)
         finally:
             sockets.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
-    def test_dead_socket_is_pruned(self, app_state):
+    async def test_dead_member_socket_is_pruned(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         from klangk.wshandler import WS_ERRORS
@@ -4881,7 +5000,8 @@ class TestNotifyServiceHealth:
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            sockets.notify_service_health("ws-1", healthy=True)
+            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await sockets.notify_service_health("ws-1", healthy=True)
             assert sock not in sockets.connections
         finally:
             sockets.connections.pop(sock, None)
@@ -4900,8 +5020,16 @@ class TestServiceHealthSnapshot:
         cs.health_message = message
         return cs
 
-    def test_replays_only_checked_workspaces(self, app_state):
-        """Healthy + unhealthy are sent; unchecked and no-check skipped."""
+    def _register(self, sock, app_state, user_id="uid-1"):
+        conn = _base_conn(
+            user={"id": user_id, "email": "a@x"}, ws=sock, app_state=app_state
+        )
+        app_state.state.sockets.connections[sock] = conn
+        return conn
+
+    async def test_replays_only_checked_member_workspaces(self, app_state):
+        """Healthy + unhealthy are sent; unchecked, no-check, and
+        non-member workspaces are skipped (#1714)."""
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         registry = app_state.state.container_registry
@@ -4936,10 +5064,21 @@ class TestServiceHealthSnapshot:
                 health_check=None,
                 health_status=None,
             )
-            sockets.send_service_health_snapshot(sock)
+            # another tenant's workspace: checked, but not granted
+            registry.states["ws-foreign"] = self._state(
+                "ws-foreign",
+                registry=registry,
+                health_check="true",
+                health_status="healthy",
+            )
+            self._register(sock, app_state)
+            await _grant_terminal(app_state, "uid-1", "ws-healthy")
+            await _grant_terminal(app_state, "uid-1", "ws-sick")
+            await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
             registry.states.update(saved)
+            sockets.connections.pop(sock, None)
 
         frames = [c[0][0] for c in sock.send_json.call_args_list]
         assert len(frames) == 2
@@ -4950,10 +5089,32 @@ class TestServiceHealthSnapshot:
         assert by_ws["ws-sick"]["health_message"] == "conn refused"
         assert "ws-unchecked" not in by_ws
         assert "ws-nocheck" not in by_ws
+        assert "ws-foreign" not in by_ws
         for f in frames:
             assert f["type"] == "service_health"
 
-    def test_targets_only_the_given_socket(self, app_state):
+    async def test_unregistered_socket_gets_nothing(self, app_state):
+        """A socket with no registered connection has no user to scope by."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        saved = dict(registry.states)
+        sock = _mock_sock()
+        try:
+            registry.states.clear()
+            registry.states["ws-1"] = self._state(
+                "ws-1",
+                registry=registry,
+                health_check="true",
+                health_status="healthy",
+            )
+            await sockets.send_service_health_snapshot(sock)
+        finally:
+            registry.states.clear()
+            registry.states.update(saved)
+        sock.send_json.assert_not_called()
+
+    async def test_targets_only_the_given_socket(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         registry = app_state.state.container_registry
@@ -4968,14 +5129,17 @@ class TestServiceHealthSnapshot:
                 health_check="true",
                 health_status="healthy",
             )
-            sockets.send_service_health_snapshot(sock)
+            self._register(sock, app_state)
+            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
             registry.states.update(saved)
+            sockets.connections.pop(sock, None)
         sock.send_json.assert_called_once()
         other.send_json.assert_not_called()
 
-    def test_dead_socket_breaks_cleanly(self, app_state):
+    async def test_dead_socket_breaks_cleanly(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         registry = app_state.state.container_registry
@@ -4998,13 +5162,17 @@ class TestServiceHealthSnapshot:
                 health_check="true",
                 health_status="unhealthy",
             )
+            self._register(sock, app_state)
+            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await _grant_terminal(app_state, "uid-1", "ws-2")
             # Must not raise; the dead socket ends the snapshot early.
-            sockets.send_service_health_snapshot(sock)
+            await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
             registry.states.update(saved)
+            sockets.connections.pop(sock, None)
 
-    def test_empty_registry_sends_nothing(self, app_state):
+    async def test_empty_registry_sends_nothing(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         registry = app_state.state.container_registry
@@ -5012,10 +5180,12 @@ class TestServiceHealthSnapshot:
         sock = _mock_sock()
         try:
             registry.states.clear()
-            sockets.send_service_health_snapshot(sock)
+            self._register(sock, app_state)
+            await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
             registry.states.update(saved)
+            sockets.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
 
@@ -5074,7 +5244,7 @@ class TestNotifyServiceHealthForwarding:
         app_state.state.sockets.connections[sock] = conn
         return conn
 
-    def test_forwards_death_frame_fields(self, app_state):
+    async def test_forwards_death_frame_fields(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         # A container-death call passes running=False + a seq; the frame
@@ -5082,7 +5252,8 @@ class TestNotifyServiceHealthForwarding:
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
-            sockets.notify_service_health(
+            await _grant_terminal(app_state, "uid-1", "ws-9")
+            await sockets.notify_service_health(
                 "ws-9",
                 healthy=False,
                 running=False,
@@ -5110,7 +5281,7 @@ class TestServiceHealthSnapshotFields:
         cs.health_seq = seq
         return cs
 
-    def test_snapshot_frame_carries_live_fields(self, app_state):
+    async def test_snapshot_frame_carries_live_fields(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         registry = app_state.state.container_registry
@@ -5121,10 +5292,18 @@ class TestServiceHealthSnapshotFields:
             registry.states["ws-1"] = self._state(
                 "ws-1", registry=registry, checked_at=1_700_000_000.0, seq=5
             )
-            sockets.send_service_health_snapshot(sock)
+            conn = _base_conn(
+                user={"id": "uid-1", "email": "a@x"},
+                ws=sock,
+                app_state=app_state,
+            )
+            sockets.connections[sock] = conn
+            await _grant_terminal(app_state, "uid-1", "ws-1")
+            await sockets.send_service_health_snapshot(sock)
         finally:
             registry.states.clear()
             registry.states.update(saved)
+            sockets.connections.pop(sock, None)
         frame = sock.send_json.call_args[0][0]
         # A snapshot is a live-container replay: running=True.
         assert frame["running"] is True


### PR DESCRIPTION
## Summary

Fixes #1714. Closes #2783.

Four fan-outs in `WebSocketState` iterated **every** authenticated WebSocket
connection with no workspace-membership filter, so any connected client
learned, for every workspace in the deployment: its UUID, running/stopped
state, health, and — when unhealthy — the bounded `health_message` tail of
another tenant's service output. The code explicitly offloaded filtering to
the client, which is a server-side cross-tenant leak regardless of what the
legitimate frontend does.

Folded in per #2783: the gate for receiving status is the new dedicated
**`monitor`** permission rather than the coarse `terminal` — health
observation is read-only and distinct from exec/attach.

## Changes

- **`WebSocketState._send_to_workspace_members`** — new scoped fan-out
  helper: connections are grouped by user, the workspace's ACE map is
  fetched once, and each distinct user is evaluated in memory
  (`check_permission_inmemory`) for `monitor` on `/workspaces/{id}`.
  `monitor` is granted by every path that grants `terminal` (owner
  wildcard, direct member share, all four role groups) and can be granted
  alone for monitoring-only members; the deployment-wide
  `view`-for-authenticated seed ACE at `/` stays too weak to count.
- `notify_container_status`, `notify_service_health`, and
  `notify_workspace_evicted` (same leak class) now route through it.
- `send_service_health_snapshot` (connect-time replay) resolves the
  allowed workspace set with a single `permissions_for_resources` pass
  and re-checks each candidate (state still live, seq unchanged) before
  sending, so a death or transition landing during the ACL pass is never
  overwritten by a stale replay frame.
- `GET /workspaces/{id}/status` now checks `monitor` (#2783) instead of
  `terminal`.
- **Migration 0015** backfills existing deployments: every principal
  holding an Allow `terminal` ACE on a workspace resource gets an
  appended Allow `monitor` ACE (wildcard owners need nothing), so the
  upgrade changes nothing for existing members. New-workspace seeding
  (`_ROLE_GROUP_PERMISSIONS`), the member-share flow, `ALL_PERMISSIONS`,
  and the Flutter ACL editor all carry `monitor` too.
- The fan-outs are async (ACL checks hit the DB). The container
  registry's status-change callback stays sync: the lifespan registers a
  wrapper (`broadcast_container_status`) that schedules the scoped
  broadcast on the running loop (strong-referenced, per the repo's #2527
  task discipline), so the registry, `track_activity`, and their tests
  are unchanged. The connect-time snapshot sits inside the handler's
  `try` so a DB failure there still runs socket cleanup.
- `send_health_heartbeats` (opt-in, no workspace data) and
  `notify_user_workspaces_changed` (already user-scoped) are untouched.

## Behavior

- The workspace list page and `klangk monitor` keep working — they see
  exactly the workspaces the logged-in user can monitor (owned + shared),
  which is the set they already filter down to client-side.
- A raw WS client no longer learns other tenants' workspace ids, status,
  or health output.
- A monitoring-only member (`monitor` without `terminal`) can now observe
  health (`GET .../status` + live frames) without being able to open a
  terminal (#2783). A view-only grantee still sees status in the
  workspace list (HTTP annotation) but receives no live deltas; an admin
  watching other tenants' workspaces via `klangk monitor` now sees only
  their own — intended, and part of the fix.

## Tests

- Negative tests at every fan-out: a connected non-member receives
  nothing; the `/`-level view-for-authenticated seed does not count as
  membership; `terminal` without `monitor` no longer grants reception.
- Positive decoupling tests: `monitor` without `terminal` receives frames
  and can read the status endpoint.
- Migration 0015: backfill covers role groups and direct user shares,
  skips deny rows and wildcard owners, idempotent.
- Cleanup runs when the connect-time snapshot raises; snapshot/death and
  snapshot/transition races are covered.
- Full backend suite green with the 100% coverage gate (`-n auto`, CI
  invocation); flutter suite green at 100%.
