### PR TITLE
Enable branch coverage in the Python 100% gates (#2834)

### DIFF
--- a/.github/workflows/sidecar-tests.yml
+++ b/.github/workflows/sidecar-tests.yml
@@ -41,9 +41,9 @@ jobs:
 
       - name: Run tests
         if: steps.filter.outputs.sidecar == 'true'
-        # -n auto: run tests in parallel across CPUs (pytest-xdist). No
-        # coverage gate here (see src/klangksidecar/pyproject.toml): proxy.py's
-        # main()/signal paths run as PID 1 of the sidecar and are exercised
+        # -n auto: run tests in parallel across CPUs (pytest-xdist). Branch
+        # coverage gate at 100% lives in src/klangksidecar/pyproject.toml
+        # (#2834); the PID-1-only entry paths carry pragmas and are exercised
         # end-to-end by test_network_sidecar_e2e.py, not by this unit suite.
         run: python -m pytest src/klangksidecar/tests -v -n auto --durations=20
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,16 +45,23 @@ devenv --quiet -O dotenv.enable:bool false shell -- flutter test --coverage
 
 `-n auto` (pytest-xdist) is **not optional** for the Python suite — it's how
 CI runs it, and it is the difference between a real and a bogus coverage
-number. The `conftest.py` sets `COVERAGE_CORE=sysmon` specifically so that
-code executed inside SQLAlchemy's greenlet context is tracked **in each
-xdist worker**; without `-n` (a single-process run) that tracking
+number. Greenlet-executed code (SQLAlchemy's async engine) is tracked via
+`concurrency = ["greenlet", "thread"]` in the repo-root pyproject's
+`[tool.coverage.run]`; without `-n` (a single-process run) that tracking
 under-counts and you'll see a false ~93% total with heavy files like
 `api/auth.py` reported at ~55%. Run with `-n auto` and coverage matches CI
 (100%, every module). Don't try to "reproduce" a coverage drop from a
 single-process run — re-run with `-n auto` first.
 
-The 100% coverage gate is enforced on the `klangk` package; a new code
-path with no test will fail the build.
+The 100% gate is **full branch coverage** (`--cov-branch`, #2834): every
+branch outcome must be exercised, not just every line — an `if` needs both
+its true and false outcomes tested (or a `# pragma: no branch` comment with
+a justification for structurally unreachable arms). The conftests no
+longer pin `COVERAGE_CORE=sysmon`: Python 3.13's `sys.monitoring` cannot
+measure branches, so the gate uses the C tracer plus the greenlet
+concurrency config above. The gate is enforced on the `klangk` and
+`klangksidecar` packages; a new code path — or a new branch outcome —
+with no test will fail the build.
 
 ### Rapid iteration: use the `testmon` task
 
@@ -134,7 +141,8 @@ that instantiates app/framework components directly.
 
 The harness exists to provide the setup production code depends on: the
 autouse fixtures stub background workers and fake the HTTP/WS backends; the
-conftest sets `COVERAGE_CORE=sysmon`; `run_test()` owns the textual event
+repo-root `[tool.coverage.run]` carries the greenlet concurrency config;
+`run_test()` owns the textual event
 loop. A standalone script skips all of that, so it either **hangs** (commonly:
 `run_test()` context-exit waits forever for a real on-mount worker making real
 network calls to a fake URL) or exercises behavior that doesn't match

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,22 +45,22 @@ devenv --quiet -O dotenv.enable:bool false shell -- flutter test --coverage
 
 `-n auto` (pytest-xdist) is **not optional** for the Python suite — it's how
 CI runs it, and it is the difference between a real and a bogus coverage
-number. Greenlet-executed code (SQLAlchemy's async engine) is tracked via
-`concurrency = ["greenlet", "thread"]` in the repo-root pyproject's
-`[tool.coverage.run]`; without `-n` (a single-process run) that tracking
-under-counts and you'll see a false ~93% total with heavy files like
-`api/auth.py` reported at ~55%. Run with `-n auto` and coverage matches CI
-(100%, every module). Don't try to "reproduce" a coverage drop from a
-single-process run — re-run with `-n auto` first.
+number. The conftests pin `COVERAGE_CORE=sysmon` (the toolchain is Python
+3.14, #2844): sys.monitoring measures branches there and tracks
+greenlet-executed code (SQLAlchemy's async engine) natively; without `-n`
+(a single-process run) that tracking under-counts and you'll see a false
+~93% total with heavy files like `api/auth.py` reported at ~55%. Run with
+`-n auto` and coverage matches CI (100%, every module). Don't try to
+"reproduce" a coverage drop from a single-process run — re-run with
+`-n auto` first.
 
 The 100% gate is **full branch coverage** (`--cov-branch`, #2834): every
 branch outcome must be exercised, not just every line — an `if` needs both
 its true and false outcomes tested (or a `# pragma: no branch` comment with
-a justification for structurally unreachable arms). The conftests no
-longer pin `COVERAGE_CORE=sysmon`: Python 3.13's `sys.monitoring` cannot
-measure branches, so the gate uses the C tracer plus the greenlet
-concurrency config above. The gate is enforced on the `klangk` and
-`klangksidecar` packages; a new code path — or a new branch outcome —
+a justification for structurally unreachable arms). No `concurrency`
+option in the coverage config: sysmon does not support it, and on 3.14 it
+is not needed. The gate is enforced on the `klangk` and `klangksidecar`
+packages; a new code path — or a new branch outcome —
 with no test will fail the build.
 
 ### Rapid iteration: use the `testmon` task
@@ -141,7 +141,7 @@ that instantiates app/framework components directly.
 
 The harness exists to provide the setup production code depends on: the
 autouse fixtures stub background workers and fake the HTTP/WS backends; the
-repo-root `[tool.coverage.run]` carries the greenlet concurrency config;
+conftests pin `COVERAGE_CORE=sysmon` for greenlet-safe branch coverage;
 `run_test()` owns the textual event
 loop. A standalone script skips all of that, so it either **hangs** (commonly:
 `run_test()` context-exit waits forever for a real on-mount worker making real

--- a/devenv.nix
+++ b/devenv.nix
@@ -417,9 +417,10 @@ in
 
   # Network sidecar unit suite — the standalone klangksidecar package
   # (#2450). Separate invocation (not folded into test-backend) because it
-  # has its own rootdir (src/klangksidecar/pyproject.toml) with NO coverage
-  # gate — proxy.py's main()/signal paths are exercised by the real-podman
-  # e2e, not here. CI mirrors this via .github/workflows/sidecar-tests.yml.
+  # has its own rootdir (src/klangksidecar/pyproject.toml) with its own
+  # coverage gate (branch coverage, 100% — #2834; the PID-1-only entry
+  # paths carry pragmas, exercised instead by the real-podman e2e). CI
+  # mirrors this via .github/workflows/sidecar-tests.yml.
   scripts.test-sidecar.exec = ''
     cd $DEVENV_ROOT
     exec ${venvPython} -m pytest src/klangksidecar/tests -v -n auto "$@"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1204,6 +1204,14 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
   info). Set it with a `nix_seed` block to arm the feature — see
   [Nix workspaces](../features/nix.md).
 
+- **Branch coverage in the Python 100% gates (#2834).** Both the
+  `klangk` and `klangksidecar` unit suites now measure branch coverage
+  (`--cov-branch`) and require every branch outcome exercised, not just
+  every line — structurally unreachable arms carry documented
+  `# pragma: no branch` comments. The sidecar suite gains a coverage gate
+  at all (previously none); contributors adding an `if` with only one
+  side tested will now fail the build until the other outcome is tested.
+
 - **`host_restart` WS event renamed to `server_recycle` (#2661).** The
   graceful recycle path (SIGHUP and scheduled `recycle`) now broadcasts
   `server_recycle {phase: draining | recycling}` instead of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,19 @@ filterwarnings = [
     "ignore::pytest.PytestUnraisableExceptionWarning",
     "ignore:coroutine .* was never awaited:RuntimeWarning",
 ]
+
+# Shared coverage config for every pytest-cov run whose CWD is the repo
+# root — coverage discovers [tool.coverage.run] relative to the CWD, not
+# the pytest rootdir, and the documented invocations (CI, devenv tasks)
+# all run from here. Branch measurement (#2834) requires the C tracer
+# core: Python 3.13's sys.monitoring has no branch events, so the sysmon
+# core can't measure branches (it silently falls back with a warning the
+# klangk suite escalates to an error). The C tracer alone under-counts
+# code executed inside SQLAlchemy's greenlet context (#456/#1393), which
+# concurrency=["greenlet", "thread"] restores. This is why neither
+# klangk conftest pins COVERAGE_CORE=sysmon anymore. Revisit sysmon
+# (branch support lands with Python 3.14's BRANCH_LEFT/RIGHT events)
+# once the toolchain moves past 3.13.
+[tool.coverage.run]
+branch = true
+concurrency = ["greenlet", "thread"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,15 +31,13 @@ filterwarnings = [
 # Shared coverage config for every pytest-cov run whose CWD is the repo
 # root — coverage discovers [tool.coverage.run] relative to the CWD, not
 # the pytest rootdir, and the documented invocations (CI, devenv tasks)
-# all run from here. Branch measurement (#2834) requires the C tracer
-# core: Python 3.13's sys.monitoring has no branch events, so the sysmon
-# core can't measure branches (it silently falls back with a warning the
-# klangk suite escalates to an error). The C tracer alone under-counts
-# code executed inside SQLAlchemy's greenlet context (#456/#1393), which
-# concurrency=["greenlet", "thread"] restores. This is why neither
-# klangk conftest pins COVERAGE_CORE=sysmon anymore. Revisit sysmon
-# (branch support lands with Python 3.14's BRANCH_LEFT/RIGHT events)
-# once the toolchain moves past 3.13.
+# all run from here. Branch measurement (#2834) rides the sysmon core
+# (pinned in both klangk conftests): Python 3.14's sys.monitoring gained
+# BRANCH_LEFT/RIGHT events, and sysmon tracks code executed inside
+# SQLAlchemy's greenlet context natively (#456/#1393) — no
+# ``concurrency`` option, which sysmon does not support (the C tracer
+# needed ``concurrency=["greenlet", "thread"]`` for the same result,
+# ~40% slower). No 3.13 fallback: the toolchain is pinned to 3.14
+# (#2844), and CI runs the suites on 3.14 exclusively.
 [tool.coverage.run]
 branch = true
-concurrency = ["greenlet", "thread"]

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -130,7 +130,10 @@ def request_with_retry(
     responses with exponential backoff.
     """
     backoff = _RETRY_BACKOFF
-    for attempt in range(_RETRY_ATTEMPTS):
+    # Every iteration ends in return/raise/continue (the last attempt
+    # returns or re-raises), so the loop never falls through its range:
+    # the arc to loop exit is unreachable.
+    for attempt in range(_RETRY_ATTEMPTS):  # pragma: no branch
         try:
             resp = http_request(
                 server_spec, method, path, timeout=timeout, **kwargs
@@ -914,7 +917,10 @@ class KlangkClient:
                 data = self._f.read(size)
                 if data:
                     self._read += len(data)
-                    if on_progress:
+                    # The wrapper is only constructed when on_progress is
+                    # set (see import_workspace), so this guard is always
+                    # true here -- its false arm is unreachable.
+                    if on_progress:  # pragma: no branch
                         on_progress(self._read, total)
                 return data
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -356,7 +356,10 @@ class KlangkApp(App):
         if target not in self.screen_stack:
             return False
         to_remove: list[Screen] = []
-        for screen in reversed(self.screen_stack):
+        # The membership guard above means the reversed walk always hits
+        # target (identity compare), so the loop can never exhaust: the
+        # arc to the pop loop without a break is unreachable.
+        for screen in reversed(self.screen_stack):  # pragma: no branch
             if screen is target:
                 break
             to_remove.append(screen)
@@ -386,7 +389,10 @@ class KlangkApp(App):
             # base and push a fresh MainScreen — pushing on top of the
             # current stack would strand the login screen underneath it and
             # corrupt the next logout (#2034).
-            if self.screen_stack:
+            # Textual keeps >=1 screen mounted; an empty stack here is
+            # the defensive teardown-race case (#2034), not a state a
+            # running app reaches.
+            if self.screen_stack:  # pragma: no branch
                 self._pop_above(self.screen_stack[0])
             self.push_screen(MainScreen())
             return
@@ -420,7 +426,7 @@ class KlangkApp(App):
         # ``target not in stack`` early return in ``_pop_above`` is what
         # prevents the ScreenStackError the old pop-until-MainScreen loop hit
         # when MainScreen wasn't in the stack (#2034).
-        if self.screen_stack:
+        if self.screen_stack:  # pragma: no branch
             self._pop_above(self.screen_stack[0])
         self.push_screen(LoginScreen())
 
@@ -477,7 +483,7 @@ class KlangkApp(App):
                 # ``_pop_above`` pops a fixed snapshot, so the teardown is
                 # bounded regardless of what a concurrent worker does between
                 # this call and the push (#2034).
-                if self.screen_stack:
+                if self.screen_stack:  # pragma: no branch
                     self._pop_above(self.screen_stack[0])
                 self.live_extra = ""
                 self.last_login = None

--- a/src/klangk/klangk/cli/tui/screens/login.py
+++ b/src/klangk/klangk/cli/tui/screens/login.py
@@ -150,7 +150,9 @@ class LoginScreen(SpatialNavScreen, StatusScreen):
         # Autofocus the first server entry (#1826).
         if lv.query(ListItem):
             lv.focus()
-            if lv.index is None:
+            # clear() above resets the index, so this is defensive against
+            # a textual version that preserves it across repopulation.
+            if lv.index is None:  # pragma: no branch
                 lv.index = 0
 
     @staticmethod

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -756,7 +756,9 @@ class WorkspaceDetailScreen(StatusScreen):
             # "both terminals grey, Down makes the second green" symptom).
             # After mount the first row highlights correctly.
             await mount
-            if lv.index is None:
+            # clear() above resets the index; the guard is defensive
+            # against a textual version that preserves it.
+            if lv.index is None:  # pragma: no branch
                 lv.index = 0
 
     async def _load_shared_terminals(self) -> None:
@@ -802,7 +804,9 @@ class WorkspaceDetailScreen(StatusScreen):
                 ]
             mount = lv.extend(items)
             await mount
-            if lv.index is None:
+            # clear() above resets the index; the guard is defensive
+            # against a textual version that preserves it.
+            if lv.index is None:  # pragma: no branch
                 lv.index = 0
 
     @staticmethod

--- a/src/klangk/klangkc-tests/tests/conftest.py
+++ b/src/klangk/klangkc-tests/tests/conftest.py
@@ -1,13 +1,12 @@
 """CLI unit test configuration."""
 
-import os
-
 import pytest
 
-# Use sysmon coverage engine for pytest-xdist compatibility — mirrors the
-# server suite's conftest (src/klangk/klangkd-tests/tests/conftest.py) so
-# coverage is tracked correctly across xdist workers (#1526).
-os.environ.setdefault("COVERAGE_CORE", "sysmon")
+# No COVERAGE_CORE pin: branch coverage (#2834) requires the C tracer
+# core (Python 3.13's sys.monitoring has no branch events, so sysmon
+# can't measure branches and falls back with a warning that
+# filterwarnings=error turns fatal). See the repo-root pyproject's
+# [tool.coverage.run] for the full rationale.
 
 
 @pytest.fixture(autouse=True)

--- a/src/klangk/klangkc-tests/tests/conftest.py
+++ b/src/klangk/klangkc-tests/tests/conftest.py
@@ -1,12 +1,14 @@
 """CLI unit test configuration."""
 
+import os
+
 import pytest
 
-# No COVERAGE_CORE pin: branch coverage (#2834) requires the C tracer
-# core (Python 3.13's sys.monitoring has no branch events, so sysmon
-# can't measure branches and falls back with a warning that
-# filterwarnings=error turns fatal). See the repo-root pyproject's
-# [tool.coverage.run] for the full rationale.
+# Use the sysmon coverage engine — mirrors the server suite's conftest
+# (src/klangk/klangkd-tests/tests/conftest.py) so coverage is tracked
+# correctly across xdist workers (#1526). On the 3.14 toolchain it also
+# measures the branch gate (#2834) and tracks greenlets natively.
+os.environ.setdefault("COVERAGE_CORE", "sysmon")
 
 
 @pytest.fixture(autouse=True)

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import sys
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -4766,3 +4767,731 @@ class TestFrameIsPredicate:
         pred = frame_is("shared_terminals")
         with pytest.raises(ConnectionError, match="terminal error"):
             pred({"type": "error"})
+
+
+class TestCliBranchGaps2834:
+    """#2834 branch gate: the CLI's guard outcomes the mainline tests
+    only take one side of."""
+
+    def test_login_redirect_http_location_no_hint(self, capsys):
+        # A redirect to a plain-http location: no https hint (the server
+        # is not telling us to upgrade the scheme).
+        from klangk.cli.auth import print_login_failure
+
+        resp = MagicMock()
+        resp.status_code = 302
+        resp.headers = {"location": "http://insecure.example/login"}
+        with pytest.raises(SystemExit):
+            print_login_failure(resp)
+        out = capsys.readouterr().err
+        assert "redirected to http://insecure.example/login" in out
+        assert "https://" not in out
+
+    def test_admin_status_probe_non_200_leaves_admin_unknown(
+        self, monkeypatch
+    ):
+        # The my-permissions probe answers 403 (token valid, endpoint
+        # denied): is_admin stays None ("unknown"), not False.
+        from klangk.cli import authcmds
+
+        resp = MagicMock()
+        resp.status_code = 403
+        client = MagicMock()
+        client.get = MagicMock(return_value=resp)
+        client.check_auth = MagicMock()
+        monkeypatch.setattr("klangk.cli.context._client", lambda: client)
+        assert authcmds.admin_status("tok") is None
+
+    def test_set_email_without_prior_email_skips_rename(self, monkeypatch):
+        # First email set for the server: nothing cached to re-key.
+        from klangk.cli import authcmds
+
+        state = MagicMock()
+        state.get_email = lambda url: None  # no prior email
+        state.rename_user = MagicMock()
+        monkeypatch.setattr("klangk.cli.context._state", lambda: state)
+        monkeypatch.setattr("klangk.cli.context.require_auth", lambda: None)
+        monkeypatch.setattr(
+            "klangk.cli.context.server_url",
+            lambda: "http://test:8995",
+        )
+        monkeypatch.setattr("klangk.cli.context._err", MagicMock())
+        client = MagicMock()
+        monkeypatch.setattr("klangk.cli.context._client", lambda: client)
+        monkeypatch.setattr(
+            "klangk.cli.authcmds.Prompt.ask",
+            lambda *a, **kw: "new@example.com",
+        )
+        authcmds.account_email()
+        state.rename_user.assert_not_called()
+
+    def test_edit_no_restart_when_create_time_settings_unchanged(self):
+        from klangk.cli.edit import restart_needed
+
+        ws = types.SimpleNamespace(
+            running=True,
+            settings={"container_memory_limit": "2g"},
+        )
+        body = {"settings": {"container_memory_limit": "2g"}}
+        assert restart_needed(ws, body) is False
+
+    def test_validate_create_specs_accepts_valid_mounts(self):
+        from klangk.cli.workspaces import _validate_create_specs
+
+        # A fully valid mount list walks every spec without exiting.
+        _validate_create_specs(["/srv/data:/data:ro"], [], [])
+
+
+class TestCliBranchGaps2834b:
+    """#2834 branch gate, part two: monitor env plumbing, the tmux
+    helpers, and the sandbox setup-skip."""
+
+    def test_monitor_event_without_workspace_id_or_health(self):
+        # An event with no workspace_id and a non-health type: neither
+        # the workspace nor the health env vars are set.
+        import klangk.cli.monitor as monitor
+
+        calls = {}
+
+        def fake_run(command, input=None, env=None, check=False):
+            calls["env"] = env
+            return MagicMock(returncode=0)
+
+        with patch.object(monitor.subprocess, "run", fake_run):
+            monitor._dispatch_monitor_event(
+                {"type": "workspace_created"}, ["/bin/true"]
+            )
+        env = calls["env"]
+        assert "KLANGK_WORKSPACE_ID" not in env
+        assert "KLANGK_HEALTHY" not in env
+
+    def test_monitor_health_event_sets_health_env(self):
+        import klangk.cli.monitor as monitor
+
+        calls = {}
+
+        def fake_run(command, input=None, env=None, check=False):
+            calls["env"] = env
+            return MagicMock(returncode=0)
+
+        with patch.object(monitor.subprocess, "run", fake_run):
+            monitor._dispatch_monitor_event(
+                {
+                    "type": "service_health",
+                    "workspace_id": "ws-1",
+                    "healthy": False,
+                    "running": False,
+                    "health_message": "probe failed",
+                    "health_checked_at": 123.0,
+                    "seq": 7,
+                },
+                ["/bin/true"],
+            )
+        env = calls["env"]
+        assert env["KLANGK_WORKSPACE_ID"] == "ws-1"
+        assert env["KLANGK_HEALTHY"] == "false"
+        assert env["KLANGK_RUNNING"] == "false"
+        assert env["KLANGK_HEALTH_MESSAGE"] == "probe failed"
+        assert env["KLANGK_HEALTH_CHECKED_AT"] == "123.0"
+        assert env["KLANGK_HEALTH_SEQ"] == "7"
+
+    def test_tmux_command_success_not_logged(self, caplog):
+        from klangk.cli import shell_popup
+
+        proc = MagicMock()
+        proc.returncode = 0
+        with patch.object(shell_popup.subprocess, "run", return_value=proc):
+            with caplog.at_level("WARNING"):
+                rc = shell_popup._default_run(
+                    ["/usr/bin/tmux", "list-sessions"], quiet=False
+                )
+        assert rc == 0
+        assert not any(
+            "tmux command failed" in r.message for r in caplog.records
+        )
+
+    def test_term_size_zero_falls_back_to_default(self):
+        from klangk.cli import shell_popup
+
+        with patch.object(
+            shell_popup.os,
+            "get_terminal_size",
+            return_value=MagicMock(columns=0, lines=0),
+        ):
+            assert shell_popup._term_size() == (80, 24)
+
+    def test_term_size_valid_reported(self):
+        from klangk.cli import shell_popup
+
+        with patch.object(
+            shell_popup.os,
+            "get_terminal_size",
+            return_value=MagicMock(columns=132, lines=43),
+        ):
+            assert shell_popup._term_size() == (132, 43)
+
+
+class TestClientBranchGaps2834:
+    """#2834 branch gate: the client's session/IO pumps' guard outcomes."""
+
+    def test_export_without_progress_callback(self, tmp_path):
+        client = KlangkClient("http://localhost:8995", "token")
+        output = tmp_path / "no-progress.tar.gz"
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.is_success = True
+        mock_resp.headers = {"content-length": "12"}
+        mock_resp.iter_bytes.return_value = [b"a", b"b"]
+        with patch("klangk.cli.transport.httpx.stream") as mock_stream:
+            mock_stream.return_value.__enter__ = MagicMock(
+                return_value=mock_resp
+            )
+            mock_stream.return_value.__exit__ = MagicMock(return_value=False)
+            client.export_workspace("ws-id", output)  # no on_progress
+        assert output.read_bytes() == b"ab"
+
+    def test_import_without_progress_callback(self, tmp_path):
+        # The upload progress wrapper without a callback: reads flow,
+        # nothing is invoked.
+        client = KlangkClient("http://localhost:8995", "token")
+        archive = tmp_path / "arch.tar.gz"
+        archive.write_bytes(b"payload-bytes")
+
+        sent = {}
+
+        def fake_request(server_url, method, path, timeout=None, **kw):
+            sent.update(kw)
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.is_success = True
+            resp.json = lambda: {
+                "id": "ws-1",
+                "name": "n",
+                "created_at": "2024-01-01T00:00:00Z",
+                "status": "stopped",
+            }
+            return resp
+
+        with patch("klangk.cli.client.http_request", fake_request):
+            client.import_workspace(archive)  # no on_progress
+        files = sent.get("files") or {}
+        assert files  # the archive rode along
+
+    @pytest.mark.asyncio
+    async def test_dispatch_agent_response_empty_data_is_dropped(self):
+        from klangk.cli.client import TerminalSession
+
+        session = TerminalSession(
+            AsyncMock(),
+            80,
+            24,
+            stdout=MagicMock(),
+            server_url="http://t",
+            token="tok",
+        )
+        session.dispatch_agent_response({"data": ""})
+        assert session.agent_queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_agent_relay_none_response_skips_send(self):
+        from klangk.cli.client import TerminalSession
+
+        session = TerminalSession(
+            AsyncMock(),
+            80,
+            24,
+            stdout=MagicMock(),
+            server_url="http://t",
+            token="tok",
+            ssh_agent_sock="/nonexistent",
+        )
+        session.agent_queue.put_nowait(b"agent-request")
+        task = asyncio.create_task(session.ssh_agent_relay_loop())
+        for _ in range(100):
+            if session.agent_queue.empty():
+                break
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)
+        # A None reply (agent gone) sent nothing and did not kill the loop.
+        assert not task.done()
+        session.ws.send.assert_not_called()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_stdout_loop_exits_via_stop_flag_after_output(self):
+        from klangk.cli.client import TerminalSession
+
+        ws = AsyncMock()
+        calls = {"n": 0}
+        never = asyncio.Event()
+
+        async def recv():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return json.dumps({"type": "terminal_output", "data": "hi"})
+            await never.wait()  # never reached: stop exits the loop first
+            raise AssertionError("unreachable")
+
+        ws.recv = recv
+
+        class _StoppingWriter:
+            def __init__(self):
+                self.written = []
+
+            def write(self, data):
+                self.written.append(data)
+                session.stop.set()  # a UI-triggered stop lands mid-stream
+
+            def flush(self):
+                pass
+
+        writer = _StoppingWriter()
+        session = TerminalSession(
+            ws,
+            80,
+            24,
+            stdout=writer,
+            server_url="http://t",
+            token="tok",
+        )
+        await asyncio.wait_for(session.stdout_loop(), 2)
+        assert writer.written == ["hi"]
+
+    @pytest.mark.asyncio
+    async def test_stdout_loop_skips_unknown_frame_type(self):
+        from klangk.cli.client import TerminalSession
+
+        ws = AsyncMock()
+        ws.recv = AsyncMock(
+            side_effect=[
+                '{"type": "status"}',
+                websockets.ConnectionClosed(MagicMock(code=1000), None),
+            ]
+        )
+        captured = []
+
+        class _Writer:
+            def write(self, data):
+                captured.append(data)
+
+            def flush(self):
+                pass
+
+        session = TerminalSession(
+            ws,
+            80,
+            24,
+            stdout=_Writer(),
+            server_url="http://t",
+            token="tok",
+        )
+        with patch.object(session, "_handle_disconnect"):
+            await session.stdout_loop()
+        assert captured == []  # the unknown frame was ignored, not written
+
+    @pytest.mark.asyncio
+    async def test_exec_stdout_forward_without_stdout_skips_write(self):
+        import base64 as b64
+
+        from klangk.cli.client import ExecSession
+
+        ws = AsyncMock()
+        ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps(
+                    {
+                        "type": "exec_output",
+                        "data": b64.b64encode(b"x").decode(),
+                    }
+                ),
+                json.dumps({"type": "mystery"}),
+                json.dumps({"type": "exec_exit", "code": 3}),
+            ]
+        )
+        session = ExecSession(
+            ws, ["true"], stdin=None, stdout=None, login=False
+        )
+        await session.stdout_forward()
+        assert session.exit_code == 3
+        ws.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exec_stdin_eof_sends_only_close(self):
+        import base64 as b64  # noqa: F401  (parity with siblings)
+
+        from klangk.cli.client import ExecSession
+
+        ws = AsyncMock()
+        stdin = io.BytesIO(b"")  # no fileno; read() -> immediate EOF
+        session = ExecSession(
+            ws, ["cat"], stdin=stdin, stdout=None, login=False
+        )
+        # The non-fd branch (no fileno): read until EOF, then close.
+        await session.stdin_forward()  # type: ignore[attr-defined]
+        sent = [json.loads(c.args[0]) for c in ws.send.await_args_list]
+        assert sent == [{"cmd": "exec_close_stdin"}]
+
+    @pytest.mark.asyncio
+    async def test_extend_escape_no_more_bytes_within_window(self):
+        import os as os_mod
+
+        from klangk.cli.client import TerminalSession
+
+        r, w = os_mod.pipe()
+        try:
+            os_mod.close(w)  # nothing more arrives
+            session = TerminalSession(
+                AsyncMock(),
+                80,
+                24,
+                stdout=MagicMock(),
+                server_url="http://t",
+                token="tok",
+            )
+            out = await session._extend_escape_sequence(r, b"\x1b")
+            assert out == b"\x1b"  # plain ESC, not a terminal query
+        finally:
+            os_mod.close(r)
+
+    @pytest.mark.asyncio
+    async def test_extend_escape_eof_read_appends_nothing(self):
+        import os as os_mod
+
+        from klangk.cli.client import TerminalSession
+
+        r, w = os_mod.pipe()
+        try:
+            os_mod.close(w)  # EOF: select fires, read returns b""
+            session = TerminalSession(
+                AsyncMock(),
+                80,
+                24,
+                stdout=MagicMock(),
+                server_url="http://t",
+                token="tok",
+            )
+            out = await session._extend_escape_sequence(r, b"\x1b")
+            assert out == b"\x1b"
+        finally:
+            os_mod.close(r)
+
+    @pytest.mark.asyncio
+    async def test_extend_escape_drains_terminal_query_exhaustively(self):
+        import os as os_mod
+
+        from klangk.cli import client as client_mod
+        from klangk.cli.client import TerminalSession
+
+        r, w = os_mod.pipe()
+        try:
+            os_mod.write(w, b"x" * 4096)  # bytes for the drain reads
+            session = TerminalSession(
+                AsyncMock(),
+                80,
+                24,
+                stdout=MagicMock(),
+                server_url="http://t",
+                token="tok",
+            )
+            with patch.object(
+                client_mod.select, "select", return_value=([r], [], [])
+            ):
+                out = await asyncio.wait_for(
+                    session._extend_escape_sequence(r, b"\x1b[?1;2c"), 5
+                )
+            assert out is None  # query response drained locally
+        finally:
+            os_mod.close(r)
+            os_mod.close(w)
+
+
+class TestCliBranchGaps2834c:
+    """#2834 branch gate, part three: sandbox service firing, the shell
+    flag normalization, config load/save edges, and the TUI state
+    guards."""
+
+    @pytest.mark.asyncio
+    async def test_service_command_waits_past_non_terminal_frames(self):
+        # The bounded terminal-start wait: an unrelated frame arrives
+        # first (ignored, loop continues), then terminal_started ends it.
+        from klangk.cli.sandboxcmd import fire_service_command
+
+        ws = AsyncMock()
+        ws.recv = AsyncMock(
+            side_effect=[
+                '{"type": "status"}',
+                '{"type": "terminal_started"}',
+            ]
+        )
+        config = types.SimpleNamespace(service_command="sleep 100")
+        await fire_service_command(ws, config, setup_ok=True)
+        ws.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_service_command_skipped_without_setup(self):
+        from klangk.cli.sandboxcmd import fire_service_command
+
+        ws = AsyncMock()
+        config = types.SimpleNamespace(service_command="sleep 100")
+        await fire_service_command(ws, config, setup_ok=False)
+        ws.send.assert_not_awaited()
+
+    def test_workspaces_table_without_shared_column(self, capsys):
+        # Rendering the rich table for own workspaces only: no Owner
+        # column, no empty appended cell.
+        from klangk.cli import workspaces as wsmod
+
+        ws = types.SimpleNamespace(
+            id="ws-t1",
+            name="solo",
+            created_at="2024-05-05T00:00:00Z",
+            status="stopped",
+            state="stopped",
+            running=False,
+        )
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        with (
+            patch("klangk.cli.context.require_auth", lambda: None),
+            patch("klangk.cli.context._client", lambda: client),
+        ):
+            wsmod.list_workspaces(shared=False, plain=False)
+        out = capsys.readouterr().out
+        assert "solo" in out
+
+    def test_workspaces_plain_without_shared_section(self, capsys):
+        from klangk.cli import workspaces as wsmod
+
+        ws = types.SimpleNamespace(
+            id="ws-t2",
+            name="plain",
+            created_at="2024-05-05T00:00:00Z",
+            status="stopped",
+            state="stopped",
+            running=False,
+        )
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        client.list_shared_workspaces.return_value = []
+        with (
+            patch("klangk.cli.context.require_auth", lambda: None),
+            patch("klangk.cli.context._client", lambda: client),
+        ):
+            wsmod.list_workspaces(plain=True, shared=False)
+        out = capsys.readouterr().out
+        assert "Shared with me" not in out
+
+    def test_config_load_skips_non_dict_user_entry(self, tmp_path):
+        # A corrupt (non-dict) user entry degrades to skipped, not a
+        # load failure.
+        import klangk.cli.config as cfgmod
+
+        state_file = tmp_path / "state.yaml"
+        state_file.write_text(
+            "active-server: http://t\n"
+            "http://t:\n"
+            "  active-user: a@b\n"
+            "  users:\n"
+            "    broken: not-a-dict\n"
+            "    ok:\n"
+            "      token: tk\n"
+        )
+        with patch.object(cfgmod, "_STATE_PATH", state_file):
+            state = cfgmod.CLIState.load()
+        assert "ok" in state.servers["http://t"].users
+        assert "broken" not in state.servers["http://t"].users
+
+    def test_config_save_skips_tokenless_user(self, tmp_path):
+        import klangk.cli.config as cfgmod
+
+        state_file = tmp_path / "state2.toml"
+        state = cfgmod.CLIState(
+            active_server="http://t",
+            servers={
+                "http://t": cfgmod.ServerState(
+                    active_user="a@b",
+                    users={
+                        "tok_user": cfgmod.UserEntry(token="tk"),
+                        "anon": cfgmod.UserEntry(token=None),
+                    },
+                )
+            },
+        )
+        with patch.object(cfgmod, "_STATE_PATH", state_file):
+            state.save()
+        text = state_file.read_text()
+        assert "tok_user" in text
+        assert "anon" not in text
+
+    def test_rename_non_active_user_keeps_active(self):
+        import klangk.cli.config as cfgmod
+
+        state = cfgmod.CLIState(
+            active_server="http://t",
+            servers={
+                "http://t": cfgmod.ServerState(
+                    active_user="active@b",
+                    users={"old@b": cfgmod.UserEntry(token="tk")},
+                )
+            },
+        )
+        state.rename_user("http://t", "old@b", "new@b")
+        ss = state.servers["http://t"]
+        assert "new@b" in ss.users and "old@b" not in ss.users
+        assert ss.active_user == "active@b"  # untouched
+
+
+class TestCliBranchGaps2834d:
+    """#2834 branch gate, part four."""
+
+    def test_import_progress_file_read_without_callback(self, tmp_path):
+        # The upload wrapper's read arm without a callback: the bytes
+        # flow through, on_progress is never invoked.
+        client = KlangkClient("http://localhost:8995", "token")
+        archive = tmp_path / "arch2.tar.gz"
+        archive.write_bytes(b"0123456789")
+
+        def fake_request(server_url, method, path, timeout=None, **kw):
+            files = kw.get("files") or {}
+            for _name, value in files.items():
+                fh = value[1] if isinstance(value, tuple) else value
+                while fh.read(4):
+                    pass  # drain exactly as httpx would
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.is_success = True
+            resp.json = lambda: {
+                "id": "ws-2",
+                "name": "n",
+                "created_at": "2024-01-01T00:00:00Z",
+                "status": "stopped",
+            }
+            return resp
+
+        with patch("klangk.cli.client.http_request", fake_request):
+            client.import_workspace(archive)  # no on_progress
+
+    @pytest.mark.asyncio
+    async def test_agent_startup_waits_past_unrelated_frames(
+        self, tmp_path, monkeypatch
+    ):
+        # The bounded agent-start wait: a non-agent non-error frame is
+        # ignored (loop continues), then ssh_agent_started ends it.
+        from klangk.cli.client import start_ssh_agent_forward
+
+        sock = tmp_path / "agent.sock"
+        sock.touch()
+        monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
+        ws = AsyncMock()
+        ws.recv = AsyncMock(
+            side_effect=[
+                '{"type": "status"}',
+                '{"type": "ssh_agent_started"}',
+            ]
+        )
+        active, local_sock = await start_ssh_agent_forward(ws, True)
+        assert active is True
+        assert local_sock == str(sock)
+
+    @pytest.mark.asyncio
+    async def test_agent_relay_none_reply_continues_loop(self):
+        from klangk.cli import client as client_mod
+        from klangk.cli.client import TerminalSession
+
+        ws = AsyncMock()
+        session = TerminalSession(
+            ws,
+            80,
+            24,
+            stdout=MagicMock(),
+            server_url="http://t",
+            token="tok",
+            ssh_agent_sock="/sock",
+        )
+        session.agent_queue.put_nowait(b"req")
+
+        def _none(sock, data):
+            return None  # agent gone: no reply, no raise
+
+        task = asyncio.create_task(session.ssh_agent_relay_loop())
+        with patch.object(client_mod, "_query_local_ssh_agent", _none):
+            for _ in range(100):
+                if session.agent_queue.empty():
+                    break
+                await asyncio.sleep(0.01)
+            await asyncio.sleep(0.05)
+            assert not task.done()
+            session.ws.send.assert_not_called()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_extend_escape_empty_open_pipe_times_out(self):
+        import os as os_mod
+
+        from klangk.cli.client import TerminalSession
+
+        r, w = os_mod.pipe()
+        try:
+            session = TerminalSession(
+                AsyncMock(),
+                80,
+                24,
+                stdout=MagicMock(),
+                server_url="http://t",
+                token="tok",
+            )
+            out = await asyncio.wait_for(
+                session._extend_escape_sequence(r, b"\x1b"), 5
+            )
+            assert out == b"\x1b"  # nothing followed within the window
+        finally:
+            os_mod.close(r)
+            os_mod.close(w)
+
+    def test_sandbox_existing_without_force_skips_setup(self, tmp_path):
+        # Re-entering an existing sandbox with --force off: no setup
+        # re-run, straight to the "Done" hint.
+        from klangk.cli import sandboxcmd
+
+        root = tmp_path
+        (root / ".klangk").mkdir()
+        cfg = types.SimpleNamespace(image="img", mounts=[], env={}, setup=None)
+        ws = types.SimpleNamespace(id="ws-exist")
+        with (
+            patch("klangk.cli.context.session_token", lambda: "tok"),
+            patch("klangk.cli.context.server_url", lambda: "http://t:8995"),
+            patch.object(sandboxcmd, "load_sandbox_config", lambda p: cfg),
+            patch.object(
+                sandboxcmd,
+                "reuse_or_refuse_workspace",
+                lambda client, w, f: ws,
+            ),
+            patch.object(sandboxcmd, "run_sandbox_setup") as setup,
+            patch("klangk.cli.context._client"),
+            patch("klangk.cli.context._err", MagicMock()),
+            patch("pathlib.Path.resolve", lambda self: root),
+        ):
+            sandboxcmd.sandbox("existing", str(root), force=False)
+        setup.assert_not_called()
+
+    def test_shell_bool_flag_skips_normalization(self):
+        # no_consent_popup already a bool: the OptionInfo normalization
+        # arm is skipped; the run then exits cleanly without a token.
+        from klangk.cli import shellcmd
+
+        with (
+            patch("klangk.cli.context.session_token", lambda: ""),
+            patch("klangk.cli.context._err", MagicMock()),
+        ):
+            import typer as typer_mod
+
+            with pytest.raises(typer_mod.Exit):
+                shellcmd.shell("ws", None, None, True)

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -3482,28 +3482,38 @@ class TestFinalBranchGaps2834:
         # rebuilding rows (rules is None -> the 1731 arm), and the
         # deferred focus-restore then finds no children, skipping the
         # index clamp (the 1749 arm) instead of crashing or jumping.
-        from textual.widgets import ListView
+        # Driven against a stub list view so the clear()'s child removal
+        # and the deferred callback are synchronous, not scheduler-bound
+        # (textual schedules both, which is flaky under xdist load).
+        from klangk.cli.tui.consent import RulesScreen
+
+        class _StubLV:
+            def __init__(self):
+                self.children = [
+                    types.SimpleNamespace(rule_id="a1"),
+                    types.SimpleNamespace(rule_id="a2"),
+                ]
+                self.index = 1
+                self.highlighted_child = self.children[1]
+                self.captured = []
+
+            def clear(self):
+                self.children = []
+
+            def call_after_refresh(self, cb):
+                self.captured.append(cb)
 
         app = _make_app()
         async with app.run_test() as pilot:
-            app.controller.apply_frame(
-                _rules_frame(allowed=[_rule("a1"), _rule("a2")])
-            )
-            app.action_rules()
             await pilot.pause()
-            screen = app.screen
-            lv = screen.query_one("#rules-list", ListView)
-            lv.index = 1  # focus a2
+            screen = RulesScreen()
+            app.push_screen(screen)
             await pilot.pause()
-            assert list(lv.children)  # rows seeded
-            # Capture (not schedule) the deferred restore, then run it
-            # by hand once the clear has landed: deterministic under any
-            # scheduler load.
-            captured = []
-            lv.call_after_refresh = captured.append
+            stub = _StubLV()
+            screen.query_one = lambda selector, cls=None: stub
             screen._rebuild_rule_list(None)
-            for _ in range(10):
-                await pilot.pause()
-            assert list(lv.children) == []
-            for cb in captured:
+            assert stub.children == []  # cleared, no rows rebuilt
+            assert stub.captured  # the restore was scheduled
+            for cb in stub.captured:
                 cb()  # no children: the clamp is skipped, nothing raises
+            assert stub.index == 1  # untouched by the skipped clamp

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -3299,3 +3299,211 @@ class TestPopupShowOffLoop:
             assert app.controller.pending == {}
             await app._popup_show_worker()
             assert len(attempts) == 1  # shown False, but nothing pending
+
+
+class TestBranchGaps2834:
+    """#2834 branch gate: decider view/controller guard outcomes."""
+
+    def test_apply_resolved_non_string_id_skips_pop(self):
+        from klangk.cli.tui.consent import ConsentDeciderController
+
+        c = ConsentDeciderController()
+        c.pending["r1"] = object()
+        status, _payload = c._apply_resolved({"request_id": 42})
+        assert status == "resolved"
+        assert "r1" in c.pending  # non-string id: nothing popped
+
+    async def test_pause_ack_ok_does_not_flash(self):
+        from klangk.cli.tui.consent import PAUSE_ACK
+
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            flashed = []
+            app._flash = lambda msg: flashed.append(msg)
+            refreshed = []
+            app._refresh = lambda: refreshed.append(1)
+            app._react(PAUSE_ACK, (True, 123.0))
+            assert flashed == []
+            assert refreshed == [1]
+
+    async def test_host_line_without_port(self):
+        from klangk.cli.tui.consent import ConsentRequest
+
+        req = ConsentRequest(
+            id="r1",
+            workspace_id="wsid",
+            dest_host="plain.example",
+            dest_port=None,
+            process_name=None,
+            pid=None,
+            requested_at=time.time(),
+        )
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            line = app._host_line(req)
+            assert "plain.example" in line
+
+    async def test_select_by_id_not_in_list_is_noop(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._select_by_id("never-seen")  # no crash, selection untouched
+
+    async def test_button_without_decision_prefix_ignored(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            decided = []
+            app._decide_id = lambda *a, **k: decided.append(a)
+
+            class _B:
+                id = "mystery-prefix"
+
+            import unittest.mock
+
+            event = unittest.mock.MagicMock()
+            event.button = _B()
+            app.on_button_pressed(event)
+            assert decided == []
+
+    async def test_duration_picker_submit_outside_decider_app(self):
+        # The picker's Enter when the app beneath is NOT the decider
+        # (nested in the main TUI): nothing decided, just dismissed.
+        import unittest.mock as um
+
+        from textual.app import App as TextualApp
+
+        from klangk.cli.tui.consent import (
+            DURATION_DEFAULT,
+            SELECTABLE_DURATIONS,
+            DurationPickerScreen,
+        )
+
+        class _OtherApp(TextualApp):
+            pass
+
+        decided = []
+        app = _OtherApp()
+        picker = DurationPickerScreen("r1", "allow", "evil.example")
+        with um.patch.object(
+            DurationPickerScreen,
+            "_decide_id",
+            lambda self, *a: decided.append(a),
+            create=True,
+        ):
+            async with app.run_test() as pilot:
+                app.push_screen(picker)
+                await pilot.pause()
+                event = um.MagicMock()
+                event.option_index = SELECTABLE_DURATIONS.index(
+                    DURATION_DEFAULT
+                )
+                picker.on_option_list_option_selected(event)
+                await pilot.pause()
+        assert decided == []
+
+    async def test_rule_highlight_loop_exhaust_is_noop(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            from klangk.cli.tui.consent import RulesScreen
+
+            rules_screen = RulesScreen()
+            app.push_screen(rules_screen)
+            await pilot.pause()
+            event = types.SimpleNamespace(
+                item=types.SimpleNamespace(rule_id="ghost"),
+                list_view=rules_screen.query_one("#rules-list"),
+            )
+            rules_screen.on_list_view_highlighted(
+                event
+            )  # not in children: no-op
+
+    async def test_rebuild_rule_list_none_rules_clears(self):
+        app = _make_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            from klangk.cli.tui.consent import RulesScreen
+
+            rules_screen = RulesScreen()
+            app.push_screen(rules_screen)
+            await pilot.pause()
+            rules_screen._rebuild_rule_list(None)
+            await pilot.pause()
+            assert list(rules_screen.query_one("#rules-list").children) == []
+
+    def test_rule_item_without_port(self):
+        from klangk.cli.tui.consent import ConsentRule
+
+        rule = ConsentRule(
+            id="a1",
+            dest_host="plain.example",
+            dest_port=None,
+            process_name=None,
+            decision="allowed",
+            duration="5m",
+            decided_at=2.0,
+            decided_by="u@x",
+        )
+        from klangk.cli.tui.consent import RulesScreen
+
+        from textual.widgets import ListItem
+
+        item = RulesScreen._rule_item(rule, "allowed")
+        assert isinstance(item, ListItem)
+
+    def test_rule_line_without_port(self):
+        from klangk.cli.tui.consent import (
+            ConsentDeciderController,
+            ConsentRule,
+            RulesScreen,
+        )
+
+        rule = ConsentRule(
+            id="a1",
+            dest_host="plain.example",
+            dest_port=None,
+            process_name=None,
+            decision="allowed",
+            duration="5m",
+            decided_at=2.0,
+            decided_by="u@x",
+        )
+        controller = ConsentDeciderController()
+        line = RulesScreen._rule_line(rule, controller, deny=False)
+        assert "plain.example" in line
+
+
+class TestFinalBranchGaps2834:
+    async def test_rebuild_rules_to_empty_skips_focus_clamp(self):
+        # A rules frame that fails to parse clears the list without
+        # rebuilding rows (rules is None -> the 1731 arm), and the
+        # deferred focus-restore then finds no children, skipping the
+        # index clamp (the 1749 arm) instead of crashing or jumping.
+        from textual.widgets import ListView
+
+        app = _make_app()
+        async with app.run_test() as pilot:
+            app.controller.apply_frame(
+                _rules_frame(allowed=[_rule("a1"), _rule("a2")])
+            )
+            app.action_rules()
+            await pilot.pause()
+            screen = app.screen
+            lv = screen.query_one("#rules-list", ListView)
+            lv.index = 1  # focus a2
+            await pilot.pause()
+            assert list(lv.children)  # rows seeded
+            # Capture (not schedule) the deferred restore, then run it
+            # by hand once the clear has landed: deterministic under any
+            # scheduler load.
+            captured = []
+            lv.call_after_refresh = captured.append
+            screen._rebuild_rule_list(None)
+            for _ in range(10):
+                await pilot.pause()
+            assert list(lv.children) == []
+            for cb in captured:
+                cb()  # no children: the clamp is skipped, nothing raises

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -8,9 +8,12 @@ and the ``add_server_to_config`` helper — under the 100% coverage gate.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import re
 import threading
 import time
+import types
+import unittest.mock as unittest_mock
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -13992,3 +13995,1067 @@ async def test_detail_delete_pop_guarded_when_screen_already_popped(
         await pilot.pause()
         assert list(app.screen_stack) == before
         assert isinstance(app.screen, MainScreen)
+
+
+class TestTuiStateBranchGaps2834:
+    """#2834 branch gate: TuiState server bookkeeping guards."""
+
+    def test_update_server_inactive_url_leaves_active_pointer(
+        self, redirect_xdg
+    ):
+        add_server_to_config("a", "https://a.example")
+        st = TuiState()
+        st.state().active_server = "https://other.example"
+        st._save_state(st.state())
+        assert st.update_server("a", "a2", "https://a2.example") is True
+        assert st.state().active_server == "https://other.example"
+
+    def test_update_server_alias_not_found(self, redirect_xdg):
+        st = TuiState()
+        assert st.update_server("missing", "x", "https://x.example") is False
+
+    def test_delete_server_not_active_keeps_pointer(self, redirect_xdg):
+        add_server_to_config("a", "https://a.example")
+        add_server_to_config("b", "https://b.example")
+        st = TuiState()
+        st.state().active_server = "https://b.example"
+        st._save_state(st.state())
+        assert st.delete_server("https://a.example") is True
+        assert st.state().active_server == "https://b.example"
+
+
+async def test_listen_for_status_without_connect_callback(monkeypatch):
+    # No on_connect: nothing fires before the frames, events still flow.
+    collected = []
+    frames = ['{"type": "workspaces_changed"}']
+    monkeypatch.setattr(
+        ws_mod, "ws_connect", lambda *a, **k: FakeCM(FakeWS(frames))
+    )
+    await listen_for_status(
+        "/sock", "tok", on_event=collected.append, on_connect=None
+    )
+    assert collected == [{"type": "workspaces_changed"}]
+
+
+class TestBaseScreenBranchGaps2834:
+    """#2834 branch gate: the shared screen/navigation guards."""
+
+    def test_btn_step_with_non_button_focus_is_noop(self):
+        # Focus sitting on nothing (or a non-button): the left/right
+        # button-step does not move focus.
+        from klangk.cli.tui.screens._base import ConfirmScreen
+
+        s = ConfirmScreen("p")
+        # Not mounted: self.focused is None -> fid None -> guard exits.
+        s.action_btn_left()
+        s.action_btn_right()
+        s.action_btn_up()
+
+    def test_error_screen_unknown_button_ignored(self):
+        # A button id the screen does not handle: nothing happens (no
+        # crash, no dismissal).
+        from klangk.cli.tui.screens._base import SessionExpiredScreen
+
+        s = SessionExpiredScreen()
+        dismissed = []
+        s.dismiss = lambda result: dismissed.append(result)
+        s.on_button_pressed(FakeBtnPress("totally-unknown"))
+        assert dismissed == []
+
+    def test_confirm_screen_cancel_button_dismisses(self):
+        from klangk.cli.tui.screens._base import ConfirmScreen
+
+        s = ConfirmScreen("p")
+        dismissed = []
+        s.dismiss = lambda result: dismissed.append(result)
+        s.on_button_pressed(FakeBtnPress("cancel"))
+        assert dismissed == [False]
+
+    def test_duplicate_screen_unknown_button_and_input_ignored(self):
+        from klangk.cli.tui.screens._base import DuplicateScreen
+
+        s = DuplicateScreen("src-name")
+        dismissed = []
+        s.dismiss = lambda result: dismissed.append(result)
+        s.on_button_pressed(FakeBtnPress("mystery"))
+        fake_input = types.SimpleNamespace(
+            input=types.SimpleNamespace(id="not-dup-name")
+        )
+        s.on_input_submitted(fake_input)
+        assert dismissed == []
+
+    def test_input_screen_unknown_button_and_input_ignored(self):
+        from klangk.cli.tui.screens._base import InputScreen
+
+        s = InputScreen("t")
+        dismissed = []
+        s.dismiss = lambda result: dismissed.append(result)
+        s.on_button_pressed(FakeBtnPress("mystery"))
+        fake_input = types.SimpleNamespace(
+            input=types.SimpleNamespace(id="not-inp_value")
+        )
+        s.on_input_submitted(fake_input)
+        assert dismissed == []
+
+    def test_spatial_up_at_chain_top_without_exit_stays(self):
+        from klangk.cli.tui.screens._base import SpatialNavScreen
+
+        class _S(SpatialNavScreen):
+            SPATIAL_CHAIN = ["top", "bottom"]
+            SPATIAL_UP_EXIT = None
+
+            @property
+            def focused(self):
+                return types.SimpleNamespace(id="top")
+
+        _S().action_spatial_up()  # no exit target: stays (no raise)
+
+    def test_spatial_down_at_chain_bottom_stays(self):
+        from klangk.cli.tui.screens._base import SpatialNavScreen
+
+        class _S(SpatialNavScreen):
+            SPATIAL_CHAIN = ["top", "bottom"]
+
+            @property
+            def focused(self):
+                return types.SimpleNamespace(id="bottom")
+
+        _S().action_spatial_down()  # at the end: stays (no raise)
+
+    def test_tab_skip_skips_disabled_and_hidden_targets(self):
+        from klangk.cli.tui.screens._base import TabSkipMixin
+
+        focused_ids = []
+
+        class _Widget:
+            def __init__(self, display, disabled):
+                self.display = display
+                self.disabled = disabled
+
+            def focus(self):
+                focused_ids.append(id(self))
+
+        class _Screen(TabSkipMixin):
+            _TAB_ORDER = ["a", "b", "c"]
+
+            @property
+            def focused(self):
+                return types.SimpleNamespace(id="a")
+
+            def query_one(self, selector):
+                return {
+                    "#b": _Widget(True, True),  # disabled: skipped
+                    "#c": _Widget(False, False),  # hidden: skipped
+                }[selector]
+
+        class _Ev:
+            key = "tab"
+
+            def stop(self):
+                pass
+
+        screen = _Screen()
+        # The focus chain is a cycle; with b/c unusable nothing focuses.
+        screen.on_key(_Ev())
+        assert focused_ids == []
+
+
+class TestAppBranchGaps2834:
+    """#2834 branch gate: the app-level screen-stack guards."""
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _status_patched():
+        import klangk.cli.tui.screens.main as m
+
+        async def noop(*a, **k):
+            return None
+
+        with unittest_mock.patch.object(m, "listen_for_status", noop):
+            yield
+
+    @staticmethod
+    def _unauthed_state():
+        return _st(
+            is_authenticated=lambda: False,
+            auth_mode=lambda: "password",
+            current_url=lambda: "https://x.example",
+            email=lambda: None,
+            token=lambda: None,
+        )
+
+    async def test_do_logout_without_main_screen(self):
+        from klangk.cli.tui.screens.login import LoginScreen
+
+        with self._status_patched():
+            st = self._unauthed_state()
+            st.logout = lambda: None
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                # From the login screen (no MainScreen mounted).
+                assert isinstance(app.screen, LoginScreen)
+                app.do_logout()
+                for _ in range(50):
+                    if isinstance(app.screen, LoginScreen):
+                        break
+                    await asyncio.sleep(0.02)
+                assert isinstance(app.screen, LoginScreen)
+
+    async def test_pop_above_top_screen_removes_nothing(self):
+        with self._status_patched():
+            app = KlangkApp(_ws())
+            async with app.run_test() as pilot:
+                from klangk.cli.tui.screens._base import ConfirmScreen
+
+                top = ConfirmScreen("sure?")
+                app.push_screen(top)
+                await pilot.pause()
+                before = len(app.screen_stack)
+                assert app._pop_above(top) is True
+                await pilot.pause()
+                # Target was already on top: nothing above it to pop.
+                assert len(app.screen_stack) == before
+                assert app.screen_stack[-1] is top
+
+    async def test_session_expired_overlay_already_gone(self):
+        from klangk.cli.tui.screens.login import LoginScreen
+
+        with self._status_patched():
+            st = self._unauthed_state()
+            st.logout = lambda: None
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                assert isinstance(app.screen, LoginScreen)
+                app._session_expired_screen = None  # already dismissed
+                app.session_expired()
+                for _ in range(50):
+                    if isinstance(app.screen, LoginScreen):
+                        break
+                    await asyncio.sleep(0.02)
+                assert isinstance(app.screen, LoginScreen)
+
+    async def test_refresh_workspaces_without_main_screen(self):
+        from klangk.cli.tui.screens.login import LoginScreen
+
+        with self._status_patched():
+            app = KlangkApp(self._unauthed_state())
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                assert isinstance(app.screen, LoginScreen)
+                app.refresh_workspaces()  # no MainScreen: silent no-op
+
+    async def test_server_down_dismiss_without_overlay(self):
+        with self._status_patched():
+            app = KlangkApp(_ws())
+            async with app.run_test():
+                app._server_down_screen = None
+                app.dismiss_server_down()
+                assert app._server_down_dismissed is True
+
+    async def test_server_down_switch_without_overlay(self):
+        with self._status_patched():
+            app = KlangkApp(_ws())
+            async with app.run_test() as pilot:
+                app._server_down_screen = None
+                app.server_down_switch_server()
+                await pilot.pause()
+                from klangk.cli.tui.screens.server import ServerSwitchScreen
+
+                assert isinstance(app.screen, ServerSwitchScreen)
+
+
+class TestMainScreenBranchGaps2834:
+    """#2834 branch gate: MainScreen guard outcomes."""
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _status_patched():
+        import klangk.cli.tui.screens.main as m
+
+        async def noop(*a, **k):
+            return None
+
+        with unittest_mock.patch.object(m, "listen_for_status", noop):
+            yield
+
+    @staticmethod
+    @contextlib.asynccontextmanager
+    async def _main():
+        app = KlangkApp(_ws())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            yield app, app.screen
+
+    async def test_unknown_button_and_input_ids_ignored(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                screen.on_button_pressed(FakeBtnPress("mystery"))
+                screen.on_input_changed(
+                    types.SimpleNamespace(
+                        input=types.SimpleNamespace(id="nope"), value=""
+                    )
+                )
+                screen.on_input_submitted(
+                    types.SimpleNamespace(
+                        input=types.SimpleNamespace(id="nope")
+                    )
+                )
+
+    async def test_reload_lists_unauthenticated_skips_last_login(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                app.tui_state.is_authenticated = lambda: False
+                ran = []
+                app.run_worker = lambda *a, **k: ran.append(a)
+                screen.reload_last_login()
+                assert not ran  # no last-login worker without a session
+
+    async def test_focus_visible_list_with_selected_index(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                lv = types.SimpleNamespace(
+                    query=lambda *a: [object()],
+                    index=3,
+                    focus=lambda: None,
+                )
+                screen._active_list = lambda: lv
+                screen._focus_visible_list()
+                assert lv.index == 3  # untouched: already selected
+
+    async def test_key_down_without_active_list(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                screen._active_list = lambda: None
+                from textual.widgets import Tabs
+
+                event = types.SimpleNamespace(
+                    key="down", focused=None, stop=lambda: None
+                )
+                screen.focused = Tabs()
+                screen.on_key(event)
+
+    async def test_key_down_with_selected_index(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                lv = types.SimpleNamespace(index=1, focus=lambda: None)
+                screen._active_list = lambda: lv
+                from textual.widgets import Tabs
+
+                stopped = []
+                event = types.SimpleNamespace(
+                    key="down",
+                    focused=None,
+                    stop=lambda: stopped.append(1),
+                )
+                screen.focused = Tabs()
+                screen.on_key(event)
+                assert stopped
+                assert lv.index == 1  # untouched
+
+    async def test_import_done_failure_keeps_stale_list(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                refreshed = []
+                screen.refresh_lists = lambda: refreshed.append(1)
+                screen._on_import_done((False, "boom"))
+                assert refreshed == []  # no refresh on failure
+                screen._on_import_done((True, "ok"))
+                assert refreshed == [1]
+
+    async def test_running_overlay_skips_unlisted_workspaces(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                screen._running_overlay = {"ws-other": True}
+                ws = types.SimpleNamespace(id="ws-mine", running=False)
+                screen._apply_running_overlay([ws])
+                assert ws.running is False  # overlay did not touch it
+
+    def test_fmt_date_missing_created_at(self):
+        assert str(MainScreen._fmt_date(types.SimpleNamespace())) == ""
+
+    async def test_restart_status_worker_skipped_when_alive(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                screen._status_worker = types.SimpleNamespace(
+                    is_finished=False
+                )
+                ran = []
+                app.run_worker = lambda *a, **k: ran.append(a)
+                screen.ensure_status_ws_worker()
+                assert not ran
+
+    async def test_token_refresh_none_result_keeps_session(self):
+        import klangk.cli.tui.screens.main as m
+
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                expired = []
+                app.session_expired = lambda: expired.append(1)
+
+                async def _none_result(state):
+                    return None
+
+                with unittest_mock.patch.object(
+                    m, "run_token_refresh_loop", _none_result
+                ):
+                    # The Pilot harness swaps _token_refresh_loop for a
+                    # noop (#1989-style); drive the saved real one.
+                    await _real_token_refresh_loop(screen)
+                assert expired == []
+
+    async def test_wait_drop_or_both_done_same_tick(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                screen._ws_drop.set()
+                loop = asyncio.get_running_loop()
+                awaiting = loop.create_future()
+                awaiting.set_exception(RuntimeError("ignored outcome"))
+                assert await screen._wait_drop_or(awaiting) is True
+
+    async def test_wait_drop_or_cancelled_after_waiter_done(self):
+        with self._status_patched():
+            async with self._main() as (app, screen):
+                screen._ws_drop.set()
+                loop = asyncio.get_running_loop()
+                awaiting = loop.create_future()
+                real_wait = asyncio.wait
+
+                async def _wait_then_cancel(fs, return_when=None):
+                    await asyncio.sleep(0)  # let the drop waiter finish
+                    task = asyncio.current_task()
+                    task.cancel()
+                    return await real_wait(fs, return_when=return_when)
+
+                with unittest_mock.patch.object(
+                    asyncio, "wait", _wait_then_cancel
+                ):
+                    with pytest.raises(asyncio.CancelledError):
+                        await screen._wait_drop_or(awaiting)
+
+
+class TestDetailScreenBranchGaps2834:
+    """#2834 branch gate: detail-screen guard outcomes."""
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _status_patched():
+        import klangk.cli.tui.screens.main as m
+
+        async def noop(*a, **k):
+            return None
+
+        with unittest_mock.patch.object(m, "listen_for_status", noop):
+            yield
+
+    @staticmethod
+    @contextlib.asynccontextmanager
+    async def _detail(wsobj=None):
+        a = wsobj or _wsobj(
+            "alpha", running=True, service_started_at=time.time() + 60
+        )
+        st = _ws()
+        st.find_workspace = lambda n: a
+        st.list_terminals = lambda *a, **k: []
+        st.list_shared_terminals = lambda *a, **k: []
+        app = KlangkApp(st)
+        async with app.run_test() as pilot:
+            app.push_screen(WorkspaceDetailScreen("alpha"))
+            await pilot.pause()
+            yield app, app.screen
+
+    async def test_detail_rows_without_uptime_for_future_timestamp(self):
+        # A service_started_at slightly in the future (clock skew): the
+        # negative elapsed is skipped, no uptime row.
+        async with self._detail() as (app, screen):
+            rows = screen._detail_rows(screen._ws)
+            assert not any(label == "uptime" for label, _ in rows)
+
+    async def test_edited_none_result_skips_reload(self):
+        async with self._detail() as (app, screen):
+            workers = []
+            screen.run_worker = lambda *a, **k: workers.append(a)
+            screen._on_edited(None)
+            assert workers == []
+
+    async def test_health_event_without_message(self):
+        async with self._detail() as (app, screen):
+            screen._apply_service_health({"running": True, "healthy": False})
+            assert screen._ws.health == "unhealthy"
+            assert screen._ws.health_message in (None, "ok")
+
+    async def test_reload_on_status_pops_when_screen_not_top(self):
+        async with self._detail() as (app, screen):
+            from klangk.cli.tui.screens._base import ConfirmScreen
+
+            app.push_screen(ConfirmScreen("modal?"))
+            await asyncio.sleep(0)
+
+            async def _noop_load():
+                pass
+
+            screen._load = _noop_load
+            screen._refresh_deploy_banner = _noop_load
+            screen._missing = True
+            await screen._reload_on_status()
+            for _ in range(50):
+                if not isinstance(app.screen, ConfirmScreen):
+                    break
+                await asyncio.sleep(0.02)
+            # The modal above was popped along with the dead detail
+            # screen: back on the list (never the orphaned modal).
+            assert not isinstance(app.screen, ConfirmScreen)
+
+    async def test_reload_on_restart_missing_skips_terminals(self):
+        async with self._detail() as (app, screen):
+            loaded = []
+
+            async def _noop_load():
+                pass
+
+            async def _load_terms():
+                loaded.append(1)
+
+            screen._load = _noop_load
+            screen._load_terminals = _load_terms
+            screen._missing = True
+            await screen._reload_on_restart()
+            assert loaded == []
+
+    async def test_shell_argv_without_server_url(self):
+        async with self._detail() as (app, screen):
+            app.tui_state.current_url = lambda: None
+            argv = screen._shell_argv("term-1")
+            assert "--server" not in argv
+
+    async def test_restart_without_ws_still_requests(self):
+        # A start whose workspace object vanished (the row was deleted
+        # mid-confirm) still requests the start.
+        async with self._detail() as (app, screen):
+            screen._ws = None
+            started = []
+            screen.app.tui_state.start_workspace = lambda name: started.append(
+                name
+            )
+            screen.app.refresh_workspaces = lambda: None
+            await screen._do_start()
+            assert started == ["alpha"]
+
+    async def test_start_without_ws_still_requests(self):
+        async with self._detail() as (app, screen):
+            screen._ws = None
+            started = []
+            screen.app.tui_state.start_workspace = lambda name: started.append(
+                name
+            )
+            screen.app.refresh_workspaces = lambda: None
+            await screen._do_start()
+            assert started == ["alpha"]
+
+    async def test_second_terminal_load_keeps_selected_index(self):
+        async with self._detail() as (app, screen):
+            await screen._load_terminals()
+            lv = screen.query_one(
+                "#term_list", __import__("textual").widgets.ListView
+            )
+            if lv.index is None:
+                lv.index = 0
+            before = lv.index
+            await screen._load_terminals()  # refresh keeps the selection
+            assert screen.query_one(
+                "#term_list", __import__("textual").widgets.ListView
+            ).index in (before, 0)
+
+
+class TestLoginServerFormBranchGaps2834:
+    """#2834 branch gate: login/server/form dispatch fall-throughs."""
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _status_patched():
+        import klangk.cli.tui.screens.main as m
+
+        async def noop(*a, **k):
+            return None
+
+        with unittest_mock.patch.object(m, "listen_for_status", noop):
+            yield
+
+    async def test_login_unknown_button_and_input_ids(self):
+        st = _st(
+            is_authenticated=lambda: False,
+            auth_mode=lambda: "password",
+            current_url=lambda: "https://x.example",
+            email=lambda: None,
+            token=lambda: None,
+        )
+        with self._status_patched():
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                screen = app.screen
+                screen.on_button_pressed(FakeBtnPress("mystery"))
+                screen.on_input_submitted(
+                    types.SimpleNamespace(
+                        input=types.SimpleNamespace(id="mystery")
+                    )
+                )
+
+    async def test_server_add_unknown_button_and_input_ids(self):
+        with self._status_patched():
+            app = KlangkApp(_ws())
+            async with app.run_test() as pilot:
+                from klangk.cli.tui.screens.server import (
+                    AddServerScreen,
+                    EditServerScreen,
+                )
+
+                add = AddServerScreen()
+                app.push_screen(add)
+                await pilot.pause()
+                add.on_button_pressed(FakeBtnPress("mystery"))
+                add.on_input_submitted(
+                    types.SimpleNamespace(
+                        input=types.SimpleNamespace(id="mystery")
+                    )
+                )
+                edit = EditServerScreen(alias="a", url="https://a")
+                app.push_screen(edit)
+                await pilot.pause()
+                edit.on_button_pressed(FakeBtnPress("mystery"))
+                edit.on_input_submitted(
+                    types.SimpleNamespace(
+                        input=types.SimpleNamespace(id="mystery")
+                    )
+                )
+
+    async def test_server_switch_edit_callback_false_result(self):
+        st = _st(
+            is_authenticated=lambda: False,
+            auth_mode=lambda: "password",
+            current_url=lambda: "https://x.example",
+            email=lambda: None,
+            token=lambda: None,
+        )
+        with self._status_patched():
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                from klangk.cli.tui.screens.server import ServerSwitchScreen
+
+                view = ServerSwitchScreen()
+                app.push_screen(view)
+                await pilot.pause()
+                from textual.widgets import Label, ListItem, ListView
+
+                item = ListItem(Label("an-alias"))
+                item.server_alias = "an-alias"
+                lv = view.query_one("#server_options", ListView)
+                lv.append(item)
+                lv.index = 0
+                await pilot.pause()
+                pushed = {}
+
+                def _push(screen, cb=None):
+                    pushed["cb"] = cb
+
+                app.push_screen = _push
+                # The edit launcher's callback with a False (dismissed,
+                # nothing changed) result: no repopulate, no server change.
+                view.action_edit_server()
+                calls = []
+                view._populate = lambda: calls.append(1)
+                cb = pushed.get("cb")
+                cb(False)
+                assert calls == []
+
+    async def test_form_dispatch_unknown_button(self):
+        from klangk.cli.tui.screens.workspace_form import (
+            dispatch_editor_button,
+        )
+
+        calls = []
+        screen = types.SimpleNamespace(
+            **{
+                name: (lambda n: lambda: calls.append(n))(name)
+                for name in (
+                    "_remove_env",
+                    "_remove_allowed_domain",
+                    "_remove_rejected_domain",
+                )
+            }
+        )
+        dispatch_editor_button(screen, "rm_env")
+        dispatch_editor_button(screen, "rm_allow")
+        dispatch_editor_button(screen, "rm_reject")
+        dispatch_editor_button(screen, "not-a-handler")
+        assert len(calls) == 3
+
+    async def test_form_add_rejected_domain_skips_duplicate(self):
+        from textual.widgets import Input as TextualInput
+
+        from klangk.cli.tui.screens.workspace_form import (
+            CreateWorkspaceScreen,
+        )
+
+        with self._status_patched():
+            app = KlangkApp(_ws())
+            async with app.run_test() as pilot:
+                screen = CreateWorkspaceScreen(
+                    allowed=[], default="img", allow_autostart=False
+                )
+                app.push_screen(screen)
+                await pilot.pause()
+                screen._rejected_domains = ["evil.example:443"]
+                inp = screen.query_one("#reject_input", TextualInput)
+                inp.value = "evil.example:443"
+                screen._msg = lambda *a, **k: None
+                screen._render_rejected_domains = lambda: None
+                screen._add_rejected_domain()
+                assert screen._rejected_domains == ["evil.example:443"]
+
+    async def test_form_unknown_input_id_falls_through(self):
+        from klangk.cli.tui.screens.workspace_form import (
+            CreateWorkspaceScreen,
+            EditWorkspaceScreen,
+        )
+
+        with self._status_patched():
+            app = KlangkApp(_ws())
+            async with app.run_test() as pilot:
+                create = CreateWorkspaceScreen(
+                    allowed=[], default="img", allow_autostart=False
+                )
+                app.push_screen(create)
+                await pilot.pause()
+                create.on_input_submitted(
+                    types.SimpleNamespace(
+                        input=types.SimpleNamespace(id="mystery")
+                    )
+                )
+                edit = EditWorkspaceScreen(
+                    workspace=_wsobj("edit-me"),
+                    allowed=[],
+                    default="img",
+                    allow_autostart=False,
+                )
+                app.push_screen(edit)
+                await pilot.pause()
+                edit.on_input_submitted(
+                    types.SimpleNamespace(
+                        input=types.SimpleNamespace(id="mystery")
+                    )
+                )
+
+
+class TestFinalBranchGaps2834:
+    """#2834 branch gate: the last uncovered guard outcomes."""
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _status_patched():
+        import klangk.cli.tui.screens.main as m
+
+        async def noop(*a, **k):
+            return None
+
+        with unittest_mock.patch.object(m, "listen_for_status", noop):
+            yield
+
+    @staticmethod
+    def _unauthed_state():
+        return _st(
+            is_authenticated=lambda: False,
+            auth_mode=lambda: "password",
+            current_url=lambda: "https://x.example",
+            email=lambda: None,
+            token=lambda: None,
+        )
+
+    async def test_server_changed_needs_login_without_main(self):
+        from klangk.cli.tui.screens.login import LoginScreen
+
+        with self._status_patched():
+            st = self._unauthed_state()
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                assert isinstance(app.screen, LoginScreen)
+                app.server_changed_needs_login()
+                await pilot.pause()
+                assert isinstance(app.screen, LoginScreen)
+
+    async def test_confirm_session_expired_overlay_already_gone(self):
+        from klangk.cli.tui.screens.login import LoginScreen
+
+        with self._status_patched():
+            st = self._unauthed_state()
+            st.logout = lambda: None
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                # The overlay was already dismissed (460 arc) and no
+                # MainScreen exists (477 arc).
+                assert isinstance(app.screen, LoginScreen)
+                app._session_expired_screen = None
+                app.confirm_session_expired()
+                for _ in range(50):
+                    if not app._expiring:
+                        break
+                    await asyncio.sleep(0.02)
+                assert isinstance(app.screen, LoginScreen)
+
+    async def test_login_server_populate_with_selected_index(self):
+        from klangk.cli.tui.screens.login import LoginScreen
+
+        with self._status_patched():
+            st = self._unauthed_state()
+            st.list_servers = lambda: [
+                types.SimpleNamespace(
+                    alias="a", url="https://a.example", user="u@a"
+                )
+            ]
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                screen = app.screen
+                assert isinstance(screen, LoginScreen)
+                lv = screen.query_one("#server_options")
+                if lv.index is None:
+                    lv.index = 0
+                # A second populate keeps the selection (not reset).
+                screen._populate_servers()
+                await pilot.pause()
+                assert lv.index == 0
+
+    async def test_detail_on_mount_with_selected_indexes(self):
+        with self._status_patched():
+            a = _wsobj("sel")
+            st = _ws()
+            st.find_workspace = lambda n: a
+            st.list_terminals = lambda *a, **k: []
+            st.list_shared_terminals = lambda *a, **k: []
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                app.push_screen(WorkspaceDetailScreen("sel"))
+                await pilot.pause()
+                screen = app.screen
+                tl = screen.query_one("#term_list")
+                sh = screen.query_one("#shared_term_list")
+                if tl.index is None:
+                    tl.index = 0
+                if sh.index is None:
+                    sh.index = 0
+                screen.on_mount()  # re-seed keeps both selections
+                await pilot.pause()
+                assert tl.index == 0
+                assert sh.index == 0
+
+    async def test_detail_reload_terminals_keeps_selection(self):
+        from textual.widgets import ListView
+
+        with self._status_patched():
+            a = _wsobj("terms")
+            st = _ws()
+            st.find_workspace = lambda n: a
+
+            def _terms(*args, **kwargs):
+                return [
+                    types.SimpleNamespace(
+                        target="@0", title="bash", shared=False, owner=None
+                    )
+                ]
+
+            st.list_terminals = _terms
+            st.list_shared_terminals = lambda *a, **k: []
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                app.push_screen(WorkspaceDetailScreen("terms"))
+                await pilot.pause()
+                screen = app.screen
+                await screen._load_terminals()
+                lv = screen.query_one("#term_list", ListView)
+                assert lv.index is not None
+                await screen._load_terminals()  # refresh keeps selection
+                assert lv.index is not None
+
+    async def test_detail_reload_on_status_raced_push_skips_self_pop(self):
+        with self._status_patched():
+            a = _wsobj("raced")
+            st = _ws()
+            st.find_workspace = lambda n: a
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                app.push_screen(WorkspaceDetailScreen("raced"))
+                await pilot.pause()
+                screen = app.screen
+
+                async def _noop_load():
+                    pass
+
+                screen._load = _noop_load
+                screen._refresh_deploy_banner = _noop_load
+                screen._missing = True
+                real_pop = app._pop_above
+
+                def _pop_then_push(target):
+                    result = real_pop(target)
+                    # A racing push lands between the teardown and the
+                    # self-pop check.
+                    from klangk.cli.tui.screens._base import ConfirmScreen
+
+                    app.push_screen(ConfirmScreen("raced in"))
+                    return result
+
+                app._pop_above = _pop_then_push
+                await screen._reload_on_status()
+                await pilot.pause()
+                # The raced-in modal is now on top: the dead detail
+                # screen did NOT pop itself beneath it.
+                from klangk.cli.tui.screens._base import ConfirmScreen
+
+                assert isinstance(app.screen, ConfirmScreen)
+                assert screen in app.screen_stack
+
+    async def test_detail_restart_and_stop_without_ws(self):
+        with self._status_patched():
+            a = _wsobj("nows")
+            st = _ws()
+            st.find_workspace = lambda n: a
+            app = KlangkApp(st)
+            async with app.run_test() as pilot:
+                app.push_screen(WorkspaceDetailScreen("nows"))
+                await pilot.pause()
+                screen = app.screen
+                screen._ws = None
+                restarted, stopped = [], []
+                screen.app.tui_state.restart_workspace = lambda name: (
+                    restarted.append(name)
+                )
+                screen.app.tui_state.stop_workspace = lambda name: (
+                    stopped.append(name)
+                )
+                screen.app.refresh_workspaces = lambda: None
+                await screen._do_restart()
+                await screen._do_stop()
+                assert restarted == ["nows"]
+                assert stopped == ["nows"]
+
+    async def test_form_edit_rejected_to_existing_value(self):
+        from textual.widgets import Input as TextualInput
+
+        from klangk.cli.tui.screens.workspace_form import (
+            EditWorkspaceScreen,
+        )
+
+        with self._status_patched():
+            app = KlangkApp(_ws())
+            async with app.run_test() as pilot:
+                screen = EditWorkspaceScreen(
+                    workspace=_wsobj("edit-dup"),
+                    allowed=[],
+                    default="img",
+                    allow_autostart=False,
+                )
+                app.push_screen(screen)
+                await pilot.pause()
+                screen._rejected_domains = ["a.example:443", "b.example:443"]
+                # A stale edit index (the row was revoked mid-edit): the
+                # add-path runs, and the value is already present.
+                screen._editing_reject = None
+                inp = screen.query_one("#reject_input", TextualInput)
+                inp.value = "a.example:443"  # already present
+                screen._msg = lambda *a, **k: None
+                screen._render_rejected_domains = lambda: None
+                screen._add_rejected_domain()
+                # No stale edit row and the value already present: the
+                # duplicate-append arm is skipped, list unchanged.
+                assert screen._rejected_domains == [
+                    "a.example:443",
+                    "b.example:443",
+                ]
+
+
+async def test_wait_drop_or_both_done_same_tick_2834(monkeypatch):
+    """#2834: both same-tick arms — the waiter fires while the raced
+    future is already done. Uncancelled: its outcome is retrieved (and
+    discarded) so asyncio never warns. Already cancelled by a racing
+    teardown: the retrieval is skipped."""
+    import klangk.cli.tui.screens.main as m
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(m, "listen_for_status", noop)
+    app = KlangkApp(_ws())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = app.screen
+        real_wait = asyncio.wait
+
+        async def _let_waiter_finish(fs, return_when=None):
+            await asyncio.sleep(0.05)  # the drop waiter completes now
+            return await real_wait(fs, return_when=return_when)
+
+        with unittest_mock.patch.object(asyncio, "wait", _let_waiter_finish):
+            # Uncancelled: the exception is retrieved and discarded.
+            screen._ws_drop.set()
+            loop = asyncio.get_running_loop()
+            awaiting = loop.create_future()
+            awaiting.set_exception(RuntimeError("superseded outcome"))
+            assert await screen._wait_drop_or(awaiting) is True
+            assert awaiting.exception() is not None
+            # Cancelled by a racing teardown before the waiter fired:
+            # no retrieval attempt on an already-cancelled future.
+            screen._ws_drop.set()
+            cancelled = loop.create_future()
+            cancelled.cancel()
+            assert await screen._wait_drop_or(cancelled) is True
+
+
+async def test_clear_server_down_without_overlay_2834(monkeypatch):
+    """#2834: recovery clearing an overlay that was never shown."""
+    import klangk.cli.tui.screens.main as m
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(m, "listen_for_status", noop)
+    app = KlangkApp(_ws())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_down_screen = None
+        app.clear_server_down()  # no overlay: silent no-op
+        assert app._server_down_dismissed is False
+
+
+async def test_token_refresh_body_actually_runs_2834(monkeypatch):
+    import klangk.cli.tui.screens.main as m
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(m, "listen_for_status", noop)
+    ran = []
+
+    async def _marker(state):
+        ran.append(state)
+        return "expired"
+
+    monkeypatch.setattr(m, "run_token_refresh_loop", _marker)
+    app = KlangkApp(_ws())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        expired = []
+        app.session_expired = lambda: expired.append(1)
+        await _real_token_refresh_loop(app.screen)
+        assert expired == [1]  # the expired result surfaces the overlay
+    assert ran

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -14812,30 +14812,6 @@ class TestFinalBranchGaps2834:
                     await asyncio.sleep(0.02)
                 assert isinstance(app.screen, LoginScreen)
 
-    async def test_login_server_populate_with_selected_index(self):
-        from klangk.cli.tui.screens.login import LoginScreen
-
-        with self._status_patched():
-            st = self._unauthed_state()
-            st.list_servers = lambda: [
-                types.SimpleNamespace(
-                    alias="a", url="https://a.example", user="u@a"
-                )
-            ]
-            app = KlangkApp(st)
-            async with app.run_test() as pilot:
-                await pilot.pause()
-                await app.workers.wait_for_complete()
-                screen = app.screen
-                assert isinstance(screen, LoginScreen)
-                lv = screen.query_one("#server_options")
-                if lv.index is None:
-                    lv.index = 0
-                # A second populate keeps the selection (not reset).
-                screen._populate_servers()
-                await pilot.pause()
-                assert lv.index == 0
-
     async def test_detail_on_mount_with_selected_indexes(self):
         with self._status_patched():
             a = _wsobj("sel")

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -14196,11 +14196,15 @@ class TestAppBranchGaps2834:
                 await app.workers.wait_for_complete()
                 # From the login screen (no MainScreen mounted).
                 assert isinstance(app.screen, LoginScreen)
+                # Capture (not schedule) the logout worker and run it to
+                # completion inline: awaiting the screen state alone is
+                # vacuous here (LoginScreen is already up), and a raced
+                # worker can outlive the coverage flush.
+                captured = []
+                app.run_worker = lambda fn, **kw: captured.append(fn)
                 app.do_logout()
-                for _ in range(50):
-                    if isinstance(app.screen, LoginScreen):
-                        break
-                    await asyncio.sleep(0.02)
+                await captured[0]()
+                await pilot.pause()
                 assert isinstance(app.screen, LoginScreen)
 
     async def test_pop_above_top_screen_removes_nothing(self):
@@ -14805,11 +14809,14 @@ class TestFinalBranchGaps2834:
                 # MainScreen exists (477 arc).
                 assert isinstance(app.screen, LoginScreen)
                 app._session_expired_screen = None
+                # Run the expiry worker inline (see do_logout test: a
+                # raced worker can outlive the coverage flush).
+                captured = []
+                app.run_worker = lambda fn, **kw: captured.append(fn)
                 app.confirm_session_expired()
-                for _ in range(50):
-                    if not app._expiring:
-                        break
-                    await asyncio.sleep(0.02)
+                await captured[0]()
+                await pilot.pause()
+                assert app._expiring is False
                 assert isinstance(app.screen, LoginScreen)
 
     async def test_detail_on_mount_with_selected_indexes(self):

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -3,12 +3,12 @@
 import os
 import sys
 
-# No COVERAGE_CORE pin: branch coverage (#2834) requires the C tracer
-# core (Python 3.13's sys.monitoring has no branch events, so sysmon
-# can't measure branches and falls back with a warning that
-# filterwarnings=error turns fatal). Greenlet-executed code is tracked
-# via concurrency=["greenlet", "thread"] in the repo-root pyproject's
-# [tool.coverage.run] instead — see there for the full rationale.
+# Must be set before coverage.py initialises in each xdist worker. The
+# sysmon core measures branches on Python 3.14 (sys.monitoring gained
+# BRANCH_LEFT/RIGHT) and tracks greenlet-executed code natively
+# (#456/#1393) — and runs the branch gate ~40% faster than the C tracer.
+# No ``concurrency`` option anywhere: sysmon does not support it.
+os.environ.setdefault("COVERAGE_CORE", "sysmon")
 
 import types
 

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -3,9 +3,12 @@
 import os
 import sys
 
-# Must be set before coverage.py initialises in each xdist worker so that
-# code executed inside SQLAlchemy's greenlet context is tracked.
-os.environ.setdefault("COVERAGE_CORE", "sysmon")
+# No COVERAGE_CORE pin: branch coverage (#2834) requires the C tracer
+# core (Python 3.13's sys.monitoring has no branch events, so sysmon
+# can't measure branches and falls back with a warning that
+# filterwarnings=error turns fatal). Greenlet-executed code is tracked
+# via concurrency=["greenlet", "thread"] in the repo-root pyproject's
+# [tool.coverage.run] instead — see there for the full rationale.
 
 import types
 

--- a/src/klangk/klangkd-tests/tests/test_acl_app_state.py
+++ b/src/klangk/klangkd-tests/tests/test_acl_app_state.py
@@ -198,3 +198,23 @@ async def test_has_permission_denies_via_resource_fn(ac, user):
     _res, _principals, _perm = ac.check_permission.call_args.args
     assert _res == "/custom-resource"
     assert _perm == "share"
+
+
+class TestAceMatchBranchGaps2834:
+    def test_unknown_system_principal_denies(self):
+        # A SYSTEM ace whose principal is neither everyone nor
+        # authenticated (a future/unknown token) matches nothing:
+        # fail-closed, not fail-open.
+        from klangk import model as model_mod
+        from klangk.acl import ace_matches_principals
+
+        assert (
+            ace_matches_principals(
+                {
+                    "principal_type": model_mod.PRINCIPAL_SYSTEM,
+                    "system_principal": "bogus",
+                },
+                {"authenticated": True, "user_id": "u", "group_ids": []},
+            )
+            is False
+        )

--- a/src/klangk/klangkd-tests/tests/test_admission.py
+++ b/src/klangk/klangkd-tests/tests/test_admission.py
@@ -1033,3 +1033,77 @@ class TestMacosMeasure:
         # The fraction wrapper still agrees.
         fraction = await macos_available_fraction(runner=fake_runner)
         assert fraction == pytest.approx(0.3)
+
+
+class TestAdmissionBranchGaps2834:
+    """#2834 branch gate: the Default-machine skip, the explicit clock,
+    and the first-unmeasurable warning."""
+
+    async def test_default_machine_without_memory_skipped(self):
+        # A Default machine whose Memory is unparseable is skipped in
+        # favor of a later Default machine with a usable value.
+        async def runner(*cmd):
+            return [
+                {"Default": True},  # no Memory key -> memory_of -> None
+                _machine(default=True),
+            ]
+
+        assert await podman_machine_memory_bytes(runner=runner) == 2 * GIB
+
+    async def test_explicit_clock_is_used(self):
+        # The _now injection point (tests pass their own monotonic clock)
+        # is honored rather than defaulting to time.monotonic.
+        async def runner(*cmd):
+            return [_machine(default=True)]
+
+        calls = []
+
+        def _now():
+            calls.append(True)
+            return 0.0
+
+        assert await podman_machine_memory_bytes(runner=runner, _now=_now)
+        assert calls
+
+    async def test_first_unmeasurable_warns_once(self, app_state, caplog):
+        # The FIRST measurement failure logs the degraded-mode warning
+        # (subsequent ones are silenced -- the already-tested path).
+        control = AdmissionControl(app_state)
+        app_state.state.settings.admission_memory_enabled = True
+        control._warned_unmeasurable = False
+        with patch.object(
+            admission_mod,
+            "available_memory_bytes",
+            new=AsyncMock(side_effect=OSError("no sysfs")),
+        ):
+            with caplog.at_level("WARNING"):
+                # A concrete limit so the measurement is actually reached.
+                await control.check_host_memory(
+                    "ws-x", {"settings": {"container_memory_limit": "1g"}}
+                )
+        assert any(
+            "cannot measure host memory" in r.message for r in caplog.records
+        )
+
+
+class TestAdmissionBranchGaps2834b:
+    async def test_already_warned_unmeasurable_stays_silent(
+        self, app_state, caplog
+    ):
+        # The SECOND measurement failure (flag already set) logs nothing:
+        # one warning per degraded episode, not per start.
+        control = AdmissionControl(app_state)
+        app_state.state.settings.admission_memory_enabled = True
+        control._warned_unmeasurable = True
+        with patch.object(
+            admission_mod,
+            "available_memory_bytes",
+            new=AsyncMock(side_effect=OSError("no sysfs")),
+        ):
+            with caplog.at_level("WARNING"):
+                await control.check_host_memory(
+                    "ws-x", {"settings": {"container_memory_limit": "1g"}}
+                )
+        assert not any(
+            "cannot measure host memory" in r.message for r in caplog.records
+        )

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -13737,3 +13737,390 @@ class TestAdminServerSchedule:
             )
         assert resp.status_code == 200
         mock_notify.assert_awaited_once()
+
+
+class TestBranchGaps2834:
+    """Branch-coverage gaps surfaced by the #2834 branch gate: the
+    false/true outcomes of guards the mainline tests only take one side
+    of (a valid custom image, an invalid mount list, a stop with no live
+    session, a failed du probe, a corrupt archive after creation, the
+    dev version fallback, a valid /admin ACL, and a non-configured OIDC
+    provider at logout)."""
+
+    async def test_version_endpoint_missing_file_falls_back_to_dev(
+        self, client, app
+    ):
+        # version_file configured but absent (a stripped deployment):
+        # the endpoint falls back to the dev placeholder instead of 500.
+        app.state.settings.version_file = "/nonexistent/version.json"
+        resp = await client.get("/api/v1/version")
+        assert resp.status_code == 200
+        assert resp.json()["version"] == "dev"
+
+    async def test_admin_acl_accepts_group_allow(
+        self, client, admin_user, app
+    ):
+        # The mirror of rejects_removing_all_group_access: a /admin ACL
+        # that keeps an Allow group entry saves fine (the validator's
+        # pass-through path).
+        group = await app.state.model.users.get_group_by_name("admin")
+        headers = await _admin_login(client)
+        resp = await client.put(
+            "/api/v1/admin/acl/resource?resource=/admin",
+            headers=headers,
+            json=[
+                {
+                    "action": model.ACTION_ALLOW,
+                    "principal_type": model.PRINCIPAL_GROUP,
+                    "permission": "admin",
+                    "group_id": group["id"],
+                },
+            ],
+        )
+        assert resp.status_code == 200
+
+    async def test_logout_nonlocal_user_with_unconfigured_provider(
+        self, client, app, user, app_state
+    ):
+        # A non-local user whose provider is no longer configured: no
+        # IdP logout URL is derived (get_provider -> None), plain logout.
+        from _helpers import wire_db_and_model
+
+        async with app_state.state.db.transaction() as db:
+            await db.execute(
+                "UPDATE users SET provider = 'gone-idp' WHERE id = ?",
+                (user["id"],),
+            )
+        wire_db_and_model(app)
+        headers = await _auth_headers(client)
+        resp = await client.post("/api/v1/auth/logout", headers=headers)
+        assert resp.status_code == 200
+        assert "oidc_logout_url" not in resp.json()
+
+    async def test_create_workspace_with_allowed_custom_image(
+        self, client, admin_user, app
+    ):
+        # An image that IS in allowed_images passes the gate (the
+        # not-allowed branch's false side) and is stored on the row.
+        app.state.settings.allowed_images = "klangk-custom:1"
+        headers = await _admin_login(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "custom-image-ws", "image": "klangk-custom:1"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["image"] == "klangk-custom:1"
+
+    async def test_create_workspace_rejects_invalid_mount(
+        self, client, admin_user, app
+    ):
+        # validate_mounts returning an error string -> 400 before any
+        # container is created.
+        with patch.object(
+            app.state.container_registry,
+            "validate_mounts",
+            return_value="mount source outside the allowed roots",
+        ):
+            headers = await _admin_login(client)
+            resp = await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={
+                    "name": "bad-mount-ws",
+                    "mounts": ["/etc:/etc:ro"],
+                },
+            )
+        assert resp.status_code == 400
+        assert "mount source" in resp.json()["detail"]
+
+    async def test_stop_workspace_running_container_no_session(
+        self, client, admin_user, app
+    ):
+        # A real stop (container running) with NO live WS session: the
+        # container_stopped broadcast is skipped, teardown still runs.
+        headers = await _admin_login(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "stop-nosess"}
+        )
+        ws_id = create_resp.json()["id"]
+        registry = app.state.container_registry
+        registry.track_activity("cid-stop-2", ws_id)
+        with (
+            patch.object(
+                registry, "stop_and_remove_container", new_callable=AsyncMock
+            ) as mock_stop,
+            patch.object(
+                registry, "notify_workspace_killed", new_callable=AsyncMock
+            ),
+            patch.object(app.state.sockets, "get_session", return_value=None),
+        ):
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/stop", headers=headers
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "stopped"
+        mock_stop.assert_awaited_once()
+        registry.states.pop(ws_id, None)
+
+    async def test_export_size_probe_failure_falls_back_to_zero(
+        self, client, admin_user, user, app, monkeypatch
+    ):
+        # home_dir exists but `du -sb` fails (permissions): the estimate
+        # falls back to 0 and the export still streams.
+        import subprocess as subprocess_mod
+
+        headers = await _admin_login(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "du-fail"}
+        )
+        ws_id = create_resp.json()["id"]
+        home = app.state.workspaces.home_path(ws_id)
+        home.mkdir(parents=True, exist_ok=True)
+
+        real_run = subprocess_mod.run
+
+        def _failing_du(cmd, *a, **kw):
+            if "du" in cmd:
+                CompletedProxy = subprocess_mod.CompletedProcess
+                return CompletedProxy(cmd, returncode=1, stdout="", stderr="x")
+            return real_run(cmd, *a, **kw)
+
+        monkeypatch.setattr(
+            "klangk.api.workspaces.subprocess.run", _failing_du
+        )
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/export", headers=headers
+        )
+        assert resp.status_code == 200
+
+    async def test_export_missing_home_dir_skips_size_probe(
+        self, client, admin_user, user, app
+    ):
+        # The workspace's home dir never materialized (created but never
+        # started): the du probe is skipped entirely, size 0.
+        headers = await _admin_login(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "no-home"}
+        )
+        ws_id = create_resp.json()["id"]
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/export", headers=headers
+        )
+        assert resp.status_code == 200
+
+    async def test_import_extraction_timeout_deletes_created_workspace(
+        self, client, admin_user, user, app, monkeypatch
+    ):
+        # The home extraction times out AFTER the row was created: the
+        # 400 path must also delete the just-created workspace (no
+        # half-imported orphan).
+        import io
+        import json as json_mod
+        import tarfile
+
+        buf = io.BytesIO()
+        from klangk.settings import KlangkSettings
+
+        ns = types.SimpleNamespace(
+            state=types.SimpleNamespace(settings=KlangkSettings(os.environ))
+        )
+        ns.state.util = util_mod.Util(ns)
+        meta_bytes = json_mod.dumps(
+            {
+                "instance_id": ns.state.util.instance_id(),
+                "name": "timeout-import",
+                "image": None,
+                "service_command": None,
+                "auto_start": False,
+                "mounts": [],
+                "env": {},
+                "health_check": None,
+                "allowed_domains": [],
+                "rejected_domains": [],
+                "settings": {},
+                "egress_mode": "static",
+                "per_handle_home": True,
+                "classification_banner": None,
+            }
+        ).encode()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta_bytes)
+            tar.addfile(info, io.BytesIO(meta_bytes))
+        buf.seek(0)
+
+        import subprocess as subprocess_mod
+
+        def _timing_out_tar(cmd, *a, **kw):
+            # Only the post-creation home-tree probe times out; the earlier
+            # metadata read (tar xzf -O workspace.json) still succeeds so the
+            # workspace row is created first.
+            if "tzf" in cmd:
+                raise subprocess_mod.TimeoutExpired(cmd="tar", timeout=30)
+            return subprocess_mod.CompletedProcess(
+                cmd, returncode=0, stdout=meta_bytes
+            )
+
+        monkeypatch.setattr(
+            "klangk.api.workspaces.subprocess.run", _timing_out_tar
+        )
+        deleted = []
+        with patch.object(
+            app.state.workspaces,
+            "delete_workspace",
+            new=AsyncMock(
+                side_effect=lambda ws_id, uid: deleted.append(ws_id)
+            ),
+        ):
+            headers = await _admin_login(client)
+            resp = await client.post(
+                "/api/v1/workspaces/import",
+                headers=headers,
+                files={
+                    "file": (
+                        "archive.tar.gz",
+                        buf.getvalue(),
+                        "application/gzip",
+                    )
+                },
+            )
+        assert resp.status_code == 400
+        assert "corrupt" in resp.json()["detail"]
+        assert deleted  # the created row was cleaned up
+
+    async def test_update_workspace_with_allowed_custom_image(
+        self, client, admin_user, app
+    ):
+        # The PUT validation's image gate: an allowed custom image passes
+        # (the not-allowed branch's false side).
+        headers = await _admin_login(client)
+        create = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "upd-image"}
+        )
+        ws_id = create.json()["id"]
+        app.state.settings.allowed_images = "klangk-custom:2"
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            headers=headers,
+            json={"image": "klangk-custom:2"},
+        )
+        assert resp.status_code == 200
+
+    async def test_update_workspace_rejects_invalid_mount(
+        self, client, admin_user, app
+    ):
+        headers = await _admin_login(client)
+        create = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "upd-mount"}
+        )
+        ws_id = create.json()["id"]
+        with patch.object(
+            app.state.container_registry,
+            "validate_mounts",
+            return_value="mount source outside the allowed roots",
+        ):
+            resp = await client.put(
+                f"/api/v1/workspaces/{ws_id}",
+                headers=headers,
+                json={"mounts": ["/etc:/etc:ro"]},
+            )
+        assert resp.status_code == 400
+        assert "mount source" in resp.json()["detail"]
+
+    async def test_export_after_home_dir_removal_skips_size_probe(
+        self, client, admin_user, app
+    ):
+        # The workspace existed (its home was materialized) but the dir
+        # was removed out-of-band: the du probe is skipped, size 0.
+        import shutil
+
+        headers = await _admin_login(client)
+        create = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "gone-home"}
+        )
+        ws_id = create.json()["id"]
+        home = app.state.workspaces.home_path(ws_id)
+        home.mkdir(parents=True, exist_ok=True)
+        shutil.rmtree(home)
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/export", headers=headers
+        )
+        assert resp.status_code == 200
+
+    async def test_update_workspace_with_valid_mounts_passes_gate(
+        self, client, admin_user, app
+    ):
+        # The PUT mount gate's pass-through side: validate_mounts returns
+        # no error and the update proceeds.
+        headers = await _admin_login(client)
+        create = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "upd-mount-ok"},
+        )
+        ws_id = create.json()["id"]
+        with patch.object(
+            app.state.container_registry,
+            "validate_mounts",
+            return_value=None,
+        ):
+            resp = await client.put(
+                f"/api/v1/workspaces/{ws_id}",
+                headers=headers,
+                json={"mounts": ["/srv/data:/data:ro"]},
+            )
+        assert resp.status_code == 200
+
+    async def test_import_corrupt_json_deletes_nothing(
+        self, client, admin_user, app
+    ):
+        # The metadata read itself times out: the failure happens BEFORE
+        # the row is created (ws None) -> nothing to delete, plain 400.
+        import subprocess as subprocess_mod
+
+        def _timing_out_tar(cmd, *a, **kw):
+            raise subprocess_mod.TimeoutExpired(cmd="tar", timeout=30)
+
+        deleted = []
+        with (
+            patch.object(
+                app.state.workspaces,
+                "delete_workspace",
+                new=AsyncMock(
+                    side_effect=lambda ws_id, uid: deleted.append(ws_id)
+                ),
+            ),
+            patch("klangk.api.workspaces.subprocess.run", _timing_out_tar),
+        ):
+            headers = await _admin_login(client)
+            resp = await client.post(
+                "/api/v1/workspaces/import",
+                headers=headers,
+                files={
+                    "file": (
+                        "archive.tar.gz",
+                        b"not-really-a-tarball",
+                        "application/gzip",
+                    )
+                },
+            )
+        assert resp.status_code == 400
+        assert "corrupt" in resp.json()["detail"]
+        assert deleted == []  # no row was ever created
+
+
+class TestInFlightCounterBranchGaps2834:
+    """#2834 branch gate: nested in-flight tracking (count past one)."""
+
+    async def test_increment_decrement_around_one(self):
+        from klangk.middleware import InFlightRequests
+
+        c = InFlightRequests()
+        c.increment()
+        assert not c._idle.is_set()
+        c.increment()  # nested request: count 2
+        c.decrement()  # back to 1: still busy
+        assert not c._idle.is_set()
+        c.decrement()  # to 0: idle
+        assert c._idle.is_set()

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1686,3 +1686,30 @@ class TestRecordActivity:
         await a.refresh_token(token)
         row = await a.app.state.model.users.get_user_by_id(user["id"])
         assert row["last_activity_at"] is not None
+
+
+class TestRefreshBranchGaps2834:
+    """#2834 branch gate: the expired-token path without a jti claim."""
+
+    async def test_refresh_expired_token_without_jti_returns_401(
+        self, db, app_state
+    ):
+        # A hand-forged expired token with no jti: there is nothing to look
+        # up, so the refresh fails with the plain 401 (not a KeyError).
+        await app_state.state.model.users.create_user(
+            "a@b.com", auth.hash_password("pw"), verified=True
+        )
+        user = await app_state.state.model.users.get_user_by_email("a@b.com")
+        expired = jwt.encode(
+            {
+                "sub": user["id"],
+                "email": user["email"],
+                "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+            },
+            _auth().secret,
+            algorithm=_auth().algorithm,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await _auth().refresh_token(expired)
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Token expired"

--- a/src/klangk/klangkd-tests/tests/test_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_consent.py
@@ -151,3 +151,35 @@ class TestEgressConsentSweeper:
         app2 = _app()
         sw.reconfigure(app2)
         assert sw.app is app2
+
+
+class TestEgressSweeperBranchGaps2834:
+    """#2834 branch gate: a retention tick that wakes BEFORE the prune
+    interval (scheduler jitter) re-sleeps without pruning."""
+
+    async def test_early_wake_resleeps_without_pruning(self, monkeypatch):
+        app = _app()
+        sw = consent.EgressConsentSweeper(app)
+        real_sleep = asyncio.sleep
+        pruned = asyncio.Event()
+        sleeps = {"n": 0}
+
+        async def _jittered_sleep(_s):
+            sleeps["n"] += 1
+            if sleeps["n"] >= 3:
+                sw._task.cancel()
+            await real_sleep(0)
+
+        async def _prune_once():
+            pruned.set()
+
+        monkeypatch.setattr(sw, "_prune", _prune_once)
+        monkeypatch.setattr(asyncio, "sleep", _jittered_sleep)
+        sw.start()
+        await pruned.wait()
+        for _ in range(200):
+            if sw._task.done() or sleeps["n"] >= 3:
+                break
+            await real_sleep(0.01)
+        await sw._task
+        app.state.model.egress_consent.prune.assert_not_awaited()

--- a/src/klangk/klangkd-tests/tests/test_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_consent.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import types
+import pytest
 from unittest.mock import AsyncMock
 
 from klangk import consent
@@ -154,32 +155,54 @@ class TestEgressConsentSweeper:
 
 
 class TestEgressSweeperBranchGaps2834:
-    """#2834 branch gate: a retention tick that wakes BEFORE the prune
-    interval (scheduler jitter) re-sleeps without pruning."""
+    """#2834 branch gate: a retention tick that wakes BEFORE the interval
+    (scheduler jitter) re-sleeps without sweeping."""
 
     async def test_early_wake_resleeps_without_pruning(self, monkeypatch):
+        import klangk.interval as iv
+
         app = _app()
         sw = consent.EgressConsentSweeper(app)
-        real_sleep = asyncio.sleep
-        pruned = asyncio.Event()
+        real_sweep = sw.sweep
+        swept = []
+
+        async def counting_sweep():
+            swept.append(1)
+            await real_sweep()
+
+        monkeypatch.setattr(sw, "sweep", counting_sweep)
+
+        # Freeze the clock and no-op the sleep, both scoped to the
+        # IntervalWorker module's namespace (a global asyncio patch would
+        # leak into same-worker neighbors under xdist).
+        clock = types.SimpleNamespace(t=1000.0)
+        monkeypatch.setattr(
+            iv, "time", types.SimpleNamespace(monotonic=lambda: clock.t)
+        )
         sleeps = {"n": 0}
 
-        async def _jittered_sleep(_s):
+        real_sleep = asyncio.sleep
+
+        async def fake_sleep(_s):
             sleeps["n"] += 1
             if sleeps["n"] >= 3:
                 sw._task.cancel()
-            await real_sleep(0)
+            await real_sleep(0)  # yield: the awaiting test interleaves
 
-        async def _prune_once():
-            pruned.set()
-
-        monkeypatch.setattr(sw, "_prune", _prune_once)
-        monkeypatch.setattr(asyncio, "sleep", _jittered_sleep)
+        # Delegate everything to the real asyncio except sleep, scoped
+        # to the IntervalWorker module's namespace only.
+        stub = types.SimpleNamespace(
+            **{
+                n: getattr(asyncio, n)
+                for n in dir(asyncio)
+                if not n.startswith("__")
+            }
+        )
+        stub.sleep = fake_sleep
+        monkeypatch.setattr(iv, "asyncio", stub)
         sw.start()
-        await pruned.wait()
-        for _ in range(200):
-            if sw._task.done() or sleeps["n"] >= 3:
-                break
-            await real_sleep(0.01)
-        await sw._task
-        app.state.model.egress_consent.prune.assert_not_awaited()
+        with pytest.raises(asyncio.CancelledError):
+            await sw._task
+        # Swept once at startup; the frozen clock makes every later tick
+        # an early wake (the not-yet arm), so no second prune ran.
+        app.state.model.egress_consent.prune.assert_awaited_once()

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1649,3 +1649,93 @@ class TestConsentCoordinatorPauseIntegration:
         # a different, never-decided host is still auto-allowed
         fut2 = await coord.hold(ws["id"], "unseen.example.com", 443)
         assert fut2.result()["reason"] == "paused"
+
+
+class TestCoordinatorBranchGaps2834:
+    """#2834 branch gate: hold/fail-close/refresh outcomes the mainline
+    revoke + stop tests only take one side of."""
+
+    async def test_stop_skips_hold_removed_mid_iteration(self):
+        # fail_all iterates a snapshot; a hold resolved+removed while an
+        # earlier one is being fail-closed is simply skipped (its task
+        # cancel is skipped, its _fail_close is a no-op).
+        app = _app(request=_request("r1"))
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.model.egress_consent.create_request = AsyncMock(
+            return_value=_request("r2")
+        )
+        await coord.hold(FULL_WS, "5.6.7.8", 80)
+        real_fail_close = coord._fail_close
+
+        async def _fail_close_expecting_one(request_id, reason="shutdown"):
+            # When the FIRST hold is fail-closed, the second vanishes (a
+            # racing resolve) -- the snapshot's second entry is then None.
+            if request_id == "r1":
+                coord._holds.pop("r2", None)
+            return await real_fail_close(request_id, reason=reason)
+
+        coord._fail_close = _fail_close_expecting_one
+        await coord.stop()  # must not raise on the vanished r2
+        assert coord._holds == {}
+
+    async def test_resolve_with_already_done_future_skips_set_result(self):
+        # A hold whose future was already resolved (a racing timeout)
+        # must not be overwritten by the decide path -- the verdict that
+        # landed first wins.
+        app = _app(request=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        fut.set_result(
+            {"decision": "deny", "reason": "timeout", "duration": "once"}
+        )
+        await coord.resolve("rid-1", "allowed", "a@x")
+        assert fut.result()["decision"] == "deny"  # not clobbered
+
+    async def test_fail_close_with_already_done_future_skips_set_result(self):
+        # Same race on the timeout path: an already-resolved future keeps
+        # its first verdict; the expire bookkeeping still runs.
+        app = _app(timeout=0.05, request=_request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        fut.set_result(
+            {"decision": "allow", "reason": "decided", "duration": "once"}
+        )
+        verdict = await fut
+        assert verdict["decision"] == "allow"  # timeout did not clobber
+        await asyncio.sleep(0.12)
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+
+    async def test_revoke_retract_false_is_silent(self, caplog):
+        # The domain-list remove reports nothing removed (the row was
+        # already retracted): no info log, revoke still succeeds.
+        app = _app()
+        forever_row = _active_row()
+        forever_row["duration"] = "forever"
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=forever_row
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        app.state.model.workspaces.remove_allowed_domain = AsyncMock(
+            return_value=False
+        )
+        coord = ConsentCoordinator(app)
+        with caplog.at_level("INFO"):
+            assert await coord.revoke("rid-1", "a@x") is True
+        assert not any(
+            "retracted from list" in r.message for r in caplog.records
+        )
+
+    async def test_refresh_rules_none_frame_skips_broadcast(self):
+        # A missing workspace returns no frame; nothing is broadcast (the
+        # decider keeps its last view).
+        app = _app()
+        coord = ConsentCoordinator(app)
+        coord.rules_frame = AsyncMock(return_value=None)
+        app.state.consent_deciders.broadcast = Mock()
+        await coord._broadcast_rules(FULL_WS)
+        app.state.consent_deciders.broadcast.assert_not_called()

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -918,3 +918,18 @@ class TestConsentDeciderRegistryReconfigure:
         )
         reg.reconfigure(new_app)
         assert reg.timeout == 99.0
+
+
+class TestDeciderRegistryBranchGaps2834:
+    """#2834 branch gate: start() is idempotent (a second start must not
+    spawn a second reaper task)."""
+
+    async def test_start_twice_keeps_single_reaper(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.start()
+        first = reg._reaper
+        assert first is not None
+        reg.start()
+        assert reg._reaper is first
+        await reg.stop()
+        assert reg._reaper is None

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -6804,3 +6804,201 @@ async def test_nix_binds_mounts_snapshot_when_enabled():
     ]
     assert env == ["KLANGKWS_NIX=1"]
     app_state.state.nix.ensure_workspace_nix.assert_awaited_once_with("ws1")
+
+
+class TestContainerBranchGaps2834:
+    """#2834 branch gate: registry/health/idle/spec outcomes the mainline
+    tests only take one side of."""
+
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.app_state = app_state
+        self.registry = app_state.state.container_registry
+
+    # --- registry ---
+
+    def test_record_activity_mapped_container_without_state_is_noop(self):
+        # The cid -> workspace mapping exists but the state is gone (a
+        # racing teardown): nothing to bump, nothing raised.
+        self.registry._cid_to_wsid["cid-gone"] = "ws-gone"
+        self.registry.record_activity("cid-gone")
+
+    def test_mark_service_started_mapped_container_without_state_noop(self):
+        self.registry._cid_to_wsid["cid-gone"] = "ws-gone"
+        self.registry.mark_service_started("cid-gone")
+
+    async def test_stop_user_containers_skips_containerless_workspace(
+        self, monkeypatch
+    ):
+        # A user's workspace without a running container contributes no
+        # kill/stop (the row's container_id is None).
+        workspaces = AsyncMock()
+        workspaces.get_user_workspaces_with_containers = AsyncMock(
+            return_value=[
+                {"id": "ws-none", "container_id": None},
+                {"id": "ws-live", "container_id": "cid-live"},
+            ]
+        )
+        self.app_state.state.model = types.SimpleNamespace(
+            workspaces=workspaces
+        )
+        killed = AsyncMock()
+        monkeypatch.setattr(self.registry, "notify_workspace_killed", killed)
+        stopped = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            self.registry, "stop_and_remove_container", stopped
+        )
+        await self.registry.stop_user_containers("u1")
+        killed.assert_awaited_once_with("ws-live", container_id="cid-live")
+
+    async def test_drain_unremovable_leftover_not_counted(self):
+        # A racing-start leftover whose removal fails is not counted as
+        # stopped (the caller treats the count as "all clear").
+        leftover = {"Id": "cid-left", "Names": "klangk-managed-x"}
+        stop = AsyncMock(return_value=False)  # removal failed
+        with patch.object(self.registry, "stop_and_remove_container", stop):
+            with patch.object(
+                self.registry.app.state.podman,
+                "list_containers",
+                AsyncMock(return_value=[leftover]),
+            ):
+                assert await self.registry._sweep_drain_leftovers() == 0
+        stop.assert_awaited_once_with("cid-left")
+
+    # --- health ---
+
+    async def test_start_health_loop_twice_keeps_single_task(self):
+        health = self.registry.health
+        health.start_health_loop()
+        first = health.health_task
+        assert first is not None
+        health.start_health_loop()
+        assert health.health_task is first
+        first.cancel()
+        try:
+            await first
+        except asyncio.CancelledError:
+            pass
+        health.health_task = None
+
+    # --- idle ---
+
+    def test_on_idle_stop_unknown_workspace_is_noop(self):
+        idle = self.registry.idle
+        idle.on_idle_stop("ws-gone", lambda wid: None)  # no state, no raise
+
+    def test_set_workspace_idle_timeout_unknown_workspace_is_noop(self):
+        idle = self.registry.idle
+        # No state -> no timeout write, no wake (must not raise trying to
+        # touch the wake event either).
+        idle.set_workspace_idle_timeout("ws-gone", 300)
+
+    async def test_idle_reap_skips_callbacks_for_vanished_state(self):
+        # Two overdue workspaces; stopping the first also removes the
+        # second's state (a racing delete): the loop must skip the second
+        # workspace's idle callbacks but still notify + stop it.
+        self.registry.track_activity("cid-a", "ws-a")
+        self.registry.track_activity("cid-b", "ws-b")
+        for ws in ("ws-a", "ws-b"):
+            self.registry.states[ws].last_activity = (
+                time.time() - self.registry.idle_timeout_seconds - 100
+            )
+        callbacks = []
+
+        async def _cb(wid):
+            callbacks.append(wid)
+
+        self.registry.on_idle_stop("ws-b", _cb)
+
+        real_stop = self.registry.stop_and_remove_container
+
+        async def _stop_and_pop(cid, **kw):
+            # The first reap also deletes the second workspace's state.
+            self.registry.states.pop("ws-b", None)
+            return await real_stop(cid, **kw)
+
+        with patch_podman(self.registry) as p:
+            with patch.object(
+                self.registry, "stop_and_remove_container", _stop_and_pop
+            ):
+                with patch.object(
+                    self.registry,
+                    "notify_workspace_killed",
+                    AsyncMock(),
+                ):
+                    task = asyncio.create_task(
+                        self.registry.cleanup_idle_containers()
+                    )
+                    await asyncio.sleep(0.05)
+                    self.registry.get_cleanup_wake().set()
+                    await asyncio.sleep(0.05)
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+        # ws-b's state vanished before its turn: no idle callbacks ran for
+        # it, but its container was still stopped.
+        assert callbacks == []
+        assert p.remove_container.await_count >= 2
+
+    async def test_orphan_token_sweep_throttles_to_interval(self, monkeypatch):
+        # Two loop passes within ORPHAN_TOKEN_SWEEP_INTERVAL: the sweep
+        # runs once (the throttle), not per pass.
+        sweeps = AsyncMock()
+        monkeypatch.setattr(
+            self.registry, "_sweep_orphaned_sidecar_tokens", sweeps
+        )
+        monkeypatch.setattr(
+            type(self.registry.idle),
+            "_cleanup_interval",
+            lambda self: 0.01,
+            raising=True,
+        )
+        task = asyncio.create_task(self.registry.cleanup_idle_containers())
+        await asyncio.sleep(0.1)  # several passes at 10ms
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        sweeps.assert_awaited_once()
+
+    # --- spec ---
+
+    def test_hosting_floor_partial_values_get_floors(self):
+        # Only the omitted hosting values take the resolver floor; each
+        # explicit one survives (including an empty base_path, #2722).
+        from klangk.container.spec import _hosting_floor
+
+        app = types.SimpleNamespace(
+            state=types.SimpleNamespace(util=MagicMock())
+        )
+        app.state.util.derive_hosting_info = MagicMock(
+            return_value=("floor.example", "https", "/floor")
+        )
+        # Hostname given, proto + base omitted.
+        assert _hosting_floor(app, "ext.example", None, None) == (
+            "ext.example",
+            "https",
+            "/floor",
+        )
+        app.state.util.derive_hosting_info = MagicMock(
+            return_value=("floor.example", "https", "/floor")
+        )
+        # Proto given, hostname + base omitted.
+        assert _hosting_floor(app, None, "http", None) == (
+            "floor.example",
+            "http",
+            "/floor",
+        )
+        app.state.util.derive_hosting_info = MagicMock(
+            return_value=("floor.example", "https", "/floor")
+        )
+        # Base given (empty string is legitimate), hostname + proto
+        # omitted.
+        assert _hosting_floor(app, None, None, "") == (
+            "floor.example",
+            "https",
+            "",
+        )

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -1297,3 +1297,67 @@ class TestRegistryShutdownCancelsCrashLoop:
             await reg.shutdown()
         await asyncio.sleep(0)  # let the cancellation propagate
         assert task.cancelled()
+
+
+class TestCrashBranchGaps2834:
+    """#2834 branch gate: the unknown-signal exit, idempotent start, a
+    superseded restart's done-callback, and the tracker-less death event."""
+
+    def test_unknown_signal_code_falls_back_to_plain_exit(self):
+        # Exit code 200 = signal 72, which no known table entry matches:
+        # the generic "exited with code" message.
+        cause, msg = classify_death(inspect_dead(exit_code=200))
+        assert (cause, msg) == (
+            "exited",
+            "main process exited with code 200",
+        )
+
+    async def test_start_twice_keeps_single_task(self, crash_env):
+        app_state = make_app_state(crash_env)
+        monitor = app_state.state.container_registry.crash
+        monitor.start()
+        first = monitor.crash_task
+        assert first is not None
+        monitor.start()
+        assert monitor.crash_task is first
+        await monitor.stop()
+
+    async def test_superseded_restart_task_pop_is_skipped(self, crash_env):
+        # A second restart scheduled for the same workspace replaces the
+        # pending entry; the FIRST task's done-callback then sees a
+        # different task and must not pop it (the second survives).
+        app_state = make_app_state(crash_env)
+        monitor = app_state.state.container_registry.crash
+        with patch_podman_methods(app_state, inspect_dead()):
+            monitor.schedule_restart("ws-race", RestartTracker())
+            first = monitor.pending["ws-race"]
+            monitor.schedule_restart("ws-race", RestartTracker())
+            second = monitor.pending["ws-race"]
+            assert second is not first
+            # Let both delayed_restart tasks finish (near-zero backoff;
+            # their workspace lookups fail harmlessly and are logged).
+            for _ in range(200):
+                if first.done() and second.done():
+                    break
+                await asyncio.sleep(0.01)
+            assert first.done() and second.done()
+        # The superseded task's callback did NOT clear the successor's
+        # entry; the successor's own callback did.
+        assert "ws-race" not in monitor.pending
+
+    async def test_broadcast_death_event_without_tracker(self, crash_env):
+        # A death with no restart tracker (restarts disabled / gave up
+        # unknown) still broadcasts, minus the restart_* fields.
+        app_state = make_app_state(crash_env)
+        monitor = app_state.state.container_registry.crash
+        session = MagicMock()
+        with patch.object(
+            app_state.state.sockets, "get_session", return_value=session
+        ):
+            monitor.broadcast_death_event(
+                "ws-crash", "exited", "main process exited", None
+            )
+        value = session.broadcast.call_args[0][0]["event"]["value"]
+        assert value["cause"] == "exited"
+        assert "restart_attempts" not in value
+        assert "gave_up" not in value

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -547,3 +547,73 @@ class TestRunDoctor:
         r = results[0]
         assert not r.ok
         assert r.is_warning
+
+
+class TestDoctorBranchGaps2834:
+    """#2834 branch gate: non-brew failure hints, the macOS skips in
+    run_doctor, and the hintless failure-block line."""
+
+    def test_non_brew_tar_failure_keeps_generic_hint(self):
+        # A non-GNU tar on a non-brew system: the generic hint (no
+        # brew-specific gnubin line).
+        with (
+            patch("shutil.which", return_value="/usr/bin/tar"),
+            patch(
+                "klangk.doctor._run",
+                return_value=(0, "bsdtar 3.6.2", ""),
+            ),
+        ):
+            r = check_gnu_tar("apt")
+            assert not r.ok
+            assert "gnubin" not in (r.hint or "")
+
+    def test_non_brew_du_failure_keeps_generic_hint(self):
+        from klangk.doctor import check_gnu_du
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/du"),
+            patch(
+                "klangk.doctor._run",
+                return_value=(1, "", ""),
+            ),
+        ):
+            r = check_gnu_du("apt")
+            assert not r.ok
+            assert "gnubin" not in (r.hint or "")
+
+    def test_darwin_skips_linux_only_checks(self):
+        # On macOS the stat + ip checks are skipped entirely (a Darwin
+        # report has neither).
+        from klangk import doctor
+
+        names = []
+
+        class _RecordingReport(doctor.DoctorReport):
+            def add(self, r):
+                names.append(r.name)
+                return super().add(r)
+
+        real_report = doctor.DoctorReport
+        doctor.DoctorReport = _RecordingReport
+        try:
+            with patch("klangk.doctor.platform.system", return_value="Darwin"):
+                doctor.run_doctor()
+        finally:
+            doctor.DoctorReport = real_report
+        assert not any("stat" in n.lower() for n in names)
+
+    def test_failure_block_without_hint(self):
+        # A hintless failing result renders without a "Run:" line.
+        from klangk.doctor import CheckResult, _append_failure_block
+
+        lines: list[str] = []
+        _append_failure_block(
+            lines,
+            [CheckResult(name="x", ok=False, message="broke")],
+            "-",
+            "Failures",
+        )
+        text = "\n".join(lines)
+        assert "Failures" in text
+        assert "x: broke" in text
+        assert "Run:" not in text

--- a/src/klangk/klangkd-tests/tests/test_eviction.py
+++ b/src/klangk/klangkd-tests/tests/test_eviction.py
@@ -1013,3 +1013,38 @@ class TestEvictionSettings:
     def test_bad_sustain_polls_rejected(self):
         with pytest.raises(ValueError):
             make_settings({"KLANGKD_MEMORY_EVICTION_SUSTAIN_POLLS": "0"})
+
+
+class TestEvictionBranchGaps2834:
+    """#2834 branch gate: malformed meminfo lines, a stat file without a
+    matching counter, and stop-before-start."""
+
+    def test_read_meminfo_skips_malformed_lines(self, tmp_path):
+        # Lines without the 3-part "Name: N kB" shape are skipped, valid
+        # ones still parse.
+        path = tmp_path / "meminfo"
+        path.write_text(
+            "MemTotal:       16384000 kB\n"
+            "Weird: 5\n"
+            "Other:       6 MB\n"
+            "MemFree:        1000 kB\n"
+        )
+        info = read_meminfo(str(path))
+        assert info["MemTotal"] == 16384000 * 1024
+        assert info["MemFree"] == 1000 * 1024
+        assert "Weird" not in info
+        assert "Other" not in info
+
+    def test_stat_value_without_match_returns_zero(self, tmp_path):
+        from klangk.container.eviction import _stat_value
+
+        path = tmp_path / "memory.stat"
+        path.write_text("anon 5\nkernel 7\n")
+        assert _stat_value(str(path), ("file", "inactive_file")) == 0
+
+    async def test_stop_when_never_started_is_noop(self):
+        from klangk.container.eviction import MemoryPressureEvictor
+
+        app = _make_app_state()
+        evictor = MemoryPressureEvictor(app)
+        await evictor.stop()  # no task -> no raise

--- a/src/klangk/klangkd-tests/tests/test_hooks.py
+++ b/src/klangk/klangkd-tests/tests/test_hooks.py
@@ -866,3 +866,57 @@ class TestFireWorkspaceCreated:
             f"/workspaces/{ws['id']}"
         )
         assert any(e["permission"] == "*" for e in entries)
+
+
+class TestHooksBranchGaps2834:
+    """#2834 branch gate: hook-field diff and created_at carry-over
+    outcomes."""
+
+    def test_changed_fields_absent_everywhere_is_no_change(self):
+        # A field deleted from the handle whose column was never set on
+        # the row: nothing to clear, nothing to write.
+        changed = hooks_mod._hook_field_changes(
+            {"name": "x"},  # no mutable fields present
+            {"name": "x"},
+        )
+        assert changed == {}
+
+    async def test_fire_created_at_already_present_kept(self, app_state):
+        # get_workspace returning created_at itself: the carry-over is a
+        # no-op (the hook response keeps the refreshed value).
+        from unittest.mock import AsyncMock
+
+        hooks = _hooks()
+
+        def _rename(handle, actor):
+            handle["name"] = "renamed-ws"
+
+        hooks.workspace_created_hook = _rename
+        hooks.workspace_created_hook_source = "test-noop"
+        hooks.workspace_created_hook_is_async = False
+        workspace = {
+            "id": "ws-1",
+            "name": "w",
+            "created_at": "t0",
+            "user_id": "u1",
+        }
+        hooks.app.state.model = types.SimpleNamespace(
+            workspaces=types.SimpleNamespace(
+                get_workspace=AsyncMock(
+                    return_value={
+                        "id": "ws-1",
+                        "name": "renamed-ws",
+                        "created_at": "t1",
+                        "user_id": "u1",
+                    }
+                ),
+                update_workspace=AsyncMock(),
+            )
+        )
+        # The hook made no attribute change, but the row was re-read and
+        # ALREADY carries created_at: the carry-over is skipped and the
+        # refreshed value wins.
+        out = await hooks.fire_workspace_created(
+            workspace, {"id": "u1", "email": "a@b"}
+        )
+        assert out["created_at"] == "t1"

--- a/src/klangk/klangkd-tests/tests/test_inactivity.py
+++ b/src/klangk/klangkd-tests/tests/test_inactivity.py
@@ -157,3 +157,42 @@ class TestInactivitySweeper:
 
 def await_count(mock) -> int:
     return mock.await_count if hasattr(mock, "await_count") else 0
+
+
+class TestInactivityBranchGaps2834:
+    """#2834 branch gate: a loop tick that wakes BEFORE the sweep interval
+    (scheduler jitter) re-sleeps without sweeping."""
+
+    async def test_early_wake_resleeps_without_sweeping(self, monkeypatch):
+        app = _app(disable_inactive=AsyncMock(return_value=[]))
+        sw = inactivity.InactivitySweeper(app)
+        real_sleep = asyncio.sleep
+        prune_done = asyncio.Event()
+        sleeps = {"n": 0}
+
+        async def _jittered_sleep(_s):
+            # Wakes instantly: no wall time passes, so the next tick's
+            # `now >= next_sweep` is False (the early-wake arm).
+            sleeps["n"] += 1
+            if sleeps["n"] >= 3:
+                sw._task.cancel()  # unwinds cleanly via the CancelledError arm
+            await real_sleep(0)
+
+        real_sweep = sw._sweep
+
+        async def _sweep_once():
+            prune_done.set()
+            await real_sweep()
+
+        monkeypatch.setattr(sw, "_sweep", _sweep_once)
+        monkeypatch.setattr(asyncio, "sleep", _jittered_sleep)
+        sw.start()
+        await prune_done.wait()
+        for _ in range(200):
+            if sw._task.done() or sleeps["n"] >= 3:
+                break
+            await real_sleep(0.01)
+        await sw._task
+        # The sweeper swept once at startup, then re-slept on the early
+        # ticks (2+ early wakes exercised the not-yet arm).
+        assert app.state.model.users.disable_inactive_users.await_count == 1

--- a/src/klangk/klangkd-tests/tests/test_inactivity.py
+++ b/src/klangk/klangkd-tests/tests/test_inactivity.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import types
+import pytest
 from unittest.mock import AsyncMock
 
 from klangk import inactivity
@@ -164,35 +165,46 @@ class TestInactivityBranchGaps2834:
     (scheduler jitter) re-sleeps without sweeping."""
 
     async def test_early_wake_resleeps_without_sweeping(self, monkeypatch):
+        import klangk.interval as iv
+
         app = _app(disable_inactive=AsyncMock(return_value=[]))
         sw = inactivity.InactivitySweeper(app)
-        real_sleep = asyncio.sleep
-        prune_done = asyncio.Event()
-        sleeps = {"n": 0}
+        real_sweep = sw.sweep
+        swept = []
 
-        async def _jittered_sleep(_s):
-            # Wakes instantly: no wall time passes, so the next tick's
-            # `now >= next_sweep` is False (the early-wake arm).
-            sleeps["n"] += 1
-            if sleeps["n"] >= 3:
-                sw._task.cancel()  # unwinds cleanly via the CancelledError arm
-            await real_sleep(0)
-
-        real_sweep = sw._sweep
-
-        async def _sweep_once():
-            prune_done.set()
+        async def counting_sweep():
+            swept.append(1)
             await real_sweep()
 
-        monkeypatch.setattr(sw, "_sweep", _sweep_once)
-        monkeypatch.setattr(asyncio, "sleep", _jittered_sleep)
+        monkeypatch.setattr(sw, "sweep", counting_sweep)
+        clock = types.SimpleNamespace(t=1000.0)
+        monkeypatch.setattr(
+            iv, "time", types.SimpleNamespace(monotonic=lambda: clock.t)
+        )
+        sleeps = {"n": 0}
+
+        real_sleep = asyncio.sleep
+
+        async def fake_sleep(_s):
+            sleeps["n"] += 1
+            if sleeps["n"] >= 3:
+                sw._task.cancel()
+            await real_sleep(0)  # yield: the awaiting test interleaves
+
+        # Delegate everything to the real asyncio except sleep, scoped
+        # to the IntervalWorker module's namespace only.
+        stub = types.SimpleNamespace(
+            **{
+                n: getattr(asyncio, n)
+                for n in dir(asyncio)
+                if not n.startswith("__")
+            }
+        )
+        stub.sleep = fake_sleep
+        monkeypatch.setattr(iv, "asyncio", stub)
         sw.start()
-        await prune_done.wait()
-        for _ in range(200):
-            if sw._task.done() or sleeps["n"] >= 3:
-                break
-            await real_sleep(0.01)
-        await sw._task
-        # The sweeper swept once at startup, then re-slept on the early
-        # ticks (2+ early wakes exercised the not-yet arm).
+        with pytest.raises(asyncio.CancelledError):
+            await sw._task
+        # The startup sweep ran once; the frozen clock makes every later
+        # tick an early wake, so the users sweep saw one pass only.
         assert app.state.model.users.disable_inactive_users.await_count == 1

--- a/src/klangk/klangkd-tests/tests/test_llm_router.py
+++ b/src/klangk/klangkd-tests/tests/test_llm_router.py
@@ -565,3 +565,15 @@ class TestParseModelEntry:
             result["litellm_params"]["api_base"] == "https://api.openai.com/v1"
         )
         assert result["litellm_params"]["api_key"] == "sk-xxx"
+
+
+class TestParseModelEntryBranchGaps2834:
+    def test_entry_without_api_base_omits_it(self):
+        # A bare provider/model with no api_base and no provider default:
+        # the params dict carries no api_base key.
+        from klangk.llm_router import parse_model_entry
+
+        entry = parse_model_entry("my-gateway/model-x")
+        params = entry["litellm_params"]
+        assert params["model"] == "my-gateway/model-x"
+        assert "api_base" not in params

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -3719,3 +3719,116 @@ async def test_request_recycle_ignored_when_shutting_down(app_state, caplog):
         lc.request_recycle(source="scheduled recycle")
     assert not lc._recycle_tasks
     assert any("recycle ignored" in r.message for r in caplog.records)
+
+
+class TestLifecycleBranchGaps2834:
+    """#2834 branch gate: the shutdown-owned drain flag and the
+    no-caddy-watchdog apply path."""
+
+    async def test_restart_during_shutdown_keeps_draining(self, app_state):
+        # A shutdown owning the process when the restart's finally runs:
+        # the drain flag must stay set (clearing it would lift the
+        # shutdown's start-refusal while exiting, #2527 review).
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        lc._recycle_lock = None
+        registry = app_state.state.container_registry
+
+        async def _startup_sees_shutdown():
+            # A shutdown lands after the abort checkpoints (during the
+            # runtime recycle): the restart completes normally, and the
+            # finally must NOT lift the shutdown's start-refusal.
+            lc.shutting_down = True
+
+        with (
+            patch.object(
+                lc,
+                "_reload_settings",
+                return_value=(
+                    make_settings({"KLANGKD_DEFAULT_PASSWORD": "test"}),
+                    None,
+                ),
+            ),
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                app_state.state.inflight_requests,
+                "wait_for_idle",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                lc, "_apply_reloaded_settings", new_callable=AsyncMock
+            ),
+            patch.object(lc, "runtime_shutdown", new_callable=AsyncMock),
+            patch.object(lc, "startup", side_effect=_startup_sees_shutdown),
+        ):
+            await lc.recycle_runtime()
+        assert registry.draining is True
+
+    async def test_apply_reloaded_settings_without_caddy_watchdog(
+        self, app_state
+    ):
+        # No caddy watchdog (nginx engine / proxy disabled) and an
+        # unchanged frontend_dir: no reload applied, no remount.
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        app_state.state.proxy_watchdog = None
+        new = make_settings({"KLANGKD_DEFAULT_PASSWORD": "test"})
+        remount = MagicMock()
+        with patch.object(lc, "_remount_frontend", remount):
+            await lc._apply_reloaded_settings(new)
+        remount.assert_not_called()
+        assert app_state.state.settings is new
+
+
+class TestGracefulExitBranchGaps2834:
+    def _server_cls(self, app_state):
+        from klangk.main import make_graceful_exit_server
+
+        return make_graceful_exit_server(app_state)
+
+    async def test_cancelled_hook_task_still_hands_exit_to_uvicorn(
+        self, app_state
+    ):
+        """#2834: a hook task CANCELLED before finishing must not hit
+        Task.exception() (which raises for cancelled tasks) -- the
+        done-callback skips the log and still calls uvicorn's exit."""
+        import types as types_mod
+
+        app_state = _make_app_state()
+        cls = self._server_cls(app_state)
+        server = types_mod.SimpleNamespace(
+            handle_exit=MagicMock(),
+            _captured_signals=[],
+            force_exit=False,
+        )
+        lc = app_state.state.lifecycle
+        started = asyncio.Event()
+
+        async def slow_hook(*, signal_num):
+            started.set()
+            await asyncio.Event().wait()  # park until cancelled
+
+        with patch.object(lc, "graceful_shutdown", side_effect=slow_hook):
+            hooked = None
+
+            def grab(sig, handler):
+                nonlocal hooked
+                hooked = handler
+                return MagicMock()
+
+            with patch("signal.signal", side_effect=grab):
+                with cls.capture_signals(server):
+                    hooked(15, None)
+                    await asyncio.wait_for(started.wait(), 5)
+                    task = next(iter(lc._shutdown_tasks))
+                    task.cancel()
+                    for _ in range(5):
+                        await asyncio.sleep(0)
+        server.handle_exit.assert_called_once_with(15, None)
+        assert lc._shutdown_tasks == set()

--- a/src/klangk/klangkd-tests/tests/test_model.py
+++ b/src/klangk/klangkd-tests/tests/test_model.py
@@ -2539,3 +2539,34 @@ class TestPasswordHistory:
         assert await users.get_password_hash(user["id"]) == "curhash"
         oidc = await users.create_user("oidc@example.com", None, verified=True)
         assert await users.get_password_hash(oidc["id"]) is None
+
+
+class TestModelBranchGaps2834:
+    """#2834 branch gate: model-layer guard outcomes."""
+
+    async def test_list_acl_unknown_principal_type_row(
+        self, db, app_state, user
+    ):
+        # A row with a principal type added by a NEWER klangkd (an
+        # upgrade race) lists without a principal label rather than
+        # crashing the ACL view.
+
+        async with app_state.state.db.transaction() as tx:
+            await tx.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  user_id, group_id, system_principal, permission)"
+                " VALUES ('/x', 0, 1, 99, ?, NULL, NULL, 1)",
+                (user["id"],),
+            )
+        entries = await app_state.state.model.acl.get_acl_entries_resolved(
+            "/x"
+        )
+        assert len(entries) == 1
+        assert "principal" not in entries[0]
+
+    async def test_dispose_engine_without_engine_is_noop(self, app_state):
+        db = app_state.state.db
+        db.engine = None
+        await db.dispose_engine()  # never started -> no raise
+        assert db.engine is None

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -1162,3 +1162,18 @@ async def test_prune_pending_toctou_guard(ec, ws, user, app_state):
     assert removed == 0
     row = await ec.get_request(stale["id"])
     assert row is not None and row["decision"] == DECISION_ALLOWED
+
+
+@pytest.mark.asyncio
+class TestPruneBranchGaps2834:
+    async def test_prune_row_cap_zero_skips_cap_prune(self, ec, ws, user):
+        # row_cap=0 disables the cap half (retention-only pruning): rows
+        # past retention still go, nothing else does.
+        ws_row = await ws.create_workspace(user["id"], "prune-nocap")
+        import time as time_mod
+
+        await ec.create_request(ws_row["id"], "9.9.9.9", 443)
+        # Nothing is past retention; a zero cap must not delete anything.
+        ec.app.state.settings.egress_consent_retention_days = 30
+        ec.app.state.settings.egress_consent_row_cap = 0
+        assert await ec.prune(now=time_mod.time()) == 0

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -551,3 +551,18 @@ async def test_update_group_rejects_workspace_role_rename(
     # Manual groups rename freely.
     manual = await users.create_group("free-to-rename")
     assert await users.update_group(manual["id"], name="renamed") is True
+
+
+class TestUsersBranchGaps2834:
+    async def test_backfill_no_handleless_rows_commits_nothing(
+        self, user, app_state
+    ):
+        # Every user already has a handle: the model's backfill runs zero
+        # UPDATEs and skips the (empty) commit entirely.
+        handle_before = user["handle"]
+        async with app_state.state.db.transaction() as tx:
+            await app_state.state.model.users.backfill_handles(tx)
+        refreshed = await app_state.state.model.users.get_user_by_email(
+            user["email"]
+        )
+        assert refreshed["handle"] == handle_before

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -1011,3 +1011,79 @@ async def test_replace_acl_entries_rejects_cross_workspace_role_group(
         f"/workspaces/{ws_a['id']}"
     )
     assert all(e["group_id"] != owners_b["id"] for e in entries)
+
+
+class TestWorkspacesModelBranchGaps2834:
+    """#2834 branch gate: ownership transfer without an owners group, and
+    the domain-list CAS retry under a losing race."""
+
+    async def test_transfer_ownership_without_owners_group(
+        self, ws, user, app_state
+    ):
+        # A workspace with no role groups (created before #2750): the
+        # transfer swaps the row + owner ACE and skips the group swap.
+        other = await app_state.state.model.users.create_user(
+            "newowner@example.com", "hash", verified=True
+        )
+        row = await ws.create_workspace(user["id"], "no-group-ws")
+        result = await ws.transfer_workspace(row["id"], other["id"])
+        assert result["user_id"] == other["id"]
+
+    async def test_domain_list_cas_retries_after_losing_race(
+        self, ws, user, app_state, monkeypatch
+    ):
+        # A concurrent writer flips the column between our SELECT and
+        # UPDATE: the CAS WHERE misses (rowcount 0) and the mutation
+        # retries against the fresh value instead of losing it.
+        row = await ws.create_workspace(user["id"], "cas-race-ws")
+        real_db = app_state.state.db
+        raced = [False]
+
+        class _RacingTx:
+            def __init__(self, cm):
+                self._cm = cm
+                self._inner = None
+
+            async def __aenter__(self):
+                self._inner = await self._cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *exc):
+                return await self._cm.__aexit__(*exc)
+
+            async def execute(self, sql, params=()):
+                if (
+                    sql.startswith("UPDATE workspaces SET allowed_domains")
+                    and not raced[0]
+                ):
+                    raced[0] = True
+                    async with real_db.transaction() as other:
+                        await other.execute(
+                            "UPDATE workspaces SET allowed_domains = ?"
+                            " WHERE id = ?",
+                            ('["racing.example:443"]', params[1]),
+                        )
+                return await self._inner.execute(sql, params)
+
+        class _RacingDB:
+            def transaction(self):
+                return _RacingTx(real_db.transaction())
+
+        monkeypatch.setattr(app_state.state, "db", _RacingDB(), raising=True)
+        try:
+            assert (
+                await ws.add_allowed_domain(row["id"], "github.com:443")
+                is True
+            )
+        finally:
+            monkeypatch.undo()
+        refreshed = await ws.get_workspace_by_id(row["id"])
+        import json as _json
+
+        val = refreshed["allowed_domains"]
+        entries = val if isinstance(val, list) else _json.loads(val or "[]")
+        names = [
+            e if isinstance(e, str) else e.get("host", "") for e in entries
+        ]
+        assert any("github.com" in n for n in names)
+        assert any("racing.example" in n for n in names)

--- a/src/klangk/klangkd-tests/tests/test_nix.py
+++ b/src/klangk/klangkd-tests/tests/test_nix.py
@@ -453,3 +453,54 @@ async def test_rmtree_rw_logs_when_retry_fails(monkeypatch, tmp_path, caplog):
 
         captured["onerror"](_boom, str(target / "x"), None)
     assert any("could not remove" in r.message for r in caplog.records)
+
+
+async def test_fuse_destroy_lazy_unmount_success_no_orphan_warning(
+    monkeypatch, tmp_path, caplog
+):
+    """#2834: the first unmount fails (busy) but the LAZY one succeeds:
+    no "left as an orphan" warning, the ws dir is still reaped."""
+    seed = _fuse_seed(tmp_path)
+    ws = tmp_path / "ws-ws1"
+    (ws / "nix").mkdir(parents=True)
+    (ws / "nix.conf").write_text("x")
+    calls = []
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(args)
+        # Plain unmount fails; the lazy (-z) retry succeeds.
+        rc = 1 if "-z" not in args else 0
+        return _Proc(rc, b"", b"mount busy")
+
+    monkeypatch.setattr(nix.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(nix.os.path, "ismount", lambda p: True)
+    n = Nix(_app(str(seed)))
+    with caplog.at_level("WARNING", logger="klangk.nix"):
+        await n.destroy_workspace_nix("ws1")
+    assert any(a[:3] == ("fusermount3", "-u", "-z") for a in calls)
+    assert not any("orphan" in r.message for r in caplog.records)
+
+
+async def test_rmtree_onerror_root_path_skips_parent_chmod(tmp_path):
+    """#2834: the rmtree error handler never chmods the shared seed
+    parent when the failing entry IS the rmtree root."""
+    import os as os_mod
+    import stat as stat_mod
+
+    parent = tmp_path / "seed"
+    parent.mkdir()
+    root = parent / "ws-x"
+    root.mkdir()
+    (root / "file").write_text("x")
+    # The root's own rmdir fails (parent read-only) -> onerror(p == root)
+    # -> the parent chmod is skipped (not ours to touch).
+    parent.chmod(0o555)
+    try:
+        nix._rmtree_rw(str(root))
+        # The seed parent was left at its original mode: the guard held.
+        assert stat_mod.S_IMODE(parent.stat().st_mode) == 0o555
+    finally:
+        parent.chmod(0o755)
+        os_mod.chmod(root, 0o755)
+        for child in root.iterdir():
+            child.chmod(0o755)

--- a/src/klangk/klangkd-tests/tests/test_oidc.py
+++ b/src/klangk/klangkd-tests/tests/test_oidc.py
@@ -980,3 +980,31 @@ class TestSyncOidcGroups:
             user["id"]
         )
         assert group["id"] in all_ids
+
+
+class TestOIDCBranchGaps2834:
+    """#2834 branch gate: the config getter's dashless-key miss and a
+    sync against an already-existing group."""
+
+    def test_get_dashless_key_missing_uses_default(self):
+        # "audience" has no dash -> no snake_case fallback is attempted;
+        # the explicit default wins.
+        assert oidc.get({"x": 1}, "audience", "the-default") == "the-default"
+
+    def test_get_dashless_key_missing_without_default_raises(self):
+        with pytest.raises(KeyError):
+            oidc.get({"x": 1}, "audience")
+
+    async def test_sync_existing_group_not_recreated(self, db, app_state):
+        # A group that already exists is looked up, not auto-created.
+        user = await app_state.state.model.users.create_user(
+            "sync-exists@example.com", "hash"
+        )
+        group = await app_state.state.model.users.create_group("already-there")
+        await oidc.OIDC(app_state).sync_oidc_groups(
+            user["id"], {"already-there"}
+        )
+        ids = await app_state.state.model.users.get_user_oidc_sync_group_ids(
+            user["id"]
+        )
+        assert ids == [group["id"]]

--- a/src/klangk/klangkd-tests/tests/test_podman_exec.py
+++ b/src/klangk/klangkd-tests/tests/test_podman_exec.py
@@ -452,3 +452,36 @@ class TestExecSession:
             await session.start(["echo"])
         cmd = mock_exec.call_args[0]
         assert "SSH_AUTH_SOCK=/tmp/agent.sock" in cmd
+
+
+class TestExecOutputBranchGaps2834:
+    async def test_output_exits_via_running_flag_after_yield(self):
+        """#2834: the generator's while-condition exit -- data arrives
+        after _running was cleared, is yielded once, then the loop
+        re-checks the flag and exits (not via the timeout break)."""
+        session = ExecSession("cid", _podman)
+        proc = _mock_proc(b"data")
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            await session.start(["echo", "data"])
+        await asyncio.sleep(0.1)
+        while not session._output_queue.empty():
+            session._output_queue.get_nowait()
+
+        session._running = True
+
+        async def _consume():
+            collected = []
+            async for data in session.output():
+                collected.append(data)
+            return collected
+
+        task = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)
+        session._running = False
+        session._output_queue.put_nowait(b"tail")
+        result = await asyncio.wait_for(task, timeout=3.0)
+        assert result == [b"tail"]
+        await session.stop()

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -1839,3 +1839,12 @@ class TestPasswordRequireCounts:
         # unsettable.
         with pytest.raises(Exception, match="72"):
             make_settings({"KLANGKD_PASSWORD_REQUIRE_SPECIAL": "73"})
+
+
+class TestCoerceBoolBranchGaps2834:
+    def test_non_bool_like_value_raises(self):
+        # Neither bool, 0/1, nor string: rejected as a settings error.
+        from klangk.workspace_settings import _coerce_bool
+
+        with pytest.raises(ValueError, match="not a boolean"):
+            _coerce_bool("nix", 5)

--- a/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
+++ b/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
@@ -113,3 +113,35 @@ class TestSidecarConnections:
         app2 = _app()
         reg.reconfigure(app2)
         assert reg.app is app2
+
+
+class TestSidecarConnectionsBranchGaps2834:
+    """#2834 branch gate: done-future skips in deregister/resolve/stop."""
+
+    async def test_deregister_skips_done_future(self):
+        # A pending ack whose future already resolved (the sidecar acked
+        # just as it disconnected) is left alone, not re-failed.
+        reg = SidecarConnections(_app())
+        sock = _Sock()
+        reg.register("ws-1", sock)
+        fut = reg.send_drop("ws-1", "h", "allowed")
+        fut.set_result(True)  # raced ack
+        reg.deregister("ws-1")  # must not raise / re-resolve
+        assert fut.result() is True
+        assert reg._pending == {}
+
+    async def test_resolve_ack_unknown_id_is_noop(self):
+        reg = SidecarConnections(_app())
+        reg.resolve_ack("never-sent", True)  # late ack after cleanup
+
+    async def test_stop_skips_done_futures(self):
+        reg = SidecarConnections(_app())
+        sock1, sock2 = _Sock(), _Sock()
+        reg.register("ws-1", sock1)
+        reg.register("ws-2", sock2)
+        f1 = reg.send_drop("ws-1", "h", "allowed")
+        f2 = reg.send_drop("ws-2", "h", "denied")
+        f1.set_result(True)  # already acked
+        await reg.stop()
+        assert f2.result() is False  # the open one was fail-closed
+        assert reg._pending == {} and reg._conns == {}

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -2326,3 +2326,47 @@ class TestServiceSessionHelpers:
 
         assert should_fire_service_command(None, "complete") is False
         assert should_fire_service_command("", "complete") is False
+
+
+class TestTerminalBranchGaps2834:
+    """#2834 branch gate: malformed window lines and the read loop's
+    condition-exit + tail flush."""
+
+    def test_parse_windows_skips_malformed_line(self):
+        from klangk.terminal import _parse_windows
+
+        windows = _parse_windows(
+            "@0|||1|||main|||1\nbroken-line-without-separators\n"
+        )
+        assert len(windows) == 1
+        assert windows[0]["id"] == "@0"
+        assert windows[0]["active"] is True
+
+    async def test_read_loop_exits_via_flag_and_flushes_tail(self):
+        # _running cleared while parked in read(): the loop re-checks the
+        # condition (not EOF) and still flushes the decoder's tail.
+
+        class _ControlledShell(FakeShell):
+            def __init__(self):
+                super().__init__(chunks=[])
+                self._gate = asyncio.Event()
+                self._pending = [b"ok"]
+
+            async def read(self):
+                if self._pending:
+                    return self._pending.pop(0)
+                await self._gate.wait()
+                return b"\xe2\x94"  # incomplete multibyte, then loop exits
+
+        fake = _ControlledShell()
+        with _patch(fake):
+            s = TerminalSession("cid", terminal=_terminal)
+            await s.start()
+        await asyncio.sleep(0.05)
+        s._running = False  # cleared while the loop is parked in read()
+        fake._gate.set()
+        await asyncio.sleep(0.05)
+        # The incomplete trailing sequence was flushed as one replacement
+        # char (not dropped) on the condition-exit path.
+        assert _drain_text(s) == "ok\ufffd"
+        await s.stop()

--- a/src/klangk/klangkd-tests/tests/test_util.py
+++ b/src/klangk/klangkd-tests/tests/test_util.py
@@ -1110,8 +1110,8 @@ class TestBridgeIdleTimeout:
 
 
 class TestPeerTrustedBranchGaps2834:
-    def test_unlisted_ip_iterates_every_entry(self):
-        # The loop-continue arm: an IP matching NO entry (the configured
-        # one or the defaults) walks the whole set and returns False.
-        u = _util({"KLANGKD_TRUSTED_PROXY_CIDRS": "203.0.113.9"})
-        assert u.peer_trusted("8.8.8.8") is False
+    def test_unlisted_ip_iterates_every_network(self):
+        # The CIDR loop-continue arm: an IP matching NO network walks
+        # them all (no short-circuit) and returns False.
+        u = _util({"KLANGKD_TRUSTED_PROXY_CIDRS": "10.0.0.0/8, 172.16.0.0/12"})
+        assert u.peer_trusted("203.0.113.9") is False

--- a/src/klangk/klangkd-tests/tests/test_util.py
+++ b/src/klangk/klangkd-tests/tests/test_util.py
@@ -1107,3 +1107,11 @@ class TestBridgeIdleTimeout:
         u = _util({"KLANGKD_BRIDGE_TIMEOUT_SECONDS": "60"})
         ws = {"settings": {"idle_timeout": 300}}
         assert u.bridge_idle_timeout_for(ws) == 60.0
+
+
+class TestPeerTrustedBranchGaps2834:
+    def test_unlisted_ip_iterates_every_entry(self):
+        # The loop-continue arm: an IP matching NO entry (the configured
+        # one or the defaults) walks the whole set and returns False.
+        u = _util({"KLANGKD_TRUSTED_PROXY_CIDRS": "203.0.113.9"})
+        assert u.peer_trusted("8.8.8.8") is False

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -1010,3 +1010,153 @@ class TestEnsureSharedHome:
             "cannot make" in r.message and str(home) in r.message
             for r in caplog.records
         )
+
+
+class TestWorkspacesServiceBranchGaps2834:
+    """#2834 branch gate: home-symlink + skel + archive + delete
+    outcomes the mainline tests only take one side of."""
+
+    async def test_symlink_to_missing_target_relinks_without_adoption(
+        self, user, app_state
+    ):
+        # A dangling handle symlink (the old user dir was deleted):
+        # nothing to adopt, straight relink; the fresh user dir means
+        # the skel still populates (created True).
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "dangling-ws"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        (home / ".users").mkdir(parents=True, exist_ok=True)
+        (home / "admin").symlink_to(".users/gone-uid")  # target absent
+        result, created = await app_state.state.workspaces.ensure_home_symlink(
+            home, "admin", "new-uid"
+        )
+        assert result == "/home/admin"
+        assert created is True  # no adoption -> skel needed
+        assert os.readlink(home / "admin") == ".users/new-uid"
+
+    async def test_adoption_skips_names_already_present(self, user, app_state):
+        # The old user dir has a file whose name already exists in the
+        # new user dir: the NEW file wins, the old one stays put.
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "adopt-collide-ws"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        (home / ".users").mkdir(parents=True, exist_ok=True)
+        old_dir = home / ".users" / "old-uid"
+        old_dir.mkdir()
+        (old_dir / "keep.txt").write_text("old")
+        new_dir = home / ".users" / "new-uid"
+        new_dir.mkdir()
+        (new_dir / "keep.txt").write_text("new")
+        (home / "admin").symlink_to(".users/old-uid")
+        (
+            _result,
+            created,
+        ) = await app_state.state.workspaces.ensure_home_symlink(
+            home, "admin", "new-uid"
+        )
+        assert created is False  # adoption path
+        # The new user's existing file was NOT clobbered.
+        assert (new_dir / "keep.txt").read_text() == "new"
+        # The colliding old file was left in the old dir.
+        assert (old_dir / "keep.txt").read_text() == "old"
+
+    async def test_populate_home_skel_explicit_home(self):
+        mock_pod = MagicMock()
+        with patch.object(
+            mock_pod,
+            "exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),
+        ) as mock_exec:
+            await ws_mod.populate_home_skel(
+                "cid-123", "uid-456", mock_pod, home="/home/custom"
+            )
+        args = mock_exec.await_args.args
+        assert args[1][1] == "/home/custom"  # the explicit home won
+
+    async def test_archive_validation_skipped_for_never_materialized_paths(
+        self, user, app_state, caplog
+    ):
+        # build_workspace_archive with a home_dir whose PARENT doesn't
+        # exist: the containment check only applies to materialized
+        # paths, so it is skipped (tar then fails on the missing source).
+        wsvc = app_state.state.workspaces
+        home = wsvc.safe_path("ws-never", "home", "deep", "gone")
+        with caplog.at_level(logging.ERROR, logger="klangk.workspaces"):
+            ok = await wsvc.build_workspace_archive(
+                {"name": "x"}, home, wsvc.safe_path("ws-never", "a.tar.gz")
+            )
+        assert ok is False
+        assert not any(
+            "Path validation failed" in r.message for r in caplog.records
+        )
+
+    async def test_archive_missing_ws_dir_skips_rmtree(
+        self, user, app_state, monkeypatch
+    ):
+        # The archived workspace's data dir is already gone: no rmtree
+        # attempt, no error (idempotent teardown).
+        wsvc = app_state.state.workspaces
+        home = wsvc.home_path("ws-x")
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "f.txt").write_text("x")
+        # The workspace's own data dir reads as already-gone (a per-handle
+        # home layout): the teardown rmtree is skipped entirely.
+        real_safe = wsvc.safe_path
+
+        def _safe_missing_ws_dir(*parts):
+            if len(parts) == 1 and parts[0] == "ws-x":
+                import pathlib
+
+                return pathlib.Path("/nonexistent-ws-data-dir")
+            return real_safe(*parts)
+
+        monkeypatch.setattr(wsvc, "safe_path", _safe_missing_ws_dir)
+        monkeypatch.setattr(
+            wsvc.app.state.model.workspaces,
+            "list_workspaces",
+            AsyncMock(
+                return_value={
+                    "items": [{"id": "ws-x", "name": "x"}],
+                    "has_more": False,
+                    "next_offset": None,
+                }
+            ),
+        )
+        removed = []
+
+        async def _spy_rmtree(path, label):
+            removed.append(label)
+
+        monkeypatch.setattr(ws_mod, "_async_rmtree", _spy_rmtree)
+        archives = await wsvc.archive_user_data(user["id"], user["email"])
+        assert archives  # the archive was still built
+        # No "workspace data" teardown ran (the dir read as absent).
+        assert not any(label.startswith("workspace data") for label in removed)
+
+    async def test_delete_workspace_model_false_skips_cleanup(
+        self, user, app_state, monkeypatch
+    ):
+        # The row already gone (a racing delete): no nix teardown, no
+        # rmtree -- just the False passthrough.
+        wsvc = app_state.state.workspaces
+        monkeypatch.setattr(
+            wsvc.app.state.model.workspaces,
+            "delete_workspace",
+            AsyncMock(return_value=False),
+        )
+        monkeypatch.setattr(
+            wsvc.app.state.model.workspaces,
+            "get_workspace",
+            AsyncMock(return_value={"id": "ws-gone", "name": "x"}),
+        )
+        removed = []
+
+        async def _spy_rmtree(path, label):
+            removed.append(path)
+
+        monkeypatch.setattr(ws_mod, "_async_rmtree", _spy_rmtree)
+        assert await wsvc.delete_workspace("ws-gone", user["id"]) is False
+        assert removed == []

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -10729,3 +10729,306 @@ class TestServerScheduleSnapshotOnConnect:
         # The SafeWebSocket wrapper was passed, not the raw one.
         (safe_ws,) = scheduler.send_snapshot_to.await_args.args
         assert safe_ws is not websocket
+
+
+class TestWshandlerBranchGaps2834:
+    """#2834 branch gate: connection/controller/session outcomes the
+    mainline tests only take one side of."""
+
+    async def test_ui_ready_without_session_still_flushes_status(
+        self, app_state
+    ):
+        # A workspace_id whose session is gone (post-teardown UI frame):
+        # no browser subscription, the pending status msg still flushes.
+        app_state = _make_app_state()
+        sock = _mock_sock()
+        conn = _base_conn(user=None, ws=sock, app_state=app_state)
+        conn.workspace_id = "ws-nosess"
+        conn.pending_status_msg = {"type": "status", "state": "connected"}
+        with patch.object(
+            app_state.state.sockets, "get_session", return_value=None
+        ):
+            await conn.handle_ui_ready()
+        assert conn.pending_status_msg is None
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            m.get("event", {}).get("name") == "container_ready" for m in sent
+        )
+
+    async def test_set_handle_existing_home_skips_skel(
+        self, user, temp_data_dir, app_state, monkeypatch
+    ):
+        # A rename whose per-handle home already exists (created=False):
+        # the skel exec is skipped -- only the symlink is refreshed.
+        app_state = _make_app_state()
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        conn.workspace_id = "ws-skel"
+        conn.container_id = "cid-skel"
+        conn.workspace = {"id": "ws-skel", "per_handle_home": True}
+        monkeypatch.setattr(
+            app_state.state.model.users,
+            "set_user_handle",
+            AsyncMock(return_value=True),
+        )
+        monkeypatch.setattr(
+            app_state.state.workspaces,
+            "ensure_home_symlink",
+            AsyncMock(return_value=("/home/newhandle", False)),
+        )
+        skel = AsyncMock()
+        monkeypatch.setattr(
+            app_state.state.workspaces, "populate_home_skel", skel
+        )
+        await conn.handle_set_handle({"handle": "newhandle"})
+        skel.assert_not_awaited()
+
+    @staticmethod
+    def _ctrl_conn(app_state, container_id=None):
+        sock = _mock_sock()
+        conn = _base_conn(user=None, ws=sock, app_state=app_state)
+        conn.container_id = container_id
+        conn.workspace_id = "ws-c"
+        return conn, sock
+
+    async def test_forward_exec_output_without_container_skips_activity(
+        self, app_state
+    ):
+        # An exec on a connection with no container: chunks relay, no
+        # activity recording attempt.
+        from klangk.wshandler.controllers import ExecController
+
+        app_state = _make_app_state()
+        conn, sock = self._ctrl_conn(app_state, container_id=None)
+        ctrl = ExecController(conn)
+        session = AsyncMock()
+        session.returncode = 0
+
+        async def fake_output():
+            yield b"x"
+
+        session.output = fake_output
+        recorded = []
+        with patch.object(
+            app_state.state.container_registry,
+            "record_activity",
+            side_effect=lambda cid: recorded.append(cid),
+        ):
+            await ctrl.forward_output(session)
+        assert recorded == []
+        assert any(
+            c[0][0]["type"] == "exec_output"
+            for c in sock.send_json.call_args_list
+        )
+
+    async def test_forward_terminal_output_without_container_skips_activity(
+        self, app_state
+    ):
+        from klangk.wshandler.controllers import TerminalController
+
+        app_state = _make_app_state()
+        conn, sock = self._ctrl_conn(app_state, container_id=None)
+        conn._user_home = "/home/x"
+        ctrl = TerminalController(conn)
+        session = AsyncMock()
+
+        async def fake_output():
+            yield "text"
+
+        session.output = fake_output
+        recorded = []
+        with patch.object(
+            app_state.state.container_registry,
+            "record_activity",
+            side_effect=lambda cid: recorded.append(cid),
+        ):
+            await ctrl.forward_output(session)
+        assert recorded == []
+        assert any(
+            c[0][0]["type"] == "terminal_output"
+            for c in sock.send_json.call_args_list
+        )
+
+    async def test_join_shared_terminal_without_session_skips_broadcast(
+        self, user, temp_data_dir, app_state
+    ):
+        # The join completes but the workspace session is gone: the
+        # terminal_started ack still goes out, no shared-list broadcast
+        # (nothing to broadcast to).
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        owner = await app_state.state.model.users.create_user(
+            "owner-nosess@test.com", "hash", verified=True
+        )
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        conn.workspace_id = "ws-nosess"
+        conn.container_id = "cid"
+        conn._user_home = "/home/joiner"
+        registry.track_activity("cid", "ws-nosess")
+        broadcast = MagicMock()
+        conn.broadcast_shared_terminals = broadcast
+        real_session = sockets.get_or_create_session("ws-nosess", app_state)
+        real_session.terminal_windows[owner["id"]] = [
+            {"name": "build", "index": 0, "id": "@0", "shared": True},
+        ]
+        # The session is present for the join's lookup, then VANISHES
+        # before the post-start broadcast (the mid-join race).
+        get_session_calls = {"n": 0}
+
+        def _vanishing_session(workspace_id):
+            get_session_calls["n"] += 1
+            return real_session if get_session_calls["n"] == 1 else None
+
+        try:
+            with (
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
+                ),
+                patch.object(_ws_controllers, "TerminalSession") as MockTS,
+                patch.object(_mock_term, "select_window"),
+                patch.object(_mock_term, "tmux_command", return_value=""),
+                patch.object(
+                    sockets, "get_session", side_effect=_vanishing_session
+                ),
+            ):
+                mock_sess = _mock_terminal()
+                MockTS.return_value = mock_sess
+
+                async def fake_output():
+                    return
+                    yield
+
+                mock_sess.output = fake_output
+                await conn.handle_join_shared_terminal(
+                    {"user_id": owner["id"], "window_id": "@0"}
+                )
+                await asyncio.sleep(0)
+            started = [
+                c[0][0]
+                for c in sock.send_json.call_args_list
+                if c[0][0].get("type") == "terminal_started"
+            ]
+            assert len(started) == 1
+            broadcast.assert_not_called()
+        finally:
+            sockets.sessions.pop("ws-nosess", None)
+            registry.states.pop("ws-nosess", None)
+
+    async def test_mark_shared_unknown_window_still_broadcasts(
+        self, app_state
+    ):
+        # The freshly-created window id is absent from the session's list
+        # (a racing refresh): nothing is flagged, the broadcast still
+        # refreshes the view.
+        from klangk.wshandler.controllers import SharedTerminalController
+
+        app_state = _make_app_state()
+        conn, sock = self._ctrl_conn(app_state, container_id="cid")
+        ctrl = SharedTerminalController(conn)
+        broadcast = MagicMock()
+        ctrl.broadcast_shared_terminals = broadcast
+        sess = MagicMock()
+        sess.terminal_windows = {"uid": [{"id": "other", "shared": False}]}
+        with patch.object(
+            app_state.state.sockets, "get_session", return_value=sess
+        ):
+            ctrl._mark_window_shared("never-seen")
+        assert sess.terminal_windows["uid"][0]["shared"] is False
+        broadcast.assert_called_once()
+
+    async def test_refresh_user_handle_skips_other_users(self, app_state):
+        # Only the renamed user's connections update; others untouched.
+        from klangk.wshandler.helpers import refresh_user_handle
+
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        mine = _base_conn(user=None, ws=_mock_sock(), app_state=app_state)
+        mine.user["id"] = "u1"
+        mine.user["handle"] = "old"
+        other = _base_conn(user=None, ws=_mock_sock(), app_state=app_state)
+        other.user["id"] = "u2"
+        other.user["handle"] = "keepme"
+        sockets.connections[mine.sock] = mine
+        sockets.connections[other.sock] = other
+        try:
+            await refresh_user_handle(sockets, "u1", "newhandle")
+        finally:
+            sockets.connections.clear()
+        assert mine.user["handle"] == "newhandle"
+        assert other.user["handle"] == "keepme"
+
+    def test_connected_user_ids_skips_agent_subscriber(self, app_state):
+        # The agent user's subscription is real (it keeps the workspace
+        # alive) but is not a "connected user" for inactivity purposes.
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        agent_conn = _base_conn(
+            user=None, ws=_mock_sock(), app_state=app_state
+        )
+        agent_conn.user["id"] = model.AGENT_USER_ID
+        human = _base_conn(user=None, ws=_mock_sock(), app_state=app_state)
+        human.user["id"] = "u-human"
+        session = WebSocketState(app_state).get_or_create_session(
+            "ws-agent", app_state
+        )
+        session.subscribers.add(agent_conn.sock)
+        session.subscribers.add(human.sock)
+        sockets.connections[agent_conn.sock] = agent_conn
+        sockets.connections[human.sock] = human
+        try:
+            assert session._connected_user_ids(sockets) == {"u-human"}
+        finally:
+            sockets.connections.clear()
+            sockets.sessions.pop("ws-agent", None)
+
+    def test_send_windows_to_user_skips_other_subscribers(self, app_state):
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        mine = _base_conn(user=None, ws=_mock_sock(), app_state=app_state)
+        mine.user["id"] = "u1"
+        other_sock = _mock_sock()
+        session = WebSocketState(app_state).get_or_create_session(
+            "ws-win", app_state
+        )
+        session.subscribers.add(mine.sock)
+        session.subscribers.add(other_sock)
+        sockets.connections[mine.sock] = mine
+        try:
+            session._send_windows_to_user(sockets, "u1", [{"id": "w"}])
+        finally:
+            sockets.connections.clear()
+            sockets.sessions.pop("ws-win", None)
+        assert mine.sock.send_json.called
+        other_sock.send_json.assert_not_called()
+
+    async def test_clear_cancels_only_undone_browser_requests(self, app_state):
+        # A browser-delegate future that already resolved is left alone;
+        # the open one is cancelled by the state clear.
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        loop = asyncio.get_running_loop()
+        done = loop.create_future()
+        done.set_result({"type": "reply"})
+        open_fut = loop.create_future()
+        sockets.pending_browser_requests["a"] = (done, _mock_sock())
+        sockets.pending_browser_requests["b"] = (open_fut, _mock_sock())
+        await sockets.disconnect_all()
+        assert done.done() and done.exception() is None
+        assert open_fut.cancelled()
+
+    async def test_browser_reply_done_future_skips_set(self, app_state):
+        # A reply racing the request's own timeout: the future is already
+        # done, the late frame is dropped without raising.
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        fut.set_result({"type": "first"})
+        sock = _mock_sock()
+        sockets.pending_browser_requests["rid"] = (fut, sock)
+        sockets.handle_browser_response({"type": "reply", "id": "rid"}, sock)
+        assert fut.result()["type"] == "first"  # not clobbered

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -76,11 +76,10 @@ line-length = 79
 # relative to the CWD, not the pytest rootdir, so the repo-root
 # pyproject's copy of this section is what the documented from-root
 # invocations read; this local copy keeps CWD-here runs identical.
-# Keep in sync with the root pyproject.toml (#2834). See there for why
-# branch coverage needs the C tracer + greenlet concurrency on 3.13.
+# Keep in sync with the root pyproject.toml (#2834). The sysmon core
+# (pinned in the conftests) needs no concurrency option.
 [tool.coverage.run]
 branch = true
-concurrency = ["greenlet", "thread"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -57,7 +57,7 @@ klangk-load-nix-seed-btrfs = "klangk.seed:load_main"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "--capture=no --cov=klangk --cov-report=term-missing --no-cov-on-fail --cov-fail-under=100 --timeout=60"
+addopts = "--capture=no --cov=klangk --cov-branch --cov-report=term-missing --no-cov-on-fail --cov-fail-under=100 --timeout=60"
 # Treat new warnings as errors so they can't re-accumulate (#1493). The
 # two ignores are pre-existing mock-induced GC artifacts (MagicMock stubs
 # whose coroutine objects are collected in a later test) -- not real bugs
@@ -70,6 +70,17 @@ filterwarnings = [
 
 [tool.ruff]
 line-length = 79
+
+# Coverage config for runs whose CWD is src/klangk itself (e.g. `cd
+# src/klangk && pytest ...`). coverage discovers [tool.coverage.run]
+# relative to the CWD, not the pytest rootdir, so the repo-root
+# pyproject's copy of this section is what the documented from-root
+# invocations read; this local copy keeps CWD-here runs identical.
+# Keep in sync with the root pyproject.toml (#2834). See there for why
+# branch coverage needs the C tracer + greenlet concurrency on 3.13.
+[tool.coverage.run]
+branch = true
+concurrency = ["greenlet", "thread"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/src/klangksidecar/klangksidecar/__main__.py
+++ b/src/klangksidecar/klangksidecar/__main__.py
@@ -1,6 +1,10 @@
 """Entry point: ``python -m klangksidecar`` runs the sidecar DNS proxy (PID 1)."""
 
-from .app import main
+# PID-1-only entry (#2834): executed only as the sidecar container's init
+# (``python3 -m klangksidecar``, see the image Dockerfile) and exercised
+# end-to-end by the real-podman e2e (test_network_sidecar_e2e.py), never
+# imported by the unit suite.
+from .app import main  # pragma: no cover
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -199,7 +199,10 @@ async def _async_main() -> None:
         if stopping:
             return
         stopping = True
-        if main_task is not None:
+        # Captured from asyncio.current_task() inside _async_main, so never
+        # None -- the guard only satisfies the type-checker (a plain loop
+        # callback would see None; _on_sigterm is registered from a task).
+        if main_task is not None:  # pragma: no branch
             main_task.cancel()
 
     try:
@@ -207,7 +210,9 @@ async def _async_main() -> None:
     except (NotImplementedError, RuntimeError):
         pass  # signal handlers need the main thread + a supported loop backend
     try:
-        while True:
+        # Exits only via the SIGTERM CancelledError above, never by falling
+        # through the condition -- the arc to loop exit is unreachable.
+        while True:  # pragma: no branch
             try:
                 data, addr = await loop.sock_recvfrom(s, 65535)
             except Exception:

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -212,7 +212,10 @@ class SidecarConsentClient:
             # there.)
             if decision == "allowed":
                 allowlist._drop_session_hosts(host)
-            elif decision == "denied":
+            # The outer guard already restricted decision to allowed/denied,
+            # so exactly one of these branches runs -- the elif's false arc
+            # (neither) is unreachable.
+            elif decision == "denied":  # pragma: no branch
                 # Clear the host-scoped deny memory (#2446) BEFORE drop_for_host
                 # forks iptables, so a SYN arriving during that window re-prompts
                 # instead of staying auto-denied (mirror of the allow revoke).
@@ -377,7 +380,9 @@ async def _activity_sampler(client, get_bytes, interval: float) -> None:
     """
     loop = asyncio.get_running_loop()
     _, prev = await loop.run_in_executor(None, _activity_delta, get_bytes, 0)
-    while True:
+    # Runs for the sidecar's lifetime; cancelled at shutdown, never exits by
+    # falling through the condition (the arc to loop exit is unreachable).
+    while True:  # pragma: no branch
         await asyncio.sleep(interval)
         try:
             bumped, prev = await loop.run_in_executor(

--- a/src/klangksidecar/klangksidecar/rules.py
+++ b/src/klangksidecar/klangksidecar/rules.py
@@ -328,7 +328,9 @@ async def _async_sweeper() -> None:
     block the loop (and so it can run concurrently with :func:`_learn_all`,
     serialized by :data:`_LOCK`).
     """
-    while True:
+    # Runs for the sidecar's lifetime; cancelled at shutdown, never exits
+    # by falling through the condition (the arc to loop exit is unreachable).
+    while True:  # pragma: no branch
         await asyncio.sleep(SWEEP_INTERVAL)
         try:
             await asyncio.get_running_loop().run_in_executor(None, sweep_once)

--- a/src/klangksidecar/pyproject.toml
+++ b/src/klangksidecar/pyproject.toml
@@ -37,19 +37,29 @@ test = [
     "pytest-asyncio>=0.24.0",
     "pytest-xdist>=3.0.0",
     "pytest-timeout>=2.3.0",
+    "pytest-cov>=6.0.0",
+    # Not used by the sidecar itself: the shared [tool.coverage.run] in
+    # the repo-root pyproject.toml (which every from-root pytest-cov run
+    # reads, CWD-relative) sets concurrency=["greenlet", "thread"] for
+    # the klangk suite, and coverage refuses to start with a greenlet
+    # concurrency it can't import. Test-only; the sidecar image installs
+    # no [test] extra (#2834).
+    "greenlet>=3.1",
 ]
 
-# No coverage gate here, by design: app.main()'s signal-handler/real-socket
-# paths only run as PID 1 of the sidecar and are exercised end-to-end by the
-# real-podman e2e (src/klangk/klangkd-tests/e2e-tests/
-# test_network_sidecar_e2e.py), not by this unit suite (mirrors how the klangk
-# suite treats the proxy today — it was never part of the klangk package, so
-# never coverage-gated). The unit suite pins the proxy's logic (spec parsing,
-# ports_for, allow/sweep, the consent state machine).
+# Coverage gate (#2834): branch coverage at 100%, mirroring the klangk
+# suite's gate, over the unit-testable proxy logic (spec parsing,
+# ports_for, allow/sweep, the consent state machine, and app.py's
+# orchestration helpers driven via asyncio tasks). The only lines outside
+# the gate are the PID-1-only entry paths (`python -m klangksidecar` ->
+# app.main -> asyncio.run(_async_main)) — those run as PID 1 of the
+# sidecar and are exercised end-to-end by the real-podman e2e
+# (src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py), so
+# they carry `# pragma: no cover` rather than unit-test scaffolding.
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "--capture=no --timeout=60"
+addopts = "--capture=no --cov=klangksidecar --cov-branch --cov-report=term-missing --no-cov-on-fail --cov-fail-under=100 --timeout=60"
 # Mirror the klangk suite's mock-induced GC warning ignores.
 filterwarnings = [
     "ignore::pytest.PytestUnraisableExceptionWarning",

--- a/src/klangksidecar/pyproject.toml
+++ b/src/klangksidecar/pyproject.toml
@@ -38,13 +38,6 @@ test = [
     "pytest-xdist>=3.0.0",
     "pytest-timeout>=2.3.0",
     "pytest-cov>=6.0.0",
-    # Not used by the sidecar itself: the shared [tool.coverage.run] in
-    # the repo-root pyproject.toml (which every from-root pytest-cov run
-    # reads, CWD-relative) sets concurrency=["greenlet", "thread"] for
-    # the klangk suite, and coverage refuses to start with a greenlet
-    # concurrency it can't import. Test-only; the sidecar image installs
-    # no [test] extra (#2834).
-    "greenlet>=3.1",
 ]
 
 # Coverage gate (#2834): branch coverage at 100%, mirroring the klangk

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import signal
+import socket
 import sys
 import time
 import types
@@ -3285,3 +3286,1412 @@ class TestSigtermShutdown:
         nfq.unbind.assert_called_once()  # teardown was NOT aborted
         sock.close.assert_called_once()
         assert sweep.cancelled()
+
+
+# --- branch-coverage gap tests (#2834) ----------------------------------------
+#
+# The 100% branch gate requires every branch OUTCOME exercised, not just every
+# line. These classes drive the paths the original suites reached only via
+# monkeypatched inner helpers (the real forward/respond/nxdomain wire paths,
+# the consent client's connect loop, the best-effort exception swallows) or
+# not at all (query_name/nxdomain_for, _resolve_ws_host, main). Where an
+# outcome is structurally unreachable in-process (PID-1-only entry,
+# never-exiting sweeper loops) the source carries `# pragma: no branch` /
+# `# pragma: no cover` with a comment instead.
+
+
+class _FakeQueryName:
+    """Stub ``dns.message.from_wire`` to return a query ``msg`` for
+    query_name/nxdomain_for tests (the dnspython stub module is the shared
+    mutable surface the suite patches, per TestARecordsWithTtl)."""
+
+    def __init__(self, proxy, monkeypatch, question=None, resp=None):
+        self.resp = resp or types.SimpleNamespace(
+            set_rcode=MagicMock(), to_wire=lambda: b"WIRE"
+        )
+        msg = types.SimpleNamespace(question=question if question is not None else [])
+        monkeypatch.setattr(proxy.dns.message, "from_wire", lambda wire: msg)
+        monkeypatch.setattr(proxy.dns.message, "make_response", lambda q: self.resp)
+
+
+class TestWireHelpers:
+    """query_name / nxdomain_for / _send_nxdomain (#2834): the wire-level
+    helpers the routing tests monkeypatch away, driven directly."""
+
+    def test_query_name_lowercases_and_strips_dot(self, proxy, monkeypatch):
+        name = types.SimpleNamespace(
+            name=types.SimpleNamespace(to_text=lambda: "Example.COM.")
+        )
+        _FakeQueryName(proxy, monkeypatch, question=[name])
+        assert proxy.query_name(b"wire") == "example.com"
+
+    def test_query_name_empty_question(self, proxy, monkeypatch):
+        # A question-less DNS message (e.g. some resolver probes) -> "" (the
+        # _decision gate then denies it, fail-closed).
+        _FakeQueryName(proxy, monkeypatch, question=[])
+        assert proxy.query_name(b"wire") == ""
+
+    def test_nxdomain_for_sets_rcode(self, proxy, monkeypatch):
+        fake = _FakeQueryName(proxy, monkeypatch)
+        assert proxy.nxdomain_for(b"query") == b"WIRE"
+        fake.resp.set_rcode.assert_called_once_with(proxy.dns.rcode.NXDOMAIN)
+
+    def test_send_nxdomain_swallows_sendto_failure(self, proxy, monkeypatch):
+        # Best-effort: a vanished client must not raise out of the recv loop.
+        _FakeQueryName(proxy, monkeypatch)
+        s = MagicMock()
+        s.sendto.side_effect = OSError("client gone")
+        proxy._send_nxdomain(s, b"q", ("127.0.0.1", 53))  # must not raise
+
+    def test_send_nxdomain_sends_wire(self, proxy, monkeypatch):
+        _FakeQueryName(proxy, monkeypatch)
+        s = MagicMock()
+        proxy._send_nxdomain(s, b"q", ("127.0.0.1", 53))
+        s.sendto.assert_called_once_with(b"WIRE", ("127.0.0.1", 53))
+
+
+class _FakeUpstreamSock:
+    """A socket.socket stand-in for _forward_marked: records the MARK
+    setsockopt + the blocking mode, closed by the caller's finally."""
+
+    def __init__(self):
+        self.opts = []
+        self.blocking = None
+        self.closed = False
+
+    def setsockopt(self, level, opt, val):
+        self.opts.append((level, opt, val))
+
+    def setblocking(self, flag):
+        self.blocking = flag
+
+    def close(self):
+        self.closed = True
+
+
+class TestForwardMarked:
+    """_forward_marked / _forward_and_learn / _forward_and_record (#2834):
+    the real upstream-forward preamble (MARK'd non-blocking socket + bounded
+    send/recv on the loop), driven with a fake socket + loop helpers."""
+
+    async def test_success_returns_response_and_closes(self, proxy, monkeypatch):
+        sock = _FakeUpstreamSock()
+        monkeypatch.setattr(proxy.socket, "socket", lambda *a, **k: sock)
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(loop, "sock_sendto", AsyncMock(return_value=len(b"q")))
+        monkeypatch.setattr(
+            loop, "sock_recvfrom", AsyncMock(return_value=(b"resp", ("9.9.9.9", 53)))
+        )
+        assert await proxy._forward_marked(b"q") == b"resp"
+        # The loop-avoidance mark + non-blocking mode were applied, and the
+        # socket was closed on success (the finally runs on every path).
+        assert (socket.SOL_SOCKET, socket.SO_MARK, proxy.MARK) in [o for o in sock.opts]
+        assert sock.blocking is False
+        assert sock.closed
+
+    async def test_upstream_failure_returns_none(self, proxy, monkeypatch):
+        # Any upstream failure/timeout -> None (the caller then just drops
+        # the query; the client's resolver retransmits).
+        sock = _FakeUpstreamSock()
+        monkeypatch.setattr(proxy.socket, "socket", lambda *a, **k: sock)
+
+        async def _boom(*a, **k):
+            raise OSError("upstream unreachable")
+
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(loop, "sock_sendto", _boom)
+        assert await proxy._forward_marked(b"q") is None
+        assert sock.closed  # closed on error too
+
+    async def test_forward_and_learn_none_resp_skips_respond(self, proxy, monkeypatch):
+        # Upstream failure: _forward_and_learn returns without touching the
+        # client-facing socket.
+        monkeypatch.setattr(
+            proxy.resolve, "_forward_marked", AsyncMock(return_value=None)
+        )
+        respond = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "_respond_allowed", respond)
+        await proxy._forward_and_learn(MagicMock(), b"q", ("c", 1), "q.name", {443})
+        respond.assert_not_awaited()
+
+    async def test_forward_and_learn_resp_answers(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy.resolve, "_forward_marked", AsyncMock(return_value=b"resp")
+        )
+        respond = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "_respond_allowed", respond)
+        s = MagicMock()
+        await proxy._forward_and_learn(s, b"q", ("c", 1), "q.name", {443})
+        respond.assert_awaited_once_with(s, b"resp", ("c", 1), "q.name", {443})
+
+    async def test_forward_and_record_none_resp_skips_respond(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy.resolve, "_forward_marked", AsyncMock(return_value=None)
+        )
+        respond = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "_respond_recorded", respond)
+        await proxy._forward_and_record(MagicMock(), b"q", ("c", 1), "q.name")
+        respond.assert_not_awaited()
+
+    async def test_forward_and_record_resp_answers(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy.resolve, "_forward_marked", AsyncMock(return_value=b"resp")
+        )
+        respond = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "_respond_recorded", respond)
+        s = MagicMock()
+        await proxy._forward_and_record(s, b"q", ("c", 1), "q.name")
+        respond.assert_awaited_once_with(s, b"resp", ("c", 1), "q.name")
+
+
+class TestRespondEdgePaths:
+    """_respond_allowed / _respond_recorded edge outcomes (#2834): a
+    response with no A records learns/records nothing but still answers, a
+    parsing failure degrades to the same, and DEBUG prints the allow/resolve
+    line."""
+
+    async def test_no_a_records_still_sends(self, proxy, monkeypatch):
+        monkeypatch.setattr(proxy.resolve, "a_records_with_ttl", lambda wire: [])
+        learn = MagicMock()
+        monkeypatch.setattr(proxy.rules, "_learn_all", learn)
+        s = MagicMock()
+        await proxy._respond_allowed(s, b"resp", ("c", 1), "q", {443})
+        learn.assert_not_called()
+        s.sendto.assert_called_once()
+
+    async def test_unparseable_response_degrades_to_no_records(
+        self, proxy, monkeypatch
+    ):
+        def _boom(wire):
+            raise ValueError("garbage wire")
+
+        monkeypatch.setattr(proxy.resolve, "a_records_with_ttl", _boom)
+        learn = MagicMock()
+        monkeypatch.setattr(proxy.rules, "_learn_all", learn)
+        s = MagicMock()
+        await proxy._respond_allowed(s, b"resp", ("c", 1), "q", {443})
+        learn.assert_not_called()
+        s.sendto.assert_called_once()
+
+    async def test_recorded_no_a_records_still_sends(self, proxy, monkeypatch):
+        monkeypatch.setattr(proxy.resolve, "a_records_with_ttl", lambda wire: [])
+        record = MagicMock()
+        monkeypatch.setattr(proxy.rules, "_record_hosts", record)
+        s = MagicMock()
+        await proxy._respond_recorded(s, b"resp", ("c", 1), "q")
+        record.assert_not_called()
+        s.sendto.assert_called_once()
+
+    async def test_recorded_unparseable_response_degrades(self, proxy, monkeypatch):
+        def _boom(wire):
+            raise ValueError("garbage wire")
+
+        monkeypatch.setattr(proxy.resolve, "a_records_with_ttl", _boom)
+        record = MagicMock()
+        monkeypatch.setattr(proxy.rules, "_record_hosts", record)
+        s = MagicMock()
+        await proxy._respond_recorded(s, b"resp", ("c", 1), "q")
+        record.assert_not_called()
+        s.sendto.assert_called_once()
+
+    async def test_debug_prints_allow_line(self, proxy, monkeypatch, capsys):
+        monkeypatch.setattr(proxy.resolve, "DEBUG", True)
+        monkeypatch.setattr(
+            proxy.resolve, "a_records_with_ttl", lambda w: [("1.2.3.4", 60)]
+        )
+        monkeypatch.setattr(proxy.rules, "_learn_all", lambda *a: None)
+        await proxy._respond_allowed(MagicMock(), b"r", ("c", 1), "q.name", {443})
+        assert "allow q.name" in capsys.readouterr().out
+
+    async def test_debug_prints_resolve_line(self, proxy, monkeypatch, capsys):
+        monkeypatch.setattr(proxy.resolve, "DEBUG", True)
+        monkeypatch.setattr(
+            proxy.resolve, "a_records_with_ttl", lambda w: [("1.2.3.4", 60)]
+        )
+        monkeypatch.setattr(proxy.rules, "_record_hosts", lambda *a: None)
+        await proxy._respond_recorded(MagicMock(), b"r", ("c", 1), "q.name")
+        assert "resolve q.name" in capsys.readouterr().out
+
+    async def test_handle_packet_debug_prints_reject_line(
+        self, proxy, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(proxy.resolve, "DEBUG", True)
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(
+            proxy.allowlist, "REJECT_SPECS", [("evil.test", None, proxy._EXACT)]
+        )
+        _FakeQueryName(proxy, monkeypatch)  # nxdomain_for wire
+        await proxy._handle_packet(MagicMock(), b"q", ("c", 1), None)
+        assert "reject evil.test" in capsys.readouterr().out
+
+    async def test_handle_packet_debug_prints_deny_line(
+        self, proxy, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(proxy.resolve, "DEBUG", True)
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "other.test")
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [])
+        monkeypatch.setattr(proxy.allowlist, "REJECT_SPECS", [])
+        _FakeQueryName(proxy, monkeypatch)  # nxdomain_for wire
+        await proxy._handle_packet(MagicMock(), b"q", ("c", 1), None)
+        assert "deny  other.test" in capsys.readouterr().out
+
+
+class TestAppTeardownHelpers:
+    """app.py's best-effort teardown helpers (#2834): each swallows its
+    resource's failure so one bad close can't abort the rest of _shutdown."""
+
+    async def test_cancel_task_swallows_task_exception(self, proxy):
+        async def _boom():
+            raise ValueError("task blew up")
+
+        t = asyncio.create_task(_boom())
+        await proxy._cancel_task(t)  # must not raise
+        assert t.done()
+
+    async def test_cancel_task_none_is_noop(self, proxy):
+        await proxy._cancel_task(None)  # no task (not started) -> no-op
+
+    async def test_unbind_nfq_swallows_remove_reader_failure(self, proxy, monkeypatch):
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(
+            loop, "remove_reader", MagicMock(side_effect=RuntimeError("no reader"))
+        )
+        nfq = MagicMock()
+        proxy._unbind_nfq(nfq)  # sync + must not raise
+        nfq.unbind.assert_called_once()  # teardown continued
+
+    async def test_unbind_nfq_swallows_unbind_failure(self, proxy):
+        nfq = MagicMock()
+        nfq.get_fd = MagicMock(return_value=7)
+        nfq.unbind = MagicMock(side_effect=RuntimeError("already unbound"))
+        proxy._unbind_nfq(nfq)  # must not raise
+
+    async def test_unbind_nfq_none_is_noop(self, proxy):
+        proxy._unbind_nfq(None)  # no queue (static mode) -> no-op
+
+    def test_close_quietly_swallows_close_failure(self, proxy):
+        sock = MagicMock()
+        sock.close = MagicMock(side_effect=OSError("already closed"))
+        proxy._close_quietly(sock)  # must not raise
+
+    async def test_close_quietly_closes(self, proxy):
+        sock = MagicMock()
+        proxy._close_quietly(sock)
+        sock.close.assert_called_once()
+
+
+class TestResolveWsHost:
+    """_resolve_ws_host (#2485, #2834): the klangkd WS host resolved to an IP
+    so the egress-accounting rule can exclude it; any failure returns None
+    (printed) -- which defeats the idle timeout, so it is loud."""
+
+    def test_resolves_host_to_ip(self, proxy, monkeypatch):
+        monkeypatch.setattr(proxy.app.socket, "gethostbyname", lambda host: "10.1.2.3")
+        assert proxy._resolve_ws_host("http://klangkd:8443/ws/x") == "10.1.2.3"
+
+    def test_unresolvable_host_returns_none_and_prints(
+        self, proxy, monkeypatch, capsys
+    ):
+        def _boom(host):
+            raise OSError("no such host")
+
+        monkeypatch.setattr(proxy.app.socket, "gethostbyname", _boom)
+        assert proxy._resolve_ws_host("http://klangkd/ws") is None
+        assert "could not resolve the klangkd WS host" in capsys.readouterr().out
+
+    def test_hostless_url_returns_none_and_prints(self, proxy, monkeypatch, capsys):
+        # A URL with no host (e.g. a bare path) -> None, same loud warning.
+        monkeypatch.setattr(proxy.app.socket, "gethostbyname", lambda host: "10.1.2.3")
+        assert proxy._resolve_ws_host("not-a-url") is None
+        assert "could not resolve the klangkd WS host" in capsys.readouterr().out
+
+
+class TestAsyncMainLoopPaths:
+    """_async_main's in-loop paths the SIGTERM tests don't reach (#2834):
+    the recv->handle happy path, the unsupported-signal-backend fallback,
+    the DEBUG shutdown line, and main()'s KeyboardInterrupt swallow."""
+
+    def _stub_static_startup(self, proxy, monkeypatch, fake_sock):
+        # Static mode (no consent URL) + stubbed iptables probes/sockets so
+        # _async_main reaches its recv loop without real kernel access.
+        monkeypatch.setattr(proxy.config, "CONSENT_URL", "")
+        monkeypatch.setattr(proxy.rules, "check_mark", lambda: None)
+        monkeypatch.setattr(proxy.socket, "socket", lambda *a, **k: fake_sock)
+
+    async def test_recv_loop_dispatches_to_handle_packet(self, proxy, monkeypatch):
+        # One received datagram is handed to _handle_packet, then the loop
+        # parks again (the gate hang doubles as the "parked" state).
+        fake_sock = MagicMock()
+        self._stub_static_startup(proxy, monkeypatch, fake_sock)
+        loop = asyncio.get_running_loop()
+        gate = asyncio.Event()
+        served = asyncio.Event()
+
+        async def recvfrom(*a, **k):
+            if not served.is_set():
+                served.set()
+                return b"q", ("127.0.0.1", 40000)
+            await gate.wait()
+            return b"", ("127.0.0.1", 0)
+
+        monkeypatch.setattr(loop, "sock_recvfrom", recvfrom)
+        handled = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "_handle_packet", handled)
+        task = asyncio.create_task(proxy._async_main())
+        for _ in range(100):
+            if served.is_set():
+                break
+            await asyncio.sleep(0.01)
+        handled.assert_awaited_once_with(fake_sock, b"q", ("127.0.0.1", 40000), None)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_recv_failure_continues_loop(self, proxy, monkeypatch):
+        # A transient recv error is swallowed and the loop keeps serving.
+        fake_sock = MagicMock()
+        self._stub_static_startup(proxy, monkeypatch, fake_sock)
+        loop = asyncio.get_running_loop()
+        calls = {"n": 0}
+        gate = asyncio.Event()
+
+        async def recvfrom(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("transient recv failure")
+            await gate.wait()
+            return b"", ("127.0.0.1", 0)
+
+        monkeypatch.setattr(loop, "sock_recvfrom", recvfrom)
+        task = asyncio.create_task(proxy._async_main())
+        for _ in range(100):
+            if calls["n"] >= 1:
+                break
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)
+        assert calls["n"] >= 2  # the loop continued past the failure
+        assert not task.done()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_unsupported_signal_backend_still_serves(self, proxy, monkeypatch):
+        # add_signal_handler raising (non-main thread / unsupported loop)
+        # must not stop the proxy from serving.
+        fake_sock = MagicMock()
+        self._stub_static_startup(proxy, monkeypatch, fake_sock)
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(
+            loop,
+            "add_signal_handler",
+            MagicMock(side_effect=NotImplementedError("no signals")),
+        )
+        gate = asyncio.Event()
+        parked = asyncio.Event()
+
+        async def recvfrom(*a, **k):
+            parked.set()
+            await gate.wait()
+            return b"", ("127.0.0.1", 0)
+
+        monkeypatch.setattr(loop, "sock_recvfrom", recvfrom)
+        task = asyncio.create_task(proxy._async_main())
+        for _ in range(100):
+            if parked.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert parked.is_set() and not task.done()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_sigterm_debug_line(self, proxy, monkeypatch, capsys):
+        # DEBUG on: the CancelledError unwind prints the shutdown line.
+        fake_sock = MagicMock()
+        self._stub_static_startup(proxy, monkeypatch, fake_sock)
+        monkeypatch.setattr(proxy.app, "DEBUG", True)
+        loop = asyncio.get_running_loop()
+        handlers = {}
+        monkeypatch.setattr(
+            loop,
+            "add_signal_handler",
+            lambda sig, cb, *a: handlers.__setitem__(sig, cb),
+        )
+        gate = asyncio.Event()
+        monkeypatch.setattr(loop, "sock_recvfrom", lambda *a, **k: gate.wait())
+        task = asyncio.create_task(proxy._async_main())
+        for _ in range(100):
+            if signal.SIGTERM in handlers:
+                break
+            await asyncio.sleep(0.01)
+        handlers[signal.SIGTERM]()
+        await asyncio.wait_for(task, timeout=2)
+        assert "stop signal received, shutting down" in capsys.readouterr().out
+
+    def test_main_runs_and_returns(self, proxy, monkeypatch):
+        # main() is the PID-1 asyncio.run wrapper; driven with a no-op body.
+        ran = []
+
+        async def _noop():
+            ran.append(True)
+
+        monkeypatch.setattr(proxy.app, "_async_main", _noop)
+        proxy.app.main()  # must return cleanly
+        assert ran
+
+    def test_main_swallows_keyboard_interrupt(self, proxy, monkeypatch):
+        # Ctrl-C at the console (before podman's SIGTERM) exits quietly.
+        async def _interrupt():
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(proxy.app, "_async_main", _interrupt)
+        proxy.app.main()  # must not raise
+
+
+class _FakeConsentWS:
+    """A websockets connection stand-in: async-context manager + async
+    iterator over scripted frames, recording sends."""
+
+    def __init__(self, frames=()):
+        self._frames = list(frames)
+        self.sent = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        async def _gen():
+            for frame in self._frames:
+                yield frame
+
+        return _gen()
+
+
+class TestConsentClientRunLoop:
+    """SidecarConsentClient._run / stop / request edge outcomes (#2834): the
+    connect-dispatch-reconnect loop (stubbed websockets.connect), the no-token
+    retry, the fail-close exception paths, and stop()'s guarded teardown."""
+
+    @staticmethod
+    def _client(proxy, url="http://klangkd/ws", hold=60.0):
+        return proxy.consent.SidecarConsentClient(url, "/nonexistent-token", hold)
+
+    async def test_run_no_token_warns_and_retries(self, proxy, monkeypatch, capsys):
+        c = self._client(proxy)
+        monkeypatch.setattr(c, "_read_token", lambda: "")
+        monkeypatch.setattr(proxy.consent, "DEBUG", True)
+
+        # Fast-forward the 1s retry sleep and stop after the first retry.
+        async def _fast_sleep(_s):
+            c._stop = True
+
+        monkeypatch.setattr(proxy.consent.asyncio, "sleep", _fast_sleep)
+        await c._run()
+        assert "workspace token not yet present" in capsys.readouterr().out
+
+    async def test_run_connects_dispatches_and_resolves_verdict(
+        self, proxy, monkeypatch
+    ):
+        # The happy path: connect (with the bearer header), receive a verdict
+        # frame for a pending request, then stop between frames.
+        c = self._client(proxy)
+        monkeypatch.setattr(c, "_read_token", lambda: "tok")
+        connect_args = []
+        ws = _FakeConsentWS(
+            frames=[
+                json.dumps(
+                    {
+                        "type": "verdict",
+                        "id": "v1",
+                        "decision": "allow",
+                        "duration": "5m",
+                    }
+                )
+            ]
+        )
+
+        def _connect(*a, **k):
+            connect_args.append((a, k))
+            return ws
+
+        monkeypatch.setattr(proxy.consent.websockets, "connect", _connect)
+        fut = asyncio.get_running_loop().create_future()
+        c._pending["v1"] = fut
+        real_dispatch = c._dispatch
+
+        async def _dispatch_then_stop(raw):
+            await real_dispatch(raw)
+            c._stop = True  # exit after the last frame instead of reconnecting
+
+        monkeypatch.setattr(c, "_dispatch", _dispatch_then_stop)
+        await c._run()
+        assert connect_args[0][1]["additional_headers"] == {
+            "Authorization": "Bearer tok"
+        }
+        assert fut.result() == ("allow", "5m")
+        assert not c.connected  # finally cleared the connection state
+
+    async def test_run_connect_error_backs_off_and_reconnects(self, proxy, monkeypatch):
+        # klangkd down: the exception path logs the TYPE only, the finally
+        # fail-closes pending requests, and the loop reconnects after backoff.
+        c = self._client(proxy)
+        monkeypatch.setattr(c, "_read_token", lambda: "tok")
+        monkeypatch.setattr(proxy.consent, "DEBUG", True)
+        attempts = {"n": 0}
+
+        def _connect(*a, **k):
+            attempts["n"] += 1
+            raise OSError("klangkd down")
+
+        monkeypatch.setattr(proxy.consent.websockets, "connect", _connect)
+        sleeps = []
+
+        async def _fast_sleep(s):
+            sleeps.append(s)
+            if len(sleeps) >= 2:
+                c._stop = True  # exits via the while condition (post-backoff)
+
+        monkeypatch.setattr(proxy.consent.asyncio, "sleep", _fast_sleep)
+        await c._run()
+        assert attempts["n"] >= 2  # reconnected after the backoff sleep
+        assert sleeps[0] == 1.0  # initial backoff
+        assert sleeps[1] == 2.0  # capped exponential backoff
+
+    async def test_stop_swallows_ws_close_failure(self, proxy):
+        # A wedged close handshake must not abort the rest of teardown.
+        c = self._client(proxy)
+        ws = MagicMock()
+        ws.close = AsyncMock(side_effect=RuntimeError("wedged"))
+        c._ws = ws
+        await c.stop()  # must not raise
+        ws.close.assert_awaited_once()
+
+    async def test_stop_without_task_is_inert(self, proxy):
+        c = self._client(proxy)
+        await c.stop()  # never started -> no task to cancel, no raise
+
+    async def test_dispatch_ignores_bad_payloads(self, proxy):
+        c = self._client(proxy)
+        await c._dispatch(b"\xff\xfe not json")  # unparseable -> ignored
+        await c._dispatch(json.dumps([1, 2, 3]))  # not an object -> ignored
+        assert c._pending == {}
+
+    async def test_request_send_failure_fail_closes(self, proxy):
+        # The WS dropped between the connected check and the send -> deny at
+        # once (never hang the held SYN).
+        c = self._client(proxy)
+        c._connected.set()
+        ws = MagicMock()
+        ws.send = AsyncMock(side_effect=RuntimeError("socket gone"))
+        c._ws = ws
+        assert await c.request("evil.test", 443) == ("deny", "once")
+        assert not c._pending  # the failed request was reaped
+
+    async def test_request_timeout_fail_closes(self, proxy):
+        c = self._client(proxy, hold=0.01)
+        c._connected.set()
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        c._ws = ws
+        # No verdict frame ever arrives -> the hold timeout denies.
+        assert await c.request("evil.test", 443) == ("deny", "once")
+        assert not c._pending
+
+    def test_bump_activity_off_loop_is_noop(self, proxy):
+        # Called from a non-async context (defensive): nothing to schedule.
+        c = self._client(proxy)
+        c._connected.set()  # pretend connected so the gate is reached
+        c.bump_activity()  # no running loop -> silent return
+
+    async def test_send_activity_without_ws_is_noop(self, proxy):
+        c = self._client(proxy)
+        c._ws = None
+        await c._send_activity()  # WS dropped between gate and send -> return
+
+    async def test_send_activity_swallows_send_failure(self, proxy):
+        c = self._client(proxy)
+        ws = MagicMock()
+        ws.send = AsyncMock(side_effect=RuntimeError("socket gone"))
+        c._ws = ws
+        await c._send_activity()  # best-effort: must not raise
+
+    async def test_sampler_swallows_tick_failure(self, proxy):
+        # One bad tick (here: the bump itself raising) defers to the next
+        # interval instead of killing the sampler task.
+        import itertools
+
+        class _BoomBump:
+            def bump_activity(self):
+                raise RuntimeError("bump exploded")
+
+        counter = itertools.count()
+
+        def get_bytes():
+            return next(counter)
+
+        task = asyncio.create_task(
+            proxy._activity_sampler(_BoomBump(), get_bytes, 0.01)
+        )
+        await asyncio.sleep(0.08)  # several ticks
+        assert not task.done()  # the failure was swallowed, sampling continues
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_handle_drop_rule_bad_host_acks_not_ok(self, proxy, monkeypatch):
+        # A malformed revoke (no host / bad decision) acks ok=False so
+        # klangkd can retry rather than consider it applied.
+        c = self._client(proxy)
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        c._ws = ws
+        await c._handle_drop_rule({"type": "drop_rule", "id": "r1"})
+        sent = json.loads(ws.send.await_args.args[0])
+        assert sent == {"type": "drop_ack", "id": "r1", "ok": False}
+
+    async def test_handle_drop_rule_drop_failure_acks_not_ok(self, proxy, monkeypatch):
+        c = self._client(proxy)
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        c._ws = ws
+        monkeypatch.setattr(
+            proxy.rules,
+            "drop_for_host",
+            lambda host, decision: (_ for _ in ()).throw(RuntimeError("iptables")),
+        )
+        await c._handle_drop_rule(
+            {
+                "type": "drop_rule",
+                "id": "r2",
+                "host": "evil.test",
+                "decision": "allowed",
+            }
+        )
+        sent = json.loads(ws.send.await_args.args[0])
+        assert sent["ok"] is False
+
+    async def test_handle_drop_rule_ack_send_failure_is_silent(
+        self, proxy, monkeypatch
+    ):
+        # Best-effort ack: a dropped ack must not raise into _run's loop.
+        c = self._client(proxy)
+        ws = MagicMock()
+        ws.send = AsyncMock(side_effect=RuntimeError("socket gone"))
+        c._ws = ws
+        monkeypatch.setattr(proxy.rules, "drop_for_host", lambda h, d: set())
+        await c._handle_drop_rule(
+            {"type": "drop_rule", "id": "r3", "host": "evil.test", "decision": "denied"}
+        )
+
+
+class TestNfqueueEdgePaths:
+    """nfqueue.py branch outcomes (#2834): the transient drain failure, the
+    non-TCP classification, the expired-verdict fallthrough, the deny-side
+    session memory, and the verdict-application failure swallows."""
+
+    async def test_drain_swallows_transient_failure(self, proxy):
+        nfq = MagicMock()
+        nfq.run = MagicMock(side_effect=RuntimeError("netlink hiccup"))
+        proxy.nfqueue._drain(nfq)  # must not raise
+
+    def test_classify_non_tcp_uses_destination_granularity(self, proxy):
+        # A queued UDP packet (no SYN tuple) falls back to (dst, dport); the
+        # source end is empty (parse_syn_tuple is TCP-only).
+        payload = _ip_payload("10.2.3.4", 53, proto=17)
+        assert proxy.nfqueue._classify_packet(payload) == (
+            "",
+            0,
+            "10.2.3.4",
+            53,
+        )
+
+    def test_classify_unparseable_returns_none(self, proxy):
+        assert proxy.nfqueue._classify_packet(b"\x00" * 8) is None
+
+    async def test_expired_cached_verdict_re_prompts(self, proxy, monkeypatch):
+        # A cache entry past its TTL must NOT be reused: the SYN proceeds to
+        # a fresh consent request (the cache only covers retransmits).
+        proxy.state._VERDICT_CACHE.clear()
+        proxy.nfqueue._INFLIGHT.clear()
+        try:
+            payload = _syn_payload("172.16.0.9", 40000, "10.2.3.4", 443, 7)
+            flow = ("172.16.0.9", 40000, "10.2.3.4", 443)
+            # Expired entry: verdict time in the past.
+            proxy.state._VERDICT_CACHE[flow] = ("deny", time.time() - 1)
+            client = MagicMock()
+            client.connected = True
+            client.request = AsyncMock(return_value=("deny", "once"))
+            monkeypatch.setattr(proxy.nfqueue, "_host_for", lambda ip: "evil.test")
+            monkeypatch.setattr(
+                proxy.nfqueue, "_session_host_allows_ttl", lambda h, p: None
+            )
+            monkeypatch.setattr(
+                proxy.nfqueue, "_session_host_denies_ttl", lambda h, p: None
+            )
+            monkeypatch.setattr(proxy.nfqueue.rules, "reject", lambda *a: None)
+            pkt = MagicMock()
+            pkt.get_payload = MagicMock(return_value=payload)
+            proxy.nfqueue._cb(pkt, client)
+            for _ in range(50):
+                if pkt.drop.called:
+                    break
+                await asyncio.sleep(0.01)
+            client.request.assert_called_once()  # fresh prompt, not the cache
+            pkt.drop.assert_called_once()
+        finally:
+            proxy.state._VERDICT_CACHE.clear()
+            proxy.nfqueue._INFLIGHT.clear()
+
+    async def test_deny_session_verdict_is_remembered(self, proxy):
+        # A timed deny adds an in-session host DENY (auto-deny retries).
+        proxy.state._SESSION_HOST_DENIES.clear()
+        try:
+            proxy.nfqueue._remember_session_verdict("deny", "evil.test", 443, 300.0)
+            assert proxy.state._SESSION_HOST_DENIES
+            host, port, mode, _exp = proxy.state._SESSION_HOST_DENIES[0]
+            assert (host, port, mode) == ("evil.test", 443, proxy._EXACT)
+        finally:
+            proxy.state._SESSION_HOST_DENIES.clear()
+
+    async def test_remember_session_verdict_once_adds_nothing(self, proxy):
+        # `once` is per-connection: no host memory.
+        proxy.state._SESSION_HOST_ALLOWS.clear()
+        proxy.state._SESSION_HOST_DENIES.clear()
+        proxy.nfqueue._remember_session_verdict("allow", "ok.test", 443, None)
+        proxy.nfqueue._remember_session_verdict("deny", "evil.test", 443, None)
+        assert not proxy.state._SESSION_HOST_ALLOWS
+        assert not proxy.state._SESSION_HOST_DENIES
+
+    async def test_remember_session_verdict_non_tcp_adds_nothing(self, proxy):
+        proxy.state._SESSION_HOST_ALLOWS.clear()
+        try:
+            proxy.nfqueue._remember_session_verdict("allow", "ok.test", 0, 300.0)
+            assert not proxy.state._SESSION_HOST_ALLOWS
+        finally:
+            proxy.state._SESSION_HOST_ALLOWS.clear()
+
+    async def test_apply_verdict_allow_learn_failure_still_accepts(
+        self, proxy, monkeypatch
+    ):
+        # A transient iptables failure installing the ACCEPT must not strand
+        # the held SYN: the verdict still accepts this connection.
+        monkeypatch.setattr(
+            proxy.nfqueue.rules,
+            "allow",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("iptables")),
+        )
+        pkt = MagicMock()
+        await proxy.nfqueue._apply_verdict(
+            pkt,
+            ("s", 1, "d", 2),
+            "10.2.3.4",
+            443,
+            "allow",
+            300.0,
+            asyncio.get_running_loop(),
+        )
+        pkt.accept.assert_called_once()
+
+    async def test_apply_verdict_deny_non_tcp_just_drops(self, proxy):
+        # port 0 (non-TCP): no RST to forge, no reject rule -- plain drop.
+        pkt = MagicMock()
+        await proxy.nfqueue._apply_verdict(
+            pkt,
+            ("s", 0, "d", 0),
+            "10.2.3.4",
+            0,
+            "deny",
+            300.0,
+            asyncio.get_running_loop(),
+        )
+        pkt.drop.assert_called_once()
+
+    async def test_apply_verdict_deny_rst_failure_still_drops(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy.nfqueue.packets,
+            "_send_rst",
+            lambda payload: (_ for _ in ()).throw(RuntimeError("no raw sock")),
+        )
+        monkeypatch.setattr(proxy.nfqueue.rules, "reject", lambda *a: None)
+        pkt = MagicMock()
+        pkt.get_payload = MagicMock(return_value=b"x")
+        await proxy.nfqueue._apply_verdict(
+            pkt,
+            ("s", 1, "d", 2),
+            "10.2.3.4",
+            443,
+            "deny",
+            300.0,
+            asyncio.get_running_loop(),
+        )
+        pkt.drop.assert_called_once()
+
+    async def test_apply_verdict_deny_reject_failure_still_drops(
+        self, proxy, monkeypatch
+    ):
+        monkeypatch.setattr(proxy.nfqueue.packets, "_send_rst", lambda payload: None)
+        monkeypatch.setattr(
+            proxy.nfqueue.rules,
+            "reject",
+            lambda *a: (_ for _ in ()).throw(RuntimeError("iptables")),
+        )
+        pkt = MagicMock()
+        pkt.get_payload = MagicMock(return_value=b"x")
+        await proxy.nfqueue._apply_verdict(
+            pkt,
+            ("s", 1, "d", 2),
+            "10.2.3.4",
+            443,
+            "deny",
+            None,
+            asyncio.get_running_loop(),
+        )
+        pkt.drop.assert_called_once()
+
+    async def test_decide_and_verdict_bounds_the_cache(self, proxy, monkeypatch):
+        # A denied-flow flood must not grow the cache unbounded: past 4096
+        # entries the whole cache is dropped (allowed flows stop arriving).
+        proxy.state._VERDICT_CACHE.clear()
+        proxy.nfqueue._INFLIGHT.clear()
+        try:
+            flow = ("172.16.0.9", 40000, "10.2.3.4", 443)
+            for i in range(4100):
+                proxy.state._VERDICT_CACHE[("10.0.0.1", i, "d", 443)] = (
+                    "deny",
+                    time.time() + 60,
+                )
+            client = MagicMock()
+            client.request = AsyncMock(return_value=("deny", "once"))
+            monkeypatch.setattr(
+                proxy.nfqueue, "_remember_session_verdict", lambda *a: None
+            )
+            monkeypatch.setattr(
+                proxy.nfqueue,
+                "_apply_verdict",
+                AsyncMock(),
+            )
+            pkt = MagicMock()
+            await proxy.nfqueue._decide_and_verdict(
+                pkt, flow, "10.2.3.4", 443, "evil.test", client
+            )
+            assert len(proxy.state._VERDICT_CACHE) == 1  # cleared + this verdict
+        finally:
+            proxy.state._VERDICT_CACHE.clear()
+            proxy.nfqueue._INFLIGHT.clear()
+
+    async def test_deny_session_host_swallows_rst_failure(self, proxy, monkeypatch):
+        monkeypatch.setattr(
+            proxy.nfqueue.packets,
+            "_send_rst",
+            lambda payload: (_ for _ in ()).throw(RuntimeError("no raw sock")),
+        )
+        monkeypatch.setattr(proxy.nfqueue.rules, "reject", lambda *a: None)
+        proxy.state._VERDICT_CACHE.clear()
+        try:
+            pkt = MagicMock()
+            proxy.nfqueue._deny_session_host(
+                pkt,
+                ("s", 1, "d", 2),
+                b"payload",
+                "10.2.3.4",
+                443,
+                time.time(),
+                30.0,
+            )
+            pkt.drop.assert_called_once()
+        finally:
+            proxy.state._VERDICT_CACHE.clear()
+
+
+class TestRulesEdgePaths:
+    """rules.py branch outcomes (#2834): the best-effort iptables swallows,
+    the sweeper loop, the idempotent installs, and the startup probes."""
+
+    def test_allow_all_ports_clears_stale_rejects(self, proxy, monkeypatch):
+        # An all-ports allow supersedes per-port REJECTs; a failed remove
+        # drops one rule, not the allow.
+        proxy.rules._REJECTED.clear()
+        proxy.rules._LEARNED.clear()
+        try:
+            monkeypatch.setattr(proxy.rules, "_remove_reject", MagicMock())
+            monkeypatch.setattr(proxy.rules, "_install", lambda ip, port: None)
+            proxy.rules._REJECTED[("1.2.3.4", 443, 0)] = time.time() + 60
+            proxy.rules.allow("1.2.3.4", None, 60)
+            assert not proxy.rules._REJECTED  # superseded reject reaped
+        finally:
+            proxy.rules._REJECTED.clear()
+            proxy.rules._LEARNED.clear()
+
+    def test_allow_all_ports_swallows_reject_remove_failure(self, proxy, monkeypatch):
+        proxy.rules._REJECTED.clear()
+        proxy.rules._LEARNED.clear()
+        try:
+            monkeypatch.setattr(
+                proxy.rules,
+                "_remove_reject",
+                MagicMock(side_effect=RuntimeError("iptables")),
+            )
+            monkeypatch.setattr(proxy.rules, "_install", lambda ip, port: None)
+            proxy.rules._REJECTED[("1.2.3.4", 443, 0)] = time.time() + 60
+            proxy.rules.allow("1.2.3.4", None, 60)  # must not raise
+        finally:
+            proxy.rules._REJECTED.clear()
+            proxy.rules._LEARNED.clear()
+
+    def test_install_reject_skipped_when_rule_exists(self, proxy, monkeypatch):
+        runs = []
+        monkeypatch.setattr(
+            proxy.rules.subprocess, "run", lambda *a, **k: runs.append(a)
+        )
+        monkeypatch.setattr(
+            proxy.rules, "_reject_rule_exists", lambda ip, port, sport: True
+        )
+        proxy.rules._install_reject("1.2.3.4", 443)
+        assert not runs  # no iptables fork for an existing rule
+
+    def test_install_skipped_when_rule_exists(self, proxy, monkeypatch):
+        runs = []
+        monkeypatch.setattr(
+            proxy.rules.subprocess, "run", lambda *a, **k: runs.append(a)
+        )
+        monkeypatch.setattr(proxy.rules, "_rule_exists", lambda ip, port: True)
+        proxy.rules._install("1.2.3.4", 443)
+        assert not runs  # no iptables fork for an existing rule
+
+    def test_drop_for_host_swallows_remove_failure(self, proxy, monkeypatch):
+        proxy.rules._LEARNED.clear()
+        try:
+            proxy.rules._LEARNED["1.2.3.4"] = {
+                "expire": time.time() + 60,
+                "rule_expire": time.time() + 60,
+                "ports": {443},
+                "host": "evil.test",
+            }
+            monkeypatch.setattr(
+                proxy.rules,
+                "_remove",
+                MagicMock(side_effect=RuntimeError("iptables")),
+            )
+            targets = proxy.rules.drop_for_host("evil.test", "allowed")
+            assert "1.2.3.4" in targets
+            assert "evil.test" in targets
+            assert not proxy.rules._LEARNED  # record dropped anyway
+        finally:
+            proxy.rules._LEARNED.clear()
+
+    def test_drop_for_host_denied_swallows_reject_remove_failure(
+        self, proxy, monkeypatch
+    ):
+        proxy.rules._REJECTED.clear()
+        try:
+            proxy.rules._REJECTED[("1.2.3.4", 443, 0)] = time.time() + 60
+            monkeypatch.setattr(
+                proxy.rules,
+                "_remove_reject",
+                MagicMock(side_effect=RuntimeError("iptables")),
+            )
+            proxy.rules.drop_for_host("1.2.3.4", "denied")  # must not raise
+            assert not proxy.rules._REJECTED
+        finally:
+            proxy.rules._REJECTED.clear()
+
+    def test_sweep_swallows_remove_failure(self, proxy, monkeypatch):
+        proxy.rules._LEARNED.clear()
+        try:
+            now = time.time()
+            proxy.rules._LEARNED["1.2.3.4"] = {
+                "expire": now - 1,
+                "rule_expire": now - 1,
+                "ports": {443},
+                "host": "x.test",
+            }
+            monkeypatch.setattr(
+                proxy.rules,
+                "_remove",
+                MagicMock(side_effect=RuntimeError("iptables")),
+            )
+            assert proxy.rules.sweep_once(now) == [("1.2.3.4", {443})]
+        finally:
+            proxy.rules._LEARNED.clear()
+
+    def test_sweep_defaults_to_wall_clock(self, proxy):
+        proxy.rules._LEARNED.clear()
+        proxy.rules._REJECTED.clear()
+        assert proxy.rules.sweep_once() == []
+
+    def test_sweep_reject_remove_failure(self, proxy, monkeypatch):
+        proxy.rules._REJECTED.clear()
+        try:
+            now = time.time()
+            proxy.rules._REJECTED[("1.2.3.4", 443, 0)] = now - 1
+            monkeypatch.setattr(
+                proxy.rules,
+                "_remove_reject",
+                MagicMock(side_effect=RuntimeError("iptables")),
+            )
+            proxy.rules.sweep_once(now)  # must not raise
+            assert not proxy.rules._REJECTED
+        finally:
+            proxy.rules._REJECTED.clear()
+
+    async def test_async_sweeper_swallows_sweep_failure(self, proxy, monkeypatch):
+        # One failed sweep defers cleanup to the next tick; the task lives on.
+        monkeypatch.setattr(proxy.rules, "SWEEP_INTERVAL", 0.01)
+        monkeypatch.setattr(
+            proxy.rules,
+            "sweep_once",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("iptables")),
+        )
+        task = asyncio.create_task(proxy.rules._async_sweeper())
+        await asyncio.sleep(0.08)
+        assert not task.done()  # swallowed, kept sweeping
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    def test_fmt_ports_all_when_none_present(self, proxy):
+        assert proxy.rules._fmt_ports({None}) == "all"
+        assert proxy.rules._fmt_ports({443, None}) == "all"  # None dominates
+        assert proxy.rules._fmt_ports({443, 8443}) == "443,8443"
+
+    def test_check_mark_passes_when_mark_settable(self, proxy, monkeypatch):
+        fake = MagicMock()
+        monkeypatch.setattr(proxy.rules.socket, "socket", lambda *a, **k: fake)
+        proxy.rules.check_mark()  # must not raise
+        fake.close.assert_called_once()
+
+    def test_check_mark_exits_without_cap_net_admin(self, proxy, monkeypatch):
+        # No CAP_NET_ADMIN -> SO_MARK fails -> fail loud at startup (the
+        # proxy's upstream forwards would loop back into itself).
+        fake = MagicMock()
+        fake.setsockopt = MagicMock(side_effect=OSError(1, "Operation not permitted"))
+        monkeypatch.setattr(proxy.rules.socket, "socket", lambda *a, **k: fake)
+        with pytest.raises(SystemExit) as exc:
+            proxy.rules.check_mark()
+        assert "CAP_NET_ADMIN" in str(exc.value)
+        fake.close.assert_called_once()  # the probe socket was still closed
+
+
+class TestAllowlistEntryTtls:
+    """allowlist.py loop outcomes (#2834): empty-host guards and the
+    just-expired race the belt-and-suspenders continue exists for."""
+
+    def test_entry_ttl_empty_host_is_none(self, proxy):
+        assert proxy._session_entry_ttl([], "", 443) is None
+
+    def test_entry_ttl_skips_just_expired_entry(self, proxy):
+        # The prune ran, but the entry expired in the microseconds between
+        # its `now` and this read: skipped, not matched.
+        lst = [("h", 443, proxy._EXACT, -1.0)]
+        assert proxy._session_entry_ttl(lst, "h", 443) is None
+
+    def test_rule_cap_skips_just_expired_allow(self, proxy, monkeypatch):
+        # Same race on the cap path: an expired session allow contributes no
+        # cap (None -> the DNS TTL is used).
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [])
+        monkeypatch.setattr(
+            proxy.allowlist.time,
+            "time",
+            lambda: 100.0,
+        )
+        # Entry expires at 100.5 -- survives the prune's read at 100.0...
+        proxy.state._SESSION_HOST_ALLOWS[:] = [("h", 443, proxy._EXACT, 100.5)]
+        # ...but the cap loop's read happens "later": advance the clock.
+        clock = iter([100.0, 101.0])
+        monkeypatch.setattr(proxy.allowlist.time, "time", lambda: next(clock))
+        try:
+            assert proxy._session_allow_rule_cap("h") is None
+        finally:
+            proxy.state._SESSION_HOST_ALLOWS[:] = []
+
+
+class TestPacketHelpers:
+    """packets.py edge outcomes (#2834): non-IPv4/short payloads, the
+    odd-length checksum pad, and the RST socket probe."""
+
+    def test_ipv4_offsets_rejects_non_ipv4(self, proxy):
+        assert proxy.packets._ipv4_offsets(b"\x55" + b"\x00" * 30) is None
+
+    def test_ipv4_offsets_rejects_short_payload(self, proxy):
+        assert proxy.packets._ipv4_offsets(b"\x45\x00") is None
+
+    def test_ones_checksum_pads_odd_length(self, proxy):
+        # RFC 1071: odd data is zero-padded; 3 bytes behave as 4.
+        assert proxy.packets._ones_checksum(b"\x01\x02\x03") == (
+            proxy.packets._ones_checksum(b"\x01\x02\x03\x00")
+        )
+
+    def test_check_rst_socket_opens_hdrincl_socket(self, proxy, monkeypatch):
+        fake = MagicMock()
+        monkeypatch.setattr(proxy.packets.socket, "socket", lambda *a, **k: fake)
+        monkeypatch.setattr(proxy.packets, "_RST_SOCK", None)
+        try:
+            proxy.packets.check_rst_socket()
+            assert proxy.packets._RST_SOCK is fake
+            fake.setblocking.assert_called_once_with(False)
+        finally:
+            monkeypatch.setattr(proxy.packets, "_RST_SOCK", None)
+
+    def test_check_rst_socket_degrades_without_net_raw(
+        self, proxy, monkeypatch, capsys
+    ):
+        # Best-effort: no raw socket -> REJECT-only fast-refuse, logged.
+        def _boom(*a, **k):
+            raise OSError(1, "Operation not permitted")
+
+        monkeypatch.setattr(proxy.packets.socket, "socket", _boom)
+        monkeypatch.setattr(proxy.packets, "_RST_SOCK", None)
+        try:
+            proxy.packets.check_rst_socket()  # must not raise
+            assert "cannot open RST socket" in capsys.readouterr().out
+        finally:
+            monkeypatch.setattr(proxy.packets, "_RST_SOCK", None)
+
+
+class TestBranchArcs:
+    """The remaining single-arc gaps (#2834): each false/negative outcome of
+    a guard the mainline tests only ever take the true side of."""
+
+    # --- allowlist.parse_specs grammar edges ---
+
+    def test_parse_specs_non_digit_port_is_host_part(self, proxy, monkeypatch):
+        # "host:x" -- a non-digit port is not a port; the spec is kept
+        # verbatim as the host (an all-ports EXACT entry).
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [])
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "example.com:x")
+        assert proxy.parse_specs() == [("example.com:x", None, proxy._EXACT)]
+
+    def test_parse_specs_empty_after_strip_is_skipped(self, proxy, monkeypatch):
+        # "." reduces to the empty host (INCLUSIVE strip) -> skipped; later
+        # specs still parse.
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", ".,ok.com")
+        assert proxy.parse_specs() == [("ok.com", None, proxy._EXACT)]
+
+    def test_entry_ttl_keeps_max_across_matching_entries(self, proxy):
+        # Two matching entries: the second (smaller) remaining TTL must not
+        # lower the best -- the max is what gates on.
+        now = time.time()
+        lst = [
+            ("h", 443, proxy._EXACT, now + 100),
+            ("h", 443, proxy._EXACT, now + 50),
+        ]
+        assert 99 < proxy._session_entry_ttl(lst, "h", 443) <= 100
+
+    # --- nfqueue port-0 (non-TCP) outcomes ---
+
+    async def test_fail_fast_no_consent_non_tcp_just_drops(self, proxy, monkeypatch):
+        # No port to RST/reject (non-TCP): the plain drop still fails fast
+        # for the caller via the connection error, not a kernel retransmit.
+        pkt = MagicMock()
+        proxy.nfqueue._fail_fast_no_consent(pkt, b"payload", "10.2.3.4", 0)
+        pkt.drop.assert_called_once()
+
+    def test_apply_cached_deny_non_tcp_skips_rst(self, proxy):
+        # A cached deny for a non-TCP flow: no RST to forge, just drop.
+        pkt = MagicMock()
+        proxy.nfqueue._apply_cached_verdict(pkt, ("deny", time.time() + 60), b"p", 0)
+        pkt.drop.assert_called_once()
+
+    async def test_deny_session_host_non_tcp_just_drops(self, proxy, monkeypatch):
+        pkt = MagicMock()
+        proxy.state._VERDICT_CACHE.clear()
+        try:
+            proxy.nfqueue._deny_session_host(
+                pkt,
+                ("s", 0, "d", 0),
+                b"payload",
+                "10.2.3.4",
+                0,
+                time.time(),
+                30.0,
+            )
+            pkt.drop.assert_called_once()
+        finally:
+            proxy.state._VERDICT_CACHE.clear()
+
+    def test_cb_without_client_drops(self, proxy, monkeypatch):
+        # Pure-static mode (no consent configured): every queued SYN drops
+        # (nothing to prompt; the allow-list ACCEPTs sit above NFQUEUE).
+        pkt = MagicMock()
+        pkt.get_payload = MagicMock(
+            return_value=_syn_payload("172.16.0.9", 40000, "10.2.3.4", 443, 7)
+        )
+        proxy.nfqueue._cb(pkt, None)
+        pkt.drop.assert_called_once()
+
+    def test_remember_session_verdict_unknown_decision_adds_nothing(self, proxy):
+        # Neither allow nor deny (a future/unknown verdict token): no host
+        # memory is installed.
+        proxy.state._SESSION_HOST_ALLOWS.clear()
+        proxy.state._SESSION_HOST_DENIES.clear()
+        try:
+            proxy.nfqueue._remember_session_verdict("bogus", "h", 443, 300.0)
+            assert not proxy.state._SESSION_HOST_ALLOWS
+            assert not proxy.state._SESSION_HOST_DENIES
+        finally:
+            proxy.state._SESSION_HOST_ALLOWS.clear()
+            proxy.state._SESSION_HOST_DENIES.clear()
+
+    # --- packets IHL edge ---
+
+    def test_ipv4_offsets_rejects_bad_ihl(self, proxy):
+        # Version 4 but IHL < 5 (a malformed header): unparseable.
+        assert proxy.packets._ipv4_offsets(b"\x41" + b"\x00" * 30) is None
+
+    # --- consent client remaining arcs ---
+
+    async def test_run_debug_prints_connected_line(self, proxy, monkeypatch, capsys):
+        c = TestConsentClientRunLoop._client(proxy)
+        monkeypatch.setattr(c, "_read_token", lambda: "tok")
+        monkeypatch.setattr(proxy.consent, "DEBUG", True)
+        ws = _FakeConsentWS(frames=[])
+
+        async def _stop_after_connect():
+            c._stop = True
+
+        # Stop inside aiter exhaustion via a dispatch hook is unnecessary
+        # here: zero frames -> the async for ends at once.
+        monkeypatch.setattr(proxy.consent.websockets, "connect", lambda *a, **k: ws)
+        real_sleep = asyncio.sleep
+
+        async def _fast_sleep(s):
+            if s >= 1.0:  # the reconnect backoff, not a tick
+                c._stop = True
+            await real_sleep(0)
+
+        monkeypatch.setattr(proxy.consent.asyncio, "sleep", _fast_sleep)
+        await c._run()
+        assert "consent: connected to" in capsys.readouterr().out
+
+    async def test_run_connect_error_without_debug(self, proxy, monkeypatch, capsys):
+        # The exception path with DEBUG off: silent retry (no type leak).
+        c = TestConsentClientRunLoop._client(proxy)
+        monkeypatch.setattr(c, "_read_token", lambda: "tok")
+        monkeypatch.setattr(
+            proxy.consent.websockets,
+            "connect",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("down")),
+        )
+        real_sleep = asyncio.sleep
+        sleeps = {"n": 0}
+
+        async def _fast_sleep(s):
+            sleeps["n"] += 1
+            if sleeps["n"] >= 2:
+                c._stop = True
+            await real_sleep(0)
+
+        monkeypatch.setattr(proxy.consent.asyncio, "sleep", _fast_sleep)
+        await c._run()
+        assert "connection error" not in capsys.readouterr().out
+
+    async def test_handle_drop_rule_unknown_decision_skips_drop(
+        self, proxy, monkeypatch
+    ):
+        # A well-formed host with an unknown decision token: no drop call,
+        # no session-memory clear -- just the not-ok ack.
+        c = TestConsentClientRunLoop._client(proxy)
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        c._ws = ws
+        dropped = []
+        monkeypatch.setattr(
+            proxy.consent.rules, "drop_for_host", lambda h, d: dropped.append(h)
+        )
+        await c._handle_drop_rule(
+            {"type": "drop_rule", "id": "r4", "host": "evil.test", "decision": "bogus"}
+        )
+        assert not dropped
+        sent = json.loads(ws.send.await_args.args[0])
+        assert sent["ok"] is False
+
+    async def test_handle_drop_rule_without_ws_skips_ack(self, proxy, monkeypatch):
+        # WS down when the revoke lands: the drop still runs (it is the
+        # side effect), the ack is skipped.
+        c = TestConsentClientRunLoop._client(proxy)
+        c._ws = None
+        dropped = []
+        monkeypatch.setattr(
+            proxy.consent.rules,
+            "drop_for_host",
+            lambda h, d: dropped.append(h) or set(),
+        )
+        await c._handle_drop_rule(
+            {
+                "type": "drop_rule",
+                "id": "r5",
+                "host": "evil.test",
+                "decision": "allowed",
+            }
+        )  # must not raise on the skipped ack
+
+    async def test_handle_drop_rule_success_acks_ok(self, proxy, monkeypatch):
+        # The applied revoke acks ok=True exactly once the rules are gone.
+        c = TestConsentClientRunLoop._client(proxy)
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        c._ws = ws
+        monkeypatch.setattr(
+            proxy.consent.rules, "drop_for_host", lambda h, d: {"1.2.3.4"}
+        )
+        await c._handle_drop_rule(
+            {
+                "type": "drop_rule",
+                "id": "r6",
+                "host": "evil.test",
+                "decision": "allowed",
+            }
+        )
+        sent = json.loads(ws.send.await_args.args[0])
+        assert sent == {"type": "drop_ack", "id": "r6", "ok": True}
+
+    def test_bump_activity_off_loop_is_noop_after_gate(self, proxy):
+        # Past the connected+ws gate with no running loop: silent return
+        # (the NFQUEUE callback is sync; defensive only).
+        c = TestConsentClientRunLoop._client(proxy)
+        c._connected.set()
+        c._ws = MagicMock()  # past the first guard
+        c.bump_activity()  # no running loop -> nothing scheduled
+
+    async def test_fail_close_skips_done_futures(self, proxy):
+        # An already-resolved pending (a verdict raced the disconnect) is
+        # left alone; only the still-open one is fail-closed.
+        c = proxy.consent.SidecarConsentClient(
+            "http://klangkd/ws", "/nonexistent-token", 60.0
+        )
+        loop = asyncio.get_running_loop()
+        done = loop.create_future()
+        done.set_result(("deny", "once"))
+        open_ = loop.create_future()
+        c._pending["a"] = done
+        c._pending["b"] = open_
+        c._fail_close_pending()
+        assert open_.result() == ("deny", "once")
+        assert not c._pending
+
+    async def test_send_activity_success(self, proxy):
+        c = TestConsentClientRunLoop._client(proxy)
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        c._ws = ws
+        await c._send_activity()
+        ws.send.assert_awaited_once_with(json.dumps({"type": "activity"}))

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -4665,11 +4665,15 @@ class TestBranchArcs:
         assert sent == {"type": "drop_ack", "id": "r6", "ok": True}
 
     def test_bump_activity_off_loop_is_noop_after_gate(self, proxy):
-        # Past the connected+ws gate with no running loop: silent return
-        # (the NFQUEUE callback is sync; defensive only).
+        # Past the connected+ws+flood gates with no running loop: silent
+        # return (the NFQUEUE callback is sync; defensive only). The last
+        # activity send is forced an hour back so the flood gate passes
+        # deterministically even on a freshly-booted runner whose
+        # monotonic clock is younger than the gate window.
         c = TestConsentClientRunLoop._client(proxy)
         c._connected.set()
         c._ws = MagicMock()  # past the first guard
+        c._last_activity_send = time.monotonic() - 3600.0
         c.bump_activity()  # no running loop -> nothing scheduled
 
     async def test_fail_close_skips_done_futures(self, proxy):

--- a/uv.lock
+++ b/uv.lock
@@ -1097,8 +1097,10 @@ nfqueue = [
     { name = "netfilterqueue" },
 ]
 test = [
+    { name = "greenlet" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
@@ -1106,9 +1108,11 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "dnspython", specifier = ">=2.7,<3" },
+    { name = "greenlet", marker = "extra == 'test'", specifier = ">=3.1" },
     { name = "netfilterqueue", marker = "extra == 'nfqueue'" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.3.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "websockets", specifier = ">=12,<17" },

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,6 @@ nfqueue = [
     { name = "netfilterqueue" },
 ]
 test = [
-    { name = "greenlet" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1108,7 +1107,6 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "dnspython", specifier = ">=2.7,<3" },
-    { name = "greenlet", marker = "extra == 'test'", specifier = ">=3.1" },
     { name = "netfilterqueue", marker = "extra == 'nfqueue'" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },


### PR DESCRIPTION
Enables branch coverage in both Python 100% gates and closes every reported partial branch (#2834).

## What changed

- **`src/klangk/pyproject.toml`**: `--cov-branch` added to the addopts — the gate now requires every branch outcome exercised, not just every line.
- **`src/klangksidecar/pyproject.toml`**: the sidecar suite gains a coverage gate at all (`--cov=klangksidecar --cov-branch --cov-fail-under=100`), plus `pytest-cov` and `greenlet` in the test extra. The PID-1-only entry paths (`__main__` → `app.main`) carry documented pragmas; everything else is unit-driven.
- **Tracer swap**: Python 3.13's `sys.monitoring` cannot measure branches, so the `COVERAGE_CORE=sysmon` conftest pins are gone. Greenlet-executed code (SQLAlchemy async) is tracked instead via `concurrency = ["greenlet", "thread"]` in the repo-root pyproject's `[tool.coverage.run]` — shared by every from-root coverage run (the sidecar test extra carries greenlet for that reason). Revisit sysmon on Python 3.14, where branch events land.
- **~210 new tests** across both suites cover the 197 partial branches (klangk) and the line+branch gaps (sidecar): the WS session pumps' exit arms, the SIGHUP/overlay screen-stack guards, the consent coordinator's race arms, the sweeper early-wake ticks, the model CAS-retry path, the API update/import/export edges, the sandbox/shell/monitor CLI outcomes, and the TUI screens' dispatch fall-throughs.
- **Documented pragmas** land only on structurally unreachable arms: never-exiting retry/worker loops, the PID-1 entry, OptionInfo-normalization false sides (a directly-called typer command receives an `OptionInfo`, always truthy), and `clear()`-defensive index guards.
- **AGENTS.md** now states the gate is full branch coverage (per this PR's review); changelog entry added.

## Verification

- `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto`: **6048 passed, 100% branch coverage** (two consecutive runs).
- `pytest src/klangksidecar/tests -n auto`: **290 passed, 100% branch coverage**.
- The sweeper early-wake tests drive a scoped clock/sleep stub on `klangk.interval`'s namespace (no global `asyncio.sleep` patch — that leaked into same-worker neighbors under xdist).
