### PR TITLE
Surface access-revoked refusals instead of a restart loop (#2891)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1604,6 +1604,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Access-revoked restart loop (#2891).** When a user's workspace access
+  was revoked (share removed, ACL changed, workspace deleted) while a
+  "Container stopped" overlay was up, pressing its Restart button was
+  refused forever with no explanation — the overlay and button kept
+  reappearing. The server now tags those WebSocket refusals with
+  machine-readable `forbidden` / `not_found` codes, and the frontend
+  swaps the overlay for an "Access to this workspace has been revoked"
+  view with only a "Back to workspaces" action.
+
 - **Files tab is hidden without the `files` permission (#2886).** A
   spectator's workspace page mounted the Files tab unconditionally, so
   opening it failed with `Cannot list this directory: Permission denied`.

--- a/src/frontend/lib/workspace/workspace_connector.dart
+++ b/src/frontend/lib/workspace/workspace_connector.dart
@@ -153,14 +153,13 @@ class WorkspaceConnector {
       onSharedTerminalDeleted,
     );
 
-    // Listen for errors — access-revoked and capacity errors are
-    // page-level dead-ends; the rest go to the restart hook.
+    // Listen for errors — page-level dead-ends vs. the restart hook.
     _errorSub = wsClient.errors.listen((error) {
       if (error.accessRevoked) {
-        // #2891: the server refuses workspace_connect / restart_container
-        // with a machine-readable `forbidden` / `not_found` code (message
-        // fallback on older servers). Retrying can never succeed — the
-        // page swaps its restart overlay for the access-revoked view.
+        // #2891: a stamped forbidden / not_found refusal of
+        // workspace_connect / restart_container. Retrying can never
+        // succeed — the page swaps its restart overlay for the
+        // access-revoked view.
         onPageError(error);
       } else if (error.code == 'capacity' ||
           _messageLooksLikeCapacity(error.message)) {
@@ -168,6 +167,15 @@ class WorkspaceConnector {
         // page — surface it on the error view instead of silently
         // dropping it when no restart is in flight. Matched by code, with
         // the message-text fallback for older servers.
+        onPageError(error);
+      } else if (_messageLooksLikeAccessRefusal(error.message)) {
+        // Legacy code-less refusal texts (an older server talking to this
+        // client): route page-level exactly as pre-#2894 did, but WITHOUT
+        // the access-revoked classification — without codes we cannot
+        // tell a genuine revocation from a sub-action denial
+        // (join/share/exec) or a podman failure whose stderr happens to
+        // say "permission denied", so the page renders the plain error
+        // view, which shows the real message (#2891 review).
         onPageError(error);
       } else {
         // #2676: anything else (e.g. a refused container restart) goes to
@@ -200,5 +208,14 @@ class WorkspaceConnector {
     final lower = message.toLowerCase();
     return lower.contains('host at capacity') ||
         lower.contains('quota reached');
+  }
+
+  /// Pre-#2894 page-level routing for refusal texts from servers that
+  /// predate the refusal codes: the same substring match the connector
+  /// always used. Deliberately NOT part of [WsError.accessRevoked] —
+  /// see the legacy branch in [_doConnect].
+  static bool _messageLooksLikeAccessRefusal(String message) {
+    final lower = message.toLowerCase();
+    return lower.contains('permission') || lower.contains('denied');
   }
 }

--- a/src/frontend/lib/workspace/workspace_connector.dart
+++ b/src/frontend/lib/workspace/workspace_connector.dart
@@ -27,18 +27,19 @@ class WorkspaceConnector {
   /// Called when a shared terminal is deleted.
   final void Function(Map<String, dynamic> msg) onSharedTerminalDeleted;
 
-  /// Called when a page-level error arrives: permission/auth refusals
-  /// and capacity refusals (#2525 — "host at capacity" / "quota
-  /// reached"), both actionable dead-ends for this page that the owner
-  /// renders on its error view.
-  final void Function(String error) onPageError;
+  /// Called when a page-level error arrives: access-revoked refusals
+  /// (#2891 — revoked share / changed ACL / deleted workspace, via
+  /// [WsError.accessRevoked]) and capacity refusals (#2525 — "host at
+  /// capacity" / "quota reached"), both actionable dead-ends for this
+  /// page that the owner renders on its error view.
+  final void Function(WsError error) onPageError;
 
-  /// Called when a non-permission error arrives while a restart is in
+  /// Called when a non-page-level error arrives while a restart is in
   /// flight (#2676): the server now refuses a failed container restart
   /// with an `error` frame instead of dropping the socket, so the page
   /// must clear its restart spinner on this callback. May fire for
   /// unrelated errors too — the owner filters by its own state.
-  final void Function(String error)? onRestartError;
+  final void Function(WsError error)? onRestartError;
 
   /// #2710: whether the deploy's browser-delegate bridge is enabled
   /// (KLANGKD_BROWSER_DELEGATE_ENABLED via /config). When false, no
@@ -48,7 +49,7 @@ class WorkspaceConnector {
 
   BrowserDelegate? _browserDelegate;
   StreamSubscription<Map<String, dynamic>>? _customEventSub;
-  StreamSubscription<String>? _errorSub;
+  StreamSubscription<WsError>? _errorSub;
   StreamSubscription<Map<String, dynamic>>? _sharedDeletedSub;
 
   WorkspaceConnector({
@@ -152,20 +153,21 @@ class WorkspaceConnector {
       onSharedTerminalDeleted,
     );
 
-    // Listen for errors — permission/auth and capacity errors are
-    // page-level; the rest go to the restart hook.
+    // Listen for errors — access-revoked and capacity errors are
+    // page-level dead-ends; the rest go to the restart hook.
     _errorSub = wsClient.errors.listen((error) {
-      final lower = error.toLowerCase();
-      if (lower.contains('permission') || lower.contains('denied')) {
+      if (error.accessRevoked) {
+        // #2891: the server refuses workspace_connect / restart_container
+        // with a machine-readable `forbidden` / `not_found` code (message
+        // fallback on older servers). Retrying can never succeed — the
+        // page swaps its restart overlay for the access-revoked view.
         onPageError(error);
-      } else if (lower.contains('host at capacity') ||
-          lower.contains('quota reached')) {
-        // #2525: an admission refusal (server sends it with the
-        // machine-readable error code `capacity`; the message text is
-        // matched because the errors stream carries only the message)
-        // is an actionable dead-end for this page — surface it on the
-        // error view instead of silently dropping it when no restart
-        // is in flight.
+      } else if (error.code == 'capacity' ||
+          _messageLooksLikeCapacity(error.message)) {
+        // #2525: an admission refusal is an actionable dead-end for this
+        // page — surface it on the error view instead of silently
+        // dropping it when no restart is in flight. Matched by code, with
+        // the message-text fallback for older servers.
         onPageError(error);
       } else {
         // #2676: anything else (e.g. a refused container restart) goes to
@@ -190,5 +192,13 @@ class WorkspaceConnector {
     _sharedDeletedSub = null;
     _browserDelegate?.stop();
     _browserDelegate = null;
+  }
+
+  /// #2525 message-text fallback for capacity refusals from servers that
+  /// predate the machine-readable `capacity` code.
+  static bool _messageLooksLikeCapacity(String message) {
+    final lower = message.toLowerCase();
+    return lower.contains('host at capacity') ||
+        lower.contains('quota reached');
   }
 }

--- a/src/frontend/lib/workspace/workspace_overlays.dart
+++ b/src/frontend/lib/workspace/workspace_overlays.dart
@@ -128,8 +128,12 @@ Widget buildContainerStoppedOverlay({
 /// container-stopped Restart press is refused with `forbidden`/`not_found`.
 /// Unlike the container-stopped overlay there is deliberately NO restart
 /// action: the refusal is permanent from this client, so retrying can never
-/// succeed; the only sensible action is leaving the page.
-Widget buildAccessRevokedView({required VoidCallback onBack}) {
+/// succeed; the only sensible action is leaving the page. [detail] (the
+/// server's refusal message) renders under the explanation for diagnosis.
+Widget buildAccessRevokedView({
+  String? detail,
+  required VoidCallback onBack,
+}) {
   return Scaffold(
     appBar: AppBar(title: const Text('Workspace')),
     body: Center(
@@ -149,6 +153,14 @@ Widget buildAccessRevokedView({required VoidCallback onBack}) {
             'Restarting will not restore access.',
             textAlign: TextAlign.center,
           ),
+          if (detail != null && detail.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              detail,
+              style: const TextStyle(fontSize: 12, color: Colors.white54),
+              textAlign: TextAlign.center,
+            ),
+          ],
           const SizedBox(height: 16),
           FilledButton(
             onPressed: onBack,

--- a/src/frontend/lib/workspace/workspace_overlays.dart
+++ b/src/frontend/lib/workspace/workspace_overlays.dart
@@ -122,6 +122,44 @@ Widget buildContainerStoppedOverlay({
   );
 }
 
+/// Full-page view shown when the user's access to the workspace has been
+/// revoked (#2891): the share was removed, the ACL changed, or the workspace
+/// was deleted while the page was open — typically discovered when a
+/// container-stopped Restart press is refused with `forbidden`/`not_found`.
+/// Unlike the container-stopped overlay there is deliberately NO restart
+/// action: the refusal is permanent from this client, so retrying can never
+/// succeed; the only sensible action is leaving the page.
+Widget buildAccessRevokedView({required VoidCallback onBack}) {
+  return Scaffold(
+    appBar: AppBar(title: const Text('Workspace')),
+    body: Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.lock_outline, size: 48),
+          const SizedBox(height: 16),
+          const Text(
+            'Access to this workspace has been revoked',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'It may have been unshared with you, your permissions may have\n'
+            'changed, or the workspace may have been deleted.\n'
+            'Restarting will not restore access.',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: onBack,
+            child: const Text('Back to workspaces'),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
 /// Overlay shown when the WebSocket drops but the container is still running.
 /// Pass [reconnecting] to show the attempt counter + "Reconnect now" instead
 /// of the plain "Reconnect" action.

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -460,9 +460,15 @@ class _WorkspacePageState extends State<WorkspacePage> {
         }
       }
       // Auto-join the first shared terminal for spectators (no
-      // code-in-isolation) so they don't see a blank cursor.
+      // code-in-isolation) so they don't see a blank cursor. Gated on the
+      // spectate permission too (#2891 review): a custom ACL can grant
+      // `terminal` without `spectate-on-shared-terminals`, and an
+      // ungated auto-join would be server-denied the moment anyone
+      // shares a terminal — swapping the page for an error view with no
+      // user action at all.
       if (_activeSharedTerminal == null &&
           !_hasPerm('code-in-isolation') &&
+          _hasPerm('spectate-on-shared-terminals') &&
           wsClient.sharedTerminals.isNotEmpty) {
         final first = wsClient.sharedTerminals[0];
         final userId = first['user_id'] as String?;
@@ -567,11 +573,15 @@ class _WorkspacePageState extends State<WorkspacePage> {
   @override
   Widget build(BuildContext context) {
     if (_error != null) {
-      return _accessRevoked
-          ? buildAccessRevokedView(onBack: () => context.go('/workspaces'))
+      final body = _accessRevoked
+          ? buildAccessRevokedView(
+              detail: _error,
+              onBack: () => context.go('/workspaces'),
+            )
           : _buildErrorView();
+      return _withMarking(body);
     }
-    if (_connecting) return _buildConnectingView();
+    if (_connecting) return _withMarking(_buildConnectingView());
 
     final wsClient = context.read<WsClient>();
     final authToken = context.read<AuthService>().token;
@@ -631,6 +641,21 @@ class _WorkspacePageState extends State<WorkspacePage> {
             ),
           ),
         ),
+        MarkingBanner(text: _marking),
+      ],
+    );
+  }
+
+  /// #2768/#2894 review: the classification marking must survive every
+  /// screen state — dead-end views included (an access revocation is now
+  /// a common full-page path, exactly when classified deployments most
+  /// need the banner). Mirrors the main build's Column wrap; an empty
+  /// marking renders nothing and reserves no space.
+  Widget _withMarking(Widget child) {
+    return Column(
+      children: [
+        MarkingBanner(text: _marking),
+        Expanded(child: child),
         MarkingBanner(text: _marking),
       ],
     );

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -71,6 +71,11 @@ class _WorkspacePageState extends State<WorkspacePage> {
   bool _restarting = false;
   bool _disconnected = false;
 
+  /// #2891: [buildAccessRevokedView] should replace the page instead of
+  /// the plain error view — set when the page error was an access-revoked
+  /// refusal (see `onPageError`).
+  bool _accessRevoked = false;
+
   /// Tracks which shared terminal (from another user) we're viewing.
   /// null means we're on our own isolated terminal.
   Map<String, String>? _activeSharedTerminal;
@@ -306,7 +311,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
           ..hideCurrentSnackBar()
           ..showSnackBar(
             SnackBar(
-              content: Text('Restart failed: $error'),
+              content: Text('Restart failed: ${error.message}'),
               duration: const Duration(seconds: 6),
               behavior: SnackBarBehavior.floating,
             ),
@@ -349,7 +354,14 @@ class _WorkspacePageState extends State<WorkspacePage> {
         }
       },
       onPageError: (error) {
-        if (mounted) setState(() => _error = error);
+        if (!mounted) return;
+        // #2891: an access-revoked refusal (revoked share / changed ACL /
+        // deleted workspace) swaps the whole page for the access-revoked
+        // view — no restart overlay, no loop.
+        setState(() {
+          _error = error.message;
+          _accessRevoked = error.accessRevoked;
+        });
       },
     );
 
@@ -554,7 +566,11 @@ class _WorkspacePageState extends State<WorkspacePage> {
 
   @override
   Widget build(BuildContext context) {
-    if (_error != null) return _buildErrorView();
+    if (_error != null) {
+      return _accessRevoked
+          ? buildAccessRevokedView(onBack: () => context.go('/workspaces'))
+          : _buildErrorView();
+    }
     if (_connecting) return _buildConnectingView();
 
     final wsClient = context.read<WsClient>();

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -25,26 +25,23 @@ class WsDebugEntry {
 ///
 /// [code] is the server's machine-readable error class (#2525 capacity,
 /// #2891 forbidden / not_found) — null on legacy servers and local
-/// failures. [accessRevoked] classifies the dead-end refusals that can
-/// never succeed on retry (share revoked, ACL changed, workspace gone).
+/// failures. [accessRevoked] is deliberately **code-driven only**: the
+/// connect/restart refusal codes the server stamps for this purpose.
+/// Code-less "Permission denied" texts are NOT classified as revoked —
+/// sub-action denials (join/share/exec) and podman restart failures also
+/// carry that wording, and mislabeling them as revocations would swap the
+/// page for a view whose copy is then a lie (#2891 review).
 class WsError {
   final String message;
   final String? code;
 
   const WsError({required this.message, this.code});
 
-  /// Whether this error means the user can no longer open this
-  /// workspace. Machine-readable code first; the message-text fallback
-  /// keeps code-less (older) servers classified the same way (#2891).
-  bool get accessRevoked =>
-      code == 'forbidden' || code == 'not_found' || _messageLooksAccessRevoked;
-
-  bool get _messageLooksAccessRevoked {
-    final lower = message.toLowerCase();
-    return lower.contains('permission') ||
-        lower.contains('denied') ||
-        lower.contains('workspace not found');
-  }
+  /// Whether this error is a stamped workspace-connect / restart refusal:
+  /// the user can no longer open this workspace, and retrying can never
+  /// succeed. Only the machine-readable codes qualify — never the message
+  /// text (see the class doc).
+  bool get accessRevoked => code == 'forbidden' || code == 'not_found';
 
   @override
   bool operator ==(Object other) =>

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -20,6 +20,43 @@ class WsDebugEntry {
       : timestamp = DateTime.now();
 }
 
+/// An error frame from the server (or a local connection/auth failure)
+/// surfaced on [WsClient.errors].
+///
+/// [code] is the server's machine-readable error class (#2525 capacity,
+/// #2891 forbidden / not_found) — null on legacy servers and local
+/// failures. [accessRevoked] classifies the dead-end refusals that can
+/// never succeed on retry (share revoked, ACL changed, workspace gone).
+class WsError {
+  final String message;
+  final String? code;
+
+  const WsError({required this.message, this.code});
+
+  /// Whether this error means the user can no longer open this
+  /// workspace. Machine-readable code first; the message-text fallback
+  /// keeps code-less (older) servers classified the same way (#2891).
+  bool get accessRevoked =>
+      code == 'forbidden' || code == 'not_found' || _messageLooksAccessRevoked;
+
+  bool get _messageLooksAccessRevoked {
+    final lower = message.toLowerCase();
+    return lower.contains('permission') ||
+        lower.contains('denied') ||
+        lower.contains('workspace not found');
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is WsError && other.message == message && other.code == code;
+
+  @override
+  int get hashCode => Object.hash(message, code);
+
+  @override
+  String toString() => code == null ? message : '$message (code: $code)';
+}
+
 /// Manages WebSocket connection to the Klangk backend, sending commands
 /// and streaming terminal output and browser bridge requests.
 class WsClient extends ChangeNotifier {
@@ -103,7 +140,7 @@ class WsClient extends ChangeNotifier {
     _listenToChannel();
   }
 
-  final _errorController = StreamController<String>.broadcast();
+  final _errorController = StreamController<WsError>.broadcast();
   final _terminalOutputController = StreamController<String>.broadcast();
   // #2527: host lifecycle notices (host_shutdown / server_recycle phases /
   // host_started) as a broadcast stream AND a listenable field for status
@@ -142,7 +179,7 @@ class WsClient extends ChangeNotifier {
       StreamController<Map<String, dynamic>>.broadcast();
   final _debugLogController = StreamController<WsDebugEntry>.broadcast();
 
-  Stream<String> get errors => _errorController.stream;
+  Stream<WsError> get errors => _errorController.stream;
   Stream<String> get terminalOutput => _terminalOutputController.stream;
   Stream<Map<String, dynamic>> get browserRequests =>
       _browserRequestController.stream;
@@ -300,11 +337,15 @@ class WsClient extends ChangeNotifier {
       final code = _channel?.closeCode;
       if (code == 4001 || code == 4002) {
         _authFailed = true;
-        _errorController.add('Session expired, please log in again');
+        _errorController.add(
+          const WsError(message: 'Session expired, please log in again'),
+        );
         _auth?.logout();
       } else {
         debugPrint('WebSocket connection failed: $e');
-        _errorController.add('Connection failed. Please try again.');
+        _errorController.add(
+          const WsError(message: 'Connection failed. Please try again.'),
+        );
       }
       return;
     }
@@ -332,8 +373,10 @@ class WsClient extends ChangeNotifier {
     'container_ready': _onContainerReady,
     'terminal_output': (json) =>
         _terminalOutputController.add(json['data'] as String? ?? ''),
-    'error': (json) =>
-        _errorController.add(json['message'] as String? ?? 'Unknown error'),
+    'error': (json) => _errorController.add(WsError(
+          message: json['message'] as String? ?? 'Unknown error',
+          code: json['code'] as String?,
+        )),
     'browser_request': _browserRequestController.add,
     'terminal_windows': _onTerminalWindows,
     'shared_terminals': _onSharedTerminals,
@@ -400,7 +443,7 @@ class WsClient extends ChangeNotifier {
 
           _handlers[type]?.call(json);
         } catch (e) {
-          _errorController.add('Parse error: $e');
+          _errorController.add(WsError(message: 'Parse error: $e'));
         }
       },
       onDone: () {
@@ -429,14 +472,16 @@ class WsClient extends ChangeNotifier {
         }
         notifyListeners();
         if (authFailure) {
-          _errorController.add('Session expired, please log in again');
+          _errorController.add(
+            const WsError(message: 'Session expired, please log in again'),
+          );
           _auth?.logout();
         } else {
           _scheduleReconnect();
         }
       },
       onError: (e) {
-        _errorController.add('WebSocket error: $e');
+        _errorController.add(WsError(message: 'WebSocket error: $e'));
         _stopHeartbeat();
         _connected = false;
         _pendingWorkspaceId ??= _currentWorkspaceId;

--- a/src/frontend/test/workspace_connector_test.dart
+++ b/src/frontend/test/workspace_connector_test.dart
@@ -235,19 +235,32 @@ void main() {
 
       await connector.connect();
 
-      // Message-text fallback for older servers without the
-      // machine-readable code (#2891).
+      // Legacy routing for older servers without the machine-readable
+      // codes (#2891 review): refusal texts still go page-level, but are
+      // NOT classified access-revoked — the page renders the plain error
+      // view (with the real message), never the revoked view.
       ws.emitError(const WsError(message: 'Permission denied'));
       await Future<void>.delayed(Duration.zero);
 
       expect(errors, [const WsError(message: 'Permission denied')]);
-      expect(errors.first.accessRevoked, isTrue);
+      expect(errors.first.accessRevoked, isFalse);
 
-      // Non-access-revoked errors are ignored
+      // A sub-action denial (legacy, code-less) is routed the same way —
+      // page-level, matching pre-#2894 behavior — and is not a
+      // revocation.
+      ws.emitError(
+        const WsError(message: 'exec requires the exec-and-sync permission'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(errors, hasLength(2));
+      expect(errors.last.accessRevoked, isFalse);
+
+      // Unrelated errors are ignored
       ws.emitError(const WsError(message: 'Connection timeout'));
       await Future<void>.delayed(Duration.zero);
 
-      expect(errors, hasLength(1));
+      expect(errors, hasLength(2));
 
       connector.dispose();
       ws.close();

--- a/src/frontend/test/workspace_connector_test.dart
+++ b/src/frontend/test/workspace_connector_test.dart
@@ -8,8 +8,8 @@ import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 class _MockWsClient extends WsClient {
   final StreamController<Map<String, dynamic>> _customEventsCtrl =
       StreamController<Map<String, dynamic>>.broadcast();
-  final StreamController<String> _errorsCtrl =
-      StreamController<String>.broadcast();
+  final StreamController<WsError> _errorsCtrl =
+      StreamController<WsError>.broadcast();
   final StreamController<Map<String, dynamic>> _sharedDeletedCtrl =
       StreamController<Map<String, dynamic>>.broadcast();
   final StreamController<Map<String, dynamic>> _browserRequestsCtrl =
@@ -29,7 +29,7 @@ class _MockWsClient extends WsClient {
   Stream<Map<String, dynamic>> get customEvents => _customEventsCtrl.stream;
 
   @override
-  Stream<String> get errors => _errorsCtrl.stream;
+  Stream<WsError> get errors => _errorsCtrl.stream;
 
   @override
   Stream<Map<String, dynamic>> get sharedTerminalDeleted =>
@@ -59,7 +59,7 @@ class _MockWsClient extends WsClient {
   void emitCustomEvent(Map<String, dynamic> event) =>
       _customEventsCtrl.add(event);
 
-  void emitError(String error) => _errorsCtrl.add(error);
+  void emitError(WsError error) => _errorsCtrl.add(error);
 
   void emitSharedDeleted(Map<String, dynamic> msg) =>
       _sharedDeletedCtrl.add(msg);
@@ -221,7 +221,7 @@ void main() {
 
     test('forwards permission errors to callback', () async {
       final ws = _MockWsClient();
-      final errors = <String>[];
+      final errors = <WsError>[];
 
       final connector = WorkspaceConnector(
         wsClient: ws,
@@ -235,13 +235,16 @@ void main() {
 
       await connector.connect();
 
-      ws.emitError('Permission denied');
+      // Message-text fallback for older servers without the
+      // machine-readable code (#2891).
+      ws.emitError(const WsError(message: 'Permission denied'));
       await Future<void>.delayed(Duration.zero);
 
-      expect(errors, ['Permission denied']);
+      expect(errors, [const WsError(message: 'Permission denied')]);
+      expect(errors.first.accessRevoked, isTrue);
 
-      // Non-permission errors are ignored
-      ws.emitError('Connection timeout');
+      // Non-access-revoked errors are ignored
+      ws.emitError(const WsError(message: 'Connection timeout'));
       await Future<void>.delayed(Duration.zero);
 
       expect(errors, hasLength(1));
@@ -252,7 +255,7 @@ void main() {
 
     test('forwards non-permission errors to onRestartError (#2676)', () async {
       final ws = _MockWsClient();
-      final restartErrors = <String>[];
+      final restartErrors = <WsError>[];
 
       final connector = WorkspaceConnector(
         wsClient: ws,
@@ -269,13 +272,19 @@ void main() {
 
       // A refused restart (server sends an error frame instead of dropping
       // the socket) reaches the hook…
-      ws.emitError('Container restart failed: dependent containers');
+      ws.emitError(
+        const WsError(
+            message: 'Container restart failed: dependent containers'),
+      );
       await Future<void>.delayed(Duration.zero);
 
-      expect(restartErrors, ['Container restart failed: dependent containers']);
+      expect(
+        restartErrors.map((e) => e.message),
+        ['Container restart failed: dependent containers'],
+      );
 
       // …but permission errors do not (they stay on onPageError).
-      ws.emitError('Permission denied');
+      ws.emitError(const WsError(message: 'Permission denied'));
       await Future<void>.delayed(Duration.zero);
 
       expect(restartErrors, hasLength(1));
@@ -286,8 +295,8 @@ void main() {
 
     test('capacity refusals surface as page errors (#2525)', () async {
       final ws = _MockWsClient();
-      final pageErrors = <String>[];
-      final restartErrors = <String>[];
+      final pageErrors = <WsError>[];
+      final restartErrors = <WsError>[];
 
       final connector = WorkspaceConnector(
         wsClient: ws,
@@ -302,30 +311,41 @@ void main() {
 
       await connector.connect();
 
-      // A host-capacity refusal (the server's error frame carries the
-      // machine-readable code `capacity`; the stream carries the
-      // message) must reach the page-error hook — including on an
-      // initial connect where no restart is in flight — instead of
-      // being silently dropped.
+      // A host-capacity refusal must reach the page-error hook —
+      // including on an initial connect where no restart is in flight —
+      // instead of being silently dropped. Message-text fallback for
+      // older servers first, then the machine-readable code.
       ws.emitError(
-        'host at capacity: 1.2 GB available, workspace wants 9.0 GB '
-        '(memory limit 8.0 GB + 1.0 GB reserve)',
+        const WsError(
+          message: 'host at capacity: 1.2 GB available, workspace wants '
+              '9.0 GB (memory limit 8.0 GB + 1.0 GB reserve)',
+        ),
       );
       await Future<void>.delayed(Duration.zero);
 
       expect(pageErrors, hasLength(1));
-      expect(pageErrors.first, contains('host at capacity'));
+      expect(pageErrors.first.message, contains('host at capacity'));
       expect(restartErrors, isEmpty);
 
-      // Same for a per-user quota refusal.
       ws.emitError(
-        'workspace quota reached: 2 of this user\'s workspaces are '
-        'already running',
+        const WsError(message: 'host at capacity', code: 'capacity'),
       );
       await Future<void>.delayed(Duration.zero);
 
       expect(pageErrors, hasLength(2));
-      expect(pageErrors.last, contains('quota reached'));
+      expect(restartErrors, isEmpty);
+
+      // Same for a per-user quota refusal.
+      ws.emitError(
+        const WsError(
+          message: "workspace quota reached: 2 of this user's workspaces "
+              'are already running',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pageErrors, hasLength(3));
+      expect(pageErrors.last.message, contains('quota reached'));
       expect(restartErrors, isEmpty);
 
       connector.dispose();
@@ -347,8 +367,54 @@ void main() {
 
       await connector.connect();
 
-      ws.emitError('Connection timeout');
+      ws.emitError(const WsError(message: 'Connection timeout'));
       await Future<void>.delayed(Duration.zero);
+
+      connector.dispose();
+      ws.close();
+    });
+
+    test('access-revoked refusals reach onPageError by code (#2891)', () async {
+      final ws = _MockWsClient();
+      final pageErrors = <WsError>[];
+      final restartErrors = <WsError>[];
+
+      final connector = WorkspaceConnector(
+        wsClient: ws,
+        workspaceId: 'ws-1',
+        featureRegistry: ToolPluginRegistry(),
+        onConnected: ({required connected, error}) {},
+        onContainerEvent: (_, __) {},
+        onSharedTerminalDeleted: (_) {},
+        onPageError: (e) => pageErrors.add(e),
+        onRestartError: (e) => restartErrors.add(e),
+      );
+
+      await connector.connect();
+
+      // A revoked share / changed ACL refuses workspace_connect and
+      // restart_container with the machine-readable `forbidden` code.
+      // It must reach the page-error hook (which swaps the restart
+      // overlay for the access-revoked view), never the restart hook —
+      // otherwise the container-stopped overlay with its Restart
+      // button re-appears and every press fails identically, forever.
+      ws.emitError(
+          const WsError(message: 'Permission denied', code: 'forbidden'));
+      await Future<void>.delayed(Duration.zero);
+
+      // A workspace deleted while the user was away (`not_found`) is
+      // the same dead-end.
+      ws.emitError(
+        const WsError(message: 'Workspace not found', code: 'not_found'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pageErrors, hasLength(2));
+      expect(pageErrors.first.code, 'forbidden');
+      expect(pageErrors.first.accessRevoked, isTrue);
+      expect(pageErrors.last.code, 'not_found');
+      expect(pageErrors.last.accessRevoked, isTrue);
+      expect(restartErrors, isEmpty);
 
       connector.dispose();
       ws.close();

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -387,5 +387,33 @@ void main() {
       await tester.tap(find.text('Back to workspaces'));
       expect(called, isTrue);
     });
+
+    testWidgets('renders the underlying refusal as detail (#2891 review)',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildAccessRevokedView(
+            detail: 'Permission denied',
+            onBack: () {},
+          ),
+        ),
+      );
+
+      expect(find.text('Permission denied'), findsOneWidget);
+    });
+
+    testWidgets('no detail line when detail is absent or empty',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: buildAccessRevokedView(onBack: () {})),
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildAccessRevokedView(detail: '', onBack: () {}),
+        ),
+      );
+
+      expect(find.text('Permission denied'), findsNothing);
+    });
   });
 }

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -359,4 +359,33 @@ void main() {
       );
     });
   });
+
+  group('access revoked view (buildAccessRevokedView, #2891)', () {
+    testWidgets('shows revocation message and no restart action',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: buildAccessRevokedView(onBack: () {})),
+      );
+
+      expect(
+        find.text('Access to this workspace has been revoked'),
+        findsOneWidget,
+      );
+      expect(find.text('Back to workspaces'), findsOneWidget);
+      // The defining constraint: no Restart button — the refusal is
+      // permanent, so retrying can never succeed.
+      expect(find.text('Restart'), findsNothing);
+      expect(find.byIcon(Icons.refresh), findsNothing);
+    });
+
+    testWidgets('back button calls callback', (tester) async {
+      var called = false;
+      await tester.pumpWidget(
+        MaterialApp(home: buildAccessRevokedView(onBack: () => called = true)),
+      );
+
+      await tester.tap(find.text('Back to workspaces'));
+      expect(called, isTrue);
+    });
+  });
 }

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1478,14 +1478,34 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(errors.last.accessRevoked, isTrue);
+    });
 
-      // An error without a code (legacy server) is still classified by
-      // its message.
-      channel.serverSend({'type': 'error', 'message': 'Permission denied'});
-      await Future.delayed(Duration.zero);
-
-      expect(errors.last.code, isNull);
-      expect(errors.last.accessRevoked, isTrue);
+    test('accessRevoked is code-driven only, never text-driven (#2891)',
+        () async {
+      // Sub-action denials and podman failures share the wording of a
+      // revocation; without a code they must NOT classify as one, or the
+      // page would swap to the access-revoked view on a lie.
+      const notRevoked = [
+        WsError(message: 'Permission denied'), // legacy server, no code
+        WsError(message: 'Workspace not found'),
+        WsError(message: 'exec requires the exec-and-sync permission'),
+        WsError(
+          message: 'Container restart failed: [Errno 13] permission denied',
+        ),
+      ];
+      for (final e in notRevoked) {
+        expect(e.accessRevoked, isFalse, reason: e.message);
+      }
+      expect(
+        const WsError(message: 'Permission denied', code: 'forbidden')
+            .accessRevoked,
+        isTrue,
+      );
+      expect(
+        const WsError(message: 'Workspace not found', code: 'not_found')
+            .accessRevoked,
+        isTrue,
+      );
     });
 
     test('invalid JSON produces parse error', () async {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -333,14 +333,15 @@ void main() {
       final client = WsClient();
       client.updateAuth(auth);
 
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       await client.connect();
       await Future.delayed(Duration.zero);
       expect(client.connected, isFalse);
       expect(errors.length, 1);
-      expect(errors[0], 'Connection failed. Please try again.');
+      expect(errors[0],
+          const WsError(message: 'Connection failed. Please try again.'));
       client.dispose();
     });
 
@@ -357,14 +358,15 @@ void main() {
       final client = WsClient();
       client.updateAuth(auth);
 
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       await client.connect();
       await Future.delayed(Duration.zero);
       expect(client.connected, isFalse);
       expect(errors.length, 1);
-      expect(errors[0], 'Session expired, please log in again');
+      expect(errors[0],
+          const WsError(message: 'Session expired, please log in again'));
       expect(client.authFailed, isTrue);
       client.dispose();
     });
@@ -587,7 +589,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       // Consume error stream to prevent unhandled errors
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       channels[0].serverError(Exception('network failure'));
@@ -614,7 +616,7 @@ void main() {
       });
       await Future.delayed(Duration.zero);
 
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       // Set close code before emitting error
@@ -1060,7 +1062,7 @@ void main() {
       });
       await Future.delayed(Duration.zero);
 
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       // Server closes with auth failure code
@@ -1069,7 +1071,10 @@ void main() {
 
       expect(client.reconnecting, isFalse);
       expect(client.reconnectAttempt, 0);
-      expect(errors, contains('Session expired, please log in again'));
+      expect(
+          errors,
+          contains(
+              const WsError(message: 'Session expired, please log in again')));
       expect(client.authFailed, isTrue);
 
       client.disconnect();
@@ -1090,7 +1095,7 @@ void main() {
       });
       await Future.delayed(Duration.zero);
 
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       // Server closes with token expired code
@@ -1099,7 +1104,10 @@ void main() {
 
       expect(client.reconnecting, isFalse);
       expect(client.reconnectAttempt, 0);
-      expect(errors, contains('Session expired, please log in again'));
+      expect(
+          errors,
+          contains(
+              const WsError(message: 'Session expired, please log in again')));
       expect(client.authFailed, isTrue);
 
       client.disconnect();
@@ -1398,34 +1406,70 @@ void main() {
     });
 
     test('receives error from server', () async {
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       channel.serverSend({'type': 'error', 'message': 'bad thing'});
       await Future.delayed(Duration.zero);
 
-      expect(errors, ['bad thing']);
+      expect(errors, [const WsError(message: 'bad thing')]);
     });
 
     test('error with null message sends Unknown error', () async {
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       channel.serverSend({'type': 'error'});
       await Future.delayed(Duration.zero);
 
-      expect(errors, ['Unknown error']);
+      expect(errors, [const WsError(message: 'Unknown error')]);
+    });
+
+    test('error code is surfaced for class-based handling (#2891)', () async {
+      final errors = <WsError>[];
+      client.errors.listen(errors.add);
+
+      // The server's access-revoked refusals carry a machine-readable
+      // code so clients can classify without parsing the message.
+      channel.serverSend({
+        'type': 'error',
+        'message': 'Permission denied',
+        'code': 'forbidden',
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(errors, [
+        const WsError(message: 'Permission denied', code: 'forbidden'),
+      ]);
+      expect(errors.first.accessRevoked, isTrue);
+
+      channel.serverSend({
+        'type': 'error',
+        'message': 'Workspace not found',
+        'code': 'not_found',
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(errors.last.accessRevoked, isTrue);
+
+      // An error without a code (legacy server) is still classified by
+      // its message.
+      channel.serverSend({'type': 'error', 'message': 'Permission denied'});
+      await Future.delayed(Duration.zero);
+
+      expect(errors.last.code, isNull);
+      expect(errors.last.accessRevoked, isTrue);
     });
 
     test('invalid JSON produces parse error', () async {
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       channel._incoming.add('not json');
       await Future.delayed(Duration.zero);
 
       expect(errors.length, 1);
-      expect(errors[0], startsWith('Parse error:'));
+      expect(errors[0].message, startsWith('Parse error:'));
     });
 
     test('server close resets connected state', () async {
@@ -1495,14 +1539,14 @@ void main() {
     });
 
     test('server error emits to error stream', () async {
-      final errors = <String>[];
+      final errors = <WsError>[];
       client.errors.listen(errors.add);
 
       channel.serverError(Exception('boom'));
       await Future.delayed(Duration.zero);
 
       expect(errors.length, 1);
-      expect(errors[0], contains('WebSocket error'));
+      expect(errors[0].message, contains('WebSocket error'));
       expect(client.connected, isFalse);
     });
   });

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -65,6 +65,33 @@ class _FakeSink extends Fake implements WebSocketSink {
 }
 
 void main() {
+  group('WsError value semantics (#2891)', () {
+    test('equality and hashCode follow message + code', () {
+      const a = WsError(message: 'Permission denied', code: 'forbidden');
+      const b = WsError(message: 'Permission denied', code: 'forbidden');
+      const c = WsError(message: 'Permission denied');
+      const d = WsError(message: 'Workspace not found', code: 'not_found');
+
+      expect(a, b);
+      expect(a, isNot(c));
+      expect(a, isNot(d));
+      // Same hash for equal values (used as set/map keys).
+      expect({a}.contains(b), isTrue);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toString carries the code when present', () {
+      expect(
+        const WsError(message: 'Permission denied').toString(),
+        'Permission denied',
+      );
+      expect(
+        const WsError(message: 'Permission denied', code: 'forbidden')
+            .toString(),
+        'Permission denied (code: forbidden)',
+      );
+    });
+  });
   setUp(() {
     testBaseUrlOverride = 'http://localhost:8997';
     SharedPreferences.setMockInitialValues({});

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -359,11 +359,14 @@ class Connection:
         if not await self.app.state.acl.check_permission(
             f"/workspaces/{workspace_id}", principals, "terminal"
         ):
-            send_error(self.sock, "Permission denied")
+            # #2891: machine-readable ``forbidden`` so clients can swap
+            # the restart/overlay loop for an access-revoked view instead
+            # of matching the message text.
+            send_error(self.sock, "Permission denied", code="forbidden")
             return
         workspace = await self.app.state.workspaces.get_workspace(workspace_id)
         if workspace is None:
-            send_error(self.sock, "Workspace not found")
+            send_error(self.sock, "Workspace not found", code="not_found")
             return
 
         logger.info(
@@ -466,7 +469,8 @@ class Connection:
             return
         # Restarting affects everyone in the workspace; require terminal.
         if not await self._has_perm("terminal"):
-            send_error(self.sock, "Permission denied")
+            # #2891: same machine-readable refusal as workspace_connect.
+            send_error(self.sock, "Permission denied", code="forbidden")
             return
 
         # Save before cleanup — cleanup clears state fields.
@@ -490,7 +494,7 @@ class Connection:
         # workspaces' non-owner members.
         workspace = await self.app.state.workspaces.get_workspace(workspace_id)
         if workspace is None:
-            send_error(self.sock, "Workspace not found")
+            send_error(self.sock, "Workspace not found", code="not_found")
             return
 
         try:

--- a/src/klangk/klangk/wshandler/helpers.py
+++ b/src/klangk/klangk/wshandler/helpers.py
@@ -112,10 +112,11 @@ def send_error(
 ) -> None:
     """Send an error frame; *code* adds a machine-readable kind.
 
-    The optional ``code`` (e.g. ``"capacity"``, #2525) lets clients tell
-    a *class* of failure apart from other start errors without parsing
-    the message text — the WS counterpart of the API's 503. Omitted for
-    legacy callers; unknown codes are ignorable by old clients.
+    The optional ``code`` (e.g. ``"capacity"``, #2525; ``"forbidden"`` /
+    ``"not_found"``, #2891) lets clients tell a *class* of failure apart
+    from other start errors without parsing the message text — the WS
+    counterpart of the API's 503. Omitted for legacy callers; unknown
+    codes are ignorable by old clients.
     """
     msg = {"type": "error", "message": message}
     if code is not None:

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -1979,7 +1979,9 @@ class TestHandleWorkspaceConnect:
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         await conn.handle_workspace_connect({"workspaceId": "fake"})
-        assert "Permission denied" in sock.send_json.call_args[0][0]["message"]
+        frame = sock.send_json.call_args[0][0]
+        assert "Permission denied" in frame["message"]
+        assert frame["code"] == "forbidden"
 
     async def test_connect_success(self, user, agent_user, app_state):
         app_state = _make_app_state()
@@ -2061,7 +2063,14 @@ class TestHandleWorkspaceConnect:
         conn = _base_conn(user={"id": "other-user", "email": "x"}, ws=sock)
         await conn.handle_workspace_connect({"workspaceId": workspace["id"]})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
-        assert any("Permission denied" in str(c) for c in calls)
+        denied = [
+            c
+            for c in calls
+            if isinstance(c, dict) and c.get("type") == "error"
+        ]
+        assert any("Permission denied" in str(c) for c in denied)
+        # #2891: machine-readable refusal code for the client.
+        assert all(c.get("code") == "forbidden" for c in denied)
 
     async def test_connect_race_deleted(self, user, app_state):
         """ACL passes but workspace deleted before lookup."""
@@ -2081,6 +2090,8 @@ class TestHandleWorkspaceConnect:
         await conn.handle_workspace_connect({"workspaceId": fake_id})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Workspace not found" in str(c) for c in calls)
+        # #2891: machine-readable refusal code for the client.
+        assert any(c.get("code") == "not_found" for c in calls)
 
     async def test_connect_container_start_valueerror(
         self, user, agent_user, app_state
@@ -5842,6 +5853,10 @@ class TestHandleRestartContainer:
             isinstance(m, dict) and "Permission denied" in m.get("message", "")
             for m in sent
         )
+        # #2891: machine-readable refusal code for the client.
+        assert any(
+            isinstance(m, dict) and m.get("code") == "forbidden" for m in sent
+        )
         # No destructive side effects: nothing torn down or (re)started.
         mock_cleanup.assert_not_called()
         mock_start.assert_not_called()
@@ -5970,6 +5985,10 @@ class TestHandleRestartContainer:
 
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("not found" in str(c) for c in calls)
+        # #2891: machine-readable refusal code for the client.
+        assert any(
+            isinstance(c, dict) and c.get("code") == "not_found" for c in calls
+        )
 
     async def test_restart_reads_workspace_fresh_from_db(
         self, user, app_state


### PR DESCRIPTION
## Summary

When a user's access to a workspace is revoked while the "Container stopped (host shutdown)" overlay is up, every Restart-button press was refused (403 / permission denied) and the overlay with its Restart button reappeared — a loop that can never succeed (#2891).

Root cause: the frontend classified server refusals by matching the error-frame message text, so any refusal that didn't contain "permission"/"denied" fell through to the restart hook, and even matched ones rendered only a terse `Error: Permission denied`. There was no dedicated access-revoked state.

## Changes

**Server (`wshandler`)**
- `workspace_connect` and `restart_container` permission denials now send `code: "forbidden"`; a missing workspace sends `code: "not_found"` (machine-readable error classes, same mechanism as the `capacity` code from #2525).
- `send_error` docstring updated for the new codes.

**Frontend**
- `WsClient.errors` now emits a `WsError` (message + optional code) instead of a bare `String`; `WsError.accessRevoked` classifies `forbidden`/`not_found` by code with a message-text fallback so older servers behave the same.
- `WorkspaceConnector` routes access-revoked errors to `onPageError` by code (capacity routing also now matches the code); everything else still goes to `onRestartError` (#2676).
- `WorkspacePage` swaps the page for a new `buildAccessRevokedView` — "Access to this workspace has been revoked", **no restart action**, only "Back to workspaces".

## Testing

- Backend: full suite green (6169 passed, 100% coverage) — assertions for the new codes added to the existing permission/not-found restart tests.
- Frontend: full suite green (1149 passed) — new tests for code-based connector routing, `WsError` code parsing + fallback, and the access-revoked view (no Restart button, Back works).

Closes #2891.
