### PR TITLE
Super-E2E suite: exercise features end-to-end inside the Docker host appliance (#2561)

### DIFF
--- a/.github/workflows/super-e2e.yml
+++ b/.github/workflows/super-e2e.yml
@@ -1,0 +1,63 @@
+name: "E2E: Super (host appliance)"
+
+# Feature tests against the real Docker host appliance (#2561): the
+# image built from src/containers/host (supervisord + klangkd + caddy +
+# nested rootless podman) booted with the shipped posture, exercised
+# black-box over its published port (auth, workspace lifecycle, files,
+# egress filtering + consent, shared terminals, health/idle, SIGHUP,
+# admin, export/import).
+#
+# NOT a per-PR gate: the build is expensive (flutter + wheel + two
+# images + docker build). Manual trigger + release branches, like
+# dist-smoke (#1611). Promote to per-PR only if it proves stable.
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
+  push:
+    branches: [release/**]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  super-e2e:
+    # Stock GitHub-hosted runners by default (docker preinstalled); the
+    # self-hosted NixOS runner (label "nix") via workflow_dispatch input,
+    # like the other e2e suites (#2772).
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/devenv-setup
+        with:
+          # build-host-image (a devenv script, not a task) handles all its
+          # own prerequisites: flutter web, wheel, workspace image, sidecar.
+          build-tasks: ""
+
+      - name: Build host image
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
+          retry="$GITHUB_WORKSPACE/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh"
+          "$retry" devenv shell -- build-host-image
+
+      - name: Run super-E2E suite
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
+          retry="$GITHUB_WORKSPACE/.github/actions/devenv-setup/scripts/retry-on-invalid-path.sh"
+          "$retry" devenv shell -- test-super-e2e
+
+      - name: Clean leftover appliance containers
+        if: always()
+        shell: bash
+        run: |
+          docker ps -aq --filter name=klangk-super-e2e- \
+            | xargs -r docker rm -f 2>/dev/null || true

--- a/devenv.nix
+++ b/devenv.nix
@@ -528,6 +528,18 @@ in
       -v --no-cov -n 2 --dist=loadscope "$@"
   '';
 
+  # Super-E2E (#2561): black-box feature tests against the real Docker
+  # host appliance (supervisord + klangkd + nested rootless podman).
+  # Requires docker + a built host image (`build-host-image`; override
+  # the image with KLANGK_SUPER_E2E_IMAGE). Serial on purpose: one
+  # appliance serves the whole session — xdist workers would each boot
+  # their own and starve the runner.
+  scripts.test-super-e2e.exec = ''
+    cd $DEVENV_ROOT
+    exec ${venvPython} -m pytest src/klangk/klangkd-tests/super-e2e \
+      -v --no-cov "$@"
+  '';
+
   # Run the whole corpus as concurrently as is safe (#1393): the unit
   # suites combine into one parallel invocation (test-unit), then the
   # e2e suites run with xdist (--dist=loadscope, 2 workers each).

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -305,6 +305,16 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Super-E2E suite (#2561).** A new pytest suite
+  (`src/klangk/klangkd-tests/super-e2e/`, run via `test-super-e2e`)
+  exercises the real Docker host container (supervisord + klangkd +
+  caddy + nested rootless podman) black-box over its published port:
+  auth, workspace lifecycle, file ops, egress filtering + interactive
+  consent, shared terminals, health/idle, SIGHUP reload, admin users,
+  export/import. The `super-e2e.yml` workflow runs it on demand and on
+  release branches; it is not a per-PR gate. See
+  [Super-E2E](../development/super-e2e.md).
+
 - **`change-acls` permission (#2764).** Raw ACL editing is now gated
   on a dedicated resource-level permission instead of `share`:
   `GET`/`PUT /api/v1/workspaces/{id}/acl` (the Advanced ACL editor) and
@@ -2365,3 +2375,9 @@ users(id)`, so the decider handler passing the decider's email violated the
 - **Proxy denies container source IPs on the catch-all (#1376).** Containers
   can only reach `/llm-proxy/`, `/api/v1/browser-delegate`, and
   `/api/v1/workspaces/post-chat-message`.
+
+- **Host image ships `iproute2` (#2561).** Without it, caddy's
+  container-subnet auto-detection failed inside the appliance and fell
+  back to denying all RFC1918 peers — a host container run with a
+  published port (`docker run -p 8997:8997`) refused every browser/API
+  request with 403. Found by the new super-E2E suite.

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -14,6 +14,7 @@ triggering.
 | **E2E: CLI Tests**      | `cli-e2e-tests.yml`              | Changes to `src/klangk/`, containers        |
 | **E2E: Frontend Tests** | `frontend-e2e-tests.yml`         | Changes to `src/klangk/`, `src/frontend/`   |
 | **E2E: Cross-Browser**  | `frontend-e2e-cross-browser.yml` | Scheduled (every 6 hours), release branches |
+| **E2E: Super (host)**   | `super-e2e.yml`                  | Manual, release branches (#2561)            |
 
 Unit tests (Python, frontend) run with `pip install` or `flutter test`
 and do not require devenv. The Python suite covers both the `klangkd`

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -21,6 +21,9 @@ test-cli-e2e
 # Frontend E2E tests (Playwright, needs flutter build + podman build)
 test-frontend-e2e
 
+# Super-E2E tests (real Docker host appliance; needs build-host-image)
+test-super-e2e
+
 # Run a specific frontend E2E test
 test-frontend-e2e --project=chromium --no-deps -g "test name"
 ```
@@ -41,6 +44,7 @@ Inside `devenv shell`, these commands are available:
 | `test-backend-e2e`       | Run backend E2E tests                       |
 | `test-cli-e2e`           | Run CLI E2E tests                           |
 | `test-frontend-e2e`      | Run frontend E2E tests (Playwright)         |
+| `test-super-e2e`         | Run super-E2E tests (host appliance)        |
 | `flutterbuildweb`        | Rebuild Flutter web only                    |
 | `build-workspace-image`  | Rebuild workspace image (podman)            |
 | `build-base-image`       | Rebuild workspace base image                |

--- a/docs/development/super-e2e.md
+++ b/docs/development/super-e2e.md
@@ -1,0 +1,60 @@
+# Super-E2E (host appliance)
+
+The super-E2E suite exercises klangk **end-to-end inside the real Docker
+host container** — the appliance self-hosted users run — rather than the
+devenv-shell deployment the other e2e suites target (#2561). It proves
+the shipped image works feature-by-feature: supervisord as PID 1, klangkd
+under it, caddy fronting the UDS, and workspaces running inside **nested
+rootless podman** with the image's own storage config and uid mappings.
+
+```bash
+# once (builds flutter web, the wheel, workspace + sidecar images, the
+# host image — tagged klangk-host:latest)
+build-host-image
+
+# run the suite (~10 minutes)
+test-super-e2e
+```
+
+`KLANGK_SUPER_E2E_IMAGE` selects a different image (default
+`klangk-host:latest`). Docker and the built host image are required —
+the suite fails loudly when either is missing (a silent skip would make
+CI green without testing anything, the gap #2561 closed).
+
+## What it covers
+
+Everything is **black-box**: the public HTTP API and WebSocket over the
+appliance's published browser port, plus `docker exec` as the control
+channel for service-state checks (process tree, nested podman, SIGHUP
+delivery to klangkd's PID).
+
+| Area                  | Module                                                                                                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Boot shape            | `test_boot_e2e.py` — supervisord PID 1, klangkd + caddy children, `/health`, the Flutter bundle served through caddy, supervisord crash-restart of klangkd, WS through the proxy                        |
+| Auth                  | `test_auth_e2e.py` — password login, 401s, registration, `/api/v1/config`                                                                                                                               |
+| Workspace lifecycle   | `test_workspace_lifecycle_e2e.py` — create → connect (bringup in nested podman) → exec → terminal → stop → start → delete                                                                               |
+| Files                 | `test_files_e2e.py` — upload / list / read / download / rename / delete                                                                                                                                 |
+| Egress filtering      | `test_egress_e2e.py` — static deny (off-list DNS is NXDOMAIN'd by the sidecar), sidecar bringup inside the appliance, interactive consent (hold → `egress_request` → deny verdict → forged-RST refusal) |
+| Shared terminals      | `test_shared_terminal_e2e.py` — share a window, a second user lists + joins it                                                                                                                          |
+| Health + idle         | `test_health_idle_e2e.py` — failing health check surfaces its stderr via the status API; the idle sweep stops an abandoned workspace (per-workspace `idle_timeout` override)                            |
+| SIGHUP                | `test_sighup_reload_e2e.py` — WS clients closed with 1012 + recycle phases, listener stays up, double-SIGHUP survived, `klangkd.yaml` edit applies after reload                                         |
+| Admin + export/import | `test_admin_export_e2e.py` — admin user CRUD; workspace export → import roundtrip                                                                                                                       |
+
+The appliance boots in **password auth** with a seeded admin user, test
+mode on, a fast health poll, and a bounded consent hold (see
+`_appliance.py`). No monkeypatching and no in-process app: the point is
+the deployed artifact.
+
+## When it runs
+
+Not a per-PR gate — the image build is too expensive. The
+[super-e2e workflow](https://github.com/mcdonc/klangk/actions/workflows/super-e2e.yml)
+runs:
+
+- on demand (`workflow_dispatch`, stock or the self-hosted nix runner),
+- on every push to a `release/**` branch, before a release is cut.
+
+Run it locally when you touch anything in the appliance's deployment
+shape: `src/containers/host/**`, the wheel packaging, the caddy engine,
+or nested-podman behavior. The suite is serial by design (one appliance
+per session).

--- a/src/containers/host/Dockerfile
+++ b/src/containers/host/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       fuse-overlayfs \
       gnupg \
       gzip \
+      iproute2 \
       passt \
       podman \
       procps \

--- a/src/klangk/klangkd-tests/super-e2e/_appliance.py
+++ b/src/klangk/klangkd-tests/super-e2e/_appliance.py
@@ -1,0 +1,225 @@
+"""The host-appliance driver for the super-E2E suite (#2561).
+
+Starts the **real Docker host image** (``src/containers/host/`` — the
+klangkd + supervisord + rootless-podman + caddy appliance) as a Docker
+container with the shipped posture (``--cap-add SYS_ADMIN``, seccomp /
+systempaths unconfined, ``/dev/fuse`` + ``/dev/net/tun`` when present —
+the flags ``docs/deployment/docker.md`` documents for operators) and
+exposes:
+
+* the published browser port (``http://localhost:<mapped>``) for
+  black-box HTTP / WebSocket clients, and
+* a ``docker exec`` control channel for service-state checks and
+  signals (SIGHUP to klangkd's PID, pgrep for the supervisord-managed
+  children, rootless ``podman ps`` for nested workspace containers).
+
+The suite never builds the image itself — CI builds it via
+``build-host-image`` before running the suite, and locally the operator
+does (``devenv shell -- build-host-image``). A missing image fails the
+session fixture loudly (a skip would make CI silently green, the exact
+gap #2561 exists to close).
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import shutil
+import socket
+import subprocess
+import time
+import uuid
+
+import httpx
+
+# The browser port baked into the host image (klangkd.yaml listen 0.0.0.0,
+# EXPOSE 8997). Only this port is published; the egress port (8995) stays
+# internal to the appliance's container network, exactly as shipped.
+_APPLIANCE_PORT = 8997
+
+# How long the first boot may take. The entrypoint loads the embedded
+# workspace + sidecar image tars into rootless podman (a minute+ on a
+# cold CI runner), then klangkd runs its podman prewarm before /health
+# answers. Generous on purpose — the failure mode to avoid is killing a
+# healthy-but-slow first boot.
+_BOOT_TIMEOUT_SECONDS = 600
+
+
+def docker_path() -> str:
+    """The docker binary, or raise with a clear message."""
+    path = shutil.which("docker")
+    if not path:
+        raise RuntimeError(
+            "super-e2e needs a docker daemon (docker not found on PATH). "
+            "Run inside `devenv shell` on a machine with Docker."
+        )
+    return path
+
+
+def _run(cmd: list[str], *, timeout: int = 120) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def image_exists(image: str) -> bool:
+    return _run(["docker", "image", "inspect", image]).returncode == 0
+
+
+def _free_host_port() -> int:
+    """A free TCP port on the host for ``-p <port>:8997``."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class Appliance:
+    """One running instance of the klangk host container."""
+
+    def __init__(self, image: str) -> None:
+        self.image = image
+        self.name = f"klangk-super-e2e-{uuid.uuid4().hex[:8]}"
+        self.port: int | None = None
+        self.container_id: str | None = None
+
+    # --- lifecycle -----------------------------------------------------
+
+    def start(self) -> None:
+        """Boot the appliance and block until ``/health`` answers 200."""
+        if not image_exists(self.image):
+            raise RuntimeError(
+                f"Host image {self.image!r} not found. Build it first:\n"
+                f"    devenv shell -- build-host-image\n"
+                f"(or point KLANGK_SUPER_E2E_IMAGE at an existing image)"
+            )
+        docker_path()
+        self.port = _free_host_port()
+        cmd = ["docker", "run", "-d", "--name", self.name]
+        # The shipped nested-podman posture (docs/deployment/docker.md):
+        # SYS_ADMIN + relaxed seccomp/systempaths for userns + mounts,
+        # /dev/fuse for fuse-overlayfs storage, /dev/net/tun for pasta
+        # networking. Device flags are conditional — a runner may lack
+        # them (the CDK pentest does the same).
+        cmd += ["--cap-add", "SYS_ADMIN"]
+        if os.path.exists("/dev/fuse"):
+            cmd += ["--device", "/dev/fuse"]
+        if os.path.exists("/dev/net/tun"):
+            cmd += ["--device", "/dev/net/tun"]
+        cmd += [
+            "--security-opt",
+            "seccomp=unconfined",
+            "--security-opt",
+            "systempaths=unconfined",
+            "--pull=never",
+        ]
+        for key, value in self._env().items():
+            cmd += ["-e", f"{key}={value}"]
+        cmd += ["-p", f"127.0.0.1:{self.port}:{_APPLIANCE_PORT}", self.image]
+        result = _run(cmd, timeout=180)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"docker run failed ({result.returncode}):\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        self.container_id = result.stdout.strip()
+        self.wait_healthy()
+
+    @staticmethod
+    def _env() -> dict[str, str]:
+        """The test config, injected as env vars on the container.
+
+        Env vars override the baked ``klangkd.yaml`` (the image's own
+        comment says so), so the appliance keeps its shipped ports/dirs
+        while the test knobs (auth, short idle timeout, fast health
+        poll, test mode) ride in from outside — the same knobs every
+        e2e server launch sets. Password auth is required: the
+        published port makes the bind non-loopback, and the no-auth
+        safety gate (#1374) refuses `none` mode there.
+        """
+        return {
+            "KLANGKD_AUTH_MODES": "password",
+            "KLANGKD_DEFAULT_USER": "admin@example.com",
+            "KLANGKD_DEFAULT_PASSWORD": "adminpass",
+            # Long enough to pass any secret-strength gate; fixed so a
+            # rerun against a kept data dir still validates tokens.
+            "KLANGKD_JWT_SECRET": secrets.token_hex(32),
+            "KLANGKD_TEST_MODE": "1",
+            # Idle default mirrors the other e2e suites (300s). The
+            # idle-stop test sets a per-workspace override instead, so
+            # long holds (consent, exec) can't be reaped mid-test.
+            "KLANGKD_IDLE_TIMEOUT_SECONDS": "300",
+            # Fast health polling for the unhealthy-workspace test.
+            "KLANGKD_HEALTH_CHECK_INTERVAL": "2",
+            "KLANGKD_HEALTH_CHECK_STARTUP_GRACE": "0.1",
+            # Bounded consent hold so a missed verdict can't stall a test.
+            "KLANGKD_EGRESS_CONSENT_TIMEOUT": "12",
+            "LOGFIRE_TOKEN": "",
+        }
+
+    # --- clients -------------------------------------------------------
+
+    @property
+    def url(self) -> str:
+        assert self.port is not None, "appliance not started"
+        return f"http://127.0.0.1:{self.port}"
+
+    def wait_healthy(self, timeout: int = _BOOT_TIMEOUT_SECONDS) -> None:
+        """Poll ``/health`` through the published port until 200."""
+        deadline = time.monotonic() + timeout
+        last_error: Exception | None = None
+        with httpx.Client(base_url=self.url, timeout=5) as client:
+            while time.monotonic() < deadline:
+                if not self._container_running():
+                    raise RuntimeError(
+                        "appliance container exited during boot; logs:\n"
+                        f"{self.logs()}"
+                    )
+                try:
+                    if client.get("/health").status_code == 200:
+                        return
+                except Exception as exc:  # not up yet
+                    last_error = exc
+                time.sleep(2.0)
+        raise RuntimeError(
+            f"appliance did not become healthy within {timeout}s "
+            f"(last error: {last_error!r}); logs:\n{self.logs()}"
+        )
+
+    def _container_running(self) -> bool:
+        result = _run(
+            ["docker", "inspect", "-f", "{{.State.Running}}", self.name]
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+
+    # --- control channel -----------------------------------------------
+
+    def exec(
+        self,
+        *args: str,
+        timeout: int = 120,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
+        """``docker exec`` inside the appliance (as the image's klangk user)."""
+        result = _run(["docker", "exec", self.name, *args], timeout=timeout)
+        if check and result.returncode != 0:
+            raise RuntimeError(
+                f"docker exec {args} failed ({result.returncode}):\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        return result
+
+    def exec_out(self, *args: str, timeout: int = 120) -> str:
+        """``docker exec`` returning trimmed stdout (check on)."""
+        return self.exec(*args, timeout=timeout).stdout.strip()
+
+    def logs(self) -> str:
+        return _run(["docker", "logs", self.name], timeout=60).stdout
+
+    def stop(self) -> None:
+        """Tear the appliance down (idempotent)."""
+        _run(["docker", "rm", "-f", self.name], timeout=120)
+
+    # --- service-state helpers -----------------------------------------
+
+    def service_pids(self, pattern: str) -> list[str]:
+        """PIDs inside the appliance matching a pgrep -f pattern."""
+        result = self.exec("pgrep", "-f", pattern, check=False)
+        return [pid for pid in result.stdout.split() if pid]

--- a/src/klangk/klangkd-tests/super-e2e/_ws.py
+++ b/src/klangk/klangkd-tests/super-e2e/_ws.py
@@ -1,0 +1,109 @@
+"""WebSocket helpers for the super-E2E suite (#2561).
+
+Thin black-box client helpers speaking the same public WS protocol the
+shipped frontend uses: ``/ws?token=...`` through the appliance's
+published port (caddy → UDS → klangkd — the real deployed data path).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+
+import websockets
+
+
+async def dial(appliance, token: str, path: str = "/ws"):
+    """Open an authenticated WS to the appliance (any endpoint path)."""
+    url = f"{appliance.url.replace('http://', 'ws://')}{path}?token={token}"
+    return await websockets.connect(url, max_size=2**20, open_timeout=30)
+
+
+def _is_container_ready(msg: dict) -> bool:
+    if msg.get("type") == "container_ready":
+        return True
+    event = msg.get("event", {})
+    return (
+        event.get("type") == "CUSTOM"
+        and event.get("name") == "container_ready"
+    )
+
+
+async def recv_until(ws, predicate, timeout: float = 60.0) -> list[dict]:
+    """Collect messages until one matches; empty list on timeout."""
+    deadline = time.monotonic() + timeout
+    messages: list[dict] = []
+    while time.monotonic() < deadline:
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=2.0)
+        except asyncio.TimeoutError:
+            continue
+        try:
+            msg = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        messages.append(msg)
+        if predicate(msg):
+            return messages
+    return messages
+
+
+async def connect_workspace(appliance, token: str, workspace_id: str):
+    """Open a WS, connect to the workspace, wait for container_ready.
+
+    Retries the whole dial through a graceful-restart window: a recycle
+    still in flight closes fresh sockets with 1012 (the drain's
+    ``disconnect_all``), so a single attempt is not conclusive — keep
+    dialing until the container genuinely comes up or the deadline
+    passes (the #2527 pattern the backend e2e suite uses).
+    """
+    deadline = time.monotonic() + 180.0
+    last: dict | None = None
+    while time.monotonic() < deadline:
+        try:
+            ws = await dial(appliance, token)
+        except websockets.ConnectionClosed:
+            await asyncio.sleep(1)  # mid-drain close; retry
+            continue
+        try:
+            await ws.send(
+                json.dumps(
+                    {
+                        "cmd": "workspace_connect",
+                        "workspaceId": workspace_id,
+                    }
+                )
+            )
+            got = await recv_until(ws, _is_container_ready, timeout=60.0)
+            if any(_is_container_ready(m) for m in got):
+                return ws
+            last = got[-1] if got else None
+        except websockets.ConnectionClosed:
+            pass  # residual 1012 from a still-draining recycle; retry
+        await ws.close()
+        await asyncio.sleep(1)
+    raise AssertionError(
+        f"container_ready not received within 180s; last={last!r}"
+    )
+
+
+async def exec_command(
+    ws, command: list[str], timeout: float = 120.0
+) -> tuple[str, int | None]:
+    """Run a command via the WS exec path; return (output, exit code)."""
+    await ws.send(json.dumps({"cmd": "exec_start", "command": command}))
+    messages = await recv_until(
+        ws, lambda m: m.get("type") == "exec_exit", timeout=timeout
+    )
+    outputs = [
+        base64.b64decode(m["data"])
+        for m in messages
+        if m.get("type") == "exec_output" and "data" in m
+    ]
+    exits = [m.get("code") for m in messages if m.get("type") == "exec_exit"]
+    return (
+        b"".join(outputs).decode(errors="replace"),
+        exits[0] if exits else None,
+    )

--- a/src/klangk/klangkd-tests/super-e2e/conftest.py
+++ b/src/klangk/klangkd-tests/super-e2e/conftest.py
@@ -1,0 +1,99 @@
+"""Shared fixtures for the super-E2E suite (#2561).
+
+One session-scoped **appliance** — the real Docker host image booted with
+the shipped nested-podman posture — serves every test. Clients are
+black-box only: the public HTTP API and WebSocket over the published
+browser port, plus a ``docker exec`` control channel for service-state
+assertions (supervisord children, rootless podman inside the appliance,
+SIGHUP delivery). No monkeypatching, no in-process app.
+
+Per-test timeout: stamped generously (see ``_SUPER_E2E_TIMEOUT``) — the
+first test also carries the session fixture's boot wait, and container
+bringup inside nested rootless podman is slower than the unit suites'
+60s cap.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from _appliance import Appliance
+
+# Boot (first test's setup) + bringup + teardown headroom. The appliance
+# fixture has its own internal 600s boot deadline; this must exceed it
+# plus the test body itself.
+_SUPER_E2E_TIMEOUT = 900
+
+# Failed test node ids — populated by the makereport hook so the session
+# teardown can decide whether dumping appliance logs is worth the noise.
+_FAILED_TESTS: list[str] = []
+
+
+def pytest_collection_modifyitems(config, items):
+    """Give every super-e2e test a generous per-test timeout."""
+    for item in items:
+        if item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(_SUPER_E2E_TIMEOUT))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if report.failed:
+        _FAILED_TESTS.append(report.nodeid)
+
+
+@pytest.fixture(scope="session")
+def appliance():
+    """Boot the host appliance once per session; tear it down after.
+
+    On failure, the teardown prints the appliance's combined logs — the
+    in-container klangkd/caddy/supervisord output is the only evidence of
+    most server-side failures, and the container (with its logs) dies at
+    ``docker rm``.
+    """
+    image = os.environ.get("KLANGK_SUPER_E2E_IMAGE", "klangk-host:latest")
+    app = Appliance(image=image)
+    app.start()
+    try:
+        yield app
+    finally:
+        if _FAILED_TESTS:
+            logs = app.logs()
+            tail = "\n".join(logs.splitlines()[-400:])
+            print(
+                f"\n=== appliance logs (tail, {_FAILED_TESTS} failed) ===\n"
+                f"{tail}\n=== end appliance logs ==="
+            )
+        app.stop()
+
+
+@pytest.fixture(scope="session")
+def api(appliance):
+    """A long-lived httpx client bound to the appliance's published port.
+
+    60s budget: register/login run PBKDF2 inside the appliance on a
+    possibly single-CPU CI container, and workspace create awaits eager
+    container bringup inside nested podman.
+    """
+    with httpx.Client(base_url=appliance.url, timeout=60.0) as client:
+        yield client
+
+
+@pytest.fixture(scope="session")
+def auth(api):
+    """Login as the seeded default (admin) user; token + headers."""
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": "admin@example.com", "password": "adminpass"},
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    return {
+        "token": token,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }

--- a/src/klangk/klangkd-tests/super-e2e/test_admin_export_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_admin_export_e2e.py
@@ -1,0 +1,99 @@
+"""Admin flows + export/import against the appliance (#2561).
+
+Admin user management (list/create/delete) and the workspace
+export → import roundtrip, through the public API exactly as an
+operator or the shipped UI would drive it.
+"""
+
+import io
+import tarfile
+import uuid
+
+
+from _ws import connect_workspace
+
+
+def test_admin_users_crud(api, auth):
+    headers = auth["headers"]
+    resp = api.get("/api/v1/admin/users?page_size=200", headers=headers)
+    assert resp.status_code == 200
+    assert any(u["email"] == "admin@example.com" for u in resp.json()["users"])
+
+    email = f"admin-made-{uuid.uuid4().hex[:8]}@example.com"
+    resp = api.post(
+        "/api/v1/admin/users",
+        headers=headers,
+        json={"email": email, "password": "made-by-admin"},
+    )
+    assert resp.status_code == 200, resp.text
+    user_id = resp.json().get("id") or resp.json()["user"]["id"]
+
+    # The new user can log in.
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": email, "password": "made-by-admin"},
+    )
+    assert resp.status_code == 200
+
+    # Delete cascades cleanly.
+    resp = api.delete(f"/api/v1/admin/users/{user_id}", headers=headers)
+    assert resp.status_code == 200
+
+
+async def test_export_import_roundtrip(appliance, api, auth):
+    headers = auth["headers"]
+    resp = api.post(
+        "/api/v1/workspaces",
+        headers=headers,
+        json={"name": f"super-export-{uuid.uuid4().hex[:8]}"},
+    )
+    assert resp.status_code == 200, resp.text
+    ws_id = resp.json()["id"]
+
+    marker = f"exported-{uuid.uuid4().hex}"
+    conn = await connect_workspace(appliance, auth["token"], ws_id)
+    try:
+        # Put a recognizable file in the workspace home.
+        resp = api.post(
+            f"/api/v1/workspaces/{ws_id}/files/upload",
+            headers=headers,
+            params={"path": f"/home/klangk/{marker}.txt"},
+            files={"file": (f"{marker}.txt", marker.encode(), "text/plain")},
+        )
+        assert resp.status_code == 200, resp.text
+    finally:
+        await conn.close()
+
+    # Export: a tar.gz containing workspace.json + home/.
+    resp = api.get(f"/api/v1/workspaces/{ws_id}/export", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "application/gzip"
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        names = tar.getnames()
+    assert "workspace.json" in names, names
+    assert any(marker in n for n in names), names
+
+    # Import under a new name.
+    new_name = f"super-import-{uuid.uuid4().hex[:8]}"
+    resp = api.post(
+        "/api/v1/workspaces/import",
+        headers=headers,
+        params={"name": new_name},
+        files={
+            "file": (
+                "export.tar.gz",
+                resp.content,
+                "application/gzip",
+            )
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    imported_id = resp.json()["id"]
+
+    # The imported workspace is visible with the new name.
+    resp = api.get("/api/v1/workspaces", headers=headers)
+    match = [w for w in resp.json() if w["id"] == imported_id]
+    assert match and match[0]["name"] == new_name, match
+
+    api.delete(f"/api/v1/workspaces/{imported_id}", headers=headers)
+    api.delete(f"/api/v1/workspaces/{ws_id}", headers=headers)

--- a/src/klangk/klangkd-tests/super-e2e/test_auth_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_auth_e2e.py
@@ -1,0 +1,63 @@
+"""Auth tests against the appliance (#2561): the password flow end users hit.
+
+The appliance boots in password mode with a seeded default user (the
+supported configuration for the published image —
+docs/deployment/docker.md).
+"""
+
+import uuid
+
+
+def test_login_success(api):
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": "admin@example.com", "password": "adminpass"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["access_token"]
+
+
+def test_login_wrong_password(api):
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": "admin@example.com", "password": "wrong"},
+    )
+    assert resp.status_code == 401
+
+
+def test_unknown_user_rejected(api):
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": "nobody@example.com", "password": "x"},
+    )
+    assert resp.status_code == 401
+
+
+def test_unauthenticated_api_denied(api):
+    assert api.get("/api/v1/workspaces").status_code == 401
+
+
+def test_register_and_login(api):
+    """Test mode auto-verifies registrations (KLANGKD_TEST_MODE=1)."""
+    email = f"super-{uuid.uuid4().hex[:8]}@example.com"
+    resp = api.post(
+        "/api/v1/auth/register",
+        json={"email": email, "password": "registerpass"},
+    )
+    assert resp.status_code == 200, resp.text
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": email, "password": "registerpass"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["access_token"]
+
+
+def test_config_instance_id(api, auth):
+    resp = api.get("/api/v1/config", headers=auth["headers"])
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["instance_id"]
+    # The appliance ships FQDN egress filtering armed (netfilter_enabled
+    # + the embedded sidecar image) — the deployed default (#2255).
+    assert data.get("netfilter_enabled") is True, data

--- a/src/klangk/klangkd-tests/super-e2e/test_boot_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_boot_e2e.py
@@ -1,0 +1,98 @@
+"""Boot-shape tests: the supervisord-managed stack as actually shipped (#2561).
+
+These prove the appliance's process tree, the caddy → UDS → uvicorn path,
+and the frontend bundle served through the shipped reverse proxy — the
+deployment surfaces none of the dev-shell e2e suites exercise.
+"""
+
+import asyncio
+import time
+
+import httpx
+
+from _ws import dial
+
+
+def test_pid1_is_supervisord(appliance):
+    comm = appliance.exec_out("cat", "/proc/1/comm")
+    assert comm == "supervisord", f"PID 1 is {comm!r}, not supervisord"
+
+
+def test_klangkd_managed_by_supervisord(appliance):
+    pids = appliance.service_pids("klangk.main")
+    assert pids, "no klangkd (python3 -m klangk.main) process running"
+
+
+def test_caddy_child_of_klangkd(appliance):
+    # klangkd forks caddy as its own child (the caddy engine, #1559);
+    # supervisord does not manage it directly.
+    pids = appliance.service_pids("caddy")
+    assert pids, "no caddy process running under klangkd"
+
+
+def test_health_endpoint(appliance):
+    with httpx.Client(base_url=appliance.url, timeout=10) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_frontend_served_through_proxy(appliance):
+    """The Flutter web bundle is served by caddy from the installed wheel."""
+    with httpx.Client(base_url=appliance.url, timeout=30) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.text
+    # Flutter 3.24+ loads main.dart.js via flutter_bootstrap.js; older
+    # builds reference it directly. Either proves the wheel's bundled
+    # frontend is what caddy serves.
+    assert "flutter_bootstrap.js" in body or "main.dart.js" in body, (
+        f"frontend bundle not referenced; body head: {body[:400]!r}"
+    )
+
+
+def test_version_endpoint(appliance, api, auth):
+    resp = api.get("/api/v1/version", headers=auth["headers"])
+    assert resp.status_code == 200
+    data = resp.json()
+    # The build-host-image flow bakes a real version (never "dev").
+    assert data.get("version") not in (None, "", "dev"), data
+
+
+async def test_ws_connects_through_proxy(appliance, auth):
+    """The public WS endpoint answers through caddy (ping/pong round-trip)."""
+    ws = await dial(appliance, auth["token"])
+    try:
+        pong = await ws.ping()
+        await asyncio.wait_for(pong, timeout=10)
+    finally:
+        await ws.close()
+
+
+def test_supervisord_restarts_klangkd(appliance, api, auth):
+    """A crashed klangkd is restarted by supervisord (autorestart=true)."""
+    pids = appliance.service_pids("klangk.main")
+    assert pids, "no klangkd process to kill"
+    appliance.exec("kill", "-9", pids[0])
+    # klangkd comes back with a fresh PID and serves /health again. The
+    # health wait (not just the pid) is the gate: the module's later tests
+    # and the rest of the suite need a settled backend, and uvicorn only
+    # re-binds its listeners once the restart completes.
+    deadline = time.monotonic() + 180
+    new_pids: list[str] = []
+    while time.monotonic() < deadline:
+        new_pids = appliance.service_pids("klangk.main")
+        if new_pids and pids[0] not in new_pids:
+            break
+        time.sleep(2)
+    assert new_pids, "klangkd did not come back after kill -9"
+    assert pids[0] not in new_pids, "stale klangkd pid still present"
+    healthy = False
+    while time.monotonic() < deadline:
+        try:
+            if api.get("/health", timeout=5).status_code == 200:
+                healthy = True
+                break
+        except Exception:
+            pass
+        time.sleep(2)
+    assert healthy, "klangkd did not serve /health after supervisord restart"

--- a/src/klangk/klangkd-tests/super-e2e/test_egress_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_egress_e2e.py
@@ -1,0 +1,188 @@
+"""Egress filtering against the appliance (#2561).
+
+Two scenarios, both fully black-box:
+
+* **Static deny** — a workspace in ``egress_mode=static`` with an
+  allow-list: an off-list DNS lookup is NXDOMAIN'd by the network
+  sidecar (no upstream, no consent prompt — deterministic on any
+  runner), and the sidecar container is visibly running inside the
+  appliance's nested rootless podman.
+
+* **Interactive consent deny** — a workspace in ``egress_mode=
+  interactive``: an outbound connection holds at the SYN, the request
+  arrives on the ``/ws/consent-decider`` stream (the same protocol the
+  shipped consent TUI speaks), a deny verdict resolves it and the
+  connection is refused fast (the sidecar's forged RST, #2345).
+"""
+
+import json
+import uuid
+
+import websockets
+
+from _ws import connect_workspace, exec_command, recv_until
+
+
+_ALLOW_LIST = ["allowed.local"]
+
+
+def _make_workspace(api, headers, **fields):
+    resp = api.post(
+        "/api/v1/workspaces",
+        headers=headers,
+        json={
+            "name": f"super-egress-{uuid.uuid4().hex[:8]}",
+            "allowed_domains": _ALLOW_LIST,
+            **fields,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def test_static_mode_denies_offlist_dns(appliance, api, auth):
+    ws_id = _make_workspace(api, auth["headers"], egress_mode="static")
+    conn = await connect_workspace(appliance, auth["token"], ws_id)
+    try:
+        # Off-list name: the sidecar answers NXDOMAIN itself (static
+        # deny) — getent finds no address and exits nonzero (2).
+        output, code = await exec_command(
+            conn, ["getent", "hosts", f"denied-{uuid.uuid4().hex[:6]}.test"]
+        )
+        assert code != 0, f"off-list host resolved: {output!r}"
+        assert output.strip() == ""
+    finally:
+        await conn.close()
+        api.delete(f"/api/v1/workspaces/{ws_id}", headers=auth["headers"])
+
+
+async def test_sidecar_runs_inside_appliance(appliance, api, auth):
+    """A filtered workspace brings up the network sidecar container (#2301)."""
+    ws_id = _make_workspace(api, auth["headers"], egress_mode="static")
+    conn = await connect_workspace(appliance, auth["token"], ws_id)
+    try:
+        result = appliance.exec(
+            "podman",
+            "ps",
+            "--filter",
+            "label=klangk.role=network-sidecar",
+            "--format",
+            "{{.Names}}",
+            check=False,
+        )
+        sidecars = [
+            line for line in result.stdout.splitlines() if line.strip()
+        ]
+        assert sidecars, (
+            "no network-sidecar container inside the appliance; podman ps "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+    finally:
+        await conn.close()
+        api.delete(f"/api/v1/workspaces/{ws_id}", headers=auth["headers"])
+
+
+async def test_interactive_consent_deny(appliance, api, auth):
+    """A held request reaches a consent decider; deny refuses fast (#2242).
+
+    The decider here is a raw WS client on ``/ws/consent-decider`` —
+    the public protocol the shipped TUI uses (ping / egress_request /
+    verdict / egress_resolved), not an in-process app.
+    """
+    token = auth["token"]
+    headers = auth["headers"]
+    ws_id = _make_workspace(api, headers, egress_mode="interactive")
+    conn = await connect_workspace(appliance, token, ws_id)
+    decider = None
+    try:
+        url = (
+            f"{appliance.url.replace('http://', 'ws://')}"
+            f"/ws/consent-decider?token={token}&workspace={ws_id}"
+        )
+        decider = await websockets.connect(url, max_size=2**20)
+
+        # Fire the connection inside the workspace; the SYN holds at the
+        # sidecar until a verdict. curl retries/timeout bounds the hold.
+        # No wrapper shell: exec_exit then carries curl's own exit code.
+        # example.com is off the allow-list (allowed.local), so its SYN is
+        # held for consent — a real, resolvable host like the backend e2e
+        # uses (test_consent_decisions_e2e.py).
+        host = "example.com"
+        await conn.send(
+            json.dumps(
+                {
+                    "cmd": "exec_start",
+                    "command": [
+                        "curl",
+                        "--max-time",
+                        "40",
+                        "-sS",
+                        f"https://{host}",
+                    ],
+                }
+            )
+        )
+
+        # The held request arrives at the decider.
+        msgs = await recv_until(
+            decider,
+            lambda m: (
+                m.get("type") == "egress_request"
+                and host in (m.get("request", {}).get("dest_host") or "")
+            ),
+            timeout=60,
+        )
+        requests = [
+            m
+            for m in msgs
+            if m.get("type") == "egress_request"
+            and host in (m.get("request", {}).get("dest_host") or "")
+        ]
+        assert requests, f"no egress_request for {host}; msgs: {msgs}"
+        request_id = requests[0]["request"]["id"]
+
+        # Deny it — the same verdict frame the TUI sends.
+        await decider.send(
+            json.dumps(
+                {
+                    "type": "verdict",
+                    "request_id": request_id,
+                    "decision": "deny",
+                    "duration": "5m",
+                }
+            )
+        )
+        resolved = await recv_until(
+            decider,
+            lambda m: (
+                m.get("type") == "egress_resolved"
+                and m.get("request_id") == request_id
+            ),
+            timeout=30,
+        )
+        assert any(
+            m.get("type") == "egress_resolved"
+            and m.get("request_id") == request_id
+            for m in resolved
+        ), f"request not resolved; msgs: {resolved}"
+
+        # The denied connection is refused fast (forged RST — exit 7),
+        # not a silent allow (exit 0) or a hang (exit 28).
+        exits = await recv_until(
+            conn,
+            lambda m: m.get("type") == "exec_exit",
+            timeout=60,
+        )
+        codes = [m.get("code") for m in exits if m.get("type") == "exec_exit"]
+        outputs = [
+            m.get("data", "") for m in exits if m.get("type") == "exec_output"
+        ]
+        assert codes == [7], (
+            f"expected curl exit 7 (connection refused), got {codes}; "
+            f"output: {outputs}"
+        )
+    finally:
+        if decider is not None:
+            await decider.close()
+        await conn.close()
+        api.delete(f"/api/v1/workspaces/{ws_id}", headers=headers)

--- a/src/klangk/klangkd-tests/super-e2e/test_files_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_files_e2e.py
@@ -1,0 +1,92 @@
+"""File operations against the appliance (#2561).
+
+The files API runs ``podman exec`` inside the nested workspace container
+(``klangk/files.py``) — here it is exercised end-to-end through the
+published port against a container the appliance itself brought up:
+upload → list → read → download → rename → delete.
+"""
+
+import uuid
+
+
+from _ws import connect_workspace
+
+
+async def test_file_roundtrip(appliance, api, auth):
+    headers = auth["headers"]
+    resp = api.post(
+        "/api/v1/workspaces",
+        headers=headers,
+        json={"name": f"super-files-{uuid.uuid4().hex[:8]}"},
+    )
+    assert resp.status_code == 200, resp.text
+    ws_id = resp.json()["id"]
+    conn = await connect_workspace(appliance, auth["token"], ws_id)
+    marker = f"super-e2e file payload {uuid.uuid4().hex}"
+    path = f"/home/klangk/super-{uuid.uuid4().hex[:8]}.txt"
+    try:
+        # upload
+        resp = api.post(
+            f"/api/v1/workspaces/{ws_id}/files/upload",
+            headers=headers,
+            params={"path": path},
+            files={"file": ("payload.txt", marker.encode(), "text/plain")},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["path"] == path
+
+        # list: the file appears in its directory
+        resp = api.get(
+            f"/api/v1/workspaces/{ws_id}/files",
+            headers=headers,
+            params={"path": "/home/klangk"},
+        )
+        assert resp.status_code == 200, resp.text
+        names = [e["name"] for e in resp.json()]
+        assert path.rsplit("/", 1)[1] in names
+
+        # read via the content API
+        resp = api.get(
+            f"/api/v1/workspaces/{ws_id}/files/content",
+            headers=headers,
+            params={"path": path},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["content"] == marker
+
+        # download streams the raw bytes
+        resp = api.get(
+            f"/api/v1/workspaces/{ws_id}/files/download",
+            headers=headers,
+            params={"path": path},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.content == marker.encode()
+
+        # rename
+        new_path = path + ".renamed"
+        resp = api.post(
+            f"/api/v1/workspaces/{ws_id}/files/rename",
+            headers=headers,
+            json={"old_path": path, "new_path": new_path},
+        )
+        assert resp.status_code == 200, resp.text
+
+        # delete
+        resp = api.delete(
+            f"/api/v1/workspaces/{ws_id}/files",
+            headers=headers,
+            params={"path": new_path},
+        )
+        assert resp.status_code == 200, resp.text
+
+        # gone: the content API 404s
+        resp = api.get(
+            f"/api/v1/workspaces/{ws_id}/files/content",
+            headers=headers,
+            params={"path": new_path},
+        )
+        assert resp.status_code == 404
+    finally:
+        await conn.close()
+        api.delete(f"/api/v1/workspaces/{ws_id}", headers=headers)

--- a/src/klangk/klangkd-tests/super-e2e/test_health_idle_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_health_idle_e2e.py
@@ -1,0 +1,85 @@
+"""Health-check surfacing + idle timeout against the appliance (#2561).
+
+The appliance boots with ``KLANGKD_IDLE_TIMEOUT_SECONDS=20`` and a 2s
+health poll (see ``_appliance.Appliance._env``) so both behaviors
+assert in bounded time:
+
+* a failing per-workspace health check surfaces its stderr + exit code
+  through the status API (#1088), and
+* a workspace whose last client disconnects is stopped by the idle
+  sweep after the timeout.
+"""
+
+import asyncio
+import time
+import uuid
+
+
+from _ws import connect_workspace
+
+
+def _create(api, headers, **fields):
+    resp = api.post(
+        "/api/v1/workspaces",
+        headers=headers,
+        json={"name": f"super-hi-{uuid.uuid4().hex[:8]}", **fields},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+def _status(api, headers, ws_id):
+    resp = api.get(f"/api/v1/workspaces/{ws_id}/status", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def test_unhealthy_check_surfaces_reason(appliance, api, auth):
+    headers = auth["headers"]
+    marker = f"super-health-{uuid.uuid4().hex[:8]}"
+    ws_id = _create(api, headers, health_check=f"echo {marker} 1>&2; exit 3")
+    conn = await connect_workspace(appliance, auth["token"], ws_id)
+    try:
+        deadline = time.monotonic() + 90
+        state = None
+        while time.monotonic() < deadline:
+            state = _status(api, headers, ws_id)
+            if state.get("health") == "unhealthy" and marker in (
+                state.get("health_message") or ""
+            ):
+                break
+            await asyncio.sleep(1)
+        assert state is not None
+        assert state["health"] == "unhealthy", state
+        assert marker in (state["health_message"] or ""), state
+        assert "exited 3" in (state["health_message"] or ""), state
+    finally:
+        await conn.close()
+        api.delete(f"/api/v1/workspaces/{ws_id}", headers=headers)
+
+
+async def test_idle_timeout_stops_workspace(appliance, api, auth):
+    """After the last WS client leaves, the idle sweep stops the container.
+
+    Uses a per-workspace ``idle_timeout`` settings override (12s) — the
+    deploy-wide default stays at 300s so no other test's containers are
+    reaped mid-flight.
+    """
+    headers = auth["headers"]
+    ws_id = _create(api, headers, settings={"idle_timeout": 12})
+    conn = await connect_workspace(appliance, auth["token"], ws_id)
+    await conn.close()
+
+    # Override 12s (check interval scales to 6s): stopped well within 90s.
+    deadline = time.monotonic() + 90
+    running = True
+    while time.monotonic() < deadline:
+        running = _status(api, headers, ws_id)["running"]
+        if not running:
+            break
+        await asyncio.sleep(2)
+    assert running is False, (
+        "workspace still running 90s after the last client left "
+        "(per-workspace idle_timeout 12s)"
+    )
+    api.delete(f"/api/v1/workspaces/{ws_id}", headers=headers)

--- a/src/klangk/klangkd-tests/super-e2e/test_shared_terminal_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_shared_terminal_e2e.py
@@ -1,0 +1,134 @@
+"""Shared-terminal scenario against the appliance (#2561).
+
+The owner shares one of their terminal windows; a second user (granted
+the ``coders`` role on the workspace) sees it in the shared list and
+joins it — the collaboration surface as deployed.
+"""
+
+import asyncio
+import json
+import uuid
+
+
+from _ws import connect_workspace, recv_until
+
+
+def _register(api, email, password):
+    resp = api.post(
+        "/api/v1/auth/register", json={"email": email, "password": password}
+    )
+    assert resp.status_code == 200, resp.text
+    resp = api.post(
+        "/api/v1/auth/login", json={"identifier": email, "password": password}
+    )
+    assert resp.status_code == 200, resp.text
+    return {
+        "email": email,
+        "token": resp.json()["access_token"],
+        "headers": {"Authorization": f"Bearer {resp.json()['access_token']}"},
+    }
+
+
+async def _start_terminal(ws):
+    await ws.send(
+        json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
+    )
+
+
+def _windows(msgs):
+    for m in reversed(msgs):
+        if m.get("type") == "terminal_windows":
+            return m.get("windows", [])
+    return None
+
+
+async def _wait_shared_contains(ws, window_id: str, timeout: float = 30):
+    """Nudge list_shared_terminals until the shared list contains the window."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    last = None
+    while asyncio.get_event_loop().time() < deadline:
+        await ws.send(json.dumps({"cmd": "list_shared_terminals"}))
+        msgs = await recv_until(
+            ws, lambda m: m.get("type") == "shared_terminals", timeout=10
+        )
+        for m in msgs:
+            if m.get("type") == "shared_terminals":
+                last = m.get("terminals", [])
+                if any(t.get("window_id") == window_id for t in last):
+                    return last
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"window {window_id} never appeared in shared_terminals; "
+        f"last list: {last}"
+    )
+
+
+async def test_share_and_join(appliance, api, auth):
+    owner = auth
+    visitor = _register(
+        api, f"visitor-{uuid.uuid4().hex[:8]}@example.com", "visitorpass"
+    )
+
+    resp = api.post(
+        "/api/v1/workspaces",
+        headers=owner["headers"],
+        json={"name": f"super-shared-{uuid.uuid4().hex[:8]}"},
+    )
+    assert resp.status_code == 200, resp.text
+    ws_id = resp.json()["id"]
+
+    # Grant the visitor the coders role (view/terminal/files).
+    resp = api.post(
+        f"/api/v1/workspaces/{ws_id}/roles/coders",
+        headers=owner["headers"],
+        json={"email": visitor["email"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    owner_ws = await connect_workspace(appliance, owner["token"], ws_id)
+    vis_ws = None
+    try:
+        await _start_terminal(owner_ws)
+        msgs = await recv_until(
+            owner_ws, lambda m: _windows([m]) is not None, timeout=60
+        )
+        windows = _windows(msgs)
+        assert windows, f"owner never got terminal_windows; msgs: {msgs}"
+        window = windows[0]
+
+        # Share it, then wait until the shared list carries it.
+        await owner_ws.send(
+            json.dumps({"cmd": "share_window", "window_id": window["id"]})
+        )
+        await _wait_shared_contains(owner_ws, window["id"])
+
+        # The visitor connects, sees the shared window, and joins it.
+        vis_ws = await connect_workspace(appliance, visitor["token"], ws_id)
+        vis_shared = await _wait_shared_contains(vis_ws, window["id"])
+        target = next(
+            (t for t in vis_shared if t.get("window_id") == window["id"]),
+            None,
+        )
+        assert target, f"visitor cannot see shared window: {vis_shared}"
+        await vis_ws.send(
+            json.dumps(
+                {
+                    "cmd": "join_shared_terminal",
+                    "user_id": target.get("user_id"),
+                    "window_id": window["id"],
+                }
+            )
+        )
+        joined = await recv_until(
+            vis_ws,
+            lambda m: m.get("type") == "terminal_started",
+            timeout=60,
+        )
+        assert any(m.get("type") == "terminal_started" for m in joined), (
+            f"visitor join produced no terminal_started; msgs: {joined}"
+        )
+    finally:
+        if vis_ws is not None:
+            await vis_ws.close()
+        await owner_ws.close()
+        api.delete(f"/api/v1/workspaces/{ws_id}", headers=owner["headers"])

--- a/src/klangk/klangkd-tests/super-e2e/test_sighup_reload_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_sighup_reload_e2e.py
@@ -1,0 +1,160 @@
+"""SIGHUP runtime recycle + config reload against the appliance (#2561).
+
+Docker containers have no service manager — supervisord is PID 1, so
+SIGHUP targets klangkd's own PID inside the appliance (found via the
+control channel), exactly what an operator's ``kill -HUP`` does on a
+bare-metal install.
+
+Asserts the shipped behaviors (#1212, #1587): the HTTP listener stays
+up, WS clients are closed with 1012 and can reconnect, a second SIGHUP
+is survived, and a config-file change is picked up by the reload.
+"""
+
+import asyncio
+import json
+import time
+
+import websockets
+
+from _ws import dial
+
+
+# The baked runtime config (src/containers/host/Dockerfile) — rewritten
+# by the reload test with a product_name added. Env vars still override
+# it (the test knobs ride in via docker run -e), so rewriting the file
+# only changes what the yaml governs.
+_BASE_YAML = "\n".join(
+    [
+        'port: "8997"',
+        'listen: "0.0.0.0"',
+        'egress_port: "8995"',
+        'data_dir: "/home/klangk/data"',
+        'customize_dir: "/home/klangk/custom"',
+        'image_name: "klangk-workspace"',
+        'version_file: "/home/klangk/version.json"',
+        'state_dir: "/tmp/klangk-state"',
+    ]
+)
+
+
+def _sighup(appliance):
+    pids = appliance.service_pids("klangk.main")
+    assert pids, "no klangkd process to signal"
+    appliance.exec("kill", "-HUP", pids[0])
+
+
+def _wait_healthy(appliance, api, timeout=120):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if api.get("/health", timeout=5).status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
+async def _wait_settled(appliance, api, auth, timeout=180):
+    """Block until the recycle fully finished: /health up AND a fresh WS
+    survives a ping. The appliance is shared across the whole session —
+    a still-draining or queued restart must not bleed into the next
+    module's connections (observed: a queued second-SIGHUP restart
+    closing the next test's WS with 1012).
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _wait_healthy(appliance, api, timeout=10):
+            await asyncio.sleep(1)
+            continue
+        try:
+            ws = await dial(appliance, auth["token"])
+            try:
+                pong = await ws.ping()
+                await asyncio.wait_for(pong, timeout=10)
+                return
+            finally:
+                await ws.close()
+        except Exception:
+            await asyncio.sleep(1)
+    raise AssertionError("appliance never settled after SIGHUP")
+
+
+async def test_sighup_closes_ws_with_1012_and_recovers(appliance, api, auth):
+    ws = await dial(appliance, auth["token"])
+    try:
+        _sighup(appliance)
+        # The server broadcasts the recycle phases, then closes with 1012.
+        closed = None
+        phases = []
+        try:
+            while True:
+                raw = await asyncio.wait_for(ws.recv(), timeout=90)
+                try:
+                    msg = json.loads(raw)
+                except (TypeError, ValueError):
+                    continue
+                if msg.get("type") == "server_recycle":
+                    phases.append(msg.get("phase"))
+        except websockets.ConnectionClosed as exc:
+            closed = exc.rcvd.code if exc.rcvd is not None else None
+        assert closed == 1012, f"expected close 1012, got {closed}"
+        assert "draining" in phases, f"missing draining phase, got {phases}"
+    finally:
+        await ws.close()
+
+    # HTTP survives the recycle and a fresh WS connects.
+    await _wait_settled(appliance, api, auth)
+
+
+async def test_double_sighup_is_survived(appliance, api, auth):
+    assert _wait_healthy(appliance, api)
+    _sighup(appliance)
+    # Settle between the two: the second HUP must queue behind a real
+    # restart (the serialization under test), not leave a queued restart
+    # that fires after the test ends — this appliance is shared by the
+    # whole session, and a late queued recycle closes the next module's
+    # sockets with 1012.
+    await _wait_settled(appliance, api, auth)
+    _sighup(appliance)
+    await _wait_settled(appliance, api, auth, timeout=240)
+
+
+async def test_config_reload_via_sighup(appliance, api, auth):
+    """A klangkd.yaml edit applies after SIGHUP without a container restart."""
+    assert _wait_healthy(appliance, api)
+    headers = auth["headers"]
+    resp = api.get("/api/v1/config", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["product_name"] != "Super After"
+
+    # Rewrite the runtime config with a product_name (as the klangk user,
+    # who owns the file), then SIGHUP klangkd's PID.
+    appliance.exec(
+        "sh",
+        "-c",
+        f"printf '%s\\nproduct_name: \"Super After\"\\n' "
+        f"'{_BASE_YAML}' > /home/klangk/etc/klangkd.yaml",
+    )
+    _sighup(appliance)
+    await _wait_settled(appliance, api, auth, timeout=240)
+
+    deadline = time.monotonic() + 60
+    product = None
+    while time.monotonic() < deadline:
+        resp = api.get("/api/v1/config", headers=headers)
+        product = resp.json().get("product_name")
+        if product == "Super After":
+            break
+        time.sleep(1)
+    assert product == "Super After", (
+        f"config not reloaded after SIGHUP; product_name={product!r}"
+    )
+
+    # Restore the shipped yaml so later reruns against the same image
+    # start from the baked state.
+    appliance.exec(
+        "sh",
+        "-c",
+        f"printf '%s\\n' '{_BASE_YAML}' > /home/klangk/etc/klangkd.yaml",
+    )

--- a/src/klangk/klangkd-tests/super-e2e/test_workspace_lifecycle_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_workspace_lifecycle_e2e.py
@@ -1,0 +1,86 @@
+"""Workspace lifecycle against the appliance (#2561).
+
+create → connect (container bringup inside the appliance's nested
+rootless podman) → exec → interactive terminal → stop → start → delete,
+all through the public API/WS surfaces.
+"""
+
+import asyncio
+import json
+import uuid
+
+
+from _ws import connect_workspace, exec_command, recv_until
+
+
+def _create(api, headers, **fields):
+    name = fields.pop("name", f"super-lifecycle-{uuid.uuid4().hex[:8]}")
+    resp = api.post(
+        "/api/v1/workspaces",
+        headers=headers,
+        json={"name": name, **fields},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _status(api, headers, ws_id):
+    resp = api.get(f"/api/v1/workspaces/{ws_id}/status", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def test_create_exec_stop_start_delete(appliance, api, auth):
+    token = auth["token"]
+    headers = auth["headers"]
+    ws = _create(api, headers)
+    ws_id = ws["id"]
+    ws_conn = await connect_workspace(appliance, token, ws_id)
+    try:
+        # exec: run a real process inside the nested container.
+        marker = f"super-{uuid.uuid4().hex[:8]}"
+        output, code = await exec_command(
+            ws_conn, ["bash", "-c", f"echo {marker}; pwd"]
+        )
+        assert code == 0, output
+        assert marker in output
+        assert "/home/klangk" in output
+
+        # interactive terminal in the same container
+        await ws_conn.send(
+            json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
+        )
+        msgs = await recv_until(
+            ws_conn, lambda m: m.get("type") == "terminal_started"
+        )
+        assert any(m.get("type") == "terminal_started" for m in msgs), msgs
+    finally:
+        await ws_conn.close()
+
+    # stop via the API: the container is stopped + removed.
+    resp = api.post(f"/api/v1/workspaces/{ws_id}/stop", headers=headers)
+    assert resp.status_code == 200
+    assert _status(api, headers, ws_id)["running"] is False
+
+    # start via the API: a fresh container comes up inside the appliance.
+    resp = api.post(f"/api/v1/workspaces/{ws_id}/start", headers=headers)
+    assert resp.status_code == 200, resp.text
+    deadline_secs = 60
+    running = False
+    for _ in range(deadline_secs):
+        running = _status(api, headers, ws_id)["running"]
+        if running:
+            break
+        await asyncio.sleep(1)
+    # Single observation: the idle sweep could stop the container between
+    # two checks, so assert on the value that ended the poll.
+    assert running is True, "container did not come back after /start"
+
+    # delete: gone for good.
+    resp = api.delete(f"/api/v1/workspaces/{ws_id}", headers=headers)
+    assert resp.status_code == 200
+    resp = api.get(f"/api/v1/workspaces/{ws_id}/status", headers=headers)
+    # The workspace row and its ACEs are cascade-deleted together, so the
+    # ACL gate refuses the monitor permission (403) before the router can
+    # answer its own 404 — either proves the workspace is unreachable.
+    assert resp.status_code in (403, 404)

--- a/zensical.toml
+++ b/zensical.toml
@@ -72,6 +72,7 @@ nav = [
     { "Releasing" = "development/releasing.md" },
     { "Building Images" = "development/building-images.md" },
     { "Stable Branches" = "development/stable-branches.md" },
+    { "Super-E2E" = "development/super-e2e.md" },
   ]},
   { "Changelog" = "changes.md" },
   { "Architecture" = [


### PR DESCRIPTION
## Summary

Builds the "super-e2e" suite from #2561: a pytest suite that runs **inside
the real Docker host image** (`src/containers/host/` — supervisord + klangkd
+ caddy + nested rootless podman) and exercises major features against the
*shipped deployment shape* rather than the devenv-shell one. Every existing
e2e suite launches klangkd from a devenv shell; nothing routinely proved the
containerized host actually works feature-by-feature.

## What's here

- **`src/klangk/klangkd-tests/super-e2e/`** — `_appliance.py` boots the
  built host image with the shipped posture (`--cap-add SYS_ADMIN`,
  seccomp/systempaths unconfined, `/dev/fuse` + `/dev/net/tun` when
  present), publishes the browser port, and provides a `docker exec`
  control channel for service-state checks (process tree, nested `podman
  ps`, SIGHUP delivery). Missing docker/image **fails loudly** (no silent
  skips). Failures dump the appliance's container logs into the pytest
  output.
- **27 black-box tests** (public HTTP API + WebSocket only, no
  monkeypatching, no in-process app):
  - *boot*: supervisord PID 1, klangkd/caddy children, `/health`, the
    Flutter bundle served through caddy, version endpoint, supervisord
    crash-restart of klangkd, WS through the proxy
  - *auth*: login / 401s / registration / `/api/v1/config`
  - *workspace lifecycle*: create → connect (bringup in nested podman) →
    exec → interactive terminal → stop → start → delete
  - *files*: upload / list / read / download / rename / delete
  - *egress*: static deny (off-list DNS is NXDOMAIN'd by the sidecar),
    sidecar bringup inside the appliance, interactive consent
    (hold → `egress_request` on the `/ws/consent-decider` stream → deny
    verdict → forged-RST refusal, exit 7)
  - *shared terminals*: owner shares a window, a second user lists + joins
  - *health + idle*: failing health check surfaces stderr via the status
    API; idle sweep stops an abandoned workspace (per-workspace
    `idle_timeout` override)
  - *SIGHUP*: WS clients closed with 1012 + recycle phases, listener
    stays up, double-SIGHUP survived, `klangkd.yaml` edit applies on
    reload
  - *admin + export/import*: user CRUD; export → import roundtrip
- **`test-super-e2e`** devenv script (serial by design — one appliance
  per session; xdist workers would each boot one and starve the runner).
  `KLANGK_SUPER_E2E_IMAGE` overrides the image (default
  `klangk-host:latest`).
- **`.github/workflows/super-e2e.yml`** — manual (`workflow_dispatch`,
  stock or nix runner) + release-branch trigger, like dist-smoke. Not a
  per-PR gate. Note: the first dispatch can only happen after this lands
  on main (workflow_dispatch needs the file on the default branch).
- **Docs** — `docs/development/super-e2e.md` (coverage, local run, when
  to run) + nav/index/CI-table entries + changelog.

## Real bug found by the suite (fixed here)

The host image did not ship `iproute2`, so `detect_host_ipv4s()` failed
inside the container and caddy fell back to the RFC1918 deny set — **every
request through a published port (`docker run -p 8997:8997`, the documented
deployment) was refused with 403**. Fixed by adding `iproute2` to the host
image's apt set; with it, caddy denies only the appliance's own eth0 IP
(the pasta-NAT container-source set) and published-port clients pass —
verified by the suite's boot tests.

## Test evidence

- `test-super-e2e`: **27 passed** in 3m34s, two consecutive full runs
  against a freshly built `klangk-host:latest` (well under the 10-minute
  budget from the issue).
- `python -m pytest scripts/tests`: 97 passed (host Dockerfile touched).
- Pre-commit hooks (actionlint, markdownlint, prettier, ruff, nixfmt,
  yamllint, trufflehog): clean.

Closes #2561
