### PR TITLE
feat(devenv): pin the Python toolchain to 3.14 (#2844)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -10,8 +10,16 @@ let
   # is collapsed into this single entry. Dev config lives in klangkd.yaml
   # (gitignored);
   # seeded from klangkd.yaml.devenv on first shell entry if missing.
+  # Task, process, and script exec environments do NOT include the
+  # uv-managed venv (.devenv/state/venv) on PATH — `python3` resolves to
+  # the bare nix interpreter from languages.python.package, which carries
+  # none of the project's dependencies. On 3.13 the ambient interpreter
+  # happened to see some propagated nix packages (pyyaml, via pyaml), which
+  # masked this for update-features; pinning 3.14 made it fail loudly.
+  # Every exec that needs project deps invokes this interpreter explicitly.
+  venvPython = config.devenv.state + "/venv/bin/python";
   backendCmd = ''
-    python3 -m klangk.main --config="$DEVENV_ROOT/klangkd.yaml"
+    ${venvPython} -m klangk.main --config="$DEVENV_ROOT/klangkd.yaml"
   '';
   featuresDir = config.devenv.root + "/.devenv/state/klangk/features";
   dataDir = config.devenv.root + "/.devenv/state/klangk/data";
@@ -262,7 +270,7 @@ in
       exec = ''
         cd $DEVENV_ROOT
         bash scripts/stub_dart_features.sh
-        exec python3 scripts/update_features.py --payload-dir "${featuresDir}"
+        exec ${venvPython} scripts/update_features.py --payload-dir "${featuresDir}"
       '';
       before = [ "klangk:flutter-build" ];
       showOutput = true;
@@ -292,7 +300,7 @@ in
   };
 
   env.SOURCE_DATE_EPOCH = "";
-  env.UV_PYTHON = config.devenv.state + "/venv/bin/python";
+  env.UV_PYTHON = venvPython;
 
   # --- Devenv-only env vars (used by shell hooks and scripts, NOT by the
   # backend — backend config lives in klangkd.yaml). ---
@@ -364,11 +372,11 @@ in
   # Live, rich-rendered view of a workspace's egress-consent history (#2242).
   # The dev klangkd's DB (klangk.db) lives under $dataDir.
   scripts.consent-watch.exec = ''
-    exec python3 "$DEVENV_ROOT/scripts/consent-watch.py" --data-dir "${dataDir}" "$@"
+    exec ${venvPython} "$DEVENV_ROOT/scripts/consent-watch.py" --data-dir "${dataDir}" "$@"
   '';
   # Interactive accept/deny of a workspace's pending consent requests (#2242).
   scripts.consent-decide.exec = ''
-    exec python3 "$DEVENV_ROOT/scripts/consent-decide.py" --data-dir "${dataDir}" "$@"
+    exec ${venvPython} "$DEVENV_ROOT/scripts/consent-decide.py" --data-dir "${dataDir}" "$@"
   '';
   scripts.trivy-host.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-host.sh" "$@"'';
   scripts.trivy-workspace.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-workspace.sh" "$@"'';
@@ -377,13 +385,13 @@ in
     if [ "$#" -eq 0 ]; then
       echo "Scanning workspace image and rendering no-fix report..." >&2
       exec bash "$DEVENV_ROOT/scripts/trivy-workspace.sh" --severity CRITICAL,HIGH --format json \
-        | python3 "$DEVENV_ROOT/scripts/trivy-report-nofix.py" -
+        | ${venvPython} "$DEVENV_ROOT/scripts/trivy-report-nofix.py" -
     fi
-    exec python3 "$DEVENV_ROOT/scripts/trivy-report-nofix.py" "$@"'';
+    exec ${venvPython} "$DEVENV_ROOT/scripts/trivy-report-nofix.py" "$@"'';
 
   scripts.update-features.exec = ''
     cd $DEVENV_ROOT
-    python3 scripts/update_features.py "$@"
+    ${venvPython} scripts/update_features.py "$@"
   '';
 
   # -n auto: run tests in parallel across CPUs (pytest-xdist)
@@ -396,7 +404,7 @@ in
     # local run catches guard-test breakage the way CI's separate
     # "build-pipeline tests" step does (#2629) — the two klangk suites
     # alone missed it.
-    exec python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests scripts/tests \
+    exec ${venvPython} -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests scripts/tests \
       -v -n auto "$@"
   '';
 
@@ -404,7 +412,7 @@ in
   # the server corpus (#1606).
   scripts.test-cli.exec = ''
     cd $DEVENV_ROOT
-    exec python -m pytest src/klangk/klangkc-tests/tests -v -n auto "$@"
+    exec ${venvPython} -m pytest src/klangk/klangkc-tests/tests -v -n auto "$@"
   '';
 
   # Network sidecar unit suite — the standalone klangksidecar package
@@ -414,14 +422,14 @@ in
   # e2e, not here. CI mirrors this via .github/workflows/sidecar-tests.yml.
   scripts.test-sidecar.exec = ''
     cd $DEVENV_ROOT
-    exec python -m pytest src/klangksidecar/tests -v -n auto "$@"
+    exec ${venvPython} -m pytest src/klangksidecar/tests -v -n auto "$@"
   '';
 
   # Both unit suites, no coverage gate — the fast "does it all pass?"
   # smoke.
   scripts.test-unit.exec = ''
     cd $DEVENV_ROOT
-    exec python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
+    exec ${venvPython} -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
       -v -n auto --no-cov "$@"
   '';
 
@@ -435,7 +443,7 @@ in
   # re-baseline.
   scripts.testmon.exec = ''
     cd $DEVENV_ROOT
-    exec python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
+    exec ${venvPython} -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
       -v -n auto --no-cov --testmon "$@"
   '';
 
@@ -454,13 +462,13 @@ in
   # contention (TUI and terminal-windows tests are latency-sensitive). #2059
   scripts.test-cli-e2e.exec = ''
     cd $DEVENV_ROOT
-    exec python -m pytest src/klangk/klangkc-tests/e2e-tests \
+    exec ${venvPython} -m pytest src/klangk/klangkc-tests/e2e-tests \
       -v --no-cov -n 2 --dist=loadscope "$@"
   '';
 
   scripts.test-terminal-windows-e2e.exec = ''
     cd $DEVENV_ROOT
-    exec python -m pytest src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py \
+    exec ${venvPython} -m pytest src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py \
       -v --no-cov "$@"
   '';
 
@@ -475,7 +483,7 @@ in
       export PYTEST_PLUGINS=klangk_podman_stderr
       export PYTHONPATH="${podmanStderrPlugin}''${PYTHONPATH:+:$PYTHONPATH}"
     fi
-    exec python -m pytest src/klangk/klangkd-tests/e2e-tests \
+    exec ${venvPython} -m pytest src/klangk/klangkd-tests/e2e-tests \
       -v --no-cov -n 2 --dist=loadscope "$@"
   '';
 
@@ -489,15 +497,15 @@ in
     cd $DEVENV_ROOT
     set -e
     echo "=== unit (server + client, parallel) ==="
-    python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
+    ${venvPython} -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
       -v -n auto --no-cov "$@"
     echo "=== sidecar unit ==="
-    python -m pytest src/klangksidecar/tests -v -n auto --no-cov "$@"
+    ${venvPython} -m pytest src/klangksidecar/tests -v -n auto --no-cov "$@"
     echo "=== server e2e ==="
-    python -m pytest src/klangk/klangkd-tests/e2e-tests \
+    ${venvPython} -m pytest src/klangk/klangkd-tests/e2e-tests \
       -v --no-cov -n 2 --dist=loadscope "$@"
     echo "=== client e2e ==="
-    python -m pytest src/klangk/klangkc-tests/e2e-tests \
+    ${venvPython} -m pytest src/klangk/klangkc-tests/e2e-tests \
       -v --no-cov -n 2 --dist=loadscope "$@"
     echo "=== all green ==="
   '';

--- a/devenv.nix
+++ b/devenv.nix
@@ -72,6 +72,10 @@ in
   };
   languages.python = {
     enable = true;
+    # Pinned to the channel's python314 rather than the `python3` alias — the
+    # toolchain version is a project decision (#2844), not an accident of
+    # whichever minor the pinned nixpkgs channel defaults to (26.05 → 3.13).
+    package = pkgs.python314;
     venv.enable = true;
     uv = {
       enable = true;

--- a/scripts/_podman_common.sh
+++ b/scripts/_podman_common.sh
@@ -18,6 +18,9 @@
 # We deliberately do NOT fall back to /etc/containers/policy.json: that file
 # is not guaranteed to exist and is the wrong place on Nix/rootless setups.
 
+# shellcheck disable=SC1091,SC2034 # sourced helper; its vars (incl. KLANGK_PYTHON) are consumed by sourcing scripts
+source "$(dirname "${BASH_SOURCE[0]}")/_python_common.sh"
+
 # shellcheck disable=SC2034 # SIG_POLICY_ARGS / BUILD_SECURITY_ARGS consumed by sourcing script
 SIG_POLICY_ARGS=()
 
@@ -118,7 +121,7 @@ klangk::stage_features() {
   if [ "${KLANGKBUILD_BUILD_INCLUDE_REMOTE:-0}" != "1" ]; then
     flags+=(--local-only)
   fi
-  python3 scripts/update_features.py "${flags[@]}"
+  "${KLANGK_PYTHON}" scripts/update_features.py "${flags[@]}"
   staging="$payload_dir/.docker"
   rm -rf "$staging"
   mkdir -p "$staging/features"

--- a/scripts/_python_common.sh
+++ b/scripts/_python_common.sh
@@ -1,0 +1,33 @@
+# shellcheck shell=bash
+# Shared helper: resolve the Python interpreter for scripts that need the
+# project's dependencies. Sourced (not executed) by:
+#   flutterbuildweb.sh, build_wheel.sh, test-push.sh, _podman_common.sh
+#
+# Task and process exec environments (devenv tasks run / processes up) do
+# NOT put the uv-managed venv (.devenv/state/venv) on PATH — ambient
+# python3 resolves to the bare nix interpreter from languages.python,
+# which carries none of the project's dependencies. On Python 3.13 that
+# ambient interpreter happened to see a few propagated nix packages
+# (pyyaml, via pyaml), masking the gap; the 3.14 package pin made it fail
+# loudly ("PyYAML is required", #2864). Inside a devenv shell the venv IS
+# on PATH, so this resolves to the same interpreter there.
+#
+# Sets KLANGK_PYTHON: the venv interpreter when the devenv venv exists,
+# plain python3 otherwise (non-devenv contexts, e.g. release runners with
+# their own interpreter).
+
+# shellcheck disable=SC2034 # KLANGK_PYTHON is consumed by sourcing scripts
+
+if [ -n "${DEVENV_ROOT:-}" ] && [ -x "${DEVENV_ROOT}/.devenv/state/venv/bin/python" ]; then
+  KLANGK_PYTHON="${DEVENV_ROOT}/.devenv/state/venv/bin/python"
+else
+  # Fall back to the sibling checkout layout: this file lives in
+  # <repo>/scripts/, the venv in <repo>/.devenv/state/venv.
+  _klangk_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  if [ -x "${_klangk_root}/.devenv/state/venv/bin/python" ]; then
+    KLANGK_PYTHON="${_klangk_root}/.devenv/state/venv/bin/python"
+  else
+    KLANGK_PYTHON=python3
+  fi
+  unset _klangk_root
+fi

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -16,6 +16,8 @@
 #   (or directly, inside a devenv shell)
 # Produces: src/klangk/dist/klangk-<version>-py3-none-any.whl
 set -euo pipefail
+# shellcheck disable=SC1091 # sourced sibling helper
+source "$(dirname "${BASH_SOURCE[0]}")/_python_common.sh"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -25,7 +27,7 @@ uv pip install build
 
 # Build the wheel from src/klangk (where pyproject.toml + the build hook live).
 cd "$REPO_ROOT/src/klangk"
-python3 -m build --wheel
+"${KLANGK_PYTHON}" -m build --wheel
 
 # Report what we produced. The script cd'd into src/klangk before building,
 # so dist/ is relative to that dir, not the caller's CWD — print absolute

--- a/scripts/flutterbuildweb.sh
+++ b/scripts/flutterbuildweb.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck disable=SC1091 # sourced sibling helper
+source "$(dirname "${BASH_SOURCE[0]}")/_python_common.sh"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
 
@@ -26,8 +28,8 @@ UPDATE_FLAGS=(--payload-dir "$PAYLOAD_DIR")
 if [ "${KLANGKBUILD_BUILD_INCLUDE_REMOTE:-0}" != "1" ]; then
   UPDATE_FLAGS+=(--local-only)
 fi
-python3 scripts/update_features.py "${UPDATE_FLAGS[@]}"
-python3 scripts/import_dart_features.py --payload-dir "$PAYLOAD_DIR"
+"${KLANGK_PYTHON}" scripts/update_features.py "${UPDATE_FLAGS[@]}"
+"${KLANGK_PYTHON}" scripts/import_dart_features.py --payload-dir "$PAYLOAD_DIR"
 
 # flterm is forked (github.com/runyaga/flterm) to build on the nix Flutter
 # (3.41 / Dart 3.11) -- upstream 0.0.3 needs Dart 3.12 for private-named
@@ -120,4 +122,4 @@ echo "Cache-bust: v=$HASH"
 # from __file__ so it lands the manifest correctly regardless of CWD. The
 # payload dir is the same one populated above — still populated, still
 # readable (the trap fires only on exit).
-python3 "$SCRIPT_DIR/import_dart_features.py" --payload-dir "$PAYLOAD_DIR" --features-only
+"${KLANGK_PYTHON}" "$SCRIPT_DIR/import_dart_features.py" --payload-dir "$PAYLOAD_DIR" --features-only

--- a/scripts/test-push.sh
+++ b/scripts/test-push.sh
@@ -21,6 +21,8 @@
 # main before pushing anyway (see AGENTS.md / the workon flow).
 
 set -uo pipefail
+# shellcheck disable=SC1091 # sourced sibling helper
+source "$(dirname "${BASH_SOURCE[0]}")/_python_common.sh"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 2
@@ -78,20 +80,20 @@ status=0
 if [ "$backend" = 1 ]; then
   echo
   echo "=== backend unit (testmon; first run in a fresh worktree baselines, ~test-unit cost) ==="
-  python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
+  "${KLANGK_PYTHON}" -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests \
     -v -n auto --no-cov --testmon || status=1
 fi
 
 if [ "$build" = 1 ]; then
   echo
   echo "=== build-pipeline contract tests (scripts/tests) ==="
-  python -m pytest scripts/tests -v || status=1
+  "${KLANGK_PYTHON}" -m pytest scripts/tests -v || status=1
 fi
 
 if [ "$sidecar" = 1 ]; then
   echo
   echo "=== sidecar unit ==="
-  python -m pytest src/klangksidecar/tests -v -n auto || status=1
+  "${KLANGK_PYTHON}" -m pytest src/klangksidecar/tests -v -n auto || status=1
 fi
 
 if [ "$frontend" = 1 ]; then


### PR DESCRIPTION
## Summary

Pins the devenv Python toolchain to **3.14** via `languages.python.package = pkgs.python314` in `devenv.nix`, with a comment recording that the choice is deliberate (#2844). The nixos-26.05 default `python3` alias still resolves to 3.13, so the interpreter was 3.13 only by accident of the channel; the E2E workflows (which inherit the nix interpreter) and every local dev shell now run 3.14.

A `package` override was chosen over `languages.python.version = "3.14"` because the latter requires adding the `nixpkgs-python` input (a second interpreter supply-chain source); the channel's own `python314` (3.14.7) stays inside the already-pinned nixpkgs.

## Update: E2E failures fixed (0faf5f1c)

The three E2E suites failed at `klangk:update-features` ("PyYAML is required"). Root cause: **task/process/script exec environments do not include the uv venv on PATH** — ambient `python3` resolves to the bare nix interpreter from `languages.python.package`. On 3.13 that interpreter happened to see pyyaml (a propagated nix package, `pyaml`, in the profile), which masked the gap; the 3.14 pin uses a bare env and exposed it.

Fix: a `venvPython` let-binding (`.devenv/state/venv/bin/python`) now fronts every exec that needs project deps — `backendCmd`, `update-features` (task + script), `consent-watch`/`consent-decide`, `trivy-workspace-report`, and all pytest task/script execs. `env.UV_PYTHON` reuses the binding. Stdlib-only calls keep the ambient interpreter. Verified locally: the task materializes features (✓), the `consent-watch` wrapper runs (rich from venv), and the shell suites stay green.

## Validation

- devenv shell reports CPython 3.14.7; `uv sync` clean (all cp314 wheels available, including greenlet/uvloop/pydantic-core).
- CI-style suite: klangkd + klangkc `-n auto` → 5855 passed, **100% coverage** (`COVERAGE_CORE=sysmon` + xdist + greenlet tracking intact across the 3.13→3.14 boundary).
- `scripts/tests` → 83 passed; sidecar suite → 189 passed.
- No new `DeprecationWarning`s under warnings-as-errors (the only 3.14 one, `asyncio.iscoroutinefunction`, was fixed at the source in #2863).

Part of #2844 (surface 1 of 6). No changelog entry: developer-facing toolchain only.
