### PR TITLE
test: de-flake superseded-restart pop test, make it discriminating

### DIFF
--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -1331,19 +1331,29 @@ class TestCrashBranchGaps2834:
         with patch_podman_methods(app_state, inspect_dead()):
             monitor.schedule_restart("ws-race", RestartTracker())
             first = monitor.pending["ws-race"]
-            monitor.schedule_restart("ws-race", RestartTracker())
+            # The successor fires far later (pre-bumped attempts -> a
+            # near-cap backoff), so "first done, second in flight" is a
+            # stable window, not a race with the successor completing.
+            late = RestartTracker()
+            late.attempts = 12
+            monitor.schedule_restart("ws-race", late)
             second = monitor.pending["ws-race"]
             assert second is not first
-            # Let both delayed_restart tasks finish (near-zero backoff;
-            # their workspace lookups fail harmlessly and are logged).
             for _ in range(200):
-                if first.done() and second.done():
+                if first.done():
                     break
                 await asyncio.sleep(0.01)
-            assert first.done() and second.done()
-        # The superseded task's callback did NOT clear the successor's
-        # entry; the successor's own callback did.
-        assert "ws-race" not in monitor.pending
+            assert first.done()
+            # The discriminating state: after the superseded task's
+            # done-callback ran, the successor's entry SURVIVES. (An
+            # unconditional pop in the callback would have cleared it —
+            # the end state alone can't tell those apart.)
+            assert monitor.pending["ws-race"] is second
+            # The successor's own callback does the popping: cancel it
+            # (done-callbacks fire on cancellation too) and observe.
+            second.cancel()
+            await asyncio.sleep(0.01)
+            assert "ws-race" not in monitor.pending
 
     async def test_broadcast_death_event_without_tracker(self, crash_env):
         # A death with no restart tracker (restarts disabled / gave up


### PR DESCRIPTION
## Summary

Closes the race that made `test_superseded_restart_task_pop_is_skipped` flake in CI (observed on the `test-backend` run in PR #2894, unrelated to that PR's changes), and makes the test actually discriminating while at it.

## The race

The test polled `first.done() and second.done()`, then immediately asserted `'ws-race' not in monitor.pending`. An asyncio future being **done** does not mean its `add_done_callback` callback (the one that pops `pending`) has run — callbacks queue via `call_soon` and execute on the next event-loop pass. When the poll observes `done()` in the same pass that queued the callback, the final assert fires too early. 40/40 single-process local runs passed; it only trips under `-n auto` load.

## The fix

- The successor tracker gets `attempts = 12`, so its backoff is ~41s (cap 60s): "first done, second still in flight" becomes a stable window instead of a race with the successor completing.
- The test now asserts `monitor.pending["ws-race"] is second` **after** the superseded task completes — the discriminating state this test exists for. The old end-state-only assert could not distinguish "the successor's callback popped" from "the superseded callback unconditionally popped mid-flight".
- It then cancels the successor (done-callbacks fire on cancellation too) and observes its own callback pop the entry.

Verified both directions: green with the real identity guard, red when the guard is removed (`if self.pending.get(ws_id) is t:` → unconditional pop).

## Testing

- Target test green; full `test_crash_recovery.py` green 5× under `-n 4`.
