### PR TITLE
fix(auth): prune activity_stamps entry when a user is deleted (#2914)

### DIFF
--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -346,6 +346,10 @@ async def delete_user(
     # Archive workspace data before deletion
     await app.state.workspaces.archive_user_data(user_id, user["email"])
     deleted = await app.state.model.users.delete_user(user_id)
+    # Prune the per-user activity-throttle stamp (#2914): placed before
+    # the not-deleted race check so even a lost race (user already gone)
+    # does not leave a stale entry behind.
+    app.state.auth.forget_user(user_id)
     if not deleted:  # pragma: no cover — race between get and delete
         raise HTTPException(status_code=404, detail="User not found")
     return {"status": "deleted"}

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -730,9 +730,10 @@ class Auth:
         """Drop the user's activity-throttle stamp (#2914).
 
         Called from the user-delete path so ``activity_stamps`` does not
-        retain ids of deleted users for the process lifetime. A stale
-        stamp only suppresses one throttled ``last_activity_at`` write,
-        so a user deleted mid-interval loses nothing.
+        retain ids of deleted users for the process lifetime. The stamp
+        is a write throttle only — pruning it is hygiene, not a
+        correctness concern (every ``record_activity`` call site drops
+        out on the missing user row anyway).
         """
         self.activity_stamps.pop(user_id, None)
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -726,6 +726,16 @@ class Auth:
         self.activity_stamps[user_id] = now
         await self.app.state.model.users.record_activity(user_id)
 
+    def forget_user(self, user_id: str) -> None:
+        """Drop the user's activity-throttle stamp (#2914).
+
+        Called from the user-delete path so ``activity_stamps`` does not
+        retain ids of deleted users for the process lifetime. A stale
+        stamp only suppresses one throttled ``last_activity_at`` write,
+        so a user deleted mid-interval loses nothing.
+        """
+        self.activity_stamps.pop(user_id, None)
+
     def decode_token(self, token: str, *, allow_expired: bool = False) -> dict:
         options = {"verify_exp": False} if allow_expired else {}
         return jwt.decode(

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -8673,6 +8673,31 @@ class TestAdminEndpoints:
         emails = [u["email"] for u in resp.json()["users"]]
         assert "testuser@example.com" not in emails
 
+    async def test_delete_user_prunes_activity_stamp(
+        self, client, app, admin_user, user, registry
+    ):
+        """#2914: the delete path drops the user's activity-throttle
+        stamp so Auth.activity_stamps retains no deleted-user ids."""
+        app.state.auth.activity_stamps[user["id"]] = 123.0
+        headers = await self._admin_headers(client)
+        with (
+            patch.object(
+                registry,
+                "stop_user_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                app.state.workspaces,
+                "archive_user_data",
+                new_callable=AsyncMock,
+            ),
+        ):
+            resp = await client.delete(
+                f"/api/v1/admin/users/{user['id']}", headers=headers
+            )
+        assert resp.status_code == 200
+        assert user["id"] not in app.state.auth.activity_stamps
+
     async def test_delete_self_forbidden(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.delete(

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1687,6 +1687,20 @@ class TestRecordActivity:
         row = await a.app.state.model.users.get_user_by_id(user["id"])
         assert row["last_activity_at"] is not None
 
+    async def test_forget_user_drops_stamp(self, user, db):
+        """#2914: forget_user prunes the throttle entry so deleted users
+        don't linger in activity_stamps for the process lifetime."""
+        a = _auth()
+        await a.record_activity(user["id"])
+        assert user["id"] in a.activity_stamps
+        a.forget_user(user["id"])
+        assert user["id"] not in a.activity_stamps
+        # Forgetting an id with no entry is a no-op.
+        a.forget_user("never-seen")
+        # After forgetting, the next call writes immediately again.
+        await a.record_activity(user["id"])
+        assert user["id"] in a.activity_stamps
+
 
 class TestRefreshBranchGaps2834:
     """#2834 branch gate: the expired-token path without a jti claim."""


### PR DESCRIPTION
## Summary

- Add `Auth.forget_user(user_id)`, which pops the user's entry from the
  `activity_stamps` throttle dict, and call it from the admin
  delete-user endpoint — the only production user-deletion site (the
  inactivity sweep disables accounts; it never deletes them).
- Without this, `activity_stamps` (`user_id -> monotonic timestamp`,
  used to throttle `users.last_activity_at` writes) retained the ids of
  deleted users for the process lifetime.
- The call sits before the not-deleted race check, so even a lost race
  (user already gone from the DB) leaves no stale entry. A stale stamp
  only suppressed one throttled write, so pruning mid-interval is
  harmless.

Closes #2914.

## Testing

- New unit test `test_forget_user_drops_stamp` (auth): stamp → forget →
  absent, no-op on unknown id, next `record_activity` writes again.
- New API test `test_delete_user_prunes_activity_stamp`: a pre-seeded
  stamp is gone after `DELETE /admin/users/{id}`.
- Full backend + CLI suite: 6312 passed, 100% branch coverage; xenon
  gate passed.
