### PR TITLE
build(devenv): pull Flutter 3.47.0 from nixpkgs-unstable

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -70,11 +70,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -2,9 +2,16 @@
   pkgs,
   config,
   lib,
+  inputs,
   ...
 }:
 let
+  # Flutter 3.47 from unstable (#2869): the pinned 26.05 channel ships
+  # 3.41.9, too old for mcp_toolkit (>= 3.44) that the flutter-mcp-toolkit
+  # integration (#2868) depends on. Pulled as a self-contained closure
+  # (flutter + its dart SDK); the rest of the toolchain stays on 26.05.
+  flutterUnstable =
+    inputs.nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system}.flutter;
   # klangkd binds a UDS and owns the Caddy reverse proxy as a child
   # (#1396, #1642); the old two-process layout (uvicorn + scripts/nginx.sh)
   # is collapsed into this single entry. Dev config lives in klangkd.yaml
@@ -101,7 +108,7 @@ in
       coreutils # GNU du -b + stat -f -c %T (macOS BSD lacks both)
       docker-client
       expect
-      flutter
+      flutterUnstable
       git # "error: Failed to find git" during devenv:git-hooks:install
       gzip
       gnutar

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,5 +6,10 @@ inputs:
         follows: nixpkgs
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-26.05
+  # Sole source of the Flutter toolchain (#2869): 26.05 carries 3.41.9,
+  # which is too old for mcp_toolkit (>= 3.44, #2868). Everything else
+  # stays on the stable channel.
+  nixpkgs-unstable:
+    url: github:NixOS/nixpkgs/nixos-unstable
 allow_unfree: true
 reload: false

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1189,6 +1189,12 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **The devenv Flutter toolchain is now 3.47.0 (#2869).** Flutter (and its
+  Dart SDK) come from a pinned `nixpkgs-unstable` input while the rest of
+  the toolchain stays on `nixos-26.05`. Contributors get Flutter 3.47 /
+  Dart 3.13, clearing the Flutter >= 3.44 requirement for the
+  flutter-mcp-toolkit integration (#2868).
+
 - **Host image base is `python:3.14-slim` (#2844).** The host and FIPS
   host container images now run CPython 3.14 (digest-pinned, OpenSSL
   3.5). Workspaces are unaffected; operators should rebuild the host

--- a/scripts/flutterbuildweb.sh
+++ b/scripts/flutterbuildweb.sh
@@ -32,7 +32,8 @@ fi
 "${KLANGK_PYTHON}" scripts/import_dart_features.py --payload-dir "$PAYLOAD_DIR"
 
 # flterm is forked (github.com/runyaga/flterm) to build on the nix Flutter
-# (3.41 / Dart 3.11) -- upstream 0.0.3 needs Dart 3.12 for private-named
+# (forked at 3.41 / Dart 3.11; the toolchain is now 3.47 / Dart 3.13, and
+# the fork still builds) -- upstream 0.0.3 needed Dart 3.12 for private-named
 # parameters; the fork removes that. No host Flutter required. KLANGKBUILD_WEB_FLUTTER
 # can still override the binary; defaults to `flutter` on PATH (nix toolchain).
 FLUTTER="${KLANGKBUILD_WEB_FLUTTER:-flutter}"

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -215,6 +215,9 @@ class ConsentRule {
   final double? decidedAt;
   final String? decidedBy;
 
+  /// True when this rule records an allow verdict ([kDecisionAllowed]).
+  bool get isAllowed => decision == kDecisionAllowed;
+
   const ConsentRule({
     required this.id,
     required this.destHost,

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -147,13 +147,15 @@ class _ConsentRulesPanelState extends State<ConsentRulesPanel> {
   }
 
   String _describe(ConsentRule rule) {
-    final host = rule.destPort != null
-        ? '${rule.destHost}:${rule.destPort}'
-        : rule.destHost;
-    final verb = rule.decision == kDecisionAllowed ? 'allow' : 'deny';
-    final proc = rule.processName == null || rule.processName!.isEmpty
-        ? ''
-        : ' (${rule.processName})';
+    var host = rule.destHost;
+    if (rule.destPort != null) {
+      host = '$host:${rule.destPort}';
+    }
+    var proc = '';
+    if (rule.processName != null && rule.processName!.isNotEmpty) {
+      proc = ' (${rule.processName})';
+    }
+    final verb = rule.isAllowed ? 'allow' : 'deny';
     return 'Remove the $verb rule for $host$proc? It will be re-consented on the next request.';
   }
 

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -304,6 +304,35 @@ void main() {
       svc.dispose();
     });
 
+    testWidgets('revoke prompt for a denied rule says deny', (
+      tester,
+    ) async {
+      final ch = _FakeChannel();
+      final svc = _serviceWithChannel(ch);
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(
+        _rulesFrame(
+          denied: [_ruleJson(id: 'v4', host: 'd.io', decision: 'denied')],
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('revoke-v4')));
+      await tester.pump();
+      await tester.pump();
+      expect(
+        find.textContaining('Remove the deny rule for d.io:443'),
+        findsOneWidget,
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Revoke'));
+      await tester.pump();
+      expect(jsonDecode(ch.sent.last as String), {
+        'type': 'revoke',
+        'request_id': 'v4',
+      });
+      svc.dispose();
+    });
+
     testWidgets('cancel does not send a revoke', (tester) async {
       final ch = _FakeChannel();
       final svc = _serviceWithChannel(ch);

--- a/src/frontend/test/server_schedule_banner_test.dart
+++ b/src/frontend/test/server_schedule_banner_test.dart
@@ -86,6 +86,20 @@ void main() {
     expect(RegExp(r'\b1h \d+m\b').hasMatch(text), isTrue);
   });
 
+  testWidgets('a past-due action shows happening now', (tester) async {
+    final fireAt = DateTime.now().toUtc().subtract(const Duration(seconds: 10));
+    await tester.pumpWidget(
+      _wrap(
+        _clientWithSchedules([
+          {'action': 'stop', 'fire_at': fireAt.toIso8601String()},
+        ]),
+      ),
+    );
+    await tester.pump();
+    final text = tester.widget<Text>(find.byType(Text).first).data!;
+    expect(text, contains('server stop happening now'));
+  });
+
   testWidgets('picks the soonest when several are pending', (tester) async {
     final later = DateTime.now().toUtc().add(const Duration(hours: 5));
     final sooner = DateTime.now().toUtc().add(const Duration(minutes: 10));


### PR DESCRIPTION
## Summary

Upgrade the devenv Flutter toolchain from 3.41.9 (nixos-26.05) to **3.47.0** by overlaying only `flutter` (and its Dart closure) from a pinned `nixpkgs-unstable` input. Everything else stays on the stable channel. This clears the Flutter >= 3.44 requirement of `mcp_toolkit` for the flutter-mcp-toolkit integration (#2868).

Closes #2869.

## Changes

- `devenv.yaml` / `devenv.lock`: new `nixpkgs-unstable` input, pinned to the rev evaluated in the issue (`83199d0d`, Flutter 3.47.0 / Dart 3.13.0).
- `devenv.nix`: `flutterUnstable` in `packages` instead of the channel flutter.
- `ConsentRulesPanel._describe` rewritten with if-blocks (behavior identical, verified by tests) — see below.
- `ConsentRule.isAllowed` getter added; deny-arm of the revoke prompt verb now explicitly tested.
- New test: past-due schedule banner shows "happening now" (`server_schedule_banner_test.dart`).
- Stale flterm fork comment in `flutterbuildweb.sh` updated (fork still builds on Dart 3.13).
- Changelog entry under `[Unreleased] → Changed`.

## Why the `_describe` rewrite

Dart 3.13's coverage instrumentation binds one source position in `_describe` to a counter that never increments (a dart-lang/sdk#53349-class mis-mapping — the line executes, the reported hits stay 0). Six source shapes were tried; the dead position always landed on an executable ternary line, failing the 100% gate. The if-block form produces a position table with no dead counter on an executable line. The same instrumentation change also exposed two genuinely untested branches, which gained tests.

## Verification

- `flutter --version` in the shell: 3.47.0 / Dart 3.13.0 / DevTools 2.60.0
- `test-frontend`: all tests pass, **100.00%** coverage (gate reached)
- `klangk:flutter-build` (web release build on the new SDK): succeeds
- `test-push`: selected areas green
