### PR TITLE
build(devenv): ratchet xenon module/average gates to rank B

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,10 +220,10 @@ are fine too (`KLANGKD` = daemon, `KLANGKC` = CLI).
 
 Every function, method, and block in `src/klangk/klangk/**/*.py`,
 `src/klangksidecar/klangksidecar/**/*.py`, and
-`scripts/**/*.py` must be xenon rank **C or better** (cyclomatic complexity
-≤ 20). The gate runs as the `xenon` pre-commit hook defined in `devenv.nix`
-(`--max-absolute C --max-modules F --max-average F` — module/average gates
-are off because they flap when only a few files are staged); it checks the
+`scripts/**/*.py` must be xenon rank **B or better** (cyclomatic complexity
+≤ 10), and the per-module and codebase **averages** must also stay rank B
+(≤ 10). The gate runs as the `xenon` pre-commit hook defined in `devenv.nix`
+(`--max-absolute B --max-modules B --max-average B`); it checks the
 staged `.py` files on every commit made through the devenv shell. Nothing
 in CI enforces it yet — the hook is the only gate, so do not bypass it
 with `--no-verify`.
@@ -241,11 +241,12 @@ the limit, extract a helper instead of growing it. Never add noqa-style
 escapes or re-widen the gate to make a commit pass.
 
 The legacy F/E/D blocks were already refactored down to C
-(#2800–#2803, #2808–#2814) and the excludes are gone. The ratchet then
-tightens to **B** (≤ 10) (#2817) and ultimately to **A** (≤ 5) in
-subsequent tranches, one PR per file/subsystem. Target rank **A** for new
-code where practical — anything looser will only be refactored again as
-the gate tightens.
+(#2800–#2803, #2808–#2814) and the C blocks to B
+(#2817, #2818–#2842); the module and codebase averages came under the gate
+at the same threshold (#2846). The ratchet ultimately tightens to **A**
+(≤ 5) in subsequent tranches, one PR per file/subsystem. Target rank **A**
+for new code where practical — anything looser will only be refactored
+again as the gate tightens.
 
 ## Process manager: devenv 2.x native (not process-compose)
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -601,18 +601,23 @@ in
       language = "system";
       pass_filenames = true;
     };
-    # Python: cyclomatic-complexity gate (#2794). Blocks must stay rank C
-    # or better (complexity <= 10); module/average gates are off (rank F)
-    # because they flap when only a few files are staged. The F/E/D-ranked
-    # legacy blocks were refactored down (#2800-#2803, #2808-#2814), the
-    # C-ranked ones in the B-ratchet (#2818-#2842), so the
-    # excludes are gone — every production .py file is checked (klangkd +
-    # CLI under src/klangk/klangk/, the network sidecar under
-    # src/klangksidecar/klangksidecar/, and scripts/).
+    # Python: cyclomatic-complexity gate (#2794). Blocks must stay rank B
+    # or better (complexity <= 10) — the F/E/D legacy blocks were refactored
+    # down (#2800-#2803, #2808-#2814), the C-ranked ones in the B-ratchet
+    # (#2818-#2842), so the excludes are gone — every production .py file is
+    # checked (klangkd + CLI under src/klangk/klangk/, the network sidecar
+    # under src/klangksidecar/klangksidecar/, and scripts/).
+    # Module and codebase averages are also gated at B (#2846): --max-modules
+    # grades each staged module on its own average, so partial staging cannot
+    # cause false failures; --max-average used to flap pre-ratchet (a global
+    # average over only the staged files), but with every block <= 10 no
+    # subset's average can exceed 10, so B-level flapping is impossible. That
+    # returns only if averages are ratcheted to A — then grade the full tree
+    # (pass_filenames = false) instead of the staged subset.
     xenon = {
       enable = true;
       name = "xenon";
-      entry = "${pkgs.xenon}/bin/xenon --max-absolute B --max-modules F --max-average F";
+      entry = "${pkgs.xenon}/bin/xenon --max-absolute B --max-modules B --max-average B";
       files = "^src/klangk/klangk/.*\\.py$|^src/klangksidecar/klangksidecar/.*\\.py$|^scripts/.*\\.py$";
       language = "system";
       pass_filenames = true;


### PR DESCRIPTION
## Summary

Ratchets the xenon pre-commit gate from `--max-absolute B --max-modules F --max-average F` to all three thresholds at **B** (closes #2846).

## Details

- `devenv.nix` hook entry now `--max-absolute B --max-modules B --max-average B`; the comment is rewritten to record why this is safe: `--max-modules` grades each staged module on its own average (partial staging can't cause false failures), and `--max-average` used to flap pre-ratchet (global average over only the staged files) but with every block ≤ 10 no subset's average can exceed 10 — B-level flapping is impossible. The A-level caveat (where flapping returns and the fix is full-tree grading, `pass_filenames = false`) is documented in the comment for whoever ratchets next.
- `AGENTS.md` xenon section updated: requirement is now rank **B** blocks plus module/codebase averages at B; ratchet history includes #2846; A remains the target for new code.
- Zero code changes — measured green before (issue #2846) and `pre-commit run xenon --all-files` passes on this branch (full tree incl. `src/klangksidecar/klangksidecar/` + `scripts/`).

No changelog entry, matching the #2843 precedent for dev-gate-only flips.
