### PR TITLE
refactor(cli): bring edit/workspace-form blocks under radon rank C

### DIFF
--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -170,9 +170,12 @@ def has_any_flags(
     )
 
 
-def interactive_edit_body(ws) -> dict:
-    """Prompt for each field (Enter keeps the current value) and build the
-    PATCH body from the answers."""
+def prompted_edit_fields(ws):
+    """Prompt for the scalar fields (Enter keeps the current value).
+
+    Returns (name, image, command, health_check, banner) — each either
+    the typed value or the ``_SENTINEL`` meaning "unchanged".
+    """
     new_name = _prompt("Name", ws.name)
     new_image = _prompt("Container Image", ws.image)
     new_command = _prompt("Service shell command", ws.service_command)
@@ -181,7 +184,21 @@ def interactive_edit_body(ws) -> dict:
     # value (the [(none)] display shows it); typing whitespace clears
     # the override back to the deploy default (#2768).
     new_banner = _prompt("Classification banner", ws.classification_banner)
+    return (
+        new_name,
+        new_image,
+        new_command,
+        new_health_check,
+        new_banner,
+    )
 
+
+def edit_lists_interactively(ws):
+    """Run the four list editors against the workspace's current lists.
+
+    Returns (mounts, mounts_changed, env, env_changed, domains,
+    domains_changed, rejected, rejected_changed).
+    """
     current_mounts = list(ws.mounts or [])
     mounts_changed = edit_list_interactively(
         current_mounts,
@@ -217,6 +234,38 @@ def interactive_edit_body(ws) -> dict:
             spec, allow_cidr=False
         ),
     )
+    return (
+        current_mounts,
+        mounts_changed,
+        current_env,
+        env_changed,
+        current_domains,
+        domains_changed,
+        current_rejected,
+        rejected_changed,
+    )
+
+
+def interactive_edit_body(ws) -> dict:
+    """Prompt for each field (Enter keeps the current value) and build the
+    PATCH body from the answers."""
+    (
+        new_name,
+        new_image,
+        new_command,
+        new_health_check,
+        new_banner,
+    ) = prompted_edit_fields(ws)
+    (
+        current_mounts,
+        mounts_changed,
+        current_env,
+        env_changed,
+        current_domains,
+        domains_changed,
+        current_rejected,
+        rejected_changed,
+    ) = edit_lists_interactively(ws)
 
     body: dict = {}
     if new_name is not _SENTINEL:
@@ -237,6 +286,89 @@ def interactive_edit_body(ws) -> dict:
         body["allowed_domains"] = current_domains or None
     if rejected_changed:
         body["rejected_domains"] = current_rejected or None
+    return body
+
+
+def validated_specs_or_exit(values: list[str], validate) -> list[str]:
+    """Validate each repeatable-flag value; exit(1) on the first bad one."""
+    for v in values:
+        err = validate(v)
+        if err:
+            context._err.print(f"[red]{err}[/red]")
+            raise typer.Exit(code=1)
+    return values
+
+
+def flag_scalar_body(
+    *,
+    name: str | None,
+    image: str | None,
+    command: str | None,
+    auto_start: bool | None,
+    per_handle_home: bool | None,
+    health_check: str | None,
+    classification_banner: str | None,
+) -> dict:
+    """Body fields for the scalar (non-repeatable) flags."""
+    body: dict = {}
+    if name is not None:
+        body["name"] = name
+    if image is not None:
+        body["image"] = image or None
+    if command is not None:
+        body["service_command"] = command or None
+    if auto_start is not None:
+        body["auto_start"] = auto_start
+    if per_handle_home is not None:
+        # Mutable (#2719); takes effect on the next connect/start —
+        # never a restart-prompt field (existing sessions keep their
+        # layout until they end).
+        body["per_handle_home"] = per_handle_home
+    if health_check is not None:
+        body["health_check"] = health_check or None
+    if classification_banner is not None:
+        body["classification_banner"] = classification_banner or None
+    return body
+
+
+def flag_list_body(
+    ws,
+    *,
+    mount: list[str] | None,
+    env: list[str] | None,
+    allow: list[str] | None,
+    reject: list[str] | None,
+    idle_timeout: int | None,
+    cpu_limit: float | None,
+    memory_limit: str | None,
+    pids_limit: int | None,
+    allow_sudo: bool | None,
+) -> dict:
+    """Body fields for the repeatable list flags and the settings bag."""
+    body: dict = {}
+    if isinstance(mount, list):
+        validated_specs_or_exit(mount, validate_mount_spec)
+        body["mounts"] = mount or None
+    if isinstance(env, list):
+        body["env"] = _parse_env_list(env) or None
+    if isinstance(allow, list):
+        validated_specs_or_exit(allow, validate_allowed_domain_spec)
+        body["allowed_domains"] = allow or None
+    if isinstance(reject, list):
+        # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+        validated_specs_or_exit(
+            reject,
+            lambda spec: validate_allowed_domain_spec(spec, allow_cidr=False),
+        )
+        body["rejected_domains"] = reject or None
+    edit_settings = _build_settings(
+        idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo
+    )
+    if edit_settings:
+        # Merge with existing settings so unspecified keys are preserved.
+        merged = dict(ws.settings or {})
+        merged.update(edit_settings)
+        body["settings"] = merged
     return body
 
 
@@ -261,56 +393,29 @@ def flag_edit_body(
     allow_sudo: bool | None,
 ) -> dict:
     """Build the PATCH body from only the flags the user provided."""
-    body: dict = {}
-    if name is not None:
-        body["name"] = name
-    if image is not None:
-        body["image"] = image or None
-    if command is not None:
-        body["service_command"] = command or None
-    if auto_start is not None:
-        body["auto_start"] = auto_start
-    if per_handle_home is not None:
-        # Mutable (#2719); takes effect on the next connect/start —
-        # never a restart-prompt field (existing sessions keep their
-        # layout until they end).
-        body["per_handle_home"] = per_handle_home
-    if health_check is not None:
-        body["health_check"] = health_check or None
-    if classification_banner is not None:
-        body["classification_banner"] = classification_banner or None
-    if isinstance(mount, list):
-        for m in mount:
-            err = validate_mount_spec(m)
-            if err:
-                context._err.print(f"[red]{err}[/red]")
-                raise typer.Exit(code=1)
-        body["mounts"] = mount or None
-    if isinstance(env, list):
-        body["env"] = _parse_env_list(env) or None
-    if isinstance(allow, list):
-        for spec in allow:
-            err = validate_allowed_domain_spec(spec)
-            if err:
-                context._err.print(f"[red]{err}[/red]")
-                raise typer.Exit(code=1)
-        body["allowed_domains"] = allow or None
-    if isinstance(reject, list):
-        for spec in reject:
-            # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
-            err = validate_allowed_domain_spec(spec, allow_cidr=False)
-            if err:
-                context._err.print(f"[red]{err}[/red]")
-                raise typer.Exit(code=1)
-        body["rejected_domains"] = reject or None
-    edit_settings = _build_settings(
-        idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo
+    body = flag_scalar_body(
+        name=name,
+        image=image,
+        command=command,
+        auto_start=auto_start,
+        per_handle_home=per_handle_home,
+        health_check=health_check,
+        classification_banner=classification_banner,
     )
-    if edit_settings:
-        # Merge with existing settings so unspecified keys are preserved.
-        merged = dict(ws.settings or {})
-        merged.update(edit_settings)
-        body["settings"] = merged
+    body.update(
+        flag_list_body(
+            ws,
+            mount=mount,
+            env=env,
+            allow=allow,
+            reject=reject,
+            idle_timeout=idle_timeout,
+            cpu_limit=cpu_limit,
+            memory_limit=memory_limit,
+            pids_limit=pids_limit,
+            allow_sudo=allow_sudo,
+        )
+    )
     return body
 
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -605,11 +605,9 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
 
     # --- create ---
 
-    def _create(self) -> None:
-        name = self.query_one("#name", Input).value.strip()
-        if not name:
-            self._msg("Name is required.", error=True)
-            return
+    def _create_payload(self) -> dict:
+        """Gather the non-name form fields into create-workspace values
+        (empty strings/lists -> None, matching the Flutter dialog)."""
         sel = self.query_one("#image", Select)
         val = sel.value
         # Send only a real, non-default selection. When the server's default
@@ -644,11 +642,26 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
             self.query_one("#classification_banner", Input).value.strip()
             or None
         )
-        mounts = list(self._mounts) or None
-        env = dict(self._env) or None
-        allowed_domains = list(self._allowed_domains) or None
-        rejected_domains = list(self._rejected_domains) or None
-        egress_mode = self.query_one("#egress_mode", Select).value
+        return {
+            "image": image,
+            "command": command,
+            "health_check": health_check,
+            "auto": auto,
+            "per_handle_home": per_handle_home,
+            "classification_banner": classification_banner,
+            "mounts": list(self._mounts) or None,
+            "env": dict(self._env) or None,
+            "allowed_domains": list(self._allowed_domains) or None,
+            "rejected_domains": list(self._rejected_domains) or None,
+            "egress_mode": self.query_one("#egress_mode", Select).value,
+        }
+
+    def _create(self) -> None:
+        name = self.query_one("#name", Input).value.strip()
+        if not name:
+            self._msg("Name is required.", error=True)
+            return
+        p = self._create_payload()
         try:
             settings = _collect_settings(self)
         except ValueError as exc:
@@ -667,18 +680,18 @@ class CreateWorkspaceScreen(TabSkipMixin, StatusScreen):
         self.run_worker(
             self._do_create_workspace(
                 name,
-                image,
-                command,
-                auto,
-                mounts,
-                env,
-                health_check,
-                allowed_domains,
-                rejected_domains,
+                p["image"],
+                p["command"],
+                p["auto"],
+                p["mounts"],
+                p["env"],
+                p["health_check"],
+                p["allowed_domains"],
+                p["rejected_domains"],
                 settings,
-                egress_mode,
-                per_handle_home,
-                classification_banner,
+                p["egress_mode"],
+                p["per_handle_home"],
+                p["classification_banner"],
             ),
             exit_on_error=False,
         )
@@ -1501,36 +1514,37 @@ class EditWorkspaceScreen(TabSkipMixin, StatusScreen):
     def _restart_needed_after_save(self, body: dict) -> bool:
         """True if a create-time field changed on a running workspace."""
         ws = self._ws
+        if not ws.running:
+            return False
         settings = body.get("settings") or {}
-        orig_mounts = list(ws.mounts or []) or None
-        orig_env = dict(ws.env or {}) or None
-        orig_domains = list(ws.allowed_domains or []) or None
-        orig_rejected = list(ws.rejected_domains or []) or None
-        return bool(ws.running) and (
-            (body["image"] or None) != (ws.image or None)
-            or body["mounts"] != orig_mounts
-            or body["env"] != orig_env
-            or (body["service_command"] or None)
-            != (ws.service_command or None)
-            or body["allowed_domains"] != orig_domains
-            or body["rejected_domains"] != orig_rejected
-            # #2409: egress_mode is a container-create-time field (it sets
-            # up --network container:<sidecar>), so a change needs a restart.
-            or body["egress_mode"] != (ws.egress_mode or EGRESS_MODE_DEFAULT)
-            # #2233: the per-workspace /nix mount is set up at create
-            # time, so toggling it on a running workspace needs a restart.
-            or (
+        old = ws.settings or {}
+        return any(
+            [
+                # Top-level create-time fields (#1778, #1749): image /
+                # service_command normalize both sides to None-when-empty,
+                # the list fields compare against their normalized snapshot.
+                (body["image"] or None) != (ws.image or None),
+                body["mounts"] != (list(ws.mounts or []) or None),
+                body["env"] != (dict(ws.env or {}) or None),
+                (body["service_command"] or None)
+                != (ws.service_command or None),
+                body["allowed_domains"]
+                != (list(ws.allowed_domains or []) or None),
+                body["rejected_domains"]
+                != (list(ws.rejected_domains or []) or None),
+                # #2409: egress_mode is a container-create-time field (it sets
+                # up --network container:<sidecar>), so a change needs a restart.
+                body["egress_mode"] != (ws.egress_mode or EGRESS_MODE_DEFAULT),
+                # #2233: the per-workspace /nix mount is set up at create
+                # time, so toggling it on a running workspace needs a restart.
                 self._nix_available
-                and settings.get("nix", False)
-                != bool((ws.settings or {}).get("nix"))
-            )
-            # #2017: the sudoers rule is written at container-create time,
-            # so a posture flip needs a restart to take effect.
-            or (
+                and settings.get("nix", False) != bool(old.get("nix")),
+                # #2017: the sudoers rule is written at container-create time,
+                # so a posture flip needs a restart to take effect.
                 self._sudo_available
                 and settings.get("allow_sudo", True)
-                != bool((ws.settings or {}).get("allow_sudo", True))
-            )
+                != bool(old.get("allow_sudo", True)),
+            ]
         )
 
     def _save(self) -> None:


### PR DESCRIPTION
## Summary

First PR of the #2794 D→C ratchet: brings the four CLI form/edit blocks at rank D down to C — both `klangk/cli/edit.py` and `klangk/cli/tui/screens/workspace_form.py` now pass `xenon --max-absolute C`. Pure extract-function / comparator-table — no behavior change.

## Details

- `cli/edit.py flag_edit_body` **D (28) → 11** via `flag_scalar_body` (scalar flags) + `flag_list_body` (repeatable flags + settings merge) + `validated_specs_or_exit` (the three duplicated validate-and-exit loops). Validation order (mounts → allow → reject) and body key order preserved.
- `cli/edit.py interactive_edit_body` **D (23) → 19** via `prompted_edit_fields` (the five scalar prompts) + `edit_lists_interactively` (the four list-editor invocations).
- `workspace_form.py EditWorkspaceScreen._restart_needed_after_save` **D (28) → 19** — the restart or-chain is now an `any([...])` comparator list with the same nine checks, early-returning when not running.
- `workspace_form.py CreateWorkspaceScreen._create` **D (22) → A** via `_create_payload` (field gathering), mirroring the `_save_body` split from #2803.

## Verification

- Full Python suite (klangkd + klangkc, `-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute C` on both files: passes.
- No changelog entry (internal refactor).
