### PR TITLE
docs(terminal): document permission-gated terminal sharing (#2709)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -185,19 +185,19 @@ exec`, and the rsync transport `klangk sync` and `klangk sandbox`
   one-shot exec working for those principals. `klangk exec`/`klangk
 sync` report a clear permission-denied error.
 
-- **Terminal sharing is permission-gated (#2709).** Promoting a
-  terminal tab to shared — and joining another member's shared
-  terminal — crosses user boundaries (every member with spectate
-  access can read the owner's terminal output), so both stay behind
-  workspace permissions: `share-terminals` for share/unshare (owners
-  and collaborators by default) and `spectate-on-shared-terminals`
-  for joining (all roles); a joiner without `code-in-shared-terminals`
-  or `share-terminals` joins read-only. The browser hides the Share
-  action (context-menu entry and broadcast-icon toggle) for members
-  lacking the permission and the server rejects the commands; private,
-  unshared terminals are unaffected. Revoke the permissions per
-  workspace in the ACL editor to stop a member sharing their own tabs
-  or watching others'.
+- **Terminal sharing verified permission-gated (#2709).** As part of
+  the #2589 exfiltration-avenue audit, terminal sharing was verified to
+  be permission-gated end-to-end (long-standing behavior, unchanged
+  this release): share/unshare requires `share-terminals` (owners and
+  collaborators by default) and joining another member's shared
+  terminal requires `spectate-on-shared-terminals` (all roles); a
+  joiner without `code-in-shared-terminals` or `share-terminals`
+  joins read-only. The browser hides the Share context-menu action for
+  members lacking the permission, the server rejects the commands, and
+  private, unshared terminals are unaffected. Revoke the permissions
+  per workspace in the ACL editor to stop a member sharing their own
+  tabs or watching others'.
+
 - **Workspace export is gated on the workspace, not admin (#2707).**
   `GET /api/v1/workspaces/{id}/export` (and `klangk export`) now
   requires the `export` permission on `/workspaces/{id}` instead of the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -184,6 +184,20 @@ exec`, and the rsync transport `klangk sync` and `klangk sandbox`
   `code-in-isolation` must add `exec-and-sync` explicitly to keep
   one-shot exec working for those principals. `klangk exec`/`klangk
 sync` report a clear permission-denied error.
+
+- **Terminal sharing is permission-gated (#2709).** Promoting a
+  terminal tab to shared — and joining another member's shared
+  terminal — crosses user boundaries (every member with spectate
+  access can read the owner's terminal output), so both stay behind
+  workspace permissions: `share-terminals` for share/unshare (owners
+  and collaborators by default) and `spectate-on-shared-terminals`
+  for joining (all roles); a joiner without `code-in-shared-terminals`
+  or `share-terminals` joins read-only. The browser hides the Share
+  action (context-menu entry and broadcast-icon toggle) for members
+  lacking the permission and the server rejects the commands; private,
+  unshared terminals are unaffected. Revoke the permissions per
+  workspace in the ACL editor to stop a member sharing their own tabs
+  or watching others'.
 - **Workspace export is gated on the workspace, not admin (#2707).**
   `GET /api/v1/workspaces/{id}/export` (and `klangk export`) now
   requires the `export` permission on `/workspaces/{id}` instead of the

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -99,7 +99,10 @@ named by your user ID, so switching tabs is instant.
 - Click **+** to create a new terminal tab (tmux window)
 - Click a tab to switch to it
 - Click **✕** on a tab to close it (only shown when more than one tab exists)
-- Right-click a tab to open a context menu with **Rename** and **Share/Unshare**
+- Right-click a tab to open a context menu with **Rename** and
+  **Share/Unshare** (the Share entry and the broadcast-icon toggle are
+  hidden for members without the `share-terminals` permission — see
+  [Role permissions](#role-permissions) below)
 
 ### Renaming tabs
 
@@ -128,6 +131,12 @@ Right-click a tab and select **Share**. The tab gains a broadcast icon
 indicating it is now shared. Other workspace members see the shared
 tab appear in their tab bar.
 
+Sharing requires the `share-terminals` permission on the workspace —
+owners and collaborators have it by default, coders and spectators do
+not. A member without the permission sees no Share action (the context
+menu shows only Rename, and the broadcast icon is absent), and the
+server rejects the request if one is sent anyway.
+
 [![Tab with broadcast icon indicating it is shared](../assets/terminal-sharing/04-shared-tab-with-icon.png)](../assets/terminal-sharing/04-shared-tab-with-icon.png)
 
 To unshare, either:
@@ -143,8 +152,11 @@ you are now seeing the same terminal session as the owner.
 
 [![Collaborator's view showing a shared terminal from another user](../assets/terminal-sharing/08-collaborator-view.png)](../assets/terminal-sharing/08-collaborator-view.png)
 
-Depending on your role, you may be able to type (read-write) or only
-watch (read-only). A lock icon indicates read-only access.
+Joining requires the `spectate-on-shared-terminals` permission (every
+role has it by default). Depending on your role, you may be able to
+type (read-write) or only watch (read-only); read-write needs
+`code-in-shared-terminals` or `share-terminals`. A lock icon indicates
+read-only access.
 
 ### Viewer tracking
 
@@ -162,7 +174,7 @@ handles of all current viewers.
 | ------------------------------ | ------ | ------ | ------------- | ---------- |
 | `terminal`                     | \*     | yes    | yes           | yes        |
 | `code-in-isolation`            | \*     | yes    | yes           |            |
-| `share-terminals`              | \*     |        |               |            |
+| `share-terminals`              | \*     |        | yes           |            |
 | `code-in-shared-terminals`     | \*     |        | yes           |            |
 | `spectate-on-shared-terminals` | \*     | yes    | yes           | yes        |
 | `files`                        | \*     | yes    | yes           |            |
@@ -170,11 +182,16 @@ handles of all current viewers.
 
 \* Owners have the wildcard (`*`) permission which implies all permissions.
 
+The table shows each seeded role's default grants; permissions can be
+tuned per workspace in the ACL editor. Sharing is enforced server-side —
+without `share-terminals` the share/unshare commands are rejected — and
+so is joining, via `spectate-on-shared-terminals`.
+
 - **Owners** can share/unshare tabs, type in shared terminals, and rename tabs.
 - **Coders** can watch shared terminals (read-only) but cannot share their own
   tabs or type in others' shared terminals. They have full isolated terminal
   and file access.
-- **Collaborators** can type in shared terminals but cannot share their own tabs.
-  They have full isolated terminal and file access.
+- **Collaborators** can share/unshare their own tabs and type in shared
+  terminals. They have full isolated terminal and file access.
 - **Spectators** can watch shared terminals in read-only mode. They cannot start
   isolated terminals or access files.

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -100,8 +100,8 @@ named by your user ID, so switching tabs is instant.
 - Click a tab to switch to it
 - Click **✕** on a tab to close it (only shown when more than one tab exists)
 - Right-click a tab to open a context menu with **Rename** and
-  **Share/Unshare** (the Share entry and the broadcast-icon toggle are
-  hidden for members without the `share-terminals` permission — see
+  **Share/Unshare** (the Share entry is hidden for members without the
+  `share-terminals` permission — see
   [Role permissions](#role-permissions) below)
 
 ### Renaming tabs
@@ -134,7 +134,8 @@ tab appear in their tab bar.
 Sharing requires the `share-terminals` permission on the workspace —
 owners and collaborators have it by default, coders and spectators do
 not. A member without the permission sees no Share action (the context
-menu shows only Rename, and the broadcast icon is absent), and the
+menu shows only Rename; a tab that is already shared keeps its
+broadcast icon as an indicator, but clicking it does nothing), and the
 server rejects the request if one is sent anyway.
 
 [![Tab with broadcast icon indicating it is shared](../assets/terminal-sharing/04-shared-tab-with-icon.png)](../assets/terminal-sharing/04-shared-tab-with-icon.png)
@@ -182,10 +183,11 @@ handles of all current viewers.
 
 \* Owners have the wildcard (`*`) permission which implies all permissions.
 
-The table shows each seeded role's default grants; permissions can be
-tuned per workspace in the ACL editor. Sharing is enforced server-side —
-without `share-terminals` the share/unshare commands are rejected — and
-so is joining, via `spectate-on-shared-terminals`.
+The table shows the terminal-sharing-related default grants for each
+seeded role; permissions can be tuned per workspace in the ACL editor.
+Sharing is enforced server-side — without `share-terminals` the
+share/unshare commands are rejected — and so is joining, via
+`spectate-on-shared-terminals`.
 
 - **Owners** can share/unshare tabs, type in shared terminals, and rename tabs.
 - **Coders** can watch shared terminals (read-only) but cannot share their own

--- a/src/frontend/test/terminal_tabs_view_test.dart
+++ b/src/frontend/test/terminal_tabs_view_test.dart
@@ -375,6 +375,34 @@ void main() {
       expect(find.text('Share'), findsOneWidget);
     });
 
+    testWidgets('context menu hides Share without share-terminals permission',
+        (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [
+        {'id': 'w1', 'name': 'bash', 'index': 0, 'active': true},
+      ];
+      client._shared = [];
+      await tester.pumpWidget(_build(
+        client,
+        // Every permission except share-terminals (#2709).
+        hasPerm: (p) => p != 'share-terminals',
+      ));
+
+      final tabFinder = find.text('bash');
+      final center = tester.getCenter(tabFinder);
+      await tester.tapAt(center, buttons: 2);
+      await tester.pumpAndSettle();
+
+      // Rename stays; Share is hidden for members lacking the permission.
+      expect(find.text('Rename'), findsOneWidget);
+      expect(find.text('Share'), findsNothing);
+
+      // No broadcast-icon toggle either.
+      expect(find.byIcon(Icons.share_outlined), findsNothing);
+      expect(find.byIcon(Icons.cell_tower), findsNothing);
+    });
+
     testWidgets('context menu share action calls toggle', (tester) async {
       final client = _MockWsClient();
       client._userId = 'user-1';

--- a/src/frontend/test/terminal_tabs_view_test.dart
+++ b/src/frontend/test/terminal_tabs_view_test.dart
@@ -398,9 +398,8 @@ void main() {
       expect(find.text('Rename'), findsOneWidget);
       expect(find.text('Share'), findsNothing);
 
-      // No broadcast-icon toggle either.
+      // No share affordance in the (closed) context menu either.
       expect(find.byIcon(Icons.share_outlined), findsNothing);
-      expect(find.byIcon(Icons.cell_tower), findsNothing);
     });
 
     testWidgets('context menu share action calls toggle', (tester) async {


### PR DESCRIPTION
Closes #2709.

## What this issue asked for vs. what existed

An audit of every acceptance criterion showed the enforcement this issue
proposes already ships (and is tested) end-to-end, predating the issue:

| AC | Status before this PR |
| --- | --- |
| `share_window` rejected without the permission | `share_terminals` gate in `SharedTerminalController.share_window`/`unshare_window` (since #321, granted to collaborators in #350); denial tests in `test_wshandler.py` |
| Existing shared windows not joinable without it | `spectate-on-shared-terminals` gate in `join_shared_terminal` + `list_shared_terminals`; denial tests |
| Flutter context menu hides Share | `onToggleShare: hasPerm('share-terminals') ? … : null` hides the menu entry |
| TUI hides/disables Share | The TUI has no share affordance at all; its shared-terminal list degrades to empty when the server nacks `list_shared_terminals` without spectate permission |
| Docs (`terminal.md`) | Role-permission table existed **but was stale** — see below |
| Changelog entry | Missing |

## What this PR changes

- **`docs/features/terminal.md`** — the role table and bullets claimed
  collaborators *cannot* share their own tabs, contradicting the code
  (and the sharing panel, and `egress-filtering.md`) since #350 granted
  collaborators `share-terminals`. Fixed the table cell + bullet, and
  documented the share (`share-terminals`) and join
  (`spectate-on-shared-terminals`, read-write via
  `code-in-shared-terminals`/`share-terminals`) permission requirements
  in the *Sharing a tab* / *Joining a shared terminal* prose.
- **`docs/changes.md`** — `Security` entry under `[Unreleased]`
  documenting the terminal-sharing permission gates as the #2589
  intra-instance exfil-hardening audit installment (worded as *verified*
  gating — the behavior is long-standing and unchanged this release).
- **`terminal_tabs_view_test.dart`** — the one genuinely missing test:
  a negative widget test asserting the tab context menu shows only
  **Rename** (no **Share** entry) for members without
  `share-terminals`.

Unshared private terminals are unaffected (as the issue requires): all
gates sit on the share/unshare/join WS commands only.

## Review

Adversarially reviewed (fresh session); both important findings were
addressed in 728fa455 — the broadcast-icon claim (the icon does render
for an already-shared tab as an inert indicator; only the context-menu
entry is hidden) and the changelog entry's implication that the gating
was new this release.

**Known follow-ups found during review (out of scope here):**

1. A member whose `share-terminals` was revoked **after** sharing a tab
   cannot unshare their own tab — `unshare_window` requires the
   permission, so the tab stays shared until the workspace owner
   removes it via the legacy delete path. Arguably the window's owner
   should always be able to unshare (it *reduces* exposure).
2. `klangk terminal share` / `klangk shell handle:name` surface a
   permission denial as a ~10s wait then a raw `asyncio.TimeoutError`
   instead of the server's "Permission denied" error frame.

## Testing

- `flutter test test/terminal_tabs_view_test.dart` — 36 passed
  (35 existing + 1 new).
- `test-push` gate: selected areas green.
