### PR TITLE
refactor(wshandler): bring dispatch/connection/decider/controllers blocks under rank B

### DIFF
--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -512,6 +512,11 @@ class Connection:
             # the error frame surfaces the actionable podman message.
             send_error(self.sock, f"Container restart failed: {exc}")
             return
+        await self._announce_restarted_container(workspace_id)
+
+    async def _announce_restarted_container(self, workspace_id) -> None:
+        """Record activity, re-bind sibling connections to the new
+        container, and send the container_ready frame."""
         self.app.state.container_registry.record_activity(self.container_id)
 
         # Update container_id on ALL connections to this workspace

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1569,14 +1569,8 @@ class SharedTerminalController:
         """Create a new shared terminal (legacy API — creates a new window
         and marks it shared)."""
 
-        if not self._conn.container_id or not self._conn._user_home:
-            return
-        if not await self._conn._has_perm("share-terminals"):
-            send_error(self._conn.sock, "Permission denied")
-            return
-        name = msg.get("name", "").strip()
-        if not name:
-            send_error(self._conn.sock, "Name required")
+        name = await self._share_terminals_name(msg)
+        if name is None:
             return
         session_name = self._conn.tmux_session_name()
         try:
@@ -1599,6 +1593,99 @@ class SharedTerminalController:
         # Sync with tmux to get proper window_id, then mark the new
         # window as shared.
         self._conn.sync_terminal_windows(windows)
+        self._mark_window_shared(new_id)
+
+    async def _resolve_shared_terminal(self, msg: dict) -> tuple | None:
+        """Validate the delete-shared-terminal request and resolve it to
+        (ws_session, owner_user_id, window_id, window_name); None after
+        sending the refusal. Only the terminal's owner — or the workspace
+        owner — may delete it: the owner_user_id comes from the client and
+        must not be trusted blindly, otherwise any collaborator with the
+        share-terminals permission could close other users' windows."""
+        if not self._conn.container_id:
+            return None
+        if not await self._conn._has_perm("share-terminals"):
+            send_error(self._conn.sock, "Permission denied")
+            return None
+
+        owner_user_id = msg.get("user_id", "").strip()
+        window_id = msg.get("window_id", "").strip()
+        if not owner_user_id or not window_id:
+            send_error(self._conn.sock, "user_id and window_id required")
+            return None
+        if not await self._may_delete_shared_terminal(owner_user_id):
+            return None
+        ws_session = self._conn.app.state.sockets.get_session(
+            self._conn.workspace_id
+        )
+        if not ws_session:
+            return None
+        match = self.find_window(
+            ws_session,
+            owner_user_id,
+            window_id,
+            error_msg="Terminal not found",
+        )
+        if match is None:
+            return None
+        return ws_session, owner_user_id, window_id, match["name"]
+
+    async def _close_shared_window(
+        self, owner_user_id: str, window_id: str
+    ) -> bool:
+        """Close the window (and its joiner sessions); False (after sending
+        the error frame) on failure."""
+        try:
+            await self._conn.app.state.terminal.kill_joiner_sessions(
+                self._conn.container_id,
+                owner_user_id,
+            )
+            await self._conn.app.state.terminal.close_window(
+                self._conn.container_id,
+                owner_user_id,
+                window_id,
+            )
+            return True
+        except Exception as e:
+            logger.exception("Failed to delete shared terminal: %s", e)
+            send_error(self._conn.sock, "Failed to delete shared terminal")
+            return False
+
+    async def _may_delete_shared_terminal(self, owner_user_id: str) -> bool:
+        """The terminal's owner — or the workspace owner — may delete it;
+        sends "Permission denied" when neither."""
+        if owner_user_id == self._conn.user["id"]:
+            return True
+        workspace = (
+            await self._conn.app.state.model.workspaces.get_workspace_by_id(
+                self._conn.workspace_id
+            )
+        )
+        if (
+            workspace is not None
+            and workspace["user_id"] == self._conn.user["id"]
+        ):
+            return True
+        send_error(self._conn.sock, "Permission denied")
+        return False
+
+    async def _share_terminals_name(self, msg: dict) -> str | None:
+        """Guard the create-shared-terminal preconditions; the stripped
+        name, or None after sending the refusal."""
+        if not self._conn.container_id or not self._conn._user_home:
+            return None
+        if not await self._conn._has_perm("share-terminals"):
+            send_error(self._conn.sock, "Permission denied")
+            return None
+        name = msg.get("name", "").strip()
+        if not name:
+            send_error(self._conn.sock, "Name required")
+            return None
+        return name
+
+    def _mark_window_shared(self, new_id) -> None:
+        """Mark the freshly-created window shared (if found) and broadcast
+        the updated shared-terminal list."""
         ws_session = self._conn.app.state.sockets.get_session(
             self._conn.workspace_id
         )
@@ -1616,58 +1703,11 @@ class SharedTerminalController:
         """Delete a shared terminal (legacy API — unshares and closes
         the window)."""
 
-        if not self._conn.container_id:
+        resolved = await self._resolve_shared_terminal(msg)
+        if resolved is None:
             return
-        if not await self._conn._has_perm("share-terminals"):
-            send_error(self._conn.sock, "Permission denied")
-            return
-
-        owner_user_id = msg.get("user_id", "").strip()
-        window_id = msg.get("window_id", "").strip()
-        if not owner_user_id or not window_id:
-            send_error(self._conn.sock, "user_id and window_id required")
-            return
-        # Only the terminal's owner — or the workspace owner — may
-        # delete it. The owner_user_id comes from the client and must
-        # not be trusted blindly, otherwise any collaborator with the
-        # share-terminals permission could close other users' windows.
-        if owner_user_id != self._conn.user["id"]:
-            workspace = await self._conn.app.state.model.workspaces.get_workspace_by_id(
-                self._conn.workspace_id
-            )
-            if (
-                workspace is None
-                or workspace["user_id"] != self._conn.user["id"]
-            ):
-                send_error(self._conn.sock, "Permission denied")
-                return
-        ws_session = self._conn.app.state.sockets.get_session(
-            self._conn.workspace_id
-        )
-        if not ws_session:
-            return
-        match = self.find_window(
-            ws_session,
-            owner_user_id,
-            window_id,
-            error_msg="Terminal not found",
-        )
-        if match is None:
-            return
-        window_name = match["name"]
-        try:
-            await self._conn.app.state.terminal.kill_joiner_sessions(
-                self._conn.container_id,
-                owner_user_id,
-            )
-            await self._conn.app.state.terminal.close_window(
-                self._conn.container_id,
-                owner_user_id,
-                window_id,
-            )
-        except Exception as e:
-            logger.exception("Failed to delete shared terminal: %s", e)
-            send_error(self._conn.sock, "Failed to delete shared terminal")
+        ws_session, owner_user_id, window_id, window_name = resolved
+        if not await self._close_shared_window(owner_user_id, window_id):
             return
         owner_windows = ws_session.terminal_windows.get(owner_user_id, [])
         owner_windows[:] = [

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -197,6 +197,73 @@ async def _dispatch_decider_message(
         await _handle_unpause(app, safe_ws, workspace, principals)
 
 
+async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
+    """Validate the decider socket's token; refuse + None on failure."""
+    token = websocket.query_params.get("token")
+    if not token:
+        await _refuse(websocket, 4001, "Missing token")
+        return None
+    result = await app.state.auth.get_user_from_token(token)
+    _hs_mark("token")
+    if result is auth.Auth.TOKEN_EXPIRED:
+        await _refuse(websocket, 4002, "Token expired")
+        return None
+    if result is None:
+        await _refuse(websocket, 4001, "Invalid token")
+        return None
+    return result
+
+
+async def _decider_receive_loop(
+    app,
+    registry,
+    safe_ws,
+    workspace,
+    user: dict,
+    decider_id: str,
+    principals,
+) -> None:
+    """Receive + dispatch decider frames until the socket drops or the
+    client falls behind."""
+    while True:
+        # Starlette raises RuntimeError ("WebSocket is not connected...")
+        # on a client disconnect during receive_text(); treat it the same
+        # as WebSocketDisconnect.
+        try:
+            raw = await safe_ws.receive_text()
+        except (WebSocketDisconnect, RuntimeError):
+            break
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(msg, dict):
+            continue
+        mtype = msg.get("type")
+        try:
+            await _dispatch_decider_message(
+                app,
+                registry,
+                safe_ws,
+                msg,
+                workspace,
+                user["id"],
+                decider_id,
+                principals,
+            )
+        except SlowClientError:
+            # Outbound queue full -- the client can't keep up. Drop it
+            # (matches the main /ws handler's slow-client handling).
+            break
+        except Exception:
+            # A single bad verdict or transient send error must not tear
+            # down the whole connection (and every other in-flight prompt
+            # on it). Log + keep going.
+            logger.exception(
+                "consent decider: error handling %r message", mtype
+            )
+
+
 async def handle_consent_decider(websocket: WebSocket, app) -> None:
     """Register a consent decider for its connection lifetime + act on holds."""
     # #2420: time the pre-accept steps so an intermittent opening-handshake
@@ -210,19 +277,9 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     def _hs_mark(label: str) -> None:
         _hs_marks.append((label, time.monotonic()))
 
-    token = websocket.query_params.get("token")
-    if not token:
-        await _refuse(websocket, 4001, "Missing token")
+    user = await _decider_authenticate(websocket, app, _hs_mark)
+    if user is None:
         return
-    result = await app.state.auth.get_user_from_token(token)
-    _hs_mark("token")
-    if result is auth.Auth.TOKEN_EXPIRED:
-        await _refuse(websocket, 4002, "Token expired")
-        return
-    if result is None:
-        await _refuse(websocket, 4001, "Invalid token")
-        return
-    user = result
     workspace = websocket.query_params.get("workspace")  # None = deploy-wide
 
     refused, principals = await _refuse_invalid_handshake(
@@ -256,43 +313,9 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         rules = await app.state.consent_coordinator.rules_frame(workspace)
         if rules is not None:
             safe_ws.send_json(rules)
-        while True:
-            # Starlette raises RuntimeError ("WebSocket is not connected...")
-            # on a client disconnect during receive_text(); treat it the same
-            # as WebSocketDisconnect.
-            try:
-                raw = await safe_ws.receive_text()
-            except (WebSocketDisconnect, RuntimeError):
-                break
-            try:
-                msg = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(msg, dict):
-                continue
-            mtype = msg.get("type")
-            try:
-                await _dispatch_decider_message(
-                    app,
-                    registry,
-                    safe_ws,
-                    msg,
-                    workspace,
-                    user["id"],
-                    decider_id,
-                    principals,
-                )
-            except SlowClientError:
-                # Outbound queue full -- the client can't keep up. Drop it
-                # (matches the main /ws handler's slow-client handling).
-                break
-            except Exception:
-                # A single bad verdict or transient send error must not tear
-                # down the whole connection (and every other in-flight prompt
-                # on it). Log + keep going.
-                logger.exception(
-                    "consent decider: error handling %r message", mtype
-                )
+        await _decider_receive_loop(
+            app, registry, safe_ws, workspace, user, decider_id, principals
+        )
     finally:
         # Connection gone (clean disconnect, error, or crash) -> drop the
         # registration so the workspace reverts to static (#2308).

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -62,22 +62,59 @@ _WS_STATE_COMMANDS: dict[str, str] = {
 }
 
 
-async def handle_websocket(websocket: WebSocket, app) -> None:
-    """Main WebSocket handler."""
-    # Authenticate via query param
+async def ws_authenticate(websocket: WebSocket, app):
+    """Validate the socket's token; close and return None on failure."""
     token = websocket.query_params.get("token")
     if not token:
         await websocket.close(code=4001, reason="Missing token")
-        return
+        return None
 
     result = await app.state.auth.get_user_from_token(token)
     if result is auth.Auth.TOKEN_EXPIRED:
         await websocket.close(code=4002, reason="Token expired")
-        return
+        return None
     if result is None:
         await websocket.close(code=4001, reason="Invalid token")
+        return None
+    return result
+
+
+async def dispatch_ws_loop(conn, safe_ws, user: dict, app) -> None:
+    """Receive/dispatch frames until the socket drops. Connection-command
+    table first, then state-command table, else an error frame."""
+    while True:
+        raw = await safe_ws.receive_text()
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            send_error(safe_ws, "Invalid JSON")
+            continue
+
+        log_ws_msg("RECV", msg, user)
+
+        cmd = msg.get("cmd")
+        entry = _WS_CONNECTION_COMMANDS.get(cmd)
+        if entry is not None:
+            method_name, takes_msg = entry
+            method = getattr(conn, method_name)
+            if takes_msg:
+                await method(msg)
+            else:
+                await method()
+        else:
+            state_method = _WS_STATE_COMMANDS.get(cmd)
+            if state_method is not None:
+                getattr(app.state.sockets, state_method)(msg, safe_ws)
+            else:
+                send_error(safe_ws, f"Unknown command: {cmd}")
+
+
+async def handle_websocket(websocket: WebSocket, app) -> None:
+    """Main WebSocket handler."""
+    # Authenticate via query param
+    user = await ws_authenticate(websocket, app)
+    if user is None:
         return
-    user = result
 
     await websocket.accept()
     safe_ws = SafeWebSocket(websocket)
@@ -103,31 +140,7 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
         if server_scheduler is not None:
             await server_scheduler.send_snapshot_to(safe_ws)
 
-        while True:
-            raw = await safe_ws.receive_text()
-            try:
-                msg = json.loads(raw)
-            except json.JSONDecodeError:
-                send_error(safe_ws, "Invalid JSON")
-                continue
-
-            log_ws_msg("RECV", msg, user)
-
-            cmd = msg.get("cmd")
-            entry = _WS_CONNECTION_COMMANDS.get(cmd)
-            if entry is not None:
-                method_name, takes_msg = entry
-                method = getattr(conn, method_name)
-                if takes_msg:
-                    await method(msg)
-                else:
-                    await method()
-            else:
-                state_method = _WS_STATE_COMMANDS.get(cmd)
-                if state_method is not None:
-                    getattr(app.state.sockets, state_method)(msg, safe_ws)
-                else:
-                    send_error(safe_ws, f"Unknown command: {cmd}")
+        await dispatch_ws_loop(conn, safe_ws, user, app)
 
     except WebSocketDisconnect:
         logger.info("WebSocket disconnected for user %s", user["email"])


### PR DESCRIPTION
## Summary

Twelfth PR of the #2817 B-ratchet: brings all 5 remaining rank-C blocks in the `wshandler/` subsystem (`dispatch.py`, `connection.py`, `decider.py`, `controllers.py` ×2) under rank B — all four files pass `xenon --max-absolute B`. Pure extract-function; no behavior change.

## Details

- `handle_websocket` (14) → **B (5)**: `ws_authenticate` (token gate), `dispatch_ws_loop` (receive/dispatch with the connection/state command tables).
- `Connection.handle_restart_container` (14) → **B (6)**: `_announce_restarted_container` (activity record, sibling re-bind, container_ready frame with the idle-timeout suffix).
- `handle_consent_decider` (13) → **B (4)**: `_decider_authenticate` (token gate + handshake timing mark), `_decider_receive_loop` (per-frame dispatch with the slow-client/error tolerance).
- `SharedTerminalController.create_shared_terminal` (13) → **B (6)**: `_share_terminals_name` (precondition guards), `_mark_window_shared`.
- `SharedTerminalController.delete_shared_terminal` (13) → **B (4)**: `_resolve_shared_terminal` (guards + owner check + window lookup), `_may_delete_shared_terminal` (sends "Permission denied" on refusal), `_close_shared_window`.

## Verification

- Full Python suite (`-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute B` on all four files: passes.
- No changelog entry (internal refactor).
