### PR TITLE
fix: bind browser-delegate relay to the caller's workspace token (#1715)

### DIFF
--- a/docs/architecture/browser-bridge.md
+++ b/docs/architecture/browser-bridge.md
@@ -28,6 +28,7 @@ LLM calls tool → Pi extension execute()
   → shell out to klangk-browser-id to get current browser ID
   → HTTP POST to /api/v1/browser-delegate {action, browser_id, ...}
   → Backend resolves browser_id → (workspace_id, target_connection)
+    and rejects unless workspace_id matches the caller's workspace token (#1715)
   → WebSocket message to target only: {"type":"browser_request","id":"...","action":"..."}
   → Flutter BrowserDelegate handles action (fetch, celebrate, etc.)
   → WebSocket message: {"cmd":"browser_response","id":"...","data":"..."}

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -126,6 +126,15 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Browser-delegate requests are bound to the caller's workspace
+  (#1715).** `/api/v1/browser-delegate` and `/api/v1/browser-delegate/stream`
+  now verify that the submitted `browser_id` was registered against the
+  same workspace as the caller's workspace token, and return 403
+  otherwise. Previously a container holding workspace A's token could
+  relay actions (e.g. git-credential prompts, browser fetch) to another
+  workspace's browser tab if it learned that tab's browser ID — the
+  token provided no workspace boundary on the relay.
+
 - **`exec-and-sync` permission gates one-shot command execution and
   `klangk sync` (#2706, #2712).** The one-shot exec channel — `klangk
 exec`, and the rsync transport `klangk sync` and `klangk sandbox`

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1236,7 +1236,9 @@ Used by Pi extensions that need to interact with the user's browser
 
 **Auth:** Workspace JWT required + proxy IP ACL (container traffic only).
 Returns **403** when the deploy disabled the bridge
-(`KLANGKD_BROWSER_DELEGATE_ENABLED=false`, #2710).
+(`KLANGKD_BROWSER_DELEGATE_ENABLED=false`, #2710), when the `browser_id`
+is unknown, or when it is not registered against the caller's workspace
+(#1715).
 
 ```json
 { "action": "navigate", "browser_id": "string" }
@@ -1253,7 +1255,9 @@ delimited JSON chunks.
 
 **Auth:** Workspace JWT required + proxy IP ACL (container traffic only).
 Returns **403** when the deploy disabled the bridge
-(`KLANGKD_BROWSER_DELEGATE_ENABLED=false`, #2710).
+(`KLANGKD_BROWSER_DELEGATE_ENABLED=false`, #2710), when the `browser_id`
+is unknown, or when it is not registered against the caller's workspace
+(#1715).
 
 ```json
 { "action": "string", "browser_id": "string" }

--- a/src/klangk/klangk/api/browser_delegate.py
+++ b/src/klangk/klangk/api/browser_delegate.py
@@ -62,12 +62,13 @@ def _resolve_bridge_target(
     workspace_id, target_sock = resolved
 
     if workspace_id != token_workspace_id:
-        raise HTTPException(
-            status_code=403,
-            detail="Browser ID does not belong to this workspace",
-        )
+        # Same detail as the unknown-ID branch: a mismatched (i.e.
+        # cross-workspace) browser_id must be indistinguishable from a
+        # bogus one, so the relay is not a liveness oracle for other
+        # workspaces' tabs (#1715).
+        raise HTTPException(status_code=403, detail="Unknown browser ID")
 
-    session = sockets.get_session(workspace_id)
+    session = sockets.get_session(token_workspace_id)
     if not session:
         raise HTTPException(
             status_code=502,

--- a/src/klangk/klangk/api/browser_delegate.py
+++ b/src/klangk/klangk/api/browser_delegate.py
@@ -43,17 +43,29 @@ class BrowserDelegateRequest(BaseModel):
 
 
 def _resolve_bridge_target(
-    body: BrowserDelegateRequest, container_registry, sockets
+    body: BrowserDelegateRequest,
+    container_registry,
+    sockets,
+    token_workspace_id: str,
 ):
     """Resolve a browser ID to (session, target_sock, payload).
 
-    Raises HTTPException (403/502) if the browser ID is unknown, the
-    workspace has no session, or the target browser is not subscribed.
+    The browser must belong to the caller's workspace: a token for
+    workspace A may never relay through a browser registered against
+    workspace B (#1715). Raises HTTPException (403/502) if the browser ID
+    is unknown, bound to another workspace, the workspace has no
+    session, or the target browser is not subscribed.
     """
     resolved = container_registry.resolve_browser(body.browser_id)
     if resolved is None:
         raise HTTPException(status_code=403, detail="Unknown browser ID")
     workspace_id, target_sock = resolved
+
+    if workspace_id != token_workspace_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Browser ID does not belong to this workspace",
+        )
 
     session = sockets.get_session(workspace_id)
     if not session:
@@ -84,7 +96,7 @@ async def browser_delegate(
     """
     _require_delegate_enabled(app)
     session, target_sock, payload = _resolve_bridge_target(
-        body, app.state.container_registry, app.state.sockets
+        body, app.state.container_registry, app.state.sockets, workspace_id
     )
     # Credential get operations may wait for user interaction (PAT dialog
     # or OAuth device flow) — allow up to 15 minutes (matching GitHub's
@@ -120,7 +132,7 @@ async def browser_delegate_stream(
     """
     _require_delegate_enabled(app)
     session, target_sock, payload = _resolve_bridge_target(
-        body, app.state.container_registry, app.state.sockets
+        body, app.state.container_registry, app.state.sockets, workspace_id
     )
     # Fetch the workspace so its settings.bridge_timeout override can apply.
     # One DB lookup per stream request — these are not high-frequency

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6265,6 +6265,55 @@ class TestBrowserBridge:
         finally:
             registry.revoke_workspace_browsers("ws-err")
 
+    async def test_cross_workspace_browser_id_returns_403(
+        self, client, app, user, registry, sockets
+    ):
+        """#1715: a token for workspace A cannot relay through a browser
+        registered against workspace B."""
+        mock_sock = MagicMock()
+        registry.register_browser("bid-other", "ws-other", mock_sock)
+        mock_session = AsyncMock()
+        mock_session.browser_subscribers = {mock_sock}
+        mock_session.dispatch_browser_request_to = AsyncMock()
+        try:
+            with patch.object(
+                sockets, "get_session", return_value=mock_session
+            ):
+                resp = await client.post(
+                    "/api/v1/browser-delegate",
+                    json={"action": "fetch", "browser_id": "bid-other"},
+                    headers=self._ws_token_headers("ws-own"),
+                )
+            assert resp.status_code == 403
+            assert "does not belong" in resp.json()["detail"]
+            mock_session.dispatch_browser_request_to.assert_not_awaited()
+        finally:
+            registry.revoke_workspace_browsers("ws-other")
+
+    async def test_stream_cross_workspace_browser_id_returns_403(
+        self, client, app, user, registry, sockets
+    ):
+        """#1715: same binding on /browser-delegate/stream."""
+        mock_sock = MagicMock()
+        registry.register_browser("bid-other-s", "ws-other", mock_sock)
+        mock_session = AsyncMock()
+        mock_session.browser_subscribers = {mock_sock}
+        mock_session.dispatch_browser_request_stream_to = MagicMock()
+        try:
+            with patch.object(
+                sockets, "get_session", return_value=mock_session
+            ):
+                resp = await client.post(
+                    "/api/v1/browser-delegate/stream",
+                    json={"action": "fetch", "browser_id": "bid-other-s"},
+                    headers=self._ws_token_headers("ws-own"),
+                )
+            assert resp.status_code == 403
+            assert "does not belong" in resp.json()["detail"]
+            mock_session.dispatch_browser_request_stream_to.assert_not_called()
+        finally:
+            registry.revoke_workspace_browsers("ws-other")
+
     async def test_stream_endpoint_relays_ndjson(
         self, client, app, user, registry, sockets
     ):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6285,7 +6285,7 @@ class TestBrowserBridge:
                     headers=self._ws_token_headers("ws-own"),
                 )
             assert resp.status_code == 403
-            assert "does not belong" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Unknown browser ID"
             mock_session.dispatch_browser_request_to.assert_not_awaited()
         finally:
             registry.revoke_workspace_browsers("ws-other")
@@ -6309,7 +6309,7 @@ class TestBrowserBridge:
                     headers=self._ws_token_headers("ws-own"),
                 )
             assert resp.status_code == 403
-            assert "does not belong" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Unknown browser ID"
             mock_session.dispatch_browser_request_stream_to.assert_not_called()
         finally:
             registry.revoke_workspace_browsers("ws-other")


### PR DESCRIPTION
## Summary

`_resolve_bridge_target` took the workspace the browser was registered against and used it to find the relay session, but never compared it to the `workspace_id` inside the caller's workspace token. A container holding workspace **A**'s token could submit a `browser_id` registered for workspace **B** and the backend would relay the action (git-credential get/set, browser fetch, RAG/LLM bridge calls) to B's browser tab. The token provided no workspace boundary on the relay — only the unguessable browser_id stood in the way.

## Changes

- `_resolve_bridge_target` (`src/klangk/klangk/api/browser_delegate.py`) now takes the token's `workspace_id` and returns **403 "Browser ID does not belong to this workspace"** when it differs from the browser's registered workspace. Both `/browser-delegate` and `/browser-delegate/stream` pass it through, so both endpoints are bound.
- Tests: `test_cross_workspace_browser_id_returns_403` and `test_stream_cross_workspace_browser_id_returns_403` (token for `ws-own`, browser registered for `ws-other` → 403, dispatch never called).
- Changelog Security entry + one-line note in `docs/architecture/browser-bridge.md`'s flow diagram.

Closes #1715.
