### PR TITLE
Ride out transient curl resets in image builds; keep pentest reporting steps from red-herringing

### DIFF
--- a/.github/workflows/cdk-workspace-pentest.yml
+++ b/.github/workflows/cdk-workspace-pentest.yml
@@ -84,7 +84,9 @@ jobs:
           ARCH="cdk_linux_amd64"
           URL="https://github.com/cdk-team/CDK/releases/download/${VER}/${ARCH}"
           echo "Downloading $URL"
-          curl -fL "$URL" -o cdk
+          # Retry flags: transient runner↔github.com blips must not fail the
+          # daily run (same posture as the image-build curls, #2797).
+          curl -fL --retry 5 --retry-delay 2 --retry-all-errors "$URL" -o cdk
           chmod +x cdk
           # Expected sha256 for v1.5.6; warn-only if version pinned elsewhere.
           EXPECTED="c6a222d823fb49a82381dbbcecbc57cd6f9d03c4222ec8c280289b6627beceb9"
@@ -165,6 +167,10 @@ jobs:
         shell: bash
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          # `out/` is normally created by the launch step; recreate it here so
+          # this always()-step can't red-herring when an earlier step failed
+          # and left no artifacts (#2797).
+          mkdir -p out
           devenv shell -- podman inspect cdk-target \
             > out/container-inspect.json 2>&1 || true
           # CDK's own view of the sandbox boundary.
@@ -182,9 +188,16 @@ jobs:
           # (a genuine regression). Add a substring here only if a finding
           # is ever intentionally accepted.
           ALLOW_PATTERNS=()
+          # `out/` is normally created by the launch step; recreate it here so
+          # this always()-step fails only on real findings, not on a missing
+          # directory left by an earlier failed step (#2797).
+          mkdir -p out
           : > out/all-criticals.txt
           : > out/new-criticals.txt
           grep -E '^Critical' out/evaluate.txt >> out/all-criticals.txt 2>/dev/null || true
+          if [ ! -f out/evaluate.txt ]; then
+            echo "::warning::out/evaluate.txt missing — CDK evaluate did not run (an earlier step failed?)"
+          fi
           cp out/all-criticals.txt out/new-criticals.txt
           for pat in "${ALLOW_PATTERNS[@]}"; do
             { grep -vF "$pat" out/new-criticals.txt || true; } > out/new.tmp
@@ -208,6 +221,9 @@ jobs:
         if: always()
         shell: bash
         run: |
+          # Recreate `out/` (#2797): an always()-step must not crash on a
+          # directory an earlier failed step never created.
+          mkdir -p out
           {
             echo "### 💣 CDK workspace pentest"
             echo
@@ -226,14 +242,14 @@ jobs:
             echo "<details><summary>CDK <code>evaluate --full</code> output</summary>"
             echo
             echo '```'
-            cat out/evaluate.txt 2>/dev/null
+            cat out/evaluate.txt 2>/dev/null || true
             echo '```'
             echo "</details>"
             if [ "${{ env.RUN_EXPLOITS }}" = "true" ]; then
               echo "<details><summary>CDK escape-exploit output</summary>"
               echo
               echo '```'
-              cat out/exploits.txt 2>/dev/null
+              cat out/exploits.txt 2>/dev/null || true
               echo '```'
               echo "</details>"
             fi

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -19,7 +19,13 @@ FROM $WORKSPACE_BASE_IMAGE
 # (base64 sha512 -> hex), or sha512sum of the fetched tarball.
 ARG PI_AGENT_VERSION=0.83.0
 ARG PI_AGENT_SHA512=b98845f85b19c68828497fc0c4171476263e66496e6f0697c80a04180d9e430b077321008546082a1fd62d77bf6bcfa4f1e4c29b16fe64dd99a3d9b342dcdb5b
-RUN curl -fsSL -o /tmp/pi-agent.tgz \
+# Network downloads in this Dockerfile use `--retry 5 --retry-delay 2
+# --retry-all-errors`: GitHub-hosted runners occasionally reset connections
+# mid-transfer (curl exit 35, #2797), and without retries a single blip
+# fails the whole image build. Integrity is unaffected — every tarball is
+# still sha-pinned and verified after a successful download.
+RUN curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+      -o /tmp/pi-agent.tgz \
       "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-${PI_AGENT_VERSION}.tgz" \
     && echo "${PI_AGENT_SHA512}  /tmp/pi-agent.tgz" | sha512sum -c - \
     && npm install -g /tmp/pi-agent.tgz \
@@ -69,7 +75,8 @@ RUN set -eu; \
       arm64) target=aarch64-unknown-linux-gnu; sha="$UV_SHA256_ARM64" ;; \
       *) echo "unsupported arch for uv: $(dpkg --print-architecture)" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/uv.tar.gz \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+      -o /tmp/uv.tar.gz \
       "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${target}.tar.gz"; \
     echo "${sha}  /tmp/uv.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/uv.tar.gz -C /tmp "uv-${target}"; \
@@ -95,7 +102,8 @@ RUN set -eu; \
       arm64) sha="$PROCESS_COMPOSE_SHA256_ARM64" ;; \
       *) echo "unsupported arch for process-compose: $ARCH" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tmp/process-compose.tar.gz \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+      -o /tmp/process-compose.tar.gz \
       "https://github.com/F1bonacc1/process-compose/releases/download/v${PROCESS_COMPOSE_VERSION}/process-compose_linux_${ARCH}.tar.gz"; \
     echo "${sha}  /tmp/process-compose.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/process-compose.tar.gz -C /usr/local/bin process-compose; \

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -84,7 +84,11 @@ ENV LC_ALL=en_US.UTF-8
 # and update this ARG.
 ARG NODESOURCE_KEY_SHA256=b42e0321dabdc24e892115da705cf061167eac12a317f23d329862d0aa0a271d
 ARG NODEJS_VERSION=26.7.0-1nodesource1
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+# GitHub-hosted runners occasionally reset connections mid-transfer (curl
+# exit 35, #2797); `--retry 5 --retry-delay 2 --retry-all-errors` rides out
+# those blips. The sha256 pin below still gates whatever lands on disk.
+RUN curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+        https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
         -o /tmp/nodesource-repo.gpg.key \
     && echo "${NODESOURCE_KEY_SHA256}  /tmp/nodesource-repo.gpg.key" | sha256sum -c - \
     && gpg --dearmor -o /usr/share/keyrings/nodesource.gpg /tmp/nodesource-repo.gpg.key \
@@ -107,7 +111,8 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
 # old key is retired. Bump: re-download the keyring, recompute sha256,
 # update this ARG.
 ARG GITHUBCLI_KEYRING_SHA256=6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+RUN curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+        https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /tmp/githubcli-archive-keyring.gpg \
     && echo "${GITHUBCLI_KEYRING_SHA256}  /tmp/githubcli-archive-keyring.gpg" | sha256sum -c - \
     && mv /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
Closes #2797.

## What

The scheduled CDK workspace pentest run ([run 33253442363](https://github.com/mcdonc/klangk/actions/runs/33253442363)) failed on a transient runner network blip — `curl: (35) Recv failure: Connection reset by peer` fetching the process-compose release tarball inside the workspace image build. The `if: always()` reporting steps then crashed on the missing `out/` directory (`out/all-criticals.txt: No such file or directory`), obscuring the real cause.

## Changes

- **curl retries** — `--retry 5 --retry-delay 2 --retry-all-errors` on every network download in the workspace image family:
  - `src/containers/workspace/Dockerfile` (pi-agent tarball, uv tarball, process-compose tarball)
  - `src/containers/workspace/Dockerfile.base` (nodesource key, githubcli keyring)
  - the CDK binary download in `cdk-workspace-pentest.yml`

  Integrity is unaffected: every download is still sha-pinned and verified after a successful fetch (the `test_supply_chain_pins.py` contract suite still passes).

- **Robust always() reporting** — `mkdir -p out` at the start of the inspect-capture, criticals-diff, and build-summary steps so an earlier failed step leaves them functional; the previously unguarded `cat out/evaluate.txt` / `cat out/exploits.txt` now carry `|| true`; the diff step emits a `::warning::` when `out/evaluate.txt` is missing so triage sees *why* there are no findings. A failed build now shows up as exactly one red step (the build), not three stacked confusing errors.

Verified the reporting-step bodies locally with `out/` absent: both exit 0 and print the warning. `scripts/tests` (build-pipeline contract suite) passes: 83 passed.
