### PR TITLE
Verify hashes of third-party software pulled at image-build time (#2063)

### DIFF
--- a/.github/workflows/image-workspace-base.yml
+++ b/.github/workflows/image-workspace-base.yml
@@ -45,9 +45,11 @@ jobs:
             --push \
             src/containers/workspace/
           # Pin the workspace build to the immutable manifest digest (#2063):
-          # a tag reference could be re-served with different content.
+          # a tag reference could be re-served with different content. NOTE:
+          # the json form is required — buildx special-cases plain
+          # '{{.Manifest…}}' formats into printing the full table.
           DIGEST="$(docker buildx imagetools inspect "$REPO:$VERSION" \
-            --format '{{.Manifest.Digest}}')"
+            --format '{{json .Manifest.Digest}}' | tr -d '"')"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "image=$REPO@$DIGEST" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/image-workspace-base.yml
+++ b/.github/workflows/image-workspace-base.yml
@@ -44,8 +44,12 @@ jobs:
             -t "$REPO:$VERSION" \
             --push \
             src/containers/workspace/
+          # Pin the workspace build to the immutable manifest digest (#2063):
+          # a tag reference could be re-served with different content.
+          DIGEST="$(docker buildx imagetools inspect "$REPO:$VERSION" \
+            --format '{{.Manifest.Digest}}')"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "image=$REPO:$VERSION" >> "$GITHUB_OUTPUT"
+          echo "image=$REPO@$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Open PR to update workspace base image pin
         env:

--- a/.github/workflows/image-workspace-fips.yml
+++ b/.github/workflows/image-workspace-fips.yml
@@ -14,7 +14,7 @@ name: FIPS Workspace Image Check
 # Publishes to GHCR (#2631): the self-hosted e2e runners pull this image
 # instead of compiling OpenSSL per-PR on the shared host (which starved
 # sibling suites' podman execs). Tags: :<calver>-<commit> plus a floating
-# :latest (the same convention pull-base-image.sh relies on). ONE-TIME
+# :latest. ONE-TIME
 # setup: flip the new ghcr package's visibility to public so anonymous
 # pulls work (as klangk-workspace-base already is); until then the e2e
 # pull falls back to a local, parallelism-capped build.

--- a/devenv.nix
+++ b/devenv.nix
@@ -324,7 +324,8 @@ in
   # the YAML (#1788).
   # Docker build platform for klangk images. On Linux, default to the host
   # architecture so arm64 machines build/run natively instead of under amd64
-  # emulation. The published GHCR base (klangk-workspace-base:latest) is
+  # emulation. The published GHCR base (klangk-workspace-base, pulled by the
+  # digest pinned in the workspace Dockerfile, #2063) is
   # multi-arch (amd64 + arm64), so we default to the host's native
   # architecture on all platforms. Override via devenv.local.nix.
   env.KLANGKBUILD_PLATFORM = lib.mkOverride 1500 (

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -126,6 +126,18 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Image builds verify every network-fetched third-party artifact
+  (#2063).** The uv and process-compose tarballs are now SHA-256-verified
+  per architecture before extraction (no more `curl | sh` / `curl | tar`
+  pipes), the Pi agent npm tarball is fetched directly and SHA-512-verified,
+  and the NodeSource / GitHub CLI / Caddy apt repo keys are hash-verified
+  before entering a keyring (Caddy's sources list is written inline). Base
+  images (workspace base, python host, Alpine sidecar, Debian FIPS builders)
+  are pulled by immutable `@sha256:` digest instead of mutable tags, with
+  the base-image workflow's auto-PR now pinning the digest. Pins live in
+  the Dockerfiles; rotation procedures are documented in
+  [Building Images](../development/building-images.md).
+
 - **Browser-delegate requests are bound to the caller's workspace
   (#1715).** `/api/v1/browser-delegate` and `/api/v1/browser-delegate/stream`
   now verify that the submitted `browser_id` was registered against the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -126,17 +126,7 @@ operators or integrators to act when upgrading.
 
 ### Security
 
-- **Image builds verify every network-fetched third-party artifact
-  (#2063).** The uv and process-compose tarballs are now SHA-256-verified
-  per architecture before extraction (no more `curl | sh` / `curl | tar`
-  pipes), the Pi agent npm tarball is fetched directly and SHA-512-verified,
-  and the NodeSource / GitHub CLI / Caddy apt repo keys are hash-verified
-  before entering a keyring (Caddy's sources list is written inline). Base
-  images (workspace base, python host, Alpine sidecar, Debian FIPS builders)
-  are pulled by immutable `@sha256:` digest instead of mutable tags, with
-  the base-image workflow's auto-PR now pinning the digest. Pins live in
-  the Dockerfiles; rotation procedures are documented in
-  [Building Images](../development/building-images.md).
+- **Image builds verify third-party inputs (#2063).** Base images (workspace base, python host, Alpine sidecar, Debian FIPS builders + nix-seed sandbox) are now pulled by immutable `@sha256:` digest, with the base-image workflow's auto-PR pinning the digest. The uv and process-compose release tarballs are SHA-256-verified per architecture before extraction (no more `curl | sh` / `curl | tar` pipes), the Pi agent npm tarball is fetched directly and SHA-512-verified, and the NodeSource / GitHub CLI / Caddy apt repo keys are hash-verified before entering a keyring (Caddy's sources list is written inline). Pins live in the Dockerfiles; rotation procedures and known residuals are documented in [Building Images](../development/building-images.md).
 
 - **Browser-delegate requests are bound to the caller's workspace
   (#1715).** `/api/v1/browser-delegate` and `/api/v1/browser-delegate/stream`

--- a/docs/development/building-images.md
+++ b/docs/development/building-images.md
@@ -65,25 +65,62 @@ accumulate. The local `:latest` tag is never pushed to GHCR.
 
 ## Workspace Base Image Pin
 
-The workspace `Dockerfile` pins its base image to a specific version
-via a build `ARG`:
+The workspace `Dockerfile` pins its base image to an **immutable digest**
+via a build `ARG` (#2063):
 
 ```dockerfile
-ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.10-e973f3c
+ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base@sha256:…
 FROM $WORKSPACE_BASE_IMAGE
 ```
 
-This means changes to `Dockerfile.base` on main don't silently
-affect other branches. The flow:
+The digest references the multi-arch manifest (amd64 + arm64); the build
+selects the platform via `--platform`. This means changes to
+`Dockerfile.base` on main don't silently affect other branches, and the
+registry cannot serve different content for the same reference. The flow:
 
 1. Someone changes `Dockerfile.base` and pushes to main.
 2. The `image-workspace-base.yml` workflow builds and pushes the new
    base image with a versioned tag.
-3. The same workflow automatically opens a PR to update the `ARG`
-   default in `src/containers/workspace/Dockerfile` to the new
-   version.
+3. The same workflow resolves the pushed manifest's digest and
+   automatically opens a PR to update the `ARG` default in
+   `src/containers/workspace/Dockerfile` to `repo@sha256:…`.
 4. A maintainer reviews and merges the PR.
 
-Stable/deploy branches keep their original pinned base version and
+Stable/deploy branches keep their original pinned base digest and
 are unaffected. To override at build time:
-`--build-arg WORKSPACE_BASE_IMAGE=ghcr.io/.../klangk-workspace-base:some-version`.
+`--build-arg WORKSPACE_BASE_IMAGE=ghcr.io/.../klangk-workspace-base@sha256:…`.
+`pull-base-image` pulls exactly this pinned reference (never a mutable
+`:latest`) so the local cache matches what a build consumes.
+
+## Pinned Third-Party Artifacts (#2063)
+
+Every artifact fetched from the network at image-build time is verified
+against a hash pinned in the Dockerfile, and every base image is pulled
+by immutable digest — a compromised registry, CDN, or MITM cannot swap
+content undetected. A mismatch fails the build loudly.
+
+| Artifact                                         | Where the pin lives                                                                | Verify/rotate on bump                                                                                                                           |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Workspace base image                             | `WORKSPACE_BASE_IMAGE` ARG in `src/containers/workspace/Dockerfile`                | automatic — the base-image workflow's auto-PR rewrites the ARG with the new `repo@digest`                                                       |
+| Pi agent npm tarball                             | `PI_AGENT_SHA512` in `src/containers/workspace/Dockerfile`                         | `npm view @earendil-works/pi-coding-agent@<ver> dist.integrity` (base64 sha512 → hex)                                                           |
+| uv                                               | `UV_SHA256_AMD64` / `UV_SHA256_ARM64` in `src/containers/workspace/Dockerfile`     | `sha256sum` of each arch tarball, or the `.sha256` sidecars in the GitHub release                                                               |
+| process-compose                                  | `PROCESS_COMPOSE_SHA256_AMD64` / `_ARM64` in `src/containers/workspace/Dockerfile` | `sha256sum` of each arch tarball                                                                                                                |
+| Debian base (workspace, FIPS builders, nix-seed) | digest in `src/containers/workspace/Dockerfile.base` (pre-existing, #2432)         | `docker buildx imagetools inspect debian:trixie-slim --format '{{.Manifest.Digest}}'`; keep the three aligned builders in sync                  |
+| python host base                                 | digest in `src/containers/host/Dockerfile`                                         | `docker buildx imagetools inspect python:3.13-slim --format '{{.Manifest.Digest}}'`                                                             |
+| Alpine (network sidecar)                         | digest in `src/containers/network/Dockerfile`                                      | `docker buildx imagetools inspect alpine:3.21 --format '{{.Manifest.Digest}}'`                                                                  |
+| NodeSource repo key                              | `NODESOURCE_KEY_SHA256` in `Dockerfile.base`                                       | `sha256sum` of the fetched `gpgkey/nodesource-repo.gpg.key` (after cross-checking the new key's fingerprint against NodeSource's docs)          |
+| GitHub CLI repo key                              | `GITHUBCLI_KEYRING_SHA256` in `Dockerfile.base`                                    | `sha256sum` of the fetched `githubcli-archive-keyring.gpg` (fingerprint in the Dockerfile comment)                                              |
+| Caddy repo key (Cloudsmith)                      | `CADDY_REPO_KEY_SHA256` in `src/containers/host/Dockerfile`                        | `sha256sum` of the fetched `gpg.key` (fingerprint in the Dockerfile comment; cross-check <https://cloudsmith.io/~caddy/repos/stable/pub-keys/>) |
+
+Notes:
+
+- The apt **sources lists** (NodeSource, GitHub CLI, Caddy) are written
+  inline in the Dockerfiles, not fetched — the GPG key is the only
+  network-sourced trust input, and apt's own signature verification then
+  covers the package indexes and `.deb`s. Caddy itself is intentionally
+  not version-pinned so rebuilds pick up security patches; its integrity
+  rests on the pinned repo key.
+- Deps of the Pi agent tarball are still resolved by npm at build time
+  (integrity-checked by npm against registry metadata, as usual).
+- `scripts/tests/test_supply_chain_pins.py` holds contract tests asserting
+  the pins exist; removing one without updating that file fails CI.

--- a/docs/development/building-images.md
+++ b/docs/development/building-images.md
@@ -94,10 +94,12 @@ are unaffected. To override at build time:
 
 ## Pinned Third-Party Artifacts (#2063)
 
-Every artifact fetched from the network at image-build time is verified
-against a hash pinned in the Dockerfile, and every base image is pulled
-by immutable digest — a compromised registry, CDN, or MITM cannot swap
-content undetected. A mismatch fails the build loudly.
+Every base image, release tarball, and apt repo key fetched from the
+network at image-build time is verified against a hash pinned in the
+Dockerfile or pulled by immutable digest — a compromised registry, CDN,
+or MITM cannot swap those inputs undetected, and a mismatch fails the
+build loudly. (Known residuals beyond that scope are listed under
+"Accepted residuals" below.)
 
 | Artifact                                         | Where the pin lives                                                                | Verify/rotate on bump                                                                                                                           |
 | ------------------------------------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -105,9 +107,9 @@ content undetected. A mismatch fails the build loudly.
 | Pi agent npm tarball                             | `PI_AGENT_SHA512` in `src/containers/workspace/Dockerfile`                         | `npm view @earendil-works/pi-coding-agent@<ver> dist.integrity` (base64 sha512 → hex)                                                           |
 | uv                                               | `UV_SHA256_AMD64` / `UV_SHA256_ARM64` in `src/containers/workspace/Dockerfile`     | `sha256sum` of each arch tarball, or the `.sha256` sidecars in the GitHub release                                                               |
 | process-compose                                  | `PROCESS_COMPOSE_SHA256_AMD64` / `_ARM64` in `src/containers/workspace/Dockerfile` | `sha256sum` of each arch tarball                                                                                                                |
-| Debian base (workspace, FIPS builders, nix-seed) | digest in `src/containers/workspace/Dockerfile.base` (pre-existing, #2432)         | `docker buildx imagetools inspect debian:trixie-slim --format '{{.Manifest.Digest}}'`; keep the three aligned builders in sync                  |
-| python host base                                 | digest in `src/containers/host/Dockerfile`                                         | `docker buildx imagetools inspect python:3.13-slim --format '{{.Manifest.Digest}}'`                                                             |
-| Alpine (network sidecar)                         | digest in `src/containers/network/Dockerfile`                                      | `docker buildx imagetools inspect alpine:3.21 --format '{{.Manifest.Digest}}'`                                                                  |
+| Debian base (workspace, FIPS builders, nix-seed) | digest in `src/containers/workspace/Dockerfile.base` (pre-existing, #2432)         | `docker buildx imagetools inspect debian:trixie-slim (read the Digest: line)`; keep the three aligned builders in sync                          |
+| python host base                                 | digest in `src/containers/host/Dockerfile`                                         | `docker buildx imagetools inspect python:3.13-slim (read the Digest: line)`                                                                     |
+| Alpine (network sidecar)                         | digest in `src/containers/network/Dockerfile`                                      | `docker buildx imagetools inspect alpine:3.21 (read the Digest: line)`                                                                          |
 | NodeSource repo key                              | `NODESOURCE_KEY_SHA256` in `Dockerfile.base`                                       | `sha256sum` of the fetched `gpgkey/nodesource-repo.gpg.key` (after cross-checking the new key's fingerprint against NodeSource's docs)          |
 | GitHub CLI repo key                              | `GITHUBCLI_KEYRING_SHA256` in `Dockerfile.base`                                    | `sha256sum` of the fetched `githubcli-archive-keyring.gpg` (fingerprint in the Dockerfile comment)                                              |
 | Caddy repo key (Cloudsmith)                      | `CADDY_REPO_KEY_SHA256` in `src/containers/host/Dockerfile`                        | `sha256sum` of the fetched `gpg.key` (fingerprint in the Dockerfile comment; cross-check <https://cloudsmith.io/~caddy/repos/stable/pub-keys/>) |
@@ -124,3 +126,26 @@ Notes:
   (integrity-checked by npm against registry metadata, as usual).
 - `scripts/tests/test_supply_chain_pins.py` holds contract tests asserting
   the pins exist; removing one without updating that file fails CI.
+
+### Accepted residuals
+
+Not everything fetched at build time is hash-verified. What remains
+trusted through TLS plus the source's own integrity mechanisms, and why
+(called out explicitly so the posture above is not over-read — #2788
+review):
+
+- **PyPI/npm dependency closures.** `pip install` of the klangk wheel's
+  deps (host image, network sidecar) and npm's resolution of the Pi
+  agent tarball's deps rely on the registry's metadata-bound integrity
+  records. Pinning the full transitive closure would require
+  `--require-hashes` lockfiles maintained outside this repo's wheels.
+- **nix-seed sandbox** (`src/containers/nix-seed/Dockerfile`): the nix
+  installer is still piped to `sh` and the devenv flake ref is mutable.
+  It is a build sandbox whose output is a content-addressed `/nix` store;
+  it is never baked into a shipped image. A malicious installer would
+  have to compromise the machine that computes those store addresses.
+- **`ssh-keyscan github.com`** in `Dockerfile.base` bakes host keys via
+  TOFU at build time rather than pinning GitHub's published
+  fingerprints.
+- **`dist-smoke-test.sh`** builds a throwaway `node:22-slim` (mutable
+  tag) smoke image — dev-only, never shipped.

--- a/scripts/pull-base-image.sh
+++ b/scripts/pull-base-image.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
+# Pull the workspace base image into the local podman store.
+#
+# Pulls exactly the reference pinned by WORKSPACE_BASE_IMAGE in the workspace
+# Dockerfile — an immutable digest since #2063 — never a mutable :latest, so
+# the local cache always matches what a workspace build consumes. The pinned
+# reference is multi-arch; podman selects the variant for the host platform.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
 # shellcheck source=_podman_common.sh disable=SC1091
 source "$SCRIPT_DIR/_podman_common.sh"
+
+DOCKERFILE="${DEVENV_ROOT:-$SCRIPT_DIR/..}/src/containers/workspace/Dockerfile"
+BASE_REF="$(sed -n 's/^ARG WORKSPACE_BASE_IMAGE=//p' "$DOCKERFILE")"
+if [ -z "$BASE_REF" ]; then
+  echo "error: WORKSPACE_BASE_IMAGE not found in $DOCKERFILE" >&2
+  exit 1
+fi
 "$PODMAN" pull \
   "${SIG_POLICY_ARGS[@]}" \
-  ghcr.io/mcdonc/klangk/klangk-workspace-base:latest
+  "$BASE_REF"

--- a/scripts/tests/test_supply_chain_pins.py
+++ b/scripts/tests/test_supply_chain_pins.py
@@ -1,0 +1,260 @@
+"""Contract tests for pinned third-party artifacts at image-build time (#2063).
+
+Every artifact fetched from the network during an image build must be
+verified against a hash pinned in the Dockerfile (or pulled by immutable
+digest), so a compromised registry/CDN or a MITM cannot swap content
+undetected. These are grep-style contract tests in the spirit of
+``test_build_script_remote_guard.py``: they assert the *verification
+mechanism* is present in the real Dockerfiles, so an edit that silently
+removes a pin is loud.
+
+What is pinned where (see docs/development/building-images.md for the
+rotation procedures):
+
+- ``src/containers/workspace/Dockerfile``
+    - workspace base image: ``@sha256:`` digest (bumped by the auto-PR from
+      .github/workflows/image-workspace-base.yml)
+    - pi agent npm tarball: SHA-512 (registry ``dist.integrity``)
+    - uv release tarball: per-arch SHA-256 (amd64/arm64)
+    - process-compose release tarball: per-arch SHA-256 (amd64/arm64)
+- ``src/containers/workspace/Dockerfile.base``
+    - debian:trixie-slim: digest (pre-existing, #2432)
+    - nodesource + github-cli repo keys: SHA-256 of the fetched key file
+- ``src/containers/host/Dockerfile``
+    - python:3.13-slim: digest
+    - Caddy Cloudsmith repo key: SHA-256 of the fetched key file
+- ``src/containers/network/Dockerfile`` — alpine:3.21: digest
+- ``src/containers/{workspace,host}/Dockerfile.fips`` and
+  ``src/containers/nix-seed/Dockerfile`` — debian:trixie-slim builders
+  share Dockerfile.base's digest pin.
+
+Caddy's apt sources list is written inline (not fetched), so the repo key is
+the only network-sourced trust input for that repo; apt's own GPG
+verification then covers the package indexes and debs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+_WORKSPACE_DF = _ROOT / "src/containers/workspace/Dockerfile"
+_WORKSPACE_BASE_DF = _ROOT / "src/containers/workspace/Dockerfile.base"
+_HOST_DF = _ROOT / "src/containers/host/Dockerfile"
+_NETWORK_DF = _ROOT / "src/containers/network/Dockerfile"
+
+# Every Dockerfile that participates in image builds. FROM lines must be
+# digest-pinned, an ARG reference, or a local build-stage alias — never a
+# mutable registry tag.
+_IMAGE_DOCKERFILES = [
+    _WORKSPACE_DF,
+    _WORKSPACE_BASE_DF,
+    _WORKSPACE_DF.with_name("Dockerfile.fips"),
+    _HOST_DF,
+    _HOST_DF.with_name("Dockerfile.fips"),
+    _NETWORK_DF,
+    _ROOT / "src/containers/nix-seed/Dockerfile",
+]
+
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+_HEX128 = re.compile(r"^[0-9a-f]{128}$")
+
+
+def _arg(df: Path, name: str) -> str:
+    """Value of a top-level ``ARG name=value`` line (no default → '')."""
+    m = re.search(rf"^ARG {name}=(\S+)", df.read_text(), re.MULTILINE)
+    return m.group(1) if m else ""
+
+
+# ── Base/host images: immutable digest references ───────────────────────────
+
+
+class TestFromLinesPinnedByDigest:
+    def test_every_image_dockerfile_from_line_is_digest_arg_or_alias(self):
+        for df in _IMAGE_DOCKERFILES:
+            text = df.read_text()
+            froms = re.findall(r"(?im)^FROM\s+(\S+)", text)
+            assert froms, f"{df} has no FROM lines — test is stale"
+            # Stage names defined in this file (``FROM … AS name``) may be
+            # used as later FROM targets without a digest.
+            stage_names = {
+                m.lower() for m in re.findall(r"(?im)^FROM\s+\S+\s+AS\s+(\S+)", text)
+            }
+            for ref in froms:
+                if ref.startswith("$"):
+                    continue  # ARG reference (value pinned elsewhere)
+                if ref.lower() in stage_names:
+                    continue  # local build-stage alias
+                assert "@sha256:" in ref, (
+                    f"{df}: FROM {ref} is not pinned by digest (#2063) — "
+                    f"mutable-tag base images let the registry serve "
+                    f"different content for the same reference"
+                )
+
+    def test_workspace_base_image_arg_is_digest(self):
+        ref = _arg(_WORKSPACE_DF, "WORKSPACE_BASE_IMAGE")
+        assert re.match(
+            r"^ghcr\.io/mcdonc/klangk/klangk-workspace-base@sha256:[0-9a-f]{64}$",
+            ref,
+        ), f"WORKSPACE_BASE_IMAGE must be a full repo@digest ref, got {ref!r}"
+
+    def test_fips_and_nix_seed_share_dockerfile_base_digest(self):
+        pinned = (
+            "debian:trixie-slim@"
+            "sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258"
+        )
+        assert pinned in _WORKSPACE_BASE_DF.read_text(), (
+            "Dockerfile.base's debian digest pin changed — update this test "
+            "AND the three aligned builders (workspace/Dockerfile.fips, "
+            "host/Dockerfile.fips, nix-seed/Dockerfile) together"
+        )
+        aligned_builders = [
+            _ROOT / "src/containers/workspace/Dockerfile.fips",
+            _ROOT / "src/containers/host/Dockerfile.fips",
+            _ROOT / "src/containers/nix-seed/Dockerfile",
+        ]
+        for df in aligned_builders:
+            assert pinned in df.read_text(), (
+                f"{df} must pin the same debian:trixie-slim digest as Dockerfile.base"
+            )
+
+    def test_base_image_workflow_pins_digest_in_auto_pr(self):
+        wf = (_ROOT / ".github/workflows/image-workspace-base.yml").read_text()
+        assert "imagetools inspect" in wf, (
+            "the base-image workflow must resolve the pushed manifest digest"
+        )
+        assert 'echo "image=$REPO@$DIGEST"' in wf, (
+            "the auto-PR must rewrite WORKSPACE_BASE_IMAGE to a repo@digest "
+            "reference, not a mutable tag (#2063)"
+        )
+
+    def test_pull_base_image_pulls_the_pinned_reference(self):
+        script = (_ROOT / "scripts/pull-base-image.sh").read_text()
+        code_lines = [
+            ln for ln in script.splitlines() if not ln.lstrip().startswith("#")
+        ]
+        assert any("WORKSPACE_BASE_IMAGE" in ln for ln in code_lines), (
+            "pull-base-image.sh must pull the reference pinned in the "
+            "workspace Dockerfile"
+        )
+        assert not any(":latest" in ln for ln in code_lines), (
+            "pull-base-image.sh must not pull a mutable :latest tag (#2063)"
+        )
+
+
+# ── Workspace image: verified tarballs (pi agent, uv, process-compose) ───────
+
+
+class TestWorkspaceTarballPins:
+    def test_pi_agent_tarball_is_sha512_verified(self):
+        text = _WORKSPACE_DF.read_text()
+        assert (
+            "registry.npmjs.org/@earendil-works/pi-coding-agent/-/"
+            "pi-coding-agent-${PI_AGENT_VERSION}.tgz" in text
+        ), "pi agent must be installed from the registry tarball URL"
+        assert re.search(
+            r"\$\{PI_AGENT_SHA512\}\s+/tmp/pi-agent\.tgz.*\| sha512sum -c -",
+            text,
+        ), "pi agent tarball must be verified (sha512sum -c) before install"
+        assert _HEX128.match(_arg(_WORKSPACE_DF, "PI_AGENT_SHA512")), (
+            "PI_AGENT_SHA512 must be a 128-hex-char sha512"
+        )
+        assert "npm install -g /tmp/pi-agent.tgz" in text, (
+            "pi agent must be installed from the verified local tarball, not "
+            "a registry-resolved version string"
+        )
+
+    def test_uv_is_per_arch_sha256_verified(self):
+        text = _WORKSPACE_DF.read_text()
+        assert "astral.sh" not in text, (
+            "uv must not be installed via the astral.sh piped installer (#2063)"
+        )
+        assert re.search(r"\$\{sha\}\s+/tmp/uv\.tar\.gz.*\| sha256sum -c -", text), (
+            "uv tarball must be verified (sha256sum -c) before extraction"
+        )
+        for arch in ("AMD64", "ARM64"):
+            assert _HEX64.match(_arg(_WORKSPACE_DF, f"UV_SHA256_{arch}")), (
+                f"UV_SHA256_{arch} must be a 64-hex-char sha256"
+            )
+        # Both arches must map to their own pin inside the build.
+        assert 'sha="$UV_SHA256_AMD64"' in text and 'sha="$UV_SHA256_ARM64"' in text
+
+    def test_process_compose_is_per_arch_sha256_verified(self):
+        text = _WORKSPACE_DF.read_text()
+        assert re.search(
+            r"\$\{sha\}\s+/tmp/process-compose\.tar\.gz.*\| sha256sum -c -", text
+        ), "process-compose tarball must be verified (sha256sum -c) before tar"
+        for arch in ("AMD64", "ARM64"):
+            assert _HEX64.match(
+                _arg(_WORKSPACE_DF, f"PROCESS_COMPOSE_SHA256_{arch}")
+            ), f"PROCESS_COMPOSE_SHA256_{arch} must be a 64-hex-char sha256"
+
+    def test_no_unverified_curl_pipes(self):
+        """No `curl ... | sh` / `curl ... | tar` piping anywhere in the
+        workspace Dockerfile — download-to-file, verify, then act."""
+        text = _WORKSPACE_DF.read_text()
+        code_lines = [ln for ln in text.splitlines() if not ln.lstrip().startswith("#")]
+        for line in code_lines:
+            assert not re.search(r"curl\s+\S*\|", line), (
+                f"piped curl in workspace Dockerfile (unverified network "
+                f"input, #2063): {line.strip()}"
+            )
+
+
+# ── Apt repo keys: verified before entering a keyring ───────────────────────
+
+
+class TestAptRepoKeyPins:
+    def test_caddy_key_is_verified_and_sources_written_inline(self):
+        text = _HOST_DF.read_text()
+        assert re.search(
+            r"\$\{CADDY_REPO_KEY_SHA256\}\s+/tmp/caddy-stable\.key.*"
+            r"\| sha256sum -c -",
+            text,
+        ), "Caddy repo key must be sha256-verified before dearmor (#2063)"
+        assert _HEX64.match(_arg(_HOST_DF, "CADDY_REPO_KEY_SHA256")), (
+            "CADDY_REPO_KEY_SHA256 must be a 64-hex-char sha256"
+        )
+        # The sources list is written inline, not fetched over the network.
+        assert (
+            "echo 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg]"
+            " https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main'"
+            in text
+        ), "Caddy apt sources list must be written inline (#2063)"
+        assert "debian.deb.txt" not in text, (
+            "Caddy sources list must not be fetched from the network (#2063)"
+        )
+
+    def test_nodesource_and_githubcli_keys_are_verified(self):
+        text = _WORKSPACE_BASE_DF.read_text()
+        assert re.search(
+            r"\$\{NODESOURCE_KEY_SHA256\}\s+/tmp/nodesource-repo\.gpg\.key.*"
+            r"\| sha256sum -c -",
+            text,
+        ), "NodeSource repo key must be sha256-verified before dearmor (#2063)"
+        assert _HEX64.match(_arg(_WORKSPACE_BASE_DF, "NODESOURCE_KEY_SHA256"))
+        assert re.search(
+            r"\$\{GITHUBCLI_KEYRING_SHA256\}\s+/tmp/githubcli-archive-keyring\.gpg.*"
+            r"\| sha256sum -c -",
+            text,
+        ), "GitHub CLI keyring must be sha256-verified before use (#2063)"
+        assert _HEX64.match(_arg(_WORKSPACE_BASE_DF, "GITHUBCLI_KEYRING_SHA256"))
+
+    def test_no_unverified_key_fetches_in_base_or_host(self):
+        """Every gpg key fetch in the base/host images lands in a file that a
+        pinned-hash check reads before the key enters a keyring."""
+        for df, needles in (
+            (
+                _WORKSPACE_BASE_DF,
+                ("nodesource-repo.gpg.key", "githubcli-archive-keyring.gpg"),
+            ),
+            (_HOST_DF, ("caddy/stable/gpg.key",)),
+        ):
+            text = df.read_text()
+            for needle in needles:
+                assert "-o /tmp/" in text and needle in text, (
+                    f"{df}: {needle} must be downloaded to a file for hash "
+                    f"verification, not piped straight into a keyring (#2063)"
+                )

--- a/scripts/tests/test_supply_chain_pins.py
+++ b/scripts/tests/test_supply_chain_pins.py
@@ -125,6 +125,13 @@ class TestFromLinesPinnedByDigest:
         assert "imagetools inspect" in wf, (
             "the base-image workflow must resolve the pushed manifest digest"
         )
+        # The json form is load-bearing: buildx special-cases plain
+        # '{{.Manifest…}}' --format values into printing the full table,
+        # which would corrupt the DIGEST capture (found in #2788 review).
+        assert "{{json .Manifest.Digest}}" in wf, (
+            "the digest extraction must use the json form — plain "
+            "'{{.Manifest.Digest}}' makes buildx print the whole table"
+        )
         assert 'echo "image=$REPO@$DIGEST"' in wf, (
             "the auto-PR must rewrite WORKSPACE_BASE_IMAGE to a repo@digest "
             "reference, not a mutable tag (#2063)"
@@ -192,15 +199,24 @@ class TestWorkspaceTarballPins:
             ), f"PROCESS_COMPOSE_SHA256_{arch} must be a 64-hex-char sha256"
 
     def test_no_unverified_curl_pipes(self):
-        """No `curl ... | sh` / `curl ... | tar` piping anywhere in the
-        workspace Dockerfile — download-to-file, verify, then act."""
-        text = _WORKSPACE_DF.read_text()
-        code_lines = [ln for ln in text.splitlines() if not ln.lstrip().startswith("#")]
-        for line in code_lines:
-            assert not re.search(r"curl\s+\S*\|", line), (
-                f"piped curl in workspace Dockerfile (unverified network "
-                f"input, #2063): {line.strip()}"
-            )
+        """No `curl ... | sh` / `curl ... | tar` piping in the image
+        Dockerfiles whose installs are fully pinned (workspace, host, base) —
+        download-to-file, verify, then act. The regex `curl[^|]*\|` matches
+        any line with `curl` followed later by a pipe (a `\S*`-anchored form
+        misses the space between flag and URL, which is how the original
+        `curl | sh` lines would slip past). nix-seed is excluded: its piped
+        nix installer is a documented accepted residual (see
+        docs/development/building-images.md, "Accepted residuals")."""
+        for df in (_WORKSPACE_DF, _HOST_DF, _WORKSPACE_BASE_DF):
+            text = df.read_text()
+            code_lines = [
+                ln for ln in text.splitlines() if not ln.lstrip().startswith("#")
+            ]
+            for line in code_lines:
+                assert not re.search(r"curl[^|]*\|", line), (
+                    f"piped curl in {df.name} (unverified network input, "
+                    f"#2063): {line.strip()}"
+                )
 
 
 # ── Apt repo keys: verified before entering a keyring ───────────────────────

--- a/src/containers/host/Dockerfile
+++ b/src/containers/host/Dockerfile
@@ -1,9 +1,28 @@
-FROM python:3.13-slim AS base
+# python:3.13-slim pinned by IMMUTABLE DIGEST (multi-arch manifest list)
+# so the registry cannot serve different content for the tag (#2063).
+# Bump: docker buildx imagetools inspect python:3.13-slim \
+#         --format '{{.Manifest.Digest}}'
+FROM python:3.13-slim@sha256:7ce4b6dfe35e55397b7cda544f8a13f191b7ae28dc5aad71fe664dbc9bc2623f AS base
 
 # Rebuild to pick up latest security patches (CVE-2026-45447 openssl).
 # The reverse proxy is Caddy (klangkd's default engine since #1559), installed
 # from the official Caddy apt repo (not in Debian's default repos). nginx is
 # gone — klangkd renders a Caddyfile and drives Caddy over its admin API.
+#
+# Supply-chain posture (#2063): the Cloudsmith GPG key is trusted only after
+# its SHA-256 is verified against the pin below — an unverified fetch lets a
+# MITM/compromised CDN choose which key signs the repo. The apt sources list
+# is written inline (not fetched), so the key is the only network-sourced
+# trust input; apt then GPG-verifies the package indexes and debs with it.
+#
+# Key provenance (for independent verification): the repo's primary key
+# fingerprint is 6576 0C51 EDEA 2017 CEA2  CA15 155B 6D79 CA56 EA34,
+# published at https://cloudsmith.io/~caddy/repos/stable/pub-keys/
+#
+# Bump: if Cloudsmith rotates the key, re-download gpg.key, recompute its
+# sha256, and update this ARG (after cross-checking the new fingerprint
+# against the pub-keys page above).
+ARG CADDY_REPO_KEY_SHA256=783dfee04b19e851a928cd87b34710213ebbe7628f98d9f34595ab83be578c00
 RUN apt-get update && apt-get install -y --no-install-recommends \
       apt-transport-https \
       bash \
@@ -23,8 +42,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       tar \
       uidmap \
     && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
-        | gpg --dearmor --yes -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
-    && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+        -o /tmp/caddy-stable.key \
+    && echo "${CADDY_REPO_KEY_SHA256}  /tmp/caddy-stable.key" | sha256sum -c - \
+    && gpg --dearmor --yes \
+        -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg /tmp/caddy-stable.key \
+    && rm -f /tmp/caddy-stable.key \
+    && echo 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main' \
         > /etc/apt/sources.list.d/caddy-stable.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends caddy \

--- a/src/containers/host/Dockerfile
+++ b/src/containers/host/Dockerfile
@@ -1,7 +1,7 @@
 # python:3.13-slim pinned by IMMUTABLE DIGEST (multi-arch manifest list)
 # so the registry cannot serve different content for the tag (#2063).
-# Bump: docker buildx imagetools inspect python:3.13-slim \
-#         --format '{{.Manifest.Digest}}'
+# Bump: docker buildx imagetools inspect python:3.13-slim
+# (read the `Digest:` line of the manifest list)
 FROM python:3.13-slim@sha256:7ce4b6dfe35e55397b7cda544f8a13f191b7ae28dc5aad71fe664dbc9bc2623f AS base
 
 # Rebuild to pick up latest security patches (CVE-2026-45447 openssl).

--- a/src/containers/host/Dockerfile.fips
+++ b/src/containers/host/Dockerfile.fips
@@ -37,7 +37,10 @@
 ARG HOST_IMAGE=klangk-host:latest
 
 # --- Stage 1: build the validated FIPS module -------------------------------
-FROM debian:trixie-slim AS fips-builder
+# Digest-pinned to the SAME debian:trixie-slim manifest as
+# src/containers/workspace/Dockerfile.base (#2063) — keep the two in sync
+# when bumping (Dockerfile.base is the source of truth).
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS fips-builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential perl wget ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/src/containers/network/Dockerfile
+++ b/src/containers/network/Dockerfile
@@ -10,7 +10,8 @@
 # module today, but the package will grow multifile, and a wheel install keeps
 # working then (#2450). entrypoint.sh execs ``python3 -m proxy``.
 # alpine:3.21 pinned by IMMUTABLE DIGEST (multi-arch manifest list, #2063).
-# Bump: docker buildx imagetools inspect alpine:3.21 --format '{{.Manifest.Digest}}'
+# Bump: docker buildx imagetools inspect alpine:3.21
+# (read the `Digest:` line of the manifest list)
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 # Runtime: iptables + python3 + the C libs netfilterqueue links (the
 # interactive-mode NFQUEUE consumer, #2242). Build deps are installed

--- a/src/containers/network/Dockerfile
+++ b/src/containers/network/Dockerfile
@@ -9,7 +9,9 @@
 # wheel's metadata — rather than a hand-copied proxy.py. proxy.py is a single
 # module today, but the package will grow multifile, and a wheel install keeps
 # working then (#2450). entrypoint.sh execs ``python3 -m proxy``.
-FROM alpine:3.21
+# alpine:3.21 pinned by IMMUTABLE DIGEST (multi-arch manifest list, #2063).
+# Bump: docker buildx imagetools inspect alpine:3.21 --format '{{.Manifest.Digest}}'
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 # Runtime: iptables + python3 + the C libs netfilterqueue links (the
 # interactive-mode NFQUEUE consumer, #2242). Build deps are installed
 # transiently to compile the netfilterqueue C extension (pulled in by the

--- a/src/containers/nix-seed/Dockerfile
+++ b/src/containers/nix-seed/Dockerfile
@@ -10,9 +10,11 @@
 # It is a BUILD SANDBOX, not a workspace image: nothing here is baked into a
 # running workspace. The seed store is content-addressed, so the base image
 # choice (debian:trixie-slim) only affects the build environment, not the
-# resulting /nix content.
+# resulting /nix content. Still pinned by digest (same manifest as
+# src/containers/workspace/Dockerfile.base, #2063) so the sandbox itself
+# cannot silently change under a mutable tag.
 
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 
 ARG NIX_INSTALL_URL=https://nixos.org/nix/install
 ARG DEVENV_FLAKE=github:cachix/devenv/latest

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -1,9 +1,29 @@
-ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.08.26-6fbab1f
+# Base image is pinned by IMMUTABLE DIGEST (#2063): a mutable tag lets the
+# registry serve different content for the same reference. The reference is
+# the multi-arch manifest (amd64 + arm64); build-workspace-image.sh selects
+# the platform via --platform. Bumped automatically by the auto-PR opened by
+# .github/workflows/image-workspace-base.yml after each base-image build
+# (the PR rewrites this line with the new repo@digest reference).
+ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base@sha256:1f05ee5e8579507c710ab2b9e7c27536ce008cff12644f2329b9a97a9d94dc02
 FROM $WORKSPACE_BASE_IMAGE
 
-# Install Pi coding agent globally. This layer is expensive (~30s) and
+# Install Pi coding agent globally. The tarball is fetched directly from the
+# npm registry and its SHA-512 verified against a pin before install (#2063):
+# `npm install pkg@version` alone accepts whatever the registry serves for
+# the version, with no pinned integrity. This layer is expensive (~30s) and
 # rarely changes, so it goes first.
-RUN npm install -g @earendil-works/pi-coding-agent@0.83.0 \
+#
+# Bump: set PI_AGENT_VERSION, then refresh PI_AGENT_SHA512 from the
+# registry's own integrity record:
+#   npm view @earendil-works/pi-coding-agent@<version> dist.integrity
+# (base64 sha512 -> hex), or sha512sum of the fetched tarball.
+ARG PI_AGENT_VERSION=0.83.0
+ARG PI_AGENT_SHA512=b98845f85b19c68828497fc0c4171476263e66496e6f0697c80a04180d9e430b077321008546082a1fd62d77bf6bcfa4f1e4c29b16fe64dd99a3d9b342dcdb5b
+RUN curl -fsSL -o /tmp/pi-agent.tgz \
+      "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-${PI_AGENT_VERSION}.tgz" \
+    && echo "${PI_AGENT_SHA512}  /tmp/pi-agent.tgz" | sha512sum -c - \
+    && npm install -g /tmp/pi-agent.tgz \
+    && rm -f /tmp/pi-agent.tgz \
     && mkdir -p /opt/klangk/pi-agent/extensions /opt/klangk/pi-agent/skills
 
 # Copy full feature repos and symlink discoverable pieces into central dirs.
@@ -32,19 +52,55 @@ RUN mkdir -p /opt/klangk/bin /opt/klangk/pi-agent/extensions \
        done
 COPY builtin-extensions/ /opt/klangk/pi-agent/extensions/
 
-# Install uv (fast Python package manager)
-RUN curl -LsSf https://astral.sh/uv/0.11.23/install.sh | sh \
-    && mv /root/.local/bin/uv /usr/local/bin/uv \
-    && mv /root/.local/bin/uvx /usr/local/bin/uvx
+# Install uv (fast Python package manager). The GitHub release tarball is
+# fetched directly and its SHA-256 verified per architecture before
+# extraction (#2063) — no piped installer script: `curl | sh` executes
+# whatever the URL serves, and the uv binary the installer then fetched was
+# equally unverified.
+#
+# Bump: set UV_VERSION, then refresh both pins with sha256sum of each arch
+# tarball (or the .sha256 sidecar files published alongside the release).
+ARG UV_VERSION=0.11.23
+ARG UV_SHA256_AMD64=e12c4cda2fe8c305510a78380a88f2c32a27e90cdcd123cefd2873388f0ebb5f
+ARG UV_SHA256_ARM64=1873a77350f6621279ae1a0d2227f2bd8b67131598f14a7eb0ba2215d3da2c98
+RUN set -eu; \
+    case "$(dpkg --print-architecture)" in \
+      amd64) target=x86_64-unknown-linux-gnu; sha="$UV_SHA256_AMD64" ;; \
+      arm64) target=aarch64-unknown-linux-gnu; sha="$UV_SHA256_ARM64" ;; \
+      *) echo "unsupported arch for uv: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/uv.tar.gz \
+      "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${target}.tar.gz"; \
+    echo "${sha}  /tmp/uv.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/uv.tar.gz -C /tmp "uv-${target}"; \
+    install -m 0755 "/tmp/uv-${target}/uv" /usr/local/bin/uv; \
+    install -m 0755 "/tmp/uv-${target}/uvx" /usr/local/bin/uvx; \
+    rm -rf /tmp/uv.tar.gz "/tmp/uv-${target}"; \
+    uv --version && uvx --version
 
 # Install process-compose supervisor (standalone Go binary, arch-aware).
 # Extracts the single binary from the release tarball into /usr/local/bin
-# so it is on PATH for all login and non-login shells.
+# so it is on PATH for all login and non-login shells. The tarball's
+# SHA-256 is verified against a pin before extraction (#2063).
+#
+# Bump: set PROCESS_COMPOSE_VERSION, then refresh both pins with sha256sum
+# of each arch tarball.
 ARG PROCESS_COMPOSE_VERSION=1.120.0
-RUN ARCH="$(dpkg --print-architecture)" \
-    && curl -fsSL "https://github.com/F1bonacc1/process-compose/releases/download/v${PROCESS_COMPOSE_VERSION}/process-compose_linux_${ARCH}.tar.gz" \
-       | tar -xz -C /usr/local/bin process-compose \
-    && chmod +x /usr/local/bin/process-compose
+ARG PROCESS_COMPOSE_SHA256_AMD64=3792e1ed9f383832eb2362154444e8564fbc8e7e8e7cff8754c68aea5eca086e
+ARG PROCESS_COMPOSE_SHA256_ARM64=c5f4fcfc63e849279ac531bce2394a918fb28746339088a7d3d02bb5fb218a68
+RUN set -eu; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "$ARCH" in \
+      amd64) sha="$PROCESS_COMPOSE_SHA256_AMD64" ;; \
+      arm64) sha="$PROCESS_COMPOSE_SHA256_ARM64" ;; \
+      *) echo "unsupported arch for process-compose: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/process-compose.tar.gz \
+      "https://github.com/F1bonacc1/process-compose/releases/download/v${PROCESS_COMPOSE_VERSION}/process-compose_linux_${ARCH}.tar.gz"; \
+    echo "${sha}  /tmp/process-compose.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/process-compose.tar.gz -C /usr/local/bin process-compose; \
+    chmod +x /usr/local/bin/process-compose; \
+    process-compose version
 
 # Entrypoint, agent context file, bash defaults (change frequently during dev)
 COPY agent-context.md /opt/klangk/agent-context.md

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -79,9 +79,21 @@ ENV LC_ALL=en_US.UTF-8
 # install Debian's separate `npm`, which would pull distro Node 20 as a
 # dependency. NodeSource keeps every 26.x patch in its repo, so this pin is
 # durable. (#2432)
+#
+# Supply-chain (#2063): the repo key's SHA-256 is verified before it enters
+# the keyring. Key provenance: primary fingerprint
+#   6F71 F525 2828 41EE DAF8 51B4 2F59 B5F9 9B1B E0B4
+# (NodeSource's documented repo key). The sources list is written inline, so
+# the key is the only network-sourced trust input. Bump: if NodeSource rotates
+# the key, re-download gpgkey/nodesource-repo.gpg.key, recompute its sha256,
+# and update this ARG.
+ARG NODESOURCE_KEY_SHA256=b42e0321dabdc24e892115da705cf061167eac12a317f23d329862d0aa0a271d
 ARG NODEJS_VERSION=26.7.0-1nodesource1
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-      | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+        -o /tmp/nodesource-repo.gpg.key \
+    && echo "${NODESOURCE_KEY_SHA256}  /tmp/nodesource-repo.gpg.key" | sha256sum -c - \
+    && gpg --dearmor -o /usr/share/keyrings/nodesource.gpg /tmp/nodesource-repo.gpg.key \
+    && rm -f /tmp/nodesource-repo.gpg.key \
     && chmod 644 /usr/share/keyrings/nodesource.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_26.x nodistro main" \
        > /etc/apt/sources.list.d/nodesource.list \
@@ -91,9 +103,19 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
     && rm -rf /var/lib/apt/lists/* \
     && chown -R root:root /var/log/apt
 
-# GitHub CLI (not in default Debian repos)
+# GitHub CLI (not in default Debian repos). Same posture as NodeSource above
+# (#2063): the archive keyring's SHA-256 is verified before use. Provenance:
+# the ring carries GitHub's current signing key (primary fingerprint
+#   2C61 0620 1985 B60E 6C7A C873 23F3 D4EA 7571 6059
+# — the fingerprint GitHub's install docs have long published) plus one
+# earlier rotation key. Bump: re-download the keyring, recompute sha256,
+# update this ARG.
+ARG GITHUBCLI_KEYRING_SHA256=6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+        -o /tmp/githubcli-archive-keyring.gpg \
+    && echo "${GITHUBCLI_KEYRING_SHA256}  /tmp/githubcli-archive-keyring.gpg" | sha256sum -c - \
+    && mv /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y --no-install-recommends gh \

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -105,10 +105,11 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
 
 # GitHub CLI (not in default Debian repos). Same posture as NodeSource above
 # (#2063): the archive keyring's SHA-256 is verified before use. Provenance:
-# the ring carries GitHub's current signing key (primary fingerprint
+# the ring carries GitHub's long-documented signing key (primary fingerprint
 #   2C61 0620 1985 B60E 6C7A C873 23F3 D4EA 7571 6059
 # — the fingerprint GitHub's install docs have long published) plus one
-# earlier rotation key. Bump: re-download the keyring, recompute sha256,
+# newer rotation key. Expect a keyring bump (loud sha256 failure) when the
+# old key is retired. Bump: re-download the keyring, recompute sha256,
 # update this ARG.
 ARG GITHUBCLI_KEYRING_SHA256=6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -39,7 +39,10 @@
 ARG WORKSPACE_IMAGE=klangk-workspace:latest
 
 # --- Stage 1: build the validated FIPS module -------------------------------
-FROM debian:trixie-slim AS fips-builder
+# Digest-pinned to the SAME debian:trixie-slim manifest as Dockerfile.base
+# (#2063) — keep the two in sync when bumping (Dockerfile.base is the source
+# of truth; its comment explains the rotation procedure).
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS fips-builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential perl wget ca-certificates && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #2063.

Every third-party artifact fetched at image-build/install time is now verified against a hash pinned in the Dockerfile, and every base image is pulled by immutable digest. A compromised registry, CDN, or MITM can no longer swap build inputs undetected — a mismatch fails the build loudly.

## Verified installs (workspace image)

- **uv** — the GitHub release tarball is fetched directly and its SHA-256 verified **per architecture** (amd64/arm64) before extraction. Replaces `curl -LsSf https://astral.sh/uv/…/install.sh | sh`, which executed whatever the URL served *and* then fetched the uv binary equally unverified.
- **process-compose** — release tarball fetched per-arch and SHA-256 verified before `tar -x` (previously piped straight into `tar` with no check).
- **Pi agent** — the npm tarball is fetched directly from `registry.npmjs.org` and its SHA-512 verified (cross-checked equal to the registry's own `dist.integrity` for 0.83.0) before `npm install -g`; `npm install pkg@version` alone accepts whatever the registry serves.

## Apt repo trust

- **Caddy (host image)** — the Cloudsmith GPG key is SHA-256-pinned before it enters the keyring, and the apt sources list is written **inline** instead of fetched (`debian.deb.txt` was previously piped in unverified). The repo's primary key fingerprint (`6576 0C51 EDEA 2017 CEA2 CA15 155B 6D79 CA56 EA34`) is documented in the Dockerfile comment for independent verification against Cloudsmith's pub-keys page. Caddy itself stays unpinned so rebuilds pick up security patches; its integrity rests on the pinned repo key + apt's signature verification.
- **NodeSource + GitHub CLI (workspace base)** — same treatment: key files SHA-256-pinned before dearmor/use, sources lists written inline.

## Immutable base images

- **Workspace base (GHCR)** — `WORKSPACE_BASE_IMAGE` now pins `@sha256:` (multi-arch manifest); the `image-workspace-base.yml` auto-PR resolves the pushed manifest digest with `buildx imagetools inspect` and rewrites the ARG to `repo@digest`.
- **python:3.13-slim** (host), **alpine:3.21** (network sidecar) — pinned by manifest-list digest.
- **debian:trixie-slim** — the two FIPS builder stages and the nix-seed sandbox now share `Dockerfile.base`'s digest pin (#2432) instead of a mutable tag.
- **`pull-base-image.sh`** pulls exactly the pinned reference instead of `:latest`.

## Docs & tests

- `docs/development/building-images.md` — new "Pinned Third-Party Artifacts" table: where each pin lives and how to rotate on a bump.
- `scripts/tests/test_supply_chain_pins.py` — contract tests asserting the pins/verification mechanism exist in the real Dockerfiles (removing one fails CI). Full `scripts/tests` suite: 83 passed.

## Empirical verification

- Full workspace image built from the digest-pinned base; `uv 0.11.23`, `uvx`, `process-compose v1.120.0`, `pi 0.83.0` confirmed installed in the built image.
- Negative test: `--build-arg PROCESS_COMPOSE_SHA256_AMD64=<zeros>` fails the build at `sha256sum -c`.
- Caddy fragment run end-to-end inside the exact pinned `python:3.13-slim` digest (key verify → dearmor → inline sources → apt → `caddy v2.11.4`).
- Network sidecar builds from the pinned Alpine digest; NodeSource/gh-cli key fragments verified inside the pinned Debian digest.
