### PR TITLE
build(devenv): ratchet xenon gate to rank C, drop excludes

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -294,10 +294,7 @@ in
   # *remote* mode against the VM, which has its own policy, so leave this empty
   # there.
   env.CONTAINERS_SIGNATURE_POLICY = lib.mkOverride 1500 (
-    if pkgs.stdenv.hostPlatform.isDarwin then
-      ""
-    else
-      config.devenv.state + "/klangk/podman/policy.json"
+    if pkgs.stdenv.hostPlatform.isDarwin then "" else config.devenv.state + "/klangk/podman/policy.json"
   );
   # Same story for registries.conf (#286): rootless podman from nix ships
   # none, so any build whose Dockerfile uses a short image name (alpine:3.21,
@@ -601,21 +598,16 @@ in
       language = "system";
       pass_filenames = true;
     };
-    # Python: cyclomatic-complexity gate (#2794). Blocks must stay rank E
-    # or better (complexity <= 40); module/average gates are off (rank F)
-    # because they flap when only a few files are staged. Baselined to the
-    # tree at introduction: the three legacy F-ranked blocks below are
-    # excluded until refactored — shrink the excludes as they are fixed.
+    # Python: cyclomatic-complexity gate (#2794). Blocks must stay rank C
+    # or better (complexity <= 20); module/average gates are off (rank F)
+    # because they flap when only a few files are staged. The F/E/D-ranked
+    # legacy blocks were refactored down (#2800-#2803, #2808-#2814), so the
+    # excludes are gone — every production .py file is checked.
     xenon = {
       enable = true;
       name = "xenon";
-      entry = "${pkgs.xenon}/bin/xenon --max-absolute E --max-modules F --max-average F";
+      entry = "${pkgs.xenon}/bin/xenon --max-absolute C --max-modules F --max-average F";
       files = "^src/klangk/klangk/.*\\.py$|^scripts/.*\\.py$";
-      excludes = [
-        "^src/klangk/klangk/cli/edit\\.py$"
-        "^src/klangk/klangk/cli/client\\.py$"
-        "^src/klangk/klangk/cli/tui/screens/workspace_form\\.py$"
-      ];
       language = "system";
       pass_filenames = true;
     };


### PR DESCRIPTION
## Summary

Ratchets the xenon complexity gate from #2795 to its final target: `--max-absolute C` (blocks ≤ 20) with the three legacy `excludes` removed — every production `.py` file (`src/klangk/klangk/` + `scripts/`) is now checked.

## Stack

**Based on `i2794-add-xenon` (#2795) — merge that first.** The gate at rank C requires the D-rank refactors to land: #2808 (forms/edit), #2810 (auth/sandbox), #2812 (decider/consent), #2813 (detail/scripts), #2814 (registry). On this branch alone the hook fails (the fixes aren't in its tree) — hence the `--no-verify` commit. **Verified against the full integration**: hook branch + all five refactor branches merged locally, `xenon --max-absolute C --max-modules F --max-average F src/klangk/klangk scripts` → clean pass. Rebase onto main once the stack lands and CI runs it for real.

## Ratchet summary (#2794)

Worst block went F (113, `cli/edit.py`) → every block ≤ C (20), via #2800, #2802, #2803, #2805, #2804, #2808–#2814. Rank counts on integrated main: 2076 A / 319 B / 95 C / 0 D / 0 E / 0 F.

No changelog entry (internal tooling).
