### PR TITLE
refactor(sidecar): bring klangksidecar blocks under rank B

### DIFF
--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -28,6 +28,40 @@ if TYPE_CHECKING:
 _SHUTDOWN_CLIENT_TIMEOUT = 2.0
 
 
+async def _cancel_task(task: asyncio.Task | None) -> None:
+    """Cancel a background task and swallow its end (best-effort teardown;
+    process exit reaps whatever remains)."""
+    if task is None:
+        return
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+def _unbind_nfq(nfq) -> None:
+    """Remove the NFQUEUE reader and unbind (each best-effort)."""
+    if nfq is None:
+        return
+    try:
+        asyncio.get_running_loop().remove_reader(nfq.get_fd())
+    except Exception:
+        pass
+    try:
+        nfq.unbind()
+    except Exception:
+        pass
+
+
+def _close_quietly(sock: socket.socket) -> None:
+    """Close a socket, swallowing errors."""
+    try:
+        sock.close()
+    except Exception:
+        pass
+
+
 async def _shutdown(
     client: SidecarConsentClient | None,
     nfq,
@@ -58,31 +92,10 @@ async def _shutdown(
             # rest of teardown -- the exact failure mode the sweep/sampler
             # guards below already widen against.
             pass
-    if sweep is not None:
-        sweep.cancel()
-        try:
-            await sweep
-        except (asyncio.CancelledError, Exception):
-            pass
-    if sampler is not None:
-        sampler.cancel()
-        try:
-            await sampler
-        except (asyncio.CancelledError, Exception):
-            pass
-    if nfq is not None:
-        try:
-            asyncio.get_running_loop().remove_reader(nfq.get_fd())
-        except Exception:
-            pass
-        try:
-            nfq.unbind()
-        except Exception:
-            pass
-    try:
-        sock.close()
-    except Exception:
-        pass
+    await _cancel_task(sweep)
+    await _cancel_task(sampler)
+    _unbind_nfq(nfq)
+    _close_quietly(sock)
 
 
 def _resolve_ws_host(consent_url: str) -> str | None:

--- a/src/klangksidecar/klangksidecar/nfqueue.py
+++ b/src/klangksidecar/klangksidecar/nfqueue.py
@@ -82,6 +82,20 @@ def _drain(nfq) -> None:
         pass  # a transient read failure defers to the next readability event
 
 
+def _classify_packet(payload: bytes) -> tuple[str, int, str, int] | None:
+    """``(src_ip, src_port, dst_ip, dst_port)`` for a queued packet, or None
+    when unparseable. The connection-level key (src IP+port + dst IP+port) is
+    what makes duration=once re-prompt every subsequent connection instead of
+    reusing a prior allow for the same destination (#2361)."""
+    src_ip, src_port, tdst, tport, _ = parse_syn_tuple(payload)
+    if tport:  # TCP: full connection tuple
+        return src_ip, src_port, tdst, tport
+    dst, port = parse_dest(payload)  # non-TCP: destination granularity
+    if not dst:
+        return None
+    return src_ip, src_port, dst, port
+
+
 def _cb(pkt, client: SidecarConsentClient | None) -> None:
     """Classify + route one queued SYN -- non-blocking (#2324, #2329).
 
@@ -98,42 +112,13 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
     if client is not None:
         client.bump_activity()
     payload = pkt.get_payload()
-    # Connection-level key (src IP+port + dst IP+port): a SYN retransmit shares
-    # its connection's tuple, a NEW connection has a new source port. Keying the
-    # verdict cache + in-flight set on the connection -- not just (dst, port) --
-    # is what makes duration=once re-prompt every subsequent connection instead
-    # of reusing a prior allow for the same destination (#2361).
-    src_ip, src_port, tdst, tport, _ = parse_syn_tuple(payload)
-    if tport:  # TCP: full connection tuple
-        dst, port = tdst, tport
-    else:  # non-TCP (UDP/other): no source port -> destination granularity
-        dst, port = parse_dest(payload)
-    if not dst or client is None:
+    key = _classify_packet(payload)
+    if key is None or client is None:
         pkt.drop()  # unparseable / pure-static (no consent configured) -> drop
         return
+    src_ip, src_port, dst, port = key
     if not client.connected:
-        # Consent WS down: consent is unavailable, so fail the off-list SYN
-        # FAST (ECONNREFUSED) like a deny verdict -- NOT a bare drop. A bare
-        # drop makes the kernel retransmit the SYN for ~127s (tcp_syn_retries),
-        # dangling the connection (#2308: no consent available -> a clean,
-        # prompt denial, not a hang). Forge the eager-deny RST inline
-        # (non-blocking sendto) so THIS connect() gets ECONNREFUSED at once,
-        # + a short REJECT (tcp-reset) backstop off-loop so retransmits are
-        # RST'd above NFQUEUE, then drop. On-list egress is unaffected
-        # (learned ACCEPT rules sit above NFQUEUE); once the WS reconnects,
-        # fresh off-list egress prompts again. The REJECT TTL is short, so no
-        # rule lingers past the outage (#2413). Unlike a `once` deny (#2463),
-        # this REJECT stays destination-scoped deliberately: during a WS outage
-        # no connection can be consented, so fail-fast (ECONNREFUSED) for every
-        # off-list connect to the same ip:port is the intended #2308 behavior,
-        # and this path writes no _VERDICT_CACHE entry, so connection-scoping
-        # would gain nothing.
-        if port:
-            packets._send_rst(payload)
-            asyncio.get_running_loop().run_in_executor(
-                None, rules.reject, dst, port, CONSENT_REJECT_TTL
-            )
-        pkt.drop()
+        _fail_fast_no_consent(pkt, payload, dst, port)
         return
     flow = (src_ip, src_port, dst, port)
     now = time.time()
@@ -141,14 +126,7 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
     # the kernel's retransmits (tcp_syn_retries) don't each re-prompt.
     cached = _VERDICT_CACHE.get(flow)
     if cached is not None and cached[1] > now:
-        if cached[0] == "allow":
-            pkt.accept()
-        else:
-            # Forge the eager-deny RST (a retried connect() to a denied flow
-            # fails fast too), then drop. TCP only (port 0 is non-TCP).
-            if port:
-                packets._send_rst(payload)
-            pkt.drop()
+        _apply_cached_verdict(pkt, cached, payload, port)
         return
     # A SYN retransmit that arrives WHILE this connection is still held (no
     # verdict yet) must not spawn a second consent request: the in-flight task
@@ -159,63 +137,131 @@ def _cb(pkt, client: SidecarConsentClient | None) -> None:
         pkt.drop()
         return
     host = _host_for(dst)  # DNS name if resolved here, else the IP
-    # An in-session host allow covers the whole domain, timed or forever
-    # (#2372, #2434): a SYN to a host:port the user already allowed -- including
-    # a CDN-rotated or resolver-cached IP that no fresh DNS resolution
-    # re-ACCEPTed -- is auto-allowed here, the last gate before prompting, so
-    # the user isn't re-asked for a domain they allowed. This is the fix for the
-    # ALLOW-REFUSED mismatch (#2434): without it a timed allow only covered the
-    # IP resolved at decision time, so a CDN-rotated IP re-entered NFQUEUE and a
-    # hold timeout there fail-closed to a deny REJECT an in-effect allow should
-    # override.
-    remaining = _session_host_allows_ttl(host, port) if port else None
-    if remaining is not None:
-        # allow() forks iptables under _LOCK -- run it off the loop thread (the
-        # file's invariant; every other allow/learn/reject call is in the
-        # executor). Fire-and-forget: conntrack ESTABLISHED,RELATED carries THIS
-        # connection after pkt.accept(); the ACCEPT rule only helps FUTURE
-        # connections, and the _VERDICT_CACHE write below covers retransmits.
-        # Learn for the allow's remaining window (timed) or ~forever; port-scoped
-        # (the consented port) -- deliberately stricter than the consent-allow
-        # path's all-ports learn (allow(dst, None, ...)).
-        asyncio.get_running_loop().run_in_executor(
-            None, rules.allow, dst, port, remaining, False
-        )
-        pkt.accept()
-        _VERDICT_CACHE[flow] = ("allow", now + VERDICT_CACHE_TTL)
-        # NOTE (#2370): revoking an allow must also drop this host from
-        # _SESSION_HOST_ALLOWS and clear _VERDICT_CACHE, or a revoked allow keeps
-        # passing (ports_for re-allow-lists it + this cache reuses the verdict).
-        # Wired with the revoke path in #2370.
-        return
-    # An in-session host deny covers the whole domain, timed or forever
-    # (#2446): a SYN to a host:port the user already denied -- including a
-    # CDN-rotated or resolver-cached IP that the per-IP _REJECTED rule does not
-    # cover -- is denied fast here, before prompting, so the user isn't re-asked
-    # for a domain they denied (the CARRYOVER-SURPRISE). Checked AFTER the allow
-    # gate above so an in-effect allow still overrides an in-effect deny.
-    deny_remaining = _session_host_denies_ttl(host, port) if port else None
-    if deny_remaining is not None:
-        # Forge the eager-deny RST so connect() fails fast (ECONNREFUSED) at
-        # once; a REJECT for the deny's remaining window backstops retransmits
-        # off-loop (reject() forks iptables under _LOCK). TCP only (port 0 is
-        # non-TCP). The _VERDICT_CACHE write covers retransmits of THIS flow.
-        if port:
-            try:
-                packets._send_rst(payload)
-            except Exception:
-                pass
-            asyncio.get_running_loop().run_in_executor(
-                None, rules.reject, dst, port, deny_remaining
-            )
-        pkt.drop()
-        _VERDICT_CACHE[flow] = ("deny", now + VERDICT_CACHE_TTL)
+    if _session_gate_holds(pkt, flow, payload, dst, port, host, now):
         return
     pkt.retain()  # keep the payload valid past this callback (deferred verdict)
     _INFLIGHT.add(flow)
     t = asyncio.create_task(_decide_and_verdict(pkt, flow, dst, port, host, client))
     _BG_TASKS.add(t)  # strong ref so the verdict task isn't GC'd
     t.add_done_callback(_BG_TASKS.discard)
+
+
+def _session_gate_holds(
+    pkt, flow, payload, dst: str, port: int, host: str, now: float
+) -> bool:
+    """The last gates before prompting, both host-scoped. An in-session host
+    ALLOW covers the whole domain, timed or forever (#2372, #2434): a SYN to
+    a host:port the user already allowed -- including a CDN-rotated or
+    resolver-cached IP that no fresh DNS resolution re-ACCEPTed -- is
+    auto-allowed, the fix for the ALLOW-REFUSED mismatch (#2434): without it
+    a timed allow only covered the IP resolved at decision time, so a
+    CDN-rotated IP re-entered NFQUEUE and a hold timeout there fail-closed to
+    a deny REJECT an in-effect allow should override.
+
+    An in-session host DENY covers the whole domain too (#2446): a SYN to a
+    host:port the user already denied -- including a CDN-rotated or
+    resolver-cached IP that the per-IP _REJECTED rule does not cover -- is
+    denied fast, before prompting (the CARRYOVER-SURPRISE). Checked AFTER
+    the allow gate so an in-effect allow still overrides an in-effect deny.
+
+    Returns True when the SYN was handled."""
+    remaining = _session_host_allows_ttl(host, port) if port else None
+    if remaining is not None:
+        _allow_session_host(pkt, flow, dst, port, now, remaining)
+        return True
+    deny_remaining = _session_host_denies_ttl(host, port) if port else None
+    if deny_remaining is not None:
+        _deny_session_host(pkt, flow, payload, dst, port, now, deny_remaining)
+        return True
+    return False
+
+
+def _fail_fast_no_consent(pkt, payload, dst: str, port: int) -> None:
+    """Consent WS down: consent is unavailable, so fail the off-list SYN
+    FAST (ECONNREFUSED) like a deny verdict -- NOT a bare drop. A bare drop
+    makes the kernel retransmit the SYN for ~127s (tcp_syn_retries),
+    dangling the connection (#2308: no consent available -> a clean, prompt
+    denial, not a hang). Forge the eager-deny RST inline (non-blocking
+    sendto) so THIS connect() gets ECONNREFUSED at once, + a short REJECT
+    (tcp-reset) backstop off-loop so retransmits are RST'd above NFQUEUE,
+    then drop. On-list egress is unaffected (learned ACCEPT rules sit above
+    NFQUEUE); once the WS reconnects, fresh off-list egress prompts again.
+    The REJECT TTL is short, so no rule lingers past the outage (#2413).
+    Unlike a `once` deny (#2463), this REJECT stays destination-scoped
+    deliberately: during a WS outage no connection can be consented, so
+    fail-fast (ECONNREFUSED) for every off-list connect to the same
+    ip:port is the intended #2308 behavior, and this path writes no
+    _VERDICT_CACHE entry, so connection-scoping would gain nothing."""
+    if port:
+        packets._send_rst(payload)
+        asyncio.get_running_loop().run_in_executor(
+            None, rules.reject, dst, port, CONSENT_REJECT_TTL
+        )
+    pkt.drop()
+
+
+def _apply_cached_verdict(pkt, cached, payload, port: int) -> None:
+    """A retransmit of an already-decided connection: reuse the verdict. A
+    cached deny forges the eager-deny RST (a retried connect() to a denied
+    flow fails fast too); TCP only (port 0 is non-TCP)."""
+    if cached[0] == "allow":
+        pkt.accept()
+    else:
+        if port:
+            packets._send_rst(payload)
+        pkt.drop()
+
+
+def _allow_session_host(
+    pkt, flow, dst: str, port: int, now: float, remaining: float
+) -> None:
+    """An in-session host allow covers the whole domain, timed or forever
+    (#2372, #2434): a SYN to a host:port the user already allowed --
+    including a CDN-rotated or resolver-cached IP that no fresh DNS
+    resolution re-ACCEPTed -- is auto-allowed, the last gate before
+    prompting, so the user isn't re-asked for a domain they allowed. This
+    is the fix for the ALLOW-REFUSED mismatch (#2434): without it a timed
+    allow only covered the IP resolved at decision time, so a CDN-rotated
+    IP re-entered NFQUEUE and a hold timeout there fail-closed to a deny
+    REJECT an in-effect allow should override."""
+    # allow() forks iptables under _LOCK -- run it off the loop thread (the
+    # file's invariant; every other allow/learn/reject call is in the
+    # executor). Fire-and-forget: conntrack ESTABLISHED,RELATED carries THIS
+    # connection after pkt.accept(); the ACCEPT rule only helps FUTURE
+    # connections, and the _VERDICT_CACHE write below covers retransmits.
+    # Learn for the allow's remaining window (timed) or ~forever; port-scoped
+    # (the consented port) -- deliberately stricter than the consent-allow
+    # path's all-ports learn (allow(dst, None, ...)).
+    asyncio.get_running_loop().run_in_executor(
+        None, rules.allow, dst, port, remaining, False
+    )
+    pkt.accept()
+    _VERDICT_CACHE[flow] = ("allow", now + VERDICT_CACHE_TTL)
+    # NOTE (#2370): revoking an allow must also drop this host from
+    # _SESSION_HOST_ALLOWS and clear _VERDICT_CACHE, or a revoked allow keeps
+    # passing (ports_for re-allow-lists it + this cache reuses the verdict).
+    # Wired with the revoke path in #2370.
+
+
+def _deny_session_host(
+    pkt, flow, payload, dst: str, port: int, now: float, deny_remaining: float
+) -> None:
+    """An in-session host deny covers the whole domain, timed or forever
+    (#2446). Forge the eager-deny RST so connect() fails fast
+    (ECONNREFUSED) at once; a REJECT for the deny's remaining window
+    backstops retransmits off-loop (reject() forks iptables under _LOCK).
+    TCP only (port 0 is non-TCP). The _VERDICT_CACHE write covers
+    retransmits of THIS flow."""
+    if port:
+        try:
+            packets._send_rst(payload)
+        except Exception:
+            pass
+        asyncio.get_running_loop().run_in_executor(
+            None, rules.reject, dst, port, deny_remaining
+        )
+    pkt.drop()
+    _VERDICT_CACHE[flow] = ("deny", now + VERDICT_CACHE_TTL)
 
 
 async def _decide_and_verdict(
@@ -256,67 +302,90 @@ async def _decide_and_verdict(
     # NFQUEUE, and a hold timeout there fail-closes to a deny REJECT an
     # in-effect allow should override -- an allow that refuses.
     ttl = _duration_ttl(duration)
-    if decision == "allow" and ttl is not None and port:
-        _add_session_host(host, port, ttl)
-    # Symmetric host-scoped memory on the deny side (#2446): a timed/forever
-    # deny is remembered by host (not just IP) so a retry -- including a
-    # CDN-rotated IP -- is denied fast without re-prompting. ``once`` (ttl
-    # None) adds nothing (per-connection). Populated before the iptables fork
-    # below so a SYN to a different IP of this host during the yield still hits
-    # _session_host_denies_ttl in _cb.
-    if decision == "deny" and ttl is not None and port:
-        _add_session_deny(host, port, ttl)
-    # Run the iptables fork (allow/reject) in the executor so it doesn't block
-    # the loop thread -- matches the DNS path's _learn_all, which also runs
-    # off the loop. The packet is retained, so verdicting after the await is
-    # safe; the rule is installed before the SYN is released.
+    _remember_session_verdict(decision, host, port, ttl)
     loop = asyncio.get_running_loop()
     try:
-        if decision == "allow":
-            # `once` (ttl None) -> no learn, just this connection (reconnect
-            # re-prompts); a timed duration -> learn all-ports for it.
-            if ttl is not None:
-                try:
-                    await loop.run_in_executor(None, rules.allow, dst, None, ttl, False)
-                except Exception:
-                    pass
-            pkt.accept()
-        else:
-            # Forge a RST directly so connect() fails fast (ECONNREFUSED) at once,
-            # independent of the conntrack/retransmit race that made the REJECT
-            # rule flaky (#2345). The REJECT rule stays as a belt-and-suspenders
-            # backstop for any retransmit the RST missed. `once` -> the short
-            # fail-close reject window; a timed duration -> that long.
-            # ``once`` is per-connection: scope the REJECT to THIS connection's
-            # source port so a NEW connection (different sport) to the same
-            # host:port re-prompts instead of being rejected above NFQUEUE for
-            # the fail-close window (#2463). A timed/forever deny stays
-            # destination-scoped -- its over-deny is correct (the DB rule +
-            # _SESSION_HOST_DENIES govern re-prompting). The source port is
-            # guarded: a real TCP SYN never has src port 0 (RFC 793), so a
-            # truthy flow[1] is the normal case; if it is ever 0 (a
-            # non-TCP/unparseable flow), fall back to destination-scoped so a
-            # future parse change can't silently re-introduce the over-deny.
-            if port:
-                try:
-                    packets._send_rst(pkt.get_payload())
-                except Exception:
-                    pass
-                reject_ttl = ttl if ttl is not None else CONSENT_REJECT_TTL
-                try:
-                    if ttl is None and flow[1]:
-                        await loop.run_in_executor(
-                            None, rules.reject, dst, port, reject_ttl, flow[1]
-                        )
-                    else:
-                        await loop.run_in_executor(
-                            None, rules.reject, dst, port, reject_ttl
-                        )
-                except Exception:
-                    pass
-            pkt.drop()
+        await _apply_verdict(pkt, flow, dst, port, decision, ttl, loop)
     finally:
         # Connection resolved (verdict cached) -> retransmits now hit the cache,
         # not the in-flight check. Always discard, even if the verdict raised,
         # so a stuck connection can't block the tuple forever.
         _INFLIGHT.discard(flow)
+
+
+def _remember_session_verdict(
+    decision: str, host: str, port: int, ttl: float | None
+) -> None:
+    """Populate the in-session host memory BEFORE the iptables fork below
+    (which yields to the executor): a SYN to a different IP of this host
+    arriving during that yield would otherwise miss the gate and re-prompt.
+
+    An allow is host-scoped (#2372; timed allows too, #2434): otherwise a
+    CDN-rotated IP of a timed-allowed host re-enters NFQUEUE, and a hold
+    timeout there fail-closes to a deny REJECT an in-effect allow should
+    override -- an allow that refuses. The deny side is symmetric (#2446): a
+    timed/forever deny is remembered by host (not just IP) so a retry --
+    including a CDN-rotated IP -- is denied fast without re-prompting.
+    ``once`` (ttl None) adds nothing (per-connection)."""
+    if ttl is None or not port:
+        return
+    if decision == "allow":
+        _add_session_host(host, port, ttl)
+    elif decision == "deny":
+        _add_session_deny(host, port, ttl)
+
+
+async def _apply_verdict(
+    pkt,
+    flow,
+    dst: str,
+    port: int,
+    decision: str,
+    ttl: float | None,
+    loop,
+) -> None:
+    """Apply the decision to the held SYN, installing the kernel rule first
+    (iptables forks run in the executor so they don't block the loop thread --
+    matches the DNS path's _learn_all; the packet is retained, so verdicting
+    after the await is safe)."""
+    if decision == "allow":
+        # `once` (ttl None) -> no learn, just this connection (reconnect
+        # re-prompts); a timed duration -> learn all-ports for it.
+        if ttl is not None:
+            try:
+                await loop.run_in_executor(None, rules.allow, dst, None, ttl, False)
+            except Exception:
+                pass
+        pkt.accept()
+        return
+    # Forge a RST directly so connect() fails fast (ECONNREFUSED) at once,
+    # independent of the conntrack/retransmit race that made the REJECT
+    # rule flaky (#2345). The REJECT rule stays as a belt-and-suspenders
+    # backstop for any retransmit the RST missed. `once` -> the short
+    # fail-close reject window; a timed duration -> that long.
+    # ``once`` is per-connection: scope the REJECT to THIS connection's
+    # source port so a NEW connection (different sport) to the same
+    # host:port re-prompts instead of being rejected above NFQUEUE for
+    # the fail-close window (#2463). A timed/forever deny stays
+    # destination-scoped -- its over-deny is correct (the DB rule +
+    # _SESSION_HOST_DENIES govern re-prompting). The source port is
+    # guarded: a real TCP SYN never has src port 0 (RFC 793), so a
+    # truthy flow[1] is the normal case; if it is ever 0 (a
+    # non-TCP/unparseable flow), fall back to destination-scoped so a
+    # future parse change can't silently re-introduce the over-deny.
+    if port:
+        try:
+            packets._send_rst(pkt.get_payload())
+        except Exception:
+            pass
+        reject_ttl = ttl if ttl is not None else CONSENT_REJECT_TTL
+        try:
+            if ttl is None and flow[1]:
+                await loop.run_in_executor(
+                    None, rules.reject, dst, port, reject_ttl, flow[1]
+                )
+            else:
+                await loop.run_in_executor(None, rules.reject, dst, port, reject_ttl)
+        except Exception:
+            pass
+    pkt.drop()

--- a/src/klangksidecar/klangksidecar/packets.py
+++ b/src/klangksidecar/klangksidecar/packets.py
@@ -27,6 +27,20 @@ def _rst_debug(msg: str) -> None:
         print(msg, flush=True)
 
 
+def _ipv4_offsets(payload: bytes) -> tuple[int, int] | None:
+    """(header_offset, ihl) for the IPv4 header, or None when the payload is
+    not IPv4 (bare L3 or with a 14-byte Ethernet prefix) or too short."""
+    off = 0
+    if len(payload) > 14 and (payload[0] >> 4) != 4 and (payload[14] >> 4) == 4:
+        off = 14  # Ethernet header
+    if off + 20 > len(payload) or (payload[off] >> 4) != 4:
+        return None
+    ihl = (payload[off] & 0x0F) * 4
+    if ihl < 20 or off + ihl > len(payload):
+        return None
+    return off, ihl
+
+
 def parse_dest(payload: bytes) -> tuple[str, int]:
     """``(dst_ip, dst_port)`` from an IPv4 packet payload, or ``("", 0)``.
 
@@ -34,14 +48,10 @@ def parse_dest(payload: bytes) -> tuple[str, int]:
     header; detect the IPv4 version nibble. Port is 0 for non-TCP/UDP. Pure
     so it can be unit-tested with synthetic bytes.
     """
-    off = 0
-    if len(payload) > 14 and (payload[0] >> 4) != 4 and (payload[14] >> 4) == 4:
-        off = 14  # Ethernet header
-    if off + 20 > len(payload) or (payload[off] >> 4) != 4:
+    hdr = _ipv4_offsets(payload)
+    if hdr is None:
         return "", 0
-    ihl = (payload[off] & 0x0F) * 4
-    if ihl < 20 or off + ihl > len(payload):
-        return "", 0
+    off, ihl = hdr
     proto = payload[off + 9]
     dst = ".".join(str(b) for b in payload[off + 16 : off + 20])
     port = 0
@@ -61,14 +71,10 @@ def parse_syn_tuple(payload: bytes) -> tuple[str, int, str, int, int]:
     Pure (mirrors :func:`parse_dest`'s L3/L4 offset logic) so it can be
     unit-tested with synthetic bytes.
     """
-    off = 0
-    if len(payload) > 14 and (payload[0] >> 4) != 4 and (payload[14] >> 4) == 4:
-        off = 14  # Ethernet header
-    if off + 20 > len(payload) or (payload[off] >> 4) != 4:
+    hdr = _ipv4_offsets(payload)
+    if hdr is None:
         return "", 0, "", 0, 0
-    ihl = (payload[off] & 0x0F) * 4
-    if ihl < 20 or off + ihl > len(payload):
-        return "", 0, "", 0, 0
+    off, ihl = hdr
     if payload[off + 9] != 6:  # TCP only
         return "", 0, "", 0, 0
     l4 = off + ihl

--- a/src/klangksidecar/klangksidecar/rules.py
+++ b/src/klangksidecar/klangksidecar/rules.py
@@ -228,21 +228,60 @@ def drop_for_host(host: str, decision: str) -> set[str]:
         targets.add(host_l)
         targets.add(host)
         if decision == "allowed":
-            for ip in [i for i in targets if i in _LEARNED]:
-                for port in list(_LEARNED[ip]["ports"]):
-                    try:
-                        _remove(ip, port)
-                    except Exception:
-                        pass
-                del _LEARNED[ip]
+            _drop_learned_rules(targets)
         elif decision == "denied":
-            for key in [k for k in _REJECTED if k[0] in targets]:
-                try:
-                    _remove_reject(*key)
-                except Exception:
-                    pass
-                del _REJECTED[key]
+            _drop_reject_rules(targets)
     return targets
+
+
+def _drop_learned_rules(targets: set[str]) -> None:
+    """Remove the learned ACCEPT rules (+ ``_LEARNED`` records) for the
+    target IPs (best-effort: a failed delete drops one rule, not the whole
+    revoke). Caller holds ``_LOCK``."""
+    for ip in [i for i in targets if i in _LEARNED]:
+        for port in list(_LEARNED[ip]["ports"]):
+            try:
+                _remove(ip, port)
+            except Exception:
+                pass
+        del _LEARNED[ip]
+
+
+def _drop_reject_rules(targets: set[str]) -> None:
+    """Remove the temporary REJECT rules for the target IPs (best-effort).
+    Caller holds ``_LOCK``."""
+    for key in [k for k in _REJECTED if k[0] in targets]:
+        try:
+            _remove_reject(*key)
+        except Exception:
+            pass
+        del _REJECTED[key]
+
+
+def _sweep_learned_record(
+    ip: str, rec: dict, now: float, expired: list[tuple[str, set]]
+) -> None:
+    """Sweep one learned-IP record in place (caller holds ``_LOCK``):
+
+    rule sweep -- the ACCEPT rule's lifetime is rule_expire when set (a
+    consent allow, whose verdict must outlive the host-mapping's DNS TTL,
+    #2408), else expire (static re-learn / backward compat); record sweep --
+    drop the host mapping once its own expire elapses and no ACCEPT rule
+    remains."""
+    rule_expire = rec.get("rule_expire", rec["expire"])
+    if rec["ports"] and rule_expire <= now:
+        ports = set(rec["ports"])
+        for port in ports:
+            try:
+                _remove(ip, port)
+            except Exception:
+                pass  # a transient failure drops one rule, not the sweep
+        expired.append((ip, ports))
+        rec["ports"] = set()  # rule gone; keep record for naming
+    # Record sweep: drop the host mapping once its own expire elapses
+    # and no ACCEPT rule remains.
+    if rec["expire"] <= now and not rec["ports"]:
+        del _LEARNED[ip]
 
 
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
@@ -271,23 +310,7 @@ def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
     expired: list[tuple[str, set]] = []
     with _LOCK:
         for ip, rec in list(_LEARNED.items()):
-            # Rule sweep: the ACCEPT rule's lifetime is rule_expire when set
-            # (a consent allow, whose verdict must outlive the host-mapping's
-            # DNS TTL, #2408), else expire (static re-learn / backward compat).
-            rule_expire = rec.get("rule_expire", rec["expire"])
-            if rec["ports"] and rule_expire <= now:
-                ports = set(rec["ports"])
-                for port in ports:
-                    try:
-                        _remove(ip, port)
-                    except Exception:
-                        pass  # a transient failure drops one rule, not the sweep
-                expired.append((ip, ports))
-                rec["ports"] = set()  # rule gone; keep record for naming
-            # Record sweep: drop the host mapping once its own expire elapses
-            # and no ACCEPT rule remains.
-            if rec["expire"] <= now and not rec["ports"]:
-                del _LEARNED[ip]
+            _sweep_learned_record(ip, rec, now, expired)
         # also sweep temporary REJECT (tcp-reset) rules for denied connections
         for key in [k for k, exp in _REJECTED.items() if exp <= now]:
             try:


### PR DESCRIPTION
## Summary

Eighteenth PR of the #2817 B-ratchet (scope update: the network sidecar is now gate-covered): brings all 7 rank-C blocks in `src/klangksidecar/klangksidecar/` under rank B — all four touched files pass `xenon --max-absolute B`. Pure extract-function; no behavior change.

## Details

- `nfqueue._cb` (18) → **B (8)**: `_classify_packet` (the connection-tuple key, TCP vs destination granularity), `_fail_fast_no_consent` (#2308/#2413 outage fail-fast), `_apply_cached_verdict` (retransmit fast path), `_session_gate_holds` (#2372/#2434/#2446 host-scoped allow/deny gates), with `_allow_session_host` / `_deny_session_host`.
- `nfqueue._decide_and_verdict` (18) → **B (5)**: `_remember_session_verdict` (pre-fork session-memory population) and `_apply_verdict` (#2345 RST + #2463 once-scoped REJECT).
- `rules.drop_for_host` (16) → **B (5)**: `_drop_learned_rules` + `_drop_reject_rules` (under `_LOCK`).
- `rules.sweep_once` (13) → **B (5)**: `_sweep_learned_record` (the two-lifetime per-record sweep, #2408).
- `packets.parse_syn_tuple` (12) / `parse_dest` (11) → **B (4/4)**: shared `_ipv4_offsets` (L3/Ethernet-prefix detection + IHL validation).
- `app._shutdown` (11) → **B (5)**: `_cancel_task`, `_unbind_nfq`, `_close_quietly`.

## Verification

- Sidecar unit suite (`src/klangksidecar/tests`, `-n auto`): 189 passed.
- Full Python suite (`-n auto`, coverage): 5834 passed, **100% coverage**.
- `xenon --max-absolute B` on all four files: passes.
- No changelog entry (internal refactor).
