### PR TITLE
Admin Events tab + container-events permission for start/stop history (#2923)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -305,6 +305,17 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Container events history API + admin Events tab (#2923).** New
+  `GET /api/v1/admin/container-events` endpoint pages through the
+  `container_events` audit table (#2915) newest-first, with an optional
+  `workspace_id` filter and a total count, and the admin section gains
+  an Events tab rendering it (when, workspace, event, actor, cause,
+  container, network namespace). Both are gated on the new dedicated
+  `container-events` permission over `/admin/container-events`: admins
+  hold it via the `/admin` wildcard, and granting it to another
+  principal on that resource delegates read-only audit access without
+  full admin.
+
 - **Container lifecycle audit trail (#2915).** Every workspace
   container start/stop is now recorded in a new `container_events`
   table with the acting principal (user, agent, or system), the cause

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -149,10 +149,11 @@ all, #2886).
 
 Not every permission is checked on a workspace resource:
 
-| Permission | Where it is checked | Controls                                        |
-| ---------- | ------------------- | ----------------------------------------------- |
-| `create`   | `/workspaces`       | Create/import workspaces                        |
-| `admin`    | `/admin`            | Instance admin functions (`/admin/*` endpoints) |
+| Permission         | Where it is checked       | Controls                                                                                              |
+| ------------------ | ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `create`           | `/workspaces`             | Create/import workspaces                                                                              |
+| `admin`            | `/admin`                  | Instance admin functions (`/admin/*` endpoints)                                                       |
+| `container-events` | `/admin/container-events` | Read the container start/stop history: `GET /admin/container-events` and the admin Events tab (#2923) |
 
 `PUT /admin/acl/resource` additionally requires `change-acls` on the
 target when that target is an individual workspace (`/workspaces/{id}`)
@@ -160,6 +161,15 @@ target when that target is an individual workspace (`/workspaces/{id}`)
 ACE rewrite of a workspace always carries the workspace's own grant.
 Collection and static resources (`/`, `/workspaces`, `/groups`,
 `/admin/*`) stay admin-only.
+
+`container-events` is the delegation-friendly read path over the
+`container_events` audit table (#2915): the admin group holds it via
+its `/admin` `*` wildcard, so admins see the Events tab out of the box.
+To let a non-admin audit the history without granting full admin, add an
+`Allow` ACE for `container-events` on `/admin/container-events`
+targeting that principal (Admin → Access Control → Container Events) —
+the more-specific resource wins the ACL walk ahead of the `/admin`
+Deny-everyone entry.
 
 ## Checking Your Permissions
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -169,7 +169,9 @@ To let a non-admin audit the history without granting full admin, add an
 `Allow` ACE for `container-events` on `/admin/container-events`
 targeting that principal (Admin → Access Control → Container Events) —
 the more-specific resource wins the ACL walk ahead of the `/admin`
-Deny-everyone entry.
+Deny-everyone entry. A delegated auditor then gets the app-bar admin
+icon and the admin section with the Events tab as their only section
+(the Access Control browser and the other tabs stay admin-only).
 
 ## Checking Your Permissions
 

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -535,6 +535,16 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
     ("POST", f"{P}/admin/invitations", {"email": "email"}, None),
     ("DELETE", f"{P}/admin/invitations/{{invitation_id}}", None, None),
     ("POST", f"{P}/admin/invitations/{{invitation_id}}/resend", None, None),
+    # Container lifecycle events history (#2923): `limit`/`offset` page
+    # through newest-first rows, `workspace_id` narrows to one workspace;
+    # the fuzzer's out-of-range ints mostly hit the 422 paths, which is
+    # the point.
+    (
+        "GET",
+        f"{P}/admin/container-events",
+        None,
+        {"limit": "int", "offset": "int", "workspace_id": "string"},
+    ),
     # Server scheduling (#2661). `action` is "stop"|"recycle"; `at` is
     # absolute ISO-8601 and `in_seconds` a positive delay — the fuzzer's
     # generic values mostly hit the 422 paths, which is the point.

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -17,6 +17,7 @@ import '../widgets/obscure_toggle.dart';
 import '../widgets/skeuo_tab.dart';
 import '../utils/system_agent.dart';
 import '../utils/validators.dart';
+import 'container_events_panel.dart';
 import 'server_schedule_panel.dart';
 
 class AdminUsersPage extends StatefulWidget {
@@ -46,6 +47,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   bool _canGroups = false;
   bool _canInvitations = false;
   bool _canServer = false;
+  bool _canEvents = false;
 
   // Pending invitation count for the tab badge — updated by the
   // _InvitationsTab widget via callback.
@@ -97,6 +99,12 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     // The schedule API needs the `admin` permission on /admin (ancestors
     // included), so gate the tab on exactly that.
     _canServer = auth.hasPermission('/admin', 'admin');
+    // The events history (#2923) is gated on the dedicated
+    // `container-events` permission over /admin/container-events — admins
+    // hold it via the /admin `*` wildcard, delegated auditors via an
+    // explicit ACE on the resource.
+    _canEvents =
+        auth.hasPermission('/admin/container-events', 'container-events');
   }
 
   Future<void> _loadUsers({int page = 1}) async {
@@ -462,6 +470,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (_canGroups) types.add('groups');
     if (_canInvitations) types.add('invitations');
     if (_canServer) types.add('server');
+    if (_canEvents) types.add('events');
     if (types.isNotEmpty) types.add('acl');
     return types;
   }
@@ -523,6 +532,13 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         view: const ServerSchedulePanel(),
       );
     }
+    if (_canEvents) {
+      addTab(
+        label: 'Events',
+        icon: Icons.history,
+        view: const ContainerEventsPanel(),
+      );
+    }
     if (tabTypes.isNotEmpty) {
       addTab(
         label: 'Access Control',
@@ -550,7 +566,11 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
           tooltip: 'Add user',
           child: const Icon(Icons.person_add),
         ),
-      'invitations' || 'groups' || 'server' => null, // FABs inside tabs
+      'invitations' ||
+      'groups' ||
+      'server' ||
+      'events' =>
+        null, // FABs inside tabs
       _ => null,
     };
   }
@@ -1844,6 +1864,7 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
     ('/admin/users', 'Users', Icons.people),
     ('/admin/invitations', 'Invitations', Icons.mail_outline),
     ('/admin/groups', 'Admin Groups', Icons.group),
+    ('/admin/container-events', 'Container Events', Icons.history),
   ];
 
   String _selectedResource = '/';

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -471,7 +471,12 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (_canInvitations) types.add('invitations');
     if (_canServer) types.add('server');
     if (_canEvents) types.add('events');
-    if (types.isNotEmpty) types.add('acl');
+    // The Access Control browser reads /admin/acl/tree, which needs full
+    // admin — a delegated container-events auditor (#2923) gets only the
+    // Events tab, not a dead ACL tab.
+    if (_canUsers || _canGroups || _canInvitations || _canServer) {
+      types.add('acl');
+    }
     return types;
   }
 
@@ -479,7 +484,6 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     final pendingCount = _invitationsPending;
     final tabs = <SkeuoTab>[];
     final views = <Widget>[];
-    final tabTypes = _tabTypes;
 
     void addTab({
       required String label,
@@ -539,7 +543,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         view: const ContainerEventsPanel(),
       );
     }
-    if (tabTypes.isNotEmpty) {
+    if (_canUsers || _canGroups || _canInvitations || _canServer) {
       addTab(
         label: 'Access Control',
         icon: Icons.security,
@@ -1984,6 +1988,10 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
                     child: AclEditor(
                       key: ValueKey(_selectedResource),
                       resource: _selectedResource,
+                      // The admin browser is where the admin-scoped
+                      // `container-events` grant is creatable (#2923);
+                      // the workspace editor keeps the curated list.
+                      permissions: AclEditorState.adminPermissions,
                     ),
                   ),
                 ),

--- a/src/frontend/lib/admin/container_events_panel.dart
+++ b/src/frontend/lib/admin/container_events_panel.dart
@@ -1,0 +1,306 @@
+// coverage:ignore-file
+/// Admin → Events tab: paged container start/stop history (#2923).
+///
+/// Reads the `container_events` audit table (#2915) through
+/// `GET /api/v1/admin/container-events` — newest first, optional
+/// workspace-id filter, offset-based paging. The tab itself is gated on
+/// the dedicated `container-events` permission over
+/// `/admin/container-events` (see [AdminUsersPage]); admins hold it via
+/// the `/admin` wildcard, other principals only via an explicit grant.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../auth/auth_service.dart';
+import '../theme/colors.dart';
+
+/// The Admin → Events tab body: filter field, paging controls, and the
+/// history table.
+class ContainerEventsPanel extends StatefulWidget {
+  const ContainerEventsPanel({super.key});
+
+  @override
+  State<ContainerEventsPanel> createState() => _ContainerEventsPanelState();
+}
+
+class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
+  static const _pageSize = 50;
+
+  List<Map<String, dynamic>> _events = [];
+  int _total = 0;
+  int _offset = 0;
+  bool _loading = true;
+  String? _error;
+
+  final _workspaceController = TextEditingController();
+  String _workspaceQuery = '';
+  Timer? _queryDebounce;
+
+  @override
+  void initState() {
+    super.initState();
+    _workspaceController.addListener(() {
+      final value = _workspaceController.text.trim();
+      if (value == _workspaceQuery) return;
+      _workspaceQuery = value;
+      _queryDebounce?.cancel();
+      _queryDebounce = Timer(
+        const Duration(milliseconds: 300),
+        () => _load(offset: 0),
+      );
+    });
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _queryDebounce?.cancel();
+    _workspaceController.dispose();
+    super.dispose();
+  }
+
+  /// URL-encode a query param map (sorted for stable, cacheable URLs).
+  static String _encodeQuery(Map<String, String> params) {
+    final pairs = <String>[];
+    for (final key in params.keys.toList()..sort()) {
+      pairs.add(
+        '${Uri.encodeQueryComponent(key)}='
+        '${Uri.encodeQueryComponent(params[key]!)}',
+      );
+    }
+    return pairs.join('&');
+  }
+
+  Future<void> _load({int offset = 0}) async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _offset = offset;
+    });
+    try {
+      final query = <String, String>{
+        'limit': '$_pageSize',
+        'offset': '$offset',
+        if (_workspaceQuery.isNotEmpty) 'workspace_id': _workspaceQuery,
+      };
+      final auth = context.read<AuthService>();
+      final resp = await auth.authGet(
+        '/api/v1/admin/container-events?${_encodeQuery(query)}',
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
+        setState(() {
+          _events = (data['items'] as List).cast<Map<String, dynamic>>();
+          _total = (data['total'] as num).toInt();
+          _loading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load events (${resp.statusCode})';
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[ContainerEventsPanel] load failed: $e');
+      if (mounted) {
+        setState(() {
+          _error = 'Could not load events. Please try again.';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  bool get _canPrev => _offset > 0;
+  bool get _canNext => _offset + _events.length < _total;
+
+  /// '12–61 of 214' — the slice currently on screen.
+  String get _rangeLabel {
+    if (_total == 0) return '0 events';
+    final first = _offset + 1;
+    final last = _offset + _events.length;
+    return '$first–$last of $_total';
+  }
+
+  /// Render an epoch-seconds `created_at` as a local 'MMM d, HH:MM' label.
+  String _timeLabel(dynamic createdAt) {
+    final secs = (createdAt as num?)?.toDouble();
+    if (secs == null) return '';
+    final dt = DateTime.fromMillisecondsSinceEpoch((secs * 1000).round());
+    final localizations = MaterialLocalizations.of(context);
+    return '${localizations.formatMediumDate(dt)} '
+        '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(dt))}';
+  }
+
+  /// 'user someone@example.com' / 'agent' / 'system' — email when the
+  /// backend resolved one, raw id otherwise (a purged user).
+  String _actorLabel(Map<String, dynamic> row) {
+    final type = row['actor_type'] as String? ?? 'system';
+    final email = row['actor_email'] as String?;
+    if (email != null && email.isNotEmpty) return '$type $email';
+    final id = row['actor_id'] as String?;
+    if (id != null && id.isNotEmpty) return '$type $id';
+    return type;
+  }
+
+  String _containerLabel(Map<String, dynamic> row) {
+    final id = row['container_id'] as String?;
+    if (id == null || id.isEmpty) return '';
+    final role = row['container_role'] as String?;
+    return role == null || role == 'workspace' ? id : '$id ($role)';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  key: const ValueKey('events-workspace-filter'),
+                  controller: _workspaceController,
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    labelText: 'Filter by workspace id',
+                    border: OutlineInputBorder(),
+                    prefixIcon: Icon(Icons.filter_list),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                icon: const Icon(Icons.refresh),
+                tooltip: 'Refresh',
+                onPressed: () => _load(offset: _offset),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  _rangeLabel,
+                  style: const TextStyle(color: KColors.textSecondary),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.chevron_left),
+                tooltip: 'Previous page',
+                onPressed: _canPrev
+                    ? () => _load(
+                          offset:
+                              _offset - _pageSize < 0 ? 0 : _offset - _pageSize,
+                        )
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.chevron_right),
+                tooltip: 'Next page',
+                onPressed: _canNext
+                    ? () => _load(offset: _offset + _events.length)
+                    : null,
+              ),
+            ],
+          ),
+        ),
+        Expanded(child: _buildBody()),
+      ],
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading && _events.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null && _events.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: () => _load(offset: 0),
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+    if (_events.isEmpty) {
+      return const Center(child: Text('No container events recorded'));
+    }
+    return ScrollConfiguration(
+      behavior: ScrollConfiguration.of(context).copyWith(scrollbars: true),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: SingleChildScrollView(
+          child: DataTable(
+            headingTextStyle: const TextStyle(
+              color: KColors.textSecondary,
+              fontWeight: FontWeight.bold,
+            ),
+            columns: const [
+              DataColumn(label: Text('When')),
+              DataColumn(label: Text('Workspace')),
+              DataColumn(label: Text('Event')),
+              DataColumn(label: Text('Actor')),
+              DataColumn(label: Text('Cause')),
+              DataColumn(label: Text('Container')),
+              DataColumn(label: Text('Network ns')),
+            ],
+            rows: [
+              for (final row in _events)
+                DataRow(
+                  cells: [
+                    DataCell(Text(_timeLabel(row['created_at']))),
+                    DataCell(Text(_workspaceLabel(row))),
+                    DataCell(_eventChip(row['event'] as String? ?? '')),
+                    DataCell(Text(_actorLabel(row))),
+                    DataCell(Text(row['cause'] as String? ?? '')),
+                    DataCell(Text(_containerLabel(row))),
+                    DataCell(Text(row['network_namespace'] as String? ?? '')),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Workspace name when the backend resolved one, raw id otherwise (a
+  /// deleted workspace still has history worth reading).
+  String _workspaceLabel(Map<String, dynamic> row) {
+    final name = row['workspace_name'] as String?;
+    if (name != null && name.isNotEmpty) return name;
+    return row['workspace_id'] as String? ?? '';
+  }
+
+  Widget _eventChip(String event) {
+    final isStart = event == 'start';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: isStart ? KColors.accentGreen : KColors.accentRed,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        event,
+        style: const TextStyle(color: Colors.white, fontSize: 12),
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/admin/container_events_panel.dart
+++ b/src/frontend/lib/admin/container_events_panel.dart
@@ -17,6 +17,7 @@ import 'package:provider/provider.dart';
 
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
+import '../utils/system_agent.dart';
 
 /// The Admin → Events tab body: filter field, paging controls, and the
 /// history table.
@@ -137,13 +138,15 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
         '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(dt))}';
   }
 
-  /// 'user someone@example.com' / 'agent' / 'system' — email when the
-  /// backend resolved one, raw id otherwise (a purged user).
+  /// 'user someone@example.com' / 'system agent' / 'system' — email when
+  /// the backend resolved one, a friendly label for the fixed agent
+  /// identity, raw id otherwise (a purged user).
   String _actorLabel(Map<String, dynamic> row) {
     final type = row['actor_type'] as String? ?? 'system';
+    final id = row['actor_id'] as String?;
+    if (id != null && id == agentUserId) return 'system agent';
     final email = row['actor_email'] as String?;
     if (email != null && email.isNotEmpty) return '$type $email';
-    final id = row['actor_id'] as String?;
     if (id != null && id.isNotEmpty) return '$type $id';
     return type;
   }

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -85,7 +85,7 @@ class _KlangkAppState extends State<KlangkApp> {
           currentUri: state.uri.toString(),
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: auth.isAdmin,
+          canAccessAdmin: auth.canAdminSection,
         );
       },
       routes: [

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -77,7 +77,7 @@ String? guardAuth({
 /// The target is permission-checked against the *current* session: an
 /// `/admin`-prefixed target (e.g. stashed by an admin's logout or expiry,
 /// then inherited by whoever logs in next on this browser) falls back to
-/// `/workspaces` unless [isAdmin] (#2670).
+/// `/workspaces` unless [canAccessAdmin] (#2670).
 ///
 /// The stash is deliberately NOT consumed here. GoRouter re-parses the
 /// *committed* location on every refreshListenable notification, and
@@ -94,12 +94,14 @@ String? guardLoggedInPublicRoute({
   required String loc,
   required Set<String> publicRoutes,
   required Set<String> featurePaths,
-  required bool isAdmin,
+  required bool canAccessAdmin,
 }) {
   if (isLoggedIn && publicRoutes.contains(loc) && !featurePaths.contains(loc)) {
     final target = pendingRedirect;
     if (target == null) return '/workspaces';
-    if (target.startsWith('/admin') && !isAdmin) return '/workspaces';
+    if (target.startsWith('/admin') && !canAccessAdmin) {
+      return '/workspaces';
+    }
     return target;
   }
   return null;
@@ -107,27 +109,28 @@ String? guardLoggedInPublicRoute({
 
 /// Admin-route gate (#2669).
 ///
-/// A logged-in non-admin on an `/admin`-prefixed route is bounced to
-/// `/workspaces` — the route is reachable by URL or a stale redirect even
-/// though the app-bar admin icon is gated, and its page is a dead end
-/// ("No admin sections available") for them.
+/// A logged-in user who cannot enter the admin section at all (see
+/// [AuthService.canAdminSection]) on an `/admin`-prefixed route is
+/// bounced to `/workspaces` — the route is reachable by URL or a stale
+/// redirect even though the app-bar admin icon is gated, and its page is
+/// a dead end ("No admin sections available") for them.
 ///
 /// Fires only for *logged-in* users: a logged-out visitor must keep the
 /// `guardAuth` flow (stash + `/login`), and `guardLoggedInPublicRoute`
 /// already rejects `/admin`-prefixed stashes for non-admins on login
 /// (#2670), so the two checks meet in the middle.
 ///
-/// Loop safety: the target `/workspaces` is not `/admin`-prefixed and no
+/// Loop safety: the target `/workspaces` is not `/admin`-refixed and no
 /// guard redirects away from it for a logged-in user, so this can never
 /// re-enter itself; the guard is pure w.r.t. its inputs, so repeated
 /// evaluations of the same committed location (GoRouter re-parses on
 /// every refreshListenable notification) all agree.
 String? guardAdminRoute({
   required bool isLoggedIn,
-  required bool isAdmin,
+  required bool canAccessAdmin,
   required String loc,
 }) {
-  if (isLoggedIn && !isAdmin && loc.startsWith('/admin')) {
+  if (isLoggedIn && !canAccessAdmin && loc.startsWith('/admin')) {
     return '/workspaces';
   }
   return null;
@@ -161,7 +164,7 @@ String? evaluateGuards({
   required String currentUri,
   required Set<String> publicRoutes,
   required Set<String> featurePaths,
-  required bool isAdmin,
+  required bool canAccessAdmin,
 }) {
   if (bannerRequired) {
     return guardBanner(bannerRequired: true, loc: loc);
@@ -178,11 +181,11 @@ String? evaluateGuards({
         loc: loc,
         publicRoutes: publicRoutes,
         featurePaths: featurePaths,
-        isAdmin: isAdmin,
+        canAccessAdmin: canAccessAdmin,
       ) ??
       guardAdminRoute(
         isLoggedIn: isLoggedIn,
-        isAdmin: isAdmin,
+        canAccessAdmin: canAccessAdmin,
         loc: loc,
       ) ??
       guardRoot(isLoggedIn: isLoggedIn, loc: loc);

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -145,6 +145,13 @@ class AuthService extends ChangeNotifier {
 
   bool get isAdmin => hasPermission('/admin', '*');
 
+  /// True for wildcard admins and for delegated container-events auditors
+  /// (#2923): the principals allowed into the admin section at all. The
+  /// route guard, the app-bar admin icon, and the Events tab all key off
+  /// this — an auditor sees only the Events tab, admins see everything.
+  bool get canAdminSection =>
+      isAdmin || hasPermission('/admin/container-events', 'container-events');
+
   /// Check if the user has a specific permission on a resource.
   bool hasPermission(String resource, String permission) {
     final perms = _permissions[resource];

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -45,6 +45,7 @@ class AclEditorState extends State<AclEditor> {
     'delete',
     'create',
     'export',
+    'container-events',
     '*',
   ];
 

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -11,7 +11,13 @@ import '../utils/system_agent.dart';
 class AclEditor extends StatefulWidget {
   final String resource;
 
-  const AclEditor({super.key, required this.resource});
+  /// Permission vocabulary for the permission dropdown. Defaults to the
+  /// workspace-sphere list ([AclEditorState.workspacePermissions]);
+  /// admin-resource callers pass [AclEditorState.adminPermissions] to
+  /// also offer the admin-scoped `container-events` (#2923).
+  final List<String>? permissions;
+
+  const AclEditor({super.key, required this.resource, this.permissions});
 
   @override
   State<AclEditor> createState() => AclEditorState();
@@ -26,7 +32,12 @@ class AclEditorState extends State<AclEditor> {
 
   static const _actionLabels = {0: 'Deny', 1: 'Allow'};
   static const _principalTypeLabels = {0: 'System', 1: 'User', 2: 'Group'};
-  static const _permissions = [
+
+  /// Workspace-sphere permissions: the curated dropdown for workspace
+  /// ACLs (the Sharing tab's Advanced editor). Admin-sphere strings
+  /// (`admin`, `manage_users`, …) are deliberately absent — they are
+  /// meaningless on `/workspaces/{id}`.
+  static const List<String> workspacePermissions = [
     'view',
     'monitor',
     'terminal',
@@ -45,9 +56,18 @@ class AclEditorState extends State<AclEditor> {
     'delete',
     'create',
     'export',
-    'container-events',
     '*',
   ];
+
+  /// Admin-resource vocabulary: the workspace list plus the
+  /// admin-scoped `container-events` history gate (#2923), offered only
+  /// where it is meaningful (the admin ACL browser).
+  static const List<String> adminPermissions = [
+    ...workspacePermissions,
+    'container-events',
+  ];
+
+  List<String> get _permissions => widget.permissions ?? workspacePermissions;
 
   @override
   void initState() {

--- a/src/frontend/lib/widgets/app_bar_actions.dart
+++ b/src/frontend/lib/widgets/app_bar_actions.dart
@@ -55,7 +55,7 @@ class AppBarActions extends StatelessWidget {
               ),
             ),
           ),
-        if (context.watch<AuthService>().isAdmin)
+        if (context.watch<AuthService>().canAdminSection)
           IconButton(
             icon:
                 const Icon(Icons.manage_accounts, color: KColors.textSecondary),

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -123,7 +123,7 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspace/abc',
       );
@@ -136,7 +136,7 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspaces',
       );
@@ -149,7 +149,7 @@ void main() {
           loc: '/celebrate',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         isNull,
       );
@@ -162,7 +162,7 @@ void main() {
           loc: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         isNull,
       );
@@ -175,7 +175,7 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         isNull,
       );
@@ -192,14 +192,14 @@ void main() {
         loc: '/login',
         publicRoutes: routes,
         featurePaths: featurePaths,
-        isAdmin: false,
+        canAccessAdmin: false,
       );
       final second = guardLoggedInPublicRoute(
         isLoggedIn: true,
         loc: '/login',
         publicRoutes: routes,
         featurePaths: featurePaths,
-        isAdmin: false,
+        canAccessAdmin: false,
       );
       expect(first, '/workspace/abc');
       expect(second, '/workspace/abc');
@@ -218,7 +218,7 @@ void main() {
             loc: '/login',
             publicRoutes: routes,
             featurePaths: featurePaths,
-            isAdmin: false,
+            canAccessAdmin: false,
           ),
           '/workspaces',
         );
@@ -234,7 +234,7 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspaces',
       );
@@ -248,7 +248,23 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: true,
+          canAccessAdmin: true,
+        ),
+        '/admin/users',
+      );
+    });
+
+    test('allows an admin target for a delegated events auditor (#2923)', () {
+      // The auditor's my-permissions carries container-events on
+      // /admin/container-events, so the stashed admin URL is honored.
+      pendingRedirect = '/admin/users';
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          canAccessAdmin: true,
         ),
         '/admin/users',
       );
@@ -262,7 +278,7 @@ void main() {
           loc: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspace/abc?file=main.dart',
       );
@@ -272,14 +288,27 @@ void main() {
   group('guardAdminRoute', () {
     test('logged-in non-admin on /admin/users -> /workspaces (#2669)', () {
       expect(
-        guardAdminRoute(isLoggedIn: true, isAdmin: false, loc: '/admin/users'),
+        guardAdminRoute(
+            isLoggedIn: true, canAccessAdmin: false, loc: '/admin/users'),
         '/workspaces',
       );
     });
 
     test('logged-in admin on /admin/users -> allowed (null)', () {
       expect(
-        guardAdminRoute(isLoggedIn: true, isAdmin: true, loc: '/admin/users'),
+        guardAdminRoute(
+            isLoggedIn: true, canAccessAdmin: true, loc: '/admin/users'),
+        isNull,
+      );
+    });
+
+    test('delegated events auditor on /admin/users -> allowed (null)', () {
+      // #2923: a non-wildcard principal holding only `container-events`
+      // on /admin/container-events can still enter the admin section —
+      // the Events tab is their only section there.
+      expect(
+        guardAdminRoute(
+            isLoggedIn: true, canAccessAdmin: true, loc: '/admin/users'),
         isNull,
       );
     });
@@ -289,14 +318,16 @@ void main() {
       // (stash + /login), and firing here would strand them on the
       // workspace list without ever seeing the login form.
       expect(
-        guardAdminRoute(isLoggedIn: false, isAdmin: false, loc: '/admin/users'),
+        guardAdminRoute(
+            isLoggedIn: false, canAccessAdmin: false, loc: '/admin/users'),
         isNull,
       );
     });
 
     test('non-admin on non-admin route -> allowed (null)', () {
       expect(
-        guardAdminRoute(isLoggedIn: true, isAdmin: false, loc: '/workspaces'),
+        guardAdminRoute(
+            isLoggedIn: true, canAccessAdmin: false, loc: '/workspaces'),
         isNull,
       );
     });
@@ -306,9 +337,9 @@ void main() {
       // refreshListenable notification; the guard must answer every
       // evaluation identically (the #2670 lesson).
       final first = guardAdminRoute(
-          isLoggedIn: true, isAdmin: false, loc: '/admin/users');
+          isLoggedIn: true, canAccessAdmin: false, loc: '/admin/users');
       final second = guardAdminRoute(
-          isLoggedIn: true, isAdmin: false, loc: '/admin/users');
+          isLoggedIn: true, canAccessAdmin: false, loc: '/admin/users');
       expect(first, second);
       expect(first, '/workspaces');
     });
@@ -343,7 +374,7 @@ void main() {
           currentUri: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/consent',
       );
@@ -363,7 +394,7 @@ void main() {
           currentUri: '/consent',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         isNull,
       );
@@ -378,7 +409,7 @@ void main() {
           currentUri: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/consent',
       );
@@ -393,7 +424,7 @@ void main() {
           currentUri: '/workspace/abc?x=1',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/login',
       );
@@ -410,7 +441,7 @@ void main() {
           currentUri: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspace/zzz',
       );
@@ -430,7 +461,7 @@ void main() {
           currentUri: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspaces',
       );
@@ -450,7 +481,7 @@ void main() {
           currentUri: '/login',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: true,
+          canAccessAdmin: true,
         ),
         '/admin/users',
       );
@@ -465,7 +496,7 @@ void main() {
           currentUri: '/admin/users',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspaces',
       );
@@ -480,7 +511,7 @@ void main() {
           currentUri: '/admin/users',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: true,
+          canAccessAdmin: true,
         ),
         isNull,
       );
@@ -498,7 +529,7 @@ void main() {
           currentUri: '/admin/users',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/login',
       );
@@ -516,7 +547,7 @@ void main() {
           currentUri: '/',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/workspaces',
       );
@@ -531,7 +562,7 @@ void main() {
           currentUri: '/workspaces',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         isNull,
       );
@@ -546,7 +577,7 @@ void main() {
           currentUri: '/celebrate',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         isNull,
       );
@@ -561,7 +592,7 @@ void main() {
           currentUri: '/consent',
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: false,
+          canAccessAdmin: false,
         ),
         '/login',
       );

--- a/src/frontend/test/app_redirect_test.dart
+++ b/src/frontend/test/app_redirect_test.dart
@@ -115,7 +115,7 @@ void main() {
           currentUri: state.uri.toString(),
           publicRoutes: routes,
           featurePaths: featurePaths,
-          isAdmin: auth.isAdmin,
+          canAccessAdmin: auth.isAdmin,
         );
       },
       routes: [

--- a/src/frontend/test/container_events_panel_test.dart
+++ b/src/frontend/test/container_events_panel_test.dart
@@ -1,0 +1,311 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_frontend/admin/admin_users_page.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// A paged events envelope, matching the backend
+/// `GET /admin/container-events` response.
+String _eventsEnvelope(
+  List<Map<String, dynamic>> items, {
+  int total = 0,
+  int limit = 50,
+  int offset = 0,
+}) =>
+    jsonEncode({
+      'items': items,
+      'total': total,
+      'limit': limit,
+      'offset': offset,
+    });
+
+Map<String, dynamic> _event(
+  String workspaceId, {
+  String? workspaceName,
+  String event = 'start',
+  String actorType = 'user',
+  String? actorId,
+  String? actorEmail,
+  String cause = 'api',
+  String? containerId,
+  String? networkNamespace,
+  double createdAt = 1767225600.0,
+}) =>
+    {
+      'id': 1,
+      'workspace_id': workspaceId,
+      'workspace_name': workspaceName,
+      'event': event,
+      'actor_type': actorType,
+      'actor_id': actorId,
+      'actor_email': actorEmail,
+      'cause': cause,
+      'container_id': containerId,
+      'container_role': 'workspace',
+      'network_namespace': networkNamespace,
+      'created_at': createdAt,
+    };
+
+/// Default JWT for a logged-in admin user.
+String get _adminToken {
+  final header = base64Url
+      .encode(utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})))
+      .replaceAll('=', '');
+  final body = base64Url
+      .encode(utf8.encode(jsonEncode({
+        'sub': 'admin-user',
+        'email': 'admin@example.com',
+      })))
+      .replaceAll('=', '');
+  return '$header.$body.fakesig';
+}
+
+/// Build a mock client serving config + my-permissions ([permissions])
+/// plus a custom handler for everything else.
+http.Client _mockClient(
+  Map<String, List<String>> permissions,
+  Future<http.Response> Function(http.Request) handler,
+) {
+  return MockClient((request) async {
+    if (request.url.path.contains('/api/v1/config')) {
+      return http.Response(
+        jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+        200,
+      );
+    }
+    if (request.url.path.contains('/api/v1/my-permissions')) {
+      return http.Response(
+        jsonEncode({
+          'user_id': 'admin-user',
+          'email': 'admin@example.com',
+          'permissions': permissions,
+          'groups': [
+            {'id': 'g1', 'name': 'admin'}
+          ],
+        }),
+        200,
+      );
+    }
+    return handler(request);
+  });
+}
+
+/// The admin permission set as the server reports it: the `/admin` `*`
+/// wildcard expands to every permission on every `/admin/*` resource in
+/// `/my-permissions`, so the Events resource is listed alongside it.
+Map<String, List<String>> get _adminPermissions => {
+      '/admin': ['*'],
+      '/admin/container-events': ['view', 'container-events'],
+    };
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({'klangk_jwt': _adminToken});
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+  });
+
+  Widget buildPage() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+        ChangeNotifierProvider(create: (_) => WsClient()),
+      ],
+      child: const MaterialApp(home: AdminUsersPage()),
+    );
+  }
+
+  /// Pump the page on a wide surface (the admin tab row overflows on the
+  /// default 800px test surface) and settle. Optionally navigates to the
+  /// Events tab before settling.
+  Future<void> pumpPage(WidgetTester tester, {bool toEvents = true}) async {
+    await tester.binding.setSurfaceSize(const Size(1600, 900));
+    await tester.pumpWidget(buildPage());
+    await tester.pumpAndSettle();
+    if (toEvents) {
+      await tester.tap(find.text('Events'));
+      await tester.pumpAndSettle();
+    }
+  }
+
+  /// Serve the container-events endpoint via [eventsFor] (called with the
+  /// parsed limit/offset/workspace_id of each request) plus the empty
+  /// users/groups/schedule loads so the page itself renders.
+  List<http.Request> serveEvents(
+    http.Response Function(
+      int limit,
+      int offset,
+      String? workspaceId,
+    ) eventsFor,
+  ) {
+    final requests = <http.Request>[];
+    testAuthHttpClientOverride =
+        _mockClient(_adminPermissions, (request) async {
+      if (request.url.path == '/api/v1/admin/container-events') {
+        requests.add(request);
+        final limit = int.parse(request.url.queryParameters['limit'] ?? '50');
+        final offset = int.parse(request.url.queryParameters['offset'] ?? '0');
+        final workspaceId = request.url.queryParameters['workspace_id'];
+        return eventsFor(limit, offset, workspaceId);
+      }
+      if (request.url.path == '/api/v1/admin/users') {
+        return http.Response(
+          jsonEncode({
+            'users': <Map<String, dynamic>>[],
+            'page': 1,
+            'page_size': 10,
+            'total': 0,
+          }),
+          200,
+        );
+      }
+      if (request.url.path == '/api/v1/admin/groups') {
+        return http.Response(jsonEncode([]), 200);
+      }
+      if (request.url.path == '/api/v1/admin/server/schedule' &&
+          request.method == 'GET') {
+        return http.Response(jsonEncode({'schedules': []}), 200);
+      }
+      return http.Response('Not found', 404);
+    });
+    return requests;
+  }
+
+  group('AdminUsersPage events tab', () {
+    testWidgets('renders history rows from the paged envelope', (tester) async {
+      serveEvents((limit, offset, workspaceId) => http.Response(
+            _eventsEnvelope([
+              _event(
+                'ws-1',
+                workspaceName: 'events-ws',
+                event: 'stop',
+                actorEmail: 'admin@example.com',
+                cause: 'idle_timeout',
+                containerId: 'cid-9',
+                networkNamespace: 'sidecar-1',
+              ),
+              _event(
+                'gone-ws',
+                actorType: 'system',
+                cause: 'auto_start',
+              ),
+            ], total: 12),
+            200,
+          ));
+
+      await pumpPage(tester);
+
+      // Resolved workspace name, and the raw id fallback for a deleted
+      // workspace.
+      expect(find.text('events-ws'), findsOneWidget);
+      expect(find.text('gone-ws'), findsOneWidget);
+      // Actor labels: email when resolved, bare type for system rows.
+      expect(
+        find.text('user admin@example.com'),
+        findsOneWidget,
+      );
+      expect(find.text('system'), findsOneWidget);
+      expect(find.text('idle_timeout'), findsOneWidget);
+      expect(find.text('cid-9'), findsOneWidget);
+      expect(find.text('sidecar-1'), findsOneWidget);
+      // Range label reflects the page slice.
+      expect(find.text('1–2 of 12'), findsOneWidget);
+    });
+
+    testWidgets('next/prev page through the history', (tester) async {
+      serveEvents((limit, offset, workspaceId) => http.Response(
+            _eventsEnvelope(
+              [
+                _event('ws-${offset + 1}', workspaceName: 'page-ws'),
+              ],
+              total: 3,
+              limit: limit,
+              offset: offset,
+            ),
+            200,
+          ));
+
+      await pumpPage(tester);
+
+      final next = find.ancestor(
+        of: find.byTooltip('Next page'),
+        matching: find.byType(IconButton),
+      );
+      final prev = find.ancestor(
+        of: find.byTooltip('Previous page'),
+        matching: find.byType(IconButton),
+      );
+      expect(tester.widget<IconButton>(prev).onPressed, isNull);
+      expect(tester.widget<IconButton>(next).onPressed, isNotNull);
+      expect(find.text('1–1 of 3'), findsOneWidget);
+
+      await tester.tap(next);
+      await tester.pumpAndSettle();
+      expect(find.text('page-ws'), findsOneWidget);
+      expect(find.text('2–2 of 3'), findsOneWidget);
+      expect(tester.widget<IconButton>(prev).onPressed, isNotNull);
+
+      await tester.tap(prev);
+      await tester.pumpAndSettle();
+      expect(find.text('1–1 of 3'), findsOneWidget);
+    });
+
+    testWidgets('workspace filter debounces into a fresh query',
+        (tester) async {
+      final requests =
+          serveEvents((limit, offset, workspaceId) => http.Response(
+                _eventsEnvelope(
+                  [
+                    if (workspaceId != null)
+                      _event(workspaceId, workspaceName: 'Filtered WS'),
+                  ],
+                  total: workspaceId == null ? 0 : 1,
+                ),
+                200,
+              ));
+
+      await pumpPage(tester);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('events-workspace-filter')),
+        'ws-filtered',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Filtered WS'), findsOneWidget);
+      final query = requests.last.url.queryParameters;
+      expect(query['workspace_id'], 'ws-filtered');
+      expect(query['offset'], '0');
+    });
+
+    testWidgets('tab hidden without the permission', (tester) async {
+      // A non-delegated, non-wildcard principal: the other admin tabs
+      // via their own grants, but no `container-events` on
+      // /admin/container-events — so no Events tab.
+      testAuthHttpClientOverride = _mockClient(
+        {
+          '/admin/users': ['view'],
+          '/admin/groups': ['view'],
+          '/admin/invitations': ['view'],
+          '/admin': ['admin'],
+        },
+        (request) async => http.Response('Not found', 404),
+      );
+
+      await pumpPage(tester, toEvents: false);
+      expect(find.text('Events'), findsNothing);
+      expect(find.text('Users'), findsOneWidget);
+    });
+  });
+}

--- a/src/frontend/test/container_events_panel_test.dart
+++ b/src/frontend/test/container_events_panel_test.dart
@@ -307,5 +307,42 @@ void main() {
       expect(find.text('Events'), findsNothing);
       expect(find.text('Users'), findsOneWidget);
     });
+
+    testWidgets('delegated auditor gets the Events tab as their only tab',
+        (tester) async {
+      // #2923 review: a principal whose only admin-sphere grant is
+      // `container-events` on /admin/container-events can enter the
+      // admin section and sees exactly one tab — Events. No Users tab
+      // (no view on /admin/users) and no Access Control browser (it
+      // reads /admin/acl/tree, which needs full admin).
+      testAuthHttpClientOverride = _mockClient(
+        {
+          '/admin/container-events': ['container-events'],
+        },
+        (request) async {
+          if (request.url.path == '/api/v1/admin/container-events') {
+            return http.Response(
+              _eventsEnvelope(
+                [
+                  _event('ws-a', workspaceName: 'audit-ws', actorType: 'system')
+                ],
+                total: 1,
+              ),
+              200,
+            );
+          }
+          return http.Response('Not found', 404);
+        },
+      );
+
+      await pumpPage(tester, toEvents: false);
+      expect(find.text('Events'), findsOneWidget);
+      expect(find.text('Users'), findsNothing);
+      expect(find.text('Access Control'), findsNothing);
+
+      await tester.tap(find.text('Events'));
+      await tester.pumpAndSettle();
+      expect(find.text('audit-ws'), findsOneWidget);
+    });
   });
 }

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -296,6 +296,7 @@ STATIC_RESOURCES = [
     "/admin/users",
     "/admin/invitations",
     "/admin/groups",
+    "/admin/container-events",
 ]
 
 ALL_PERMISSIONS = [
@@ -321,6 +322,7 @@ ALL_PERMISSIONS = [
     "admin",
     "manage_users",
     "manage_invitations",
+    "container-events",
     "*",
 ]
 

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -870,18 +870,6 @@ async def replace_resource_acl(
     return await app.state.model.acl.get_acl_entries_resolved(resource)
 
 
-STATIC_RESOURCES = [
-    "/",
-    "/workspaces",
-    "/groups",
-    "/admin",
-    "/admin/users",
-    "/admin/invitations",
-    "/admin/groups",
-    "/admin/container-events",
-]
-
-
 class ServerScheduleRequest(BaseModel):
     """Body for scheduling a server stop/recycle (#2661)."""
 

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -878,6 +878,7 @@ STATIC_RESOURCES = [
     "/admin/users",
     "/admin/invitations",
     "/admin/groups",
+    "/admin/container-events",
 ]
 
 
@@ -946,3 +947,65 @@ async def cancel_server_schedule(
         raise HTTPException(status_code=404, detail="Schedule not found")
     await app.state.server_scheduler.notify_pending()
     return {"cancelled": schedule_id}
+
+
+# --- Container lifecycle events (#2923) ---
+
+
+async def _annotate_events(app, rows: list[dict]) -> list[dict]:
+    """Resolve workspace names and actor emails for one page of events.
+
+    Cosmetic joins bounded by the page size: a deleted workspace or a
+    purged user yields ``None`` and the client falls back to the raw id.
+    System/agent actors carry no email by construction.
+    """
+    names: dict[str, str | None] = {}
+    emails: dict[str, str | None] = {}
+    for row in rows:
+        wid = row["workspace_id"]
+        if wid not in names:
+            ws = await app.state.model.workspaces.get_workspace(wid)
+            names[wid] = ws["name"] if ws else None
+        actor_id = row["actor_id"]
+        if row["actor_type"] == "user" and actor_id not in emails:
+            user = await app.state.model.users.get_user_by_id(actor_id)
+            emails[actor_id] = user["email"] if user else None
+    return [
+        {
+            **row,
+            "workspace_name": names.get(row["workspace_id"]),
+            "actor_email": emails.get(row["actor_id"]),
+        }
+        for row in rows
+    ]
+
+
+@router.get("/admin/container-events")
+async def list_container_events(
+    request: Request,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    workspace_id: str | None = None,
+    viewer: dict = Depends(acl.has_permission("container-events")),
+):
+    """Paged container start/stop history (#2923).
+
+    Newest-first rows from the ``container_events`` audit table
+    (#2915) plus the filter-matching total, optionally narrowed to one
+    workspace. Gated on the dedicated ``container-events`` permission
+    over the URL-derived resource ``/admin/container-events``: the
+    admin group holds it through its ``/admin`` ``*`` wildcard, and a
+    non-admin gets it only via an explicit ACE on that resource —
+    read-only audit access without full admin.
+    """
+    app = request.app
+    rows = await app.state.model.container_events.list_events(
+        workspace_id, limit=limit, offset=offset
+    )
+    total = await app.state.model.container_events.count_events(workspace_id)
+    return {
+        "items": await _annotate_events(app, rows),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -29,9 +29,13 @@ from klangk import netfilter as netfilter_mod
 from klangk import oidc as oidc_mod
 from klangk import features as features_mod
 from klangk.model.container_events import (
+    CAUSE_API,
+    CAUSE_AUTO_START,
     CAUSE_DELETE,
     CAUSE_RESTART,
     CAUSE_STOP,
+    EVENT_START,
+    EVENT_STOP,
 )
 from _helpers import make_settings
 from klangk.wshandler.session import WebSocketState
@@ -14225,6 +14229,185 @@ class TestAdminServerSchedule:
             )
         assert resp.status_code == 200
         mock_notify.assert_awaited_once()
+
+
+class TestContainerEventsAPI:
+    """#2923: the paged container-events history read + its dedicated
+    ``container-events`` permission gate."""
+
+    async def _admin_headers(self, client):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
+        )
+        return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+    async def _make_workspace(self, client, headers, name):
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": name},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["id"]
+
+    async def test_admin_pages_history_with_resolved_names(
+        self, client, app, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        ws_id = await self._make_workspace(client, headers, "events-ws")
+        events = app.state.model.container_events
+        await events.record(
+            ws_id,
+            EVENT_START,
+            CAUSE_API,
+            actor_id=admin_user["id"],
+            container_id="cid-old",
+        )
+        await events.record(
+            ws_id,
+            EVENT_STOP,
+            CAUSE_STOP,
+            actor_id=admin_user["id"],
+            container_id="cid-new",
+            network_namespace="sidecar-1",
+        )
+        await events.record(ws_id, EVENT_START, CAUSE_AUTO_START)
+
+        resp = await client.get(
+            "/api/v1/admin/container-events", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total"] == 3
+        assert data["limit"] == 50
+        assert data["offset"] == 0
+        # Newest first: the system-caused auto-start leads.
+        assert [i["container_id"] for i in data["items"]] == [
+            None,
+            "cid-new",
+            "cid-old",
+        ]
+        newest = data["items"][0]
+        assert newest["actor_type"] == "system"
+        assert newest["actor_id"] is None
+        assert newest["actor_email"] is None
+        oldest = data["items"][2]
+        assert oldest["actor_type"] == "user"
+        assert oldest["actor_email"] == "testadmin@example.com"
+        for item in data["items"]:
+            assert item["workspace_name"] == "events-ws"
+            assert item["workspace_id"] == ws_id
+
+    async def test_workspace_filter_and_offset_paging(
+        self, client, app, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        ws_a = await self._make_workspace(client, headers, "events-a")
+        ws_b = await self._make_workspace(client, headers, "events-b")
+        events = app.state.model.container_events
+        for i in range(3):
+            await events.record(
+                ws_a, EVENT_START, CAUSE_API, container_id=f"a-{i}"
+            )
+        await events.record(ws_b, EVENT_START, CAUSE_API, container_id="b-0")
+
+        resp = await client.get(
+            "/api/v1/admin/container-events",
+            headers=headers,
+            params={"workspace_id": ws_a, "limit": 2, "offset": 1},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 3  # ws_b's row is filtered out of the count
+        assert [i["container_id"] for i in data["items"]] == ["a-1", "a-0"]
+        assert data["limit"] == 2
+        assert data["offset"] == 1
+
+    async def test_deleted_workspace_and_purged_actor_fall_back_to_ids(
+        self, client, app, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        events = app.state.model.container_events
+        # A workspace that no longer exists and a user row that never
+        # did: history outlives the rows it annotates.
+        await events.record(
+            "gone-ws",
+            EVENT_STOP,
+            CAUSE_DELETE,
+            actor_id="no-such-user",
+        )
+        resp = await client.get(
+            "/api/v1/admin/container-events", headers=headers
+        )
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["workspace_name"] is None
+        assert item["workspace_id"] == "gone-ws"
+        assert item["actor_email"] is None
+
+    async def test_bad_query_rejected(self, client, app, admin_user):
+        headers = await self._admin_headers(client)
+        for params in ({"limit": 0}, {"limit": 501}, {"offset": -1}):
+            resp = await client.get(
+                "/api/v1/admin/container-events",
+                headers=headers,
+                params=params,
+            )
+            assert resp.status_code == 422, (params, resp.text)
+
+    async def test_plain_user_forbidden(self, client, app, user):
+        headers = await _auth_headers(client)
+        resp = await client.get(
+            "/api/v1/admin/container-events", headers=headers
+        )
+        assert resp.status_code == 403
+
+    async def test_delegated_grant_reads_without_admin(
+        self, client, app, user, app_state
+    ):
+        # The whole point of the dedicated permission (#2923): hand a
+        # non-admin read-only audit access via an ACE on the resource —
+        # the more-specific path wins the ACL walk over /admin's
+        # Deny-everyone.
+        await app_state.state.model.acl.add_acl_entry(
+            "/admin/container-events",
+            0,
+            model.ACTION_ALLOW,
+            "container-events",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        events = app_state.state.model.container_events
+        await events.record(
+            "ws-delegated", EVENT_START, CAUSE_API, container_id="d-0"
+        )
+
+        headers = await _auth_headers(client)
+        resp = await client.get(
+            "/api/v1/admin/container-events", headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["container_id"] == "d-0"
+
+        # /my-permissions surfaces the resource + permission so the
+        # frontend can show the tab to the delegated auditor.
+        resp = await client.get("/api/v1/my-permissions", headers=headers)
+        perms = resp.json()["permissions"]
+        assert "container-events" in perms.get("/admin/container-events", [])
+
+    async def test_admin_my_permissions_lists_resource(
+        self, client, app, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        resp = await client.get("/api/v1/my-permissions", headers=headers)
+        perms = resp.json()["permissions"]
+        assert "container-events" in perms.get("/admin/container-events", [])
 
 
 class TestBranchGaps2834:

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -35,17 +35,17 @@ api_auth = sys.modules["klangk.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 96
+EXPECTED_ROUTE_COUNT = 97
 
-# Per-domain submodules and the number of routes each owns.  91 sub-routes
+# Per-domain submodules and the number of routes each owns.  92 sub-routes
 # + 3 routes defined directly on the main router (version, config,
-# my-permissions) + 2 on the root router (health, empty) == 96.
+# my-permissions) + 2 on the root router (health, empty) == 97.
 SUBMODULE_ROUTES = {
     "auth": 17,  # 15 + the 2 OIDC login/callback routes (merged from oidc_auth)
     "workspaces": 27,
     "resources": 10,  # 6 files + 4 images/volumes (merged submodules)
     "browser_delegate": 2,
-    "admin": 33,
+    "admin": 34,
     "llm_proxy": 2,
 }
 
@@ -247,8 +247,8 @@ class TestSubmoduleStructure:
         total = 0
         for submod in SUBMODULE_ROUTES:
             total += len(import_module(f"klangk.api.{submod}").router.routes)
-        # 91 sub-routes + 3 direct (version/config/my-permissions) + 2
-        # root (health/empty) == 96.
+        # 92 sub-routes + 3 direct (version/config/my-permissions) + 2
+        # root (health/empty) == 97.
         assert total == EXPECTED_ROUTE_COUNT - 3 - 2
 
     def test_common_module_has_no_router(self):
@@ -308,3 +308,6 @@ def test_all_permissions_single_source():
     assert "change-acls" in api.ALL_PERMISSIONS
     # #2883's egress-consent gate must be reportable the same way.
     assert "egress-consent" in api.ALL_PERMISSIONS
+    # #2923's container-events history gate must be reportable the
+    # same way (the admin Events tab keys off /my-permissions).
+    assert "container-events" in api.ALL_PERMISSIONS

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -311,3 +311,17 @@ def test_all_permissions_single_source():
     # #2923's container-events history gate must be reportable the
     # same way (the admin Events tab keys off /my-permissions).
     assert "container-events" in api.ALL_PERMISSIONS
+
+
+def test_static_resources_single_source():
+    """``STATIC_RESOURCES`` must have exactly one definition — the live
+    one in ``api/__init__.py`` (it feeds /my-permissions). A duplicate in
+    api/admin.py drifted silently once (same failure class as the
+    ``ALL_PERMISSIONS`` copy #2765 removed); it was deleted for #2923 —
+    keep it deleted."""
+    import klangk.api.admin as api_admin
+
+    assert not hasattr(api_admin, "STATIC_RESOURCES")
+    # #2923's events resource must be reported so the frontend can gate
+    # the Events tab on the dedicated permission.
+    assert "/admin/container-events" in api.STATIC_RESOURCES


### PR DESCRIPTION
Closes #2923.

## Summary

Adds the admin UI + API to page through the `container_events` audit
history (#2915), gated on a **new dedicated `container-events`
permission** over `/admin/container-events` rather than the admin group,
so read-only audit access can be delegated without full admin.

### Backend

- `GET /api/v1/admin/container-events` — newest-first paged rows
  (`limit` ≤ 200 / `offset`), optional `workspace_id` filter, plus the
  filter-matching `total`. Rows are annotated with `workspace_name` and
  `actor_email` (fall back to raw ids for deleted workspaces / purged
  users).
- Gate: `has_permission("container-events")` on the URL-derived resource
  `/admin/container-events`. The admin group's seeded `/admin` `*`
  wildcard covers it (no migration needed); a non-admin gets it only via
  an explicit ACE on the resource, which wins the ACL walk over
  `/admin`'s Deny-everyone.
- `container-events` joins `ALL_PERMISSIONS`; `/admin/container-events`
  joins `STATIC_RESOURCES` so `/my-permissions` drives tab visibility.

### Frontend

- New **Events** tab in the admin section: when, workspace, event
  (start/stop chip), actor, cause, container (+ role), netns — with
  prev/next paging, a debounced workspace-id filter, and empty/error
  states. Shown only when `/my-permissions` reports `container-events`
  on the resource.
- `container-events` added to the ACL editor permission vocabulary and
  `/admin/container-events` to the admin ACL browser resources, so the
  delegation grant is creatable from the UI.

### Tests

- API: paging/filter/annotation, 403 for plain users, delegated-grant
  read + `/my-permissions` visibility, 422 on bad query params; route
  parity counts bumped (96 → 97).
- Flutter: rows render from the envelope, prev/next paging, debounced
  filter query, tab hidden without the permission.

Full suites pass the CI way: `klangkd`+`klangkc` 6398 passed at 100%
branch coverage, `flutter test --coverage` 1172 passed, xenon clean.
