### PR TITLE
fix(tests): poll for death frame instead of fixed sleep in idle-cleanup test

### DIFF
--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -6549,7 +6549,17 @@ class TestHealthMonitorDeath:
                 task = asyncio.create_task(reg.cleanup_idle_containers())
                 await asyncio.sleep(0.05)
                 reg.get_cleanup_wake().set()
-                await asyncio.sleep(0.05)
+                # The notify chain between the wake and send_json has
+                # several awaits (idle callbacks, the real ACL fetch in
+                # _send_to_workspace_members) -- a fixed sleep races
+                # task.cancel() against them under CI load (#2806).
+                # Poll with a generous deadline instead; a genuine
+                # regression still fails, just 5s later.
+                deadline = time.monotonic() + 5.0
+                while (
+                    not sock.send_json.called and time.monotonic() < deadline
+                ):
+                    await asyncio.sleep(0.01)
                 task.cancel()
                 try:
                     await task


### PR DESCRIPTION
Fixes #2806.

`test_idle_cleanup_emits_death_frame` synchronized the cleanup-loop task with two fixed `sleep(0.05)` calls and cancelled it after the second. The notify chain between `wake.set()` and the death-frame `send_json` traverses several await points (idle callbacks, the real sqlite ACL fetch in `_send_to_workspace_members`), so under CI load the cancel could land mid-chain — before the frame was sent — producing the flaky `AssertionError: Expected 'send_json' to have been called.` (run 33258047254 on PR #2804).

Replaces the second fixed sleep with a bounded poll (10ms interval, 5s deadline) on `sock.send_json.called`. Verified:

- 30/30 passes before and after the change on an idle machine.
- Injecting a 0.3s delay at the ACL fetch (the exact stress that reproduced the CI failure on the old code — identical assertion error) now passes.

No production code changed.
