### PR TITLE
refactor: bring remaining rank-D blocks under rank C

### DIFF
--- a/scripts/fuzz-idle.py
+++ b/scripts/fuzz-idle.py
@@ -734,6 +734,73 @@ async def check_idle_seconds(
         )
 
 
+async def configure_workspace(ctx: Ctx, spec: WsSpec) -> None:
+    """Apply the scenario's settings patches (invalid-probe + override)."""
+    api = ctx.api
+    if spec.invalid_patch:
+        # Values the settings coercion must reject (workspace_settings.py
+        # _coerce_nonnegative_int): negative, non-numeric string, empty
+        # string, non-integer float. Each must 400, never 5xx.
+        for bad in (-5, "notanumber", "", 1.5):
+            resp = await api.patch_settings(spec.ws_id, {"idle_timeout": bad})
+            if not 400 <= resp.status_code < 500:
+                ctx.anomalies.add(
+                    "invalid-patch",
+                    f"{spec.name}: PATCH idle_timeout={bad!r} -> "
+                    f"{resp.status_code} (expected 4xx)",
+                    scenario=spec.scenario_json(),
+                )
+        spec.note("invalid-patches-sent")
+    if spec.override is not None:
+        resp = await api.patch_settings(spec.ws_id, {"idle_timeout": spec.override})
+        if resp.status_code != 200:
+            ctx.anomalies.add(
+                "patch",
+                f"{spec.name}: PATCH override {spec.override} -> {resp.status_code}",
+                scenario=spec.scenario_json(),
+            )
+        spec.note(f"override={spec.override}")
+
+
+async def start_scenario_workspace(
+    ctx: Ctx, spec: WsSpec
+) -> tuple[WsTerminal | None, dict]:
+    """Start the workspace per its pattern; returns (terminal-or-None,
+    running-status)."""
+    api = ctx.api
+    term: WsTerminal | None = None
+    if spec.pattern in WS_PATTERNS:
+        term = WsTerminal(ctx.server, api.token, spec.ws_id)
+        spec.note("ws-connect")
+        await term.connect()
+        if spec.pattern != "quiet_ws":
+            await term.start_terminal()
+            await asyncio.sleep(1)
+            await term.send_input(" ")
+    else:
+        spec.note("api-start")
+        resp = await api.start(spec.ws_id)
+        if resp.status_code != 200:
+            ctx.anomalies.add(
+                "start",
+                f"{spec.name}: start -> {resp.status_code}",
+            )
+    st = await wait_running(ctx, spec)
+    cid = st.get("container_id") or ""
+    spec.note(f"running cid={cid[:12]}")
+
+    # Sanity: the status endpoint reports the effective timeout.
+    if st.get("idle_timeout") != spec.eff_timeout:
+        ctx.anomalies.add(
+            "status-timeout",
+            f"{spec.name}: status idle_timeout="
+            f"{st.get('idle_timeout')} != effective "
+            f"{spec.eff_timeout}",
+            scenario=spec.scenario_json(),
+        )
+    return term, st
+
+
 async def run_ws_scenario(ctx: Ctx, spec: WsSpec, tick: int) -> None:
     """One workspace lifecycle: create -> configure -> start -> activity
     pattern -> invariants -> restart check -> cleanup."""
@@ -743,61 +810,11 @@ async def run_ws_scenario(ctx: Ctx, spec: WsSpec, tick: int) -> None:
     term: WsTerminal | None = None
     try:
         # -- configure ------------------------------------------------------
-        if spec.invalid_patch:
-            # Values the settings coercion must reject (workspace_settings.py
-            # _coerce_nonnegative_int): negative, non-numeric string, empty
-            # string, non-integer float. Each must 400, never 5xx.
-            for bad in (-5, "notanumber", "", 1.5):
-                resp = await api.patch_settings(spec.ws_id, {"idle_timeout": bad})
-                if not 400 <= resp.status_code < 500:
-                    ctx.anomalies.add(
-                        "invalid-patch",
-                        f"{spec.name}: PATCH idle_timeout={bad!r} -> "
-                        f"{resp.status_code} (expected 4xx)",
-                        scenario=spec.scenario_json(),
-                    )
-            spec.note("invalid-patches-sent")
-        if spec.override is not None:
-            resp = await api.patch_settings(spec.ws_id, {"idle_timeout": spec.override})
-            if resp.status_code != 200:
-                ctx.anomalies.add(
-                    "patch",
-                    f"{spec.name}: PATCH override {spec.override} -> "
-                    f"{resp.status_code}",
-                    scenario=spec.scenario_json(),
-                )
-            spec.note(f"override={spec.override}")
+        await configure_workspace(ctx, spec)
 
         # -- start ----------------------------------------------------------
-        if spec.pattern in WS_PATTERNS:
-            term = WsTerminal(ctx.server, api.token, spec.ws_id)
-            spec.note("ws-connect")
-            await term.connect()
-            if spec.pattern != "quiet_ws":
-                await term.start_terminal()
-                await asyncio.sleep(1)
-                await term.send_input(" ")
-        else:
-            spec.note("api-start")
-            resp = await api.start(spec.ws_id)
-            if resp.status_code != 200:
-                ctx.anomalies.add(
-                    "start",
-                    f"{spec.name}: start -> {resp.status_code}",
-                )
-        st = await wait_running(ctx, spec)
+        term, st = await start_scenario_workspace(ctx, spec)
         cid = st.get("container_id") or ""
-        spec.note(f"running cid={cid[:12]}")
-
-        # Sanity: the status endpoint reports the effective timeout.
-        if st.get("idle_timeout") != spec.eff_timeout:
-            ctx.anomalies.add(
-                "status-timeout",
-                f"{spec.name}: status idle_timeout="
-                f"{st.get('idle_timeout')} != effective "
-                f"{spec.eff_timeout}",
-                scenario=spec.scenario_json(),
-            )
 
         state = {
             "last_activity": time.monotonic(),  # bringup is itself activity

--- a/scripts/update_features.py
+++ b/scripts/update_features.py
@@ -278,7 +278,7 @@ def read_lock(lock_path):
     return {e["name"]: e for e in (data or {}).get("features", [])}
 
 
-def main(argv=None):
+def parse_args(argv=None):
     parser = argparse.ArgumentParser(
         description="Materialize features declared in the checked-in features.yaml."
     )
@@ -309,7 +309,77 @@ def main(argv=None):
             "shape stays consistent (#1664)."
         ),
     )
-    args = parser.parse_args(argv)
+    return parser.parse_args(argv)
+
+
+def select_features(config: dict, only: str | None) -> list:
+    """The declared features, filtered to ``only`` when one is named."""
+    features = config.get("features", [])
+    if not features:
+        print("No features listed in features.yaml")
+        return []
+    if only:
+        matched = [p for p in features if feature_name(p) == only]
+        if not matched:
+            print(f"Feature '{only}' not found in features.yaml", file=sys.stderr)
+            sys.exit(1)
+        return matched
+    return features
+
+
+def materialize_feature(feature: dict, args, lock_map: dict, payload_dir: str):
+    """Fetch/link one declared feature; its lock entry, or None on skip."""
+    if "git" in feature:
+        if args.local_only:
+            print(
+                f"  SKIP: {feature['name']} (git entry, --local-only)",
+                file=sys.stderr,
+            )
+            # Record the skip in the lock so its shape stays consistent
+            # (every declared feature appears) without fetching. Preserve
+            # a real SHA from the prior lock if one exists (an interleaved
+            # `update_features <name>` may have already resolved it) — only
+            # write sha='skipped' when there's nothing better to keep.
+            prior = lock_map.get(feature["name"])
+            prior_sha = prior.get("sha") if prior else None
+            lock_map[feature["name"]] = {
+                "name": feature["name"],
+                "git": feature["git"],
+                "path": feature.get("path", ""),
+                "ref": feature.get("ref", "main"),
+                "sha": prior_sha if prior_sha and prior_sha != "skipped" else "skipped",
+            }
+            return None
+        return fetch_feature(feature, payload_dir)
+    if "path" in feature:
+        return link_feature(feature, payload_dir)
+    print(
+        f"  SKIP: entry needs 'git' or 'path' key: {feature}",
+        file=sys.stderr,
+    )
+    return None
+
+
+def prune_dropped_features(config: dict, lock_map: dict, payload_dir: str) -> None:
+    """Remove features that were in the old lockfile but dropped from
+    features.yaml."""
+    yaml_names = {
+        feature_name(p) for p in config.get("features", []) if "git" in p or "path" in p
+    }
+    for name in list(lock_map):
+        if name not in yaml_names:
+            feature_dir = os.path.join(payload_dir, name)
+            if os.path.islink(feature_dir):
+                os.unlink(feature_dir)
+                print(f"  Removed {name} (no longer in features.yaml)")
+            elif os.path.isdir(feature_dir):
+                shutil.rmtree(feature_dir)
+                print(f"  Removed {name} (no longer in features.yaml)")
+            del lock_map[name]
+
+
+def main(argv=None):
+    args = parse_args(argv)
 
     if not os.path.isfile(YAML_PATH):
         print(
@@ -326,19 +396,9 @@ def main(argv=None):
     with open(YAML_PATH) as f:
         config = yaml.safe_load(f)
 
-    features = config.get("features", [])
+    features = select_features(config, args.only)
     if not features:
-        print("No features listed in features.yaml")
         return 0
-
-    # Filter to a single feature if requested
-    only = args.only
-    if only:
-        matched = [p for p in features if feature_name(p) == only]
-        if not matched:
-            print(f"Feature '{only}' not found in features.yaml", file=sys.stderr)
-            sys.exit(1)
-        features = matched
 
     print(f"Fetching {len(features)} feature{'s' if len(features) != 1 else ''}...")
     if not args.payload_dir:
@@ -349,58 +409,12 @@ def main(argv=None):
     lock_map = dict(old_lock)
 
     for feature in features:
-        if "git" in feature:
-            if args.local_only:
-                print(
-                    f"  SKIP: {feature['name']} (git entry, --local-only)",
-                    file=sys.stderr,
-                )
-                # Record the skip in the lock so its shape stays consistent
-                # (every declared feature appears) without fetching. Preserve
-                # a real SHA from the prior lock if one exists (an interleaved
-                # `update_features <name>` may have already resolved it) — only
-                # write sha='skipped' when there's nothing better to keep.
-                prior = lock_map.get(feature["name"])
-                prior_sha = prior.get("sha") if prior else None
-                lock_map[feature["name"]] = {
-                    "name": feature["name"],
-                    "git": feature["git"],
-                    "path": feature.get("path", ""),
-                    "ref": feature.get("ref", "main"),
-                    "sha": prior_sha
-                    if prior_sha and prior_sha != "skipped"
-                    else "skipped",
-                }
-                continue
-            entry = fetch_feature(feature, payload_dir)
-        elif "path" in feature:
-            entry = link_feature(feature, payload_dir)
-        else:
-            print(
-                f"  SKIP: entry needs 'git' or 'path' key: {feature}",
-                file=sys.stderr,
-            )
-            continue
+        entry = materialize_feature(feature, args, lock_map, payload_dir)
         if entry:
             lock_map[entry["name"]] = entry
 
-    # Remove features that were in the old lockfile but dropped from features.yaml
-    if not only:
-        yaml_names = {
-            feature_name(p)
-            for p in config.get("features", [])
-            if "git" in p or "path" in p
-        }
-        for name in list(lock_map):
-            if name not in yaml_names:
-                feature_dir = os.path.join(payload_dir, name)
-                if os.path.islink(feature_dir):
-                    os.unlink(feature_dir)
-                    print(f"  Removed {name} (no longer in features.yaml)")
-                elif os.path.isdir(feature_dir):
-                    shutil.rmtree(feature_dir)
-                    print(f"  Removed {name} (no longer in features.yaml)")
-                del lock_map[name]
+    if not args.only:
+        prune_dropped_features(config, lock_map, payload_dir)
 
     write_lock(list(lock_map.values()), lock_path)
     print(f"Wrote {lock_path} with {len(lock_map)} features")

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -41,6 +41,65 @@ from .workspace_form import EditWorkspaceScreen
 logger = logging.getLogger(__name__)
 
 
+def format_uptime(elapsed: int) -> str:
+    """Render whole seconds as e.g. ``2d 3h 5m`` (largest non-zero units)."""
+    parts = []
+    days, rem = divmod(elapsed, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, _ = divmod(rem, 60)
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    parts.append(f"{minutes}m")
+    return " ".join(parts)
+
+
+def optional_detail_rows(ws, deploy_banner: str) -> list[tuple[str, str]]:
+    """The conditional (label, value) rows for the workspace detail table."""
+    rows: list[tuple[str, str]] = []
+    if ws.health_message:
+        rows.append(("health note", ws.health_message))
+    if ws.image:
+        rows.append(("image", ws.image))
+    if ws.service_command:
+        rows.append(("service command", ws.service_command))
+    if ws.health_check:
+        rows.append(("health check", ws.health_check))
+    rows.append(("auto-start", "on" if ws.auto_start else "off"))
+    banner = effective_marking(
+        getattr(ws, "classification_banner", None), deploy_banner
+    )
+    if banner:
+        rows.append(("classification", banner))
+    if ws.mounts:
+        rows.append(("mounts", "\n".join(str(m) for m in ws.mounts)))
+    if ws.env:
+        rows.append(
+            (
+                "environment",
+                "\n".join(f"{k}={v}" for k, v in ws.env.items()),
+            )
+        )
+    if ws.allowed_domains:
+        rows.append(
+            (
+                "allowed domains",
+                "\n".join(str(d) for d in ws.allowed_domains),
+            )
+        )
+    if ws.rejected_domains:
+        rows.append(
+            (
+                "rejected domains",
+                "\n".join(str(d) for d in ws.rejected_domains),
+            )
+        )
+    if ws.owner_email:
+        rows.append(("owner", ws.owner_email))
+    return rows
+
+
 class WorkspaceDetailScreen(StatusScreen):
     """Read-only workspace detail + restart / duplicate / delete actions."""
 
@@ -389,55 +448,8 @@ class WorkspaceDetailScreen(StatusScreen):
         if ws.running and ws.service_started_at:
             elapsed = int(time.time() - ws.service_started_at)
             if elapsed >= 0:
-                parts = []
-                days, rem = divmod(elapsed, 86400)
-                hours, rem = divmod(rem, 3600)
-                minutes, _ = divmod(rem, 60)
-                if days:
-                    parts.append(f"{days}d")
-                if hours:
-                    parts.append(f"{hours}h")
-                parts.append(f"{minutes}m")
-                rows.append(("uptime", " ".join(parts)))
-        if ws.health_message:
-            rows.append(("health note", ws.health_message))
-        if ws.image:
-            rows.append(("image", ws.image))
-        if ws.service_command:
-            rows.append(("service command", ws.service_command))
-        if ws.health_check:
-            rows.append(("health check", ws.health_check))
-        rows.append(("auto-start", "on" if ws.auto_start else "off"))
-        banner = effective_marking(
-            getattr(ws, "classification_banner", None), deploy_banner
-        )
-        if banner:
-            rows.append(("classification", banner))
-        if ws.mounts:
-            rows.append(("mounts", "\n".join(str(m) for m in ws.mounts)))
-        if ws.env:
-            rows.append(
-                (
-                    "environment",
-                    "\n".join(f"{k}={v}" for k, v in ws.env.items()),
-                )
-            )
-        if ws.allowed_domains:
-            rows.append(
-                (
-                    "allowed domains",
-                    "\n".join(str(d) for d in ws.allowed_domains),
-                )
-            )
-        if ws.rejected_domains:
-            rows.append(
-                (
-                    "rejected domains",
-                    "\n".join(str(d) for d in ws.rejected_domains),
-                )
-            )
-        if ws.owner_email:
-            rows.append(("owner", ws.owner_email))
+                rows.append(("uptime", format_uptime(elapsed)))
+        rows.extend(optional_detail_rows(ws, deploy_banner))
         return rows
 
     @staticmethod


### PR DESCRIPTION
## Summary

Final refactor PR of the #2794 D→C ratchet: brings the last three rank-D blocks under C. With this merged, every block in the production scope (`src/klangk/klangk` + `scripts`) is rank C or better, and the xenon gate can flip to `--max-absolute C` with the excludes removed.

## Details

- `cli/tui/screens/workspace_detail.py _detail_rows` **D (23) → A**, split into `format_uptime` (pure d/h/m renderer) and `optional_detail_rows` (the conditional rows); `_detail_rows` keeps the base rows + uptime row.
- `scripts/update_features.py main` **D (26) → A**, split into `parse_args`, `select_features` (single-feature filter), `materialize_feature` (git/path dispatch incl. the `--local-only` skipped-lock entry with prior-SHA preservation), and `prune_dropped_features`.
- `scripts/fuzz-idle.py run_ws_scenario` **D (23) → B**, configure phase (`configure_workspace`) and start phase (`start_scenario_workspace`) extracted; the runtime-change and pattern closures and the observation loop unchanged.

## Verification

- Full Python suite (klangkd + klangkc, `-n auto`, coverage): 5834 passed, **100% coverage**; `scripts/tests`: 83 passed.
- `xenon --max-absolute C` on all three files: passes.
- No changelog entry (internal refactor).
