### PR TITLE
fix(server): break podman/container import cycle; split create_container args

### DIFF
--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -21,6 +21,10 @@ import os
 from dataclasses import dataclass
 
 from .. import workspace_settings as ws_settings
+from ..podman import (
+    SHARED_HOME as SHARED_HOME,
+    SHARED_HOME_NAME as SHARED_HOME_NAME,
+)
 from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST, ssl_env_vars
 from .ports import CONTAINER_PORT_START, DEFAULT_PORTS_PER_WORKSPACE
 
@@ -43,10 +47,15 @@ logger = logging.getLogger(__name__)
 # so every site that used to recompute ``/home/{agent_handle()}`` from
 # the DB reads these constants instead — one source of truth for both
 # the shared-layout home and the agent/service-session home (#2720
-# review: "make them both the same").
-SHARED_HOME_NAME = "klangk"
-SHARED_HOME = f"/home/{SHARED_HOME_NAME}"
-
+# review: "make them both the same"). The definitions live in
+# ``podman.py`` (below this package, where the ``work_dir`` default
+# needs them — importing them from here would drag
+# ``container/__init__`` into podman's module init and close the
+# podman↔container import cycle); re-exported here so the
+# ``workspaces``/``wshandler``/``health`` import sites keep working
+# without a cycle through the ``container`` package. Re-exported from
+# ``podman.py`` at the imports above (same-name ``as`` marks the
+# intentional re-export).
 _VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
 
 

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -24,10 +24,21 @@ import tempfile
 import time
 from collections.abc import AsyncGenerator
 
-from .container.spec import SHARED_HOME
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
+
+# The shared-home path inside workspace containers. Defined here — the
+# lowest-level module that needs it (the ``work_dir`` default below) —
+# because ``podman`` sits *below* the ``container`` package and must not
+# import from it (that drags ``container/__init__`` in while this module
+# is still initializing: the podman↔container.sidecar/registry import
+# cycle). ``container.spec`` re-exports both so the workspaces /
+# wshandler / health import sites keep working; the agent identity's
+# handle is fixed to this name (#2718, immutable), one source of truth
+# for the shared-layout home and the agent/service-session home (#2720).
+SHARED_HOME_NAME = "klangk"
+SHARED_HOME = f"/home/{SHARED_HOME_NAME}"
 
 
 def subprocess_env() -> dict[str, str]:
@@ -263,6 +274,106 @@ class Podman:
         rc, out, _err = await self.run(["logs", container_id], check=False)
         return out if rc == 0 else ""
 
+    @staticmethod
+    def _create_base_args(
+        name: str,
+        pull: str,
+        replace: bool,
+        init: bool,
+        interactive: bool,
+        userns: str | None,
+    ) -> list[str]:
+        """``create`` subcommand + name/pull/mode/userns flags."""
+        args = ["create", f"--pull={pull}", "--name", name]
+        if replace:
+            args.append("--replace")
+        if init:
+            args.append("--init")
+        if interactive:
+            args.append("-i")
+        if userns:
+            args += ["--userns", userns]
+        return args
+
+    @staticmethod
+    def _create_capability_args(
+        cap_drop: list[str] | None, cap_add: list[str] | None
+    ) -> list[str]:
+        """One ``--cap-drop`` / ``--cap-add`` flag per entry."""
+        args: list[str] = []
+        for cap in cap_drop or []:
+            args += ["--cap-drop", cap]
+        for cap in cap_add or []:
+            args += ["--cap-add", cap]
+        return args
+
+    @staticmethod
+    def _create_resource_args(
+        cpus: float | None, memory: str | None, pids_limit: int | None
+    ) -> list[str]:
+        """Deploy-wide resource caps (#34) — each flag only when non-None,
+        so an unset limit = no flag = no behavior change."""
+        args: list[str] = []
+        if cpus is not None:
+            args += ["--cpus", str(cpus)]
+        if memory is not None:
+            args += ["--memory", memory]
+        if pids_limit is not None:
+            args += ["--pids-limit", str(pids_limit)]
+        return args
+
+    @staticmethod
+    def _create_label_args(
+        labels: dict[str, str] | None, annotations: dict[str, str] | None
+    ) -> list[str]:
+        """``--label`` / ``--annotation`` flags (per-workspace OCI-hook
+        annotations, #1770)."""
+        args: list[str] = []
+        for key, value in (labels or {}).items():
+            args += ["--label", f"{key}={value}"]
+        for key, value in (annotations or {}).items():
+            args += ["--annotation", f"{key}={value}"]
+        return args
+
+    @staticmethod
+    def _create_storage_args(
+        binds: list[str] | None,
+        tmpfs: dict[str, str] | None,
+        publish: list[tuple[int, int] | tuple[str, int, int]] | None,
+    ) -> list[str]:
+        """Volume / tmpfs / port-publish flags (``publish`` entries are
+        ``(host_port, container_port)`` or ``(bind_addr, host_port,
+        container_port)``)."""
+        args: list[str] = []
+        for bind in binds or []:
+            args += ["-v", bind]
+        for path, opts in (tmpfs or {}).items():
+            args += ["--tmpfs", f"{path}:{opts}"]
+        for entry in publish or []:
+            if len(entry) == 3:
+                bind, host_port, container_port = entry
+                args += ["-p", f"{bind}:{host_port}:{container_port}"]
+            else:
+                host_port, container_port = entry
+                args += ["-p", f"{host_port}:{container_port}"]
+        return args
+
+    @staticmethod
+    def _create_dns_args(
+        add_hosts: list[str] | None,
+        dns: list[str] | None,
+        dns_search: list[str] | None,
+    ) -> list[str]:
+        """Hosts-file / DNS server / DNS search flags."""
+        args: list[str] = []
+        for host in add_hosts or []:
+            args += ["--add-host", host]
+        for server in dns or []:
+            args += ["--dns", server]
+        for domain in dns_search or []:
+            args += ["--dns-search", domain]
+        return args
+
     async def create_container(
         self,
         name: str,
@@ -324,48 +435,16 @@ class Podman:
         args: list[str] = []
         for d in hooks_dir or []:
             args += ["--hooks-dir", d]
-        args += ["create", f"--pull={pull}", "--name", name]
-        if replace:
-            args.append("--replace")
-        if init:
-            args.append("--init")
-        if interactive:
-            args.append("-i")
-        if userns:
-            args += ["--userns", userns]
-        for cap in cap_drop or []:
-            args += ["--cap-drop", cap]
-        for cap in cap_add or []:
-            args += ["--cap-add", cap]
-        if cpus is not None:
-            args += ["--cpus", str(cpus)]
-        if memory is not None:
-            args += ["--memory", memory]
-        if pids_limit is not None:
-            args += ["--pids-limit", str(pids_limit)]
+        args += self._create_base_args(
+            name, pull, replace, init, interactive, userns
+        )
+        args += self._create_capability_args(cap_drop, cap_add)
+        args += self._create_resource_args(cpus, memory, pids_limit)
         if network:
             args += ["--network", network]
-        for key, value in (labels or {}).items():
-            args += ["--label", f"{key}={value}"]
-        for key, value in (annotations or {}).items():
-            args += ["--annotation", f"{key}={value}"]
-        for bind in binds or []:
-            args += ["-v", bind]
-        for path, opts in (tmpfs or {}).items():
-            args += ["--tmpfs", f"{path}:{opts}"]
-        for entry in publish or []:
-            if len(entry) == 3:
-                bind, host_port, container_port = entry
-                args += ["-p", f"{bind}:{host_port}:{container_port}"]
-            else:
-                host_port, container_port = entry
-                args += ["-p", f"{host_port}:{container_port}"]
-        for host in add_hosts or []:
-            args += ["--add-host", host]
-        for server in dns or []:
-            args += ["--dns", server]
-        for domain in dns_search or []:
-            args += ["--dns-search", domain]
+        args += self._create_label_args(labels, annotations)
+        args += self._create_storage_args(binds, tmpfs, publish)
+        args += self._create_dns_args(add_hosts, dns, dns_search)
         for entry in env or []:
             args += ["-e", entry]
         args.append(image)

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -64,6 +66,28 @@ def _exec(*results):
 def _args(mock_exec, call_index=0):
     """The podman args (sans binary) from the Nth create_subprocess_exec."""
     return list(mock_exec.call_args_list[call_index].args[1:])
+
+
+# --- import order (podman ↔ container cycle) ---
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "from klangk import podman",
+        "import klangk.container",
+        "from klangk.container.sidecar import NetworkSidecarMixin",
+        "from klangk.container.registry import ContainerRegistry",
+    ],
+)
+def test_importable_first_in_fresh_interpreter(stmt):
+    # Regression: importing ``klangk.podman`` first used to raise
+    # AttributeError/ImportError — podman.py imported
+    # ``container.spec`` for SHARED_HOME, which executes
+    # ``container/__init__`` while ``klangk.podman`` is still partially
+    # initialized, and registry/sidecar import names from it. Each import
+    # order must succeed standalone (#2794).
+    subprocess.run([sys.executable, "-c", stmt], check=True)
 
 
 # --- classify ---
@@ -266,6 +290,85 @@ class TestCreateContainer:
         ]
         assert ["-e", "K=V"] == args[args.index("-e") : args.index("-e") + 2]
         assert args[-1] == "img"
+
+    async def test_full_argv_order(self):
+        # Exact ordered argv with every option set — guards the flag-group
+        # order through refactors of the assembly code (#2794).
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container(
+                "n",
+                "img",
+                hooks_dir=["/hk1", "/hk2"],
+                labels={"a": "1"},
+                annotations={"klangk.x": "v"},
+                binds=["/h:/c"],
+                tmpfs={"/tmp": "rw,size=2g"},
+                publish=[("127.0.0.1", 4000, 4000), (9000, 8000)],
+                add_hosts=["h:host-gateway"],
+                dns=["8.8.8.8"],
+                dns_search=["corp.example"],
+                env=["K=V"],
+                init=True,
+                interactive=True,
+                userns="keep-id",
+                cap_drop=["NET_RAW"],
+                cap_add=["NET_ADMIN"],
+                cpus=2.0,
+                memory="512m",
+                pids_limit=512,
+                command=["--config", "/app/config.yaml"],
+                network="container:abc",
+            )
+        assert _args(m) == [
+            "--hooks-dir",
+            "/hk1",
+            "--hooks-dir",
+            "/hk2",
+            "create",
+            "--pull=never",
+            "--name",
+            "n",
+            "--replace",
+            "--init",
+            "-i",
+            "--userns",
+            "keep-id",
+            "--cap-drop",
+            "NET_RAW",
+            "--cap-add",
+            "NET_ADMIN",
+            "--cpus",
+            "2.0",
+            "--memory",
+            "512m",
+            "--pids-limit",
+            "512",
+            "--network",
+            "container:abc",
+            "--label",
+            "a=1",
+            "--annotation",
+            "klangk.x=v",
+            "-v",
+            "/h:/c",
+            "--tmpfs",
+            "/tmp:rw,size=2g",
+            "-p",
+            "127.0.0.1:4000:4000",
+            "-p",
+            "9000:8000",
+            "--add-host",
+            "h:host-gateway",
+            "--dns",
+            "8.8.8.8",
+            "--dns-search",
+            "corp.example",
+            "-e",
+            "K=V",
+            "img",
+            "--config",
+            "/app/config.yaml",
+        ]
 
     async def test_publish_with_bind_address(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:


### PR DESCRIPTION
## Summary

Final refactor of the #2794 E→D complexity ratchet — plus a real bug it surfaced: a podman↔container circular import that made `import klangk.podman` (and any single-file test run of `test_podman.py`) raise in a fresh interpreter.

## Circular import fix

- `from klangk import podman` in a fresh interpreter raised `AttributeError: partially initialized module 'klangk.podman' has no attribute 'PodmanError'`. Chain: `podman.py` imported `container.spec` for `SHARED_HOME` → that executes `container/__init__` → `registry.py`/`sidecar.py` import names from the still-partial `klangk.podman`.
- Root fix: `SHARED_HOME` / `SHARED_HOME_NAME` now live in `podman.py` — the lowest-level module that needs them (the `work_dir` parameter default). `container.spec` re-exports both (same-name `as`, ruff-recognized) so every existing `from .container.spec import SHARED_HOME` site is unchanged.
- Regression test: each of `klangk.podman`, `klangk.container`, `container.sidecar`, `container.registry` imported first in a fresh subprocess.

## create_container split

- `Podman.create_container` **E (35) → A**, split into `_create_base_args` / `_create_capability_args` / `_create_resource_args` / `_create_label_args` / `_create_storage_args` / `_create_dns_args` static builders, following the existing `_exec_args` pattern.
- Guard test added **before** the split: exact full ordered argv with every option set (`test_full_argv_order`), plus the existing per-flag assertions.

## Verification

- Full Python suite (klangkd + klangkc, `-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute D` on `podman.py`: passes. `test_podman.py` now runs standalone.
- No changelog entry (internal refactor; the import cycle was never reachable in normal entry orders — server main imports container-first).

With this merged, all five E/F blocks are ≤ D and the xenon gate in #2795 can flip to `--max-absolute D` with the excludes removed.
