### PR TITLE
refactor(tui): split EditWorkspaceScreen._save into body/restart helpers

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -1420,11 +1420,9 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
 
     # --- save ---
 
-    def _save(self) -> None:
-        name = self.query_one("#name", Input).value.strip()
-        if not name:
-            self._msg("Name is required.", error=True)
-            return
+    def _save_body(self, name: str) -> dict | None:
+        """Gather the form fields into a PUT body; None on invalid input
+        (the error has already been shown via ``_msg``)."""
         sel = self.query_one("#image", Select)
         val = sel.value
         image = val if (val and val != "(none)") else None
@@ -1457,7 +1455,7 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
             settings = _collect_settings(self)
         except ValueError as exc:
             self._msg(str(exc), error=True)
-            return
+            return None
         # PUT settings is a full-replace bag, so seed from the existing
         # bag unconditionally — API-only keys the form does not represent
         # (e.g. bridge_timeout) and toggle-gated keys (nix, allow_sudo)
@@ -1498,38 +1496,56 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
         }
         if merged_settings:
             body["settings"] = merged_settings
+        return body
+
+    def _restart_needed_after_save(self, body: dict) -> bool:
+        """True if a create-time field changed on a running workspace."""
         ws = self._ws
+        settings = body.get("settings") or {}
         orig_mounts = list(ws.mounts or []) or None
         orig_env = dict(ws.env or {}) or None
         orig_domains = list(ws.allowed_domains or []) or None
         orig_rejected = list(ws.rejected_domains or []) or None
-        restart_needed = bool(ws.running) and (
-            (image or None) != (ws.image or None)
-            or mounts != orig_mounts
-            or env != orig_env
-            or (command or None) != (ws.service_command or None)
-            or allowed_domains != orig_domains
-            or rejected_domains != orig_rejected
+        return bool(ws.running) and (
+            (body["image"] or None) != (ws.image or None)
+            or body["mounts"] != orig_mounts
+            or body["env"] != orig_env
+            or (body["service_command"] or None)
+            != (ws.service_command or None)
+            or body["allowed_domains"] != orig_domains
+            or body["rejected_domains"] != orig_rejected
             # #2409: egress_mode is a container-create-time field (it sets
             # up --network container:<sidecar>), so a change needs a restart.
-            or egress_mode != (ws.egress_mode or EGRESS_MODE_DEFAULT)
+            or body["egress_mode"] != (ws.egress_mode or EGRESS_MODE_DEFAULT)
             # #2233: the per-workspace /nix mount is set up at create
             # time, so toggling it on a running workspace needs a restart.
             or (
                 self._nix_available
-                and merged_settings.get("nix", False)
+                and settings.get("nix", False)
                 != bool((ws.settings or {}).get("nix"))
             )
             # #2017: the sudoers rule is written at container-create time,
             # so a posture flip needs a restart to take effect.
             or (
                 self._sudo_available
-                and merged_settings.get("allow_sudo", True)
+                and settings.get("allow_sudo", True)
                 != bool((ws.settings or {}).get("allow_sudo", True))
             )
         )
+
+    def _save(self) -> None:
+        name = self.query_one("#name", Input).value.strip()
+        if not name:
+            self._msg("Name is required.", error=True)
+            return
+        body = self._save_body(name)
+        if body is None:
+            return
+        ws = self._ws
         self.run_worker(
-            self._do_save(name, body, ws, restart_needed),
+            self._do_save(
+                name, body, ws, self._restart_needed_after_save(body)
+            ),
             exit_on_error=False,
         )
 


### PR DESCRIPTION
## Summary

Third refactor of the #2794 complexity ratchet: splits `EditWorkspaceScreen._save` in `klangk/cli/tui/screens/workspace_form.py` (rank **F, 44** — the last F block outside the xenon excludes' reason for existing) into two helpers. Pure extract-function — no behavior change.

## Details

- `_save()` → rank **A**; extracted `_save_body(name)` (field gathering + settings merge, **C (17)**) and `_restart_needed_after_save(body)` (the create-time-field diff, **D (28)**). The whole file now passes a `--max-absolute D` gate (worst block: `_restart_needed_after_save` at 28).
- Body key order, the settings full-replace merge (#2017 review), nix/allow_sudo explicit-value rules (#2233/#2017), and every comment moved verbatim. The restart diff now reads its values from the assembled `body` (identical values — `body["settings"] or {}` matches the old empty-bag case).
- With the gate flip, this file can come off the xenon excludes list.

## Verification

- Full Python suite (klangkd + klangkc, `-n auto`, coverage): 5829 passed, **100% coverage**.
- `xenon --max-absolute D` on the file: passes.
- No changelog entry (internal refactor).
