### PR TITLE
fix(cli): #2877 review follow-up — timeout detail, handshake parity, exec

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1569,8 +1569,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 - **`klangk terminal share` / `unshare` / `ls` (#2876).** A server
   refusal — e.g. `Permission denied` for a member without the
   `share-terminals` permission — now prints a one-line error and exits
-  nonzero instead of a raw Python traceback. A server that silently
-  drops the command reports a timeout message instead of a stack trace.
+  nonzero instead of a raw Python traceback. Timeouts name the failing
+  wait, and a 4001/4002 handshake rejection reports the session-expired
+  hint instead of a stack trace.
+
+- **`klangk exec` (#2876).** Server errors and expired sessions during
+  exec now print a one-line message and exit nonzero instead of a raw
+  traceback, matching the terminal commands.
 
 - **Boot auto-start no longer ignores a disabled `allow_autostart`
   (#2796).** `KLANGKD_ALLOW_AUTOSTART=false` (any non-truthy non-empty

--- a/src/klangk/klangk/cli/context.py
+++ b/src/klangk/klangk/cli/context.py
@@ -8,9 +8,11 @@ single-responsibility modules, all imported back into
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import typer
+import websockets
 from rich.console import Console
 
 from .auth import fetch_config, local_login, seed_config, _UNREACHABLE
@@ -36,6 +38,39 @@ app = typer.Typer(
 )
 
 _err = Console(stderr=True)
+
+
+def run_ws_command(body):
+    """Run an async ws command body, surfacing failures as a clean exit.
+
+    Returns whatever *body* returns (e.g. an exit code). Server ``error``
+    frames — e.g. the "Permission denied" a member without
+    ``share-terminals`` gets — raise ``ConnectionError`` fast out of the
+    ``frame_is`` predicates (#2633); a silent server drop raises
+    ``TimeoutError``, carrying the failing wait's detail when it has
+    any. Both, plus a handshake rejection, reach the user as a one-line
+    message and a nonzero exit instead of a raw traceback (#2876) —
+    the same presentation ``klangk shell`` uses (shellcmd.py),
+    including the 4001/4002 session-expired special case.
+    """
+    try:
+        return asyncio.run(body())
+    except ConnectionError as e:
+        _err.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from None
+    except asyncio.TimeoutError as e:
+        detail = str(e) or "Timed out waiting for the server to respond"
+        _err.print(f"[red]{detail}[/red]")
+        raise typer.Exit(code=1) from None
+    except websockets.InvalidStatus as e:
+        if e.response.status_code in (4001, 4002):
+            _err.print(
+                "[red]Session expired. Run `klangk login`"
+                " to re-authenticate.[/red]"
+            )
+        else:
+            _err.print(f"[red]Connection rejected: {e}[/red]")
+        raise typer.Exit(code=1) from None
 
 
 def _cfg() -> CLIConfig:

--- a/src/klangk/klangk/cli/execsync.py
+++ b/src/klangk/klangk/cli/execsync.py
@@ -8,7 +8,6 @@ single-responsibility modules, all imported back into
 
 from __future__ import annotations
 
-import asyncio
 import re
 import shutil
 import subprocess
@@ -120,8 +119,8 @@ def exec_cmd(
     surl = context.server_url()
     token = context.session_token()
 
-    exit_code = asyncio.run(
-        ws_exec(
+    exit_code = context.run_ws_command(
+        lambda: ws_exec(
             surl,
             token,
             ws.id,

--- a/src/klangk/klangk/cli/terminals.py
+++ b/src/klangk/klangk/cli/terminals.py
@@ -70,31 +70,9 @@ def frame_is(frame_type: str):
 
 # Seconds to wait for the shared_terminals confirmation frame after a
 # share_window/unshare_window command. A server that silently drops the
-# command (no error frame) makes the CLI time out here — keep short so
-# the failure surfaces fast (#2876).
-_CONFIRM_TIMEOUT = 10
-
-
-def run_ws_command(body) -> None:
-    """Run an async ws command body, surfacing failures as a clean exit.
-
-    Server ``error`` frames — e.g. the "Permission denied" a member
-    without ``share-terminals`` gets — already raise ``ConnectionError``
-    fast out of the ``frame_is`` predicates (#2633); a silent server
-    drop times out instead. Both must reach the user as a one-line
-    message and a nonzero exit, not a raw traceback (#2876) — the same
-    presentation ``klangk shell`` already uses.
-    """
-    try:
-        asyncio.run(body())
-    except ConnectionError as e:
-        context._err.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1) from None
-    except asyncio.TimeoutError:
-        context._err.print(
-            "[red]Timed out waiting for the server to respond[/red]"
-        )
-        raise typer.Exit(code=1) from None
+# command (no error frame) surfaces as a timeout here rather than a
+# hang (#2876); module-level so tests can shrink it.
+CONFIRM_TIMEOUT = 10
 
 
 terminal_app = typer.Typer(
@@ -164,7 +142,7 @@ def terminals(
                 conn, json.dumps({"cmd": "terminal_stop"})
             )
 
-    run_ws_command(_list)
+    context.run_ws_command(_list)
 
 
 _VALID_ROLES = ["owner", "coder", "collaborator", "spectator"]
@@ -293,7 +271,7 @@ def share_terminal(
             )
             # Wait for shared_terminals confirmation
             await recv_until(
-                conn, frame_is("shared_terminals"), _CONFIRM_TIMEOUT
+                conn, frame_is("shared_terminals"), CONFIRM_TIMEOUT
             )
             context._err.print(
                 f"[green]Terminal '{terminal}' is now shared[/green]"
@@ -303,7 +281,7 @@ def share_terminal(
                 conn, json.dumps({"cmd": "terminal_stop"})
             )
 
-    run_ws_command(_share)
+    context.run_ws_command(_share)
 
 
 @terminal_app.command("unshare")
@@ -346,7 +324,7 @@ def unshare_terminal(
             )
             # Wait for shared_terminals confirmation
             await recv_until(
-                conn, frame_is("shared_terminals"), _CONFIRM_TIMEOUT
+                conn, frame_is("shared_terminals"), CONFIRM_TIMEOUT
             )
             context._err.print(
                 f"[green]Terminal '{terminal}' is no longer shared[/green]"
@@ -356,4 +334,4 @@ def unshare_terminal(
                 conn, json.dumps({"cmd": "terminal_stop"})
             )
 
-    run_ws_command(_unshare)
+    context.run_ws_command(_unshare)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import time
 
 from _helpers import tracked_mkdtemp
 import klangk.cli.execsync
@@ -1757,7 +1758,7 @@ class TestMainCLI:
                 main.terminals("nope")
 
     def test_terminals_connection_failure(
-        self, logged_in_cfg, monkeypatch, reset_env
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
     ):
         from klangk.cli import main
 
@@ -1786,8 +1787,11 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
-            with pytest.raises(typer.Exit):
+            with pytest.raises(typer.Exit) as exc:
                 main.terminals("my-ws")
+        assert exc.value.exit_code == 1
+        # The server's error message reached stderr as a one-liner.
+        assert "fail" in capfd.readouterr().err
 
     def test_share_connection_failure(
         self, logged_in_cfg, monkeypatch, reset_env, capfd
@@ -1819,8 +1823,10 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
-            with pytest.raises(typer.Exit):
+            with pytest.raises(typer.Exit) as exc:
                 main.share_terminal("my-ws", "build")
+        assert exc.value.exit_code == 1
+        assert "fail" in capfd.readouterr().err
 
     def test_unshare_connection_failure(
         self, logged_in_cfg, monkeypatch, reset_env, capfd
@@ -1852,8 +1858,10 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
-            with pytest.raises(typer.Exit):
+            with pytest.raises(typer.Exit) as exc:
                 main.unshare_terminal("my-ws", "build")
+        assert exc.value.exit_code == 1
+        assert "fail" in capfd.readouterr().err
 
     @staticmethod
     def _ws_mock(ws):
@@ -1903,10 +1911,15 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
+            t0 = time.monotonic()
             with pytest.raises(typer.Exit) as exc:
                 main.share_terminal("my-ws", "build")
+            elapsed = time.monotonic() - t0
         assert exc.value.exit_code == 1
         assert "Permission denied" in capfd.readouterr().err
+        # Pin the fast property (#2876): a swallowed error frame would
+        # stall the full CONFIRM_TIMEOUT before failing.
+        assert elapsed < 5
         # The denial answered an actually-sent share_window command.
         sent = [json.loads(s) for s in sock.sent if isinstance(s, str)]
         assert any(s.get("cmd") == "share_window" for s in sent)
@@ -1936,10 +1949,13 @@ class TestMainCLI:
             ),
         ):
             os.environ["TERM"] = "xterm-256color"
+            t0 = time.monotonic()
             with pytest.raises(typer.Exit) as exc:
                 main.unshare_terminal("my-ws", "build")
+            elapsed = time.monotonic() - t0
         assert exc.value.exit_code == 1
         assert "Permission denied" in capfd.readouterr().err
+        assert elapsed < 5
         sent = [json.loads(s) for s in sock.sent if isinstance(s, str)]
         assert any(s.get("cmd") == "unshare_window" for s in sent)
 
@@ -1958,7 +1974,7 @@ class TestMainCLI:
         )
         # No shared_terminals after share_window: recv blocks, the
         # confirm wait expires against the shrunken timeout.
-        monkeypatch.setattr("klangk.cli.terminals._CONFIRM_TIMEOUT", 0.05)
+        monkeypatch.setattr("klangk.cli.terminals.CONFIRM_TIMEOUT", 0.05)
         sock = _ScriptedWS(self._startup_frames(self._WINDOWS))
         with (
             patch.object(
@@ -1972,7 +1988,87 @@ class TestMainCLI:
             with pytest.raises(typer.Exit) as exc:
                 main.share_terminal("my-ws", "build")
         assert exc.value.exit_code == 1
-        assert "Timed out" in capfd.readouterr().err
+        # A bare TimeoutError (no detail) falls back to the generic text.
+        err = capfd.readouterr().err
+        assert "Timed out waiting for the server to respond" in err
+
+    def test_run_ws_command_timeout_keeps_detail(
+        self, logged_in_cfg, monkeypatch, capfd
+    ):
+        """A TimeoutError carrying detail (wait_container_ready names the
+        failing wait) surfaces that detail, not the generic text."""
+
+        async def body():
+            raise asyncio.TimeoutError("Timed out waiting for container_ready")
+
+        with pytest.raises(typer.Exit) as exc:
+            context_mod.run_ws_command(body)
+        assert exc.value.exit_code == 1
+        err = capfd.readouterr().err
+        assert "container_ready" in err
+        assert "Timed out waiting for container_ready" in err
+
+    def test_share_terminal_handshake_rejected_session_expired(
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
+    ):
+        """A 4001/4002 handshake rejection prints the session-expired
+        message, matching klangk shell (#2877 review follow-up)."""
+        from websockets import InvalidStatus, Response
+
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        with (
+            patch.object(
+                context_mod, "_client", return_value=self._ws_mock(ws)
+            ),
+            patch(
+                "klangk.cli.transport.websockets.connect",
+                side_effect=InvalidStatus(
+                    Response(4002, "Token expired", {}, b"")
+                ),
+            ),
+        ):
+            os.environ["TERM"] = "xterm-256color"
+            with pytest.raises(typer.Exit) as exc:
+                main.share_terminal("my-ws", "build")
+        assert exc.value.exit_code == 1
+        assert "Session expired" in capfd.readouterr().err
+
+    def test_share_terminal_handshake_rejected_other(
+        self, logged_in_cfg, monkeypatch, reset_env, capfd
+    ):
+        """A non-auth handshake rejection (e.g. 500) prints the rejection
+        instead of a raw InvalidStatus traceback."""
+        from websockets import InvalidStatus, Response
+
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        with (
+            patch.object(
+                context_mod, "_client", return_value=self._ws_mock(ws)
+            ),
+            patch(
+                "klangk.cli.transport.websockets.connect",
+                side_effect=InvalidStatus(
+                    Response(500, "Internal Server Error", {}, b"")
+                ),
+            ),
+        ):
+            os.environ["TERM"] = "xterm-256color"
+            with pytest.raises(typer.Exit) as exc:
+                main.share_terminal("my-ws", "build")
+        assert exc.value.exit_code == 1
+        assert "Connection rejected" in capfd.readouterr().err
 
     def test_unshare_terminal_not_found(
         self, logged_in_cfg, monkeypatch, reset_env
@@ -4071,6 +4167,68 @@ class TestMainCLI:
                 )
         assert result.exit_code == 0
         assert mock_exec.call_args.kwargs["login"] is False
+
+    def test_exec_connection_error_clean_exit(self, logged_in_cfg):
+        """A server error during exec (e.g. permission denied) prints a
+        one-line message and exits 1, not a raw traceback (#2876)."""
+        from klangk.cli import main
+        from klangk.cli.client import Workspace
+        from typer.testing import CliRunner
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch.object(
+                klangk.cli.execsync,
+                "ws_exec",
+                AsyncMock(side_effect=ConnectionError("Permission denied")),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    main.app, ["exec", "my-ws", "echo", "hi"]
+                )
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+
+    def test_exec_handshake_session_expired_clean_exit(self, logged_in_cfg):
+        """A 4001/4002 handshake rejection during exec prints the
+        session-expired message, matching klangk shell."""
+        from websockets import InvalidStatus, Response
+
+        from klangk.cli import main
+        from klangk.cli.client import Workspace
+        from typer.testing import CliRunner
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+
+        with patch.object(context_mod, "_client", return_value=client):
+            with patch.object(
+                klangk.cli.execsync,
+                "ws_exec",
+                AsyncMock(
+                    side_effect=InvalidStatus(
+                        Response(4002, "Token expired", {}, b"")
+                    )
+                ),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    main.app, ["exec", "my-ws", "echo", "hi"]
+                )
+        assert result.exit_code == 1
+        assert "Session expired" in result.output
 
     def test_exec_strips_leading_dashdash_separator(self, logged_in_cfg):
         """With allow_extra_args + allow_interspersed_args=False, Click


### PR DESCRIPTION
## Summary

Addresses every actionable finding from the adversarial review of #2877
(review verdict APPROVE with follow-ups). Continues #2876.

## Changes

- **`run_ws_command` moved to `cli/context.py`** (shared home) and now
  **returns the body's result**, so `klangk exec` can pass the remote
  exit code through.
- **Timeout arm keeps diagnostics** (review important #1): `except
  TimeoutError as e` prints the exception's own detail when present —
  `wait_container_ready` raises `TimeoutError("Timed out waiting for
  container_ready")` — falling back to the generic message only for bare
  timeouts (`recv_until`).
- **Handshake parity made true** (review important #2): the helper now
  catches `websockets.InvalidStatus` exactly like `klangk shell` —
  4001/4002 prints the session-expired hint, other statuses print
  "Connection rejected: …". The docstring's parity claim is now accurate.
- **`klangk exec` closed** (review scope note): `execsync.py` had the
  same raw-escape gap; it now goes through `run_ws_command`. (`sync`
  rides `klangk exec --raw` as its rsync transport, so it is covered
  too; `monitor`/`sandbox` already had their own handling.)
- **Nits**: `_CONFIRM_TIMEOUT` → `CONFIRM_TIMEOUT` (AGENTS.md
  no-leading-underscore rule; comment no longer claims the value
  changed); permission-denied tests pin the **fast** property with a
  wall-clock assert (`elapsed < 5s` — a swallowed error frame would burn
  the full 10s before failing); the dropped stderr asserts in the three
  `*_connection_failure` tests are restored (dead `capfd` gone).

## Not addressed (deliberately)

- **Rich-markup injection** via server-controlled messages
  (`context._err.print(f"[red]{e}[/red]")` can raise `MarkupError` on a
  message containing `[/...]`): pre-existing pattern shared with
  `shellcmd.py`; fixing it right means deciding escaping across all
  command modules. Left for a separate change.

## Testing

- Full suite the CI way: `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — **6153 passed, 100% coverage**.
- New tests: timeout-detail unit test, handshake-rejected (4002 + 500) for
  share, exec ConnectionError + exec session-expired, exec exit-code
  passthrough still covered by existing tests.
- pre-commit (incl. xenon) green.
