### PR TITLE
Fix WindowEventWatcher start()/stop() race orphaning the tmux control-mode reader

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1620,6 +1620,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Window watcher start/stop race (#2929).** A quick connect→disconnect
+  on a live workspace could land `stop()` inside the tmux control-mode
+  watcher's still-in-flight start, leaving the host-side podman exec
+  reader and the container-side tmux control session running with
+  nothing left to ever stop them. The watcher now records the stop
+  request before reading its teardown state, so a racing start tears
+  itself down once its exec completes.
+
 - **Workspace session background tasks are now strongly referenced
   (#2913).** The tmux window-watcher start/stop and the debounced window
   re-sync ran as unreferenced fire-and-forget tasks, which CPython may

--- a/src/klangk/klangk/wshandler/window_watcher.py
+++ b/src/klangk/klangk/wshandler/window_watcher.py
@@ -61,7 +61,9 @@ async def _terminate_watcher_proc(proc) -> None:
 class WindowEventWatcher:
     """A long-lived ``tmux -C`` control client for one container.
 
-    :meth:`start` spawns it (idempotent); :meth:`stop` tears it down.
+    :meth:`start` spawns it (idempotent while live or in flight);
+    :meth:`stop` tears it down. A stopped watcher is single-use: a
+    later :meth:`start` never spawns (#2929).
     ``on_change`` is called synchronously from the reader task once per
     relevant event; callers debounce.
     """

--- a/src/klangk/klangk/wshandler/window_watcher.py
+++ b/src/klangk/klangk/wshandler/window_watcher.py
@@ -72,6 +72,18 @@ class WindowEventWatcher:
         self._on_change = on_change
         self._proc: asyncio.subprocess.Process | None = None
         self._task: asyncio.Task | None = None
+        # Start/stop race guard (#2929). ``start()``'s podman exec is a slow
+        # await, and a ``stop()`` landing inside it found ``_task``/``_proc``
+        # still unset and no-opped — the exec then completed into fields
+        # nothing would ever tear down, orphaning the host-side reader and
+        # the container-side control client. ``_starting`` marks an
+        # in-flight start so re-entrant ``start()`` calls no-op; ``_stopped``
+        # is set by ``stop()`` *before* it reads any field, so a racing
+        # ``start()`` observes it right after its exec await and tears the
+        # fresh client down itself instead of orphaning it. A stopped
+        # watcher is single-use: a later ``start()`` never spawns.
+        self._starting = False
+        self._stopped = False
         # Unique per-watcher session name so a stale client from a prior
         # instance (e.g. across a container restart) never collides.
         self._ctrl_session = f"__klangk_ctrl-{uuid.uuid4().hex[:8]}"
@@ -81,22 +93,36 @@ class WindowEventWatcher:
     ) -> None:
         if self._task is not None and not self._task.done():
             return
-        self._proc = await asyncio.create_subprocess_exec(
-            self.podman.bin,
-            "exec",
-            "-i",
-            self._container_id,
-            "tmux",
-            "-C",
-            "new-session",
-            "-s",
-            self._ctrl_session,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,
-            env=subprocess_env(),
-        )
+        if self._starting or self._stopped:
+            return
+        self._starting = True
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self.podman.bin,
+                "exec",
+                "-i",
+                self._container_id,
+                "tmux",
+                "-C",
+                "new-session",
+                "-s",
+                self._ctrl_session,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+                env=subprocess_env(),
+            )
+        finally:
+            self._starting = False
+        if self._stopped:
+            # stop() ran while the exec above was in flight: its field reads
+            # saw nothing to tear down, so finish the job here rather than
+            # assigning fields nothing will ever stop (#2929).
+            await _terminate_watcher_proc(proc)
+            await self._kill_ctrl_session()
+            return
+        self._proc = proc
         self._task = asyncio.create_task(self.read_loop())
 
     async def read_loop(self) -> None:
@@ -116,6 +142,10 @@ class WindowEventWatcher:
             logger.exception("WindowEventWatcher read loop error")
 
     async def stop(self) -> None:
+        # Set the flag before reading any teardown state, so a start()
+        # whose exec is still in flight observes it once the exec returns
+        # (#2929).
+        self._stopped = True
         if self._task is not None and not self._task.done():
             self._task.cancel()
             try:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -204,6 +204,23 @@ def _wsobj(name, **k):
     return Workspace(id="id-" + name, name=name, created_at="x", **k)
 
 
+async def _drain_workers(app, pilot) -> None:
+    """Wait until every app worker — including ones spawned mid-wait — has
+    finished, then flush the pending UI messages.
+
+    ``app.workers.wait_for_complete()`` gathers only the workers present at
+    call time, so a worker that spawns more workers at its end (the detail
+    screen's ``_mount_async`` spawns the terminal/shared loaders) can be
+    missed by a single call. Loop on the live count instead. Needed because
+    the render pipelines' ``clear()`` transiently resets the ListView index
+    to None before the re-seed, and on slow runners (macOS CI, #2932) a bare
+    ``pilot.pause()`` can observe that window.
+    """
+    while len(app.workers):
+        await app.workers.wait_for_complete()
+    await pilot.pause()
+
+
 def _attach_notify_spy(app) -> list:
     """Spy on ``app.notify`` and return the list of toasted messages (#2019).
 
@@ -14830,6 +14847,9 @@ class TestFinalBranchGaps2834:
             async with app.run_test() as pilot:
                 app.push_screen(WorkspaceDetailScreen("sel"))
                 await pilot.pause()
+                await _drain_workers(
+                    app, pilot
+                )  # first mount pipeline settles
                 screen = app.screen
                 tl = screen.query_one("#term_list")
                 sh = screen.query_one("#shared_term_list")
@@ -14838,7 +14858,7 @@ class TestFinalBranchGaps2834:
                 if sh.index is None:
                     sh.index = 0
                 screen.on_mount()  # re-seed keeps both selections
-                await pilot.pause()
+                await _drain_workers(app, pilot)  # second pipeline settles
                 assert tl.index == 0
                 assert sh.index == 0
 

--- a/src/klangk/klangkd-tests/tests/test_window_watcher.py
+++ b/src/klangk/klangkd-tests/tests/test_window_watcher.py
@@ -169,6 +169,77 @@ class TestWatcherLifecycle:
     async def test_stop_without_task_or_proc(self):
         await self._watcher().stop()  # no-arg teardown must not raise
 
+    async def test_start_stop_race_tears_down_racing_exec(self):
+        # #2929: stop() landing inside start()'s slow podman exec used to
+        # no-op (fields still unset); the exec then completed into
+        # _proc/_task that nothing would ever stop — orphaning the
+        # host-side reader and the container-side control client.
+        podman = MagicMock()
+        podman.exec_container = AsyncMock()
+        watcher = self._watcher(podman)
+        proc = MagicMock(returncode=None)
+        proc.wait = AsyncMock()
+        stdout = MagicMock()
+        stdout.readline = AsyncMock(return_value=b"")
+        proc.stdout = stdout
+        exec_started = asyncio.Event()
+        release_exec = asyncio.Event()
+
+        async def slow_exec(*args, **kwargs):
+            exec_started.set()
+            await release_exec.wait()
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=slow_exec):
+            start_task = asyncio.create_task(watcher.start())
+            await exec_started.wait()
+            await watcher.stop()  # mid-exec: _task/_proc still unset
+            release_exec.set()
+            await start_task
+
+        assert watcher._task is None and watcher._proc is None
+        proc.terminate.assert_called_once()
+        # The racing client's tmux control session was killed too.
+        podman.exec_container.assert_awaited_once()
+
+    async def test_concurrent_starts_spawn_one_exec(self):
+        # A second start() while the first is still awaiting its podman
+        # exec must no-op instead of spawning a second control client
+        # that would overwrite (and orphan) the first (#2929).
+        watcher = self._watcher()
+        proc = MagicMock(returncode=None)
+        stdout = MagicMock()
+        stdout.readline = AsyncMock(return_value=b"")
+        proc.stdout = stdout
+        exec_started = asyncio.Event()
+        release_exec = asyncio.Event()
+
+        async def slow_exec(*args, **kwargs):
+            exec_started.set()
+            await release_exec.wait()
+            return proc
+
+        with patch(
+            "asyncio.create_subprocess_exec", side_effect=slow_exec
+        ) as spawn:
+            first = asyncio.create_task(watcher.start())
+            await exec_started.wait()
+            second = asyncio.create_task(watcher.start())
+            release_exec.set()
+            await asyncio.gather(first, second)
+            assert spawn.call_count == 1
+        assert watcher._task is not None
+
+    async def test_start_after_stop_never_spawns(self):
+        # A stopped watcher is single-use: a later start() must not
+        # spawn a control client that no teardown is watching (#2929).
+        watcher = self._watcher()
+        await watcher.stop()
+        with patch("asyncio.create_subprocess_exec") as spawn:
+            await watcher.start()
+            spawn.assert_not_called()
+        assert watcher._task is None and watcher._proc is None
+
     async def test_kill_ctrl_session_swallows_errors(self):
         watcher = self._watcher()
         watcher.podman.exec_container = AsyncMock(

--- a/src/klangk/klangkd-tests/tests/test_window_watcher.py
+++ b/src/klangk/klangkd-tests/tests/test_window_watcher.py
@@ -240,6 +240,102 @@ class TestWatcherLifecycle:
             spawn.assert_not_called()
         assert watcher._task is None and watcher._proc is None
 
+    async def test_start_race_exec_failure_resets_and_propagates(self):
+        # #2929, failure half of the race: the container dying mid-start
+        # (the issue's common trigger) makes the exec itself raise. The
+        # finally must reset _starting — a refactor moving that reset out
+        # of the finally would strand it True and permanently disable the
+        # watcher — and the exception must propagate to the fire-and-forget
+        # wrapper's logging instead of being swallowed here.
+        watcher = self._watcher()
+        exec_started = asyncio.Event()
+        release_exec = asyncio.Event()
+
+        async def failing_exec(*args, **kwargs):
+            exec_started.set()
+            await release_exec.wait()
+            raise RuntimeError("container gone")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=failing_exec):
+            start_task = asyncio.create_task(watcher.start())
+            await exec_started.wait()
+            await watcher.stop()  # mid-exec: fields still unset
+            release_exec.set()
+            with pytest.raises(RuntimeError):
+                await start_task
+
+        assert watcher._starting is False
+        assert watcher._task is None and watcher._proc is None
+
+    async def test_stop_twice_is_idempotent(self):
+        # #2929: a second stop() after a full teardown must not re-cancel,
+        # re-terminate, or re-kill the (already torn-down) session.
+        watcher = self._watcher()
+        watcher._task = asyncio.ensure_future(asyncio.sleep(3600))
+        proc = MagicMock(returncode=None)
+        proc.wait = AsyncMock()
+        watcher._proc = proc
+        podman = MagicMock()
+        podman.exec_container = AsyncMock()
+        watcher.podman = podman
+        await watcher.stop()
+        await watcher.stop()
+        assert watcher._task is None and watcher._proc is None
+        proc.terminate.assert_called_once()
+        podman.exec_container.assert_awaited_once()
+
+    async def test_stop_during_racy_teardown_no_double_kill(self):
+        # #2929: a second stop() landing while the racing start() is still
+        # inside its teardown awaits must not double-terminate the client
+        # or double-kill its control session (stop() reads only fields the
+        # racy path never assigns).
+        from klangk.wshandler.window_watcher import (
+            _terminate_watcher_proc as real_terminate,
+        )
+
+        podman = MagicMock()
+        podman.exec_container = AsyncMock()
+        watcher = self._watcher(podman)
+        proc = MagicMock(returncode=None)
+        proc.wait = AsyncMock()
+        stdout = MagicMock()
+        stdout.readline = AsyncMock(return_value=b"")
+        proc.stdout = stdout
+        exec_started = asyncio.Event()
+        release_exec = asyncio.Event()
+        teardown_entered = asyncio.Event()
+        release_teardown = asyncio.Event()
+
+        async def slow_exec(*args, **kwargs):
+            exec_started.set()
+            await release_exec.wait()
+            return proc
+
+        async def slow_teardown(p):
+            teardown_entered.set()
+            await release_teardown.wait()
+            await real_terminate(p)
+
+        with (
+            patch(
+                "klangk.wshandler.window_watcher._terminate_watcher_proc",
+                slow_teardown,
+            ),
+            patch("asyncio.create_subprocess_exec", side_effect=slow_exec),
+        ):
+            start_task = asyncio.create_task(watcher.start())
+            await exec_started.wait()
+            await watcher.stop()  # mid-exec no-op; flag recorded
+            release_exec.set()
+            await teardown_entered.wait()  # start() is now tearing down
+            await watcher.stop()  # second stop during that teardown
+            release_teardown.set()
+            await start_task
+
+        assert watcher._task is None and watcher._proc is None
+        proc.terminate.assert_called_once()
+        podman.exec_container.assert_awaited_once()
+
     async def test_kill_ctrl_session_swallows_errors(self):
         watcher = self._watcher()
         watcher.podman.exec_container = AsyncMock(


### PR DESCRIPTION
## Summary

Fixes #2929.

`WindowEventWatcher.start()`'s podman exec is a slow await, and a `stop()`
landing inside it found `_task`/`_proc` still unset and no-opped. The exec
then completed into fields nothing would ever tear down — orphaning the
host-side podman exec reader and the container-side tmux control session
on a quick connect→disconnect against a live container.

## Changes

- `stop()` sets a `_stopped` flag **before** reading any teardown state;
  `start()` checks it right after its exec await and before assigning
  `_proc`/`_task`. Since the post-exec check-and-assign block is
  synchronous, exactly one of the two paths owns the teardown in every
  interleaving: either `stop()` sees the assigned fields, or `start()`
  sees the flag and terminates the fresh client + kills its control
  session itself.
- `_starting` guards re-entrant `start()` calls: a second concurrent
  start while the first is awaiting its exec no-ops instead of spawning a
  second control client that would overwrite and orphan the first.
- A stopped watcher is single-use: a later `start()` never spawns.

## Testing

- `test_start_stop_race_tears_down_racing_exec` — stop() mid-exec; the
  racing start tears down (terminate + kill-session), assigns nothing.
- `test_concurrent_starts_spawn_one_exec` — one exec for two concurrent
  starts.
- `test_start_after_stop_never_spawns` — single-use semantics.
- Review follow-up (fresh-eyes review): `test_start_race_exec_failure_
  resets_and_propagates` (exec raises mid-race — `_starting` reset by the
  `finally`, exception propagates to the fire-and-forget wrapper),
  `test_stop_twice_is_idempotent`, and
  `test_stop_during_racy_teardown_no_double_kill` (second stop while the
  racing start is inside its teardown awaits).
- Full suite (`klangkd-tests` + `klangkc-tests`, `-n auto`, coverage):
  6322 passed, 100% branch coverage maintained.
