### PR TITLE
refactor(consent): bring decider handler and TUI frame applier under rank C

### DIFF
--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -331,6 +331,58 @@ class ConsentDeciderController:
         # renders an empty state until then.
         self.rules: EgressRules | None = None
 
+    def _apply_request(self, msg: dict) -> tuple[str, object]:
+        req = _parse_request(msg.get("request"))
+        if req is None:
+            return IGNORED, None
+        self.pending[req.id] = req
+        return ADDED, req
+
+    def _apply_resolved(self, msg: dict) -> tuple[str, object]:
+        rid = msg.get("request_id")
+        if isinstance(rid, str):
+            self.pending.pop(rid, None)
+        return RESOLVED, (rid, msg.get("decision"))
+
+    def _apply_rules(self, msg: dict) -> tuple[str, object]:
+        rules = _parse_rules(msg)
+        if rules is None:
+            return IGNORED, None
+        self.rules = rules
+        return RULES, rules
+
+    def _apply_revoke_ack(self, msg: dict) -> tuple[str, object]:
+        # #2341: server confirmed a revoke. On success drop the row from the
+        # cached snapshot (idempotent -- the server also pushes a refreshed
+        # ``egress_rules``); on failure leave it enforced. ``request_id`` may
+        # be absent on a malformed frame -> rid None, no mutation.
+        rid = msg.get("request_id")
+        ok = bool(msg.get("ok"))
+        if ok and isinstance(rid, str) and self.rules is not None:
+            self.rules = replace(
+                self.rules,
+                allowed=tuple(r for r in self.rules.allowed if r.id != rid),
+                denied=tuple(r for r in self.rules.denied if r.id != rid),
+            )
+        return REVOKE_ACK, (
+            rid if isinstance(rid, str) else None,
+            ok,
+        )
+
+    def _apply_pause_ack(self, msg: dict) -> tuple[str, object]:
+        # #2332: server replied to a pause/unpause. The pause window itself
+        # arrives in the subsequent refreshed ``egress_rules`` frame (the
+        # server broadcasts one on every pause/unpause); this ack only
+        # signals success/failure so the view can flash on a nack. ``until``
+        # is None for an unpause or a failed pause.
+        until = msg.get("until")
+        return PAUSE_ACK, (
+            bool(msg.get("ok")),
+            float(until)
+            if isinstance(until, (int, float)) and not isinstance(until, bool)
+            else None,
+        )
+
     def apply_frame(self, raw: str) -> tuple[str, object]:
         """Parse + apply one inbound server frame.
 
@@ -348,55 +400,15 @@ class ConsentDeciderController:
             return IGNORED, None
         mtype = msg.get("type")
         if mtype == "egress_request":
-            req = _parse_request(msg.get("request"))
-            if req is None:
-                return IGNORED, None
-            self.pending[req.id] = req
-            return ADDED, req
+            return self._apply_request(msg)
         if mtype == "egress_resolved":
-            rid = msg.get("request_id")
-            if isinstance(rid, str):
-                self.pending.pop(rid, None)
-            return RESOLVED, (rid, msg.get("decision"))
+            return self._apply_resolved(msg)
         if mtype == "egress_rules":
-            rules = _parse_rules(msg)
-            if rules is None:
-                return IGNORED, None
-            self.rules = rules
-            return RULES, rules
+            return self._apply_rules(msg)
         if mtype == "revoke_ack":
-            # #2341: server confirmed a revoke. On success drop the row from the
-            # cached snapshot (idempotent -- the server also pushes a refreshed
-            # ``egress_rules``); on failure leave it enforced. ``request_id`` may
-            # be absent on a malformed frame -> rid None, no mutation.
-            rid = msg.get("request_id")
-            ok = bool(msg.get("ok"))
-            if ok and isinstance(rid, str) and self.rules is not None:
-                self.rules = replace(
-                    self.rules,
-                    allowed=tuple(
-                        r for r in self.rules.allowed if r.id != rid
-                    ),
-                    denied=tuple(r for r in self.rules.denied if r.id != rid),
-                )
-            return REVOKE_ACK, (
-                rid if isinstance(rid, str) else None,
-                ok,
-            )
+            return self._apply_revoke_ack(msg)
         if mtype == "pause_ack":
-            # #2332: server replied to a pause/unpause. The pause window itself
-            # arrives in the subsequent refreshed ``egress_rules`` frame (the
-            # server broadcasts one on every pause/unpause); this ack only
-            # signals success/failure so the view can flash on a nack. ``until``
-            # is None for an unpause or a failed pause.
-            until = msg.get("until")
-            return PAUSE_ACK, (
-                bool(msg.get("ok")),
-                float(until)
-                if isinstance(until, (int, float))
-                and not isinstance(until, bool)
-                else None,
-            )
+            return self._apply_pause_ack(msg)
         if mtype == "pong":
             return PONG, None
         if mtype == "error":

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -81,6 +81,122 @@ async def _refuse(
     await websocket.close(code=code, reason=reason)
 
 
+async def _refuse_invalid_handshake(
+    websocket: WebSocket, app, workspace: str | None, user: dict
+) -> bool:
+    """Authorization + static-mode gate for a consent decider.
+
+    Workspace-scoped deciders need terminal access to the workspace (owner
+    or member); deploy-wide deciders need admin. Mirrors the main /ws
+    handler's workspace gate (wshandler/connection.py).
+
+    #2394: a static-mode workspace never holds egress for a human decision
+    (its non-allow-listed egress is denied immediately with a static
+    verdict). Refuse a workspace-scoped decider at registration so the
+    static/interactive boundary is structural (enforced here), not just
+    behavioral (the coordinator's hold-time ``_is_interactive`` gate stays
+    as defense-in-depth). Reads the same egress_mode the coordinator does.
+    Deploy-wide deciders (workspace None) are unaffected -- they cover
+    interactive workspaces without flipping a static one.
+
+    NB: these closes run before websocket.accept(), so the ASGI server
+    (uvicorn) answers the handshake with a bare HTTP 403 -- the close code
+    and reason are NOT transmitted to the client (same as the authz close
+    above). _refuse() therefore also logs the reason server-side (#2490):
+    the log line is the only place a 403 storm is attributable.
+
+    Returns (refused, principals) — principals (needed by the pause /
+    unpause handlers) is only meaningful when not refused."""
+    principals = await app.state.acl.get_principals(user["id"])
+    if workspace is not None:
+        allowed = await app.state.acl.check_permission(
+            f"/workspaces/{workspace}", principals, "terminal"
+        )
+    else:
+        allowed = await app.state.acl.check_permission(
+            "/admin", principals, "admin"
+        )
+    if not allowed:
+        await _refuse(websocket, 4003, "Forbidden", user.get("email"))
+        return True, principals
+    if workspace is not None:
+        ws = await app.state.model.workspaces.get_workspace(workspace)
+        if ws is None:
+            # Vanished between the authz check and now (a delete race) -- the
+            # workspace authz just passed against can no longer be registered.
+            await _refuse(websocket, 4003, "Forbidden", user.get("email"))
+            return True, principals
+        if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
+            await _refuse(
+                websocket,
+                4003,
+                "workspace egress mode is not interactive",
+                user.get("email"),
+            )
+            return True, principals
+    return False, principals
+
+
+def _log_handshake_timing(t0: float, marks: list[tuple[str, float]]) -> None:
+    """#2420: log the pre-accept step timings (see handle_consent_decider)."""
+    prev = t0
+    parts: list[str] = []
+    for label, t in marks:
+        parts.append(f"{label}={(t - prev) * 1000:.0f}ms")
+        prev = t
+    logger.info(
+        "consent decider handshake accepted: %.0fms (%s)",
+        (marks[-1][1] - t0) * 1000,
+        " ".join(parts),
+    )
+
+
+async def _dispatch_decider_message(
+    app,
+    registry,
+    safe_ws,
+    msg: dict,
+    workspace: str | None,
+    user_id: str,
+    decider_id: str,
+    principals,
+) -> None:
+    """Act on one parsed decider frame by its ``type``.
+
+    Unknown types are ignored. Raises whatever the per-type handler raises
+    (SlowClientError from sends is handled by the receive loop)."""
+    mtype = msg.get("type")
+    if mtype == "ping":
+        registry.touch(decider_id)
+        safe_ws.send_json({"type": "pong"})
+    elif mtype == "verdict":
+        await _handle_verdict(app, safe_ws, msg, workspace, user_id)
+    elif mtype == "revoke":
+        # #2339: drop the sidecar rule + mark the verdict revoked.
+        # ok=False if it's not an active verdict, is outside this
+        # decider's workspace, or the sidecar never acked the drop.
+        ok = await app.state.consent_coordinator.revoke(
+            msg.get("request_id"),
+            user_id,
+            decider_workspace=workspace,
+        )
+        safe_ws.send_json(
+            {
+                "type": "revoke_ack",
+                "request_id": msg.get("request_id"),
+                "ok": ok,
+            }
+        )
+    elif mtype == "pause":
+        # #2332: pause interactive consent prompting for this
+        # decider's workspace for a window. A deploy-wide decider
+        # (workspace None) has no single workspace to pause -> nack.
+        await _handle_pause(app, safe_ws, msg, workspace, principals)
+    elif mtype == "unpause":
+        # #2332: clear an active pause for this decider's workspace.
+        await _handle_unpause(app, safe_ws, workspace, principals)
+
+
 async def handle_consent_decider(websocket: WebSocket, app) -> None:
     """Register a consent decider for its connection lifetime + act on holds."""
     # #2420: time the pre-accept steps so an intermittent opening-handshake
@@ -109,66 +225,16 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     user = result
     workspace = websocket.query_params.get("workspace")  # None = deploy-wide
 
-    # Authorization: workspace-scoped deciders need terminal access to the
-    # workspace (owner or member); deploy-wide deciders need admin. Mirrors the
-    # main /ws handler's workspace gate (wshandler/connection.py).
-    principals = await app.state.acl.get_principals(user["id"])
-    if workspace is not None:
-        allowed = await app.state.acl.check_permission(
-            f"/workspaces/{workspace}", principals, "terminal"
-        )
-    else:
-        allowed = await app.state.acl.check_permission(
-            "/admin", principals, "admin"
-        )
-    if not allowed:
-        await _refuse(websocket, 4003, "Forbidden", user.get("email"))
+    refused, principals = await _refuse_invalid_handshake(
+        websocket, app, workspace, user
+    )
+    if refused:
         return
     _hs_mark("authz")
-
-    # #2394: a static-mode workspace never holds egress for a human decision
-    # (its non-allow-listed egress is denied immediately with a static
-    # verdict). Refuse a workspace-scoped decider at registration so the
-    # static/interactive boundary is structural (enforced here), not just
-    # behavioral (the coordinator's hold-time ``_is_interactive`` gate stays
-    # as defense-in-depth). Reads the same egress_mode the coordinator does.
-    # Deploy-wide deciders (workspace None) are unaffected -- they cover
-    # interactive workspaces without flipping a static one.
-    #
-    # NB: these closes run before websocket.accept(), so the ASGI server
-    # (uvicorn) answers the handshake with a bare HTTP 403 -- the close code
-    # and reason are NOT transmitted to the client (same as the authz close
-    # above). _refuse() therefore also logs the reason server-side (#2490):
-    # the log line is the only place a 403 storm is attributable.
-    if workspace is not None:
-        ws = await app.state.model.workspaces.get_workspace(workspace)
-        if ws is None:
-            # Vanished between the authz check and now (a delete race) -- the
-            # workspace authz just passed against can no longer be registered.
-            await _refuse(websocket, 4003, "Forbidden", user.get("email"))
-            return
-        if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
-            await _refuse(
-                websocket,
-                4003,
-                "workspace egress mode is not interactive",
-                user.get("email"),
-            )
-            return
-
     _hs_mark("workspace")
     await websocket.accept()
     _hs_mark("accept")
-    _prev = _hs_t0
-    _parts: list[str] = []
-    for label, t in _hs_marks:
-        _parts.append(f"{label}={(t - _prev) * 1000:.0f}ms")
-        _prev = t
-    logger.info(
-        "consent decider handshake accepted: %.0fms (%s)",
-        (_hs_marks[-1][1] - _hs_t0) * 1000,
-        " ".join(_parts),
-    )
+    _log_handshake_timing(_hs_t0, _hs_marks)
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
     registry = app.state.consent_deciders
@@ -206,40 +272,16 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
                 continue
             mtype = msg.get("type")
             try:
-                if mtype == "ping":
-                    registry.touch(decider_id)
-                    safe_ws.send_json({"type": "pong"})
-                elif mtype == "verdict":
-                    await _handle_verdict(
-                        app, safe_ws, msg, workspace, user["id"]
-                    )
-                elif mtype == "revoke":
-                    # #2339: drop the sidecar rule + mark the verdict revoked.
-                    # ok=False if it's not an active verdict, is outside this
-                    # decider's workspace, or the sidecar never acked the drop.
-                    ok = await app.state.consent_coordinator.revoke(
-                        msg.get("request_id"),
-                        user["id"],
-                        decider_workspace=workspace,
-                    )
-                    safe_ws.send_json(
-                        {
-                            "type": "revoke_ack",
-                            "request_id": msg.get("request_id"),
-                            "ok": ok,
-                        }
-                    )
-                elif mtype == "pause":
-                    # #2332: pause interactive consent prompting for this
-                    # decider's workspace for a window. A deploy-wide decider
-                    # (workspace None) has no single workspace to pause -> nack.
-                    await _handle_pause(
-                        app, safe_ws, msg, workspace, principals
-                    )
-                elif mtype == "unpause":
-                    # #2332: clear an active pause for this decider's workspace.
-                    await _handle_unpause(app, safe_ws, workspace, principals)
-                # unknown types are ignored
+                await _dispatch_decider_message(
+                    app,
+                    registry,
+                    safe_ws,
+                    msg,
+                    workspace,
+                    user["id"],
+                    decider_id,
+                    principals,
+                )
             except SlowClientError:
                 # Outbound queue full -- the client can't keep up. Drop it
                 # (matches the main /ws handler's slow-client handling).


### PR DESCRIPTION
## Summary

Fourth PR of the #2794 D→C ratchet: brings both consent-side rank-D blocks under C — `wshandler/decider.py` and `cli/tui/consent.py` now pass `xenon --max-absolute C`. Pure extract-function — no behavior change.

## Details

- `wshandler/decider.py handle_consent_decider` **D (23) → C (13)**, split into `_refuse_invalid_handshake` (the ACL gate + #2394 static-mode boundary; returns `(refused, principals)` so the pause/unpause handlers keep their principals), `_log_handshake_timing` (#2420 step timings), and `_dispatch_decider_message` (the ping/verdict/revoke/pause/unpause dispatch). The receive loop, SlowClientError drop, register-before-snapshot ordering, and all close codes/reasons unchanged.
- `cli/tui/consent.py ConsentDeciderController.apply_frame` **D (23) → A**, split into per-frame-type appliers (`_apply_request` / `_apply_resolved` / `_apply_rules` / `_apply_revoke_ack` / `_apply_pause_ack`) with the dispatch keeping pong/error inline. Outcome tuples and state mutations identical.

## Verification

- Full Python suite (klangkd + klangkc, `-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute C` on both files: passes.
- No changelog entry (internal refactor).
