### PR TITLE
refactor(scripts): shared fuzzlib/consentlib scaffolds

### DIFF
--- a/scripts/consent-decide.py
+++ b/scripts/consent-decide.py
@@ -19,27 +19,16 @@ from __future__ import annotations
 import argparse
 import ipaddress
 import json
-import os
 import sqlite3
 import sys
 import time
-from pathlib import Path
+from consentlib import data_dir
 
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
 console = Console()
-
-
-def _data_dir(arg: str | None) -> Path:
-    path = arg or os.environ.get("KLANGKD_DATA_DIR")
-    if not path:
-        sys.exit(
-            "data dir not set: pass --data-dir or export KLANGKD_DATA_DIR "
-            "(the klangkd dir containing klangk.db)"
-        )
-    return Path(path)
 
 
 def _resolve_user(conn: sqlite3.Connection, email: str) -> str:
@@ -175,7 +164,7 @@ def main() -> None:
     )
     args = ap.parse_args()
 
-    db_path = _data_dir(args.data_dir) / "klangk.db"
+    db_path = data_dir(args.data_dir) / "klangk.db"
     if not db_path.exists():
         sys.exit(f"DB not found: {db_path}")
     conn = sqlite3.connect(f"file:{db_path}?mode=rw", uri=True, timeout=10)

--- a/scripts/consent-watch.py
+++ b/scripts/consent-watch.py
@@ -16,11 +16,10 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import os
 import sqlite3
 import sys
 import time
-from pathlib import Path
+from consentlib import data_dir
 
 from rich.console import Console
 from rich.live import Live
@@ -33,16 +32,6 @@ _DECISION_STYLE = {
     "denied": "bold red",
     "expired": "dim",
 }
-
-
-def _data_dir(arg: str | None) -> Path:
-    path = arg or os.environ.get("KLANGKD_DATA_DIR")
-    if not path:
-        sys.exit(
-            "data dir not set: pass --data-dir or export KLANGKD_DATA_DIR "
-            "(the klangkd dir containing klangk.db)"
-        )
-    return Path(path)
 
 
 def _fetch(conn: sqlite3.Connection, ws: str) -> list[tuple]:
@@ -98,7 +87,7 @@ def main() -> None:
     ap.add_argument("--interval", type=float, default=1.0, help="refresh seconds")
     args = ap.parse_args()
 
-    db_path = _data_dir(args.data_dir) / "klangk.db"
+    db_path = data_dir(args.data_dir) / "klangk.db"
     if not db_path.exists():
         sys.exit(f"DB not found: {db_path}")
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)

--- a/scripts/consentlib.py
+++ b/scripts/consentlib.py
@@ -1,0 +1,19 @@
+"""Shared helpers for the consent CLI scripts (consent-watch, consent-decide)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def data_dir(arg: str | None) -> Path:
+    """The klangkd data dir: the --data-dir argument, else $KLANGKD_DATA_DIR;
+    exits with guidance when neither is set."""
+    path = arg or os.environ.get("KLANGKD_DATA_DIR")
+    if not path:
+        sys.exit(
+            "data dir not set: pass --data-dir or export KLANGKD_DATA_DIR "
+            "(the klangkd dir containing klangk.db)"
+        )
+    return Path(path)

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -42,6 +42,8 @@ import uuid
 
 import httpx
 
+from fuzzlib import configure_logging, draw_seed, uds_login
+
 logger = logging.getLogger("fuzz")
 
 # ---------------------------------------------------------------------------
@@ -675,21 +677,6 @@ def wait_for_server(uds_path: str, timeout: float = 30) -> None:
     raise TimeoutError("Server did not start in time")
 
 
-def login(uds_path: str) -> str:
-    """Log in as admin and return the access token (over the UDS)."""
-    with httpx.Client(
-        transport=httpx.HTTPTransport(uds=uds_path),
-        base_url="http://klangkd",
-        timeout=10,
-    ) as c:
-        r = c.post(
-            "/api/v1/auth/login",
-            json={"email": "admin@example.com", "password": "admin"},
-        )
-        r.raise_for_status()
-        return r.json()["access_token"]
-
-
 # ---------------------------------------------------------------------------
 # Anomaly tracking
 # ---------------------------------------------------------------------------
@@ -1070,7 +1057,7 @@ async def run_fuzz(
             # Periodically re-login in case the token was invalidated
             if tracker.requests_sent % 200 == 0:
                 try:
-                    new_token = login(uds_path)
+                    new_token = uds_login(uds_path, "admin@example.com", "admin")
                     headers["Authorization"] = f"Bearer {new_token}"
                 except Exception:
                     pass  # will continue with old or no token
@@ -1173,18 +1160,12 @@ def main():
     )
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-    # Suppress noisy per-request httpx logging
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    configure_logging()
 
     if args.check:
         sys.exit(check_endpoints())
 
-    seed = args.seed if args.seed is not None else random.randint(0, 2**32)
+    seed = draw_seed(args.seed)
 
     tracker = AnomalyTracker()
 
@@ -1196,7 +1177,7 @@ def main():
             wait_for_server(uds_path)
             logger.info("Server is up")
 
-            token = login(uds_path)
+            token = uds_login(uds_path, "admin@example.com", "admin")
             logger.info("Logged in as admin")
 
             logger.info(

--- a/scripts/fuzz-idle.py
+++ b/scripts/fuzz-idle.py
@@ -68,6 +68,8 @@ import uuid
 from dataclasses import dataclass, field
 
 import httpx
+
+from fuzzlib import configure_logging, draw_seed
 import websockets
 
 logger = logging.getLogger("fuzz-idle")
@@ -1401,8 +1403,7 @@ def main() -> None:
         help="Directory for server.log + scenarios.json (default: tempdir)",
     )
     args = parser.parse_args()
-    if args.seed is None:
-        args.seed = random.randint(0, 2**32)
+    args.seed = draw_seed(args.seed)
 
     # Line-buffered stdout so a killed run (CI timeout) still shows its
     # progress; SIGTERM -> SystemExit so the finally-teardown (server stop,
@@ -1414,12 +1415,8 @@ def main() -> None:
 
     signal.signal(signal.SIGTERM, _on_sigterm)
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    configure_logging()
+    # websockets handshake noise is idle-specific (the sidecar WS loop).
     logging.getLogger("websockets").setLevel(logging.WARNING)
 
     sys.exit(asyncio.run(run(args)))

--- a/scripts/fuzzlib.py
+++ b/scripts/fuzzlib.py
@@ -1,0 +1,38 @@
+"""Shared scaffolding for the fuzz harnesses (fuzz-api, fuzz-idle)."""
+
+from __future__ import annotations
+
+import logging
+import random
+
+import httpx
+
+
+def configure_logging() -> None:
+    """The fuzz-log posture: INFO root, per-request httpx noise suppressed."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+
+def draw_seed(raw: int | None) -> int:
+    """The run's RNG seed: the --seed value, else a fresh draw."""
+    return raw if raw is not None else random.randint(0, 2**32)
+
+
+def uds_login(uds_path: str, email: str, password: str) -> str:
+    """Log in over the backend UDS and return the access token."""
+    with httpx.Client(
+        transport=httpx.HTTPTransport(uds=uds_path),
+        base_url="http://klangkd",
+        timeout=10,
+    ) as c:
+        r = c.post(
+            "/api/v1/auth/login",
+            json={"email": email, "password": password},
+        )
+        r.raise_for_status()
+        return r.json()["access_token"]


### PR DESCRIPTION
## Summary

Third PR of the #2849 consolidation: shared scaffolds for the fuzz and consent scripts. Pure refactor; no behavior change.

## Details

- **`scripts/fuzzlib.py`**: `configure_logging()` (the identical basicConfig + httpx/httpcore suppression), `draw_seed(raw)` (the identical `--seed`-or-draw), and `uds_login(uds_path, email, password)` (fuzz-api's admin login, parameterized). `fuzz-api.py` and `fuzz-idle.py` both consume the first two; fuzz-api's two `login(uds_path)` call sites become `uds_login(...)` with the same credentials. fuzz-idle keeps its extra `websockets` log suppression (sidecar-WS specific).
- **`scripts/consentlib.py`**: `data_dir(arg)` — the byte-identical `_data_dir` from `consent-watch.py` + `consent-decide.py` (7 lines each).
- The scripts' own mains stay (arg-parsing differs per harness); only the genuinely shared bodies moved.

## Verification

- `scripts/tests`: 83 passed; `python scripts/fuzz-api.py --check` clean (100 routes, no drift).
- ruff format + check clean.
- No changelog entry (internal tooling).
