### PR TITLE
refactor(container): bring container subsystem blocks under rank B

### DIFF
--- a/src/klangk/klangk/container/crash.py
+++ b/src/klangk/klangk/container/crash.py
@@ -291,8 +291,21 @@ class CrashRecoveryMonitor:
         would (a) restart a workspace the user just stopped, or (b) tear
         down the freshly-started container — both demonstrated in review.
         """
+        snapshot = self._liveness_snapshot()
+        if not snapshot:
+            return
+        liveness = await self._listed_liveness()
+        if liveness is None:
+            return
+        for ws_id, state, cid, epoch in snapshot:
+            await self._sweep_one(ws_id, state, cid, epoch, liveness)
+
+    def _liveness_snapshot(self) -> list:
+        """(ws_id, state, container_id, stop_epoch) for every container to
+        check, excluding in-flight expected stops and pending restarts —
+        captured BEFORE any await (review #2625)."""
         registry = self.app.state.container_registry
-        snapshot = [
+        return [
             (
                 ws_id,
                 state,
@@ -302,51 +315,63 @@ class CrashRecoveryMonitor:
             for ws_id, state in registry.states.items()
             if ws_id not in registry.stopping and ws_id not in self.pending
         ]
-        if not snapshot:
-            return
+
+    async def _listed_liveness(self) -> dict | None:
+        """container ident -> ps State for this instance, or None when the
+        batched listing failed."""
         try:
             listed = await self.app.state.podman.list_containers(
                 f"klangk.instance={self.app.state.util.instance_id()}"
             )
         except (podman.PodmanError, OSError) as e:
             logger.debug("Crash-recovery liveness listing failed: %s", e)
+            return None
+        return {container_ident(c): (c.get("State") or "") for c in listed}
+
+    async def _sweep_one(
+        self,
+        ws_id: str,
+        state,
+        cid: str,
+        epoch: int,
+        liveness: dict,
+    ) -> None:
+        """Revalidate one snapshot row post-await, then classify a death or
+        reset the tracker of a stable survivor."""
+        registry = self.app.state.container_registry
+        # Post-await revalidation: skip anything the world moved under.
+        if registry.states.get(ws_id) is not state:
+            return  # state replaced/removed (rebind, user start/stop)
+        if state.container_id != cid:
+            return  # rebound to a fresh container — not our death
+        if ws_id in registry.stopping:
+            return  # an expected stop is now in flight
+        if registry.stop_epoch.get(ws_id, 0) != epoch:
+            return  # a stop began AND completed during the listing
+        observed = liveness.get(cid)
+        if observed is not None and observed not in _DEAD_STATES:
+            # Alive (running / created / paused / ...): nothing to do.
+            self.maybe_reset_tracker(ws_id)
             return
-        liveness = {container_ident(c): (c.get("State") or "") for c in listed}
-        for ws_id, state, cid, epoch in snapshot:
-            # Post-await revalidation: skip anything the world moved under.
-            if registry.states.get(ws_id) is not state:
-                continue  # state replaced/removed (rebind, user start/stop)
-            if state.container_id != cid:
-                continue  # rebound to a fresh container — not our death
-            if ws_id in registry.stopping:
-                continue  # an expected stop is now in flight
-            if registry.stop_epoch.get(ws_id, 0) != epoch:
-                continue  # a stop began AND completed during the listing
-            observed = liveness.get(cid)
-            if observed is not None and observed not in _DEAD_STATES:
-                # Alive (running / created / paused / ...): nothing to do.
-                self.maybe_reset_tracker(ws_id)
-                continue
-            # Absent from the listing (removed externally) or listed in
-            # a dead state — classify via one per-container inspect.
-            try:
-                info = await self.app.state.podman.inspect_container(cid)
-            except (podman.PodmanError, OSError) as e:
-                logger.debug(
-                    "Crash-recovery inspect failed for workspace %s: %s",
-                    ws_id,
-                    e,
-                )
-                continue
-            try:
-                await self.handle_death(ws_id, cid, info, epoch=epoch)
-            except Exception as e:  # pragma: no cover - defensive
-                logger.error(
-                    "Crash-recovery death handling failed for workspace "
-                    "%s: %s",
-                    ws_id,
-                    e,
-                )
+        # Absent from the listing (removed externally) or listed in
+        # a dead state — classify via one per-container inspect.
+        try:
+            info = await self.app.state.podman.inspect_container(cid)
+        except (podman.PodmanError, OSError) as e:
+            logger.debug(
+                "Crash-recovery inspect failed for workspace %s: %s",
+                ws_id,
+                e,
+            )
+            return
+        try:
+            await self.handle_death(ws_id, cid, info, epoch=epoch)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error(
+                "Crash-recovery death handling failed for workspace %s: %s",
+                ws_id,
+                e,
+            )
 
     def maybe_reset_tracker(self, ws_id: str) -> None:
         """Drop the retry counter once a restarted container is stable.
@@ -396,12 +421,10 @@ class CrashRecoveryMonitor:
         # Entry guards: if the world moved between the sweep's detection
         # and now, this death is not ours to handle.
         state = registry.states.get(ws_id)
-        if state is None or state.container_id != container_id:
-            return  # workspace state gone or rebound (user action raced)
-        if ws_id in registry.stopping:
-            return  # an expected stop is in flight
-        if epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch:
-            return  # a stop began and completed during detection
+        if not self._death_guards_pass(
+            registry, ws_id, state, container_id, epoch
+        ):
+            return
         memory_limit = await self._effective_memory_limit(ws_id)
         # Re-validate after the await (#331): a user-driven reconnect
         # (start_container -> _handle_existing_container removes the dead
@@ -411,14 +434,10 @@ class CrashRecoveryMonitor:
         # in flight. The entry guards above ran before that await; acting
         # on the post-await state would tear down the freshly-started
         # container's registry state and network sidecar.
-        if registry.states.get(ws_id) is not state:
-            return  # state replaced/removed (a user start re-bound it)
-        if state.container_id != container_id:
-            return  # rebound to a fresh container — not our death
-        if ws_id in registry.stopping:
-            return  # an expected stop is now in flight
-        if epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch:
-            return  # a stop began and completed during the limit read
+        if not self._death_guards_pass(
+            registry, ws_id, state, container_id, epoch
+        ):
+            return  # the world moved during the limit read (#331)
         cause, message = classify_death(info, memory_limit)
         tracker = self.trackers.get(ws_id) or RestartTracker()
         tracker.last_cause = message
@@ -449,6 +468,19 @@ class CrashRecoveryMonitor:
         # both cases the user action owns the workspace now — record the
         # death event for viewers, but drop the tracker and never
         # restart.
+        self._finalize_death(registry, ws_id, cause, message, tracker, epoch)
+
+    def _finalize_death(
+        self,
+        registry,
+        ws_id: str,
+        cause,
+        message: str,
+        tracker: RestartTracker,
+        epoch: int | None,
+    ) -> None:
+        """Post-teardown disposition: interleaved user action wins (no
+        restart), else disabled-recovery / crash-loop / schedule-restart."""
         if (
             epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch
         ) or registry.states.get(ws_id) is not None:
@@ -480,6 +512,22 @@ class CrashRecoveryMonitor:
             return
         self.schedule_restart(ws_id, tracker)
         self.broadcast_death_event(ws_id, cause, message, tracker)
+
+    @staticmethod
+    def _death_guards_pass(
+        registry, ws_id: str, state, container_id: str, epoch: int | None
+    ) -> bool:
+        """Whether the death is still ours to handle: the registry state is
+        present and bound to this container, no expected stop is in flight,
+        and no stop began-and-completed since the epoch was captured
+        (review #2625). ``state`` may be None (already gone)."""
+        if state is None or state.container_id != container_id:
+            return False  # workspace state gone or rebound (user action raced)
+        if ws_id in registry.stopping:
+            return False  # an expected stop is in flight
+        if epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch:
+            return False  # a stop began and completed during detection
+        return True
 
     async def _effective_memory_limit(self, ws_id: str) -> str | None:
         """The workspace's effective ``--memory`` (bag override or deploy)."""

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -109,44 +109,14 @@ def cgroup_memory_headroom(
     page cache is excluded), the same approximation k8s uses for node
     pressure. A limit smaller than the floor is ignored.
     """
-    v2_max = None
     try:
-        text = open(f"{cgroup_dir}/memory.max").read().strip()
-        if text != "max":
-            v2_max = int(text)
-    except (OSError, ValueError):
-        pass
-    try:
+        v2_max = _v2_memory_limit(cgroup_dir)
         if v2_max is not None:
-            limit = v2_max
-            current = _read_int_file(f"{cgroup_dir}/memory.current")
-            inactive_file = 0
-            try:
-                for line in open(f"{cgroup_dir}/memory.stat"):
-                    name, _, value = line.partition(" ")
-                    if name == "inactive_file":
-                        inactive_file = int(value)
-                        break
-            except (OSError, ValueError):
-                pass
+            limit, current, inactive_file = _cgroup_v2_usage(
+                cgroup_dir, v2_max
+            )
         else:
-            limit = _read_int_file(
-                f"{cgroup_dir}/memory/memory.limit_in_bytes"
-            )
-            if limit >= _CGROUP_LIMIT_UNLIMITED:
-                return None
-            current = _read_int_file(
-                f"{cgroup_dir}/memory/memory.usage_in_bytes"
-            )
-            inactive_file = 0
-            try:
-                for line in open(f"{cgroup_dir}/memory/memory.stat"):
-                    name, _, value = line.partition(" ")
-                    if name in ("total_inactive_file", "inactive_file"):
-                        inactive_file = int(value)
-                        break
-            except (OSError, ValueError):
-                pass
+            limit, current, inactive_file = _cgroup_v1_usage(cgroup_dir)
     except (OSError, ValueError):
         return None
     # "0" (or a bogus negative) is not a limit — e.g. a transient
@@ -158,6 +128,54 @@ def cgroup_memory_headroom(
         # Over the ceiling (limit hit, accounted with lag): no headroom.
         return limit, limit
     return limit, working_set
+
+
+def _v2_memory_limit(cgroup_dir: str) -> int | None:
+    """The finite cgroup-v2 ``memory.max``, or None when unlimited
+    (``max``) / unreadable."""
+    try:
+        text = open(f"{cgroup_dir}/memory.max").read().strip()
+        if text != "max":
+            return int(text)
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def _cgroup_v2_usage(cgroup_dir: str, limit: int) -> tuple[int, int, int]:
+    """(limit, current, inactive_file) from cgroup-v2 files."""
+    current = _read_int_file(f"{cgroup_dir}/memory.current")
+    inactive_file = _stat_value(
+        f"{cgroup_dir}/memory.stat", ("inactive_file",)
+    )
+    return limit, current, inactive_file
+
+
+def _cgroup_v1_usage(cgroup_dir: str) -> tuple[int, int, int]:
+    """(limit, current, inactive_file) from cgroup-v1 files; raises
+    ValueError when the limit is unlimited (no finite ceiling)."""
+    limit = _read_int_file(f"{cgroup_dir}/memory/memory.limit_in_bytes")
+    if limit >= _CGROUP_LIMIT_UNLIMITED:
+        raise ValueError("unlimited cgroup v1 memory limit")
+    current = _read_int_file(f"{cgroup_dir}/memory/memory.usage_in_bytes")
+    inactive_file = _stat_value(
+        f"{cgroup_dir}/memory/memory.stat",
+        ("total_inactive_file", "inactive_file"),
+    )
+    return limit, current, inactive_file
+
+
+def _stat_value(stat_path: str, names: tuple[str, ...]) -> int:
+    """The value of the first matching counter in a memory.stat file, 0 when
+    absent or unreadable."""
+    try:
+        for line in open(stat_path):
+            name, _, value = line.partition(" ")
+            if name in names:
+                return int(value)
+    except (OSError, ValueError):
+        pass
+    return 0
 
 
 def parse_vm_stat(

--- a/src/klangk/klangk/container/idle.py
+++ b/src/klangk/klangk/container/idle.py
@@ -64,36 +64,16 @@ class IdleMonitor:
         registry = self.app.state.container_registry
         last_token_sweep = 0.0
         while True:
-            timeouts = [
-                s.idle_timeout
-                for s in registry.states.values()
-                if s.idle_timeout is not None
-            ]
-            if timeouts:
-                interval = max(2, min(timeouts) // 2)
-            else:
-                interval = registry.check_interval_seconds
             wake = self.get_cleanup_wake()
             wake.clear()
             try:
-                await asyncio.wait_for(wake.wait(), timeout=interval)
+                await asyncio.wait_for(
+                    wake.wait(), timeout=self._cleanup_interval()
+                )
             except asyncio.TimeoutError:
                 pass
             now = time.time()
-            to_stop = []
-            for ws_id, state in list(registry.states.items()):
-                timeout = state.get_idle_timeout()
-                idle_secs = now - state.last_activity
-                logger.debug(
-                    "Idle check: %s idle %.0fs / %ds",
-                    state.container_id[:12],
-                    idle_secs,
-                    timeout,
-                )
-                if timeout > 0 and idle_secs > timeout:
-                    to_stop.append((state.container_id, ws_id))
-
-            for cid, wid in to_stop:
+            for cid, wid in self._idle_overdue(now):
                 logger.info(
                     "Stopping idle container %s (workspace %s)",
                     cid,
@@ -101,11 +81,7 @@ class IdleMonitor:
                 )
                 state = registry.states.get(wid)
                 if state:
-                    for cb in list(state.idle_callbacks):
-                        try:
-                            await cb(wid)
-                        except Exception as e:
-                            logger.error("Idle callback error: %s", e)
+                    await self._run_idle_callbacks(state, wid)
                 await registry.notify_workspace_killed(wid, container_id=cid)
                 await registry.stop_and_remove_container(cid)
 
@@ -119,6 +95,46 @@ class IdleMonitor:
                     await registry._sweep_orphaned_sidecar_tokens()
                 except Exception as e:
                     logger.warning("Orphan sidecar-token sweep failed: %s", e)
+
+    def _cleanup_interval(self) -> float:
+        """Half the smallest active idle timeout (floor 2s), else the
+        configured check interval."""
+        registry = self.app.state.container_registry
+        timeouts = [
+            s.idle_timeout
+            for s in registry.states.values()
+            if s.idle_timeout is not None
+        ]
+        if timeouts:
+            return max(2, min(timeouts) // 2)
+        return registry.check_interval_seconds
+
+    def _idle_overdue(self, now: float) -> list[tuple[str, str]]:
+        """(container_id, ws_id) for workspaces idle past their timeout."""
+        registry = self.app.state.container_registry
+        to_stop = []
+        for ws_id, state in list(registry.states.items()):
+            timeout = state.get_idle_timeout()
+            idle_secs = now - state.last_activity
+            logger.debug(
+                "Idle check: %s idle %.0fs / %ds",
+                state.container_id[:12],
+                idle_secs,
+                timeout,
+            )
+            if timeout > 0 and idle_secs > timeout:
+                to_stop.append((state.container_id, ws_id))
+        return to_stop
+
+    @staticmethod
+    async def _run_idle_callbacks(state, wid: str) -> None:
+        """Fire a workspace's idle callbacks; one raising callback must not
+        block the rest or the stop itself."""
+        for cb in list(state.idle_callbacks):
+            try:
+                await cb(wid)
+            except Exception as e:
+                logger.error("Idle callback error: %s", e)
 
     def start_cleanup_loop(self) -> None:
         registry = self.app.state.container_registry

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -135,6 +135,39 @@ async def safe_remove(podman_inst, container_id: str, *, what: str) -> bool:
         return False
 
 
+def host_bound_ports(info: dict) -> set[int]:
+    """Host ports published by an inspected container (from HostConfig
+    PortBindings)."""
+    bindings = info.get("HostConfig", {}).get("PortBindings") or {}
+    bound = set()
+    for ports_list in bindings.values():
+        for entry in ports_list or []:
+            try:
+                bound.add(int(entry["HostPort"]))
+            except (KeyError, ValueError, TypeError):
+                pass
+    return bound
+
+
+async def remove_stale_container(
+    podman, stale_id: str, bound: set[int], wanted_ports: set[int]
+) -> None:
+    """Remove a stale container holding a wanted port; best-effort."""
+    try:
+        await podman.remove_container(stale_id)
+        logger.info(
+            "Removed stale container %s (ports %s)",
+            stale_id[:12],
+            bound & wanted_ports,
+        )
+    except PodmanError as del_exc:
+        logger.warning(
+            "Could not remove stale container %s: %s",
+            stale_id[:12],
+            del_exc,
+        )
+
+
 class ContainerRegistry(NetworkSidecarMixin):
     """Manages all container state and podman interactions.
 
@@ -293,23 +326,28 @@ class ContainerRegistry(NetworkSidecarMixin):
             for opt in options.split(","):
                 if opt and opt not in _VALID_MOUNT_OPTIONS:
                     return f"Invalid mount {spec!r}: unknown option {opt!r}"
-        if not _is_named_volume(source):
-            if self._is_protected(source):
-                return (
-                    f"Invalid mount {spec!r}: source is a protected host path"
-                )
-            if self.allowed_mount_roots:
-                resolved = os.path.realpath(source)
-                if not any(
-                    resolved == root or resolved.startswith(root + "/")
-                    for root in self.allowed_mount_roots
-                ):
-                    allowed = ", ".join(self.allowed_mount_roots)
-                    return (
-                        f"Invalid mount {spec!r}: bind mount source must be "
-                        f"under an allowed root ({allowed})"
-                    )
-        return None
+        if _is_named_volume(source):
+            return None
+        return self._validate_bind_source(spec, source)
+
+    def _validate_bind_source(self, spec: str, source: str) -> str | None:
+        """A non-named-volume source must not be a protected host path and
+        (when allowed roots are configured) must live under one."""
+        if self._is_protected(source):
+            return f"Invalid mount {spec!r}: source is a protected host path"
+        if not self.allowed_mount_roots:
+            return None
+        resolved = os.path.realpath(source)
+        if any(
+            resolved == root or resolved.startswith(root + "/")
+            for root in self.allowed_mount_roots
+        ):
+            return None
+        allowed = ", ".join(self.allowed_mount_roots)
+        return (
+            f"Invalid mount {spec!r}: bind mount source must be "
+            f"under an allowed root ({allowed})"
+        )
 
     def validate_mounts(self, mounts: list[str]) -> str | None:
         """Validate a list of mount specs. Returns first error or None."""
@@ -1142,28 +1180,11 @@ class ContainerRegistry(NetworkSidecarMixin):
             info = await podman.inspect_container(stale_id)
             if info is None:
                 continue
-            bindings = info.get("HostConfig", {}).get("PortBindings") or {}
-            bound = set()
-            for ports_list in bindings.values():
-                for entry in ports_list or []:
-                    try:
-                        bound.add(int(entry["HostPort"]))
-                    except (KeyError, ValueError, TypeError):
-                        pass
+            bound = host_bound_ports(info)
             if bound & wanted_ports:
-                try:
-                    await podman.remove_container(stale_id)
-                    logger.info(
-                        "Removed stale container %s (ports %s)",
-                        stale_id[:12],
-                        bound & wanted_ports,
-                    )
-                except PodmanError as del_exc:
-                    logger.warning(
-                        "Could not remove stale container %s: %s",
-                        stale_id[:12],
-                        del_exc,
-                    )
+                await remove_stale_container(
+                    podman, stale_id, bound, wanted_ports
+                )
 
     async def _start_with_port_conflict_retry(
         self,
@@ -1881,33 +1902,6 @@ class ContainerRegistry(NetworkSidecarMixin):
         a racing re-bind — is logged and not counted).
         """
 
-        async def drain_one(ws_id: str, cid: str) -> bool:
-            await self.notify_workspace_killed(ws_id, container_id=cid)
-            ok = await self.stop_and_remove_container(cid, workspace_id=ws_id)
-            if not ok:
-                logger.warning(
-                    "Drain: workspace %s container %s not stopped "
-                    "(failed or re-bound by a racing start)",
-                    ws_id,
-                    cid[:12],
-                )
-                return False
-            # Same "stopped on purpose" broadcast as the /stop endpoint:
-            # clients re-render as stopped, not disconnected.
-            session = self.app.state.sockets.get_session(ws_id)
-            if session:
-                session.broadcast(
-                    {
-                        "type": "event",
-                        "event": {
-                            "type": "CUSTOM",
-                            "name": "container_stopped",
-                            "value": {"reason": reason},
-                        },
-                    }
-                )
-            return True
-
         # Snapshot so a container exiting mid-drain cannot mutate the
         # dict under us.
         tracked = [
@@ -1916,9 +1910,46 @@ class ContainerRegistry(NetworkSidecarMixin):
             if state.container_id
         ]
         results = await asyncio.gather(
-            *(drain_one(ws_id, cid) for ws_id, cid in tracked),
+            *(self._drain_one(ws_id, cid, reason) for ws_id, cid in tracked),
             return_exceptions=True,
         )
+        stopped = self._count_drained(tracked, results)
+        # Label sweep: catch starts that raced the gate (created after
+        # the snapshot) and anything else instance-labelled still alive.
+        stopped += await self._sweep_drain_leftovers()
+        return stopped
+
+    async def _drain_one(self, ws_id: str, cid: str, reason: str) -> bool:
+        """Notify + stop one workspace for a drain, with the same
+        "stopped on purpose" broadcast as the /stop endpoint (clients
+        re-render as stopped, not disconnected)."""
+        await self.notify_workspace_killed(ws_id, container_id=cid)
+        ok = await self.stop_and_remove_container(cid, workspace_id=ws_id)
+        if not ok:
+            logger.warning(
+                "Drain: workspace %s container %s not stopped "
+                "(failed or re-bound by a racing start)",
+                ws_id,
+                cid[:12],
+            )
+            return False
+        session = self.app.state.sockets.get_session(ws_id)
+        if session:
+            session.broadcast(
+                {
+                    "type": "event",
+                    "event": {
+                        "type": "CUSTOM",
+                        "name": "container_stopped",
+                        "value": {"reason": reason},
+                    },
+                }
+            )
+        return True
+
+    @staticmethod
+    def _count_drained(tracked: list[tuple[str, str]], results: list) -> int:
+        """Count the successful drains; log the raising ones."""
         stopped = 0
         for (ws_id, _cid), result in zip(tracked, results, strict=True):
             if isinstance(result, BaseException):
@@ -1927,8 +1958,12 @@ class ContainerRegistry(NetworkSidecarMixin):
                 )
             elif result:
                 stopped += 1
-        # Label sweep: catch starts that raced the gate (created after
-        # the snapshot) and anything else instance-labelled still alive.
+        return stopped
+
+    async def _sweep_drain_leftovers(self) -> int:
+        """Label sweep: catch starts that raced the drain gate (created
+        after the snapshot) and anything else instance-labelled still
+        alive. Returns the count additionally stopped."""
         try:
             leftovers = await self.app.state.podman.list_containers(
                 f"klangk.instance={self.app.state.util.instance_id()}"
@@ -1936,6 +1971,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         except (podman.PodmanError, OSError) as e:
             logger.warning("Drain: error sweeping leftover containers: %s", e)
             leftovers = []
+        stopped = 0
         for c in leftovers:
             cid = container_ident(c)
             if not cid:

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -184,6 +184,73 @@ def resolve_tmp_size(app, workspace_settings: dict | None) -> str | None:
     )
 
 
+def _hosting_floor(
+    app,
+    hosting_hostname: str | None,
+    hosting_proto: str | None,
+    hosting_base_path: str | None,
+) -> tuple[str, str, str]:
+    """Fill any omitted hosting value with the resolver's floor
+    (``derive_hosting_info`` with no request)."""
+    if (
+        hosting_hostname is None
+        or hosting_proto is None
+        or hosting_base_path is None
+    ):
+        h, p, b = app.state.util.derive_hosting_info(None, None)
+        # Use ``is None`` (not ``or``): an explicit empty base_path
+        # (root deployment) is a legitimate value that must survive,
+        # not be clobbered by the resolved floor.
+        if hosting_hostname is None:
+            hosting_hostname = h
+        if hosting_proto is None:
+            hosting_proto = p
+        if hosting_base_path is None:
+            hosting_base_path = b
+    return hosting_hostname, hosting_proto, hosting_base_path
+
+
+def _append_hosted_env(
+    app,
+    env_vars: list[str],
+    host_ports: list[int],
+    hosting_hostname: str,
+    hosting_proto: str,
+    hosting_base_path: str,
+) -> None:
+    """Hosted-app serving env. Omitted entirely when the workspace has
+    no host ports (KLANGKD_HOSTED_PORTS_PER_WORKSPACE=0, or a
+    per-workspace value of 0): KLANGKWS_PORT_MAPPINGS absent makes
+    klangk-hosted-url / get_hosted_url error out cleanly, and the
+    KLANGKWS_HOSTING_* vars are meaningless without hosting. #1237
+    Also omitted in headless deployments (KLANGKD_PORT unset, #2732):
+    /hosted/ is served by the browser listener, which headless mode
+    does not render, so any hosted URL baked now would be dead on
+    arrival — the same clean-error outcome as the cap-0 case."""
+    if host_ports and app.state.settings.port is not None:
+        mappings = [
+            f"{CONTAINER_PORT_START + i}:{hp}"
+            for i, hp in enumerate(host_ports)
+        ]
+        env_vars.append(f"KLANGKWS_PORT_MAPPINGS={','.join(mappings)}")
+        env_vars.append(f"KLANGKWS_HOSTING_HOSTNAME={hosting_hostname}")
+        env_vars.append(f"KLANGKWS_HOSTING_PROTO={hosting_proto}")
+        env_vars.append(f"KLANGKWS_HOSTING_BASE_PATH={hosting_base_path}")
+
+
+def _append_feature_env(
+    app, env_vars: list[str], extra_env: dict[str, str] | None
+) -> None:
+    """Feature flags, then caller extras (an extra wins by appending
+    later)."""
+    for k, v in app.state.features.container_env().items():
+        env_vars.append(f"{k}={v}")
+
+    if extra_env:
+        for k, v in extra_env.items():
+            env_vars.append(f"{k}={v}")
+
+
 def build_env(
     app,
     workspace_id: str,
@@ -207,21 +274,9 @@ def build_env(
     (the same resolver the request paths use), so a deployer's
     ``KLANGKD_HOSTING_HOSTNAME`` is honored on every start — eager or not.
     """
-    if (
-        hosting_hostname is None
-        or hosting_proto is None
-        or hosting_base_path is None
-    ):
-        h, p, b = app.state.util.derive_hosting_info(None, None)
-        # Use ``is None`` (not ``or``): an explicit empty base_path
-        # (root deployment) is a legitimate value that must survive,
-        # not be clobbered by the resolved floor.
-        if hosting_hostname is None:
-            hosting_hostname = h
-        if hosting_proto is None:
-            hosting_proto = p
-        if hosting_base_path is None:
-            hosting_base_path = b
+    hosting_hostname, hosting_proto, hosting_base_path = _hosting_floor(
+        app, hosting_hostname, hosting_proto, hosting_base_path
+    )
     env_vars: list[str] = []
     egress_port = app.state.settings.egress_port
     proxy_url = f"http://host.containers.internal:{egress_port}/llm-proxy"
@@ -238,15 +293,14 @@ def build_env(
     # /hosted/ is served by the browser listener, which headless mode
     # does not render, so any hosted URL baked now would be dead on
     # arrival — the same clean-error outcome as the cap-0 case.
-    if host_ports and app.state.settings.port is not None:
-        mappings = [
-            f"{CONTAINER_PORT_START + i}:{hp}"
-            for i, hp in enumerate(host_ports)
-        ]
-        env_vars.append(f"KLANGKWS_PORT_MAPPINGS={','.join(mappings)}")
-        env_vars.append(f"KLANGKWS_HOSTING_HOSTNAME={hosting_hostname}")
-        env_vars.append(f"KLANGKWS_HOSTING_PROTO={hosting_proto}")
-        env_vars.append(f"KLANGKWS_HOSTING_BASE_PATH={hosting_base_path}")
+    _append_hosted_env(
+        app,
+        env_vars,
+        host_ports,
+        hosting_hostname,
+        hosting_proto,
+        hosting_base_path,
+    )
     env_vars.append(f"KLANGKWS_WORKSPACE_ID={workspace_id}")
     env_vars.append(f"KLANGKWS_AGENT_HOME={agent_home}")
     env_vars.append(
@@ -267,13 +321,7 @@ def build_env(
     # ever needed. Emitted only when a trustable cert dir is present.
     env_vars.extend(ssl_env_vars(ssl_dir))
 
-    for k, v in app.state.features.container_env().items():
-        env_vars.append(f"{k}={v}")
-
-    if extra_env:
-        for k, v in extra_env.items():
-            env_vars.append(f"{k}={v}")
-
+    _append_feature_env(app, env_vars, extra_env)
     return env_vars
 
 
@@ -294,6 +342,29 @@ def build_mounts(
     return binds
 
 
+async def _ensure_named_volume(app, user_id, podman, source: str) -> None:
+    """Create a missing named volume (instance-labelled, owner-tagged) or
+    validate an existing one belongs to this instance and user."""
+    info = await podman.inspect_volume(source)
+    if info is None:
+        labels = {
+            "klangk.managed": "true",
+            "klangk.instance": app.state.util.instance_id(),
+        }
+        if user_id:
+            labels["klangk.user-id"] = user_id
+        await podman.create_volume(source, labels)
+        return
+    vol_labels = info.get("Labels") or {}
+    if vol_labels.get("klangk.instance") != app.state.util.instance_id():
+        raise ValueError(
+            f"Volume {source!r} is not managed by this klangk instance"
+        )
+    vol_owner = vol_labels.get("klangk.user-id")
+    if vol_owner and user_id and vol_owner != user_id:
+        raise ValueError(f"Volume {source!r} belongs to another user")
+
+
 async def ensure_volumes(
     app,
     extra_mounts: list[str] | None,
@@ -306,30 +377,7 @@ async def ensure_volumes(
     for mount_spec in extra_mounts:
         source = mount_spec.split(":")[0]
         if _is_named_volume(source):
-            info = await podman.inspect_volume(source)
-            if info is None:
-                labels = {
-                    "klangk.managed": "true",
-                    "klangk.instance": app.state.util.instance_id(),
-                }
-                if user_id:
-                    labels["klangk.user-id"] = user_id
-                await podman.create_volume(source, labels)
-            else:
-                vol_labels = info.get("Labels") or {}
-                if (
-                    vol_labels.get("klangk.instance")
-                    != app.state.util.instance_id()
-                ):
-                    raise ValueError(
-                        f"Volume {source!r} is not managed "
-                        "by this klangk instance"
-                    )
-                vol_owner = vol_labels.get("klangk.user-id")
-                if vol_owner and user_id and vol_owner != user_id:
-                    raise ValueError(
-                        f"Volume {source!r} belongs to another user"
-                    )
+            await _ensure_named_volume(app, user_id, podman, source)
         elif not os.path.exists(source):
             raise ValueError(f"Bind mount source does not exist: {source}")
 


### PR DESCRIPTION
## Summary

Tenth PR of the #2817 B-ratchet: brings all 10 remaining rank-C blocks in the `container/` subsystem (`crash.py`, `idle.py`, `eviction.py`, `registry.py`, `spec.py`) under rank B — all five files pass `xenon --max-absolute B`. Pure extract-function; no behavior change.

## Details

- `CrashRecoveryMonitor.sweep_once` (17) → **B (3)**: `_liveness_snapshot` (pre-await capture), `_listed_liveness` (batched ps), `_sweep_one` (post-await revalidation + classify).
- `CrashRecoveryMonitor.handle_death` (17) → **B (5)**: `_death_guards_pass` (the shared entry/post-await race guards, used at both await boundaries), `_finalize_death` (post-teardown disposition).
- `IdleMonitor.cleanup_idle_containers` (15) → **B (5)**: `_cleanup_interval`, `_idle_overdue`, `_run_idle_callbacks`.
- `cgroup_memory_headroom` (15) → **B (5)**: `_v2_memory_limit`, `_cgroup_v2_usage`, `_cgroup_v1_usage`, `_stat_value` (the unlimited-v1 limit still maps to None via the outer except).
- `ContainerRegistry.validate_mount_spec` (15) → **B (7)**: `_validate_bind_source` (protected-path + allowed-root checks).
- `ContainerRegistry._resolve_port_conflict` (12) → **B (4)**: free functions `host_bound_ports` + `remove_stale_container`.
- `ContainerRegistry.drain_all_containers` (11) → **B (2)**: `drain_one` closure became `_drain_one`; `_count_drained`, `_sweep_drain_leftovers`.
- `build_env` (15) → **B (5)**: `_hosting_floor`, `_append_hosted_env`, `_append_feature_env`.
- `ensure_volumes` (12) → **B (3)**: `_ensure_named_volume` (create-or-validate).

## Verification

- Full Python suite (`-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute B` on all five files: passes.
- No changelog entry (internal refactor).
