### PR TITLE
fix(cli): terminal share/unshare/ls surface server errors cleanly (#2876)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1566,6 +1566,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`klangk terminal share` / `unshare` / `ls` (#2876).** A server
+  refusal — e.g. `Permission denied` for a member without the
+  `share-terminals` permission — now prints a one-line error and exits
+  nonzero instead of a raw Python traceback. A server that silently
+  drops the command reports a timeout message instead of a stack trace.
+
 - **Boot auto-start no longer ignores a disabled `allow_autostart`
   (#2796).** `KLANGKD_ALLOW_AUTOSTART=false` (any non-truthy non-empty
   string) previously read as _enabled_ on the boot path — workspaces with

--- a/src/klangk/klangk/cli/terminals.py
+++ b/src/klangk/klangk/cli/terminals.py
@@ -68,6 +68,35 @@ def frame_is(frame_type: str):
     return predicate
 
 
+# Seconds to wait for the shared_terminals confirmation frame after a
+# share_window/unshare_window command. A server that silently drops the
+# command (no error frame) makes the CLI time out here — keep short so
+# the failure surfaces fast (#2876).
+_CONFIRM_TIMEOUT = 10
+
+
+def run_ws_command(body) -> None:
+    """Run an async ws command body, surfacing failures as a clean exit.
+
+    Server ``error`` frames — e.g. the "Permission denied" a member
+    without ``share-terminals`` gets — already raise ``ConnectionError``
+    fast out of the ``frame_is`` predicates (#2633); a silent server
+    drop times out instead. Both must reach the user as a one-line
+    message and a nonzero exit, not a raw traceback (#2876) — the same
+    presentation ``klangk shell`` already uses.
+    """
+    try:
+        asyncio.run(body())
+    except ConnectionError as e:
+        context._err.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from None
+    except asyncio.TimeoutError:
+        context._err.print(
+            "[red]Timed out waiting for the server to respond[/red]"
+        )
+        raise typer.Exit(code=1) from None
+
+
 terminal_app = typer.Typer(
     name="terminal",
     help="Manage workspace terminals.",
@@ -135,7 +164,7 @@ def terminals(
                 conn, json.dumps({"cmd": "terminal_stop"})
             )
 
-    asyncio.run(_list())
+    run_ws_command(_list)
 
 
 _VALID_ROLES = ["owner", "coder", "collaborator", "spectator"]
@@ -263,7 +292,9 @@ def share_terminal(
                 json.dumps({"cmd": "share_window", "window_id": match["id"]})
             )
             # Wait for shared_terminals confirmation
-            await recv_until(conn, frame_is("shared_terminals"), 10)
+            await recv_until(
+                conn, frame_is("shared_terminals"), _CONFIRM_TIMEOUT
+            )
             context._err.print(
                 f"[green]Terminal '{terminal}' is now shared[/green]"
             )
@@ -272,7 +303,7 @@ def share_terminal(
                 conn, json.dumps({"cmd": "terminal_stop"})
             )
 
-    asyncio.run(_share())
+    run_ws_command(_share)
 
 
 @terminal_app.command("unshare")
@@ -314,7 +345,9 @@ def unshare_terminal(
                 json.dumps({"cmd": "unshare_window", "window_id": match["id"]})
             )
             # Wait for shared_terminals confirmation
-            await recv_until(conn, frame_is("shared_terminals"), 10)
+            await recv_until(
+                conn, frame_is("shared_terminals"), _CONFIRM_TIMEOUT
+            )
             context._err.print(
                 f"[green]Terminal '{terminal}' is no longer shared[/green]"
             )
@@ -323,4 +356,4 @@ def unshare_terminal(
                 conn, json.dumps({"cmd": "terminal_stop"})
             )
 
-    asyncio.run(_unshare())
+    run_ws_command(_unshare)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1,5 +1,6 @@
 """Tests for klangk CLI commands (main.py)."""
 
+import asyncio
 import json
 
 from _helpers import tracked_mkdtemp
@@ -38,6 +39,37 @@ def _raise_no_network(*_a, **_k):
     fast instead of waiting on a real ~6s connection timeout. The admin
     path itself is covered by the ``test_*_shows_admin_*`` tests (#1989)."""
     raise RuntimeError("no network in tests")
+
+
+class _ScriptedWS:
+    """Async-CM websocket stub that replays frames, then blocks forever.
+
+    Blocking after the script runs out (rather than raising
+    StopAsyncIteration) reproduces a server that never sends the awaited
+    frame — a swallowed error frame would surface as the full timeout,
+    not an immediate failure (#2876).
+    """
+
+    def __init__(self, frames):
+        self._frames = list(frames)
+        self.sent = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def recv(self):
+        if self._frames:
+            return self._frames.pop(0)
+        await asyncio.sleep(60)  # cancelled by the caller's wait_for
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        pass
 
 
 @pytest.fixture
@@ -1754,11 +1786,11 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
-            with pytest.raises(ConnectionError):
+            with pytest.raises(typer.Exit):
                 main.terminals("my-ws")
 
     def test_share_connection_failure(
-        self, logged_in_cfg, monkeypatch, reset_env
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
     ):
         from klangk.cli import main
 
@@ -1787,11 +1819,11 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
-            with pytest.raises(ConnectionError):
+            with pytest.raises(typer.Exit):
                 main.share_terminal("my-ws", "build")
 
     def test_unshare_connection_failure(
-        self, logged_in_cfg, monkeypatch, reset_env
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
     ):
         from klangk.cli import main
 
@@ -1820,8 +1852,127 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
-            with pytest.raises(ConnectionError):
+            with pytest.raises(typer.Exit):
                 main.unshare_terminal("my-ws", "build")
+
+    @staticmethod
+    def _ws_mock(ws):
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        return client
+
+    @staticmethod
+    def _startup_frames(windows):
+        """Handshake + terminal_start frames for a terminal command."""
+        return [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps({"type": "terminal_started"}),
+            json.dumps({"type": "terminal_windows", "windows": windows}),
+        ]
+
+    _WINDOWS = [
+        {"id": "@0", "index": 0, "name": "1", "active": True},
+        {"id": "@1", "index": 1, "name": "build", "active": False},
+    ]
+
+    def test_share_terminal_permission_denied(
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
+    ):
+        """Server 'Permission denied' for share_window exits fast and
+        clean — one-line message, nonzero exit, no traceback (#2876)."""
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        frames = self._startup_frames(self._WINDOWS) + [
+            json.dumps({"type": "error", "message": "Permission denied"}),
+        ]
+        sock = _ScriptedWS(frames)
+        with (
+            patch.object(
+                context_mod, "_client", return_value=self._ws_mock(ws)
+            ),
+            patch(
+                "klangk.cli.transport.websockets.connect", return_value=sock
+            ),
+        ):
+            os.environ["TERM"] = "xterm-256color"
+            with pytest.raises(typer.Exit) as exc:
+                main.share_terminal("my-ws", "build")
+        assert exc.value.exit_code == 1
+        assert "Permission denied" in capfd.readouterr().err
+        # The denial answered an actually-sent share_window command.
+        sent = [json.loads(s) for s in sock.sent if isinstance(s, str)]
+        assert any(s.get("cmd") == "share_window" for s in sent)
+
+    def test_unshare_terminal_permission_denied(
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
+    ):
+        """Server 'Permission denied' for unshare_window exits fast and
+        clean (#2876)."""
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        frames = self._startup_frames(self._WINDOWS) + [
+            json.dumps({"type": "error", "message": "Permission denied"}),
+        ]
+        sock = _ScriptedWS(frames)
+        with (
+            patch.object(
+                context_mod, "_client", return_value=self._ws_mock(ws)
+            ),
+            patch(
+                "klangk.cli.transport.websockets.connect", return_value=sock
+            ),
+        ):
+            os.environ["TERM"] = "xterm-256color"
+            with pytest.raises(typer.Exit) as exc:
+                main.unshare_terminal("my-ws", "build")
+        assert exc.value.exit_code == 1
+        assert "Permission denied" in capfd.readouterr().err
+        sent = [json.loads(s) for s in sock.sent if isinstance(s, str)]
+        assert any(s.get("cmd") == "unshare_window" for s in sent)
+
+    def test_share_terminal_timeout_clean(
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
+    ):
+        """A silent server drop (no error frame, no confirmation) reports
+        a timeout message and exits nonzero instead of a raw
+        asyncio.TimeoutError traceback (#2876)."""
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        # No shared_terminals after share_window: recv blocks, the
+        # confirm wait expires against the shrunken timeout.
+        monkeypatch.setattr("klangk.cli.terminals._CONFIRM_TIMEOUT", 0.05)
+        sock = _ScriptedWS(self._startup_frames(self._WINDOWS))
+        with (
+            patch.object(
+                context_mod, "_client", return_value=self._ws_mock(ws)
+            ),
+            patch(
+                "klangk.cli.transport.websockets.connect", return_value=sock
+            ),
+        ):
+            os.environ["TERM"] = "xterm-256color"
+            with pytest.raises(typer.Exit) as exc:
+                main.share_terminal("my-ws", "build")
+        assert exc.value.exit_code == 1
+        assert "Timed out" in capfd.readouterr().err
 
     def test_unshare_terminal_not_found(
         self, logged_in_cfg, monkeypatch, reset_env


### PR DESCRIPTION
## Summary

Closes #2876.

The issue reported that a permission denial on `klangk terminal share`
surfaces as a ~10s stall and a raw `asyncio.TimeoutError` traceback.
Empirically (temp tests against the real command functions), the
fast-fail predicates already in place raise `ConnectionError` with the
server's message in ~0s on both described paths — the `frame_is`
error-raise (#2633) covers the share/unshare confirm waits, and the
join wait in the `klangk shell` path checks `error` frames explicitly.
The reviewer's stall diagnosis was stale.

What *was* still broken, and is fixed here: the `terminal share` /
`unshare` / `ls` typer commands let that fast `ConnectionError` escape
`asyncio.run` as a raw Python traceback, and a silently-dropping server
escaped as a raw `TimeoutError` after the 10s confirm wait. The command
bodies now run through `run_ws_command`, which prints a one-line red
message and exits nonzero — the same presentation `klangk shell`
already uses.

## Changes

- **`src/klangk/klangk/cli/terminals.py`** — new `run_ws_command`
  helper converts `ConnectionError` / `asyncio.TimeoutError` into a
  clean message + `typer.Exit(1)`; used by `terminals`, `share_terminal`,
  `unshare_terminal`. The 10s confirm wait moves to a module constant
  `_CONFIRM_TIMEOUT` so tests can shrink it.
- **`src/klangk/klangkc-tests/tests/test_cli_main.py`** — `_ScriptedWS`
  stub replays frames then blocks forever (a swallowed error would
  otherwise hide behind the full timeout); new permission-denied tests
  for share and unshare (fast, clean, nonzero exit), a confirm-timeout
  test, and the three connection-failure tests now assert the clean
  exit instead of the propagated `ConnectionError`.
- **`docs/changes.md`** — `Fixed` entry under `[Unreleased]`.

## Testing

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — 6148 passed, 100% coverage.
- `pre-commit` (incl. xenon) green.
