### PR TITLE
fix(terminal): allow unsharing an own tab without share-terminals

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1576,9 +1576,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   permission (#2875).** A workspace member who shared a terminal tab and
   then lost the permission was stuck: the tab stayed shared (readable by
   every member with spectate access) with no working unshare control.
-  Unsharing now always works for the tab's owner — the broadcast icon
-  and the context menu's Unshare entry stay operable — since unsharing
-  only reduces exposure. Sharing still requires the permission.
+  The server now always lets a member unshare their own tab — the UI
+  affordances stay operable wherever own tabs are visible, and `klangk
+terminal unshare` works for any role — since unsharing only reduces
+  exposure. Sharing still requires the permission.
 
 - **Boot auto-start no longer ignores a disabled `allow_autostart`
   (#2796).** `KLANGKD_ALLOW_AUTOSTART=false` (any non-truthy non-empty

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1572,6 +1572,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   nonzero instead of a raw Python traceback. A server that silently
   drops the command reports a timeout message instead of a stack trace.
 
+- **Unsharing a terminal tab no longer requires the `share-terminals`
+  permission (#2875).** A workspace member who shared a terminal tab and
+  then lost the permission was stuck: the tab stayed shared (readable by
+  every member with spectate access) with no working unshare control.
+  Unsharing now always works for the tab's owner — the broadcast icon
+  and the context menu's Unshare entry stay operable — since unsharing
+  only reduces exposure. Sharing still requires the permission.
+
 - **Boot auto-start no longer ignores a disabled `allow_autostart`
   (#2796).** `KLANGKD_ALLOW_AUTOSTART=false` (any non-truthy non-empty
   string) previously read as _enabled_ on the boot path — workspaces with

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -136,10 +136,13 @@ Sharing requires the `share-terminals` permission on the workspace —
 owners and collaborators have it by default, coders and spectators do
 not. A member without the permission sees no Share action (the context
 menu shows only Rename), and the server rejects the request if one is
-sent anyway. Unsharing is **not** permission-gated: a member who loses
-the permission keeps working Unshare affordances (context menu and
-broadcast-icon click) on tabs they already shared, so a revoked
-permission can never strand a tab in the shared state.
+sent anyway. Unsharing is **not** permission-gated — the server always
+lets a member unshare their own tab, so a revoked permission can never
+strand a tab in the shared state. The Unshare affordances (context menu
+and broadcast icon) stay operable wherever your own tabs are shown; a
+member demoted to a role without isolated terminals (a spectator) no
+longer sees their own tab strip and can unshare from the CLI instead
+(`klangk terminal unshare`).
 
 [![Tab with broadcast icon indicating it is shared](../assets/terminal-sharing/04-shared-tab-with-icon.png)](../assets/terminal-sharing/04-shared-tab-with-icon.png)
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -101,7 +101,8 @@ named by your user ID, so switching tabs is instant.
 - Click **✕** on a tab to close it (only shown when more than one tab exists)
 - Right-click a tab to open a context menu with **Rename** and
   **Share/Unshare** (the Share entry is hidden for members without the
-  `share-terminals` permission — see
+  `share-terminals` permission; **Unshare** stays available for a tab
+  that is already shared — see
   [Role permissions](#role-permissions) below)
 
 ### Renaming tabs
@@ -134,9 +135,11 @@ tab appear in their tab bar.
 Sharing requires the `share-terminals` permission on the workspace —
 owners and collaborators have it by default, coders and spectators do
 not. A member without the permission sees no Share action (the context
-menu shows only Rename; a tab that is already shared keeps its
-broadcast icon as an indicator, but clicking it does nothing), and the
-server rejects the request if one is sent anyway.
+menu shows only Rename), and the server rejects the request if one is
+sent anyway. Unsharing is **not** permission-gated: a member who loses
+the permission keeps working Unshare affordances (context menu and
+broadcast-icon click) on tabs they already shared, so a revoked
+permission can never strand a tab in the shared state.
 
 [![Tab with broadcast icon indicating it is shared](../assets/terminal-sharing/04-shared-tab-with-icon.png)](../assets/terminal-sharing/04-shared-tab-with-icon.png)
 
@@ -185,8 +188,9 @@ handles of all current viewers.
 
 The table shows the terminal-sharing-related default grants for each
 seeded role; permissions can be tuned per workspace in the ACL editor.
-Sharing is enforced server-side — without `share-terminals` the
-share/unshare commands are rejected — and so is joining, via
+Sharing is enforced server-side — without `share-terminals` the share
+command is rejected (unsharing your own tab is always allowed, since it
+only reduces exposure) — and so is joining, via
 `spectate-on-shared-terminals`.
 
 - **Owners** can share/unshare tabs, type in shared terminals, and rename tabs.

--- a/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
+++ b/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
@@ -310,6 +310,88 @@ test.describe("workspace roles", () => {
       await cleanup();
     }
   });
+
+  test("demoted member can still unshare an already-shared tab", async ({
+    page,
+    request,
+  }) => {
+    // A member who shares a tab and then loses share-terminals must not
+    // be stranded with a permanently shared tab (#2875).
+    const ownerEmail = `demote-owner-${Date.now()}@test.example.com`;
+    const owner = await registerUser(request, ownerEmail);
+    const { workspaceId, cleanup } = await createWorkspace(
+      request,
+      owner.headers,
+      "demote-test",
+    );
+    try {
+      const memberEmail = `demote-member-${Date.now()}@test.example.com`;
+      const member = await registerUser(request, memberEmail);
+      await addToRole(
+        request,
+        owner.headers,
+        workspaceId,
+        "collaborators",
+        memberEmail,
+      );
+
+      await openWorkspace(page, ownerEmail, workspaceId, {
+        waitForTerminal: true,
+      });
+
+      const memberWs = await connectWs(member.token, workspaceId);
+      try {
+        // Member starts an isolated terminal and shares its first window.
+        memberWs.send({ cmd: "terminal_start", cols: 80, rows: 24 });
+        let initWindows: WsMessage = { type: "none" };
+        let gotStarted = false;
+        await memberWs.recvUntil((m) => {
+          if (m.type === "terminal_started") gotStarted = true;
+          if (m.type === "terminal_windows") initWindows = m;
+          return gotStarted && initWindows.type === "terminal_windows";
+        }, 60_000);
+        const firstWindow = (
+          initWindows.windows as Array<Record<string, unknown>>
+        )[0];
+
+        memberWs.send({ cmd: "share_window", window_id: firstWindow.id });
+        await memberWs.recvUntil(
+          (m) =>
+            m.type === "shared_terminals" &&
+            (m.terminals as Array<Record<string, unknown>>).some(
+              (t) => t.window_id === firstWindow.id,
+            ),
+        );
+
+        // Owner demotes member to spectator — share-terminals revoked.
+        const resp = await request.patch(
+          `${API_BASE}/api/v1/workspaces/${workspaceId}/roles`,
+          {
+            headers: owner.headers,
+            data: { email: memberEmail, role: "spectators" },
+          },
+        );
+        expect(resp.ok()).toBeTruthy();
+
+        // Unsharing the already-shared tab still succeeds.
+        memberWs.send({ cmd: "unshare_window", window_id: firstWindow.id });
+        await memberWs.recvUntil(
+          (m) =>
+            m.type === "shared_terminal_deleted" &&
+            m.window_id === firstWindow.id,
+        );
+
+        // Sharing it again is still denied without the permission.
+        memberWs.send({ cmd: "share_window", window_id: firstWindow.id });
+        const err = await memberWs.recvUntil((m) => m.type === "error");
+        expect((err.message as string).toLowerCase()).toContain("permission");
+      } finally {
+        memberWs.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 test.describe("shared terminal visibility", () => {

--- a/src/frontend/lib/workspace/terminal_tabs_view.dart
+++ b/src/frontend/lib/workspace/terminal_tabs_view.dart
@@ -52,6 +52,25 @@ class TerminalTabsView extends StatelessWidget {
     );
   }
 
+  /// Share/unshare handler for an own terminal tab.
+  ///
+  /// Sharing needs the ``share-terminals`` permission, but unsharing an
+  /// already-shared tab never does — it only reduces exposure, and a
+  /// member whose permission was revoked after sharing must still be
+  /// able to unshare (#2875).
+  VoidCallback? _toggleShareHandler(Map<String, dynamic> w) {
+    final wid = w['id'] as String? ?? '';
+    final isShared = _isWindowShared(wid);
+    if (!hasPerm('share-terminals') && !isShared) return null;
+    return () {
+      if (isShared) {
+        wsClient.sendUnshareWindow(wid);
+      } else {
+        wsClient.sendShareWindow(wid);
+      }
+    };
+  }
+
   List<Map<String, dynamic>> _getViewers(String ownerUserId, String windowId) {
     for (final s in wsClient.sharedTerminals) {
       if (s['user_id'] == ownerUserId && s['window_id'] == windowId) {
@@ -128,16 +147,7 @@ class TerminalTabsView extends StatelessWidget {
                               w['index'] as int,
                               newName,
                             ),
-                            onToggleShare: hasPerm('share-terminals')
-                                ? () {
-                                    final wid = w['id'] as String? ?? '';
-                                    if (_isWindowShared(wid)) {
-                                      wsClient.sendUnshareWindow(wid);
-                                    } else {
-                                      wsClient.sendShareWindow(wid);
-                                    }
-                                  }
-                                : null,
+                            onToggleShare: _toggleShareHandler(w),
                           ),
                       // "+" for new terminal
                       if (hasPerm('code-in-isolation'))

--- a/src/frontend/test/terminal_tabs_view_test.dart
+++ b/src/frontend/test/terminal_tabs_view_test.dart
@@ -375,6 +375,68 @@ void main() {
       expect(find.text('Share'), findsOneWidget);
     });
 
+    testWidgets('broadcast icon unshares without share-terminals permission',
+        (tester) async {
+      // A member who shared a tab and then lost the permission must
+      // still be able to unshare their own tab (#2875).
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [
+        {'id': 'w1', 'name': 'bash', 'index': 0, 'active': true},
+      ];
+      client._shared = [
+        {
+          'user_id': 'user-1',
+          'window_id': 'w1',
+          'handle': 'me',
+          'window_name': 'bash',
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) => p != 'share-terminals',
+      ));
+
+      await tester.tap(find.byIcon(Icons.cell_tower));
+      expect(client.sentCommands, contains('unshare:w1'));
+    });
+
+    testWidgets(
+        'context menu offers Unshare without share-terminals permission',
+        (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [
+        {'id': 'w1', 'name': 'bash', 'index': 0, 'active': true},
+      ];
+      client._shared = [
+        {
+          'user_id': 'user-1',
+          'window_id': 'w1',
+          'handle': 'me',
+          'window_name': 'bash',
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) => p != 'share-terminals',
+      ));
+
+      final center = tester.getCenter(find.text('bash'));
+      await tester.tapAt(center, buttons: 2);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Rename'), findsOneWidget);
+      expect(find.text('Unshare'), findsOneWidget);
+      expect(find.text('Share'), findsNothing);
+
+      await tester.tap(find.text('Unshare'));
+      await tester.pumpAndSettle();
+      expect(client.sentCommands, contains('unshare:w1'));
+    });
+
     testWidgets('context menu hides Share without share-terminals permission',
         (tester) async {
       final client = _MockWsClient();

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1346,12 +1346,15 @@ class SharedTerminalController:
         self.broadcast_shared_terminals(ws_session)
 
     async def unshare_window(self, msg: dict) -> None:
-        """Remove sharing from a window and kick joiners."""
+        """Remove sharing from a window and kick joiners.
+
+        Only ever operates on the caller's own windows, so — unlike
+        ``share_window`` — it needs no ``share-terminals`` permission:
+        unsharing *reduces* exposure, and gating it would strand a
+        member whose permission was revoked after sharing (#2875).
+        """
 
         if not self._conn.container_id or not self._conn._user_home:
-            return
-        if not await self._conn._has_perm("share-terminals"):
-            send_error(self._conn.sock, "Permission denied")
             return
 
         window_id = msg.get("window_id", "")

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1371,6 +1371,11 @@ class SharedTerminalController:
         match = self.find_window(ws_session, user_id, window_id)
         if match is None:
             return
+        if not match.get("shared"):
+            # Already unshared — a no-op (idempotent, and cheap if a
+            # zero-permission client spams the command: no joiner
+            # kills, no broadcasts).
+            return
         match["shared"] = False
         # Kick spectators/collaborators
         try:

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -8056,7 +8056,7 @@ class TestShareWindowHandlers:
     async def test_unshare_window_without_permission(self, user, app_state):
         """Unsharing an own window needs no share-terminals permission —
         a member whose permission was revoked after sharing must not be
-        stranded with an unreadable-to-no-one tab (#2875)."""
+        left with a tab that stays readable to everyone (#2875)."""
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock = _mock_sock()
@@ -9107,6 +9107,53 @@ class TestSharedTerminalController:
                 await ctrl.unshare_window({"window_id": "@0"})
             assert ws.terminal_windows[user["id"]][0]["shared"] is False
             kill.assert_awaited_once_with("cid", "uid")
+        finally:
+            sockets.sessions.pop("ws-1", None)
+
+    async def test_unshare_window_other_users_window_not_found(
+        self, user, temp_data_dir, app_state
+    ):
+        """The unshare loosening (#2875) is scoped to the caller's own
+        windows: another user's window id is rejected and their shared
+        flag is untouched — the property the permission removal rests on."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
+        ws.terminal_windows["other-user"] = [
+            {"id": "@5", "name": "theirs", "shared": True}
+        ]
+        try:
+            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
+                await ctrl.unshare_window({"window_id": "@5"})
+            assert sock.send_json.call_args[0][0]["message"] == (
+                "Window not found"
+            )
+            assert ws.terminal_windows["other-user"][0]["shared"] is True
+            kill.assert_not_awaited()
+        finally:
+            sockets.sessions.pop("ws-1", None)
+
+    async def test_unshare_window_already_unshared_is_noop(
+        self, user, temp_data_dir, app_state
+    ):
+        """Unsharing a not-shared window is a cheap no-op — no joiner
+        kills, no shared_terminal_deleted broadcast."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
+        ws.terminal_windows[user["id"]] = [
+            {"id": "@0", "name": "a", "shared": False}
+        ]
+        try:
+            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
+                await ctrl.unshare_window({"window_id": "@0"})
+            kill.assert_not_awaited()
+            sent = [c[0][0] for c in sock.send_json.call_args_list]
+            assert not any(
+                s.get("type") == "shared_terminal_deleted" for s in sent
+            )
         finally:
             sockets.sessions.pop("ws-1", None)
 

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -8053,17 +8053,33 @@ class TestShareWindowHandlers:
         conn = _base_conn(user=user)
         await conn.handle_unshare_window({"window_id": "@0"})
 
-    async def test_unshare_window_permission_denied(self, user):
+    async def test_unshare_window_without_permission(self, user, app_state):
+        """Unsharing an own window needs no share-terminals permission —
+        a member whose permission was revoked after sharing must not be
+        stranded with an unreadable-to-no-one tab (#2875)."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        with patch.object(
-            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=False)
-        ):
-            await conn.handle_unshare_window({"window_id": "@0"})
-        calls = [c[0][0] for c in sock.send_json.call_args_list]
-        assert any("Permission" in c.get("message", "") for c in calls)
+        conn.workspace_id = "ws-1"
+        session = sockets.get_or_create_session("ws-1", app_state)
+        session.terminal_windows[user["id"]] = [
+            {"name": "1", "index": 0, "id": "@0", "shared": True}
+        ]
+        try:
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=False),
+            ):
+                await conn.handle_unshare_window({"window_id": "@0"})
+            assert session.terminal_windows[user["id"]][0]["shared"] is False
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            assert not any("Permission" in c.get("message", "") for c in calls)
+        finally:
+            sockets.sessions.pop("ws-1", None)
 
     async def test_unshare_window_missing_id(self, user):
         sock = _mock_sock()
@@ -9052,10 +9068,29 @@ class TestSharedTerminalController:
         ctrl, _, _ = self._controller(user=user, container_id=None)
         await ctrl.unshare_window({"window_id": "@0"})
 
-    async def test_unshare_window_no_perm(self, user):
-        ctrl, sock, _ = self._controller(user=user, has_perm=False)
-        await ctrl.unshare_window({"window_id": "@0"})
-        assert "Permission" in sock.send_json.call_args[0][0]["message"]
+    async def test_unshare_window_without_perm_still_unshares(
+        self, user, temp_data_dir, app_state
+    ):
+        """Unsharing an own window skips the share-terminals gate —
+        it only reduces exposure (#2875)."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        ctrl, sock, _ = self._controller(
+            user=user, app_state=app_state, has_perm=False
+        )
+        ws = self._ws_session(app_state=app_state)
+        ws.terminal_windows[user["id"]] = [
+            {"id": "@0", "name": "a", "shared": True}
+        ]
+        try:
+            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
+                await ctrl.unshare_window({"window_id": "@0"})
+            assert ws.terminal_windows[user["id"]][0]["shared"] is False
+            kill.assert_awaited_once_with("cid", "uid")
+            sent = [c[0][0] for c in sock.send_json.call_args_list]
+            assert not any("Permission" in c.get("message", "") for c in sent)
+        finally:
+            sockets.sessions.pop("ws-1", None)
 
     async def test_unshare_window_marks_unshared_and_kicks(
         self, user, temp_data_dir, app_state


### PR DESCRIPTION
## Summary

A workspace member who shared a terminal tab and then lost the
`share-terminals` permission could never unshare it: both `share_window`
and `unshare_window` required the permission, so the tab stayed shared
(readable by every member with spectate access) with only a dead
broadcast-icon glyph in the UI, until the owner removed it via the legacy
`delete_shared_terminal` path (which closes the window entirely).

Unsharing only ever reduces exposure and only touches the caller's own
windows, so the gate served no protective purpose.

## Changes

- **Server** (`wshandler/controllers.py`): `unshare_window` no longer
  checks `share-terminals`; `share_window` still does.
- **Frontend** (`terminal_tabs_view.dart`): the broadcast icon and the
  context-menu Unshare entry stay operable for an already-shared own tab
  without the permission (`_toggleShareHandler`); Share stays hidden and
  server-denied.
- **Tests**: the two tests asserting the old denial are now regression
  tests proving unshare succeeds with all permissions revoked
  (connection- and controller-level); two new widget tests (icon +
  context menu without perm); one new E2E test covering the full flow —
  collaborator shares, owner demotes to spectator, member unshares
  successfully, re-share is denied.
- **Docs**: `docs/features/terminal.md` no longer documents the dead
  broadcast icon; changelog entry added under `[Unreleased]` → Fixed.

Closes #2875.
