### PR TITLE
fix(frontend): gate the Files tab on the files permission (#2886)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1589,6 +1589,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Files tab is hidden without the `files` permission (#2886).** A
+  spectator's workspace page mounted the Files tab unconditionally, so
+  opening it failed with `Cannot list this directory: Permission denied`.
+  The tab now mounts only for principals whose workspace permissions
+  include `files` (or `*`) — the same gate as the Sharing tab — and
+  `?file=`/`?dir=` deep-links and terminal path taps no-op instead.
+
 - **`klangk terminal share` / `unshare` / `ls` (#2876).** A server
   refusal — e.g. `Permission denied` for a member without the
   `share-terminals` permission — now prints a one-line error and exits

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -100,7 +100,7 @@ When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/w
 | `view`           | Can see the workspace exists                                                                                                              |
 | `monitor`        | Can observe health/status: `GET /workspaces/{id}/status` and the `container_status` / `service_health` WebSocket frames (#2783)           |
 | `terminal`       | Can open a terminal / exec commands                                                                                                       |
-| `files`          | Can browse file listings (metadata); reading file bodies additionally needs `files-download`                                              |
+| `files`          | Can browse file listings (metadata) and gets the Files tab; reading file bodies additionally needs `files-download`                       |
 | `files-download` | Can fetch file bytes: `/files/download` (raw stream/tar) and `/files/content` (text reader) — needs `files` too                           |
 | `files-write`    | Can mutate files: upload, rename, delete (needs `files` too)                                                                              |
 | `exec-and-sync`  | Can run one-shot commands (`klangk exec`) and sync (`klangk sync`) against the workspace                                                  |
@@ -135,7 +135,8 @@ but not
 `files-download` can browse listings and metadata only. To grant viewing
 without bulk export there is no longer a middle setting: grant both
 `files` + `files-download` (viewer fully works) or withhold `files`
-(browsing itself is denied).
+(browsing itself is denied — the web UI's Files tab does not mount at
+all, #2886).
 
 `export` is a workspace permission checked on `/workspaces/{id}`: the owner's wildcard ACE and the seeded `owners-<id>` role group both cover it, so owners can export their own workspaces without any extra grant, and a **Deny** `export` ACE for **Everyone** on the workspace resource (positioned ahead of the wildcards) revokes it per workspace. Admins do **not** get export implicitly — they must be an owner or hold an explicit grant. See [Export & Import](../features/export-import.md#export).
 

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -4,10 +4,14 @@ import '../terminal/ghostty_terminal.dart';
 import '../file_viewer/file_viewer_panel.dart';
 import '../widgets/skeuo_tab.dart';
 
-/// IDE layout: tabs (Terminal + Files + feature-contributed tabs) with optional
-/// debug pane at the bottom separated by a draggable divider.
+/// IDE layout: tabs (Terminal + optional Files + feature-contributed tabs)
+/// with optional debug pane at the bottom separated by a draggable divider.
 class IdeLayout extends StatefulWidget {
-  final Widget fileViewer;
+  /// Files pane. Null mounts no Files tab at all — the caller passes null
+  /// for principals without the `files` permission (#2886), so the panel
+  /// never fetches a listing it has no grant for. Deep-links and terminal
+  /// path taps that target the viewer no-op in that case.
+  final Widget? fileViewer;
   final Widget terminal;
   final Widget? settings;
   final Widget? sharing;
@@ -56,6 +60,13 @@ class IdeLayoutState extends State<IdeLayout> {
   int _selectedIndex = 0;
   double _debugHeight = 0; // collapsed by default
 
+  // #2886: whether the CURRENT initialFile/initialDir deep-link has been
+  // opened (or was absent). Re-armed when either changes; consulted when
+  // the Files pane arrives late (permissions fetch racing the first
+  // build), so an unconsumed deep-link opens once its target exists
+  // instead of being dropped.
+  bool _initialHandled = false;
+
   // Feature-tab badge subscriptions (#1976): a feature tab may expose a live
   // badge (unread count) via WorkspaceTabPlugin.badge. We listen and rebuild
   // the strip on change. Map key is the tab (identity-stable from the
@@ -85,6 +96,8 @@ class IdeLayoutState extends State<IdeLayout> {
     super.didUpdateWidget(oldWidget);
     if (widget.initialFile != oldWidget.initialFile ||
         widget.initialDir != oldWidget.initialDir) {
+      // A new deep-link re-arms the open-once latch.
+      _initialHandled = false;
       _maybeOpenInitial();
     }
     // Re-subscribe only when the featureTabs LIST identity changes. This
@@ -95,6 +108,32 @@ class IdeLayoutState extends State<IdeLayout> {
     // would churn (#1976 review nit).
     if (!identical(widget.featureTabs, oldWidget.featureTabs)) {
       _subscribeFeatureBadges();
+    }
+    // #2886: the Files pane mounts only with the `files` permission, which
+    // can arrive after the first build (async permissions fetch) or be
+    // revoked mid-session (ACL edited live). The Files tab occupies index
+    // 1, so its appearance/disappearance shifts every later tab's index —
+    // nudge the selection so it keeps pointing at the same logical tab
+    // (and stays in range for the IndexedStack). Only a null-ness change
+    // counts: the caller rebuilds the pane widget on every parent rebuild,
+    // so instance identity would fire every frame.
+    if (oldWidget.fileViewer == null && widget.fileViewer != null) {
+      if (_selectedIndex >= 1) setState(() => _selectedIndex += 1);
+      // A pending deep-link that no-op'd while the pane was absent (the
+      // permissions fetch raced the first build) now has its target.
+      _maybeOpenInitial();
+    } else if (oldWidget.fileViewer != null && widget.fileViewer == null) {
+      final wasOnFiles = _selectedIndex == 1;
+      // Terminal (index 0) is unaffected — do NOT subtract into -1 and
+      // hand IndexedStack an out-of-range index. Index > 1 shifts down to
+      // keep pointing at the same later tab; index 1 (the removed Files
+      // tab) falls back to Terminal.
+      setState(
+        () => _selectedIndex = _selectedIndex > 1 ? _selectedIndex - 1 : 0,
+      );
+      // Landing on Terminal from the removed tab focuses its input, the
+      // same as selecting the tab would.
+      if (wasOnFiles) _focusPane(0);
     }
   }
 
@@ -154,13 +193,18 @@ class IdeLayoutState extends State<IdeLayout> {
 
   /// Opens the deep-linked [IdeLayout.initialFile] (preferred) or
   /// [IdeLayout.initialDir] in the Files tab once the panel is built. Deferred
-  /// to after the frame so the fileViewer's state is attached.
+  /// to after the frame so the fileViewer's state is attached. Skipped (and
+  /// retried on pane arrival) while there is no Files pane — no `files`
+  /// permission yet (#2886).
   void _maybeOpenInitial() {
+    if (_initialHandled) return;
     final file = widget.initialFile;
     final dir = widget.initialDir;
     final hasFile = file != null && file.isNotEmpty;
     final hasDir = dir != null && dir.isNotEmpty;
     if (!hasFile && !hasDir) return;
+    if (widget.fileViewer == null) return;
+    _initialHandled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (hasFile) {
@@ -172,13 +216,17 @@ class IdeLayoutState extends State<IdeLayout> {
   }
 
   /// Switches to the Files tab and opens [path] in the existing viewer.
+  /// No-op without a Files pane (no `files` permission, #2886).
   void openFile(String path) {
+    if (widget.fileViewer == null) return;
     _selectTab(1);
     widget.fileViewerKey?.currentState?.openFile(path);
   }
 
   /// Switches to the Files tab and browses directory [path].
+  /// No-op without a Files pane (no `files` permission, #2886).
   void openDirectory(String path) {
+    if (widget.fileViewer == null) return;
     _selectTab(1);
     widget.fileViewerKey?.currentState?.openDir(path);
   }
@@ -188,7 +236,7 @@ class IdeLayoutState extends State<IdeLayout> {
     final changed = index != oldIndex;
     if (changed) {
       setState(() => _selectedIndex = index);
-      if (index == 1) {
+      if (index == 1 && widget.fileViewer != null) {
         widget.fileViewerKey?.currentState?.refresh();
       }
       // Feature-tab visibility (#1976).
@@ -218,12 +266,6 @@ class IdeLayoutState extends State<IdeLayout> {
         isSelected: _selectedIndex == 0,
         onTap: () => _selectTab(0),
       ),
-      SkeuoTab(
-        label: 'Files',
-        icon: Icons.folder_outlined,
-        isSelected: _selectedIndex == 1,
-        onTap: () => _selectTab(1),
-      ),
     ];
     final content = <Widget>[
       Container(
@@ -231,8 +273,24 @@ class IdeLayoutState extends State<IdeLayout> {
         padding: const EdgeInsets.only(left: 6, top: 4),
         child: widget.terminal,
       ),
-      Material(color: KColors.bgCanvas, child: widget.fileViewer),
     ];
+    // Files tab: mounted only when the caller passes a pane — without the
+    // `files` permission there is no tab to click and no listing fetch
+    // (#2886). Tab/content indices below shift down accordingly (the
+    // feature-tab start index is computed from tabs.length, not assumed).
+    if (widget.fileViewer != null) {
+      tabs.add(
+        SkeuoTab(
+          label: 'Files',
+          icon: Icons.folder_outlined,
+          isSelected: _selectedIndex == 1,
+          onTap: () => _selectTab(1),
+        ),
+      );
+      content.add(
+        Material(color: KColors.bgCanvas, child: widget.fileViewer!),
+      );
+    }
 
     void addTab(
       String label,

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -652,16 +652,21 @@ class _WorkspacePageState extends State<WorkspacePage> {
 
   Widget _buildIdeLayout(WsClient wsClient, String? authToken) {
     return IdeLayout(
-      fileViewer: FileViewerPanel(
-        key: _fileViewerKey,
-        wsClient: wsClient,
-        workspaceId: widget.workspaceId,
-        authToken: authToken,
-        userHome: wsClient.userHome,
-        registry: _fileRenderers,
-        canDownload: _hasPerm('files-download'),
-        canWrite: _hasPerm('files-write'),
-      ),
+      // #2886: no `files` permission → no Files tab at all (spectators,
+      // terminal-only shares) — same my-permissions gate as Sharing/Network,
+      // so the panel never fetches a listing the backend will 403.
+      fileViewer: _hasPerm('files')
+          ? FileViewerPanel(
+              key: _fileViewerKey,
+              wsClient: wsClient,
+              workspaceId: widget.workspaceId,
+              authToken: authToken,
+              userHome: wsClient.userHome,
+              registry: _fileRenderers,
+              canDownload: _hasPerm('files-download'),
+              canWrite: _hasPerm('files-write'),
+            )
+          : null,
       featureTabs: _featureTabs,
       terminal: TerminalTabsView(
         wsClient: wsClient,

--- a/src/frontend/test/ide_layout_initial_file_test.dart
+++ b/src/frontend/test/ide_layout_initial_file_test.dart
@@ -64,6 +64,55 @@ Widget _ide(GlobalKey<FileViewerPanelState> fvKey, WsClient ws, String? file,
       ),
     );
 
+/// Rebuilds IdeLayout with the Files pane granted mid-session — the shape
+/// of the permissions-fetch race where `files` lands after the first build
+/// (#2886).
+class _LatePaneHarness extends StatefulWidget {
+  const _LatePaneHarness({
+    super.key,
+    required this.fvKey,
+    required this.ws,
+    this.initialFile,
+  });
+  final GlobalKey<FileViewerPanelState> fvKey;
+  final WsClient ws;
+  final String? initialFile;
+  @override
+  State<_LatePaneHarness> createState() => _LatePaneHarnessState();
+}
+
+class _LatePaneHarnessState extends State<_LatePaneHarness> {
+  bool _showFiles = false;
+  void grantFiles() => setState(() => _showFiles = true);
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 1000,
+          height: 700,
+          child: IdeLayout(
+            fileViewerKey: widget.fvKey,
+            fileViewer: _showFiles
+                ? FileViewerPanel(
+                    key: widget.fvKey,
+                    wsClient: widget.ws,
+                    workspaceId: 'ws-1',
+                    authToken: 'tok',
+                    userHome: '/home/tester',
+                    canDownload: true,
+                    canWrite: true,
+                  )
+                : null,
+            terminal: const Text('TERMINAL_CONTENT'),
+            initialFile: widget.initialFile,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 void main() {
   setUp(clearFileListCacheForTest);
   tearDown(() {
@@ -137,6 +186,59 @@ void main() {
     await tester.pumpWidget(_ide(fvKey, ws, null, dir: '/home/docs'));
     await tester.pumpAndSettle();
     expect(find.text('docs'), findsOneWidget);
+    ws.close();
+  });
+
+  testWidgets(
+      'initialFile no-ops without a Files pane (no files permission, #2886)',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 1000,
+            height: 700,
+            child: IdeLayout(
+              fileViewer: null,
+              terminal: const Text('TERMINAL_CONTENT'),
+              initialFile: '/home/docs/note.txt',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // No crash, no tab switch off Terminal, no Files tab to switch to.
+    expect(find.text('Files'), findsNothing);
+    expect(find.text('TERMINAL_CONTENT'), findsOneWidget);
+  });
+
+  testWidgets(
+      'pending initialFile opens once the pane arrives late (permissions race)',
+      (tester) async {
+    testBaseUrlOverride = 'http://localhost:8997';
+    testHttpClientOverride = _client();
+    final fvKey = GlobalKey<FileViewerPanelState>();
+    final ws = _MockWsClient();
+    final harnessKey = GlobalKey<_LatePaneHarnessState>();
+    await tester.pumpWidget(
+      _LatePaneHarness(
+        key: harnessKey,
+        fvKey: fvKey,
+        ws: ws,
+        initialFile: '/home/docs/note.txt',
+      ),
+    );
+    await tester.pumpAndSettle();
+    // First build has no Files pane: the deep-link waits, nothing opens.
+    expect(find.text('ide body'), findsNothing);
+
+    harnessKey.currentState!.grantFiles();
+    await tester.pumpAndSettle();
+
+    // The pane's arrival re-runs the pending deep-link.
+    expect(find.text('ide body'), findsOneWidget);
     ws.close();
   });
 }

--- a/src/frontend/test/ide_layout_test.dart
+++ b/src/frontend/test/ide_layout_test.dart
@@ -3,6 +3,44 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/layout/ide_layout.dart';
 import 'package:klangk_frontend/widgets/skeuo_tab.dart';
 
+/// A stateful harness that rebuilds IdeLayout with/without the Files pane
+/// — the shape the async permissions fetch produces mid-session (the gate
+/// flips after the first build, #2886).
+class _FilesHarness extends StatefulWidget {
+  const _FilesHarness({super.key, required this.showFiles});
+  final bool showFiles;
+  @override
+  State<_FilesHarness> createState() => _FilesHarnessState();
+}
+
+class _FilesHarnessState extends State<_FilesHarness> {
+  late bool _showFiles;
+  @override
+  void initState() {
+    super.initState();
+    _showFiles = widget.showFiles;
+  }
+
+  void setShowFiles(bool v) => setState(() => _showFiles = v);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 1280,
+          height: 720,
+          child: IdeLayout(
+            fileViewer: _showFiles ? const Text('FILES_CONTENT') : null,
+            terminal: const Text('TERMINAL_CONTENT'),
+            sharing: const Text('SHARING_CONTENT'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 void main() {
   group('SkeuoTab', () {
     testWidgets('renders badge when provided', (tester) async {
@@ -325,6 +363,108 @@ void main() {
     testWidgets('no sharing tab when sharing is null', (tester) async {
       await tester.pumpWidget(buildLayout());
       expect(find.text('Sharing'), findsNothing);
+    });
+
+    group('files-permission gating (#2886)', () {
+      testWidgets('no Files tab or pane when fileViewer is null',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 1280,
+                height: 720,
+                child: IdeLayout(
+                  fileViewer: null,
+                  terminal: const Text('TERMINAL_CONTENT'),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Files'), findsNothing);
+        expect(find.text('TERMINAL_CONTENT'), findsOneWidget);
+      });
+
+      testWidgets('revoking the pane mid-session keeps a later tab selected',
+          (tester) async {
+        final harnessKey = GlobalKey<_FilesHarnessState>();
+        await tester
+            .pumpWidget(_FilesHarness(key: harnessKey, showFiles: true));
+        await tester.pumpAndSettle();
+        expect(find.text('Files'), findsOneWidget);
+
+        await tester.tap(find.text('Sharing'));
+        await tester.pumpAndSettle();
+        expect(find.text('SHARING_CONTENT'), findsOneWidget);
+
+        // Permissions arrive / the ACL changes: no `files` → no Files tab.
+        harnessKey.currentState!.setShowFiles(false);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Files'), findsNothing);
+        // The Sharing selection followed its shifted index, not off the end.
+        expect(find.text('SHARING_CONTENT'), findsOneWidget);
+      });
+
+      testWidgets(
+          'revoking the pane while Terminal is selected stays on Terminal',
+          (tester) async {
+        final harnessKey = GlobalKey<_FilesHarnessState>();
+        await tester
+            .pumpWidget(_FilesHarness(key: harnessKey, showFiles: true));
+        await tester.pumpAndSettle();
+        // Default selection is Terminal (index 0) — the landing tab.
+        expect(find.text('TERMINAL_CONTENT'), findsOneWidget);
+
+        harnessKey.currentState!.setShowFiles(false);
+        await tester.pumpAndSettle();
+
+        // Regression (#2887 review): index 0 must not decrement to -1 and
+        // blow up IndexedStack — Terminal stays selected and visible.
+        expect(find.text('TERMINAL_CONTENT'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets(
+          'revoking the pane while Files is selected falls back to Terminal',
+          (tester) async {
+        final harnessKey = GlobalKey<_FilesHarnessState>();
+        await tester
+            .pumpWidget(_FilesHarness(key: harnessKey, showFiles: true));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Files'));
+        await tester.pumpAndSettle();
+        expect(find.text('FILES_CONTENT'), findsOneWidget);
+
+        harnessKey.currentState!.setShowFiles(false);
+        await tester.pumpAndSettle();
+
+        expect(find.text('FILES_CONTENT'), findsNothing);
+        expect(find.text('TERMINAL_CONTENT'), findsOneWidget);
+      });
+
+      testWidgets('granting the pane mid-session keeps a later tab selected',
+          (tester) async {
+        final harnessKey = GlobalKey<_FilesHarnessState>();
+        await tester
+            .pumpWidget(_FilesHarness(key: harnessKey, showFiles: false));
+        await tester.pumpAndSettle();
+        expect(find.text('Files'), findsNothing);
+
+        await tester.tap(find.text('Sharing'));
+        await tester.pumpAndSettle();
+        expect(find.text('SHARING_CONTENT'), findsOneWidget);
+
+        harnessKey.currentState!.setShowFiles(true);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Files'), findsOneWidget);
+        expect(find.text('SHARING_CONTENT'), findsOneWidget);
+      });
     });
 
     testWidgets('selecting same tab does not rebuild', (tester) async {


### PR DESCRIPTION
## What

A spectator's workspace page mounted the **Files** tab unconditionally; opening it fetched `GET /workspaces/{id}/files`, which 403'd without the `files` permission, showing `Cannot list this directory: Permission denied`. The tab now mounts only when `my-permissions` reports `files` (or `*`) — the same gate as the Sharing tab (`share`) and the Network tab (`egress-consent`, #2884). No backend change: the endpoint gate stays as is.

## Changes

- **`IdeLayout.fileViewer` is now nullable** (`ide_layout.dart`): no pane → no Files tab, and `openFile`/`openDirectory` (deep-links `?file=`/`?dir=`, terminal path taps) no-op.
- **`workspace_page.dart`** passes the panel only for `_hasPerm('files')`, matching the Sharing/Network gating pattern. A member with `files` but not `files-download`/`files-write` still gets the tab (existing degraded behavior).
- **Mid-session pane flips are handled**: the pane can appear after the first build (async permissions fetch) or vanish on a live ACL edit, and the Files tab occupies index 1, shifting every later tab. `didUpdateWidget` nudges `_selectedIndex` so the selection stays on the same logical tab (and in range for the IndexedStack), and a deep-link that no-op'd while the pane was absent opens when it arrives.
- Docs: `acl.md` `files` row and the withhold-`files` paragraph note the tab no longer mounts; changelog under Fixed.

## Verification

- New widget tests: no Files tab/pane without a pane; revoke-while-selected falls back to Terminal; revoke/grant mid-session keeps a later tab selected; deep-link no-ops without a pane and opens on late pane arrival.
- Full suites after rebase: Flutter 1129 passed; analyzer shows only the 5 pre-existing findings (same as main).
- `dart format`, markdownlint, prettier clean via pre-commit.

Closes #2886.
