### PR TITLE
ci: add pip-audit dependency CVE scanning

### DIFF
--- a/.github/workflows/python-deps-audit.yml
+++ b/.github/workflows/python-deps-audit.yml
@@ -1,0 +1,71 @@
+name: Python Deps Audit
+
+# pip-audit the locked Python dependency resolution (#2856) — the
+# third-party layer that trufflehog (git-history secrets) and CodeQL
+# (first-party SAST) don't cover. scripts/pip-audit.sh audits exactly
+# what uv.lock pins, per shipping member: the klangk wheel closure
+# (klangkd server + klangk CLI) and the klangksidecar wheel closure,
+# extras included.
+#
+# PRs run only when the resolution can have changed (uv.lock / any
+# workspace pyproject.toml / the audit's own files). The weekly schedule
+# always runs — catching new CVEs published against an unchanged lockfile
+# is its whole point — and fails loudly on any finding not accepted in
+# scripts/pip-audit-ignore.txt.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Tuesdays 06:00 UTC (trivy scans Mondays 06:00; fuzz is daily).
+    - cron: "0 6 * * 2"
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      # Only PRs are path-filtered. Scheduled and manual runs must always
+      # audit, so the filter step is skipped for them and every step below
+      # falls through to "run" (see the || conditions).
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            deps:
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - 'src/klangk/pyproject.toml'
+              - 'src/klangksidecar/pyproject.toml'
+              - 'scripts/pip-audit.sh'
+              - 'scripts/pip-audit-ignore.txt'
+              - '.github/workflows/python-deps-audit.yml'
+
+      - uses: actions/setup-python@v6
+        if: github.event_name != 'pull_request' || steps.filter.outputs.deps == 'true'
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        if: github.event_name != 'pull_request' || steps.filter.outputs.deps == 'true'
+        # Pinned to the uv the devenv ships; a newer uv.lock revision fails
+        # loudly under --frozen until this pin is bumped to match.
+        run: pipx install uv==0.11.21
+
+      - name: Run pip-audit
+        if: github.event_name != 'pull_request' || steps.filter.outputs.deps == 'true'
+        run: bash scripts/pip-audit.sh
+
+      - name: Skip notice
+        if: github.event_name == 'pull_request' && steps.filter.outputs.deps != 'true'
+        run: echo "No dependency changes — skipping pip-audit"

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -23,9 +23,10 @@ image, the proxy).
 
 ## Security
 
-| Workflow   | File         | Description                              |
-| ---------- | ------------ | ---------------------------------------- |
-| **CodeQL** | `codeql.yml` | GitHub code scanning for vulnerabilities |
+| Workflow              | File                    | Description                                   |
+| --------------------- | ----------------------- | --------------------------------------------- |
+| **CodeQL**            | `codeql.yml`            | GitHub code scanning for vulnerabilities      |
+| **Python Deps Audit** | `python-deps-audit.yml` | pip-audit of the locked Python dependency set |
 
 ## Container images
 

--- a/scripts/pip-audit-ignore.txt
+++ b/scripts/pip-audit-ignore.txt
@@ -1,0 +1,19 @@
+# pip-audit vulnerability allowlist (#2856).
+#
+# One advisory ID per line. Every entry must carry a justification comment
+# block directly above the ID (why the finding is accepted) ending in a
+# "# Re-review: YYYY-MM-DD" date. scripts/tests/test_pip_audit.py enforces
+# the format and the expiry: when the date passes, re-review the advisory —
+# bump the date if it is still unfixable / not applicable, otherwise delete
+# the entry and fix the dependency. Anything NOT listed here fails the
+# audit (PR and scheduled runs alike).
+
+# ecdsa 0.19.2, pulled in transitively by python-jose[cryptography]
+# (klangk wheel). Minerva timing attack on ECDSA signing / keygen / ECDH.
+# No fix will ever ship: upstream declares side-channel attacks out of
+# scope for the project. Not applicable to klangk: klangkd signs its own
+# JWTs with HS256 (klangk/auth.py) and only *verifies* OIDC id_tokens
+# (RS256/ES256, klangk/oidc.py); the advisory states signature
+# verification is unaffected.
+# Re-review: 2027-08-30
+PYSEC-2026-1325

--- a/scripts/pip-audit.sh
+++ b/scripts/pip-audit.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# pip-audit the locked Python dependency resolution (#2856).
+#
+# Audits the exact resolution recorded in uv.lock — not whatever happens
+# to be installed in the current environment — for each workspace member
+# that ships to users:
+#   * klangk        — the `pip install klangk` wheel (klangkd server +
+#                     klangk CLI; its metadata also drives what the
+#                     container images install)
+#   * klangksidecar — the network-sidecar wheel (installed by its image)
+#
+# `uv export --frozen --all-extras` pins each member's full transitive
+# closure (runtime + test/nfqueue extras); `--no-deps` audits exactly
+# those pins without installing anything (netfilterqueue, for one, cannot
+# build on a stock runner). Vulnerabilities accepted permanently-or-pending
+# live in pip-audit-ignore.txt, next to this script; any finding not
+# listed there fails the run.
+#
+# Usage: devenv shell -- bash scripts/pip-audit.sh
+#   (or directly, with uv on PATH — how CI runs it)
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+# Keep in sync with the uv pin in .github/workflows/python-deps-audit.yml.
+PIP_AUDIT_VERSION=2.10.1
+ALLOWLIST="$SCRIPT_DIR/pip-audit-ignore.txt"
+
+# Expand the committed allowlist into --ignore-vuln flags: one advisory ID
+# per non-comment line (the justification lives in the # comment above it).
+ignore_flags=()
+while IFS= read -r vuln_id; do
+  ignore_flags+=(--ignore-vuln "$vuln_id")
+done < <(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST")
+
+audit_member() {
+  local label="$1" member_dir="$2"
+  local reqs
+  reqs=$(mktemp --suffix=.requirements.txt)
+  echo "=== pip-audit: $label ==="
+  (
+    cd "$member_dir"
+    uv export --frozen --all-extras --no-hashes --no-emit-workspace \
+      --format requirements-txt -o "$reqs"
+  )
+  uvx "pip-audit@$PIP_AUDIT_VERSION" -r "$reqs" --no-deps --desc on \
+    "${ignore_flags[@]}"
+}
+
+audit_member "klangk (klangkd server + klangk CLI wheel)" \
+  "$REPO_ROOT/src/klangk"
+audit_member "klangksidecar (network sidecar wheel)" \
+  "$REPO_ROOT/src/klangksidecar"

--- a/scripts/tests/test_pip_audit.py
+++ b/scripts/tests/test_pip_audit.py
@@ -1,0 +1,86 @@
+"""Contract tests for the pip-audit allowlist and runner (#2856).
+
+The allowlist (``scripts/pip-audit-ignore.txt``) is the single place where
+a pip-audit finding may be accepted; the runner (``scripts/pip-audit.sh``)
+expands it into ``--ignore-vuln`` flags. These tests pin the format so an
+entry can't silently degrade into an unjustified suppression: every ID
+needs a justification comment block above it plus an unexpired re-review
+date, and the workflow must stay free of inline ignore flags.
+"""
+
+import datetime as dt
+import re
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+ALLOWLIST = SCRIPTS_DIR / "pip-audit-ignore.txt"
+RUNNER = SCRIPTS_DIR / "pip-audit.sh"
+WORKFLOW = SCRIPTS_DIR.parent / ".github/workflows/python-deps-audit.yml"
+
+# Advisory IDs pip-audit accepts (PYSEC-*, GHSA-*, plus alias schemes).
+ID_RE = re.compile(r"^(?:GHSA|PYSEC|OSV|CVE)-[0-9A-Za-z-]+$")
+REVIEW_RE = re.compile(r"^#\s*Re-review:\s*(\d{4}-\d{2}-\d{2})\s*$")
+
+
+def parse_entries(text):
+    """Yield ``(id, comment_lines)`` per allowlist entry.
+
+    Comment lines accumulate into the block of the next ID line; a blank
+    line detaches the preceding comments (file headers, entry spacing)
+    from it. This is the same shape scripts/pip-audit.sh relies on when
+    it strips comments to build ``--ignore-vuln`` flags.
+    """
+    block = []
+    for line in text.splitlines():
+        if line.startswith("#"):
+            block.append(line)
+        elif line.strip():
+            yield line.strip(), block
+            block = []
+        else:
+            block = []
+    return
+
+
+def entries():
+    return list(parse_entries(ALLOWLIST.read_text()))
+
+
+def review_dates(comment_lines):
+    return [m.group(1) for m in map(REVIEW_RE.match, comment_lines) if m]
+
+
+def test_ids_are_well_formed_and_unique():
+    ids = [vuln_id for vuln_id, _ in entries()]
+    assert ids, "allowlist is empty — drop the file and its wiring instead"
+    for vuln_id in ids:
+        assert ID_RE.match(vuln_id), f"malformed advisory ID: {vuln_id}"
+    assert len(ids) == len(set(ids)), "duplicate advisory ID in allowlist"
+
+
+def test_every_entry_has_a_justification_comment():
+    for vuln_id, block in entries():
+        rationale = [line for line in block if not REVIEW_RE.match(line)]
+        assert rationale, f"{vuln_id}: no justification comment above the ID"
+
+
+def test_every_entry_has_an_unexpired_review_date():
+    today = dt.datetime.now(dt.timezone.utc).date()
+    for vuln_id, block in entries():
+        dates = review_dates(block)
+        assert len(dates) == 1, f"{vuln_id}: expected exactly one Re-review date"
+        when = dt.date.fromisoformat(dates[0])
+        assert when >= today, (
+            f"{vuln_id}: re-review date {when} has passed — re-review the "
+            "advisory, then bump it (or drop the entry and fix the dep)"
+        )
+
+
+def test_runner_consumes_the_allowlist():
+    """scripts/pip-audit.sh must read IDs from the file, not hardcode them."""
+    assert "pip-audit-ignore.txt" in RUNNER.read_text()
+
+
+def test_workflow_has_no_inline_ignores():
+    """Acceptance criterion (#2856): no --ignore-vuln flags in the workflow."""
+    assert "--ignore-vuln" not in WORKFLOW.read_text()


### PR DESCRIPTION
## Summary

Adds pip-audit CVE scanning of the locked Python dependency resolution (#2856) — the third-party layer that trufflehog (git-history secrets) and CodeQL (first-party SAST) don't cover. A compromised or vulnerable transitive dep ships straight into users' environments via `pip install klangk` / the sidecar wheel, and the same metadata drives what the container images install.

**`scripts/pip-audit.sh`** audits exactly what `uv.lock` pins, per shipping member: `uv export --frozen --all-extras --no-emit-workspace` produces the full transitive closure (runtime + `test`/`nfqueue` extras) for the `klangk` wheel (klangkd server + CLI) and the `klangksidecar` wheel, then `uvx pip-audit@2.10.1 --no-deps` audits those pins — nothing is installed, so `netfilterqueue` never has to build on the runner.

**`python-deps-audit.yml`**: weekly schedule (Tuesdays 06:00 UTC) + `workflow_dispatch` + PR trigger path-filtered to `uv.lock` / workspace `pyproject.toml`s / the audit's own files via the existing `dorny/paths-filter` pattern. Scheduled and manual runs skip the filter entirely — catching new CVEs against an unchanged lockfile is their whole point — and every run fails loudly on any finding not in the allowlist.

**`scripts/pip-audit-ignore.txt`**: the committed allowlist (no inline `--ignore-vuln` flags anywhere in the workflow). One advisory ID per line, each with a justification comment and an unexpired re-review date. Current triage of `main`: exactly one finding, `PYSEC-2026-1325` (ecdsa Minerva timing attack, via python-jose) — no fix will ever ship (upstream declares side channels out of scope), and it's not applicable here: klangkd signs JWTs with HS256 and only *verifies* OIDC id_tokens, which the advisory states is unaffected.

`scripts/tests/test_pip_audit.py` pins the allowlist contract (well-formed unique IDs, justification per ID, unexpired review dates, no inline ignores in the workflow), so an entry can't silently degrade into an unjustified suppression — and a passing review date fails the suite until the entry is re-reviewed.

Verified locally: `bash scripts/pip-audit.sh` exits 0 on current `main` (klangk slice: "No known vulnerabilities found, 1 ignored"; sidecar slice clean), plus shfmt/shellcheck/yamllint/actionlint/ruff/xenon/prettier and the full `scripts/tests` suite (88 passed). No changelog entry (CI/dev tooling, #2843 precedent); `docs/development/ci.md` Security table updated.

Closes #2856.
