### PR TITLE
feat(egress): always log allowed egress, not just denied (#2304)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -254,15 +254,17 @@ sync` report a clear permission-denied error.
 ### Added
 
 - **Unconditional full-egress audit logging (#2304).** Every egress
-  decision is now recorded to `egress_consent` — allowed as well as denied
-  — with the decision and decider (policy = `decided_by` NULL, human = user
-  id); there is no opt-in setting. The sidecar's DNS proxy reports each
-  outcome it decides (allow-listed resolutions as `allowed`, reject-listed
-  NXDOMAINs as `denied`), a paused-mode auto-allow is recorded, and rows are
-  deduplicated per (workspace, host, port) and bounded by the existing
+  decision that reaches klangkd — DNS-layer outcomes and SYN-gate verdicts,
+  allowed as well as denied — is now recorded to `egress_consent` with the
+  decision and decider (policy = `decided_by` NULL, human = user id); there
+  is no opt-in setting. The sidecar's DNS proxy reports each outcome it
+  decides (allow-listed resolutions as `allowed`, reject-listed NXDOMAINs
+  as `denied`), a paused-mode auto-allow is recorded, and rows are deduped
+  per (workspace, host, port) and bounded by the existing
   `KLANGKD_EGRESS_CONSENT_RETENTION_DAYS` / `KLANGKD_EGRESS_CONSENT_ROW_CAP`
-  sweep. Per-connection TCP/UDP flow audit (dst endpoints + resolved IPs) is
-  the follow-up scope.
+  sweep. Per-connection flow audit (session-host/cached-verdict auto-allows,
+  WS-outage fail-close denies, dst endpoints + resolved IPs) is the
+  follow-up scope.
 
 - **`KLANGKD_CLASSIFICATION_BANNER` (#2768).** Deploy-wide default
   classification marking (free text) for the always-visible marking banner

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -253,6 +253,17 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Unconditional full-egress audit logging (#2304).** Every egress
+  decision is now recorded to `egress_consent` — allowed as well as denied
+  — with the decision and decider (policy = `decided_by` NULL, human = user
+  id); there is no opt-in setting. The sidecar's DNS proxy reports each
+  outcome it decides (allow-listed resolutions as `allowed`, reject-listed
+  NXDOMAINs as `denied`), a paused-mode auto-allow is recorded, and rows are
+  deduplicated per (workspace, host, port) and bounded by the existing
+  `KLANGKD_EGRESS_CONSENT_RETENTION_DAYS` / `KLANGKD_EGRESS_CONSENT_ROW_CAP`
+  sweep. Per-connection TCP/UDP flow audit (dst endpoints + resolved IPs) is
+  the follow-up scope.
+
 - **`KLANGKD_CLASSIFICATION_BANNER` (#2768).** Deploy-wide default
   classification marking (free text) for the always-visible marking banner
   the Application Security and Development STIG requires ("markings at the

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -85,9 +85,9 @@ workspace lacks `CAP_NET_ADMIN` so it cannot flush the ruleset.
 
 ## Consent recording (all modes)
 
-Every egress decision — **denied _and_ allowed** — is recorded to the
-`egress_consent` table, regardless of `egress_mode` (#2242, #2304 —
-full-egress auditing is unconditional, not an opt-in setting):
+Every egress decision that reaches klangkd — **denied _and_ allowed** —
+is recorded to the `egress_consent` table, regardless of `egress_mode`
+(#2242, #2304 — auditing needs no opt-in setting):
 
 - **static** -> recorded `denied` immediately, `decided_by` NULL (policy,
   no human). Static mode is strictly better than silent deny: every
@@ -105,12 +105,21 @@ which sees every FQDN egress attempt, allowed or not — reports each
 outcome it decides over its consent WebSocket, recorded as one
 `decided_by`-NULL policy row per host: `allowed` for every allow-listed
 (or in-session-consented) resolution that resolves + learns, `denied`
-for every reject-listed name NXDOMAIN'd. A paused-mode auto-allow is
-recorded the same way. Interactive off-list queries report nothing at
-the DNS layer — their decision point is the connection SYN, whose human
-or policy verdict is already recorded above. Frames are deduplicated
-per host per WebSocket session on the sidecar, and the rows are bounded
-by the same retention/cap sweep as everything else.
+for every reject-listed name NXDOMAIN'd. A paused-mode auto-allow with
+no prior verdict is recorded the same way (a replayed in-effect verdict
+is not — its human row already exists). Interactive off-list queries
+report nothing at the DNS layer — their decision point is the connection
+SYN, whose human or policy verdict is already recorded above.
+
+The audit frames are best-effort and session-bounded: one frame per
+host per WebSocket session on the sidecar, capped at 4096 hosts (past
+the cap the sidecar logs once and stops reporting new hosts until the
+WS reconnects), and a lost frame re-reports on that host's next
+resolution. Per-connection decisions that never reach klangkd —
+session-host and cached-verdict auto-allows at NFQUEUE, and WS-outage
+fail-close denies — are not recorded (per-connection flow audit is the
+follow-up scope). The rows are bounded by the same retention/cap sweep
+as everything else.
 
 The table is bounded (#2303): a retention window
 (`KLANGKD_EGRESS_CONSENT_RETENTION_DAYS`, default 30 days) deletes

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -85,8 +85,9 @@ workspace lacks `CAP_NET_ADMIN` so it cannot flush the ruleset.
 
 ## Consent recording (all modes)
 
-Every blocked or off-list destination is recorded to the `egress_consent`
-table, regardless of `egress_mode` (#2242):
+Every egress decision — **denied _and_ allowed** — is recorded to the
+`egress_consent` table, regardless of `egress_mode` (#2242, #2304 —
+full-egress auditing is unconditional, not an opt-in setting):
 
 - **static** -> recorded `denied` immediately, `decided_by` NULL (policy,
   no human). Static mode is strictly better than silent deny: every
@@ -98,6 +99,18 @@ table, regardless of `egress_mode` (#2242):
   when no decider answers within `egress_consent_timeout`.
 - **allow** -> off-list destinations recorded `allowed`, `decided_by`
   NULL (#2406) — a log of everything the workspace actually reached.
+
+The DNS layer itself is audited too (#2304): the sidecar's DNS proxy —
+which sees every FQDN egress attempt, allowed or not — reports each
+outcome it decides over its consent WebSocket, recorded as one
+`decided_by`-NULL policy row per host: `allowed` for every allow-listed
+(or in-session-consented) resolution that resolves + learns, `denied`
+for every reject-listed name NXDOMAIN'd. A paused-mode auto-allow is
+recorded the same way. Interactive off-list queries report nothing at
+the DNS layer — their decision point is the connection SYN, whose human
+or policy verdict is already recorded above. Frames are deduplicated
+per host per WebSocket session on the sidecar, and the rows are bounded
+by the same retention/cap sweep as everything else.
 
 The table is bounded (#2303): a retention window
 (`KLANGKD_EGRESS_CONSENT_RETENTION_DAYS`, default 30 days) deletes

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -153,11 +153,25 @@ class ConsentCoordinator:
                 # #2332: prompting is paused workspace-wide. A destination
                 # with an in-effect recorded DENY is still blocked (the pause
                 # does not override existing verdicts); everything else is
-                # auto-allowed (no hold, no prompt, no row -- the sidecar
+                # auto-allowed (no hold, no prompt -- the sidecar
                 # learns/accepts the SYN like a static allow). Allow-list
                 # rules are enforced earlier at the sidecar DNS layer, so a
                 # host reaching this gate is already not allow-listed.
                 verdict = await self._paused_verdict(workspace_id, dst, dport)
+                if verdict["decision"] == VERDICT_ALLOW:
+                    # #2304: an auto-allow is still an observed egress
+                    # outcome -- record it (policy, decided_by NULL) so
+                    # auditing is unconditional. A paused-deny is a replay
+                    # of a verdict whose row already exists; no new row.
+                    try:
+                        model = self.app.state.model.egress_consent
+                        await model.record_static_allow(
+                            workspace_id, dst, dport
+                        )
+                    except Exception:
+                        logger.exception(
+                            "consent: paused-allow recording failed"
+                        )
                 fut = loop.create_future()
                 fut.set_result(verdict)
                 return fut
@@ -796,3 +810,31 @@ class ConsentCoordinator:
         """egress_mode == allow: default-permit (record + allow, no prompt) (#2406)."""
         ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
         return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_ALLOW
+
+    async def record_dns_event(
+        self, workspace_id: str, decision: str, host: str
+    ) -> None:
+        """Record a DNS-layer egress outcome from the sidecar (#2304).
+
+        The sidecar's DNS proxy reports every outcome it itself decides --
+        ``allowed`` (allow-list / in-session-allowed name forwarded + learned)
+        or ``denied`` (reject-listed name NXDOMAIN'd) -- unconditionally, so
+        full egress auditing needs no opt-in setting. Routed to the existing
+        static policy rows (``decided_by`` NULL, port NULL): one row per
+        (workspace, host) via the dedup indexes, pruned by the retention
+        sweeper like any other terminal row. Best-effort -- a recording
+        failure is logged and swallowed (an audit gap must never break the
+        relay loop or the sidecar's egress path).
+        """
+        try:
+            consent = self.app.state.model.egress_consent
+            if decision == DECISION_ALLOWED:
+                await consent.record_static_allow(workspace_id, host, None)
+            elif decision == DECISION_DENIED:
+                await consent.record_static_denial(workspace_id, host, None)
+        except Exception:
+            logger.exception(
+                "consent: dns egress recording failed (%s %s)",
+                decision,
+                str(host)[:60],
+            )

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -157,12 +157,16 @@ class ConsentCoordinator:
                 # learns/accepts the SYN like a static allow). Allow-list
                 # rules are enforced earlier at the sidecar DNS layer, so a
                 # host reaching this gate is already not allow-listed.
-                verdict = await self._paused_verdict(workspace_id, dst, dport)
-                if verdict["decision"] == VERDICT_ALLOW:
-                    # #2304: an auto-allow is still an observed egress
+                verdict, replayed = await self._paused_verdict(
+                    workspace_id, dst, dport
+                )
+                if verdict["decision"] == VERDICT_ALLOW and not replayed:
+                    # #2304: a pause auto-allow is still an observed egress
                     # outcome -- record it (policy, decided_by NULL) so
-                    # auditing is unconditional. A paused-deny is a replay
-                    # of a verdict whose row already exists; no new row.
+                    # auditing needs no opt-in. A replayed verdict (an
+                    # in-effect allow/deny already decided by a human) is NOT
+                    # re-recorded: its row exists, and a policy row on top
+                    # would duplicate the human decision.
                     try:
                         model = self.app.state.model.egress_consent
                         await model.record_static_allow(
@@ -257,8 +261,9 @@ class ConsentCoordinator:
 
     async def _paused_verdict(
         self, workspace_id: str, dst: str, dport: int | None
-    ) -> dict:
-        """Verdict for a held SYN while prompting is paused (#2332).
+    ) -> tuple[dict, bool]:
+        """Verdict for a held SYN while prompting is paused (#2332), plus
+        whether it replayed an in-effect recorded verdict.
 
         A destination with an in-effect recorded DENY is still blocked (the
         pause respects existing verdicts); everything else is auto-allowed
@@ -266,21 +271,30 @@ class ConsentCoordinator:
         carries the connection) without learning the IP, so each NEW
         connection re-gates: once the pause elapses, new connections to the
         same host prompt again (none linger auto-allowed past the window).
+        The second return value is True when the verdict replays a recorded
+        row (deny or allow) -- the caller skips the #2304 policy-allow
+        recording in that case, since the human row already exists.
         """
         row = await self.app.state.model.egress_consent.active_verdict_for(
             workspace_id, dst, dport
         )
         if row is not None and row["decision"] == DECISION_DENIED:
-            return {
-                "decision": VERDICT_DENY,
-                "reason": "paused_deny",
+            return (
+                {
+                    "decision": VERDICT_DENY,
+                    "reason": "paused_deny",
+                    "duration": DURATION_ONCE,
+                },
+                True,
+            )
+        return (
+            {
+                "decision": VERDICT_ALLOW,
+                "reason": "paused",
                 "duration": DURATION_ONCE,
-            }
-        return {
-            "decision": VERDICT_ALLOW,
-            "reason": "paused",
-            "duration": DURATION_ONCE,
-        }
+            },
+            row is not None,
+        )
 
     def _register_hold(self, request: dict) -> asyncio.Future:
         """Register a held request + arm its timeout + fan out (interactive path)."""

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -33,6 +33,7 @@ import logging
 from fastapi import WebSocket, WebSocketDisconnect
 
 from .. import auth
+from ..model.egress_consent import DECISION_ALLOWED, DECISION_DENIED
 from .safe_websocket import WS_ERRORS, SlowClientError, SafeWebSocket
 
 logger = logging.getLogger(__name__)
@@ -110,7 +111,7 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
                 decision = msg.get("decision")
                 host = msg.get("host")
                 if (
-                    decision in ("allowed", "denied")
+                    decision in (DECISION_ALLOWED, DECISION_DENIED)
                     and isinstance(host, str)
                     and host
                 ):

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -4,9 +4,13 @@ The network sidecar connects here -- one socket per workspace, at startup --
 and sends each blocked egress destination as ``{type:egress, id, dst, dport}``.
 For each, the coordinator gate-checks: interactive + a live decider -> the
 request is *held* (the sidecar keeps the connection in-flight) and this
-endpoint relays the eventual verdict back as ``{type:verdict, id, decision}``;
+endpoint relays the eventual verdict back as ``{type:verdict, id, decision}`;
 otherwise the coordinator records a static denial and returns deny at once,
-and the sidecar NXDOMAIN/DROPs immediately (no hold).
+and the sidecar NXDOMAIN/DROPs immediately (no hold). It also accepts
+``{type:egress_dns, decision, host}`` frames -- the DNS proxy's unconditional
+outcome audit (#2304; every allow-listed resolution ``allowed``, every
+reject-listed NXDOMAIN ``denied``) -- recorded as policy rows without a
+verdict round-trip.
 
 Auth is the workspace's own JWT (the sidecar shares it, validated by Caddy's
 ``forward_auth`` and re-decoded here for the workspace id) -- the same
@@ -95,6 +99,28 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
                 state = app.state.container_registry.states.get(workspace_id)
                 if state is not None:
                     state.record_activity()
+                continue
+            if mtype == "egress_dns":
+                # Sidecar reports a DNS-layer egress outcome (#2304): every
+                # allow-listed resolution (allowed) and reject-listed
+                # NXDOMAIN (denied) is recorded unconditionally -- full
+                # egress auditing with no opt-in setting. One task per frame
+                # (like the egress relays) so the DB write never blocks the
+                # receive loop; best-effort inside the coordinator.
+                decision = msg.get("decision")
+                host = msg.get("host")
+                if (
+                    decision in ("allowed", "denied")
+                    and isinstance(host, str)
+                    and host
+                ):
+                    task = asyncio.create_task(
+                        coordinator.record_dns_event(
+                            workspace_id, decision, host
+                        )
+                    )
+                    relay_tasks.add(task)
+                    task.add_done_callback(relay_tasks.discard)
                 continue
             if mtype != "egress":
                 continue

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -35,6 +35,7 @@ import random
 import re
 import shlex
 import signal
+import sqlite3
 import subprocess
 import sys
 import time
@@ -788,6 +789,9 @@ _DETAIL_PREFIX_NAMES: list[tuple[str, str]] = [
     ("concurrent same-host deduped to one prompt, but both", "ALLOW-REFUSED"),
     ("fan-out phase failed", "UNEXPECTED-ERROR"),
     ("run aborted", "UNEXPECTED-ERROR"),
+    # egress_consent row verification for allow verdicts (#2304).
+    ("db-row mismatch", "DB-ROW-MISMATCH"),
+    ("no decided row", "DB-ROW-MISMATCH"),
 ]
 
 OUTCOME_NAMES: dict[str, str] = {
@@ -832,6 +836,7 @@ OUTCOME_NAMES: dict[str, str] = {
     "CONCURRENT-NOT-DEDUPED": "concurrent connections to the same destination each produced a prompt (the coordinator's per-destination dedup is broken -- each should collapse to one).",
     "ONCE-CROSS-CONN": "a `once` verdict on one connection released a separate concurrent connection to the same host (the verdict leaked across connections -- #2361).",
     "RETRANSMIT-DUPLICATED": "a held connection's SYN retransmits produced more than one consent request (the in-flight dedup is broken -- #2366).",
+    "DB-ROW-MISMATCH": "a resolved human allow did not leave the correct egress_consent row (decision / duration / decided_by / revoked) -- the audit trail contradicts the verdict. #2304",
 }
 
 _EXPECT_CONN_NAMES = {
@@ -932,6 +937,9 @@ class SmokeTest:
         # + stop_server) must run exactly once even though it is reachable
         # from the async finally, atexit, and the SIGTERM handler (#2443).
         self._cleaned_up = False
+        # The smoke decider's user id, looked up lazily for the egress_consent
+        # row verification (#2304) and cached.
+        self._decider_uid: str | None = None
 
     # -- interrupt-safe cleanup -----------------------------------------
     @staticmethod
@@ -1469,7 +1477,91 @@ class SmokeTest:
             "would mismatch (#2417)"
         )
 
+    # -- egress_consent row verification (#2304) -------------------------
+
+    def _db_connect(self) -> sqlite3.Connection | None:
+        """Read-only connection to klangkd's SQLite DB, or None when the DB
+        is not reachable (external ``--server`` runs have no data_dir; the
+        row check then silently skips rather than fail spuriously)."""
+        if not self.server or not self.server.get("data_dir"):
+            return None
+        path = os.path.join(self.server["data_dir"], "klangk.db")
+        if not os.path.exists(path):
+            return None
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=10)
+        con.row_factory = sqlite3.Row
+        return con
+
+    def _decider_user_id(self) -> str | None:
+        """The smoke decider's user id (smoke@example.com), cached."""
+        if self._decider_uid is not None:
+            return self._decider_uid
+        con = self._db_connect()
+        if con is None:
+            return None
+        try:
+            cur = con.execute(
+                "SELECT id FROM users WHERE email = ?", ("smoke@example.com",)
+            )
+            row = cur.fetchone()
+        finally:
+            con.close()
+        if row is not None:
+            self._decider_uid = row["id"]
+        return self._decider_uid
+
+    def _check_allow_row(self, canon: str, duration: str) -> str | None:
+        """Verify the egress_consent row a resolved human allow must leave
+        (#2304), so the fuzz run checks the audit trail, not just enforcement.
+
+        The NEWEST decided row for (workspace, host, 443) must be
+        ``decision='allowed'``, ``duration`` exactly this verdict's token,
+        ``decided_by`` the decider's user id (a human allow, never a policy
+        row), and not revoked. Ordering by ``decided_at`` DESC is safe: a
+        later allow can only create its request after any prior pending row
+        for the destination expired (pending dedup), so no later-dated row
+        for this (host, port) can predate the allow being checked. Returns
+        None when the row is correct (or unverifiable), else a detail string.
+        """
+        con = self._db_connect()
+        if con is None:
+            return None  # no DB visibility -> skip (external --server)
+        try:
+            cur = con.execute(
+                "SELECT decision, duration, decided_by, revoked_at"
+                " FROM egress_consent"
+                " WHERE workspace_id = ? AND dest_host = ? AND dest_port = ?"
+                " AND decided_at IS NOT NULL"
+                " ORDER BY decided_at DESC LIMIT 1",
+                (self.ws_id, canon, 443),
+            )
+            row = cur.fetchone()
+        finally:
+            con.close()
+        if row is None:
+            return f"no decided row for {canon}:443 after an allow verdict"
+        uid = self._decider_user_id()
+        problems: list[str] = []
+        if row["decision"] != "allowed":
+            problems.append(f"decision={row['decision']!r}")
+        if row["duration"] != duration:
+            problems.append(
+                f"duration={row['duration']!r} (want {duration!r})"
+            )
+        if row["decided_by"] is None:
+            problems.append(
+                "decided_by NULL (policy row, not a human verdict)"
+            )
+        elif uid is not None and row["decided_by"] != uid:
+            problems.append(f"decided_by={row['decided_by']!r} (want {uid!r})")
+        if row["revoked_at"] is not None:
+            problems.append("revoked_at set")
+        if problems:
+            return f"db-row mismatch for {canon}:443: " + ", ".join(problems)
+        return None
+
     # -- per-iteration -----------------------------------------------------
+
     async def _run_step(self, pilot, step: _Step) -> _Result:
         canon = _canonical(step.host)
         now = time.time()
@@ -1522,6 +1614,7 @@ class SmokeTest:
                     )
                 )
             action_taken = step.action
+            db_problem = None
             if step.action == "none":
                 # No verdict: the server auto-expires the held request at the
                 # consent timeout (a one-shot deny) -> nothing carries over.
@@ -1539,11 +1632,24 @@ class SmokeTest:
                 await pilot.pause()
                 resolved = await _wait_resolved(self.app, rid, timeout=20.0)
                 sidecar = "resolved" if resolved else "held(!)"
+                if decision == DECISION_ALLOWED and resolved:
+                    # #2304: a resolved human allow must leave the correct
+                    # egress_consent row -- the fuzz run checks the audit
+                    # trail too, not just enforcement. resolve() commits the
+                    # row before the egress_resolved broadcast _wait_resolved
+                    # observed, so the row is already durable here.
+                    db_problem = self._check_allow_row(canon, step.duration)
+                    if db_problem is None:
+                        sidecar = "resolved+db\u2713"
                 # once is consumed by this connection; the rest cover the dest.
                 self.model.record(canon, decision, step.duration, time.time())
             text = await _wait_result(self.container, outfile)
             exit_code = _parse_exit(text)
             status = _classify_conn(expect_conn, exit_code)
+            if db_problem is not None:
+                # A wrong audit row contradicts the recording contract
+                # deterministically -- a hard mismatch, not a finding.
+                status = MISMATCH
             res = self._record(
                 _Result(
                     step,
@@ -1554,6 +1660,7 @@ class SmokeTest:
                     sidecar,
                     exit_code,
                     status,
+                    detail=db_problem or "",
                 )
             )
             await self._retries_after_verdict(pilot, step, canon)

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -778,6 +778,63 @@ class TestConsentCoordinatorHoldPaused:
         app.state.model.egress_consent.record_static_denial.assert_not_awaited()
         assert coord._holds == {}
 
+    async def test_paused_auto_allow_records_policy_allow_row(self):
+        # #2304: an auto-allow while paused is still an observed egress
+        # outcome -- recorded (policy, decided_by NULL) so auditing is
+        # unconditional, not just for prompted verdicts.
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result()["decision"] == "allow"
+        app.state.model.egress_consent.record_static_allow.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 443
+        )
+
+    async def test_paused_deny_records_no_new_row(self):
+        # A paused-deny is a replay of an in-effect verdict whose row already
+        # exists -- no new record (#2304).
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        app.state.model.egress_consent.active_verdict_for = AsyncMock(
+            return_value={
+                "id": "rid-1",
+                "workspace_id": FULL_WS,
+                "dest_host": "1.2.3.4",
+                "dest_port": 443,
+                "decision": "denied",
+            }
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result()["decision"] == "deny"
+        app.state.model.egress_consent.record_static_allow.assert_not_awaited()
+        app.state.model.egress_consent.record_static_denial.assert_not_awaited()
+
+    async def test_paused_allow_recording_failure_does_not_break_verdict(self):
+        # The recording is best-effort: a DB error must not turn the paused
+        # auto-allow into a deny or a raise (#2304).
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        app.state.model.egress_consent.record_static_allow = AsyncMock(
+            side_effect=RuntimeError("db down")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result()["decision"] == "allow"
+
     async def test_paused_respects_recorded_deny(self):
         # A recorded in-effect deny still blocks while paused (the pause does
         # not override existing verdicts).
@@ -1315,6 +1372,48 @@ def _sidecar_app(token_result=FULL_WS):
     return app, coord
 
 
+class TestRecordDnsEvent:
+    """DNS-layer outcome recording from the sidecar (#2304): unconditional
+    full-egress auditing (no opt-in setting), routed to the static policy rows."""
+
+    async def test_allowed_routes_to_static_allow(self):
+        app = _app()
+        coord = ConsentCoordinator(app)
+        await coord.record_dns_event(FULL_WS, "allowed", "ok.test")
+        app.state.model.egress_consent.record_static_allow.assert_awaited_once_with(
+            FULL_WS, "ok.test", None
+        )
+        app.state.model.egress_consent.record_static_denial.assert_not_awaited()
+
+    async def test_denied_routes_to_static_denial(self):
+        app = _app()
+        coord = ConsentCoordinator(app)
+        await coord.record_dns_event(FULL_WS, "denied", "evil.test")
+        app.state.model.egress_consent.record_static_denial.assert_awaited_once_with(
+            FULL_WS, "evil.test", None
+        )
+        app.state.model.egress_consent.record_static_allow.assert_not_awaited()
+
+    async def test_unknown_decision_is_noop(self):
+        # Anything but allowed/denied (the handler also filters, but the
+        # coordinator is defense-in-depth) records nothing.
+        app = _app()
+        coord = ConsentCoordinator(app)
+        await coord.record_dns_event(FULL_WS, "pending", "odd.test")
+        app.state.model.egress_consent.record_static_allow.assert_not_awaited()
+        app.state.model.egress_consent.record_static_denial.assert_not_awaited()
+
+    async def test_model_error_is_swallowed(self):
+        # Best-effort audit: a recording failure is logged + swallowed so it
+        # can never break the sidecar relay loop.
+        app = _app()
+        app.state.model.egress_consent.record_static_allow = AsyncMock(
+            side_effect=RuntimeError("db down")
+        )
+        coord = ConsentCoordinator(app)
+        await coord.record_dns_event(FULL_WS, "allowed", "ok.test")  # no raise
+
+
 class TestEgressSidecarWS:
     async def test_missing_token_rejected(self):
         from klangk.wshandler.sidecar import handle_egress_sidecar
@@ -1406,6 +1505,55 @@ class TestEgressSidecarWS:
         app.state.sidecar_connections.resolve_ack.assert_called_once_with(
             "ack-1", True
         )
+        await ws.feed(WebSocketDisconnect())
+        await handler
+
+    async def test_egress_dns_frame_records_outcome(self):
+        # #2304: a {type:egress_dns} frame (the DNS proxy reporting an outcome
+        # it decided itself) is recorded via the coordinator, off the receive
+        # loop (a task, like the egress relays).
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, coord = _sidecar_app()
+        ws = _FakeWS({"token": FULL_WS})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(
+            json.dumps(
+                {
+                    "type": "egress_dns",
+                    "decision": "allowed",
+                    "host": "ok.test",
+                }
+            )
+        )
+        await asyncio.sleep(0.05)
+        coord.record_dns_event.assert_awaited_once_with(
+            FULL_WS, "allowed", "ok.test"
+        )
+        await ws.feed(WebSocketDisconnect())
+        await handler
+
+    async def test_egress_dns_invalid_frames_ignored(self):
+        # A bad decision value or a non-string host records nothing (the
+        # frame is skipped, not fatal to the socket).
+        from klangk.wshandler.sidecar import handle_egress_sidecar
+
+        app, coord = _sidecar_app()
+        ws = _FakeWS({"token": FULL_WS})
+        handler = asyncio.create_task(handle_egress_sidecar(ws, app))
+        await ws.feed(
+            json.dumps(
+                {"type": "egress_dns", "decision": "maybe", "host": "x.test"}
+            )
+        )
+        await ws.feed(
+            json.dumps(
+                {"type": "egress_dns", "decision": "allowed", "host": 123}
+            )
+        )
+        await ws.feed(json.dumps({"type": "egress_dns"}))
+        await asyncio.sleep(0.05)
+        coord.record_dns_event.assert_not_awaited()
         await ws.feed(WebSocketDisconnect())
         await handler
 

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -819,6 +819,31 @@ class TestConsentCoordinatorHoldPaused:
         app.state.model.egress_consent.record_static_allow.assert_not_awaited()
         app.state.model.egress_consent.record_static_denial.assert_not_awaited()
 
+    async def test_paused_allow_verdict_replays_without_new_row(self):
+        # An in-effect ALLOW verdict replayed while paused is NOT re-recorded
+        # (#2304): the human row already exists; a policy row on top would
+        # duplicate the decision.
+        import time
+
+        app = _app(request=_request())
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        app.state.model.egress_consent.active_verdict_for = AsyncMock(
+            return_value={
+                "id": "rid-1",
+                "workspace_id": FULL_WS,
+                "dest_host": "1.2.3.4",
+                "dest_port": 443,
+                "decision": "allowed",
+            }
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result()["decision"] == "allow"
+        app.state.model.egress_consent.record_static_allow.assert_not_awaited()
+        app.state.model.egress_consent.record_static_denial.assert_not_awaited()
+
     async def test_paused_allow_recording_failure_does_not_break_verdict(self):
         # The recording is best-effort: a DB error must not turn the paused
         # auto-allow into a deny or a raise (#2304).

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -80,6 +80,12 @@ class SidecarConsentClient:
         # ``{type:activity}`` frame sent. 0.0 so the first event always forwards.
         self._last_activity_send = 0.0
         self._activity_tasks: set[asyncio.Task] = set()
+        # DNS-layer outcome reporting (#2304): hosts already reported this WS
+        # session (see :meth:`record_dns`). Cleared on reconnect -- a fresh
+        # session against a possibly restarted klangkd re-reports once per
+        # host (the DB-side dedup index still collapses repeats).
+        self._dns_reported: set[str] = set()
+        self._dns_tasks: set[asyncio.Task] = set()
 
     @property
     def connected(self) -> bool:
@@ -304,12 +310,63 @@ class SidecarConsentClient:
         except Exception:
             pass  # best-effort: a dropped frame just delays the next idle bump
 
+    # Cap on the DNS-outcome dedup set (#2304): bounds memory (and frames for
+    # new hosts) under a hostile resolver storm. Past the cap, hosts already
+    # reported keep their dedup; new hosts are simply not reported this
+    # session (their egress still flows/gets gated normally -- only the audit
+    # frame is dropped). Mirrors _VERDICT_CACHE's 4096 discipline in state.py.
+    _DNS_REPORT_CAP = 4096
+
+    def record_dns(self, decision: str, host: str) -> None:
+        """Best-effort DNS-layer egress outcome report to klangkd (#2304).
+
+        The DNS proxy sees every FQDN egress attempt and now ALWAYS reports
+        the outcome -- allowed (allow-list / in-session allow) or denied
+        (reject-list / static off-list NXDOMAIN) -- so full egress auditing
+        is unconditional, not an opt-in setting. klangkd records a
+        policy-decided row (decided_by NULL) per (workspace, host); this
+        sidecar-side dedup (one frame per host per WS session) keeps a query
+        storm from re-sending hosts the DB-side unique index would collapse
+        anyway. Cleared on reconnect (fresh session). Sync-safe: called from
+        the DNS loop's coroutines, schedules the WS send as a task. Never
+        raises -- audit must not break egress.
+        """
+        if not self._connected.is_set() or self._ws is None:
+            return
+        if host in self._dns_reported:
+            return
+        if len(self._dns_reported) >= self._DNS_REPORT_CAP:
+            return
+        self._dns_reported.add(host)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # not on a loop (defensive) -> nothing to schedule
+        t = loop.create_task(self._send_dns(decision, host))
+        self._dns_tasks.add(t)  # strong ref so the send isn't GC'd mid-flight
+        t.add_done_callback(self._dns_tasks.discard)
+
+    async def _send_dns(self, decision: str, host: str) -> None:
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            await ws.send(
+                json.dumps({"type": "egress_dns", "decision": decision, "host": host})
+            )
+        except Exception:
+            pass  # best-effort: a dropped frame skips this host's audit row
+
     def _fail_close_pending(self) -> None:
         # A lost connection is a fresh session against a (possibly restarted)
         # coordinator, so prior verdicts must not be trusted: in-flight flows
         # re-prompt after reconnect instead of being silently re-allowed/denied
         # by a stale cached verdict (#2326 review).
         _VERDICT_CACHE.clear()
+        # Fresh session (#2304) also resets the DNS-outcome dedup: the next
+        # connection may face a restarted klangkd whose egress_consent rows
+        # may have been pruned, so each host's outcome is re-reported once.
+        self._dns_reported.clear()
         for lid in list(self._pending):
             fut = self._pending.pop(lid, None)
             if fut is not None and not fut.done():

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -86,6 +86,9 @@ class SidecarConsentClient:
         # host (the DB-side dedup index still collapses repeats).
         self._dns_reported: set[str] = set()
         self._dns_tasks: set[asyncio.Task] = set()
+        # Set once when the DNS-report cap engages (one log line per session,
+        # #2304 review); reset with the dedup set on reconnect.
+        self._dns_cap_logged = False
 
     @property
     def connected(self) -> bool:
@@ -311,20 +314,24 @@ class SidecarConsentClient:
             pass  # best-effort: a dropped frame just delays the next idle bump
 
     # Cap on the DNS-outcome dedup set (#2304): bounds memory (and frames for
-    # new hosts) under a hostile resolver storm. Past the cap, hosts already
-    # reported keep their dedup; new hosts are simply not reported this
-    # session (their egress still flows/gets gated normally -- only the audit
-    # frame is dropped). Mirrors _VERDICT_CACHE's 4096 discipline in state.py.
+    # new hosts) under a hostile resolver storm. Past the cap the set STOPS
+    # GROWING: hosts already reported keep their dedup; new hosts are not
+    # reported for the rest of this WS session (their egress still flows /
+    # gets gated normally -- only the audit frame is dropped) until a
+    # reconnect re-arms it. Deliberately NOT a clear-and-rearm like
+    # _VERDICT_CACHE: denied flows stop hitting NFQUEUE once learned, but a
+    # workspace can emit unlimited fresh DNS names for free, so clearing
+    # under a flood would re-open unbounded frame sends. 4096 matches
+    # _VERDICT_CACHE's size as a familiar bound, not its mechanism.
     _DNS_REPORT_CAP = 4096
 
     def record_dns(self, decision: str, host: str) -> None:
         """Best-effort DNS-layer egress outcome report to klangkd (#2304).
 
-        The DNS proxy sees every FQDN egress attempt and now ALWAYS reports
-        the outcome -- allowed (allow-list / in-session allow) or denied
-        (reject-list / static off-list NXDOMAIN) -- so full egress auditing
-        is unconditional, not an opt-in setting. klangkd records a
-        policy-decided row (decided_by NULL) per (workspace, host); this
+        The DNS proxy reports every outcome it itself decides -- ``allowed``
+        (allow-list / in-session allow) or ``denied`` (reject-list NXDOMAIN)
+        -- so full egress auditing needs no opt-in setting. klangkd records
+        a policy-decided row (decided_by NULL) per (workspace, host); this
         sidecar-side dedup (one frame per host per WS session) keeps a query
         storm from re-sending hosts the DB-side unique index would collapse
         anyway. Cleared on reconnect (fresh session). Sync-safe: called from
@@ -336,11 +343,23 @@ class SidecarConsentClient:
         if host in self._dns_reported:
             return
         if len(self._dns_reported) >= self._DNS_REPORT_CAP:
+            # Log once per session so an operator auditing a busy workspace
+            # can see why fresh hosts stopped appearing (#2304 review: the
+            # cap must not silently disable the feature).
+            if not self._dns_cap_logged:
+                self._dns_cap_logged = True
+                print(
+                    f"dns-proxy: egress-audit report cap reached"
+                    f" ({self._DNS_REPORT_CAP} hosts this session); new hosts"
+                    " are not reported until the WS reconnects (#2304)",
+                    flush=True,
+                )
             return
         self._dns_reported.add(host)
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
+            self._dns_reported.discard(host)
             return  # not on a loop (defensive) -> nothing to schedule
         t = loop.create_task(self._send_dns(decision, host))
         self._dns_tasks.add(t)  # strong ref so the send isn't GC'd mid-flight
@@ -349,13 +368,17 @@ class SidecarConsentClient:
     async def _send_dns(self, decision: str, host: str) -> None:
         ws = self._ws
         if ws is None:
+            self._dns_reported.discard(host)
             return
         try:
             await ws.send(
                 json.dumps({"type": "egress_dns", "decision": decision, "host": host})
             )
         except Exception:
-            pass  # best-effort: a dropped frame skips this host's audit row
+            # Transient loss, not sticky (#2304 review): drop the dedup entry
+            # so the NEXT resolution of this host re-reports -- the audit row
+            # then lands one resolution late instead of never.
+            self._dns_reported.discard(host)
 
     def _fail_close_pending(self) -> None:
         # A lost connection is a fresh session against a (possibly restarted)
@@ -363,10 +386,12 @@ class SidecarConsentClient:
         # re-prompt after reconnect instead of being silently re-allowed/denied
         # by a stale cached verdict (#2326 review).
         _VERDICT_CACHE.clear()
-        # Fresh session (#2304) also resets the DNS-outcome dedup: the next
-        # connection may face a restarted klangkd whose egress_consent rows
-        # may have been pruned, so each host's outcome is re-reported once.
+        # Fresh session (#2304) also resets the DNS-outcome dedup + its cap
+        # log flag: the next connection may face a restarted klangkd whose
+        # egress_consent rows may have been pruned, so each host's outcome is
+        # re-reported once.
         self._dns_reported.clear()
+        self._dns_cap_logged = False
         for lid in list(self._pending):
             fut = self._pending.pop(lid, None)
             if fut is not None and not fut.done():

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -148,18 +148,22 @@ async def _forward_and_learn(
     addr: tuple[str, int],
     qname: str,
     port_set: set[int | None],
-) -> None:
+) -> bool:
     """Forward a query wire to the upstream + learn/respond (allow path).
 
     Shared by the static-allow path and the consent-allow path (which passes
     ``{None}`` -- all-ports, like a port-less allow spec). Uses a non-blocking
     socket + the loop's sock_* helpers so the await yields to other holds +
-    the WS receive loop while the upstream is pending.
+    the WS receive loop while the upstream is pending. Returns True iff the
+    upstream answered and the allow path ran -- the caller reports the
+    outcome for egress auditing (#2304); an upstream failure is not an
+    allow (nothing was resolved or learned).
     """
     resp = await _forward_marked(data)
     if resp is None:
-        return
+        return False
     await _respond_allowed(s, resp, addr, qname, port_set)
+    return True
 
 
 async def _respond_recorded(
@@ -234,6 +238,16 @@ async def _handle_packet(
     NO ACCEPT -- its connection SYN is consent-gated at NFQUEUE (#2324), so the
     human decision window is the kernel's connect timeout (~127s), not the
     resolver's <=30s getaddrinfo cap. Static mode (no client) -> NXDOMAIN.
+
+    Egress auditing (#2304) is unconditional (no opt-in setting): every
+    outcome the DNS layer itself decides is reported to klangkd for
+    recording -- ``allowed`` for a forwarded+learned allow-list /
+    in-session-allowed name, ``denied`` for a reject-listed name (NXDOMAIN,
+    both modes). A static off-list NXDOMAIN has no channel (a client-less
+    sidecar has no WS). The interactive off-list path deliberately reports
+    nothing here: the query resolves (not denied at this layer) and the
+    decision point is the connection SYN, whose verdict -- human or policy --
+    is already recorded by the coordinator via the ``egress`` frame.
     """
     try:
         qname = query_name(data)
@@ -253,6 +267,8 @@ async def _handle_packet(
         if DEBUG:
             print(f"reject {qname}", flush=True)
         _send_nxdomain(s, data, addr)
+        if client is not None:
+            client.record_dns("denied", qname)  # audit (#2304): policy deny
         return
     ports = ports_for(qname)
     deny, port_set = _decision(qname, ports)
@@ -266,4 +282,6 @@ async def _handle_packet(
         else:
             _send_nxdomain(s, data, addr)
         return
-    await _forward_and_learn(s, data, addr, qname, port_set)
+    if await _forward_and_learn(s, data, addr, qname, port_set):
+        if client is not None:
+            client.record_dns("allowed", qname)  # audit (#2304): policy allow

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -1702,7 +1702,7 @@ class TestRecordDns:
     async def test_cap_stops_new_hosts(self, proxy, tmp_path, monkeypatch):
         # Past the dedup-set cap the set stops growing: new hosts are not
         # reported this session (egress itself is unaffected -- only the
-        # audit frame is dropped).
+        # audit frame is dropped), and the cap logs exactly once.
         c, sent = self._client(proxy, tmp_path)
         monkeypatch.setattr(c, "_DNS_REPORT_CAP", 2)
         c.record_dns("allowed", "a.test")
@@ -1712,6 +1712,16 @@ class TestRecordDns:
         hosts = sorted(json.loads(f)["host"] for f in sent)
         assert hosts == ["a.test", "b.test"]
         assert "c.test" not in c._dns_reported  # cap also bounds memory
+        assert c._dns_cap_logged is True  # the cap is visible, not silent
+        c.record_dns("allowed", "d.test")  # still past cap -> no re-log spam
+        await self._drain(c)
+        assert c._dns_cap_logged is True
+
+    async def test_cap_flag_resets_on_reconnect(self, proxy, tmp_path):
+        c, sent = self._client(proxy, tmp_path)
+        c._dns_cap_logged = True  # a prior session tripped the cap
+        c._fail_close_pending()  # what _run's finally does on disconnect
+        assert c._dns_cap_logged is False  # fresh session re-arms the cap
 
     async def test_reconnect_clears_dedup(self, proxy, tmp_path):
         # A lost connection is a fresh session (#2304): _fail_close_pending
@@ -1733,17 +1743,27 @@ class TestRecordDns:
         await self._drain(c)
         assert c._dns_tasks == set()
 
-    async def test_send_error_is_swallowed(self, proxy, tmp_path):
+    async def test_send_error_is_swallowed_and_re_reports(self, proxy, tmp_path):
+        # #2304 review: a send failure is transient loss, not sticky -- the
+        # dedup entry is dropped so the NEXT resolution of the host
+        # re-reports (the audit row lands one resolution late, not never).
         c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
         c._connected.set()
+        fails = {"n": 0}
 
         class _BadWS:
             async def send(self, frame):
+                fails["n"] += 1
                 raise OSError("gone")
 
         c._ws = _BadWS()
         c.record_dns("allowed", "ok.test")  # must not raise
         await self._drain(c)  # the scheduled send raises internally, swallowed
+        assert fails["n"] == 1
+        assert "ok.test" not in c._dns_reported  # dedup entry dropped
+        c.record_dns("allowed", "ok.test")  # re-reported on the next hit
+        await self._drain(c)
+        assert fails["n"] == 2
 
 
 class TestEgressAcct:

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -1644,6 +1644,108 @@ class TestBumpActivity:
         await self._drain(c)  # the scheduled send raises internally, swallowed
 
 
+class TestRecordDns:
+    """DNS-layer outcome reporting (#2304): every allow-listed resolution
+    (allowed) and reject-listed NXDOMAIN (denied) is reported to klangkd,
+    deduped per host for the WS session so a query storm can't flood frames."""
+
+    def _client(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, frame):
+                sent.append(frame)
+
+        c._ws = _FakeWS()
+        return c, sent
+
+    async def _drain(self, c):
+        # run any scheduled dns-send tasks to completion (deterministic)
+        if c._dns_tasks:
+            await asyncio.gather(*c._dns_tasks, return_exceptions=True)
+
+    async def test_allowed_sends_egress_dns_frame(self, proxy, tmp_path):
+        c, sent = self._client(proxy, tmp_path)
+        c.record_dns("allowed", "ok.test")
+        await self._drain(c)
+        assert [json.loads(f) for f in sent] == [
+            {"type": "egress_dns", "decision": "allowed", "host": "ok.test"}
+        ]
+
+    async def test_denied_sends_egress_dns_frame(self, proxy, tmp_path):
+        c, sent = self._client(proxy, tmp_path)
+        c.record_dns("denied", "evil.test")
+        await self._drain(c)
+        assert [json.loads(f) for f in sent] == [
+            {"type": "egress_dns", "decision": "denied", "host": "evil.test"}
+        ]
+
+    async def test_repeat_host_deduped_within_session(self, proxy, tmp_path):
+        # One frame per host per session: a resolver hammering the same
+        # allow-listed name sends the outcome once (the DB-side unique index
+        # would collapse the rows anyway).
+        c, sent = self._client(proxy, tmp_path)
+        for _ in range(50):
+            c.record_dns("allowed", "ok.test")
+        await self._drain(c)
+        assert len(sent) == 1
+
+    async def test_distinct_hosts_each_reported(self, proxy, tmp_path):
+        c, sent = self._client(proxy, tmp_path)
+        c.record_dns("allowed", "a.test")
+        c.record_dns("denied", "b.test")
+        await self._drain(c)
+        assert len(sent) == 2
+
+    async def test_cap_stops_new_hosts(self, proxy, tmp_path, monkeypatch):
+        # Past the dedup-set cap the set stops growing: new hosts are not
+        # reported this session (egress itself is unaffected -- only the
+        # audit frame is dropped).
+        c, sent = self._client(proxy, tmp_path)
+        monkeypatch.setattr(c, "_DNS_REPORT_CAP", 2)
+        c.record_dns("allowed", "a.test")
+        c.record_dns("allowed", "b.test")
+        c.record_dns("allowed", "c.test")  # past cap -> dropped
+        await self._drain(c)
+        hosts = sorted(json.loads(f)["host"] for f in sent)
+        assert hosts == ["a.test", "b.test"]
+        assert "c.test" not in c._dns_reported  # cap also bounds memory
+
+    async def test_reconnect_clears_dedup(self, proxy, tmp_path):
+        # A lost connection is a fresh session (#2304): _fail_close_pending
+        # clears the dedup so each host re-reports once on reconnect (klangkd
+        # may have restarted / pruned its rows in between).
+        c, sent = self._client(proxy, tmp_path)
+        c.record_dns("allowed", "ok.test")
+        await self._drain(c)
+        assert len(sent) == 1
+        c._fail_close_pending()  # what _run's finally does on disconnect
+        assert c._dns_reported == set()
+        c.record_dns("allowed", "ok.test")
+        await self._drain(c)
+        assert len(sent) == 2  # re-reported once for the new session
+
+    async def test_disconnected_is_noop(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c.record_dns("allowed", "ok.test")  # not connected -> no schedule/raise
+        await self._drain(c)
+        assert c._dns_tasks == set()
+
+    async def test_send_error_is_swallowed(self, proxy, tmp_path):
+        c = proxy.SidecarConsentClient("http://h/ev", str(tmp_path / "t"), 5)
+        c._connected.set()
+
+        class _BadWS:
+            async def send(self, frame):
+                raise OSError("gone")
+
+        c._ws = _BadWS()
+        c.record_dns("allowed", "ok.test")  # must not raise
+        await self._drain(c)  # the scheduled send raises internally, swallowed
+
+
 class TestEgressAcct:
     """mangle-OUTPUT egress byte accounting (#2485): the in-kernel rule the
     idle-activity sampler polls, scoped to unmarked (workspace) traffic and
@@ -2587,6 +2689,33 @@ class TestHandlePacket:
         fwd.assert_awaited_once()  # forwarded + learned, not denied
         s.sendto.assert_not_called()  # no NXDOMAIN
 
+    async def test_allowed_name_reports_outcome(self, proxy, monkeypatch):
+        # #2304: an allow-listed resolution is reported to klangkd (allowed,
+        # by policy) for unconditional audit -- but only when the upstream
+        # actually answered (_forward_and_learn True).
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "allowed.test")
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [("allowed.test", None, False)])
+        fwd = AsyncMock(return_value=True)
+        monkeypatch.setattr(proxy.resolve, "_forward_and_learn", fwd)
+        s = MagicMock()
+        client = MagicMock()
+        client.connected = True
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        client.record_dns.assert_called_once_with("allowed", "allowed.test")
+
+    async def test_allowed_upstream_failure_reports_nothing(self, proxy, monkeypatch):
+        # An upstream failure is not an allow: nothing was resolved/learned,
+        # so no audit row (#2304).
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "allowed.test")
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [("allowed.test", None, False)])
+        fwd = AsyncMock(return_value=False)
+        monkeypatch.setattr(proxy.resolve, "_forward_and_learn", fwd)
+        s = MagicMock()
+        client = MagicMock()
+        client.connected = True
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        client.record_dns.assert_not_called()
+
     async def test_denied_no_client_sends_nxdomain(self, proxy, monkeypatch):
         monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "evil.test")
         monkeypatch.setattr(proxy.allowlist, "SPECS", [])
@@ -2594,6 +2723,23 @@ class TestHandlePacket:
         s = MagicMock()
         await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
         s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+
+    async def test_static_denied_with_client_reports_nothing_at_dns(
+        self, proxy, monkeypatch
+    ):
+        # #2304: an off-list name in interactive mode is NOT denied at the
+        # DNS layer (it resolves; the SYN is the decision point, recorded via
+        # the egress frame) -- so nothing is reported here. (The off-list +
+        # no-client NXDOMAIN path also reports nothing: no WS exists.)
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [])
+        rec = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "_forward_and_record", rec)
+        client = MagicMock()
+        client.connected = True
+        s = MagicMock()
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        client.record_dns.assert_not_called()
 
     async def test_denied_with_client_resolves_and_records(self, proxy, monkeypatch):
         # Interactive: a denied name resolves + records IP->host (NO ACCEPT) so
@@ -2637,6 +2783,21 @@ class TestHandlePacket:
         await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), None)
         s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
         fwd.assert_not_awaited()
+
+    async def test_rejected_name_reports_denied(self, proxy, monkeypatch):
+        # #2304: a reject-listed NXDOMAIN is a policy denial decided at the
+        # DNS layer -- reported for unconditional audit (both modes; here
+        # with a client, which is the only mode with a WS channel).
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(
+            proxy.allowlist, "REJECT_SPECS", [("evil.test", None, proxy._EXACT)]
+        )
+        monkeypatch.setattr(proxy.resolve, "nxdomain_for", lambda d: b"NXD")
+        s = MagicMock()
+        client = MagicMock()
+        client.connected = True
+        await proxy._handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        client.record_dns.assert_called_once_with("denied", "evil.test")
 
     async def test_rejected_name_nxdomain_even_with_client(self, proxy, monkeypatch):
         # Reject takes precedence over consent: even in interactive mode a


### PR DESCRIPTION
## Summary

Closes #2304.

Full-egress auditing is now **unconditional** — per the amended direction on the issue, there is no `egress_log_all` setting: allowed egress is logged alongside denied, always, with the decision and decider (policy rows carry `decided_by` NULL; human verdicts carry the user id, as before).

The sidecar's DNS proxy sees every FQDN egress attempt and now reports each outcome **it itself decides** over the existing consent WebSocket as a new `{type:egress_dns}` frame:

- `allowed` — an allow-listed (or in-session-consented) name that the upstream resolved and the proxy learned/responded. An upstream failure reports nothing (it is not an allow).
- `denied` — a reject-listed name NXDOMAIN'd (both modes).

klangkd records these via the new `ConsentCoordinator.record_dns_event`, routed to the existing `record_static_allow` / `record_static_denial` rows (port NULL, `decided_by` NULL) — one row per (workspace, host) via the existing dedup indexes, bounded by the existing retention/row-cap sweep. A paused-mode auto-allow is now recorded the same way (#2332 previously wrote no row). The interactive off-list path deliberately reports nothing at the DNS layer: its decision point is the connection SYN, whose human or policy verdict is already recorded via the `egress` frame.

## Volume bounding

- Sidecar-side: one frame per host per WS session (dedup set cleared on reconnect — a fresh session against a possibly restarted/pruned klangkd re-reports once), capped at 4096 hosts; sends are best-effort fire-and-forget tasks.
- klangkd-side: each frame is handled off the receive loop (a task, like the egress relays); recording failures are logged and swallowed — an audit gap must never break egress. DB rows are deduped per (workspace, host, port) and pruned by the retention/cap sweeper like any other terminal row.

## Not in this PR

Tracked in #2786 (the per-connection flow-audit follow-up to #2304).

Per-connection TCP/UDP flow audit — dst endpoints, resolved IPs per row, and an ACCEPT-path NFLOG/pass-through-NFQUEUE hook capturing every accepted TCP connection and non-DNS UDP flow. The DNS layer covers every FQDN egress attempt (where nearly all egress starts); raw-IP flows need the kernel hook.

## Tests

- Sidecar: `record_dns` unit tests (frame shape, per-host dedup, cap, reconnect clear, disconnect no-op, send-error swallow) + `_handle_packet` reporting tests (allow reports when forwarded, upstream failure silent, rejected reports denied, interactive off-list silent at DNS).
- klangkd: `record_dns_event` routing + unknown-decision noop + error-swallow; paused-allow row recording (+ paused-deny records nothing, failure doesn't break the verdict); WS handler `egress_dns` frame + invalid-frame tests.
- Full klangk suite 5777 passed at 100% coverage (CI invocation); sidecar suite 201 passed.
