### PR TITLE
refactor(server): extract IntervalWorker base for interval-loop housekeepers

### DIFF
--- a/src/klangk/klangk/consent/egress.py
+++ b/src/klangk/klangk/consent/egress.py
@@ -18,10 +18,9 @@ predicate the coordinator gate-checks with.
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import time
 
+from ..interval import IntervalWorker
 from ..model.workspaces import EGRESS_MODE_INTERACTIVE
 
 logger = logging.getLogger(__name__)
@@ -46,7 +45,7 @@ async def workspace_is_interactive(app, workspace_id: str) -> bool:
     return app.state.consent_deciders.has_decider(workspace_id)
 
 
-class EgressConsentSweeper:
+class EgressConsentSweeper(IntervalWorker):
     """Prune the egress_consent retention table on a wall-clock interval.
 
     Constructed once in :func:`build_app` and stored on ``app.state``;
@@ -60,51 +59,15 @@ class EgressConsentSweeper:
     ``app``).
     """
 
-    def __init__(self, app) -> None:
-        self.app = app
-        self._task: asyncio.Task | None = None
+    # Live-read (a property, not a captured constant) so a patched/test
+    # module global applies on the next cycle.
+    @property
+    def interval(self) -> float:
+        return PRUNE_INTERVAL
 
-    def reconfigure(self, app) -> None:
-        self.app = app
+    log_label = "egress consent: retention sweep"
 
-    def start(self) -> None:
-        """Start the sweep loop (idempotent). Runs until :meth:`stop`."""
-        if self._task is None:
-            self._task = asyncio.create_task(self._run())
-
-    async def stop(self) -> None:
-        """Cancel the sweep loop."""
-        if self._task is not None:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
-
-    async def _run(self) -> None:
-        # 0.0 sweeps once immediately on startup (a prior run may have left
-        # the table past the window / over the cap), then every
-        # PRUNE_INTERVAL.
-        next_prune = 0.0
-        try:
-            while True:
-                if time.monotonic() >= next_prune:
-                    try:
-                        await self._prune()
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        logger.warning(
-                            "egress consent: retention sweep failed",
-                            exc_info=True,
-                        )
-                    next_prune = time.monotonic() + PRUNE_INTERVAL
-                await asyncio.sleep(max(0.0, next_prune - time.monotonic()))
-        except asyncio.CancelledError:
-            pass
-
-    async def _prune(self) -> None:
+    async def sweep(self) -> None:
         """One retention sweep: prune rows past retention / over the cap.
 
         Settings are read live inside the model call (SIGHUP reload-safe:

--- a/src/klangk/klangk/inactivity.py
+++ b/src/klangk/klangk/inactivity.py
@@ -14,18 +14,17 @@ correctness path.
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import time
 
 from klangk import wshandler
+from klangk.interval import IntervalWorker
 
 logger = logging.getLogger(__name__)
 
 SWEEP_INTERVAL = 3600.0
 
 
-class InactivitySweeper:
+class InactivitySweeper(IntervalWorker):
     """Disable dormant accounts on a wall-clock interval (#2588).
 
     Constructed once in :func:`klangk.main.build_app` and stored on
@@ -36,50 +35,15 @@ class InactivitySweeper:
     ``app``).
     """
 
-    def __init__(self, app) -> None:
-        self.app = app
-        self._task: asyncio.Task | None = None
+    # Live-read (a property, not a captured constant) so a patched/test
+    # module global applies on the next cycle.
+    @property
+    def interval(self) -> float:
+        return SWEEP_INTERVAL
 
-    def reconfigure(self, app) -> None:
-        self.app = app
+    log_label = "inactivity: dormant-account sweep"
 
-    def start(self) -> None:
-        """Start the sweep loop (idempotent). Runs until :meth:`stop`."""
-        if self._task is None:
-            self._task = asyncio.create_task(self._run())
-
-    async def stop(self) -> None:
-        """Cancel the sweep loop."""
-        if self._task is not None:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
-
-    async def _run(self) -> None:
-        # 0.0 sweeps once immediately on startup, then every
-        # SWEEP_INTERVAL.
-        next_sweep = 0.0
-        try:
-            while True:
-                if time.monotonic() >= next_sweep:
-                    try:
-                        await self._sweep()
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        logger.warning(
-                            "inactivity: dormant-account sweep failed",
-                            exc_info=True,
-                        )
-                    next_sweep = time.monotonic() + SWEEP_INTERVAL
-                await asyncio.sleep(max(0.0, next_sweep - time.monotonic()))
-        except asyncio.CancelledError:
-            pass
-
-    async def _sweep(self) -> None:
+    async def sweep(self) -> None:
         """One sweep: disable accounts past the inactivity window."""
         days = self.app.state.settings.inactivity_disable_days
         if days <= 0:

--- a/src/klangk/klangk/interval.py
+++ b/src/klangk/klangk/interval.py
@@ -1,0 +1,84 @@
+"""Shared background-worker scaffold: a cancel-safe interval loop.
+
+Several app-state housekeepers (inactivity disable, egress-consent
+retention, the server-action scheduler) are the same shape: start once in
+the lifespan, run an interval loop whose unit of work is log-and-continue,
+stop cleanly on shutdown. :class:`IntervalWorker` owns that shape;
+subclasses implement :meth:`sweep` (one unit of work) and set
+:data:`interval` plus the log labels.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class IntervalWorker:
+    """App-state background worker: interval loop + start/stop lifecycle.
+
+    The loop sweeps once immediately on start, then every
+    :data:`interval`. A raising sweep is logged and retried an interval
+    later — housekeeping, never a correctness path (:meth:`sweep` decides
+    its own failure posture). Owns only ``app``; settings are read live
+    inside the sweep so a SIGHUP reload applies on the next pass
+    (:meth:`reconfigure` swaps ``app``).
+    """
+
+    #: Seconds between sweeps.
+    interval = 3600.0
+
+    #: The failure log line's prefix (``"<log_label> failed"``).
+    log_label = "worker"
+
+    def __init__(self, app) -> None:
+        self.app = app
+        self._task: asyncio.Task | None = None
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    def start(self) -> None:
+        """Start the loop (idempotent). Runs until :meth:`stop`."""
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Cancel the loop."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _run(self) -> None:
+        # 0.0 sweeps once immediately on startup, then every interval.
+        next_sweep = 0.0
+        try:
+            while True:
+                if time.monotonic() >= next_sweep:
+                    try:
+                        await self.sweep()
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        logger.warning(
+                            "%s failed", self.log_label, exc_info=True
+                        )
+                    next_sweep = time.monotonic() + self.interval
+                await asyncio.sleep(max(0.0, next_sweep - time.monotonic()))
+        except asyncio.CancelledError:
+            self.on_stopped()
+            raise
+
+    def on_stopped(self) -> None:
+        """Hook fired when the loop is cancelled (default: nothing)."""
+
+    async def sweep(self) -> None:
+        """One unit of periodic work; failures are logged, not fatal."""
+        raise NotImplementedError  # pragma: no cover - abstract hook

--- a/src/klangk/klangk/server_schedule.py
+++ b/src/klangk/klangk/server_schedule.py
@@ -24,10 +24,10 @@ The schedule is persisted in the DB, so it survives a klangkd restart:
 on boot the loop simply re-reads the pending rows.
 """
 
-import asyncio
 import logging
 import os
 import signal
+from klangk.interval import IntervalWorker
 from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
@@ -46,36 +46,30 @@ _MAX_IN_SECONDS = 1e10
 _BROADCAST_INTERVAL_SECONDS = 30.0
 
 
-class ServerScheduler:
+class ServerScheduler(IntervalWorker):
     """Owns the scheduled server-action loop (app-only ownership, #1563)."""
 
+    # Live-read (a property, not a captured constant) so tests can patch
+    # the module global and SIGHUP-adjacent changes apply next cycle.
+    @property
+    def interval(self) -> float:
+        return _POLL_INTERVAL_SECONDS
+
+    log_label = "Server scheduler tick"
+
     def __init__(self, app) -> None:
-        self.app = app
-        self._task: asyncio.Task | None = None
+        super().__init__(app)
         self._last_broadcast: datetime | None = None
         self._last_snapshot: list[dict] | None = None
 
-    def reconfigure(self, app) -> None:
-        self.app = app
-
-    # --- lifecycle ---
-
     def start(self) -> None:
-        """Launch the schedule loop (idempotent)."""
-        if self._task is not None and not self._task.done():
-            return
-        self._task = asyncio.get_event_loop().create_task(self._run())
+        """Launch the schedule loop (idempotent); logs the start."""
+        if self._task is None:
+            logger.info("Server scheduler loop started")
+        super().start()
 
-    async def stop(self) -> None:
-        """Cancel the loop and wait for it."""
-        task = self._task
-        self._task = None
-        if task is not None:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+    def on_stopped(self) -> None:
+        logger.info("Server scheduler loop stopped")
 
     # --- snapshot / broadcast ---
 
@@ -114,26 +108,7 @@ class ServerScheduler:
             # owns cleanup on disconnect.
             pass
 
-    # --- loop ---
-
-    async def _run(self) -> None:
-        logger.info("Server scheduler loop started")
-        try:
-            while True:
-                try:
-                    await self._tick()
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    # One bad tick (DB hiccup, podman error) must not kill
-                    # the loop — the schedule stays armed for the next one.
-                    logger.exception("Server scheduler tick failed")
-                await asyncio.sleep(_POLL_INTERVAL_SECONDS)
-        except asyncio.CancelledError:
-            logger.info("Server scheduler loop stopped")
-            raise
-
-    async def _tick(self) -> None:
+    async def sweep(self) -> None:
         schedules = await self.snapshot()
         now = datetime.now(timezone.utc)
         # 7: a malformed fire_at row (manual DB edit) must not kill the

--- a/src/klangk/klangkd-tests/tests/test_inactivity.py
+++ b/src/klangk/klangkd-tests/tests/test_inactivity.py
@@ -126,17 +126,17 @@ class TestInactivitySweeper:
         model — read live each pass, so a SIGHUP flip applies next sweep."""
         app = _app(days=0)
         sw = inactivity.InactivitySweeper(app)
-        await sw._sweep()
+        await sw.sweep()
         assert await_count(app.state.model.users.disable_inactive_users) == 0
 
     async def test_days_passed_live_from_settings(self):
         """The sweep reads settings each pass (SIGHUP reload-safe)."""
         app = _app(days=7)
         mock = app.state.model.users.disable_inactive_users
-        await inactivity.InactivitySweeper(app)._sweep()
+        await inactivity.InactivitySweeper(app).sweep()
         mock.assert_awaited_once_with(7)
         app.state.settings.inactivity_disable_days = 3
-        await inactivity.InactivitySweeper(app)._sweep()
+        await inactivity.InactivitySweeper(app).sweep()
         assert mock.await_args_list[-1] == ((3,), {})
 
     async def test_disabled_users_are_logged_and_kicked(self, caplog):
@@ -148,7 +148,7 @@ class TestInactivitySweeper:
             )
         )
         with caplog.at_level("INFO", logger="klangk.inactivity"):
-            await inactivity.InactivitySweeper(app)._sweep()
+            await inactivity.InactivitySweeper(app).sweep()
         assert "gone@example.com" in caplog.text
         app.state.sockets.disconnect_user.assert_awaited_once_with(
             "u1", code=4001, reason="Account disabled"

--- a/src/klangk/klangkd-tests/tests/test_server_schedule.py
+++ b/src/klangk/klangkd-tests/tests/test_server_schedule.py
@@ -257,7 +257,7 @@ class TestServerScheduler:
             created_by="u1",
         )
         with patch("klangk.server_schedule.os.kill") as mock_kill:
-            await scheduler._tick()
+            await scheduler.sweep()
         mock_kill.assert_called_once()
         args = mock_kill.call_args[0]
         assert args[1] is signal.SIGTERM
@@ -276,7 +276,7 @@ class TestServerScheduler:
             datetime.now(timezone.utc) - timedelta(seconds=1),
             created_by="u1",
         )
-        await scheduler._tick()
+        await scheduler.sweep()
         lifecycle.request_recycle.assert_called_once_with(
             source="scheduled recycle"
         )
@@ -298,7 +298,7 @@ class TestServerScheduler:
             created_by="u1",
         )
         with patch("klangk.server_schedule.os.kill") as mock_kill:
-            await scheduler._tick()
+            await scheduler.sweep()
         mock_kill.assert_not_called()
         # The row was still consumed — it must not re-fire on a restart.
         assert await app.state.model.server_schedules.pending_schedules() == []
@@ -348,7 +348,7 @@ class TestServerScheduler:
                 ),
             )
         with patch("klangk.server_schedule.os.kill"):
-            await scheduler._tick()  # must not raise
+            await scheduler.sweep()  # must not raise
         # The healthy row still broadcasts; the bad one is carried in the
         # pending list (never fired) so clients see it exists.
         snapshot = [m for m in sent if m["type"] == "server_schedule"]
@@ -369,7 +369,7 @@ class TestServerScheduler:
             datetime.now(timezone.utc) - timedelta(seconds=1),
             created_by="u1",
         )
-        await scheduler._tick()
+        await scheduler.sweep()
         lifecycle.request_recycle.assert_not_called()
         # The row was still consumed — it must not re-fire on a restart.
         assert await app.state.model.server_schedules.pending_schedules() == []
@@ -383,7 +383,7 @@ class TestServerScheduler:
                 datetime.now(timezone.utc) + timedelta(hours=1),
                 created_by="u1",
             )
-            await scheduler._tick()
+            await scheduler.sweep()
         mock_kill.assert_not_called()
         assert "server_schedule_fired" not in [m["type"] for m in sent]
         assert sent and sent[-1]["type"] == "server_schedule"
@@ -397,16 +397,16 @@ class TestServerScheduler:
             datetime.now(timezone.utc) + timedelta(hours=1),
             created_by="u1",
         )
-        await scheduler._tick()
+        await scheduler.sweep()
         first = len(sent)
-        await scheduler._tick()  # immediately again: set unchanged, cadence
+        await scheduler.sweep()  # immediately again: set unchanged, cadence
         # not elapsed -> no second broadcast.
         assert len(sent) == first
         # Pretend the cadence window elapsed.
         scheduler._last_broadcast = datetime.now(timezone.utc) - timedelta(
             seconds=31
         )
-        await scheduler._tick()
+        await scheduler.sweep()
         assert len(sent) == first + 1
 
     async def test_start_stop_idempotent(self, sched_app):
@@ -433,7 +433,7 @@ class TestLoop:
             # Second tick: stop the loop.
             asyncio.current_task().cancel()
 
-        scheduler._tick = flaky_tick
+        scheduler.sweep = flaky_tick
         with patch("klangk.server_schedule._POLL_INTERVAL_SECONDS", 0.01):
             with pytest.raises(asyncio.CancelledError):
                 await asyncio.wait_for(scheduler._run(), timeout=5)


### PR DESCRIPTION
## Summary

Second PR of the #2849 consolidation: the three interval-loop housekeepers (`InactivitySweeper`, `EgressConsentSweeper`, `ServerScheduler`) now share an `IntervalWorker` base (`klangk/interval.py`) owning the loop, `start`/`stop`/`reconfigure` lifecycle, and the sweep-then-sleep-to-next cadence. Pure refactor; no behavior change.

## Details

- `IntervalWorker`: immediate first sweep, then every `interval`; a raising sweep logs `"<log_label> failed"` and retries an interval later; cancellation fires an `on_stopped` hook and re-raises (the scheduler's old log line is preserved via that hook). `sweep()` is the one subclass hook.
- Each subclass keeps its exact failure-log wording via `log_label`, and reads its interval through a **live property** over the module constant — preserving test patchability (`monkeypatch.setattr(inactivity, "SWEEP_INTERVAL", ...)`) and any future runtime tuning; a captured class attribute would have frozen the value at import.
- `ServerScheduler` keeps its start/stop log lines and its extra `__init__` state; its `stop`'s null-before-await ordering folds into the base's null-after-await (stop is single-caller; the difference is unobservable).
- Swept `window_watcher.py` and `container/eviction.py` per the issue: both differ materially (subprocess lifecycle; per-cycle sustain/hysteresis state) — deliberately not converted.
- Tests renamed with the hook (`_sweep`/`_tick` → `sweep`).

## Verification

- Full Python suite (`-n auto`, coverage): 5834 passed, **100% coverage**.
- ruff format + check clean.
- No changelog entry (internal refactor).
