### PR TITLE
refactor(server): bring server-misc, model, and consent blocks under rank B

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -987,55 +987,7 @@ class CaddyWatchdog:
                 os.unlink(self.admin_socket)
             except FileNotFoundError:
                 pass
-            self._proc = await asyncio.create_subprocess_exec(
-                bin_path,
-                "run",
-                "--config",
-                str(bootstrap_cfg),
-                "--adapter",
-                "caddyfile",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-                preexec_fn=_proxy_preexec,
-            )
-            stderr_task = asyncio.create_task(
-                self._relay_stderr(self._proc.stderr)
-            )
-            logger.info(
-                "caddy started (pid %d), admin UDS %s",
-                self._proc.pid,
-                self.admin_socket,
-            )
-            load_ok = False
-            if await self._wait_for_admin():
-                try:
-                    await self.load_config()
-                    load_ok = True
-                    self._log_listeners()
-                except Exception as exc:  # noqa: BLE001
-                    logger.error(
-                        "caddy POST /load failed (killing for respawn): %s",
-                        exc,
-                    )
-            else:
-                logger.error(
-                    "caddy admin UDS never came up at %s", self.admin_socket
-                )
-            if not load_ok and self._proc and self._proc.returncode is None:
-                # A failed /load leaves Caddy serving a *blank* config (no
-                # sites) — a healthy process doing nothing, which would never
-                # exit and so never respawn. Kill it so the backoff loop
-                # retries, mirroring nginx's fail-fast-on-bad-config behavior.
-                try:
-                    self._proc.terminate()
-                except ProcessLookupError:
-                    pass
-            rc = await self._proc.wait()
-            stderr_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await stderr_task
-            self._proc = None
+            rc = await self._watch_once(bin_path, bootstrap_cfg, env)
             if self._stopping:
                 return
             if self._bind_fatal:
@@ -1052,6 +1004,67 @@ class CaddyWatchdog:
             )
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 30.0)
+
+    async def _watch_once(
+        self, bin_path: str, bootstrap_cfg: Path, env: dict
+    ) -> int:  # pragma: no cover – covered by the e2e suite
+        """One spawn -> admin-wait -> config-push -> wait cycle; returns
+        caddy's exit code."""
+        self._proc = await asyncio.create_subprocess_exec(
+            bin_path,
+            "run",
+            "--config",
+            str(bootstrap_cfg),
+            "--adapter",
+            "caddyfile",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            preexec_fn=_proxy_preexec,
+        )
+        stderr_task = asyncio.create_task(
+            self._relay_stderr(self._proc.stderr)
+        )
+        logger.info(
+            "caddy started (pid %d), admin UDS %s",
+            self._proc.pid,
+            self.admin_socket,
+        )
+        await self._load_or_kill()
+        rc = await self._proc.wait()
+        stderr_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await stderr_task
+        self._proc = None
+        return rc
+
+    async def _load_or_kill(self) -> None:  # pragma: no cover – e2e
+        """Push the real config over the admin API once the admin UDS is up;
+        when that fails (or the UDS never came up), kill Caddy so the backoff
+        loop retries. A failed /load leaves Caddy serving a *blank* config
+        (no sites) — a healthy process doing nothing, which would never exit
+        and so never respawn, mirroring nginx's fail-fast-on-bad-config
+        behavior."""
+        load_ok = False
+        if await self._wait_for_admin():
+            try:
+                await self.load_config()
+                load_ok = True
+                self._log_listeners()
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "caddy POST /load failed (killing for respawn): %s",
+                    exc,
+                )
+        else:
+            logger.error(
+                "caddy admin UDS never came up at %s", self.admin_socket
+            )
+        if not load_ok and self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+            except ProcessLookupError:
+                pass
 
     async def start(self) -> None:
         """Bootstrap Caddy (admin on a UDS, no config) and start the watchdog.

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -64,6 +64,40 @@ _REVOKE_ACK_TIMEOUT = 5.0
 _PAUSE_SECONDS = {"15m": 900, "1h": 3600, "1d": 86400}
 
 
+def _build_verdict(
+    row: dict | None, decision: str, duration: str
+) -> tuple[dict, str, dict | None, dict | None]:
+    """(verdict, resolved_label, forever_allow_row, forever_deny_row) for a
+    decided request. A `forever` verdict additionally captures its row for
+    persistence: the allow mutates the workspace's allow-list (#2368) and the
+    deny its deny-list (#2369) so either survives a container/sidecar restart;
+    captured here, persisted after the Future is resolved (the deciding
+    connection gets its in-memory ACCEPT first) and before the rules refresh
+    (so the view reflects the new entry)."""
+    if row is None:
+        return (
+            {"decision": VERDICT_DENY, "reason": "gone"},
+            "expired",
+            None,
+            None,
+        )
+    if decision == "allowed":
+        verdict = {
+            "decision": VERDICT_ALLOW,
+            "reason": "decided",
+            "duration": duration,
+        }
+        forever_allow = row if duration == DURATION_FOREVER else None
+        return verdict, "allowed", forever_allow, None
+    verdict = {
+        "decision": VERDICT_DENY,
+        "reason": "decided",
+        "duration": duration,
+    }
+    forever_deny = row if duration == DURATION_FOREVER else None
+    return verdict, "denied", None, forever_deny
+
+
 class ConsentCoordinator:
     """In-process holds for egress requests awaiting a verdict (#2311).
 
@@ -330,35 +364,12 @@ class ConsentCoordinator:
             verdict = {"decision": VERDICT_DENY, "reason": "error"}
             resolved = "expired"
         else:
-            if row is None:
-                verdict = {"decision": VERDICT_DENY, "reason": "gone"}
-                resolved = "expired"
-            elif decision == "allowed":
-                verdict = {
-                    "decision": VERDICT_ALLOW,
-                    "reason": "decided",
-                    "duration": duration,
-                }
-                resolved = "allowed"
-                # A `forever` allow persists by mutating the workspace's
-                # allow-list (#2368) so it survives a container/sidecar
-                # restart. Captured here, persisted after the Future is
-                # resolved (the deciding connection gets its in-memory ACCEPT
-                # first) and before the rules refresh (so the view reflects
-                # the new entry).
-                if duration == DURATION_FOREVER:
-                    forever_allow_row = row
-            else:
-                verdict = {
-                    "decision": VERDICT_DENY,
-                    "reason": "decided",
-                    "duration": duration,
-                }
-                resolved = "denied"
-                # A `forever` deny persists by mutating the workspace's
-                # deny-list (#2369) -- the mirror of the allow side above.
-                if duration == DURATION_FOREVER:
-                    forever_deny_row = row
+            (
+                verdict,
+                resolved,
+                forever_allow_row,
+                forever_deny_row,
+            ) = _build_verdict(row, decision, duration)
         if not hold["future"].done():
             hold["future"].set_result(verdict)
         self._broadcast_resolved(request_id, hold["workspace_id"], resolved)
@@ -719,6 +730,12 @@ class ConsentCoordinator:
         ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
         if ws is None:
             return None
+        return await self._rules_frame_for(ws, workspace_id)
+
+    async def _rules_frame_for(self, ws: dict, workspace_id: str) -> dict:
+        """The assembled frame: static lists, grouped in-effect verdicts,
+        and the live pause window (#2332, read fresh so a self-expired pause
+        shows as cleared)."""
         rows = await self.app.state.model.egress_consent.list_active(
             workspace_id
         )
@@ -739,8 +756,6 @@ class ConsentCoordinator:
             "reject_list": ws.get("rejected_domains") or [],
             "allowed": [r for r in rows if r["decision"] == DECISION_ALLOWED],
             "denied": [r for r in rows if r["decision"] == DECISION_DENIED],
-            # #2332 (pause control): the live pause window, or None when not
-            # paused (read fresh so a self-expired pause shows as cleared).
             "paused": paused,
         }
 

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -588,6 +588,35 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
     return report
 
 
+def _append_result_line(lines: list[str], r) -> None:
+    """One result with its ✓/⚠/✗ marker, plus the fix hint when present."""
+    if r.ok:
+        lines.append(f"  ✓ {r.name}: {r.message}")
+    elif r.is_warning:
+        lines.append(f"  ⚠ {r.name}: {r.message}")
+    else:
+        lines.append(f"  ✗ {r.name}: {r.message}")
+    if r.hint:
+        lines.append("")
+        lines.append(f"    Run:  {r.hint}")
+        lines.append("")
+
+
+def _append_failure_block(
+    lines: list[str], results: list, marker: str, heading: str
+) -> None:
+    """A repeated failure block with fix hints (#1968)."""
+    if not results:
+        return
+    lines.append(heading)
+    lines.append("")
+    for r in results:
+        lines.append(f"  {marker} {r.name}: {r.message}")
+        if r.hint:
+            lines.append(f"    Run:  {r.hint}")
+        lines.append("")
+
+
 def format_report(report: DoctorReport) -> str:
     """Format a doctor report for terminal output."""
     lines: list[str] = []
@@ -602,16 +631,7 @@ def format_report(report: DoctorReport) -> str:
     lines.append("")
 
     for r in report.results:
-        if r.ok:
-            lines.append(f"  ✓ {r.name}: {r.message}")
-        elif r.is_warning:
-            lines.append(f"  ⚠ {r.name}: {r.message}")
-        else:
-            lines.append(f"  ✗ {r.name}: {r.message}")
-        if r.hint:
-            lines.append("")
-            lines.append(f"    Run:  {r.hint}")
-            lines.append("")
+        _append_result_line(lines, r)
 
     lines.append("")
     errors = report.errors
@@ -631,23 +651,12 @@ def format_report(report: DoctorReport) -> str:
     # Repeat each failure with its fix so the user doesn't have to
     # scroll back up through a long check list (#1968).
     lines.append("")
-    if errors:
-        lines.append("Errors (must fix before starting klangkd):")
-        lines.append("")
-        for r in errors:
-            lines.append(f"  ✗ {r.name}: {r.message}")
-            if r.hint:
-                lines.append(f"    Run:  {r.hint}")
-            lines.append("")
-
-    if warnings:
-        lines.append("Warnings (recommended but not required):")
-        lines.append("")
-        for r in warnings:
-            lines.append(f"  ⚠ {r.name}: {r.message}")
-            if r.hint:
-                lines.append(f"    Run:  {r.hint}")
-            lines.append("")
+    _append_failure_block(
+        lines, errors, "✗", "Errors (must fix before starting klangkd):"
+    )
+    _append_failure_block(
+        lines, warnings, "⚠", "Warnings (recommended but not required):"
+    )
 
     return "\n".join(lines)
 

--- a/src/klangk/klangk/features.py
+++ b/src/klangk/klangk/features.py
@@ -103,6 +103,35 @@ def is_valid_container_env_key(key: str) -> bool:
     return key.startswith(_CONTAINER_ENV_KEY_PREFIX)
 
 
+def _deploy_feature_names(raw: str) -> set[str]:
+    """Parse the deploy-chosen comma-separated list: trimmed, empties
+    dropped (e.g. "a,,b", a trailing comma)."""
+    return {
+        part for part in (entry.strip() for entry in raw.split(",")) if part
+    }
+
+
+def _manifest_default_names(manifest: dict) -> set[str]:
+    """The manifest's ``defaults`` list as a name set; empty when absent or
+    malformed."""
+    defaults = manifest.get("defaults", [])
+    if isinstance(defaults, list):
+        return {d for d in defaults if isinstance(d, str)}
+    return set()
+
+
+def _all_manifest_feature_names(manifest: dict) -> set[str]:
+    """Every compiled-in feature name. Skip non-dict entries, missing names,
+    and empty names."""
+    return {
+        name
+        for f in manifest.get("features", [])
+        if isinstance(f, dict)
+        and isinstance((name := f.get("name")), str)
+        and name
+    }
+
+
 class Features:
     """Feature manifest reader + config-key bridge.
 
@@ -231,27 +260,14 @@ class Features:
         if raw is not None and raw.strip():
             # Explicit deploy-chosen list: exact comma-separated membership.
             # Trim each entry and drop empties (e.g. "a,,b", a trailing comma).
-            return {
-                part
-                for part in (entry.strip() for entry in raw.split(","))
-                if part
-            }
-        defaults = self._manifest.get("defaults", [])
-        if isinstance(defaults, list):
-            names = {d for d in defaults if isinstance(d, str)}
-            if names:
-                return names
+            return _deploy_feature_names(raw)
+        names = _manifest_default_names(self._manifest)
+        if names:
+            return names
         # No deploy list and no usable defaults → every compiled-in feature
         # active (back-compat, mirroring the frontend's step-3 fallback for
-        # a source deploy with no built manifest). Skip non-dict entries,
-        # missing names, and empty names.
-        return {
-            name
-            for f in self._manifest.get("features", [])
-            if isinstance(f, dict)
-            and isinstance((name := f.get("name")), str)
-            and name
-        }
+        # a source deploy with no built manifest).
+        return _all_manifest_feature_names(self._manifest)
 
     def container_env(self) -> dict[str, str]:
         """Return env vars to inject into workspace containers.

--- a/src/klangk/klangk/files.py
+++ b/src/klangk/klangk/files.py
@@ -59,6 +59,86 @@ def validate_path(path: str) -> str:
     return normalized
 
 
+def classify_find_errors(
+    container_id: str, path: str, err: str, rc: int
+) -> None:
+    """Act on find's stderr diagnostics: start-point failures raise (or
+    list empty for ENOENT), child-entry failures only warn (the readable
+    entries survive), and a total lack of diagnostics surfaces as a
+    generic OSError."""
+    start_errors = []
+    child_errors = []
+    for line in err.splitlines():
+        if not line.strip():
+            continue
+        m = _FIND_ERROR_PATH_RE.match(line)
+        if m and m.group(1) == path:
+            start_errors.append(line)
+        else:
+            child_errors.append(line)
+    if child_errors:
+        logger.warning(
+            "list_files: skipped unreadable entries under %s in "
+            "container %s: %s",
+            path,
+            container_id,
+            " | ".join(child_errors),
+        )
+    if start_errors:
+        message = " ".join(" ".join(start_errors).split())
+        if "No such file or directory" in message:
+            # ENOENT lists as empty (a missing directory is not
+            # an error — matches stat_path/read_file).
+            return
+        logger.warning(
+            "list_files failed for %s in container %s: %s",
+            path,
+            container_id,
+            message,
+        )
+        if "Permission denied" in message:
+            # A permission-denied volume root rendered as a
+            # mysterious "Empty directory" (#2766) — surfaced,
+            # not swallowed.
+            raise PermissionError(message)
+        raise OSError(message)
+    if not child_errors:
+        # rc != 0 with no diagnostics at all: cannot classify —
+        # surface it rather than guess.
+        raise OSError(f"find exited with status {rc}")
+
+
+def _parse_find_line(line: str, path: str) -> dict | None:
+    """One ``find -printf`` line as an entry dict, or None for a
+    malformed/short line."""
+    parts = line.split("\t")
+    if len(parts) != 5:
+        return None
+    name, ftype, size_str, mtime_str, ctime_str = parts
+    is_dir = ftype == "d"
+    entry_path = path.rstrip("/") + "/" + name if path != "/" else "/" + name
+    try:
+        size = int(size_str) if not is_dir else None
+    except ValueError:
+        size = None
+    try:
+        mtime = float(mtime_str)
+    except ValueError:
+        mtime = 0.0
+    try:
+        ctime = float(ctime_str)
+    except ValueError:
+        ctime = 0.0
+    return {
+        "name": name,
+        "path": entry_path,
+        "is_dir": is_dir,
+        "size": size,
+        "mtime": mtime,
+        "ctime": ctime,
+    }
+
+
 class Files:
     """File operations inside workspace containers via ``podman exec``.
 
@@ -106,78 +186,15 @@ class Files:
             # prints the readable entries on stdout. Only a start-point
             # failure fails the listing; child failures degrade to a
             # logged warning plus the surviving entries (#2769 review).
-            start_errors = []
-            child_errors = []
-            for line in err.splitlines():
-                if not line.strip():
-                    continue
-                m = _FIND_ERROR_PATH_RE.match(line)
-                if m and m.group(1) == path:
-                    start_errors.append(line)
-                else:
-                    child_errors.append(line)
-            if child_errors:
-                logger.warning(
-                    "list_files: skipped unreadable entries under %s in "
-                    "container %s: %s",
-                    path,
-                    container_id,
-                    " | ".join(child_errors),
-                )
-            if start_errors:
-                message = " ".join(" ".join(start_errors).split())
-                if "No such file or directory" in message:
-                    # ENOENT lists as empty (a missing directory is not
-                    # an error — matches stat_path/read_file).
-                    return []
-                logger.warning(
-                    "list_files failed for %s in container %s: %s",
-                    path,
-                    container_id,
-                    message,
-                )
-                if "Permission denied" in message:
-                    # A permission-denied volume root rendered as a
-                    # mysterious "Empty directory" (#2766) — surfaced,
-                    # not swallowed.
-                    raise PermissionError(message)
-                raise OSError(message)
-            if not child_errors:
-                # rc != 0 with no diagnostics at all: cannot classify —
-                # surface it rather than guess.
-                raise OSError(f"find exited with status {rc}")
-        entries = []
-        for line in out.strip().splitlines():
-            parts = line.split("\t")
-            if len(parts) != 5:
-                continue
-            name, ftype, size_str, mtime_str, ctime_str = parts
-            is_dir = ftype == "d"
-            entry_path = (
-                path.rstrip("/") + "/" + name if path != "/" else "/" + name
+            classify_find_errors(container_id, path, err, rc)
+        entries = [
+            e
+            for e in (
+                _parse_find_line(line, path)
+                for line in out.strip().splitlines()
             )
-            try:
-                size = int(size_str) if not is_dir else None
-            except ValueError:
-                size = None
-            try:
-                mtime = float(mtime_str)
-            except ValueError:
-                mtime = 0.0
-            try:
-                ctime = float(ctime_str)
-            except ValueError:
-                ctime = 0.0
-            entries.append(
-                {
-                    "name": name,
-                    "path": entry_path,
-                    "is_dir": is_dir,
-                    "size": size,
-                    "mtime": mtime,
-                    "ctime": ctime,
-                }
-            )
+            if e is not None
+        ]
         entries.sort(key=lambda e: e["name"])
         return entries
 

--- a/src/klangk/klangk/fips.py
+++ b/src/klangk/klangk/fips.py
@@ -289,17 +289,29 @@ async def probe_container(podman, container_id: str) -> tuple[bool, str]:
     except Exception as e:  # podman-level failure — treat as no-python
         rc, out, err = -1, "", f"{type(e).__name__}: {e}"
     if rc == 0:
-        line = out.strip().splitlines()[-1] if out.strip() else ""
-        if line.startswith("ok:"):
-            return True, line[3:]
-        if line.startswith("fail:"):
-            return False, line[5:]
-        if line.startswith("unknown:"):
-            return False, line[8:]
-        return False, f"probe-output-unparseable: {line[:120]!r}"
+        return _parse_probe_output(out)
     # No usable python3 in the image — try the openssl CLI directly.
     if not _missing_binary(err):
         return False, f"probe-exec-failed rc={rc}: {err.strip()[:120]}"
+    return await _probe_via_openssl_cli(podman, container_id)
+
+
+def _parse_probe_output(out: str) -> tuple[bool, str]:
+    """The python probe script's last-line verdict (ok:/fail:/unknown:)."""
+    line = out.strip().splitlines()[-1] if out.strip() else ""
+    if line.startswith("ok:"):
+        return True, line[3:]
+    if line.startswith("fail:"):
+        return False, line[5:]
+    if line.startswith("unknown:"):
+        return False, line[8:]
+    return False, f"probe-output-unparseable: {line[:120]!r}"
+
+
+async def _probe_via_openssl_cli(
+    podman, container_id: str
+) -> tuple[bool, str]:
+    """The openssl-CLI fallback probe for images without python3."""
     try:
         rc, out, err = await podman.exec_container(
             container_id, _cli_probe_cmd(), timeout=30

--- a/src/klangk/klangk/hooks.py
+++ b/src/klangk/klangk/hooks.py
@@ -148,6 +148,20 @@ def _validate_hook_strings(app, changed: dict) -> str | None:
     return None
 
 
+def _hook_field_changes(handle, workspace: dict) -> dict:
+    """The mutable fields a hook actually changed: deleted-from-handle means
+    clear-the-column, a differing value means replace it."""
+    changed = {}
+    for field in _HOOK_MUTABLE_FIELDS:
+        if field not in handle:
+            # Deleted from the handle → clear the column.
+            if field in workspace:
+                changed[field] = None
+        elif handle[field] != workspace.get(field):
+            changed[field] = handle[field]
+    return changed
+
+
 def _validate_hook_lists(changed: dict) -> str | None:
     """Settings bag and domain lists: parsed/normalized in place."""
     if "settings" in changed and changed["settings"] is not None:
@@ -166,19 +180,25 @@ def _validate_hook_lists(changed: dict) -> str | None:
         "rejected_domains" in changed
         and changed["rejected_domains"] is not None
     ):
-        for spec in changed["rejected_domains"]:
-            if spec.strip() and "/" in spec:
-                return (
-                    "invalid rejected_domains: no CIDR specs (a rejected"
-                    f" name is NXDOMAIN'd before resolution): {spec!r}"
-                )
-        try:
-            changed["rejected_domains"] = parse_allowed_domains(
-                changed["rejected_domains"], label="rejected_domains"
-            )
-        except ValueError as exc:
-            return f"invalid rejected_domains: {exc}"
+        return _validate_hook_rejected_domains(changed)
     return None
+
+
+def _validate_hook_rejected_domains(changed: dict) -> str | None:
+    """The rejected-domains list: no CIDR specs (a rejected name is
+    NXDOMAIN'd before resolution), then parsed/normalized in place."""
+    for spec in changed["rejected_domains"]:
+        if spec.strip() and "/" in spec:
+            return (
+                "invalid rejected_domains: no CIDR specs (a rejected"
+                f" name is NXDOMAIN'd before resolution): {spec!r}"
+            )
+    try:
+        changed["rejected_domains"] = parse_allowed_domains(
+            changed["rejected_domains"], label="rejected_domains"
+        )
+    except ValueError as exc:
+        return f"invalid rejected_domains: {exc}"
 
 
 def _validate_hook_changes(app, changed: dict) -> str | None:
@@ -424,14 +444,7 @@ class Hooks:
                 exc_info=True,
             )
             return workspace
-        changed = {}
-        for field in _HOOK_MUTABLE_FIELDS:
-            if field not in handle:
-                # Deleted from the handle → clear the column.
-                if field in workspace:
-                    changed[field] = None
-            elif handle[field] != workspace.get(field):
-                changed[field] = handle[field]
+        changed = _hook_field_changes(handle, workspace)
         if not changed:
             return workspace
         invalid = _validate_hook_changes(self.app, changed)

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -285,56 +285,7 @@ class Lifecycle:
         # (the same default oidc.auth_modes() applies).
         auth_modes = settings.auth_modes or "none"
 
-        if auth_modes in ("password", "both"):
-            # Password mode: require a staged password. Fail-fast if unset —
-            # auto-generation was removed to prevent lockout on detached
-            # deployments (#1645).
-            password = settings.default_password
-            if password is None:
-                raise ConfigurationError(
-                    f"auth_modes={auth_modes} requires KLANGKD_DEFAULT_PASSWORD "
-                    "(set it in klangkd.yaml or the env). Refusing to boot "
-                    "without a known admin password."
-                )
-            # The default admin password must satisfy the same policy every
-            # other password setter enforces (#2581). Fail fast at startup —
-            # seeding a non-compliant password and letting it fail at first
-            # change would strand deployments whose policy was tightened
-            # after the seed ran.
-            _policy_errors = []
-            min_len = int(settings.min_password_length or "8")
-            if len(password) < min_len:
-                _policy_errors.append(
-                    f"is shorter than KLANGKD_MIN_PASSWORD_LENGTH={min_len}"
-                )
-            _counts = password_class_counts(password)
-            for _key, _name in _PASSWORD_CLASSES:
-                _need = getattr(settings, f"password_require_{_key}")
-                if _need > 0 and _counts[_key] < _need:
-                    _policy_errors.append(
-                        f"lacks the {_need} required {_name}"
-                        f"{'s' if _need != 1 else ''} "
-                        f"(KLANGKD_PASSWORD_REQUIRE_{_key.upper()}={_need})"
-                    )
-            if _policy_errors:
-                raise ConfigurationError(
-                    "KLANGKD_DEFAULT_PASSWORD violates the configured "
-                    f"password policy: it {_policy_errors[0]}"
-                    + (
-                        f" (and {len(_policy_errors) - 1} more issue(s))"
-                        if len(_policy_errors) > 1
-                        else ""
-                    )
-                    + ". Fix the password or loosen the policy; refusing to "
-                    "boot with a seeded admin that already violates it."
-                )
-            password_hash = await asyncio.to_thread(
-                auth.hash_password, password
-            )
-        else:
-            # none / oidc: seed with null password. The row exists for
-            # /auth/local token minting; no endpoint checks the hash.
-            password_hash = None
+        password_hash = await self._default_admin_password_hash(auth_modes)
 
         user = await self.app.state.model.users.create_user(
             email, password_hash, verified=True
@@ -351,6 +302,62 @@ class Lifecycle:
                 "Created default admin user '%s' (no password — auth_modes=%s)",
                 email,
                 auth_modes,
+            )
+
+    async def _default_admin_password_hash(self, auth_modes: str):
+        """The default admin's password hash for the mode: hashed
+        KLANGKD_DEFAULT_PASSWORD (validated against the policy, #2581,
+        fail-fast) for password/both; None for none/oidc (the row exists for
+        /auth/local token minting; no endpoint checks the hash)."""
+        settings = self.app.state.settings
+        if auth_modes not in ("password", "both"):
+            return None
+        # Password mode: require a staged password. Fail-fast if unset —
+        # auto-generation was removed to prevent lockout on detached
+        # deployments (#1645).
+        password = settings.default_password
+        if password is None:
+            raise ConfigurationError(
+                f"auth_modes={auth_modes} requires KLANGKD_DEFAULT_PASSWORD "
+                "(set it in klangkd.yaml or the env). Refusing to boot "
+                "without a known admin password."
+            )
+        self._validate_default_password_policy(settings, password)
+        return await asyncio.to_thread(auth.hash_password, password)
+
+    @staticmethod
+    def _validate_default_password_policy(settings, password: str) -> None:
+        """The default admin password must satisfy the same policy every
+        other password setter enforces (#2581). Fail fast at startup —
+        seeding a non-compliant password and letting it fail at first
+        change would strand deployments whose policy was tightened
+        after the seed ran."""
+        _policy_errors = []
+        min_len = int(settings.min_password_length or "8")
+        if len(password) < min_len:
+            _policy_errors.append(
+                f"is shorter than KLANGKD_MIN_PASSWORD_LENGTH={min_len}"
+            )
+        _counts = password_class_counts(password)
+        for _key, _name in _PASSWORD_CLASSES:
+            _need = getattr(settings, f"password_require_{_key}")
+            if _need > 0 and _counts[_key] < _need:
+                _policy_errors.append(
+                    f"lacks the {_need} required {_name}"
+                    f"{'s' if _need != 1 else ''} "
+                    f"(KLANGKD_PASSWORD_REQUIRE_{_key.upper()}={_need})"
+                )
+        if _policy_errors:
+            raise ConfigurationError(
+                "KLANGKD_DEFAULT_PASSWORD violates the configured "
+                f"password policy: it {_policy_errors[0]}"
+                + (
+                    f" (and {len(_policy_errors) - 1} more issue(s))"
+                    if len(_policy_errors) > 1
+                    else ""
+                )
+                + ". Fix the password or loosen the policy; refusing to "
+                "boot with a seeded admin that already violates it."
             )
 
     async def _enforce_password_mode_has_hashed_admin(

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -646,15 +646,7 @@ def main(  # pragma: no cover
     # ERROR per retry. A different winner PID is reported fresh.
     existing = check_pid_preflight(settings)
     if existing is not None:
-        marker = refusal_marker_path(settings)
-        if marker is None or not refusal_already_reported(marker, existing):
-            logger.error(
-                "Another klangk instance (PID %d) is already running — "
-                "refusing to start",
-                existing,
-            )
-            if marker is not None:
-                mark_refusal_reported(marker, existing)
+        _report_pid_collision(settings, existing)
         sys.exit(1)
 
     # Port-probe check: catch cross-deploy collisions the PID-file
@@ -665,25 +657,7 @@ def main(  # pragma: no cover
     # through Caddy — probe those before starting. The proxy hasn't
     # started yet, so a live listener on our configured port means
     # another klangkd (or its proxy) already owns it.
-    for port_str, label in (
-        (settings.port, "browser"),
-        (settings.egress_port, "egress"),
-    ):
-        if port_str is None:
-            continue
-        port_int = int(port_str)
-        listen_host = (
-            settings.listen if label == "browser" else settings.egress_listen
-        )
-        if check_port_preflight(listen_host, port_int):
-            logger.error(
-                "Another process is already listening on %s:%d (%s port) "
-                "— refusing to start. Is another klangkd running?",
-                listen_host,
-                port_int,
-                label,
-            )
-            sys.exit(1)
+    _check_port_collisions(settings)
 
     # Bind the UDS. A stale socket from a kill -9'd process makes the
     # bind fail with EADDRINUSE — unlink first (the pidfile guard in the
@@ -885,6 +859,52 @@ from .api._common import get_app_dep  # noqa: F401, E402
 # passed to uvicorn. The E2E suites launch real ``klangkd``
 # (``python -m klangk.main``) and contact it over its UDS — no
 # ``module:app`` string import anywhere (#1525).
+
+
+def _report_pid_collision(settings, existing: int) -> None:  # pragma: no cover
+    """Report the losing PID-collision refusal, de-duplicated against the
+    live winner PID (#2021): a supervisor's restart loop logs the refusal
+    once (first collision) and then stays quiet for retries against the
+    same winner, instead of spamming one ERROR per retry. A different
+    winner PID is reported fresh."""
+    marker = refusal_marker_path(settings)
+    if marker is None or not refusal_already_reported(marker, existing):
+        logger.error(
+            "Another klangk instance (PID %d) is already running — "
+            "refusing to start",
+            existing,
+        )
+        if marker is not None:
+            mark_refusal_reported(marker, existing)
+
+
+def _check_port_collisions(settings) -> None:  # pragma: no cover
+    """Port-probe check: catch cross-deploy collisions the PID-file guard
+    misses (#2211). Two klangkd instances from different checkouts
+    (different $DEVENV_STATE → different state_dir → separate instance-id /
+    PID files) never see each other's PID file. But they share the same TCP
+    ports (browser + egress) through Caddy — probe those before starting.
+    The proxy hasn't started yet, so a live listener on our configured port
+    means another klangkd (or its proxy) already owns it."""
+    for port_str, label in (
+        (settings.port, "browser"),
+        (settings.egress_port, "egress"),
+    ):
+        if port_str is None:
+            continue
+        port_int = int(port_str)
+        listen_host = (
+            settings.listen if label == "browser" else settings.egress_listen
+        )
+        if check_port_preflight(listen_host, port_int):
+            logger.error(
+                "Another process is already listening on %s:%d (%s port) "
+                "— refusing to start. Is another klangkd running?",
+                listen_host,
+                port_int,
+                label,
+            )
+            sys.exit(1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -646,62 +646,78 @@ class EgressConsentModel:
         deleted = 0
 
         if retention_days > 0:
-            cutoff = now - retention_days * 86400.0
+            deleted += await self._prune_retention(
+                now - retention_days * 86400.0, now
+            )
+        if row_cap > 0:
+            deleted += await self._prune_row_cap(row_cap, now)
+        return deleted
+
+    async def _prune_retention(self, cutoff: float, now: float) -> int:
+        """Delete rows whose terminal timestamp predates *cutoff*.
+
+        TOCTOU guard: the snapshot and the deletes run in separate
+        transactions, so a row snapshotted as pending may have been
+        decided in between -- deleting it would silently drop a fresh
+        verdict. Pending candidates are therefore re-checked against
+        their decision at DELETE time. Non-pending candidates need no
+        re-check: their eligibility is monotonic (allowed/denied can
+        only transition to revoked, still eligible; expired/revoked/
+        static rows never change decision).
+        """
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, decision, duration, decided_at, decided_by"
+            " FROM egress_consent"
+            " WHERE COALESCE(revoked_at, decided_at, requested_at) < ?",
+            (cutoff,),
+        )
+        pending_ids = [
+            r["id"]
+            for r in rows
+            if r["decision"] == DECISION_PENDING
+            and self._prune_eligible(r, now)
+        ]
+        other_ids = [
+            r["id"]
+            for r in rows
+            if r["decision"] != DECISION_PENDING
+            and self._prune_eligible(r, now)
+        ]
+        deleted = await self._delete_ids(
+            pending_ids, require_decision=DECISION_PENDING
+        )
+        deleted += await self._delete_ids(other_ids)
+        return deleted
+
+    async def _prune_row_cap(self, row_cap: int, now: float) -> int:
+        """Per workspace over the cap, delete the oldest eligible rows down
+        to it (belt-and-suspenders against a flood of decided requests
+        outpacing age-based pruning; live ``pending`` rows are never deleted
+        by this pass)."""
+        over = await self.app.state.db.fetchall(
+            "SELECT workspace_id, COUNT(*) AS cnt"
+            " FROM egress_consent GROUP BY workspace_id HAVING cnt > ?",
+            (row_cap,),
+        )
+        deleted = 0
+        for entry in over:
+            excess = entry["cnt"] - row_cap
             rows = await self.app.state.db.fetchall(
                 "SELECT id, decision, duration, decided_at, decided_by"
                 " FROM egress_consent"
-                " WHERE COALESCE(revoked_at, decided_at, requested_at) < ?",
-                (cutoff,),
+                " WHERE workspace_id = ? AND decision != ?"
+                " ORDER BY COALESCE(revoked_at, decided_at,"
+                " requested_at) ASC",
+                (entry["workspace_id"], DECISION_PENDING),
             )
-            # TOCTOU guard: the snapshot and the deletes run in separate
-            # transactions, so a row snapshotted as pending may have been
-            # decided in between -- deleting it would silently drop a fresh
-            # verdict. Pending candidates are therefore re-checked against
-            # their decision at DELETE time. Non-pending candidates need no
-            # re-check: their eligibility is monotonic (allowed/denied can
-            # only transition to revoked, still eligible; expired/revoked/
-            # static rows never change decision).
-            pending_ids = [
-                r["id"]
-                for r in rows
-                if r["decision"] == DECISION_PENDING
-                and self._prune_eligible(r, now)
-            ]
-            other_ids = [
-                r["id"]
-                for r in rows
-                if r["decision"] != DECISION_PENDING
-                and self._prune_eligible(r, now)
-            ]
-            deleted += await self._delete_ids(
-                pending_ids, require_decision=DECISION_PENDING
-            )
-            deleted += await self._delete_ids(other_ids)
-
-        if row_cap > 0:
-            over = await self.app.state.db.fetchall(
-                "SELECT workspace_id, COUNT(*) AS cnt"
-                " FROM egress_consent GROUP BY workspace_id HAVING cnt > ?",
-                (row_cap,),
-            )
-            for entry in over:
-                excess = entry["cnt"] - row_cap
-                rows = await self.app.state.db.fetchall(
-                    "SELECT id, decision, duration, decided_at, decided_by"
-                    " FROM egress_consent"
-                    " WHERE workspace_id = ? AND decision != ?"
-                    " ORDER BY COALESCE(revoked_at, decided_at,"
-                    " requested_at) ASC",
-                    (entry["workspace_id"], DECISION_PENDING),
-                )
-                ids = []
-                for r in rows:
-                    if excess <= 0:
-                        break
-                    if self._prune_eligible(r, now):
-                        ids.append(r["id"])
-                        excess -= 1
-                deleted += await self._delete_ids(ids)
+            ids = []
+            for r in rows:
+                if excess <= 0:
+                    break
+                if self._prune_eligible(r, now):
+                    ids.append(r["id"])
+                    excess -= 1
+            deleted += await self._delete_ids(ids)
         return deleted
 
     async def _delete_ids(

--- a/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
+++ b/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
@@ -41,6 +41,21 @@ from klangk.model.migrations.base import Migration
 _RESOURCE = "/groups"
 
 
+def _is_seeded_shape(rows) -> bool:
+    """Whether the /groups ACL still holds exactly the single
+    system-authenticated create entry the seed wrote."""
+    return bool(
+        len(rows) == 1
+        and rows[0][0] == 0  # position
+        and rows[0][1] == ACTION_ALLOW
+        and rows[0][2] == PRINCIPAL_SYSTEM
+        and rows[0][3] is None  # user_id
+        and rows[0][4] is None  # group_id
+        and rows[0][5] == SYSTEM_AUTHENTICATED
+        and rows[0][6] == "create"
+    )
+
+
 async def apply(db) -> None:
     cursor = await db.execute(
         "SELECT position, action, principal_type, user_id, group_id,"
@@ -51,17 +66,7 @@ async def apply(db) -> None:
     rows = await cursor.fetchall()
     if not rows:
         return  # nothing seeded on /groups — fresh/pre-seed deployment
-    seeded_shape = (
-        len(rows) == 1
-        and rows[0][0] == 0  # position
-        and rows[0][1] == ACTION_ALLOW
-        and rows[0][2] == PRINCIPAL_SYSTEM
-        and rows[0][3] is None  # user_id
-        and rows[0][4] is None  # group_id
-        and rows[0][5] == SYSTEM_AUTHENTICATED
-        and rows[0][6] == "create"
-    )
-    if not seeded_shape:
+    if not _is_seeded_shape(rows):
         return  # operator-customized — leave for the manual step
     await db.execute(
         "DELETE FROM acl_entries WHERE resource = ?", (_RESOURCE,)

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -186,6 +186,13 @@ async def init_workspaces_table(db) -> None:
     # Migration: add auto_start column to existing workspaces tables
     cursor = await db.execute("PRAGMA table_info(workspaces)")
     ws_cols = {row[1] for row in await cursor.fetchall()}
+    await migrate_workspaces_columns(db, ws_cols)
+
+
+async def migrate_workspaces_columns(db, ws_cols: set) -> None:
+    """Every workspaces-table column migration for databases created
+    before the column shipped (ADD COLUMN, plus the legacy rename)."""
+
     # Migration: rename default_command -> service_command (#1203).
     # The on-disk column is renamed in place (SQLite >= 3.25 supports
     # ALTER TABLE ... RENAME COLUMN). Fresh installs already create the
@@ -196,68 +203,73 @@ async def init_workspaces_table(db) -> None:
             "ALTER TABLE workspaces"
             " RENAME COLUMN default_command TO service_command"
         )
-    if "auto_start" not in ws_cols:
-        await db.execute(
+    adds = [
+        # Migration: add auto_start column to existing workspaces tables
+        (
+            "auto_start",
             "ALTER TABLE workspaces"
-            " ADD COLUMN auto_start INTEGER NOT NULL DEFAULT 0"
-        )
-    # Migration: add setup_state column (#1033). Defaults to
-    # 'complete' so existing workspaces (already set up in their
-    # persisted volumes) keep firing their service command.
-    if "setup_state" not in ws_cols:
-        await db.execute(
+            " ADD COLUMN auto_start INTEGER NOT NULL DEFAULT 0",
+        ),
+        # Migration: add setup_state column (#1033). Defaults to
+        # 'complete' so existing workspaces (already set up in their
+        # persisted volumes) keep firing their service command.
+        (
+            "setup_state",
             "ALTER TABLE workspaces"
-            " ADD COLUMN setup_state TEXT NOT NULL DEFAULT 'complete'"
-        )
-    # Migration: add health_check column (#1015). NULL by default
-    # so existing workspaces keep the no-health-monitoring behavior.
-    if "health_check" not in ws_cols:
-        await db.execute("ALTER TABLE workspaces ADD COLUMN health_check TEXT")
-    # Migration: add mounts/env columns (#1264). These are in the
-    # CREATE TABLE above but had no ADD COLUMN migration, so DBs
-    # created before they shipped lacked them and errored on any
-    # read/write of mounts/env. NULL by default (no mounts/overrides).
-    if "mounts" not in ws_cols:
-        await db.execute("ALTER TABLE workspaces ADD COLUMN mounts TEXT")
-    if "env" not in ws_cols:
-        await db.execute("ALTER TABLE workspaces ADD COLUMN env TEXT")
-    # Migration: add allowed_domains column (#1365). NULL by default
-    # so existing workspaces keep unrestricted outbound networking;
-    # the filter is opt-in per workspace AND per deploy.
-    if "allowed_domains" not in ws_cols:
-        await db.execute(
-            "ALTER TABLE workspaces ADD COLUMN allowed_domains TEXT"
-        )
-    # Migration: add rejected_domains column (#2367). NULL by default
-    # so existing workspaces keep no static deny-list; the operator opts
-    # in per workspace.
-    if "rejected_domains" not in ws_cols:
-        await db.execute(
-            "ALTER TABLE workspaces ADD COLUMN rejected_domains TEXT"
-        )
-    # Migration: add settings column (#864). NULL by default so
-    # existing workspaces keep inheriting every deploy-wide default
-    # (no per-workspace overrides). One JSON bag holds every
-    # behavioral override (idle_timeout, bridge_timeout, cpu_limit,
-    # memory_limit, pids_limit, ...) so future settings need no new
-    # column/migration. Structural fields stay as dedicated columns.
-    if "settings" not in ws_cols:
-        await db.execute("ALTER TABLE workspaces ADD COLUMN settings TEXT")
-    # Migration: add egress_mode column (#2239). 'static' = immutable
-    # allow-list at create time (today's behavior); 'interactive' =
-    # prompt on first connection to unknown host.
-    if "egress_mode" not in ws_cols:
-        await db.execute(
+            " ADD COLUMN setup_state TEXT NOT NULL DEFAULT 'complete'",
+        ),
+        # Migration: add health_check column (#1015). NULL by default
+        # so existing workspaces keep the no-health-monitoring behavior.
+        (
+            "health_check",
+            "ALTER TABLE workspaces ADD COLUMN health_check TEXT",
+        ),
+        # Migration: add mounts/env columns (#1264). These are in the
+        # CREATE TABLE above but had no ADD COLUMN migration, so DBs
+        # created before they shipped lacked them and errored on any
+        # read/write of mounts/env. NULL by default (no mounts/overrides).
+        ("mounts", "ALTER TABLE workspaces ADD COLUMN mounts TEXT"),
+        ("env", "ALTER TABLE workspaces ADD COLUMN env TEXT"),
+        # Migration: add allowed_domains column (#1365). NULL by default
+        # so existing workspaces keep unrestricted outbound networking;
+        # the filter is opt-in per workspace AND per deploy.
+        (
+            "allowed_domains",
+            "ALTER TABLE workspaces ADD COLUMN allowed_domains TEXT",
+        ),
+        # Migration: add rejected_domains column (#2367). NULL by default
+        # so existing workspaces keep no static deny-list; the operator opts
+        # in per workspace.
+        (
+            "rejected_domains",
+            "ALTER TABLE workspaces ADD COLUMN rejected_domains TEXT",
+        ),
+        # Migration: add settings column (#864). NULL by default so
+        # existing workspaces keep inheriting every deploy-wide default
+        # (no per-workspace overrides). One JSON bag holds every
+        # behavioral override (idle_timeout, bridge_timeout, cpu_limit,
+        # memory_limit, pids_limit, ...) so future settings need no new
+        # column/migration. Structural fields stay as dedicated columns.
+        ("settings", "ALTER TABLE workspaces ADD COLUMN settings TEXT"),
+        # Migration: add egress_mode column (#2239). 'static' = immutable
+        # allow-list at create time (today's behavior); 'interactive' =
+        # prompt on first connection to unknown host.
+        (
+            "egress_mode",
             "ALTER TABLE workspaces"
-            " ADD COLUMN egress_mode TEXT NOT NULL DEFAULT 'static'"
-        )
-    # Migration: add consent_paused_until column (#2332). NULL by default
-    # so existing workspaces keep prompting normally; the pause is opt-in
-    # via the decider TUI control.
-    if "consent_paused_until" not in ws_cols:
-        await db.execute(
-            "ALTER TABLE workspaces ADD COLUMN consent_paused_until REAL"
-        )
+            " ADD COLUMN egress_mode TEXT NOT NULL DEFAULT 'static'",
+        ),
+        # Migration: add consent_paused_until column (#2332). NULL by default
+        # so existing workspaces keep prompting normally; the pause is opt-in
+        # via the decider TUI control.
+        (
+            "consent_paused_until",
+            "ALTER TABLE workspaces ADD COLUMN consent_paused_until REAL",
+        ),
+    ]
+    for column, ddl in adds:
+        if column not in ws_cols:
+            await db.execute(ddl)
 
 
 async def init_core_tables(db) -> None:

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -234,6 +234,21 @@ def parse_user_ts(value: str | None) -> datetime | None:
     return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 
+def _user_is_inactive(row, cutoff) -> bool:
+    """Whether a user's newest of last_activity/last_login/created (a
+    never-used account ages from creation) predates *cutoff*."""
+    stamps = [
+        ts
+        for ts in (
+            parse_user_ts(row["last_activity_at"]),
+            parse_user_ts(row["last_login_at"]),
+            parse_user_ts(row["created_at"]),
+        )
+        if ts is not None
+    ]
+    return bool(stamps) and max(stamps) < cutoff
+
+
 class UsersModel:
     """User/group/handle operations, resolved through ``app_state.db``.
 
@@ -983,16 +998,7 @@ class UsersModel:
             for row in await cursor.fetchall():
                 if row["id"] == AGENT_USER_ID or row["id"] in admin_ids:
                     continue
-                stamps = [
-                    ts
-                    for ts in (
-                        parse_user_ts(row["last_activity_at"]),
-                        parse_user_ts(row["last_login_at"]),
-                        parse_user_ts(row["created_at"]),
-                    )
-                    if ts is not None
-                ]
-                if not stamps or max(stamps) >= cutoff:
+                if not _user_is_inactive(row, cutoff):
                     continue
                 await db.execute(
                     "UPDATE users SET disabled = 1 WHERE id = ?",

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -63,21 +63,34 @@ def _valid_domain_spec(spec: str) -> bool:
     # leading ``.`` is INCLUSIVE (apex + subdomains); ``*.`` is SUBDOMAINS only.
     # Strip the sigil and validate the remaining ``host[:port]`` grammar; a bare
     # ``*``, ``*.``, or ``.`` has no matchable base (#2256).
-    if spec.startswith("*."):
-        spec = spec[2:]
-        if not spec:
-            return False
-    elif spec.startswith("."):
-        spec = spec[1:]
-        if not spec:
-            return False
+    spec = _strip_host_sigil(spec)
+    if not spec:
+        return False
     if not _DOMAIN_RE.match(spec):
         return False
-    # The regex accepts up to 5 digits; additionally reject ports > 65535.
-    if ":" in spec:
-        port_str = spec.rsplit(":", 1)[1]
-        if port_str and port_str.isdigit() and int(port_str) > 65535:
-            return False
+    return _valid_spec_port(spec)
+
+
+def _strip_host_sigil(spec: str) -> str:
+    """Strip an nginx-style host-scope sigil (#2377): a bare host is EXACT
+    (apex only); a leading ``.`` is INCLUSIVE (apex + subdomains); ``*.`` is
+    SUBDOMAINS only. A bare ``*``, ``*.``, or ``.`` has no matchable base
+    (#2256) and strips to the empty string."""
+    if spec.startswith("*."):
+        return spec[2:]
+    if spec.startswith("."):
+        return spec[1:]
+    return spec
+
+
+def _valid_spec_port(spec: str) -> bool:
+    """The regex accepts up to 5 digits; additionally reject ports
+    > 65535."""
+    if ":" not in spec:
+        return True
+    port_str = spec.rsplit(":", 1)[1]
+    if port_str and port_str.isdigit() and int(port_str) > 65535:
+        return False
     return True
 
 

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -97,6 +97,62 @@ class Podman:
         """The resolved podman binary path (for ``ExecSession`` etc.)."""
         return self._bin
 
+    @staticmethod
+    async def _wait_podman(
+        proc, timeout: float | None, cmd_label: str
+    ) -> bool:
+        """Wait for a podman process, killing it on timeout; returns whether
+        it timed out."""
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=timeout)
+            return False
+        except asyncio.TimeoutError:
+            logger.warning(
+                "podman-timeout: %s exceeded %.1fs — killing",
+                cmd_label,
+                timeout,
+            )
+            proc.kill()
+            await proc.wait()
+            return True
+
+    @staticmethod
+    def _finish_podman_run(
+        proc,
+        timed_out: bool,
+        err: str,
+        cmd_label: str,
+        timeout: float | None,
+        args: list[str],
+        check: bool,
+        timings: tuple[float, float, float, float],
+    ) -> tuple[int, str]:
+        """Apply the timeout override, log timings, and enforce *check*."""
+        rc = proc.returncode or 0
+        if timed_out:
+            rc = -1
+            err = err or f"{cmd_label} timed out after {timeout}s"
+        t0, t1, t2, t3 = timings
+        elapsed = t3 - t0
+        logger.debug(
+            "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs"
+            " total=%.3fs",
+            cmd_label,
+            t1 - t0,
+            t2 - t1,
+            t3 - t2,
+            elapsed,
+        )
+        if elapsed > 2.0 and err.strip():  # pragma: no cover
+            logger.debug(
+                "podman-timing: %s stderr: %s", cmd_label, err.strip()
+            )
+        if check and rc != 0:
+            raise PodmanError(
+                classify(err), err.strip() or f"podman {args[0]}"
+            )
+        return rc, err
+
     async def run(
         self,
         args: list[str],
@@ -138,45 +194,22 @@ class Podman:
                 proc.stdin.write(stdin_data)
                 await proc.stdin.drain()
                 proc.stdin.close()
-            timed_out = False
-            try:
-                await asyncio.wait_for(proc.wait(), timeout=timeout)
-            except asyncio.TimeoutError:
-                timed_out = True
-                logger.warning(
-                    "podman-timeout: %s exceeded %.1fs — killing",
-                    cmd_label,
-                    timeout,
-                )
-                proc.kill()
-                await proc.wait()
+            timed_out = await self._wait_podman(proc, timeout, cmd_label)
             t3 = time.monotonic()
             out_f.seek(0)
             err_f.seek(0)
             out = out_f.read().decode("utf-8", errors="replace")
             err = err_f.read().decode("utf-8", errors="replace")
-        rc = proc.returncode or 0
-        if timed_out:
-            rc = -1
-            err = err or f"{cmd_label} timed out after {timeout}s"
-        elapsed = t3 - t0
-        logger.debug(
-            "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs"
-            " total=%.3fs",
+        rc, err = self._finish_podman_run(
+            proc,
+            timed_out,
+            err,
             cmd_label,
-            t1 - t0,
-            t2 - t1,
-            t3 - t2,
-            elapsed,
+            timeout,
+            args,
+            check,
+            (t0, t1, t2, t3),
         )
-        if elapsed > 2.0 and err.strip():  # pragma: no cover
-            logger.debug(
-                "podman-timing: %s stderr: %s", cmd_label, err.strip()
-            )
-        if check and rc != 0:
-            raise PodmanError(
-                classify(err), err.strip() or f"podman {args[0]}"
-            )
         return rc, out, err
 
     async def run_raw(
@@ -210,45 +243,22 @@ class Podman:
                 proc.stdin.write(stdin_data)
                 await proc.stdin.drain()
                 proc.stdin.close()
-            timed_out = False
-            try:
-                await asyncio.wait_for(proc.wait(), timeout=timeout)
-            except asyncio.TimeoutError:
-                timed_out = True
-                logger.warning(
-                    "podman-timeout: %s exceeded %.1fs — killing",
-                    cmd_label,
-                    timeout,
-                )
-                proc.kill()
-                await proc.wait()
+            timed_out = await self._wait_podman(proc, timeout, cmd_label)
             t3 = time.monotonic()
             out_f.seek(0)
             err_f.seek(0)
             out_bytes = out_f.read()
             err = err_f.read().decode("utf-8", errors="replace")
-        rc = proc.returncode or 0
-        if timed_out:
-            rc = -1
-            err = err or f"{cmd_label} timed out after {timeout}s"
-        elapsed = t3 - t0
-        logger.debug(
-            "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs"
-            " total=%.3fs",
+        rc, err = self._finish_podman_run(
+            proc,
+            timed_out,
+            err,
             cmd_label,
-            t1 - t0,
-            t2 - t1,
-            t3 - t2,
-            elapsed,
+            timeout,
+            args,
+            check,
+            (t0, t1, t2, t3),
         )
-        if elapsed > 2.0 and err.strip():  # pragma: no cover
-            logger.debug(
-                "podman-timing: %s stderr: %s", cmd_label, err.strip()
-            )
-        if check and rc != 0:
-            raise PodmanError(
-                classify(err), err.strip() or f"podman {args[0]}"
-            )
         return rc, out_bytes, err
 
     # --- Containers ---

--- a/src/klangk/klangk/seed.py
+++ b/src/klangk/klangk/seed.py
@@ -151,6 +151,20 @@ async def _build_image(
         await _run(podman_bin, args, timeout=2400.0)
 
 
+def _extract_seed_members(tar, out: str) -> None:
+    """Extract only ``nix`` + ``etc/nix/nix.conf`` members (every member is
+    a whitelisted relative path; ``filter="fully_trusted"`` preserves the
+    seed's uid-1000 ownership — the workspace klangk user)."""
+    for member in tar:
+        name = member.name[2:] if member.name.startswith("./") else member.name
+        if (
+            name == "nix"
+            or name.startswith("nix/")
+            or name == "etc/nix/nix.conf"
+        ):
+            tar.extract(member, out, filter="fully_trusted")
+
+
 def _export_to_dir_sync(podman_bin: str, cid: str, out: str) -> None:
     """Stream ``podman export <cid>`` into :mod:`tarfile`, extracting only
     ``nix`` + ``etc/nix/nix.conf`` into *out*.
@@ -171,18 +185,7 @@ def _export_to_dir_sync(podman_bin: str, cid: str, out: str) -> None:
     extracted = False
     try:
         with tarfile.open(fileobj=proc.stdout, mode="r|") as tar:
-            for member in tar:
-                name = (
-                    member.name[2:]
-                    if member.name.startswith("./")
-                    else member.name
-                )
-                if (
-                    name == "nix"
-                    or name.startswith("nix/")
-                    or name == "etc/nix/nix.conf"
-                ):
-                    tar.extract(member, out, filter="fully_trusted")
+            _extract_seed_members(tar, out)
             extracted = True
     except tarfile.TarError:
         # Empty / truncated stream — checked against proc.returncode below.

--- a/src/klangk/klangk/ssl_trust.py
+++ b/src/klangk/klangk/ssl_trust.py
@@ -91,21 +91,31 @@ def system_ca_bundle(self_bundle: str | None = None) -> str | None:
     back to ``certifi`` (an httpx dependency).
     """
     dvp = ssl.get_default_verify_paths()
+    self_real = os.path.realpath(self_bundle) if self_bundle else None
+    cand = _first_existing_ca(_openssl_ca_candidates(dvp), self_real)
+    if cand is not None:
+        return cand
+    return _first_existing_ca([certifi.where()], self_real)
+
+
+def _openssl_ca_candidates(dvp) -> list[str]:
+    """The compiled-in OpenSSL default CA file (preferred — not influenced
+    by ``SSL_CERT_FILE``) and the env-derived one, de-duplicated."""
     candidates: list[str] = []
     if dvp.openssl_cafile:
         candidates.append(dvp.openssl_cafile)
     if dvp.cafile and dvp.cafile != dvp.openssl_cafile:
         candidates.append(dvp.cafile)
-    self_real = os.path.realpath(self_bundle) if self_bundle else None
+    return candidates
+
+
+def _first_existing_ca(candidates: list[str], self_real) -> str | None:
+    """The first candidate that exists and is not the bundle being built."""
     for cand in candidates:
         if self_real and os.path.realpath(cand) == self_real:
             continue
         if os.path.isfile(cand):
             return cand
-    where = certifi.where()
-    if where and (not self_real or os.path.realpath(where) != self_real):
-        if os.path.isfile(where):
-            return where
     return None
 
 

--- a/src/klangk/klangk/window_watcher.py
+++ b/src/klangk/klangk/window_watcher.py
@@ -40,6 +40,24 @@ def is_window_event(line: str) -> bool:
     return line.startswith(_WINDOW_EVENT_PREFIXES)
 
 
+async def _terminate_watcher_proc(proc) -> None:  # pragma: no cover
+    """Terminate the watcher subprocess: TERM, a 3s grace, then KILL
+    (both racing a process that is already gone)."""
+    if proc.returncode is not None:
+        return
+    try:
+        proc.terminate()
+    except ProcessLookupError:
+        pass
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=3)
+    except (asyncio.TimeoutError, ProcessLookupError):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+
 class WindowEventWatcher:
     """A long-lived ``tmux -C`` control client for one container.
 
@@ -107,23 +125,17 @@ class WindowEventWatcher:
         self._task = None
         proc = self._proc
         self._proc = None
-        if proc is not None and proc.returncode is None:
-            try:
-                proc.terminate()
-            except ProcessLookupError:
-                pass
-            try:
-                await asyncio.wait_for(proc.wait(), timeout=3)
-            except (asyncio.TimeoutError, ProcessLookupError):
-                try:
-                    proc.kill()
-                except ProcessLookupError:
-                    pass
         if proc is not None:
-            try:
-                await self._podman.exec_container(
-                    self._container_id,
-                    ["tmux", "kill-session", "-t", self._ctrl_session],
-                )
-            except Exception:  # pragma: no cover
-                pass
+            await _terminate_watcher_proc(proc)
+            await self._kill_ctrl_session()
+
+    async def _kill_ctrl_session(
+        self,
+    ) -> None:  # pragma: no cover - subprocess
+        try:
+            await self._podman.exec_container(
+                self._container_id,
+                ["tmux", "kill-session", "-t", self._ctrl_session],
+            )
+        except Exception:  # pragma: no cover
+            pass

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -118,6 +118,14 @@ async def _async_rmtree(path: Path | str, label: str = "") -> None:
     await asyncio.to_thread(rmtree, path, label)
 
 
+def _unlink_stale_handle_symlink(workspace_home, target: str) -> None:
+    """Remove any existing symlink for this user (handle rename)."""
+    for entry in workspace_home.iterdir():
+        if entry.is_symlink() and os.readlink(entry) == target:
+            entry.unlink()
+            break
+
+
 def _ensure_home_symlink_sync(
     workspace_home: Path,
     handle: str,
@@ -150,10 +158,7 @@ def _ensure_home_symlink_sync(
         return f"/home/{handle}", created
 
     # Remove any existing symlink for this user (handle rename).
-    for entry in workspace_home.iterdir():
-        if entry.is_symlink() and os.readlink(entry) == target:
-            entry.unlink()
-            break
+    _unlink_stale_handle_symlink(workspace_home, target)
 
     # The handle path may already exist — e.g., a symlink pointing to a
     # different user's directory from a workspace import.  Adopt the old


### PR DESCRIPTION
## Summary

Thirteenth PR of the #2817 B-ratchet: brings all 22 remaining rank-C blocks in the server-misc / model / consent set under rank B — every touched file passes `xenon --max-absolute B`. Pure extract-function; no behavior change.

## Details

- `podman.run`/`run_raw` (13/13) → **B**: shared `_wait_podman` (timeout kill) + `_finish_podman_run` (rc override, timing logs, check enforcement).
- `Files.list_files` (18) → **B (3)**: `classify_find_errors` (#2769 start-vs-child failure classification), `_parse_find_line`.
- `format_report` (16) → **B**: `_append_result_line`, `_append_failure_block` (#1968).
- `EgressConsentModel.prune` (16) → **B (3)**: `_prune_retention` (TOCTOU-guarded pending split), `_prune_row_cap`.
- `init_workspaces_table` (14) → **B (2)**: `migrate_workspaces_columns` — the ten ADD-COLUMN migrations became a data-driven `(column, ddl)` loop.
- `ConsentCoordinator.resolve` (14) → **B (8)**: `_build_verdict` (module-level; forever-rows for #2368/#2369); `rules_frame` (11) → `_rules_frame_for`.
- `Lifecycle.seed_default_user` (14) → **B (5)**: `_default_admin_password_hash` + `_validate_default_password_policy` (#2581 fail-fast).
- `hooks.py` (14/13) → **B**: `_hook_field_changes`, `_validate_hook_rejected_domains`.
- `Features._active_feature_names` (14) → **B (4)**: `_deploy_feature_names`, `_manifest_default_names`, `_all_manifest_feature_names`.
- `main` (14) → **B**: `_report_pid_collision` (#2021 dedup), `_check_port_collisions` (#2211) — both defined before the CLI `app()` invocation.
- `system_ca_bundle` (13) → **B (2)**: `_openssl_ca_candidates`, `_first_existing_ca`.
- `probe_container` (12) → **B (3)**: `_parse_probe_output`, `_probe_via_openssl_cli`.
- `_ensure_home_symlink_sync` (11), `WindowEventWatcher.stop` (11), `_export_to_dir_sync` (11), `CaddyWatchdog._watch` (11), `disable_inactive_users` (11), `m0014.apply` (11), `_valid_domain_spec` (14) → **B** via small extractions (`_unlink_stale_handle_symlink`, `_terminate_watcher_proc`/`_kill_ctrl_session`, `_extract_seed_members`, `_watch_once`/`_load_or_kill`, `_user_is_inactive`, `_is_seeded_shape`, `_strip_host_sigil`/`_valid_spec_port`).

## Verification

- Full Python suite (`-n auto`, coverage): 5834 passed, **100% coverage** (pragmas moved verbatim with their e2e-only blocks).
- `xenon --max-absolute B` on all 19 touched files: passes.
- No changelog entry (internal refactor).
