### PR TITLE
build(devenv): add xenon cyclomatic-complexity pre-commit hook

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -601,6 +601,24 @@ in
       language = "system";
       pass_filenames = true;
     };
+    # Python: cyclomatic-complexity gate (#2794). Blocks must stay rank E
+    # or better (complexity <= 40); module/average gates are off (rank F)
+    # because they flap when only a few files are staged. Baselined to the
+    # tree at introduction: the three legacy F-ranked blocks below are
+    # excluded until refactored — shrink the excludes as they are fixed.
+    xenon = {
+      enable = true;
+      name = "xenon";
+      entry = "${pkgs.xenon}/bin/xenon --max-absolute E --max-modules F --max-average F";
+      files = "^src/klangk/klangk/.*\\.py$|^scripts/.*\\.py$";
+      excludes = [
+        "^src/klangk/klangk/cli/edit\\.py$"
+        "^src/klangk/klangk/cli/client\\.py$"
+        "^src/klangk/klangk/cli/tui/screens/workspace_form\\.py$"
+      ];
+      language = "system";
+      pass_filenames = true;
+    };
     # Dart
     dart-format = {
       enable = true;


### PR DESCRIPTION
## Summary

Adds a **xenon** (radon-based) cyclomatic-complexity gate to the devenv git hooks (#2794), next to `ruff check` / `ruff format`.

## Details

- New `git-hooks.hooks.xenon` entry in `devenv.nix`, running `xenon` from `pkgs.xenon` on staged Python files under `src/klangk/klangk/` and `scripts/` (production code only — tests/e2e are out of scope).
- Threshold baselined so the hook passes on the current tree: `--max-absolute E` (blocks must stay complexity ≤ 40); module and average gates are disabled (rank `F`) because they flap when only a few files are staged.
- The three legacy rank-F blocks are excluded via the hook's `excludes` until refactored — `cli/edit.py` (`edit`, 113), `cli/client.py` (`ws_shell`, 63), `cli/tui/screens/workspace_form.py` (`_save`). Shrink the exclude list as they are fixed; the gate has teeth everywhere else (verified: introducing/revealing an F-rank block exits non-zero).
- `.pre-commit-config.yaml` is generated (gitignored) and regenerates on next shell entry — no other files change.
- Dev tooling only, no user-visible change → no changelog entry.
