### PR TITLE
refactor: consolidate second tranche of jscpd residual clones (#2904)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -44,6 +44,44 @@ let
       install -Dm555 -t $out/bin flutter_mcp_${flutterMcpToolkitVersion}_*/bin/*
     '';
   };
+  # jscpd token-clone scanner (#2904): 5.x ships a prebuilt Rust binary
+  # via platform-specific npm packages (esbuild-style), so it is not in
+  # nixpkgs; pin the binary per platform with fixed hashes (the fmtk
+  # pattern). One pinned version keeps clone reports reproducible across
+  # contributors and CI. The `klangk:jscpd` task runs it over the backend.
+  jscpdBinaryVersion = "5.0.16";
+  jscpd = pkgs.stdenv.mkDerivation {
+    pname = "jscpd";
+    version = jscpdBinaryVersion;
+    src = pkgs.fetchurl {
+      url =
+        if pkgs.stdenv.isDarwin then
+          "https://registry.npmjs.org/jscpd-darwin-"
+          + (if pkgs.stdenv.hostPlatform.darwinArch == "arm64" then "arm64" else "x64")
+          + "/-/jscpd-darwin-"
+          + (if pkgs.stdenv.hostPlatform.darwinArch == "arm64" then "arm64" else "x64")
+          + "-${jscpdBinaryVersion}.tgz"
+        else
+          "https://registry.npmjs.org/jscpd-linux-x64-gnu/-/jscpd-linux-x64-gnu-${jscpdBinaryVersion}.tgz";
+      hash =
+        if pkgs.stdenv.isDarwin then
+          (
+            if pkgs.stdenv.hostPlatform.darwinArch == "arm64" then
+              "sha256-vntXwMkns8HqtHwVzxthzun0tpRAe755YKB5k4c3Wqg="
+            else
+              "sha256-X2hK+EAgrXGRLUymdo5qgTuWoFQ3U0cz9J064UFQppM="
+          )
+        else
+          "sha256-+6PhbDzUn0e4sQgsUs/kF0C5HlMOixZvlNolO9a4VdI=";
+    };
+    sourceRoot = ".";
+    dontConfigure = true;
+    dontBuild = true;
+    dontStrip = true;
+    installPhase = ''
+      install -Dm555 -t $out/bin package/bin/jscpd
+    '';
+  };
   # klangkd binds a UDS and owns the Caddy reverse proxy as a child
   # (#1396, #1642); the old two-process layout (uvicorn + scripts/nginx.sh)
   # is collapsed into this single entry. Dev config lives in klangkd.yaml
@@ -146,6 +184,7 @@ in
       gzip
       gnutar
       caddy # reverse-proxy engine (Caddy, sole engine in 2.X, #1559/#1642)
+      jscpd # token-clone scanner (#2904), pinned rust binary (see above)
       podman
       ruff
       sqlite.bin
@@ -227,6 +266,13 @@ in
     # stricter or equal, never more lenient.
     "klangk:xenon" = {
       exec = "xenon --max-absolute B --max-modules B --max-average B $(git ls-files 'src/klangk/klangk/*.py' 'src/klangksidecar/klangksidecar/*.py' 'scripts/*.py')";
+    };
+    # Token-clone scan of the backend (#2904): the same invocation the
+    # consolidation issues used (--min-tokens 70). Advisory only — the
+    # residual clones (frozen migrations, cross-boundary signatures,
+    # pydantic field lists) are deliberate; see #2904 for the rationale.
+    "klangk:jscpd" = {
+      exec = "jscpd src/klangk/klangk --min-tokens 70 --silent";
     };
     "klangk:flutter-build" = {
       exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh"'';

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -495,6 +495,25 @@ class AddGroupMemberRequest(BaseModel):
 # --- User-accessible group endpoints (ACL-gated per group) ---
 
 
+async def get_group_or_404(app, group_id: str) -> dict:
+    """Fetch a group or raise the shared 404 (every group endpoint)."""
+    group = await app.state.model.users.get_group_by_id(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    return group
+
+
+async def update_group_fields(app, group_id: str, req) -> dict:
+    """Apply a group PATCH (both the permission-gated and admin routes)."""
+    await get_group_or_404(app, group_id)
+    updated = await app.state.model.users.update_group(
+        group_id, name=req.name, description=req.description
+    )
+    if not updated:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    return {"status": "updated"}
+
+
 async def _group_resource(request: Request, user: dict) -> str:  # noqa: ARG001
     """Resource function for group-level permission checks."""
     group_id = request.path_params.get("group_id")
@@ -570,15 +589,7 @@ async def user_update_group(
     app=Depends(get_app_dep),
 ):
     """Update a group (requires edit permission on the group)."""
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
-    updated = await app.state.model.users.update_group(
-        group_id, name=req.name, description=req.description
-    )
-    if not updated:
-        raise HTTPException(status_code=400, detail="No fields to update")
-    return {"status": "updated"}
+    return await update_group_fields(app, group_id, req)
 
 
 @router.delete("/groups/{group_id}")
@@ -588,9 +599,7 @@ async def user_delete_group(
     app=Depends(get_app_dep),
 ):
     """Delete a group (requires delete permission on the group)."""
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
+    await get_group_or_404(app, group_id)
     await app.state.model.users.delete_group(group_id)
     await app.state.model.acl.delete_acl_entries_for_resource(
         f"/groups/{group_id}"
@@ -605,9 +614,7 @@ async def user_list_group_members(
     app=Depends(get_app_dep),
 ):
     """List group members (requires view permission on the group)."""
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
+    await get_group_or_404(app, group_id)
     return await app.state.model.users.get_group_members(group_id)
 
 
@@ -621,9 +628,7 @@ async def user_add_group_member(
     app=Depends(get_app_dep),
 ):
     """Add a member (requires manage_members permission on the group)."""
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
+    await get_group_or_404(app, group_id)
     target = await app.state.model.users.get_user_by_id(req.user_id)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
@@ -708,15 +713,7 @@ async def update_group(
     admin: dict = Depends(acl.has_permission("admin")),
     app=Depends(get_app_dep),
 ):
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
-    updated = await app.state.model.users.update_group(
-        group_id, name=req.name, description=req.description
-    )
-    if not updated:
-        raise HTTPException(status_code=400, detail="No fields to update")
-    return {"status": "updated"}
+    return await update_group_fields(app, group_id, req)
 
 
 @router.delete("/admin/groups/{group_id}")
@@ -725,9 +722,7 @@ async def delete_group(
     admin: dict = Depends(acl.has_permission("admin")),
     app=Depends(get_app_dep),
 ):
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
+    await get_group_or_404(app, group_id)
     await app.state.model.users.delete_group(group_id)
     return {"status": "deleted"}
 
@@ -738,9 +733,7 @@ async def list_group_members(
     admin: dict = Depends(acl.has_permission("admin")),
     app=Depends(get_app_dep),
 ):
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
+    await get_group_or_404(app, group_id)
     return await app.state.model.users.get_group_members(group_id)
 
 
@@ -751,9 +744,7 @@ async def add_group_member(
     admin: dict = Depends(acl.has_permission("admin")),
     app=Depends(get_app_dep),
 ):
-    group = await app.state.model.users.get_group_by_id(group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group not found")
+    await get_group_or_404(app, group_id)
     user = await app.state.model.users.get_user_by_id(req.user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -467,6 +467,27 @@ class ChangePasswordRequest(BaseModel):
     new_password: str
 
 
+async def verify_password_confirmation(
+    app, user: dict, password: str, *, incorrect_detail: str
+) -> None:
+    """Re-check the caller's password for a sensitive account change.
+
+    Shared by change-password / change-email / change-handle. OIDC-only
+    users have no password; their credentials are managed by their
+    identity provider and must not crash on a NULL hash.
+    """
+    stored = await app.state.model.users.get_user_by_email(user["email"])
+    if stored is not None and not stored.get("password_hash"):
+        raise HTTPException(
+            status_code=403,
+            detail="Account is managed by your identity provider",
+        )
+    if stored is None or not await asyncio.to_thread(
+        auth.verify_password, password, stored["password_hash"]
+    ):
+        raise HTTPException(status_code=401, detail=incorrect_detail)
+
+
 @router.post("/auth/change-password")
 async def change_password(
     req: ChangePasswordRequest,
@@ -474,24 +495,12 @@ async def change_password(
     user: dict = Depends(auth.get_current_user),
 ):
     """Change password. Requires current password."""
-    stored = await request.app.state.model.users.get_user_by_email(
-        user["email"]
-    )
-    # OIDC-only users have no password; their credentials are managed
-    # by their identity provider and must not crash on a NULL hash.
-    if stored is not None and not stored.get("password_hash"):
-        raise HTTPException(
-            status_code=403,
-            detail="Account is managed by your identity provider",
-        )
-    if stored is None or not await asyncio.to_thread(
-        auth.verify_password,
+    await verify_password_confirmation(
+        request.app,
+        user,
         req.current_password,
-        stored["password_hash"],
-    ):
-        raise HTTPException(
-            status_code=401, detail="Current password is incorrect"
-        )
+        incorrect_detail="Current password is incorrect",
+    )
     request.app.state.auth.validate_password(req.new_password)
     await request.app.state.auth.validate_password_not_reused(
         user["id"], req.new_password
@@ -518,18 +527,9 @@ async def change_email(
     app=Depends(get_app_dep),
 ):
     """Change email. Requires password. Marks account as unverified."""
-    stored = await app.state.model.users.get_user_by_email(user["email"])
-    # OIDC-only users have no password; their credentials are managed
-    # by their identity provider and must not crash on a NULL hash.
-    if stored is not None and not stored.get("password_hash"):
-        raise HTTPException(
-            status_code=403,
-            detail="Account is managed by your identity provider",
-        )
-    if stored is None or not await asyncio.to_thread(
-        auth.verify_password, req.password, stored["password_hash"]
-    ):
-        raise HTTPException(status_code=401, detail="Password is incorrect")
+    await verify_password_confirmation(
+        app, user, req.password, incorrect_detail="Password is incorrect"
+    )
     auth.validate_email(req.email)
     existing = await app.state.model.users.get_user_by_email(req.email)
     if existing is not None and existing["id"] != user["id"]:
@@ -567,18 +567,9 @@ async def change_handle(
     app=Depends(get_app_dep),
 ):
     """Change the current user's handle. Requires password confirmation."""
-    stored = await app.state.model.users.get_user_by_email(user["email"])
-    # OIDC-only users have no password; their credentials are managed
-    # by their identity provider and must not crash on a NULL hash.
-    if stored is not None and not stored.get("password_hash"):
-        raise HTTPException(
-            status_code=403,
-            detail="Account is managed by your identity provider",
-        )
-    if stored is None or not await asyncio.to_thread(
-        auth.verify_password, req.password, stored["password_hash"]
-    ):
-        raise HTTPException(status_code=401, detail="Password is incorrect")
+    await verify_password_confirmation(
+        app, user, req.password, incorrect_detail="Password is incorrect"
+    )
     try:
         await app.state.model.users.set_user_handle(user["id"], req.handle)
     except ValueError as e:

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -9,7 +9,7 @@ import subprocess
 import tempfile
 import time
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import (
     APIRouter,
@@ -182,6 +182,17 @@ def _annotate_running(items: list[dict], container_registry) -> list[dict]:
     return items
 
 
+# Shared list-endpoint query parameters (owned/shared listings): the
+# Annotated aliases keep the two endpoints' OpenAPI contract identical
+# while declaring the pagination controls once (#2904). Defaults stay
+# on the ``=`` in each signature (FastAPI's rule for Annotated params).
+LimitQuery = Annotated[int | None, Query(ge=1, le=100)]
+OffsetQuery = Annotated[int | None, Query(ge=0)]
+SortQuery = Annotated[Literal["name", "created"], Query()]
+OrderQuery = Annotated[Literal["asc", "desc"], Query()]
+SearchQuery = Annotated[str | None, Query()]
+
+
 async def _list_response(fetch, app, limit, offset):
     """Shared list-endpoint body (#2553): bare/envelope shape + running
     annotation. *fetch* is a callable(limit, offset) returning the model's
@@ -203,11 +214,11 @@ async def _list_response(fetch, app, limit, offset):
 async def list_workspaces(
     user: dict = Depends(auth.get_current_user),
     app=Depends(get_app_dep),
-    limit: int | None = Query(None, ge=1, le=100),
-    offset: int | None = Query(None, ge=0),
-    sort: Literal["name", "created"] = Query("created"),
-    order: Literal["asc", "desc"] = Query("desc"),
-    q: str | None = Query(None),
+    limit: LimitQuery = None,
+    offset: OffsetQuery = None,
+    sort: SortQuery = "created",
+    order: OrderQuery = "desc",
+    q: SearchQuery = None,
 ):
     """List workspaces owned by the user.
 
@@ -231,11 +242,11 @@ async def list_workspaces(
 async def list_shared_workspaces(
     user: dict = Depends(auth.get_current_user),
     app=Depends(get_app_dep),
-    limit: int | None = Query(None, ge=1, le=100),
-    offset: int | None = Query(None, ge=0),
-    sort: Literal["name", "created"] = Query("created"),
-    order: Literal["asc", "desc"] = Query("desc"),
-    q: str | None = Query(None),
+    limit: LimitQuery = None,
+    offset: OffsetQuery = None,
+    sort: SortQuery = "created",
+    order: OrderQuery = "desc",
+    q: SearchQuery = None,
 ):
     """List workspaces shared with the user.
 

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -988,6 +988,22 @@ def is_container_ready_event(msg) -> bool:
     )
 
 
+async def recv_json_messages(ws, timeout: float):
+    """Yield decoded server messages until *timeout* elapses overall.
+
+    The shared bounded receive loop of the terminal command paths
+    (#2546): each caller breaks on the frame it needs (and buffers or
+    ignores the rest) while one deadline caps the whole exchange.
+    Raises asyncio.TimeoutError when the deadline passes first."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:  # pragma: no cover
+            raise asyncio.TimeoutError
+        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        yield json.loads(raw)
+
+
 @asynccontextmanager
 async def workspace_ws(server_spec, token, workspace_id, max_size=None):
     """Connected workspace WebSocket, ready for commands.
@@ -1125,13 +1141,7 @@ async def start_ssh_agent_forward(
     if forward_agent and local_agent_sock and os.path.exists(local_agent_sock):
         await ws.send(json.dumps({"cmd": "ssh_agent_start"}))
         try:
-            deadline = asyncio.get_event_loop().time() + 10
-            while True:
-                remaining = deadline - asyncio.get_event_loop().time()
-                if remaining <= 0:  # pragma: no cover
-                    break
-                raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-                msg = json.loads(raw)
+            async for msg in recv_json_messages(ws, 10):
                 if msg.get("type") == "ssh_agent_started":
                     ssh_agent_active = True
                     break
@@ -1159,13 +1169,12 @@ async def drain_terminal_startup(
     shared_terminals: list[dict] = []
     buffered_output: list[str] = []
     try:
-        deadline = asyncio.get_event_loop().time() + 30
-        while True:
-            remaining = deadline - asyncio.get_event_loop().time()
-            if remaining <= 0:  # pragma: no cover
-                raise asyncio.TimeoutError
-            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-            msg = json.loads(raw)
+        # recv_json_messages only ends by raising (deadline), so the
+        # async-for can never complete normally — break/raise are the
+        # only exits.
+        async for msg in recv_json_messages(  # pragma: no branch
+            ws, 30
+        ):
             if msg.get("type") == "terminal_windows":
                 own_windows = msg.get("windows", [])
                 if not needs_shared:
@@ -1206,14 +1215,11 @@ async def join_shared_terminal(
             }
         )
     )
-    # Wait for terminal_started confirmation
-    deadline = asyncio.get_event_loop().time() + 10
-    while True:
-        remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:  # pragma: no cover
-            raise asyncio.TimeoutError
-        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-        msg = json.loads(raw)
+    # Wait for terminal_started confirmation (the generator only ends
+    # by raising — break/raise are the only exits).
+    async for msg in recv_json_messages(  # pragma: no branch
+        ws, 10
+    ):
         if msg.get("type") == "terminal_started":
             break
         if msg.get("type") == "terminal_output":
@@ -1305,13 +1311,8 @@ async def create_own_window(
             }
         )
     )
-    deadline = asyncio.get_event_loop().time() + 10
-    while True:
-        remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:  # pragma: no cover
-            raise asyncio.TimeoutError
-        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-        msg = json.loads(raw)
+    match: dict | None = None
+    async for msg in recv_json_messages(ws, 10):
         if msg.get("type") == "terminal_windows":
             new_windows = msg.get("windows", [])
             match = next(

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -11,6 +11,16 @@ from __future__ import annotations
 import typer
 
 from . import context
+from .options import (
+    ALLOW_OPTION,
+    CPU_LIMIT_OPTION,
+    ENV_OPTION,
+    IDLE_TIMEOUT_OPTION,
+    MEMORY_LIMIT_OPTION,
+    MOUNT_OPTION,
+    PIDS_LIMIT_OPTION,
+    REJECT_OPTION,
+)
 from .workspaces import _build_settings, _parse_env_list, _prompt, _SENTINEL
 from .mount import validate_allowed_domain_spec, validate_mount_spec
 
@@ -431,53 +441,6 @@ def merged_flag_settings(
     return merged
 
 
-def flag_edit_body(
-    ws,
-    *,
-    name: str | None,
-    image: str | None,
-    command: str | None,
-    auto_start: bool | None,
-    per_handle_home: bool | None,
-    health_check: str | None,
-    classification_banner: str | None,
-    mount: list[str] | None,
-    env: list[str] | None,
-    allow: list[str] | None,
-    reject: list[str] | None,
-    idle_timeout: int | None,
-    cpu_limit: float | None,
-    memory_limit: str | None,
-    pids_limit: int | None,
-    allow_sudo: bool | None,
-) -> dict:
-    """Build the PATCH body from only the flags the user provided."""
-    body = flag_scalar_body(
-        name=name,
-        image=image,
-        command=command,
-        auto_start=auto_start,
-        per_handle_home=per_handle_home,
-        health_check=health_check,
-        classification_banner=classification_banner,
-    )
-    body.update(
-        flag_list_body(
-            ws,
-            mount=mount,
-            env=env,
-            allow=allow,
-            reject=reject,
-            idle_timeout=idle_timeout,
-            cpu_limit=cpu_limit,
-            memory_limit=memory_limit,
-            pids_limit=pids_limit,
-            allow_sudo=allow_sudo,
-        )
-    )
-    return body
-
-
 def restart_needed(ws, body: dict) -> bool:
     """True if any create-time field changed on a running workspace."""
     if ws.running and bool(body.keys() & CREATE_TIME_KEYS):
@@ -540,43 +503,14 @@ def edit(
             "health (exit 0 = healthy). Use '' to clear."
         ),
     ),
-    mount: list[str] | None = typer.Option(
-        None,
-        "--mount",
-        help="Mount, repeatable (e.g. /home/me/src:/work/src, nix-vol:/nix)",
-    ),
-    env: list[str] | None = typer.Option(
-        None,
-        "--env",
-        help="Environment variable, repeatable (e.g. KEY=VALUE)",
-    ),
-    allow: list[str] | None = typer.Option(
-        None,
-        "--allow",
-        help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
-    ),
-    reject: list[str] | None = typer.Option(
-        None,
-        "--reject",
-        help=(
-            "Rejected egress domain (NXDOMAIN'd), repeatable "
-            "(e.g. evil.example.com). CIDR ranges are not supported."
-        ),
-    ),
-    idle_timeout: int | None = typer.Option(
-        None,
-        "--idle-timeout",
-        help="Idle timeout in seconds (0 = never idle out)",
-    ),
-    cpu_limit: float | None = typer.Option(
-        None, "--cpu-limit", help="CPU limit (e.g. 2.0)"
-    ),
-    memory_limit: str | None = typer.Option(
-        None, "--memory-limit", help="Memory limit (e.g. 4g, 512m)"
-    ),
-    pids_limit: int | None = typer.Option(
-        None, "--pids-limit", help="PIDs limit (e.g. 512)"
-    ),
+    mount: list[str] | None = MOUNT_OPTION,
+    env: list[str] | None = ENV_OPTION,
+    allow: list[str] | None = ALLOW_OPTION,
+    reject: list[str] | None = REJECT_OPTION,
+    idle_timeout: int | None = IDLE_TIMEOUT_OPTION,
+    cpu_limit: float | None = CPU_LIMIT_OPTION,
+    memory_limit: str | None = MEMORY_LIMIT_OPTION,
+    pids_limit: int | None = PIDS_LIMIT_OPTION,
     allow_sudo: bool | None = typer.Option(
         None,
         "--sudo/--no-sudo",
@@ -624,8 +558,7 @@ def edit(
         allow_sudo=allow_sudo,
         classification_banner=classification_banner,
     ):
-        body = flag_edit_body(
-            ws,
+        body = flag_scalar_body(
             name=name,
             image=image,
             command=command,
@@ -633,15 +566,20 @@ def edit(
             per_handle_home=per_handle_home,
             health_check=health_check,
             classification_banner=classification_banner,
-            mount=mount,
-            env=env,
-            allow=allow,
-            reject=reject,
-            idle_timeout=idle_timeout,
-            cpu_limit=cpu_limit,
-            memory_limit=memory_limit,
-            pids_limit=pids_limit,
-            allow_sudo=allow_sudo,
+        )
+        body.update(
+            flag_list_body(
+                ws,
+                mount=mount,
+                env=env,
+                allow=allow,
+                reject=reject,
+                idle_timeout=idle_timeout,
+                cpu_limit=cpu_limit,
+                memory_limit=memory_limit,
+                pids_limit=pids_limit,
+                allow_sudo=allow_sudo,
+            )
         )
     else:
         body = interactive_edit_body(ws)

--- a/src/klangk/klangk/cli/options.py
+++ b/src/klangk/klangk/cli/options.py
@@ -1,0 +1,50 @@
+"""Shared ``typer.Option`` declarations for the workspace commands.
+
+The create and edit commands expose the same repeatable flags with the
+same help text; declaring each option once keeps the two signatures from
+drifting (#2904). Reusing one ``OptionInfo`` across commands is safe —
+typer reads it when building each command's click parameters and never
+mutates it.
+"""
+
+from __future__ import annotations
+
+import typer
+
+MOUNT_OPTION = typer.Option(
+    None,
+    "--mount",
+    help="Mount, repeatable (e.g. /home/me/src:/work/src, nix-vol:/nix)",
+)
+ENV_OPTION = typer.Option(
+    None,
+    "--env",
+    help="Environment variable, repeatable (e.g. KEY=VALUE)",
+)
+ALLOW_OPTION = typer.Option(
+    None,
+    "--allow",
+    help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
+)
+REJECT_OPTION = typer.Option(
+    None,
+    "--reject",
+    help=(
+        "Rejected egress domain (NXDOMAIN'd), repeatable "
+        "(e.g. evil.example.com). CIDR ranges are not supported."
+    ),
+)
+IDLE_TIMEOUT_OPTION = typer.Option(
+    None,
+    "--idle-timeout",
+    help="Idle timeout in seconds (0 = never idle out)",
+)
+CPU_LIMIT_OPTION = typer.Option(
+    None, "--cpu-limit", help="CPU limit (e.g. 2.0)"
+)
+MEMORY_LIMIT_OPTION = typer.Option(
+    None, "--memory-limit", help="Memory limit (e.g. 4g, 512m)"
+)
+PIDS_LIMIT_OPTION = typer.Option(
+    None, "--pids-limit", help="PIDs limit (e.g. 512)"
+)

--- a/src/klangk/klangk/cli/terminals.py
+++ b/src/klangk/klangk/cli/terminals.py
@@ -240,48 +240,12 @@ def share_terminal(
     ),
 ) -> None:
     """Share a terminal with other workspace members."""
-    ws, sspec, token = _resolve_workspace_and_url(workspace)
-    max_size = context.ws_max_size()
-
-    async def _share() -> None:
-        async with workspace_ws(
-            sspec, token, ws.id, max_size=max_size
-        ) as conn:
-            await conn.send(json.dumps({"cmd": "ui_ready"}))
-
-            # Wait for container_ready
-            await recv_until_event(conn, 60)
-
-            # Start terminal to get window list
-            cols, rows = get_terminal_size()
-            await conn.send(
-                json.dumps(
-                    {"cmd": "terminal_start", "cols": cols, "rows": rows}
-                )
-            )
-            msg = await recv_until(conn, frame_is("terminal_windows"), 30)
-            own_windows: list[dict] = msg.get("windows", [])
-            match, err = _resolve_own_window(own_windows, terminal)
-            if err is not None:
-                context._err.print(f"[red]{err}[/red]")
-                raise typer.Exit(code=1)
-
-            await conn.send(
-                json.dumps({"cmd": "share_window", "window_id": match["id"]})
-            )
-            # Wait for shared_terminals confirmation
-            await recv_until(
-                conn, frame_is("shared_terminals"), CONFIRM_TIMEOUT
-            )
-            context._err.print(
-                f"[green]Terminal '{terminal}' is now shared[/green]"
-            )
-
-            await send_ignore_closed(
-                conn, json.dumps({"cmd": "terminal_stop"})
-            )
-
-    context.run_ws_command(_share)
+    _set_terminal_shared(
+        workspace,
+        terminal,
+        cmd="share_window",
+        done_msg=f"Terminal '{terminal}' is now shared",
+    )
 
 
 @terminal_app.command("unshare")
@@ -292,10 +256,28 @@ def unshare_terminal(
     ),
 ) -> None:
     """Stop sharing a terminal."""
+    _set_terminal_shared(
+        workspace,
+        terminal,
+        cmd="unshare_window",
+        done_msg=f"Terminal '{terminal}' is no longer shared",
+    )
+
+
+def _set_terminal_shared(
+    workspace: str, terminal: str, *, cmd: str, done_msg: str
+) -> None:
+    """Shared body of ``klangk terminal share`` / ``unshare``.
+
+    Connects, starts a scratch terminal to enumerate the own-window
+    list, resolves *terminal* to one window, sends *cmd* (``share_window``
+    or ``unshare_window``) for it, waits for the refreshed
+    shared-terminals list, then stops the scratch terminal.
+    """
     ws, sspec, token = _resolve_workspace_and_url(workspace)
     max_size = context.ws_max_size()
 
-    async def _unshare() -> None:
+    async def run() -> None:
         async with workspace_ws(
             sspec, token, ws.id, max_size=max_size
         ) as conn:
@@ -312,26 +294,20 @@ def unshare_terminal(
                 )
             )
             msg = await recv_until(conn, frame_is("terminal_windows"), 30)
-            own_windows: list[dict] = msg.get("windows", [])
-
-            match, err = _resolve_own_window(own_windows, terminal)
+            match, err = _resolve_own_window(msg.get("windows", []), terminal)
             if err is not None:
                 context._err.print(f"[red]{err}[/red]")
                 raise typer.Exit(code=1)
 
-            await conn.send(
-                json.dumps({"cmd": "unshare_window", "window_id": match["id"]})
-            )
+            await conn.send(json.dumps({"cmd": cmd, "window_id": match["id"]}))
             # Wait for shared_terminals confirmation
             await recv_until(
                 conn, frame_is("shared_terminals"), CONFIRM_TIMEOUT
             )
-            context._err.print(
-                f"[green]Terminal '{terminal}' is no longer shared[/green]"
-            )
+            context._err.print(f"[green]{done_msg}[/green]")
 
             await send_ignore_closed(
                 conn, json.dumps({"cmd": "terminal_stop"})
             )
 
-    context.run_ws_command(_unshare)
+    context.run_ws_command(run)

--- a/src/klangk/klangk/cli/tui/screens/_base.py
+++ b/src/klangk/klangk/cli/tui/screens/_base.py
@@ -131,6 +131,20 @@ class ButtonRowModalScreen(ModalScreen[_ScreenResult]):
         value (False for ConfirmScreen; None for Input/Duplicate)."""
         self.dismiss(None)
 
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """OK commits, anything else cancels. Subclasses with other
+        button sets override (ConfirmScreen dismisses by which button
+        it was)."""
+        if event.button.id == "ok":
+            self._commit()
+        elif event.button.id == "cancel":
+            self._dismiss_cancel()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Enter in the input field is an OK."""
+        if event.input.id == self._INPUT:
+            self._commit()
+
 
 def confirm_then(screen, work):
     """A ConfirmScreen callback that runs *work* on *screen*'s worker when
@@ -536,16 +550,6 @@ class DuplicateScreen(ButtonRowModalScreen):
         name = self.query_one("#dup_name", Input).value.strip()
         self.dismiss(name or None)
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "ok":
-            self._commit()
-        elif event.button.id == "cancel":
-            self.dismiss(None)
-
-    def on_input_submitted(self, event: Input.Submitted) -> None:
-        if event.input.id == "dup_name":
-            self._commit()
-
 
 def _human_bytes(n: float) -> str:
     """Format a byte count as e.g. ``"12.3 MB"``."""
@@ -627,16 +631,6 @@ class InputScreen(ButtonRowModalScreen):
     def _commit(self) -> None:
         val = self.query_one("#inp_value", Input).value.strip()
         self.dismiss(val or None)
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "ok":
-            self._commit()
-        elif event.button.id == "cancel":
-            self.dismiss(None)
-
-    def on_input_submitted(self, event: Input.Submitted) -> None:
-        if event.input.id == "inp_value":
-            self._commit()
 
 
 class CheatsheetScreen(ModalScreen):

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -128,6 +128,195 @@ def dispatch_editor_button(screen, bid: str) -> None:
         getattr(screen, handler)()
 
 
+# Enter in an editor input is an Add (mirrors _EDITOR_BUTTON_HANDLERS).
+_EDITOR_INPUT_HANDLERS = {
+    "mount_input": "_add_mount",
+    "env_input": "_add_env",
+    "allow_input": "_add_allowed_domain",
+    "reject_input": "_add_rejected_domain",
+}
+
+
+def compose_general_pane(
+    image_select, *, name="", auto_start=False, nix=False, allow_sudo=True
+) -> ComposeResult:
+    """The General tab: identity + the three deploy-gated toggles.
+
+    Shared by the create and edit forms (#1891, #2904) — the panes build
+    the same widget tree; the seeds differ (create defaults vs the
+    workspace's current values)."""
+    with TabPane("General", id="general_pane"):
+        yield Horizontal(
+            Static("Name"), Input(value=name, id="name"), classes="field-row"
+        )
+        yield Horizontal(Static("Image"), image_select, classes="field-row")
+        yield Checkbox("Auto start", value=auto_start, id="auto_start")
+        yield Checkbox("Mount /nix dir", value=nix, id="nix")
+        yield Checkbox(
+            "Allow sudo (uncheck to lock down)",
+            value=allow_sudo,
+            id="allow_sudo",
+        )
+
+
+def compose_mounts_pane() -> ComposeResult:
+    """The Mounts tab: string-list editor (shared by both forms)."""
+    with TabPane("Mounts", id="mounts_pane"):
+        yield Static(
+            "Mounts  (source:/container/path[:opts])",
+            classes="editor-label",
+        )
+        yield Horizontal(
+            Input(
+                id="mount_input",
+                placeholder="/host/path:/container/path",
+            ),
+            Button("Add", id="add_mount"),
+            Button("Remove", id="rm_mount"),
+        )
+        yield OptionList(id="mount_list", classes="editor-list")
+
+
+def compose_environment_pane() -> ComposeResult:
+    """The Environment tab: KEY=VALUE list editor (shared by both forms)."""
+    with TabPane("Environment", id="env_pane"):
+        yield Static("Environment  (KEY=VALUE)", classes="editor-label")
+        yield Horizontal(
+            Input(id="env_input", placeholder="KEY=VALUE"),
+            Button("Add", id="add_env"),
+            Button("Remove", id="rm_env"),
+        )
+        yield OptionList(id="env_list", classes="editor-list")
+
+
+def compose_netfilter_pane(egress_mode: str) -> ComposeResult:
+    """The Netfilter tab: egress-mode picker + allow/reject editors
+    (shared by both forms)."""
+    with TabPane("Netfilter", id="netfilter_pane"):
+        yield Horizontal(
+            Static("Egress mode"),
+            Select(
+                _EGRESS_MODE_OPTIONS,
+                value=egress_mode,
+                id="egress_mode",
+            ),
+            classes="field-row",
+        )
+        yield Static(
+            "Allowed Domains  (host or host:port; empty = unrestricted)",
+            classes="editor-label",
+        )
+        yield Horizontal(
+            Input(id="allow_input", placeholder="github.com:443"),
+            Button("Add", id="add_allow"),
+            Button("Remove", id="rm_allow"),
+        )
+        yield OptionList(id="allow_list", classes="editor-list")
+        yield Static(
+            "Rejected Domains  "
+            "(host or host:port; NXDOMAIN'd unconditionally)",
+            classes="editor-label",
+        )
+        yield Horizontal(
+            Input(id="reject_input", placeholder="evil.example.com"),
+            Button("Add", id="add_reject"),
+            Button("Remove", id="rm_reject"),
+        )
+        yield OptionList(id="reject_list", classes="editor-list")
+
+
+def compose_resources_pane(seeded: dict[str, str]) -> ComposeResult:
+    """The Resources tab: the five limit inputs (shared by both forms;
+    *seeded* carries the edit form's current values, all-empty on
+    create)."""
+    with TabPane("Resources", id="resources_pane"):
+        yield Horizontal(
+            Static("Idle timeout (s)"),
+            Input(
+                value=seeded["idle_timeout"],
+                id="idle_timeout",
+                placeholder="seconds (0 = never)",
+            ),
+            classes="field-row",
+        )
+        yield Horizontal(
+            Static("CPU limit"),
+            Input(
+                value=seeded["cpu_limit"],
+                id="cpu_limit",
+                placeholder="e.g. 2.0",
+            ),
+            classes="field-row",
+        )
+        yield Horizontal(
+            Static("Memory limit"),
+            Input(
+                value=seeded["memory_limit"],
+                id="memory_limit",
+                placeholder="e.g. 4g, 512m",
+            ),
+            classes="field-row",
+        )
+        yield Horizontal(
+            Static("PIDs limit"),
+            Input(
+                value=seeded["pids_limit"],
+                id="pids_limit",
+                placeholder="e.g. 512",
+            ),
+            classes="field-row",
+        )
+        yield Horizontal(
+            Static("/tmp size"),
+            Input(
+                value=seeded["tmp_size"],
+                id="tmp_size",
+                placeholder="e.g. 2g, 512m",
+            ),
+            classes="field-row",
+        )
+
+
+def compose_advanced_pane(
+    *,
+    per_handle_home: bool,
+    classification_banner: str = "",
+    service_command: str = "",
+    health_check: str = "",
+) -> ComposeResult:
+    """The Advanced tab: home layout, marking, service command, health
+    check (shared by both forms; the seeds differ)."""
+    with TabPane("Advanced", id="advanced_pane"):
+        yield Horizontal(
+            Static("Home layout"),
+            Checkbox(
+                "per-handle (off = shared home)",
+                value=per_handle_home,
+                id="per_handle_home",
+            ),
+            classes="field-row",
+        )
+        yield Horizontal(
+            Static("Marking"),
+            Input(
+                value=classification_banner,
+                id="classification_banner",
+                placeholder=("e.g. CUI (empty = server default)"),
+            ),
+            classes="field-row",
+        )
+        yield Horizontal(
+            Static("Command"),
+            Input(value=service_command, id="command"),
+            classes="field-row",
+        )
+        yield Horizontal(
+            Static("Health"),
+            Input(value=health_check, id="health_check"),
+            classes="field-row",
+        )
+
+
 # Egress-mode picker options for the create/edit Netfilter tab (#2409).
 # The CLI is an isolated client (AGENTS.md "CLI subpackage isolation") and
 # cannot import the server's EGRESS_MODE_* constants, so the mode strings are
@@ -346,6 +535,116 @@ class WorkspaceFormMixin:
         inp.focus()
         self._msg(f"Editing {label} — press Add to update.")
 
+    # --- env (dict-keyed) editor actions, the analogue of the string
+    # list editors above; #1778 in-place edits track a key rather than
+    # an index, so the edit form passes its _editing_env attr ---
+
+    def add_env_entry(self, editing_attr: str | None = None) -> None:
+        """Add the env input's KEY=VALUE to the map, then re-render.
+
+        With *editing_attr* naming an in-place-edit key attribute
+        (EditWorkspaceScreen, #1778), a pending edit of another key is
+        removed first so the update lands under the (possibly renamed)
+        new key."""
+        inp = self.query_one("#env_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate_env_entry(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        key, _, value = v.partition("=")
+        if editing_attr:
+            old = getattr(self, editing_attr)
+            if old is not None:
+                self._env.pop(old, None)
+                setattr(self, editing_attr, None)
+        self._env[key] = value
+        inp.value = ""
+        self._msg("")
+        self._render_env()
+
+    def remove_env_entry(self, editing_attr: str | None = None) -> None:
+        """Delete the highlighted env key from the map, then re-render.
+
+        Clears a pending in-place edit (*editing_attr*) along with it."""
+        ol = self.query_one("#env_list", OptionList)
+        idx = ol.highlighted
+        keys = list(self._env)
+        if idx is None or not 0 <= idx < len(keys):
+            return
+        del self._env[keys[idx]]
+        if editing_attr:
+            setattr(self, editing_attr, None)
+        self._render_env()
+
+    # --- shared on_mount / event dispatch (create + edit) ---
+
+    def image_select(self) -> Select:
+        """The image picker: preselected when a default is available,
+        blank otherwise (the server applies its default image)."""
+        if self._select_value is not None:
+            return Select(
+                self._select_options, value=self._select_value, id="image"
+            )
+        return Select(self._select_options, id="image")
+
+    def form_on_mount(self) -> None:
+        """Shared on_mount: apply deploy-gated toggle visibility, seed
+        the list editors, and focus Name (General is the entry tab).
+        Screens with extra toggles (create's home-layout default)
+        handle theirs before/after calling this."""
+        shown = self._allow_autostart
+        cb = self.query_one("#auto_start", Checkbox)
+        cb.display = shown
+        cb.disabled = not shown
+        # The nix toggle is shown only when the server has a nix backend
+        # (#2233); otherwise hidden + disabled so Tab skips it.
+        nix_cb = self.query_one("#nix", Checkbox)
+        nix_cb.display = self._nix_available
+        nix_cb.disabled = not self._nix_available
+        # #2017: the sudo toggle is shown only when the deploy allows
+        # sudo; hidden otherwise (the knob could only ever be a no-op).
+        sudo_cb = self.query_one("#allow_sudo", Checkbox)
+        sudo_cb.display = self._sudo_available
+        sudo_cb.disabled = not self._sudo_available
+        self._skip_editors_on_tab()
+        self._render_mounts()
+        self._render_env()
+        self._render_allowed_domains()
+        self._render_rejected_domains()
+        # General tab is active on entry — focus Name so the user can
+        # start typing immediately (the tab strip is one Up away, #1891).
+        self.query_one("#name", Input).focus()
+
+    def handle_form_button(
+        self, event: Button.Pressed, *, submit_id: str, cancel_result, submit
+    ) -> None:
+        """Shared button dispatch: cancel dismisses (with
+        *cancel_result*), the screen's submit button runs *submit*, and
+        anything else falls through to the editor buttons."""
+        bid = event.button.id
+        if bid == "cancel":
+            self.dismiss(cancel_result)
+            return
+        if bid == submit_id:
+            submit()
+            return
+        dispatch_editor_button(self, bid)
+
+    def handle_form_input_submitted(
+        self, event: Input.Submitted, *, submit_ids, submit
+    ) -> None:
+        """Shared Enter dispatch: an editor input Adds its entry; a
+        scalar input in *submit_ids* submits the form."""
+        eid = event.input.id
+        action = _EDITOR_INPUT_HANDLERS.get(eid)
+        if action is not None:
+            getattr(self, action)()
+        elif eid in submit_ids:
+            submit()
+
     def _active_tab(self) -> str:
         """The id of the currently active form tab pane."""
         return self.query_one("#form_tabs", TabbedContent).active
@@ -494,150 +793,18 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         yield from super().compose()
 
     def compose_body(self) -> ComposeResult:
-        if self._select_value is not None:
-            image_select = Select(
-                self._select_options, value=self._select_value, id="image"
-            )
-        else:
-            # No valid default to preselect — leave the picker unselected
-            # (the server applies its default image if none is chosen).
-            image_select = Select(self._select_options, id="image")
         with NonFocusableVerticalScroll(id="create_box"):
             yield Static("New workspace", classes="title")
             yield Static("", id="create_msg")
             with TabbedContent(id="form_tabs"):
-                with TabPane("General", id="general_pane"):
-                    yield Horizontal(
-                        Static("Name"), Input(id="name"), classes="field-row"
-                    )
-                    yield Horizontal(
-                        Static("Image"), image_select, classes="field-row"
-                    )
-                    yield Checkbox("Auto start", id="auto_start")
-                    yield Checkbox("Mount /nix dir", id="nix")
-                    yield Checkbox(
-                        "Allow sudo (uncheck to lock down)",
-                        value=True,
-                        id="allow_sudo",
-                    )
-                with TabPane("Mounts", id="mounts_pane"):
-                    yield Static(
-                        "Mounts  (source:/container/path[:opts])",
-                        classes="editor-label",
-                    )
-                    yield Horizontal(
-                        Input(
-                            id="mount_input",
-                            placeholder="/host/path:/container/path",
-                        ),
-                        Button("Add", id="add_mount"),
-                        Button("Remove", id="rm_mount"),
-                    )
-                    yield OptionList(id="mount_list", classes="editor-list")
-                with TabPane("Environment", id="env_pane"):
-                    yield Static(
-                        "Environment  (KEY=VALUE)", classes="editor-label"
-                    )
-                    yield Horizontal(
-                        Input(id="env_input", placeholder="KEY=VALUE"),
-                        Button("Add", id="add_env"),
-                        Button("Remove", id="rm_env"),
-                    )
-                    yield OptionList(id="env_list", classes="editor-list")
-                with TabPane("Netfilter", id="netfilter_pane"):
-                    yield Horizontal(
-                        Static("Egress mode"),
-                        Select(
-                            _EGRESS_MODE_OPTIONS,
-                            value=EGRESS_MODE_DEFAULT,
-                            id="egress_mode",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Static(
-                        "Allowed Domains  "
-                        "(host or host:port; empty = unrestricted)",
-                        classes="editor-label",
-                    )
-                    yield Horizontal(
-                        Input(id="allow_input", placeholder="github.com:443"),
-                        Button("Add", id="add_allow"),
-                        Button("Remove", id="rm_allow"),
-                    )
-                    yield OptionList(id="allow_list", classes="editor-list")
-                    yield Static(
-                        "Rejected Domains  "
-                        "(host or host:port; NXDOMAIN'd unconditionally)",
-                        classes="editor-label",
-                    )
-                    yield Horizontal(
-                        Input(
-                            id="reject_input", placeholder="evil.example.com"
-                        ),
-                        Button("Add", id="add_reject"),
-                        Button("Remove", id="rm_reject"),
-                    )
-                    yield OptionList(id="reject_list", classes="editor-list")
-                with TabPane("Resources", id="resources_pane"):
-                    yield Horizontal(
-                        Static("Idle timeout (s)"),
-                        Input(
-                            id="idle_timeout",
-                            placeholder="seconds (0 = never)",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("CPU limit"),
-                        Input(id="cpu_limit", placeholder="e.g. 2.0"),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Memory limit"),
-                        Input(
-                            id="memory_limit",
-                            placeholder="e.g. 4g, 512m",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("PIDs limit"),
-                        Input(id="pids_limit", placeholder="e.g. 512"),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("/tmp size"),
-                        Input(id="tmp_size", placeholder="e.g. 2g, 512m"),
-                        classes="field-row",
-                    )
-                with TabPane("Advanced", id="advanced_pane"):
-                    yield Horizontal(
-                        Static("Home layout"),
-                        Checkbox(
-                            "per-handle (off = shared home)",
-                            value=bool(self._default_per_handle_home),
-                            id="per_handle_home",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Marking"),
-                        Input(
-                            id="classification_banner",
-                            placeholder=("e.g. CUI (empty = server default)"),
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Command"),
-                        Input(id="command"),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Health"),
-                        Input(id="health_check"),
-                        classes="field-row",
-                    )
+                yield from compose_general_pane(self.image_select())
+                yield from compose_mounts_pane()
+                yield from compose_environment_pane()
+                yield from compose_netfilter_pane(EGRESS_MODE_DEFAULT)
+                yield from compose_resources_pane(_seeded_setting_values({}))
+                yield from compose_advanced_pane(
+                    per_handle_home=bool(self._default_per_handle_home),
+                )
             yield Horizontal(
                 Button("Cancel", id="cancel"),
                 Button("Create", id="create", variant="primary"),
@@ -645,20 +812,7 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             )
 
     def on_mount(self) -> None:
-        shown = self._allow_autostart
-        cb = self.query_one("#auto_start", Checkbox)
-        cb.display = shown
-        cb.disabled = not shown
-        # The nix toggle is shown only when the server has a nix backend
-        # (#2233); otherwise hidden + disabled so Tab skips it.
-        nix_cb = self.query_one("#nix", Checkbox)
-        nix_cb.display = self._nix_available
-        nix_cb.disabled = not self._nix_available
-        # #2017: the sudo toggle is shown only when the deploy allows sudo;
-        # hidden otherwise (the knob could only ever be a no-op).
-        sudo_cb = self.query_one("#allow_sudo", Checkbox)
-        sudo_cb.display = self._sudo_available
-        sudo_cb.disabled = not self._sudo_available
+        self.form_on_mount()
         # The home-layout toggle is hidden when the deploy default is
         # unknown (fetch failure): an offered choice we can't pre-reflect
         # would pin a possibly-wrong value, so the field is omitted and
@@ -666,14 +820,6 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         phh_cb = self.query_one("#per_handle_home", Checkbox)
         phh_cb.display = self._default_per_handle_home is not None
         phh_cb.disabled = self._default_per_handle_home is None
-        self._skip_editors_on_tab()
-        self._render_mounts()
-        self._render_env()
-        self._render_allowed_domains()
-        self._render_rejected_domains()
-        # General tab is active on entry — focus Name so the user can start
-        # typing immediately (the tab strip is one Up away, #1891).
-        self.query_one("#name", Input).focus()
 
     def _msg(self, text: str, *, error: bool = False) -> None:
         self.query_one("#create_msg", Static).update(
@@ -698,28 +844,10 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     # --- env list editor ---
 
     def _add_env(self) -> None:
-        inp = self.query_one("#env_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
-        err = validate_env_entry(v)
-        if err:
-            self._msg(err, error=True)
-            return
-        key, _, value = v.partition("=")
-        self._env[key] = value
-        inp.value = ""
-        self._msg("")
-        self._render_env()
+        self.add_env_entry()
 
     def _remove_env(self) -> None:
-        ol = self.query_one("#env_list", OptionList)
-        idx = ol.highlighted
-        keys = list(self._env)
-        if idx is None or not 0 <= idx < len(keys):
-            return
-        del self._env[keys[idx]]
-        self._render_env()
+        self.remove_env_entry()
 
     # --- allowed-domains list editor (#1745) ---
 
@@ -905,37 +1033,29 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     # --- event handlers ---
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        bid = event.button.id
-        if bid == "cancel":
-            self.dismiss(None)
-            return
-        if bid == "create":
-            self._create()
-            return
-        dispatch_editor_button(self, bid)
+        self.handle_form_button(
+            event,
+            submit_id="create",
+            cancel_result=None,
+            submit=self._create,
+        )
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        eid = event.input.id
-        if eid == "mount_input":
-            self._add_mount()
-        elif eid == "env_input":
-            self._add_env()
-        elif eid == "allow_input":
-            self._add_allowed_domain()
-        elif eid == "reject_input":
-            self._add_rejected_domain()
-        elif eid in (
-            "name",
-            "command",
-            "health_check",
-            "classification_banner",
-            "idle_timeout",
-            "cpu_limit",
-            "memory_limit",
-            "pids_limit",
-            "tmp_size",
-        ):
-            self._create()
+        self.handle_form_input_submitted(
+            event,
+            submit_ids=(
+                "name",
+                "command",
+                "health_check",
+                "classification_banner",
+                "idle_timeout",
+                "cpu_limit",
+                "memory_limit",
+                "pids_limit",
+                "tmp_size",
+            ),
+            submit=self._create,
+        )
 
 
 def _edit_picker_options(
@@ -1095,183 +1215,35 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         yield from super().compose()
 
     def compose_body(self) -> ComposeResult:
-        if self._select_value is not None:
-            image_select = Select(
-                self._select_options, value=self._select_value, id="image"
-            )
-        else:  # pragma: no cover
-            image_select = Select(self._select_options, id="image")
         with NonFocusableVerticalScroll(id="edit_box"):
             yield Static(
                 Text(f"Edit workspace: {self._ws.name}"), classes="title"
             )
             yield Static("", id="edit_msg")
             with TabbedContent(id="form_tabs"):
-                with TabPane("General", id="general_pane"):
-                    yield Horizontal(
-                        Static("Name"),
-                        Input(value=self._ws.name or "", id="name"),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Image"), image_select, classes="field-row"
-                    )
-                    yield Checkbox(
-                        "Auto start",
-                        value=self._ws.auto_start,
-                        id="auto_start",
-                    )
-                    yield Checkbox(
-                        "Mount /nix dir",
-                        value=bool((self._ws.settings or {}).get("nix")),
-                        id="nix",
-                    )
-                    yield Checkbox(
-                        "Allow sudo (uncheck to lock down)",
-                        value=bool(
-                            (self._ws.settings or {}).get("allow_sudo", True)
-                        ),
-                        id="allow_sudo",
-                    )
-                with TabPane("Mounts", id="mounts_pane"):
-                    yield Static(
-                        "Mounts  (source:/container/path[:opts])",
-                        classes="editor-label",
-                    )
-                    yield Horizontal(
-                        Input(
-                            id="mount_input",
-                            placeholder="/host/path:/container/path",
-                        ),
-                        Button("Add", id="add_mount"),
-                        Button("Remove", id="rm_mount"),
-                    )
-                    yield OptionList(id="mount_list", classes="editor-list")
-                with TabPane("Environment", id="env_pane"):
-                    yield Static(
-                        "Environment  (KEY=VALUE)", classes="editor-label"
-                    )
-                    yield Horizontal(
-                        Input(id="env_input", placeholder="KEY=VALUE"),
-                        Button("Add", id="add_env"),
-                        Button("Remove", id="rm_env"),
-                    )
-                    yield OptionList(id="env_list", classes="editor-list")
-                with TabPane("Netfilter", id="netfilter_pane"):
-                    yield Horizontal(
-                        Static("Egress mode"),
-                        Select(
-                            _EGRESS_MODE_OPTIONS,
-                            value=self._egress_mode,
-                            id="egress_mode",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Static(
-                        "Allowed Domains  "
-                        "(host or host:port; empty = unrestricted)",
-                        classes="editor-label",
-                    )
-                    yield Horizontal(
-                        Input(id="allow_input", placeholder="github.com:443"),
-                        Button("Add", id="add_allow"),
-                        Button("Remove", id="rm_allow"),
-                    )
-                    yield OptionList(id="allow_list", classes="editor-list")
-                    yield Static(
-                        "Rejected Domains  "
-                        "(host or host:port; NXDOMAIN'd unconditionally)",
-                        classes="editor-label",
-                    )
-                    yield Horizontal(
-                        Input(
-                            id="reject_input", placeholder="evil.example.com"
-                        ),
-                        Button("Add", id="add_reject"),
-                        Button("Remove", id="rm_reject"),
-                    )
-                    yield OptionList(id="reject_list", classes="editor-list")
-                with TabPane("Resources", id="resources_pane"):
-                    seeded = _seeded_setting_values(self._ws.settings or {})
-                    yield Horizontal(
-                        Static("Idle timeout (s)"),
-                        Input(
-                            value=seeded["idle_timeout"],
-                            id="idle_timeout",
-                            placeholder="seconds (0 = never)",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("CPU limit"),
-                        Input(
-                            value=seeded["cpu_limit"],
-                            id="cpu_limit",
-                            placeholder="e.g. 2.0",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Memory limit"),
-                        Input(
-                            value=seeded["memory_limit"],
-                            id="memory_limit",
-                            placeholder="e.g. 4g, 512m",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("PIDs limit"),
-                        Input(
-                            value=seeded["pids_limit"],
-                            id="pids_limit",
-                            placeholder="e.g. 512",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("/tmp size"),
-                        Input(
-                            value=seeded["tmp_size"],
-                            id="tmp_size",
-                            placeholder="e.g. 2g, 512m",
-                        ),
-                        classes="field-row",
-                    )
-                with TabPane("Advanced", id="advanced_pane"):
-                    yield Horizontal(
-                        Static("Home layout"),
-                        Checkbox(
-                            "per-handle (off = shared home)",
-                            value=self._per_handle_home,
-                            id="per_handle_home",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Marking"),
-                        Input(
-                            value=self._ws.classification_banner or "",
-                            id="classification_banner",
-                            placeholder="e.g. CUI (empty = server default)",
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Command"),
-                        Input(
-                            value=self._ws.service_command or "", id="command"
-                        ),
-                        classes="field-row",
-                    )
-                    yield Horizontal(
-                        Static("Health"),
-                        Input(
-                            value=self._ws.health_check or "",
-                            id="health_check",
-                        ),
-                        classes="field-row",
-                    )
+                yield from compose_general_pane(
+                    self.image_select(),
+                    name=self._ws.name or "",
+                    auto_start=self._ws.auto_start,
+                    nix=bool((self._ws.settings or {}).get("nix")),
+                    allow_sudo=bool(
+                        (self._ws.settings or {}).get("allow_sudo", True)
+                    ),
+                )
+                yield from compose_mounts_pane()
+                yield from compose_environment_pane()
+                yield from compose_netfilter_pane(self._egress_mode)
+                yield from compose_resources_pane(
+                    _seeded_setting_values(self._ws.settings or {})
+                )
+                yield from compose_advanced_pane(
+                    per_handle_home=self._per_handle_home,
+                    classification_banner=(
+                        self._ws.classification_banner or ""
+                    ),
+                    service_command=self._ws.service_command or "",
+                    health_check=self._ws.health_check or "",
+                )
             yield Horizontal(
                 Button("Cancel", id="cancel"),
                 Button("Save", id="save", variant="primary"),
@@ -1279,27 +1251,7 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             )
 
     def on_mount(self) -> None:
-        shown = self._allow_autostart
-        cb = self.query_one("#auto_start", Checkbox)
-        cb.display = shown
-        cb.disabled = not shown
-        # The nix toggle is shown only when the server has a nix backend
-        # (#2233); otherwise hidden + disabled so Tab skips it.
-        nix_cb = self.query_one("#nix", Checkbox)
-        nix_cb.display = self._nix_available
-        nix_cb.disabled = not self._nix_available
-        # #2017: the sudo toggle is shown only when the deploy allows sudo.
-        sudo_cb = self.query_one("#allow_sudo", Checkbox)
-        sudo_cb.display = self._sudo_available
-        sudo_cb.disabled = not self._sudo_available
-        self._skip_editors_on_tab()
-        self._render_mounts()
-        self._render_env()
-        self._render_allowed_domains()
-        self._render_rejected_domains()
-        # General tab is active on entry — focus Name so the user can start
-        # typing immediately (the tab strip is one Up away, #1891).
-        self.query_one("#name", Input).focus()
+        self.form_on_mount()
 
     def _msg(self, text: str, *, error: bool = False) -> None:
         self.query_one("#edit_msg", Static).update(
@@ -1326,33 +1278,10 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         )
 
     def _add_env(self) -> None:
-        inp = self.query_one("#env_input", Input)
-        v = inp.value.strip()
-        if not v:
-            return
-        err = validate_env_entry(v)
-        if err:
-            self._msg(err, error=True)
-            return
-        key, _, value = v.partition("=")
-        old = self._editing_env
-        if old is not None:
-            self._env.pop(old, None)
-            self._editing_env = None
-        self._env[key] = value
-        inp.value = ""
-        self._msg("")
-        self._render_env()
+        self.add_env_entry(editing_attr="_editing_env")
 
     def _remove_env(self) -> None:
-        ol = self.query_one("#env_list", OptionList)
-        idx = ol.highlighted
-        keys = list(self._env)
-        if idx is None or not 0 <= idx < len(keys):
-            return
-        del self._env[keys[idx]]
-        self._editing_env = None
-        self._render_env()
+        self.remove_env_entry(editing_attr="_editing_env")
 
     def _add_allowed_domain(self) -> None:
         self._add_list_entry(
@@ -1692,36 +1621,28 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     # --- event handlers ---
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        bid = event.button.id
-        if bid == "cancel":
-            self.dismiss(False)
-            return
-        if bid == "save":
-            self._save()
-            return
-        dispatch_editor_button(self, bid)
+        self.handle_form_button(
+            event,
+            submit_id="save",
+            cancel_result=False,
+            submit=self._save,
+        )
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        eid = event.input.id
-        if eid == "mount_input":
-            self._add_mount()
-        elif eid == "env_input":
-            self._add_env()
-        elif eid == "allow_input":
-            self._add_allowed_domain()
-        elif eid == "reject_input":
-            self._add_rejected_domain()
-        elif eid in (
-            "name",
-            "command",
-            "health_check",
-            "classification_banner",
-            "idle_timeout",
-            "cpu_limit",
-            "memory_limit",
-            "pids_limit",
-        ):
-            self._save()
+        self.handle_form_input_submitted(
+            event,
+            submit_ids=(
+                "name",
+                "command",
+                "health_check",
+                "classification_banner",
+                "idle_timeout",
+                "cpu_limit",
+                "memory_limit",
+                "pids_limit",
+            ),
+            submit=self._save,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -28,6 +28,16 @@ from .client import KlangkClient  # noqa: F401 (type annotations)
 from .client import WorkspaceNotFoundError
 from . import context
 from .mount import validate_allowed_domain_spec, validate_mount_spec
+from .options import (
+    ALLOW_OPTION,
+    CPU_LIMIT_OPTION,
+    ENV_OPTION,
+    IDLE_TIMEOUT_OPTION,
+    MEMORY_LIMIT_OPTION,
+    MOUNT_OPTION,
+    PIDS_LIMIT_OPTION,
+    REJECT_OPTION,
+)
 
 
 def workspace_status(ws) -> tuple[str, str]:
@@ -234,43 +244,14 @@ def create(
         "-c",
         help="Service shell command (see `klangk edit --command`).",
     ),
-    mount: list[str] | None = typer.Option(
-        None,
-        "--mount",
-        help="Mount, repeatable (e.g. /home/me/src:/work/src, nix-vol:/nix)",
-    ),
-    env: list[str] | None = typer.Option(
-        None,
-        "--env",
-        help="Environment variable, repeatable (e.g. KEY=VALUE)",
-    ),
-    allow: list[str] | None = typer.Option(
-        None,
-        "--allow",
-        help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
-    ),
-    reject: list[str] | None = typer.Option(
-        None,
-        "--reject",
-        help=(
-            "Rejected egress domain (NXDOMAIN'd), repeatable "
-            "(e.g. evil.example.com). CIDR ranges are not supported."
-        ),
-    ),
-    idle_timeout: int | None = typer.Option(
-        None,
-        "--idle-timeout",
-        help="Idle timeout in seconds (0 = never idle out)",
-    ),
-    cpu_limit: float | None = typer.Option(
-        None, "--cpu-limit", help="CPU limit (e.g. 2.0)"
-    ),
-    memory_limit: str | None = typer.Option(
-        None, "--memory-limit", help="Memory limit (e.g. 4g, 512m)"
-    ),
-    pids_limit: int | None = typer.Option(
-        None, "--pids-limit", help="PIDs limit (e.g. 512)"
-    ),
+    mount: list[str] | None = MOUNT_OPTION,
+    env: list[str] | None = ENV_OPTION,
+    allow: list[str] | None = ALLOW_OPTION,
+    reject: list[str] | None = REJECT_OPTION,
+    idle_timeout: int | None = IDLE_TIMEOUT_OPTION,
+    cpu_limit: float | None = CPU_LIMIT_OPTION,
+    memory_limit: str | None = MEMORY_LIMIT_OPTION,
+    pids_limit: int | None = PIDS_LIMIT_OPTION,
     allow_sudo: bool | None = typer.Option(
         None,
         "--sudo/--no-sudo",

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -11,6 +11,29 @@ from .users import AGENT_USER_ID, backfill_handles
 _DURATION_CHECK_VALUES = ", ".join(f"'{d}'" for d in sorted(DURATIONS))
 _DECISION_CHECK_VALUES = ", ".join(f"'{d}'" for d in sorted(DECISIONS))
 
+# egress_consent column DDL (#2239 baseline + #2339 revoked columns):
+# the baseline CREATE and the in-place-migration rebuild must describe
+# the same shape, so the column list is written once and the two CREATE
+# statements differ only in table name / IF NOT EXISTS.
+_EGRESS_CONSENT_COLUMNS = f"""(
+            id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            dest_host TEXT NOT NULL,
+            dest_port INTEGER,
+            pid INTEGER,
+            process_name TEXT,
+            decision TEXT NOT NULL DEFAULT 'pending'
+                CHECK (decision IN ({_DECISION_CHECK_VALUES})),
+            duration TEXT
+                CHECK (duration IS NULL OR duration IN
+                    ({_DURATION_CHECK_VALUES})),
+            requested_at REAL NOT NULL,
+            decided_at REAL,
+            decided_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+            revoked_at REAL,
+            revoked_by TEXT REFERENCES users(id) ON DELETE SET NULL
+        )"""
+
 
 async def init_users_table(db) -> None:
     """users table: baseline CREATE, the pre-migrations-era table
@@ -363,26 +386,12 @@ async def init_egress_consent_table(db) -> None:
     # connections that need human approval. CHECK constraints enforce
     # the decision state machine at the storage layer — the same
     # DB-backstop philosophy as the agent-user triggers above.
-    await db.execute(f"""
-        CREATE TABLE IF NOT EXISTS egress_consent (
-            id TEXT PRIMARY KEY,
-            workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-            dest_host TEXT NOT NULL,
-            dest_port INTEGER,
-            pid INTEGER,
-            process_name TEXT,
-            decision TEXT NOT NULL DEFAULT 'pending'
-                CHECK (decision IN ({_DECISION_CHECK_VALUES})),
-            duration TEXT
-                CHECK (duration IS NULL OR duration IN
-                    ({_DURATION_CHECK_VALUES})),
-            requested_at REAL NOT NULL,
-            decided_at REAL,
-            decided_by TEXT REFERENCES users(id) ON DELETE SET NULL,
-            revoked_at REAL,
-            revoked_by TEXT REFERENCES users(id) ON DELETE SET NULL
-        )
-    """)
+    await db.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS egress_consent
+        {_EGRESS_CONSENT_COLUMNS}
+        """
+    )
     # egress_consent: add the `revoked` decision (#2339) + the
     # `revoked_at`/`revoked_by` audit columns (and attach the CHECKs). The
     # table may already exist from #2338 (has the duration CHECK but not
@@ -396,26 +405,12 @@ async def init_egress_consent_table(db) -> None:
     )
     ec_sql_row = await ec_sql_cur.fetchone()
     if ec_sql_row and "revoked_at" not in ec_sql_row[0]:
-        await db.execute(f"""
-            CREATE TABLE egress_consent_new (
-                id TEXT PRIMARY KEY,
-                workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-                dest_host TEXT NOT NULL,
-                dest_port INTEGER,
-                pid INTEGER,
-                process_name TEXT,
-                decision TEXT NOT NULL DEFAULT 'pending'
-                    CHECK (decision IN ({_DECISION_CHECK_VALUES})),
-                duration TEXT
-                    CHECK (duration IS NULL OR duration IN
-                        ({_DURATION_CHECK_VALUES})),
-                requested_at REAL NOT NULL,
-                decided_at REAL,
-                decided_by TEXT REFERENCES users(id) ON DELETE SET NULL,
-                revoked_at REAL,
-                revoked_by TEXT REFERENCES users(id) ON DELETE SET NULL
-            )
-        """)
+        await db.execute(
+            f"""
+            CREATE TABLE egress_consent_new
+            {_EGRESS_CONSENT_COLUMNS}
+            """
+        )
         ec_info = await db.execute("PRAGMA table_info(egress_consent)")
         ec_old_cols = {r[1] for r in await ec_info.fetchall()}
         ec_shared = [

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -196,31 +196,56 @@ _WORKSPACE_FULL_COLUMNS = (
 )
 
 
-def _workspace_row_to_dict(row, *, auto_start=True) -> dict:
-    return {
+# JSON-blob columns decoded by the shared row mappers (one decode
+# rule, #2551/#2904).
+_JSON_BLOB_COLUMNS = (
+    "mounts",
+    "env",
+    "allowed_domains",
+    "rejected_domains",
+    "settings",
+)
+
+
+def _workspace_core_fields(row, *, auto_start=True) -> dict:
+    """Workspace fields shared by every API item shape: scalar columns
+    plus the JSON-blob columns decoded. The full-row, listing, and
+    shared-listing mappers build on this so the field list cannot drift
+    (#2551)."""
+    fields = {
         "id": row["id"],
-        "user_id": row["user_id"],
         "name": row["name"],
         "container_id": row["container_id"],
-        "num_ports": row["num_ports"],
         "image": row["image"],
         "service_command": row["service_command"],
         "auto_start": bool(row["auto_start"]) if auto_start else True,
         "setup_state": row["setup_state"],
         "health_check": row["health_check"],
-        "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
-        "env": json.loads(row["env"]) if row["env"] else None,
-        "allowed_domains": json.loads(row["allowed_domains"])
-        if row["allowed_domains"]
-        else None,
-        "rejected_domains": json.loads(row["rejected_domains"])
-        if row["rejected_domains"]
-        else None,
-        "settings": json.loads(row["settings"]) if row["settings"] else None,
         "egress_mode": row["egress_mode"],
         "per_handle_home": bool(row["per_handle_home"]),
         "classification_banner": row["classification_banner"],
     }
+    for col in _JSON_BLOB_COLUMNS:
+        fields[col] = json.loads(row[col]) if row[col] else None
+    return fields
+
+
+def _workspace_row_to_dict(row, *, auto_start=True) -> dict:
+    """The full-row shape: core fields plus the owner-only columns."""
+    return {
+        **_workspace_core_fields(row, auto_start=auto_start),
+        "user_id": row["user_id"],
+        "num_ports": row["num_ports"],
+    }
+
+
+def _workspace_list_item(row, *, owner_email: bool = False) -> dict:
+    """The listing shape: core fields plus ``created_at`` (and
+    ``owner_email`` for the shared-with-me listing)."""
+    item = {**_workspace_core_fields(row), "created_at": row["created_at"]}
+    if owner_email:
+        item["owner_email"] = row["owner_email"]
+    return item
 
 
 def coerce_workspace_field(key: str, value) -> object:
@@ -267,6 +292,52 @@ def mutate_domain_entries(current: list, spec: str, add: bool) -> bool:
         return True
     current.pop(idx)
     return False
+
+
+def _validated_create_kwargs(
+    *,
+    image: str | None = None,
+    service_command: str | None = None,
+    auto_start: bool = False,
+    mounts: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    setup_state: str = SETUP_STATE_COMPLETE,
+    health_check: str | None = None,
+    allowed_domains: list[str] | None = None,
+    rejected_domains: list[str] | None = None,
+    settings: dict | None = None,
+    egress_mode: str = EGRESS_MODE_DEFAULT,
+    per_handle_home: bool = True,
+    classification_banner: str | None = None,
+) -> dict:
+    """Validate the create params shared by both create methods and
+    return the :meth:`_insert_workspace_row` kwargs (banner normalized).
+
+    Defaults mirror the public create signatures. Raises ``ValueError``
+    on invalid enum values (checked before any write)."""
+    if setup_state not in SETUP_STATES:
+        raise ValueError(f"Invalid setup_state: {setup_state!r}")
+    if egress_mode not in EGRESS_MODES:
+        raise ValueError(f"Invalid egress_mode: {egress_mode!r}")
+    if not isinstance(per_handle_home, bool):
+        raise ValueError(f"Invalid per_handle_home: {per_handle_home!r}")
+    return dict(
+        image=image,
+        service_command=service_command,
+        auto_start=auto_start,
+        mounts=mounts,
+        env=env,
+        setup_state=setup_state,
+        health_check=health_check,
+        allowed_domains=allowed_domains,
+        rejected_domains=rejected_domains,
+        settings=settings,
+        egress_mode=egress_mode,
+        per_handle_home=per_handle_home,
+        classification_banner=normalize_classification_banner(
+            classification_banner
+        ),
+    )
 
 
 class WorkspacesModel:
@@ -496,89 +567,47 @@ class WorkspacesModel:
                 " wildcard owner ACE + owners-group membership makes its"
                 " UUID a privileged principal) — system agent"
             )
-        if setup_state not in SETUP_STATES:
-            raise ValueError(f"Invalid setup_state: {setup_state!r}")
-        if egress_mode not in EGRESS_MODES:
-            raise ValueError(f"Invalid egress_mode: {egress_mode!r}")
-        if not isinstance(per_handle_home, bool):
-            raise ValueError(f"Invalid per_handle_home: {per_handle_home!r}")
-        classification_banner = normalize_classification_banner(
-            classification_banner
+        insert = _validated_create_kwargs(
+            image=image,
+            service_command=service_command,
+            auto_start=auto_start,
+            mounts=mounts,
+            env=env,
+            setup_state=setup_state,
+            health_check=health_check,
+            allowed_domains=allowed_domains,
+            rejected_domains=rejected_domains,
+            settings=settings,
+            egress_mode=egress_mode,
+            per_handle_home=per_handle_home,
+            classification_banner=classification_banner,
         )
         async with self.app.state.db.transaction() as db:
-            ws = await self._insert_workspace_row(
-                db,
-                user_id,
-                name,
-                image=image,
-                service_command=service_command,
-                auto_start=auto_start,
-                mounts=mounts,
-                env=env,
-                setup_state=setup_state,
-                health_check=health_check,
-                allowed_domains=allowed_domains,
-                rejected_domains=rejected_domains,
-                settings=settings,
-                egress_mode=egress_mode,
-                per_handle_home=per_handle_home,
-                classification_banner=classification_banner,
-            )
+            ws = await self._insert_workspace_row(db, user_id, name, **insert)
             await self._seed_workspace_acl(db, ws, user_id)
             return ws
 
     async def create_workspace(
-        self,
-        user_id: str,
-        name: str,
-        image: str | None = None,
-        service_command: str | None = None,
-        auto_start: bool = False,
-        mounts: list[str] | None = None,
-        env: dict[str, str] | None = None,
-        setup_state: str = SETUP_STATE_COMPLETE,
-        health_check: str | None = None,
-        allowed_domains: list[str] | None = None,
-        rejected_domains: list[str] | None = None,
-        settings: dict | None = None,
-        egress_mode: str = EGRESS_MODE_DEFAULT,
-        per_handle_home: bool = True,
-        classification_banner: str | None = None,
+        self, user_id: str, name: str, **create_kwargs
     ) -> dict:
         """Insert a workspace row only (no ACL seeding).
+
+        Takes the same keyword arguments as
+        :meth:`create_workspace_with_acl` (``image``, ``service_command``,
+        ``auto_start``, ``mounts``, ``env``, ``setup_state``,
+        ``health_check``, ``allowed_domains``, ``rejected_domains``,
+        ``settings``, ``egress_mode``, ``per_handle_home``,
+        ``classification_banner``); validation is shared with it.
 
         Prefer :meth:`create_workspace_with_acl` for normal workspace
         creation — it seeds the owner ACE and role groups atomically and is
         what the service layer uses. This row-only primitive is kept for
         callers that manage ACLs separately.
         """
-        if setup_state not in SETUP_STATES:
-            raise ValueError(f"Invalid setup_state: {setup_state!r}")
-        if egress_mode not in EGRESS_MODES:
-            raise ValueError(f"Invalid egress_mode: {egress_mode!r}")
-        if not isinstance(per_handle_home, bool):
-            raise ValueError(f"Invalid per_handle_home: {per_handle_home!r}")
-        classification_banner = normalize_classification_banner(
-            classification_banner
-        )
+        insert = _validated_create_kwargs(**create_kwargs)
         async with self.app.state.db.transaction() as db:
             return await self._insert_workspace_row(
-                db,
-                user_id,
-                name,
-                image=image,
-                service_command=service_command,
-                auto_start=auto_start,
-                mounts=mounts,
-                env=env,
-                setup_state=setup_state,
-                health_check=health_check,
-                allowed_domains=allowed_domains,
-                rejected_domains=rejected_domains,
-                settings=settings,
-                egress_mode=egress_mode,
-                per_handle_home=per_handle_home,
-                classification_banner=classification_banner,
+                db, user_id, name, **insert
             )
 
     async def list_workspaces(
@@ -614,34 +643,7 @@ class WorkspacesModel:
             f" {where} {order_by} LIMIT ? OFFSET ?",
             tuple(params),
         )
-        items = [
-            {
-                "id": row["id"],
-                "name": row["name"],
-                "container_id": row["container_id"],
-                "image": row["image"],
-                "service_command": row["service_command"],
-                "auto_start": bool(row["auto_start"]),
-                "setup_state": row["setup_state"],
-                "health_check": row["health_check"],
-                "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
-                "env": json.loads(row["env"]) if row["env"] else None,
-                "allowed_domains": json.loads(row["allowed_domains"])
-                if row["allowed_domains"]
-                else None,
-                "rejected_domains": json.loads(row["rejected_domains"])
-                if row["rejected_domains"]
-                else None,
-                "settings": json.loads(row["settings"])
-                if row["settings"]
-                else None,
-                "egress_mode": row["egress_mode"],
-                "per_handle_home": bool(row["per_handle_home"]),
-                "classification_banner": row["classification_banner"],
-                "created_at": row["created_at"],
-            }
-            for row in rows
-        ]
+        items = [_workspace_list_item(row) for row in rows]
         has_more = len(items) > limit
         items = items[:limit]
         return {
@@ -706,37 +708,6 @@ class WorkspacesModel:
         )
         return rows
 
-    @staticmethod
-    def _shared_workspace_item(row) -> dict:
-        """One shared-workspaces row as an API item (JSON columns
-        parsed)."""
-        return {
-            "id": row["id"],
-            "name": row["name"],
-            "container_id": row["container_id"],
-            "image": row["image"],
-            "service_command": row["service_command"],
-            "auto_start": bool(row["auto_start"]),
-            "setup_state": row["setup_state"],
-            "health_check": row["health_check"],
-            "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
-            "env": json.loads(row["env"]) if row["env"] else None,
-            "allowed_domains": json.loads(row["allowed_domains"])
-            if row["allowed_domains"]
-            else None,
-            "rejected_domains": json.loads(row["rejected_domains"])
-            if row["rejected_domains"]
-            else None,
-            "settings": json.loads(row["settings"])
-            if row["settings"]
-            else None,
-            "egress_mode": row["egress_mode"],
-            "per_handle_home": bool(row["per_handle_home"]),
-            "classification_banner": row["classification_banner"],
-            "created_at": row["created_at"],
-            "owner_email": row["owner_email"],
-        }
-
     async def list_shared_workspaces(
         self,
         user_id: str,
@@ -756,7 +727,7 @@ class WorkspacesModel:
         rows = await self._shared_workspace_rows(
             user_id, sort, order, q, limit, offset
         )
-        items = [self._shared_workspace_item(row) for row in rows]
+        items = [_workspace_list_item(row, owner_email=True) for row in rows]
         has_more = len(items) > limit
         items = items[:limit]
         return {

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -161,7 +161,25 @@ class Podman:
         stdin_data: bytes | None = None,
         timeout: float | None = 30.0,
     ) -> tuple[int, str, str]:
-        """Run ``podman <args>`` and return ``(returncode, stdout, stderr)``.
+        """Run ``podman <args>`` and return ``(returncode, stdout, stderr)``
+        (stdout decoded as UTF-8 text).
+
+        See :meth:`run_raw` — this is the text-decoding wrapper over it.
+        """
+        rc, out_bytes, err = await self.run_raw(
+            args, check=check, stdin_data=stdin_data, timeout=timeout
+        )
+        return rc, out_bytes.decode("utf-8", errors="replace"), err
+
+    async def run_raw(
+        self,
+        args: list[str],
+        *,
+        check: bool = True,
+        stdin_data: bytes | None = None,
+        timeout: float | None = 30.0,
+    ) -> tuple[int, bytes, str]:
+        """Like ``run`` but returns raw stdout bytes (for binary data).
 
         Output is captured to temp files rather than ``stdout=PIPE`` +
         ``communicate()``.  Lifecycle commands such as ``podman start`` can
@@ -172,55 +190,6 @@ class Podman:
         On timeout the process is killed and a ``PodmanError(500, ...)`` is
         raised (unless *check* is False, in which case rc=-1 is returned).
         """
-        cmd_label = f"podman {args[0]}" if args else "podman"
-        t0 = time.monotonic()
-        with (
-            tempfile.TemporaryFile() as out_f,
-            tempfile.TemporaryFile() as err_f,
-        ):
-            t1 = time.monotonic()
-            proc = await asyncio.create_subprocess_exec(
-                self._bin,
-                *args,
-                stdin=(
-                    asyncio.subprocess.PIPE if stdin_data is not None else None
-                ),
-                stdout=out_f,
-                stderr=err_f,
-                env=subprocess_env(),
-            )
-            t2 = time.monotonic()
-            if stdin_data is not None:
-                proc.stdin.write(stdin_data)
-                await proc.stdin.drain()
-                proc.stdin.close()
-            timed_out = await self._wait_podman(proc, timeout, cmd_label)
-            t3 = time.monotonic()
-            out_f.seek(0)
-            err_f.seek(0)
-            out = out_f.read().decode("utf-8", errors="replace")
-            err = err_f.read().decode("utf-8", errors="replace")
-        rc, err = self._finish_podman_run(
-            proc,
-            timed_out,
-            err,
-            cmd_label,
-            timeout,
-            args,
-            check,
-            (t0, t1, t2, t3),
-        )
-        return rc, out, err
-
-    async def run_raw(
-        self,
-        args: list[str],
-        *,
-        check: bool = True,
-        stdin_data: bytes | None = None,
-        timeout: float | None = 30.0,
-    ) -> tuple[int, bytes, str]:
-        """Like ``run`` but returns raw stdout bytes (for binary data)."""
         cmd_label = f"podman {args[0]}" if args else "podman"
         t0 = time.monotonic()
         with (

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -951,9 +951,32 @@ class WebSocketState:
         ``server_schedule`` / ``server_schedule_fired`` frames. Dead sockets
         are dropped (dispatch.py owns cleanup on disconnect).
         """
+        self.fanout(message)
+
+    def fanout(
+        self,
+        message: dict,
+        *,
+        user_id: str | None = None,
+        predicate=None,
+    ) -> None:
+        """Send *message* to every (matching) connection; drop dead ones.
+
+        The shared broadcast core of the typed ``notify_*`` methods
+        (host shutdown/recycle/started, per-user workspace/terminal
+        changes, the heartbeat opt-in). ``user_id`` restricts delivery
+        to that user's connections (None = every authenticated
+        connection); *predicate* further filters on the connection (the
+        heartbeat opt-in flag). A socket that errors on send is
+        discarded from the registry — dispatch.py owns the rest of
+        disconnect cleanup.
+        """
         dead = []
         for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
+            uid = conn.user.get("id")
+            if uid is None or (user_id is not None and uid != user_id):
+                continue
+            if predicate is not None and not predicate(conn):
                 continue
             try:
                 sock.send_json(message)
@@ -973,17 +996,7 @@ class WebSocketState:
         :meth:`notify_host_started` instead, because its runtime comes
         back.
         """
-        message: dict = {"type": "host_shutdown"}
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
-                continue
-            try:
-                sock.send_json(message)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        self.fanout({"type": "host_shutdown"})
 
     def notify_server_recycle(self, phase: str) -> None:
         """Broadcast a server-recycle progress event (#2527, #2661).
@@ -993,20 +1006,7 @@ class WebSocketState:
         can show a "server recycling" notice before the per-workspace
         stop frames and the 1012 disconnect arrive.
         """
-        message: dict = {
-            "type": "server_recycle",
-            "phase": phase,
-        }
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
-                continue
-            try:
-                sock.send_json(message)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        self.fanout({"type": "server_recycle", "phase": phase})
 
     def notify_host_started(self) -> None:
         """Broadcast host-started to all connections (#2527).
@@ -1015,17 +1015,7 @@ class WebSocketState:
         reconnecting (the recycle drops every WebSocket with 1012); it is
         the all-clear counterpart to :meth:`notify_server_recycle`.
         """
-        message: dict = {"type": "host_started"}
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
-                continue
-            try:
-                sock.send_json(message)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        self.fanout({"type": "host_started"})
 
     async def notify_service_health(
         self,
@@ -1138,22 +1128,15 @@ class WebSocketState:
         each tick, so the heartbeat's presence proves the health loop
         itself is alive -- if the loop stalls, heartbeats stop.
         """
-        frame = {
-            "type": "service_health_heartbeat",
-            "timestamp": _iso_utc(time.time()),
-        }
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") is None:
-                continue
-            if not getattr(conn, "wants_health_heartbeat", False):
-                continue
-            try:
-                sock.send_json(frame)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        self.fanout(
+            {
+                "type": "service_health_heartbeat",
+                "timestamp": _iso_utc(time.time()),
+            },
+            predicate=lambda conn: getattr(
+                conn, "wants_health_heartbeat", False
+            ),
+        )
 
     def handle_subscribe_health_heartbeat(
         self, msg: dict, sock: SafeWebSocket
@@ -1178,17 +1161,7 @@ class WebSocketState:
         tab without a manual refresh.  Fire-and-forget like the other
         per-connection sends; a dead socket is simply discarded.
         """
-        message = {"type": "workspaces_changed"}
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") != user_id:
-                continue
-            try:
-                sock.send_json(message)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        self.fanout({"type": "workspaces_changed"}, user_id=user_id)
 
     def notify_user_terminals_changed(
         self,
@@ -1209,16 +1182,7 @@ class WebSocketState:
         message = {"type": "terminals_changed", "workspace_id": workspace_id}
         if windows is not None:
             message["windows"] = windows
-        dead = []
-        for sock, conn in self.connections.items():
-            if conn.user.get("id") != user_id:
-                continue
-            try:
-                sock.send_json(message)
-            except WS_ERRORS:
-                dead.append((sock, conn))
-        for sock, _ in dead:
-            self.connections.pop(sock, None)
+        self.fanout(message, user_id=user_id)
 
     def _replay_service_health(
         self, sock, registry, cs, seq: int, allowed: set

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -164,7 +164,9 @@ async def test_classification_banner_roundtrip(ws, user):
 
 
 async def test_classification_banner_empty_normalizes_to_inherit(ws, user):
-    created = await ws.create_workspace(user["id"], "inherit", "")
+    created = await ws.create_workspace(
+        user["id"], "inherit", classification_banner=""
+    )
     assert created["classification_banner"] is None
     got = await ws.get_workspace_by_id(created["id"])
     assert got["classification_banner"] is None


### PR DESCRIPTION
# Second-tranche code consolidation (jscpd residual clones)

Closes #2904. Follow-up to #2901/#2903: collapses the clone pairs a jscpd scan (`--min-tokens 70`) flagged over `src/klangk/klangk` — **27 pairs / 452 duplicated lines (0.78%) → 7 / 105 (0.18%)**. No behavior change.

## Consolidations

- **cli**: shared `typer.Option` constants for the create/edit repeatable flags (`cli/options.py`); `edit()` calls `flag_scalar_body` + `flag_list_body` directly (`flag_edit_body` removed)
- **cli/client**: the three deadline-bounded ws recv loops → `recv_json_messages` generator (ssh-agent wait too)
- **cli/terminals**: share/unshare command bodies → `_set_terminal_shared`
- **tui workspace forms**: the six `compose_body` tab panes → module-level `compose_*` generators; on_mount / env editors / button+input dispatch → `WorkspaceFormMixin` methods (create's `tmp_size` submit id and edit's cancel-dismisses-`False` kept as-is)
- **tui _base**: Duplicate/InputScreen ok/cancel + input-submitted handlers hoisted into `ButtonRowModalScreen`
- **wshandler session**: the six broadcast fan-out loops → `fanout(user_id=, predicate=)`
- **api/auth**: password re-check ×3 → `verify_password_confirmation`
- **api/admin**: group fetch-404 ×7 → `get_group_or_404`; the two group PATCH bodies → `update_group_fields`
- **api/workspaces**: list-endpoint query params → `Annotated` aliases (OpenAPI schema byte-identical, verified before/after)
- **model/workspaces**: `_workspace_core_fields` + `_workspace_list_item` mappers (full-row / listing / shared shapes built on one field list); create validation + insert kwargs → `_validated_create_kwargs`; the row-only `create_workspace` takes the same kwargs via `**create_kwargs` (one test call site updated from positional to keyword)
- **model/schema**: egress_consent column DDL written once, shared by the baseline CREATE and the #2339 rebuild
- **podman**: `run()` is now the text-decoding wrapper over `run_raw()`

## Residual clones (7, deliberate)

- 3 in the frozen permission/file-mirror migrations (`m0011`–`m0018`) — excluded per #2901's rationale
- `cli/client.py` ↔ server `workspaces.py` create signature — crosses the `cli/` isolation boundary, unsatisfiable by design
- `CreateWorkspaceRequest` ↔ `UpdateWorkspaceRequest` field lists — idiomatic pydantic models with different defaults/nullability
- shared option references between `create`/`edit` (the sameness the constants exist to express) and `_validated_create_kwargs`' signature mirroring the public create API

## Tooling

jscpd is now pinned in the devenv toolchain (platform binary 5.0.16, fixed-hash fetchurl like `fmtk`) with an advisory `klangk:jscpd` task — no more `npx`. A commit-hook gate was considered and left out (clone detection must scan the whole tree, not staged files; `--max-duplicate-rate` only bounds a ratio).

## Verification

- Full backend suite the CI way (`-n auto`): **6169 passed, 100% branch coverage maintained**
- `scripts/tests`: 97 passed
- xenon B gate passes; ruff format/check clean
