### PR TITLE
build(devenv): make xenon runnable directly in a devenv shell

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -99,6 +99,7 @@ in
       sqlite.bin
       rsync
       twine
+      xenon # cyclomatic-complexity gate tool (#2828): same pinned build as the hook
       zensical
     ]
     ++ (
@@ -166,6 +167,14 @@ in
       '';
       after = [ "devenv:python:virtualenv" ];
       before = [ "devenv:enterShell" ];
+    };
+    # The complexity gate as a one-word task (#2828): the exact hook
+    # invocation over the exact hook file set, so `devenv shell -- xenon`
+    # (ad hoc) and `pre-commit run xenon` (staged) can't drift. Note the
+    # hook grades the STAGED subset; this task grades the whole tree —
+    # stricter or equal, never more lenient.
+    "klangk:xenon" = {
+      exec = "xenon --max-absolute B --max-modules B --max-average B $(git ls-files 'src/klangk/klangk/*.py' 'src/klangksidecar/klangksidecar/*.py' 'scripts/*.py')";
     };
     "klangk:flutter-build" = {
       exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh"'';

--- a/scripts/tests/test_supply_chain_pins.py
+++ b/scripts/tests/test_supply_chain_pins.py
@@ -199,7 +199,7 @@ class TestWorkspaceTarballPins:
             ), f"PROCESS_COMPOSE_SHA256_{arch} must be a 64-hex-char sha256"
 
     def test_no_unverified_curl_pipes(self):
-        """No `curl ... | sh` / `curl ... | tar` piping in the image
+        r"""No `curl ... | sh` / `curl ... | tar` piping in the image
         Dockerfiles whose installs are fully pinned (workspace, host, base) —
         download-to-file, verify, then act. The regex `curl[^|]*\|` matches
         any line with `curl` followed later by a pipe (a `\S*`-anchored form


### PR DESCRIPTION
## Summary

Closes #2828: adds `pkgs.xenon` to the devshell `packages`, so `xenon` runs directly inside a devenv shell from the same pinned nix evaluation the pre-commit hook uses.

## Changes

- **`devenv.nix`**: `pkgs.xenon` added to `packages`; the hook's `${pkgs.xenon}/bin/xenon` and the shell's `xenon` are now the same build (single `pkgs.xenon` reference each).
- **`klangk:xenon` task**: runs the gate's exact invocation (`--max-absolute B --max-modules B --max-average B`) over the gate's file set via `git ls-files` — the hook grades the staged subset, the task the whole tree, so the task is stricter-or-equal, never more lenient. `devenv shell -- xenon` ad hoc, `devenv tasks run klangk:xenon` full-tree.
- **`scripts/tests/test_supply_chain_pins.py`**: the `test_no_unverified_curl_pipes` docstring is now raw (`r"""`) — its `curl[^|]*\|` regex example emitted a `SyntaxWarning: invalid escape sequence '\|'` whenever radon parsed the file, which the new task surfaced on every run. No behavior change.

## Verification

- `devenv --quiet -O dotenv.enable:bool false shell -- xenon --version` → `0.9.3` (was exit 127).
- Full-tree task invocation exits 0, no warnings; `pre-commit run xenon --all-files` passes.
- `scripts/tests`: 83 passed.
- No changelog entry (internal tooling).
