### PR TITLE
feat(dev): integrate flutter-mcp-toolkit (fmtk) for agent inspection of the frontend

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -28,15 +28,14 @@ jobs:
               - 'scripts/lcov-report.py'
               - '.github/workflows/frontend-tests.yml'
 
-      # Pin Flutter to the nixpkgs version (devenv ships 3.41.9) so CI and
-      # local dev run the same SDK. A stable bump to 3.47.0 changed the
-      # coverage tool's multi-line ternary attribution and broke the 100%
-      # gate (#2378); pinning here keeps them in lockstep. Bump alongside
-      # the nixpkgs Flutter when upgrading.
+      # Pin Flutter to the nixpkgs-unstable version (devenv ships 3.47.0,
+      # #2869) so CI and local runs stay in lockstep — the local coverage
+      # tooling's multi-line ternary attribution and the 100% gate depend on
+      # it (#2378). Bump alongside the nixpkgs Flutter when upgrading.
       - uses: subosito/flutter-action@v2
         if: steps.filter.outputs.frontend == 'true'
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.47.0"
           cache: true
 
       - name: Create stub klangk_features package

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ output.log
 
 # Fuzz test output
 fuzz-server.log
+
+# flutter-mcp-toolkit CLI state (#2868)
+.flutter_mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,6 +384,48 @@ Nothing to do in `docs/changes.md` itself — the `[Unreleased]` heading you cre
 at cut time is already in place for the next cycle's entries. Just start adding new
 entries under it.
 
+## Inspecting the running frontend (`fmtk` / flutter-mcp-toolkit)
+
+The devenv ships the `fmtk` CLI (flutter-mcp-toolkit, a pinned release
+derivation in `devenv.nix`, #2868). It lets an agent inspect and drive a
+debug run of the frontend: semantic snapshots, widget details, taps and
+typing, hot reload, app logs and errors. pi has no MCP client, so CLI mode
+is the interface — there is no MCP server wiring to maintain.
+
+Workflow:
+
+Run the frontend in debug on a real browser device (not `-d web-server`,
+which never exposes a VM service without the debug Chrome extension):
+
+```bash
+devenv --quiet shell -- sh -c 'cd src/frontend && flutter run --debug -d chrome --web-port 8124'
+```
+
+Note the `A Dart VM Service ... is available at:` URL from its output and use
+it verbatim as a `ws://` URI (append `/ws`). Then, from the repo root (fmtk
+keeps state in `.flutter_mcp/`, gitignored):
+
+```bash
+URI=ws://127.0.0.1:PORT/TOKEN/ws
+devenv --quiet -O dotenv.enable:bool false shell -- fmtk doctor --vm-service-uri $URI
+devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec --name semantic_snapshot --vm-service-uri $URI --args '{}'
+devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec --name tap_widget --vm-service-uri $URI --args '{"ref": "s_1"}'
+devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec --name get_recent_logs --vm-service-uri $URI --args '{}'
+```
+
+Snapshot nodes carry `ref`s (`s_0`, `s_1`, …) usable in `tap_widget`,
+`enter_text`, `fill_form`, and friends. `fmtk capabilities` lists all
+commands; `fmtk schema --name <command>` prints each command's arg schema.
+`get_app_errors`, `hot_reload_flutter`, and `evaluate_dart_expression` are
+the other high-signal ones.
+
+The app side is the debug-only `mcp_toolkit` bootstrap in
+`src/frontend/lib/main.dart` — it registers the `ext.mcp.toolkit.*` VM
+service extensions, is const-folded out of release builds, and is inert in
+widget tests. Pixel screenshots on web additionally ride Chrome CDP
+(fmtk auto-discovers it; `--web-browser-debugging-port` overrides);
+semantic snapshots and interactions need no CDP.
+
 ## Demo video recording
 
 Before **every** full recording run (CLI + browser scenes, or a re-run of just

--- a/devenv.nix
+++ b/devenv.nix
@@ -12,6 +12,38 @@ let
   # (flutter + its dart SDK); the rest of the toolchain stays on 26.05.
   flutterUnstable =
     inputs.nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system}.flutter;
+  # flutter-mcp-toolkit CLI (`fmtk`, #2868): lets agents inspect and drive
+  # a debug-run of the frontend (semantic snapshots, taps/typing, hot
+  # reload, logs). Not in nixpkgs and not on pub.dev — upstream ships
+  # prebuilt Dart AOT binaries via GitHub Releases only. Pinned here as a
+  # fixed-hash fetchurl derivation; plain glibc ELF on Linux (no patchelf
+  # needed) and ad-hoc Mach-O on macOS. See AGENTS.md "Inspecting the
+  # running frontend" for the workflow.
+  flutterMcpToolkitVersion = "5.1.0";
+  flutterMcpToolkit = pkgs.stdenv.mkDerivation {
+    pname = "flutter-mcp-toolkit";
+    version = flutterMcpToolkitVersion;
+    src = pkgs.fetchurl {
+      url = "https://github.com/Arenukvern/mcp_flutter/releases/download/v${flutterMcpToolkitVersion}/flutter_mcp_${flutterMcpToolkitVersion}_${
+        if pkgs.stdenv.isDarwin then "darwin-arm64" else "linux-x64"
+      }.tar.gz";
+      hash =
+        if pkgs.stdenv.isDarwin then
+          "sha256-L8QhIYwJZz/X+lnQYY6ftW2qQD66cWGoutwdY0wGZaI="
+        else
+          "sha256-+3sC3DaXvWxgqvFpaqKwr1rS19JcCBPZ8zNC5gK8ko0=";
+    };
+    sourceRoot = ".";
+    dontConfigure = true;
+    dontBuild = true;
+    # Dart AOT executables are ELF + an appended snapshot blob; strip would
+    # truncate the snapshot and leave a bare dartaotruntime ("not an AOT
+    # snapshot" on every invocation).
+    dontStrip = true;
+    installPhase = ''
+      install -Dm555 -t $out/bin flutter_mcp_${flutterMcpToolkitVersion}_*/bin/*
+    '';
+  };
   # klangkd binds a UDS and owns the Caddy reverse proxy as a child
   # (#1396, #1642); the old two-process layout (uvicorn + scripts/nginx.sh)
   # is collapsed into this single entry. Dev config lives in klangkd.yaml
@@ -108,6 +140,7 @@ in
       coreutils # GNU du -b + stat -f -c %T (macOS BSD lacks both)
       docker-client
       expect
+      flutterMcpToolkit
       flutterUnstable
       git # "error: Failed to find git" during devenv:git-hooks:install
       gzip

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -265,6 +265,13 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **`fmtk` — flutter-mcp-toolkit CLI in the devenv shell (#2868).** Agents
+  can inspect and drive a debug run of the frontend (semantic snapshots,
+  widget refs, taps/typing, hot reload, app logs) via the pinned
+  `flutter-mcp-toolkit` release binary. The frontend registers the debug-only
+  `mcp_toolkit` VM service extensions (release builds are unaffected). See
+  AGENTS.md "Inspecting the running frontend" for the workflow.
+
 - **Admission control: `KLANGKD_ADMISSION_MEMORY_ENABLED`,
   `KLANGKD_ADMISSION_MEMORY_MARGIN` (#2525).** Opt-in start-time
   host-capacity check: before a workspace container is created,

--- a/src/frontend/lib/main.dart
+++ b/src/frontend/lib/main.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:flterm/flterm.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, kReleaseMode;
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import 'package:klangk_features/klangk_features.dart';
+import 'package:mcp_toolkit/mcp_toolkit.dart';
 import 'package:provider/provider.dart';
 import 'app.dart';
 import 'auth/auth_service.dart';
@@ -16,6 +17,19 @@ import 'utils/web_helpers_stub.dart'
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // flutter-mcp-toolkit debug bridge (#2868): registers the ext.mcp.toolkit.*
+  // VM service extensions that the `fmtk` CLI (in the devenv shell) uses to
+  // inspect and drive this app during development — semantic snapshots,
+  // widget details, taps/typing, hot reload, logs. Const-folded out of
+  // release builds (kReleaseMode), and inert in widget tests: the extensions
+  // idle until an MCP client calls them. See AGENTS.md "Inspecting the
+  // running frontend".
+  if (!kReleaseMode) {
+    MCPToolkitBinding.instance
+      ..initialize()
+      ..initializeFlutterToolkit();
+  }
 
   // Register features early so their routes are available when GoRouter
   // is created (before any workspace page is opened). Active-set filter

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
     git:
       url: https://github.com/runyaga/sheetifye.git
       ref: klangk-compat
+  mcp_toolkit: ^5.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Integrate [flutter-mcp-toolkit](https://github.com/Arenukvern/mcp_flutter) so agents can inspect and drive a debug run of the frontend: semantic snapshots with widget refs, taps/typing, hot reload, app logs and errors.

Closes #2868.

## Route

The issue's original plan (podman GHCR container) turned out to ship **only the MCP stdio server** — not the `fmtk` CLI — and pi has no MCP client. The working route is the **GitHub release CLI**, pinned as a `fetchurl` derivation in `devenv.nix` (not in nixpkgs, not on pub.dev):

- `flutter-mcp-toolkit` v5.1.0, linux-x64 + darwin-arm64 tarballs, fixed hashes.
- `dontStrip = true` is load-bearing: Dart AOT executables are ELF + appended snapshot; `strip` truncates the snapshot and leaves a bare `dartaotruntime` that fails every command.

## Changes

- `devenv.nix`: `flutterMcpToolkit` derivation; `fmtk` / `flutter-mcp-toolkit` on the shell PATH.
- `src/frontend/lib/main.dart`: debug-only `mcp_toolkit` bootstrap registering the `ext.mcp.toolkit.*` VM service extensions. Const-folded out of release — **zero** toolkit references in the shipped `main.dart.js` — and inert in widget tests.
- `src/frontend/pubspec.yaml`: `mcp_toolkit: ^5.1.0` (needs the Flutter 3.47 toolchain from #2869/#2870).
- `AGENTS.md`: "Inspecting the running frontend" — full workflow (`flutter run --debug -d chrome`, VM service URI, `fmtk exec` recipes; notes `-d web-server` never exposes a VM service).
- `.gitignore`: `.flutter_mcp/` (fmtk state).
- Changelog entry under `[Unreleased] → Added`.

## Verification

End to end against a live `flutter run --debug -d chrome`:

- `fmtk exec get_extension_rpcs` → all `ext.mcp.toolkit.*` extensions registered (tap, enter_text, semantic_snapshot, navigate, hot_reload, logs, errors).
- `fmtk exec semantic_snapshot` → live widget tree with refs (`Klangk`, `Log In`, bounds, centers).
- `fmtk exec get_recent_logs` / `get_app_errors` → work.
- `fmtk doctor` → dart/flutter SDK checks pass.
- Frontend suite: **100.00%** coverage (bridge invisible to the gate; `main.dart` is not coverage-tracked).
- `klangk:flutter-build` web release build: succeeds; `grep -c ext.mcp.toolkit main.dart.js` → 0.
- `test-push`: green.
