### PR TITLE
Registry: prune _workspace_locks and stop_epoch for deleted workspaces

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1627,6 +1627,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   watcher's stop, the per-workspace tmux control-mode teardown never
   completed, leaking the host-side podman exec reader and its
   container-side tmux control client until the container stopped.
+- **Memory leak on workspace delete (#2912).** Deleting a workspace
+  (or a user, whose workspaces cascade-delete) now drops the daemon's
+  per-workspace registry entries — one start/stop lock and one stop-epoch
+  counter per workspace id ever started, previously retained for the
+  process lifetime. Found by the long-lived-process memory audit (#2911).
 
 - **`klangkd doctor` names the right package for a missing `ip` command
   (#2921).** The warning hint now says `sudo dnf install iproute` on the

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -345,6 +345,10 @@ async def delete_user(
     await app.state.container_registry.stop_user_containers(user_id)
     # Archive workspace data before deletion
     await app.state.workspaces.archive_user_data(user_id, user["email"])
+    # Capture the user's workspace ids before the DB cascade removes the
+    # rows, so the per-workspace registry entries can be pruned after the
+    # delete (#2912).
+    ws_ids = await app.state.model.workspaces.get_user_workspace_ids(user_id)
     deleted = await app.state.model.users.delete_user(user_id)
     # Prune the per-user activity-throttle stamp (#2914): placed before
     # the not-deleted race check so even a lost race (user already gone)
@@ -352,6 +356,11 @@ async def delete_user(
     app.state.auth.forget_user(user_id)
     if not deleted:  # pragma: no cover — race between get and delete
         raise HTTPException(status_code=404, detail="User not found")
+    # #2912: the cascade-deleted ids can never be started again -- drop
+    # their registry entries (per-workspace lock + stop epoch).
+    registry = app.state.container_registry
+    for ws_id in ws_ids:
+        registry.prune_workspace_registry_entries(ws_id)
     return {"status": "deleted"}
 
 

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -482,6 +482,23 @@ class ContainerRegistry(NetworkSidecarMixin):
         lock = self._workspace_locks.get(workspace_id)
         return lock is not None and lock.locked()
 
+    def prune_workspace_registry_entries(self, workspace_id: str) -> None:
+        """Drop the per-workspace lock and stop-epoch entries (#2912).
+
+        Called **only** from workspace *delete* paths (the workspace
+        delete endpoint and the admin user-delete cascade), after the
+        DB row is gone: the id can never be started again, so the
+        #1258 reason the lock entry outlives every stop (a racing start
+        must serialize against the in-flight stop's lock object) no
+        longer applies. Bounds ``_workspace_locks`` and ``stop_epoch``
+        against unbounded growth from workspace create/delete churn,
+        mirroring how :meth:`prune_service_session_locks` bounds the
+        per-container lock dict (#1351). A no-op when neither entry
+        exists (the workspace was never started in this process).
+        """
+        self._workspace_locks.pop(workspace_id, None)
+        self.stop_epoch.pop(workspace_id, None)
+
     # --- State tracking ---
 
     def track_activity(
@@ -1694,7 +1711,9 @@ class ContainerRegistry(NetworkSidecarMixin):
         create a brand-new lock object that does not serialize against the
         in-flight one -- reopening the very race this method exists to
         prevent. The retained entry is a single small object per workspace
-        ever seen and is cleared on process restart.
+        ever seen and is cleared on process restart, or on workspace
+        *delete* (:meth:`prune_workspace_registry_entries`, #2912) -- the
+        only path on which the id can never be started again.
 
         Every caller of this method is an *expected* stop (user stop, idle
         stop, delete, logout, shutdown — plus the crash monitor's own

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -487,14 +487,26 @@ class ContainerRegistry(NetworkSidecarMixin):
 
         Called **only** from workspace *delete* paths (the workspace
         delete endpoint and the admin user-delete cascade), after the
-        DB row is gone: the id can never be started again, so the
-        #1258 reason the lock entry outlives every stop (a racing start
-        must serialize against the in-flight stop's lock object) no
-        longer applies. Bounds ``_workspace_locks`` and ``stop_epoch``
-        against unbounded growth from workspace create/delete churn,
-        mirroring how :meth:`prune_service_session_locks` bounds the
-        per-container lock dict (#1351). A no-op when neither entry
-        exists (the workspace was never started in this process).
+        DB row is gone: no *new* start can pass its existence check,
+        so the #1258 reason the lock entry outlives every stop (a
+        racing start must serialize against the in-flight stop's lock
+        object) no longer applies to fresh starts. A start that
+        already passed its DB check before the delete committed may
+        still hold or wait on the popped lock — the pop removes the
+        dict entry, not the lock object, so the holder keeps a working
+        lock; the orphaned container it may leave behind is the
+        pre-existing delete-vs-start race outcome, not a new one.
+
+        The stop-epoch pop resets the workspace to the implicit 0
+        (``get``'s default, i.e. "never stopped"): the #2625 crash
+        guards compare epochs by inequality, so anything deleted
+        mid-detection reads as "changed" and skips — it can never
+        cause a wrong restart. Bounds ``_workspace_locks`` and
+        ``stop_epoch`` against unbounded growth from workspace
+        create/delete churn, mirroring how
+        :meth:`prune_service_session_locks` bounds the per-container
+        lock dict (#1351). A no-op when neither entry exists (the
+        workspace was never started in this process).
         """
         self._workspace_locks.pop(workspace_id, None)
         self.stop_epoch.pop(workspace_id, None)
@@ -1713,7 +1725,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         prevent. The retained entry is a single small object per workspace
         ever seen and is cleared on process restart, or on workspace
         *delete* (:meth:`prune_workspace_registry_entries`, #2912) -- the
-        only path on which the id can never be started again.
+        only path after which no new start can begin for the id.
 
         Every caller of this method is an *expected* stop (user stop, idle
         stop, delete, logout, shutdown — plus the crash monitor's own

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -563,6 +563,11 @@ class Workspaces:
             await self.app.state.nix.destroy_workspace_nix(workspace_id)
             ws_dir = self.safe_path(workspace_id)
             await async_rmtree(ws_dir, f"workspace {workspace_id}")
+            # #2912: the id can never be started again -- drop the
+            # per-workspace registry entries (lock + stop epoch).
+            self.app.state.container_registry.prune_workspace_registry_entries(
+                workspace_id
+            )
         return deleted
 
     # --- home symlink ---

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -499,6 +499,8 @@ class Workspaces:
             )
         except Exception:
             # Clean up the DB record and directories on port allocation failure
+            # (no registry prune needed: the workspace never started, so it
+            # holds no per-workspace lock/epoch entries).
             await self.app.state.model.workspaces.delete_workspace(
                 workspace["id"], user_id
             )
@@ -558,16 +560,19 @@ class Workspaces:
             workspace_id, user_id
         )
         if deleted:
+            # #2912: prune first — the row is already gone (the model
+            # delete is a transactional rowcount==1), and the teardowns
+            # below are best-effort: a raising destroy_workspace_nix
+            # must not leave the registry entries behind (the retry
+            # DELETE 404s, so nothing else would ever pop them).
+            self.app.state.container_registry.prune_workspace_registry_entries(
+                workspace_id
+            )
             # #2201: drop the per-workspace nix clone if nix is enabled
             # (no-op otherwise).
             await self.app.state.nix.destroy_workspace_nix(workspace_id)
             ws_dir = self.safe_path(workspace_id)
             await async_rmtree(ws_dir, f"workspace {workspace_id}")
-            # #2912: the id can never be started again -- drop the
-            # per-workspace registry entries (lock + stop epoch).
-            self.app.state.container_registry.prune_workspace_registry_entries(
-                workspace_id
-            )
         return deleted
 
     # --- home symlink ---

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2640,6 +2640,31 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
 
+    async def test_delete_workspace_prunes_registry_entries(
+        self, client, app, user, registry, app_state
+    ):
+        """#2912: delete drops the per-workspace lock + stop-epoch entries
+        (the id can never be started again)."""
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "pruned"}
+        )
+        ws_id = create_resp.json()["id"]
+        registry._get_workspace_lock(ws_id)
+        registry.stop_epoch[ws_id] = 4
+
+        with patch.object(
+            registry,
+            "stop_and_remove_container",
+            new_callable=AsyncMock,
+        ):
+            resp = await client.delete(
+                f"/api/v1/workspaces/{ws_id}", headers=headers
+            )
+        assert resp.status_code == 200
+        assert ws_id not in registry._workspace_locks
+        assert ws_id not in registry.stop_epoch
+
     async def test_delete_no_permission(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.delete(
@@ -8793,6 +8818,52 @@ class TestAdminEndpoints:
             user["id"]
         )
         assert len(ws_list) == 0
+
+    async def test_delete_user_prunes_workspace_registry_entries(
+        self, client, app, admin_user, ws_admin, registry, app_state
+    ):
+        """#2912: the user-delete cascade prunes the per-workspace lock +
+        stop-epoch entries for every workspace the user owned."""
+        user = ws_admin  # ws_admin returns the user dict
+        headers = await self._admin_headers(client)
+        user_login = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
+        )
+        user_headers = {
+            "Authorization": f"Bearer {user_login.json()['access_token']}"
+        }
+        ws_resp = await client.post(
+            "/api/v1/workspaces",
+            headers=user_headers,
+            json={"name": "cascade-prune"},
+        )
+        assert ws_resp.status_code == 200
+        ws_id = ws_resp.json()["id"]
+        registry._get_workspace_lock(ws_id)
+        registry.stop_epoch[ws_id] = 1
+
+        with (
+            patch.object(
+                registry,
+                "stop_user_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                app.state.workspaces,
+                "archive_user_data",
+                new_callable=AsyncMock,
+            ),
+        ):
+            resp = await client.delete(
+                f"/api/v1/admin/users/{user['id']}", headers=headers
+            )
+        assert resp.status_code == 200
+        assert ws_id not in registry._workspace_locks
+        assert ws_id not in registry.stop_epoch
 
     async def test_list_user_workspaces_admin(
         self, client, admin_user, ws_admin

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -7014,3 +7014,31 @@ class TestRegistryIdleDelegation2910:
         assert registry.cleanup_wake is wake
         registry.cleanup_wake = None
         assert registry.cleanup_wake is None
+
+
+class TestRegistryWorkspaceEntryPrune2912:
+    """#2912: workspace *delete* is the only release path for the
+    per-workspace lock and stop-epoch entries -- stops must retain them
+    (#1258: a racing start has to serialize against the in-flight stop's
+    lock object), but a deleted id can never be started again."""
+
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.state.container_registry
+
+    def test_prune_drops_lock_and_epoch_entries(self):
+        reg = self.registry
+        lock = reg._get_workspace_lock("ws-prune")
+        reg.stop_epoch["ws-prune"] = 3
+        reg.prune_workspace_registry_entries("ws-prune")
+        assert "ws-prune" not in reg._workspace_locks
+        assert "ws-prune" not in reg.stop_epoch
+        # The popped lock object itself is untouched -- an in-flight
+        # holder keeps a working lock; only the dict entry is dropped.
+        assert not lock.locked()
+
+    def test_prune_is_noop_for_never_started_workspace(self):
+        reg = self.registry
+        reg.prune_workspace_registry_entries("ws-never")
+        assert "ws-never" not in reg._workspace_locks
+        assert "ws-never" not in reg.stop_epoch

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -7042,3 +7042,22 @@ class TestRegistryWorkspaceEntryPrune2912:
         reg.prune_workspace_registry_entries("ws-never")
         assert "ws-never" not in reg._workspace_locks
         assert "ws-never" not in reg.stop_epoch
+
+    async def test_prune_while_held_replaces_lock_identity(self):
+        # A start that already passed its DB check may still hold the lock
+        # when a delete prunes it (#2912 review): the holder keeps a
+        # working lock object, but a later _get_workspace_lock builds a
+        # fresh one that does not serialize against it, and
+        # workspace_operation_in_flight stops reporting the workspace.
+        # Pin those semantics for the (orphaned) raced container.
+        reg = self.registry
+        held = reg._get_workspace_lock("ws-held")
+        await held.acquire()
+        try:
+            reg.prune_workspace_registry_entries("ws-held")
+            assert reg.workspace_operation_in_flight("ws-held") is False
+            fresh = reg._get_workspace_lock("ws-held")
+            assert fresh is not held
+            assert not fresh.locked()
+        finally:
+            held.release()

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -1211,3 +1211,27 @@ class TestWorkspacesServiceBranchGaps2834:
         assert await wsvc.delete_workspace(ws["id"], user["id"]) is True
         assert ws["id"] not in registry._workspace_locks
         assert ws["id"] not in registry.stop_epoch
+
+    async def test_delete_workspace_prunes_before_teardown_failures(
+        self, user, app_state, monkeypatch
+    ):
+        # #2912 review: the prune runs before the best-effort teardowns --
+        # a raising destroy_workspace_nix must not resurrect the leak (a
+        # retry DELETE 404s once the row is gone, so nothing else would
+        # ever pop the entries).
+        wsvc = app_state.state.workspaces
+        ws = await wsvc.create_workspace(user["id"], "nix-dies")
+        registry = app_state.state.container_registry
+        registry._get_workspace_lock(ws["id"])
+        registry.stop_epoch[ws["id"]] = 1
+
+        async def _raise(workspace_id):
+            raise RuntimeError("nix teardown broke")
+
+        monkeypatch.setattr(
+            wsvc.app.state.nix, "destroy_workspace_nix", _raise
+        )
+        with pytest.raises(RuntimeError, match="nix teardown broke"):
+            await wsvc.delete_workspace(ws["id"], user["id"])
+        assert ws["id"] not in registry._workspace_locks
+        assert ws["id"] not in registry.stop_epoch

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -1196,3 +1196,18 @@ class TestWorkspacesServiceBranchGaps2834:
         monkeypatch.setattr(ws_mod, "async_rmtree", _spy_rmtree)
         assert await wsvc.delete_workspace("ws-gone", user["id"]) is False
         assert removed == []
+
+    async def test_delete_workspace_prunes_registry_entries(
+        self, user, app_state
+    ):
+        # #2912: a successful delete drops the per-workspace registry
+        # entries (lock + stop epoch) -- the id can never be started
+        # again, so the #1258 retention reason no longer applies.
+        wsvc = app_state.state.workspaces
+        ws = await wsvc.create_workspace(user["id"], "prune-me")
+        registry = app_state.state.container_registry
+        registry._get_workspace_lock(ws["id"])
+        registry.stop_epoch[ws["id"]] = 2
+        assert await wsvc.delete_workspace(ws["id"], user["id"]) is True
+        assert ws["id"] not in registry._workspace_locks
+        assert ws["id"] not in registry.stop_epoch


### PR DESCRIPTION
## Summary

- Add `ContainerRegistry.prune_workspace_registry_entries()` (#2912): drops the per-workspace `_workspace_locks` and `stop_epoch` entries for a deleted workspace id. Called only from delete paths — the workspace delete funnel (`Workspaces.delete_workspace`, after the DB row is gone) and the admin user-delete cascade (ids captured via `get_user_workspace_ids` before the cascade, pruned after) — because a deleted id can never be started again, so the #1258 reason stops retain the entries (a racing start must serialize against the in-flight stop's lock object) no longer applies. Mirrors the `prune_service_session_locks` pattern (#1351).
- Changelog entry under `[Unreleased]` → Fixed.

## Testing

- Unit tests for the prune method (drops both entries; no-op for a never-started id).
- Service-level test: `Workspaces.delete_workspace` prunes on success (the model-False path already skips cleanup, still covered).
- API tests: `DELETE /workspaces/{id}` and `DELETE /admin/users/{id}` prune the seeded entries.
- Full Python suite green: 6315 passed, 100% branch coverage.

Closes #2912.
