### PR TITLE
refactor: consolidate duplicated code blocks (#2901)

### DIFF
--- a/src/klangk/klangk/api/_common.py
+++ b/src/klangk/klangk/api/_common.py
@@ -110,3 +110,21 @@ class WorkspaceAclEntry(BaseModel):
     user_id: str | None = None
     group_id: str | None = None
     system_principal: int | None = None
+
+
+def serialize_acl_entries(entries: list[WorkspaceAclEntry]) -> list[dict]:
+    """Map an ACE request list to the model's row-dict shape, renumbering
+    positions in submission order (shared by the admin resource-level and
+    per-workspace ACL replace endpoints)."""
+    return [
+        {
+            "position": i,
+            "action": e.action,
+            "principal_type": e.principal_type,
+            "permission": e.permission,
+            "user_id": e.user_id,
+            "group_id": e.group_id,
+            "system_principal": e.system_principal,
+        }
+        for i, e in enumerate(entries)
+    ]

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -33,6 +33,7 @@ from ._common import (
     WorkspaceAclEntry,
     admin_resource,
     send_email,
+    serialize_acl_entries,
 )
 
 logger = logging.getLogger(__name__)
@@ -860,18 +861,7 @@ async def replace_resource_acl(
                 detail=f"change-acls permission required on {workspace}",
             )
 
-    acl_entries = [
-        {
-            "position": i,
-            "action": e.action,
-            "principal_type": e.principal_type,
-            "permission": e.permission,
-            "user_id": e.user_id,
-            "group_id": e.group_id,
-            "system_principal": e.system_principal,
-        }
-        for i, e in enumerate(entries)
-    ]
+    acl_entries = serialize_acl_entries(entries)
     await app.state.model.acl.replace_acl_entries(resource, acl_entries)
     return await app.state.model.acl.get_acl_entries_resolved(resource)
 

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -51,6 +51,7 @@ from ..util import (
 from ._common import (
     WorkspaceAclEntry,
     autostart_allowed,
+    serialize_acl_entries,
     workspace_collection_resource,
     workspace_resource,
 )
@@ -1711,19 +1712,9 @@ async def replace_workspace_acl(
     migration 0017 backfilled it onto existing ``share`` holders.
     """
     resource = f"/workspaces/{workspace_id}"
-    acl_entries = [
-        {
-            "position": i,
-            "action": e.action,
-            "principal_type": e.principal_type,
-            "permission": e.permission,
-            "user_id": e.user_id,
-            "group_id": e.group_id,
-            "system_principal": e.system_principal,
-        }
-        for i, e in enumerate(entries)
-    ]
-    await app.state.model.acl.replace_acl_entries(resource, acl_entries)
+    await app.state.model.acl.replace_acl_entries(
+        resource, serialize_acl_entries(entries)
+    )
     return await app.state.model.acl.get_acl_entries_resolved(resource)
 
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -735,90 +735,92 @@ class Auth:
             options=options,
         )
 
-    # --- email-verification tokens ---
-
-    def create_verification_token(self, user_id: str) -> str:
-        """Create a JWT token for email verification."""
-        expire = datetime.now(timezone.utc) + timedelta(
-            hours=self.verify_token_expire_hours
-        )
-        payload = {"sub": user_id, "purpose": "verify", "exp": expire}
+    def _create_purpose_token(
+        self,
+        subject: str,
+        purpose: str,
+        expire_hours: int,
+        extra: dict[str, str] | None = None,
+    ) -> str:
+        """Create a signed JWT tagged with *purpose*, expiring in
+        *expire_hours*, carrying *extra* claims."""
+        expire = datetime.now(timezone.utc) + timedelta(hours=expire_hours)
+        payload = {"sub": subject, "purpose": purpose, "exp": expire}
+        if extra:
+            payload.update(extra)
         return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
-    def decode_verification_token(self, token: str) -> str | None:
-        """Decode a verification token. Returns user_id or None if invalid."""
+    def _decode_purpose_token(self, token: str, purpose: str) -> dict | None:
+        """Decode a JWT and require its ``purpose`` claim to match.
+
+        Returns the payload, or None when the token is invalid, expired,
+        or was minted for a different purpose.
+        """
         try:
             payload = jwt.decode(
                 token, self.secret, algorithms=[self.algorithm]
             )
-            if payload.get("purpose") != "verify":
-                return None
-            return payload.get("sub")
         except JWTError:
             return None
+        if payload.get("purpose") != purpose:
+            return None
+        return payload
+
+    # --- email-verification tokens ---
+
+    def create_verification_token(self, user_id: str) -> str:
+        """Create a JWT token for email verification."""
+        return self._create_purpose_token(
+            user_id, "verify", self.verify_token_expire_hours
+        )
+
+    def decode_verification_token(self, token: str) -> str | None:
+        """Decode a verification token. Returns user_id or None if invalid."""
+        payload = self._decode_purpose_token(token, "verify")
+        return payload.get("sub") if payload is not None else None
 
     # --- password-reset tokens ---
 
     def create_password_reset_token(self, user_id: str) -> str:
         """Create a JWT token for password reset."""
-        expire = datetime.now(timezone.utc) + timedelta(
-            hours=self.reset_token_expire_hours
+        return self._create_purpose_token(
+            user_id, "reset", self.reset_token_expire_hours
         )
-        payload = {"sub": user_id, "purpose": "reset", "exp": expire}
-        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
     def decode_password_reset_token(self, token: str) -> str | None:
         """Decode a password reset token. Returns user_id or None."""
-        try:
-            payload = jwt.decode(
-                token, self.secret, algorithms=[self.algorithm]
-            )
-            if payload.get("purpose") != "reset":
-                return None
-            return payload.get("sub")
-        except JWTError:
-            return None
+        payload = self._decode_purpose_token(token, "reset")
+        return payload.get("sub") if payload is not None else None
 
     # --- invitation tokens ---
 
     def create_invitation_token(self, invitation_id: str, email: str) -> str:
         """Create a JWT token for an invitation."""
-        expire = datetime.now(timezone.utc) + timedelta(
-            hours=self.invite_token_expire_hours
+        return self._create_purpose_token(
+            invitation_id,
+            "invite",
+            self.invite_token_expire_hours,
+            extra={"email": email},
         )
-        payload = {
-            "sub": invitation_id,
-            "email": email,
-            "purpose": "invite",
-            "exp": expire,
-        }
-        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
     def decode_invitation_token(self, token: str) -> tuple[str, str] | None:
         """Decode an invitation token. Returns (invitation_id, email) or None."""
-        try:
-            payload = jwt.decode(
-                token, self.secret, algorithms=[self.algorithm]
-            )
-            if payload.get("purpose") != "invite":
-                return None
-            inv_id = payload.get("sub")
-            email = payload.get("email")
-            if not inv_id or not email:
-                return None
-            return (inv_id, email)
-        except JWTError:
+        payload = self._decode_purpose_token(token, "invite")
+        if payload is None:
             return None
+        invitation_id = payload.get("sub")
+        email = payload.get("email")
+        if not invitation_id or not email:
+            return None
+        return (invitation_id, email)
 
     # --- workspace tokens ---
 
     def create_workspace_token(self, workspace_id: str) -> str:
         """Create a JWT token identifying a workspace for container→host auth."""
-        expire = datetime.now(timezone.utc) + timedelta(
-            hours=self.workspace_token_expire_hours
+        return self._create_purpose_token(
+            workspace_id, "workspace", self.workspace_token_expire_hours
         )
-        payload = {"sub": workspace_id, "purpose": "workspace", "exp": expire}
-        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
     def decode_workspace_token(self, token: str) -> str | None:
         """Decode a workspace token.

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -652,11 +652,15 @@ class KlangkClient:
             )
         self._raise_for_status(resp)
 
-    def restart_workspace(self, name: str) -> None:
-        ws = self.resolve_workspace(name)
-        resp = self.post(f"/api/v1/workspaces/{ws.id}/restart")
+    def _post_workspace_action(self, workspace_id: str, action: str) -> None:
+        """POST /api/v1/workspaces/{id}/{action} (start/stop/restart)."""
+        resp = self.post(f"/api/v1/workspaces/{workspace_id}/{action}")
         self.check_auth(resp)
         self._raise_for_status(resp)
+
+    def restart_workspace(self, name: str) -> None:
+        ws = self.resolve_workspace(name)
+        self._post_workspace_action(ws.id, "restart")
 
     def restart_workspace_by_id(self, workspace_id: str) -> None:
         """Restart a workspace container by id.
@@ -664,15 +668,11 @@ class KlangkClient:
         Id-based counterpart to :meth:`restart_workspace` for callers (the
         sandbox driver) that already hold the workspace id.
         """
-        resp = self.post(f"/api/v1/workspaces/{workspace_id}/restart")
-        self.check_auth(resp)
-        self._raise_for_status(resp)
+        self._post_workspace_action(workspace_id, "restart")
 
     def stop_workspace(self, name: str) -> None:
         ws = self.resolve_workspace(name)
-        resp = self.post(f"/api/v1/workspaces/{ws.id}/stop")
-        self.check_auth(resp)
-        self._raise_for_status(resp)
+        self._post_workspace_action(ws.id, "stop")
 
     def stop_workspace_by_id(self, workspace_id: str) -> None:
         """Stop a running workspace container by id.
@@ -681,15 +681,11 @@ class KlangkClient:
         sandbox driver) that already hold the workspace id and want to
         skip the name→id resolution round-trip.
         """
-        resp = self.post(f"/api/v1/workspaces/{workspace_id}/stop")
-        self.check_auth(resp)
-        self._raise_for_status(resp)
+        self._post_workspace_action(workspace_id, "stop")
 
     def start_workspace(self, name: str) -> None:
         ws = self.resolve_workspace(name)
-        resp = self.post(f"/api/v1/workspaces/{ws.id}/start")
-        self.check_auth(resp)
-        self._raise_for_status(resp)
+        self._post_workspace_action(ws.id, "start")
 
     def duplicate_workspace(self, name: str, new_name: str) -> dict:
         ws = self.resolve_workspace(name)

--- a/src/klangk/klangk/cli/execsync.py
+++ b/src/klangk/klangk/cli/execsync.py
@@ -226,38 +226,3 @@ def images() -> None:
     for img in data["allowed"]:
         prefix = "*" if img == data["default"] else " "
         console.print(f"  {prefix} {img}")
-
-
-vol_app = typer.Typer(
-    name="volumes",
-    help="Manage container volumes for workspaces.",
-    rich_markup_mode="rich",
-)
-context.app.add_typer(vol_app, name="volumes")
-
-
-# --- Admin commands (site-wide admin privilege required) ---
-# Grouped under `admin` to separate site-wide management (users,
-# invitations, access control) from workspace-scoped commands. Every
-# command here hits an endpoint gated by the admin ACL permission
-# (acl.has_permission("admin")), so non-admins get a clear 403.
-admin_app = typer.Typer(
-    name="admin",
-    help="Site-wide administration (requires admin privileges).",
-    rich_markup_mode="rich",
-)
-context.app.add_typer(admin_app, name="admin")
-
-# Nested noun subgroups, matching the existing `volumes`/`terminal`
-# precedent so `admin --help` stays scannable as `admin <noun> <verb>`.
-admin_users_app = typer.Typer(
-    name="users", help="Manage user accounts.", rich_markup_mode="rich"
-)
-admin_app.add_typer(admin_users_app, name="users")
-
-admin_invitations_app = typer.Typer(
-    name="invitations",
-    help="Manage user invitations.",
-    rich_markup_mode="rich",
-)
-admin_app.add_typer(admin_invitations_app, name="invitations")

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -46,7 +46,10 @@ from ._base import (
     confirm_then,
 )
 from .server import ServerSwitchScreen
-from .workspace_form import CreateWorkspaceScreen, EditWorkspaceScreen
+from .workspace_form import (
+    CreateWorkspaceScreen,
+    open_edit_screen,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -611,14 +614,28 @@ class MainScreen(StatusScreen):
             confirm_then(self, partial(self._do_restart, name)),
         )
 
-    async def _do_restart(self, name: str) -> None:
+    async def _do_lifecycle(
+        self, verb: str, name: str, *, refresh_hints: bool
+    ) -> None:
+        """Run a workspace lifecycle op off-thread and flash the result.
+
+        *verb* is capitalized ("Restart"/"Stop"/"Start"); the operation
+        runs in a worker thread via ``asyncio.to_thread`` so the textual
+        event loop stays responsive.
+        """
         try:
-            await asyncio.to_thread(self.app.tui_state.restart_workspace, name)
+            method = getattr(self.app.tui_state, f"{verb.lower()}_workspace")
+            await asyncio.to_thread(method, name)
         except Exception as exc:
-            self._flash(f"Restart failed: {exc}")
+            self._flash(f"{verb} failed: {exc}")
             return
-        self._flash(f"Restart requested for '{name}'.")
+        self._flash(f"{verb} requested for '{name}'.")
         self.app.refresh_workspaces()
+        if refresh_hints:
+            self._refresh_action_hints()
+
+    async def _do_restart(self, name: str) -> None:
+        await self._do_lifecycle("Restart", name, refresh_hints=False)
 
     def action_stop(self) -> None:
         name = self._require_highlighted()
@@ -638,24 +655,10 @@ class MainScreen(StatusScreen):
             self.run_worker(self._do_start(name), exit_on_error=False)
 
     async def _do_stop(self, name: str) -> None:
-        try:
-            await asyncio.to_thread(self.app.tui_state.stop_workspace, name)
-        except Exception as exc:
-            self._flash(f"Stop failed: {exc}")
-            return
-        self._flash(f"Stop requested for '{name}'.")
-        self.app.refresh_workspaces()
-        self._refresh_action_hints()
+        await self._do_lifecycle("Stop", name, refresh_hints=True)
 
     async def _do_start(self, name: str) -> None:
-        try:
-            await asyncio.to_thread(self.app.tui_state.start_workspace, name)
-        except Exception as exc:
-            self._flash(f"Start failed: {exc}")
-            return
-        self._flash(f"Start requested for '{name}'.")
-        self.app.refresh_workspaces()
-        self._refresh_action_hints()
+        await self._do_lifecycle("Start", name, refresh_hints=True)
 
     def action_duplicate(self) -> None:
         name = self._require_highlighted()
@@ -723,37 +726,7 @@ class MainScreen(StatusScreen):
         except Exception as exc:
             self._flash(f"Could not load workspace: {exc}")
             return
-        try:
-            data = await asyncio.to_thread(state.list_images)
-            default = data.get("default", "") or ""
-            allowed = list(data.get("allowed") or [])
-            nix_available = data.get("nix_available") is True
-            sudo_available = data.get("sudo_available") is True
-        except AuthError:
-            self.app.session_expired()
-            return
-        except Exception:
-            default, allowed = "", []
-            nix_available = False
-            sudo_available = False
-        try:
-            allow_autostart = await asyncio.to_thread(state.allow_autostart)
-        except AuthError:
-            self.app.session_expired()
-            return
-        except Exception:
-            allow_autostart = False
-        self.app.push_screen(
-            EditWorkspaceScreen(
-                workspace=ws,
-                allowed=allowed,
-                default=default,
-                allow_autostart=allow_autostart,
-                nix_available=nix_available,
-                sudo_available=sudo_available,
-            ),
-            self._on_edited,
-        )
+        await open_edit_screen(self, state, ws, self._on_edited)
 
     def _on_edited(self, result) -> None:
         if result:

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -37,7 +37,7 @@ from ._base import (
     TransferScreen,
     confirm_then,
 )
-from .workspace_form import EditWorkspaceScreen
+from .workspace_form import open_edit_screen
 
 logger = logging.getLogger(__name__)
 
@@ -547,37 +547,7 @@ class WorkspaceDetailScreen(StatusScreen):
 
     async def _do_edit(self) -> None:
         state = self.app.tui_state
-        try:
-            data = await asyncio.to_thread(state.list_images)
-            default = data.get("default", "") or ""
-            allowed = list(data.get("allowed") or [])
-            nix_available = data.get("nix_available") is True
-            sudo_available = data.get("sudo_available") is True
-        except AuthError:
-            self.app.session_expired()
-            return
-        except Exception:
-            default, allowed = "", []
-            nix_available = False
-            sudo_available = False
-        try:
-            allow_autostart = await asyncio.to_thread(state.allow_autostart)
-        except AuthError:
-            self.app.session_expired()
-            return
-        except Exception:
-            allow_autostart = False
-        self.app.push_screen(
-            EditWorkspaceScreen(
-                workspace=self._ws,
-                allowed=allowed,
-                default=default,
-                allow_autostart=allow_autostart,
-                nix_available=nix_available,
-                sudo_available=sudo_available,
-            ),
-            self._on_edited,
-        )
+        await open_edit_screen(self, state, self._ws, self._on_edited)
 
     def _on_edited(self, result: str | bool | None) -> None:
         if isinstance(result, str):

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+from collections.abc import Callable
 
 import httpx
 
@@ -157,6 +158,47 @@ def render_form_list(
         ol.add_option(Option(Text(fmt(item)), id=f"{id_prefix}{i}"))
 
 
+async def open_edit_screen(screen, state, workspace, on_edited) -> None:
+    """Load image/autostart metadata off-thread and open the edit form.
+
+    Shared by the workspace-list (main) and workspace-detail screens.
+    An image-listing failure degrades to empty defaults (the form's
+    image field then accepts free text); an autostart failure leaves it
+    disabled; ``AuthError`` ends the session via ``session_expired``.
+    """
+    try:
+        data = await asyncio.to_thread(state.list_images)
+        default = data.get("default", "") or ""
+        allowed = list(data.get("allowed") or [])
+        nix_available = data.get("nix_available") is True
+        sudo_available = data.get("sudo_available") is True
+    except AuthError:
+        screen.app.session_expired()
+        return
+    except Exception:
+        default, allowed = "", []
+        nix_available = False
+        sudo_available = False
+    try:
+        allow_autostart = await asyncio.to_thread(state.allow_autostart)
+    except AuthError:
+        screen.app.session_expired()
+        return
+    except Exception:
+        allow_autostart = False
+    screen.app.push_screen(
+        EditWorkspaceScreen(
+            workspace=workspace,
+            allowed=allowed,
+            default=default,
+            allow_autostart=allow_autostart,
+            nix_available=nix_available,
+            sudo_available=sudo_available,
+        ),
+        on_edited,
+    )
+
+
 class WorkspaceFormMixin:
     """Shared body of the create/edit workspace form screens: the four list
     renderers (same widget ids + backing attributes) and the tab strip's
@@ -221,6 +263,88 @@ class WorkspaceFormMixin:
         render_form_list(
             self, "#reject_list", self._rejected_domains, str, "(none)", "r"
         )
+
+    # --- shared string-list editor actions (mounts / allowed /
+    # rejected domains); the env editor stays bespoke (dict-keyed,
+    # #1778 in-place edits track a key rather than an index) ---
+
+    def _add_list_entry(
+        self,
+        input_id: str,
+        entries: list[str],
+        validate: Callable[[str], str | None],
+        render: Callable[[], None],
+        *,
+        dedupe: bool = False,
+        editing_attr: str | None = None,
+    ) -> None:
+        """Add the input's value to *entries*, then re-render.
+
+        With *editing_attr* naming an in-place-edit index attribute
+        (EditWorkspaceScreen, #1778), a valid index updates that entry in
+        place instead of appending. *dedupe* skips the append when the
+        value is already present.
+        """
+        inp = self.query_one(input_id, Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        idx = getattr(self, editing_attr) if editing_attr else None
+        replacing = idx is not None and 0 <= idx < len(entries)
+        if replacing:
+            entries[idx] = v
+        elif not dedupe or v not in entries:
+            entries.append(v)
+        if replacing and editing_attr:
+            setattr(self, editing_attr, None)
+        inp.value = ""
+        self._msg("")
+        render()
+
+    def _remove_list_entry(
+        self,
+        option_list_id: str,
+        entries: list[str],
+        render: Callable[[], None],
+        editing_attr: str | None = None,
+    ) -> None:
+        """Delete the highlighted entry from *entries*, then re-render.
+
+        Clears the in-place-edit index (*editing_attr*) so a pending edit
+        does not retarget the shifted indices.
+        """
+        ol = self.query_one(option_list_id, OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(entries):
+            return
+        del entries[idx]
+        if editing_attr:
+            setattr(self, editing_attr, None)
+        render()
+
+    def _edit_list_entry(
+        self,
+        option_list_id: str,
+        input_id: str,
+        entries: list[str],
+        editing_attr: str,
+        label: str,
+    ) -> None:
+        """Load the highlighted entry into the input for in-place editing
+        (#1778). *label* names the entry kind in the status message."""
+        ol = self.query_one(option_list_id, OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(entries):
+            return
+        setattr(self, editing_attr, idx)
+        inp = self.query_one(input_id, Input)
+        inp.value = entries[idx]
+        inp.focus()
+        self._msg(f"Editing {label} — press Add to update.")
 
     def _active_tab(self) -> str:
         """The id of the currently active form tab pane."""
@@ -559,26 +683,17 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     # --- mounts list editor ---
 
     def _add_mount(self) -> None:
-        inp = self.query_one("#mount_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
-        err = validate_mount_spec(v)
-        if err:
-            self._msg(err, error=True)
-            return
-        self._mounts.append(v)
-        inp.value = ""
-        self._msg("")
-        self._render_mounts()
+        self._add_list_entry(
+            "#mount_input",
+            self._mounts,
+            validate_mount_spec,
+            self._render_mounts,
+        )
 
     def _remove_mount(self) -> None:
-        ol = self.query_one("#mount_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._mounts):
-            return
-        del self._mounts[idx]
-        self._render_mounts()
+        self._remove_list_entry(
+            "#mount_list", self._mounts, self._render_mounts
+        )
 
     # --- env list editor ---
 
@@ -609,53 +724,37 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     # --- allowed-domains list editor (#1745) ---
 
     def _add_allowed_domain(self) -> None:
-        inp = self.query_one("#allow_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
-        err = validate_allowed_domain_spec(v)
-        if err:
-            self._msg(err, error=True)
-            return
-        if v not in self._allowed_domains:
-            self._allowed_domains.append(v)
-        inp.value = ""
-        self._msg("")
-        self._render_allowed_domains()
+        self._add_list_entry(
+            "#allow_input",
+            self._allowed_domains,
+            validate_allowed_domain_spec,
+            self._render_allowed_domains,
+            dedupe=True,
+        )
 
     def _remove_allowed_domain(self) -> None:
-        ol = self.query_one("#allow_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._allowed_domains):
-            return
-        del self._allowed_domains[idx]
-        self._render_allowed_domains()
+        self._remove_list_entry(
+            "#allow_list", self._allowed_domains, self._render_allowed_domains
+        )
 
     # --- rejected-domains list editor (#2386, mirrors allowed-domains) ---
 
     def _add_rejected_domain(self) -> None:
-        inp = self.query_one("#reject_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
         # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
-        err = validate_allowed_domain_spec(v, allow_cidr=False)
-        if err:
-            self._msg(err, error=True)
-            return
-        if v not in self._rejected_domains:
-            self._rejected_domains.append(v)
-        inp.value = ""
-        self._msg("")
-        self._render_rejected_domains()
+        self._add_list_entry(
+            "#reject_input",
+            self._rejected_domains,
+            lambda spec: validate_allowed_domain_spec(spec, allow_cidr=False),
+            self._render_rejected_domains,
+            dedupe=True,
+        )
 
     def _remove_rejected_domain(self) -> None:
-        ol = self.query_one("#reject_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._rejected_domains):
-            return
-        del self._rejected_domains[idx]
-        self._render_rejected_domains()
+        self._remove_list_entry(
+            "#reject_list",
+            self._rejected_domains,
+            self._render_rejected_domains,
+        )
 
     # --- tab + keyboard navigation (#1891) ---
 
@@ -1210,32 +1309,21 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     # --- list editors: add / remove / in-place edit (#1778) ---
 
     def _add_mount(self) -> None:
-        inp = self.query_one("#mount_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
-        err = validate_mount_spec(v)
-        if err:
-            self._msg(err, error=True)
-            return
-        idx = self._editing_mount
-        if idx is not None and 0 <= idx < len(self._mounts):
-            self._mounts[idx] = v
-            self._editing_mount = None
-        else:
-            self._mounts.append(v)
-        inp.value = ""
-        self._msg("")
-        self._render_mounts()
+        self._add_list_entry(
+            "#mount_input",
+            self._mounts,
+            validate_mount_spec,
+            self._render_mounts,
+            editing_attr="_editing_mount",
+        )
 
     def _remove_mount(self) -> None:
-        ol = self.query_one("#mount_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._mounts):
-            return
-        del self._mounts[idx]
-        self._editing_mount = None
-        self._render_mounts()
+        self._remove_list_entry(
+            "#mount_list",
+            self._mounts,
+            self._render_mounts,
+            editing_attr="_editing_mount",
+        )
 
     def _add_env(self) -> None:
         inp = self.query_one("#env_input", Input)
@@ -1267,45 +1355,33 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         self._render_env()
 
     def _add_allowed_domain(self) -> None:
-        inp = self.query_one("#allow_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
-        err = validate_allowed_domain_spec(v)
-        if err:
-            self._msg(err, error=True)
-            return
-        idx = self._editing_allow
-        if idx is not None and 0 <= idx < len(self._allowed_domains):
-            self._allowed_domains[idx] = v
-            self._editing_allow = None
-        elif v not in self._allowed_domains:
-            self._allowed_domains.append(v)
-        inp.value = ""
-        self._msg("")
-        self._render_allowed_domains()
+        self._add_list_entry(
+            "#allow_input",
+            self._allowed_domains,
+            validate_allowed_domain_spec,
+            self._render_allowed_domains,
+            dedupe=True,
+            editing_attr="_editing_allow",
+        )
 
     def _remove_allowed_domain(self) -> None:
-        ol = self.query_one("#allow_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._allowed_domains):
-            return
-        del self._allowed_domains[idx]
-        self._editing_allow = None
-        self._render_allowed_domains()
+        self._remove_list_entry(
+            "#allow_list",
+            self._allowed_domains,
+            self._render_allowed_domains,
+            editing_attr="_editing_allow",
+        )
 
     # --- in-place edit: load the highlighted item into the input (#1778) ---
 
     def _edit_mount(self) -> None:
-        ol = self.query_one("#mount_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._mounts):
-            return
-        self._editing_mount = idx
-        inp = self.query_one("#mount_input", Input)
-        inp.value = self._mounts[idx]
-        inp.focus()
-        self._msg("Editing mount — press Add to update.")
+        self._edit_list_entry(
+            "#mount_list",
+            "#mount_input",
+            self._mounts,
+            "_editing_mount",
+            "mount",
+        )
 
     def _edit_env(self) -> None:
         ol = self.query_one("#env_list", OptionList)
@@ -1321,57 +1397,43 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         self._msg("Editing env var — press Add to update.")
 
     def _edit_allowed_domain(self) -> None:
-        ol = self.query_one("#allow_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._allowed_domains):
-            return
-        self._editing_allow = idx
-        inp = self.query_one("#allow_input", Input)
-        inp.value = self._allowed_domains[idx]
-        inp.focus()
-        self._msg("Editing allowed-domain — press Add to update.")
+        self._edit_list_entry(
+            "#allow_list",
+            "#allow_input",
+            self._allowed_domains,
+            "_editing_allow",
+            "allowed-domain",
+        )
 
     # --- rejected-domains list editor (#2386, mirrors allowed-domains) ---
 
     def _add_rejected_domain(self) -> None:
-        inp = self.query_one("#reject_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
         # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
-        err = validate_allowed_domain_spec(v, allow_cidr=False)
-        if err:
-            self._msg(err, error=True)
-            return
-        idx = self._editing_reject
-        if idx is not None and 0 <= idx < len(self._rejected_domains):
-            self._rejected_domains[idx] = v
-            self._editing_reject = None
-        elif v not in self._rejected_domains:
-            self._rejected_domains.append(v)
-        inp.value = ""
-        self._msg("")
-        self._render_rejected_domains()
+        self._add_list_entry(
+            "#reject_input",
+            self._rejected_domains,
+            lambda spec: validate_allowed_domain_spec(spec, allow_cidr=False),
+            self._render_rejected_domains,
+            dedupe=True,
+            editing_attr="_editing_reject",
+        )
 
     def _remove_rejected_domain(self) -> None:
-        ol = self.query_one("#reject_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._rejected_domains):
-            return
-        del self._rejected_domains[idx]
-        self._editing_reject = None
-        self._render_rejected_domains()
+        self._remove_list_entry(
+            "#reject_list",
+            self._rejected_domains,
+            self._render_rejected_domains,
+            editing_attr="_editing_reject",
+        )
 
     def _edit_rejected_domain(self) -> None:
-        ol = self.query_one("#reject_list", OptionList)
-        idx = ol.highlighted
-        if idx is None or not 0 <= idx < len(self._rejected_domains):
-            return
-        self._editing_reject = idx
-        inp = self.query_one("#reject_input", Input)
-        inp.value = self._rejected_domains[idx]
-        inp.focus()
-        self._msg("Editing rejected-domain — press Add to update.")
+        self._edit_list_entry(
+            "#reject_list",
+            "#reject_input",
+            self._rejected_domains,
+            "_editing_reject",
+            "rejected-domain",
+        )
 
     # --- tab + keyboard navigation (#1891) ---
 

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -349,18 +349,29 @@ def dup(
     )
 
 
+def run_workspace_action(name: str, method: str, verb: str) -> None:
+    """Run a workspace lifecycle command (rm/restart/stop/start).
+
+    Auth-gates, resolves the client lazily (after the auth check, matching
+    the original per-command ordering), maps a missing workspace to the
+    standard "No workspace named" error + exit 1, and echoes
+    ``<verb> workspace <name>`` on success.
+    """
+    context.require_auth()
+    try:
+        getattr(context._client(), method)(name)
+    except WorkspaceNotFoundError:
+        context._err.print(f"[red]No workspace named[/red] '{name}'")
+        raise typer.Exit(code=1) from None
+    typer.echo(f"{verb} workspace {name}")
+
+
 @context.app.command("rm")
 def rm(
     name: str = typer.Argument(..., help="Workspace name"),
 ) -> None:
     """Delete a workspace."""
-    context.require_auth()
-    try:
-        context._client().delete_workspace(name)
-    except WorkspaceNotFoundError:
-        context._err.print(f"[red]No workspace named[/red] '{name}'")
-        raise typer.Exit(code=1) from None
-    typer.echo(f"Deleted workspace {name}")
+    run_workspace_action(name, "delete_workspace", "Deleted")
 
 
 @context.app.command("members")
@@ -393,13 +404,7 @@ def restart(
     name: str = typer.Argument(..., help="Workspace name"),
 ) -> None:
     """Restart the container for a workspace."""
-    context.require_auth()
-    try:
-        context._client().restart_workspace(name)
-    except WorkspaceNotFoundError:
-        context._err.print(f"[red]No workspace named[/red] '{name}'")
-        raise typer.Exit(code=1) from None
-    typer.echo(f"Restarted workspace {name}")
+    run_workspace_action(name, "restart_workspace", "Restarted")
 
 
 @context.app.command("stop")
@@ -407,13 +412,7 @@ def stop(
     name: str = typer.Argument(..., help="Workspace name"),
 ) -> None:
     """Stop the container for a workspace."""
-    context.require_auth()
-    try:
-        context._client().stop_workspace(name)
-    except WorkspaceNotFoundError:
-        context._err.print(f"[red]No workspace named[/red] '{name}'")
-        raise typer.Exit(code=1) from None
-    typer.echo(f"Stopped workspace {name}")
+    run_workspace_action(name, "stop_workspace", "Stopped")
 
 
 @context.app.command("start")
@@ -421,13 +420,7 @@ def start(
     name: str = typer.Argument(..., help="Workspace name"),
 ) -> None:
     """Start the container for a workspace."""
-    context.require_auth()
-    try:
-        context._client().start_workspace(name)
-    except WorkspaceNotFoundError:
-        context._err.print(f"[red]No workspace named[/red] '{name}'")
-        raise typer.Exit(code=1) from None
-    typer.echo(f"Started workspace {name}")
+    run_workspace_action(name, "start_workspace", "Started")
 
 
 @context.app.command("export")

--- a/src/klangk/klangk/hooks.py
+++ b/src/klangk/klangk/hooks.py
@@ -39,7 +39,10 @@ from typing import Any, Callable
 from .container import ContainerRegistry
 from .exceptions import ConfigurationError
 from .model import EGRESS_MODES, SETUP_STATES
-from .model.workspaces import normalize_classification_banner
+from .model.workspaces import (
+    UPDATABLE_WORKSPACE_FIELDS,
+    normalize_classification_banner,
+)
 from .netfilter import parse_allowed_domains
 from .workspace_settings import validate_nix_optin, validate_settings
 
@@ -54,25 +57,10 @@ logger = logging.getLogger(__name__)
 # ``create_workspace_with_acl``. Keys outside this set (id, user_id,
 # container_id, num_ports, created_at) are not persisted — they are
 # provisioned, not declarative. Deleting a mutable key from the handle
-# clears the column (``del workspace["env"]`` persists NULL).
-_HOOK_MUTABLE_FIELDS = frozenset(
-    {
-        "name",
-        "image",
-        "service_command",
-        "auto_start",
-        "setup_state",
-        "health_check",
-        "mounts",
-        "env",
-        "allowed_domains",
-        "rejected_domains",
-        "settings",
-        "egress_mode",
-        "per_handle_home",
-        "classification_banner",
-    }
-)
+# clears the column (``del workspace["env"]`` persists NULL). Shared
+# constant (model.workspaces owns it — the same set gates
+# ``update_workspace``).
+_HOOK_MUTABLE_FIELDS = UPDATABLE_WORKSPACE_FIELDS
 
 
 def _parse_hook_value(raw: str) -> tuple[str, str]:

--- a/src/klangk/klangk/model/acl.py
+++ b/src/klangk/klangk/model/acl.py
@@ -264,31 +264,39 @@ class ACLModel:
             )
             return cursor.rowcount
 
+    async def get_acl_entries_by_principal(
+        self, principal_type: int, principal_column: str, principal_id: str
+    ) -> list[dict]:
+        """Get all ACL entries for a principal.
+
+        *principal_column* is ``"user_id"`` or ``"group_id"`` and must
+        match *principal_type* (``PRINCIPAL_USER``/``PRINCIPAL_GROUP``).
+        """
+        rows = await self.app.state.db.fetchall(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            f" FROM acl_entries WHERE principal_type = ? AND"
+            f" {principal_column} = ?"
+            " ORDER BY resource, position",
+            (principal_type, principal_id),
+        )
+        return [dict(row) for row in rows]
+
     async def get_acl_entries_by_principal_user(
         self, user_id: str
     ) -> list[dict]:
         """Get all ACL entries referencing a specific user."""
-        rows = await self.app.state.db.fetchall(
-            "SELECT id, resource, position, action, principal_type,"
-            " user_id, group_id, system_principal, permission"
-            " FROM acl_entries WHERE principal_type = ? AND user_id = ?"
-            " ORDER BY resource, position",
-            (PRINCIPAL_USER, user_id),
+        return await self.get_acl_entries_by_principal(
+            PRINCIPAL_USER, "user_id", user_id
         )
-        return [dict(row) for row in rows]
 
     async def get_acl_entries_by_principal_group(
         self, group_id: str
     ) -> list[dict]:
         """Get all ACL entries referencing a specific group."""
-        rows = await self.app.state.db.fetchall(
-            "SELECT id, resource, position, action, principal_type,"
-            " user_id, group_id, system_principal, permission"
-            " FROM acl_entries WHERE principal_type = ? AND group_id = ?"
-            " ORDER BY resource, position",
-            (PRINCIPAL_GROUP, group_id),
+        return await self.get_acl_entries_by_principal(
+            PRINCIPAL_GROUP, "group_id", group_id
         )
-        return [dict(row) for row in rows]
 
     async def get_acl_tree_summary(self) -> list[dict]:
         """Get all distinct resources with their ACE counts."""

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -493,12 +493,12 @@ class UsersModel:
                 "source": source,
             }
 
-    async def get_group_by_name(self, name: str) -> dict | None:
-        """Find a group by name."""
+    async def _get_group_by(self, where: str, value: str) -> dict | None:
+        """Fetch one group row matching *where* and map it to a dict."""
         row = await self.app.state.db.fetchone(
             "SELECT id, name, description, source, created_at"
-            " FROM groups WHERE name = ?",
-            (name,),
+            f" FROM groups WHERE {where}",
+            (value,),
         )
         if row is None:
             return None
@@ -510,22 +510,13 @@ class UsersModel:
             "created_at": row["created_at"],
         }
 
+    async def get_group_by_name(self, name: str) -> dict | None:
+        """Find a group by name."""
+        return await self._get_group_by("name = ?", name)
+
     async def get_group_by_id(self, group_id: str) -> dict | None:
         """Find a group by ID."""
-        row = await self.app.state.db.fetchone(
-            "SELECT id, name, description, source, created_at"
-            " FROM groups WHERE id = ?",
-            (group_id,),
-        )
-        if row is None:
-            return None
-        return {
-            "id": row["id"],
-            "name": row["name"],
-            "description": row["description"],
-            "source": row["source"],
-            "created_at": row["created_at"],
-        }
+        return await self._get_group_by("id = ?", group_id)
 
     async def list_groups(
         self,

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -16,6 +16,29 @@ from .users import (
 # Must match the DB default and container.DEFAULT_PORTS_PER_WORKSPACE.
 DEFAULT_PORTS_PER_WORKSPACE = 5
 
+# Declarative workspace-row fields ``update_workspace`` persists (and,
+# mirrored as-is, the only fields a workspace-created hook may mutate in
+# place — see hooks._parse/apply; keys outside this set are provisioned,
+# not declarative). Single source of truth for both callers.
+UPDATABLE_WORKSPACE_FIELDS = frozenset(
+    {
+        "name",
+        "image",
+        "service_command",
+        "auto_start",
+        "setup_state",
+        "health_check",
+        "mounts",
+        "env",
+        "allowed_domains",
+        "rejected_domains",
+        "settings",
+        "egress_mode",
+        "per_handle_home",
+        "classification_banner",
+    }
+)
+
 # Per-workspace role groups created for every workspace. The key is the
 # group-name suffix appended to ``<suffix>-<workspace_id>``; the value is the
 # ordered list of permissions granted to that group on ``/workspaces/{id}``.
@@ -929,26 +952,10 @@ class WorkspacesModel:
         **fields: str | None,
     ) -> bool:
         """Update workspace fields. Only provided fields are changed."""
-        allowed = {
-            "name",
-            "image",
-            "service_command",
-            "auto_start",
-            "setup_state",
-            "health_check",
-            "mounts",
-            "env",
-            "allowed_domains",
-            "rejected_domains",
-            "settings",
-            "egress_mode",
-            "per_handle_home",
-            "classification_banner",
-        }
         to_set = {
             k: coerce_workspace_field(k, v)
             for k, v in fields.items()
-            if k in allowed
+            if k in UPDATABLE_WORKSPACE_FIELDS
         }
         if not to_set:
             return False

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -263,15 +263,25 @@ class Podman:
 
     # --- Containers ---
 
-    async def inspect_container(self, container_id: str) -> dict | None:
-        """Return the inspect dict for a container, or None if it is gone."""
-        rc, out, _err = await self.run(
-            ["container", "inspect", container_id], check=False
-        )
+    async def _inspect_first(self, args: list[str]) -> dict | None:
+        """Run a ``podman inspect``-style command; first record or None."""
+        rc, out, _err = await self.run(args, check=False)
         if rc != 0:
             return None
         data = json.loads(out)
         return data[0] if data else None
+
+    async def _list_json(self, args: list[str]) -> list[dict]:
+        """Run a listing command; parsed JSON output (empty list if none)."""
+        _rc, out, _err = await self.run(args)
+        out = out.strip()
+        return json.loads(out) if out else []
+
+    async def inspect_container(self, container_id: str) -> dict | None:
+        """Return the inspect dict for a container, or None if it is gone."""
+        return await self._inspect_first(
+            ["container", "inspect", container_id]
+        )
 
     async def container_logs(self, container_id: str) -> str:
         """Return the container's combined stdout/stderr logs (empty if gone).
@@ -663,23 +673,15 @@ class Podman:
 
     async def list_containers(self, label: str) -> list[dict]:
         """List containers matching ``label`` (``key=value``)."""
-        _rc, out, _err = await self.run(
+        return await self._list_json(
             ["ps", "-a", "--filter", f"label={label}", "--format", "json"]
         )
-        out = out.strip()
-        return json.loads(out) if out else []
 
     # --- Volumes ---
 
     async def inspect_volume(self, name: str) -> dict | None:
         """Return a volume's inspect dict, or None if it does not exist."""
-        rc, out, _err = await self.run(
-            ["volume", "inspect", name], check=False
-        )
-        if rc != 0:
-            return None
-        data = json.loads(out)
-        return data[0] if data else None
+        return await self._inspect_first(["volume", "inspect", name])
 
     async def create_volume(
         self, name: str, labels: dict[str, str] | None = None
@@ -697,11 +699,9 @@ class Podman:
 
     async def list_volumes(self, label: str) -> list[dict]:
         """List volumes matching ``label`` (``key=value``)."""
-        _rc, out, _err = await self.run(
+        return await self._list_json(
             ["volume", "ls", "--filter", f"label={label}", "--format", "json"]
         )
-        out = out.strip()
-        return json.loads(out) if out else []
 
     async def remove_volume(self, name: str) -> None:
         """Remove a volume.

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -33,7 +33,6 @@ import logging
 import math
 import os
 import re
-import subprocess
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Mapping
 
@@ -63,6 +62,11 @@ from klangk.netfilter import parse_allowed_domains
 # neither settings nor anything that does) — used by the
 # classification_banner field validator below.
 from klangk.model.workspaces import normalize_classification_banner
+
+# And util's cmd: runner (util is stdlib-only, so no cycle) — the single
+# implementation of the ``cmd:`` secret prefix, shared with
+# util.resolve_file_value.
+from klangk.util import run_cmd_value
 from pydantic_settings.sources.providers.env import parse_env_vars
 
 logger = logging.getLogger(__name__)
@@ -405,8 +409,10 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # file: / cmd: indirection resolver (shared by all read paths)
 # ---------------------------------------------------------------------------
-
-_CMD_TIMEOUT_SECONDS = 10
+# (The cmd: runner itself is util.run_cmd_value; only the file: reader
+# lives here — its OSError is returned to the caller for strerror-only
+# logging, a contract util's string-returning read_file_value does not
+# have.)
 
 # Default frontend dir: the built Flutter Web UI ships inside the wheel at
 # klangk/frontend (force-include, #1600), so an installed (non-editable)
@@ -428,29 +434,6 @@ def _read_file(value: str) -> tuple[str | None, OSError | None]:
     except OSError as e:
         e.filename = e.filename or path
         return None, e
-
-
-def _run_cmd(value: str) -> tuple[str | None, str | None]:
-    """Strip a ``cmd:`` prefix and run the referenced command."""
-    command = value[4:]
-    try:
-        proc = subprocess.run(
-            command,
-            shell=True,
-            capture_output=True,
-            text=True,
-            timeout=_CMD_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        return None, f"timed out after {_CMD_TIMEOUT_SECONDS}s"
-    except OSError as e:  # pragma: no cover — shell=True means /bin/sh spawns; OSError only if sh itself is missing
-        return None, str(e)
-    if proc.returncode != 0:
-        return (
-            None,
-            f"exited with code {proc.returncode}: {proc.stderr.strip()}",
-        )
-    return proc.stdout.strip(), None
 
 
 def _resolve_indirection(value: str | None, key: str = "") -> str | None:
@@ -493,7 +476,7 @@ def _resolve_indirection(value: str | None, key: str = "") -> str | None:
             return None
         return contents
     if value.startswith("cmd:"):
-        contents, err = _run_cmd(value)
+        contents, err = run_cmd_value(value)
         if err is not None:
             logger.error(
                 "Cannot resolve %s via cmd: %s",

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -61,8 +61,11 @@ class TestResolveIndirection:
     def test_cmd_timeout(self, monkeypatch):
         # Patch the timeout short so we don't actually wait the default
         # _CMD_TIMEOUT_SECONDS (10s); the test only asserts the timeout
-        # path fires. ``sleep 5`` outlasts the patched 0.5s timeout (#1989).
-        monkeypatch.setattr("klangk.settings._CMD_TIMEOUT_SECONDS", 0.5)
+        # path fires. ``sleep 5`` outlasts the patched 0.5s timeout
+        # (#1989). The constant lives in klangk.util since the cmd:
+        # runner was consolidated there (shared with
+        # util.resolve_file_value).
+        monkeypatch.setattr("klangk.util._CMD_TIMEOUT_SECONDS", 0.5)
         result = _resolve_indirection("cmd:sleep 5")
         assert result is None
 


### PR DESCRIPTION
Closes #2901

## Summary

Consolidates the duplicated code blocks identified in #2901, plus four more
found by running `pylint --enable=duplicate-code` (R0801) over the package.
Pure internal refactor — no behavior change, no CLI/HTTP contract change,
no changelog entries (internal refactors are exempt per AGENTS.md).

## Consolidations

| Duplication | Consolidated into |
|---|---|
| 4 purpose-JWT create/decode pairs (`auth.py`) | `_create_purpose_token` / `_decode_purpose_token` |
| 6 workspace lifecycle POST wrappers (`cli/client.py`) | `_post_workspace_action` |
| `rm`/`restart`/`stop`/`start` command bodies (`cli/workspaces.py`) | `run_workspace_action` |
| `_do_restart`/`_do_stop`/`_do_start` TUI workers (`tui/screens/main.py`) | `_do_lifecycle` |
| 25 string-list editor methods across both form screens (`workspace_form.py`) | mixin `_add_list_entry` / `_remove_list_entry` / `_edit_list_entry` |
| edit-screen loader duplicated in `main.py` + `workspace_detail.py` | `workspace_form.open_edit_screen` |
| ACE request serialization (`api/admin.py` + `api/workspaces.py`) | `_common.serialize_acl_entries` |
| `get_group_by_name`/`_by_id` (`model/users.py`) | `_get_group_by` |
| principal query pair (`model/acl.py`) | `get_acl_entries_by_principal` |
| `inspect_container`/`inspect_volume`, `list_containers`/`list_volumes` (`podman.py`) | `_inspect_first` / `_list_json` |
| 15-field updatable-set literal (`model/workspaces.py` + `hooks.py`) | `UPDATABLE_WORKSPACE_FIELDS` |
| `cmd:` secret runner duplicated in `settings.py` | `util.run_cmd_value` |
| dead `vol_app`/`admin_app` typer registrations in `cli/execsync.py` (leftover from the #2542 split; never imported — real ones live in `cli/admin.py`) | deleted |

## Notes

- The env list editor stays bespoke in both form screens: it is dict-keyed
  and its #1778 in-place edits track a key rather than an index.
- The applied permission migrations (m0013/m0016/m0017/m0018) keep their
  duplicated promote-holders loops — migration history stays frozen; a
  shared `migrations/promote.py` helper is available for *future*
  migrations (noted in #2901).
- The `podman.py`/`terminal.py` async session reader duplication (also in
  #2901) was left for a follow-up — it touches async lifecycle internals
  of two subsystems and deserves its own careful PR.
- `test_settings.py::test_cmd_timeout` now patches
  `klangk.util._CMD_TIMEOUT_SECONDS` (the constant moved with the runner).

## Testing

Full backend suite the CI way:

```
python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -q -n auto
6169 passed; 100% branch coverage maintained (TOTAL 20191 stmts / 5708 branches, 0 missing)
```

`pre-commit run xenon --all-files` passes (rank B gate).
