### PR TITLE
feat(dev): one-command fmtk harness (fmtk-up/fmtk-seed/fmtk-down) (#2881)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,42 @@ UI-driving notes (verified against the harness):
 - Material dialogs do not always close on the escape key — tap their
   `Cancel` button instead.
 
+Driving the terminal (verified against the harness):
+
+- The terminal is a canvas (flterm): semantic snapshots show the tab
+  strip (the own-terminal tab, the "+" new-terminal button) but never
+  the terminal content, and `enter_text` needs an editable ref, so it
+  cannot type there. `get_screenshots` also does not work on this
+  target (app-owned capture, needs the permission bridge).
+- Key-by-key typing is unreliable: `press_key` dispatches lowercase
+  letters, `Enter`, and `Space`, but rejects `/`, `-`, `.`, `_`, and
+  uppercase letters (`unknown_key`) — and even a dispatched `Enter`
+  may not submit a line to the PTY.
+- The reliable path is `evaluate_dart_expression` with
+  `libraryUri: package:klangk_frontend/terminal/ghostty_terminal.dart`
+  (the pubspec name, not the repo name). Walk the element tree for the
+  live `GhosttyTerminalState`, then:
+  - `st._terminal.sendText('echo hi && whoami\n')` — types AND
+    executes (raw input, not bracketed paste); `paste()` only puts
+    text on the input line without submitting it.
+  - `st._terminal.createFormatter(format: FormatterFormat.plain,
+unwrap: true, trim: true).format()` — dumps the visible buffer
+    (command, output, prompt, tmux status bar); wrap in
+    `try/finally { f.dispose(); }`. This is the substitute for
+    screenshots.
+  - `st.widget.wsClient` exposes `connected`, `terminalWindows`
+    (own PTYs; 0 for spectators), and `sharedTerminals`.
+- Caveats: `sendText` returns success even with no PTY behind the
+  view (spectator) — always confirm execution by reading the buffer
+  output. The container must be running
+  (`POST /api/v1/workspaces/{id}/start`, poll `running`); commands
+  otherwise go nowhere. `debug_dump_focus_tree` showing
+  `ghostty-terminal [PRIMARY FOCUS]` is a good sanity check before
+  typing.
+- Own-terminal UI (the tab + "+") is gated on `code-in-isolation`:
+  owners, coders, and collaborators get an own terminal; spectators
+  get none (`terminalWindows` is 0 and `sendText` is inert).
+
 The app side is the debug-only `mcp_toolkit` bootstrap in
 `src/frontend/lib/main.dart` — it registers the `ext.mcp.toolkit.*` VM
 service extensions, is const-folded out of release builds, and is inert in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,32 +392,90 @@ debug run of the frontend: semantic snapshots, widget details, taps and
 typing, hot reload, app logs and errors. pi has no MCP client, so CLI mode
 is the interface — there is no MCP server wiring to maintain.
 
-Workflow:
-
-Run the frontend in debug on a real browser device (not `-d web-server`,
-which never exposes a VM service without the debug Chrome extension):
+Workflow — use the harness (issue #2881), from the repo root:
 
 ```bash
-devenv --quiet shell -- sh -c 'cd src/frontend && flutter run --debug -d chrome --web-port 8124'
+devenv --quiet shell -- fmtk-up
 ```
 
-Note the `A Dart VM Service ... is available at:` URL from its output and use
-it verbatim as a `ws://` URI (append `/ws`). Then, from the repo root (fmtk
-keeps state in `.flutter_mcp/`, gitignored):
+It boots a scratch klangkd (127.0.0.1:8998, own state under
+`.devenv/state/fmtk`, admin@example.com/admin123abc), an origin-splitting
+caddy on 127.0.0.1:8124 (`/api/*` + `/ws` to the backend, everything else
+to the flutter dev server on 8125), the fixture, and
+`flutter run --debug -d chrome` — then prints the VM-service `ws://` URI
+and a ready-to-paste fmtk prefix. Run devenv from the repo **root**
+(src/frontend has its own devenv.lock without flutter, so `devenv shell`
+there fails with `flutter: not found`).
+
+Launch speed: Ctrl-C stops only the flutter run — the backend, proxy,
+and seeded state stay up, so the next `fmtk-up` reuses them (skipping
+backend boot, proxy boot, and `pub get`) and is ready in roughly the
+flutter compile time alone. `fmtk-down` stops the kept services
+(`--wipe` also deletes the scratch state; `fmtk-up --fresh` is
+`fmtk-down --wipe` + launch).
+
+The harness exists because the frontend is same-origin only: `baseUrl`
+derives from the page origin (klangk-plugin-api `backend_url`), so a
+debug app loaded straight from the flutter dev server calls its own
+origin for `/api/v1/...` and gets 404s. The caddy proxy plus the
+`CHROME_EXECUTABLE` wrapper (`scripts/fmtk-chrome.sh`, which rewrites the
+opened URL to the proxy origin) make the debug run reach the backend.
+
+The fixture (seeded by `fmtk-up`, or standalone via
+`devenv --quiet shell -- fmtk-seed`) covers every role bucket of the
+`fmtk-verify` workspace's Sharing panel — password `fmtk-Pass123!`:
+
+- `fmtk-admin@example.com` — `admin` group member and workspace owner:
+  everything visible (Sharing tab with role buckets AND the Advanced ACL
+  editor).
+- `fmtk-collaborator@example.com` — collaborators bucket member.
+- `fmtk-coder@example.com` — coders bucket member.
+- `fmtk-spectator@example.com` — spectators bucket member; NO Sharing
+  tab.
+
+Each fixture opens the workspace page: fmtk-admin via its owner wildcard,
+the role members because every role group carries `terminal` — the WS
+`workspace_connect` gate requires it, so a member whose only grants omit
+`terminal` cannot open the workspace page at all ("Error: Permission
+denied" before any tab renders) — keep that in mind when inventing
+synthetic permission sets.
+
+With the harness up (from another shell, repo root):
 
 ```bash
-URI=ws://127.0.0.1:PORT/TOKEN/ws
+URI=<the ws:// URI fmtk-up printed>
 devenv --quiet -O dotenv.enable:bool false shell -- fmtk doctor --vm-service-uri $URI
 devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec --name semantic_snapshot --vm-service-uri $URI --args '{}'
 devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec --name tap_widget --vm-service-uri $URI --args '{"ref": "s_1"}'
-devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec --name get_recent_logs --vm-service-uri $URI --args '{}'
+devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec --name enter_text --vm-service-uri $URI --args '{"ref": "s_2", "text": "fmtk-admin@example.com"}'
 ```
 
 Snapshot nodes carry `ref`s (`s_0`, `s_1`, …) usable in `tap_widget`,
 `enter_text`, `fill_form`, and friends. `fmtk capabilities` lists all
-commands; `fmtk schema --name <command>` prints each command's arg schema.
-`get_app_errors`, `hot_reload_flutter`, and `evaluate_dart_expression` are
-the other high-signal ones.
+commands; `fmtk schema --name <command>` prints each command's arg schema
+(`get_recent_logs` takes no `limit` — pass `'{}'`). `get_app_errors`,
+`hot_reload_flutter`, and `evaluate_dart_expression` are the other
+high-signal ones (though `evaluate_dart_expression` can't import
+packages, so it can't drive GoRouter — for hash-route navigation use the
+Chrome tab's CDP: the port is the one on the running Chrome's
+`remote-debugging-port=` flag, which flutter chooses; `fmtk-up` prints
+it, and `/json/list` on that port finds the page target).
+
+UI-driving notes (verified against the harness):
+
+- Log in via the two `textField`s + the `Log In` button; the app lands
+  on `/workspaces`. Workspaces you own sit under "Owned by Me"; shared
+  ones under the "Shared with Me" segment — tap the segment first, then
+  the workspace card.
+- The app bar's right edge holds, in order: the email chip (navigates to
+  Settings), an admin icon (only for `admin`-group members), and the
+  logout icon (rightmost). In snapshots these appear as unlabeled
+  `button`s — pick by bounds (top-right corner), not label.
+- Icon-only tabs and icon buttons also show up as unlabeled `tappable`/
+  `button` nodes; identify them by order (the tab strip reads
+  Terminal, Files, Network, Sharing, Settings) or by bounds.
+- Material dialogs do not always close on the escape key — tap their
+  `Cancel` button instead.
 
 The app side is the debug-only `mcp_toolkit` bootstrap in
 `src/frontend/lib/main.dart` — it registers the `ext.mcp.toolkit.*` VM

--- a/devenv.nix
+++ b/devenv.nix
@@ -639,6 +639,18 @@ in
     exec zensical build "$@"
   '';
 
+  # fmtk harness (#2881): one command to a debug frontend driven against a
+  # live backend — scratch klangkd + origin-splitting caddy + `flutter run
+  # --debug -d chrome` + the fixture matrix, printing the VM-service URI.
+  # See scripts/fmtk-up.sh and AGENTS.md "Inspecting the running frontend".
+  scripts.fmtk-up.exec = ''exec bash "$DEVENV_ROOT/scripts/fmtk-up.sh"'';
+  # Stop the harness services fmtk-up keeps alive (backend + proxy);
+  # --wipe also deletes the scratch state.
+  scripts.fmtk-down.exec = ''exec bash "$DEVENV_ROOT/scripts/fmtk-down.sh" "$@"'';
+  # Idempotent fixture seeding (also run by fmtk-up): sharer/acler/viewer
+  # users + the fmtk-verify workspace against a running backend.
+  scripts.fmtk-seed.exec = ''exec ${venvPython} "$DEVENV_ROOT/scripts/fmtk-seed.py" "$@"'';
+
   scripts.serve-docs.exec = ''
     cd $DEVENV_ROOT
     exec zensical serve --dev-addr 0.0.0.0:9111 "$@"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -305,6 +305,13 @@ sync` report a clear permission-denied error.
   workspaces must now hold `change-acls` there (grant it on the
   workspace, or on `/workspaces` / `/` for deploy-wide coverage). See
   [ACL](../reference/acl.md).
+- **`fmtk-up` / `fmtk-down` / `fmtk-seed` — one-command fmtk harness (#2881).**
+  `devenv shell -- fmtk-up` boots a scratch backend, an origin-splitting
+  proxy, a seeded fixture, and a debug `flutter run -d chrome`, then
+  prints the VM-service URI for `fmtk` (see AGENTS.md "Inspecting the
+  running frontend"). Ctrl-C keeps the backend+proxy for a fast
+  re-launch; `fmtk-down` stops them (`--wipe` resets the fixture), and
+  `fmtk-seed` re-seeds standalone.
 
 - **Native YAML booleans for string-typed boolean settings (#2796).**
   `allow_sudo`, `allow_autostart`, `disable_registration`,

--- a/scripts/fmtk-chrome.sh
+++ b/scripts/fmtk-chrome.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# CHROME_EXECUTABLE wrapper for `flutter run --debug -d chrome` under the
+# fmtk harness (issue #2881, scripts/fmtk-up.sh).
+#
+# The frontend is same-origin only: `baseUrl` derives from the page origin
+# (klangk-plugin-api backend_url), so the debug app served by the flutter
+# dev server (127.0.0.1:8125) would call 127.0.0.1:8125/api/v1/... and get
+# 404s. fmtk-up.sh fronts the debug run with an origin-splitting caddy on
+# 127.0.0.1:8124 (API + /ws -> klangkd, everything else -> the dev server).
+# This wrapper rewrites the URL flutter tells Chrome to open from the dev
+# server origin to the proxy origin, so the app loads through the proxy and
+# its same-origin API calls reach the backend.
+#
+# Do NOT add --remote-debugging-port here: flutter passes its own (it wins,
+# last flag takes precedence) and fmtk-up.sh discovers that port from the
+# running Chrome's command line instead.
+set -euo pipefail
+
+chrome_bin="${FMTK_CHROME:-}"
+if [[ -z $chrome_bin ]]; then
+  for candidate in google-chrome chromium google-chrome-stable chromium-browser; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      chrome_bin="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z $chrome_bin ]]; then
+  echo "fmtk-chrome.sh: no Chrome/Chromium found on PATH; set FMTK_CHROME" >&2
+  exit 1
+fi
+
+args=()
+for arg in "$@"; do
+  case "$arg" in
+  http://127.0.0.1:8125* | http://localhost:8125*) arg="http://127.0.0.1:8124/#/" ;;
+  esac
+  args+=("$arg")
+done
+
+exec "$chrome_bin" --no-first-run --no-default-browser-check "${args[@]}"

--- a/scripts/fmtk-down.sh
+++ b/scripts/fmtk-down.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Stop the fmtk harness services (issue #2881).
+#
+#   devenv --quiet shell -- fmtk-down [--wipe]
+#
+# fmtk-up keeps the scratch backend + proxy alive across launches (fast
+# re-launch); this stops them: the debug flutter run, its Chrome, the
+# scratch klangkd (which takes its caddy children with it), and the
+# harness caddy. --wipe also deletes the scratch state dir (fresh DB on
+# the next fmtk-up; same as fmtk-up --fresh).
+#
+# Patterns use [x] bracket tricks so pkill never matches this script's
+# own command line.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEVENV_STATE="${DEVENV_STATE:-$REPO_ROOT/.devenv/state}"
+STATE_DIR="${FMTK_STATE:-$DEVENV_STATE/fmtk}"
+FLUTTER_PORT="${FMTK_FLUTTER_PORT:-8125}"
+
+log() { printf '\033[1m[fmtk-down]\033[0m %s\n' "$*"; }
+
+for pattern in \
+  "run --debug -d chrome.*--web-port $FLUTTER_PORT" \
+  "[c]hrome.*127.0.0.1:8124" \
+  "klangk[.]main --config $STATE_DIR/klangkd.yaml" \
+  "[c]addy run --config $STATE_DIR/proxy.Caddyfile"; do
+  if pkill -TERM -f "$pattern" 2>/dev/null; then
+    log "stopped: $pattern"
+  fi
+done
+sleep 2
+for pattern in \
+  "run --debug -d chrome.*--web-port $FLUTTER_PORT" \
+  "[c]hrome.*127.0.0.1:8124" \
+  "klangk[.]main --config $STATE_DIR/klangkd.yaml" \
+  "[c]addy run --config $STATE_DIR/proxy.Caddyfile"; do
+  pkill -KILL -f "$pattern" 2>/dev/null || true
+done
+
+if [[ ${1:-} == "--wipe" ]]; then
+  rm -rf "$STATE_DIR"
+  log "wiped scratch state: $STATE_DIR"
+elif [[ -n ${1:-} ]]; then
+  log "unknown flag: $1 (only --wipe)"
+  exit 2
+fi
+log "done"

--- a/scripts/fmtk-seed.py
+++ b/scripts/fmtk-seed.py
@@ -1,0 +1,205 @@
+"""Seed the fmtk verification fixture against a klangkd instance (#2881).
+
+Wired as the ``fmtk-seed`` devenv script; run automatically by
+``scripts/fmtk-up.sh`` (which boots the scratch backend this targets), or
+standalone against any backend via ``--url``.
+
+Creates, idempotently, five fixture users covering every role bucket of
+the ``fmtk-verify`` workspace's Sharing panel:
+
+  ================== ==========================  =========================
+  user               grants                     exercises
+  ================== ==========================  =========================
+  fmtk-admin         ``admin`` group member;    everything: Sharing tab
+                     owns the workspace         with role buckets AND
+                                                the Advanced ACL editor
+  fmtk-collaborator  collaborators role group   Collaborators bucket
+  fmtk-coder         coders role group          Coders bucket
+  fmtk-spectator     spectators role group      Spectators bucket; no
+                                                Sharing tab
+  ================== ==========================  =========================
+
+The workspace is created with fmtk-admin's own token, so fmtk-admin holds
+the owner wildcard ACE and sees it under "Owned by Me" (``GET
+/workspaces`` lists only owned workspaces). Every role group carries
+``terminal``, so each member opens the workspace page (the WS
+``workspace_connect`` gate requires it — a member whose only grants omit
+``terminal`` gets "Permission denied" before any tab renders).
+
+All fixture users share the password ``fmtk-Pass123!``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+WORKSPACE_NAME = "fmtk-verify"
+FIXTURE_PASSWORD = "fmtk-Pass123!"
+FIXTURES = (
+    "fmtk-admin",
+    "fmtk-collaborator",
+    "fmtk-coder",
+    "fmtk-spectator",
+)
+# fixture user suffix -> workspace role group (bucket membership)
+ROLE_MEMBERSHIPS = {
+    "fmtk-collaborator": "collaborators",
+    "fmtk-coder": "coders",
+    "fmtk-spectator": "spectators",
+}
+
+
+def api(base: str, token: str, method: str, path: str, body=None):
+    """One JSON API call; returns (status, parsed_json_or_text)."""
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        base + path,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode()
+        try:
+            return exc.code, json.loads(raw)
+        except ValueError:
+            return exc.code, raw
+
+
+def login(base: str, email: str, password: str) -> str:
+    status, body = api(
+        base,
+        "",
+        "POST",
+        "/api/v1/auth/login",
+        {"identifier": email, "password": password},
+    )
+    if status != 200:
+        sys.exit(f"login as {email} failed ({status}): {body}")
+    return body["access_token"]
+
+
+def ensure_users(base: str, token: str) -> dict[str, str]:
+    """Create missing fixture users; returns email -> user_id."""
+    _, listing = api(base, token, "GET", "/api/v1/admin/users")
+    ids = {u["email"]: u["id"] for u in listing["users"]}
+    for name in FIXTURES:
+        email = f"{name}@example.com"
+        if email in ids:
+            continue
+        status, body = api(
+            base,
+            token,
+            "POST",
+            "/api/v1/admin/users",
+            {"email": email, "password": FIXTURE_PASSWORD},
+        )
+        if status != 200:
+            sys.exit(f"create {email} failed ({status}): {body}")
+        ids[email] = body["id"]
+        print(f"created user {email}")
+    return ids
+
+
+def ensure_admin_group_member(base: str, token: str, user_id: str) -> None:
+    """Idempotently add fmtk-admin to the ``admin`` group."""
+    _, listing = api(base, token, "GET", "/api/v1/admin/groups?page_size=100")
+    group = next(g for g in listing["groups"] if g["name"] == "admin")
+    _, members = api(base, token, "GET", f"/api/v1/admin/groups/{group['id']}/members")
+    if any(m["id"] == user_id for m in members):
+        return
+    status, body = api(
+        base,
+        token,
+        "POST",
+        f"/api/v1/admin/groups/{group['id']}/members",
+        {"user_id": user_id},
+    )
+    if status != 200:
+        sys.exit(f"add admin-group member failed ({status}): {body}")
+    print("added fmtk-admin to the admin group")
+
+
+def ensure_workspace(base: str, owner_token: str) -> str:
+    """Find (or create) the fixture workspace as its owner; returns id."""
+    _, mine = api(base, owner_token, "GET", "/api/v1/workspaces")
+    for ws in mine:
+        if ws["name"] == WORKSPACE_NAME:
+            return ws["id"]
+    status, body = api(
+        base,
+        owner_token,
+        "POST",
+        "/api/v1/workspaces",
+        {"name": WORKSPACE_NAME},
+    )
+    if status != 200:
+        sys.exit(f"create workspace failed ({status}): {body}")
+    print(f"created workspace {WORKSPACE_NAME} (owned by fmtk-admin)")
+    return body["id"]
+
+
+def ensure_role_member(
+    base: str, token: str, ws_id: str, role: str, email: str
+) -> None:
+    """Idempotently add ``email`` to the workspace's ``role`` bucket."""
+    _, roles = api(base, token, "GET", f"/api/v1/workspaces/{ws_id}/roles")
+    bucket = next(r for r in roles if r["role"] == role)
+    if any(m["email"] == email for m in bucket["members"]):
+        return
+    status, body = api(
+        base,
+        token,
+        "POST",
+        f"/api/v1/workspaces/{ws_id}/roles/{role}",
+        {"email": email},
+    )
+    if status != 200:
+        sys.exit(f"add {email} to {role} failed ({status}): {body}")
+    print(f"added {email} to {role}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:8998",
+        help="backend base URL (default: the fmtk-up scratch backend)",
+    )
+    parser.add_argument("--admin-email", default="admin@example.com")
+    parser.add_argument("--admin-password", default="admin123abc")
+    args = parser.parse_args()
+
+    token = login(args.url, args.admin_email, args.admin_password)
+    ids = ensure_users(args.url, token)
+    ensure_admin_group_member(args.url, token, ids["fmtk-admin@example.com"])
+    owner_token = login(args.url, "fmtk-admin@example.com", FIXTURE_PASSWORD)
+    ws_id = ensure_workspace(args.url, owner_token)
+    for name, role in ROLE_MEMBERSHIPS.items():
+        ensure_role_member(args.url, owner_token, ws_id, role, f"{name}@example.com")
+    print(
+        f"\nfixture ready on {args.url} — workspace {WORKSPACE_NAME} "
+        f"({ws_id[:8]}…)\n"
+        f"logins (password {FIXTURE_PASSWORD} for all):\n"
+        "  fmtk-admin@example.com          -> admin group + owner:"
+        " everything\n"
+        "  fmtk-collaborator@example.com   -> collaborators bucket\n"
+        "  fmtk-coder@example.com          -> coders bucket\n"
+        "  fmtk-spectator@example.com      -> spectators bucket, no Sharing"
+        " tab"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fmtk-up.sh
+++ b/scripts/fmtk-up.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# fmtk harness: one command to a debug frontend driven against a live
+# backend (issue #2881).
+#
+#   devenv --quiet shell -- fmtk-up
+#
+# Boots, from the repo root (run devenv from the ROOT — src/frontend has
+# its own devenv.lock without flutter):
+#
+#   1. a scratch klangkd on 127.0.0.1:8998 (own state dir under
+#      $DEVENV_STATE/fmtk, password auth, fixed admin creds) — a fresh DB,
+#      so it never touches the dev stack's data or ports (8997/8995);
+#   2. an origin-splitting caddy on 127.0.0.1:8124: /api/* and /ws go to
+#      the backend, everything else to the flutter dev server on 8125 —
+#      the frontend is same-origin only, so the debug app must be loaded
+#      through this proxy to reach the backend;
+#   3. the fixture (scripts/fmtk-seed.py): fmtk-admin owner plus
+#      fmtk-collaborator / fmtk-coder / fmtk-spectator role members on
+#      the "fmtk-verify" workspace;
+#   4. `flutter run --debug -d chrome` on 8125 with CHROME_EXECUTABLE set
+#      to scripts/fmtk-chrome.sh, which rewrites the opened URL to the
+#      proxy origin (8124).
+#
+# Then prints the Dart VM Service ws:// URI plus a ready-to-paste fmtk
+# prefix, and waits. Ctrl-C stops the flutter run but KEEPS the backend
+# + proxy running (and the seeded state), so the next `fmtk-up` skips
+# steps 1-3 and is ready in roughly the flutter compile time alone.
+# `fmtk-down` (scripts/fmtk-down.sh) stops the kept services;
+# `fmtk-up --fresh` wipes the scratch state first (fresh DB).
+#
+# Overridable: FMTK_BACKEND_PORT (8998), FMTK_EGRESS_PORT (8996),
+# FMTK_PROXY_PORT (8124), FMTK_FLUTTER_PORT (8125), FMTK_STATE.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEVENV_ROOT="${DEVENV_ROOT:-$REPO_ROOT}"
+DEVENV_STATE="${DEVENV_STATE:-$REPO_ROOT/.devenv/state}"
+BACKEND_PORT="${FMTK_BACKEND_PORT:-8998}"
+EGRESS_PORT="${FMTK_EGRESS_PORT:-8996}"
+PROXY_PORT="${FMTK_PROXY_PORT:-8124}"
+FLUTTER_PORT="${FMTK_FLUTTER_PORT:-8125}"
+STATE_DIR="${FMTK_STATE:-$DEVENV_STATE/fmtk}"
+VENV_PYTHON="$DEVENV_STATE/venv/bin/python"
+START=$SECONDS
+
+log() { printf '\033[1m[fmtk-up +%2ds]\033[0m %s\n' "$((SECONDS - START))" "$*"; }
+die() {
+  log "ERROR: $*"
+  reap_boot_pids
+  exit 1
+}
+
+if [[ ${1:-} == "--fresh" ]]; then
+  "$REPO_ROOT/scripts/fmtk-down.sh" --wipe || true
+elif [[ -n ${1:-} ]]; then
+  die "unknown flag: $1 (only --fresh)"
+fi
+
+# --- preflight ---------------------------------------------------------
+for tool in caddy flutter curl; do
+  command -v "$tool" >/dev/null 2>&1 || die "$tool not on PATH (run inside the devenv shell, from the repo root)"
+done
+[[ -x $VENV_PYTHON ]] || die "venv python missing at $VENV_PYTHON (enter the devenv shell once first)"
+if ss -tln "sport = :$FLUTTER_PORT" | grep -q LISTEN; then
+  die "port $FLUTTER_PORT already in use (a previous fmtk-up still running? override with FMTK_FLUTTER_PORT)"
+fi
+mkdir -p "$STATE_DIR"
+
+# Children we must clean up on exit: only the flutter run. The backend
+# and caddy are deliberately KEPT across launches (fast re-launch), so
+# they are tracked in BOOT_PIDS only until healthy — die() below reaps
+# them if the boot itself fails, but a successful launch leaves them
+# running (fmtk-down stops them).
+FLUTTER_PID=""
+BOOT_PIDS=()
+reap_boot_pids() {
+  local pid
+  for pid in "${BOOT_PIDS[@]:-}"; do
+    [[ -n $pid ]] && kill -TERM -- "-$pid" 2>/dev/null
+  done
+}
+cleanup() {
+  trap - EXIT INT TERM
+  log "stopping the flutter run (backend + proxy stay up for fast re-launch; fmtk-down stops them)"
+  [[ -n $FLUTTER_PID ]] && kill -TERM -- "-$FLUTTER_PID" 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# Is OUR scratch backend (the one whose --config lives in $STATE_DIR)
+# alive and healthy? Only then may we reuse it — never adopt an
+# unrelated listener on the port.
+backend_is_ours_and_healthy() {
+  pgrep -f "klangk.main --config $STATE_DIR/klangkd.yaml" >/dev/null 2>&1 &&
+    curl -sf -o /dev/null "http://127.0.0.1:$BACKEND_PORT/api/v1/config"
+}
+
+wait_http() { # wait_http <url> <name> <timeout_s>
+  local deadline=$((SECONDS + $3))
+  while ((SECONDS < deadline)); do
+    curl -sf -o /dev/null "$1" && return 0
+    sleep 1
+  done
+  die "timed out waiting for $2 at $1"
+}
+
+# --- 1. scratch backend (reused when ours and healthy) ------------------
+if backend_is_ours_and_healthy; then
+  log "reusing running scratch klangkd on :$BACKEND_PORT"
+else
+  for port in "$BACKEND_PORT" "$EGRESS_PORT"; do
+    if ss -tln "sport = :$port" | grep -q LISTEN; then
+      die "port $port is in use by something else (not our healthy scratch backend) — run fmtk-down, or override FMTK_*_PORT"
+    fi
+  done
+  cat >"$STATE_DIR/klangkd.yaml" <<EOF
+port: "$BACKEND_PORT"
+listen: "127.0.0.1"
+egress_port: "$EGRESS_PORT"
+idle_timeout_seconds: "300"
+auth_modes: password
+jwt_secret: fmtk-scratch-secret
+default_user: admin@example.com
+default_password: admin123abc
+state_dir: "$STATE_DIR/klangk"
+data_dir: "$STATE_DIR/klangk/data"
+EOF
+  log "starting scratch klangkd on :$BACKEND_PORT (state: $STATE_DIR/klangk)"
+  setsid "$VENV_PYTHON" -m klangk.main --config "$STATE_DIR/klangkd.yaml" \
+    >"$STATE_DIR/klangkd.log" 2>&1 &
+  BOOT_PIDS+=($!)
+  wait_http "http://127.0.0.1:$BACKEND_PORT/api/v1/config" "backend" 90
+  BOOT_PIDS=()
+fi
+
+# --- 2. origin-splitting proxy (reused when healthy) -------------------
+if curl -sf -o /dev/null "http://127.0.0.1:$PROXY_PORT/api/v1/config" &&
+  pgrep -f "caddy run --config $STATE_DIR/proxy.Caddyfile" >/dev/null 2>&1; then
+  log "reusing caddy proxy on :$PROXY_PORT"
+else
+  if ss -tln "sport = :$PROXY_PORT" | grep -q LISTEN; then
+    die "port $PROXY_PORT is in use by something else — run fmtk-down, or override FMTK_PROXY_PORT"
+  fi
+  cat >"$STATE_DIR/proxy.Caddyfile" <<EOF
+http://:$PROXY_PORT {
+	bind 127.0.0.1
+	handle /api/* {
+		reverse_proxy 127.0.0.1:$BACKEND_PORT
+	}
+	handle /ws {
+		reverse_proxy 127.0.0.1:$BACKEND_PORT
+	}
+	handle {
+		reverse_proxy 127.0.0.1:$FLUTTER_PORT
+	}
+}
+EOF
+  log "starting caddy proxy on :$PROXY_PORT (api+ws -> :$BACKEND_PORT, rest -> :$FLUTTER_PORT)"
+  setsid caddy run --config "$STATE_DIR/proxy.Caddyfile" --adapter caddyfile \
+    >"$STATE_DIR/caddy.log" 2>&1 &
+  BOOT_PIDS+=($!)
+  wait_http "http://127.0.0.1:$PROXY_PORT/api/v1/config" "proxy" 30
+  BOOT_PIDS=()
+fi
+
+# --- 3. fixture (idempotent; a no-op on a kept backend) ----------------
+log "seeding fixture (idempotent)"
+"$VENV_PYTHON" "$REPO_ROOT/scripts/fmtk-seed.py" --url "http://127.0.0.1:$BACKEND_PORT" ||
+  die "seed failed (see above)"
+
+# --- 4. flutter debug run ----------------------------------------------
+# --no-pub skips `flutter pub get` when deps are already resolved
+# (package_config exists and predates pubspec.lock); the first run in a
+# cold checkout resolves normally.
+FLUTTER_ARGS=(run --debug -d chrome --web-hostname 127.0.0.1 --web-port "$FLUTTER_PORT")
+PKG_CONFIG="$REPO_ROOT/src/frontend/.dart_tool/package_config.json"
+if [[ -f $PKG_CONFIG && ! $PKG_CONFIG -nt "$REPO_ROOT/src/frontend/pubspec.lock" ]]; then
+  FLUTTER_ARGS+=(--no-pub)
+fi
+log "starting flutter run --debug -d chrome (first build can take a while)"
+cd "$REPO_ROOT/src/frontend" || exit 2
+CHROME_EXECUTABLE="$REPO_ROOT/scripts/fmtk-chrome.sh" \
+  setsid flutter "${FLUTTER_ARGS[@]}" \
+  >"$STATE_DIR/flutter.log" 2>&1 &
+FLUTTER_PID=$!
+
+VM_URI=""
+deadline=$((SECONDS + 600))
+while ((SECONDS < deadline)); do
+  VM_URI="$(grep -o 'ws://[^ ]*/ws' "$STATE_DIR/flutter.log" | head -1 || true)"
+  [[ -n $VM_URI ]] && break
+  kill -0 "$FLUTTER_PID" 2>/dev/null || {
+    tail -30 "$STATE_DIR/flutter.log"
+    die "flutter run exited before exposing a VM service"
+  }
+  sleep 2
+done
+[[ -n $VM_URI ]] || die "no Dart VM Service in flutter.log after 600s"
+
+CDP_PORT="$(pgrep -af 'chrome' | grep -o 'remote-debugging-port=[0-9]*' | cut -d= -f2 | head -1 || true)"
+
+cat <<EOF
+
+=====================================================================
+ fmtk harness ready (#2881)
+
+   VM service:    $VM_URI
+   app (chrome):  http://127.0.0.1:$PROXY_PORT/#/
+   backend:       http://127.0.0.1:$BACKEND_PORT   (admin@example.com / admin123abc)
+   chrome CDP:    ${CDP_PORT:-unknown — pgrep chrome for remote-debugging-port}
+
+ Fixture logins (password fmtk-Pass123! for all):
+   fmtk-admin@example.com          admin group + owner -> everything
+   fmtk-collaborator@example.com   collaborators bucket
+   fmtk-coder@example.com          coders bucket
+   fmtk-spectator@example.com      spectators bucket, NO Sharing tab
+
+ Drive it (from the repo root, another shell):
+
+   URI='$VM_URI'
+   devenv --quiet -O dotenv.enable:bool false shell -- fmtk exec \\
+     --name semantic_snapshot --vm-service-uri "\$URI" --args '{}'
+
+ Logs: $STATE_DIR/{klangkd,caddy,flutter}.log — Ctrl-C stops the flutter run
+ and KEEPS backend+proxy for a fast re-launch; 'fmtk-down' stops them
+ ('fmtk-down --wipe' also deletes the scratch state).
+=====================================================================
+
+EOF
+wait "$FLUTTER_PID"

--- a/scripts/tests/test_fmtk_harness.py
+++ b/scripts/tests/test_fmtk_harness.py
@@ -1,0 +1,137 @@
+"""Contract tests for the fmtk harness (#2881).
+
+``scripts/fmtk-up.sh`` (the ``fmtk-up`` devenv script) composes the scratch
+backend, origin-splitting proxy, fixture seed, and debug flutter run that an
+agent needs to drive the live frontend with fmtk; ``scripts/fmtk-chrome.sh``
+is the CHROME_EXECUTABLE URL-rewriting wrapper; ``scripts/fmtk-seed.py``
+(``fmtk-seed``) seeds the fixture; ``scripts/fmtk-down.sh`` (``fmtk-down``)
+stops the services fmtk-up keeps alive. These grep-style tests pin the
+wiring so a future edit that silently drops a piece is loud — in the spirit
+of ``test_test_push_task.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEVENV_NIX = _REPO_ROOT / "devenv.nix"
+_UP = _REPO_ROOT / "scripts" / "fmtk-up.sh"
+_DOWN = _REPO_ROOT / "scripts" / "fmtk-down.sh"
+_CHROME = _REPO_ROOT / "scripts" / "fmtk-chrome.sh"
+_SEED = _REPO_ROOT / "scripts" / "fmtk-seed.py"
+_AGENTS = _REPO_ROOT / "AGENTS.md"
+
+
+def test_shell_scripts_exist_and_are_executable():
+    for script in (_UP, _DOWN, _CHROME):
+        assert script.is_file(), f"{script} is missing"
+        mode = script.stat().st_mode
+        assert mode & stat.S_IXUSR, f"{script} must be executable"
+        first = script.read_text().splitlines()[0]
+        assert first.startswith("#!"), f"{script} needs a shebang"
+
+
+def test_seed_script_exists():
+    assert _SEED.is_file(), "scripts/fmtk-seed.py is missing"
+
+
+def test_devenv_wires_the_scripts():
+    nix = _DEVENV_NIX.read_text()
+    for name, path in (
+        ("fmtk-up", "fmtk-up.sh"),
+        ("fmtk-down", "fmtk-down.sh"),
+        ("fmtk-seed", "fmtk-seed.py"),
+    ):
+        assert f"scripts.{name}.exec" in nix, (
+            f"devenv.nix no longer defines scripts.{name}.exec"
+        )
+        assert f"scripts/{path}" in nix, f"{name} must delegate to the script"
+
+
+def test_up_boots_all_pieces():
+    """The harness must compose backend, proxy, seed, and flutter run."""
+    up = _UP.read_text()
+    assert "klangk.main --config" in up, "fmtk-up must boot a scratch klangkd"
+    assert "caddy run" in up, "fmtk-up must start the origin-splitting proxy"
+    assert "fmtk-seed.py" in up, "fmtk-up must run the fixture seed"
+    assert "flutter run --debug -d chrome" in up, (
+        "fmtk-up must start the debug flutter run"
+    )
+    # same-origin split: /api and /ws to the backend, rest to the dev server
+    assert "handle /api/*" in up and "handle /ws" in up, (
+        "the proxy must route /api/* and /ws to the backend"
+    )
+
+
+def test_up_reuses_kept_services_for_fast_relaunch():
+    """Launch speed (#2881): the harness must reuse a healthy kept
+    backend + proxy instead of re-booting them, and must not re-run pub
+    get when deps are already resolved."""
+    up = _UP.read_text()
+    assert "backend_is_ours_and_healthy" in up, (
+        "fmtk-up must health-check OUR scratch backend before reusing it"
+    )
+    assert "reusing running scratch klangkd" in up, "backend reuse path"
+    assert "reusing caddy proxy" in up, "proxy reuse path"
+    assert "--no-pub" in up, "skip pub get when package_config is fresh"
+
+
+def test_up_uses_the_chrome_wrapper():
+    """The debug run must load the app through the proxy via the wrapper."""
+    assert "fmtk-chrome.sh" in _UP.read_text(), (
+        "fmtk-up must set CHROME_EXECUTABLE to the URL-rewriting wrapper"
+    )
+    chrome = _CHROME.read_text()
+    assert "8124" in chrome, "the wrapper must rewrite to the proxy origin"
+    active = [ln for ln in chrome.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any("--remote-debugging-port" in ln for ln in active), (
+        "the wrapper must not add --remote-debugging-port (flutter's own "
+        "flag wins; the port is discovered from the process list instead)"
+    )
+
+
+def test_down_stops_the_right_processes():
+    """fmtk-down must target only harness-owned processes (bracket-trick
+    patterns, state-dir-scoped) and support --wipe."""
+    down = _DOWN.read_text()
+    for pattern in (
+        "run --debug -d chrome",
+        "[c]hrome.*127.0.0.1:8124",
+        "klangk[.]main --config",
+        "[c]addy run --config",
+        "--wipe",
+    ):
+        assert pattern in down, f"fmtk-down must handle: {pattern}"
+
+
+def test_seed_matrix_wiring():
+    """Fixture wiring: admin-group owner plus one member per role bucket.
+
+    The workspace must be created with fmtk-admin's token so it owns it
+    (``GET /workspaces`` lists only owned workspaces). Every role group
+    carries ``terminal``, so each member opens the workspace page (the WS
+    ``workspace_connect`` gate requires it — #2881 pain point 2).
+    """
+    seed = _SEED.read_text()
+    assert "fmtk-admin" in seed and '"admin"' in seed, (
+        "fmtk-admin must exist and join the admin group"
+    )
+    for removed in ("fmtk-sharer", "fmtk-acler", "fmtk-viewer"):
+        assert removed not in seed, f"the {removed} fixture was removed"
+    for role in ("collaborators", "coders", "spectators"):
+        assert f'"{role}"' in seed, f"a fixture must sit in {role}"
+    assert "owner_token" in seed, (
+        "the workspace must be created with fmtk-admin's token (ownership)"
+    )
+
+
+def test_agents_documents_the_harness():
+    agents = _AGENTS.read_text()
+    assert "fmtk-up" in agents, "AGENTS.md must point at the fmtk-up harness"
+    assert "fmtk-down" in agents, "AGENTS.md must document fmtk-down"


### PR DESCRIPTION
Closes #2881.

## What

One-command live-frontend verification harness, replacing the ~40 minutes of ad-hoc setup (scratch backend, same-origin proxy, chrome wrapper, seeding, VM-service plumbing) the #2879 verification needed:

- **`fmtk-up`** — boots the scratch klangkd (:8998) + origin-splitting caddy (:8124, `/api/*`+`/ws` → backend, rest → flutter :8125), seeds the fixture, launches `flutter run --debug -d chrome` via the `fmtk-chrome.sh` wrapper, and prints the VM-service `ws://` URI + CDP port ready for `fmtk`. Ctrl-C keeps the backend+proxy alive; the next `fmtk-up` reuses them and skips `pub get` (~104s warm vs ~128s cold; `--fresh` forces a clean boot).
- **`fmtk-seed`** — idempotent seeding: `fmtk-admin` (owner, `admin` group), `fmtk-collaborator`, `fmtk-coder`, `fmtk-spectator` role-bucket members (password `fmtk-Pass123!`), workspace `fmtk-verify` owned by fmtk-admin. `--reset` for a clean slate.
- **`fmtk-down`** — tears everything down; `--wipe` removes state.
- Contract tests for all three in `scripts/tests/test_fmtk_harness.py` (9 tests); devenv tasks wired via `scripts.<name>.exec`.
- AGENTS.md gains the harness workflow + UI-driving and terminal-driving notes (VM-service eval, `createFormatter` buffer reads, CDP clicks, `systemd-run` for background helpers).

Port/state overrides: `FMTK_*_PORT`, `FMTK_STATE`.

Exercised end-to-end during #2883's investigation: the #2881 fixture's spectator/coder/collaborator users probed `/ws/consent-decider` handshakes, and the shared-terminal spectating flow (viewer sees live output, input inert) was driven through the real UI.

## Notes for reviewers

- The same-origin constraint is why the proxy exists: the frontend derives `baseUrl` from page origin, so the debug app must load through one origin that routes API/WS to the backend.
- The workspace is created with fmtk-admin's token (not the seed admin) so `GET /workspaces` lists it for the owner — the admin group has no workspace-listing grant.
