### PR TITLE
refactor(scripts): bring fuzz-api and tooling script blocks under rank B

### DIFF
--- a/scripts/check_deferred_imports.py
+++ b/scripts/check_deferred_imports.py
@@ -120,19 +120,20 @@ def check_deferred_imports(package_dir: str) -> list[str]:
             if _is_marked(source_lines, node.lineno, "allow-deferred-import"):
                 continue
 
-            rel = pyfile.relative_to(root.parent)
-            if isinstance(node, ast.Import):
-                names = ", ".join(a.name for a in node.names)
-                errors.append(f"{rel}:{node.lineno}: deferred import: import {names}")
-            else:
-                module = node.module or ""
-                prefix = "." * node.level + module
-                names = ", ".join(a.name for a in node.names)
-                errors.append(
-                    f"{rel}:{node.lineno}: deferred import:"
-                    f" from {prefix} import {names}"
-                )
+            errors.append(_deferred_import_error(root, pyfile, node))
     return errors
+
+
+def _deferred_import_error(root: Path, pyfile: Path, node) -> str:
+    """The error line for one flagged deferred import."""
+    rel = pyfile.relative_to(root.parent)
+    if isinstance(node, ast.Import):
+        names = ", ".join(a.name for a in node.names)
+        return f"{rel}:{node.lineno}: deferred import: import {names}"
+    module = node.module or ""
+    prefix = "." * node.level + module
+    names = ", ".join(a.name for a in node.names)
+    return f"{rel}:{node.lineno}: deferred import: from {prefix} import {names}"
 
 
 def _find_package_root(filepath: Path) -> Path | None:

--- a/scripts/consent-decide.py
+++ b/scripts/consent-decide.py
@@ -126,6 +126,39 @@ def _display(row: sqlite3.Row) -> None:
     console.print(Panel(table, title=f"[bold]{row['id'][:8]}[/bold]", expand=False))
 
 
+def _prompt_and_decide(conn, ws: str, row, user_id: str, seen: set) -> None:
+    """Show one pending request, prompt for a/d/s, and apply the verdict."""
+    _display(row)
+    choice = (
+        console.input(
+            "[bold][[a]][/bold]ccept / [bold][[d]][/bold]eny / [bold][[s]][/bold]kip > "
+        )
+        .strip()
+        .lower()
+    )
+    if choice == "a":
+        _decide(conn, row["id"], "allowed", user_id, "workspace")
+        added = _allow_destination(conn, ws, row)
+        conn.commit()
+        seen.add(row["id"])
+        console.print(
+            f"[green]allowed[/green] {_dest(row)}"
+            + (
+                " (added to allow-list; recreate the workspace to apply)"
+                if added
+                else " (already in allow-list)"
+            )
+        )
+    elif choice == "d":
+        _decide(conn, row["id"], "denied", user_id)
+        conn.commit()
+        seen.add(row["id"])
+        console.print(f"[red]denied[/red] {_dest(row)}")
+    else:
+        seen.add(row["id"])
+        console.print("skipped")
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("workspace_id", help="workspace id (full or prefix)")
@@ -164,37 +197,7 @@ def main() -> None:
                 continue
             sys.stdout.write("\r" + " " * 50 + "\r")
             for row in pending:
-                _display(row)
-                choice = (
-                    console.input(
-                        "[bold][[a]][/bold]ccept / "
-                        "[bold][[d]][/bold]eny / "
-                        "[bold][[s]][/bold]kip > "
-                    )
-                    .strip()
-                    .lower()
-                )
-                if choice == "a":
-                    _decide(conn, row["id"], "allowed", user_id, "workspace")
-                    added = _allow_destination(conn, ws, row)
-                    conn.commit()
-                    seen.add(row["id"])
-                    console.print(
-                        f"[green]allowed[/green] {_dest(row)}"
-                        + (
-                            " (added to allow-list; recreate the workspace to apply)"
-                            if added
-                            else " (already in allow-list)"
-                        )
-                    )
-                elif choice == "d":
-                    _decide(conn, row["id"], "denied", user_id)
-                    conn.commit()
-                    seen.add(row["id"])
-                    console.print(f"[red]denied[/red] {_dest(row)}")
-                else:
-                    seen.add(row["id"])
-                    console.print("skipped")
+                _prompt_and_decide(conn, ws, row, user_id, seen)
     except KeyboardInterrupt:
         console.print("\nbye.")
     finally:

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -747,62 +747,20 @@ class AnomalyTracker:
             lines.append(f"  {status}: {self.by_status[status]}")
         lines.append("")
 
-        if self.server_errors:
-            lines.append(f"SERVER ERRORS (5xx): {len(self.server_errors)}")
-            for e in self.server_errors[:50]:
-                lines.append(
-                    f"  [{e['time']}] {e['method']} {e['path']} → {e['status']}"
-                )
-                if "body" in e:
-                    lines.append(f"    body: {e['body']}")
-            if len(self.server_errors) > 50:
-                lines.append(f"  ... and {len(self.server_errors) - 50} more")
-        else:
-            lines.append("SERVER ERRORS (5xx): 0 ✓")
-
-        lines.append("")
-        if self.timeouts:
-            lines.append(f"TIMEOUTS: {len(self.timeouts)}")
-        else:
-            lines.append("TIMEOUTS: 0 ✓")
-
-        if self.connection_errors:
-            lines.append(f"CONNECTION ERRORS: {len(self.connection_errors)}")
-            lines.append("  (server may have crashed)")
-        else:
-            lines.append("CONNECTION ERRORS: 0 ✓")
-
-        # Check server stderr for unhandled exceptions
-        lines.append("")
-        stderr_lines = stderr_output.strip().splitlines()
-        exception_lines = [
-            line
-            for line in stderr_lines
-            if any(
-                kw in line.lower()
-                for kw in [
-                    "traceback",
-                    "error",
-                    "exception",
-                    "unhandled",
-                    "segfault",
-                    "killed",
-                    "fatal",
-                ]
-            )
-            # Filter out expected/normal log lines
-            and "INFO" not in line
-            and "WARNING" not in line
-            and "password" not in line.lower()
-        ]
-        if exception_lines:
-            lines.append(f"SERVER STDERR ANOMALIES: {len(exception_lines)}")
-            for exc_line in exception_lines[:30]:
-                lines.append(f"  {exc_line.rstrip()}")
-            if len(exception_lines) > 30:
-                lines.append(f"  ... and {len(exception_lines) - 30} more")
-        else:
-            lines.append("SERVER STDERR ANOMALIES: 0 ✓")
+        _report_server_errors(lines, self.server_errors)
+        _report_simple_counts(
+            lines,
+            [
+                ("TIMEOUTS", self.timeouts, None),
+                (
+                    "CONNECTION ERRORS",
+                    self.connection_errors,
+                    "(server may have crashed)",
+                ),
+            ],
+        )
+        exception_lines = _stderr_anomaly_lines(stderr_output)
+        _report_stderr_anomalies(lines, exception_lines)
 
         lines.append("")
         has_anomalies = bool(
@@ -814,6 +772,75 @@ class AnomalyTracker:
             lines.append("RESULT: CLEAN ✓")
         lines.append("=" * 60)
         return "\n".join(lines)
+
+
+def _report_server_errors(lines: list[str], errors: list[dict]) -> None:
+    """The 5xx section: first 50 entries with bodies, then a remainder
+    count."""
+    lines.append("")
+    if not errors:
+        lines.append("SERVER ERRORS (5xx): 0 ✓")
+        return
+    lines.append(f"SERVER ERRORS (5xx): {len(errors)}")
+    for e in errors[:50]:
+        lines.append(f"  [{e['time']}] {e['method']} {e['path']} → {e['status']}")
+        if "body" in e:
+            lines.append(f"    body: {e['body']}")
+    if len(errors) > 50:
+        lines.append(f"  ... and {len(errors) - 50} more")
+
+
+def _report_simple_counts(
+    lines: list[str], sections: list[tuple[str, list, str | None]]
+) -> None:
+    """The timeout / connection-error count sections (one leading blank
+    before the group)."""
+    for i, (label, entries, note) in enumerate(sections):
+        if i == 0:
+            lines.append("")
+        if entries:
+            lines.append(f"{label}: {len(entries)}")
+            if note:
+                lines.append(f"  {note}")
+        else:
+            lines.append(f"{label}: 0 ✓")
+
+
+_STDERR_ANOMALY_KEYWORDS = [
+    "traceback",
+    "error",
+    "exception",
+    "unhandled",
+    "segfault",
+    "killed",
+    "fatal",
+]
+
+
+def _stderr_anomaly_lines(stderr_output: str) -> list[str]:
+    """Server-stderr lines that look like unhandled exceptions, with
+    expected/normal log lines (INFO/WARNING/password noise) filtered out."""
+    return [
+        line
+        for line in stderr_output.strip().splitlines()
+        if any(kw in line.lower() for kw in _STDERR_ANOMALY_KEYWORDS)
+        and "INFO" not in line
+        and "WARNING" not in line
+        and "password" not in line.lower()
+    ]
+
+
+def _report_stderr_anomalies(lines: list[str], exception_lines: list) -> None:
+    """The stderr-anomaly section: first 30 lines, then a remainder count."""
+    lines.append("")
+    if not exception_lines:
+        lines.append("SERVER STDERR ANOMALIES: 0 ✓")
+        return
+    lines.append(f"SERVER STDERR ANOMALIES: {len(exception_lines)}")
+    for exc_line in exception_lines[:30]:
+        lines.append(f"  {exc_line.rstrip()}")
+    if len(exception_lines) > 30:
+        lines.append(f"  ... and {len(exception_lines) - 30} more")
 
 
 # ---------------------------------------------------------------------------
@@ -891,6 +918,19 @@ def seed_fuzz_fixtures(
     return workspace_ids, user_ids, group_ids
 
 
+def _fill_id_placeholder(
+    rng: random.Random, path: str, placeholder: str, ids: list[str]
+) -> str:
+    """Substitute one id placeholder: a known id, a random known id, or a
+    fresh fuzzed uuid when none are known."""
+    if placeholder not in path:
+        return path
+    return path.replace(
+        placeholder,
+        rng.choice(ids + [fuzz_uuid(rng)]) if ids else fuzz_uuid(rng),
+    )
+
+
 def fill_path_params(
     rng: random.Random,
     path_template: str,
@@ -900,28 +940,13 @@ def fill_path_params(
 ) -> str:
     """Substitute fuzzed values for the ``{param}`` placeholders."""
     path = path_template
-    if "{workspace_id}" in path:
-        path = path.replace(
-            "{workspace_id}",
-            rng.choice(workspace_ids + [fuzz_uuid(rng)])
-            if workspace_ids
-            else fuzz_uuid(rng),
-        )
-    if "{member_id}" in path:
-        path = path.replace(
-            "{member_id}",
-            rng.choice(user_ids + [fuzz_uuid(rng)]) if user_ids else fuzz_uuid(rng),
-        )
-    if "{user_id}" in path:
-        path = path.replace(
-            "{user_id}",
-            rng.choice(user_ids + [fuzz_uuid(rng)]) if user_ids else fuzz_uuid(rng),
-        )
-    if "{group_id}" in path:
-        path = path.replace(
-            "{group_id}",
-            rng.choice(group_ids + [fuzz_uuid(rng)]) if group_ids else fuzz_uuid(rng),
-        )
+    for placeholder, ids in (
+        ("{workspace_id}", workspace_ids),
+        ("{member_id}", user_ids),
+        ("{user_id}", user_ids),
+        ("{group_id}", group_ids),
+    ):
+        path = _fill_id_placeholder(rng, path, placeholder, ids)
     if "{role}" in path:
         path = path.replace("{role}", rng.choice(ROLES))
     if "{invitation_id}" in path:

--- a/scripts/inline_sources_in_map.py
+++ b/scripts/inline_sources_in_map.py
@@ -21,6 +21,28 @@ import sys
 from pathlib import Path
 
 
+def _resolve_against_bases(map_dir: Path, stripped: str) -> Path | None:
+    """Try every directory between map_dir and `/`, plus $HOME. dart2js
+    emits paths with a `../` depth that doesn't quite match the map file's
+    directory (app `lib/` paths are off by one, pub-cache paths by several),
+    so walk up and try each candidate base — the first one where stripped
+    resolves is the source."""
+    bases: list[Path] = []
+    cur = map_dir
+    while True:
+        bases.append(cur)
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    if Path.home() not in bases:
+        bases.append(Path.home())
+    for base in bases:
+        cand = (base / stripped).resolve()
+        if cand.is_file():
+            return cand
+    return None
+
+
 def resolve(uri: str, flutter_sdk: Path, map_dir: Path) -> Path | None:
     """Map a sourcemap URI to an on-disk path, or None if unresolvable."""
     if uri.startswith("file:///"):
@@ -32,45 +54,35 @@ def resolve(uri: str, flutter_sdk: Path, map_dir: Path) -> Path | None:
         rel = uri[len("org-dartlang-sdk:///lib/") :]
         return flutter_sdk / "bin" / "cache" / "flutter_web_sdk" / "lib" / rel
     if "://" not in uri:
-        # dart2js emits paths relative to where it was invoked, but with one
-        # too many `../` for the actual map-file directory; the relative form
-        # treats `web/main.dart.js.map` as if it were nested an extra level
-        # deeper. Try map-dir-relative first; if that misses, strip the leading
-        # `../` segments and try project-root- and $HOME-relative as fallbacks.
-        direct = (map_dir / uri).resolve()
-        if direct.is_file():
-            return direct
-        # Strip leading `../` parts to get the inner path (e.g.
-        # `.pub-cache/hosted/pub.dev/...` or `lib/auth/...`).
-        stripped = uri
-        while stripped.startswith("../"):
-            stripped = stripped[3:]
-        # Try every directory between map_dir and `/`, plus $HOME. dart2js
-        # emits paths with a `../` depth that doesn't quite match the map
-        # file's directory (app `lib/` paths are off by one, pub-cache paths
-        # by several), so walk up and try each candidate base — the first
-        # one where stripped resolves is the source.
-        bases: list[Path] = []
-        cur = map_dir
-        while True:
-            bases.append(cur)
-            if cur.parent == cur:
-                break
-            cur = cur.parent
-        if Path.home() not in bases:
-            bases.append(Path.home())
-        for base in bases:
-            cand = (base / stripped).resolve()
-            if cand.is_file():
-                return cand
-        # Bare filename fallback: dart2js emits `main.dart` and
-        # `web_plugin_registrant.dart` without a directory prefix. Search the
-        # Flutter project (map_dir's grandparent) for the first match.
-        if "/" not in stripped:
-            project = map_dir.parent.parent
-            for candidate in project.rglob(stripped):
-                if candidate.is_file():
-                    return candidate
+        return _resolve_relative_uri(uri, map_dir)
+    return None
+
+
+def _resolve_relative_uri(uri: str, map_dir: Path) -> Path | None:
+    """Resolve dart2js's relative emitted paths, which carry one too many
+    `../` for the actual map-file directory (the relative form treats
+    `web/main.dart.js.map` as if it were nested an extra level deeper). Try
+    map-dir-relative first; if that misses, strip the leading `../` segments
+    and try project-root- and $HOME-relative as fallbacks."""
+    direct = (map_dir / uri).resolve()
+    if direct.is_file():
+        return direct
+    # Strip leading `../` parts to get the inner path (e.g.
+    # `.pub-cache/hosted/pub.dev/...` or `lib/auth/...`).
+    stripped = uri
+    while stripped.startswith("../"):
+        stripped = stripped[3:]
+    cand = _resolve_against_bases(map_dir, stripped)
+    if cand is not None:
+        return cand
+    # Bare filename fallback: dart2js emits `main.dart` and
+    # `web_plugin_registrant.dart` without a directory prefix. Search the
+    # Flutter project (map_dir's grandparent) for the first match.
+    if "/" not in stripped:
+        project = map_dir.parent.parent
+        for candidate in project.rglob(stripped):
+            if candidate.is_file():
+                return candidate
     return None
 
 

--- a/scripts/lcov-report.py
+++ b/scripts/lcov-report.py
@@ -4,14 +4,9 @@
 import sys
 
 
-def main():
-    path = sys.argv[1] if len(sys.argv) > 1 else "coverage/lcov.info"
-    try:
-        with open(path) as f:
-            lines = f.readlines()
-    except FileNotFoundError:
-        return
-
+def parse_lcov(lines: list[str]) -> tuple[dict, dict]:
+    """(per-file {hit, total}, per-file uncovered line numbers) from an lcov
+    tracefile."""
     files = {}
     uncovered_lines: dict[str, list[int]] = {}
     current = None
@@ -27,10 +22,11 @@ def main():
             files.setdefault(current, {})["hit"] = int(line[3:])
         elif line.startswith("LF:"):
             files.setdefault(current, {})["total"] = int(line[3:])
+    return files, uncovered_lines
 
-    if not files:
-        return
 
+def print_file_table(files: dict) -> float:
+    """The per-file coverage table; returns the total percentage."""
     total_hit = total_lines = 0
     print()
     print(f"{'File':<55} {'Lines':>6} {'Hit':>6} {'Cov':>6}")
@@ -46,22 +42,25 @@ def main():
     pct = (total_hit / total_lines * 100) if total_lines else 0
     print("-" * 75)
     print(f"{'TOTAL':<55} {total_lines:>6} {total_hit:>6} {pct:>5.1f}%")
+    return pct
 
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "coverage/lcov.info"
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        return
+
+    files, uncovered_lines = parse_lcov(lines)
+    if not files:
+        return
+
+    pct = print_file_table(files)
     required = 100.0
     if pct < required:
-        missing = [
-            (f, d)
-            for f, d in sorted(files.items())
-            if d.get("hit", 0) < d.get("total", 0)
-        ]
-        for f, d in missing:
-            short = f.replace("lib/", "")
-            hit, total = d.get("hit", 0), d.get("total", 0)
-            line_nums = uncovered_lines.get(f, [])
-            if line_nums:
-                print(f"  {short}: {total - hit} lines uncovered: {line_nums}")
-            else:
-                print(f"  {short}: {total - hit} lines uncovered")
+        print_uncovered(files, uncovered_lines)
         print(
             f"\nFAIL Required test coverage of {required}% "
             f"not reached. Total coverage: {pct:.2f}%"
@@ -72,6 +71,22 @@ def main():
             f"\nRequired test coverage of {required}% reached. "
             f"Total coverage: {pct:.2f}%"
         )
+
+
+def print_uncovered(files: dict, uncovered_lines: dict) -> None:
+    """Each file with missing lines, with the uncovered line numbers when
+    known."""
+    missing = [
+        (f, d) for f, d in sorted(files.items()) if d.get("hit", 0) < d.get("total", 0)
+    ]
+    for f, d in missing:
+        short = f.replace("lib/", "")
+        hit, total = d.get("hit", 0), d.get("total", 0)
+        line_nums = uncovered_lines.get(f, [])
+        if line_nums:
+            print(f"  {short}: {total - hit} lines uncovered: {line_nums}")
+        else:
+            print(f"  {short}: {total - hit} lines uncovered")
 
 
 if __name__ == "__main__":

--- a/scripts/update_features.py
+++ b/scripts/update_features.py
@@ -116,6 +116,44 @@ def _copy_feature_tree(source, dest):
         shutil.rmtree(git_dir)
 
 
+def _feature_from_local_tree(
+    feature,
+    features_dir,
+    name,
+    git_url,
+    subpath,
+    ref,
+    local_origin,
+):
+    """The unresolvable-ref fallback: GitHub PR builds check out a synthesized
+    merge commit whose SHA exists only on the runner, so `git ls-remote` can
+    never resolve it. For features that live in *this* repo, fall back to the
+    already-checked-out working tree (which has the exact content being
+    built) instead of cloning; never silently degrade to the remote's default
+    branch."""
+    dest = os.path.join(features_dir, name)
+    local_path = os.path.join(ROOT, subpath) if subpath else ROOT
+    if not (
+        local_origin
+        and _normalize_git_url(git_url) == local_origin
+        and os.path.isdir(local_path)
+    ):
+        print(f"  ERROR: Could not resolve ref '{ref}' for {git_url}", file=sys.stderr)
+        return None
+    print(
+        f"  {name}: ref '{ref}' not on remote; "
+        f"using local working tree {subpath or '.'}/"
+    )
+    _copy_feature_tree(local_path, dest)
+    return {
+        "name": name,
+        "git": git_url,
+        "path": subpath,
+        "ref": ref,
+        "sha": "local",
+    }
+
+
 def fetch_feature(feature, features_dir):
     """Fetch a single feature from a git repo into features_dir.
 
@@ -141,26 +179,9 @@ def fetch_feature(feature, features_dir):
     # that live in *this* repo, fall back to the already-checked-out working
     # tree (which has the exact content being built) instead of cloning.
     if sha is None:
-        local_path = os.path.join(ROOT, subpath) if subpath else ROOT
-        if (
-            local_origin
-            and _normalize_git_url(git_url) == local_origin
-            and os.path.isdir(local_path)
-        ):
-            print(
-                f"  {name}: ref '{ref}' not on remote; "
-                f"using local working tree {subpath or '.'}/"
-            )
-            _copy_feature_tree(local_path, dest)
-            return {
-                "name": name,
-                "git": git_url,
-                "path": subpath,
-                "ref": ref,
-                "sha": "local",
-            }
-        print(f"  ERROR: Could not resolve ref '{ref}' for {git_url}", file=sys.stderr)
-        return None
+        return _feature_from_local_tree(
+            feature, features_dir, name, git_url, subpath, ref, local_origin
+        )
 
     print(f"  {name}: {git_url} @ {ref} -> {sha[:12]}")
 


### PR DESCRIPTION
## Summary

Fourteenth PR of the #2817 B-ratchet: brings all 8 remaining rank-C blocks in `scripts/` under rank B — the six touched files pass `xenon --max-absolute B`. Pure extract-function; no behavior change.

## Details

- `AnomalyTracker.report` (20) → **B (7)**: `_report_server_errors`, `_report_simple_counts`, `_stderr_anomaly_lines` (keyword table extracted), `_report_stderr_anomalies`. Report text is byte-identical.
- `fill_path_params` (15) → **B (9)**: the four id placeholders became a loop over `_fill_id_placeholder`.
- `lcov-report.py main` (19) → **B (4)**: `parse_lcov`, `print_file_table`, `print_uncovered`.
- `inline_sources_in_map.resolve` (15) → **B (6)**: `_resolve_relative_uri` (the dart2js `../`-depth fallbacks), `_resolve_against_bases`.
- `check_deferred_imports` (14) → **B (7)**: `_deferred_import_error`.
- `fetch_feature` (13) → **B (5)**: `_feature_from_local_tree` (the CI-merge-commit local-working-tree fallback).
- `consent-decide.py main` (11) → **B (4)**: `_prompt_and_decide`.

## Verification

- `scripts/tests`: 83 passed (the CI step covering these files).
- `xenon --max-absolute B` on all six files: passes.
- No changelog entry (internal tooling).
