### PR TITLE
docs(workspaces): document per-workspace idle timeout override (#1018)

### DIFF
--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -154,8 +154,9 @@ cross-tenant and cross-user data access on shared hosts.
 
 ## Idle timeout
 
-Containers stop automatically after 30 minutes of inactivity
-(configurable via `KLANGKD_IDLE_TIMEOUT_SECONDS`). Activity includes
+Containers stop automatically after 60 minutes of inactivity
+(configurable deploy-wide via `KLANGKD_IDLE_TIMEOUT_SECONDS`; the
+default was raised from 30 to 60 minutes in #2480). Activity includes
 terminal input, file operations, and AI agent events — so containers
 stay alive during long-running LLM requests as long as events are
 flowing.
@@ -170,6 +171,25 @@ so they're immediately available when you or a collaborator reconnect.
 Only the idle timeout (or an explicit, admin-gated _Shutdown container_
 command) tears a container down. This lets long-lived services outlive
 any single user's session (#301, #1235).
+
+### Per-workspace override
+
+A workspace owner can override the deploy-wide default for a single
+workspace (#1018) — for example to keep a long-running service alive
+indefinitely, or to reap an expensive scratch workspace faster:
+
+- **Web UI:** set **Idle Timeout (s)** in the workspace's Settings tab
+  (or on the create-workspace dialog).
+- **CLI:** pass `--idle-timeout` to `klangk create` or `klangk edit`.
+- **API:** set `settings.idle_timeout` (a full-replace on `POST`/`PUT`,
+  or a partial merge on `PATCH /api/v1/workspaces/{id}/settings`).
+
+The value is seconds. `0` means **never idle out**; unset means the
+deploy-wide `KLANGKD_IDLE_TIMEOUT_SECONDS` default. An override takes
+effect the next time the container starts — a running container keeps
+its current timeout until it is restarted. Auto-started workspaces are
+pinned to `0` at boot so they come up unattended and stay up between
+user connections.
 
 ## Export and import
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -870,6 +870,29 @@ user from all roles.
 
 ---
 
+### PATCH `/api/v1/workspaces/{id}/settings`
+
+Partial-merge update of the workspace's per-workspace `settings` bag —
+each key in the body sets/replaces that override; `null` **deletes**
+the key (reverting it to the deploy-wide default); keys not present
+are left untouched. See the `settings` field on
+[POST `/api/v1/workspaces`](#post-apiv1workspaces) for the known keys.
+
+**Auth:** JWT required. User must have `edit` permission on `/workspaces/{id}`.
+
+```json
+{ "idle_timeout": 0 }
+```
+
+```json
+{ "settings": { "idle_timeout": 0, "cpu_limit": 2.0 } }
+```
+
+An empty patch (`{}`) is rejected with `400`. Like a `PUT`, a changed
+`idle_timeout` applies the next time the container starts.
+
+---
+
 ### POST `/api/v1/admin/groups`
 
 Create a new group (admin).
@@ -1334,7 +1357,8 @@ are created automatically.
   "mounts": ["my-volume:/home/user/data"],
   "env": { "MY_VAR": "value" },
   "per_handle_home": true,
-  "classification_banner": "CUI"
+  "classification_banner": "CUI",
+  "settings": { "idle_timeout": 0 }
 }
 ```
 
@@ -1343,6 +1367,20 @@ All fields except `name` are optional. `per_handle_home` selects the
 gives each member a private `/home/<handle>`, `false` (the server
 default, `KLANGKD_PER_HANDLE_HOME`) shares one `/home/klangk`. Omit it
 to inherit the server default.
+
+`settings` is a bag of per-workspace behavioral overrides (#864). Known
+keys (unknown keys are rejected with `400`):
+
+| Key              | Type    | Meaning                                                                                                           |
+| ---------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `idle_timeout`   | int (s) | Idle timeout override; `0` = never idle out, unset = deploy default (#1018). Applies at the next container start. |
+| `bridge_timeout` | int (s) | Browser-delegate stream bridge timeout.                                                                           |
+| `cpu_limit`      | float   | `--cpus` limit (e.g. `2.0`).                                                                                      |
+| `memory_limit`   | string  | `--memory` limit (e.g. `"4g"`, `"512m"`).                                                                         |
+| `pids_limit`     | int     | `--pids-limit` (e.g. `512`).                                                                                      |
+| `tmp_size`       | string  | `/tmp` tmpfs size (e.g. `"4g"`).                                                                                  |
+| `nix`            | bool    | Mount a per-workspace `/nix`.                                                                                     |
+| `allow_sudo`     | bool    | Restrict sudo (deploy `KLANGKD_ALLOW_SUDO` is a ceiling).                                                         |
 
 `classification_banner` is the workspace's classification marking,
 rendered as the persistent banner on the workspace page (#2768). Free
@@ -1676,13 +1714,20 @@ command, volume mounts, environment variables). All fields optional.
   "mounts": ["vol:/data"],
   "env": { "KEY": "VALUE" },
   "per_handle_home": false,
-  "classification_banner": ""
+  "classification_banner": "",
+  "settings": { "idle_timeout": 600 }
 }
 ```
 
 `per_handle_home` may be flipped here too; the new layout applies from
 the workspace's next connect/start (open terminals keep their layout
 until they end).
+
+`settings` is a **full replace** of the
+[settings bag](#post-apiv1workspaces) — keys absent from the request are
+reverted to the deploy-wide default, and an explicit `null` clears the
+whole bag. Use `PATCH /api/v1/workspaces/{id}/settings` to merge
+individual keys instead.
 
 `classification_banner` (#2768) replaces the workspace's marking
 outright; an empty value clears the override back to the deploy-wide

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -247,12 +247,14 @@ klangk create my-project --command 'npm run dev'  # with a service command
 klangk create my-project -c 'npm run dev'         # short form of --command
 klangk create my-project --per-handle-home       # per-member private homes (default: shared /home/klangk)
 klangk create my-project --allow github.com:443 --allow pypi.org  # with egress allowlist
+klangk create my-project --idle-timeout 0        # per-workspace idle timeout (seconds; 0 = never idle out)
 klangk edit my-project                  # interactive edit (name, image, command, health check, mounts, env, allowed domains)
 klangk edit my-project --auto-start     # enable auto-start on server boot
 klangk edit my-project --no-auto-start  # disable auto-start
 klangk edit my-project --env FOO=bar    # set env var via flag
 klangk edit my-project --allow github.com:443     # set allowed egress domain via flag
 klangk edit my-project --shared-home             # switch layout (applies from next connect/start)
+klangk edit my-project --idle-timeout 600 # set per-workspace idle timeout in seconds (0 = never idle out)
 klangk dup my-project my-copy           # duplicate a workspace
 klangk shell my-project                 # drop into bash inside the container
 klangk shell my-project debug           # attach to the "debug" terminal window (created if it doesn't exist)

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -282,6 +282,10 @@ port: "8997"
 | `bridge_timeout_seconds` |                                  | `KLANGKD_BRIDGE_TIMEOUT_SECONDS` |
 | `idle_timeout_seconds`   | `3600`                           | `KLANGKD_IDLE_TIMEOUT_SECONDS`   |
 
+`idle_timeout_seconds` is the deploy-wide default; a workspace can
+override it per-workspace (`settings.idle_timeout` — see
+[Workspaces § Idle timeout](../features/workspaces.md#idle-timeout)).
+
 ### Container / workspace
 
 | Key                                 | Default                         | Env var                                     |


### PR DESCRIPTION
Closes #1018.

## What

The functional work for per-workspace idle timeout already shipped with
the settings bag (#864) — `settings.idle_timeout` is validated, stored,
applied at every container start (fixed for all start paths in #2514),
and exposed in the web UI Settings tab/create dialog, `klangk
create`/`edit --idle-timeout`, and the TUI. What was missing was
**documentation**: none of it was written down anywhere outside the
changelog.

This PR documents it (docs only, no code changes):

- **`docs/features/workspaces.md`** — new "Per-workspace override"
  subsection under Idle timeout: where to set it (web UI **Idle Timeout
  (s)** field, CLI `--idle-timeout`, API `settings.idle_timeout`),
  `0` = never idle out, applies at the next container start,
  auto-started workspaces are pinned to `0`. Also fixes the stale
  "30 minutes" default (now 60, #2480).
- **`docs/reference/cli.md`** — `--idle-timeout` examples for
  `klangk create` and `klangk edit`.
- **`docs/reference/api-endpoints.md`** — documents the `settings` bag
  (full key table) on POST/PUT, its full-replace semantics on PUT, and
  adds the previously undocumented
  `PATCH /api/v1/workspaces/{id}/settings` endpoint (partial merge,
  `null` = delete key).
- **`docs/reference/klangkd-config.md`** — cross-reference from the
  deploy-wide `idle_timeout_seconds` row to the per-workspace override.

## Testing

Docs-only change: `markdownlint` and the zensical docs build pass; the
build shows the same 10 pre-existing warnings (all in
`reference/environment.md`) before and after. `test-push`: no test
areas touched.
