### PR TITLE
fix(frontend): clear stopped overlay on any container_ready

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1596,6 +1596,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   include `files` (or `*`) — the same gate as the Sharing tab — and
   `?file=`/`?dir=` deep-links and terminal path taps no-op instead.
 
+- **Workspace stopped overlay now clears when the container returns on
+  its own (#2701).** The blocking "Container stopped — Restart" overlay
+  only cleared when the restart came from its own button; if the
+  container came back by any other path (auto-start, restart from
+  elsewhere), the overlay stayed on top of a live terminal. Any
+  `container_ready` event now clears it.
+
 - **`klangk terminal share` / `unshare` / `ls` (#2876).** A server
   refusal — e.g. `Permission denied` for a member without the
   `share-terminals` permission — now prints a one-line error and exits

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1596,12 +1596,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   include `files` (or `*`) — the same gate as the Sharing tab — and
   `?file=`/`?dir=` deep-links and terminal path taps no-op instead.
 
-- **Workspace stopped overlay now clears when the container returns on
-  its own (#2701).** The blocking "Container stopped — Restart" overlay
-  only cleared when the restart came from its own button; if the
-  container came back by any other path (auto-start, restart from
-  elsewhere), the overlay stayed on top of a live terminal. Any
-  `container_ready` event now clears it.
+- **Workspace stopped overlay now clears when the container returns on its
+  own (#2701).** The blocking "Container stopped — Restart" overlay
+  only cleared when the restart came from its own button; if the container
+  came back another way (socket reconnect after a server cycle, auto-start,
+  a restart initiated from the settings panel), the overlay stayed on top
+  of a live terminal. Any `container_ready` event on the socket now
+  clears it.
 
 - **`klangk terminal share` / `unshare` / `ls` (#2876).** A server
   refusal — e.g. `Permission denied` for a member without the

--- a/src/frontend/lib/workspace/workspace_overlays.dart
+++ b/src/frontend/lib/workspace/workspace_overlays.dart
@@ -10,6 +10,61 @@ import 'package:flutter/material.dart';
 
 import '../theme/colors.dart';
 
+/// Immutable next-state for the container-stopped / restarting flags that
+/// drive [buildContainerStoppedOverlay]. Returned by
+/// [containerEventTransition]; `null` from it means "no change".
+typedef ContainerOverlayState = ({
+  bool containerStopped,
+  bool restarting,
+  String stopReason,
+});
+
+/// Pure state transition for the container lifecycle events that drive the
+/// container-stopped overlay. Kept beside the overlay builder it feeds so it
+/// is unit-testable without mounting the full `WorkspacePage` (same rationale
+/// as the builders below).
+///
+/// - `container_stopped` raises the overlay with the event's reason, except
+///   #2661: a stop whose reason is the server's own recycle is NOT
+///   user-actionable — the server stays up, the WebSocket drops with 1012
+///   and auto-reconnects, and auto-start brings the workspace back. Raising
+///   the blocking "stopped — click Restart" overlay would demand a click for
+///   a cycle that needs none; the reconnect overlay owns the gap. An event
+///   while the overlay is already up is likewise a no-op.
+/// - `container_ready` clears the overlay AND any in-flight restart spinner.
+///   #2701: the container can come back on its own (auto-start, restart
+///   initiated elsewhere) — the overlay must clear on ANY `container_ready`,
+///   not just one that follows an overlay-initiated restart, or it stays up
+///   demanding a manual Restart click over a live terminal. A routine
+///   `container_ready` (nothing raised, nothing in flight) is a no-op so it
+///   does not trigger a rebuild.
+ContainerOverlayState? containerEventTransition({
+  required String name,
+  required ContainerOverlayState current,
+  Map<String, dynamic>? value,
+}) {
+  if (name == 'container_stopped') {
+    if (current.containerStopped) return null;
+    final reason = value?['reason']?.toString() ?? '';
+    if (reason == 'server recycle') return null;
+    return (
+      containerStopped: true,
+      restarting: current.restarting,
+      stopReason:
+          reason.isEmpty ? 'Container stopped' : 'Container stopped ($reason)',
+    );
+  }
+  if (name == 'container_ready' &&
+      (current.restarting || current.containerStopped)) {
+    return (
+      containerStopped: false,
+      restarting: false,
+      stopReason: current.stopReason,
+    );
+  }
+  return null;
+}
+
 /// Overlay shown when the workspace container has stopped (idle timeout,
 /// manual stop, or crash). Pass [restarting] to swap the action area for a
 /// spinner; [stopReason] is shown verbatim when not restarting.

--- a/src/frontend/lib/workspace/workspace_overlays.dart
+++ b/src/frontend/lib/workspace/workspace_overlays.dart
@@ -32,12 +32,14 @@ typedef ContainerOverlayState = ({
 ///   a cycle that needs none; the reconnect overlay owns the gap. An event
 ///   while the overlay is already up is likewise a no-op.
 /// - `container_ready` clears the overlay AND any in-flight restart spinner.
-///   #2701: the container can come back on its own (auto-start, restart
-///   initiated elsewhere) — the overlay must clear on ANY `container_ready`,
-///   not just one that follows an overlay-initiated restart, or it stays up
-///   demanding a manual Restart click over a live terminal. A routine
-///   `container_ready` (nothing raised, nothing in flight) is a no-op so it
-///   does not trigger a rebuild.
+///   #2701: the container can come back without this client pressing the
+///   overlay's Restart button (socket reconnect after a server cycle, the
+///   workspace auto-starting, a restart initiated from this client's
+///   settings panel) — the overlay must clear on ANY `container_ready` on
+///   this socket, not just one that follows an overlay-initiated restart,
+///   or it stays up demanding a manual Restart click over a live terminal.
+///   A routine `container_ready` (nothing raised, nothing in flight) is a
+///   no-op so it does not trigger a rebuild.
 ContainerOverlayState? containerEventTransition({
   required String name,
   required ContainerOverlayState current,

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -266,27 +266,21 @@ class _WorkspacePageState extends State<WorkspacePage> {
       },
       onContainerEvent: (name, value) {
         if (!mounted) return;
-        if (name == 'container_stopped' && !_containerStopped) {
-          final reason = value?['reason'] ?? '';
-          // #2661: a stop whose reason is the server's own recycle is
-          // NOT user-actionable — the server stays up, the WebSocket
-          // drops with 1012 and auto-reconnects, and auto-start brings
-          // the workspace back. Raising the blocking "stopped — click
-          // Restart" overlay here would demand a click for a cycle
-          // that needs none; the reconnect overlay owns the gap.
-          if (reason == 'server recycle') return;
-          setState(() {
-            _containerStopped = true;
-            _stopReason = reason.toString().isNotEmpty
-                ? 'Container stopped ($reason)'
-                : 'Container stopped';
-          });
-        } else if (name == 'container_ready' && _restarting) {
-          setState(() {
-            _restarting = false;
-            _containerStopped = false;
-          });
-        }
+        final next = containerEventTransition(
+          name: name,
+          value: value,
+          current: (
+            containerStopped: _containerStopped,
+            restarting: _restarting,
+            stopReason: _stopReason,
+          ),
+        );
+        if (next == null) return;
+        setState(() {
+          _containerStopped = next.containerStopped;
+          _restarting = next.restarting;
+          _stopReason = next.stopReason;
+        });
       },
       // #2676: the server refuses a failed restart with an error frame
       // (instead of dropping the socket), so the spinner must clear here —

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -9,6 +9,134 @@ import 'package:klangk_frontend/workspace/workspace_overlays.dart';
 void main() {
   Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
+  group('containerEventTransition', () {
+    const idle = (
+      containerStopped: false,
+      restarting: false,
+      stopReason: '',
+    );
+
+    test('container_stopped raises the overlay with the reason', () {
+      final next = containerEventTransition(
+        name: 'container_stopped',
+        current: idle,
+        value: {'reason': 'idle timeout'},
+      );
+      expect(next, isNotNull);
+      expect(next!.containerStopped, isTrue);
+      expect(next.stopReason, 'Container stopped (idle timeout)');
+    });
+
+    test('container_stopped without a reason uses the generic message', () {
+      final next = containerEventTransition(
+        name: 'container_stopped',
+        current: idle,
+      );
+      expect(next!.stopReason, 'Container stopped');
+    });
+
+    test('server recycle stop does not raise the overlay (#2661)', () {
+      expect(
+        containerEventTransition(
+          name: 'container_stopped',
+          current: idle,
+          value: {'reason': 'server recycle'},
+        ),
+        isNull,
+      );
+    });
+
+    test('container_stopped while already stopped is a no-op', () {
+      const stopped = (
+        containerStopped: true,
+        restarting: false,
+        stopReason: 'Container stopped (idle timeout)',
+      );
+      expect(
+        containerEventTransition(
+          name: 'container_stopped',
+          current: stopped,
+          value: {'reason': 'crash'},
+        ),
+        isNull,
+      );
+    });
+
+    test('container_stopped keeps an in-flight restart spinner up', () {
+      final next = containerEventTransition(
+        name: 'container_stopped',
+        current: (
+          containerStopped: false,
+          restarting: true,
+          stopReason: '',
+        ),
+        value: {'reason': 'crash'},
+      );
+      expect(next!.restarting, isTrue);
+    });
+
+    test('container_ready clears an overlay-initiated restart', () {
+      final next = containerEventTransition(
+        name: 'container_ready',
+        current: (
+          containerStopped: true,
+          restarting: true,
+          stopReason: 'Container stopped',
+        ),
+      );
+      expect(next!.containerStopped, isFalse);
+      expect(next.restarting, isFalse);
+    });
+
+    test(
+        'container_ready clears the overlay even without an overlay-initiated '
+        'restart (#2701)', () {
+      // The container came back on its own (auto-start, restart from
+      // elsewhere): no restart was pressed here, but the overlay must go.
+      final next = containerEventTransition(
+        name: 'container_ready',
+        current: (
+          containerStopped: true,
+          restarting: false,
+          stopReason: 'Container stopped (idle timeout)',
+        ),
+      );
+      expect(next, isNotNull);
+      expect(next!.containerStopped, isFalse);
+      expect(next.restarting, isFalse);
+    });
+
+    test('container_ready clears a lone restart spinner', () {
+      final next = containerEventTransition(
+        name: 'container_ready',
+        current: (
+          containerStopped: false,
+          restarting: true,
+          stopReason: '',
+        ),
+      );
+      expect(next!.restarting, isFalse);
+    });
+
+    test('routine container_ready is a no-op (no rebuild)', () {
+      expect(
+        containerEventTransition(name: 'container_ready', current: idle),
+        isNull,
+      );
+    });
+
+    test('unrelated events are ignored', () {
+      expect(
+        containerEventTransition(
+          name: 'terminal_output',
+          current: idle,
+          value: {'data': 'x'},
+        ),
+        isNull,
+      );
+    });
+  });
+
   group('container stopped overlay (buildContainerStoppedOverlay)', () {
     testWidgets('shows reason and restart button', (tester) async {
       await tester.pumpWidget(wrap(

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -1,7 +1,9 @@
-/// Tests for the container-stopped and disconnected overlays in
-/// `WorkspacePage.build`. These exercise the REAL extracted overlay builders
-/// (`buildContainerStoppedOverlay` / `buildDisconnectedOverlay`) rather than
-/// duplicated standalone copies, so the actual page rendering is covered.
+/// Tests for the container-stopped and disconnected overlays and the
+/// container lifecycle event transition (`containerEventTransition`) that
+/// drives them. These exercise the REAL extracted builders / pure function
+/// from `workspace_overlays.dart` rather than duplicated standalone copies
+/// (the full `WorkspacePage` cannot be mounted in tests — see the note in
+/// `workspace_overlays.dart`), so the actual page logic is covered.
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/workspace/workspace_overlays.dart';


### PR DESCRIPTION
## Summary

- The workspace page's `onContainerEvent` only cleared the container-stopped overlay when the restart was initiated from the overlay's own button (`_restarting`); a container that came back by any other path (auto-start, restart initiated elsewhere) left the blocking "Container stopped — Restart" overlay on top of a live terminal (#2701).
- Extracted the lifecycle transition into a pure `containerEventTransition` in `workspace_overlays.dart` (beside the overlay builder it feeds — same testability rationale as the builders) and clear the overlay on **any** `container_ready`, guarded so a routine `container_ready` triggers no rebuild.
- The #2661 server-recycle exception (don't raise the overlay for a server-driven stop) is preserved unchanged.
- Changelog entry under `[Unreleased]` → `Fixed`.

## Testing

- 10 new unit tests for `containerEventTransition` in `workspace_page_test.dart`, including the #2701 regression (overlay up, `_restarting == false`, `container_ready` arrives → overlay clears) and the no-rebuild guard for routine events.
- Full frontend suite green the CI way (`flutter test --coverage`, 1133 tests); `flutter analyze` shows only pre-existing findings in untouched files.

Fixes #2701
