### PR TITLE
fix(acl): egress-consent permission gates consent deciding (#2883)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -157,6 +157,19 @@ operators or integrators to act when upgrading.
   `monitor` can be granted alone for monitoring-only members who
   should observe health without exec/attach access.
 
+- **New `egress-consent` permission gates egress decisions (#2883).**
+  Registering a consent decider (the web Network tab, the consent
+  banner, `klangk consent-decide`), deciding held requests, revoking
+  verdicts, and pausing prompting now require `egress-consent` instead
+  of `terminal` — a spectator (watch-only) can no longer decide a
+  workspace's egress, and the Network tab and consent banner no longer
+  render for members without the permission. Owners, coders, and
+  collaborators hold it by default (existing deployments are backfilled
+  by migration 0018); pause/unpause no longer additionally require
+  `share-terminals`. Members granted only `terminal` via a custom ACL
+  must be granted `egress-consent` explicitly to keep deciding. See
+  [ACLs](../reference/acl.md).
+
 - **Workspace status WebSocket broadcasts are now scoped to workspace
   members (#1714).** `container_status`, `service_health` (including
   the connect-time snapshot), and `workspace_evicted` frames were

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -166,8 +166,10 @@ operators or integrators to act when upgrading.
   render for members without the permission. Owners, coders, and
   collaborators hold it by default (existing deployments are backfilled
   by migration 0018); pause/unpause no longer additionally require
-  `share-terminals`. Members granted only `terminal` via a custom ACL
-  must be granted `egress-consent` explicitly to keep deciding. See
+  `share-terminals`. Members or groups granted only `terminal` — whether
+  via a custom ACL or the simple Sharing tab (its grants do not include
+  `egress-consent`) — must be granted `egress-consent` explicitly to
+  keep deciding; grant it in the Advanced ACL editor. See
   [ACLs](../reference/acl.md).
 
 - **Workspace status WebSocket broadcasts are now scoped to workspace

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -197,11 +197,13 @@ Several deciders may be connected at once (two CLI sessions and the web
 UI, say): each pending request is fanned out to all of them and the first
 decision wins (#2244).
 
-**Authorization.** A workspace-scoped decider needs `terminal` access to
-the workspace (owner, member, or spectator); a deploy-wide decider needs
-admin. A verdict can only decide a request inside the decider's own
-workspace. Pausing prompting (below) additionally requires
-`share-terminals` (owner or collaborator).
+**Authorization.** A workspace-scoped decider needs the `egress-consent`
+permission on the workspace (owner, coder, or collaborator — #2883;
+spectators are watch-only and never see the Network tab or the consent
+banner); a deploy-wide decider needs admin. A verdict can only decide a
+request inside the decider's own workspace. Pausing prompting (below)
+shares the same single gate — anyone who may register a decider may
+also pause.
 
 ### Decision durations
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -186,6 +186,7 @@ handles of all current viewers.
 | `spectate-on-shared-terminals` | \*     | yes    | yes           | yes        |
 | `files`                        | \*     | yes    | yes           |            |
 | `exec-and-sync`                | \*     | yes    | yes           |            |
+| `egress-consent`               | \*     | yes    | yes           |            |
 
 \* Owners have the wildcard (`*`) permission which implies all permissions.
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -95,21 +95,22 @@ When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/w
 
 **Permissions checked on workspace resources**:
 
-| Permission       | Controls                                                                                                                                  |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `view`           | Can see the workspace exists                                                                                                              |
-| `monitor`        | Can observe health/status: `GET /workspaces/{id}/status` and the `container_status` / `service_health` WebSocket frames (#2783)           |
-| `terminal`       | Can open a terminal / exec commands                                                                                                       |
-| `files`          | Can browse file listings (metadata) and gets the Files tab; reading file bodies additionally needs `files-download`                       |
-| `files-download` | Can fetch file bytes: `/files/download` (raw stream/tar) and `/files/content` (text reader) — needs `files` too                           |
-| `files-write`    | Can mutate files: upload, rename, delete (needs `files` too)                                                                              |
-| `exec-and-sync`  | Can run one-shot commands (`klangk exec`) and sync (`klangk sync`) against the workspace                                                  |
-| `edit`           | Can change workspace settings (name, image, command, mounts, env)                                                                         |
-| `share`          | Can manage who has access (Sharing tab: member and group shares)                                                                          |
-| `change-acls`    | Can rewrite the raw ACE list (`GET`/`PUT /workspaces/{id}/acl`, the Advanced ACL editor) and assign roles (#2764); owners hold it via `*` |
-| `delete`         | Can delete the workspace                                                                                                                  |
-| `export`         | Can export the workspace as a `.tar.gz` archive (#2707)                                                                                   |
-| `*`              | All of the above                                                                                                                          |
+| Permission       | Controls                                                                                                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `view`           | Can see the workspace exists                                                                                                                                                                                                                      |
+| `monitor`        | Can observe health/status: `GET /workspaces/{id}/status` and the `container_status` / `service_health` WebSocket frames (#2783)                                                                                                                   |
+| `terminal`       | Can open a terminal / exec commands                                                                                                                                                                                                               |
+| `egress-consent` | Can decide held egress requests in interactive mode: register a decider (web Network tab, consent banner, `klangk consent-decide`), send verdicts, revoke, and pause prompting — owners/coders/collaborators by default, spectators never (#2883) |
+| `files`          | Can browse file listings (metadata) and gets the Files tab; reading file bodies additionally needs `files-download`                                                                                                                               |
+| `files-download` | Can fetch file bytes: `/files/download` (raw stream/tar) and `/files/content` (text reader) — needs `files` too                                                                                                                                   |
+| `files-write`    | Can mutate files: upload, rename, delete (needs `files` too)                                                                                                                                                                                      |
+| `exec-and-sync`  | Can run one-shot commands (`klangk exec`) and sync (`klangk sync`) against the workspace                                                                                                                                                          |
+| `edit`           | Can change workspace settings (name, image, command, mounts, env)                                                                                                                                                                                 |
+| `share`          | Can manage who has access (Sharing tab: member and group shares)                                                                                                                                                                                  |
+| `change-acls`    | Can rewrite the raw ACE list (`GET`/`PUT /workspaces/{id}/acl`, the Advanced ACL editor) and assign roles (#2764); owners hold it via `*`                                                                                                         |
+| `delete`         | Can delete the workspace                                                                                                                                                                                                                          |
+| `export`         | Can export the workspace as a `.tar.gz` archive (#2707)                                                                                                                                                                                           |
+| `*`              | All of the above                                                                                                                                                                                                                                  |
 
 Withholding `files-download` hides every download affordance and returns
 403 from both byte-moving endpoints: `/files/download` (raw stream or

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -29,6 +29,7 @@ class AclEditorState extends State<AclEditor> {
     'view',
     'monitor',
     'terminal',
+    'egress-consent',
     'code-in-isolation',
     'spectate-on-shared-terminals',
     'code-in-shared-terminals',

--- a/src/frontend/lib/workspace/consent_surface.dart
+++ b/src/frontend/lib/workspace/consent_surface.dart
@@ -1,0 +1,18 @@
+/// Mount policy for the consent-decider surface (#2246, #2883).
+///
+/// Pure predicate, kept outside [WorkspacePage] so the gate is
+/// unit-tested directly (importing the page from a test would pull its
+/// whole widget tree into the coverage denominator).
+
+/// Whether the consent-decider surface (the consent banner and the
+/// Network tab) may mount for this member: the workspace must be in
+/// interactive egress mode (#2246) AND the member must hold
+/// `egress-consent` (or the `*` wildcard) — spectators are watch-only
+/// and never decide egress (#2883).
+bool consentSurfaceAllowed({
+  required String egressMode,
+  required List<String> permissions,
+}) {
+  if (egressMode != 'interactive') return false;
+  return permissions.contains('egress-consent') || permissions.contains('*');
+}

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -32,19 +32,7 @@ import 'workspace_settings_panel.dart';
 import 'workspace_sharing_panel.dart';
 import 'terminal_tabs_view.dart';
 import 'workspace_connector.dart';
-
-/// Whether the consent-decider surface (the [ConsentBanner] and the
-/// Network tab) may mount for this member: the workspace must be in
-/// interactive egress mode (#2246) AND the member must hold
-/// `egress-consent` (or the `*` wildcard) — spectators are watch-only
-/// and never decide egress (#2883). Pure so the gate is unit-tested.
-bool consentSurfaceAllowed({
-  required String egressMode,
-  required List<String> permissions,
-}) {
-  if (egressMode != 'interactive') return false;
-  return permissions.contains('egress-consent') || permissions.contains('*');
-}
+import 'consent_surface.dart';
 
 class WorkspacePage extends StatefulWidget {
   final String workspaceId;

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -33,6 +33,19 @@ import 'workspace_sharing_panel.dart';
 import 'terminal_tabs_view.dart';
 import 'workspace_connector.dart';
 
+/// Whether the consent-decider surface (the [ConsentBanner] and the
+/// Network tab) may mount for this member: the workspace must be in
+/// interactive egress mode (#2246) AND the member must hold
+/// `egress-consent` (or the `*` wildcard) — spectators are watch-only
+/// and never decide egress (#2883). Pure so the gate is unit-tested.
+bool consentSurfaceAllowed({
+  required String egressMode,
+  required List<String> permissions,
+}) {
+  if (egressMode != 'interactive') return false;
+  return permissions.contains('egress-consent') || permissions.contains('*');
+}
+
 class WorkspacePage extends StatefulWidget {
   final String workspaceId;
 
@@ -235,14 +248,16 @@ class _WorkspacePageState extends State<WorkspacePage> {
     return null;
   }
 
-  /// Create + connect the consent-decider service for an interactive-mode
-  /// workspace (#2246). Static (or unknown) mode mounts no banner; nor
-  /// does a member without `egress-consent` (#2883) — a spectator is
-  /// watch-only and must not decide egress, so neither the banner nor
-  /// the Network tab ever mount for them.
+  /// Create + connect the consent-decider service when the consent
+  /// surface is allowed (see [consentSurfaceAllowed]).
   void _maybeInitConsent(String? token) {
-    if (_egressMode != 'interactive' || token == null) return;
-    if (!_hasPerm('egress-consent')) return;
+    if (token == null) return;
+    if (!consentSurfaceAllowed(
+      egressMode: _egressMode,
+      permissions: _workspacePermissions,
+    )) {
+      return;
+    }
     _consent ??= ConsentDeciderService(
       workspaceId: widget.workspaceId,
       token: token,

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -173,6 +173,10 @@ class _WorkspacePageState extends State<WorkspacePage> {
     // current value, not the one cached at login. Runs on mount and on
     // every workspaces-changed push.
     await auth.refreshDeployConfig();
+    // Fetch per-resource permissions BEFORE the workspace row: the
+    // consent init below gates on egress-consent (#2883), so the
+    // permission list must be loaded by then.
+    await _fetchPermissions();
     try {
       final ws = await _findWorkspace(auth, '/api/v1/workspaces') ??
           await _findWorkspace(auth, '/api/v1/workspaces/shared');
@@ -192,7 +196,10 @@ class _WorkspacePageState extends State<WorkspacePage> {
     } catch (e) {
       debugPrint('[WorkspacePage] fetch workspace name failed: $e');
     }
-    // Fetch per-resource permissions for tab visibility
+  }
+
+  Future<void> _fetchPermissions() async {
+    final auth = context.read<AuthService>();
     debugPrint('[WorkspacePage] fetching workspace permissions');
     try {
       final resource = '/workspaces/${widget.workspaceId}';
@@ -229,9 +236,13 @@ class _WorkspacePageState extends State<WorkspacePage> {
   }
 
   /// Create + connect the consent-decider service for an interactive-mode
-  /// workspace (#2246). Static (or unknown) mode mounts no banner.
+  /// workspace (#2246). Static (or unknown) mode mounts no banner; nor
+  /// does a member without `egress-consent` (#2883) — a spectator is
+  /// watch-only and must not decide egress, so neither the banner nor
+  /// the Network tab ever mount for them.
   void _maybeInitConsent(String? token) {
     if (_egressMode != 'interactive' || token == null) return;
+    if (!_hasPerm('egress-consent')) return;
     _consent ??= ConsentDeciderService(
       workspaceId: widget.workspaceId,
       token: token,

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/workspace/workspace_overlays.dart';
+import 'package:klangk_frontend/workspace/workspace_page.dart';
 
 void main() {
   Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
@@ -166,6 +167,66 @@ void main() {
 
       await tester.tap(find.text('Back to workspaces'));
       expect(called, isTrue);
+    });
+  });
+
+  /// #2883: the consent surface (banner + Network tab) mount gate. The
+  /// predicate is pure and unit-tested directly — spectators
+  /// (terminal-only) and static/allow-mode members never mount it.
+  group('consentSurfaceAllowed (#2883)', () {
+    test('interactive + egress-consent mounts', () {
+      expect(
+        consentSurfaceAllowed(
+          egressMode: 'interactive',
+          permissions: ['view', 'monitor', 'terminal', 'egress-consent'],
+        ),
+        isTrue,
+      );
+    });
+
+    test('interactive + owner wildcard mounts', () {
+      expect(
+        consentSurfaceAllowed(
+          egressMode: 'interactive',
+          permissions: ['*'],
+        ),
+        isTrue,
+      );
+    });
+
+    test('spectator (terminal-only, no egress-consent) never mounts', () {
+      expect(
+        consentSurfaceAllowed(
+          egressMode: 'interactive',
+          permissions: [
+            'view',
+            'monitor',
+            'terminal',
+            'spectate-on-shared-terminals'
+          ],
+        ),
+        isFalse,
+      );
+    });
+
+    test('no permissions at all never mounts (fail-closed)', () {
+      expect(
+        consentSurfaceAllowed(
+          egressMode: 'interactive',
+          permissions: [],
+        ),
+        isFalse,
+      );
+    });
+
+    test('static egress mode never mounts, even with the permission', () {
+      expect(
+        consentSurfaceAllowed(
+          egressMode: 'static',
+          permissions: ['egress-consent', '*'],
+        ),
+        isFalse,
+      );
     });
   });
 }

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/workspace/workspace_overlays.dart';
-import 'package:klangk_frontend/workspace/workspace_page.dart';
+import 'package:klangk_frontend/workspace/consent_surface.dart';
 
 void main() {
   Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -293,6 +293,7 @@ ALL_PERMISSIONS = [
     "edit",
     "delete",
     "terminal",
+    "egress-consent",
     "code-in-isolation",
     "exec-and-sync",
     "spectate-on-shared-terminals",

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -322,8 +322,9 @@ def consent_decide(
     held egress requests (a blocked destination the sidecar is holding for
     a verdict), and lets you accept (allow once) or deny each one while it
     is held. Accepting lets that exact connection proceed; denying (or the
-    countdown hitting zero) fails it. Requires terminal access to the
-    workspace (owner/member/spectator).
+    countdown hitting zero) fails it. Requires the egress-consent
+    permission on the workspace (owner, coder, or collaborator — #2883;
+    spectators are watch-only).
     """
     context.require_auth()
     client = context._client()

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -65,6 +65,7 @@ from klangk.model.migrations import m0014_groups_create_admin
 from klangk.model.migrations import m0015_classification_banner
 from klangk.model.migrations import m0016_monitor_permission
 from klangk.model.migrations import m0017_change_acls_permission
+from klangk.model.migrations import m0018_egress_consent_permission
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -90,6 +91,7 @@ MIGRATIONS: list[Migration] = [
     m0015_classification_banner.migration,
     m0016_monitor_permission.migration,
     m0017_change_acls_permission.migration,
+    m0018_egress_consent_permission.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0018_egress_consent_permission.py
+++ b/src/klangk/klangk/model/migrations/m0018_egress_consent_permission.py
@@ -1,4 +1,4 @@
-"""Migration 0017: grant ``egress-consent`` to existing role groups.
+"""Migration 0018: grant ``egress-consent`` to existing role groups.
 
 Egress consent is now gated on the dedicated ``egress-consent``
 permission (#2883) instead of ``terminal`` — enforced at the
@@ -15,9 +15,14 @@ For every ``coders-``/``collaborators-<workspace_id>`` role group, an
 ``Allow`` ACE for ``egress-consent`` is appended at the end of that
 resource's ACL (max position + 1) unless one already exists. Owners
 need nothing (their seeded ACE is the ``*`` wildcard); spectators never
-had consent. Admins who granted ``terminal`` to other principals via
-custom ACEs (e.g. simple member shares) must add ``egress-consent``
-explicitly to preserve deciding for them.
+had consent. The match is by role-group name + source marker, not by
+ACEs: a coders/collaborators group whose ``terminal`` grant an admin
+deliberately stripped still gains ``egress-consent`` (matching the
+issue's wording: the backfill covers the role groups of every existing
+workspace; stripping the group's deciding is then an owner edit).
+Admins who granted ``terminal`` to other principals via custom ACEs
+(e.g. simple member shares) must add ``egress-consent`` explicitly to
+preserve deciding for them.
 """
 
 import re

--- a/src/klangk/klangk/model/migrations/m0018_egress_consent_permission.py
+++ b/src/klangk/klangk/model/migrations/m0018_egress_consent_permission.py
@@ -1,0 +1,69 @@
+"""Migration 0017: grant ``egress-consent`` to existing role groups.
+
+Egress consent is now gated on the dedicated ``egress-consent``
+permission (#2883) instead of ``terminal`` — enforced at the
+``/ws/consent-decider`` registration handshake, so a spectator
+(watch-only) can no longer register a decider, decide held requests,
+revoke verdicts, or pause prompting. New workspaces seed the permission
+into their ``coders``/``collaborators`` role groups via
+``_ROLE_GROUP_PERMISSIONS``; this migration backfills existing
+workspaces so the upgrade does not silently stop members who could
+already decide from deciding (preserving prior behavior: withholding
+``egress-consent`` is an owner/admin choice, not the new default).
+
+For every ``coders-``/``collaborators-<workspace_id>`` role group, an
+``Allow`` ACE for ``egress-consent`` is appended at the end of that
+resource's ACL (max position + 1) unless one already exists. Owners
+need nothing (their seeded ACE is the ``*`` wildcard); spectators never
+had consent. Admins who granted ``terminal`` to other principals via
+custom ACEs (e.g. simple member shares) must add ``egress-consent``
+explicitly to preserve deciding for them.
+"""
+
+import re
+
+from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_GROUP
+from klangk.model.migrations.base import Migration
+
+_CONSENT_ROLES = ("coders", "collaborators")
+_ROLE_GROUP_RE = re.compile(r"^(%s)-(.+)$" % "|".join(_CONSENT_ROLES))
+
+
+async def apply(db) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM groups WHERE source = 'workspace-role'"
+    )
+    role_groups = [row[0] for row in await cursor.fetchall()]
+    for name in role_groups:
+        m = _ROLE_GROUP_RE.match(name)
+        if m is None:
+            continue  # owners/spectators (and unknown suffixes) untouched
+        ws_id = m.group(2)
+        resource = f"/workspaces/{ws_id}"
+        existing = await db.execute(
+            "SELECT 1 FROM acl_entries"
+            " WHERE resource = ? AND group_id = ("
+            "   SELECT id FROM groups WHERE name = ?)"
+            " AND permission = 'egress-consent' LIMIT 1",
+            (resource, name),
+        )
+        if await existing.fetchone() is not None:
+            continue
+        max_pos = await db.execute(
+            "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
+            " WHERE resource = ?",
+            (resource,),
+        )
+        pos = (await max_pos.fetchone())[0] + 1
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type,"
+            "  user_id, group_id, system_principal, permission)"
+            " VALUES (?, ?, ?, ?, NULL,"
+            "  (SELECT id FROM groups WHERE name = ?), NULL,"
+            "  'egress-consent')",
+            (resource, pos, ACTION_ALLOW, PRINCIPAL_GROUP, name),
+        )
+
+
+migration = Migration(18, "0018_egress_consent_permission", apply)

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -26,6 +26,7 @@ _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
     "coders": [
         "monitor",
         "terminal",
+        "egress-consent",
         "code-in-isolation",
         "exec-and-sync",
         "spectate-on-shared-terminals",
@@ -36,6 +37,7 @@ _ROLE_GROUP_PERMISSIONS: dict[str, list[str]] = {
     "collaborators": [
         "monitor",
         "terminal",
+        "egress-consent",
         "code-in-isolation",
         "exec-and-sync",
         "code-in-shared-terminals",

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -21,12 +21,15 @@ it reverts to static allow-list.
   drop it (first-decision-wins).
 
 Authorization (#2244 closes the #2308 authz gap): a workspace-scoped decider
-(``?workspace=<id>``) must have ``terminal`` access to that workspace (owner,
-member, or spectator -- anyone who can open a terminal there); a deploy-wide
-decider (no ``workspace``) must be an admin. A verdict is honored only if it
-targets the decider's own workspace (defense-in-depth), enforced in ``resolve``
-via ``decider_workspace``. Auth mirrors the main ``/ws`` handler: a user JWT in
-the ``token`` query param.
+(``?workspace=<id>``) must have the ``egress-consent`` permission on that
+workspace (owner, coder, or collaborator -- #2883; spectators are
+watch-only and never register); a deploy-wide decider (no ``workspace``)
+must be an admin. A verdict is honored only if it targets the decider's
+own workspace (defense-in-depth), enforced in ``resolve`` via
+``decider_workspace``. Pause/unpause share the same single gate as the
+connection itself (#2883): anyone who may register may also pause.
+Auth mirrors the main ``/ws`` handler: a user JWT in the ``token``
+query param.
 
 Outbound writes go through :class:`SafeWebSocket` (bounded queue +
 ``SlowClientError``) like the main ``/ws`` handler.
@@ -86,9 +89,12 @@ async def _refuse_invalid_handshake(
 ) -> bool:
     """Authorization + static-mode gate for a consent decider.
 
-    Workspace-scoped deciders need terminal access to the workspace (owner
-    or member); deploy-wide deciders need admin. Mirrors the main /ws
-    handler's workspace gate (wshandler/connection.py).
+    Workspace-scoped deciders need the ``egress-consent`` permission on
+    the workspace (owner, coder, or collaborator -- #2883; a spectator
+    has only watch access and is refused here, so it can never reach the
+    verdict/revoke/pause handlers); deploy-wide deciders need admin.
+    Mirrors the main /ws handler's workspace gate
+    (wshandler/connection.py).
 
     #2394: a static-mode workspace never holds egress for a human decision
     (its non-allow-listed egress is denied immediately with a static
@@ -105,12 +111,11 @@ async def _refuse_invalid_handshake(
     above). _refuse() therefore also logs the reason server-side (#2490):
     the log line is the only place a 403 storm is attributable.
 
-    Returns (refused, principals) — principals (needed by the pause /
-    unpause handlers) is only meaningful when not refused."""
+    Returns True when the handshake was refused."""
     principals = await app.state.acl.get_principals(user["id"])
     if workspace is not None:
         allowed = await app.state.acl.check_permission(
-            f"/workspaces/{workspace}", principals, "terminal"
+            f"/workspaces/{workspace}", principals, "egress-consent"
         )
     else:
         allowed = await app.state.acl.check_permission(
@@ -118,14 +123,14 @@ async def _refuse_invalid_handshake(
         )
     if not allowed:
         await _refuse(websocket, 4003, "Forbidden", user.get("email"))
-        return True, principals
+        return True
     if workspace is not None:
         ws = await app.state.model.workspaces.get_workspace(workspace)
         if ws is None:
             # Vanished between the authz check and now (a delete race) -- the
             # workspace authz just passed against can no longer be registered.
             await _refuse(websocket, 4003, "Forbidden", user.get("email"))
-            return True, principals
+            return True
         if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
             await _refuse(
                 websocket,
@@ -133,8 +138,8 @@ async def _refuse_invalid_handshake(
                 "workspace egress mode is not interactive",
                 user.get("email"),
             )
-            return True, principals
-    return False, principals
+            return True
+    return False
 
 
 def _log_handshake_timing(t0: float, marks: list[tuple[str, float]]) -> None:
@@ -159,7 +164,6 @@ async def _dispatch_decider_message(
     workspace: str | None,
     user_id: str,
     decider_id: str,
-    principals,
 ) -> None:
     """Act on one parsed decider frame by its ``type``.
 
@@ -191,10 +195,10 @@ async def _dispatch_decider_message(
         # #2332: pause interactive consent prompting for this
         # decider's workspace for a window. A deploy-wide decider
         # (workspace None) has no single workspace to pause -> nack.
-        await _handle_pause(app, safe_ws, msg, workspace, principals)
+        await _handle_pause(app, safe_ws, msg, workspace)
     elif mtype == "unpause":
         # #2332: clear an active pause for this decider's workspace.
-        await _handle_unpause(app, safe_ws, workspace, principals)
+        await _handle_unpause(app, safe_ws, workspace)
 
 
 async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
@@ -221,7 +225,6 @@ async def _decider_receive_loop(
     workspace,
     user: dict,
     decider_id: str,
-    principals,
 ) -> None:
     """Receive + dispatch decider frames until the socket drops or the
     client falls behind."""
@@ -249,7 +252,6 @@ async def _decider_receive_loop(
                 workspace,
                 user["id"],
                 decider_id,
-                principals,
             )
         except SlowClientError:
             # Outbound queue full -- the client can't keep up. Drop it
@@ -282,10 +284,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         return
     workspace = websocket.query_params.get("workspace")  # None = deploy-wide
 
-    refused, principals = await _refuse_invalid_handshake(
-        websocket, app, workspace, user
-    )
-    if refused:
+    if await _refuse_invalid_handshake(websocket, app, workspace, user):
         return
     _hs_mark("authz")
     _hs_mark("workspace")
@@ -314,7 +313,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         if rules is not None:
             safe_ws.send_json(rules)
         await _decider_receive_loop(
-            app, registry, safe_ws, workspace, user, decider_id, principals
+            app, registry, safe_ws, workspace, user, decider_id
         )
     finally:
         # Connection gone (clean disconnect, error, or crash) -> drop the
@@ -323,26 +322,21 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         await safe_ws.stop_sender()
 
 
-async def _can_pause(app, workspace, principals) -> bool:
-    """Pause/unpause authz (#2332, review I1).
+def _can_pause(workspace: str | None) -> bool:
+    """Pause/unpause eligibility (#2332, #2883).
 
-    Pause silences ALL consent prompts workspace-wide for a window (a
-    workspace-wide policy change, broader than deciding one request), so it
-    needs a higher bar than the connection's ``terminal`` gate: the
-    ``share-terminals`` permission (collaborators + owners). Spectators and
-    coders (terminal only) may still connect and decide individual requests.
+    The old higher ``share-terminals`` bar is gone: pause/unpause ride
+    the connection's own ``egress-consent`` gate, so every decider that
+    registered may also pause. Only a deploy-wide decider (workspace
+    None) has no single workspace to pause.
     """
-    if workspace is None:
-        return False  # deploy-wide decider has no single workspace to pause
-    return await app.state.acl.check_permission(
-        f"/workspaces/{workspace}", principals, "share-terminals"
-    )
+    return workspace is not None
 
 
-async def _handle_pause(app, safe_ws, msg, workspace, principals) -> None:
+async def _handle_pause(app, safe_ws, msg, workspace) -> None:
     """Pause consent prompting for the decider's workspace (#2332)."""
-    if not await _can_pause(app, workspace, principals):
-        # Missing share-terminals, or a deploy-wide decider with no target.
+    if not _can_pause(workspace):
+        # A deploy-wide decider has no single workspace to pause.
         safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
         return
     result = await app.state.consent_coordinator.pause(
@@ -357,9 +351,9 @@ async def _handle_pause(app, safe_ws, msg, workspace, principals) -> None:
     )
 
 
-async def _handle_unpause(app, safe_ws, workspace, principals) -> None:
+async def _handle_unpause(app, safe_ws, workspace) -> None:
     """Clear an active consent pause for the decider's workspace (#2332)."""
-    if not await _can_pause(app, workspace, principals):
+    if not _can_pause(workspace):
         safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
         return
     result = await app.state.consent_coordinator.unpause(workspace)

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -827,7 +827,7 @@ OUTCOME_NAMES: dict[str, str] = {
     "PAUSE-REFUSED": "an off-list host was refused or hung while paused instead of auto-allowing -- the pause did not take effect at the gate. #2332",
     "PAUSE-POLICY-BYPASS": "a static policy (allow-list / rejected_domains) was bypassed or changed while paused -- pause must affect only the interactive hold, not the DNS-layer lists. #2332",
     "PAUSE-RESUME-BROKEN": "after resume, an off-list host was not re-held for consent (the pause lingered, or the re-hold failed). #2332",
-    "PAUSE-ACK-FAILED": "the pause/unpause pause_ack came back not-ok (authz/protocol: missing share-terminals, unknown duration, or a deploy-wide decider). #2332/#2389",
+    "PAUSE-ACK-FAILED": "the pause/unpause pause_ack came back not-ok (protocol: unknown duration, or a deploy-wide decider). #2332/#2389/#2883",
     "FANOUT-SERIALIZED": "N concurrent off-list connects did not all surface a held request simultaneously (the NFQUEUE consumer serialized them -- a #2331/#2337 regression).",
     "CONCURRENT-NOT-DEDUPED": "concurrent connections to the same destination each produced a prompt (the coordinator's per-destination dedup is broken -- each should collapse to one).",
     "ONCE-CROSS-CONN": "a `once` verdict on one connection released a separate concurrent connection to the same host (the verdict leaked across connections -- #2361).",

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -306,3 +306,5 @@ def test_all_permissions_single_source():
     assert "monitor" in api.ALL_PERMISSIONS
     # #2764's raw-ACL-editing gate must be reportable the same way.
     assert "change-acls" in api.ALL_PERMISSIONS
+    # #2883's egress-consent gate must be reportable the same way.
+    assert "egress-consent" in api.ALL_PERMISSIONS

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -329,6 +329,61 @@ class TestConsentDeciderWS:
         assert ws.accepted is False
         assert app.state.consent_deciders.has_decider(WS) is False
 
+    async def test_terminal_only_member_is_refused_at_handshake(self):
+        # #2883: spectating is watch-only. A member holding only
+        # ``terminal`` (the spectator profile) must be refused at the
+        # decider registration handshake -- it can never reach the
+        # verdict/revoke/pause handlers.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "spec@x"})
+
+        async def check(resource, principals, perm):
+            return perm == "terminal"  # terminal yes, egress-consent no
+
+        app.state.acl.check_permission = AsyncMock(side_effect=check)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4003, "Forbidden")
+        assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+
+    async def test_egress_consent_member_registers_and_decides(self):
+        # #2883: the ``egress-consent`` permission alone admits a decider
+        # (owner/coder/collaborator profile) -- verdicts flow through.
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "coder@x"})
+
+        async def check(resource, principals, perm):
+            return perm == "egress-consent"
+
+        app.state.acl.check_permission = AsyncMock(side_effect=check)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS},
+            [
+                json.dumps(
+                    {
+                        "type": "verdict",
+                        "request_id": "rid",
+                        "decision": "allowed",
+                    }
+                ),
+                WebSocketDisconnect(),
+            ],
+        )
+        await handle_consent_decider(ws, app)
+        assert ws.accepted is True
+        app.state.consent_coordinator.resolve.assert_awaited_once_with(
+            "rid",
+            "allowed",
+            "u1",
+            duration="tilrestart",
+            decider_workspace=WS,
+        )
+
     async def test_forbidden_logs_user_and_workspace(self, caplog):
         # #2490: an authz refusal names the user + workspace in the log --
         # and never the token (it rides the query string; leaking it into
@@ -657,19 +712,18 @@ class TestConsentDeciderWS:
         ]
         assert acks and acks[0]["ok"] is False
 
-    async def test_pause_requires_share_terminals_not_just_terminal(self):
-        # I1 (#2332): pause is a workspace-wide policy change, so it needs
-        # share-terminals (collaborators + owners), not just the terminal
-        # access that gates the connection. A terminal-only member (e.g. a
-        # spectator) may connect + decide requests but NOT pause.
+    async def test_pause_requires_no_permission_beyond_registration(self):
+        # #2883: the old ``share-terminals`` bar is gone -- pause/unpause
+        # ride the connection's own ``egress-consent`` gate. A coder
+        # (egress-consent, no share-terminals) registers AND can pause.
         from fastapi import WebSocketDisconnect
 
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"id": "u1", "email": "spec@x"})
+        app = _ws_app({"id": "u1", "email": "coder@x"})
 
         async def check(resource, principals, perm):
-            return perm == "terminal"  # terminal yes, share-terminals no
+            return perm == "egress-consent"  # no share-terminals
 
         app.state.acl.check_permission = AsyncMock(side_effect=check)
         ws = _FakeWS(
@@ -677,24 +731,24 @@ class TestConsentDeciderWS:
             ['{"type":"pause","duration":"15m"}', WebSocketDisconnect()],
         )
         await handle_consent_decider(ws, app)
-        app.state.consent_coordinator.pause.assert_not_awaited()
+        app.state.consent_coordinator.pause.assert_awaited_once_with(WS, "15m")
         acks = [
             json.loads(m)
             for m in ws.sent
             if json.loads(m).get("type") == "pause_ack"
         ]
-        assert acks and acks[0]["ok"] is False
+        assert acks and acks[0]["ok"] is True
 
-    async def test_unpause_requires_share_terminals(self):
-        # Same higher bar applies to unpause (a workspace-wide state change).
+    async def test_unpause_requires_no_permission_beyond_registration(self):
+        # Same single gate applies to unpause.
         from fastapi import WebSocketDisconnect
 
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"id": "u1", "email": "spec@x"})
+        app = _ws_app({"id": "u1", "email": "coder@x"})
 
         async def check(resource, principals, perm):
-            return perm == "terminal"
+            return perm == "egress-consent"
 
         app.state.acl.check_permission = AsyncMock(side_effect=check)
         ws = _FakeWS(
@@ -702,33 +756,7 @@ class TestConsentDeciderWS:
             ['{"type":"unpause"}', WebSocketDisconnect()],
         )
         await handle_consent_decider(ws, app)
-        app.state.consent_coordinator.unpause.assert_not_awaited()
-        acks = [
-            json.loads(m)
-            for m in ws.sent
-            if json.loads(m).get("type") == "pause_ack"
-        ]
-        assert acks and acks[0]["ok"] is False
-
-    async def test_pause_allowed_with_share_terminals(self):
-        # A collaborator (share-terminals) can pause; the coordinator is called
-        # and a success pause_ack comes back.
-        from fastapi import WebSocketDisconnect
-
-        from klangk.wshandler.decider import handle_consent_decider
-
-        app = _ws_app({"id": "u1", "email": "collab@x"})
-
-        async def check(resource, principals, perm):
-            return perm in ("terminal", "share-terminals")
-
-        app.state.acl.check_permission = AsyncMock(side_effect=check)
-        ws = _FakeWS(
-            {"token": "tok", "workspace": WS},
-            ['{"type":"pause","duration":"1h"}', WebSocketDisconnect()],
-        )
-        await handle_consent_decider(ws, app)
-        app.state.consent_coordinator.pause.assert_awaited_once_with(WS, "1h")
+        app.state.consent_coordinator.unpause.assert_awaited_once_with(WS)
         acks = [
             json.loads(m)
             for m in ws.sent

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -69,6 +69,7 @@ class TestRunner:
             (15, "0015_classification_banner"),
             (16, "0016_monitor_permission"),
             (17, "0017_change_acls_permission"),
+            (18, "0018_egress_consent_permission"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -152,6 +153,7 @@ class TestRunner:
                 (15, "0015_classification_banner"),
                 (16, "0016_monitor_permission"),
                 (17, "0017_change_acls_permission"),
+                (18, "0018_egress_consent_permission"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -1012,6 +1014,145 @@ class TestM0014GroupsCreateAdmin:
             await db.__aexit__(None, None, None)
 
 
+class TestM0018EgressConsentPermission:
+    """m0018: backfill ``egress-consent`` onto existing role groups
+    (#2883).
+
+    Exercised against a hand-built post-m0010 schema (groups with the
+    ``source`` marker, minimal ``acl_entries``) by calling ``apply``
+    directly, mirroring the m0013 pattern.
+    """
+
+    WS_ID = "11111111-2222-3333-4444-555555555555"
+    RESOURCE = f"/workspaces/{WS_ID}"
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0018-egress.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT, source TEXT)"
+        )
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT)"
+        )
+        for role in ("owners", "coders", "collaborators", "spectators"):
+            await db.execute(
+                "INSERT INTO groups (id, name, source) VALUES (?, ?, ?)",
+                (f"g-{role}", f"{role}-{self.WS_ID}", "workspace-role"),
+            )
+        await db.execute(
+            "INSERT INTO groups (id, name, source) VALUES (?, ?, ?)",
+            ("g-human", "human", "manual"),
+        )
+        # A pre-#2883 seeded ACL: owner wildcard + one ACE per role group.
+        for resource, pos, gid, perm in (
+            (self.RESOURCE, 0, "g-owners", "*"),
+            (self.RESOURCE, 1, "g-coders", "terminal"),
+            (self.RESOURCE, 2, "g-collaborators", "terminal"),
+            (self.RESOURCE, 3, "g-spectators", "terminal"),
+        ):
+            await db.execute(
+                "INSERT INTO acl_entries (resource, position, action,"
+                " principal_type, group_id, permission)"
+                " VALUES (?, ?, 1, 2, ?, ?)",
+                (resource, pos, gid, perm),
+            )
+        return db
+
+    async def _consent_aces(self, db) -> dict[str, int]:
+        """group_id -> count of egress-consent Allow ACEs."""
+        cursor = await db.execute(
+            "SELECT group_id, COUNT(*) FROM acl_entries"
+            " WHERE permission = 'egress-consent' AND action = 1"
+            " GROUP BY group_id"
+        )
+        return {row[0]: row[1] for row in await cursor.fetchall()}
+
+    async def test_backfill_grants_consent_roles_only(self, tmp_path):
+        from klangk.model.migrations import m0018_egress_consent_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await m0018_egress_consent_permission.migration.apply(db)
+            # Coders/collaborators gain it; owners are covered by the
+            # wildcard; spectators (watch-only) never do.
+            assert await self._consent_aces(db) == {
+                "g-coders": 1,
+                "g-collaborators": 1,
+            }
+            # Appended after the seeded entries, not interleaved.
+            cursor = await db.execute(
+                "SELECT position FROM acl_entries"
+                " WHERE permission = 'egress-consent'"
+                " AND group_id = 'g-coders'"
+            )
+            assert (await cursor.fetchone())[0] == 4
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_idempotent(self, tmp_path):
+        from klangk.model.migrations import m0018_egress_consent_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await m0018_egress_consent_permission.migration.apply(db)
+            await m0018_egress_consent_permission.migration.apply(db)
+            assert await self._consent_aces(db) == {
+                "g-coders": 1,
+                "g-collaborators": 1,
+            }
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_skips_manual_groups(self, tmp_path):
+        """A manual group named like a role group is untouched — the
+        backfill matches on the workspace-role source marker."""
+        from klangk.model.migrations import m0018_egress_consent_permission
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO groups (id, name, source) VALUES (?, ?, ?)",
+                ("g-lookalike", f"coders-{self.WS_ID}-lookalike", "manual"),
+            )
+            await m0018_egress_consent_permission.migration.apply(db)
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM acl_entries WHERE group_id ="
+                " 'g-lookalike'"
+            )
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_backfill_empty_tables(self, tmp_path):
+        """No groups: nothing raises, nothing is written."""
+        from klangk.model.migrations import m0018_egress_consent_permission
+
+        db = aiosqlite.connect(str(tmp_path / "m0018-egress-empty.db"))
+        db = await db.__aenter__()
+        try:
+            await db.execute(
+                "CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT,"
+                " source TEXT)"
+            )
+            await db.execute(
+                "CREATE TABLE acl_entries ("
+                " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                " resource TEXT, position INTEGER, action INTEGER,"
+                " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+                " system_principal INTEGER, permission TEXT)"
+            )
+            await m0018_egress_consent_permission.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+
 class TestRenameDetection:
     async def test_renamed_shipped_migration_raises(self, tmp_path):
         """A recorded id whose name changed must fail loudly — a silent
@@ -1357,7 +1498,7 @@ class TestM0017ChangeAclsPermission:
     async def _db(self, tmp_path):
         import aiosqlite
 
-        db = aiosqlite.connect(str(tmp_path / "m0017.db"))
+        db = aiosqlite.connect(str(tmp_path / "m0018-egress.db"))
         db = await db.__aenter__()
         await db.execute(
             "CREATE TABLE acl_entries ("
@@ -1498,7 +1639,7 @@ class TestM0017ChangeAclsPermission:
 
         from klangk.model.migrations import m0017_change_acls_permission
 
-        db = aiosqlite.connect(str(tmp_path / "m0017-empty.db"))
+        db = aiosqlite.connect(str(tmp_path / "m0018-egress-empty.db"))
         db = await db.__aenter__()
         try:
             await db.execute(

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -1498,7 +1498,7 @@ class TestM0017ChangeAclsPermission:
     async def _db(self, tmp_path):
         import aiosqlite
 
-        db = aiosqlite.connect(str(tmp_path / "m0018-egress.db"))
+        db = aiosqlite.connect(str(tmp_path / "m0017.db"))
         db = await db.__aenter__()
         await db.execute(
             "CREATE TABLE acl_entries ("
@@ -1639,7 +1639,7 @@ class TestM0017ChangeAclsPermission:
 
         from klangk.model.migrations import m0017_change_acls_permission
 
-        db = aiosqlite.connect(str(tmp_path / "m0018-egress-empty.db"))
+        db = aiosqlite.connect(str(tmp_path / "m0017-empty.db"))
         db = await db.__aenter__()
         try:
             await db.execute(

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -200,11 +200,12 @@ async def test_create_workspace_with_acl_seeds_owner_and_role_groups(
     # Position counter is global across all groups (no collisions).
     positions = sorted(e["position"] for e in entries)
     assert positions == list(range(len(entries)))
-    # 1 owner ACE + 1 + 8 + 10 + 3 group ACEs (coders/collaborators carry
+    # 1 owner ACE + 1 + 9 + 11 + 3 group ACEs (coders/collaborators carry
     # `files-download`/`files-write` alongside `files` (#2705),
-    # `exec-and-sync` (#2706/#2712), and `monitor` (#2783) joins every
-    # role that has `terminal`, spectators included).
-    assert len(entries) == 1 + 1 + 8 + 10 + 3
+    # `exec-and-sync` (#2706/#2712), `monitor` (#2783) joins every
+    # role that has `terminal`, spectators included, and
+    # `egress-consent` (#2883) joins coders/collaborators).
+    assert len(entries) == 1 + 1 + 9 + 11 + 3
     # Coder/collaborator grants include both transfer permissions and
     # the exec-channel permission.
     for suffix in ["coders", "collaborators"]:
@@ -222,7 +223,20 @@ async def test_create_workspace_with_acl_seeds_owner_and_role_groups(
             "files-download",
             "files-write",
             "exec-and-sync",
+            "egress-consent",
         } <= perms
+
+    # Spectators are watch-only: no consent permission is seeded (#2883).
+    spectator_group = await app_state.state.model.users.get_group_by_name(
+        f"spectators-{ws['id']}"
+    )
+    spectator_perms = {
+        e["permission"]
+        for e in entries
+        if e["principal_type"] == model.PRINCIPAL_GROUP
+        and e["group_id"] == spectator_group["id"]
+    }
+    assert "egress-consent" not in spectator_perms
 
 
 async def test_create_workspace_with_acl_rollback_on_seeding_failure(


### PR DESCRIPTION
## What

Spectating is watch-only: a spectator could register a consent decider (`/ws/consent-decider` gated only on `terminal`), decide held egress requests, revoke verdicts, and pause prompting. This adds the dedicated **`egress-consent`** permission and gates all of egress consent on it (#2883).

## Changes

- **New `egress-consent` permission**, added to `ALL_PERMISSIONS` (so `my-permissions` reports it) and seeded into the `coders`/`collaborators` role groups; owners are covered by their `*` wildcard.
- **Handshake gate** (`wshandler/decider.py`): workspace-scoped decider registration now checks `egress-consent` instead of `terminal` — a spectator gets `4003 Forbidden` before `accept()`, so the verdict/revoke/pause handlers are unreachable.
- **Pause single gate**: `_can_pause`'s higher `share-terminals` bar is removed — everyone who can register can pause/unpause (deploy-wide deciders still nack: no single workspace). The now-unused `principals` plumbing through the receive loop is gone.
- **Migration 0018** (`m0018_egress_consent_permission.py`, m0013 pattern): backfills `egress-consent` onto existing `coders-`/`collaborators-<ws>` role groups — idempotent, skips owners (`*`) / spectators / manual groups.
- **Frontend** (`workspace_page.dart`): the permission fetch now runs before the consent init, and `_maybeInitConsent` gates on `egress-consent`; the Network tab and ConsentBanner mount only when the service exists, so spectators see neither.
- **CLI + docs**: `consent-decide` help updated; `acl.md` permission table, `egress-filtering.md` authorization paragraph, `terminal.md` role matrix; changelog entry under Security.

## Verification

- Unit: terminal-only (spectator-profile) stub refused at the handshake; `egress-consent`-only stub registers, decides, and pauses (the old share-terminals pause tests flipped); m0017 migration tests (grant/idempotent/manual-skip/empty); seeded-ACL test asserts spectators get no `egress-consent`.
- Full suites after rebase: Python 6160 passed @ 100% branch coverage; Flutter 1108 passed.
- Live (fmtk harness against this branch): spectator → WS `403`, permissions without `egress-consent`, workspace page shows Terminal/Files only; coder/collaborator → accepted, `pause_ack ok:true` (coder has no `share-terminals` — single gate works), Network tab present.

Closes #2883.
