### PR TITLE
fix(doctor): map the ip binary to the iproute2 package in install hints (#2921)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1620,6 +1620,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`klangkd doctor` names the right package for a missing `ip` command
+  (#2921).** The warning hint now says `sudo dnf install iproute2` (apt,
+  zypper, apk, pacman likewise) instead of `sudo dnf install ip`, which
+  names a nonexistent package.
+
 - **Admin users list marks the system agent (#2892).** The built-in
   `klangk@example.com` user now carries a SYSTEM badge and a fixed-identity
   note instead of looking like an ordinary account, and tapping its row no

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1621,9 +1621,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 ### Fixed
 
 - **`klangkd doctor` names the right package for a missing `ip` command
-  (#2921).** The warning hint now says `sudo dnf install iproute2` (apt,
-  zypper, apk, pacman likewise) instead of `sudo dnf install ip`, which
-  names a nonexistent package.
+  (#2921).** The warning hint now says `sudo dnf install iproute` on the
+  Red Hat family and `sudo apt install iproute2` elsewhere (zypper, apk,
+  pacman, brew likewise) instead of `sudo dnf install ip`, which names a
+  nonexistent package.
 
 - **Admin users list marks the system agent (#2892).** The built-in
   `klangk@example.com` user now carries a SYSTEM badge and a fixed-identity

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -158,15 +158,17 @@ _PACKAGE_HINTS: dict[str, dict[str, str]] = {
         "apt": "uidmap",
     },
     # Container subnet auto-detection (`ip -4 addr show`, #2089).
-    # Linux-only check — same package name everywhere except brew
-    # (skipped on Darwin), where the check never runs.
+    # The binary ships as `iproute` on the Red Hat family (dnf/yum) and
+    # `iproute2` everywhere else — brew covers Linuxbrew hosts (the formula
+    # is Linux-only, but the check is Darwin-skipped anyway).
     "ip": {
-        "dnf": "iproute2",
-        "yum": "iproute2",
+        "dnf": "iproute",
+        "yum": "iproute",
         "apt": "iproute2",
         "zypper": "iproute2",
         "apk": "iproute2",
         "pacman": "iproute2",
+        "brew": "iproute2",
     },
 }
 
@@ -569,8 +571,8 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
             ip_result.message = (
                 "ip not found — container subnet auto-detection will fall "
                 "back to broad RFC1918 ranges (172.16/12 + 10/8). Install "
-                "iproute2 for precise detection, or set "
-                "KLANGKD_CONTAINER_SUBNETS explicitly."
+                "the iproute/iproute2 package for your distro for precise "
+                "detection, or set KLANGKD_CONTAINER_SUBNETS explicitly."
             )
         report.add(ip_result)
 

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -157,6 +157,17 @@ _PACKAGE_HINTS: dict[str, dict[str, str]] = {
         "dnf": "shadow-utils",
         "apt": "uidmap",
     },
+    # Container subnet auto-detection (`ip -4 addr show`, #2089).
+    # Linux-only check — same package name everywhere except brew
+    # (skipped on Darwin), where the check never runs.
+    "ip": {
+        "dnf": "iproute2",
+        "yum": "iproute2",
+        "apt": "iproute2",
+        "zypper": "iproute2",
+        "apk": "iproute2",
+        "pacman": "iproute2",
+    },
 }
 
 

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -127,6 +127,13 @@ class TestInstallHint:
             == "sudo apt install obscure-tool"
         )
 
+    def test_ip_maps_to_iproute2(self):
+        """The ip binary ships as the iproute2 package (#2921) — 'install ip'
+        names a nonexistent package on every major manager."""
+        assert install_hint("ip", "dnf") == "sudo dnf install iproute2"
+        assert install_hint("ip", "apt") == "sudo apt install iproute2"
+        assert install_hint("ip", "pacman") == "sudo pacman install iproute2"
+
 
 class TestCheckBinary:
     def test_missing_binary(self):

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -128,11 +128,16 @@ class TestInstallHint:
         )
 
     def test_ip_maps_to_iproute2(self):
-        """The ip binary ships as the iproute2 package (#2921) — 'install ip'
-        names a nonexistent package on every major manager."""
-        assert install_hint("ip", "dnf") == "sudo dnf install iproute2"
+        """The ip binary ships as `iproute` on Red Hat family and `iproute2`
+        elsewhere (#2921) — the binary name alone names a nonexistent
+        package on every major manager."""
+        assert install_hint("ip", "dnf") == "sudo dnf install iproute"
+        assert install_hint("ip", "yum") == "sudo yum install iproute"
         assert install_hint("ip", "apt") == "sudo apt install iproute2"
+        assert install_hint("ip", "zypper") == "sudo zypper install iproute2"
+        assert install_hint("ip", "apk") == "sudo apk install iproute2"
         assert install_hint("ip", "pacman") == "sudo pacman install iproute2"
+        assert install_hint("ip", "brew") == "brew install iproute2"
 
 
 class TestCheckBinary:


### PR DESCRIPTION
## Summary

`klangkd doctor`'s optional `ip` check (#2089, Linux-only) warned correctly
when `ip` was missing, but the fix hint named a nonexistent package:
`install_hint("ip", ...)` fell back to the binary name because
`_PACKAGE_HINTS` had no `"ip"` entry — doctor printed e.g.
`Run: sudo dnf install ip`.

Adds the entry with the correct package per manager: `iproute` on the Red
Hat family (dnf/yum — upstream is named iproute2, the Fedora/RHEL package
is not), `iproute2` on apt/zypper/apk/pacman, and `brew` for Linuxbrew
hosts (the Homebrew formula is Linux-only and the check is Darwin-skipped
anyway). The warning prose is now distro-neutral. Found by an adversarial
review pass: the first version mapped every manager to `iproute2`,
reintroducing the exact bug class on dnf/yum.

Also updates `docs/changes.md` ([Unreleased] → Fixed).

## Test plan

- [x] `TestInstallHint::test_ip_maps_to_iproute2` asserts all seven rows
- [x] Full backend suite the CI way (`-n auto`): 6310 passed, 100% branch coverage
- [x] xenon pre-commit hook passed

Closes #2921
