### PR TITLE
feat(api): permission-gate /files/content (text reader endpoint) (#2713)

### DIFF
--- a/customize/custom/hooks/workspace_created.py
+++ b/customize/custom/hooks/workspace_created.py
@@ -66,11 +66,13 @@ async def on_workspace_created(workspace, actor):
     workspace["egress_mode"] = "static"
 
     # --- Example 2: ACL rewrite ---------------------------------------
-    # Browse-without-download posture: keep the coders and collaborators
-    # groups' ``files`` grant (browse/read in the file viewer) but drop
-    # ``files-download`` and ``files-write`` (edit/uncomment to match your
-    # deployment's stance). Entries whose ``principal`` is the group name
-    # identify the role groups — they are named ``<role>-<workspace id>``.
+    # Browse-only posture: keep the coders and collaborators groups'
+    # ``files`` grant (browse listings in the file viewer) but drop
+    # ``files-download`` and ``files-write`` — without ``files-download``
+    # no file body can be read or downloaded (edit/uncomment to match
+    # your deployment's stance). Entries whose ``principal`` is the
+    # group name identify the role groups — they are named
+    # ``<role>-<workspace id>``.
     entries = await workspace.acl_entries()
     kept = [
         entry

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -254,14 +254,16 @@ sync` report a clear permission-denied error.
   message (e.g. `Failed to create window`); the full exception detail is
   logged server-side instead.
 
-- **OIDC `cli_redirect` userinfo bypass (#2571).** The localhost-only
-  guard on the CLI login redirect used prefix matching, so a crafted
-  `cli_redirect` like `http://localhost:1@attacker.example/` passed the
-  check while actually routing to the attacker's host — a victim
-  completing a normal IdP login had their session token redirected to
-  it. The target is now parsed and must be plain `http` to `localhost`
-  or `127.0.0.1` with a port and no userinfo; anything else falls back to
-  the web flow.
+- **`/files/content` now requires `files-download` (#2713).** The file
+  viewer's text-reader endpoint
+  (`GET /api/v1/workspaces/{id}/files/content`) is gated by the
+  `files-download` permission like `/files/download` (#2705), closing
+  the remaining scripted bulk-read avenue for members with `files`
+  alone. Operators who relied on text viewing without download must
+  also grant `files-download` (or withhold `files` entirely). The web
+  file viewer degrades gracefully: listings and metadata stay visible
+  and the content pane reports the denial. See
+  [ACLs](../reference/acl.md).
 
 ### Added
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -254,6 +254,15 @@ sync` report a clear permission-denied error.
   message (e.g. `Failed to create window`); the full exception detail is
   logged server-side instead.
 
+- **OIDC `cli_redirect` userinfo bypass (#2571).** The localhost-only
+  guard on the CLI login redirect used prefix matching, so a crafted
+  `cli_redirect` like `http://localhost:1@attacker.example/` passed the
+  check while actually routing to the attacker's host — a victim
+  completing a normal IdP login had their session token redirected to
+  it. The target is now parsed and must be plain `http` to `localhost`
+  or `127.0.0.1` with a port and no userinfo; anything else falls back to
+  the web flow.
+
 - **`/files/content` now requires `files-download` (#2713).** The file
   viewer's text-reader endpoint
   (`GET /api/v1/workspaces/{id}/files/content`) is gated by the
@@ -341,8 +350,9 @@ create`/`edit --classification-banner`, and the create/edit UIs; the
   roles) grant both permissions; a schema migration mirrors existing
   `files` grants so current behavior is unchanged. Without the
   permission the file viewer hides its download affordances and binary
-  renderers (image, PDF, video, spreadsheet) cannot fetch bytes — text
-  viewing still works. The CLI/TUI expose no file-download affordances.
+  renderers (image, PDF, video, spreadsheet) cannot fetch bytes — and
+  since #2713 the text reader (`/files/content`) requires the
+  permission too. The CLI/TUI expose no file-download affordances.
 
 - **`KLANGKD_WORKSPACE_CREATED_HOOK` (#2762).** New customize-dir hook:
   a deployment-local Python file (point the env var at it, like

--- a/docs/deployment/customizing.md
+++ b/docs/deployment/customizing.md
@@ -217,7 +217,7 @@ Both sync and async hook functions are supported. ACL rewrites require the `asyn
 
 **Failure semantics: log-and-continue.** The hook is a mutation extension point, not a gate — if it raises, the workspace still exists and the create response is returned normally. Errors are logged as a WARNING with the hook source, workspace id, and the exception, so partial effects stay visible. A missing hook file or a missing/uncallable `on_workspace_created` export _is_ a startup failure (same as a broken login hook).
 
-The sample hook's example: force every new workspace to `egress_mode: static`, and keep the coders/collaborators role groups' `files` grant while dropping `files-download` and `files-write` for a browse-without-download posture. Adapt it to your deployment's stance.
+The sample hook's example: force every new workspace to `egress_mode: static`, and keep the coders/collaborators role groups' `files` grant while dropping `files-download` and `files-write` for a browse-only posture (listings and metadata stay visible; no file body can be read or downloaded). Adapt it to your deployment's stance.
 
 ### OIDC Authentication
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -100,8 +100,8 @@ When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/w
 | `view`           | Can see the workspace exists                                                                                                    |
 | `monitor`        | Can observe health/status: `GET /workspaces/{id}/status` and the `container_status` / `service_health` WebSocket frames (#2783) |
 | `terminal`       | Can open a terminal / exec commands                                                                                             |
-| `files`          | Can browse/read files                                                                                                           |
-| `files-download` | Can download raw bytes via `/files/download` (needs `files` too)                                                                |
+| `files`          | Can browse file listings (metadata); reading file bodies additionally needs `files-download`                                    |
+| `files-download` | Can fetch file bytes: `/files/download` (raw stream/tar) and `/files/content` (text reader) — needs `files` too                 |
 | `files-write`    | Can mutate files: upload, rename, delete (needs `files` too)                                                                    |
 | `exec-and-sync`  | Can run one-shot commands (`klangk exec`) and sync (`klangk sync`) against the workspace                                        |
 | `edit`           | Can change workspace settings (name, image, command, mounts, env)                                                               |
@@ -110,11 +110,13 @@ When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/w
 | `export`         | Can export the workspace as a `.tar.gz` archive (#2707)                                                                         |
 | `*`              | All of the above                                                                                                                |
 
-Withholding `files-download` keeps the in-app file viewer working for text
-files (read via `/files/content`) but hides every download affordance and
-returns 403 from `/files/download`. Binary renderers (image, PDF, video,
-spreadsheet) fetch raw bytes through the download endpoint, so they cannot
-render without it.
+Withholding `files-download` hides every download affordance and returns
+403 from both byte-moving endpoints: `/files/download` (raw stream or
+tar.gz) and `/files/content` (the viewer's text reader, #2713). The file
+list itself keeps working — names, sizes, and mtimes stay visible — but
+no file body can be read: text renderers show a permission-denied state
+and binary renderers (image, PDF, video, spreadsheet), which fetch raw
+bytes through the download endpoint, cannot render.
 
 Withholding `files-write` disables every mutating route — upload
 (`/files/upload`), rename (`/files/rename`), and delete (`DELETE
@@ -124,12 +126,14 @@ drag-and-drop zone or upload hints, no Rename/Delete in the context menu,
 and text-editor renderers go read-only (their Save uploads through that
 endpoint).
 
-Note the limit of the download gate: it blocks byte-perfect, unbounded export
-(any file size, whole directories as tar.gz), **not** content access.
-`files` alone still lets a member read any file up to 1 MB via
-`/files/content` — text files intact, binary files mostly (the bytes are
-decoded lossily). To cut a member off from workspace content entirely,
-withhold `files` as well.
+The download gate covers every endpoint that moves file bytes out of the
+workspace — byte-perfect, unbounded export (any file size, whole
+directories as tar.gz) via `/files/download`, and lossy text reads (up to
+1 MB per file) via `/files/content`. A member with `files` but not
+`files-download` can browse listings and metadata only. To grant viewing
+without bulk export there is no longer a middle setting: grant both
+`files` + `files-download` (viewer fully works) or withhold `files`
+(browsing itself is denied).
 
 `export` is a workspace permission checked on `/workspaces/{id}`: the owner's wildcard ACE and the seeded `owners-<id>` role group both cover it, so owners can export their own workspaces without any extra grant, and a **Deny** `export` ACE for **Everyone** on the workspace resource (positioned ahead of the wildcards) revokes it per workspace. Admins do **not** get export implicitly — they must be an owner or hold an explicit grant. See [Export & Import](../features/export-import.md#export).
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -120,16 +120,17 @@ bytes through the download endpoint, cannot render.
 
 Withholding `files-write` disables every mutating route — upload
 (`/files/upload`), rename (`/files/rename`), and delete (`DELETE
-/files`) — so a `files`-only member can browse and read but not modify
-the workspace. In the file viewer the matching affordances disappear: no
+/files`) — so a `files`-only member can browse listings but not read
+file bodies or modify the workspace. In the file viewer the matching affordances disappear: no
 drag-and-drop zone or upload hints, no Rename/Delete in the context menu,
 and text-editor renderers go read-only (their Save uploads through that
 endpoint).
 
-The download gate covers every endpoint that moves file bytes out of the
-workspace — byte-perfect, unbounded export (any file size, whole
-directories as tar.gz) via `/files/download`, and lossy text reads (up to
-1 MB per file) via `/files/content`. A member with `files` but not
+The download gate covers every files endpoint that moves file bytes
+out of the workspace — byte-perfect, unbounded export (any file size,
+whole directories as tar.gz) via `/files/download`, and lossy text
+reads (up to 1 MB per file) via `/files/content`. A member with `files`
+but not
 `files-download` can browse listings and metadata only. To grant viewing
 without bulk export there is no longer a middle setting: grant both
 `files` + `files-download` (viewer fully works) or withhold `files`

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -717,8 +717,9 @@ No request body.
 Read the contents of a file inside the workspace container. Requires a
 running container (returns 409 if stopped).
 
-**Auth:** JWT required. User must have `files` permission on
-`/workspaces/{id}`. Query param: `path` (absolute container path).
+**Auth:** JWT required. User must have both `files` and `files-download`
+permissions on `/workspaces/{id}` (#2713). Query param: `path` (absolute
+container path).
 
 No request body.
 

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -55,10 +55,12 @@ class FileViewerPanel extends StatefulWidget {
   final FileRendererRegistry? registry;
 
   /// Whether the user holds the `files-download` permission. When false,
-  /// download affordances are hidden and raw-byte fetches fail fast
-  /// (#2705) — the viewer itself keeps working for text via
-  /// `/files/content`. Required (no default) so a construction site can
-  /// never accidentally fail open to download.
+  /// download affordances are hidden and every content fetch fails fast
+  /// (#2705, #2713) — the text reader (`/files/content`) and the binary
+  /// byte path (`/files/download`) are both gated by that permission, so
+  /// the file list stays browsable but no file body can be read.
+  /// Required (no default) so a construction site can never accidentally
+  /// fail open to download.
   final bool canDownload;
 
   /// Whether the user holds the `files-write` permission. When false,
@@ -247,6 +249,11 @@ class FileViewerPanelState extends State<FileViewerPanel> {
   /// Reads a file's decoded text via the `/files/content` endpoint. Injected
   /// into [RenderableFile.readText] for the renderer to call lazily.
   Future<String> _readFileText(String path) async {
+    if (!widget.canDownload) {
+      // The `files-download` permission is absent (#2713) — the text
+      // reader endpoint is gated like the download endpoint.
+      throw Exception('Download not permitted');
+    }
     final response = await _client.get(
       Uri.parse(
         '$_baseUrl/api/v1/workspaces/${widget.workspaceId}/files/content?path=${Uri.encodeComponent(path)}',

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -1977,6 +1977,120 @@ void main() {
     });
   });
 
+  group('FileViewerPanel content permission (#2713)', () {
+    Future<_MockWsClient> pump(
+      WidgetTester tester, {
+      bool canDownload = false,
+      GlobalKey<FileViewerPanelState>? key,
+    }) async {
+      testHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/files/content')) {
+          return http.Response(
+            jsonEncode({'content': 'print("hi")'}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/files')) {
+          return http.Response(
+            jsonEncode([
+              {
+                'name': 'notes.py',
+                'path': '/home/tester/notes.py',
+                'is_dir': false,
+                'size': 42,
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      final client = _MockWsClient();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: buildPanel(
+                wsClient: client,
+                key: key,
+                canDownload: canDownload,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return client;
+    }
+
+    testWidgets('file list still renders when permission absent',
+        (tester) async {
+      final client = await pump(tester);
+
+      // Metadata (name + size) stays visible — only file bodies are gated.
+      expect(find.text('notes.py'), findsOneWidget);
+      expect(find.textContaining('42 bytes'), findsOneWidget);
+      client.close();
+    });
+
+    testWidgets('content pane shows permission-denied state', (tester) async {
+      final client = await pump(tester);
+
+      await tester.tap(find.text('notes.py'));
+      await tester.pumpAndSettle();
+
+      // The text fetch fails fast; the renderer surfaces the reason. The
+      // filename header (metadata) is still visible alongside it.
+      expect(
+        find.textContaining('Download not permitted'),
+        findsOneWidget,
+      );
+      expect(find.text('notes.py'), findsOneWidget);
+
+      // Closing the viewer returns to the intact file list.
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('42 bytes'), findsOneWidget);
+      client.close();
+    });
+
+    testWidgets('text read succeeds when permitted', (tester) async {
+      final key = GlobalKey<FileViewerPanelState>();
+      final client = await pump(tester, canDownload: true, key: key);
+
+      await tester.tap(find.text('notes.py'));
+      await tester.pumpAndSettle();
+
+      // The viewer renders without a denial (the code renderer draws
+      // through HighlightView spans, so assert on the loader + the
+      // absence of the error state instead of raw text).
+      expect(find.textContaining('Failed to load file'), findsNothing);
+      final content =
+          await key.currentState!.readFileTextForTest('/home/tester/notes.py');
+      expect(content, 'print("hi")');
+      client.close();
+    });
+
+    testWidgets('text fetch fails fast with a clear error', (tester) async {
+      final key = GlobalKey<FileViewerPanelState>();
+      final client = await pump(tester, key: key);
+
+      await expectLater(
+        key.currentState!.readFileTextForTest('/home/tester/notes.py'),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Download not permitted'),
+          ),
+        ),
+      );
+      client.close();
+    });
+  });
+
   group('FileViewerPanel write permission (#2705)', () {
     Future<_MockWsClient> pump(
       WidgetTester tester, {

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -94,6 +94,9 @@ async def read_file(
     workspace_id: str,
     path: str,
     user: dict = Depends(acl.has_permission("files", workspace_resource)),
+    _download: dict = Depends(
+        acl.has_permission("files-download", workspace_resource)
+    ),
     app=Depends(get_app_dep),
 ):
     cid = _require_container(workspace_id, app.state.container_registry)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -7612,6 +7612,88 @@ class TestFileRoutes:
         finally:
             self._cleanup(ws_id)
 
+    async def test_read_denied_without_files_download(
+        self, client, user, app_state
+    ):
+        """`files` alone no longer grants the text reader either (#2713)
+        — browsing still works, `/files/content` does not."""
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            other = await self._member_headers_with_perms(
+                app_state, client, ws_id, ["view", "terminal", "files"]
+            )
+            with patch.object(
+                _mock_pod,
+                "exec_container",
+                new_callable=AsyncMock,
+                return_value=(0, "regular file\t11", ""),
+            ):
+                resp = await client.get(
+                    f"/api/v1/workspaces/{ws_id}/files?path=/home/klangk",
+                    headers=other,
+                )
+                assert resp.status_code == 200
+                resp = await client.get(
+                    f"/api/v1/workspaces/{ws_id}/files/content"
+                    "?path=/home/klangk/read.txt",
+                    headers=other,
+                )
+            assert resp.status_code == 403
+        finally:
+            self._cleanup(ws_id)
+
+    async def test_read_allowed_with_files_download(
+        self, client, user, app_state
+    ):
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            other = await self._member_headers_with_perms(
+                app_state,
+                client,
+                ws_id,
+                ["view", "terminal", "files", "files-download"],
+            )
+            with patch.object(
+                _mock_pod,
+                "exec_container",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (0, "regular file\t11", ""),  # stat
+                    (0, "read me", ""),  # cat
+                ],
+            ):
+                resp = await client.get(
+                    f"/api/v1/workspaces/{ws_id}/files/content"
+                    "?path=/home/klangk/read.txt",
+                    headers=other,
+                )
+            assert resp.status_code == 200
+            assert resp.json()["content"] == "read me"
+        finally:
+            self._cleanup(ws_id)
+
+    async def test_read_files_download_alone_insufficient(
+        self, client, user, app_state
+    ):
+        """`files-download` without `files` grants nothing (#2713): the
+        text reader requires both, mirroring the download route."""
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            other = await self._member_headers_with_perms(
+                app_state, client, ws_id, ["files-download"]
+            )
+            resp = await client.get(
+                f"/api/v1/workspaces/{ws_id}/files/content"
+                "?path=/home/klangk/read.txt",
+                headers=other,
+            )
+            assert resp.status_code == 403
+        finally:
+            self._cleanup(ws_id)
+
     async def test_upload_denied_without_files_write(
         self, client, user, app_state
     ):


### PR DESCRIPTION
Closes #2713.

## What

`GET /api/v1/workspaces/{id}/files/content` — the file viewer's text-reader endpoint — now requires the `files-download` permission in addition to `files`, exactly like `/files/download` (#2705). Both endpoints that move file bytes out of the workspace are now gated, so a member with `files` alone can browse listings/metadata but cannot script a bulk reader through the text path.

## Web viewer degradation

- File list and metadata (names, sizes, mtimes) stay visible; browsing is unaffected.
- Selecting a file fails fast client-side when the permission is absent; every renderer surfaces `Download not permitted` in the content pane (same path binary renderers already used).
- Closing the viewer returns to the intact list.

## Changes

- `src/klangk/klangk/api/resources.py` — `read_file` gains the `files-download` dependency (mirrors `download_file`).
- `file_viewer_panel.dart` — `_readFileText` fail-fast + `canDownload` doc update.
- Tests — 3 backend (`test_api.py`: denied / allowed / alone-insufficient) + 4 frontend (`file_viewer_panel_test.dart`: list still renders, permission-denied content pane, permitted read, fail-fast loader).
- Docs — `acl.md` (permission table, gate scope), `api-endpoints.md` (auth line), customize sample hook comment, changelog Security entry.

## Test evidence

- Backend: 6050 passed, 100% coverage (`-n auto`, CI invocation).
- Frontend: 1105 passed, 100% coverage (`test-frontend`).
- pre-commit (xenon, ruff, prettier, dart format, markdownlint): all green.
