### PR TITLE
refactor(cli): split klangk edit into focused helpers

### DIFF
--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -14,6 +14,337 @@ from . import context
 from .workspaces import _build_settings, _parse_env_list, _prompt, _SENTINEL
 from .mount import validate_allowed_domain_spec, validate_mount_spec
 
+# Body fields baked into the container at create time: changing one on a
+# running workspace does nothing until the container is restarted.
+CREATE_TIME_KEYS = {
+    "image",
+    "mounts",
+    "env",
+    "service_command",
+    "allowed_domains",
+    "rejected_domains",
+}
+
+# Settings-bag keys baked into the container at create time: nix (the
+# /nix mount, #2233) and allow_sudo (the sudoers rule, #2017). A flip on
+# a running workspace needs a restart to take effect — the TUI and web
+# panel detect the same pair.
+CREATE_TIME_SETTINGS_DEFAULTS = {"nix": False, "allow_sudo": True}
+
+
+def edit_list_interactively(
+    items: list[str],
+    *,
+    header: str,
+    empty_note: str,
+    add_prompt: str,
+    remove_what: str,
+    validate,
+) -> bool:
+    """Add/remove loop for a repeatable string list; True if changed."""
+    changed = False
+    while True:
+        if items:
+            typer.echo(f"\n{header}:")
+            for i, item in enumerate(items, 1):
+                typer.echo(f"  {i}. {item}")
+        else:
+            typer.echo(f"\n{empty_note}")
+
+        add = input(add_prompt).strip()
+        if add:
+            err = validate(add)
+            if err:
+                typer.echo(err)
+                continue
+            items.append(add)
+            changed = True
+            continue
+
+        if items:
+            rm = input(
+                f"Remove {remove_what} number (or Enter to skip): "
+            ).strip()
+            if rm:
+                try:
+                    idx = int(rm) - 1
+                    if 0 <= idx < len(items):
+                        removed = items.pop(idx)
+                        typer.echo(f"Removed: {removed}")
+                        changed = True
+                        continue
+                    else:
+                        typer.echo("Invalid number.")
+                        continue
+                except ValueError:
+                    typer.echo("Invalid number.")
+                    continue
+
+        break  # both add and remove were skipped
+    return changed
+
+
+def edit_env_interactively(env: dict) -> bool:
+    """Add/remove loop for the env-var map; True if changed."""
+    changed = False
+    while True:
+        if env:
+            typer.echo("\nCurrent environment variables:")
+            env_items = list(env.items())
+            for i, (k, v) in enumerate(env_items, 1):
+                typer.echo(f"  {i}. {k}={v}")
+        else:
+            typer.echo("\nNo environment variables configured.")
+
+        add = input(
+            "\nAdd env var (e.g. KEY=VALUE, or Enter to skip): "
+        ).strip()
+        if add:
+            if "=" not in add:
+                typer.echo("Invalid format, expected KEY=VALUE.")
+                continue
+            key, _, value = add.partition("=")
+            env[key] = value
+            changed = True
+            continue
+
+        if env:
+            rm = input("Remove env var number (or Enter to skip): ").strip()
+            if rm:
+                try:
+                    idx = int(rm) - 1
+                    env_items = list(env.items())
+                    if 0 <= idx < len(env_items):
+                        removed_key = env_items[idx][0]
+                        del env[removed_key]
+                        typer.echo(f"Removed: {removed_key}")
+                        changed = True
+                        continue
+                    else:
+                        typer.echo("Invalid number.")
+                        continue
+                except ValueError:
+                    typer.echo("Invalid number.")
+                    continue
+
+        break  # both add and remove were skipped
+    return changed
+
+
+def has_any_flags(
+    *,
+    name: str | None,
+    image: str | None,
+    command: str | None,
+    auto_start: bool | None,
+    per_handle_home: bool | None,
+    health_check: str | None,
+    mount: list[str] | None,
+    env: list[str] | None,
+    allow: list[str] | None,
+    reject: list[str] | None,
+    idle_timeout: int | None,
+    cpu_limit: float | None,
+    memory_limit: str | None,
+    pids_limit: int | None,
+    allow_sudo: bool | None,
+    classification_banner: str | None,
+) -> bool:
+    return (
+        name is not None
+        or image is not None
+        or command is not None
+        or auto_start is not None
+        or per_handle_home is not None
+        or health_check is not None
+        or isinstance(mount, list)
+        or isinstance(env, list)
+        or isinstance(allow, list)
+        or isinstance(reject, list)
+        or idle_timeout is not None
+        or cpu_limit is not None
+        or memory_limit is not None
+        or pids_limit is not None
+        or allow_sudo is not None
+        or classification_banner is not None
+    )
+
+
+def interactive_edit_body(ws) -> dict:
+    """Prompt for each field (Enter keeps the current value) and build the
+    PATCH body from the answers."""
+    new_name = _prompt("Name", ws.name)
+    new_image = _prompt("Container Image", ws.image)
+    new_command = _prompt("Service shell command", ws.service_command)
+    new_health_check = _prompt("Health check command", ws.health_check)
+    # Plain label like the sibling prompts: Enter keeps the current
+    # value (the [(none)] display shows it); typing whitespace clears
+    # the override back to the deploy default (#2768).
+    new_banner = _prompt("Classification banner", ws.classification_banner)
+
+    current_mounts = list(ws.mounts or [])
+    mounts_changed = edit_list_interactively(
+        current_mounts,
+        header="Current mounts",
+        empty_note="No mounts configured.",
+        add_prompt="\nAdd mount (e.g. /host/path:/container/path, or Enter to skip): ",
+        remove_what="mount",
+        validate=validate_mount_spec,
+    )
+
+    current_env = dict(ws.env or {})
+    env_changed = edit_env_interactively(current_env)
+
+    current_domains = list(ws.allowed_domains or [])
+    domains_changed = edit_list_interactively(
+        current_domains,
+        header="Allowed egress domains",
+        empty_note="No egress allowlist (unrestricted networking).",
+        add_prompt="\nAdd domain (e.g. github.com:443, or Enter to skip): ",
+        remove_what="domain",
+        validate=validate_allowed_domain_spec,
+    )
+
+    current_rejected = list(ws.rejected_domains or [])
+    # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2386).
+    rejected_changed = edit_list_interactively(
+        current_rejected,
+        header="Rejected egress domains (NXDOMAIN'd)",
+        empty_note="No egress denylist.",
+        add_prompt="\nAdd rejected domain (e.g. evil.example.com, or Enter to skip): ",
+        remove_what="rejected domain",
+        validate=lambda spec: validate_allowed_domain_spec(
+            spec, allow_cidr=False
+        ),
+    )
+
+    body: dict = {}
+    if new_name is not _SENTINEL:
+        body["name"] = new_name or ws.name  # don't allow empty name
+    if new_image is not _SENTINEL:
+        body["image"] = new_image or None
+    if new_command is not _SENTINEL:
+        body["service_command"] = new_command or None
+    if new_health_check is not _SENTINEL:
+        body["health_check"] = new_health_check or None
+    if new_banner is not _SENTINEL:
+        body["classification_banner"] = new_banner or None
+    if mounts_changed:
+        body["mounts"] = current_mounts or None
+    if env_changed:
+        body["env"] = current_env or None
+    if domains_changed:
+        body["allowed_domains"] = current_domains or None
+    if rejected_changed:
+        body["rejected_domains"] = current_rejected or None
+    return body
+
+
+def flag_edit_body(
+    ws,
+    *,
+    name: str | None,
+    image: str | None,
+    command: str | None,
+    auto_start: bool | None,
+    per_handle_home: bool | None,
+    health_check: str | None,
+    classification_banner: str | None,
+    mount: list[str] | None,
+    env: list[str] | None,
+    allow: list[str] | None,
+    reject: list[str] | None,
+    idle_timeout: int | None,
+    cpu_limit: float | None,
+    memory_limit: str | None,
+    pids_limit: int | None,
+    allow_sudo: bool | None,
+) -> dict:
+    """Build the PATCH body from only the flags the user provided."""
+    body: dict = {}
+    if name is not None:
+        body["name"] = name
+    if image is not None:
+        body["image"] = image or None
+    if command is not None:
+        body["service_command"] = command or None
+    if auto_start is not None:
+        body["auto_start"] = auto_start
+    if per_handle_home is not None:
+        # Mutable (#2719); takes effect on the next connect/start —
+        # never a restart-prompt field (existing sessions keep their
+        # layout until they end).
+        body["per_handle_home"] = per_handle_home
+    if health_check is not None:
+        body["health_check"] = health_check or None
+    if classification_banner is not None:
+        body["classification_banner"] = classification_banner or None
+    if isinstance(mount, list):
+        for m in mount:
+            err = validate_mount_spec(m)
+            if err:
+                context._err.print(f"[red]{err}[/red]")
+                raise typer.Exit(code=1)
+        body["mounts"] = mount or None
+    if isinstance(env, list):
+        body["env"] = _parse_env_list(env) or None
+    if isinstance(allow, list):
+        for spec in allow:
+            err = validate_allowed_domain_spec(spec)
+            if err:
+                context._err.print(f"[red]{err}[/red]")
+                raise typer.Exit(code=1)
+        body["allowed_domains"] = allow or None
+    if isinstance(reject, list):
+        for spec in reject:
+            # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+            err = validate_allowed_domain_spec(spec, allow_cidr=False)
+            if err:
+                context._err.print(f"[red]{err}[/red]")
+                raise typer.Exit(code=1)
+        body["rejected_domains"] = reject or None
+    edit_settings = _build_settings(
+        idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo
+    )
+    if edit_settings:
+        # Merge with existing settings so unspecified keys are preserved.
+        merged = dict(ws.settings or {})
+        merged.update(edit_settings)
+        body["settings"] = merged
+    return body
+
+
+def restart_needed(ws, body: dict) -> bool:
+    """True if any create-time field changed on a running workspace."""
+    if ws.running and bool(body.keys() & CREATE_TIME_KEYS):
+        return True
+    if ws.running and "settings" in body:
+        bag = body["settings"] or {}
+        old = ws.settings or {}
+        for key, default in CREATE_TIME_SETTINGS_DEFAULTS.items():
+            if bag.get(key, default) != old.get(key, default):
+                return True
+    return False
+
+
+def apply_edit(client, ws, body: dict, restart: bool) -> None:
+    resp = client.put(f"/api/v1/workspaces/{ws.id}", json=body)
+    if resp.status_code == 404:
+        context._err.print("[red]Workspace not found[/red]")
+        raise typer.Exit(code=1)
+    resp.raise_for_status()
+    typer.echo(f"Updated workspace {ws.name}")
+
+    if restart:
+        context._err.print(
+            "[yellow]The running container is not affected by this "
+            "edit — restart the workspace to apply.[/yellow]"
+        )
+        answer = input("Restart now? [y/N] ").strip().lower()
+        if answer in ("y", "yes"):
+            client.restart_workspace(ws.name)
+            typer.echo(f"Restarted workspace {ws.name}")
+
 
 @context.app.command()
 def edit(
@@ -111,321 +442,48 @@ def edit(
     client = context._client()
     ws = context.resolve_or_exit(client, workspace)
 
-    has_flags = (
-        name is not None
-        or image is not None
-        or command is not None
-        or auto_start is not None
-        or per_handle_home is not None
-        or health_check is not None
-        or isinstance(mount, list)
-        or isinstance(env, list)
-        or isinstance(allow, list)
-        or isinstance(reject, list)
-        or idle_timeout is not None
-        or cpu_limit is not None
-        or memory_limit is not None
-        or pids_limit is not None
-        or allow_sudo is not None
-        or classification_banner is not None
-    )
-    if not has_flags:
-        # Interactive mode
-        new_name = _prompt("Name", ws.name)
-        new_image = _prompt("Container Image", ws.image)
-        new_command = _prompt("Service shell command", ws.service_command)
-        new_health_check = _prompt("Health check command", ws.health_check)
-        # Plain label like the sibling prompts: Enter keeps the current
-        # value (the [(none)] display shows it); typing whitespace clears
-        # the override back to the deploy default (#2768).
-        new_banner = _prompt("Classification banner", ws.classification_banner)
-
-        # Interactive mount editing loop
-        current_mounts = list(ws.mounts or [])
-        mounts_changed = False
-        while True:
-            if current_mounts:
-                typer.echo("\nCurrent mounts:")
-                for i, m in enumerate(current_mounts, 1):
-                    typer.echo(f"  {i}. {m}")
-            else:
-                typer.echo("\nNo mounts configured.")
-
-            add = input(
-                "\nAdd mount (e.g. /host/path:/container/path, or Enter to skip): "
-            ).strip()
-            if add:
-                err = validate_mount_spec(add)
-                if err:
-                    typer.echo(err)
-                    continue
-                current_mounts.append(add)
-                mounts_changed = True
-                continue
-
-            if current_mounts:
-                rm = input("Remove mount number (or Enter to skip): ").strip()
-                if rm:
-                    try:
-                        idx = int(rm) - 1
-                        if 0 <= idx < len(current_mounts):
-                            removed = current_mounts.pop(idx)
-                            typer.echo(f"Removed: {removed}")
-                            mounts_changed = True
-                            continue
-                        else:
-                            typer.echo("Invalid number.")
-                            continue
-                    except ValueError:
-                        typer.echo("Invalid number.")
-                        continue
-
-            break  # both add and remove were skipped
-
-        # Interactive env var editing loop
-        current_env = dict(ws.env or {})
-        env_changed = False
-        while True:
-            if current_env:
-                typer.echo("\nCurrent environment variables:")
-                env_items = list(current_env.items())
-                for i, (k, v) in enumerate(env_items, 1):
-                    typer.echo(f"  {i}. {k}={v}")
-            else:
-                typer.echo("\nNo environment variables configured.")
-
-            add = input(
-                "\nAdd env var (e.g. KEY=VALUE, or Enter to skip): "
-            ).strip()
-            if add:
-                if "=" not in add:
-                    typer.echo("Invalid format, expected KEY=VALUE.")
-                    continue
-                key, _, value = add.partition("=")
-                current_env[key] = value
-                env_changed = True
-                continue
-
-            if current_env:
-                rm = input(
-                    "Remove env var number (or Enter to skip): "
-                ).strip()
-                if rm:
-                    try:
-                        idx = int(rm) - 1
-                        env_items = list(current_env.items())
-                        if 0 <= idx < len(env_items):
-                            removed_key = env_items[idx][0]
-                            del current_env[removed_key]
-                            typer.echo(f"Removed: {removed_key}")
-                            env_changed = True
-                            continue
-                        else:
-                            typer.echo("Invalid number.")
-                            continue
-                    except ValueError:
-                        typer.echo("Invalid number.")
-                        continue
-
-            break  # both add and remove were skipped
-
-        # Interactive allowed-domains editing loop
-        current_domains = list(ws.allowed_domains or [])
-        domains_changed = False
-        while True:
-            if current_domains:
-                typer.echo("\nAllowed egress domains:")
-                for i, d in enumerate(current_domains, 1):
-                    typer.echo(f"  {i}. {d}")
-            else:
-                typer.echo("\nNo egress allowlist (unrestricted networking).")
-
-            add = input(
-                "\nAdd domain (e.g. github.com:443, or Enter to skip): "
-            ).strip()
-            if add:
-                err = validate_allowed_domain_spec(add)
-                if err:
-                    typer.echo(err)
-                    continue
-                current_domains.append(add)
-                domains_changed = True
-                continue
-
-            if current_domains:
-                rm = input("Remove domain number (or Enter to skip): ").strip()
-                if rm:
-                    try:
-                        idx = int(rm) - 1
-                        if 0 <= idx < len(current_domains):
-                            removed = current_domains.pop(idx)
-                            typer.echo(f"Removed: {removed}")
-                            domains_changed = True
-                            continue
-                        else:
-                            typer.echo("Invalid number.")
-                            continue
-                    except ValueError:
-                        typer.echo("Invalid number.")
-                        continue
-
-            break  # both add and remove were skipped
-
-        # Interactive rejected-domains editing loop (#2386)
-        current_rejected = list(ws.rejected_domains or [])
-        rejected_changed = False
-        while True:
-            if current_rejected:
-                typer.echo("\nRejected egress domains (NXDOMAIN'd):")
-                for i, d in enumerate(current_rejected, 1):
-                    typer.echo(f"  {i}. {d}")
-            else:
-                typer.echo("\nNo egress denylist.")
-
-            add = input(
-                "\nAdd rejected domain (e.g. evil.example.com, or Enter to skip): "
-            ).strip()
-            if add:
-                # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
-                err = validate_allowed_domain_spec(add, allow_cidr=False)
-                if err:
-                    typer.echo(err)
-                    continue
-                current_rejected.append(add)
-                rejected_changed = True
-                continue
-
-            if current_rejected:
-                rm = input("Remove domain number (or Enter to skip): ").strip()
-                if rm:
-                    try:
-                        idx = int(rm) - 1
-                        if 0 <= idx < len(current_rejected):
-                            removed = current_rejected.pop(idx)
-                            typer.echo(f"Removed: {removed}")
-                            rejected_changed = True
-                            continue
-                        else:
-                            typer.echo("Invalid number.")
-                            continue
-                    except ValueError:
-                        typer.echo("Invalid number.")
-                        continue
-
-            break  # both add and remove were skipped
-
-        body: dict = {}
-        if new_name is not _SENTINEL:
-            body["name"] = new_name or ws.name  # don't allow empty name
-        if new_image is not _SENTINEL:
-            body["image"] = new_image or None
-        if new_command is not _SENTINEL:
-            body["service_command"] = new_command or None
-        if new_health_check is not _SENTINEL:
-            body["health_check"] = new_health_check or None
-        if new_banner is not _SENTINEL:
-            body["classification_banner"] = new_banner or None
-        if mounts_changed:
-            body["mounts"] = current_mounts or None
-        if env_changed:
-            body["env"] = current_env or None
-        if domains_changed:
-            body["allowed_domains"] = current_domains or None
-        if rejected_changed:
-            body["rejected_domains"] = current_rejected or None
-    else:
-        # Flags mode — only send provided fields
-        body = {}
-        if name is not None:
-            body["name"] = name
-        if image is not None:
-            body["image"] = image or None
-        if command is not None:
-            body["service_command"] = command or None
-        if auto_start is not None:
-            body["auto_start"] = auto_start
-        if per_handle_home is not None:
-            # Mutable (#2719); takes effect on the next connect/start —
-            # never a restart-prompt field (existing sessions keep their
-            # layout until they end).
-            body["per_handle_home"] = per_handle_home
-        if health_check is not None:
-            body["health_check"] = health_check or None
-        if classification_banner is not None:
-            body["classification_banner"] = classification_banner or None
-        if isinstance(mount, list):
-            for m in mount:
-                err = validate_mount_spec(m)
-                if err:
-                    context._err.print(f"[red]{err}[/red]")
-                    raise typer.Exit(code=1)
-            body["mounts"] = mount or None
-        if isinstance(env, list):
-            body["env"] = _parse_env_list(env) or None
-        if isinstance(allow, list):
-            for spec in allow:
-                err = validate_allowed_domain_spec(spec)
-                if err:
-                    context._err.print(f"[red]{err}[/red]")
-                    raise typer.Exit(code=1)
-            body["allowed_domains"] = allow or None
-        if isinstance(reject, list):
-            for spec in reject:
-                # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
-                err = validate_allowed_domain_spec(spec, allow_cidr=False)
-                if err:
-                    context._err.print(f"[red]{err}[/red]")
-                    raise typer.Exit(code=1)
-            body["rejected_domains"] = reject or None
-        edit_settings = _build_settings(
-            idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo
+    if has_any_flags(
+        name=name,
+        image=image,
+        command=command,
+        auto_start=auto_start,
+        per_handle_home=per_handle_home,
+        health_check=health_check,
+        mount=mount,
+        env=env,
+        allow=allow,
+        reject=reject,
+        idle_timeout=idle_timeout,
+        cpu_limit=cpu_limit,
+        memory_limit=memory_limit,
+        pids_limit=pids_limit,
+        allow_sudo=allow_sudo,
+        classification_banner=classification_banner,
+    ):
+        body = flag_edit_body(
+            ws,
+            name=name,
+            image=image,
+            command=command,
+            auto_start=auto_start,
+            per_handle_home=per_handle_home,
+            health_check=health_check,
+            classification_banner=classification_banner,
+            mount=mount,
+            env=env,
+            allow=allow,
+            reject=reject,
+            idle_timeout=idle_timeout,
+            cpu_limit=cpu_limit,
+            memory_limit=memory_limit,
+            pids_limit=pids_limit,
+            allow_sudo=allow_sudo,
         )
-        if edit_settings:
-            # Merge with existing settings so unspecified keys are preserved.
-            merged = dict(ws.settings or {})
-            merged.update(edit_settings)
-            body["settings"] = merged
+    else:
+        body = interactive_edit_body(ws)
 
     if not body:
         typer.echo("No changes.")
         return
 
-    # Detect if any create-time field changed on a running workspace.
-    _CREATE_TIME_KEYS = {
-        "image",
-        "mounts",
-        "env",
-        "service_command",
-        "allowed_domains",
-        "rejected_domains",
-    }
-    restart_needed = ws.running and bool(body.keys() & _CREATE_TIME_KEYS)
-    # Settings-bag keys that are baked into the container at create time:
-    # nix (the /nix mount, #2233) and allow_sudo (the sudoers rule, #2017).
-    # A flip on a running workspace needs a restart to take effect — the
-    # TUI and web panel detect the same pair.
-    if ws.running and "settings" in body:
-        _bag = body["settings"] or {}
-        _old = ws.settings or {}
-        _defaults = {"nix": False, "allow_sudo": True}
-        for _key, _default in _defaults.items():
-            if _bag.get(_key, _default) != _old.get(_key, _default):
-                restart_needed = True
-                break
-
-    resp = client.put(f"/api/v1/workspaces/{ws.id}", json=body)
-    if resp.status_code == 404:
-        context._err.print("[red]Workspace not found[/red]")
-        raise typer.Exit(code=1)
-    resp.raise_for_status()
-    typer.echo(f"Updated workspace {ws.name}")
-
-    if restart_needed:
-        context._err.print(
-            "[yellow]The running container is not affected by this "
-            "edit — restart the workspace to apply.[/yellow]"
-        )
-        answer = input("Restart now? [y/N] ").strip().lower()
-        if answer in ("y", "yes"):
-            client.restart_workspace(ws.name)
-            typer.echo(f"Restarted workspace {ws.name}")
+    apply_edit(client, ws, body, restart_needed(ws, body))


### PR DESCRIPTION
## Summary

First refactor of the #2794 complexity ratchet: splits `klangk/cli/edit.py`'s 113-complexity `edit()` (rank F, the worst block in the tree) into focused helpers. Pure extract-function — no behavior change.

## Details

- `edit()` → **A (3)** (was **F (113)**); worst remaining helper is `flag_edit_body` at **D (28)** — the whole file now passes a `--max-absolute D` gate.
- Extracted: `has_any_flags`, `interactive_edit_body`, `flag_edit_body`, `restart_needed`, `apply_edit`, and two interactive list editors (`edit_list_interactively` — unifies the three near-identical mounts/allow/reject add-remove loops, `edit_env_interactively`).
- Prompt strings, echo output, validation order, body key order, and control flow (including the invalid-number → re-display-header loop behavior) preserved verbatim.
- Create-time key sets (`CREATE_TIME_KEYS`, `CREATE_TIME_SETTINGS_DEFAULTS`) hoisted to module constants with their original comments.
- With the gate flip in #2795's follow-up, `src/klangk/klangk/cli/edit.py` can come off the xenon excludes list.

## Verification

- Full Python suite (klangkd + klangkc, `-n auto`, coverage): 5829 passed, **100% coverage** — every extracted helper is exercised.
- `xenon --max-absolute D` on the file: passes.
- No changelog entry (internal refactor).
