### PR TITLE
feat(server): audit container starts/stops with actor attribution

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -308,12 +308,15 @@ sync` report a clear permission-denied error.
 - **Container lifecycle audit trail (#2915).** Every workspace
   container start/stop is now recorded in a new `container_events`
   table with the acting principal (user, agent, or system), the cause
-  (api/create/ws_connect/auto_start/crash_restart/stop/restart/delete/
-  idle_timeout/eviction/logout/drain/shutdown), the podman container
+  (api/create/ws_connect/auto_start/crash_restart | stop/restart/delete/
+  crash_teardown/idle_timeout/eviction/logout/drain/shutdown), the
+  podman container
   id, and — for egress-filtered workspaces — the network sidecar
-  container whose netns the workspace shares. Recording is
+  container whose netns the workspace shares. Labeled workspace
+  containers stopped by the shutdown/drain orphan sweeps are
+  attributed too (by their `klangk.workspace` label). Recording is
   best-effort and never fails the start/stop itself; rows accumulate
-  under `data_dir`'s SQLite DB (retention is a follow-up).
+  under `data_dir`'s SQLite DB (retention is #2924).
 
 - **Super-E2E suite (#2561).** A new pytest suite
   (`src/klangk/klangkd-tests/super-e2e/`, run via `test-super-e2e`)

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -310,9 +310,10 @@ sync` report a clear permission-denied error.
   table with the acting principal (user, agent, or system), the cause
   (api/create/ws_connect/auto_start/crash_restart | stop/restart/delete/
   crash_teardown/idle_timeout/eviction/logout/drain/shutdown), the
-  podman container
-  id, and — for egress-filtered workspaces — the network sidecar
-  container whose netns the workspace shares. Labeled workspace
+  podman container, and its role — workspace or network sidecar
+  (sidecar create/teardown lands as system-caused `sidecar_start`/
+  `sidecar_stop` rows; workspace rows carry the sidecar container id
+  as `network_namespace` for egress-filtered workspaces). Labeled
   containers stopped by the shutdown/drain orphan sweeps are
   attributed too (by their `klangk.workspace` label). Recording is
   best-effort and never fails the start/stop itself; rows accumulate

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -305,6 +305,16 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Container lifecycle audit trail (#2915).** Every workspace
+  container start/stop is now recorded in a new `container_events`
+  table with the acting principal (user, agent, or system), the cause
+  (api/create/ws_connect/auto_start/crash_restart/stop/restart/delete/
+  idle_timeout/eviction/logout/drain/shutdown), the podman container
+  id, and — for egress-filtered workspaces — the network sidecar
+  container whose netns the workspace shares. Recording is
+  best-effort and never fails the start/stop itself; rows accumulate
+  under `data_dir`'s SQLite DB (retention is a follow-up).
+
 - **Super-E2E suite (#2561).** A new pytest suite
   (`src/klangk/klangkd-tests/super-e2e/`, run via `test-super-e2e`)
   exercises the real Docker host container (supervisord + klangkd +

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -314,10 +314,11 @@ sync` report a clear permission-denied error.
   (sidecar create/teardown lands as system-caused `sidecar_start`/
   `sidecar_stop` rows; workspace rows carry the sidecar container id
   as `network_namespace` for egress-filtered workspaces). Labeled
-  containers stopped by the shutdown/drain orphan sweeps are
-  attributed too (by their `klangk.workspace` label). Recording is
-  best-effort and never fails the start/stop itself; rows accumulate
-  under `data_dir`'s SQLite DB (retention is #2924).
+  containers stopped by the shutdown/drain orphan sweeps, the boot
+  reaps, and the sidecar dependent-container teardowns are attributed
+  too (by their `klangk.workspace` label). Recording is best-effort
+  and never fails the start/stop itself; rows accumulate under
+  `data_dir`'s SQLite DB (retention is #2924).
 
 - **Super-E2E suite (#2561).** A new pytest suite
   (`src/klangk/klangkd-tests/super-e2e/`, run via `test-super-e2e`)

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -31,6 +31,12 @@ from .. import (
     wshandler,
 )
 from ..exceptions import NodeDrainingError, WorkspaceCapacityError
+from ..model.container_events import (
+    CAUSE_CREATE,
+    CAUSE_DELETE,
+    CAUSE_RESTART,
+    CAUSE_STOP,
+)
 from ..workspace_settings import (
     validate_nix_optin,
     validate_settings,
@@ -336,7 +342,7 @@ async def create_workspace(
     # start_container (see ContainerRegistry.bringup, #1244), gated on
     # setup_state so workspaces whose setup.sh hasn't run yet defer until
     # complete.
-    await _eager_start(app, body, ws)
+    await _eager_start(app, body, ws, user["id"])
 
     app.state.sockets.notify_user_workspaces_changed(user["id"])
     return ws
@@ -394,13 +400,15 @@ def _validate_create_fields(body, app) -> dict:
     }
 
 
-async def _eager_start(app, body, ws) -> None:
+async def _eager_start(app, body, ws, actor_id: str | None) -> None:
     """Eagerly start the container when the body asked for it; errors are
     logged but never fail the create."""
     if not body.auto_start:
         return
     try:
-        await app.state.workspaces.start_workspace(ws)
+        await app.state.workspaces.start_workspace(
+            ws, actor_id=actor_id, cause=CAUSE_CREATE
+        )
     except NodeDrainingError:
         # A graceful-restart drain raced the create (#2527): the
         # workspace row exists but no container may start. Not worth
@@ -739,7 +747,10 @@ async def delete_workspace(
     # stopping the container kills it either way.
     if cid:
         await app.state.container_registry.stop_and_remove_container(
-            cid, workspace_id=workspace_id
+            cid,
+            workspace_id=workspace_id,
+            cause=CAUSE_DELETE,
+            actor_id=user["id"],
         )
     await wshandler.reset_workspace_state(app.state.sockets, workspace_id)
 
@@ -794,13 +805,18 @@ async def restart_workspace(
     )
     if cid:
         await app.state.container_registry.stop_and_remove_container(
-            cid, workspace_id=workspace_id
+            cid,
+            workspace_id=workspace_id,
+            cause=CAUSE_RESTART,
+            actor_id=user["id"],
         )
     await wshandler.reset_workspace_state(app.state.sockets, workspace_id)
     # Start a fresh container; the service command fires via the
     # create choke point in start_container.
     try:
-        await app.state.workspaces.start_workspace(workspace)
+        await app.state.workspaces.start_workspace(
+            workspace, actor_id=user["id"], cause=CAUSE_RESTART
+        )
     except NodeDrainingError as exc:
         # A draining node refuses fresh starts (#2527); the stop above
         # already happened, so the workspace is simply left stopped.
@@ -847,7 +863,10 @@ async def stop_workspace(
             workspace_id, container_id=cid
         )
         await app.state.container_registry.stop_and_remove_container(
-            cid, workspace_id=workspace_id
+            cid,
+            workspace_id=workspace_id,
+            cause=CAUSE_STOP,
+            actor_id=user["id"],
         )
         # Notify live WS viewers that the container was stopped on purpose
         # so the UI shows "stopped" rather than "disconnected" (re-homed
@@ -889,7 +908,9 @@ async def start_workspace(
     if app.state.container_registry.get_state(workspace_id) is not None:
         return {"status": "already_running"}
     try:
-        await app.state.workspaces.start_workspace(workspace)
+        await app.state.workspaces.start_workspace(
+            workspace, actor_id=user["id"]
+        )
     except NodeDrainingError as exc:
         # Draining node (#2527): clear 503 so clients/CLI can distinguish
         # "temporarily disabled by a restart" from a config error.

--- a/src/klangk/klangk/container/crash.py
+++ b/src/klangk/klangk/container/crash.py
@@ -34,6 +34,10 @@ import time
 from datetime import datetime, timezone
 
 from .. import podman
+from ..model.container_events import (
+    CAUSE_CRASH_RESTART,
+    CAUSE_CRASH_TEARDOWN,
+)
 from .sidecar import container_ident
 from .spec import resolve_memory_limit
 
@@ -457,7 +461,7 @@ class CrashRecoveryMonitor:
         # Teardown under the expected-stop marker (this stop is on
         # purpose — the restart, if any, is scheduled after it).
         await registry.stop_and_remove_container(
-            container_id, workspace_id=ws_id
+            container_id, workspace_id=ws_id, cause=CAUSE_CRASH_TEARDOWN
         )
         # Post-teardown sync guards (#2524 review): NO await between these
         # checks and either the tracker insert or the create_task inside
@@ -619,7 +623,7 @@ class CrashRecoveryMonitor:
                 return
             try:
                 cid, _status = await self.app.state.workspaces.start_workspace(
-                    ws
+                    ws, cause=CAUSE_CRASH_RESTART
                 )
                 tracker.last_started_at = time.time()
                 tracker.next_attempt_at = None

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -37,6 +37,8 @@ import asyncio
 import logging
 import platform
 
+from ..model.container_events import CAUSE_EVICTION
+
 logger = logging.getLogger(__name__)
 
 # Floor for the poll interval so a misconfigured tiny interval cannot
@@ -494,7 +496,9 @@ class MemoryPressureEvictor:
             victim.workspace_id, container_id=victim.container_id
         )
         await registry.stop_and_remove_container(
-            victim.container_id, workspace_id=victim.workspace_id
+            victim.container_id,
+            workspace_id=victim.workspace_id,
+            cause=CAUSE_EVICTION,
         )
         return True
 

--- a/src/klangk/klangk/container/idle.py
+++ b/src/klangk/klangk/container/idle.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import time
 
+from ..model.container_events import CAUSE_IDLE_TIMEOUT
 from .sidecar import ORPHAN_TOKEN_SWEEP_INTERVAL
 
 logger = logging.getLogger(__name__)
@@ -83,7 +84,9 @@ class IdleMonitor:
                 if state:
                     await self._run_idle_callbacks(state, wid)
                 await registry.notify_workspace_killed(wid, container_id=cid)
-                await registry.stop_and_remove_container(cid)
+                await registry.stop_and_remove_container(
+                    cid, cause=CAUSE_IDLE_TIMEOUT
+                )
 
             # Periodic orphan sidecar-token sweep (#2309): reclaim
             # ws-tokens/<id> files whose workspace row is gone. Piggybacks

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -43,7 +43,11 @@ from .basics import (
     workspace_container_name,
     workspace_name_slug,
 )
-from .sidecar import NetworkSidecarMixin, container_ident
+from .sidecar import (
+    NetworkSidecarMixin,
+    container_ident,
+    labeled_workspace_id,
+)
 from .spec import (
     ContainerStartSpec,
     SHARED_HOME,
@@ -794,24 +798,55 @@ class ContainerRegistry(NetworkSidecarMixin):
             await self.app.state.workspaces.ensure_shared_home_dir(
                 spec.workspace_id
             )
-            result = await self.start_container_inner(spec)
+            result = await self.start_container_inner_or_audited(spec)
             bag = spec.workspace_settings or {}
             if "idle_timeout" in bag:
                 self.idle.set_workspace_idle_timeout(
                     spec.workspace_id, bag["idle_timeout"]
                 )
-            # Lifecycle audit (#2915): a real transition (created or
-            # restarted) is recorded; 'connected' attached to an already-
-            # running container and is no transition at all.
-            if result[1] != "connected":
+            return result
+
+    async def start_container_inner_or_audited(
+        self, spec: ContainerStartSpec
+    ) -> tuple[str, str]:
+        """Run the under-lock start, backstopping the audit row (#2915
+        review).
+
+        If the inner start raises *after* the container was created and
+        tracked (e.g. the bringup exec fails), the container is real and
+        running — the crash monitor can later tear it down, and a stop
+        row with no matching start row would be a lie by omission. On
+        failure a start row is recorded (best-effort) for the tracked
+        container, then the exception propagates unchanged. Failures
+        before any container exists (drain gate, admission, port
+        allocation) leave no state and record nothing — no container,
+        no start.
+        """
+        try:
+            result = await self.start_container_inner(spec)
+        except BaseException:
+            state = self.states.get(spec.workspace_id)
+            if state is not None and state.container_id:
                 await self.record_container_event(
                     spec.workspace_id,
-                    result[0],
+                    state.container_id,
                     EVENT_START,
                     cause=spec.audit_cause,
                     actor_id=spec.audit_actor_id,
                 )
-            return result
+            raise
+        # Success: a real transition (created / restarted) is recorded;
+        # 'connected' attached to an already-running container and is no
+        # transition at all.
+        if result[1] != "connected":
+            await self.record_container_event(
+                spec.workspace_id,
+                result[0],
+                EVENT_START,
+                cause=spec.audit_cause,
+                actor_id=spec.audit_actor_id,
+            )
+        return result
 
     async def record_container_event(
         self,
@@ -1550,6 +1585,10 @@ class ContainerRegistry(NetworkSidecarMixin):
             if workspace_id in self._ws_with_network_sidecar:
                 await self.stop_network_sidecar(workspace_id)
                 self._ws_with_network_sidecar.discard(workspace_id)
+                # The sidecar's id is no longer a live netns owner —
+                # drop it or a later stop row would name a removed
+                # sidecar (#2915 review).
+                self._ws_netns_owner.pop(workspace_id, None)
             raise
         return container_id
 
@@ -2092,7 +2131,15 @@ class ContainerRegistry(NetworkSidecarMixin):
             if not cid:
                 continue
             logger.info("Drain: sweeping racing-start container %s", cid[:12])
-            if await self.stop_and_remove_container(cid, cause=CAUSE_DRAIN):
+            # Labeled workspace containers keep their stop row (#2915
+            # review): the label says which workspace owns them even when
+            # the registry never tracked them. Sidecars / unlabeled stay
+            # unattributed.
+            if await self.stop_and_remove_container(
+                cid,
+                workspace_id=labeled_workspace_id(c),
+                cause=CAUSE_DRAIN,
+            ):
                 stopped += 1
         return stopped
 
@@ -2278,9 +2325,14 @@ class ContainerRegistry(NetworkSidecarMixin):
                         "Removing orphaned klangk container %s",
                         cid,
                     )
+                    # Labeled workspace containers keep their stop row
+                    # (#2915 review) — a prior-session workspace stopped
+                    # at shutdown must not vanish from the audit trail.
                     tasks.append(
                         self.stop_and_remove_container(
-                            cid, cause=CAUSE_SHUTDOWN
+                            cid,
+                            workspace_id=labeled_workspace_id(c),
+                            cause=CAUSE_SHUTDOWN,
                         )
                     )
         except (

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -25,6 +25,8 @@ from ..model.container_events import (
     CAUSE_SHUTDOWN,
     EVENT_START,
     EVENT_STOP,
+    ROLE_SIDECAR,
+    ROLE_WORKSPACE,
 )
 from ..podman import PodmanError
 from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST
@@ -857,14 +859,19 @@ class ContainerRegistry(NetworkSidecarMixin):
         cause: str,
         actor_id: str | None = None,
         network_namespace: str | None = None,
+        container_role: str = ROLE_WORKSPACE,
     ) -> None:
         """Best-effort container_events write (#2915).
 
         Auditing must never fail the start/stop path it annotates: a
         DB error is logged and swallowed. Netns defaults to the live
-        sidecar mapping when the caller didn't capture one (starts).
+        sidecar mapping when the caller didn't capture one (workspace
+        starts); sidecar rows own their netns, so theirs stays NULL.
         """
-        netns = network_namespace or self._ws_netns_owner.get(workspace_id)
+        if container_role == ROLE_WORKSPACE:
+            netns = network_namespace or self._ws_netns_owner.get(workspace_id)
+        else:
+            netns = None
         try:
             await self.app.state.model.container_events.record(
                 workspace_id,
@@ -873,6 +880,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                 actor_id=actor_id,
                 container_id=container_id,
                 network_namespace=netns,
+                container_role=container_role,
             )
         except Exception as e:  # noqa: BLE001 — audit is best-effort
             logger.warning(
@@ -2127,21 +2135,38 @@ class ContainerRegistry(NetworkSidecarMixin):
             leftovers = []
         stopped = 0
         for c in leftovers:
-            cid = container_ident(c)
-            if not cid:
-                continue
-            logger.info("Drain: sweeping racing-start container %s", cid[:12])
-            # Labeled workspace containers keep their stop row (#2915
-            # review): the label says which workspace owns them even when
-            # the registry never tracked them. Sidecars / unlabeled stay
-            # unattributed.
-            if await self.stop_and_remove_container(
-                cid,
-                workspace_id=labeled_workspace_id(c),
-                cause=CAUSE_DRAIN,
-            ):
-                stopped += 1
+            stopped += await self.sweep_stop_audited(c, cause=CAUSE_DRAIN)
         return stopped
+
+    async def sweep_stop_audited(self, c: dict, *, cause: str) -> bool:
+        """Stop one sweep/orphan container, recording its audit row for
+        labeled containers of either role (#2915).
+
+        Workspace-labeled containers pass their label-resolved
+        workspace_id (stop row + #2286 sidecar teardown); sidecar-labeled
+        ones get a system-caused sidecar stop row; unlabeled containers
+        record nothing.
+        """
+        cid = container_ident(c)
+        if not cid:
+            return False
+        labels = c.get("Labels") or {}
+        if labels.get("klangk.role") == "network-sidecar":
+            ok = await self.stop_and_remove_container(cid, cause=cause)
+            ws_id = labels.get("klangk.workspace")
+            if ok and ws_id:
+                await self.record_container_event(
+                    ws_id,
+                    cid,
+                    EVENT_STOP,
+                    cause=cause,
+                    container_role=ROLE_SIDECAR,
+                )
+            return ok
+        logger.info("Sweep: stopping leftover klangk container %s", cid[:12])
+        return await self.stop_and_remove_container(
+            cid, workspace_id=labeled_workspace_id(c), cause=cause
+        )
 
     # --- Pre-warm ---
 
@@ -2325,15 +2350,12 @@ class ContainerRegistry(NetworkSidecarMixin):
                         "Removing orphaned klangk container %s",
                         cid,
                     )
-                    # Labeled workspace containers keep their stop row
-                    # (#2915 review) — a prior-session workspace stopped
-                    # at shutdown must not vanish from the audit trail.
+                    # Labeled containers keep their stop row
+                    # (#2915 review) — a prior-session workspace or its
+                    # sidecar stopped at shutdown must not vanish from the
+                    # audit trail.
                     tasks.append(
-                        self.stop_and_remove_container(
-                            cid,
-                            workspace_id=labeled_workspace_id(c),
-                            cause=CAUSE_SHUTDOWN,
-                        )
+                        self.sweep_stop_audited(c, cause=CAUSE_SHUTDOWN)
                     )
         except (
             podman.PodmanError,

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -19,6 +19,13 @@ from .. import podman
 from .. import fips as fips_mod
 from ..exceptions import NodeDrainingError
 from ..model.workspaces import EGRESS_MODE_ALLOW, EGRESS_MODE_INTERACTIVE
+from ..model.container_events import (
+    CAUSE_DRAIN,
+    CAUSE_LOGOUT,
+    CAUSE_SHUTDOWN,
+    EVENT_START,
+    EVENT_STOP,
+)
 from ..podman import PodmanError
 from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST
 from ..settings import parse_bool_setting
@@ -199,6 +206,13 @@ class ContainerRegistry(NetworkSidecarMixin):
         # best-effort network sidecar teardown on stop, so a non-filtered workspace
         # stop doesn't fire a speculative remove.
         self._ws_with_network_sidecar: set[str] = set()
+        # The live network sidecar's container id per workspace (#2915):
+        # the netns owner a filtered workspace joins via
+        # ``--network container:<id>``. Recorded on container_events rows
+        # (start: right off the bringup; stop: captured before teardown).
+        # Populated only for sidecars started by this process — a stop of
+        # a prior-session workspace records NULL for the namespace.
+        self._ws_netns_owner: dict[str, str] = {}
         # Workspaces with an expected stop in flight (#2524): the crash
         # monitor skips these so a user/idle/logout stop — which holds
         # this marker across its slow podman remove — is never misread
@@ -786,7 +800,52 @@ class ContainerRegistry(NetworkSidecarMixin):
                 self.idle.set_workspace_idle_timeout(
                     spec.workspace_id, bag["idle_timeout"]
                 )
+            # Lifecycle audit (#2915): a real transition (created or
+            # restarted) is recorded; 'connected' attached to an already-
+            # running container and is no transition at all.
+            if result[1] != "connected":
+                await self.record_container_event(
+                    spec.workspace_id,
+                    result[0],
+                    EVENT_START,
+                    cause=spec.audit_cause,
+                    actor_id=spec.audit_actor_id,
+                )
             return result
+
+    async def record_container_event(
+        self,
+        workspace_id: str,
+        container_id: str | None,
+        event: str,
+        *,
+        cause: str,
+        actor_id: str | None = None,
+        network_namespace: str | None = None,
+    ) -> None:
+        """Best-effort container_events write (#2915).
+
+        Auditing must never fail the start/stop path it annotates: a
+        DB error is logged and swallowed. Netns defaults to the live
+        sidecar mapping when the caller didn't capture one (starts).
+        """
+        netns = network_namespace or self._ws_netns_owner.get(workspace_id)
+        try:
+            await self.app.state.model.container_events.record(
+                workspace_id,
+                event,
+                cause,
+                actor_id=actor_id,
+                container_id=container_id,
+                network_namespace=netns,
+            )
+        except Exception as e:  # noqa: BLE001 — audit is best-effort
+            logger.warning(
+                "container_events audit write failed for %s (%s): %s",
+                workspace_id[:8],
+                event,
+                e,
+            )
 
     async def handle_existing_container(
         self,
@@ -1442,8 +1501,10 @@ class ContainerRegistry(NetworkSidecarMixin):
         create_kwargs.pop("add_hosts", None)
         create_kwargs.pop("publish", None)
         # Remember this workspace has a live network sidecar so its stop
-        # tears the network sidecar down (#2254).
+        # tears the network sidecar down (#2254), and keep its id as the
+        # netns owner for container_events attribution (#2915).
         self._ws_with_network_sidecar.add(workspace_id)
+        self._ws_netns_owner[workspace_id] = network_sidecar_id
 
     async def _create_start_shielded(
         self,
@@ -1661,7 +1722,12 @@ class ContainerRegistry(NetworkSidecarMixin):
         return container_id, "created"
 
     async def stop_and_remove_container(
-        self, container_id: str, workspace_id: str | None = None
+        self,
+        container_id: str,
+        workspace_id: str | None = None,
+        *,
+        cause: str,
+        actor_id: str | None = None,
     ) -> bool:
         """Stop and remove a container.
 
@@ -1702,8 +1768,16 @@ class ContainerRegistry(NetworkSidecarMixin):
         ``self.stopping`` for the duration so the crash monitor's sweep
         cannot misread the in-flight removal as an unexpected death, and
         any pending crash-restart for it is cancelled (#2524).
+
+        ``cause`` (required, #2915) labels the container_events audit row —
+        every caller states why it stops the container (api/stop,
+        restart, delete, idle_timeout, eviction, logout, drain, shutdown,
+        crash_teardown). ``actor_id`` is the acting principal when a user
+        (or the agent) fired the stop; None records a system actor.
         """
         ws_id = workspace_id or self._cid_to_wsid.get(container_id)
+        # Netns owner captured before teardown pops it (#2915).
+        netns = self._ws_netns_owner.get(ws_id)
         if ws_id:
             self.stopping.add(ws_id)
             # Bumped synchronously at stop ENTRY, before any await: the
@@ -1752,6 +1826,7 @@ class ContainerRegistry(NetworkSidecarMixin):
                         # session is cleaned up even if it isn't tracked in
                         # _ws_with_network_sidecar (#2286).
                         self._ws_with_network_sidecar.discard(ws_id)
+                        self._ws_netns_owner.pop(ws_id, None)
                         await self.stop_network_sidecar(ws_id)
                         self._cid_to_wsid.pop(container_id, None)
                         self.revoke_workspace_browsers(ws_id)
@@ -1770,7 +1845,16 @@ class ContainerRegistry(NetworkSidecarMixin):
             self.prune_service_session_locks(set(self._cid_to_wsid))
             # Gone via this call AND (untracked, or our registry state torn
             # down — i.e. not left alone by the rebind guard).
-            return stopped if ws_id is None else (stopped and torn_down)
+            result = stopped if ws_id is None else (stopped and torn_down)
+            await self.audit_stop(
+                ws_id,
+                container_id,
+                result,
+                cause=cause,
+                actor_id=actor_id,
+                netns=netns,
+            )
+            return result
         finally:
             if ws_id:
                 self.stopping.discard(ws_id)
@@ -1779,6 +1863,32 @@ class ContainerRegistry(NetworkSidecarMixin):
                 # removes are slow and interleave) must still cancel it.
                 # Expected deaths never restart, no matter the ordering.
                 self.crash.on_expected_stop(ws_id)
+
+    async def audit_stop(
+        self,
+        ws_id: str | None,
+        container_id: str,
+        gone: bool,
+        *,
+        cause: str,
+        actor_id: str | None,
+        netns: str | None,
+    ) -> None:
+        """Record a stop event when the container is a resolvable,
+        actually-stopped workspace (#2915).
+
+        Sweep/orphan stops without a workspace id are skipped — that
+        population includes network sidecars, which are not workspaces.
+        """
+        if ws_id and gone:
+            await self.record_container_event(
+                ws_id,
+                container_id,
+                EVENT_STOP,
+                cause=cause,
+                actor_id=actor_id,
+                network_namespace=netns,
+            )
 
     async def notify_workspace_killed(
         self,
@@ -1852,7 +1962,10 @@ class ContainerRegistry(NetworkSidecarMixin):
                     ws["id"], container_id=ws["container_id"]
                 )
                 await self.stop_and_remove_container(
-                    ws["container_id"], workspace_id=ws["id"]
+                    ws["container_id"],
+                    workspace_id=ws["id"],
+                    cause=CAUSE_LOGOUT,
+                    actor_id=user_id,
                 )
 
     def new_starts_blocked_reason(self) -> str | None:
@@ -1924,7 +2037,9 @@ class ContainerRegistry(NetworkSidecarMixin):
         "stopped on purpose" broadcast as the /stop endpoint (clients
         re-render as stopped, not disconnected)."""
         await self.notify_workspace_killed(ws_id, container_id=cid)
-        ok = await self.stop_and_remove_container(cid, workspace_id=ws_id)
+        ok = await self.stop_and_remove_container(
+            cid, workspace_id=ws_id, cause=CAUSE_DRAIN
+        )
         if not ok:
             logger.warning(
                 "Drain: workspace %s container %s not stopped "
@@ -1977,7 +2092,7 @@ class ContainerRegistry(NetworkSidecarMixin):
             if not cid:
                 continue
             logger.info("Drain: sweeping racing-start container %s", cid[:12])
-            if await self.stop_and_remove_container(cid):
+            if await self.stop_and_remove_container(cid, cause=CAUSE_DRAIN):
                 stopped += 1
         return stopped
 
@@ -2148,7 +2263,10 @@ class ContainerRegistry(NetworkSidecarMixin):
         # container teardown below.
         await self.crash.stop()
         tracked_ids = set(self._cid_to_wsid.keys())
-        tasks = [self.stop_and_remove_container(cid) for cid in tracked_ids]
+        tasks = [
+            self.stop_and_remove_container(cid, cause=CAUSE_SHUTDOWN)
+            for cid in tracked_ids
+        ]
         try:
             containers = await self.app.state.podman.list_containers(
                 f"klangk.instance={self.app.state.util.instance_id()}"
@@ -2160,7 +2278,11 @@ class ContainerRegistry(NetworkSidecarMixin):
                         "Removing orphaned klangk container %s",
                         cid,
                     )
-                    tasks.append(self.stop_and_remove_container(cid))
+                    tasks.append(
+                        self.stop_and_remove_container(
+                            cid, cause=CAUSE_SHUTDOWN
+                        )
+                    )
         except (
             podman.PodmanError,
             OSError,

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -22,6 +22,7 @@ from ..model.workspaces import EGRESS_MODE_ALLOW, EGRESS_MODE_INTERACTIVE
 from ..model.container_events import (
     CAUSE_DRAIN,
     CAUSE_LOGOUT,
+    CAUSE_REAP,
     CAUSE_SHUTDOWN,
     EVENT_START,
     EVENT_STOP,
@@ -2144,28 +2145,56 @@ class ContainerRegistry(NetworkSidecarMixin):
 
         Workspace-labeled containers pass their label-resolved
         workspace_id (stop row + #2286 sidecar teardown); sidecar-labeled
-        ones get a system-caused sidecar stop row; unlabeled containers
-        record nothing.
+        ones route through the label-based removal choke point
+        (:meth:`_remove_network_sidecar`) so the ``sidecar_stop`` row is
+        written exactly once — a sidecar already torn down by its
+        workspace's stop is simply absent from that listing, instead of
+        producing a second row from a 404-tolerant sweep stop (#2915
+        review). Label-less containers record nothing.
         """
         cid = container_ident(c)
         if not cid:
             return False
         labels = c.get("Labels") or {}
+        ws_id = labels.get("klangk.workspace")
         if labels.get("klangk.role") == "network-sidecar":
-            ok = await self.stop_and_remove_container(cid, cause=cause)
-            ws_id = labels.get("klangk.workspace")
-            if ok and ws_id:
-                await self.record_container_event(
-                    ws_id,
-                    cid,
-                    EVENT_STOP,
-                    cause=cause,
-                    container_role=ROLE_SIDECAR,
+            if not ws_id:
+                logger.info(
+                    "Sweep: stopping label-less sidecar container %s",
+                    cid[:12],
                 )
-            return ok
+                return await self.stop_and_remove_container(cid, cause=cause)
+            logger.info(
+                "Sweep: stopping leftover sidecar %s for %s",
+                cid[:12],
+                ws_id[:8],
+            )
+            return await self._remove_network_sidecar(ws_id)
         logger.info("Sweep: stopping leftover klangk container %s", cid[:12])
         return await self.stop_and_remove_container(
             cid, workspace_id=labeled_workspace_id(c), cause=cause
+        )
+
+    async def record_reap(self, c: dict) -> None:
+        """Audit row for a reaped labeled container (#2915 review).
+
+        The boot reaps are the mass teardown an audit trail exists for:
+        after an unclean klangkd death, every reaped container's start
+        row would otherwise dangle with no matching stop. Label-less
+        containers record nothing (nothing to correlate them to).
+        """
+        labels = c.get("Labels") or {}
+        ws_id = labels.get("klangk.workspace")
+        cid = container_ident(c)
+        if not ws_id or not cid:
+            return
+        role = (
+            ROLE_SIDECAR
+            if labels.get("klangk.role") == "network-sidecar"
+            else ROLE_WORKSPACE
+        )
+        await self.record_container_event(
+            ws_id, cid, EVENT_STOP, cause=CAUSE_REAP, container_role=role
         )
 
     # --- Pre-warm ---
@@ -2231,9 +2260,10 @@ class ContainerRegistry(NetworkSidecarMixin):
             if not cid:
                 continue
             logger.info("Reaping leftover container %s on startup", cid[:12])
-            await safe_remove(
+            if await safe_remove(
                 self.app.state.podman, cid, what="leftover container"
-            )
+            ):
+                await self.record_reap(c)
 
     async def reap_dead_owner_containers(self) -> None:
         """Reap managed containers whose owning klangkd is no longer running.
@@ -2309,9 +2339,10 @@ class ContainerRegistry(NetworkSidecarMixin):
                 cid[:12],
                 owner_pid,
             )
-            await safe_remove(
+            if await safe_remove(
                 self.app.state.podman, cid, what="dead-owner container"
-            )
+            ):
+                await self.record_reap(c)
 
     # --- Shutdown ---
 

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -13,6 +13,13 @@ import os
 import time
 
 from .. import podman
+from ..model.container_events import (
+    CAUSE_SIDECAR_START,
+    CAUSE_SIDECAR_STOP,
+    EVENT_START,
+    EVENT_STOP,
+    ROLE_SIDECAR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -269,6 +276,15 @@ class NetworkSidecarMixin:
                 name,
                 cid[:12],
             )
+            # Lifecycle audit (#2915): sidecar rows are system-caused and
+            # never carry a netns owner — the sidecar IS the owner.
+            await self.record_container_event(
+                workspace_id,
+                cid,
+                EVENT_START,
+                cause=CAUSE_SIDECAR_START,
+                container_role=ROLE_SIDECAR,
+            )
             return cid
         except podman.PodmanError as exc:
             logger.warning(
@@ -294,6 +310,18 @@ class NetworkSidecarMixin:
             exc = await self._force_remove_sidecar(workspace_id, ident)
             if exc is not None:
                 failures.append((ident, exc))
+                continue
+            # Lifecycle audit (#2915): every successful label-based
+            # sidecar removal — workspace teardown, the create path's
+            # stale-generation clear, the failure-path teardown — lands
+            # here, so this is the sidecar stop choke point.
+            await self.record_container_event(
+                workspace_id,
+                ident,
+                EVENT_STOP,
+                cause=CAUSE_SIDECAR_STOP,
+                container_role=ROLE_SIDECAR,
+            )
         return failures
 
     async def _blocked_sidecar_failures(

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -50,6 +50,23 @@ def container_ident(c: dict) -> str:
     return ident
 
 
+def labeled_workspace_id(c: dict) -> str | None:
+    """The workspace id a ``podman ps`` dict is labeled for, when the
+    container is the workspace container itself (#2915).
+
+    Both the workspace container and its network sidecar carry
+    ``klangk.workspace=<id>``; ``klangk.role`` is the discriminator
+    (same check as ``_adopt_labeled_container`` and the sidecar
+    sweeps). Used by the shutdown/drain orphan sweeps so a labeled
+    workspace container stopped without registry tracking still gets
+    its stop row — and its sidecar teardown (#2286 semantics).
+    """
+    labels = c.get("Labels") or {}
+    if labels.get("klangk.role") != "workspace":
+        return None
+    return labels.get("klangk.workspace") or None
+
+
 class NetworkSidecarMixin:
     """Sidecar lifecycle methods mixed into ``ContainerRegistry``.
 

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -14,6 +14,7 @@ import time
 
 from .. import podman
 from ..model.container_events import (
+    CAUSE_SIDECAR_DEPENDENT,
     CAUSE_SIDECAR_START,
     CAUSE_SIDECAR_STOP,
     EVENT_START,
@@ -79,8 +80,11 @@ class NetworkSidecarMixin:
 
     All state lives on ``self`` (the registry): ``self.app`` for
     settings/podman/workspaces, and the registry's own dicts for
-    tracking. See the method docstrings (carried over verbatim from
-    the old container.py) for the #NNNN history.
+    tracking. The lifecycle-audit hooks (#2915) call
+    ``self.record_container_event`` — a ContainerRegistry method, part
+    of this mixin's implicit contract (it is only ever mixed into
+    ContainerRegistry). See the method docstrings (carried over
+    verbatim from the old container.py) for the #NNNN history.
     """
 
     def network_sidecar_enabled(self) -> bool:
@@ -268,6 +272,19 @@ class NetworkSidecarMixin:
             cid = await self.app.state.podman.create_container(
                 name, image, **sidecar_kwargs
             )
+            # Lifecycle audit (#2915 review): record at CREATION, before
+            # start/readiness — a sidecar that fails to become ready still
+            # exists and its eventual removal records sidecar_stop, so the
+            # pair must balance even on the failure path. Sidecar rows are
+            # system-caused and never carry a netns owner (the sidecar IS
+            # the owner).
+            await self.record_container_event(
+                workspace_id,
+                cid,
+                EVENT_START,
+                cause=CAUSE_SIDECAR_START,
+                container_role=ROLE_SIDECAR,
+            )
             await self.start_with_port_conflict_retry(cid, publish or [], name)
             await self._wait_sidecar_proxy_ready(cid, name)
             logger.info(
@@ -275,15 +292,6 @@ class NetworkSidecarMixin:
                 workspace_id[:8],
                 name,
                 cid[:12],
-            )
-            # Lifecycle audit (#2915): sidecar rows are system-caused and
-            # never carry a netns owner — the sidecar IS the owner.
-            await self.record_container_event(
-                workspace_id,
-                cid,
-                EVENT_START,
-                cause=CAUSE_SIDECAR_START,
-                container_role=ROLE_SIDECAR,
             )
             return cid
         except podman.PodmanError as exc:
@@ -623,6 +631,15 @@ class NetworkSidecarMixin:
                     "network sidecar for %s",
                     ident[:12],
                     workspace_id[:8],
+                )
+                # Lifecycle audit (#2915 review): these are workspace
+                # containers destroyed to unblock a sidecar removal —
+                # without a row their start rows would dangle forever.
+                await self.record_container_event(
+                    workspace_id,
+                    ident,
+                    EVENT_STOP,
+                    cause=CAUSE_SIDECAR_DEPENDENT,
                 )
             except podman.PodmanError as exc:
                 logger.warning(

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -25,6 +25,7 @@ from ..podman import (
     SHARED_HOME as SHARED_HOME,
     SHARED_HOME_NAME as SHARED_HOME_NAME,
 )
+from ..model.container_events import CAUSE_API
 from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST, ssl_env_vars
 from .basics import CONTAINER_PORT_START, DEFAULT_PORTS_PER_WORKSPACE
 
@@ -109,6 +110,13 @@ class ContainerStartSpec:
     rejected_domains: list[str] | None = None
     workspace_settings: dict | None = None
     egress_mode: str = "static"
+    # Lifecycle-audit attribution (#2915): who asked for this start and
+    # why. Traveled on the spec (the single-field extension point this
+    # class exists to provide) so every start path — API, WS connect,
+    # crash restart, boot auto-start — carries it into the choke point.
+    # ``audit_actor_id`` None means an autonomous (system) cause.
+    audit_cause: str = CAUSE_API
+    audit_actor_id: str | None = None
     # Home layout (#2169 chunk 2, #2720): True -> per-handle
     # /home/{handle} symlinks; False -> the single shared /home/klangk.
     # Traveled on the spec so ContainerState carries it for the health

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -35,14 +35,14 @@ ACTOR_AGENT = "agent"
 ACTOR_SYSTEM = "system"
 
 # Canonical causes. Start causes:
-CAUSE_API = "api"  # POST /start (or the start half of /restart)
+CAUSE_API = "api"  # POST /start
 CAUSE_CREATE = "create"  # eager start at workspace create (auto_start body)
 CAUSE_WS_CONNECT = "ws_connect"  # first WS connection started the container
 CAUSE_AUTO_START = "auto_start"  # boot-time auto_start_workspaces sweep
 CAUSE_CRASH_RESTART = "crash_restart"  # crash monitor's delayed restart
 # Stop causes:
 CAUSE_STOP = "stop"  # POST /stop
-CAUSE_RESTART = "restart"  # the stop half of POST /restart
+CAUSE_RESTART = "restart"  # either half of POST /restart (stop + fresh start)
 CAUSE_DELETE = "delete"  # workspace deletion cascade
 CAUSE_IDLE_TIMEOUT = "idle_timeout"  # inactivity stop (container/idle.py)
 CAUSE_EVICTION = "eviction"  # memory-pressure eviction (container/eviction.py)

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -50,12 +50,20 @@ CAUSE_LOGOUT = "logout"  # owner logged out (stop_user_containers)
 CAUSE_CRASH_TEARDOWN = "crash_teardown"  # crash monitor removing a corpse
 CAUSE_DRAIN = "drain"  # graceful-restart / scheduled drain
 CAUSE_SHUTDOWN = "shutdown"  # klangkd shutdown orphan sweep
+CAUSE_SIDECAR_START = "sidecar_start"  # network sidecar created for a start
+CAUSE_SIDECAR_STOP = "sidecar_stop"  # network sidecar torn down
+
+# Which klangk-managed container a row describes. Workspace rows carry
+# actor attribution; sidecar rows are always system-caused (their
+# lifecycle is slaved to the workspace's).
+ROLE_WORKSPACE = "workspace"
+ROLE_SIDECAR = "network-sidecar"
 
 # Canonical column list so the read shape cannot drift from the schema
 # (a column added to the table is added here once).
 _EVENT_COLUMNS = (
     "id, workspace_id, event, actor_type, actor_id, cause,"
-    " container_id, network_namespace, created_at"
+    " container_id, container_role, network_namespace, created_at"
 )
 
 
@@ -92,18 +100,23 @@ class ContainerEventsModel:
         actor_id: str | None = None,
         container_id: str | None = None,
         network_namespace: str | None = None,
+        container_role: str = ROLE_WORKSPACE,
     ) -> None:
         """Insert one lifecycle event row.
 
         ``actor_type`` is derived from ``actor_id`` (None -> system,
         the agent identity -> agent, anything else -> user).
+        ``container_role`` distinguishes workspace containers from their
+        network sidecars; sidecar rows never carry a netns owner (they
+        ARE the netns owner).
         """
         async with self.app.state.db.transaction() as db:
             await db.execute(
                 "INSERT INTO container_events"
                 " (workspace_id, event, actor_type, actor_id, cause,"
-                "  container_id, network_namespace, created_at)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "  container_id, container_role, network_namespace,"
+                "  created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     workspace_id,
                     event,
@@ -111,6 +124,7 @@ class ContainerEventsModel:
                     actor_id,
                     cause,
                     container_id,
+                    container_role,
                     network_namespace,
                     time.time(),
                 ),

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -1,0 +1,144 @@
+"""Container lifecycle audit events (#2915).
+
+Every container start and stop is recorded with the acting principal
+(the user / agent who fired it, or ``system`` for autonomous causes
+like idle timeouts, evictions, drains, and the boot auto-start) plus
+the identifiers an operator needs to correlate the event with podman:
+the workspace container id and, for egress-filtered workspaces, the
+network sidecar container whose netns the workspace shares.
+
+Recording is best-effort: an audit write failure is logged and never
+fails the start/stop path it annotates (see
+``ContainerRegistry.record_container_event``).
+
+Retention/bounding (like the egress-consent table) is deliberately not
+implemented here — tracked as a follow-up in #2915. An admin-facing
+paged view is tracked separately.
+"""
+
+import logging
+import time
+
+from .users import AGENT_USER_ID
+
+logger = logging.getLogger(__name__)
+
+# Event kinds.
+EVENT_START = "start"
+EVENT_STOP = "stop"
+
+# Actor classification, derived from ``actor_id`` at record time:
+# the fixed system-agent identity is its own class; a missing actor is
+# an autonomous (system) cause.
+ACTOR_USER = "user"
+ACTOR_AGENT = "agent"
+ACTOR_SYSTEM = "system"
+
+# Canonical causes. Start causes:
+CAUSE_API = "api"  # POST /start (or the start half of /restart)
+CAUSE_CREATE = "create"  # eager start at workspace create (auto_start body)
+CAUSE_WS_CONNECT = "ws_connect"  # first WS connection started the container
+CAUSE_AUTO_START = "auto_start"  # boot-time auto_start_workspaces sweep
+CAUSE_CRASH_RESTART = "crash_restart"  # crash monitor's delayed restart
+# Stop causes:
+CAUSE_STOP = "stop"  # POST /stop
+CAUSE_RESTART = "restart"  # the stop half of POST /restart
+CAUSE_DELETE = "delete"  # workspace deletion cascade
+CAUSE_IDLE_TIMEOUT = "idle_timeout"  # inactivity stop (container/idle.py)
+CAUSE_EVICTION = "eviction"  # memory-pressure eviction (container/eviction.py)
+CAUSE_LOGOUT = "logout"  # owner logged out (stop_user_containers)
+CAUSE_CRASH_TEARDOWN = "crash_teardown"  # crash monitor removing a corpse
+CAUSE_DRAIN = "drain"  # graceful-restart / scheduled drain
+CAUSE_SHUTDOWN = "shutdown"  # klangkd shutdown orphan sweep
+
+# Canonical column list so the read shape cannot drift from the schema
+# (a column added to the table is added here once).
+_EVENT_COLUMNS = (
+    "id, workspace_id, event, actor_type, actor_id, cause,"
+    " container_id, network_namespace, created_at"
+)
+
+
+def actor_type_for(actor_id: str | None) -> str:
+    """Classify an acting principal id into an ``actor_type``."""
+    if actor_id is None:
+        return ACTOR_SYSTEM
+    if actor_id == AGENT_USER_ID:
+        return ACTOR_AGENT
+    return ACTOR_USER
+
+
+def row_to_dict(row) -> dict:
+    """Row-tuple -> dict with the column names of ``_EVENT_COLUMNS``."""
+    keys = [c.strip() for c in _EVENT_COLUMNS.split(",")]
+    return dict(zip(keys, row, strict=True))
+
+
+class ContainerEventsModel:
+    """CRUD for the ``container_events`` table."""
+
+    def __init__(self, app):
+        self.app = app
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    async def record(
+        self,
+        workspace_id: str,
+        event: str,
+        cause: str,
+        *,
+        actor_id: str | None = None,
+        container_id: str | None = None,
+        network_namespace: str | None = None,
+    ) -> None:
+        """Insert one lifecycle event row.
+
+        ``actor_type`` is derived from ``actor_id`` (None -> system,
+        the agent identity -> agent, anything else -> user).
+        """
+        async with self.app.state.db.transaction() as db:
+            await db.execute(
+                "INSERT INTO container_events"
+                " (workspace_id, event, actor_type, actor_id, cause,"
+                "  container_id, network_namespace, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    workspace_id,
+                    event,
+                    actor_type_for(actor_id),
+                    actor_id,
+                    cause,
+                    container_id,
+                    network_namespace,
+                    time.time(),
+                ),
+            )
+
+    async def list_events(
+        self,
+        workspace_id: str | None = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
+        """Newest-first event history, optionally filtered to a workspace."""
+        sql = f"SELECT {_EVENT_COLUMNS} FROM container_events"
+        params: list = []
+        if workspace_id is not None:
+            sql += " WHERE workspace_id = ?"
+            params.append(workspace_id)
+        sql += " ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?"
+        rows = await self.app.state.db.fetchall(sql, (*params, limit, offset))
+        return [row_to_dict(row) for row in rows]
+
+    async def count_events(self, workspace_id: str | None = None) -> int:
+        """Row count for paging, with the same optional workspace filter."""
+        sql = "SELECT COUNT(*) FROM container_events"
+        params: tuple = ()
+        if workspace_id is not None:
+            sql += " WHERE workspace_id = ?"
+            params = (workspace_id,)
+        row = await self.app.state.db.fetchone(sql, params)
+        return row[0] if row else 0

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -52,6 +52,10 @@ CAUSE_DRAIN = "drain"  # graceful-restart / scheduled drain
 CAUSE_SHUTDOWN = "shutdown"  # klangkd shutdown orphan sweep
 CAUSE_SIDECAR_START = "sidecar_start"  # network sidecar created for a start
 CAUSE_SIDECAR_STOP = "sidecar_stop"  # network sidecar torn down
+CAUSE_SIDECAR_DEPENDENT = (
+    "sidecar_dependent"  # workspace container force-removed to free a sidecar
+)
+CAUSE_REAP = "reap"  # boot reaps (instance leftovers / dead owners)
 
 # Which klangk-managed container a row describes. Workspace rows carry
 # actor attribution; sidecar rows are always system-caused (their

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -66,6 +66,7 @@ from klangk.model.migrations import m0015_classification_banner
 from klangk.model.migrations import m0016_monitor_permission
 from klangk.model.migrations import m0017_change_acls_permission
 from klangk.model.migrations import m0018_egress_consent_permission
+from klangk.model.migrations import m0019_container_events
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -92,6 +93,7 @@ MIGRATIONS: list[Migration] = [
     m0016_monitor_permission.migration,
     m0017_change_acls_permission.migration,
     m0018_egress_consent_permission.migration,
+    m0019_container_events.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0019_container_events.py
+++ b/src/klangk/klangk/model/migrations/m0019_container_events.py
@@ -1,17 +1,21 @@
 """Migration 0019: the ``container_events`` audit table (#2915).
 
-Persists every workspace-container start/stop with the acting principal
-(``actor_type`` user/agent/system + ``actor_id``), the ``cause``
-(api/restart/delete/idle-timeout/eviction/logout/drain/shutdown/...),
-and the podman correlation ids: the workspace ``container_id`` and the
-``network_namespace`` — the network sidecar container whose netns the
-workspace shares (NULL for unfiltered workspaces).
+Persists every klangk-managed container start/stop with the acting
+principal (``actor_type`` user/agent/system + ``actor_id``), the
+``cause``, and the podman correlation ids: the ``container_id``, its
+``container_role`` ('workspace' | 'network-sidecar', CHECK-constrained),
+and — on workspace rows — the ``network_namespace``: the network sidecar
+container whose netns the workspace shares (NULL for unfiltered
+workspaces and on sidecar rows, which ARE the netns owner).
 
-Written at the two lifecycle choke points
-(``ContainerRegistry.start_container`` and
-``stop_and_remove_container``), best-effort: a failed audit write is
-logged, never fatal to the start/stop itself. Retention/bounding is a
-deliberate follow-up (#2915), so the table grows without bound for now.
+Written at the lifecycle choke points — workspace rows at
+``ContainerRegistry.start_container`` / ``stop_and_remove_container``
+(plus the failed-start backstop, the labeled sweep stops, and the boot
+reaps), sidecar rows at ``start_network_sidecar`` creation and the
+label-based removal choke point (plus the dependent-container forced
+removals). All writes are best-effort: a failed audit write is logged,
+never fatal to the start/stop itself. Retention/bounding is a deliberate
+follow-up (#2924), so the table grows without bound for now.
 """
 
 from klangk.model.migrations.base import Migration
@@ -28,7 +32,8 @@ async def apply(db) -> None:
             actor_id TEXT,
             cause TEXT NOT NULL,
             container_id TEXT,
-            container_role TEXT NOT NULL DEFAULT 'workspace',
+            container_role TEXT NOT NULL DEFAULT 'workspace'
+                CHECK (container_role IN ('workspace', 'network-sidecar')),
             network_namespace TEXT,
             created_at REAL NOT NULL
         )

--- a/src/klangk/klangk/model/migrations/m0019_container_events.py
+++ b/src/klangk/klangk/model/migrations/m0019_container_events.py
@@ -28,6 +28,7 @@ async def apply(db) -> None:
             actor_id TEXT,
             cause TEXT NOT NULL,
             container_id TEXT,
+            container_role TEXT NOT NULL DEFAULT 'workspace',
             network_namespace TEXT,
             created_at REAL NOT NULL
         )

--- a/src/klangk/klangk/model/migrations/m0019_container_events.py
+++ b/src/klangk/klangk/model/migrations/m0019_container_events.py
@@ -1,0 +1,44 @@
+"""Migration 0019: the ``container_events`` audit table (#2915).
+
+Persists every workspace-container start/stop with the acting principal
+(``actor_type`` user/agent/system + ``actor_id``), the ``cause``
+(api/restart/delete/idle-timeout/eviction/logout/drain/shutdown/...),
+and the podman correlation ids: the workspace ``container_id`` and the
+``network_namespace`` — the network sidecar container whose netns the
+workspace shares (NULL for unfiltered workspaces).
+
+Written at the two lifecycle choke points
+(``ContainerRegistry.start_container`` and
+``stop_and_remove_container``), best-effort: a failed audit write is
+logged, never fatal to the start/stop itself. Retention/bounding is a
+deliberate follow-up (#2915), so the table grows without bound for now.
+"""
+
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS container_events (
+            id INTEGER PRIMARY KEY,
+            workspace_id TEXT NOT NULL,
+            event TEXT NOT NULL,
+            actor_type TEXT NOT NULL,
+            actor_id TEXT,
+            cause TEXT NOT NULL,
+            container_id TEXT,
+            network_namespace TEXT,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_container_events_ws_time
+            ON container_events (workspace_id, created_at DESC)
+        """
+    )
+
+
+migration = Migration(19, "0019_container_events", apply)

--- a/src/klangk/klangk/model/model.py
+++ b/src/klangk/klangk/model/model.py
@@ -19,6 +19,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 from .acl import ACLModel
+from .container_events import ContainerEventsModel
 from .egress_consent import EgressConsentModel
 from .server_schedules import ServerSchedulesModel
 from .ports import PortsModel
@@ -175,6 +176,7 @@ class Model:
         self.acl = ACLModel(app)
         self.workspaces = WorkspacesModel(app)
         self.egress_consent = EgressConsentModel(app)
+        self.container_events = ContainerEventsModel(app)
         self.server_schedules = ServerSchedulesModel(app)
 
     def reconfigure(self, app) -> None:
@@ -189,6 +191,7 @@ class Model:
             self.acl,
             self.workspaces,
             self.egress_consent,
+            self.container_events,
             self.server_schedules,
         ):
             sub.reconfigure(app)

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from . import container, model
 from .container.spec import SHARED_HOME, SHARED_HOME_NAME
+from .model.container_events import CAUSE_API, CAUSE_AUTO_START
 from .settings import parse_bool_setting
 
 logger = logging.getLogger(__name__)
@@ -671,7 +672,9 @@ class Workspaces:
 
     # --- lifecycle ---
 
-    async def start_workspace(self, ws: dict) -> tuple[str, str]:
+    async def start_workspace(
+        self, ws: dict, *, actor_id: str | None = None, cause: str = CAUSE_API
+    ) -> tuple[str, str]:
         """Start a container for a workspace immediately.
 
         Thin wrapper around ``self.app.state.container_registry.start_container``
@@ -683,6 +686,10 @@ class Workspaces:
         ``idle_timeout`` overrides from the settings bag are applied inside
         ``start_container`` (the single start choke point); only
         ``auto_start_workspaces`` (the boot path) pins it to 0.
+
+        ``actor_id``/``cause`` (#2915) ride the spec into the choke point's
+        container_events audit row — every caller states who asked for the
+        start and why (API user, crash monitor, boot auto-start).
 
         Returns ``(container_id, status)``.
         """
@@ -712,6 +719,8 @@ class Workspaces:
                 egress_mode=ws.get(
                     "egress_mode", model.EGRESS_MODE_INTERACTIVE
                 ),
+                audit_cause=cause,
+                audit_actor_id=actor_id,
                 per_handle_home=ws.get("per_handle_home", True),
             )
         )
@@ -752,7 +761,9 @@ class Workspaces:
             if i > 0:
                 await asyncio.sleep(random.uniform(0.5, 2.0))
             try:
-                cid, status = await self.start_workspace(ws)
+                cid, status = await self.start_workspace(
+                    ws, cause=CAUSE_AUTO_START
+                )
                 # Auto-started containers are boot services: pin them alive
                 # so they do not idle out between user connections. Only the
                 # boot path does this -- create/restart use the default idle

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from .. import container, model
 from ..container.spec import SHARED_HOME
 from ..exceptions import NodeDrainingError, WorkspaceCapacityError
+from ..model.container_events import CAUSE_WS_CONNECT
 from ..terminal import TerminalSession
 from ..podman import ExecSession, PodmanError
 from .safe_websocket import SafeWebSocket, WS_ERRORS
@@ -298,6 +299,8 @@ class Connection:
                 egress_mode=workspace.get(
                     "egress_mode", model.EGRESS_MODE_INTERACTIVE
                 ),
+                audit_cause=CAUSE_WS_CONNECT,
+                audit_actor_id=self.user["id"],
                 per_handle_home=workspace.get("per_handle_home", True),
             )
         )

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -28,6 +28,11 @@ from klangk import util as util_mod
 from klangk import netfilter as netfilter_mod
 from klangk import oidc as oidc_mod
 from klangk import features as features_mod
+from klangk.model.container_events import (
+    CAUSE_DELETE,
+    CAUSE_RESTART,
+    CAUSE_STOP,
+)
 from _helpers import make_settings
 from klangk.wshandler.session import WebSocketState
 import types
@@ -2689,7 +2694,10 @@ class TestWorkspaceRoutes:
             )
         assert resp.status_code == 200
         mock_rm.assert_awaited_once_with(
-            "fake-container-id", workspace_id=ws_id
+            "fake-container-id",
+            workspace_id=ws_id,
+            cause=CAUSE_DELETE,
+            actor_id=user["id"],
         )
 
     async def test_delete_workspace_cleans_up_groups(
@@ -2809,7 +2817,12 @@ class TestWorkspaceRoutes:
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "restarted"
-        mock_stop.assert_awaited_once_with("cid-restart", workspace_id=ws_id)
+        mock_stop.assert_awaited_once_with(
+            "cid-restart",
+            workspace_id=ws_id,
+            cause=CAUSE_RESTART,
+            actor_id=user["id"],
+        )
         # #1244: restart re-starts the container (not just stop+remove),
         # so the service command re-fires at the create choke point and
         # the workspace recovers.
@@ -2900,7 +2913,12 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 200
         assert resp.json()["status"] == "stopped"
         mock_killed.assert_awaited_once_with(ws_id, container_id="cid-stop")
-        mock_stop.assert_awaited_once_with("cid-stop", workspace_id=ws_id)
+        mock_stop.assert_awaited_once_with(
+            "cid-stop",
+            workspace_id=ws_id,
+            cause=CAUSE_STOP,
+            actor_id=user["id"],
+        )
         # Re-homed from the retired WS shutdown_container handler: REST /stop
         # broadcasts container_stopped so live viewers show "stopped".
         mock_session.broadcast.assert_called_once()

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -21,6 +21,7 @@ from klangk import (
     util as util_mod,
 )
 from klangk.container.spec import nix_binds
+from klangk.model.container_events import CAUSE_API, CAUSE_DRAIN
 from _helpers import make_settings
 
 
@@ -4431,7 +4432,9 @@ class TestStopContainer:
         lock = self.registry._get_workspace_lock("ws")
 
         with patch_podman(self.registry) as p:
-            await self.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container(
+                "cid", cause=CAUSE_API
+            )
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in self.registry.states
         assert "cid" not in self.registry._cid_to_wsid
@@ -4464,7 +4467,9 @@ class TestStopContainer:
             self.registry,
             list_containers=AsyncMock(return_value=[net_sidecar]),
         ) as p:
-            await self.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container(
+                "cid", cause=CAUSE_API
+            )
         removes = [c.args[0] for c in p.remove_container.await_args_list]
         assert "cid" in removes  # the workspace container
         # #2286: the sidecar is removed by id (label-based), not by name.
@@ -4500,7 +4505,7 @@ class TestStopContainer:
             list_containers=AsyncMock(return_value=[net_sidecar]),
         ) as p:
             await self.registry.stop_and_remove_container(
-                "cid-from-db", workspace_id=ws_id
+                "cid-from-db", workspace_id=ws_id, cause=CAUSE_API
             )
         removes = [c.args[0] for c in p.remove_container.await_args_list]
         # The workspace container is removed ...
@@ -4523,7 +4528,9 @@ class TestStopContainer:
             assert len(locks) == 3
 
             with patch_podman(self.registry):
-                await self.registry.stop_and_remove_container("alive")
+                await self.registry.stop_and_remove_container(
+                    "alive", cause=CAUSE_API
+                )
 
             # The stopped container's entry and the orphans are gone; the dict
             # is empty because no container remains tracked.
@@ -4541,7 +4548,9 @@ class TestStopContainer:
                 side_effect=podman.PodmanError(404, "gone")
             ),
         ):
-            await self.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container(
+                "cid", cause=CAUSE_API
+            )
         # Should still remove from tracking
         assert "ws" not in self.registry.states
         assert "cid" not in self.registry._cid_to_wsid
@@ -4555,7 +4564,9 @@ class TestStopContainer:
         # Tracked + clean remove → True.
         self.registry.track_activity("cid-a", "ws-a")
         with patch_podman(self.registry):
-            ok = await self.registry.stop_and_remove_container("cid-a")
+            ok = await self.registry.stop_and_remove_container(
+                "cid-a", cause=CAUSE_API
+            )
         assert ok is True
 
         # Tracked + podman failure → False.
@@ -4566,7 +4577,9 @@ class TestStopContainer:
                 side_effect=podman.PodmanError(500, "boom")
             ),
         ):
-            ok = await self.registry.stop_and_remove_container("cid-b")
+            ok = await self.registry.stop_and_remove_container(
+                "cid-b", cause=CAUSE_API
+            )
         assert ok is False
 
         # Re-bound by a racing start → the fresh container is left alone;
@@ -4575,7 +4588,7 @@ class TestStopContainer:
         self.registry.track_activity("cid-new", "ws-c")  # re-bind
         with patch_podman(self.registry):
             ok = await self.registry.stop_and_remove_container(
-                "cid-old", workspace_id="ws-c"
+                "cid-old", workspace_id="ws-c", cause=CAUSE_API
             )
         assert ok is False
         # The fresh container's state survived.
@@ -4583,7 +4596,9 @@ class TestStopContainer:
 
         # Untracked container (no workspace) + clean remove → True.
         with patch_podman(self.registry):
-            ok = await self.registry.stop_and_remove_container("cid-x")
+            ok = await self.registry.stop_and_remove_container(
+                "cid-x", cause=CAUSE_API
+            )
         assert ok is True
 
     async def test_stop_serializes_under_workspace_lock(self):
@@ -4598,7 +4613,9 @@ class TestStopContainer:
                 # While the lock is held (as start_container would hold
                 # it), stop must not be able to remove state.
                 task = asyncio.create_task(
-                    self.registry.stop_and_remove_container("cid")
+                    self.registry.stop_and_remove_container(
+                        "cid", cause=CAUSE_API
+                    )
                 )
                 # Yield repeatedly so the stop task has a chance to run;
                 # it should be blocked on the lock.
@@ -4633,7 +4650,9 @@ class TestStopContainer:
                 # Start stop; it runs podman (instant), peeks cid-old->ws,
                 # then blocks on the lock we hold.
                 task = asyncio.create_task(
-                    self.registry.stop_and_remove_container("cid-old")
+                    self.registry.stop_and_remove_container(
+                        "cid-old", cause=CAUSE_API
+                    )
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
@@ -4676,7 +4695,9 @@ class TestStopContainer:
                 # Start stop; it removes the old workspace container, peeks
                 # cid-old->ws, then blocks on the lock we hold.
                 task = asyncio.create_task(
-                    self.registry.stop_and_remove_container("cid-old")
+                    self.registry.stop_and_remove_container(
+                        "cid-old", cause=CAUSE_API
+                    )
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
@@ -4706,7 +4727,9 @@ class TestStopContainer:
         lock_before = self.registry._get_workspace_lock("ws")
 
         with patch_podman(self.registry):
-            await self.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container(
+                "cid", cause=CAUSE_API
+            )
         assert "ws" in self.registry._workspace_locks
         lock_after = self.registry._get_workspace_lock("ws")
         assert lock_after is lock_before
@@ -4722,7 +4745,9 @@ class TestRemoveContainer:
         lock = self.registry._get_workspace_lock("ws")
 
         with patch_podman(self.registry) as p:
-            await self.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container(
+                "cid", cause=CAUSE_API
+            )
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in self.registry.states
         assert "cid" not in self.registry._cid_to_wsid
@@ -4740,7 +4765,9 @@ class TestRemoveContainer:
                 side_effect=podman.PodmanError(404, "gone")
             ),
         ):
-            await self.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container(
+                "cid", cause=CAUSE_API
+            )
         assert "ws" not in self.registry.states
         assert "cid" not in self.registry._cid_to_wsid
         # The workspace lock entry is deliberately retained (#1258).
@@ -6863,7 +6890,7 @@ class TestContainerBranchGaps2834:
                 AsyncMock(return_value=[leftover]),
             ):
                 assert await self.registry._sweep_drain_leftovers() == 0
-        stop.assert_awaited_once_with("cid-left")
+        stop.assert_awaited_once_with("cid-left", cause=CAUSE_DRAIN)
 
     # --- health ---
 
@@ -6931,7 +6958,13 @@ class TestContainerBranchGaps2834:
                     )
                     await asyncio.sleep(0.05)
                     self.registry.get_cleanup_wake().set()
-                    await asyncio.sleep(0.05)
+                    # Both reaps must land before the cancel; each now
+                    # carries a container_events audit write (#2915), so
+                    # poll for the second stop instead of a fixed sleep.
+                    for _ in range(200):
+                        if p.remove_container.await_count >= 2:
+                            break
+                        await asyncio.sleep(0.01)
                     task.cancel()
                     try:
                         await task

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -6890,7 +6890,9 @@ class TestContainerBranchGaps2834:
                 AsyncMock(return_value=[leftover]),
             ):
                 assert await self.registry._sweep_drain_leftovers() == 0
-        stop.assert_awaited_once_with("cid-left", cause=CAUSE_DRAIN)
+        stop.assert_awaited_once_with(
+            "cid-left", workspace_id=None, cause=CAUSE_DRAIN
+        )
 
     # --- health ---
 

--- a/src/klangk/klangkd-tests/tests/test_container_events.py
+++ b/src/klangk/klangkd-tests/tests/test_container_events.py
@@ -1,0 +1,277 @@
+"""Container lifecycle audit events (#2915).
+
+Covers the ``container_events`` table (migration 0019), the
+``ContainerEventsModel`` CRUD, and the recording hooks at the two
+lifecycle choke points — ``ContainerRegistry.start_container`` and
+``stop_and_remove_container`` — including actor classification
+(user/agent/system), the best-effort failure path, and the netns-owner
+attribution for egress-filtered workspaces.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from test_container import patch_podman
+from klangk.container.spec import ContainerStartSpec
+from klangk.model.container_events import (
+    ACTOR_AGENT,
+    ACTOR_SYSTEM,
+    ACTOR_USER,
+    CAUSE_AUTO_START,
+    CAUSE_IDLE_TIMEOUT,
+    CAUSE_STOP,
+    EVENT_START,
+    EVENT_STOP,
+    actor_type_for,
+)
+from klangk.model.users import AGENT_USER_ID
+
+
+@pytest.fixture
+async def registry(app_state, db):
+    """The conftest app_state plus a podman instance for patch_podman."""
+    from klangk.podman import Podman
+
+    app_state.state.podman = Podman(app_state)
+    return app_state.state.container_registry
+
+
+class TestActorClassification:
+    def test_none_is_system(self):
+        assert actor_type_for(None) == ACTOR_SYSTEM
+
+    def test_agent_identity_is_agent(self):
+        assert actor_type_for(AGENT_USER_ID) == ACTOR_AGENT
+
+    def test_any_other_id_is_user(self):
+        assert actor_type_for("some-user-id") == ACTOR_USER
+
+
+class TestContainerEventsModel:
+    async def test_record_and_list_newest_first(self, app_state, db):
+        events = app_state.state.model.container_events
+        await events.record("ws-a", EVENT_START, "api", actor_id="u1")
+        await events.record("ws-a", EVENT_STOP, CAUSE_STOP, actor_id="u1")
+        await events.record("ws-b", EVENT_START, CAUSE_AUTO_START)
+        rows = await events.list_events()
+        assert [r["workspace_id"] for r in rows] == ["ws-b", "ws-a", "ws-a"]
+        assert rows[0]["actor_type"] == ACTOR_SYSTEM
+        assert rows[0]["actor_id"] is None
+        assert rows[2]["actor_type"] == ACTOR_USER
+        assert rows[2]["actor_id"] == "u1"
+
+    async def test_list_filter_limit_offset(self, app_state, db):
+        events = app_state.state.model.container_events
+        for i in range(5):
+            await events.record(
+                "ws-a", EVENT_START, "api", container_id=f"cid-{i}"
+            )
+        await events.record("ws-b", EVENT_START, "api")
+        assert await events.count_events() == 6
+        assert await events.count_events("ws-a") == 5
+        page = await events.list_events("ws-a", limit=2, offset=1)
+        assert [r["container_id"] for r in page] == ["cid-3", "cid-2"]
+
+    async def test_record_carries_cause_and_namespace(self, app_state, db):
+        events = app_state.state.model.container_events
+        await events.record(
+            "ws-a",
+            EVENT_START,
+            CAUSE_IDLE_TIMEOUT,
+            actor_id=None,
+            container_id="cid-9",
+            network_namespace="sidecar-cid",
+        )
+        row = (await events.list_events("ws-a"))[0]
+        assert row["event"] == EVENT_START
+        assert row["cause"] == CAUSE_IDLE_TIMEOUT
+        assert row["container_id"] == "cid-9"
+        assert row["network_namespace"] == "sidecar-cid"
+        assert row["created_at"] > 0
+
+
+class TestMigration:
+    async def test_table_and_index_created(self, app_state, db):
+        tables = await app_state.state.db.fetchall(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+            " AND name = 'container_events'"
+        )
+        assert tables, "container_events table missing after init_db"
+        indexes = await app_state.state.db.fetchall(
+            "SELECT name FROM sqlite_master WHERE type = 'index'"
+            " AND name = 'idx_container_events_ws_time'"
+        )
+        assert indexes, "container_events index missing after init_db"
+
+
+class TestRegistryRecording:
+    async def test_start_records_created_transition(
+        self, app_state, db, monkeypatch
+    ):
+        registry = app_state.state.container_registry
+        monkeypatch.setattr(
+            app_state.state.workspaces,
+            "ensure_shared_home_dir",
+            AsyncMock(),
+        )
+        with patch.object(
+            registry,
+            "start_container_inner",
+            AsyncMock(return_value=("cid-1", "created")),
+        ):
+            cid, status = await registry.start_container(
+                ContainerStartSpec(
+                    workspace_id="ws-a",
+                    home_path="/home/x",
+                    audit_cause=CAUSE_AUTO_START,
+                )
+            )
+        assert (cid, status) == ("cid-1", "created")
+        row = (
+            await app_state.state.model.container_events.list_events("ws-a")
+        )[0]
+        assert row["event"] == EVENT_START
+        assert row["cause"] == CAUSE_AUTO_START
+        assert row["actor_type"] == ACTOR_SYSTEM
+        assert row["container_id"] == "cid-1"
+
+    async def test_connected_attach_records_nothing(
+        self, app_state, db, monkeypatch
+    ):
+        registry = app_state.state.container_registry
+        monkeypatch.setattr(
+            app_state.state.workspaces,
+            "ensure_shared_home_dir",
+            AsyncMock(),
+        )
+        with patch.object(
+            registry,
+            "start_container_inner",
+            AsyncMock(return_value=("cid-1", "connected")),
+        ):
+            await registry.start_container(
+                ContainerStartSpec(workspace_id="ws-a", home_path="/home/x")
+            )
+        assert (
+            await app_state.state.model.container_events.count_events("ws-a")
+            == 0
+        )
+
+    async def test_stop_records_with_actor_and_netns(
+        self, app_state, db, registry, workspace
+    ):
+        ws_id = workspace["id"]
+        registry.track_activity("cid-1", ws_id)
+        # A live sidecar mapping (#2915): the netns owner is captured on
+        # the stop row even though teardown pops it.
+        registry._ws_netns_owner[ws_id] = "sidecar-cid"
+        with patch_podman(registry):
+            ok = await registry.stop_and_remove_container(
+                "cid-1",
+                workspace_id=ws_id,
+                cause=CAUSE_STOP,
+                actor_id="some-user-id",
+            )
+        assert ok is True
+        row = (
+            await app_state.state.model.container_events.list_events(ws_id)
+        )[0]
+        assert row["event"] == EVENT_STOP
+        assert row["cause"] == CAUSE_STOP
+        assert row["actor_type"] == ACTOR_USER
+        assert row["actor_id"] == "some-user-id"
+        assert row["container_id"] == "cid-1"
+        assert row["network_namespace"] == "sidecar-cid"
+        assert ws_id not in registry._ws_netns_owner
+
+    async def test_failed_remove_records_nothing(
+        self, app_state, db, registry
+    ):
+        from klangk.podman import PodmanError
+
+        registry.track_activity("cid-dead", "ws-x")
+        with patch_podman(
+            registry,
+            remove_container=AsyncMock(side_effect=PodmanError(500, "boom")),
+        ):
+            ok = await registry.stop_and_remove_container(
+                "cid-dead", workspace_id="ws-x", cause=CAUSE_STOP
+            )
+        assert ok is False
+        assert (
+            await app_state.state.model.container_events.count_events("ws-x")
+            == 0
+        )
+
+    async def test_unresolvable_workspace_records_nothing(
+        self, app_state, db, registry
+    ):
+        with patch_podman(registry):
+            ok = await registry.stop_and_remove_container(
+                "cid-orphan", cause=CAUSE_STOP
+            )
+        assert ok is True
+        assert await app_state.state.model.container_events.count_events() == 0
+
+    async def test_audit_write_failure_is_not_fatal(self, app_state, db):
+        registry = app_state.state.container_registry
+        with patch.object(
+            app_state.state.model.container_events,
+            "record",
+            AsyncMock(side_effect=RuntimeError("db gone")),
+        ):
+            # Neither start nor stop may raise when the audit write fails.
+            await registry.record_container_event(
+                "ws-a", "cid-1", EVENT_START, cause="api"
+            )
+
+    async def test_netns_defaults_to_live_mapping(self, app_state, db):
+        registry = app_state.state.container_registry
+        registry._ws_netns_owner["ws-a"] = "sidecar-live"
+        await registry.record_container_event(
+            "ws-a", "cid-1", EVENT_START, cause="api"
+        )
+        row = (
+            await app_state.state.model.container_events.list_events("ws-a")
+        )[0]
+        assert row["network_namespace"] == "sidecar-live"
+
+
+class TestStartWorkspaceThreading:
+    async def test_actor_and_cause_ride_the_spec(self, app_state, db):
+        registry = app_state.state.container_registry
+        captured = {}
+
+        async def fake_start(spec):
+            captured["spec"] = spec
+            return spec.existing_container_id or "cid-new", "created"
+
+        with patch.object(registry, "start_container", fake_start):
+            cid, status = await app_state.state.workspaces.start_workspace(
+                {
+                    "id": "ws-a",
+                    "user_id": "u1",
+                    "container_id": "cid-old",
+                },
+                actor_id="u1",
+                cause=CAUSE_AUTO_START,
+            )
+        assert (cid, status) == ("cid-old", "created")
+        assert captured["spec"].audit_actor_id == "u1"
+        assert captured["spec"].audit_cause == CAUSE_AUTO_START
+
+    async def test_defaults_are_api_and_system_actor(self, app_state, db):
+        registry = app_state.state.container_registry
+        captured = {}
+
+        async def fake_start(spec):
+            captured["spec"] = spec
+            return "cid-new", "created"
+
+        with patch.object(registry, "start_container", fake_start):
+            await app_state.state.workspaces.start_workspace(
+                {"id": "ws-a", "user_id": "u1"}
+            )
+        assert captured["spec"].audit_actor_id is None
+        assert captured["spec"].audit_cause == "api"

--- a/src/klangk/klangkd-tests/tests/test_container_events.py
+++ b/src/klangk/klangkd-tests/tests/test_container_events.py
@@ -13,14 +13,19 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from test_container import patch_podman
+from test_wshandler import _base_conn
 from klangk.container.spec import ContainerStartSpec
 from klangk.model.container_events import (
     ACTOR_AGENT,
     ACTOR_SYSTEM,
     ACTOR_USER,
     CAUSE_AUTO_START,
+    CAUSE_DRAIN,
     CAUSE_IDLE_TIMEOUT,
+    CAUSE_LOGOUT,
+    CAUSE_SHUTDOWN,
     CAUSE_STOP,
+    CAUSE_WS_CONNECT,
     EVENT_START,
     EVENT_STOP,
     actor_type_for,
@@ -275,3 +280,197 @@ class TestStartWorkspaceThreading:
             )
         assert captured["spec"].audit_actor_id is None
         assert captured["spec"].audit_cause == "api"
+
+
+class TestWsConnectAttribution:
+    async def test_ws_connect_start_carries_connecting_user(
+        self, app_state, db, registry, user, workspace
+    ):
+        """The normal web-UI start path (first WS connection) records the
+        connecting user with the ws_connect cause (#2915 review)."""
+        from klangk.wshandler import WebSocketState
+
+        app_state.state.sockets = WebSocketState(app_state)
+        conn = _base_conn(user=user, app_state=app_state)
+        captured = {}
+
+        async def fake_start(spec):
+            captured["spec"] = spec
+            return "cid-ws", "created"
+
+        with patch.object(
+            app_state.state.container_registry,
+            "start_container",
+            fake_start,
+        ):
+            await conn.start_workspace_container(workspace["id"], workspace)
+        assert captured["spec"].audit_cause == CAUSE_WS_CONNECT
+        assert captured["spec"].audit_actor_id == user["id"]
+
+
+class TestLogoutAttribution:
+    async def _stop_user_containers(self, app_state, db, registry, uid):
+        with patch.object(
+            app_state.state.model.workspaces,
+            "get_user_workspaces_with_containers",
+            AsyncMock(
+                return_value=[{"id": "ws-lo", "container_id": "cid-lo"}]
+            ),
+        ):
+            with patch_podman(registry):
+                await registry.stop_user_containers(uid)
+        return (
+            await app_state.state.model.container_events.list_events("ws-lo")
+        )[0]
+
+    async def test_logout_stop_attributes_the_user(
+        self, app_state, db, registry
+    ):
+        row = await self._stop_user_containers(app_state, db, registry, "u-1")
+        assert row["event"] == EVENT_STOP
+        assert row["cause"] == CAUSE_LOGOUT
+        assert row["actor_type"] == ACTOR_USER
+        assert row["actor_id"] == "u-1"
+
+    async def test_logout_stop_attributes_the_agent(
+        self, app_state, db, registry
+    ):
+        row = await self._stop_user_containers(
+            app_state, db, registry, AGENT_USER_ID
+        )
+        assert row["actor_type"] == ACTOR_AGENT
+        assert row["actor_id"] == AGENT_USER_ID
+
+
+class TestLabeledSweepAttribution:
+    async def test_drain_sweep_records_labeled_workspace_stop(
+        self, app_state, db, registry
+    ):
+        from klangk.container.sidecar import labeled_workspace_id
+
+        leftover = {
+            "Id": "cid-sweep",
+            "Labels": {
+                "klangk.workspace": "ws-sweep",
+                "klangk.role": "workspace",
+            },
+        }
+        assert labeled_workspace_id(leftover) == "ws-sweep"
+        with patch_podman(
+            registry, list_containers=AsyncMock(return_value=[leftover])
+        ):
+            assert await registry._sweep_drain_leftovers() == 1
+        row = (
+            await app_state.state.model.container_events.list_events(
+                "ws-sweep"
+            )
+        )[0]
+        assert row["event"] == EVENT_STOP
+        assert row["cause"] == CAUSE_DRAIN
+        assert row["actor_type"] == ACTOR_SYSTEM
+
+    async def test_sidecar_label_is_not_a_workspace(self):
+        from klangk.container.sidecar import labeled_workspace_id
+
+        sidecar = {
+            "Id": "net-cid",
+            "Labels": {
+                "klangk.workspace": "ws-x",
+                "klangk.role": "network-sidecar",
+            },
+        }
+        assert labeled_workspace_id(sidecar) is None
+        assert labeled_workspace_id({"Id": "x"}) is None
+
+    async def test_shutdown_sweep_records_labeled_workspace_stop(
+        self, app_state, db, registry, monkeypatch
+    ):
+        """The shutdown orphan loop attributes labeled workspace containers
+        (#2915 review): a prior-session workspace stopped at shutdown
+        keeps its stop row."""
+        orphan = {
+            "Id": "cid-orphan",
+            "Labels": {
+                "klangk.workspace": "ws-orphan",
+                "klangk.role": "workspace",
+            },
+        }
+        registry._cid_to_wsid.pop("cid-orphan", None)
+        with patch_podman(
+            registry, list_containers=AsyncMock(return_value=[orphan])
+        ):
+            with patch.object(
+                registry, "notify_workspace_killed", AsyncMock()
+            ):
+                await registry.shutdown()
+        row = (
+            await app_state.state.model.container_events.list_events(
+                "ws-orphan"
+            )
+        )[0]
+        assert row["event"] == EVENT_STOP
+        assert row["cause"] == CAUSE_SHUTDOWN
+
+
+class TestFailedStartBackstop:
+    async def test_bringup_failure_still_records_start(
+        self, app_state, db, registry, workspace
+    ):
+        """A container created but whose bringup raises is real and
+        tracked — the start row must exist (#2915 review) so a later
+        crash_teardown stop is not an orphan in the audit trail."""
+        ws_id = workspace["id"]
+        from klangk import ssl_trust
+        from klangk.terminal import Terminal
+
+        app_state.state.ssl_trust = ssl_trust.SSLTrust(app_state)
+        app_state.state.terminal = Terminal(app_state)
+        with patch_podman(registry):
+            with patch.object(
+                registry,
+                "bringup",
+                AsyncMock(side_effect=RuntimeError("exec failed")),
+            ):
+                with pytest.raises(RuntimeError):
+                    await registry.start_container(
+                        ContainerStartSpec(
+                            workspace_id=ws_id,
+                            home_path="/tmp/home",
+                            audit_cause=CAUSE_WS_CONNECT,
+                            audit_actor_id="u-9",
+                        )
+                    )
+        row = (
+            await app_state.state.model.container_events.list_events(ws_id)
+        )[0]
+        assert row["event"] == EVENT_START
+        assert row["cause"] == CAUSE_WS_CONNECT
+        assert row["actor_id"] == "u-9"
+        assert row["container_id"] == "new-cid"
+
+    async def test_pre_create_refusal_records_nothing(
+        self, app_state, db, registry, workspace
+    ):
+        """A refusal before any container exists (drain gate) leaves no
+        start row — no container, no start."""
+        with patch_podman(registry):
+            with patch.object(
+                registry,
+                "new_starts_blocked_reason",
+                return_value="node is draining",
+            ):
+                from klangk.exceptions import NodeDrainingError
+
+                with pytest.raises(NodeDrainingError):
+                    await registry.start_container(
+                        ContainerStartSpec(
+                            workspace_id=workspace["id"],
+                            home_path="/tmp/home",
+                        )
+                    )
+        assert (
+            await app_state.state.model.container_events.count_events(
+                workspace["id"]
+            )
+            == 0
+        )

--- a/src/klangk/klangkd-tests/tests/test_container_events.py
+++ b/src/klangk/klangkd-tests/tests/test_container_events.py
@@ -474,3 +474,102 @@ class TestFailedStartBackstop:
             )
             == 0
         )
+
+
+class TestSidecarLifecycle:
+    async def test_sidecar_start_recorded(self, app_state, db, registry):
+        """A filtered workspace's sidecar create lands as a system-caused
+        sidecar_start row with no netns owner (it IS the owner)."""
+        with patch_podman(registry):
+            cid = await registry.start_network_sidecar(
+                "ws-sc", ["allow.example.com"]
+            )
+        assert cid == "new-cid"
+        row = (
+            await app_state.state.model.container_events.list_events("ws-sc")
+        )[0]
+        assert row["event"] == EVENT_START
+        assert row["cause"] == "sidecar_start"
+        assert row["container_role"] == "network-sidecar"
+        assert row["actor_type"] == ACTOR_SYSTEM
+        assert row["container_id"] == "new-cid"
+        assert row["network_namespace"] is None
+
+    async def test_sidecar_stop_recorded_via_label_removal(
+        self, app_state, db, registry
+    ):
+        """The label-based sidecar removal choke point (workspace teardown,
+        stale-generation clear, failure teardown) records sidecar_stop."""
+        sidecar = {
+            "Id": "net-cid",
+            "Labels": {
+                "klangk.workspace": "ws-sc",
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            registry, list_containers=AsyncMock(return_value=[sidecar])
+        ):
+            assert await registry._remove_network_sidecar("ws-sc") is True
+        row = (
+            await app_state.state.model.container_events.list_events("ws-sc")
+        )[0]
+        assert row["event"] == EVENT_STOP
+        assert row["cause"] == "sidecar_stop"
+        assert row["container_role"] == "network-sidecar"
+        assert row["container_id"] == "net-cid"
+        assert row["network_namespace"] is None
+
+    async def test_sidecar_role_never_inherits_netns_owner(
+        self, app_state, db, registry
+    ):
+        registry._ws_netns_owner["ws-sc"] = "sidecar-live"
+        await registry.record_container_event(
+            "ws-sc",
+            "cid-x",
+            EVENT_STOP,
+            cause="sidecar_stop",
+            container_role="network-sidecar",
+        )
+        row = (
+            await app_state.state.model.container_events.list_events("ws-sc")
+        )[0]
+        assert row["network_namespace"] is None
+
+
+class TestSweepSidecarAttribution:
+    async def test_drain_sweep_records_sidecar_stop(
+        self, app_state, db, registry
+    ):
+        leftover = {
+            "Id": "net-cid",
+            "Labels": {
+                "klangk.workspace": "ws-sc",
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            registry, list_containers=AsyncMock(return_value=[leftover])
+        ):
+            assert await registry._sweep_drain_leftovers() == 1
+        row = (
+            await app_state.state.model.container_events.list_events("ws-sc")
+        )[0]
+        assert row["event"] == EVENT_STOP
+        assert row["cause"] == CAUSE_DRAIN
+        assert row["container_role"] == "network-sidecar"
+
+    async def test_drain_sweep_unlabeled_sidecar_records_nothing(
+        self, app_state, db, registry
+    ):
+        """A sidecar without its workspace label cannot be correlated —
+        stopped (counted) but not recorded."""
+        leftover = {
+            "Id": "net-cid",
+            "Labels": {"klangk.role": "network-sidecar"},
+        }
+        with patch_podman(
+            registry, list_containers=AsyncMock(return_value=[leftover])
+        ):
+            assert await registry._sweep_drain_leftovers() == 1
+        assert await app_state.state.model.container_events.count_events() == 0

--- a/src/klangk/klangkd-tests/tests/test_container_events.py
+++ b/src/klangk/klangkd-tests/tests/test_container_events.py
@@ -556,8 +556,12 @@ class TestSweepSidecarAttribution:
             await app_state.state.model.container_events.list_events("ws-sc")
         )[0]
         assert row["event"] == EVENT_STOP
-        assert row["cause"] == CAUSE_DRAIN
+        # Sidecar sweep stops route through the label-based choke point,
+        # so their cause is sidecar_stop (not the sweep's cause).
+        assert row["cause"] == "sidecar_stop"
         assert row["container_role"] == "network-sidecar"
+        assert row["network_namespace"] is None
+        assert row["actor_type"] == ACTOR_SYSTEM
 
     async def test_drain_sweep_unlabeled_sidecar_records_nothing(
         self, app_state, db, registry
@@ -573,3 +577,169 @@ class TestSweepSidecarAttribution:
         ):
             assert await registry._sweep_drain_leftovers() == 1
         assert await app_state.state.model.container_events.count_events() == 0
+
+
+class TestSweepSidecarSingleRow:
+    async def test_workspace_then_sidecar_sweep_records_each_once(
+        self, app_state, db, registry
+    ):
+        """The blocking double-record from review: a drain sweep whose
+        leftover list holds a workspace container AND its sidecar must
+        produce exactly one stop row per container — the sidecar routes
+        through the label-based choke point, so the already-removed
+        sidecar's stale sweep entry finds nothing to record."""
+        ws_leftover = {
+            "Id": "cid-ws",
+            "Labels": {
+                "klangk.workspace": "ws-pair",
+                "klangk.role": "workspace",
+            },
+        }
+        sidecar = {
+            "Id": "net-cid",
+            "Labels": {
+                "klangk.workspace": "ws-pair",
+                "klangk.role": "network-sidecar",
+            },
+        }
+        label_lists = [[sidecar], []]
+
+        async def fake_list(filter_arg):
+            if "klangk.instance=" in filter_arg:
+                return [ws_leftover, sidecar]
+            # workspace-label listing: the sidecar once, then gone
+            # (removed by the workspace stop's teardown).
+            return label_lists.pop(0) if label_lists else []
+
+        with patch_podman(
+            registry, list_containers=AsyncMock(side_effect=fake_list)
+        ):
+            assert await registry._sweep_drain_leftovers() == 2
+        rows = await app_state.state.model.container_events.list_events(
+            "ws-pair"
+        )
+        stops = [r for r in rows if r["event"] == EVENT_STOP]
+        assert len(stops) == 2
+        by_role = {r["container_role"]: r for r in stops}
+        assert by_role["workspace"]["cause"] == CAUSE_DRAIN
+        assert by_role["workspace"]["container_id"] == "cid-ws"
+        assert by_role["network-sidecar"]["cause"] == "sidecar_stop"
+        assert by_role["network-sidecar"]["container_id"] == "net-cid"
+        assert by_role["network-sidecar"]["network_namespace"] is None
+        assert by_role["network-sidecar"]["actor_type"] == ACTOR_SYSTEM
+
+
+class TestReaperAttribution:
+    async def test_instance_reap_records_both_roles(
+        self, app_state, db, registry
+    ):
+        leftover_ws = {
+            "Id": "cid-reap-ws",
+            "Labels": {
+                "klangk.workspace": "ws-reap",
+                "klangk.role": "workspace",
+            },
+        }
+        leftover_sc = {
+            "Id": "cid-reap-sc",
+            "Labels": {
+                "klangk.workspace": "ws-reap",
+                "klangk.role": "network-sidecar",
+            },
+        }
+        with patch_podman(
+            registry,
+            list_containers=AsyncMock(return_value=[leftover_ws, leftover_sc]),
+        ):
+            await registry.reap_instance_containers()
+        rows = {
+            r["container_id"]: r
+            for r in await app_state.state.model.container_events.list_events(
+                "ws-reap"
+            )
+        }
+        assert rows["cid-reap-ws"]["cause"] == "reap"
+        assert rows["cid-reap-ws"]["container_role"] == "workspace"
+        assert rows["cid-reap-sc"]["cause"] == "reap"
+        assert rows["cid-reap-sc"]["container_role"] == "network-sidecar"
+
+    async def test_labelless_reap_records_nothing(
+        self, app_state, db, registry
+    ):
+        leftover = {"Id": "cid-anon", "Labels": {"klangk.managed": "true"}}
+        with patch_podman(
+            registry, list_containers=AsyncMock(return_value=[leftover])
+        ):
+            await registry.reap_instance_containers()
+        assert await app_state.state.model.container_events.count_events() == 0
+
+
+class TestDependentRemovalAttribution:
+    async def test_dependent_teardown_records_workspace_stop(
+        self, app_state, db, registry
+    ):
+        dependent = {
+            "Id": "cid-dep",
+            "Labels": {
+                "klangk.workspace": "ws-dep",
+                "klangk.role": "workspace",
+            },
+        }
+        with patch_podman(
+            registry, list_containers=AsyncMock(return_value=[dependent])
+        ):
+            await registry._remove_dependent_workspace_containers("ws-dep")
+        row = (
+            await app_state.state.model.container_events.list_events("ws-dep")
+        )[0]
+        assert row["event"] == EVENT_STOP
+        assert row["cause"] == "sidecar_dependent"
+        assert row["container_role"] == "workspace"
+        assert row["container_id"] == "cid-dep"
+
+
+class TestSidecarStartFailureBackstop:
+    async def test_start_row_survives_start_failure(
+        self, app_state, db, registry
+    ):
+        from klangk.podman import PodmanError
+
+        with patch_podman(registry):
+            with patch.object(
+                registry,
+                "start_with_port_conflict_retry",
+                AsyncMock(side_effect=PodmanError(500, "port clash")),
+            ):
+                with pytest.raises(PodmanError):
+                    await registry.start_network_sidecar(
+                        "ws-fail", ["allow.example.com"]
+                    )
+        row = (
+            await app_state.state.model.container_events.list_events("ws-fail")
+        )[0]
+        assert row["event"] == EVENT_START
+        assert row["cause"] == "sidecar_start"
+        assert row["container_id"] == "new-cid"
+
+    async def test_start_row_survives_readiness_timeout(
+        self, app_state, db, registry
+    ):
+        from klangk.podman import PodmanError
+
+        with patch_podman(registry):
+            with patch.object(
+                registry,
+                "_wait_sidecar_proxy_ready",
+                AsyncMock(side_effect=PodmanError(500, "never ready")),
+            ):
+                with pytest.raises(PodmanError):
+                    await registry.start_network_sidecar(
+                        "ws-fail2", ["allow.example.com"]
+                    )
+        row = (
+            await app_state.state.model.container_events.list_events(
+                "ws-fail2"
+            )
+        )[0]
+        assert row["event"] == EVENT_START
+        assert row["container_id"] == "new-cid"

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -19,6 +19,7 @@ from klangk.container.crash import (
     classify_death,
 )
 from klangk.wshandler.session import WebSocketState
+from klangk.model.container_events import CAUSE_API
 from _helpers import make_settings, wire_db_and_model
 
 
@@ -413,7 +414,7 @@ class TestSweep:
             # cancels crash state, but the rebind check leaves the live
             # state (bound to cid-crash) untouched.
             await reg.stop_and_remove_container(
-                "stale-cid", workspace_id="ws-crash"
+                "stale-cid", workspace_id="ws-crash", cause=CAUSE_API
             )
             parked.set()
             await sweep
@@ -703,7 +704,7 @@ class TestRestartEnabled:
         ws_row = {"id": "ws-crash", "name": "ws", "settings": {}}
         started = []
 
-        async def fake_start(ws):
+        async def fake_start(ws, **kwargs):
             started.append(ws["id"])
             return "new-cid", "created"
 
@@ -804,7 +805,7 @@ class TestRestartEnabled:
         dead_state(reg)
         calls = []
 
-        async def failing_start(ws):
+        async def failing_start(ws, **kwargs):
             calls.append(ws["id"])
             raise RuntimeError("mount source missing")
 
@@ -862,7 +863,7 @@ class TestExpectedStopsNeverRestart:
         # The user hits /stop: expected death path.
         with patch_podman_methods(app_state, INSPECT_RUNNING):
             await reg.stop_and_remove_container(
-                "cid-crash", workspace_id="ws-crash"
+                "cid-crash", workspace_id="ws-crash", cause=CAUSE_API
             )
         await asyncio.sleep(0)  # let the cancellation propagate
         assert task.cancelled()
@@ -898,7 +899,7 @@ class TestExpectedStopsNeverRestart:
         ):
             stop_task = asyncio.create_task(
                 reg.stop_and_remove_container(
-                    "cid-crash", workspace_id="ws-crash"
+                    "cid-crash", workspace_id="ws-crash", cause=CAUSE_API
                 )
             )
             await asyncio.sleep(0.005)
@@ -959,7 +960,7 @@ class TestExpectedStopsNeverRestart:
                     # The user /stop runs to completion while death
                     # handling is parked (bumps the stop epoch).
                     await reg.stop_and_remove_container(
-                        "cid-crash", workspace_id="ws-crash"
+                        "cid-crash", workspace_id="ws-crash", cause=CAUSE_API
                     )
                     teardown_parked.set()
                     await death
@@ -1001,7 +1002,7 @@ class TestExpectedStopsNeverRestart:
             await asyncio.sleep(0)  # sweep parks in the liveness listing
             # The user /stop completes fully underneath the listing.
             await reg.stop_and_remove_container(
-                "cid-crash", workspace_id="ws-crash"
+                "cid-crash", workspace_id="ws-crash", cause=CAUSE_API
             )
             parked.set()
             await sweep
@@ -1215,7 +1216,7 @@ class TestDeathFrameCarriesCause:
         monitor = reg.crash
         dead_state(reg)
 
-        async def cancellable_start(ws):
+        async def cancellable_start(ws, **kwargs):
             raise asyncio.CancelledError()
 
         with patch_podman_methods(app_state, inspect_dead()):

--- a/src/klangk/klangkd-tests/tests/test_draining.py
+++ b/src/klangk/klangkd-tests/tests/test_draining.py
@@ -291,7 +291,9 @@ class TestDrain:
             n = await registry.drain_all_containers()
         assert n == 1
         assert swept == ["cid-race"]
-        assert any("racing-start" in r.message for r in caplog.records)
+        assert any(
+            "leftover klangk container" in r.message for r in caplog.records
+        )
 
     async def test_drain_sweep_tolerates_podman_errors(
         self, app_state, db, caplog

--- a/src/klangk/klangkd-tests/tests/test_draining.py
+++ b/src/klangk/klangkd-tests/tests/test_draining.py
@@ -178,7 +178,7 @@ class TestDrain:
         self._stub_sweep(app_state)
         stopped = []
 
-        async def fake_stop(cid, workspace_id=None):
+        async def fake_stop(cid, workspace_id=None, cause=None, actor_id=None):
             stopped.append(workspace_id)
             return True
 
@@ -203,7 +203,7 @@ class TestDrain:
         in_flight: list[str] = []
         overlapped: list[str] = []
 
-        async def fake_stop(cid, workspace_id=None):
+        async def fake_stop(cid, workspace_id=None, cause=None, actor_id=None):
             in_flight.append(workspace_id)
             await asyncio.sleep(0.02)
             if len(in_flight) > 1:
@@ -230,7 +230,7 @@ class TestDrain:
         self._track(app_state, registry, 2)
         self._stub_sweep(app_state)
 
-        async def fake_stop(cid, workspace_id=None):
+        async def fake_stop(cid, workspace_id=None, cause=None, actor_id=None):
             return workspace_id == "ws-0"
 
         with (
@@ -249,7 +249,7 @@ class TestDrain:
         self._track(app_state, registry, 2)
         self._stub_sweep(app_state)
 
-        async def fake_stop(cid, workspace_id=None):
+        async def fake_stop(cid, workspace_id=None, cause=None, actor_id=None):
             if workspace_id == "ws-1":
                 raise RuntimeError("podman exploded")
             return True
@@ -280,7 +280,7 @@ class TestDrain:
         )
         swept = []
 
-        async def fake_stop(cid, workspace_id=None):
+        async def fake_stop(cid, workspace_id=None, cause=None, actor_id=None):
             swept.append(cid)
             return True
 
@@ -312,7 +312,7 @@ class TestDrain:
             )
         )
 
-        async def fake_stop(cid, workspace_id=None):
+        async def fake_stop(cid, workspace_id=None, cause=None, actor_id=None):
             return True
 
         with (
@@ -438,7 +438,7 @@ class TestDrain:
 
         registry.on_workspace_killed = on_killed
 
-        async def fake_stop(cid, workspace_id=None):
+        async def fake_stop(cid, workspace_id=None, cause=None, actor_id=None):
             return True
 
         # No patch on notify_workspace_killed — the real wrapper is the

--- a/src/klangk/klangkd-tests/tests/test_eviction.py
+++ b/src/klangk/klangkd-tests/tests/test_eviction.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from klangk import container
+from klangk.model.container_events import CAUSE_EVICTION
 from klangk.container.eviction import (
     MemoryPressureEvictor,
     available_fraction,
@@ -384,7 +385,9 @@ class TestEvictOne:
         # the stop (the death frame needs live registry state). The
         # notification names the dead container (#331 re-bind guard).
         killed.assert_awaited_once_with("ws-old", container_id="cid-old")
-        stopped.assert_awaited_once_with("cid-old", workspace_id="ws-old")
+        stopped.assert_awaited_once_with(
+            "cid-old", workspace_id="ws-old", cause=CAUSE_EVICTION
+        )
         assert killed.await_count == stopped.await_count == 1
 
     async def test_broadcasts_workspace_evicted_event(self):
@@ -433,7 +436,9 @@ class TestEvictOne:
         registry.stop_and_remove_container = stopped
 
         assert await evictor.evict_one(0.03) is True
-        stopped.assert_awaited_once_with("cid-idle", workspace_id="ws-idle")
+        stopped.assert_awaited_once_with(
+            "cid-idle", workspace_id="ws-idle", cause=CAUSE_EVICTION
+        )
 
     async def test_stopping_workspace_skipped(self):
         app, evictor = self._evictor()

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -70,6 +70,7 @@ class TestRunner:
             (16, "0016_monitor_permission"),
             (17, "0017_change_acls_permission"),
             (18, "0018_egress_consent_permission"),
+            (19, "0019_container_events"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -154,6 +155,7 @@ class TestRunner:
                 (16, "0016_monitor_permission"),
                 (17, "0017_change_acls_permission"),
                 (18, "0018_egress_consent_permission"),
+                (19, "0019_container_events"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(


### PR DESCRIPTION
## Summary

Implements #2915: a persistent audit trail for every klangk-managed
container start and stop, with the acting principal, the cause, and the
podman correlation ids.

- **New `container_events` table** (migration 0019) + `ContainerEventsModel`
  (`record` / `list_events` / `count_events`, with paged reads ready for
  the admin UI in #2923).
- **Workspace rows** recorded at the two lifecycle choke points
  (`ContainerRegistry.start_container`, `stop_and_remove_container`):
  every path funnels through them — API start/stop/restart/delete with the
  requesting user, eager create start, WS-connect start (the connecting
  user), boot auto-start, crash restart, idle-timeout stop, eviction,
  logout, drain, shutdown. `cause` is a required keyword on
  `stop_and_remove_container`, so no caller can silently mislabel its stop.
- **Sidecar rows** (`container_role = 'network-sidecar'`): `sidecar_start`
  recorded at container creation (so an unready sidecar's later removal has
  its matching start row), `sidecar_stop` at the label-based removal choke
  point — exactly once per container. Sweep stops of sidecars route through
  that choke point (a 404-tolerant sweep stop can never double-record).
- **Nothing vanishes**: labeled containers stopped by the shutdown/drain
  orphan sweeps, the boot reapers (instance leftovers, dead owners), and the
  sidecar dependent-container teardowns all land rows by their
  `klangk.workspace` label. A bringup failure after a successful create
  still records the start row (the container is real and tracked), so a
  later crash-teardown stop is never an orphan in the trail.
- **Netns attribution**: egress-filtered workspace rows carry the live
  sidecar container id in `network_namespace` (captured before teardown);
  sidecar rows never do (they *are* the owner).
- All writes are **best-effort**: a DB failure logs a warning and never
  fails the start/stop it annotates.

Retention/bounding is deliberately out of scope (#2924); the admin-facing
paged view is #2923.

## Review

Two adversarial fresh-eyes review rounds (both REQUEST CHANGES on first
pass); all findings addressed — including a proven double-record of sidecar
stops, the boot reapers' invisible mass teardown, dependent-removal rows,
and the failed-start backstop.

## Verification

- `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — 6347 passed, 100% branch coverage
- `pre-commit run xenon --all-files` — passed
- 35 new tests in `test_container_events.py` (model, migration, choke
  points, attribution through real calls for WS-connect/logout/sweeps/
  reapers/dependents, failure backstops, the double-record regression)

Closes #2915
