### PR TITLE
WorkspaceSession: hold strong references to fire-and-forget tasks

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1620,6 +1620,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace session background tasks are now strongly referenced
+  (#2913).** The tmux window-watcher start/stop and the debounced window
+  re-sync ran as unreferenced fire-and-forget tasks, which CPython may
+  garbage-collect mid-execution; when the collected task was the window
+  watcher's stop, the per-workspace tmux control-mode teardown never
+  completed and stranded a host-side subprocess pair until the container
+  stopped. Tasks are held in a module-level set until they finish.
+
 - **`klangkd doctor` names the right package for a missing `ip` command
   (#2921).** The warning hint now says `sudo dnf install iproute` on the
   Red Hat family and `sudo apt install iproute2` elsewhere (zypper, apk,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1623,10 +1623,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 - **Workspace session background tasks are now strongly referenced
   (#2913).** The tmux window-watcher start/stop and the debounced window
   re-sync ran as unreferenced fire-and-forget tasks, which CPython may
-  garbage-collect mid-execution; when the collected task was the window
+  garbage-collect mid-execution. When the collected task was the window
   watcher's stop, the per-workspace tmux control-mode teardown never
-  completed and stranded a host-side subprocess pair until the container
-  stopped. Tasks are held in a module-level set until they finish.
+  completed, leaking the host-side podman exec reader and its
+  container-side tmux control client until the container stopped.
 
 - **`klangkd doctor` names the right package for a missing `ip` command
   (#2921).** The warning hint now says `sudo dnf install iproute` on the

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -22,6 +22,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Strong references to the session's fire-and-forget tasks (#2913): the
+# event loop only keeps strong references to tasks while they are
+# scheduled, so an unreferenced task suspended in an await is
+# GC-eligible mid-execution — the same hazard guarded against by
+# ``lifecycle._status_broadcast_tasks`` (#1714 review) and
+# ``consent._activity_tasks`` in klangksidecar. Module-level, NOT an
+# instance attribute: the ``reset()`` case spawns ``watcher.stop()``
+# (the per-workspace tmux ``-C`` control-mode teardown), which must
+# finish after its session has been dropped and popped from the
+# sockets map — an instance set would die with the session and leave
+# the teardown task unreferenced again. The done-callback discard
+# keeps the set from growing without bound.
+_session_tasks: set[asyncio.Task] = set()
+
+
+def spawn_session_task(coro) -> asyncio.Task:
+    """Schedule *coro* in the background, holding a strong reference (#2913).
+
+    See ``_session_tasks`` above: the caller may drop every other
+    reference (fire-and-forget) without exposing the task to
+    mid-execution garbage collection.
+    """
+    task = asyncio.create_task(coro)
+    _session_tasks.add(task)
+    task.add_done_callback(_session_tasks.discard)
+    return task
+
 
 def merge_window_entries(old: list[dict], windows: list[dict]) -> list[dict]:
     """Fold a fresh tmux ``list_windows`` result into the session map.
@@ -269,7 +296,7 @@ class WorkspaceSession:
         watcher = self._window_watcher
         self._window_watcher = None
         if watcher is not None:
-            asyncio.create_task(watcher.stop())
+            spawn_session_task(watcher.stop())
         self._last_windows.clear()
         self._window_generations.clear()
 
@@ -374,7 +401,7 @@ class WorkspaceSession:
             self.container_id,
             self._schedule_window_sync,
         )
-        asyncio.create_task(self._window_watcher.start())
+        spawn_session_task(self._window_watcher.start())
 
     def _schedule_window_sync(self) -> None:
         """Debounce a burst of control-mode events into one re-sync."""
@@ -410,7 +437,7 @@ class WorkspaceSession:
 
     def _dispatch_window_sync(self) -> None:
         self._window_sync_handle = None
-        asyncio.create_task(self._sync_windows_once())
+        spawn_session_task(self._sync_windows_once())
 
     async def _sync_windows_once(self) -> None:
         """Re-broadcast ``terminal_windows`` to each connected user when tmux's

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -7,8 +7,9 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Coroutine
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .. import model
 from ..acl import check_permission_inmemory, resource_ancestors
@@ -32,12 +33,32 @@ logger = logging.getLogger(__name__)
 # (the per-workspace tmux ``-C`` control-mode teardown), which must
 # finish after its session has been dropped and popped from the
 # sockets map — an instance set would die with the session and leave
-# the teardown task unreferenced again. The done-callback discard
-# keeps the set from growing without bound.
+# the teardown task unreferenced again. The done-callback
+# (:func:`_finish_session_task`) discards from the set and logs a
+# failure, since nobody awaits a fire-and-forget task to observe it.
 _session_tasks: set[asyncio.Task] = set()
 
 
-def spawn_session_task(coro) -> asyncio.Task:
+def _finish_session_task(task: asyncio.Task) -> None:
+    """Done-callback for :func:`spawn_session_task` (#2913).
+
+    Discards the strong reference so the set cannot grow without
+    bound, and logs an unobserved failure: these tasks are
+    fire-and-forget, so without this an exception would surface only
+    as asyncio's context-free ``Task exception was never retrieved``
+    at task GC — the same reason ``lifecycle.broadcast_container_status``
+    wraps its broadcast in try/except + logging (#1714). Retrieving the
+    exception here also marks it seen for asyncio.
+    """
+    _session_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("Background session task failed", exc_info=exc)
+
+
+def spawn_session_task(coro: Coroutine[Any, Any, Any]) -> asyncio.Task:
     """Schedule *coro* in the background, holding a strong reference (#2913).
 
     See ``_session_tasks`` above: the caller may drop every other
@@ -46,7 +67,7 @@ def spawn_session_task(coro) -> asyncio.Task:
     """
     task = asyncio.create_task(coro)
     _session_tasks.add(task)
-    task.add_done_callback(_session_tasks.discard)
+    task.add_done_callback(_finish_session_task)
     return task
 
 

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import gc
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from klangk.wshandler.session import (
@@ -443,9 +444,12 @@ async def test_reset_stops_window_watcher():
     watcher = MagicMock()
     watcher.stop = AsyncMock()
     sess._window_watcher = watcher
-    with patch("asyncio.create_task") as create_task:
+    with patch(
+        "klangk.wshandler.session.spawn_session_task",
+        side_effect=lambda coro: coro.close(),
+    ) as spawn:
         await sess.reset()
-    create_task.assert_called_once()
+    spawn.assert_called_once()
     watcher.stop.assert_not_awaited()  # scheduled, not awaited inline
 
 
@@ -454,16 +458,22 @@ async def test_start_window_sync_schedules_watcher_start():
     sess.container_id = "cid"
     with patch("klangk.wshandler.session.WindowEventWatcher") as cls:
         cls.return_value.start = AsyncMock()
-        with patch("asyncio.create_task") as create_task:
+        with patch(
+            "klangk.wshandler.session.spawn_session_task",
+            side_effect=lambda coro: coro.close(),
+        ) as spawn:
             sess.start_window_sync()
-        create_task.assert_called_once()
+        spawn.assert_called_once()
 
 
 async def test_dispatch_window_sync_schedules_once():
     sess, _, _ = _session_with_user()
-    with patch("asyncio.create_task") as create_task:
+    with patch(
+        "klangk.wshandler.session.spawn_session_task",
+        side_effect=lambda coro: coro.close(),
+    ) as spawn:
         sess._dispatch_window_sync()
-    create_task.assert_called_once()
+    spawn.assert_called_once()
 
 
 async def test_token_renewal_loop_exits_without_expiry():
@@ -496,7 +506,7 @@ async def test_spawn_session_task_holds_strong_reference_until_done():
 
     async def hangs() -> None:
         started.set()
-        await asyncio.sleep(30)
+        await asyncio.Event().wait()
 
     task = spawn_session_task(hangs())
     await started.wait()
@@ -510,13 +520,72 @@ async def test_spawn_session_task_holds_strong_reference_until_done():
     assert task not in _session_tasks  # done-callback discarded it
 
 
+async def test_spawn_session_task_logs_unawaited_failures(caplog):
+    """A spawned task that fails is logged, not silently dropped.
+
+    Fire-and-forget means nobody awaits these tasks (#2926 review),
+    so without the done-callback log a failure in e.g.
+    ``WindowEventWatcher.start`` (``create_subprocess_exec`` can raise)
+    would surface only as asyncio's context-free ``Task exception was
+    never retrieved`` at task GC.
+    """
+    with caplog.at_level(logging.ERROR, logger="klangk.wshandler.session"):
+
+        async def boom() -> None:
+            raise RuntimeError("teardown exploded")
+
+        task = spawn_session_task(boom())
+        try:
+            await task
+        except RuntimeError:
+            pass
+        await asyncio.sleep(0)  # drain the done-callback
+
+    assert "Background session task failed" in caplog.text
+    assert "teardown exploded" in caplog.text
+    assert task not in _session_tasks
+
+
+async def test_spawn_session_task_no_error_log_on_cancel(caplog):
+    """A cancelled fire-and-forget task is a normal teardown, not a
+    failure: the done-callback must not log it (#2926 review)."""
+    started = asyncio.Event()
+
+    async def hangs() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    with caplog.at_level(logging.ERROR, logger="klangk.wshandler.session"):
+        task = spawn_session_task(hangs())
+        await started.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)  # drain the done-callback
+
+    assert not caplog.records
+    assert task not in _session_tasks
+
+
 async def test_reset_stop_task_survives_session_drop():
     """The ``watcher.stop()`` task outlives the dying session (#2913).
 
     ``reset()`` runs after the session is popped from the sockets map,
     so an instance-attribute reference set would be collected with the
-    session and strand the teardown task again. The module-level set
-    keeps the still-in-flight stop alive even with no other reference.
+    session and strand the teardown task again.
+
+    The hazard construction is deliberate: the task suspends on an
+    inline ``Event().wait()`` whose only referents loop back through
+    the task itself (coroutine frame → event → future → wakeup
+    callback → task), so with no external reference the whole cycle is
+    collectable — unlike a not-yet-started task (referenced by its
+    ready-queue handle) or a plain ``sleep`` (anchored in the loop's
+    timer heap), which survive ``gc.collect()`` even unreferenced.
+    With the module-level set in place the cycle has an external root:
+    after ``gc.collect()`` the task is still pending and responsive to
+    cancellation.
     """
     sess, _, _ = _session_with_user()
     watcher = MagicMock()
@@ -525,17 +594,15 @@ async def test_reset_stop_task_survives_session_drop():
 
     async def slow_stop() -> None:
         stopping.set()
-        await asyncio.sleep(30)
+        await asyncio.Event().wait()  # unreferenced waitable: pure cycle
 
     watcher.stop = slow_stop
     sess._window_watcher = watcher
 
     await sess.reset()
     del watcher, sess  # no external references to the session or watcher
-    gc.collect()
-    await stopping.wait()
-    # The stop task is still alive and referenced module-level even
-    # though its session (and every local reference) is gone; finish it.
+    await stopping.wait()  # yield: the stop task runs and suspends
+    gc.collect()  # would collect the cycle without the strong reference
     pending = {t for t in _session_tasks if t not in before and not t.done()}
     assert pending, "the in-flight watcher.stop() task lost its reference"
     for t in pending:

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -1,9 +1,15 @@
 """Tests for WorkspaceSession's tmux window-sync (debounce + re-broadcast)."""
 
 import asyncio
+import gc
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from klangk.wshandler.session import WorkspaceSession, WebSocketState
+from klangk.wshandler.session import (
+    WorkspaceSession,
+    WebSocketState,
+    _session_tasks,
+    spawn_session_task,
+)
 
 
 def _session_with_user(user_id: str = "u1", handle: str | None = None):
@@ -474,3 +480,68 @@ async def test_token_renewal_loop_exits_without_container():
     sess.container_id = None
     with patch("klangk.wshandler.session.asyncio.sleep", new=AsyncMock()):
         await sess._token_renewal_loop()  # renewal unreachable: exit
+
+
+# --- #2913: fire-and-forget tasks must be strongly referenced ---------
+
+
+async def test_spawn_session_task_holds_strong_reference_until_done():
+    """A spawned task stays referenced while in flight, is discarded on done.
+
+    An unreferenced task suspended in an await is GC-eligible
+    mid-execution (#2913); the module-level set must hold it until it
+    completes, then drop it so the set cannot grow unboundedly.
+    """
+    started = asyncio.Event()
+
+    async def hangs() -> None:
+        started.set()
+        await asyncio.sleep(30)
+
+    task = spawn_session_task(hangs())
+    await started.wait()
+    assert task in _session_tasks  # referenced while suspended in an await
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert task not in _session_tasks  # done-callback discarded it
+
+
+async def test_reset_stop_task_survives_session_drop():
+    """The ``watcher.stop()`` task outlives the dying session (#2913).
+
+    ``reset()`` runs after the session is popped from the sockets map,
+    so an instance-attribute reference set would be collected with the
+    session and strand the teardown task again. The module-level set
+    keeps the still-in-flight stop alive even with no other reference.
+    """
+    sess, _, _ = _session_with_user()
+    watcher = MagicMock()
+    stopping = asyncio.Event()
+    before = set(_session_tasks)
+
+    async def slow_stop() -> None:
+        stopping.set()
+        await asyncio.sleep(30)
+
+    watcher.stop = slow_stop
+    sess._window_watcher = watcher
+
+    await sess.reset()
+    del watcher, sess  # no external references to the session or watcher
+    gc.collect()
+    await stopping.wait()
+    # The stop task is still alive and referenced module-level even
+    # though its session (and every local reference) is gone; finish it.
+    pending = {t for t in _session_tasks if t not in before and not t.done()}
+    assert pending, "the in-flight watcher.stop() task lost its reference"
+    for t in pending:
+        t.cancel()
+        try:
+            await t
+        except asyncio.CancelledError:
+            pass
+        assert t not in _session_tasks  # discarded by the done-callback


### PR DESCRIPTION
## Summary

Fixes #2913 (from the #2911 long-lived-process memory audit): three
`asyncio.create_task` call sites in `WorkspaceSession` dropped the task
reference on the floor — per CPython semantics, an unreferenced task
suspended in an `await` is GC-eligible mid-execution. The worst case was
the `reset()`-spawned `watcher.stop()`: if collected, the per-workspace
tmux `-C` control-mode teardown never completed, stranding a host-side
`podman exec` reader subprocess pair until the container stopped.

## Changes

- New `spawn_session_task()` helper in `klangk/wshandler/session.py`:
  `create_task` + a strong reference in the module-level `_session_tasks`
  set, discarded by a done-callback (mirrors `lifecycle._status_broadcast_tasks`
  from #1714). Module-level on purpose — the `reset()` stop task must
  outlive the dying session, so an instance attribute is not enough.
- All three fire-and-forget sites now route through it:
  - `WorkspaceSession.reset()` → `watcher.stop()`
  - `WorkspaceSession.start_window_sync()` → `watcher.start()`
  - `WorkspaceSession._dispatch_window_sync()` → `_sync_windows_once()`
- Tests: reference-held-while-in-flight / discarded-on-done, and a
  reset-specific test proving the stop task survives session drop +
  `gc.collect()`.
- Changelog entry under `[Unreleased]` → Fixed.

## Testing

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — 6312 passed, 100% coverage (branch).
- `pre-commit run xenon` / `ruff-format` clean.
