### PR TITLE
test(cli): audit no-cover pragmas in klangk.cli (#2910, part 1)

### DIFF
--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -78,7 +78,7 @@ def local_login(server_url: str) -> tuple[str, str]:
     return email, token
 
 
-def oidc_browser_login(  # pragma: no cover
+def oidc_browser_login(
     server_url: str,
     provider_id: str,
     state: CLIState,
@@ -375,7 +375,7 @@ def refresh_token(server_url: str, token: str) -> str | None:
         return None
 
 
-def _log_logout_caller() -> None:  # pragma: no cover
+def _log_logout_caller() -> None:
     """Diagnostic: log the parent-process chain that invoked logout.
 
     Walks /proc upward so the next spurious logout reveals its spawner

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -53,6 +53,8 @@ RESIZE_POLL_INTERVAL = 1.0  # seconds between terminal size checks
 _RETRY_BACKOFF = 2.0  # seconds, doubled each retry
 
 _WS_CONNECT_TIMEOUT = 60  # seconds to wait for container_ready
+_HEARTBEAT_INTERVAL = 60  # seconds between terminal heartbeats
+_STDIN_DRAIN_TIMEOUT = 2  # seconds to let exec stdin forwarder finish
 
 
 def query_local_ssh_agent(sock_path: str, data: bytes) -> bytes | None:
@@ -70,16 +72,16 @@ def query_local_ssh_agent(sock_path: str, data: bytes) -> bytes | None:
         header = b""
         while len(header) < 4:
             chunk = agent.recv(4 - len(header))
-            if not chunk:  # pragma: no cover
+            if not chunk:
                 break
             header += chunk
-        if len(header) < 4:  # pragma: no cover
+        if len(header) < 4:
             return None
         msg_len = struct.unpack(">I", header)[0]
         body = b""
         while len(body) < msg_len:
             chunk = agent.recv(msg_len - len(body))
-            if not chunk:  # pragma: no cover
+            if not chunk:
                 break
             body += chunk
         return header + body
@@ -971,7 +973,7 @@ async def recv_until(conn, predicate, timeout: float = 30.0):
     end = loop.time() + timeout
     while True:
         remaining = end - loop.time()
-        if remaining <= 0:  # pragma: no cover
+        if remaining <= 0:
             raise asyncio.TimeoutError
         raw = await asyncio.wait_for(conn.recv(), timeout=remaining)
         msg = json.loads(raw)
@@ -998,7 +1000,7 @@ async def recv_json_messages(ws, timeout: float):
     deadline = asyncio.get_event_loop().time() + timeout
     while True:
         remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:  # pragma: no cover
+        if remaining <= 0:
             raise asyncio.TimeoutError
         raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
         yield json.loads(raw)
@@ -1185,11 +1187,11 @@ async def drain_terminal_startup(
                     break
             elif msg.get("type") == "terminal_output":
                 buffered_output.append(msg.get("data", ""))
-            elif msg.get("type") == "error":  # pragma: no cover
+            elif msg.get("type") == "error":
                 raise ConnectionError(
                     f"Server error: {msg.get('message', 'unknown')}"
                 )
-    except asyncio.TimeoutError:  # pragma: no cover
+    except asyncio.TimeoutError:
         raise ConnectionError(
             "Terminal did not start within 30 seconds"
         ) from None
@@ -1312,7 +1314,13 @@ async def create_own_window(
         )
     )
     match: dict | None = None
-    async for msg in recv_json_messages(ws, 10):
+    # recv_json_messages only ends by raising (deadline), so the
+    # async-for can never complete normally — break/raise are the only
+    # exits (the arc to ``if match is None`` without a break is
+    # unreachable).
+    async for msg in recv_json_messages(  # pragma: no branch
+        ws, 10
+    ):
         if msg.get("type") == "terminal_windows":
             new_windows = msg.get("windows", [])
             match = next(
@@ -1326,7 +1334,7 @@ async def create_own_window(
             raise ConnectionError(
                 f"Failed to create window: {msg.get('message')}"
             )
-    if match is None:  # pragma: no cover
+    if match is None:
         raise ConnectionError(f"Window '{window}' not created")
     return match
 
@@ -1369,7 +1377,7 @@ async def run_terminal_session(
     """4. Put terminal in raw mode, run shell, restore.
 
     raw_mode path: tcgetattr + tty.setraw + _raw_mode_exit +
-    terminal_stop  # pragma: no cover
+    terminal_stop.
     """
     if raw_mode:
         old_settings = _raw_mode_enter()
@@ -1493,11 +1501,14 @@ class _ShellSession:
         self.stop = asyncio.Event()
         self.agent_queue: asyncio.Queue[bytes] = asyncio.Queue()
 
-    async def heartbeat_loop(self) -> None:  # pragma: no cover
-        """Send a heartbeat every 60 s until stopped."""
+    async def heartbeat_loop(self) -> None:
+        """Send a heartbeat every :data:`_HEARTBEAT_INTERVAL` s until
+        stopped."""
         while not self.stop.is_set():
             try:
-                await asyncio.wait_for(self.stop.wait(), timeout=60)
+                await asyncio.wait_for(
+                    self.stop.wait(), timeout=_HEARTBEAT_INTERVAL
+                )
                 return
             except asyncio.TimeoutError:
                 pass
@@ -1545,7 +1556,7 @@ class _ShellSession:
             except (OSError, ConnectionError) as e:
                 logger.warning("SSH agent relay: %s", e)
 
-    async def run(self) -> None:  # pragma: no cover
+    async def run(self) -> None:
         raise NotImplementedError
 
 
@@ -1610,7 +1621,7 @@ class TerminalSession(_ShellSession):
                     data = await self._extend_escape_sequence(fd, data)
                     if data is None:
                         continue
-            except (OSError, io.UnsupportedOperation):  # pragma: no cover
+            except (OSError, io.UnsupportedOperation):
                 return
             await self.ws.send(
                 json.dumps(
@@ -1647,7 +1658,7 @@ class TerminalSession(_ShellSession):
                 break
             try:
                 await self._loop.run_in_executor(None, os.read, fd, 256)
-            except OSError:  # pragma: no cover
+            except OSError:
                 break
         return None
 
@@ -1719,7 +1730,7 @@ class TerminalSession(_ShellSession):
                 await asyncio.wait_for(
                     self.stop.wait(), timeout=RESIZE_POLL_INTERVAL
                 )
-                return  # pragma: no cover
+                return
             except asyncio.TimeoutError:
                 pass
             new_cols, new_rows = get_terminal_size()
@@ -1798,14 +1809,14 @@ class ExecSession(_ShellSession):
                     None,
                     lambda: select.select([fd], [], [], 0.2)[0],
                 )
-                if not ready:  # pragma: no cover
+                if not ready:
                     continue
                 data = await self._loop.run_in_executor(
                     None, os.read, fd, 65536
                 )
                 if not data:
                     break
-                await self.ws.send(  # pragma: no cover
+                await self.ws.send(
                     json.dumps(
                         {
                             "cmd": "exec_input",
@@ -1829,7 +1840,7 @@ class ExecSession(_ShellSession):
     async def stdout_forward(self) -> None:
         while True:
             msg = await self.ws.recv()
-            if isinstance(msg, bytes):  # pragma: no cover
+            if isinstance(msg, bytes):
                 msg = msg.decode("utf-8", errors="replace")
             data = json.loads(msg)
             if data.get("type") == "exec_output":
@@ -1888,8 +1899,8 @@ class ExecSession(_ShellSession):
                 pass
         self.stop.set()
         try:
-            await asyncio.wait_for(stdin_task, timeout=2)
-        except asyncio.TimeoutError:  # pragma: no cover
+            await asyncio.wait_for(stdin_task, timeout=_STDIN_DRAIN_TIMEOUT)
+        except asyncio.TimeoutError:
             stdin_task.cancel()
             try:
                 await stdin_task
@@ -1898,7 +1909,7 @@ class ExecSession(_ShellSession):
         heartbeat_task.cancel()
         try:
             await heartbeat_task
-        except asyncio.CancelledError:  # pragma: no cover
+        except asyncio.CancelledError:
             pass
         agent_task.cancel()
         try:

--- a/src/klangk/klangk/cli/context.py
+++ b/src/klangk/klangk/cli/context.py
@@ -74,16 +74,16 @@ def run_ws_command(body):
 
 
 def cfg() -> CLIConfig:
-    global cfg_cache  # pragma: no cover
-    if cfg_cache is None:  # pragma: no cover
-        cfg_cache = CLIConfig.load()  # pragma: no cover
+    global cfg_cache
+    if cfg_cache is None:
+        cfg_cache = CLIConfig.load()
     return cfg_cache
 
 
 def state() -> CLIState:
-    global state_cache  # pragma: no cover
-    if state_cache is None:  # pragma: no cover
-        state_cache = CLIState.load()  # pragma: no cover
+    global state_cache
+    if state_cache is None:
+        state_cache = CLIState.load()
     return state_cache
 
 
@@ -115,7 +115,7 @@ def server_url() -> str:
     raise typer.Exit(code=1)
 
 
-def client() -> KlangkClient:  # pragma: no cover
+def client() -> KlangkClient:
     return KlangkClient(server_url(), state().get_token(server_url()))
 
 

--- a/src/klangk/klangk/cli/execsync.py
+++ b/src/klangk/klangk/cli/execsync.py
@@ -163,7 +163,7 @@ def sync(
     context.require_auth()
 
     klangk_bin = shutil.which("klangk")
-    if not klangk_bin:  # pragma: no cover
+    if not klangk_bin:
         context.err.print("[red]Cannot find klangk in PATH[/red]")
         raise typer.Exit(code=1)
 
@@ -218,7 +218,7 @@ def images() -> None:
     context.require_auth()
     try:
         data = context.client().list_images()
-    except httpx.HTTPStatusError as exc:  # pragma: no cover
+    except httpx.HTTPStatusError as exc:
         detail = exc.response.json().get("detail", exc.response.text)
         context.err.print(f"[red]Failed to list images:[/red] {detail}")
         raise typer.Exit(code=1) from None

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -217,7 +217,7 @@ def maybe_launch_tui(ctx: typer.Context) -> None:
         raise typer.Exit(code=1)
 
 
-def main() -> None:  # pragma: no cover
+def main() -> None:
     try:
         app()
     except AuthError as exc:
@@ -234,5 +234,7 @@ def main() -> None:  # pragma: no cover
         raise SystemExit(1) from None
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover — module-exec arm
+    # (python -m klangk.cli.main) can't run under in-process tests;
+    # the wheel's console script exercises main() directly instead.
     main()

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -189,7 +189,7 @@ def run_sandbox_setup(
                 client=client,
             )
         )
-    except websockets.InvalidStatus as e:  # pragma: no cover
+    except websockets.InvalidStatus as e:
         if e.response.status_code in (4001, 4002):
             context.err.print(
                 "[red]Session expired.[/red] Run"
@@ -222,7 +222,7 @@ def sandbox(
     ``klangk shell`` afterwards to connect.
     """
     token = context.session_token()
-    if not token:  # pragma: no cover
+    if not token:
         context.err.print(
             "[red]Not logged in[/red] — run [bold]klangk login[/bold] first."
         )
@@ -275,7 +275,7 @@ async def mark_setup_state(client, workspace_id: str, new_state: str) -> None:
         await asyncio.to_thread(
             client.set_setup_state, workspace_id, new_state
         )
-    except Exception as e:  # pragma: no cover
+    except Exception as e:
         context.err.print(
             f"[yellow]Warning: could not mark setup_state"
             f" = {new_state}: {e}[/yellow]"
@@ -309,7 +309,7 @@ async def decide_egress_reset(config, client) -> tuple[bool, str | None]:
         return False, None
     try:
         cfg = await asyncio.to_thread(client.config)
-    except Exception as e:  # pragma: no cover
+    except Exception as e:
         cfg = {}
         context.err.print(
             "[yellow]Warning: could not read server config"
@@ -335,14 +335,14 @@ async def reset_egress_and_stop(client, workspace_id: str) -> None:
             workspace_id,
             egress_mode="interactive",
         )
-    except Exception as e:  # pragma: no cover
+    except Exception as e:
         context.err.print(
             "[yellow]Warning: could not reset egress_mode"
             f" to interactive: {e}[/yellow]"
         )
     try:
         await asyncio.to_thread(client.stop_workspace_by_id, workspace_id)
-    except Exception as e:  # pragma: no cover
+    except Exception as e:
         context.err.print(
             f"[yellow]Warning: could not stop container"
             f" after setup: {e}[/yellow]"
@@ -353,7 +353,9 @@ async def reset_egress_and_stop(client, workspace_id: str) -> None:
     )
 
 
-async def fire_service_command(ws, config, setup_ok: bool) -> None:
+async def fire_service_command(
+    ws, config, setup_ok: bool, timeout: float = 30
+) -> None:
     """Fire the service command via terminal_start so it's up (#1033:
     deferred until setup_state is complete, then launched in the
     dedicated service-cmd tmux window). Skipped on setup failure -- the
@@ -366,10 +368,10 @@ async def fire_service_command(ws, config, setup_ok: bool) -> None:
     )
     # Wait (bounded) for the terminal to start so the command actually
     # runs before we disconnect. Other messages are ignored.
-    deadline = asyncio.get_event_loop().time() + 30
+    deadline = asyncio.get_event_loop().time() + timeout
     while True:
         remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:  # pragma: no cover
+        if remaining <= 0:
             break
         try:
             raw = await asyncio.wait_for(ws.recv(), timeout=remaining)

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -157,12 +157,12 @@ def resolve_shell_workspace(client, workspace: str | None):
     for i, w in enumerate(workspaces, 1):
         typer.echo(f"  {i}. {w.name}")
     choice = input("> ").strip()
-    if not choice:  # pragma: no cover
+    if not choice:
         raise typer.Exit()
     try:
         idx = int(choice) - 1
-    except ValueError:  # pragma: no cover
-        raise typer.Exit(code=1)  # pragma: no cover
+    except ValueError:
+        raise typer.Exit(code=1)
     return workspaces[idx]
 
 
@@ -204,11 +204,11 @@ def shell(
     if not isinstance(no_consent_popup, bool):
         no_consent_popup = False
     token = context.session_token()
-    if not token:  # pragma: no cover
+    if not token:
         context.err.print(
             "[red]Not logged in[/red] — run [bold]klangk login[/bold] first."
-        )  # pragma: no cover
-        raise typer.Exit(code=1)  # pragma: no cover
+        )
+        raise typer.Exit(code=1)
 
     client = context.client()
 

--- a/src/klangk/klangk/cli/terminals.py
+++ b/src/klangk/klangk/cli/terminals.py
@@ -39,7 +39,7 @@ async def recv_until_event(conn, timeout: float, on_message=None):
     deadline = asyncio.get_event_loop().time() + timeout
     while True:
         remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:  # pragma: no cover
+        if remaining <= 0:
             raise asyncio.TimeoutError
         raw = await asyncio.wait_for(conn.recv(), timeout=remaining)
         msg = json.loads(raw)

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -429,7 +429,7 @@ class MainScreen(StatusScreen):
             self.query_one(
                 "#sort_btn", Button
             ).label = f"sort: {self._sort_key} {arrow}"
-        except NoMatches:  # pragma: no cover
+        except NoMatches:  # pragma: no cover - not yet mounted
             pass
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -5894,6 +5894,10 @@ class TestSandboxCommandGuards:
 
         response = MagicMock()
         response.status_code = 4002
+        # Neutralize the arg-building preamble: CI has no
+        # co-located klangkd UDS, so server_url() would Exit
+        # before the patched exception ever fires.
+        monkeypatch.setattr(sandboxcmd.context, "ws_max_size", lambda: 2**20)
         monkeypatch.setattr(
             sandboxcmd,
             "sandbox_setup_only",
@@ -5917,6 +5921,10 @@ class TestSandboxCommandGuards:
 
         response = MagicMock()
         response.status_code = 500
+        # Neutralize the arg-building preamble: CI has no
+        # co-located klangkd UDS, so server_url() would Exit
+        # before the patched exception ever fires.
+        monkeypatch.setattr(sandboxcmd.context, "ws_max_size", lambda: 2**20)
         monkeypatch.setattr(
             sandboxcmd,
             "sandbox_setup_only",

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the klangk CLI."""
 
 import asyncio
+import base64
 import json
 import os
 import sys
@@ -1054,7 +1055,7 @@ class TestOIDCCLILogin:
 
         # Start the OIDC callback server (reuse the handler from auth.py)
         # We replicate the handler here to test the actual escaping logic
-        # without needing to invoke oidc_browser_login (pragma: no cover)
+        # without needing to invoke oidc_browser_login
         import html as html_mod
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -5493,3 +5494,649 @@ class TestCliBranchGaps2834d:
 
             with pytest.raises(typer_mod.Exit):
                 shellcmd.shell("ws", None, None, True)
+
+
+# --- No-cover audit tests (#2910) ---------------------------------------
+# Every path below used to carry a bare ``# pragma: no cover``. Each
+# test exercises one formerly-excluded site for real so the pragma could
+# be removed; the few structurally untestable sites that remain keep
+# their pragma only with an inline justification.
+
+
+class TestQueryLocalSshAgentShortReads:
+    """_query_local_ssh_agent: agent socket closing early / truncating."""
+
+    def _run(self, *args):
+        from klangk.cli.client import query_local_ssh_agent
+
+        return query_local_ssh_agent(*args)
+
+    def test_agent_closes_before_header(self, tmp_path):
+        import socket as socket_mod
+        import threading
+
+        path = str(tmp_path / "agent.sock")
+        listener = socket_mod.socket(
+            socket_mod.AF_UNIX, socket_mod.SOCK_STREAM
+        )
+        listener.bind(path)
+        listener.listen(1)
+        accepted = threading.Event()
+
+        def server():
+            conn, _ = listener.accept()
+            accepted.set()
+            conn.recv(1024)  # drain the request so close() is a FIN, not RST
+            conn.close()  # reply with nothing
+
+        threading.Thread(target=server, daemon=True).start()
+        result = self._run(path, b"\x00\x00\x00\x05hello")
+        listener.close()
+        assert result is None
+
+    def test_agent_truncates_body(self, tmp_path):
+        import socket as socket_mod
+        import struct
+        import threading
+
+        path = str(tmp_path / "agent.sock")
+        listener = socket_mod.socket(
+            socket_mod.AF_UNIX, socket_mod.SOCK_STREAM
+        )
+        listener.bind(path)
+        listener.listen(1)
+
+        def server():
+            conn, _ = listener.accept()
+            conn.recv(1024)  # drain the request so close() is a FIN, not RST
+            conn.sendall(struct.pack(">I", 8) + b"short")  # 3 of 8 bytes
+            conn.close()
+
+        threading.Thread(target=server, daemon=True).start()
+        result = self._run(path, b"\x00\x00\x00\x05hello")
+        listener.close()
+        assert result == struct.pack(">I", 8) + b"short"
+
+
+class TestBoundedRecvTimeouts:
+    """The ``remaining <= 0`` deadline arms of the bounded recv loops."""
+
+    def test_recv_until_zero_timeout(self):
+        from klangk.cli.client import recv_until
+
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(recv_until(AsyncMock(), lambda m: True, 0))
+
+    def test_recv_json_messages_zero_timeout(self):
+        from klangk.cli.client import recv_json_messages
+
+        async def scenario():
+            agen = recv_json_messages(AsyncMock(), 0)
+            try:
+                await agen.__anext__()
+            finally:
+                await agen.aclose()
+
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(scenario())
+
+    def test_recv_until_event_zero_timeout_with_callback(self):
+        from klangk.cli.terminals import recv_until_event
+
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(
+                recv_until_event(AsyncMock(), 0, on_message=lambda m: None)
+            )
+
+
+class TestDrainTerminalStartupGuards:
+    """drain_terminal_startup / create_own_window error paths."""
+
+    def _frames(self, *msgs):
+        class FakeRecv:
+            def __init__(self, frames):
+                self._frames = list(frames)
+
+            async def recv(self):
+                return json.dumps(self._frames.pop(0)).encode()
+
+            async def send(self, msg):
+                pass
+
+        return FakeRecv(list(msgs))
+
+    def test_error_frame_raises(self):
+        from klangk.cli.client import drain_terminal_startup
+
+        with pytest.raises(ConnectionError, match="Server error: nope"):
+            asyncio.run(
+                drain_terminal_startup(
+                    self._frames({"type": "error", "message": "nope"}), False
+                )
+            )
+
+    def test_timeout_raises_connection_error(self):
+        from klangk.cli.client import drain_terminal_startup
+
+        class NeverStarts:
+            async def recv(self):
+                raise asyncio.TimeoutError
+
+        with pytest.raises(ConnectionError, match="did not start"):
+            asyncio.run(drain_terminal_startup(NeverStarts(), False))
+
+    def test_create_own_window_not_in_refreshed_list(self):
+        from klangk.cli.client import create_own_window
+
+        ws = self._frames(
+            {
+                "type": "terminal_windows",
+                "windows": [{"id": "1", "name": "other"}],
+            }
+        )
+        with pytest.raises(ConnectionError, match="not created"):
+            asyncio.run(create_own_window(ws, "mine", []))
+
+
+class TestShellSessionHeartbeatAndRun:
+    async def test_heartbeat_sends_until_stopped(self, monkeypatch):
+        import klangk.cli.client as client_mod
+        from klangk.cli.client import _ShellSession
+
+        monkeypatch.setattr(client_mod, "_HEARTBEAT_INTERVAL", 0.01)
+        session = _ShellSession(AsyncMock())
+
+        async def send_heartbeat_once(msg):
+            session.stop.set()
+
+        session.ws.send = AsyncMock(side_effect=send_heartbeat_once)
+        await asyncio.wait_for(session.heartbeat_loop(), 5)
+        sent = [json.loads(c.args[0]) for c in session.ws.send.await_args_list]
+        assert sent == [{"cmd": "heartbeat"}]
+
+    async def test_heartbeat_skips_send_when_stopped(self, monkeypatch):
+        """The wait_for times out *and* stop is set before the re-check:
+        the send is skipped and the loop exits without a heartbeat."""
+        import klangk.cli.client as client_mod
+        from klangk.cli.client import _ShellSession
+
+        session = _ShellSession(AsyncMock())
+        real_wait_for = asyncio.wait_for
+
+        async def stop_then_time_out(fut, timeout):
+            session.stop.set()
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr(client_mod.asyncio, "wait_for", stop_then_time_out)
+        await session.heartbeat_loop()
+        session.ws.send.assert_not_awaited()
+        monkeypatch.setattr(client_mod.asyncio, "wait_for", real_wait_for)
+
+    async def test_run_is_abstract(self):
+        from klangk.cli.client import _ShellSession
+
+        session = _ShellSession(AsyncMock())
+        with pytest.raises(NotImplementedError):
+            await session.run()
+
+
+class TestTerminalSessionPumpGuards:
+    def _session(self, **kwargs):
+        from klangk.cli.client import TerminalSession
+
+        defaults = dict(stdout=MagicMock(), server_url="http://t", token="tok")
+        defaults.update(kwargs)
+        return TerminalSession(AsyncMock(), 80, 24, **defaults)
+
+    async def test_stdin_loop_oserror_returns(self):
+        session = self._session()
+        buf = BytesIO(b"x")
+        buf.fileno = lambda: 99
+        session.stdin = buf
+
+        with (
+            patch(
+                "klangk.cli.client.select.select", return_value=([99], [], [])
+            ),
+            patch("klangk.cli.client.os.read", side_effect=OSError("fd gone")),
+        ):
+            await asyncio.wait_for(session.stdin_loop(), 5)
+        session.ws.send.assert_not_awaited()
+
+    async def test_extend_escape_drain_oserror_breaks(self):
+        session = self._session()
+        r = 77
+        reads = [b"[?1;2c", OSError("fd gone")]
+
+        def fake_read(fd, n):
+            item = reads.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        with (
+            patch(
+                "klangk.cli.client.select.select", return_value=([r], [], [])
+            ),
+            patch("klangk.cli.client.os.read", side_effect=fake_read),
+        ):
+            out = await asyncio.wait_for(
+                session._extend_escape_sequence(r, b"\x1b"), 5
+            )
+        assert out is None  # query response drained despite the failing fd
+
+    async def test_resize_loop_returns_when_stopped(self):
+        session = self._session()
+
+        task = asyncio.create_task(session.resize_loop())
+        await asyncio.sleep(0.05)
+        session.stop.set()
+        await asyncio.wait_for(task, 5)
+        session.ws.send.assert_not_awaited()  # no size change: no resize
+
+
+class TestExecSessionStdinStdioGuards:
+    def _fd_stdin(self, fd):
+        stdin = MagicMock()
+        stdin.fileno.return_value = fd
+        return stdin
+
+    async def test_stdin_forward_not_ready_then_input(self):
+        from klangk.cli.client import ExecSession
+
+        r, w = os.pipe()
+        try:
+            os.write(w, b"hi")
+            os.close(w)
+            session = ExecSession(
+                AsyncMock(), command=["cat"], stdin=self._fd_stdin(r)
+            )
+
+            selects = [[], [r], [r], [r]]
+
+            def fake_select(rl, wl, xl, timeout=None):
+                return (selects.pop(0), [], [])
+
+            with patch(
+                "klangk.cli.client.select.select", side_effect=fake_select
+            ):
+                await asyncio.wait_for(session.stdin_forward(), 5)
+
+            sent = [
+                json.loads(c.args[0]) for c in session.ws.send.await_args_list
+            ]
+            assert sent == [
+                {"cmd": "exec_input", "data": "aGk="},
+                {"cmd": "exec_close_stdin"},
+            ]
+        finally:
+            os.close(r)
+
+    async def test_stdout_forward_decodes_bytes_frames(self):
+        from klangk.cli.client import ExecSession
+
+        ws = AsyncMock()
+        ws.recv = AsyncMock(
+            return_value=json.dumps({"type": "exec_exit", "code": 3}).encode()
+        )
+        session = ExecSession(ws, command=["true"], stdin=None)
+        await asyncio.wait_for(session.stdout_forward(), 5)
+        assert session.exit_code == 3
+
+    async def test_run_drains_stdin_with_timeout(self, monkeypatch):
+        """stdin forwarder stuck (never ready) is cancelled after the
+        drain timeout instead of hanging exec cleanup."""
+        import klangk.cli.client as client_mod
+        from klangk.cli.client import ExecSession
+
+        import time as time_mod
+
+        monkeypatch.setattr(client_mod, "_STDIN_DRAIN_TIMEOUT", 0.05)
+        r, w = os.pipe()
+        try:
+            os.close(w)  # EOF only when read; select patched to never fire
+
+            def blocked_select(rl, wl, xl, timeout=None):
+                time_mod.sleep(0.3)  # still in flight when the drain times out
+                return ([], [], [])
+
+            session = ExecSession(
+                AsyncMock(), command=["true"], stdin=self._fd_stdin(r)
+            )
+            session.ws.recv = AsyncMock(
+                return_value=json.dumps({"type": "exec_exit", "code": 0})
+            )
+            with patch(
+                "klangk.cli.client.select.select", side_effect=blocked_select
+            ):
+                code = await asyncio.wait_for(session.run(), 10)
+            assert code == 0
+        finally:
+            os.close(r)
+
+
+class TestExecSessionTimeout:
+    async def test_exec_deadline_maps_to_124(self):
+        from klangk.cli.client import ExecSession
+
+        async def hang():
+            await asyncio.sleep(3600)
+
+        ws = AsyncMock()
+        ws.recv = AsyncMock(side_effect=hang)
+        session = ExecSession(
+            ws, command=["sleep", "10"], stdin=None, timeout=0.05
+        )
+        assert await asyncio.wait_for(session.run(), 10) == 124
+
+
+class TestMainEntryPointHandlers:
+    """cli.main(): each user-facing failure maps to SystemExit(1)."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            AuthError("bad token"),
+            httpx.ConnectError("down"),
+            httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=MagicMock()
+            ),
+            websockets.ConnectionClosed(None, None),
+        ],
+    )
+    def test_handler_exits_1(self, exc, monkeypatch):
+        import klangk.cli.main as main_mod
+
+        monkeypatch.setattr(main_mod, "app", MagicMock(side_effect=exc))
+        with pytest.raises(SystemExit) as caught:
+            main_mod.main()
+        assert caught.value.code == 1
+
+
+class TestExecSyncGuards:
+    def test_sync_missing_klangk_binary(self, monkeypatch, tmp_path):
+        from klangk.cli import execsync
+
+        monkeypatch.setattr(execsync.context, "require_auth", lambda: None)
+        monkeypatch.setattr(execsync.shutil, "which", lambda name: None)
+        monkeypatch.setattr(execsync.context, "err", MagicMock())
+        with pytest.raises(typer.Exit):
+            execsync.sync(MagicMock(), str(tmp_path), "ws:/work")
+
+    def test_images_http_error_exits(self, monkeypatch):
+        from klangk.cli import execsync
+
+        response = MagicMock()
+        response.json.return_value = {"detail": "denied"}
+        response.text = "denied"
+        failing = MagicMock()
+        failing.list_images.side_effect = httpx.HTTPStatusError(
+            "403", request=MagicMock(), response=response
+        )
+        monkeypatch.setattr(execsync.context, "require_auth", lambda: None)
+        monkeypatch.setattr(execsync.context, "client", lambda: failing)
+        monkeypatch.setattr(execsync.context, "err", MagicMock())
+        with pytest.raises(typer.Exit):
+            execsync.images()
+
+
+class TestSandboxCommandGuards:
+    def test_sandbox_without_token_exits(self, monkeypatch, tmp_path):
+        from klangk.cli import sandboxcmd
+
+        monkeypatch.setattr(sandboxcmd.context, "session_token", lambda: "")
+        monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
+        with pytest.raises(typer.Exit):
+            sandboxcmd.sandbox("ws", str(tmp_path))
+
+    def test_run_sandbox_setup_expired_session_exits(self, monkeypatch):
+        from klangk.cli import sandboxcmd
+
+        response = MagicMock()
+        response.status_code = 4002
+        monkeypatch.setattr(
+            sandboxcmd,
+            "sandbox_setup_only",
+            MagicMock(side_effect=websockets.InvalidStatus(response)),
+        )
+        monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
+        with pytest.raises(typer.Exit):
+            sandboxcmd.run_sandbox_setup(
+                "http://s",
+                "tok",
+                "ws",
+                "ws-id",
+                MagicMock(),
+                Path("/tmp"),
+                "handle",
+                MagicMock(),
+            )
+
+    def test_run_sandbox_setup_other_status_reraises(self, monkeypatch):
+        from klangk.cli import sandboxcmd
+
+        response = MagicMock()
+        response.status_code = 500
+        monkeypatch.setattr(
+            sandboxcmd,
+            "sandbox_setup_only",
+            MagicMock(side_effect=websockets.InvalidStatus(response)),
+        )
+        monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
+        with pytest.raises(websockets.InvalidStatus):
+            sandboxcmd.run_sandbox_setup(
+                "http://s",
+                "tok",
+                "ws",
+                "ws-id",
+                MagicMock(),
+                Path("/tmp"),
+                "handle",
+                MagicMock(),
+            )
+
+    def test_mark_setup_state_warns_on_failure(self):
+        from klangk.cli.sandboxcmd import mark_setup_state
+
+        client = MagicMock()
+        client.set_setup_state.side_effect = RuntimeError("boom")
+        asyncio.run(mark_setup_state(client, "ws", "done"))  # must not raise
+
+    def test_decide_egress_reset_config_error(self):
+        from klangk.cli.sandboxcmd import decide_egress_reset
+
+        client = MagicMock()
+        client.config.side_effect = RuntimeError("unreachable")
+        config = types.SimpleNamespace(auto_start=False)
+        reset, reason = asyncio.run(decide_egress_reset(config, client))
+        assert reset is False
+        assert reason == "no network sidecar on this server"
+
+    def test_reset_egress_and_stop_warns_on_failures(self):
+        from klangk.cli.sandboxcmd import reset_egress_and_stop
+
+        client = MagicMock()
+        client.update_workspace.side_effect = RuntimeError("no")
+        client.stop_workspace_by_id.side_effect = RuntimeError("no")
+        asyncio.run(reset_egress_and_stop(client, "ws"))  # must not raise
+
+    def test_fire_service_command_deadline_expires(self):
+        from types import SimpleNamespace
+
+        from klangk.cli.sandboxcmd import fire_service_command
+
+        config = SimpleNamespace(service_command="make dev")
+        ws = AsyncMock()
+        asyncio.run(fire_service_command(ws, config, True, timeout=0))
+        sent = [json.loads(c.args[0]) for c in ws.send.await_args_list]
+        assert sent == [{"cmd": "terminal_start", "cols": 80, "rows": 24}]
+
+
+class TestShellWorkspacePickGuards:
+    def _two_workspaces(self):
+        return [
+            types.SimpleNamespace(name="a"),
+            types.SimpleNamespace(name="b"),
+        ]
+
+    def test_empty_choice_exits(self):
+        from klangk.cli.shellcmd import resolve_shell_workspace
+
+        with patch("builtins.input", return_value="  "):
+            with pytest.raises(typer.Exit):
+                resolve_shell_workspace(MagicMock(), None)
+
+    def test_non_numeric_choice_exits_1(self):
+        from klangk.cli.shellcmd import resolve_shell_workspace
+
+        client = MagicMock()
+        client.list_workspaces.return_value = self._two_workspaces()
+        with patch("builtins.input", return_value="abc"):
+            with pytest.raises(typer.Exit) as caught:
+                resolve_shell_workspace(client, None)
+        assert caught.value.exit_code == 1
+
+
+class TestOidcBrowserLogin:
+    """The localhost-callback browser flow, driven without a browser."""
+
+    @staticmethod
+    def _token(email="user@example.com"):
+        payload = base64.urlsafe_b64encode(
+            json.dumps({"email": email}).encode()
+        ).decode()
+        return f"hdr.{payload}.sig"
+
+    def _drive_callback(self, query, capture):
+        """Patch webbrowser.open to hit the callback URL directly."""
+        import urllib.request
+        import urllib.error
+        from urllib.parse import parse_qs, urlparse
+
+        def fake_open(url):
+            capture.append(url)
+            redirect = parse_qs(urlparse(url).query)["cli_redirect"][0]
+            try:
+                urllib.request.urlopen(f"{redirect}?{query}")
+            except urllib.error.HTTPError:
+                pass  # 400 pages still land in the handler
+
+        return fake_open
+
+    def test_success_saves_credentials(self, monkeypatch):
+        from klangk.cli.auth import oidc_browser_login
+
+        capture: list[str] = []
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback(f"token={self._token()}", capture),
+        )
+        state = CLIState()
+        oidc_browser_login("http://srv", "prov", state)
+        assert capture and "cli_redirect" in capture[0]
+        assert state.get_token("http://srv") == self._token()
+
+    def test_success_with_malformed_token_uses_unknown_email(
+        self, monkeypatch
+    ):
+        from klangk.cli.auth import oidc_browser_login
+
+        bad_token = "hdr.not-valid-b64!.sig"
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback(f"token={bad_token}", []),
+        )
+        state = CLIState()
+        oidc_browser_login("http://srv", "prov", state)
+        assert state.get_token("http://srv") == bad_token
+
+    def test_error_callback_exits_1(self, monkeypatch):
+        from klangk.cli.auth import oidc_browser_login
+
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback("error=Denied", []),
+        )
+        with pytest.raises(SystemExit):
+            oidc_browser_login("http://srv", "prov", CLIState())
+
+    def test_no_callback_times_out(self, monkeypatch):
+        import klangk.cli.auth as auth_mod
+
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open", lambda url: False
+        )
+        # A thread whose join() returns instantly: no callback ever lands.
+        monkeypatch.setattr(
+            auth_mod.threading,
+            "Thread",
+            lambda **kw: MagicMock(join=lambda timeout=None: None),
+        )
+        with pytest.raises(SystemExit):
+            auth_mod.oidc_browser_login("http://srv", "prov", CLIState())
+
+
+class TestLogLogoutCaller:
+    """/proc walk: every malformed-process arm must break, never raise."""
+
+    @staticmethod
+    def _patch_open(monkeypatch, cmdline, stat):
+        import builtins
+
+        real_open = builtins.open
+
+        def fake_open(file, *args, **kwargs):
+            name = str(file)
+            if name.endswith("/cmdline"):
+                if isinstance(cmdline, Exception):
+                    raise cmdline
+                return BytesIO(cmdline)
+            if name.endswith("/stat"):
+                if isinstance(stat, Exception):
+                    raise stat
+                return BytesIO(stat)
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+    def test_ppid_1_stops_the_walk(self, monkeypatch):
+        import klangk.cli.auth as auth_mod
+
+        monkeypatch.setattr(auth_mod.os, "getppid", lambda: 42)
+        self._patch_open(monkeypatch, b"cmd\0", b"42 (cmd) S 1 1")
+        auth_mod._log_logout_caller()  # must not raise
+
+    def test_cmdline_unreadable_stops(self, monkeypatch):
+        import klangk.cli.auth as auth_mod
+
+        monkeypatch.setattr(auth_mod.os, "getppid", lambda: 42)
+        self._patch_open(monkeypatch, OSError("gone"), b"")
+        auth_mod._log_logout_caller()
+
+    def test_stat_unreadable_stops(self, monkeypatch):
+        import klangk.cli.auth as auth_mod
+
+        monkeypatch.setattr(auth_mod.os, "getppid", lambda: 42)
+        self._patch_open(monkeypatch, b"cmd\0", OSError("gone"))
+        auth_mod._log_logout_caller()
+
+    def test_stat_malformed_stops(self, monkeypatch):
+        import klangk.cli.auth as auth_mod
+
+        monkeypatch.setattr(auth_mod.os, "getppid", lambda: 42)
+        self._patch_open(monkeypatch, b"cmd\0", b"42 (cmd) S not-a-pid")
+        auth_mod._log_logout_caller()
+
+
+class TestContextClientConstructor:
+    def test_client_builds_from_cached_state(self, monkeypatch):
+        import klangk.cli.context as context
+
+        st = CLIState()
+        st.set_credentials("http://srv", "u@x", "tok-1")
+        monkeypatch.setattr(context, "state_cache", st)
+        monkeypatch.setattr(context, "cfg_cache", CLIConfig())
+        monkeypatch.setattr(context, "server_override", None)
+        client = context.client()
+        assert client.server_url == "http://srv"
+        assert client.token == "tok-1"

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -6128,6 +6128,29 @@ class TestLogLogoutCaller:
         self._patch_open(monkeypatch, b"cmd\0", OSError("gone"))
         auth_mod._log_logout_caller()
 
+    def test_walk_exhausts_eight_iterations(self, monkeypatch):
+        """A deep chain (never reaching init, never repeating) exhausts
+        the 8-iteration budget and falls out of the loop normally."""
+        import builtins
+
+        import klangk.cli.auth as auth_mod
+
+        real_open = builtins.open
+        stat_ppid = iter(range(1000, 1020))
+
+        def deep_chain_open(file, *args, **kwargs):
+            name = str(file)
+            if name.endswith("/cmdline"):
+                return BytesIO(b"proc\0")
+            if name.endswith("/stat"):
+                ppid = next(stat_ppid)
+                return BytesIO(f"42 (proc) S {ppid}".encode())
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", deep_chain_open)
+        monkeypatch.setattr(auth_mod.os, "getppid", lambda: 100)
+        auth_mod._log_logout_caller()  # must not raise
+
     def test_stat_malformed_stops(self, monkeypatch):
         import klangk.cli.auth as auth_mod
 

--- a/src/klangk/klangkc-tests/tests/test_transport.py
+++ b/src/klangk/klangkc-tests/tests/test_transport.py
@@ -286,6 +286,6 @@ class TestWsConnect:
             pytest.raises(OSError, match="connection refused"),
         ):
             async with ws_connect("/tmp/klangk.sock", token="tok"):
-                pass  # pragma: no cover
+                pass  # pragma: no cover — __aenter__ raises before the body runs
 
         mock_sock.close.assert_called_once()


### PR DESCRIPTION
Part 1 of #2910 — the `cli/` subpackage (the largest chunk: 53 of 159 `no cover` sites in gated source).

## What changed

**Removed 45 bare `# pragma: no cover` markers** from `klangk/cli/` and covered every formerly-excluded path with real tests (42 new tests in `klangkc-tests/tests/test_cli.py`):

- `client.py` — ssh-agent socket short reads (real AF_UNIX sockets), bounded-recv deadline arms, `drain_terminal_startup` error/timeout frames, `create_own_window` not-created, `_ShellSession.run` abstract, heartbeat send + skip-send arms, stdin/resize pump OSError guards, `_extend_escape_sequence` drain OSError, exec stdin-forward not-ready + bytes frames, stdin-drain timeout, exec deadline → exit 124
- `auth.py` — `oidc_browser_login` end-to-end (browser patched to hit the localhost callback: success, malformed JWT → unknown email, error param, timeout), `_log_logout_caller` `/proc`-walk break arms
- `main.py` — all four entry-point exception handlers → SystemExit(1)
- `context.py` — `cfg()`/`state()` cache arms and `client()` (were stale: conftest resets the caches per test)
- `execsync.py`, `sandboxcmd.py`, `shellcmd.py`, `terminals.py` — missing-binary, HTTP-error, no-token, InvalidStatus 4001/4002 + re-raise, best-effort warning handlers, service-command deadline, workspace-pick input guards

**Testability refactors** (small): `_HEARTBEAT_INTERVAL` / `_STDIN_DRAIN_TIMEOUT` module constants, `fire_service_command(timeout=…)` parameter.

**Kept** 8 pragmas, each with an inline justification: httpx-multipart callbacks, not-yet-mounted TUI `NoMatches` guards (main.py's now matches the other two), the `__main__` module-exec arm, and the duplicate `require_auth` guard in monitor. `create_own_window`'s async-for gains the same documented `no-branch` pragma `drain_terminal_startup` already carried.

**Test files**: `test_transport.py`'s unreachable `pass` gets a justification; stale pragma reference in a `test_cli.py` comment dropped.

## Verification

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` → 6216 passed, **100% total coverage** (branch gate held)
- `scripts/tests` → 97 passed
- xenon gate passed

No changelog entry — test-infrastructure work, invisible to operators.
