### PR TITLE
llm_router: hold strong reference on passthrough client aclose task

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1628,6 +1628,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   completed, leaking the host-side podman exec reader and its
   container-side tmux control client until the container stopped.
 
+- **LLM router: replaced upstream clients are now closed reliably
+  (#2928).** Reconfiguring the passthrough LLM provider (e.g. on SIGHUP)
+  closed the old upstream HTTP client via an unreferenced background
+  task that CPython could garbage-collect mid-execution, leaving its
+  connections open; a failing close was also silently dropped. The close
+  is now strongly referenced and its failure logged.
+
 - **`klangkd doctor` names the right package for a missing `ip` command
   (#2921).** The warning hint now says `sudo dnf install iproute` on the
   Red Hat family and `sudo apt install iproute2` elsewhere (zypper, apk,

--- a/src/klangk/klangk/llm_router.py
+++ b/src/klangk/klangk/llm_router.py
@@ -51,6 +51,51 @@ from klangk.settings import resolve_indirection
 
 logger = logging.getLogger(__name__)
 
+# Strong references for the fire-and-forget passthrough-client close
+# tasks (#2928): an unreferenced task suspended in an await is
+# GC-eligible mid-execution (CPython semantics), which would leave the
+# replaced client's connections unclosed. Mirrors
+# ``lifecycle._status_broadcast_tasks`` (#1714) and
+# ``wshandler.session._session_tasks`` (#2913). Module-level, not an
+# instance attribute: the close must outlive the router whose
+# ``_configure_from_settings`` (re)spawned it.
+_aclose_tasks: set[asyncio.Task] = set()
+
+
+def _finish_aclose_task(task: asyncio.Task) -> None:
+    """Done callback for :func:`_spawn_aclose` (#2928).
+
+    Discards the strong reference so the set cannot grow without
+    bound, and logs an unobserved failure: the close is fire-and-forget,
+    so without this an exception would surface only as asyncio's
+    context-free ``Task exception was never retrieved`` at task GC.
+    Retrieving the exception here also marks it seen for asyncio
+    (same as ``_finish_session_task``, #2913).
+    """
+    _aclose_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("LLM passthrough client close failed", exc_info=exc)
+
+
+def _spawn_aclose(client: httpx.AsyncClient) -> None:
+    """Schedule *client*'s ``aclose()`` holding a strong reference (#2928).
+
+    No-op outside a running event loop (sync boot order / sync test
+    harnesses): there is nothing to schedule on then, and the process
+    exit path closes the sockets anyway.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    task = loop.create_task(client.aclose())
+    _aclose_tasks.add(task)
+    task.add_done_callback(_finish_aclose_task)
+
+
 # Provider defaults: well-known providers whose api_base can be omitted.
 _PROVIDER_DEFAULTS: dict[str, str] = {
     "openai": "https://api.openai.com/v1",
@@ -211,12 +256,7 @@ class LLMRouter:
 
         # Close any previous passthrough client before switching modes.
         if self._http_client is not None:
-            try:
-                asyncio.get_event_loop().create_task(
-                    self._http_client.aclose()
-                )
-            except RuntimeError:
-                pass
+            _spawn_aclose(self._http_client)
             self._http_client = None
 
         if is_passthrough(model_list):

--- a/src/klangk/klangkd-tests/tests/test_llm_router.py
+++ b/src/klangk/klangkd-tests/tests/test_llm_router.py
@@ -1,5 +1,7 @@
 """Unit tests for the in-process LLM router (#2071, #2072)."""
 
+import asyncio
+import logging
 import os
 import tempfile
 import types
@@ -7,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 
+from klangk import llm_router as llm_router_mod
 from klangk.llm_router import (
     LLMRouter,
     is_passthrough,
@@ -590,3 +593,91 @@ class TestConfigureOutsideEventLoop2910:
         )
         router._configure_from_settings(settings)
         assert router._http_client is None
+
+
+class TestAcloseTaskRefs2928:
+    """The replaced client's aclose runs as a strongly-referenced
+    fire-and-forget task (#2928): held while pending, discarded on
+    completion, failures logged, cancellation silent."""
+
+    async def _drain_aclose_tasks(self) -> None:
+        """Yield until the done callbacks have drained the module set.
+
+        A task's done callbacks run one loop turn after the task itself
+        completes, so a single ``sleep(0)`` races the discard.
+        """
+        for _ in range(100):
+            if not llm_router_mod._aclose_tasks:
+                return
+            await asyncio.sleep(0)
+        raise AssertionError("aclose tasks did not drain")
+
+    def _passthrough_router(self):
+        app = _app()
+        app.state.settings.llm_models = [
+            {"model_name": "*", "litellm_params": {"api_base": "http://x:1"}}
+        ]
+        return LLMRouter(app)
+
+    def _reconfigure_to_router_mode(self, router, client):
+        router._http_client = client
+        router.reconfigure(
+            _app({"KLANGKD_LLM_MODELS": "openai/gpt-4o::sk-xxx"})
+        )
+        assert router._http_client is None
+
+    async def test_aclose_task_holds_strong_reference(self):
+        """While the close is pending the task lives in the module set
+        (the only strong reference); after completion it is discarded."""
+        router = self._passthrough_router()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_aclose():
+            started.set()
+            await release.wait()
+
+        client = AsyncMock()
+        client.aclose.side_effect = slow_aclose
+        self._reconfigure_to_router_mode(router, client)
+
+        await started.wait()
+        assert llm_router_mod._aclose_tasks
+        release.set()
+        await self._drain_aclose_tasks()
+        client.aclose.assert_called_once()
+
+    async def test_aclose_failure_is_logged_not_lost(self, caplog):
+        router = self._passthrough_router()
+        client = AsyncMock()
+        client.aclose.side_effect = RuntimeError("boom")
+        self._reconfigure_to_router_mode(router, client)
+
+        await self._drain_aclose_tasks()
+        errors = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.ERROR
+            and "client close failed" in r.getMessage()
+        ]
+        assert errors, "expected the aclose failure to be logged"
+
+    async def test_cancelled_aclose_task_is_silent(self, caplog):
+        """A cancelled close logs nothing and still drains the set."""
+        caplog.set_level(logging.DEBUG)
+        router = self._passthrough_router()
+        started = asyncio.Event()
+
+        async def hanging_aclose():
+            started.set()
+            await asyncio.Event().wait()
+
+        client = AsyncMock()
+        client.aclose.side_effect = hanging_aclose
+        self._reconfigure_to_router_mode(router, client)
+        await started.wait()
+
+        (task,) = tuple(llm_router_mod._aclose_tasks)
+        task.cancel()
+        await self._drain_aclose_tasks()
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]


### PR DESCRIPTION
## Summary

Fixes #2928.

`_configure_from_settings` closed the previous passthrough httpx client with a fire-and-forget task whose reference was dropped on the floor — GC-eligible mid-execution (same hazard class as #2913/#2926), with failures surfacing only as asyncio's context-free `Task exception was never retrieved`, scheduled via the deprecated (3.12+) `asyncio.get_event_loop()`.

Route the close through `_spawn_aclose`, following the established pattern (`lifecycle._status_broadcast_tasks` #1714, `wshandler.session.spawn_session_task` #2913): a module-level `_aclose_tasks` set holds the strong reference; the done callback discards it, logs unobserved failures (marking the exception seen for asyncio), and treats cancellation as silent. Scheduling uses `asyncio.get_running_loop()`; outside a running loop the close is a no-op, preserving the old `RuntimeError` arm's behavior.

## Tests

Three new tests in `TestAcloseTaskRefs2928`: strong-ref held while the close is pending and discarded on completion; a failing close is logged; a cancelled close is silent and drains the set. `llm_router.py` at 100% branch coverage; full backend + CLI suite green (6319 passed, 100%).

A note for reviewers: a done callback runs one loop turn after task completion, so the tests drain via a bounded `sleep(0)` loop rather than a single yield — a single `sleep(0)` races the discard.
