### PR TITLE
refactor(tui): shared confirm_then helper for confirm-dialog callbacks

### DIFF
--- a/src/klangk/klangk/cli/tui/screens/_base.py
+++ b/src/klangk/klangk/cli/tui/screens/_base.py
@@ -93,6 +93,22 @@ class ButtonRowModalScreen(ModalScreen[_ScreenResult]):
         self.dismiss(None)
 
 
+def confirm_then(screen, work):
+    """A ConfirmScreen callback that runs *work* on *screen*'s worker when
+    confirmed (the shared "confirm, then run the action" shape).
+
+    *work* is a zero-arg coroutine factory (a bound method, or
+    ``functools.partial``), evaluated only on confirm.
+    """
+
+    def _on_confirm(confirmed: bool) -> None:
+        if not confirmed:
+            return
+        screen.run_worker(work(), exit_on_error=False)
+
+    return _on_confirm
+
+
 class ConfirmScreen(ButtonRowModalScreen[bool]):
     """A yes/no confirmation dialog. Dismisses with True on confirm.
 

--- a/src/klangk/klangk/cli/tui/screens/login.py
+++ b/src/klangk/klangk/cli/tui/screens/login.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from urllib.parse import urlparse
 
 from rich.text import Text
@@ -27,6 +28,7 @@ from ._base import (
     ServerListView,
     SpatialNavScreen,
     StatusScreen,
+    confirm_then,
 )
 
 
@@ -211,13 +213,9 @@ class LoginScreen(SpatialNavScreen, StatusScreen):
             return
         url = child.name
 
-        def _on_confirm(confirmed: bool) -> None:
-            if not confirmed:
-                return
-            self.run_worker(self._do_delete_server(url), exit_on_error=False)
-
         self.app.push_screen(
-            ConfirmScreen(f"Delete server {url}?"), _on_confirm
+            ConfirmScreen(f"Delete server {url}?"),
+            confirm_then(self, partial(self._do_delete_server, url)),
         )
 
     async def _do_delete_server(self, url: str) -> None:

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 import datetime
 import logging
 import random
@@ -40,6 +41,7 @@ from ._base import (
     StatusScreen,
     TransferScreen,
     WorkspaceListView,
+    confirm_then,
 )
 from .server import ServerSwitchScreen
 from .workspace_form import CreateWorkspaceScreen, EditWorkspaceScreen
@@ -597,11 +599,6 @@ class MainScreen(StatusScreen):
         if not name:
             return
 
-        def _on_confirm(confirmed: bool) -> None:
-            if not confirmed:
-                return
-            self.run_worker(self._do_restart(name), exit_on_error=False)
-
         self.app.push_screen(
             ConfirmScreen(
                 f"Restart '{name}'? This ends active terminal sessions"
@@ -609,7 +606,7 @@ class MainScreen(StatusScreen):
                 yes_label="Restart",
                 yes_variant="warning",
             ),
-            _on_confirm,
+            confirm_then(self, partial(self._do_restart, name)),
         )
 
     async def _do_restart(self, name: str) -> None:
@@ -627,19 +624,13 @@ class MainScreen(StatusScreen):
             return
         ws = self._highlighted_ws()
         if ws is not None and ws.running:
-
-            def _on_confirm(confirmed: bool) -> None:
-                if not confirmed:
-                    return
-                self.run_worker(self._do_stop(name), exit_on_error=False)
-
             self.app.push_screen(
                 ConfirmScreen(
                     f"Stop '{name}'? This ends active terminal sessions.",
                     yes_label="Stop",
                     yes_variant="warning",
                 ),
-                _on_confirm,
+                confirm_then(self, partial(self._do_stop, name)),
             )
         else:
             self.run_worker(self._do_start(name), exit_on_error=False)
@@ -694,17 +685,12 @@ class MainScreen(StatusScreen):
         if not name:
             return
 
-        def _on_confirm(confirmed: bool) -> None:
-            if not confirmed:
-                return
-            self.run_worker(self._do_delete(name), exit_on_error=False)
-
         self.app.push_screen(
             ConfirmScreen(
                 f"Delete '{name}'? This permanently deletes the workspace"
                 " and its container.",
             ),
-            _on_confirm,
+            confirm_then(self, partial(self._do_delete, name)),
         )
 
     async def _do_delete(self, name: str) -> None:

--- a/src/klangk/klangk/cli/tui/screens/server.py
+++ b/src/klangk/klangk/cli/tui/screens/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 
 from rich.text import Text
 
@@ -21,7 +22,12 @@ from textual.widgets import (
 
 from ...config import AliasConflictError
 from ...transport import is_valid_server_spec
-from ._base import ConfirmScreen, SpatialListView, StatusScreen
+from ._base import (
+    ConfirmScreen,
+    SpatialListView,
+    StatusScreen,
+    confirm_then,
+)
 
 
 class ServerSwitchScreen(StatusScreen):
@@ -120,14 +126,9 @@ class ServerSwitchScreen(StatusScreen):
             return
         url = child.name
 
-        def _on_confirm(confirmed: bool) -> None:
-            if confirmed:
-                self.run_worker(
-                    self._do_delete_and_refresh(url), exit_on_error=False
-                )
-
         self.app.push_screen(
-            ConfirmScreen(f"Delete server {url}?"), _on_confirm
+            ConfirmScreen(f"Delete server {url}?"),
+            confirm_then(self, partial(self._do_delete_and_refresh, url)),
         )
 
     async def _do_delete_and_refresh(self, url: str) -> None:

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -35,6 +35,7 @@ from ._base import (
     SpatialListView,
     StatusScreen,
     TransferScreen,
+    confirm_then,
 )
 from .workspace_form import EditWorkspaceScreen
 
@@ -1149,11 +1150,6 @@ class WorkspaceDetailScreen(StatusScreen):
     # --- actions ---
 
     def action_restart(self) -> None:
-        def _on_confirm(confirmed: bool) -> None:
-            if not confirmed:
-                return
-            self.run_worker(self._do_restart, exit_on_error=False)
-
         self.app.push_screen(
             ConfirmScreen(
                 f"Restart '{self._name}'? This ends active terminal"
@@ -1161,7 +1157,7 @@ class WorkspaceDetailScreen(StatusScreen):
                 yes_label="Restart",
                 yes_variant="warning",
             ),
-            _on_confirm,
+            confirm_then(self, self._do_restart),
         )
 
     async def _do_restart(self) -> None:
@@ -1187,18 +1183,13 @@ class WorkspaceDetailScreen(StatusScreen):
             self.run_worker(self._do_start, exit_on_error=False)
 
     def _confirm_stop(self) -> None:
-        def _on_confirm(confirmed: bool) -> None:
-            if not confirmed:
-                return
-            self.run_worker(self._do_stop, exit_on_error=False)
-
         self.app.push_screen(
             ConfirmScreen(
                 f"Stop '{self._name}'? This ends active terminal sessions.",
                 yes_label="Stop",
                 yes_variant="warning",
             ),
-            _on_confirm,
+            confirm_then(self, self._do_stop),
         )
 
     async def _do_stop(self) -> None:
@@ -1232,17 +1223,12 @@ class WorkspaceDetailScreen(StatusScreen):
         self.app.refresh_workspaces()
 
     def action_delete(self) -> None:
-        def _on_confirm(confirmed: bool) -> None:
-            if not confirmed:
-                return
-            self.run_worker(self._do_delete, exit_on_error=False)
-
         self.app.push_screen(
             ConfirmScreen(
                 f"Delete '{self._name}'? This permanently deletes the"
                 " workspace and its container."
             ),
-            _on_confirm,
+            confirm_then(self, self._do_delete),
         )
 
     async def _do_delete(self) -> None:


### PR DESCRIPTION
## Summary

Fourth PR of the #2849 consolidation: the eight `_on_confirm` confirm-dialog callbacks across `server.py`, `login.py`, `workspace_detail.py` (×3), and `main.py` (×3) collapse into one `confirm_then(screen, work)` helper in `cli/tui/screens/_base.py`. Pure refactor; no behavior change.

## Details

- `confirm_then(screen, work)` returns the ConfirmScreen callback: on confirm it runs `work()` (a zero-arg coroutine factory — a bound method, or `functools.partial` where the action takes the workspace/server name) as a screen worker with `exit_on_error=False`; a declined confirm does nothing. `work` is evaluated only on confirm, matching the old closures' laziness.
- The one guard-less variant (`server.py`'s `if confirmed: run_worker(...)`) gains the same early-return — identical observable behavior (decline did nothing before either).
- The `action_cancel` ×3 were assessed and deliberately left: each dismisses a different value (`False`/`None`/hook), so a shared helper would parameterize away the entire body.

## Verification

- Full Python suite (`-n auto`, coverage): 5834 passed, **100% coverage**.
- ruff format + check clean.
- No changelog entry (internal refactor).
