### PR TITLE
fix(frontend): mark the system agent user as special in admin UIs

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1620,6 +1620,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Admin users list marks the system agent (#2892).** The built-in
+  `klangk@example.com` user now carries a SYSTEM badge and a fixed-identity
+  note instead of looking like an ordinary account, and tapping its row no
+  longer opens the edit dialog (its email, handle, and password are fixed).
+  The group-member and ACL user pickers omit it as well, matching the
+  server's refusal to make it a principal.
+
 - **Access-revoked restart loop (#2891).** When a user's workspace access
   was revoked (share removed, ACL changed, workspace deleted) while a
   "Container stopped" overlay was up, pressing its Restart button was

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1624,8 +1624,8 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   `klangk@example.com` user now carries a SYSTEM badge and a fixed-identity
   note instead of looking like an ordinary account, and tapping its row no
   longer opens the edit dialog (its email, handle, and password are fixed).
-  The group-member and ACL user pickers omit it as well, matching the
-  server's refusal to make it a principal.
+  The group-member, ACL, share-with-user, and transfer-ownership pickers
+  omit it as well, matching the server's refusal to make it a principal.
 
 - **Access-revoked restart loop (#2891).** When a user's workspace access
   was revoked (share removed, ACL changed, workspace deleted) while a

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -430,8 +430,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
                     style: TextStyle(color: KColors.textMuted, fontSize: 12),
                   )
                 : null,
-            // Tap opens the edit dialog; every field it offers (email,
-            // handle, password) is immutable on the agent.
+            // The agent row is not tappable: the edit dialog's every
+            // field (email, handle, password) is fixed on it, so opening
+            // it could only ever end in a rejection.
             onTap: isAgent ? null : () => _editUser(user),
             trailing: Row(
               mainAxisSize: MainAxisSize.min,

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -15,6 +15,7 @@ import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
 import '../widgets/obscure_toggle.dart';
 import '../widgets/skeuo_tab.dart';
+import '../utils/system_agent.dart';
 import '../utils/validators.dart';
 import 'server_schedule_panel.dart';
 
@@ -388,16 +389,28 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       itemBuilder: (ctx, i) {
         final user = _users[i];
         final isSelf = user['id'] == context.read<AuthService>().userId;
-        final isSystem = user['provider'] == 'system';
+        // The system agent (#2892): its identity is fixed and the backend
+        // rejects every edit, delete, disable, and group-membership call
+        // on it, so the row is marked and none of those actions are
+        // offered.
+        final isAgent = isSystemAgent(user);
         final email = user['email'] as String? ?? '';
         final initial = email.isNotEmpty ? email[0].toUpperCase() : '?';
         return Card(
           margin: const EdgeInsets.only(bottom: 8),
           child: ListTile(
-            leading: _UserAvatar(initial: initial, email: email),
+            leading: _UserAvatar(
+              initial: initial,
+              email: email,
+              isAgent: isAgent,
+            ),
             title: Row(
               children: [
-                Text(email),
+                Flexible(child: Text(email)),
+                if (isAgent) ...[
+                  const SizedBox(width: 8),
+                  const _SystemAgentBadge(),
+                ],
                 if ((user['handle'] as String?)?.isNotEmpty == true) ...[
                   const SizedBox(width: 8),
                   Text(
@@ -410,11 +423,20 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
                 ],
               ],
             ),
-            onTap: () => _editUser(user),
+            subtitle: isAgent
+                ? const Text(
+                    'Built-in system agent — fixed identity; it cannot be '
+                    'edited, disabled, or deleted',
+                    style: TextStyle(color: KColors.textMuted, fontSize: 12),
+                  )
+                : null,
+            // Tap opens the edit dialog; every field it offers (email,
+            // handle, password) is immutable on the agent.
+            onTap: isAgent ? null : () => _editUser(user),
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                if (!isSelf && !isSystem) ...[
+                if (!isSelf && !isAgent) ...[
                   IconButton(
                     icon: const Icon(
                       Icons.delete_outline,
@@ -969,8 +991,12 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
     }
 
     final memberIds = _members.map((m) => m['id']).toSet();
-    final nonMembers =
-        _allUsers.where((u) => !memberIds.contains(u['id'])).toList();
+    final nonMembers = _allUsers
+        .where((u) => !memberIds.contains(u['id']))
+        // The agent can never be a group member (the backend rejects
+        // making it an ACL principal), so don't offer it (#2892).
+        .where((u) => !isSystemAgent(u))
+        .toList();
 
     return AlertDialog(
       title: Text('Members of "$_groupName"'),
@@ -1731,8 +1757,13 @@ class _InviteUserDialogState extends State<_InviteUserDialog> {
 class _UserAvatar extends StatelessWidget {
   final String initial;
   final String email;
+  final bool isAgent;
 
-  const _UserAvatar({required this.initial, required this.email});
+  const _UserAvatar({
+    required this.initial,
+    required this.email,
+    this.isAgent = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1744,17 +1775,52 @@ class _UserAvatar extends StatelessWidget {
         children: [
           CircleAvatar(
             radius: 20,
-            backgroundColor: KColors.colorForString(email),
-            child: Text(
-              initial,
-              style: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.w600,
-                fontSize: 16,
-              ),
-            ),
+            backgroundColor:
+                isAgent ? KColors.accentAmber : KColors.colorForString(email),
+            child: isAgent
+                ? const Icon(
+                    Icons.smart_toy,
+                    color: Colors.white,
+                    size: 20,
+                  )
+                : Text(
+                    initial,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 16,
+                    ),
+                  ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Small tag marking the built-in system agent's row in the users list
+/// (#2892): its identity is fixed and the destructive/edit actions other
+/// rows get are omitted rather than offered-and-rejected.
+class _SystemAgentBadge extends StatelessWidget {
+  const _SystemAgentBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: KColors.accentAmber.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: KColors.accentAmber.withValues(alpha: 0.5)),
+      ),
+      child: const Text(
+        'SYSTEM',
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.5,
+          color: KColors.accentAmber,
+        ),
       ),
     );
   }

--- a/src/frontend/lib/utils/system_agent.dart
+++ b/src/frontend/lib/utils/system_agent.dart
@@ -1,21 +1,23 @@
-/// The built-in system agent user, as seen by admin UIs (#2892).
+/// The built-in system agent user, as seen by user-targeting UIs (#2892).
 ///
-/// The agent (email `klangk@example.com`, handle `klangk`) realizes its
-/// capabilities through in-container physical access, never as an
-/// authenticated principal. The backend therefore rejects — with
-/// `AgentPrincipalError` — deleting it, changing its email/handle/password,
-/// disabling it, or making it an ACL principal or group member. Admin
-/// surfaces use [isSystemAgent] to mark the row and omit those actions
-/// instead of offering them and surfacing the rejection.
+/// The agent realizes its capabilities through in-container physical
+/// access, never as an authenticated principal. The backend therefore
+/// rejects — with `AgentPrincipalError` — deleting it, changing its
+/// email/handle/password, disabling it, or making it an ACL principal or
+/// group member. Surfaces that offer such actions use [isSystemAgent] to
+/// omit them for the agent instead of offering them and surfacing the
+/// rejection.
 
 /// The agent's fixed, published id (`AGENT_USER_ID` in the backend model).
 const String agentUserId = '00000000-0000-0000-0000-000000000001';
 
-/// True when [user] — a row from `GET /admin/users` — is the system agent.
+/// True when [user] — a row from a user-listing endpoint — is the system
+/// agent.
 ///
-/// The seeded agent row carries `provider == 'system'`, a value unique to
-/// it (human/OIDC users are `local` or an OIDC provider slug) that a DB
-/// trigger keeps immutable; the id check pins the published constant too,
-/// so either marker identifies the row.
-bool isSystemAgent(Map<String, dynamic> user) =>
-    user['id'] == agentUserId || user['provider'] == 'system';
+/// Matched by id alone: it is the invariant every backend guard and DB
+/// trigger keys on, and it is a UUID primary key, so no other row can
+/// hold it. `users.provider` is deliberately NOT a marker — an OIDC
+/// provider id is stored verbatim in that column, so a provider named
+/// `system` would flag its human users as the agent and strip their
+/// edit/delete affordances.
+bool isSystemAgent(Map<String, dynamic> user) => user['id'] == agentUserId;

--- a/src/frontend/lib/utils/system_agent.dart
+++ b/src/frontend/lib/utils/system_agent.dart
@@ -1,0 +1,21 @@
+/// The built-in system agent user, as seen by admin UIs (#2892).
+///
+/// The agent (email `klangk@example.com`, handle `klangk`) realizes its
+/// capabilities through in-container physical access, never as an
+/// authenticated principal. The backend therefore rejects — with
+/// `AgentPrincipalError` — deleting it, changing its email/handle/password,
+/// disabling it, or making it an ACL principal or group member. Admin
+/// surfaces use [isSystemAgent] to mark the row and omit those actions
+/// instead of offering them and surfacing the rejection.
+
+/// The agent's fixed, published id (`AGENT_USER_ID` in the backend model).
+const String agentUserId = '00000000-0000-0000-0000-000000000001';
+
+/// True when [user] — a row from `GET /admin/users` — is the system agent.
+///
+/// The seeded agent row carries `provider == 'system'`, a value unique to
+/// it (human/OIDC users are `local` or an OIDC provider slug) that a DB
+/// trigger keeps immutable; the id check pins the published constant too,
+/// so either marker identifies the row.
+bool isSystemAgent(Map<String, dynamic> user) =>
+    user['id'] == agentUserId || user['provider'] == 'system';

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
+import '../utils/system_agent.dart';
 
 /// Reusable ACL editor widget for any resource path.
 /// Shows ACE entries with add/remove/reorder, saves on button press.
@@ -180,6 +181,10 @@ class AclEditorState extends State<AclEditor> {
     } catch (e) {
       debugPrint('[AclEditor] fetch users failed: $e');
     }
+    // The system agent realizes capabilities through physical access, not
+    // principalship — the backend rejects an ACE for it, so the picker
+    // omits it (#2892).
+    users = users.where((u) => !isSystemAgent(u)).toList();
     try {
       groups = await _loadPickerGroups(auth);
     } catch (e) {

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
+import '../utils/system_agent.dart';
 import 'marking_banner.dart' show classificationBannerMaxLength;
 import 'workspace_section_nav.dart';
 import '../utils/web_helpers_stub.dart'
@@ -1444,9 +1445,13 @@ class _SettingsFormState extends State<_SettingsForm> {
                         '/api/v1/users/search?q=${Uri.encodeQueryComponent(q.trim())}',
                       );
                       if (resp.statusCode == 200) {
-                        searchResults.value = List<Map<String, dynamic>>.from(
-                          jsonDecode(resp.body) as List,
-                        );
+                        // The agent can never own a workspace (the backend
+                        // rejects making it an ACL principal), so the
+                        // transfer autocomplete never offers it (#2892).
+                        searchResults.value = (jsonDecode(resp.body) as List)
+                            .map((e) => Map<String, dynamic>.from(e as Map))
+                            .where((r) => !isSystemAgent(r))
+                            .toList();
                       }
                     } catch (e) {
                       // coverage:ignore-start

--- a/src/frontend/lib/workspace/workspace_sharing_panel.dart
+++ b/src/frontend/lib/workspace/workspace_sharing_panel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
+import '../utils/system_agent.dart';
 import '../widgets/acl_editor.dart';
 
 /// Workspace sharing panel with role-based buckets.
@@ -171,9 +172,13 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
                         '/api/v1/users/search?q=${Uri.encodeQueryComponent(q.trim())}',
                       );
                       if (resp.statusCode == 200) {
-                        searchResults.value = List<Map<String, dynamic>>.from(
-                          jsonDecode(resp.body) as List,
-                        );
+                        // The agent can never hold a role (the backend
+                        // rejects making it an ACL principal), so the
+                        // autocomplete never offers it (#2892).
+                        searchResults.value = (jsonDecode(resp.body) as List)
+                            .map((e) => Map<String, dynamic>.from(e as Map))
+                            .where((r) => !isSystemAgent(r))
+                            .toList();
                       }
                     } catch (e) {
                       debugPrint(

--- a/src/frontend/test/acl_editor_test.dart
+++ b/src/frontend/test/acl_editor_test.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/utils/system_agent.dart';
 import 'package:klangk_frontend/widgets/acl_editor.dart';
 
 /// Default JWT for a logged-in admin user.
@@ -67,6 +68,16 @@ Map<String, dynamic> _user(String email) => {
       'handle': '',
       'verified': true,
       'provider': 'local',
+      'created_at': '2026-01-01T00:00:00',
+    };
+
+/// The built-in system agent row, as `GET /admin/users` serves it.
+Map<String, dynamic> _agentUser() => {
+      'id': agentUserId,
+      'email': 'klangk@example.com',
+      'handle': 'klangk',
+      'verified': true,
+      'provider': 'system',
       'created_at': '2026-01-01T00:00:00',
     };
 
@@ -153,7 +164,7 @@ void main() {
     final principalField = find.byWidgetPredicate(
       (widget) =>
           widget is DropdownButtonFormField<int> &&
-          widget.decoration?.labelText == 'Principal Type',
+          widget.decoration.labelText == 'Principal Type',
     );
     await tester.tap(principalField);
     await tester.pumpAndSettle();
@@ -168,7 +179,7 @@ void main() {
     final groupField = find.byWidgetPredicate(
       (widget) =>
           widget is DropdownButtonFormField<String> &&
-          widget.decoration?.labelText == 'Group',
+          widget.decoration.labelText == 'Group',
     );
     await tester.tap(groupField);
     await tester.pumpAndSettle();
@@ -182,5 +193,60 @@ void main() {
     // A group that is both manual and referenced appears exactly once in
     // the menu (dedupe by id): table + menu = 2, not 3.
     expect(find.text('aa-manual-alpha'), findsNWidgets(2));
+  });
+
+  testWidgets('user picker omits the system agent (#2892)', (tester) async {
+    testAuthHttpClientOverride = MockClient((request) async {
+      final path = request.url.path;
+      if (path == '/api/v1/workspaces/ws1/acl') {
+        return http.Response(jsonEncode(_entries()), 200);
+      }
+      if (path == '/api/v1/admin/users') {
+        return http.Response(
+          jsonEncode({
+            'users': [_agentUser(), _user('alice@example.com')],
+            'page': 1,
+            'page_size': 200,
+            'total': 2,
+          }),
+          200,
+        );
+      }
+      if (path == '/api/v1/admin/groups') {
+        return http.Response(
+          jsonEncode({
+            'groups': <Map<String, dynamic>>[],
+            'page': 1,
+            'page_size': 200,
+            'total': 0,
+          }),
+          200,
+        );
+      }
+      return http.Response('Not found', 404);
+    });
+
+    await tester.pumpWidget(buildEditor());
+    await tester.pumpAndSettle();
+
+    // Open the add-entry dialog; principal type defaults to User.
+    await tester.tap(find.widgetWithIcon(TextButton, Icons.add));
+    await tester.pumpAndSettle();
+
+    final userField = find.byWidgetPredicate(
+      (widget) =>
+          widget is DropdownButtonFormField<String> &&
+          widget.decoration.labelText == 'User',
+    );
+    await tester.tap(userField);
+    await tester.pumpAndSettle();
+
+    // The agent realizes capabilities through physical access, never
+    // principalship — the backend rejects an ACE for it, so the picker
+    // must not offer it.
+    expect(find.text('klangk@example.com'), findsNothing);
+    // Alice appears twice: once in the untouched entries table, once in
+    // the open picker menu.
+    expect(find.text('alice@example.com'), findsNWidgets(2));
   });
 }

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/admin/admin_users_page.dart';
 import 'package:klangk_frontend/admin/server_schedule_panel.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/utils/system_agent.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
@@ -45,6 +46,16 @@ Map<String, dynamic> _user(String email, {String id = ''}) => {
       'handle': '',
       'verified': true,
       'provider': 'local',
+      'created_at': '2026-01-01T00:00:00',
+    };
+
+/// The built-in system agent row, as `GET /admin/users` serves it.
+Map<String, dynamic> _agentUser() => {
+      'id': agentUserId,
+      'email': 'klangk@example.com',
+      'handle': 'klangk',
+      'verified': true,
+      'provider': 'system',
       'created_at': '2026-01-01T00:00:00',
     };
 
@@ -1284,6 +1295,100 @@ void main() {
 
       expect(find.byType(AlertDialog), findsNothing);
       expect(deleted, isEmpty);
+    });
+  });
+
+  group('AdminUsersPage system agent row (#2892)', () {
+    testWidgets('marks the agent row and omits its edit/delete affordances',
+        (tester) async {
+      serveUsers(
+        (page, pageSize, sort, order, q) => [
+          _agentUser(),
+          _user('alice@example.com', id: 'u1'),
+        ],
+        total: 2,
+      );
+      await pumpPage(tester);
+
+      // The agent row is badged, subtitled, and avatar-marked; the
+      // ordinary user row is not.
+      expect(find.text('SYSTEM'), findsOneWidget);
+      expect(find.byIcon(Icons.smart_toy), findsOneWidget);
+      expect(find.textContaining('Built-in system agent'), findsOneWidget);
+
+      // Delete appears for the ordinary (non-self) user only.
+      expect(iconButton('Delete user'), findsOneWidget);
+
+      // Tapping the agent row opens nothing — every field the edit
+      // dialog offers is immutable on it.
+      await tester.tap(find.text('klangk@example.com'));
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsNothing);
+
+      // Tapping the ordinary user still opens the edit dialog.
+      await tester.tap(find.text('alice@example.com'));
+      await tester.pumpAndSettle();
+      expect(find.text('Edit User'), findsOneWidget);
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('agent-only list shows no delete action at all',
+        (tester) async {
+      serveUsers(
+        (page, pageSize, sort, order, q) => [_agentUser()],
+        total: 1,
+      );
+      await pumpPage(tester);
+
+      expect(find.byTooltip('Delete user'), findsNothing);
+    });
+
+    testWidgets('manage-members picker omits the system agent', (tester) async {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/v1/admin/users') {
+          return http.Response(
+            _usersEnvelope(
+              [_agentUser(), _user('carol@example.com', id: 'u-carol')],
+              total: 2,
+            ),
+            200,
+          );
+        }
+        if (path == '/api/v1/admin/groups') {
+          return http.Response(
+            _groupsEnvelope([_group('admins', id: 'g1')], total: 1),
+            200,
+          );
+        }
+        if (path == '/api/v1/admin/groups/g1/members') {
+          return http.Response(
+            jsonEncode([_user('bob@example.com', id: 'u-bob')]),
+            200,
+          );
+        }
+        if (path == '/api/v1/admin/invitations') {
+          return http.Response(emptyInvitationsEnvelope(), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pumpPage(tester);
+      await tester.tap(find.text('Groups'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('admins'));
+      await tester.pumpAndSettle();
+
+      // The add-member dropdown offers carol but never the agent (the
+      // backend rejects making it an ACL principal).
+      final dropdown = tester.widget<DropdownButton<String>>(
+        find.byType(DropdownButton<String>),
+      );
+      final values = dropdown.items!.map((item) => item.value).toList();
+      expect(values, contains('u-carol'));
+      expect(values, isNot(contains(agentUserId)));
     });
   });
 }

--- a/src/frontend/test/system_agent_test.dart
+++ b/src/frontend/test/system_agent_test.dart
@@ -4,29 +4,30 @@ import 'package:klangk_frontend/utils/system_agent.dart';
 void main() {
   group('isSystemAgent', () {
     test('matches the fixed agent id', () {
-      expect(isSystemAgent({'id': agentUserId, 'provider': 'local'}), isTrue);
+      expect(isSystemAgent({'id': agentUserId, 'provider': 'system'}), isTrue);
     });
 
-    test('matches a system-provider row by provider alone', () {
+    test('a provider=system row that is not the agent is not matched', () {
+      // An OIDC provider id is stored verbatim in users.provider, so a
+      // provider named `system` produces ordinary users with that value.
+      // They must keep their normal edit/delete affordances — only the
+      // fixed id identifies the agent.
       expect(
-        isSystemAgent({'id': 'some-other-id', 'provider': 'system'}),
-        isTrue,
+        isSystemAgent({'id': 'u-oidc', 'provider': 'system'}),
+        isFalse,
       );
     });
 
     test('ordinary local and OIDC users are not the agent', () {
-      expect(
-        isSystemAgent({'id': 'u1', 'provider': 'local'}),
-        isFalse,
-      );
+      expect(isSystemAgent({'id': 'u1', 'provider': 'local'}), isFalse);
       expect(
         isSystemAgent({'id': 'u2', 'provider': 'sso.example.com'}),
         isFalse,
       );
     });
 
-    test('missing provider field is tolerated', () {
-      expect(isSystemAgent({'id': 'u1'}), isFalse);
+    test('missing id field is tolerated', () {
+      expect(isSystemAgent({'provider': 'system'}), isFalse);
     });
   });
 }

--- a/src/frontend/test/system_agent_test.dart
+++ b/src/frontend/test/system_agent_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/utils/system_agent.dart';
+
+void main() {
+  group('isSystemAgent', () {
+    test('matches the fixed agent id', () {
+      expect(isSystemAgent({'id': agentUserId, 'provider': 'local'}), isTrue);
+    });
+
+    test('matches a system-provider row by provider alone', () {
+      expect(
+        isSystemAgent({'id': 'some-other-id', 'provider': 'system'}),
+        isTrue,
+      );
+    });
+
+    test('ordinary local and OIDC users are not the agent', () {
+      expect(
+        isSystemAgent({'id': 'u1', 'provider': 'local'}),
+        isFalse,
+      );
+      expect(
+        isSystemAgent({'id': 'u2', 'provider': 'sso.example.com'}),
+        isFalse,
+      );
+    });
+
+    test('missing provider field is tolerated', () {
+      expect(isSystemAgent({'id': 'u1'}), isFalse);
+    });
+  });
+}

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/utils/system_agent.dart';
 import 'package:klangk_frontend/workspace/workspace_settings_panel.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
@@ -2248,6 +2249,35 @@ void main() {
 
       expect(find.text('Confirm Transfer'), findsOneWidget);
       expect(find.textContaining('target@test.com'), findsOneWidget);
+    });
+
+    testWidgets('search omits the system agent (#2892)', (tester) async {
+      testAuthHttpClientOverride = _client(
+        searchResults: [
+          {'id': agentUserId, 'email': 'klangk@example.com'},
+          {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+        ],
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byType(TextField).last,
+        'target',
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      // The agent can never own a workspace — the backend would only
+      // reject the transfer — so the autocomplete filters it out.
+      expect(find.text('klangk@example.com'), findsNothing);
+      expect(find.text('target@test.com'), findsOneWidget);
     });
 
     testWidgets('confirm executes transfer successfully', (tester) async {

--- a/src/frontend/test/workspace_sharing_panel_test.dart
+++ b/src/frontend/test/workspace_sharing_panel_test.dart
@@ -8,6 +8,7 @@ import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/utils/system_agent.dart';
 import 'package:klangk_frontend/workspace/workspace_sharing_panel.dart';
 
 /// Default JWT for a logged-in user.
@@ -284,6 +285,29 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Add to owners'), findsNothing);
     expect(requests, contains('POST /api/v1/workspaces/ws1/roles/owners'));
+  });
+
+  testWidgets('add dialog autocomplete omits the system agent (#2892)',
+      (tester) async {
+    stubHttp(
+      searchResults: [
+        {'id': agentUserId, 'email': 'klangk@example.com'},
+        {'id': 'u-new', 'email': 'newuser@example.com'},
+      ],
+    );
+    await tester.pumpWidget(buildPanel(canEditAcl: true));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Add user').first);
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'k');
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpAndSettle();
+
+    // The agent can never hold a role, so the backend would only reject
+    // it — the autocomplete filters it out and offers the human hit only.
+    expect(find.text('klangk@example.com'), findsNothing);
+    expect(find.text('newuser@example.com'), findsOneWidget);
   });
 
   testWidgets('add dialog submits a typed email directly', (tester) async {


### PR DESCRIPTION
## Summary

The built-in system agent user (`klangk@example.com`, fixed id
`00000000-0000-0000-0000-000000000001`) rendered as an ordinary row in the
Flutter admin users list: no visual distinction, a tappable edit dialog whose
every field (email / handle / password) the backend rejects with
`AgentPrincipalError`, and it was offered in the group-member picker and the
ACL editor's user picker even though making it an ACL principal is refused
server-side.

Closes #2892.

## Changes

- **Users list** (`admin_users_page.dart`): the agent row now carries a
  SYSTEM badge next to the email, a bot avatar instead of the letter
  avatar, and a "fixed identity" subtitle; the row is no longer tappable
  (the edit dialog could never succeed on it). The delete button stays
  hidden — that part already existed (`provider == 'system'` gate, #457).
- **Detection** (`utils/system_agent.dart`, new): the fixed published
  `AGENT_USER_ID` or `provider == 'system'` (unique to the agent, kept
  immutable by a DB trigger). Unit-tested.
- **Pickers**: the manage-members dialog and the ACL editor's add-entry
  user dropdown omit the agent, matching the server's refusal to make it
  a principal / group member.
- Changelog entry under `[Unreleased]` / `Fixed`.

The CLI admin users list already shows a Provider column and has no
user-delete/edit command, so it has no equivalent blind spot.

## Testing

- New `test/system_agent_test.dart` (unit, both detection branches).
- `admin_users_page_test.dart`: agent row badge/avatar/subtitle, no edit
  dialog on tap, no delete action in an agent-only list, manage-members
  picker omits it.
- `acl_editor_test.dart`: user picker omits the agent.
- Full `flutter test --coverage`: 1166 passing, 100% coverage held.
