### PR TITLE
refactor(cli): bring auth/status/sandbox blocks under radon rank C

### DIFF
--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -184,36 +184,33 @@ margin:0;background:#1a1a2e;color:#e0e0e0">
         raise SystemExit(1)
 
 
-def login(
-    server_url: str,
-    email: str | None = None,
-    password: str | None = None,
-) -> None:
-    """Prompt for credentials, store JWT in state."""
-    state = CLIState.load()
+def already_logged_in(state, server_url: str, email: str) -> bool:
+    """True (and prints) when a cached token for *email* still works."""
+    ss = state.servers.get(server_url)
+    cached = ss.users.get(email) if ss else None
+    if not (cached and cached.token):
+        return False
+    try:
+        resp = http_request(
+            server_url,
+            "GET",
+            "/api/v1/workspaces",
+            headers={"Authorization": f"Bearer {cached.token}"},
+            timeout=5.0,
+        )
+        if resp.status_code == 200:
+            state.set_credentials(server_url, email, cached.token)
+            state.save()
+            _out.print(f"Already logged in as [bold]{email}[/bold]")
+            return True
+    except httpx.HTTPError:
+        pass  # Token invalid or server unreachable — fall through
+    return False
 
-    # If we already have a cached token for this user, verify it.
-    if email:
-        ss = state.servers.get(server_url)
-        cached = ss.users.get(email) if ss else None
-        if cached and cached.token:
-            try:
-                resp = http_request(
-                    server_url,
-                    "GET",
-                    "/api/v1/workspaces",
-                    headers={"Authorization": f"Bearer {cached.token}"},
-                    timeout=5.0,
-                )
-                if resp.status_code == 200:
-                    state.set_credentials(server_url, email, cached.token)
-                    state.save()
-                    _out.print(f"Already logged in as [bold]{email}[/bold]")
-                    return
-            except httpx.HTTPError:
-                pass  # Token invalid or server unreachable — fall through
 
-    # Probe the server to verify it's a klangk instance
+def fetch_config_or_exit(server_url: str):
+    """Probe the server; exit(1) with a hint if it isn't a klangk instance
+    or is unreachable."""
     config = fetch_config(server_url)
     if config is None:
         _err.print(
@@ -228,50 +225,65 @@ def login(
     if config == _UNREACHABLE:
         _err.print(f"[red]Error:[/red] could not reach {server_url}")
         raise SystemExit(1)
+    return config
 
-    # Default-safe per #1374: a missing/unparseable auth_modes field falls
-    # back to password so an old server never routes to the /auth/local arm.
-    auth_modes = "password"
-    if config:
-        providers = config.get("oidc_providers", [])
-        auth_modes = config.get("auth_modes", "password")
 
-        if auth_modes == "none":
-            email, token = local_login(server_url)
-            state.set_credentials(server_url, email, token)
-            state.save()
-            seed_config(server_url, email)
-            _out.print(f"Logged in as [bold]{email}[/bold] (no-auth mode)")
-            return
+def select_oidc_provider(providers: list) -> dict:
+    """The single provider, or prompt when several are configured."""
+    if len(providers) == 1:
+        return providers[0]
+    _out.print("Select an SSO provider:")
+    for i, p in enumerate(providers, 1):
+        _out.print(f"  {i}. {p['display_name']}")
+    choice = Prompt.ask(
+        "[bold]Provider[/bold]",
+        default="1",
+    )
+    try:
+        idx = int(choice) - 1
+        return providers[idx]
+    except (ValueError, IndexError):
+        _err.print("[red]Invalid choice[/red]")
+        raise SystemExit(1)
 
-        if providers and auth_modes in ("oidc", "both"):
-            # Use OIDC if password login is disabled, or if the user
-            # didn't explicitly provide email/password credentials
-            use_oidc = auth_modes == "oidc" or (
-                email is None and password is None
-            )
-            if use_oidc:
-                if len(providers) == 1:
-                    provider = providers[0]
-                else:
-                    _out.print("Select an SSO provider:")
-                    for i, p in enumerate(providers, 1):
-                        _out.print(f"  {i}. {p['display_name']}")
-                    choice = Prompt.ask(
-                        "[bold]Provider[/bold]",
-                        default="1",
-                    )
-                    try:
-                        idx = int(choice) - 1
-                        provider = providers[idx]
-                    except (ValueError, IndexError):
-                        _err.print("[red]Invalid choice[/red]")
-                        raise SystemExit(1)
 
-                _oidc_browser_login(server_url, provider["id"], state)
-                return
+def try_oidc_login(server_url, email, password, config, state) -> bool:
+    """Run the OIDC browser flow when the server config calls for it.
 
-    # Fall through to password login (accepts an email or a handle, #616)
+    Uses OIDC if password login is disabled, or if the user didn't
+    explicitly provide email/password credentials. Returns True when the
+    flow ran (login is then complete)."""
+    providers = config.get("oidc_providers", [])
+    auth_modes = config.get("auth_modes", "password")
+    if not (providers and auth_modes in ("oidc", "both")):
+        return False
+    use_oidc = auth_modes == "oidc" or (email is None and password is None)
+    if not use_oidc:
+        return False
+    provider = select_oidc_provider(providers)
+    _oidc_browser_login(server_url, provider["id"], state)
+    return True
+
+
+def print_login_failure(resp) -> None:
+    """Explain a non-200 login response (redirect hint or server detail)."""
+    if resp.status_code in (301, 302, 307, 308):
+        location = resp.headers.get("location", "")
+        _err.print(f"[red]Login failed:[/red] server redirected to {location}")
+        if location.startswith("https://"):
+            _err.print("[yellow]Hint:[/yellow] use https:// in the server URL")
+    else:
+        try:
+            detail = resp.json().get("detail", f"HTTP {resp.status_code}")
+        except Exception:
+            detail = f"HTTP {resp.status_code}"
+        _err.print(f"[red]Login failed:[/red] {detail}")
+    raise SystemExit(1)
+
+
+def password_login(server_url, email, password, state) -> None:
+    """Prompt for credentials (accepts an email or a handle, #616), POST
+    them, and persist the returned token."""
     email = email or Prompt.ask("[bold]Email or handle[/bold]")
     password = password or Prompt.ask("[bold]Password[/bold]", password=True)
 
@@ -283,22 +295,7 @@ def login(
         timeout=15.0,
     )
     if resp.status_code != 200:
-        if resp.status_code in (301, 302, 307, 308):
-            location = resp.headers.get("location", "")
-            _err.print(
-                f"[red]Login failed:[/red] server redirected to {location}"
-            )
-            if location.startswith("https://"):
-                _err.print(
-                    "[yellow]Hint:[/yellow] use https:// in the server URL"
-                )
-        else:
-            try:
-                detail = resp.json().get("detail", f"HTTP {resp.status_code}")
-            except Exception:
-                detail = f"HTTP {resp.status_code}"
-            _err.print(f"[red]Login failed:[/red] {detail}")
-        raise SystemExit(1)
+        print_login_failure(resp)
 
     token = resp.json()["access_token"]
 
@@ -306,6 +303,41 @@ def login(
     state.save()
     seed_config(server_url, email)
     _out.print(f"Logged in as [bold]{email}[/bold]")
+
+
+def login(
+    server_url: str,
+    email: str | None = None,
+    password: str | None = None,
+) -> None:
+    """Prompt for credentials, store JWT in state."""
+    state = CLIState.load()
+
+    # If we already have a cached token for this user, verify it.
+    if email and already_logged_in(state, server_url, email):
+        return
+
+    # Probe the server to verify it's a klangk instance
+    config = fetch_config_or_exit(server_url)
+
+    # Default-safe per #1374: a missing/unparseable auth_modes field falls
+    # back to password so an old server never routes to the /auth/local arm.
+    auth_modes = "password"
+    if config:
+        auth_modes = config.get("auth_modes", "password")
+
+        if auth_modes == "none":
+            email, token = local_login(server_url)
+            state.set_credentials(server_url, email, token)
+            state.save()
+            seed_config(server_url, email)
+            _out.print(f"Logged in as [bold]{email}[/bold] (no-auth mode)")
+            return
+
+        if try_oidc_login(server_url, email, password, config, state):
+            return
+
+    password_login(server_url, email, password, state)
 
 
 def refresh_token(server_url: str, token: str) -> str | None:

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -68,20 +68,11 @@ def logout(
 
 
 @context.app.command()
-def status(
-    plain: bool = typer.Option(False, "--plain", help="Plain text output"),
-) -> None:
-    """Show connection info (server, user, admin status)."""
-    # status works even with no active server (unlike other commands).
-    url = context._server_override or context._state().active_server
-    state = context._state()
-    token = state.get_token(url) if url else None
-    email = state.get_email(url) if url else None
-    user_id = decode_token_claims(token).get("sub") if token else None
-    # Admin status comes from /my-permissions (the canonical source the
-    # frontend uses for isAdmin). Best-effort: if the probe fails (offline,
-    # token expired, old server without /admin in the static set) status
-    # still reports everything else rather than erroring out.
+def admin_status(token: str | None) -> bool | None:
+    """Admin status from /my-permissions (the canonical source the
+    frontend uses for isAdmin). Best-effort: if the probe fails (offline,
+    token expired, old server without /admin in the static set) status
+    still reports everything else rather than erroring out."""
     is_admin: bool | None = None
     if token:
         try:
@@ -93,17 +84,22 @@ def status(
                 is_admin = "*" in perms.get("/admin", [])
         except Exception:
             is_admin = None
-    if plain:
-        print(f"server={url or '(none)'}")
-        if token:
-            print(f"user={email or 'unknown'}")
-            print(f"user_id={user_id or 'unknown'}")
-            print("status=logged_in")
-            if is_admin is not None:
-                print(f"admin={'yes' if is_admin else 'no'}")
-        else:
-            print("status=not_logged_in")
-        return
+    return is_admin
+
+
+def print_status_plain(url, token, email, user_id, is_admin) -> None:
+    print(f"server={url or '(none)'}")
+    if token:
+        print(f"user={email or 'unknown'}")
+        print(f"user_id={user_id or 'unknown'}")
+        print("status=logged_in")
+        if is_admin is not None:
+            print(f"admin={'yes' if is_admin else 'no'}")
+    else:
+        print("status=not_logged_in")
+
+
+def print_status_table(url, token, email, user_id, is_admin) -> None:
     console = Console()
     table = Table(show_header=False, box=None, pad_edge=False)
     table.add_column(style="bold")
@@ -120,6 +116,23 @@ def status(
     else:
         table.add_row("Status", "[yellow]not logged in[/yellow]")
     console.print(table)
+
+
+def status(
+    plain: bool = typer.Option(False, "--plain", help="Plain text output"),
+) -> None:
+    """Show connection info (server, user, admin status)."""
+    # status works even with no active server (unlike other commands).
+    url = context._server_override or context._state().active_server
+    state = context._state()
+    token = state.get_token(url) if url else None
+    email = state.get_email(url) if url else None
+    user_id = decode_token_claims(token).get("sub") if token else None
+    is_admin = admin_status(token)
+    if plain:
+        print_status_plain(url, token, email, user_id, is_admin)
+        return
+    print_status_table(url, token, email, user_id, is_admin)
 
 
 # ---------------------------------------------------------------------

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -67,7 +67,6 @@ def logout(
     do_logout(resolved_url)
 
 
-@context.app.command()
 def admin_status(token: str | None) -> bool | None:
     """Admin status from /my-permissions (the canonical source the
     frontend uses for isAdmin). Best-effort: if the probe fails (offline,
@@ -118,6 +117,7 @@ def print_status_table(url, token, email, user_id, is_admin) -> None:
     console.print(table)
 
 
+@context.app.command()
 def status(
     plain: bool = typer.Option(False, "--plain", help="Plain text output"),
 ) -> None:

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -246,6 +246,118 @@ def sandbox(
     )
 
 
+async def mark_setup_state(client, workspace_id: str, new_state: str) -> None:
+    """Best-effort setup_state update with a warning on failure (#1033)."""
+    if client is None:
+        return
+    try:
+        await asyncio.to_thread(
+            client.set_setup_state, workspace_id, new_state
+        )
+    except Exception as e:  # pragma: no cover
+        context._err.print(
+            f"[yellow]Warning: could not mark setup_state"
+            f" = {new_state}: {e}[/yellow]"
+        )
+
+
+async def decide_egress_reset(config, client) -> tuple[bool, str | None]:
+    """#2404: choose the post-install egress posture.
+
+    The workspace was created in 'allow' so setup.sh could egress without
+    a decider; now drop to the safe 'interactive' default -- but only when
+    that is safe and meaningful:
+
+      - auto-start workspaces boot unattended (no decider connected),
+        and interactive DENIES egress with no decider, so their service
+        command could never reach its upstream. Leave them in allow.
+      - interactive is fail-closed: start_container refuses to start
+        unfiltered when no network sidecar is configured. So only reset
+        when the server can actually enforce it (netfilter_enabled).
+
+    When neither skip applies, reset egress_mode to interactive and
+    stop the container; egress_mode is applied by the sidecar at
+    container START (not on the live container), so the stop forces the
+    next start -- the user's `klangk shell` -- up in interactive mode.
+    The service command is not fired in that case: it re-fires at the
+    create choke point on that next start. Returns (reset, skipped_reason).
+    """
+    if config.auto_start:
+        return False, "auto-start workspace boots unattended"
+    if client is None:
+        return False, None
+    try:
+        cfg = await asyncio.to_thread(client.config)
+    except Exception as e:  # pragma: no cover
+        cfg = {}
+        context._err.print(
+            "[yellow]Warning: could not read server config"
+            f" ({e}); leaving workspace in allow[/yellow]"
+        )
+    if not cfg.get("netfilter_enabled"):
+        return False, "no network sidecar on this server"
+    return True, None
+
+
+async def reset_egress_and_stop(client, workspace_id: str) -> None:
+    """Drop to the safe interactive default and stop the container.
+
+    egress_mode applies at the next container START (not on the live
+    container), so the stop forces the next `klangk shell` up in
+    consent-gated mode. The service command is NOT fired here -- the
+    container is being stopped, and it re-fires at the create choke
+    point on that next start.
+    """
+    try:
+        await asyncio.to_thread(
+            client.update_workspace,
+            workspace_id,
+            egress_mode="interactive",
+        )
+    except Exception as e:  # pragma: no cover
+        context._err.print(
+            "[yellow]Warning: could not reset egress_mode"
+            f" to interactive: {e}[/yellow]"
+        )
+    try:
+        await asyncio.to_thread(client.stop_workspace_by_id, workspace_id)
+    except Exception as e:  # pragma: no cover
+        context._err.print(
+            f"[yellow]Warning: could not stop container"
+            f" after setup: {e}[/yellow]"
+        )
+    context._err.print(
+        "[dim]Workspace stopped; egress reset to interactive"
+        " for the next start.[/dim]"
+    )
+
+
+async def fire_service_command(ws, config, setup_ok: bool) -> None:
+    """Fire the service command via terminal_start so it's up (#1033:
+    deferred until setup_state is complete, then launched in the
+    dedicated service-cmd tmux window). Skipped on setup failure -- the
+    service command's prerequisites are not met.
+    """
+    if not (config.service_command and setup_ok):
+        return
+    await ws.send(
+        json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
+    )
+    # Wait (bounded) for the terminal to start so the command actually
+    # runs before we disconnect. Other messages are ignored.
+    deadline = asyncio.get_event_loop().time() + 30
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:  # pragma: no cover
+            break
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        except (asyncio.TimeoutError, websockets.ConnectionClosed):
+            break
+        if json.loads(raw).get("type") == "terminal_started":
+            break
+
+
 async def sandbox_setup_only(
     server_spec,
     token,
@@ -285,131 +397,27 @@ async def sandbox_setup_only(
         # re-setup it may be 'complete'/'failed'; either way this is
         # idempotent and ensures a visitor during (re-)setup is blocked
         # from firing the service command prematurely.
-        if client is not None:
-            try:
-                await asyncio.to_thread(
-                    client.set_setup_state, workspace_id, "pending"
-                )
-            except Exception as e:  # pragma: no cover
-                context._err.print(
-                    f"[yellow]Warning: could not mark setup_state"
-                    f" = pending: {e}[/yellow]"
-                )
+        await mark_setup_state(client, workspace_id, "pending")
         exit_code = await sandbox_setup(ws, config, sandbox_root, handle)
 
         # Mark setup_state before anything else (#1033). 'complete'
         # when setup ran and returned 0, or when there was no setup
         # command at all (nothing to fail); 'failed' otherwise.
         setup_ok = exit_code is None or exit_code == 0
-        new_state = "complete" if setup_ok else "failed"
-        if client is not None:
-            try:
-                await asyncio.to_thread(
-                    client.set_setup_state, workspace_id, new_state
-                )
-            except Exception as e:  # pragma: no cover
-                context._err.print(
-                    f"[yellow]Warning: could not mark setup_state"
-                    f" = {new_state}: {e}[/yellow]"
-                )
+        await mark_setup_state(
+            client, workspace_id, "complete" if setup_ok else "failed"
+        )
 
-        # #2404: choose the post-install egress posture. The workspace was
-        # created in 'allow' so setup.sh could egress without a decider; now
-        # drop to the safe 'interactive' default -- but only when that is
-        # safe and meaningful:
-        #   - auto-start workspaces boot unattended (no decider connected),
-        #     and interactive DENIES egress with no decider, so their service
-        #     command could never reach its upstream. Leave them in allow.
-        #   - interactive is fail-closed: start_container refuses to start
-        #     unfiltered when no network sidecar is configured. So only reset
-        #     when the server can actually enforce it (netfilter_enabled).
-        # When neither skip applies, reset egress_mode to interactive and
-        # stop the container. egress_mode is applied by the sidecar at
-        # container START (not on the live container), so the stop forces the
-        # next start -- the user's `klangk shell` -- up in interactive mode.
-        # The service command is not fired here: it re-fires at the create
-        # choke point on that next start.
-        reset_to_interactive = False
-        skipped_reason = None
-        if config.auto_start:
-            skipped_reason = "auto-start workspace boots unattended"
-        elif client is not None:
-            try:
-                cfg = await asyncio.to_thread(client.config)
-            except Exception as e:  # pragma: no cover
-                cfg = {}
-                context._err.print(
-                    "[yellow]Warning: could not read server config"
-                    f" ({e}); leaving workspace in allow[/yellow]"
-                )
-            if not cfg.get("netfilter_enabled"):
-                skipped_reason = "no network sidecar on this server"
-            else:
-                reset_to_interactive = True
-
+        reset_to_interactive, skipped_reason = await decide_egress_reset(
+            config, client
+        )
         if reset_to_interactive and client is not None:
-            # Drop to the safe interactive default and stop the container.
-            # egress_mode applies at the next container START (not on the
-            # live container), so the stop forces the next `klangk shell`
-            # up in consent-gated mode. The service command is NOT fired
-            # here -- the container is being stopped, and it re-fires at
-            # the create choke point on that next start.
-            try:
-                await asyncio.to_thread(
-                    client.update_workspace,
-                    workspace_id,
-                    egress_mode="interactive",
-                )
-            except Exception as e:  # pragma: no cover
-                context._err.print(
-                    "[yellow]Warning: could not reset egress_mode"
-                    f" to interactive: {e}[/yellow]"
-                )
-            try:
-                await asyncio.to_thread(
-                    client.stop_workspace_by_id, workspace_id
-                )
-            except Exception as e:  # pragma: no cover
-                context._err.print(
-                    "[yellow]Warning: could not stop container"
-                    f" after setup: {e}[/yellow]"
-                )
-            context._err.print(
-                "[dim]Workspace stopped; egress reset to interactive"
-                " for the next start.[/dim]"
-            )
+            await reset_egress_and_stop(client, workspace_id)
         else:
             # Stay in allow (auto-start, no sidecar, or no client to
             # decide). The container keeps running, so fire the service
-            # command now so it's up (#1033: deferred until setup_state is
-            # complete, then launched via terminal_start in the dedicated
-            # service-cmd tmux window). Skipped on setup failure -- the
-            # service command's prerequisites are not met.
-            if config.service_command and setup_ok:
-                await ws.send(
-                    json.dumps(
-                        {"cmd": "terminal_start", "cols": 80, "rows": 24}
-                    )
-                )
-                # Wait (bounded) for the terminal to start so the command
-                # actually runs before we disconnect. Other messages are
-                # ignored.
-                deadline = asyncio.get_event_loop().time() + 30
-                while True:
-                    remaining = deadline - asyncio.get_event_loop().time()
-                    if remaining <= 0:  # pragma: no cover
-                        break
-                    try:
-                        raw = await asyncio.wait_for(
-                            ws.recv(), timeout=remaining
-                        )
-                    except (
-                        asyncio.TimeoutError,
-                        websockets.ConnectionClosed,
-                    ):
-                        break
-                    if json.loads(raw).get("type") == "terminal_started":
-                        break
+            # command now so it's up.
+            await fire_service_command(ws, config, setup_ok)
             if client is not None:
                 context._err.print(
                     "[dim]Workspace left in allow mode"


### PR DESCRIPTION
## Summary

Third PR of the #2794 D→C ratchet: brings the three CLI auth/sandbox rank-D blocks under C — `cli/auth.py`, `cli/authcmds.py`, and `cli/sandboxcmd.py` now pass `xenon --max-absolute C`. Pure extract-function — no behavior change.

## Details

- `cli/auth.py login` **D (25) → B**, split into `already_logged_in` (cached-token verify), `fetch_config_or_exit` (server probe + hints), `try_oidc_login` + `select_oidc_provider` (the provider choice prompt), and `password_login` + `print_login_failure` (redirect-hint / detail rendering). Auth-mode dispatch order and the #1374 default-safe fallback unchanged.
- `cli/authcmds.py status` **D (21) → A**, split into `admin_status` (the best-effort /my-permissions probe) and the `--plain` / rich-table renderers.
- `cli/sandboxcmd.py sandbox_setup_only` **D (22) → A**, split into `mark_setup_state` (deduplicates the two identical pending/result update blocks), `decide_egress_reset` (the #2404 posture decision), `reset_egress_and_stop`, and `fire_service_command` (terminal_start + bounded wait). All `# pragma: no cover` markers and warning strings moved verbatim.

## Verification

- Full Python suite (klangkd + klangkc, `-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute C` on all three files: passes.
- No changelog entry (internal refactor).
