### PR TITLE
refactor(wshandler): move window_watcher into the wshandler package

### DIFF
--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from .. import model
 from ..acl import check_permission_inmemory, resource_ancestors
 from ..terminal import SERVICE_CMD_WINDOW
-from ..window_watcher import WindowEventWatcher
+from .window_watcher import WindowEventWatcher
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
 from .constants import log_ws_msg
 

--- a/src/klangk/klangk/wshandler/window_watcher.py
+++ b/src/klangk/klangk/wshandler/window_watcher.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 import uuid
 
-from .podman import Podman, subprocess_env
+from ..podman import Podman, subprocess_env
 
 logger = logging.getLogger(__name__)
 

--- a/src/klangk/klangkd-tests/tests/test_window_watcher.py
+++ b/src/klangk/klangkd-tests/tests/test_window_watcher.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from klangk.window_watcher import WindowEventWatcher, is_window_event
+from klangk.wshandler.window_watcher import WindowEventWatcher, is_window_event
 
 
 def test_is_window_event_matches_relevant_events():


### PR DESCRIPTION
## Summary

Tier 3, item 2 of #2858: `klangk/window_watcher.py` (141 lines) moves to `klangk/wshandler/window_watcher.py` — a locality move, not a merge. Its sole production consumer is `wshandler/session.py` (`WindowEventWatcher` keeps every client's tmux tab strip in sync).

## Details

Body verbatim; only the intra-package import depths change (`.podman` → `..podman`) plus the two importer paths (`session.py`, `test_window_watcher.py`). The `wshandler` package docstring is untouched.

## Verification

- Full Python suite (`-n auto`, coverage): 5832 passed, **100% coverage**.
- ruff format + check clean.
- No changelog entry (internal refactor).
