### PR TITLE
refactor(server): bring sidecar and util blocks under rank B

### DIFF
--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -185,22 +185,188 @@ class NetworkSidecarMixin:
             )
         name = self._network_sidecar_name(workspace_id, slug)
         # Pick an upstream that differs from the REDIRECT target (1.1.1.1).
-        # KLANGKNETWORK_EGRESS_UPSTREAM (when set in klangkd's env) pins the
-        # sidecar's upstream resolver verbatim, mirroring the MIN_TTL /
-        # SWEEP_INTERVAL forwarding below — an operator may want workspaces to
-        # use a specific resolver (e.g. a corporate DNS), and the egress
-        # smoketest uses it to point the sidecar at a controlled-DNS fixture
-        # (#2424) so chosen hostnames resolve to single stable test IPs.
-        # Absent -> auto-detect a host resolver that differs from 1.1.1.1.
-        env_upstream = os.environ.get("KLANGKNETWORK_EGRESS_UPSTREAM")
-        if env_upstream:
-            upstream = env_upstream
-        else:
-            nf = getattr(self.app.state, "netfilter", None)
-            resolvers = nf.resolvers() if nf else []
-            upstream = next(
-                (r for r in resolvers if r != "1.1.1.1"), "8.8.8.8"
+        env, binds = self._network_sidecar_env(
+            workspace_id, allowed_domains, rejected_domains
+        )
+
+        # Label the network sidecar with this klangk instance so the startup reaper
+        # (reap_instance_containers) and the shutdown orphan sweep cull any
+        # network sidecar left behind by a failed stop — the same culling workspace
+        # containers get (#2254 review). #2342: klangk.managed + klangk.pid also
+        # let the dead-owner reap (reap_dead_owner_containers) cull a sidecar
+        # whose creating klangkd died uncleanly, the same as a workspace container.
+        labels = self._network_sidecar_labels(workspace_id, slug)
+
+        # #2265: a sidecar from a prior generation may linger (an unclean
+        # stop, or the workspace container was killed externally so
+        # stop_and_remove_container never ran for it). Clear it before create
+        # so create_container doesn't collide and the caller doesn't
+        # fail-closed. Removal is by the klangk.workspace label (#2286), not
+        # the name — the name now carries the workspace-name slug, which may
+        # differ from a prior generation's (a rename) and can't be
+        # reconstructed from the id alone. The instance reaper is the
+        # backstop for orphans; this just keeps a restart from deadlocking.
+        # #2676: when the clear fails — a container is still joined to the
+        # old sidecar's netns (podman's "dependent containers" refusal) or
+        # podman otherwise refuses the removal — refuse here with a clear
+        # error instead of swallowing it and letting create_container's
+        # --replace collide with the same refusal (a raw 500 + traceback at
+        # the caller, guaranteed whenever the dependent survives). Inside
+        # the try so the fail-closed warning below logs it like any other
+        # sidecar start failure.
+        try:
+            if not await self._remove_network_sidecar(workspace_id):
+                raise podman.PodmanError(
+                    500,
+                    "cannot remove the existing network sidecar for "
+                    f"workspace {workspace_id[:8]}: a container is still "
+                    "joined to its network namespace (podman's dependent "
+                    "containers refusal) or podman refused the removal; "
+                    "stop or remove the workspace's containers before "
+                    "starting it again",
+                )
+            # NET_RAW lets the proxy forge the eager-deny RST directly from
+            # the NFQUEUE callback (#2345) so a denied connect() gets
+            # ECONNREFUSED at once, independent of the conntrack/retransmit
+            # race that made the iptables REJECT rule flaky. Safe to grant
+            # here (unlike on the workspace): the sidecar runs only klangk's
+            # own proxy, no untrusted code.
+            sidecar_kwargs = dict(
+                cap_add=["NET_ADMIN", "NET_RAW"],
+                dns=["1.1.1.1"],
+                env=env,
+                labels=labels,
+                publish=publish,
+                pull="missing",
             )
+            if binds:
+                sidecar_kwargs["binds"] = binds
+            cid = await self.app.state.podman.create_container(
+                name, image, **sidecar_kwargs
+            )
+            await self._start_with_port_conflict_retry(
+                cid, publish or [], name
+            )
+            await self._wait_sidecar_proxy_ready(cid, name)
+            logger.info(
+                "network sidecar started for %s: %s (%s)",
+                workspace_id[:8],
+                name,
+                cid[:12],
+            )
+            return cid
+        except podman.PodmanError as exc:
+            logger.warning(
+                "network sidecar failed for %s: %s — fail-closed at caller",
+                workspace_id[:8],
+                exc,
+            )
+            raise
+
+    async def _remove_sidecar_attempts(
+        self, workspace_id: str, containers: list[dict]
+    ) -> list[tuple[str, podman.PodmanError]]:
+        """Force-remove each labeled sidecar; the (ident, error) pairs that
+        failed."""
+        failures: list[tuple[str, podman.PodmanError]] = []
+        for c in containers:
+            labels = c.get("Labels") or {}
+            if labels.get("klangk.role") != "network-sidecar":
+                continue
+            ident = container_ident(c)
+            if not ident:
+                continue
+            exc = await self._force_remove_sidecar(workspace_id, ident)
+            if exc is not None:
+                failures.append((ident, exc))
+        return failures
+
+    async def _blocked_sidecar_failures(
+        self,
+        workspace_id: str,
+        failures: list[tuple[str, podman.PodmanError]],
+    ) -> list[tuple[str, podman.PodmanError]] | None:
+        """Which failed removals still block (a same-label sidecar that
+        survived), or None when the state is unknowable (list failure)."""
+        remaining = await self._list_workspace_containers(workspace_id)
+        if remaining is None:
+            return None
+        remaining_sidecars = {
+            container_ident(c)
+            for c in remaining
+            if (c.get("Labels") or {}).get("klangk.role") == "network-sidecar"
+        }
+        return [(i, e) for i, e in failures if i in remaining_sidecars]
+
+    def _network_sidecar_labels(
+        self, workspace_id: str, slug: str
+    ) -> dict[str, str]:
+        """Instance/correlation labels for the network sidecar (see the
+        inline notes in the original block)."""
+        labels = {
+            "klangk.managed": "true",
+            "klangk.instance": self.app.state.util.instance_id(),
+            # The main klangkd daemon process's PID — the liveness signal the
+            # dead-owner reap keys on (#2342). Not conmon / the container's
+            # PID 1 / a podman subprocess: those die with the daemon anyway.
+            "klangk.pid": str(os.getpid()),
+            # #2286: a shared klangk.workspace label + a klangk.role label let
+            # one `podman ps --filter label=klangk.workspace=<id>` correlate
+            # the sidecar with its workspace; the slug is mirrored for
+            # exact-match filtering. (Supersedes the old write-only
+            # klangk.network-sidecar.)
+            "klangk.workspace": workspace_id,
+            "klangk.role": "network-sidecar",
+            "klangk.workspace-name": slug,
+        }
+        return labels
+
+    async def _wait_sidecar_proxy_ready(self, cid: str, name: str) -> None:
+        """#2277: wait for the sidecar's DNS proxy to be listening before
+        returning, so the workspace never joins a netns whose OUTPUT is
+        still ACCEPT (entrypoint mid-flight) — a fail-open window. The
+        proxy prints "dns-proxy listening" once bound; poll its logs.
+        Fail-closed: if the sidecar exits first or the proxy never binds,
+        raise so the caller refuses to start the workspace rather than
+        run it unfiltered."""
+        # #2277: wait for the proxy to be listening before returning, so the
+        # workspace never joins a netns whose OUTPUT is still ACCEPT
+        # (entrypoint mid-flight) — a fail-open window. The proxy prints
+        # "dns-proxy listening" once bound; poll its logs. Fail-closed: if
+        # the sidecar exits first or the proxy never binds, raise so the
+        # caller refuses to start the workspace rather than run it unfiltered.
+        deadline = time.monotonic() + _NETWORK_SIDECAR_READY_TIMEOUT
+        ready = False
+        while time.monotonic() < deadline:
+            logs = await self.app.state.podman.container_logs(cid)
+            if _NETWORK_SIDECAR_READY_TOKEN in logs:
+                ready = True
+                break
+            state = await self.app.state.podman.inspect_container(cid)
+            status = (state or {}).get("State", {}).get("Status", "")
+            if status in ("exited", "stopped"):
+                raise podman.PodmanError(
+                    500,
+                    f"network sidecar {name} exited before the DNS proxy "
+                    f"was ready; logs:\n{logs}",
+                )
+            await asyncio.sleep(_NETWORK_SIDECAR_READY_POLL)
+        if not ready:
+            raise podman.PodmanError(
+                500,
+                f"network sidecar {name} DNS proxy did not become ready "
+                f"within {_NETWORK_SIDECAR_READY_TIMEOUT:.0f}s; the "
+                "workspace would join an unfiltered netns",
+            )
+
+    def _network_sidecar_env(
+        self,
+        workspace_id: str,
+        allowed_domains: list[str] | None,
+        rejected_domains: list[str] | None,
+    ) -> tuple[list[str], list[str]]:
+        """(env, binds) for the network sidecar container."""
+        upstream = self._network_sidecar_upstream()
         env = [
             f"KLANGKNETWORK_EGRESS_ALLOW={','.join(allowed_domains or [])}",
             f"KLANGKNETWORK_EGRESS_REJECT={','.join(rejected_domains or [])}",
@@ -254,121 +420,16 @@ class NetworkSidecarMixin:
                 f"{self._sidecar_token_path(workspace_id)}"
                 ":/run/klangk/workspace-token:ro"
             )
-        # Label the network sidecar with this klangk instance so the startup reaper
-        # (reap_instance_containers) and the shutdown orphan sweep cull any
-        # network sidecar left behind by a failed stop — the same culling workspace
-        # containers get (#2254 review). #2342: klangk.managed + klangk.pid also
-        # let the dead-owner reap (reap_dead_owner_containers) cull a sidecar
-        # whose creating klangkd died uncleanly, the same as a workspace container.
-        labels = {
-            "klangk.managed": "true",
-            "klangk.instance": self.app.state.util.instance_id(),
-            # The main klangkd daemon process's PID — the liveness signal the
-            # dead-owner reap keys on (#2342). Not conmon / the container's
-            # PID 1 / a podman subprocess: those die with the daemon anyway.
-            "klangk.pid": str(os.getpid()),
-            # #2286: a shared klangk.workspace label + a klangk.role label let
-            # one `podman ps --filter label=klangk.workspace=<id>` correlate
-            # the sidecar with its workspace; the slug is mirrored for
-            # exact-match filtering. (Supersedes the old write-only
-            # klangk.network-sidecar.)
-            "klangk.workspace": workspace_id,
-            "klangk.role": "network-sidecar",
-            "klangk.workspace-name": slug,
-        }
-        # #2265: a sidecar from a prior generation may linger (an unclean
-        # stop, or the workspace container was killed externally so
-        # stop_and_remove_container never ran for it). Clear it before create
-        # so create_container doesn't collide and the caller doesn't
-        # fail-closed. Removal is by the klangk.workspace label (#2286), not
-        # the name — the name now carries the workspace-name slug, which may
-        # differ from a prior generation's (a rename) and can't be
-        # reconstructed from the id alone. The instance reaper is the
-        # backstop for orphans; this just keeps a restart from deadlocking.
-        # #2676: when the clear fails — a container is still joined to the
-        # old sidecar's netns (podman's "dependent containers" refusal) or
-        # podman otherwise refuses the removal — refuse here with a clear
-        # error instead of swallowing it and letting create_container's
-        # --replace collide with the same refusal (a raw 500 + traceback at
-        # the caller, guaranteed whenever the dependent survives). Inside
-        # the try so the fail-closed warning below logs it like any other
-        # sidecar start failure.
-        try:
-            if not await self._remove_network_sidecar(workspace_id):
-                raise podman.PodmanError(
-                    500,
-                    "cannot remove the existing network sidecar for "
-                    f"workspace {workspace_id[:8]}: a container is still "
-                    "joined to its network namespace (podman's dependent "
-                    "containers refusal) or podman refused the removal; "
-                    "stop or remove the workspace's containers before "
-                    "starting it again",
-                )
-            # NET_RAW lets the proxy forge the eager-deny RST directly from
-            # the NFQUEUE callback (#2345) so a denied connect() gets
-            # ECONNREFUSED at once, independent of the conntrack/retransmit
-            # race that made the iptables REJECT rule flaky. Safe to grant
-            # here (unlike on the workspace): the sidecar runs only klangk's
-            # own proxy, no untrusted code.
-            sidecar_kwargs = dict(
-                cap_add=["NET_ADMIN", "NET_RAW"],
-                dns=["1.1.1.1"],
-                env=env,
-                labels=labels,
-                publish=publish,
-                pull="missing",
-            )
-            if binds:
-                sidecar_kwargs["binds"] = binds
-            cid = await self.app.state.podman.create_container(
-                name, image, **sidecar_kwargs
-            )
-            await self._start_with_port_conflict_retry(
-                cid, publish or [], name
-            )
-            # #2277: wait for the proxy to be listening before returning, so the
-            # workspace never joins a netns whose OUTPUT is still ACCEPT
-            # (entrypoint mid-flight) — a fail-open window. The proxy prints
-            # "dns-proxy listening" once bound; poll its logs. Fail-closed: if
-            # the sidecar exits first or the proxy never binds, raise so the
-            # caller refuses to start the workspace rather than run it unfiltered.
-            deadline = time.monotonic() + _NETWORK_SIDECAR_READY_TIMEOUT
-            ready = False
-            while time.monotonic() < deadline:
-                logs = await self.app.state.podman.container_logs(cid)
-                if _NETWORK_SIDECAR_READY_TOKEN in logs:
-                    ready = True
-                    break
-                state = await self.app.state.podman.inspect_container(cid)
-                status = (state or {}).get("State", {}).get("Status", "")
-                if status in ("exited", "stopped"):
-                    raise podman.PodmanError(
-                        500,
-                        f"network sidecar {name} exited before the DNS proxy "
-                        f"was ready; logs:\n{logs}",
-                    )
-                await asyncio.sleep(_NETWORK_SIDECAR_READY_POLL)
-            if not ready:
-                raise podman.PodmanError(
-                    500,
-                    f"network sidecar {name} DNS proxy did not become ready "
-                    f"within {_NETWORK_SIDECAR_READY_TIMEOUT:.0f}s; the "
-                    "workspace would join an unfiltered netns",
-                )
-            logger.info(
-                "network sidecar started for %s: %s (%s)",
-                workspace_id[:8],
-                name,
-                cid[:12],
-            )
-            return cid
-        except podman.PodmanError as exc:
-            logger.warning(
-                "network sidecar failed for %s: %s — fail-closed at caller",
-                workspace_id[:8],
-                exc,
-            )
-            raise
+        return env, binds
+
+    def _network_sidecar_upstream(self) -> str:
+        """The sidecar's upstream resolver (pinned env var or detected)."""
+        env_upstream = os.environ.get("KLANGKNETWORK_EGRESS_UPSTREAM")
+        if env_upstream:
+            return env_upstream
+        nf = getattr(self.app.state, "netfilter", None)
+        resolvers = nf.resolvers() if nf else []
+        return next((r for r in resolvers if r != "1.1.1.1"), "8.8.8.8")
 
     async def _stop_network_sidecar(self, workspace_id: str) -> None:
         """Best-effort remove the network sidecar for a workspace (#2254, #2286).
@@ -413,32 +474,18 @@ class NetworkSidecarMixin:
         containers = await self._list_workspace_containers(workspace_id)
         if containers is None:
             return True
-        failures: list[tuple[str, podman.PodmanError]] = []
-        for c in containers:
-            labels = c.get("Labels") or {}
-            if labels.get("klangk.role") != "network-sidecar":
-                continue
-            ident = container_ident(c)
-            if not ident:
-                continue
-            exc = await self._force_remove_sidecar(workspace_id, ident)
-            if exc is not None:
-                failures.append((ident, exc))
+        failures = await self._remove_sidecar_attempts(
+            workspace_id, containers
+        )
         if not failures:
             return True
         # A removal refused. Re-list: the error may be a benign race (the
         # container vanished between list and rm — "no such container");
         # only a sidecar that is still present can collide with the create
         # that follows, so judge by observable state, not the error text.
-        remaining = await self._list_workspace_containers(workspace_id)
-        if remaining is None:
+        blocked = await self._blocked_sidecar_failures(workspace_id, failures)
+        if blocked is None:
             return True
-        remaining_sidecars = {
-            container_ident(c)
-            for c in remaining
-            if (c.get("Labels") or {}).get("klangk.role") == "network-sidecar"
-        }
-        blocked = [(i, e) for i, e in failures if i in remaining_sidecars]
         for ident, exc in blocked:
             logger.warning(
                 "network sidecar %s for %s could not be removed: %s",

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -261,6 +261,23 @@ _LOOPBACK_ADDRS = {
 }
 
 
+def trusted_forwarded_ip(headers) -> str | None:
+    """The parsed IP from trusted proxy headers (X-Real-IP, then the first
+    hop of X-Forwarded-For), or None when absent or unparseable (garbage or
+    a proxy chain appending client-controlled text — fall back to the peer
+    instead of trusting an unvalidated string)."""
+    real_ip = headers.get("x-real-ip") or ""
+    if not real_ip:
+        xff = headers.get("x-forwarded-for") or ""
+        real_ip = xff.split(",")[0].strip() if xff else ""
+    if not real_ip:
+        return None
+    try:
+        return str(ipaddress.ip_address(real_ip))
+    except ValueError:
+        return None
+
+
 class Util:
     """App-state-owned helpers that transitively depend on settings (#1503).
 
@@ -537,19 +554,9 @@ class Util:
             and headers is not None
         )
         if trust:
-            real_ip = headers.get("x-real-ip") or ""
-            if not real_ip:
-                xff = headers.get("x-forwarded-for") or ""
-                real_ip = xff.split(",")[0].strip() if xff else ""
-            if real_ip:
-                try:
-                    return str(ipaddress.ip_address(real_ip))
-                except ValueError:
-                    # A trusted peer forwarded a value that is not an
-                    # IP (garbage, or a proxy chain appending
-                    # client-controlled text). Fall back to the peer
-                    # instead of trusting an unvalidated string.
-                    pass
+            forwarded = trusted_forwarded_ip(headers)
+            if forwarded is not None:
+                return forwarded
         if candidate is None:
             return None
         try:
@@ -611,13 +618,28 @@ class Util:
         hostname = self.app.state.settings.hosting_hostname
         proto = self.app.state.settings.hosting_proto
         base_path = self.app.state.settings.hosting_base_path
-        pinned = bool(hostname)
-        forwarded = False
         trust = (
             (not self.reject_proxy_headers())
             and self.connection_peer_is_trusted(client_host)
             and headers is not None
         )
+        hostname = self._hosting_hostname(headers, hostname, trust)
+        if not proto:
+            proto = self._hosting_proto(headers, trust)
+        if base_path is None:
+            base_path = self._hosting_base_path(headers, trust)
+        return hostname, proto, base_path
+
+    def _hosting_hostname(
+        self, headers, env_hostname: str, trust: bool
+    ) -> str:
+        """Resolve the hosting hostname: env pin, else trusted
+        X-Forwarded-Host, else the Host header, else ``localhost``. A
+        synthetic (non-pinned, non-forwarded) loopback hostname is pointed
+        at the browser listener (#2732)."""
+        hostname = env_hostname
+        pinned = bool(hostname)
+        forwarded = False
         if not hostname and headers is not None:
             if trust:
                 forwarded_host = headers.get("x-forwarded-host")
@@ -630,17 +652,21 @@ class Util:
             hostname = "localhost"
         if not pinned and not forwarded:
             hostname = self.browser_listener_hostname(hostname)
-        if not proto:
-            if headers is not None and trust:
-                proto = headers.get("x-forwarded-proto") or "http"
-            else:
-                proto = "http"
-        if base_path is None:
-            if headers is not None and trust:
-                base_path = headers.get("x-forwarded-prefix") or ""
-            else:
-                base_path = ""
-        return hostname, proto, base_path
+        return hostname
+
+    @staticmethod
+    def _hosting_proto(headers, trust: bool) -> str:
+        """Resolve the proto: trusted X-Forwarded-Proto, else ``http``."""
+        if headers is not None and trust:
+            return headers.get("x-forwarded-proto") or "http"
+        return "http"
+
+    @staticmethod
+    def _hosting_base_path(headers, trust: bool) -> str:
+        """Resolve the base path: trusted X-Forwarded-Prefix, else ``""``."""
+        if headers is not None and trust:
+            return headers.get("x-forwarded-prefix") or ""
+        return ""
 
     def browser_listener_hostname(self, hostname: str) -> str:
         """Point a synthetic loopback hostname at the browser listener (#2732).

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -34,26 +34,34 @@ from .safe_websocket import WS_ERRORS, SlowClientError, SafeWebSocket
 logger = logging.getLogger(__name__)
 
 
-async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
-    """Receive blocked-egress events from the sidecar; relay verdicts back."""
-    # forward_auth validated the workspace JWT from the Authorization header
-    # on the egress site; re-read it here for the workspace id. The ?token=
-    # query-param fallback covers the ingress path and handler-level tests.
+async def authenticate_egress_socket(websocket: WebSocket, app) -> str | None:
+    """Validate the sidecar socket's workspace token; close and return None
+    on failure (forward_auth already checked the header on the egress site)."""
     authorization = websocket.headers.get("authorization", "")
     token = authorization[7:] if authorization.startswith("Bearer ") else None
     if not token:
         token = websocket.query_params.get("token")
     if not token:
         await websocket.close(code=4001, reason="Missing token")
-        return
+        return None
     result = app.state.auth.decode_workspace_token(token)
     if result is auth.Auth.WORKSPACE_TOKEN_EXPIRED:
         await websocket.close(code=4002, reason="Token expired")
-        return
+        return None
     if result is None:
         await websocket.close(code=4001, reason="Invalid token")
+        return None
+    return result
+
+
+async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
+    """Receive blocked-egress events from the sidecar; relay verdicts back."""
+    # forward_auth validated the workspace JWT from the Authorization header
+    # on the egress site; re-read it here for the workspace id. The ?token=
+    # query-param fallback covers the ingress path and handler-level tests.
+    workspace_id = await authenticate_egress_socket(websocket, app)
+    if workspace_id is None:
         return
-    workspace_id = result
 
     await websocket.accept()
     coordinator = app.state.consent_coordinator
@@ -78,45 +86,9 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
                 continue
             if not isinstance(msg, dict):
                 continue
-            mtype = msg.get("type")
-            if mtype == "drop_ack":
-                # Sidecar confirmed a rule-drop (revocation, #2339): resolve
-                # the awaiting revoke's ack Future.
-                app.state.sidecar_connections.resolve_ack(
-                    msg.get("id"), bool(msg.get("ok", False))
-                )
-                continue
-            if mtype == "activity":
-                # Sidecar reports egress/network activity (#2479): an
-                # egress-only workload bypasses klangkd, so without this its
-                # idle timer would never advance and the container would be
-                # reaped mid-egress. The sidecar flood-gates the frame; here
-                # the bump is a single float write on this loop thread.
-                state = app.state.container_registry.states.get(workspace_id)
-                if state is not None:
-                    state.record_activity()
-                continue
-            if mtype != "egress":
-                continue
-            local_id = msg.get("id")
-            dst = msg.get("dst")
-            dport = msg.get("dport")
-            if not isinstance(local_id, str) or not isinstance(dst, str):
-                continue
-            if dport is not None and (
-                not isinstance(dport, int) or isinstance(dport, bool)
-            ):
-                continue
-            # One relay task per egress event: it holds via the coordinator
-            # (awaiting the verdict Future) and sends the verdict when ready,
-            # without blocking the receive loop (other events stream through).
-            task = asyncio.create_task(
-                _relay_verdict(
-                    safe, coordinator, workspace_id, local_id, dst, dport
-                )
+            dispatch_sidecar_message(
+                app, safe, coordinator, workspace_id, relay_tasks, msg
             )
-            relay_tasks.add(task)
-            task.add_done_callback(relay_tasks.discard)
     finally:
         # Sidecar gone (disconnect/restart/crash): drop its registration (any
         # in-flight revoke ack fails at once) + cancel in-flight relays.
@@ -124,6 +96,64 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
         for task in list(relay_tasks):
             task.cancel()
         await safe.stop_sender()
+
+
+def dispatch_sidecar_message(
+    app,
+    safe: SafeWebSocket,
+    coordinator,
+    workspace_id: str,
+    relay_tasks: set[asyncio.Task],
+    msg: dict,
+) -> None:
+    """Act on one decoded sidecar frame (drop-ack, activity, or egress)."""
+    mtype = msg.get("type")
+    if mtype == "drop_ack":
+        # Sidecar confirmed a rule-drop (revocation, #2339): resolve
+        # the awaiting revoke's ack Future.
+        app.state.sidecar_connections.resolve_ack(
+            msg.get("id"), bool(msg.get("ok", False))
+        )
+        return
+    if mtype == "activity":
+        # Sidecar reports egress/network activity (#2479): an
+        # egress-only workload bypasses klangkd, so without this its
+        # idle timer would never advance and the container would be
+        # reaped mid-egress. The sidecar flood-gates the frame; here
+        # the bump is a single float write on this loop thread.
+        state = app.state.container_registry.states.get(workspace_id)
+        if state is not None:
+            state.record_activity()
+        return
+    if mtype != "egress":
+        return
+    fields = parse_egress_fields(msg)
+    if fields is None:
+        return
+    local_id, dst, dport = fields
+    # One relay task per egress event: it holds via the coordinator
+    # (awaiting the verdict Future) and sends the verdict when ready,
+    # without blocking the receive loop (other events stream through).
+    task = asyncio.create_task(
+        _relay_verdict(safe, coordinator, workspace_id, local_id, dst, dport)
+    )
+    relay_tasks.add(task)
+    task.add_done_callback(relay_tasks.discard)
+
+
+def parse_egress_fields(msg: dict) -> tuple[str, str, int | None] | None:
+    """(local_id, dst, dport) from an egress frame, or None on a malformed
+    one."""
+    local_id = msg.get("id")
+    dst = msg.get("dst")
+    dport = msg.get("dport")
+    if not isinstance(local_id, str) or not isinstance(dst, str):
+        return None
+    if dport is not None and (
+        not isinstance(dport, int) or isinstance(dport, bool)
+    ):
+        return None
+    return local_id, dst, dport
 
 
 async def _relay_verdict(


### PR DESCRIPTION
## Summary

Ninth PR of the #2817 B-ratchet: brings the 5 remaining rank-C blocks in `wshandler/sidecar.py`, `container/sidecar.py`, and `util.py` under rank B — all three files pass `xenon --max-absolute B`. Pure extract-function; no behavior change.

## Details

- `handle_egress_sidecar` (20) → **B (8)**: `authenticate_egress_socket` (token gate with the 4001/4002 closes), `dispatch_sidecar_message` (per-frame drop-ack/activity/egress dispatch), `parse_egress_fields` (frame validation).
- `NetworkSidecarMixin._start_network_sidecar` (20) → **B (8)**: `_network_sidecar_env` (env + binds incl. the consent-stack wiring), `_network_sidecar_upstream`, `_network_sidecar_labels`, `_wait_sidecar_proxy_ready` (#2277 ready poll).
- `NetworkSidecarMixin._remove_network_sidecar` (15) → **B (5)**: `_remove_sidecar_attempts` + `_blocked_sidecar_failures`.
- `Util.derive_hosting_info` (20) → **B (3)**: `_hosting_hostname` (env pin → forwarded → Host → localhost, with the #2732 browser-listener rewrite), `_hosting_proto`, `_hosting_base_path`.
- `Util.effective_client_ip` (12) → **B (6)**: `trusted_forwarded_ip` (X-Real-IP / first XFF hop, parsed or None).

## Verification

- Full Python suite (`-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute B` on all three files: passes.
- No changelog entry (internal refactor).
