### PR TITLE
fix(frontend): password visibility toggle is not a tab stop (#2893)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1281,7 +1281,8 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 - **Password-field visibility toggle (#2893).** The "eye" toggle on
   password fields (login, settings, invitations, password reset, admin
   user forms) is no longer a Tab stop — Tab moves only between input
-  fields. The toggle stays clickable and reachable via directional focus.
+  fields. The toggle is now mouse/touch-only: it has no keyboard
+  activation path (screen-reader semantics navigation still reaches it).
 
 - **The devenv Flutter toolchain is now 3.47.0 (#2869).** Flutter (and its
   Dart SDK) come from a pinned `nixpkgs-unstable` input while the rest of

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1278,6 +1278,11 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **Password-field visibility toggle (#2893).** The "eye" toggle on
+  password fields (login, settings, invitations, password reset, admin
+  user forms) is no longer a Tab stop — Tab moves only between input
+  fields. The toggle stays clickable and reachable via directional focus.
+
 - **The devenv Flutter toolchain is now 3.47.0 (#2869).** Flutter (and its
   Dart SDK) come from a pinned `nixpkgs-unstable` input while the rest of
   the toolchain stays on `nixos-26.05`. Contributors get Flutter 3.47 /

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -1,15 +1,19 @@
 // coverage:ignore-file
 import 'dart:async';
 import 'dart:convert';
+
 // ignore: unused_import
 import '../theme/colors.dart';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import '../auth/auth_service.dart';
 import '../auth/password_policy.dart';
 import '../widgets/acl_editor.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
+import '../widgets/obscure_toggle.dart';
 import '../widgets/skeuo_tab.dart';
 import '../utils/validators.dart';
 import 'server_schedule_panel.dart';
@@ -66,8 +70,10 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       if (value == _usersQuery) return;
       _usersQuery = value;
       _usersQueryDebounce?.cancel();
-      _usersQueryDebounce =
-          Timer(const Duration(milliseconds: 300), () => _loadUsers(page: 1));
+      _usersQueryDebounce = Timer(
+        const Duration(milliseconds: 300),
+        () => _loadUsers(page: 1),
+      );
     });
     _loadUsers();
   }
@@ -137,9 +143,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     final auth = context.read<AuthService>();
     final result = await showDialog<Map<String, dynamic>>(
       context: context,
-      builder: (ctx) => _AddUserDialog(
-        passwordPolicy: auth.passwordPolicy,
-      ),
+      builder: (ctx) => _AddUserDialog(passwordPolicy: auth.passwordPolicy),
     );
     if (result == null) return;
 
@@ -266,16 +270,12 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
           '$count $word and all their data:';
     }
 
-    final children = <Widget>[
-      Text(summary),
-    ];
+    final children = <Widget>[Text(summary)];
 
     // List the names (capped at 100 by the fetch; scrollable so a long
     // list doesn't blow out the dialog).
     if (!fetchFailed && count > 0) {
-      children.add(
-        const SizedBox(height: 12),
-      );
+      children.add(const SizedBox(height: 12));
       children.add(
         ConstrainedBox(
           constraints: const BoxConstraints(maxHeight: 240),
@@ -620,8 +620,10 @@ class _GroupsTabState extends State<_GroupsTab> {
       if (value == _groupsQuery) return;
       _groupsQuery = value;
       _groupsQueryDebounce?.cancel();
-      _groupsQueryDebounce =
-          Timer(const Duration(milliseconds: 300), () => _loadGroups(page: 1));
+      _groupsQueryDebounce = Timer(
+        const Duration(milliseconds: 300),
+        () => _loadGroups(page: 1),
+      );
     });
     _loadGroups();
   }
@@ -857,10 +859,7 @@ class _GroupsTabState extends State<_GroupsTab> {
         children: [
           _AdminListToolbar(
             key: const ValueKey('admin-groups-toolbar'),
-            columns: const [
-              ('Name', 'name'),
-              ('Created', 'created'),
-            ],
+            columns: const [('Name', 'name'), ('Created', 'created')],
             sort: _groupsSort,
             order: _groupsOrder,
             onChangeSort: _changeGroupsSort,
@@ -916,9 +915,7 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
     final membersResp = await auth.authGet(
       '/api/v1/admin/groups/$_groupId/members',
     );
-    final usersResp = await auth.authGet(
-      '/api/v1/admin/users?page_size=200',
-    );
+    final usersResp = await auth.authGet('/api/v1/admin/users?page_size=200');
     if (!mounted) return;
     if (membersResp.statusCode != 200 || usersResp.statusCode != 200) {
       setState(() => _loading = false);
@@ -940,9 +937,7 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
       body: jsonEncode({'user_id': userId}),
     );
     if (resp.statusCode == 200) {
-      final r = await auth.authGet(
-        '/api/v1/admin/groups/$_groupId/members',
-      );
+      final r = await auth.authGet('/api/v1/admin/groups/$_groupId/members');
       if (r.statusCode == 200 && mounted) {
         setState(() {
           _members = List<Map<String, dynamic>>.from(jsonDecode(r.body));
@@ -1081,7 +1076,9 @@ class _InvitationsTabState extends State<_InvitationsTab> {
       _invitationsQuery = value;
       _invitationsQueryDebounce?.cancel();
       _invitationsQueryDebounce = Timer(
-          const Duration(milliseconds: 300), () => _loadInvitations(page: 1));
+        const Duration(milliseconds: 300),
+        () => _loadInvitations(page: 1),
+      );
     });
     _loadInvitations();
   }
@@ -1105,9 +1102,7 @@ class _InvitationsTabState extends State<_InvitationsTab> {
           '&sort=${Uri.encodeQueryComponent(_invitationsSort)}'
           '&order=${Uri.encodeQueryComponent(_invitationsOrder)}'
           '${q.isNotEmpty ? '&q=${Uri.encodeQueryComponent(q)}' : ''}';
-      final resp = await auth.authGet(
-        '/api/v1/admin/invitations?$query',
-      );
+      final resp = await auth.authGet('/api/v1/admin/invitations?$query');
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
         if (mounted) {
@@ -1140,9 +1135,8 @@ class _InvitationsTabState extends State<_InvitationsTab> {
     if (resp.statusCode == 200) {
       _loadInvitations(page: 1);
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Invitation sent to $email')));
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Invitation sent to $email')));
       }
     } else {
       if (mounted) {
@@ -1431,11 +1425,9 @@ class _AddUserDialogState extends State<_AddUserDialog> {
                   // and surface a violation as soon as it's typed.
                   helperText: policy.helperText,
                   errorText: policyError,
-                  suffixIcon: IconButton(
-                    icon: Icon(_obscurePassword
-                        ? Icons.visibility_off
-                        : Icons.visibility),
-                    onPressed: () =>
+                  suffixIcon: KObscureToggle(
+                    obscured: _obscurePassword,
+                    onToggle: () =>
                         setState(() => _obscurePassword = !_obscurePassword),
                   ),
                 ),
@@ -1453,11 +1445,9 @@ class _AddUserDialogState extends State<_AddUserDialog> {
                   border: const OutlineInputBorder(),
                   errorText:
                       passwordsMismatch ? 'Passwords do not match' : null,
-                  suffixIcon: IconButton(
-                    icon: Icon(_obscureConfirm
-                        ? Icons.visibility_off
-                        : Icons.visibility),
-                    onPressed: () =>
+                  suffixIcon: KObscureToggle(
+                    obscured: _obscureConfirm,
+                    onToggle: () =>
                         setState(() => _obscureConfirm = !_obscureConfirm),
                   ),
                 ),
@@ -1603,11 +1593,9 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                 helperText: settingPassword ? policy.helperText : null,
                 errorText: policyError,
                 border: const OutlineInputBorder(),
-                suffixIcon: IconButton(
-                  icon: Icon(_obscurePassword
-                      ? Icons.visibility_off
-                      : Icons.visibility),
-                  onPressed: () =>
+                suffixIcon: KObscureToggle(
+                  obscured: _obscurePassword,
+                  onToggle: () =>
                       setState(() => _obscurePassword = !_obscurePassword),
                 ),
               ),
@@ -1628,11 +1616,9 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                   border: const OutlineInputBorder(),
                   errorText:
                       passwordsMismatch ? 'Passwords do not match' : null,
-                  suffixIcon: IconButton(
-                    icon: Icon(_obscureConfirm
-                        ? Icons.visibility_off
-                        : Icons.visibility),
-                    onPressed: () =>
+                  suffixIcon: KObscureToggle(
+                    obscured: _obscureConfirm,
+                    onToggle: () =>
                         setState(() => _obscureConfirm = !_obscureConfirm),
                   ),
                 ),
@@ -1746,10 +1732,7 @@ class _UserAvatar extends StatelessWidget {
   final String initial;
   final String email;
 
-  const _UserAvatar({
-    required this.initial,
-    required this.email,
-  });
+  const _UserAvatar({required this.initial, required this.email});
 
   @override
   Widget build(BuildContext context) {

--- a/src/frontend/lib/auth/accept_invite_page.dart
+++ b/src/frontend/lib/auth/accept_invite_page.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+
 import 'auth_service.dart';
 import '../utils/page_title.dart';
 import '../widgets/klangk_logo.dart';
+import '../widgets/obscure_toggle.dart';
 
 class AcceptInvitePage extends StatefulWidget {
   final String token;
@@ -91,9 +94,12 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
                 children: [
                   const KlangkLogo(height: 80),
                   const SizedBox(height: 24),
-                  Text('Missing invitation token.',
-                      style: TextStyle(
-                          color: Theme.of(context).colorScheme.error)),
+                  Text(
+                    'Missing invitation token.',
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
                   const SizedBox(height: 16),
                   TextButton(
                     onPressed: () => context.go('/login'),
@@ -135,12 +141,11 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
                     decoration: InputDecoration(
                       labelText: 'Password',
                       border: const OutlineInputBorder(),
-                      suffixIcon: IconButton(
-                        icon: Icon(_obscurePassword
-                            ? Icons.visibility_off
-                            : Icons.visibility),
-                        onPressed: () => setState(
-                            () => _obscurePassword = !_obscurePassword),
+                      suffixIcon: KObscureToggle(
+                        obscured: _obscurePassword,
+                        onToggle: () => setState(
+                          () => _obscurePassword = !_obscurePassword,
+                        ),
                       ),
                     ),
                     obscureText: _obscurePassword,
@@ -158,12 +163,11 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
                     decoration: InputDecoration(
                       labelText: 'Confirm Password',
                       border: const OutlineInputBorder(),
-                      suffixIcon: IconButton(
-                        icon: Icon(_obscurePassword
-                            ? Icons.visibility_off
-                            : Icons.visibility),
-                        onPressed: () => setState(
-                            () => _obscurePassword = !_obscurePassword),
+                      suffixIcon: KObscureToggle(
+                        obscured: _obscurePassword,
+                        onToggle: () => setState(
+                          () => _obscurePassword = !_obscurePassword,
+                        ),
                       ),
                     ),
                     obscureText: _obscurePassword,
@@ -177,9 +181,12 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
                   ),
                   if (_error != null) ...[
                     const SizedBox(height: 16),
-                    Text(_error!,
-                        style: TextStyle(
-                            color: Theme.of(context).colorScheme.error)),
+                    Text(
+                      _error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
                   ],
                   const SizedBox(height: 24),
                   SizedBox(

--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -1,14 +1,17 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+
 import 'auth_service.dart';
 import 'pending_redirect.dart';
 import '../branding.dart';
 import '../utils/page_title.dart';
 import '../utils/validators.dart';
+import '../widgets/obscure_toggle.dart';
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../widgets/klangk_logo.dart';
@@ -236,15 +239,10 @@ class _LoginPageState extends State<LoginPage> {
         decoration: InputDecoration(
           labelText: 'Password',
           border: const OutlineInputBorder(),
-          suffixIcon: IconButton(
-            icon: Icon(
-              _obscurePassword ? Icons.visibility_off : Icons.visibility,
-            ),
-            onPressed: () {
-              setState(() {
-                _obscurePassword = !_obscurePassword;
-              });
-            },
+          suffixIcon: KObscureToggle(
+            obscured: _obscurePassword,
+            onToggle: () =>
+                setState(() => _obscurePassword = !_obscurePassword),
           ),
         ),
         obscureText: _obscurePassword,

--- a/src/frontend/lib/auth/reset_password_page.dart
+++ b/src/frontend/lib/auth/reset_password_page.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+
 import 'auth_service.dart';
 import '../utils/page_title.dart';
 import '../widgets/klangk_logo.dart';
+import '../widgets/obscure_toggle.dart';
 
 class ResetPasswordPage extends StatefulWidget {
   final String token;
@@ -91,9 +94,12 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
                 children: [
                   const KlangkLogo(height: 80),
                   const SizedBox(height: 24),
-                  Text('Missing reset token.',
-                      style: TextStyle(
-                          color: Theme.of(context).colorScheme.error)),
+                  Text(
+                    'Missing reset token.',
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
                   const SizedBox(height: 16),
                   TextButton(
                     onPressed: () => context.go('/login'),
@@ -130,12 +136,11 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
                     decoration: InputDecoration(
                       labelText: 'New Password',
                       border: const OutlineInputBorder(),
-                      suffixIcon: IconButton(
-                        icon: Icon(_obscurePassword
-                            ? Icons.visibility_off
-                            : Icons.visibility),
-                        onPressed: () => setState(
-                            () => _obscurePassword = !_obscurePassword),
+                      suffixIcon: KObscureToggle(
+                        obscured: _obscurePassword,
+                        onToggle: () => setState(
+                          () => _obscurePassword = !_obscurePassword,
+                        ),
                       ),
                     ),
                     obscureText: _obscurePassword,
@@ -153,12 +158,11 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
                     decoration: InputDecoration(
                       labelText: 'Confirm Password',
                       border: const OutlineInputBorder(),
-                      suffixIcon: IconButton(
-                        icon: Icon(_obscurePassword
-                            ? Icons.visibility_off
-                            : Icons.visibility),
-                        onPressed: () => setState(
-                            () => _obscurePassword = !_obscurePassword),
+                      suffixIcon: KObscureToggle(
+                        obscured: _obscurePassword,
+                        onToggle: () => setState(
+                          () => _obscurePassword = !_obscurePassword,
+                        ),
                       ),
                     ),
                     obscureText: _obscurePassword,
@@ -172,9 +176,12 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
                   ),
                   if (_error != null) ...[
                     const SizedBox(height: 16),
-                    Text(_error!,
-                        style: TextStyle(
-                            color: Theme.of(context).colorScheme.error)),
+                    Text(
+                      _error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
                   ],
                   const SizedBox(height: 24),
                   SizedBox(

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -1,13 +1,17 @@
 import 'dart:convert';
+
 // ignore: unused_import
 import '../theme/colors.dart';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import 'auth_service.dart';
 import '../utils/page_title.dart';
 import '../utils/validators.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
+import '../widgets/obscure_toggle.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -49,9 +53,7 @@ class _SettingsPageState extends State<SettingsPage> {
     return Scaffold(
       appBar: AppBar(
         title: const AppBarTitle(title: 'Settings'),
-        actions: const [
-          AppBarActions(),
-        ],
+        actions: const [AppBarActions()],
       ),
       body: Center(
         child: SingleChildScrollView(
@@ -63,22 +65,31 @@ class _SettingsPageState extends State<SettingsPage> {
               children: [
                 Row(
                   children: [
-                    const Icon(Icons.account_circle,
-                        size: 28, color: KColors.textSecondary),
+                    const Icon(
+                      Icons.account_circle,
+                      size: 28,
+                      color: KColors.textSecondary,
+                    ),
                     const SizedBox(width: 12),
-                    Text(email,
-                        style: const TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.w700,
-                            color: KColors.textSecondary)),
+                    Text(
+                      email,
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w700,
+                        color: KColors.textSecondary,
+                      ),
+                    ),
                     if (_currentHandle != null &&
                         _currentHandle!.isNotEmpty) ...[
                       const SizedBox(width: 12),
-                      Text('@$_currentHandle',
-                          style: const TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w500,
-                              color: KColors.textSecondary)),
+                      Text(
+                        '@$_currentHandle',
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          color: KColors.textSecondary,
+                        ),
+                      ),
                     ],
                   ],
                 ),
@@ -195,15 +206,21 @@ class _PasswordSectionState extends State<_PasswordSection> {
         children: [
           Row(
             children: [
-              const Icon(Icons.lock_outline,
-                  size: 18, color: KColors.textSecondary),
+              const Icon(
+                Icons.lock_outline,
+                size: 18,
+                color: KColors.textSecondary,
+              ),
               const SizedBox(width: 8),
-              Text('Change Password',
-                  style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                      color: KColors.textSecondary,
-                      letterSpacing: 0.3)),
+              Text(
+                'Change Password',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  color: KColors.textSecondary,
+                  letterSpacing: 0.3,
+                ),
+              ),
             ],
           ),
           const SizedBox(height: 16),
@@ -215,10 +232,9 @@ class _PasswordSectionState extends State<_PasswordSection> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
-              suffixIcon: IconButton(
-                icon: Icon(
-                    _obscureCurrent ? Icons.visibility_off : Icons.visibility),
-                onPressed: () =>
+              suffixIcon: KObscureToggle(
+                obscured: _obscureCurrent,
+                onToggle: () =>
                     setState(() => _obscureCurrent = !_obscureCurrent),
               ),
             ),
@@ -234,10 +250,9 @@ class _PasswordSectionState extends State<_PasswordSection> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
-              suffixIcon: IconButton(
-                icon:
-                    Icon(_obscureNew ? Icons.visibility_off : Icons.visibility),
-                onPressed: () => setState(() => _obscureNew = !_obscureNew),
+              suffixIcon: KObscureToggle(
+                obscured: _obscureNew,
+                onToggle: () => setState(() => _obscureNew = !_obscureNew),
               ),
             ),
             obscureText: _obscureNew,
@@ -258,10 +273,9 @@ class _PasswordSectionState extends State<_PasswordSection> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
-              suffixIcon: IconButton(
-                icon:
-                    Icon(_obscureNew ? Icons.visibility_off : Icons.visibility),
-                onPressed: () => setState(() => _obscureNew = !_obscureNew),
+              suffixIcon: KObscureToggle(
+                obscured: _obscureNew,
+                onToggle: () => setState(() => _obscureNew = !_obscureNew),
               ),
             ),
             obscureText: _obscureNew,
@@ -407,15 +421,21 @@ class _HandleSectionState extends State<_HandleSection> {
         children: [
           Row(
             children: [
-              const Icon(Icons.alternate_email,
-                  size: 18, color: KColors.textSecondary),
+              const Icon(
+                Icons.alternate_email,
+                size: 18,
+                color: KColors.textSecondary,
+              ),
               const SizedBox(width: 8),
-              Text('Change Handle',
-                  style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                      color: KColors.textSecondary,
-                      letterSpacing: 0.3)),
+              Text(
+                'Change Handle',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  color: KColors.textSecondary,
+                  letterSpacing: 0.3,
+                ),
+              ),
             ],
           ),
           if (widget.currentHandle != null) ...[
@@ -454,10 +474,9 @@ class _HandleSectionState extends State<_HandleSection> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
-              suffixIcon: IconButton(
-                icon: Icon(
-                    _obscurePassword ? Icons.visibility_off : Icons.visibility),
-                onPressed: () =>
+              suffixIcon: KObscureToggle(
+                obscured: _obscurePassword,
+                onToggle: () =>
                     setState(() => _obscurePassword = !_obscurePassword),
               ),
             ),
@@ -569,15 +588,21 @@ class _EmailSectionState extends State<_EmailSection> {
         children: [
           Row(
             children: [
-              const Icon(Icons.email_outlined,
-                  size: 18, color: KColors.textSecondary),
+              const Icon(
+                Icons.email_outlined,
+                size: 18,
+                color: KColors.textSecondary,
+              ),
               const SizedBox(width: 8),
-              Text('Change Email',
-                  style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                      color: KColors.textSecondary,
-                      letterSpacing: 0.3)),
+              Text(
+                'Change Email',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  color: KColors.textSecondary,
+                  letterSpacing: 0.3,
+                ),
+              ),
             ],
           ),
           const SizedBox(height: 16),
@@ -607,10 +632,9 @@ class _EmailSectionState extends State<_EmailSection> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
-              suffixIcon: IconButton(
-                icon: Icon(
-                    _obscurePassword ? Icons.visibility_off : Icons.visibility),
-                onPressed: () =>
+              suffixIcon: KObscureToggle(
+                obscured: _obscurePassword,
+                onToggle: () =>
                     setState(() => _obscurePassword = !_obscurePassword),
               ),
             ),

--- a/src/frontend/lib/widgets/obscure_toggle.dart
+++ b/src/frontend/lib/widgets/obscure_toggle.dart
@@ -3,10 +3,12 @@ import 'package:flutter/material.dart';
 /// Password-visibility ("eye") toggle for an [InputDecoration] suffixIcon.
 ///
 /// Deliberately skipped by Tab traversal (#2893): tabbing through a form
-/// moves only between input fields — the eye stays mouse-clickable and
-/// reachable via directional/programmatic focus, it is just not a tab stop.
-/// The skip must live on the [IconButton]'s own [FocusNode]: a skipping
-/// ancestor does not exclude the button's internal node from traversal.
+/// moves only between input fields. The eye is mouse/touch-only — Tab and
+/// Shift+Tab skip it, and arrow keys cannot reach it (inside a text field
+/// they move the caret) — though screen-reader semantics navigation still
+/// finds it. The skip must live on the [IconButton]'s own [FocusNode]: a
+/// skipping ancestor does not exclude the button's internal node from
+/// traversal.
 class KObscureToggle extends StatefulWidget {
   const KObscureToggle({
     super.key,

--- a/src/frontend/lib/widgets/obscure_toggle.dart
+++ b/src/frontend/lib/widgets/obscure_toggle.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Password-visibility ("eye") toggle for an [InputDecoration] suffixIcon.
+///
+/// Deliberately skipped by Tab traversal (#2893): tabbing through a form
+/// moves only between input fields — the eye stays mouse-clickable and
+/// reachable via directional/programmatic focus, it is just not a tab stop.
+/// The skip must live on the [IconButton]'s own [FocusNode]: a skipping
+/// ancestor does not exclude the button's internal node from traversal.
+class KObscureToggle extends StatefulWidget {
+  const KObscureToggle({
+    super.key,
+    required this.obscured,
+    required this.onToggle,
+  });
+
+  /// Whether the field text is currently hidden (shows the "reveal" eye).
+  final bool obscured;
+
+  /// Invoked when the user clicks the toggle.
+  final VoidCallback onToggle;
+
+  @override
+  State<KObscureToggle> createState() => _KObscureToggleState();
+}
+
+class _KObscureToggleState extends State<KObscureToggle> {
+  final FocusNode _focusNode = FocusNode(skipTraversal: true);
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      focusNode: _focusNode,
+      icon: Icon(widget.obscured ? Icons.visibility_off : Icons.visibility),
+      onPressed: widget.onToggle,
+    );
+  }
+}

--- a/src/frontend/test/obscure_toggle_test.dart
+++ b/src/frontend/test/obscure_toggle_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/widgets/obscure_toggle.dart';
+
+void main() {
+  group('KObscureToggle', () {
+    // One FocusNode per field so the assertions identify the focused
+    // field directly instead of walking the widget tree for keys.
+    late FocusNode first, pw, last;
+
+    Widget buildForm({Widget? suffix}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              TextField(key: const Key('first'), focusNode: first),
+              TextFormField(
+                key: const Key('pw'),
+                focusNode: pw,
+                autofocus: true,
+                decoration: InputDecoration(suffixIcon: suffix),
+              ),
+              TextField(key: const Key('last'), focusNode: last),
+            ],
+          ),
+        ),
+      );
+    }
+
+    setUp(() {
+      first = FocusNode();
+      pw = FocusNode();
+      last = FocusNode();
+    });
+
+    tearDown(() {
+      first.dispose();
+      pw.dispose();
+      last.dispose();
+    });
+
+    bool focusInEye() {
+      final ctx = FocusManager.instance.primaryFocus?.context;
+      return ctx?.findAncestorWidgetOfExactType<IconButton>() != null;
+    }
+
+    testWidgets('shows the hidden-text eye while obscured, reveal eye after',
+        (tester) async {
+      var obscured = true;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (_, setState) => KObscureToggle(
+              obscured: obscured,
+              onToggle: () => setState(() => obscured = !obscured),
+            ),
+          ),
+        ),
+      ));
+      expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+      expect(find.byIcon(Icons.visibility), findsOneWidget);
+    });
+
+    testWidgets('Tab out of the password field skips the toggle (#2893)',
+        (tester) async {
+      await tester.pumpWidget(buildForm(
+        suffix: KObscureToggle(obscured: true, onToggle: () {}),
+      ));
+      await tester.pump();
+      expect(pw.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      // Focus jumps straight to the next input — not the eye IconButton.
+      expect(last.hasFocus, isTrue);
+      expect(focusInEye(), isFalse);
+    });
+
+    testWidgets('control: a plain suffix IconButton IS a tab stop',
+        (tester) async {
+      // Guards the skip test above: proves this harness detects a
+      // focusable suffix button, so the skip assertion is not vacuous.
+      await tester.pumpWidget(buildForm(
+        suffix: IconButton(
+          icon: const Icon(Icons.visibility),
+          onPressed: () {},
+        ),
+      ));
+      await tester.pump();
+      expect(pw.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      expect(last.hasFocus, isFalse);
+      expect(focusInEye(), isTrue);
+    });
+  });
+}

--- a/src/frontend/test/obscure_toggle_test.dart
+++ b/src/frontend/test/obscure_toggle_test.dart
@@ -81,6 +81,26 @@ void main() {
       expect(focusInEye(), isFalse);
     });
 
+    testWidgets('Tab from the previous field enters the password field',
+        (tester) async {
+      // The filed repro was email -> Tab -> eye (#2893). Pin the forward
+      // direction too: focus must move straight into the password input,
+      // never the toggle.
+      await tester.pumpWidget(buildForm(
+        suffix: KObscureToggle(obscured: true, onToggle: () {}),
+      ));
+      await tester.pump();
+      first.requestFocus();
+      await tester.pump();
+      expect(first.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      expect(pw.hasFocus, isTrue);
+      expect(focusInEye(), isFalse);
+    });
+
     testWidgets('control: a plain suffix IconButton IS a tab stop',
         (tester) async {
       // Guards the skip test above: proves this harness detects a


### PR DESCRIPTION
## Summary

Closes #2893.

Tabbing through a form that contains a password field stopped on the
eye toggle (a focusable `IconButton` in the `suffixIcon` slot) between
input fields. All 14 eye toggles across the UI (login, settings ×5,
accept-invite ×2, reset-password ×2, admin user forms ×4 across two
dialogs) now render through a shared `KObscureToggle` widget whose
`FocusNode` has `skipTraversal: true` — Tab and Shift+Tab move only
between input boxes.

The toggle is **mouse/touch-only** after this change: keyboard focus can
no longer reach it (Tab/Shift+Tab skip it; arrow keys move the text
caret inside fields and never select the small suffix icon — verified by
test). Screen-reader semantics navigation still reaches it. This is the
behavior #2893 asked for; wording in the changelog and widget doc states
it plainly.

Note: the skip must live on the button's own FocusNode; wrapping the
button in `Focus(skipTraversal: true)` does not exclude the button's
internal node from traversal (verified by test).

## Changes

- **`src/frontend/lib/widgets/obscure_toggle.dart`** — new
  `KObscureToggle` (stateful, owns the skipping `FocusNode`, disposes
  it).
- **`login_page.dart`, `settings_page.dart`, `accept_invite_page.dart`,
  `reset_password_page.dart`, `admin_users_page.dart`** — replace every
  inline visibility `IconButton` suffix with `KObscureToggle`. The
  larger diffs in `settings_page.dart` / `admin_users_page.dart` also
  carry the repo `dart format` pre-commit hook's whole-file reformat
  (tall-style collapse of pre-existing expressions), hook-enforced.
- **`test/obscure_toggle_test.dart`** — icon/tap behavior; Tab out of a
  password field lands on the next field and never focuses the eye; Tab
  from the previous field enters the password field directly (the filed
  repro direction); a control test proves the harness detects a plain
  focusable suffix button (so the skip assertions are not vacuous).
- **`docs/changes.md`** — `Changed` entry under `[Unreleased]`.

## Testing

- `flutter test test/obscure_toggle_test.dart` (4 tests) + the page
  suites that exercise the touched forms — all pass.
- `flutter test --coverage` — 1148 passed (before the forward-direction
  test; CI re-runs authoritative).
- `flutter analyze` — no new issues.
