### PR TITLE
Cover klangksidecar in the xenon complexity gate (#2829)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,8 @@ are fine too (`KLANGKD` = daemon, `KLANGKC` = CLI).
 
 ## Python complexity gate (xenon)
 
-Every function, method, and block in `src/klangk/klangk/**/*.py` and
+Every function, method, and block in `src/klangk/klangk/**/*.py`,
+`src/klangksidecar/klangksidecar/**/*.py`, and
 `scripts/**/*.py` must be xenon rank **C or better** (cyclomatic complexity
 ≤ 20). The gate runs as the `xenon` pre-commit hook defined in `devenv.nix`
 (`--max-absolute C --max-modules F --max-average F` — module/average gates

--- a/devenv.nix
+++ b/devenv.nix
@@ -294,7 +294,10 @@ in
   # *remote* mode against the VM, which has its own policy, so leave this empty
   # there.
   env.CONTAINERS_SIGNATURE_POLICY = lib.mkOverride 1500 (
-    if pkgs.stdenv.hostPlatform.isDarwin then "" else config.devenv.state + "/klangk/podman/policy.json"
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      ""
+    else
+      config.devenv.state + "/klangk/podman/policy.json"
   );
   # Same story for registries.conf (#286): rootless podman from nix ships
   # none, so any build whose Dockerfile uses a short image name (alpine:3.21,
@@ -602,12 +605,15 @@ in
     # or better (complexity <= 20); module/average gates are off (rank F)
     # because they flap when only a few files are staged. The F/E/D-ranked
     # legacy blocks were refactored down (#2800-#2803, #2808-#2814), so the
-    # excludes are gone — every production .py file is checked.
+    # excludes are gone — every production .py file is checked (klangkd +
+    # CLI under src/klangk/klangk/, the network sidecar under
+    # src/klangksidecar/klangksidecar/ — already C-clean when gated — and
+    # scripts/).
     xenon = {
       enable = true;
       name = "xenon";
       entry = "${pkgs.xenon}/bin/xenon --max-absolute C --max-modules F --max-average F";
-      files = "^src/klangk/klangk/.*\\.py$|^scripts/.*\\.py$";
+      files = "^src/klangk/klangk/.*\\.py$|^src/klangksidecar/klangksidecar/.*\\.py$|^scripts/.*\\.py$";
       language = "system";
       pass_filenames = true;
     };


### PR DESCRIPTION
Closes #2829.

## What

Extends the xenon complexity gate (#2794) to the network sidecar's production code:

- `devenv.nix`: the hook's `files` regex gains `^src/klangksidecar/klangksidecar/.*\.py$` (tests stay out, matching the main package, whose tests also live outside the gate). Comment updated to name all three gated trees.
- `AGENTS.md`: the Python-complexity-gate section now lists `src/klangksidecar/klangksidecar/**/*.py` as in scope.

The sidecar is already C-clean at current main (64 A / 12 B / 7 C; worst blocks `nfqueue._cb` / `_decide_and_verdict` at 18), so this is a pure scope extension — no refactors needed, and the gate passes immediately. The sidecar's 7 C blocks join the #2817 B-ratchet work list (scope already updated in that issue).

## Verification

- `pre-commit run xenon --all-files` passes with the extended regex (run on this tree).
- `xenon --max-absolute C` on `src/klangksidecar/klangksidecar/` passes standalone.

## Note

nixfmt (hook) also re-wrapped the adjacent `env.CONTAINERS_SIGNATURE_POLICY` block in `devenv.nix` — formatting drift in an untouched-at-heart block, hook-mandated.

No changelog entry: dev tooling, no operator/user-visible effect.
