### PR TITLE
First-class /users, /groups, /invitations, /server, /events, /acl resources (#2944)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -33,10 +33,10 @@ operators or integrators to act when upgrading.
 ### Breaking
 
 - **`/admin/*` API paths moved to first-class resources (#2944).**
-  Scripts and clients calling `/api/v1/admin/users*`,
-  `/api/v1/admin/groups*`, `/api/v1/admin/invitations*`,
-  `/api/v1/admin/server/schedule*`, `/api/v1/admin/container-events`,
-  or `/api/v1/admin/acl/*` must switch to `/api/v1/users*`,
+  Scripts and clients calling `/api/v1/users*`,
+  `/api/v1/groups*`, `/api/v1/invitations*`,
+  `/api/v1/server/schedule*`, `/api/v1/events`,
+  or `/api/v1/acl/*` must switch to `/api/v1/users*`,
   `/api/v1/groups*`, `/api/v1/invitations*`, `/api/v1/server/schedule*`,
   `/api/v1/events`, and `/api/v1/acl/*` respectively. The CLI, web
   frontend, e2e suites, and seeds are already migrated.
@@ -75,7 +75,7 @@ operators or integrators to act when upgrading.
 
 - **`GET /api/v1/groups` now returns a paged envelope (#2750).** The
   response is `{groups, page, page_size, total}` (same shape as
-  `GET /api/v1/admin/groups`) instead of a bare list that was silently
+  `GET /api/v1/groups`) instead of a bare list that was silently
   truncated at 200 rows. Integrators must read the `groups` key and
   paginate with `page`/`page_size`.
 
@@ -350,7 +350,7 @@ sync` report a clear permission-denied error.
   [ACLs](reference/acl.md).
 
 - **Container events history API + admin Events tab (#2923).** New
-  `GET /api/v1/admin/container-events` endpoint pages through the
+  `GET /api/v1/events` endpoint pages through the
   `container_events` audit table (#2915) newest-first, with an optional
   `workspace_id` filter and a total count, and the admin section gains
   an Events tab rendering it (when, workspace, event, actor, cause,
@@ -398,7 +398,7 @@ sync` report a clear permission-denied error.
   `GET`/`PUT /api/v1/workspaces/{id}/acl` (the Advanced ACL editor) and
   the role-group writes (`POST`/`DELETE`/`PATCH
 /api/v1/workspaces/{id}/roles*`, which can mint an `owners-` member)
-  require `change-acls`; `PUT /api/v1/admin/acl/resource` additionally
+  require `change-acls`; `PUT /api/v1/acl/resource` additionally
   requires it when the target is an individual workspace. The simple
   sharing surface (member and group shares with the fixed permission
   set) stays on `share`. Owners are covered by their `*` wildcard, and
@@ -526,7 +526,7 @@ create`/`edit --classification-banner`, and the create/edit UIs; the
 - **Group `source` marker and filtering (#2750).** Groups now carry a
   `source` column: `manual` for human-managed groups,
   `workspace-role` for the four role groups seeded per workspace.
-  `GET /api/v1/groups` and `GET /api/v1/admin/groups` accept a `source`
+  `GET /api/v1/groups` and `GET /api/v1/groups` accept a `source`
   query filter and include it in each row, so pickers can hide the
   machine-generated role-group names. Existing rows are backfilled by a
   schema migration. Role groups are now also rejected as share/ACL
@@ -622,7 +622,7 @@ last login` status line — including live segments such as the
   `no server running on …sock` into the terminal after the shell ends.
 - **Scheduled server stop/recycle (#2661).** Admins can schedule a
   server stop or recycle at an absolute time or after a delay
-  (`POST /api/v1/admin/server/schedule` with
+  (`POST /api/v1/server/schedule` with
   `{action: "stop" | "recycle", at | in_seconds}`; list/cancel via
   `GET`/`DELETE` on the same resource). Schedules persist in the DB
   across `klangkd` restarts and fire without anyone connected. A
@@ -734,7 +734,7 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
   Login, token refresh, and authenticated requests then fail with
   `403 Account disabled` and live WebSocket connections are closed
   (4001 → client logout) until an admin re-enables the account via
-  `PATCH /api/v1/admin/users/{id}`. Admin-group members and the system
+  `PATCH /api/v1/users/{id}`. Admin-group members and the system
   agent are exempt; the setting is reloadable on SIGHUP. See
   [Authentication](features/authentication.md).
 
@@ -751,7 +751,7 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
   concurrent with an active session from a different workstation,
   klangkd writes an audit record to the server log — the signal to
   review for shared or stolen credentials. The new
-  `GET /api/v1/admin/users/{id}/sessions` endpoint lists a user's
+  `GET /api/v1/users/{id}/sessions` endpoint lists a user's
   active sessions with their workstations. See
   [Authentication](features/authentication.md).
 
@@ -1644,7 +1644,7 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 ### Removed
 
 - **`/groups` write endpoints (#2940, closing #2941).** Group
-  management consolidates onto `/api/v1/admin/groups` behind
+  management consolidates onto `/api/v1/groups` behind
   `manage-groups`: `POST/PATCH/DELETE /api/v1/groups` and the
   `/groups/{id}/members` write/read endpoints are gone (their
   semantics — creator ACL grant on create, ACE cleanup on delete —
@@ -1652,7 +1652,7 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   authenticated listing. The seeded `/groups` Allow `create` ACE is no
   longer emitted; rows already in upgraded deployments are inert.
   Scripts calling the removed endpoints must switch to
-  `/api/v1/admin/groups`.
+  `/api/v1/groups`.
 
 - **`KLANGKD_TRUST_OUTER_PROXY` (#2596).** Dead setting removed: it was
   never read by any code (a leftover from the old nginx renderer). No

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,15 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **`/admin/*` API paths moved to first-class resources (#2944).**
+  Scripts and clients calling `/api/v1/admin/users*`,
+  `/api/v1/admin/groups*`, `/api/v1/admin/invitations*`,
+  `/api/v1/admin/server/schedule*`, `/api/v1/admin/container-events`,
+  or `/api/v1/admin/acl/*` must switch to `/api/v1/users*`,
+  `/api/v1/groups*`, `/api/v1/invitations*`, `/api/v1/server/schedule*`,
+  `/api/v1/events`, and `/api/v1/acl/*` respectively. The CLI, web
+  frontend, e2e suites, and seeds are already migrated.
+
 - **Hand-crafted `admin` ACEs stop matching split routes (#2940).** ACLs
   granting the literal `admin` permission on `/admin` (rather than the
   seeded `*` wildcard) no longer satisfy the per-tab endpoints — grant

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -80,7 +80,7 @@ operators or integrators to act when upgrading.
 
 - **`GET /api/v1/groups` now returns a paged envelope (#2750).** The
   response is `{groups, page, page_size, total}` (same shape as
-  `GET /api/v1/groups`) instead of a bare list that was silently
+  `GET /api/v1/admin/groups`) instead of a bare list that was silently
   truncated at 200 rows. Integrators must read the `groups` key and
   paginate with `page`/`page_size`.
 
@@ -531,7 +531,7 @@ create`/`edit --classification-banner`, and the create/edit UIs; the
 - **Group `source` marker and filtering (#2750).** Groups now carry a
   `source` column: `manual` for human-managed groups,
   `workspace-role` for the four role groups seeded per workspace.
-  `GET /api/v1/groups` and `GET /api/v1/groups` accept a `source`
+  `GET /api/v1/groups` and `GET /api/v1/admin/groups` accept a `source`
   query filter and include it in each row, so pickers can hide the
   machine-generated role-group names. Existing rows are backfilled by a
   schema migration. Role groups are now also rejected as share/ACL

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -39,7 +39,12 @@ operators or integrators to act when upgrading.
   or `/api/v1/acl/*` must switch to `/api/v1/users*`,
   `/api/v1/groups*`, `/api/v1/invitations*`, `/api/v1/server/schedule*`,
   `/api/v1/events`, and `/api/v1/acl/*` respectively. The CLI, web
-  frontend, e2e suites, and seeds are already migrated.
+  frontend, e2e suites, and seeds are already migrated. Delegations
+  granted on the old `/admin/users`, `/admin/groups`, … sub-resources
+  match nothing anymore — re-grant the `manage-*` permission on the
+  new first-class resource. The pre-existing `/groups` Allow `create`
+  seed is migrated automatically (m0021); any other custom `/groups`
+  rows are left for a manual re-grant.
 
 - **Hand-crafted `admin` ACEs stop matching split routes (#2940).** ACLs
   granting the literal `admin` permission on `/admin` (rather than the

--- a/docs/deployment/behind-a-proxy.md
+++ b/docs/deployment/behind-a-proxy.md
@@ -232,7 +232,7 @@ or `reject-proxy-headers: true`):
   event the feature exists to catch — an attacker using stolen
   credentials from a second machine leaves no trace.
 - **The admin session list is misleading.**
-  `GET /api/v1/admin/users/{id}/sessions` shows the proxy's address
+  `GET /api/v1/users/{id}/sessions` shows the proxy's address
   for every session. An operator cannot tell workstations apart, and
   account sharing looks the same as normal use.
 - **The failure is silent.** Nothing errors, no warning is logged, and
@@ -279,7 +279,7 @@ Only the audit signal is lost.
 1. Log in as a test user from workstation A.
 2. Log in as the same user from a different network (workstation B —
    for example, a phone hotspot).
-3. As admin, call `GET /api/v1/admin/users/{id}/sessions`. The two
+3. As admin, call `GET /api/v1/users/{id}/sessions`. The two
    sessions must show different `source_ip` values, and each must be
    the real client address — not the proxy's.
 4. The klangkd log must contain

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -158,7 +158,7 @@ recycles never race — they run strictly one after another.
 
 The signal paths above act **on receipt**. For a planned action, an
 admin can schedule a server stop or recycle ahead of time
-(`POST /api/v1/admin/server/schedule` — see
+(`POST /api/v1/server/schedule` — see
 [Server Scheduling](../features/server-scheduling.md)). Schedules
 persist in the DB across `klangkd` restarts, and every connected
 client sees a live countdown (web UI banner, TUI status line) from the

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -154,7 +154,7 @@ reported as different, and a user logging in twice from the same
 machine is not audited.
 
 Admins can query a user's active sessions at any time — see
-[`GET /api/v1/users/{id}/sessions`](../reference/api-endpoints.md#get-apiv1adminusersidsessions)
+[`GET /api/v1/users/{id}/sessions`](../reference/api-endpoints.md#get-apiv1usersidsessions)
 in the API reference. Each row shows when the session was established,
 when it expires, and the workstation it came from.
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -154,7 +154,7 @@ reported as different, and a user logging in twice from the same
 machine is not audited.
 
 Admins can query a user's active sessions at any time — see
-[`GET /api/v1/admin/users/{id}/sessions`](../reference/api-endpoints.md#get-apiv1adminusersidsessions)
+[`GET /api/v1/users/{id}/sessions`](../reference/api-endpoints.md#get-apiv1adminusersidsessions)
 in the API reference. Each row shows when the session was established,
 when it expires, and the workstation it came from.
 
@@ -194,9 +194,9 @@ Two classes of account are never auto-disabled:
 - the system agent (it does not authenticate).
 
 A disabled account keeps all of its data; an admin re-enables it via
-`PATCH /api/v1/admin/users/{id}` with `{"disabled": false}` (admins
+`PATCH /api/v1/users/{id}` with `{"disabled": false}` (admins
 cannot disable their own account through the same endpoint).
-`GET /api/v1/admin/users` reports each user's `disabled`,
+`GET /api/v1/users` reports each user's `disabled`,
 `last_login_at`, and `last_activity_at` fields. The setting is
 reloadable on SIGHUP.
 

--- a/docs/features/export-import.md
+++ b/docs/features/export-import.md
@@ -27,7 +27,7 @@ The ACL walk is first-match-wins from the workspace resource upward, so the deny
 
 > **Not a hard guarantee:** the workspace ACL is writable by anyone holding the `change-acls` permission (#2764) — which the owner wildcard grants. An owner (or any change-acls holder) can edit the workspace ACL and delete the deny entry, re-enabling export. The deny is effective against principals who _cannot_ rewrite the workspace ACL (members, spectators, coders, and share-only collaborators); to revoke export against the owner too, remove them from the owners role / wildcard grant or take the workspace away — or block the endpoint at the reverse proxy.
 
-Add the entry via the workspace **Sharing → Advanced ACL** editor in the web UI or `PUT /api/v1/admin/acl/resource`. To grant export to a narrow set of users on a workspace, add an **Allow** `export` ACE for that user/group at an even lower position. In the web UI the Export card appears in the workspace **Settings** tab (which needs `edit`); a user granted only `export` should use the CLI (`klangk export`) or the API directly.
+Add the entry via the workspace **Sharing → Advanced ACL** editor in the web UI or `PUT /api/v1/acl/resource`. To grant export to a narrow set of users on a workspace, add an **Allow** `export` ACE for that user/group at an even lower position. In the web UI the Export card appears in the workspace **Settings** tab (which needs `edit`); a user granted only `export` should use the CLI (`klangk export`) or the API directly.
 
 ## Import
 

--- a/docs/features/server-scheduling.md
+++ b/docs/features/server-scheduling.md
@@ -44,24 +44,24 @@ another session (or via the API) appears and disappears immediately.
 
 For scripting, the same operations are available through the API (see
 [API Reference](../reference/api-endpoints.md) —
-`/api/v1/admin/server/schedule`):
+`/api/v1/server/schedule`):
 
 ```bash
 # Stop the server tonight at 23:00 (server-local time of the fire_at)
-curl -X POST https://klangk.example.com/api/v1/admin/server/schedule \
+curl -X POST https://klangk.example.com/api/v1/server/schedule \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"action": "stop", "at": "2026-08-24T23:00:00+02:00"}'
 
 # Recycle the server after a 30-minute grace window
-curl -X POST https://klangk.example.com/api/v1/admin/server/schedule \
+curl -X POST https://klangk.example.com/api/v1/server/schedule \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"action": "recycle", "in_seconds": 1800}'
 
 # List pending schedules / cancel one
-curl https://klangk.example.com/api/v1/admin/server/schedule -H "Authorization: Bearer $TOKEN"
-curl -X DELETE https://klangk.example.com/api/v1/admin/server/schedule/<id> \
+curl https://klangk.example.com/api/v1/server/schedule -H "Authorization: Bearer $TOKEN"
+curl -X DELETE https://klangk.example.com/api/v1/server/schedule/<id> \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -168,16 +168,16 @@ Every governed surface is a first-class top-level resource (#2944);
 each carries **one** flat `manage-*` permission covering all of its
 actions — no per-action splits:
 
-| Permission               | Where it is checked | Controls                                                                                                                                                              |
-| ------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `create`                 | `/workspaces`       | Create/import workspaces (renamed `create-workspace` in the workspaces tranche)                                                                                       |
-| `manage-users`           | `/users`            | The whole Users surface: list users and their workspaces, create, edit, unlock, delete, read active login sessions. `GET /users/search` stays authenticated (pickers) |
-| `manage-groups`          | `/groups`           | The whole Groups surface: create, edit, delete, manage members. `GET /groups` stays authenticated (pickers)                                                           |
-| `manage-invitations`     | `/invitations`      | List, send, resend, revoke invitations                                                                                                                                |
-| `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel — plus the drain/consent decider WS handshake                                                                     |
-| `manage-events`          | `/events`           | Read the container start/stop history (`GET /events`) — read-only audit                                                                                               |
-| `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                        |
-| `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing in the API checks it anymore (#2944)                                                                    |
+| Permission               | Where it is checked | Controls                                                                                                                                                                                                                            |
+| ------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `create`                 | `/workspaces`       | Create/import workspaces (renamed `create-workspace` in the workspaces tranche)                                                                                                                                                     |
+| `manage-users`           | `/users`            | The whole Users surface: list users and their workspaces, create, edit, unlock, delete, read active login sessions. `GET /users/search` stays authenticated (pickers)                                                               |
+| `manage-groups`          | `/groups`           | The whole Groups surface: create, edit, delete, manage members. `GET /groups` stays authenticated (pickers)                                                                                                                         |
+| `manage-invitations`     | `/invitations`      | List, send, resend, revoke invitations                                                                                                                                                                                              |
+| `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel — plus the drain/consent decider WS handshake                                                                                                                                   |
+| `manage-events`          | `/events`           | Read the container start/stop history (`GET /events`) — read-only audit                                                                                                                                                             |
+| `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                                                                                      |
+| `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing checks it on `/admin` anymore (#2944) — but the workspace-transfer gate still checks the name `admin` on each `/workspaces/{id}` until the workspaces tranche (#2946) |
 
 `PUT /acl/resource` additionally requires `change-acls` on the target
 when that target is an individual workspace (`/workspaces/{id}`) — the

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -4,7 +4,7 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 
 ## Core Concepts
 
-- **Resources**: paths in a tree that mirror the URL structure (`/`, `/workspaces`, `/workspaces/{id}`, `/admin`, `/admin/users`, etc.)
+- **Resources**: paths in a tree that mirror the URL structure (`/`, `/workspaces`, `/workspaces/{id}`, `/users`, `/groups`, etc.)
 - **Principals**: who the ACE applies to — a specific user, a group, or a system principal (`Everyone` or `Authenticated`)
 - **Permissions**: what action is allowed or denied (e.g., `view`, `create`, `edit`, `delete`, `terminal`, `files`, `share`, `*`)
 - **ACEs**: `(Allow/Deny, principal, permission)` entries ordered by position on a resource
@@ -16,25 +16,42 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 /                              (root)
 ├── /workspaces                (workspace collection)
 │   └── /workspaces/{id}       (specific workspace)
-├── /admin
-│   ├── /admin/users
-│   ├── /admin/invitations
-│   └── /admin/groups
-└── /auth                      (public — no ACL checks)
+├── /users                     (flat — no per-id nodes)
+├── /groups                    (flat)
+├── /invitations               (flat)
+├── /server                    (flat — lifecycle schedules)
+├── /events                    (flat — read-only audit)
+├── /acl                       (flat — the ACL editor itself)
+└── /admin                     (marker only — nothing checks here, #2944)
 ```
 
 ## Default ACEs (seeded on first startup)
 
-| Resource      | Action | Principal     | Permission |
-| ------------- | ------ | ------------- | ---------- |
-| `/`           | Allow  | Authenticated | `view`     |
-| `/`           | Deny   | Everyone      | `*`        |
-| `/workspaces` | Allow  | group:admins  | `create`   |
-| `/groups`     | Allow  | group:admins  | `create`   |
-| `/admin`      | Allow  | group:admins  | `*`        |
-| `/admin`      | Deny   | Everyone      | `*`        |
+| Resource       | Action | Principal     | Permission               |
+| -------------- | ------ | ------------- | ------------------------ |
+| `/`            | Allow  | Authenticated | `view`                   |
+| `/`            | Deny   | Everyone      | `*`                      |
+| `/workspaces`  | Allow  | group:admins  | `create`                 |
+| `/users`       | Allow  | group:admins  | `manage-users`           |
+| `/users`       | Deny   | Everyone      | `*`                      |
+| `/groups`      | Allow  | group:admins  | `manage-groups`          |
+| `/groups`      | Deny   | Everyone      | `*`                      |
+| `/invitations` | Allow  | group:admins  | `manage-invitations`     |
+| `/invitations` | Deny   | Everyone      | `*`                      |
+| `/server`      | Allow  | group:admins  | `manage-server-schedule` |
+| `/server`      | Deny   | Everyone      | `*`                      |
+| `/events`      | Allow  | group:admins  | `manage-events`          |
+| `/events`      | Deny   | Everyone      | `*`                      |
+| `/acl`         | Allow  | group:admins  | `manage-acls`            |
+| `/acl`         | Deny   | Everyone      | `*`                      |
+| `/admin`       | Allow  | group:admins  | `*` (admin marker only)  |
+| `/admin`       | Deny   | Everyone      | `*`                      |
 
-These defaults mean: any logged-in user can view pages; only members of the `admins` group can create workspaces, create groups, or access admin functions; unauthenticated users are denied everything.
+These defaults mean: any logged-in user can view pages; only members of
+the `admins` group can create workspaces or hold a `manage-*`
+permission; unauthenticated users are denied everything. `/admin`
+checks nothing anymore (#2944) — its `*` row only marks "instance
+administrator" for permission-map consumers.
 
 ### Granting workspace creation to non-admin users
 
@@ -66,11 +83,11 @@ Groups replace the old role system. A group is a named collection of users. Two 
 
 **API endpoints**:
 
-- `GET /api/v1/admin/groups` — list all groups
-- `POST /api/v1/admin/groups` — create group `{"name": "...", "description": "..."}`
-- `DELETE /api/v1/admin/groups/{id}` — delete group (cascades: removes all ACEs referencing it)
-- `POST /api/v1/admin/groups/{id}/members` — add user `{"user_id": "..."}`
-- `DELETE /api/v1/admin/groups/{id}/members/{user_id}` — remove user
+- `GET /api/v1/groups` — list all groups (authenticated)
+- `POST /api/v1/groups` — create group `{"name": "...", "description": "..."}` (manage-groups)
+- `DELETE /api/v1/groups/{id}` — delete group (cascades: removes all ACEs referencing it)
+- `POST /api/v1/groups/{id}/members` — add user `{"user_id": "..."}`
+- `DELETE /api/v1/groups/{id}/members/{user_id}` — remove user
 
 ### Per-workspace role groups (#2750)
 
@@ -145,53 +162,51 @@ all, #2886).
 
 `export` is a workspace permission checked on `/workspaces/{id}`: the owner's wildcard ACE and the seeded `owners-<id>` role group both cover it, so owners can export their own workspaces without any extra grant, and a **Deny** `export` ACE for **Everyone** on the workspace resource (positioned ahead of the wildcards) revokes it per workspace. Admins do **not** get export implicitly — they must be an owner or hold an explicit grant. See [Export & Import](../features/export-import.md#export).
 
-### Collection- and admin-scoped permissions
+### First-class resource permissions
 
-Not every permission is checked on a workspace resource:
+Every governed surface is a first-class top-level resource (#2944);
+each carries **one** flat `manage-*` permission covering all of its
+actions — no per-action splits:
 
-| Permission               | Where it is checked                                  | Controls                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `create`                 | `/workspaces`                                        | Create/import workspaces                                                                                                                                                                                                                               |
-| `admin`                  | `/admin`                                             | Legacy catch-all — nothing in the HTTP API checks it anymore (the `/admin/*` routes all moved to `manage-*` names, #2940); still checked by the drain/consent decider WS (`wshandler/decider.py`) and the workspace-transfer gate until their tranches |
-| `manage-events`          | `/admin/container-events`                            | Read the container start/stop history: `GET /admin/container-events` and the admin Events tab (#2923; renamed from `container-events` in #2940)                                                                                                        |
-| `manage-users`           | `/admin/users` (and `/admin/users/{id}` via walk-up) | The whole Users tab: list users and their workspaces, create, edit, unlock, delete, and read active login sessions (#2940)                                                                                                                             |
-| `manage-groups`          | `/admin/groups`                                      | The whole Groups tab: list, create, edit, delete, manage members (#2940; the `/groups` writes were removed and their semantics — creator ACL grant, ACE cleanup — ported here)                                                                         |
-| `manage-invitations`     | `/admin/invitations`                                 | The whole Invitations tab: list, send, resend, revoke (#2940)                                                                                                                                                                                          |
-| `manage-acls`            | `/admin/acl`                                         | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /admin/acl/*` (#2940) — root-equivalent, see below                                                                                                           |
-| `manage-server-schedule` | `/admin/server`                                      | Server stop/recycle schedules: list, create, cancel (#2940)                                                                                                                                                                                            |
+| Permission               | Where it is checked | Controls                                                                                                                                                              |
+| ------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `create`                 | `/workspaces`       | Create/import workspaces (renamed `create-workspace` in the workspaces tranche)                                                                                       |
+| `manage-users`           | `/users`            | The whole Users surface: list users and their workspaces, create, edit, unlock, delete, read active login sessions. `GET /users/search` stays authenticated (pickers) |
+| `manage-groups`          | `/groups`           | The whole Groups surface: create, edit, delete, manage members. `GET /groups` stays authenticated (pickers)                                                           |
+| `manage-invitations`     | `/invitations`      | List, send, resend, revoke invitations                                                                                                                                |
+| `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel — plus the drain/consent decider WS handshake                                                                     |
+| `manage-events`          | `/events`           | Read the container start/stop history (`GET /events`) — read-only audit                                                                                               |
+| `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                        |
+| `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing in the API checks it anymore (#2944)                                                                    |
 
-Each admin tab has **one** permission covering all of its actions — there
-are no per-action splits: `manage-users` grants list + create + edit +
-delete + sessions, not a read-only view. The read-only exception is
-`manage-events`, which only pages through history.
-
-`PUT /admin/acl/resource` additionally requires `change-acls` on the
-target when that target is an individual workspace (`/workspaces/{id}`)
-— the same resource-level gate as `PUT /workspaces/{id}/acl`, so a raw
-ACE rewrite of a workspace always carries the workspace's own grant.
-Collection and static resources (`/`, `/workspaces`, `/groups`,
-`/admin/*`) are governed by the `manage-acls` check on `/admin/acl`
-(#2940).
+`PUT /acl/resource` additionally requires `change-acls` on the target
+when that target is an individual workspace (`/workspaces/{id}`) — the
+same resource-level gate as `PUT /workspaces/{id}/acl`, so a raw ACE
+rewrite of a workspace always carries the workspace's own grant.
 
 **`manage-acls` is root-equivalent.** A holder can rewrite ACLs on any
-resource — including `/admin` and `/` — so granting it to a principal
-is granting instance-wide control, exactly like adding them to the
-admins group. Grant it only to administrators. (Until the workspaces
-tranche renames the workspace-scoped `change-acls` to `share-advanced`,
-the two names coexist: `change-acls` on a workspace resource is the
-workspace-level gate; `manage-acls` is the global editor.)
+resource — including `/` and the other first-class trees — so granting
+it to a principal is granting instance-wide control, exactly like
+adding them to the admins group. Grant it only to administrators.
+(Until the workspaces tranche renames the workspace-scoped
+`change-acls` to `share-advanced`, the two names coexist:
+`change-acls` on a workspace resource is the workspace-level gate;
+`manage-acls` is the global editor.)
 
-Every admin tab permission follows the same delegation recipe as
-`manage-events` (#2923, generalized in #2940): the admin group holds it
-via its `/admin` `*` wildcard, so admins see every tab out of the box.
-To delegate a whole tab to a non-admin, add an `Allow` ACE for the
-permission on its sub-resource (Admin → Access Control) — the
-more-specific resource wins the ACL walk ahead of the `/admin`
-Deny-everyone entry. A delegated user then gets the app-bar admin icon
-and the admin section showing exactly the tabs their ACEs grant (e.g.
-`manage-users` on `/admin/users` alone: the Users tab, all of it).
-`GET /groups` remains an authenticated-user listing (pickers, share
-dialogs) — it is not part of the admin section.
+Delegation is per-resource (the same recipe as the Events auditor,
+issue #2923): the admin group holds each `manage-*` via its seeded
+Allow row.
+To delegate a whole surface to a non-admin, add an `Allow` ACE for the
+permission on that resource (Admin → Access Control) — it wins the ACL
+walk ahead of the resource's Deny-everyone row. A delegated user then
+gets the app-bar admin icon and the admin section showing exactly the
+tabs their ACEs grant (e.g. `manage-users` on `/users`: the Users tab,
+all of it). `GET /groups` and `GET /users/search` remain
+authenticated-user reads (pickers, share dialogs).
+
+Upgrading from a pre-#2944 deployment: migration 0021 inserts the six
+Allow/Deny pairs for the admins group. If you had pre-staged rows on
+one of those resources, the migration leaves it untouched.
 
 ## Checking Your Permissions
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -15,11 +15,11 @@ are under `/api/v1` except `/health`, `/empty`, and the
 
 ## Endpoints
 
-### DELETE `/api/v1/admin/groups/{id}`
+### DELETE `/api/v1/groups/{id}`
 
 Delete a group (admin).
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/admin/groups` (#2940).
+**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
 
 No request body.
 
@@ -29,11 +29,11 @@ No request body.
 
 ---
 
-### DELETE `/api/v1/admin/groups/{id}/members/{user_id}`
+### DELETE `/api/v1/groups/{id}/members/{user_id}`
 
 Remove a user from a group (admin).
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/admin/groups` (#2940).
+**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
 
 No request body.
 
@@ -43,11 +43,11 @@ No request body.
 
 ---
 
-### DELETE `/api/v1/admin/server/schedule/{schedule_id}`
+### DELETE `/api/v1/server/schedule/{schedule_id}`
 
 Cancel a pending server stop/recycle schedule (#2661). All connected clients' countdowns update immediately.
 
-**Auth:** JWT required. User must have the `manage-server-schedule` permission on `/admin/server` (#2940).
+**Auth:** JWT required. User must have the `manage-server-schedule` permission on `/server` (#2944).
 
 No request body.
 
@@ -61,11 +61,11 @@ See [Server Scheduling](../features/server-scheduling.md).
 
 ---
 
-### DELETE `/api/v1/admin/invitations/{id}`
+### DELETE `/api/v1/invitations/{id}`
 
 Revoke a pending invitation.
 
-**Auth:** JWT required. User must have the `manage-invitations` permission on `/admin/invitations` (#2940).
+**Auth:** JWT required. User must have the `manage-invitations` permission on `/invitations` (#2944).
 
 No request body.
 
@@ -75,11 +75,11 @@ No request body.
 
 ---
 
-### DELETE `/api/v1/admin/users/{id}`
+### DELETE `/api/v1/users/{id}`
 
 Delete a user account. Cannot delete self or the system agent user.
 
-**Auth:** JWT required. User must have the `manage-users` permission on `/admin/users` (#2940).
+**Auth:** JWT required. User must have the `manage-users` permission on `/users` (#2944).
 
 No request body.
 
@@ -89,12 +89,12 @@ No request body.
 
 ---
 
-### POST `/api/v1/admin/users/{id}/unlockout`
+### POST `/api/v1/users/{id}/unlockout`
 
 Reset a user's login lockout, allowing them to log in immediately after
 being locked out due to too many failed attempts.
 
-**Auth:** JWT required. User must have the `manage-users` permission on `/admin/users` (#2940).
+**Auth:** JWT required. User must have the `manage-users` permission on `/users` (#2944).
 
 No request body.
 
@@ -104,7 +104,7 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/users/{id}/sessions`
+### GET `/api/v1/users/{id}/sessions`
 
 List a user's active sessions with their workstation identity — the
 queryable half of concurrent-logon auditing. One item per unexpired
@@ -113,7 +113,7 @@ session was established from (null = unknown, e.g. sessions created
 before the audit feature), `user_agent` is the client's User-Agent
 string (null = none was sent). Expired sessions are excluded.
 
-**Auth:** JWT required. User must have the `manage-users` permission on `/admin/users` (#2940).
+**Auth:** JWT required. User must have the `manage-users` permission on `/users` (#2944).
 
 No request body.
 
@@ -132,11 +132,11 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/acl/by-principal/group/{id}`
+### GET `/api/v1/acl/by-principal/group/{id}`
 
 List all ACL entries granted to a specific group across all resources.
 
-**Auth:** JWT required. User must have the `manage-acls` permission on `/admin/acl` (#2940).
+**Auth:** JWT required. User must have the `manage-acls` permission on `/acl` (#2944).
 
 No request body.
 
@@ -154,11 +154,11 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/acl/by-principal/user/{id}`
+### GET `/api/v1/acl/by-principal/user/{id}`
 
 List all ACL entries granted to a specific user across all resources.
 
-**Auth:** JWT required. User must have the `manage-acls` permission on `/admin/acl` (#2940).
+**Auth:** JWT required. User must have the `manage-acls` permission on `/acl` (#2944).
 
 No request body.
 
@@ -176,7 +176,7 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/acl/resource`
+### GET `/api/v1/acl/resource`
 
 Get the ACL entries for a specific resource. Query param: `resource`
 (e.g. `/workspaces/uuid`).
@@ -202,11 +202,11 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/acl/tree`
+### GET `/api/v1/acl/tree`
 
 Get a summary of the entire ACL tree across all resources.
 
-**Auth:** JWT required. User must have the `manage-acls` permission on `/admin/acl` (#2940).
+**Auth:** JWT required. User must have the `manage-acls` permission on `/acl` (#2944).
 
 No request body.
 
@@ -219,11 +219,11 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/groups`
+### GET `/api/v1/groups`
 
 List groups (admin) with pagination, filtering, and the paged envelope.
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/admin/groups` (#2940).
+**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
 
 Query parameters:
 
@@ -254,11 +254,11 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/groups/{id}/members`
+### GET `/api/v1/groups/{id}/members`
 
 List members of a group (admin).
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/admin/groups` (#2940).
+**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
 
 No request body.
 
@@ -268,11 +268,11 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/server/schedule`
+### GET `/api/v1/server/schedule`
 
 List pending server stop/recycle schedules (#2661). Rows exist only while pending — fired or cancelled schedules are deleted.
 
-**Auth:** JWT required. User must have the `manage-server-schedule` permission on `/admin/server` (#2940).
+**Auth:** JWT required. User must have the `manage-server-schedule` permission on `/server` (#2944).
 
 No request body.
 
@@ -294,11 +294,11 @@ See [Server Scheduling](../features/server-scheduling.md).
 
 ---
 
-### GET `/api/v1/admin/invitations`
+### GET `/api/v1/invitations`
 
 List all invitations (pending, accepted, and revoked).
 
-**Auth:** JWT required. User must have the `manage-invitations` permission on `/admin/invitations` (#2940).
+**Auth:** JWT required. User must have the `manage-invitations` permission on `/invitations` (#2944).
 
 No request body.
 
@@ -318,11 +318,11 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/users`
+### GET `/api/v1/users`
 
 List all user accounts in the system.
 
-**Auth:** JWT required. User must have the `manage-users` permission on `/admin/users` (#2940).
+**Auth:** JWT required. User must have the `manage-users` permission on `/users` (#2944).
 
 No request body.
 
@@ -344,13 +344,13 @@ No request body.
 
 ---
 
-### GET `/api/v1/admin/users/{id}/workspaces`
+### GET `/api/v1/users/{id}/workspaces`
 
 List workspaces owned by a user (admin). Used by the admin UI to show
 what a delete-user will destroy (#1224). Returns the standard pagination
 envelope.
 
-**Auth:** JWT required. User must have the `manage-users` permission on `/admin/users` (#2940).
+**Auth:** JWT required. User must have the `manage-users` permission on `/users` (#2944).
 
 Query params: `limit` (1–200, default 100), `offset` (default 0).
 
@@ -484,19 +484,6 @@ No request body.
 `auth_modes` is a string — one of `password`, `oidc`, `both`, or `none`
 (no-login single-user mode). The frontend and CLI branch on this value;
 see [Auth Modes](../features/auth-modes.md).
-
----
-
-### GET `/api/v1/groups`
-
-List groups visible to the current user, with the same paged envelope and
-query parameters as the admin endpoint (`page`, `page_size`, `sort`,
-`order`, `q`, and the `source` marker filter, #2750). Any authenticated
-caller. Previously returned a bare list hard-capped at 200 rows.
-
-**Auth:** JWT required. The write side of group management lives at
-`/api/v1/admin/groups` behind the `manage-groups` permission
-(#2940) — the `/groups` write endpoints were removed.
 
 ---
 
@@ -829,11 +816,11 @@ No request body.
 
 ---
 
-### PATCH `/api/v1/admin/groups/{id}`
+### PATCH `/api/v1/groups/{id}`
 
 Update a group's name or description (admin).
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/admin/groups` (#2940).
+**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
 
 ```json
 { "name": "new-name", "description": "updated description" }
@@ -845,7 +832,7 @@ Update a group's name or description (admin).
 
 ---
 
-### PATCH `/api/v1/admin/users/{id}`
+### PATCH `/api/v1/users/{id}`
 
 Update a user's email, password, handle, or enabled state (admin). All
 fields optional. `disabled` (see
@@ -856,7 +843,7 @@ and its live WebSocket connections are closed (4001 → client logout).
 Admins cannot disable their own account, and the system agent cannot be
 disabled.
 
-**Auth:** JWT required. User must have the `manage-users` permission on `/admin/users` (#2940).
+**Auth:** JWT required. User must have the `manage-users` permission on `/users` (#2944).
 
 ```json
 {
@@ -914,11 +901,11 @@ An empty patch (`{}`) is rejected with `400`. Like a `PUT`, a changed
 
 ---
 
-### POST `/api/v1/admin/groups`
+### POST `/api/v1/groups`
 
 Create a new group (admin).
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/admin/groups` (#2940).
+**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
 
 ```json
 { "name": "my-group", "description": "optional description" }
@@ -930,11 +917,11 @@ Create a new group (admin).
 
 ---
 
-### POST `/api/v1/admin/groups/{id}/members`
+### POST `/api/v1/groups/{id}/members`
 
 Add a user to a group (admin).
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/admin/groups` (#2940).
+**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
 
 ```json
 { "user_id": "uuid" }
@@ -946,11 +933,11 @@ Add a user to a group (admin).
 
 ---
 
-### POST `/api/v1/admin/server/schedule`
+### POST `/api/v1/server/schedule`
 
 Schedule a server stop or recycle for a future time (#2661). Provide `at` (absolute ISO-8601; a naive timestamp is interpreted as UTC) or `in_seconds` (positive relative delay; ignored when `at` is given); `action` is `stop` or `recycle`. The schedule persists in the DB across `klangkd` restarts; when it fires: a **stop** runs the graceful TERM/INT path and the process exits (code 0) — the service manager owns what happens next; a **recycle** runs the SIGHUP graceful restart in-process (listener and DB stay up) and never exits. In both, workspaces are drained gracefully and every connected client sees a live countdown.
 
-**Auth:** JWT required. User must have the `manage-server-schedule` permission on `/admin/server` (#2940).
+**Auth:** JWT required. User must have the `manage-server-schedule` permission on `/server` (#2944).
 
 ```json
 { "action": "recycle", "at": "2026-08-24T23:00:00+02:00" }
@@ -974,11 +961,11 @@ See [Server Scheduling](../features/server-scheduling.md).
 
 ---
 
-### POST `/api/v1/admin/invitations`
+### POST `/api/v1/invitations`
 
 Send an invitation email to a new user.
 
-**Auth:** JWT required. User must have the `manage-invitations` permission on `/admin/invitations` (#2940).
+**Auth:** JWT required. User must have the `manage-invitations` permission on `/invitations` (#2944).
 
 ```json
 { "email": "user@example.com" }
@@ -990,11 +977,11 @@ Send an invitation email to a new user.
 
 ---
 
-### POST `/api/v1/admin/invitations/{id}/resend`
+### POST `/api/v1/invitations/{id}/resend`
 
 Resend an invitation email.
 
-**Auth:** JWT required. User must have the `manage-invitations` permission on `/admin/invitations` (#2940).
+**Auth:** JWT required. User must have the `manage-invitations` permission on `/invitations` (#2944).
 
 No request body.
 
@@ -1004,14 +991,14 @@ No request body.
 
 ---
 
-### POST `/api/v1/admin/users`
+### POST `/api/v1/users`
 
 Create a new user account. By default the user is created verified with
 the given password. Set `send_verification_email` to `true` to create
 the user unverified and send a verification email so they can set their
 own password (the `password` field is ignored in this case).
 
-**Auth:** JWT required. User must have the `manage-users` permission on `/admin/users` (#2940).
+**Auth:** JWT required. User must have the `manage-users` permission on `/users` (#2944).
 
 With password (default):
 
@@ -1637,7 +1624,7 @@ Add a user to a workspace role. Valid roles: `owners`, `coders`,
 
 ---
 
-### PUT `/api/v1/admin/acl/resource`
+### PUT `/api/v1/acl/resource`
 
 Replace all ACL entries for a specific resource. Query param: `resource`.
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -221,9 +221,12 @@ No request body.
 
 ### GET `/api/v1/groups`
 
-List groups (admin) with pagination, filtering, and the paged envelope.
+List groups with pagination, filtering, and the paged envelope — the
+one listing surface for every reader (pickers, share dialogs, the
+admin Groups tab).
 
-**Auth:** JWT required. User must have `manage-groups` permission on `/groups` (#2944).
+**Auth:** JWT required — any authenticated caller; writes on the tree
+need `manage-groups` (#2944).
 
 Query parameters:
 

--- a/sandboxes/tests/test_revoke_sync_e2e.py
+++ b/sandboxes/tests/test_revoke_sync_e2e.py
@@ -100,7 +100,7 @@ class TestRevokeSyncBlocksExec:
         # Non-admin member (the site admin's '*' on '/' inherits sync
         # everywhere, so the member is the population the gate targets).
         r = httpx.post(
-            f"{server['url']}/api/v1/admin/users",
+            f"{server['url']}/api/v1/users",
             headers=request.cls._admin_headers,
             json={"email": MEMBER_EMAIL, "password": MEMBER_PASSWORD},
             timeout=30,
@@ -151,7 +151,7 @@ class TestRevokeSyncBlocksExec:
 
     def _member_id(self):
         r = httpx.get(
-            f"{self._base_url}/api/v1/admin/users",
+            f"{self._base_url}/api/v1/users",
             headers=self._admin_headers,
             timeout=30,
         )

--- a/scripts/fmtk-seed.py
+++ b/scripts/fmtk-seed.py
@@ -92,7 +92,7 @@ def login(base: str, email: str, password: str) -> str:
 
 def ensure_users(base: str, token: str) -> dict[str, str]:
     """Create missing fixture users; returns email -> user_id."""
-    _, listing = api(base, token, "GET", "/api/v1/admin/users")
+    _, listing = api(base, token, "GET", "/api/v1/users")
     ids = {u["email"]: u["id"] for u in listing["users"]}
     for name in FIXTURES:
         email = f"{name}@example.com"
@@ -102,7 +102,7 @@ def ensure_users(base: str, token: str) -> dict[str, str]:
             base,
             token,
             "POST",
-            "/api/v1/admin/users",
+            "/api/v1/users",
             {"email": email, "password": FIXTURE_PASSWORD},
         )
         if status != 200:
@@ -114,16 +114,16 @@ def ensure_users(base: str, token: str) -> dict[str, str]:
 
 def ensure_admin_group_member(base: str, token: str, user_id: str) -> None:
     """Idempotently add fmtk-admin to the ``admins`` group."""
-    _, listing = api(base, token, "GET", "/api/v1/admin/groups?page_size=100")
+    _, listing = api(base, token, "GET", "/api/v1/groups?page_size=100")
     group = next(g for g in listing["groups"] if g["name"] == "admins")
-    _, members = api(base, token, "GET", f"/api/v1/admin/groups/{group['id']}/members")
+    _, members = api(base, token, "GET", f"/api/v1/groups/{group['id']}/members")
     if any(m["id"] == user_id for m in members):
         return
     status, body = api(
         base,
         token,
         "POST",
-        f"/api/v1/admin/groups/{group['id']}/members",
+        f"/api/v1/groups/{group['id']}/members",
         {"user_id": user_id},
     )
     if status != 200:

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -874,7 +874,7 @@ def seed_fuzz_fixtures(
         uid = create_fixture_id(
             uds_path,
             headers,
-            "/api/v1/admin/users",
+            "/api/v1/users",
             {
                 "email": f"fuzzuser{i}@example.com",
                 "password": "fuzzpass",
@@ -886,7 +886,7 @@ def seed_fuzz_fixtures(
         gid = create_fixture_id(
             uds_path,
             headers,
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             {"name": f"fuzz-group-{i}"},
             ok_codes=(200, 201),
         )

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -459,89 +459,88 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
     ("GET", f"{P}/users/search", None, {"q": "string"}),
     ("GET", f"{P}/my-permissions", None, {"resource": "string"}),
     # Groups: the authenticated listing; the management surface at
-    # /admin/groups is covered in the Admin section below (#2941-fold
-    # — the /groups writes are gone).
+    # /groups is covered in the section below (#2944).
     ("GET", f"{P}/groups", None, None),
     # Admin
-    ("GET", f"{P}/admin/users", None, None),
+    ("GET", f"{P}/users", None, None),
     (
         "POST",
-        f"{P}/admin/users",
+        f"{P}/users",
         {"email": "email", "password": "password"},
         None,
     ),
-    ("DELETE", f"{P}/admin/users/{{user_id}}", None, None),
+    ("DELETE", f"{P}/users/{{user_id}}", None, None),
     (
         "PATCH",
-        f"{P}/admin/users/{{user_id}}",
+        f"{P}/users/{{user_id}}",
         {"email": "email", "password": "password", "handle": "string"},
         None,
     ),
     (
         "GET",
-        f"{P}/admin/users/{{user_id}}/workspaces",
+        f"{P}/users/{{user_id}}/workspaces",
         None,
         {"limit": "int", "offset": "int"},
     ),
-    ("POST", f"{P}/admin/users/{{user_id}}/unlockout", None, None),
-    ("GET", f"{P}/admin/users/{{user_id}}/sessions", None, None),
-    ("GET", f"{P}/admin/groups", None, None),
+    ("POST", f"{P}/users/{{user_id}}/unlockout", None, None),
+    ("GET", f"{P}/users/{{user_id}}/sessions", None, None),
+    ("GET", f"{P}/groups", None, None),
     (
         "POST",
-        f"{P}/admin/groups",
+        f"{P}/groups",
         {"name": "string", "description": "string"},
         None,
     ),
     (
         "PATCH",
-        f"{P}/admin/groups/{{group_id}}",
+        f"{P}/groups/{{group_id}}",
         {"name": "string", "description": "string"},
         None,
     ),
-    ("DELETE", f"{P}/admin/groups/{{group_id}}", None, None),
-    ("GET", f"{P}/admin/groups/{{group_id}}/members", None, None),
+    ("DELETE", f"{P}/groups/{{group_id}}", None, None),
+    ("GET", f"{P}/groups/{{group_id}}/members", None, None),
     (
         "POST",
-        f"{P}/admin/groups/{{group_id}}/members",
+        f"{P}/groups/{{group_id}}/members",
         {"user_id": "uuid"},
         None,
     ),
     (
         "DELETE",
-        f"{P}/admin/groups/{{group_id}}/members/{{user_id}}",
+        f"{P}/groups/{{group_id}}/members/{{user_id}}",
         None,
         None,
     ),
-    ("GET", f"{P}/admin/invitations", None, None),
-    ("POST", f"{P}/admin/invitations", {"email": "email"}, None),
-    ("DELETE", f"{P}/admin/invitations/{{invitation_id}}", None, None),
-    ("POST", f"{P}/admin/invitations/{{invitation_id}}/resend", None, None),
+    ("GET", f"{P}/invitations", None, None),
+    ("POST", f"{P}/invitations", {"email": "email"}, None),
+    ("DELETE", f"{P}/invitations/{{invitation_id}}", None, None),
+    ("POST", f"{P}/invitations/{{invitation_id}}/resend", None, None),
     # Container lifecycle events history (#2923): `limit`/`offset` page
     # through newest-first rows, `workspace_id` narrows to one workspace;
     # the fuzzer's out-of-range ints mostly hit the 422 paths, which is
     # the point.
     (
         "GET",
-        f"{P}/admin/container-events",
+        f"{P}/events",
         None,
         {"limit": "int", "offset": "int", "workspace_id": "string"},
     ),
     # Server scheduling (#2661). `action` is "stop"|"recycle"; `at` is
     # absolute ISO-8601 and `in_seconds` a positive delay — the fuzzer's
     # generic values mostly hit the 422 paths, which is the point.
-    ("GET", f"{P}/admin/server/schedule", None, None),
+    ("GET", f"{P}/server/schedule", None, None),
     (
         "POST",
-        f"{P}/admin/server/schedule",
+        f"{P}/server/schedule",
         {"action": "string", "at": "string", "in_seconds": "int"},
         None,
     ),
-    ("DELETE", f"{P}/admin/server/schedule/{{schedule_id}}", None, None),
-    ("GET", f"{P}/admin/acl/tree", None, None),
-    ("GET", f"{P}/admin/acl/by-principal/user/{{user_id}}", None, None),
-    ("GET", f"{P}/admin/acl/by-principal/group/{{group_id}}", None, None),
-    ("GET", f"{P}/admin/acl/resource", None, {"resource": "string"}),
-    ("PUT", f"{P}/admin/acl/resource", {"entries": "value"}, None),
+    ("DELETE", f"{P}/server/schedule/{{schedule_id}}", None, None),
+    ("GET", f"{P}/acl/tree", None, None),
+    ("GET", f"{P}/acl/by-principal/user/{{user_id}}", None, None),
+    ("GET", f"{P}/acl/by-principal/group/{{group_id}}", None, None),
+    ("GET", f"{P}/acl/resource", None, {"resource": "string"}),
+    ("PUT", f"{P}/acl/resource", {"entries": "value"}, None),
     # Browser delegate
     ("POST", f"{P}/browser-delegate", {"action": "string", "data": "value"}, None),
     (

--- a/src/frontend/e2e-tests/demo/demo-helpers.ts
+++ b/src/frontend/e2e-tests/demo/demo-helpers.ts
@@ -291,7 +291,7 @@ export async function ensureUser(
   const admin = await adminLogin(request);
   await postJson(
     request,
-    `${DEMO_URL}/api/v1/admin/users`,
+    `${DEMO_URL}/api/v1/users`,
     {
       email,
       password,

--- a/src/frontend/e2e-tests/demo/demo-seed.ts
+++ b/src/frontend/e2e-tests/demo/demo-seed.ts
@@ -157,7 +157,7 @@ async function findUserId(
   email: string,
   adminToken: string,
 ): Promise<string | null> {
-  const r = await get("/admin/users", adminToken);
+  const r = await get("/users", adminToken);
   if (!r.ok) return null;
   const data = JSON.parse(r.body);
   const arr = Array.isArray(data) ? data : (data.users ?? []);
@@ -170,7 +170,7 @@ async function findGroupId(
   name: string,
   adminToken: string,
 ): Promise<string | null> {
-  const r = await get("/admin/groups", adminToken);
+  const r = await get("/groups", adminToken);
   if (!r.ok) return null;
   const data = JSON.parse(r.body);
   const arr = Array.isArray(data) ? data : (data.groups ?? []);
@@ -186,7 +186,7 @@ async function ensureAdmin(
   const gid = await findGroupId("admins", adminToken);
   if (!gid) return false;
   const r = await post(
-    `/admin/groups/${gid}/members`,
+    `/groups/${gid}/members`,
     { user_id: userId },
     adminToken,
   );
@@ -211,7 +211,7 @@ async function resetDemoUsers(bootstrapToken: string): Promise<void> {
   for (const email of emails) {
     const id = await findUserId(email, bootstrapToken);
     if (id) {
-      await req("DELETE", `/admin/users/${id}`, undefined, bootstrapToken);
+      await req("DELETE", `/users/${id}`, undefined, bootstrapToken);
       console.log(
         `  ✓ deleted user ${email} (cascades workspaces + containers)`,
       );
@@ -229,13 +229,13 @@ async function ensureUser(
 ): Promise<{ created: boolean; id: string }> {
   const existing = await findUserId(email, adminToken);
   if (existing) return { created: false, id: existing };
-  const create = await post("/admin/users", { email, password }, adminToken);
+  const create = await post("/users", { email, password }, adminToken);
   if (!create.ok && !/already|exists/i.test(create.body)) {
     throw new Error(
       `create user ${email} failed (${create.status}): ${create.body.slice(0, 160)}`,
     );
   }
-  // POST /admin/users returns {id,...}; fall back to a lookup just in case.
+  // POST /users returns {id,...}; fall back to a lookup just in case.
   const id =
     JSON.parse(create.body).id ?? (await findUserId(email, adminToken));
   return { created: true, id };

--- a/src/frontend/e2e-tests/e2e/api.spec.ts
+++ b/src/frontend/e2e-tests/e2e/api.spec.ts
@@ -365,7 +365,7 @@ test.describe("API", () => {
     );
 
     // Admin can list users
-    const listResp = await request.get(`${API_BASE}/api/v1/admin/users`, {
+    const listResp = await request.get(`${API_BASE}/api/v1/users`, {
       headers: adminHeaders,
     });
     expect(listResp.ok()).toBeTruthy();
@@ -376,24 +376,21 @@ test.describe("API", () => {
     expect(testUser).toBeTruthy();
 
     // Non-admin cannot list users
-    const forbiddenResp = await request.get(`${API_BASE}/api/v1/admin/users`, {
+    const forbiddenResp = await request.get(`${API_BASE}/api/v1/users`, {
       headers: userHeaders,
     });
     expect(forbiddenResp.status()).toBe(403);
 
     // Create a group and add the user to it
-    const createGroupResp = await request.post(
-      `${API_BASE}/api/v1/admin/groups`,
-      {
-        headers: adminHeaders,
-        data: { name: "editor" },
-      },
-    );
+    const createGroupResp = await request.post(`${API_BASE}/api/v1/groups`, {
+      headers: adminHeaders,
+      data: { name: "editor" },
+    });
     expect(createGroupResp.ok()).toBeTruthy();
     const editorGroup = await createGroupResp.json();
 
     const addMemberResp = await request.post(
-      `${API_BASE}/api/v1/admin/groups/${editorGroup.id}/members`,
+      `${API_BASE}/api/v1/groups/${editorGroup.id}/members`,
       { headers: adminHeaders, data: { user_id: testUser.id } },
     );
     expect(addMemberResp.ok()).toBeTruthy();
@@ -401,7 +398,7 @@ test.describe("API", () => {
     // Verify group membership was added (via the group's members endpoint,
     // since per-user groups are no longer embedded in the users list)
     const membersResp = await request.get(
-      `${API_BASE}/api/v1/admin/groups/${editorGroup.id}/members`,
+      `${API_BASE}/api/v1/groups/${editorGroup.id}/members`,
       { headers: adminHeaders },
     );
     expect(membersResp.ok()).toBeTruthy();
@@ -410,20 +407,20 @@ test.describe("API", () => {
 
     // Admin can remove user from group
     const removeMemberResp = await request.delete(
-      `${API_BASE}/api/v1/admin/groups/${editorGroup.id}/members/${testUser.id}`,
+      `${API_BASE}/api/v1/groups/${editorGroup.id}/members/${testUser.id}`,
       { headers: adminHeaders },
     );
     expect(removeMemberResp.ok()).toBeTruthy();
 
     // Admin can delete a user
     const deleteResp = await request.delete(
-      `${API_BASE}/api/v1/admin/users/${testUser.id}`,
+      `${API_BASE}/api/v1/users/${testUser.id}`,
       { headers: adminHeaders },
     );
     expect(deleteResp.ok()).toBeTruthy();
 
     // Verify user is gone
-    const listResp3 = await request.get(`${API_BASE}/api/v1/admin/users`, {
+    const listResp3 = await request.get(`${API_BASE}/api/v1/users`, {
       headers: adminHeaders,
     });
     const deletedUser = (await listResp3.json()).users.find(
@@ -433,7 +430,7 @@ test.describe("API", () => {
 
     // Clean up the test group
     const deleteGroupResp = await request.delete(
-      `${API_BASE}/api/v1/admin/groups/${editorGroup.id}`,
+      `${API_BASE}/api/v1/groups/${editorGroup.id}`,
       { headers: adminHeaders },
     );
     expect(deleteGroupResp.ok()).toBeTruthy();
@@ -452,7 +449,7 @@ test.describe("API", () => {
     const adminHeaders = { Authorization: `Bearer ${adminToken}` };
 
     // Verify the admin API returns users
-    const resp = await request.get(`${API_BASE}/api/v1/admin/users`, {
+    const resp = await request.get(`${API_BASE}/api/v1/users`, {
       headers: adminHeaders,
     });
     expect(resp.ok()).toBeTruthy();
@@ -468,7 +465,7 @@ test.describe("API", () => {
     });
     expect(regResp.ok()).toBeTruthy();
 
-    const resp2 = await request.get(`${API_BASE}/api/v1/admin/users`, {
+    const resp2 = await request.get(`${API_BASE}/api/v1/users`, {
       headers: adminHeaders,
     });
     const updatedUsers = (await resp2.json()).users;
@@ -479,7 +476,7 @@ test.describe("API", () => {
 
     // Update email via API
     const patchResp = await request.patch(
-      `${API_BASE}/api/v1/admin/users/${newUser.id}`,
+      `${API_BASE}/api/v1/users/${newUser.id}`,
       {
         headers: adminHeaders,
         data: { email: "e2e-admin-renamed@test.example.com" },
@@ -488,7 +485,7 @@ test.describe("API", () => {
     expect(patchResp.ok()).toBeTruthy();
 
     // Verify rename
-    const resp3 = await request.get(`${API_BASE}/api/v1/admin/users`, {
+    const resp3 = await request.get(`${API_BASE}/api/v1/users`, {
       headers: adminHeaders,
     });
     expect(
@@ -499,13 +496,13 @@ test.describe("API", () => {
 
     // Delete via API
     const deleteResp = await request.delete(
-      `${API_BASE}/api/v1/admin/users/${newUser.id}`,
+      `${API_BASE}/api/v1/users/${newUser.id}`,
       { headers: adminHeaders },
     );
     expect(deleteResp.ok()).toBeTruthy();
 
     // Verify deleted
-    const resp4 = await request.get(`${API_BASE}/api/v1/admin/users`, {
+    const resp4 = await request.get(`${API_BASE}/api/v1/users`, {
       headers: adminHeaders,
     });
     expect(
@@ -748,12 +745,9 @@ test.describe("API", () => {
     };
 
     // Read the root resource ACL
-    let resp = await request.get(
-      `${API_BASE}/api/v1/admin/acl/resource?resource=/`,
-      {
-        headers: adminHeaders,
-      },
-    );
+    let resp = await request.get(`${API_BASE}/api/v1/acl/resource?resource=/`, {
+      headers: adminHeaders,
+    });
     expect(resp.ok()).toBeTruthy();
     const rootAces = await resp.json();
     expect(rootAces.length).toBeGreaterThan(0);
@@ -766,7 +760,7 @@ test.describe("API", () => {
 
     // Read /admin resource ACL
     resp = await request.get(
-      `${API_BASE}/api/v1/admin/acl/resource?resource=/admin`,
+      `${API_BASE}/api/v1/acl/resource?resource=/admin`,
       {
         headers: adminHeaders,
       },
@@ -781,7 +775,7 @@ test.describe("API", () => {
 
     // Modify /admin/groups ACL: add a view entry, then restore
     resp = await request.get(
-      `${API_BASE}/api/v1/admin/acl/resource?resource=/admin/groups`,
+      `${API_BASE}/api/v1/acl/resource?resource=/admin/groups`,
       { headers: adminHeaders },
     );
     const originalGroupsAces = await resp.json();
@@ -806,7 +800,7 @@ test.describe("API", () => {
     ];
 
     resp = await request.put(
-      `${API_BASE}/api/v1/admin/acl/resource?resource=/admin/groups`,
+      `${API_BASE}/api/v1/acl/resource?resource=/admin/groups`,
       { headers: adminHeaders, data: newEntries },
     );
     expect(resp.ok()).toBeTruthy();
@@ -822,7 +816,7 @@ test.describe("API", () => {
       system_principal: a.system_principal ?? null,
     }));
     resp = await request.put(
-      `${API_BASE}/api/v1/admin/acl/resource?resource=/admin/groups`,
+      `${API_BASE}/api/v1/acl/resource?resource=/admin/groups`,
       { headers: adminHeaders, data: restore },
     );
     expect(resp.ok()).toBeTruthy();
@@ -841,15 +835,18 @@ test.describe("API", () => {
     const resources = [
       "/",
       "/workspaces",
-      "/admin",
-      "/admin/users",
-      "/admin/invitations",
-      "/admin/groups",
+      "/users",
+      "/invitations",
+      "/groups",
+      "/server",
+      "/events",
+      "/acl",
+      "/admin", // instance-admin wildcard marker (#2944)
     ];
 
     for (const resource of resources) {
       const resp = await request.get(
-        `${API_BASE}/api/v1/admin/acl/resource?resource=${encodeURIComponent(resource)}`,
+        `${API_BASE}/api/v1/acl/resource?resource=${encodeURIComponent(resource)}`,
         { headers: adminHeaders },
       );
       expect(resp.ok()).toBeTruthy();
@@ -1044,7 +1041,7 @@ test.describe("API", () => {
     );
 
     const resp = await request.get(
-      `${API_BASE}/api/v1/admin/acl/resource?resource=/`,
+      `${API_BASE}/api/v1/acl/resource?resource=/`,
       { headers: userHeaders },
     );
     expect(resp.status()).toBe(403);

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -70,8 +70,8 @@ async function makeUserAdmin(
   userId: string,
 ): Promise<void> {
   const aHeaders = await adminHeaders(request);
-  // /api/v1/admin/groups returns a paged envelope {groups: [...], ...}.
-  const groupsResp = await request.get(`${API_BASE}/api/v1/admin/groups`, {
+  // /api/v1/groups returns a paged envelope {groups: [...], ...}.
+  const groupsResp = await request.get(`${API_BASE}/api/v1/groups`, {
     headers: aHeaders,
   });
   const body = await groupsResp.json();
@@ -81,10 +81,10 @@ async function makeUserAdmin(
     : undefined;
   if (!adminGroup) return;
   // Add the user (ignore 409 if already a member).
-  await request.post(
-    `${API_BASE}/api/v1/admin/groups/${adminGroup.id}/members`,
-    { headers: aHeaders, data: { user_id: userId } },
-  );
+  await request.post(`${API_BASE}/api/v1/groups/${adminGroup.id}/members`, {
+    headers: aHeaders,
+    data: { user_id: userId },
+  });
 }
 
 /** Register a new user via API (test mode allows unauthenticated registration).

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -91,23 +91,19 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   void _resolvePermissions() {
     final auth = context.read<AuthService>();
-    // One permission per tab (#2940): `manage-<thing>` grants full
-    // control of that tab's actions — the admin group holds every name
-    // via the /admin * wildcard; a delegated user gets exactly what
-    // their ACE on the sub-resource grants (the Events tab, #2923,
-    // follows the same shape with read-only `manage-events`).
-    _canUsers = auth.hasPermission('/admin/users', 'manage-users');
-    // Groups tab rides /admin/groups behind manage-groups (#2941-fold:
-    // the single group-management surface; the /groups writes are gone).
-    _canGroups = auth.hasPermission('/admin/groups', 'manage-groups');
-    _canInvitations =
-        auth.hasPermission('/admin/invitations', 'manage-invitations');
-    _canServer = auth.hasPermission('/admin/server', 'manage-server-schedule');
-    _canEvents = auth.hasPermission('/admin/container-events', 'manage-events');
-    // The Access Control browser reads /admin/acl/*, gated on
-    // `manage-acls` (#2940) — root-equivalent (it can rewrite ACLs on
-    // any resource), so it is granted only to administrators.
-    _canAcl = auth.hasPermission('/admin/acl', 'manage-acls');
+    // One permission per tab on its first-class resource (#2944): a
+    // `manage-<thing>` grant covers the whole tab; admins hold every
+    // name via the seeded per-resource rows (plus the /admin wildcard
+    // marker), a delegated user gets exactly what their ACE grants.
+    _canUsers = auth.hasPermission('/users', 'manage-users');
+    _canGroups = auth.hasPermission('/groups', 'manage-groups');
+    _canInvitations = auth.hasPermission('/invitations', 'manage-invitations');
+    _canServer = auth.hasPermission('/server', 'manage-server-schedule');
+    _canEvents = auth.hasPermission('/events', 'manage-events');
+    // The Access Control browser reads /acl/*, gated on `manage-acls`
+    // (#2940) — root-equivalent (it can rewrite ACLs on any
+    // resource), so it is granted only to administrators.
+    _canAcl = auth.hasPermission('/acl', 'manage-acls');
   }
 
   Future<void> _loadUsers({int page = 1}) async {
@@ -127,7 +123,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       final q = _usersQuery.trim();
       if (q.isNotEmpty) query['q'] = q;
       final resp = await auth.authGet(
-        '/api/v1/admin/users?${_encodeQuery(query)}',
+        '/api/v1/users?${_encodeQuery(query)}',
       );
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
@@ -160,7 +156,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (result == null) return;
 
     final resp = await auth.authPost(
-      '/api/v1/admin/users',
+      '/api/v1/users',
       body: jsonEncode(result),
     );
     if (resp.statusCode == 200) {
@@ -197,7 +193,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     var fetchFailed = false;
     try {
       final wsResp = await auth.authGet(
-        '/api/v1/admin/users/$userId/workspaces?limit=100',
+        '/api/v1/users/$userId/workspaces?limit=100',
       );
       if (wsResp.statusCode == 200) {
         final body = jsonDecode(wsResp.body);
@@ -242,7 +238,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     );
     if (confirm != true) return;
 
-    final resp = await auth.authDelete('/api/v1/admin/users/$userId');
+    final resp = await auth.authDelete('/api/v1/users/$userId');
     if (resp.statusCode == 200) {
       _loadUsers();
     } else {
@@ -335,7 +331,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     );
     if (result == null) return;
     final resp = await auth.authPatch(
-      '/api/v1/admin/users/${user['id']}',
+      '/api/v1/users/${user['id']}',
       body: jsonEncode(result),
     );
     if (resp.statusCode == 200) {
@@ -705,7 +701,7 @@ class _GroupsTabState extends State<_GroupsTab> {
       final source = _groupsSource;
       if (source != null) query['source'] = source;
       final resp = await auth.authGet(
-        '/api/v1/admin/groups?${_encodeQuery(query)}',
+        '/api/v1/groups?${_encodeQuery(query)}',
       );
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
@@ -764,7 +760,7 @@ class _GroupsTabState extends State<_GroupsTab> {
     if (result != true || nameCtrl.text.trim().isEmpty) return;
     final auth = context.read<AuthService>();
     final resp = await auth.authPost(
-      '/api/v1/admin/groups',
+      '/api/v1/groups',
       body: jsonEncode({
         'name': nameCtrl.text.trim(),
         if (descCtrl.text.trim().isNotEmpty)
@@ -803,7 +799,7 @@ class _GroupsTabState extends State<_GroupsTab> {
     );
     if (confirm != true) return;
     final auth = context.read<AuthService>();
-    final resp = await auth.authDelete('/api/v1/admin/groups/$groupId');
+    final resp = await auth.authDelete('/api/v1/groups/$groupId');
     if (!mounted) return;
     if (resp.statusCode == 200) {
       _loadGroups();
@@ -990,7 +986,7 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
   Future<void> _loadMembers() async {
     final auth = context.read<AuthService>();
     final resp = await auth.authGet(
-      '/api/v1/admin/groups/$_groupId/members',
+      '/api/v1/groups/$_groupId/members',
     );
     if (!mounted) return;
     setState(() {
@@ -1021,7 +1017,7 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
   Future<void> _addMember(String userId) async {
     final auth = context.read<AuthService>();
     final resp = await auth.authPost(
-      '/api/v1/admin/groups/$_groupId/members',
+      '/api/v1/groups/$_groupId/members',
       body: jsonEncode({'user_id': userId}),
     );
     if (resp.statusCode == 200) {
@@ -1034,7 +1030,7 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
     final member = _members[index];
     final auth = context.read<AuthService>();
     final resp = await auth.authDelete(
-      '/api/v1/admin/groups/$_groupId/members/${member['id']}',
+      '/api/v1/groups/$_groupId/members/${member['id']}',
     );
     if (resp.statusCode == 200 && mounted) {
       setState(() => _members.removeAt(index));
@@ -1196,7 +1192,7 @@ class _InvitationsTabState extends State<_InvitationsTab> {
           '&sort=${Uri.encodeQueryComponent(_invitationsSort)}'
           '&order=${Uri.encodeQueryComponent(_invitationsOrder)}'
           '${q.isNotEmpty ? '&q=${Uri.encodeQueryComponent(q)}' : ''}';
-      final resp = await auth.authGet('/api/v1/admin/invitations?$query');
+      final resp = await auth.authGet('/api/v1/invitations?$query');
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
         if (mounted) {
@@ -1223,7 +1219,7 @@ class _InvitationsTabState extends State<_InvitationsTab> {
 
     final auth = context.read<AuthService>();
     final resp = await auth.authPost(
-      '/api/v1/admin/invitations',
+      '/api/v1/invitations',
       body: jsonEncode({'email': email}),
     );
     if (resp.statusCode == 200) {
@@ -1271,7 +1267,7 @@ class _InvitationsTabState extends State<_InvitationsTab> {
 
     final auth = context.read<AuthService>();
     final resp = await auth.authDelete(
-      '/api/v1/admin/invitations/$invitationId',
+      '/api/v1/invitations/$invitationId',
     );
     if (resp.statusCode == 200) {
       _loadInvitations(page: _invitationsPage);
@@ -1290,7 +1286,7 @@ class _InvitationsTabState extends State<_InvitationsTab> {
   Future<void> _resendInvitation(String invitationId, String email) async {
     final auth = context.read<AuthService>();
     final resp = await auth.authPost(
-      '/api/v1/admin/invitations/$invitationId/resend',
+      '/api/v1/invitations/$invitationId/resend',
     );
     if (mounted) {
       if (resp.statusCode == 200) {
@@ -1912,25 +1908,29 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
   static const _resources = [
     ('/', 'Root', Icons.home),
     ('/workspaces', 'Workspaces', Icons.folder),
-    ('/groups', 'Groups', Icons.group),
     ('/users', 'Users', Icons.people),
-    ('/admin', 'Admin', Icons.manage_accounts),
+    ('/groups', 'Groups', Icons.group),
+    ('/invitations', 'Invitations', Icons.mail_outline),
+    ('/server', 'Server', Icons.dns),
+    ('/events', 'Events', Icons.history),
+    ('/acl', 'ACL', Icons.security),
   ];
 
-  /// The permission(s) that matter on each node (#2940): the endpoint
+  /// The permission(s) that matter on each node (#2944): the endpoint
   /// checks key on these names, so the browser shows the mapping next
   /// to the ACE list instead of leaving the operator to guess which
-  /// name the server actually asks for on this resource.
+  /// name the server actually asks for on this resource. /admin no
+  /// longer appears — it is only the instance-admin wildcard marker.
   static const _resourceHints = {
     '/': 'view — held by every authenticated user via the seed',
     '/workspaces':
         'create — workspace creation; per-workspace permissions live on each /workspaces/{id}',
-    '/groups':
-        'No permission — authenticated listing; management is under /admin',
-    '/users':
-        'No permission checked yet — `search-users` arrives with the workspaces tranche (#2890)',
-    '/admin':
-        'manage-users, manage-invitations, manage-groups, manage-server-schedule, manage-events, manage-acls (root-equivalent) — or * for everything',
+    '/users': 'manage-users (search stays authenticated for pickers)',
+    '/groups': 'manage-groups (listing stays authenticated for pickers)',
+    '/invitations': 'manage-invitations',
+    '/server': 'manage-server-schedule',
+    '/events': 'manage-events (read-only audit)',
+    '/acl': 'manage-acls — root-equivalent, administrators only',
   };
 
   String _selectedResource = '/';

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -470,7 +470,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (_canInvitations) types.add('invitations');
     if (_canServer) types.add('server');
     if (_canEvents) types.add('events');
-    // The Access Control browser reads /admin/acl/*, gated on
+    // The Access Control browser reads /acl/*, gated on
     // `manage-acls` (#2940) — a delegated container-events auditor
     // (#2923) gets only the Events tab, not a dead ACL tab.
     if (_canAcl) {
@@ -542,7 +542,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         view: const ContainerEventsPanel(),
       );
     }
-    // The Access Control browser reads /admin/acl/*, gated on
+    // The Access Control browser reads /acl/*, gated on
     // `manage-acls` (#2940) — shown exactly to its holders.
     if (_canAcl) {
       addTab(
@@ -951,7 +951,7 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
   /// Type-ahead picker results from the authenticated
   /// `GET /users/search` surface: a `manage-groups`-only delegate
   /// (no `manage-users`) must still be able to add members, so the
-  /// picker never reads `/admin/users` (#2943 review).
+  /// picker never reads the manage-users-gated listing (#2943 review).
   List<Map<String, dynamic>> _results = [];
   final _searchController = TextEditingController();
   Timer? _searchDebounce;

--- a/src/frontend/lib/admin/container_events_panel.dart
+++ b/src/frontend/lib/admin/container_events_panel.dart
@@ -2,7 +2,7 @@
 /// Admin → Events tab: paged container start/stop history (#2923).
 ///
 /// Reads the `container_events` audit table (#2915) through
-/// `GET /api/v1/admin/container-events` — newest first, optional
+/// `GET /api/v1/events` — newest first, optional
 /// workspace-id filter, offset-based paging. The tab itself is gated on
 /// the dedicated `manage-events` permission over
 /// `/admin/container-events` (see [AdminUsersPage]); admins hold it via
@@ -90,7 +90,7 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
       };
       final auth = context.read<AuthService>();
       final resp = await auth.authGet(
-        '/api/v1/admin/container-events?${_encodeQuery(query)}',
+        '/api/v1/events?${_encodeQuery(query)}',
       );
       if (!mounted) return;
       if (resp.statusCode == 200) {

--- a/src/frontend/lib/admin/server_schedule_panel.dart
+++ b/src/frontend/lib/admin/server_schedule_panel.dart
@@ -4,7 +4,7 @@
 ///
 /// The pending list is snapshot-driven: the `server_schedule` WS frame
 /// (broadcast on every change, see [WsClient]) is the live truth, with a
-/// REST `GET /api/v1/admin/server/schedule` load as the source before the
+/// REST `GET /api/v1/server/schedule` load as the source before the
 /// first snapshot arrives (and as a post-mutation refresh). Countdowns
 /// tick locally from each schedule's `fire_at` — same approach as the
 /// client banner (#2661), whose parse/format helpers are reused here.
@@ -106,7 +106,7 @@ class _ServerSchedulePanelState extends State<ServerSchedulePanel> {
     });
     try {
       final auth = context.read<AuthService>();
-      final resp = await auth.authGet('/api/v1/admin/server/schedule');
+      final resp = await auth.authGet('/api/v1/server/schedule');
       if (!mounted) return;
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
@@ -176,8 +176,8 @@ class _ServerSchedulePanelState extends State<ServerSchedulePanel> {
     if (confirm != true) return;
     if (!mounted) return;
     final auth = context.read<AuthService>();
-    final resp = await auth
-        .authDelete('/api/v1/admin/server/schedule/${schedule['id']}');
+    final resp =
+        await auth.authDelete('/api/v1/server/schedule/${schedule['id']}');
     if (!mounted) return;
     if (resp.statusCode == 200) {
       // The authoritative update is the next `server_schedule` WS
@@ -413,7 +413,7 @@ class _ScheduleServerActionDialogState
     });
     final auth = context.read<AuthService>();
     final resp = await auth.authPost(
-      '/api/v1/admin/server/schedule',
+      '/api/v1/server/schedule',
       body: body,
     );
     if (!mounted) return;

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -152,12 +152,12 @@ class AuthService extends ChangeNotifier {
   /// see everything.
   bool get canAdminSection =>
       isAdmin ||
-      hasPermission('/admin/users', 'manage-users') ||
-      hasPermission('/admin/invitations', 'manage-invitations') ||
-      hasPermission('/admin/groups', 'manage-groups') ||
-      hasPermission('/admin/server', 'manage-server-schedule') ||
-      hasPermission('/admin/container-events', 'manage-events') ||
-      hasPermission('/admin/acl', 'manage-acls');
+      hasPermission('/users', 'manage-users') ||
+      hasPermission('/invitations', 'manage-invitations') ||
+      hasPermission('/groups', 'manage-groups') ||
+      hasPermission('/server', 'manage-server-schedule') ||
+      hasPermission('/events', 'manage-events') ||
+      hasPermission('/acl', 'manage-acls');
 
   /// Check if the user has a specific permission on a resource.
   bool hasPermission(String resource, String permission) {

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -125,7 +125,7 @@ class AclEditorState extends State<AclEditor> {
     if (parts.length >= 3 && parts[1] == 'workspaces') {
       return '/api/v1/workspaces/${parts[2]}/acl';
     }
-    return '/api/v1/admin/acl/resource?resource=${Uri.encodeQueryComponent(widget.resource)}';
+    return '/api/v1/acl/resource?resource=${Uri.encodeQueryComponent(widget.resource)}';
   }
 
   void _removeEntry(int index) {
@@ -177,7 +177,7 @@ class AclEditorState extends State<AclEditor> {
   Future<List<Map<String, dynamic>>> _loadPickerGroups(AuthService auth) async {
     final groups = await _fetchEnvelopeAll(
       auth,
-      '/api/v1/admin/groups',
+      '/api/v1/groups',
       'groups',
       query: const {'source': 'manual'},
     );
@@ -205,7 +205,7 @@ class AclEditorState extends State<AclEditor> {
     List<Map<String, dynamic>> users = [];
     List<Map<String, dynamic>> groups = [];
     try {
-      users = await _fetchEnvelopeAll(auth, '/api/v1/admin/users', 'users');
+      users = await _fetchEnvelopeAll(auth, '/api/v1/users', 'users');
     } catch (e) {
       debugPrint('[AclEditor] fetch users failed: $e');
     }

--- a/src/frontend/test/acl_editor_test.dart
+++ b/src/frontend/test/acl_editor_test.dart
@@ -111,7 +111,7 @@ void main() {
       if (path == '/api/v1/workspaces/ws1/acl') {
         return http.Response(jsonEncode(_entries()), 200);
       }
-      if (path == '/api/v1/admin/users') {
+      if (path == '/api/v1/users') {
         return http.Response(
           jsonEncode({
             'users': [_user('alice@example.com')],
@@ -122,7 +122,7 @@ void main() {
           200,
         );
       }
-      if (path == '/api/v1/admin/groups') {
+      if (path == '/api/v1/groups') {
         final page = int.parse(request.url.queryParameters['page'] ?? '1');
         requestedGroupPages.add(page);
         capturedSource = request.url.queryParameters['source'];
@@ -201,7 +201,7 @@ void main() {
       if (path == '/api/v1/workspaces/ws1/acl') {
         return http.Response(jsonEncode(_entries()), 200);
       }
-      if (path == '/api/v1/admin/users') {
+      if (path == '/api/v1/users') {
         return http.Response(
           jsonEncode({
             'users': [_agentUser(), _user('alice@example.com')],
@@ -212,7 +212,7 @@ void main() {
           200,
         );
       }
-      if (path == '/api/v1/admin/groups') {
+      if (path == '/api/v1/groups') {
         return http.Response(
           jsonEncode({
             'groups': <Map<String, dynamic>>[],

--- a/src/frontend/test/acl_editor_test.dart
+++ b/src/frontend/test/acl_editor_test.dart
@@ -71,7 +71,7 @@ Map<String, dynamic> _user(String email) => {
       'created_at': '2026-01-01T00:00:00',
     };
 
-/// The built-in system agent row, as `GET /admin/users` serves it.
+/// The built-in system agent row, as the users listing serves it.
 Map<String, dynamic> _agentUser() => {
       'id': agentUserId,
       'email': 'klangk@example.com',

--- a/src/frontend/test/admin_invitations_page_test.dart
+++ b/src/frontend/test/admin_invitations_page_test.dart
@@ -77,11 +77,11 @@ http.Client _mockClient(
           'email': 'admin@example.com',
           'permissions': {
             '/admin': ['*'],
-            '/admin/users': ['manage-users'],
-            '/admin/groups': ['manage-groups'],
-            '/admin/invitations': ['manage-invitations'],
-            '/admin/server': ['manage-server-schedule'],
-            '/admin/acl': ['manage-acls'],
+            '/users': ['manage-users'],
+            '/groups': ['manage-groups'],
+            '/invitations': ['manage-invitations'],
+            '/server': ['manage-server-schedule'],
+            '/acl': ['manage-acls'],
           },
           'groups': [
             {'id': 'g1', 'name': 'admin'}
@@ -90,7 +90,7 @@ http.Client _mockClient(
         200,
       );
     }
-    if (request.url.path == '/api/v1/admin/server/schedule' &&
+    if (request.url.path == '/api/v1/server/schedule' &&
         request.method == 'GET') {
       return http.Response(jsonEncode({'schedules': []}), 200);
     }
@@ -165,7 +165,7 @@ void main() {
     int pendingCount = 0,
   }) {
     testAuthHttpClientOverride = _mockClient((request) async {
-      if (request.url.path == '/api/v1/admin/invitations') {
+      if (request.url.path == '/api/v1/invitations') {
         final page = int.parse(request.url.queryParameters['page'] ?? '1');
         final pageSize =
             int.parse(request.url.queryParameters['page_size'] ?? '10');
@@ -183,7 +183,7 @@ void main() {
           200,
         );
       }
-      if (request.url.path == '/api/v1/admin/users') {
+      if (request.url.path == '/api/v1/users') {
         // Paged users envelope expected by the page.
         return http.Response(
           jsonEncode({
@@ -195,7 +195,7 @@ void main() {
           200,
         );
       }
-      if (request.url.path == '/api/v1/admin/groups') {
+      if (request.url.path == '/api/v1/groups') {
         return http.Response(jsonEncode([]), 200);
       }
       return http.Response('Not found', 404);
@@ -277,7 +277,7 @@ void main() {
       String? capturedSort;
       String? capturedOrder;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           capturedSort = request.url.queryParameters['sort'];
           capturedOrder = request.url.queryParameters['order'];
           final page = int.parse(request.url.queryParameters['page'] ?? '1');
@@ -290,7 +290,7 @@ void main() {
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(
             jsonEncode({
               'users': <Map<String, dynamic>>[],
@@ -301,7 +301,7 @@ void main() {
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           return http.Response(jsonEncode([]), 200);
         }
         return http.Response('Not found', 404);
@@ -336,7 +336,7 @@ void main() {
     testWidgets('sends email filter query live (debounced)', (tester) async {
       String? capturedQ;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           capturedQ = request.url.queryParameters['q'];
           final page = int.parse(request.url.queryParameters['page'] ?? '1');
           return http.Response(
@@ -348,7 +348,7 @@ void main() {
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(
             jsonEncode({
               'users': <Map<String, dynamic>>[],
@@ -359,7 +359,7 @@ void main() {
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           return http.Response(jsonEncode([]), 200);
         }
         return http.Response('Not found', 404);
@@ -392,7 +392,7 @@ void main() {
     /// [posts].
     void serveInvitationsCapturePosts(List<Map<String, dynamic>> posts) {
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           if (request.method == 'POST') {
             posts.add(jsonDecode(request.body) as Map<String, dynamic>);
             return http.Response(
@@ -405,7 +405,7 @@ void main() {
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(
             jsonEncode({
               'users': <Map<String, dynamic>>[],
@@ -416,7 +416,7 @@ void main() {
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           return http.Response(jsonEncode([]), 200);
         }
         return http.Response('Not found', 404);

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -101,11 +101,11 @@ http.Client _mockClient(
           'email': 'admin@example.com',
           'permissions': {
             '/admin': ['*'],
-            '/admin/users': ['manage-users'],
-            '/admin/groups': ['manage-groups'],
-            '/admin/invitations': ['manage-invitations'],
-            '/admin/server': ['manage-server-schedule'],
-            '/admin/acl': ['manage-acls'],
+            '/users': ['manage-users'],
+            '/groups': ['manage-groups'],
+            '/invitations': ['manage-invitations'],
+            '/server': ['manage-server-schedule'],
+            '/acl': ['manage-acls'],
           },
           'groups': [
             {'id': 'g1', 'name': 'admins'}
@@ -114,7 +114,7 @@ http.Client _mockClient(
         200,
       );
     }
-    if (request.url.path == '/api/v1/admin/server/schedule' &&
+    if (request.url.path == '/api/v1/server/schedule' &&
         request.method == 'GET') {
       return http.Response(jsonEncode({'schedules': []}), 200);
     }
@@ -194,7 +194,7 @@ void main() {
     int total = 25,
   }) {
     testAuthHttpClientOverride = _mockClient((request) async {
-      if (request.url.path == '/api/v1/admin/users') {
+      if (request.url.path == '/api/v1/users') {
         final page = int.parse(request.url.queryParameters['page'] ?? '1');
         final pageSize =
             int.parse(request.url.queryParameters['page_size'] ?? '10');
@@ -207,10 +207,10 @@ void main() {
           200,
         );
       }
-      if (request.url.path == '/api/v1/admin/invitations') {
+      if (request.url.path == '/api/v1/invitations') {
         return http.Response(emptyInvitationsEnvelope(), 200);
       }
-      if (request.url.path == '/api/v1/admin/groups') {
+      if (request.url.path == '/api/v1/groups') {
         return http.Response(_groupsEnvelope([]), 200);
       }
       return http.Response('Not found', 404);
@@ -226,13 +226,13 @@ void main() {
     int total = 25,
   }) {
     testAuthHttpClientOverride = _mockClient((request) async {
-      if (request.url.path == '/api/v1/admin/users') {
+      if (request.url.path == '/api/v1/users') {
         return http.Response(_usersEnvelope([]), 200);
       }
-      if (request.url.path == '/api/v1/admin/invitations') {
+      if (request.url.path == '/api/v1/invitations') {
         return http.Response(emptyInvitationsEnvelope(), 200);
       }
-      if (request.url.path == '/api/v1/admin/groups') {
+      if (request.url.path == '/api/v1/groups') {
         final page = int.parse(request.url.queryParameters['page'] ?? '1');
         final pageSize =
             int.parse(request.url.queryParameters['page_size'] ?? '10');
@@ -325,7 +325,7 @@ void main() {
       String? capturedSort;
       String? capturedOrder;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           capturedSort = request.url.queryParameters['sort'];
           capturedOrder = request.url.queryParameters['order'];
           return http.Response(
@@ -333,10 +333,10 @@ void main() {
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           return http.Response(_groupsEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
@@ -371,17 +371,17 @@ void main() {
     testWidgets('sends email filter query live (debounced)', (tester) async {
       String? capturedQ;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           capturedQ = request.url.queryParameters['q'];
           return http.Response(
             _usersEnvelope([_user('needle@example.com')], total: 1),
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           return http.Response(_groupsEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
@@ -446,14 +446,14 @@ void main() {
               'user_id': 'admin-user',
               'email': 'admin@example.com',
               'permissions': {
-                '/admin/users': ['manage-users'],
+                '/users': ['manage-users'],
               },
               'groups': [],
             }),
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(_usersEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
@@ -554,13 +554,13 @@ void main() {
       String? capturedSort;
       String? capturedOrder;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(_usersEnvelope([]), 200);
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           capturedSort = request.url.queryParameters['sort'];
           capturedOrder = request.url.queryParameters['order'];
           return http.Response(
@@ -599,13 +599,13 @@ void main() {
     testWidgets('defaults the groups browser to manual-only', (tester) async {
       String? capturedSource;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(_usersEnvelope([]), 200);
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           capturedSource = request.url.queryParameters['source'];
           return http.Response(
             _groupsEnvelope([_group('admins')], total: 1),
@@ -632,13 +632,13 @@ void main() {
         (tester) async {
       final capturedSources = <String?>[];
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(_usersEnvelope([]), 200);
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           capturedSources.add(request.url.queryParameters['source']);
           // No filter (show all): the manual group plus a seeded role
           // group both come back.
@@ -678,13 +678,13 @@ void main() {
     testWidgets('sends name filter query live (debounced)', (tester) async {
       String? capturedQ;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/users') {
           return http.Response(_usersEnvelope([]), 200);
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
+        if (request.url.path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (request.url.path == '/api/v1/admin/groups') {
+        if (request.url.path == '/api/v1/groups') {
           capturedQ = request.url.queryParameters['q'];
           return http.Response(
             _groupsEnvelope([_group('needle-group')], total: 1),
@@ -743,7 +743,7 @@ void main() {
     }) {
       testAuthHttpClientOverride = _mockClient((request) async {
         final path = request.url.path;
-        if (path == '/api/v1/admin/users') {
+        if (path == '/api/v1/users') {
           if (request.method == 'POST') {
             writes.add({
               '_method': 'POST',
@@ -766,18 +766,17 @@ void main() {
             200,
           );
         }
-        if (path.startsWith('/api/v1/admin/users/') &&
-            request.method == 'PATCH') {
+        if (path.startsWith('/api/v1/users/') && request.method == 'PATCH') {
           writes.add({
             '_method': 'PATCH',
             ...jsonDecode(request.body) as Map<String, dynamic>,
           });
           return http.Response(jsonEncode({'status': 'updated'}), 200);
         }
-        if (path == '/api/v1/admin/invitations') {
+        if (path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (path == '/api/v1/admin/groups') {
+        if (path == '/api/v1/groups') {
           return http.Response(_groupsEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
@@ -1190,13 +1189,13 @@ void main() {
     }) {
       testAuthHttpClientOverride = _mockClient((request) async {
         final path = request.url.path;
-        if (path == '/api/v1/admin/users') {
+        if (path == '/api/v1/users') {
           return http.Response(
             _usersEnvelope([_user('alice@example.com', id: 'u1')], total: 1),
             200,
           );
         }
-        if (path == '/api/v1/admin/users/u1/workspaces') {
+        if (path == '/api/v1/users/u1/workspaces') {
           return http.Response(
             jsonEncode({
               'items': workspaces,
@@ -1206,14 +1205,14 @@ void main() {
             200,
           );
         }
-        if (path == '/api/v1/admin/users/u1' && request.method == 'DELETE') {
+        if (path == '/api/v1/users/u1' && request.method == 'DELETE') {
           deletedIds.add('u1');
           return http.Response(jsonEncode({'status': 'deleted'}), 200);
         }
-        if (path == '/api/v1/admin/invitations') {
+        if (path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
-        if (path == '/api/v1/admin/groups') {
+        if (path == '/api/v1/groups') {
           return http.Response(_groupsEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
@@ -1362,19 +1361,19 @@ void main() {
             200,
           );
         }
-        if (path == '/api/v1/admin/groups') {
+        if (path == '/api/v1/groups') {
           return http.Response(
             _groupsEnvelope([_group('admins', id: 'g1')], total: 1),
             200,
           );
         }
-        if (path == '/api/v1/admin/groups/g1/members') {
+        if (path == '/api/v1/groups/g1/members') {
           return http.Response(
             jsonEncode([_user('bob@example.com', id: 'u-bob')]),
             200,
           );
         }
-        if (path == '/api/v1/admin/invitations') {
+        if (path == '/api/v1/invitations') {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
         return http.Response('Not found', 404);
@@ -1414,20 +1413,20 @@ void main() {
               'user_id': 'admin-user',
               'email': 'admin@example.com',
               'permissions': {
-                '/admin/groups': ['manage-groups'],
+                '/groups': ['manage-groups'],
               },
               'groups': [],
             }),
             200,
           );
         }
-        if (path == '/api/v1/admin/groups') {
+        if (path == '/api/v1/groups') {
           return http.Response(
             _groupsEnvelope([_group('helpdesk', id: 'g9')], total: 1),
             200,
           );
         }
-        if (path == '/api/v1/admin/groups/g9/members') {
+        if (path == '/api/v1/groups/g9/members') {
           return http.Response(
             jsonEncode([_user('bob@example.com', id: 'u-bob')]),
             200,
@@ -1486,16 +1485,23 @@ void main() {
 
       // Only top-level resources — no admin sub-resources (#2940):
       // the tabs are permission checks, not ACL destinations.
-      for (final label in ['Root', 'Workspaces', 'Groups', 'Users', 'Admin']) {
-        expect(sidebarNode(label), findsOneWidget);
-      }
       for (final label in [
+        'Root',
+        'Workspaces',
+        'Users',
+        'Groups',
         'Invitations',
         'Server',
         'Events',
+        'ACL',
       ]) {
-        expect(sidebarNode(label), findsNothing);
+        expect(sidebarNode(label), findsOneWidget);
       }
+      // The full noun tree — nothing else (no /admin node).
+      expect(
+          find.descendant(
+              of: find.byType(ListView), matching: find.text('Admin')),
+          findsNothing);
 
       // Root is selected first: its hint names the seeded permission.
       expect(
@@ -1503,16 +1509,19 @@ void main() {
         findsOneWidget,
       );
 
-      // The Admin node's hint names the tab permissions (delegation
-      // happens by ACEs here, not on per-tab sub-resources).
-      await tester.tap(sidebarNode('Admin'));
+      // The Users node's hint names its tab permission; /admin no
+      // longer appears at all (#2944 — instance-admin marker only).
+      await tester.tap(sidebarNode('Users'));
       await tester.pumpAndSettle();
       expect(
-        find.textContaining('manage-users, manage-invitations'),
+        find.textContaining('Checked permission: manage-users'),
         findsOneWidget,
       );
+      expect(sidebarNode('Admin'), findsNothing);
+      await tester.tap(sidebarNode('ACL'));
+      await tester.pumpAndSettle();
       expect(
-        find.textContaining('manage-acls (root-equivalent)'),
+        find.textContaining('manage-acls — root-equivalent'),
         findsOneWidget,
       );
     });

--- a/src/frontend/test/container_events_panel_test.dart
+++ b/src/frontend/test/container_events_panel_test.dart
@@ -101,8 +101,8 @@ http.Client _mockClient(
 /// `/my-permissions`, so the Events resource is listed alongside it.
 Map<String, List<String>> get _adminPermissions => {
       '/admin': ['*'],
-      '/admin/users': ['manage-users'],
-      '/admin/container-events': ['view', 'manage-events'],
+      '/users': ['manage-users'],
+      '/events': ['view', 'manage-events'],
     };
 
 void main() {
@@ -152,14 +152,14 @@ void main() {
     final requests = <http.Request>[];
     testAuthHttpClientOverride =
         _mockClient(_adminPermissions, (request) async {
-      if (request.url.path == '/api/v1/admin/container-events') {
+      if (request.url.path == '/api/v1/events') {
         requests.add(request);
         final limit = int.parse(request.url.queryParameters['limit'] ?? '50');
         final offset = int.parse(request.url.queryParameters['offset'] ?? '0');
         final workspaceId = request.url.queryParameters['workspace_id'];
         return eventsFor(limit, offset, workspaceId);
       }
-      if (request.url.path == '/api/v1/admin/users') {
+      if (request.url.path == '/api/v1/users') {
         return http.Response(
           jsonEncode({
             'users': <Map<String, dynamic>>[],
@@ -170,10 +170,10 @@ void main() {
           200,
         );
       }
-      if (request.url.path == '/api/v1/admin/groups') {
+      if (request.url.path == '/api/v1/groups') {
         return http.Response(jsonEncode([]), 200);
       }
-      if (request.url.path == '/api/v1/admin/server/schedule' &&
+      if (request.url.path == '/api/v1/server/schedule' &&
           request.method == 'GET') {
         return http.Response(jsonEncode({'schedules': []}), 200);
       }
@@ -296,9 +296,9 @@ void main() {
       // /admin/container-events — so no Events tab.
       testAuthHttpClientOverride = _mockClient(
         {
-          '/admin/users': ['manage-users'],
-          '/admin/groups': ['manage-groups'],
-          '/admin/invitations': ['manage-invitations'],
+          '/users': ['manage-users'],
+          '/groups': ['manage-groups'],
+          '/invitations': ['manage-invitations'],
           '/admin': ['admin'],
         },
         (request) async => http.Response('Not found', 404),
@@ -318,10 +318,10 @@ void main() {
       // reads /admin/acl/tree, which needs full admin).
       testAuthHttpClientOverride = _mockClient(
         {
-          '/admin/container-events': ['manage-events'],
+          '/events': ['manage-events'],
         },
         (request) async {
-          if (request.url.path == '/api/v1/admin/container-events') {
+          if (request.url.path == '/api/v1/events') {
             return http.Response(
               _eventsEnvelope(
                 [

--- a/src/frontend/test/server_schedule_panel_test.dart
+++ b/src/frontend/test/server_schedule_panel_test.dart
@@ -228,7 +228,7 @@ void main() {
     testWidgets('renders pending schedules soonest first with countdowns',
         (tester) async {
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule') {
+        if (request.url.path == '/api/v1/server/schedule') {
           return http.Response(
             _schedulesEnvelope([
               _schedule('s2', 'recycle', const Duration(hours: 5, seconds: 30)),
@@ -262,7 +262,7 @@ void main() {
     testWidgets('shows the empty state when nothing is scheduled',
         (tester) async {
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule') {
+        if (request.url.path == '/api/v1/server/schedule') {
           return http.Response(_schedulesEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
@@ -277,7 +277,7 @@ void main() {
         (tester) async {
       var calls = 0;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule') {
+        if (request.url.path == '/api/v1/server/schedule') {
           calls++;
           return http.Response('boom', 500);
         }
@@ -298,7 +298,7 @@ void main() {
         (tester) async {
       var gets = 0;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule') {
+        if (request.url.path == '/api/v1/server/schedule') {
           gets++;
           return http.Response(
             _schedulesEnvelope(
@@ -331,11 +331,10 @@ void main() {
       var pending = [_schedule('s1', 'stop', const Duration(hours: 1))];
       testAuthHttpClientOverride = _mockClient((request) async {
         final path = request.url.path;
-        if (path == '/api/v1/admin/server/schedule' &&
-            request.method == 'GET') {
+        if (path == '/api/v1/server/schedule' && request.method == 'GET') {
           return http.Response(_schedulesEnvelope(pending), 200);
         }
-        if (path == '/api/v1/admin/server/schedule/s1' &&
+        if (path == '/api/v1/server/schedule/s1' &&
             request.method == 'DELETE') {
           deleted.add('s1');
           pending = [];
@@ -365,15 +364,14 @@ void main() {
       var deleted = 0;
       testAuthHttpClientOverride = _mockClient((request) async {
         final path = request.url.path;
-        if (path == '/api/v1/admin/server/schedule' &&
-            request.method == 'GET') {
+        if (path == '/api/v1/server/schedule' && request.method == 'GET') {
           return http.Response(
             _schedulesEnvelope(
                 [_schedule('s1', 'recycle', const Duration(hours: 2))]),
             200,
           );
         }
-        if (path == '/api/v1/admin/server/schedule/s1' &&
+        if (path == '/api/v1/server/schedule/s1' &&
             request.method == 'DELETE') {
           deleted++;
           return http.Response('{}', 200);
@@ -395,15 +393,14 @@ void main() {
     testWidgets('a failed cancel surfaces the API detail', (tester) async {
       testAuthHttpClientOverride = _mockClient((request) async {
         final path = request.url.path;
-        if (path == '/api/v1/admin/server/schedule' &&
-            request.method == 'GET') {
+        if (path == '/api/v1/server/schedule' && request.method == 'GET') {
           return http.Response(
             _schedulesEnvelope(
                 [_schedule('s1', 'stop', const Duration(hours: 1))]),
             200,
           );
         }
-        if (path == '/api/v1/admin/server/schedule/s1' &&
+        if (path == '/api/v1/server/schedule/s1' &&
             request.method == 'DELETE') {
           return http.Response(
               jsonEncode({'detail': 'Schedule not found'}), 404);
@@ -424,7 +421,7 @@ void main() {
 
     testWidgets('a past-due schedule shows "happening now"', (tester) async {
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule') {
+        if (request.url.path == '/api/v1/server/schedule') {
           return http.Response(
             _schedulesEnvelope(
                 [_schedule('s1', 'stop', const Duration(seconds: -10))]),
@@ -442,7 +439,7 @@ void main() {
 
     testWidgets('a malformed fire_at degrades to "fires soon"', (tester) async {
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule') {
+        if (request.url.path == '/api/v1/server/schedule') {
           return http.Response(
             jsonEncode({
               'schedules': [
@@ -475,8 +472,7 @@ void main() {
       final hangingGet = Completer<http.Response>();
       testAuthHttpClientOverride = _mockClient((request) async {
         final path = request.url.path;
-        if (path == '/api/v1/admin/server/schedule' &&
-            request.method == 'GET') {
+        if (path == '/api/v1/server/schedule' && request.method == 'GET') {
           gets++;
           if (gets == 1) {
             return http.Response(
@@ -487,7 +483,7 @@ void main() {
           }
           return hangingGet.future;
         }
-        if (path == '/api/v1/admin/server/schedule/s1' &&
+        if (path == '/api/v1/server/schedule/s1' &&
             request.method == 'DELETE') {
           return http.Response(jsonEncode({'cancelled': 's1'}), 200);
         }
@@ -528,11 +524,10 @@ void main() {
       var pending = [_schedule('s1', 'stop', const Duration(hours: 1))];
       testAuthHttpClientOverride = _mockClient((request) async {
         final path = request.url.path;
-        if (path == '/api/v1/admin/server/schedule' &&
-            request.method == 'GET') {
+        if (path == '/api/v1/server/schedule' && request.method == 'GET') {
           return http.Response(_schedulesEnvelope(pending), 200);
         }
-        if (path == '/api/v1/admin/server/schedule/s1' &&
+        if (path == '/api/v1/server/schedule/s1' &&
             request.method == 'DELETE') {
           pending = [];
           return http.Response(jsonEncode({'cancelled': 's1'}), 200);
@@ -604,7 +599,7 @@ void main() {
         (tester) async {
       Map<String, dynamic>? posted;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule' &&
+        if (request.url.path == '/api/v1/server/schedule' &&
             request.method == 'POST') {
           posted = jsonDecode(request.body) as Map<String, dynamic>;
           return http.Response(
@@ -636,7 +631,7 @@ void main() {
     testWidgets('shows the API 422 detail inline and stays open',
         (tester) async {
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule' &&
+        if (request.url.path == '/api/v1/server/schedule' &&
             request.method == 'POST') {
           return http.Response(
             jsonEncode({'detail': "'in_seconds' must be positive"}),
@@ -662,7 +657,7 @@ void main() {
         (tester) async {
       Map<String, dynamic>? posted;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/server/schedule' &&
+        if (request.url.path == '/api/v1/server/schedule' &&
             request.method == 'POST') {
           posted = jsonDecode(request.body) as Map<String, dynamic>;
           return http.Response(

--- a/src/klangk/klangk/acl.py
+++ b/src/klangk/klangk/acl.py
@@ -77,14 +77,19 @@ def check_permission_inmemory(
 def request_to_resource(request: Request) -> str:
     """Derive a resource path from the request URL.
 
-    Maps URL paths to the ACL resource tree:
+    Maps URL paths to the ACL resource tree (#2944: every governed
+    surface is a first-class top-level resource; the old /admin
+    subtree is gone):
+
       /workspaces          -> /workspaces
       /workspaces/{id}     -> /workspaces/{id}
       /workspaces/{id}/... -> /workspaces/{id}
-      /admin/users         -> /admin/users
-      /admin/users/{id}    -> /admin/users/{id}
-      /admin/invitations   -> /admin/invitations
-      /admin/groups        -> /admin/groups
+      /users/...           -> /users        (flat, no per-id nodes)
+      /groups/...          -> /groups
+      /invitations/...     -> /invitations
+      /server/...          -> /server
+      /events              -> /events
+      /acl/...             -> /acl
     """
     # Strip the versioned API prefix to get the logical resource path.
     path = request.url.path
@@ -96,12 +101,6 @@ def request_to_resource(request: Request) -> str:
 
     if parts[0] == "workspaces" and len(parts) >= 2:
         return f"/workspaces/{parts[1]}"
-    if parts[0] == "admin":
-        if len(parts) >= 3:
-            return f"/admin/{parts[1]}/{parts[2]}"
-        if len(parts) >= 2:
-            return f"/admin/{parts[1]}"
-        return "/admin"
     return "/" + parts[0]
 
 

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -293,13 +293,11 @@ STATIC_RESOURCES = [
     "/workspaces",
     "/groups",
     "/users",
+    "/invitations",
+    "/server",
+    "/events",
+    "/acl",
     "/admin",
-    "/admin/users",
-    "/admin/invitations",
-    "/admin/groups",
-    "/admin/container-events",
-    "/admin/acl",
-    "/admin/server",
 ]
 
 ALL_PERMISSIONS = [

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -26,7 +26,6 @@ from ..model import (
     GROUP_SOURCES,
     PRINCIPAL_GROUP,
     PRINCIPAL_SYSTEM,
-    PRINCIPAL_USER,
     SYSTEM_AUTHENTICATED,
 )
 from .common import (
@@ -81,7 +80,7 @@ def _validate_admin_acl(entries, resource: str) -> None:
         )
 
 
-@router.post("/admin/invitations")
+@router.post("/invitations")
 async def send_invitation(
     req: SendInviteRequest,
     request: Request,
@@ -138,7 +137,7 @@ async def send_invitation(
     }
 
 
-@router.get("/admin/invitations")
+@router.get("/invitations")
 async def list_invitations(
     page: int = 1,
     page_size: int = 10,
@@ -160,7 +159,7 @@ async def list_invitations(
     )
 
 
-@router.delete("/admin/invitations/{invitation_id}")
+@router.delete("/invitations/{invitation_id}")
 async def revoke_invitation(
     invitation_id: str,
     admin: dict = Depends(acl.has_permission("manage-invitations")),
@@ -178,7 +177,7 @@ async def revoke_invitation(
     return {"status": "revoked"}
 
 
-@router.post("/admin/invitations/{invitation_id}/resend")
+@router.post("/invitations/{invitation_id}/resend")
 async def resend_invitation(
     invitation_id: str,
     request: Request,
@@ -216,7 +215,7 @@ async def resend_invitation(
     return {"status": "resent"}
 
 
-@router.get("/admin/users")
+@router.get("/users")
 async def list_users(
     page: int = 1,
     page_size: int = 10,
@@ -237,7 +236,7 @@ class AdminCreateUserRequest(BaseModel):
     send_verification_email: bool = False
 
 
-@router.post("/admin/users")
+@router.post("/users")
 async def admin_create_user(
     req: AdminCreateUserRequest,
     request: Request,
@@ -307,7 +306,7 @@ async def admin_create_user(
     return {"id": user["id"], "email": user["email"], "status": "created"}
 
 
-@router.get("/admin/users/{user_id}/workspaces")
+@router.get("/users/{user_id}/workspaces")
 async def list_user_workspaces(
     user_id: str,
     limit: int | None = Query(None, ge=1, le=200),
@@ -329,7 +328,7 @@ async def list_user_workspaces(
     )
 
 
-@router.delete("/admin/users/{user_id}")
+@router.delete("/users/{user_id}")
 async def delete_user(
     user_id: str,
     admin: dict = Depends(acl.has_permission("manage-users")),
@@ -370,7 +369,7 @@ class UpdateUserRequest(auth.BaseModel):
     disabled: bool | None = None
 
 
-@router.patch("/admin/users/{user_id}")
+@router.patch("/users/{user_id}")
 async def update_user(
     user_id: str,
     req: UpdateUserRequest,
@@ -440,7 +439,7 @@ async def _update_user_disabled(
             )
 
 
-@router.post("/admin/users/{user_id}/unlockout")
+@router.post("/users/{user_id}/unlockout")
 async def unlock_user(
     user_id: str,
     admin: dict = Depends(acl.has_permission("manage-users")),
@@ -454,7 +453,7 @@ async def unlock_user(
     return {"status": "unlocked"}
 
 
-@router.get("/admin/users/{user_id}/sessions")
+@router.get("/users/{user_id}/sessions")
 async def list_user_sessions(
     user_id: str,
     admin: dict = Depends(acl.has_permission("manage-users")),
@@ -527,7 +526,7 @@ async def update_group_fields(app, group_id: str, req) -> dict:
 
 
 @router.get("/groups")
-async def user_list_groups(
+async def list_groups(
     page: int = 1,
     page_size: int = 10,
     sort: str = "name",
@@ -537,15 +536,16 @@ async def user_list_groups(
     user: dict = Depends(auth.get_current_user),
     app=Depends(get_app_dep),
 ):
-    """List groups (any authenticated user can see groups).
+    """List groups (#2944): one surface for every reader — pickers,
+    share dialogs, and the admin Groups tab all read here, so the
+    listing is authenticated rather than manage-groups-gated (a
+    manage-groups delegate without manage-users still needs it).
 
-    Returns the paged envelope ``{groups, page, page_size, total}`` —
-    the same shape as the admin endpoint (#2750; previously a bare list
-    hard-capped at 200 rows). ``source=manual`` hides the seeded
-    per-workspace role groups; ``source=workspace-role`` shows only
-    them; the default shows all. The write side lives at
-    ``/admin/groups`` behind ``manage-groups`` (the ``/groups`` writes
-    were removed, #2941-fold).
+    Returns the paged envelope ``{groups, page, page_size, total}``
+    (#2750). ``source=manual`` hides the seeded per-workspace role
+    groups; ``source=workspace-role`` shows only them; the default
+    shows all. Writes (create/edit/delete, members) on this tree are
+    gated ``manage-groups``.
     """
     if source is not None and source not in GROUP_SOURCES:
         raise HTTPException(
@@ -562,42 +562,11 @@ async def user_list_groups(
     )
 
 
-# --- Admin group endpoints (single group-management surface, #2941-fold) ---
+# --- Group management writes (single surface, #2941-fold; moved to
+# /groups in #2944) ---
 
 
-@router.get("/admin/groups")
-async def list_groups(
-    page: int = 1,
-    page_size: int = 10,
-    sort: str = "name",
-    order: str = "asc",
-    q: str | None = None,
-    source: str | None = None,
-    admin: dict = Depends(acl.has_permission("manage-groups")),
-    app=Depends(get_app_dep),
-):
-    """List groups with the paged envelope; rows carry ``source``.
-
-    ``source=manual`` hides the seeded per-workspace role groups;
-    ``source=workspace-role`` shows only them; the default shows all
-    (#2750).
-    """
-    if source is not None and source not in GROUP_SOURCES:
-        raise HTTPException(
-            status_code=422,
-            detail="source must be one of: manual, workspace-role",
-        )
-    return await app.state.model.users.list_groups(
-        page=page,
-        page_size=page_size,
-        sort=sort,
-        order=order,
-        q=q,
-        source=source,
-    )
-
-
-@router.post("/admin/groups")
+@router.post("/groups")
 async def create_group(
     req: CreateGroupRequest,
     admin: dict = Depends(acl.has_permission("manage-groups")),
@@ -609,21 +578,10 @@ async def create_group(
             status_code=409, detail="A group with this name already exists"
         )
     group = await app.state.model.users.create_group(req.name, req.description)
-    # The creator gets full ACL access to the group (ported from the
-    # removed POST /groups, #2941-fold: a delegated group manager owns
-    # what they create).
-    await app.state.model.acl.add_acl_entry(
-        f"/groups/{group['id']}",
-        0,
-        ACTION_ALLOW,
-        "*",
-        PRINCIPAL_USER,
-        user_id=admin["id"],
-    )
     return group
 
 
-@router.patch("/admin/groups/{group_id}")
+@router.patch("/groups/{group_id}")
 async def update_group(
     group_id: str,
     req: UpdateGroupRequest,
@@ -633,7 +591,7 @@ async def update_group(
     return await update_group_fields(app, group_id, req)
 
 
-@router.delete("/admin/groups/{group_id}")
+@router.delete("/groups/{group_id}")
 async def delete_group(
     group_id: str,
     admin: dict = Depends(acl.has_permission("manage-groups")),
@@ -649,7 +607,7 @@ async def delete_group(
     return {"status": "deleted"}
 
 
-@router.get("/admin/groups/{group_id}/members")
+@router.get("/groups/{group_id}/members")
 async def list_group_members(
     group_id: str,
     admin: dict = Depends(acl.has_permission("manage-groups")),
@@ -659,7 +617,7 @@ async def list_group_members(
     return await app.state.model.users.get_group_members(group_id)
 
 
-@router.post("/admin/groups/{group_id}/members")
+@router.post("/groups/{group_id}/members")
 async def add_group_member(
     group_id: str,
     req: AddGroupMemberRequest,
@@ -674,7 +632,7 @@ async def add_group_member(
     return {"status": "added"}
 
 
-@router.delete("/admin/groups/{group_id}/members/{user_id}")
+@router.delete("/groups/{group_id}/members/{user_id}")
 async def remove_group_member(
     group_id: str,
     user_id: str,
@@ -694,7 +652,7 @@ async def remove_group_member(
 # --- ACL management endpoints ---
 
 
-@router.get("/admin/acl/tree")
+@router.get("/acl/tree")
 async def get_acl_tree(
     admin: dict = Depends(acl.has_permission("manage-acls")),
     app=Depends(get_app_dep),
@@ -702,7 +660,7 @@ async def get_acl_tree(
     return await app.state.model.acl.get_acl_tree_summary()
 
 
-@router.get("/admin/acl/by-principal/user/{user_id}")
+@router.get("/acl/by-principal/user/{user_id}")
 async def get_acl_by_user(
     user_id: str,
     admin: dict = Depends(acl.has_permission("manage-acls")),
@@ -711,7 +669,7 @@ async def get_acl_by_user(
     return await app.state.model.acl.get_acl_entries_by_principal_user(user_id)
 
 
-@router.get("/admin/acl/by-principal/group/{group_id}")
+@router.get("/acl/by-principal/group/{group_id}")
 async def get_acl_by_group(
     group_id: str,
     admin: dict = Depends(acl.has_permission("manage-acls")),
@@ -722,7 +680,7 @@ async def get_acl_by_group(
     )
 
 
-@router.get("/admin/acl/resource")
+@router.get("/acl/resource")
 async def get_resource_acl(
     resource: str,
     admin: dict = Depends(acl.has_permission("manage-acls")),
@@ -746,7 +704,7 @@ def workspace_scope(resource: str) -> str | None:
     return None
 
 
-@router.put("/admin/acl/resource")
+@router.put("/acl/resource")
 async def replace_resource_acl(
     resource: str,
     entries: list[WorkspaceAclEntry],
@@ -787,7 +745,7 @@ class ServerScheduleRequest(BaseModel):
     in_seconds: float | None = None  # relative delay, > 0
 
 
-@router.post("/admin/server/schedule")
+@router.post("/server/schedule")
 async def schedule_server_action(
     payload: ServerScheduleRequest,
     request: Request,
@@ -818,7 +776,7 @@ async def schedule_server_action(
     return schedule
 
 
-@router.get("/admin/server/schedule")
+@router.get("/server/schedule")
 async def list_server_schedules(
     request: Request,
     admin: dict = Depends(acl.has_permission("manage-server-schedule")),
@@ -829,7 +787,7 @@ async def list_server_schedules(
     }
 
 
-@router.delete("/admin/server/schedule/{schedule_id}")
+@router.delete("/server/schedule/{schedule_id}")
 async def cancel_server_schedule(
     schedule_id: str,
     request: Request,
@@ -877,7 +835,7 @@ async def _annotate_events(app, rows: list[dict]) -> list[dict]:
     ]
 
 
-@router.get("/admin/container-events")
+@router.get("/events")
 async def list_container_events(
     request: Request,
     limit: int = Query(50, ge=1, le=200),

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -848,10 +848,10 @@ async def list_container_events(
     Newest-first rows from the ``container_events`` audit table
     (#2915) plus the filter-matching total, optionally narrowed to one
     workspace. Gated on the dedicated ``manage-events`` permission
-    over the URL-derived resource ``/events``: the
-    admin group holds it through its ``/admin`` ``*`` wildcard, and a
-    non-admin gets it only via an explicit ACE on that resource —
-    read-only audit access without full admin.
+    over the URL-derived resource ``/events``: the admin group holds it
+    through the seeded Allow row, and a non-admin gets it only via an
+    explicit ACE on that resource — read-only audit access without
+    full admin.
     """
     app = request.app
     rows = await app.state.model.container_events.list_events(

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -848,7 +848,7 @@ async def list_container_events(
     Newest-first rows from the ``container_events`` audit table
     (#2915) plus the filter-matching total, optionally narrowed to one
     workspace. Gated on the dedicated ``manage-events`` permission
-    over the URL-derived resource ``/admin/container-events``: the
+    over the URL-derived resource ``/events``: the
     admin group holds it through its ``/admin`` ``*`` wildcard, and a
     non-admin gets it only via an explicit ACE on that resource —
     read-only audit access without full admin.

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -71,7 +71,7 @@ def admin_users_ls(
     context.require_auth()
     client = context.client()
     resp = client.get(
-        "/api/v1/admin/users",
+        "/api/v1/users",
         params={"page": page, "page_size": page_size},
     )
     client.check_auth(resp)
@@ -157,7 +157,7 @@ def admin_users_set_password(
             raise typer.Exit(code=1)
 
     resp = client.patch(
-        f"/api/v1/admin/users/{user_id}",
+        f"/api/v1/users/{user_id}",
         json={"password": password},
     )
     client.check_auth(resp)
@@ -182,7 +182,7 @@ def admin_invitations_send(
         raise typer.Exit(code=1)
     context.require_auth()
     client = context.client()
-    resp = client.post("/api/v1/admin/invitations", json={"email": email})
+    resp = client.post("/api/v1/invitations", json={"email": email})
     client.check_auth(resp)
     if resp.status_code != 200:
         admin_error(resp)
@@ -194,7 +194,7 @@ def admin_invitations_ls() -> None:
     """List all invitations (admin only)."""
     context.require_auth()
     client = context.client()
-    resp = client.get("/api/v1/admin/invitations?page_size=200")
+    resp = client.get("/api/v1/invitations?page_size=200")
     client.check_auth(resp)
     if resp.status_code != 200:
         admin_error(resp)

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -181,13 +181,40 @@ class Lifecycle:
             PRINCIPAL_GROUP,
             group_id=admin_group_id,
         )
-        # /groups: no seed — the write surface moved to /admin/groups
-        # behind manage-groups (#2941-fold), covered for admins by the
-        # /admin * wildcard above. Deployers delegate whole-tab access
-        # with an Allow manage-groups ACE on /admin/groups. Upgraded
-        # deployments keep their old /groups `create` ACE; it is inert
-        # (nothing checks permissions on /groups writes anymore).
-        # /admin: admin group gets full access, deny everyone else
+        # First-class resources (#2944): each governed surface is a
+        # top-level tree with one flat manage-* permission — Allow for
+        # the admins group, Deny everyone. The walk from these
+        # resources never passes through /admin, so each needs its own
+        # rows (migration 0021 inserts the same pair on existing
+        # deployments).
+        for resource, permission in (
+            ("/users", "manage-users"),
+            ("/groups", "manage-groups"),
+            ("/invitations", "manage-invitations"),
+            ("/server", "manage-server-schedule"),
+            ("/events", "manage-events"),
+            ("/acl", "manage-acls"),
+        ):
+            await self.app.state.model.acl.add_acl_entry(
+                resource,
+                0,
+                ACTION_ALLOW,
+                permission,
+                PRINCIPAL_GROUP,
+                group_id=admin_group_id,
+            )
+            await self.app.state.model.acl.add_acl_entry(
+                resource,
+                1,
+                ACTION_DENY,
+                "*",
+                PRINCIPAL_SYSTEM,
+                system_principal=SYSTEM_EVERYONE,
+            )
+        # /admin: kept as the instance-administrator marker — Allow *
+        # for admins, deny everyone. No route checks a permission here
+        # anymore (#2944); the wildcard marks "is an instance admin"
+        # for /my-permissions consumers (the frontend's isAdmin).
         await self.app.state.model.acl.add_acl_entry(
             "/admin",
             0,

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -68,6 +68,7 @@ from klangk.model.migrations import m0017_change_acls_permission
 from klangk.model.migrations import m0018_egress_consent_permission
 from klangk.model.migrations import m0019_container_events
 from klangk.model.migrations import m0020_rename_admin_group
+from klangk.model.migrations import m0021_first_class_resource_acls
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -96,6 +97,7 @@ MIGRATIONS: list[Migration] = [
     m0018_egress_consent_permission.migration,
     m0019_container_events.migration,
     m0020_rename_admin_group.migration,
+    m0021_first_class_resource_acls.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
+++ b/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
@@ -23,13 +23,22 @@ Details:
   as the instance-administrator wildcard marker (``isAdmin`` in the
   frontend reads ``*`` on ``/admin`` via ``/my-permissions``).
 - Positions: each inserted resource gets Allow at 0, Deny at 1,
-  mirroring the seed layout. A resource that already has rows (an
-  operator pre-staged grants) is skipped entirely — never half-merged
-  onto unknown positions.
+  mirroring the seed layout.
+- ``/groups`` carries a well-known legacy row on every deployment
+  first-booted before #2943: migration 0014 rewrote the seed to a
+  single ``Allow create`` row for the admin group. That row matches no
+  ``manage-groups`` check, so leaving it would lock admins out of
+  group management — the exact failure this migration exists to
+  prevent. When ``/groups`` holds **exactly** that legacy shape it is
+  replaced with the standard pair (the m0014 precedent). Any other
+  non-empty shape is an operator customization: skipped untouched,
+  with the manual step documented in the changelog.
+- A fresh database (entirely empty ``acl_entries``) is a no-op — the
+  boot seeds own it; inserting here would trip the seed's
+  empty-table gate and lose the ``/``, ``/workspaces``, and ``/admin``
+  rows.
 - Idempotent by construction: the per-resource existence check no-ops
-  on re-run, and fresh DBs get the rows from ``seed_default_acls``
-  (this migration still inserts them harmlessly before that seeding —
-  the seed itself is gated on an empty table and skips).
+  on re-run.
 """
 
 from klangk.model.acl import (
@@ -52,6 +61,21 @@ RESOURCES = {
 }
 
 
+def _is_legacy_groups_shape(rows) -> bool:
+    """Whether /groups holds exactly the m0014-rewritten seed: a single
+    ``Allow create`` row for a group principal at position 0."""
+    return bool(
+        len(rows) == 1
+        and rows[0][0] == 0  # position
+        and rows[0][1] == ACTION_ALLOW
+        and rows[0][2] == PRINCIPAL_GROUP
+        and rows[0][3] is None  # user_id
+        and rows[0][4] is not None  # group_id
+        and rows[0][5] is None  # system_principal
+        and rows[0][6] == "create"
+    )
+
+
 async def apply(db) -> None:
     cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
     if (await cursor.fetchone())[0] == 0:
@@ -66,11 +90,25 @@ async def apply(db) -> None:
 
     for resource, permission in RESOURCES.items():
         cursor = await db.execute(
-            "SELECT COUNT(*) FROM acl_entries WHERE resource = ?",
+            "SELECT position, action, principal_type, user_id, group_id,"
+            " system_principal, permission FROM acl_entries"
+            " WHERE resource = ?",
             (resource,),
         )
-        if (await cursor.fetchone())[0] > 0:
-            continue  # operator pre-staged rows here; don't disturb them
+        rows = list(await cursor.fetchall())
+        if rows:
+            if resource == "/groups" and _is_legacy_groups_shape(rows):
+                # The well-known m0014 seed: replace it — nothing checks
+                # `create` on /groups anymore, so leaving it would lock
+                # admins out of group management (#2945 review).
+                await db.execute(
+                    "DELETE FROM acl_entries WHERE resource = ?",
+                    (resource,),
+                )
+            else:
+                # Operator pre-staged/customized rows; don't disturb
+                # them (manual step documented in the changelog).
+                continue
         if admins_id is not None:
             await db.execute(
                 "INSERT INTO acl_entries"

--- a/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
+++ b/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
@@ -1,0 +1,97 @@
+"""Migration 0021: seed the first-class resource ACLs (#2944).
+
+Every governed surface moved off the ``/admin`` subtree onto first-class
+top-level resources — ``/users``, ``/groups``, ``/invitations``,
+``/server``, ``/events``, ``/acl`` — each checked against its flat
+``manage-*`` permission. The ACL walk from those resources goes up to
+``/`` and never passes through ``/admin``, so an existing deployment's
+``/admin`` Allow ``*`` wildcard (admins) cannot satisfy the moved
+checks: without new rows, **admins lock themselves out** of users,
+groups, invitations, server scheduling, events, and the ACL editor the
+moment this code boots.
+
+This migration inserts, for each resource, the two rows a fresh install
+seeds (``seed_default_acls``): Allow ``manage-*`` for the admins group,
+Deny ``*`` for Everyone. It must ship in the same release as the
+endpoint moves.
+
+Details:
+
+- The admins group is located by name (``admins``; migration 0020
+  renamed legacy ``admin`` rows), matching the seeds' shape.
+- The old ``/admin`` rows are left in place untouched: they still serve
+  as the instance-administrator wildcard marker (``isAdmin`` in the
+  frontend reads ``*`` on ``/admin`` via ``/my-permissions``).
+- Positions: each inserted resource gets Allow at 0, Deny at 1,
+  mirroring the seed layout. A resource that already has rows (an
+  operator pre-staged grants) is skipped entirely — never half-merged
+  onto unknown positions.
+- Idempotent by construction: the per-resource existence check no-ops
+  on re-run, and fresh DBs get the rows from ``seed_default_acls``
+  (this migration still inserts them harmlessly before that seeding —
+  the seed itself is gated on an empty table and skips).
+"""
+
+from klangk.model.acl import (
+    ACTION_ALLOW,
+    ACTION_DENY,
+    PRINCIPAL_GROUP,
+    PRINCIPAL_SYSTEM,
+    SYSTEM_EVERYONE,
+)
+from klangk.model.migrations.base import Migration
+
+# resource -> the permission admins get on it
+RESOURCES = {
+    "/users": "manage-users",
+    "/groups": "manage-groups",
+    "/invitations": "manage-invitations",
+    "/server": "manage-server-schedule",
+    "/events": "manage-events",
+    "/acl": "manage-acls",
+}
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        # Fresh database: the boot seeds (seed_default_acls) own this —
+        # inserting here would make the seed gate (empty-table check)
+        # skip and lose the /, /workspaces, and /admin rows.
+        return
+
+    cursor = await db.execute("SELECT id FROM groups WHERE name = 'admins'")
+    row = await cursor.fetchone()
+    admins_id = row[0] if row is not None else None
+
+    for resource, permission in RESOURCES.items():
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM acl_entries WHERE resource = ?",
+            (resource,),
+        )
+        if (await cursor.fetchone())[0] > 0:
+            continue  # operator pre-staged rows here; don't disturb them
+        if admins_id is not None:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, user_id,"
+                "  group_id, system_principal, permission)"
+                " VALUES (?, 0, ?, ?, NULL, ?, NULL, ?)",
+                (
+                    resource,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    admins_id,
+                    permission,
+                ),
+            )
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type, user_id,"
+            "  group_id, system_principal, permission)"
+            " VALUES (?, 1, ?, ?, NULL, NULL, ?, '*')",
+            (resource, ACTION_DENY, PRINCIPAL_SYSTEM, SYSTEM_EVERYONE),
+        )
+
+
+migration = Migration(21, "0021_first_class_resource_acls", apply)

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -24,7 +24,7 @@ Authorization (#2244 closes the #2308 authz gap): a workspace-scoped decider
 (``?workspace=<id>``) must have the ``egress-consent`` permission on that
 workspace (owner, coder, or collaborator -- #2883; spectators are
 watch-only and never register); a deploy-wide decider (no ``workspace``)
-must be an admin. A verdict is honored only if it targets the decider's
+must hold `manage-server-schedule`. A verdict is honored only if it targets the decider's
 own workspace (defense-in-depth), enforced in ``resolve`` via
 ``decider_workspace``. Pause/unpause share the same single gate as the
 connection itself (#2883): anyone who may register may also pause.

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -118,8 +118,11 @@ async def _refuse_invalid_handshake(
             f"/workspaces/{workspace}", principals, "egress-consent"
         )
     else:
+        # Server-lifecycle decisions (drain/recycle consent) are
+        # instance-sphere: manage-server-schedule on /server (#2944;
+        # previously the legacy `admin`-on-`/admin` gate).
         allowed = await app.state.acl.check_permission(
-            "/admin", principals, "admin"
+            "/server", principals, "manage-server-schedule"
         )
     if not allowed:
         await _refuse(websocket, 4003, "Forbidden", user.get("email"))

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -6232,7 +6232,7 @@ class TestAdminUsersCLI:
         assert "hero@example.com" in result.stdout
         client.patch.assert_called_once()
         called_path = client.patch.call_args.args[0]
-        assert called_path == "/api/v1/admin/users/u-1"
+        assert called_path == "/api/v1/users/u-1"
 
     def test_set_password_by_handle(self, logged_in_cfg, monkeypatch):
         """set-password resolves a *handle* to a user id (#616)."""
@@ -6264,7 +6264,7 @@ class TestAdminUsersCLI:
         )
         assert result.exit_code == 0
         client.patch.assert_called_once()
-        assert client.patch.call_args.args[0] == "/api/v1/admin/users/u-1"
+        assert client.patch.call_args.args[0] == "/api/v1/users/u-1"
 
     def test_set_password_prompt_match(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main

--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -117,7 +117,7 @@ def _make_user_admin(api, user_id, admin_headers):
     if not user_id:
         return
     # Find the admin group.
-    resp = api.get("/api/v1/admin/groups", headers=admin_headers)
+    resp = api.get("/api/v1/groups", headers=admin_headers)
     if resp.status_code != 200:
         return
     body = resp.json()
@@ -128,7 +128,7 @@ def _make_user_admin(api, user_id, admin_headers):
     if not admin_group:
         return
     api.post(
-        f"/api/v1/admin/groups/{admin_group['id']}/members",
+        f"/api/v1/groups/{admin_group['id']}/members",
         json={"user_id": user_id},
         headers=admin_headers,
     )
@@ -182,14 +182,14 @@ class TestConfig:
 
 class TestGroupManagement:
     def test_list_groups(self, api, admin_headers):
-        resp = api.get("/api/v1/admin/groups", headers=admin_headers)
+        resp = api.get("/api/v1/groups", headers=admin_headers)
         assert resp.status_code == 200
         groups = resp.json()["groups"]
         assert any(g["name"] == "admins" for g in groups)
 
     def test_create_group(self, api, admin_headers):
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "editors", "description": "Can edit stuff"},
         )
@@ -200,12 +200,12 @@ class TestGroupManagement:
 
     def test_create_duplicate_group_fails(self, api, admin_headers):
         api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "dup-group"},
         )
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "dup-group"},
         )
@@ -213,13 +213,13 @@ class TestGroupManagement:
 
     def test_update_group(self, api, admin_headers):
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "to-rename"},
         )
         group_id = resp.json()["id"]
         resp = api.patch(
-            f"/api/v1/admin/groups/{group_id}",
+            f"/api/v1/groups/{group_id}",
             headers=admin_headers,
             json={"name": "renamed-group", "description": "Updated"},
         )
@@ -227,38 +227,34 @@ class TestGroupManagement:
 
     def test_delete_group(self, api, admin_headers):
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "to-delete"},
         )
         group_id = resp.json()["id"]
-        resp = api.delete(
-            f"/api/v1/admin/groups/{group_id}", headers=admin_headers
-        )
+        resp = api.delete(f"/api/v1/groups/{group_id}", headers=admin_headers)
         assert resp.status_code == 200
         # Verify gone
-        resp = api.get("/api/v1/admin/groups", headers=admin_headers)
+        resp = api.get("/api/v1/groups", headers=admin_headers)
         assert not any(g["id"] == group_id for g in resp.json()["groups"])
 
     def test_add_and_list_members(self, api, admin_headers, user_a):
         # Create a group
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "team-a"},
         )
         group_id = resp.json()["id"]
 
         # Get user A's ID
-        resp = api.get(
-            "/api/v1/admin/users?page_size=200", headers=admin_headers
-        )
+        resp = api.get("/api/v1/users?page_size=200", headers=admin_headers)
         users = resp.json()["users"]
         alice = next(u for u in users if u["email"] == user_a["email"])
 
         # Add user A to group
         resp = api.post(
-            f"/api/v1/admin/groups/{group_id}/members",
+            f"/api/v1/groups/{group_id}/members",
             headers=admin_headers,
             json={"user_id": alice["id"]},
         )
@@ -266,7 +262,7 @@ class TestGroupManagement:
 
         # List members
         resp = api.get(
-            f"/api/v1/admin/groups/{group_id}/members", headers=admin_headers
+            f"/api/v1/groups/{group_id}/members", headers=admin_headers
         )
         assert resp.status_code == 200
         members = resp.json()
@@ -275,32 +271,30 @@ class TestGroupManagement:
 
     def test_remove_member(self, api, admin_headers, user_b):
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "temp-group"},
         )
         group_id = resp.json()["id"]
 
-        resp = api.get(
-            "/api/v1/admin/users?page_size=200", headers=admin_headers
-        )
+        resp = api.get("/api/v1/users?page_size=200", headers=admin_headers)
         bob = next(
             u for u in resp.json()["users"] if u["email"] == user_b["email"]
         )
 
         api.post(
-            f"/api/v1/admin/groups/{group_id}/members",
+            f"/api/v1/groups/{group_id}/members",
             headers=admin_headers,
             json={"user_id": bob["id"]},
         )
         resp = api.delete(
-            f"/api/v1/admin/groups/{group_id}/members/{bob['id']}",
+            f"/api/v1/groups/{group_id}/members/{bob['id']}",
             headers=admin_headers,
         )
         assert resp.status_code == 200
 
         resp = api.get(
-            f"/api/v1/admin/groups/{group_id}/members", headers=admin_headers
+            f"/api/v1/groups/{group_id}/members", headers=admin_headers
         )
         assert resp.json() == []
 
@@ -310,35 +304,40 @@ class TestGroupManagement:
 
 class TestPermissionDenials:
     def test_non_admin_cannot_list_groups(self, api, nonadmin_user):
+        """#2944: GET /groups is the authenticated picker listing (200);
+        the gated reads are the members/acl surfaces."""
+        resp = api.get("/api/v1/groups", headers=nonadmin_user["headers"])
+        assert resp.status_code == 200
+        assert "groups" in resp.json()
+
         resp = api.get(
-            "/api/v1/admin/groups", headers=nonadmin_user["headers"]
+            "/api/v1/groups/some-id/members",
+            headers=nonadmin_user["headers"],
         )
         assert resp.status_code == 403
 
     def test_non_admin_cannot_create_group(self, api, nonadmin_user):
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=nonadmin_user["headers"],
             json={"name": "hacker-group"},
         )
         assert resp.status_code == 403
 
     def test_non_admin_cannot_list_users(self, api, nonadmin_user):
-        resp = api.get("/api/v1/admin/users", headers=nonadmin_user["headers"])
+        resp = api.get("/api/v1/users", headers=nonadmin_user["headers"])
         assert resp.status_code == 403
 
     def test_non_admin_cannot_create_user(self, api, nonadmin_user):
         resp = api.post(
-            "/api/v1/admin/users",
+            "/api/v1/users",
             headers=nonadmin_user["headers"],
             json={"email": "evil@example.com", "password": "testpass"},
         )
         assert resp.status_code == 403
 
     def test_non_admin_cannot_view_acl_tree(self, api, nonadmin_user):
-        resp = api.get(
-            "/api/v1/admin/acl/tree", headers=nonadmin_user["headers"]
-        )
+        resp = api.get("/api/v1/acl/tree", headers=nonadmin_user["headers"])
         assert resp.status_code == 403
 
     def test_non_admin_cannot_delete_other_workspace(
@@ -382,7 +381,7 @@ class TestPermissionDenials:
         resp = api.get("/api/v1/workspaces")
         assert resp.status_code == 401
 
-        resp = api.get("/api/v1/admin/users")
+        resp = api.get("/api/v1/users")
         assert resp.status_code == 401
 
 
@@ -391,7 +390,7 @@ class TestPermissionDenials:
 
 class TestACLIntrospection:
     def test_acl_tree(self, api, admin_headers):
-        resp = api.get("/api/v1/admin/acl/tree", headers=admin_headers)
+        resp = api.get("/api/v1/acl/tree", headers=admin_headers)
         assert resp.status_code == 200
         tree = resp.json()
         resources = [t["resource"] for t in tree]
@@ -400,13 +399,13 @@ class TestACLIntrospection:
 
     def test_acl_by_group(self, api, admin_headers):
         # Get admin group ID
-        resp = api.get("/api/v1/admin/groups", headers=admin_headers)
+        resp = api.get("/api/v1/groups", headers=admin_headers)
         admin_group = next(
             g for g in resp.json()["groups"] if g["name"] == "admins"
         )
 
         resp = api.get(
-            f"/api/v1/admin/acl/by-principal/group/{admin_group['id']}",
+            f"/api/v1/acl/by-principal/group/{admin_group['id']}",
             headers=admin_headers,
         )
         assert resp.status_code == 200
@@ -425,15 +424,13 @@ class TestACLIntrospection:
         ws_id = resp.json()["id"]
 
         # Get user A's ID
-        resp = api.get(
-            "/api/v1/admin/users?page_size=200", headers=admin_headers
-        )
+        resp = api.get("/api/v1/users?page_size=200", headers=admin_headers)
         alice = next(
             u for u in resp.json()["users"] if u["email"] == user_a["email"]
         )
 
         resp = api.get(
-            f"/api/v1/admin/acl/by-principal/user/{alice['id']}",
+            f"/api/v1/acl/by-principal/user/{alice['id']}",
             headers=admin_headers,
         )
         assert resp.status_code == 200
@@ -666,7 +663,7 @@ class TestWorkspaceSharingACL:
         ws_id = resp.json()["id"]
 
         # ACL tree should include this workspace
-        resp = api.get("/api/v1/admin/acl/tree", headers=admin_headers)
+        resp = api.get("/api/v1/acl/tree", headers=admin_headers)
         assert any(
             t["resource"] == f"/workspaces/{ws_id}" for t in resp.json()
         )
@@ -678,7 +675,7 @@ class TestWorkspaceSharingACL:
         assert resp.status_code == 200
 
         # ACL tree should no longer include this workspace
-        resp = api.get("/api/v1/admin/acl/tree", headers=admin_headers)
+        resp = api.get("/api/v1/acl/tree", headers=admin_headers)
         assert not any(
             t["resource"] == f"/workspaces/{ws_id}" for t in resp.json()
         )
@@ -693,11 +690,11 @@ class TestGrantAdminViaGroup:
     ):
         """Adding a user to the admin group gives them admin permissions."""
         # Verify non-admin cannot access admin endpoints
-        resp = api.get("/api/v1/admin/users", headers=nonadmin_user["headers"])
+        resp = api.get("/api/v1/users", headers=nonadmin_user["headers"])
         assert resp.status_code == 403
 
         # Get admin group
-        resp = api.get("/api/v1/admin/groups", headers=admin_headers)
+        resp = api.get("/api/v1/groups", headers=admin_headers)
         admin_group = next(
             g for g in resp.json()["groups"] if g["name"] == "admins"
         )
@@ -706,7 +703,7 @@ class TestGrantAdminViaGroup:
 
         # Add user to admin group
         resp = api.post(
-            f"/api/v1/admin/groups/{admin_group['id']}/members",
+            f"/api/v1/groups/{admin_group['id']}/members",
             headers=admin_headers,
             json={"user_id": user_id},
         )
@@ -714,7 +711,7 @@ class TestGrantAdminViaGroup:
 
         # Group membership is checked on every request, not cached in JWT
         resp = api.get(
-            "/api/v1/admin/users?page_size=200",
+            "/api/v1/users?page_size=200",
             headers=nonadmin_user["headers"],
         )
         assert resp.status_code == 200
@@ -722,13 +719,13 @@ class TestGrantAdminViaGroup:
 
         # Clean up — remove user from admin group
         resp = api.delete(
-            f"/api/v1/admin/groups/{admin_group['id']}/members/{user_id}",
+            f"/api/v1/groups/{admin_group['id']}/members/{user_id}",
             headers=admin_headers,
         )
         assert resp.status_code == 200
 
         # Verify access revoked immediately (no re-login needed)
-        resp = api.get("/api/v1/admin/users", headers=nonadmin_user["headers"])
+        resp = api.get("/api/v1/users", headers=nonadmin_user["headers"])
         assert resp.status_code == 403
 
 
@@ -752,9 +749,7 @@ class TestACLCascades:
         )
 
         # Get user's ID
-        resp = api.get(
-            "/api/v1/admin/users?page_size=200", headers=admin_headers
-        )
+        resp = api.get("/api/v1/users?page_size=200", headers=admin_headers)
         target = next(
             u
             for u in resp.json()["users"]
@@ -763,20 +758,20 @@ class TestACLCascades:
 
         # Verify ACE exists
         resp = api.get(
-            f"/api/v1/admin/acl/by-principal/user/{target['id']}",
+            f"/api/v1/acl/by-principal/user/{target['id']}",
             headers=admin_headers,
         )
         assert len(resp.json()) > 0
 
         # Delete user
         resp = api.delete(
-            f"/api/v1/admin/users/{target['id']}", headers=admin_headers
+            f"/api/v1/users/{target['id']}", headers=admin_headers
         )
         assert resp.status_code == 200
 
         # ACEs should be gone
         resp = api.get(
-            f"/api/v1/admin/acl/by-principal/user/{target['id']}",
+            f"/api/v1/acl/by-principal/user/{target['id']}",
             headers=admin_headers,
         )
         assert resp.json() == []
@@ -785,7 +780,7 @@ class TestACLCascades:
         """Deleting a group removes its ACEs from all resources."""
         # Create a group with an ACE
         resp = api.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=admin_headers,
             json={"name": "cascade-group"},
         )
@@ -793,19 +788,17 @@ class TestACLCascades:
 
         # Verify group shows in ACL queries
         resp = api.get(
-            f"/api/v1/admin/acl/by-principal/group/{group_id}",
+            f"/api/v1/acl/by-principal/group/{group_id}",
             headers=admin_headers,
         )
         # No ACEs yet for this group — that's fine, CASCADE is on FK
 
         # Delete the group
-        resp = api.delete(
-            f"/api/v1/admin/groups/{group_id}", headers=admin_headers
-        )
+        resp = api.delete(f"/api/v1/groups/{group_id}", headers=admin_headers)
         assert resp.status_code == 200
 
         # Group should be gone
-        resp = api.get("/api/v1/admin/groups", headers=admin_headers)
+        resp = api.get("/api/v1/groups", headers=admin_headers)
         assert not any(g["id"] == group_id for g in resp.json()["groups"])
 
 
@@ -935,7 +928,7 @@ class TestAdminResourceACL:
     def test_get_workspaces_acl(self, api, admin_headers):
         """Admin can read the /workspaces static resource ACL."""
         resp = api.get(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=admin_headers,
         )
         assert resp.status_code == 200
@@ -949,7 +942,7 @@ class TestAdminResourceACL:
         """Admin can add and remove ACEs on /workspaces."""
         # Get current
         resp = api.get(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=admin_headers,
         )
         original = resp.json()
@@ -976,7 +969,7 @@ class TestAdminResourceACL:
             },
         ]
         resp = api.put(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=admin_headers,
             json=new_entries,
         )
@@ -996,7 +989,7 @@ class TestAdminResourceACL:
             for e in original
         ]
         resp = api.put(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=admin_headers,
             json=restore,
         )
@@ -1006,7 +999,7 @@ class TestAdminResourceACL:
     def test_non_admin_denied(self, api, nonadmin_user):
         """Non-admin cannot access the resource ACL endpoint."""
         resp = api.get(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=nonadmin_user["headers"],
         )
         assert resp.status_code == 403

--- a/src/klangk/klangkd-tests/e2e-tests/test_concurrent_logon_audit_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_concurrent_logon_audit_e2e.py
@@ -128,7 +128,7 @@ class TestConcurrentLogonAudit:
 
         admin = _login(api, "admin@example.com", "127.0.0.1", "adminpass")
         resp = api.get(
-            f"/api/v1/admin/users/{user_id}/sessions",
+            f"/api/v1/users/{user_id}/sessions",
             headers=_bearer(admin),
         )
         assert resp.status_code == 200, resp.text
@@ -151,7 +151,7 @@ class TestConcurrentLogonAudit:
             "id"
         ]
         resp = api.get(
-            f"/api/v1/admin/users/{user_id}/sessions",
+            f"/api/v1/users/{user_id}/sessions",
             headers=_bearer(token),
         )
         assert resp.status_code == 403

--- a/src/klangk/klangkd-tests/e2e-tests/test_server_schedule_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_server_schedule_e2e.py
@@ -67,7 +67,7 @@ async def test_scheduled_stop_fires_graceful_exit():
         token = _login(own)
         async with await _open_ws(own, token) as ws:
             resp = own["client"].post(
-                "/api/v1/admin/server/schedule",
+                "/api/v1/server/schedule",
                 headers={"Authorization": f"Bearer {token}"},
                 json={"action": "stop", "in_seconds": 3},
                 timeout=10,
@@ -120,7 +120,7 @@ async def test_scheduled_recycle_stays_up():
         token = _login(own)
         async with await _open_ws(own, token) as ws:
             resp = own["client"].post(
-                "/api/v1/admin/server/schedule",
+                "/api/v1/server/schedule",
                 headers={"Authorization": f"Bearer {token}"},
                 json={"action": "recycle", "in_seconds": 3},
                 timeout=10,
@@ -170,7 +170,7 @@ async def test_past_due_stop_fires_on_boot():
     # Create a schedule 1s out, then stop the server before it fires:
     # stop it by killing the process hard so the row survives unfired.
     resp = own["client"].post(
-        "/api/v1/admin/server/schedule",
+        "/api/v1/server/schedule",
         headers={"Authorization": f"Bearer {token}"},
         json={"action": "stop", "in_seconds": 1},
         timeout=10,

--- a/src/klangk/klangkd-tests/super-e2e/test_admin_export_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_admin_export_e2e.py
@@ -15,13 +15,13 @@ from _ws import connect_workspace
 
 def test_admin_users_crud(api, auth):
     headers = auth["headers"]
-    resp = api.get("/api/v1/admin/users?page_size=200", headers=headers)
+    resp = api.get("/api/v1/users?page_size=200", headers=headers)
     assert resp.status_code == 200
     assert any(u["email"] == "admin@example.com" for u in resp.json()["users"])
 
     email = f"admin-made-{uuid.uuid4().hex[:8]}@example.com"
     resp = api.post(
-        "/api/v1/admin/users",
+        "/api/v1/users",
         headers=headers,
         json={"email": email, "password": "made-by-admin"},
     )
@@ -36,7 +36,7 @@ def test_admin_users_crud(api, auth):
     assert resp.status_code == 200
 
     # Delete cascades cleanly.
-    resp = api.delete(f"/api/v1/admin/users/{user_id}", headers=headers)
+    resp = api.delete(f"/api/v1/users/{user_id}", headers=headers)
     assert resp.status_code == 200
 
 

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -175,6 +175,32 @@ async def admin_group(app_state):
         PRINCIPAL_GROUP,
         group_id=group["id"],
     )
+    # First-class resource seeds (#2944), mirroring seed_default_acls.
+    for resource, permission in (
+        ("/users", "manage-users"),
+        ("/groups", "manage-groups"),
+        ("/invitations", "manage-invitations"),
+        ("/server", "manage-server-schedule"),
+        ("/events", "manage-events"),
+        ("/acl", "manage-acls"),
+    ):
+        await acl.add_acl_entry(
+            resource,
+            0,
+            ACTION_ALLOW,
+            permission,
+            PRINCIPAL_GROUP,
+            group_id=group["id"],
+        )
+        await acl.add_acl_entry(
+            resource,
+            1,
+            ACTION_DENY,
+            "*",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_EVERYONE,
+        )
+    # /admin stays as the instance-admin wildcard marker (#2944).
     await acl.add_acl_entry(
         "/admin",
         0,

--- a/src/klangk/klangkd-tests/tests/test_acl.py
+++ b/src/klangk/klangkd-tests/tests/test_acl.py
@@ -186,7 +186,7 @@ class TestCheckPermission:
 class TestCheckPermissionInMemory:
     """The batched in-memory path must match the per-call async path."""
 
-    _RESOURCES = ["/", "/workspaces", "/admin/users"]
+    _RESOURCES = ["/", "/workspaces", "/users"]
     _PERMISSIONS = ["view", "edit", "create", "terminal", "*"]
 
     async def test_inmemory_matches_async_across_resources(
@@ -212,7 +212,7 @@ class TestCheckPermissionInMemory:
             user_id=user["id"],
         )
         await app_state.state.model.acl.add_acl_entry(
-            "/admin/users",
+            "/users",
             0,
             ACTION_DENY,
             "view",
@@ -363,20 +363,24 @@ class TestRequestToResource:
 
     def test_admin_users(self):
         assert (
-            acl.request_to_resource(self._make_request("/admin/users"))
-            == "/admin/users"
+            acl.request_to_resource(self._make_request("/users")) == "/users"
         )
 
-    def test_admin_users_detail(self):
-        assert (
-            acl.request_to_resource(self._make_request("/admin/users/u1"))
-            == "/admin/users/u1"
-        )
-
-    def test_admin_base(self):
-        assert (
-            acl.request_to_resource(self._make_request("/admin")) == "/admin"
-        )
+    def test_flat_resources_collapse_to_collection(self):
+        """#2944: entity trees are flat — per-id paths collapse to the
+        collection so a single manage-* grant covers every object."""
+        for path in (
+            "/users/u1",
+            "/groups/g1/members/u2",
+            "/invitations/i1",
+            "/server/schedule/s1",
+            "/events",
+            "/acl/resource",
+        ):
+            expected = "/" + path.strip("/").split("/")[0]
+            assert (
+                acl.request_to_resource(self._make_request(path)) == expected
+            ), path
 
     def test_other_path(self):
         assert (

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6170,10 +6170,9 @@ class TestWorkspaceGroupSharing:
 
 
 class TestUserGroupEndpoints:
-    """GET /groups (authenticated listing) + the /admin/groups management
-    surface behind manage-groups (#2941-fold: the /groups writes were
-    removed; their semantics — creator ACL grant, ACE cleanup on delete —
-    were ported onto /admin/groups)."""
+    """The /groups surface (#2944): an authenticated listing plus
+    manage-groups-gated writes (creator grant dropped — flat
+    permissions; ACE cleanup on delete retained)."""
 
     async def test_list_groups(self, client, user):
         headers = await _auth_headers(client)
@@ -9188,7 +9187,7 @@ class TestAdminResourceACL:
         assert workspace_scope("/workspaces") is None
         assert workspace_scope("/workspaces/") is None
         assert workspace_scope("/") is None
-        assert workspace_scope("/admin/users/x") is None
+        assert workspace_scope("/users/x") is None
         assert workspace_scope("") is None
         # Malformed: empty id segments are not a workspace target.
         assert workspace_scope("/workspaces//abc") is None
@@ -14679,7 +14678,8 @@ class TestAdminTabPermissions:
     async def test_wildcard_admin_keeps_full_access(
         self, client, app, admin_user
     ):
-        """The seeded /admin Allow * satisfies every tab permission."""
+        """The seeded per-resource Allow rows satisfy every tab
+        permission for admins (plus the /admin wildcard marker)."""
         headers = await self._admin_headers(client)
         for path in (
             "/api/v1/users",
@@ -14690,6 +14690,20 @@ class TestAdminTabPermissions:
         ):
             resp = await client.get(path, headers=headers)
             assert resp.status_code == 200, (path, resp.text)
+
+    async def test_old_admin_paths_are_gone(self, client, admin_user):
+        """#2944: the /admin/* API paths 404 — nothing lives there."""
+        headers = await self._admin_headers(client)
+        for path in (
+            "/api/v1/admin/users",
+            "/api/v1/admin/groups",
+            "/api/v1/admin/invitations",
+            "/api/v1/admin/acl/tree",
+            "/api/v1/admin/server/schedule",
+            "/api/v1/admin/container-events",
+        ):
+            resp = await client.get(path, headers=headers)
+            assert resp.status_code == 404, path
 
     async def test_plain_user_locked_out_everywhere(self, client, app, user):
         headers = await _auth_headers(client)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6216,20 +6216,18 @@ class TestUserGroupEndpoints:
         headers = await self._admin_login(client)
         await app_state.state.model.users.create_group("a-manual-g")
         resp = await client.get(
-            "/api/v1/admin/groups?source=manual", headers=headers
+            "/api/v1/groups?source=manual", headers=headers
         )
         assert resp.status_code == 200
         assert all(g["source"] == "manual" for g in resp.json()["groups"])
-        bad = await client.get(
-            "/api/v1/admin/groups?source=nope", headers=headers
-        )
+        bad = await client.get("/api/v1/groups?source=nope", headers=headers)
         assert bad.status_code == 422
 
     async def test_admin_groups_lifecycle(self, client, app, admin_user):
         """The single management surface, driven by a wildcard admin."""
         headers = await self._admin_login(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "lifecycle-group", "description": "d"},
         )
@@ -6237,30 +6235,19 @@ class TestUserGroupEndpoints:
         group = resp.json()
         gid = group["id"]
 
-        # Ported from POST /groups: the creator gets full ACL access.
-        entries = await app.state.model.acl.get_acl_entries(f"/groups/{gid}")
-        assert any(
-            e["permission"] == "*"
-            and e["principal_type"] == model.PRINCIPAL_USER
-            and e["user_id"] == admin_user["id"]
-            for e in entries
-        )
-
         resp = await client.patch(
-            f"/api/v1/admin/groups/{gid}",
+            f"/api/v1/groups/{gid}",
             headers=headers,
             json={"description": "updated"},
         )
         assert resp.status_code == 200
 
         resp = await client.get(
-            f"/api/v1/admin/groups/{gid}/members", headers=headers
+            f"/api/v1/groups/{gid}/members", headers=headers
         )
         assert resp.status_code == 200
 
-        resp = await client.delete(
-            f"/api/v1/admin/groups/{gid}", headers=headers
-        )
+        resp = await client.delete(f"/api/v1/groups/{gid}", headers=headers)
         assert resp.status_code == 200
         # Ported from DELETE /groups: the group's ACEs are cleaned up.
         entries = await app.state.model.acl.get_acl_entries(f"/groups/{gid}")
@@ -6269,12 +6256,12 @@ class TestUserGroupEndpoints:
     async def test_admin_create_group_duplicate(self, client, admin_user):
         headers = await self._admin_login(client)
         await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "dup-admin-group"},
         )
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "dup-admin-group"},
         )
@@ -6283,7 +6270,7 @@ class TestUserGroupEndpoints:
     async def test_admin_update_nonexistent_group(self, client, admin_user):
         headers = await self._admin_login(client)
         resp = await client.patch(
-            "/api/v1/admin/groups/fake-id",
+            "/api/v1/groups/fake-id",
             headers=headers,
             json={"name": "x"},
         )
@@ -6292,46 +6279,33 @@ class TestUserGroupEndpoints:
     async def test_admin_update_group_no_fields(self, client, admin_user):
         headers = await self._admin_login(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "noupdate-group"},
         )
         gid = resp.json()["id"]
         resp = await client.patch(
-            f"/api/v1/admin/groups/{gid}",
+            f"/api/v1/groups/{gid}",
             headers=headers,
             json={},
         )
         assert resp.status_code == 400
 
-    async def test_old_groups_writes_are_gone(self, client, user):
-        """The /groups write surface is removed (#2941-fold): 404, and
-        GET /groups still works for authenticated listing."""
+    async def test_groups_listing_authenticated_writes_gated(
+        self, client, user
+    ):
+        """#2944: GET /groups is the authenticated listing (pickers);
+        writes on the tree need manage-groups."""
         headers = await _auth_headers(client)
-        # The collection path still exists (GET /groups), so a write
-        # method is a 405; the {id}-based write paths are gone entirely.
-        resp = await client.post(
-            "/api/v1/groups", headers=headers, json={"name": "x"}
-        )
-        assert resp.status_code == 405
-        resp = await client.patch(
-            "/api/v1/groups/some-id", headers=headers, json={"name": "x"}
-        )
-        assert resp.status_code == 404
-        resp = await client.delete("/api/v1/groups/some-id", headers=headers)
-        assert resp.status_code == 404
-        resp = await client.post(
-            "/api/v1/groups/some-id/members",
-            headers=headers,
-            json={"user_id": "u"},
-        )
-        assert resp.status_code == 404
-        resp = await client.delete(
-            "/api/v1/groups/some-id/members/u", headers=headers
-        )
-        assert resp.status_code == 404
         resp = await client.get("/api/v1/groups", headers=headers)
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.text
+
+        resp = await client.post(
+            "/api/v1/groups", headers=headers, json={"name": "nope"}
+        )
+        assert resp.status_code == 403
+        resp = await client.delete("/api/v1/groups/some-id", headers=headers)
+        assert resp.status_code == 403
 
     async def _admin_login(self, client):
         resp = await client.post(
@@ -8094,7 +8068,7 @@ class TestAdminEndpoints:
 
     async def test_list_users(self, client, admin_user, user):
         headers = await self._admin_headers(client)
-        resp = await client.get("/api/v1/admin/users", headers=headers)
+        resp = await client.get("/api/v1/users", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         users = body["users"]
@@ -8118,7 +8092,7 @@ class TestAdminEndpoints:
             await app_state.state.model.users.create_user(
                 f"u{i}@example.com", None, verified=True
             )
-        resp = await client.get("/api/v1/admin/users", headers=headers)
+        resp = await client.get("/api/v1/users", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         assert body["page"] == 1
@@ -8135,10 +8109,10 @@ class TestAdminEndpoints:
                 f"pg{i}@example.com", None, verified=True
             )
         page1 = await client.get(
-            "/api/v1/admin/users?page=1&page_size=3", headers=headers
+            "/api/v1/users?page=1&page_size=3", headers=headers
         )
         page2 = await client.get(
-            "/api/v1/admin/users?page=2&page_size=3", headers=headers
+            "/api/v1/users?page=2&page_size=3", headers=headers
         )
         assert page1.status_code == 200
         assert page2.status_code == 200
@@ -8168,7 +8142,7 @@ class TestAdminEndpoints:
                 e, None, verified=True
             )
         resp = await client.get(
-            "/api/v1/admin/users?sort=email&order=asc&page_size=50",
+            "/api/v1/users?sort=email&order=asc&page_size=50",
             headers=headers,
         )
         emails = [u["email"] for u in resp.json()["users"]]
@@ -8188,11 +8162,11 @@ class TestAdminEndpoints:
                 e, None, verified=True
             )
         asc = await client.get(
-            "/api/v1/admin/users?sort=email&order=asc&page_size=50",
+            "/api/v1/users?sort=email&order=asc&page_size=50",
             headers=headers,
         )
         desc = await client.get(
-            "/api/v1/admin/users?sort=email&order=desc&page_size=50",
+            "/api/v1/users?sort=email&order=desc&page_size=50",
             headers=headers,
         )
         asc_emails = [u["email"] for u in asc.json()["users"]]
@@ -8210,7 +8184,7 @@ class TestAdminEndpoints:
             "haystack@example.com", None, verified=True
         )
         resp = await client.get(
-            "/api/v1/admin/users?q=needle&page_size=50", headers=headers
+            "/api/v1/users?q=needle&page_size=50", headers=headers
         )
         body = resp.json()
         emails = [u["email"] for u in body["users"]]
@@ -8223,7 +8197,7 @@ class TestAdminEndpoints:
         headers = await self._admin_headers(client)
         # An unknown sort column must not 500 (falls back to created_at).
         resp = await client.get(
-            "/api/v1/admin/users?sort=evil%3B%20DROP%20TABLE&order=asc",
+            "/api/v1/users?sort=evil%3B%20DROP%20TABLE&order=asc",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -8240,13 +8214,13 @@ class TestAdminEndpoints:
         headers = {
             "Authorization": f"Bearer {login_resp.json()['access_token']}"
         }
-        resp = await client.get("/api/v1/admin/users", headers=headers)
+        resp = await client.get("/api/v1/users", headers=headers)
         assert resp.status_code == 403
 
     async def test_admin_create_user(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/users",
+            "/api/v1/users",
             headers=headers,
             json={"email": "newuser@example.com", "password": "testpass123"},
         )
@@ -8266,7 +8240,7 @@ class TestAdminEndpoints:
     async def test_admin_create_user_duplicate(self, client, admin_user, user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/users",
+            "/api/v1/users",
             headers=headers,
             json={"email": "testuser@example.com", "password": "testpass"},
         )
@@ -8276,7 +8250,7 @@ class TestAdminEndpoints:
     async def test_admin_create_user_short_password(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/users",
+            "/api/v1/users",
             headers=headers,
             json={"email": "short@example.com", "password": "ab"},
         )
@@ -8293,7 +8267,7 @@ class TestAdminEndpoints:
             new_callable=AsyncMock,
         ) as mock_email:
             resp = await client.post(
-                "/api/v1/admin/users",
+                "/api/v1/users",
                 headers=headers,
                 json={
                     "email": "verify@example.com",
@@ -8319,7 +8293,7 @@ class TestAdminEndpoints:
     ):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/users",
+            "/api/v1/users",
             headers=headers,
             json={"email": "nopw@example.com"},
         )
@@ -8338,7 +8312,7 @@ class TestAdminEndpoints:
             "Authorization": f"Bearer {login_resp.json()['access_token']}"
         }
         resp = await client.post(
-            "/api/v1/admin/users",
+            "/api/v1/users",
             headers=headers,
             json={"email": "new@example.com", "password": "testpass123"},
         )
@@ -8359,13 +8333,11 @@ class TestAdminEndpoints:
             ),
         ):
             resp = await client.delete(
-                f"/api/v1/admin/users/{user['id']}", headers=headers
+                f"/api/v1/users/{user['id']}", headers=headers
             )
         assert resp.status_code == 200
         # Verify user is gone
-        resp = await client.get(
-            "/api/v1/admin/users?page_size=200", headers=headers
-        )
+        resp = await client.get("/api/v1/users?page_size=200", headers=headers)
         emails = [u["email"] for u in resp.json()["users"]]
         assert "testuser@example.com" not in emails
 
@@ -8389,7 +8361,7 @@ class TestAdminEndpoints:
             ),
         ):
             resp = await client.delete(
-                f"/api/v1/admin/users/{user['id']}", headers=headers
+                f"/api/v1/users/{user['id']}", headers=headers
             )
         assert resp.status_code == 200
         assert user["id"] not in app.state.auth.activity_stamps
@@ -8397,7 +8369,7 @@ class TestAdminEndpoints:
     async def test_delete_self_forbidden(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.delete(
-            f"/api/v1/admin/users/{admin_user['id']}", headers=headers
+            f"/api/v1/users/{admin_user['id']}", headers=headers
         )
         assert resp.status_code == 400
 
@@ -8413,7 +8385,7 @@ class TestAdminEndpoints:
         )
         headers = await self._admin_headers(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"password": "testpass"},
         )
@@ -8421,7 +8393,7 @@ class TestAdminEndpoints:
         assert "current" in resp.json()["detail"]
         # A novel password still succeeds.
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"password": "novel-pass-1"},
         )
@@ -8430,7 +8402,7 @@ class TestAdminEndpoints:
     async def test_delete_nonexistent_user(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.delete(
-            "/api/v1/admin/users/nonexistent-id", headers=headers
+            "/api/v1/users/nonexistent-id", headers=headers
         )
         assert resp.status_code == 404
 
@@ -8446,7 +8418,7 @@ class TestAdminEndpoints:
         await Lifecycle(_seed_state).seed_agent_user()
         headers = await self._admin_headers(client)
         resp = await client.delete(
-            f"/api/v1/admin/users/{model.AGENT_USER_ID}", headers=headers
+            f"/api/v1/users/{model.AGENT_USER_ID}", headers=headers
         )
         assert resp.status_code == 400
         assert "system agent" in resp.json()["detail"]
@@ -8481,7 +8453,7 @@ class TestAdminEndpoints:
             new_callable=AsyncMock,
         ):
             resp = await client.delete(
-                f"/api/v1/admin/users/{user['id']}", headers=headers
+                f"/api/v1/users/{user['id']}", headers=headers
             )
         assert resp.status_code == 200
         # Workspace should be gone (CASCADE)
@@ -8530,7 +8502,7 @@ class TestAdminEndpoints:
             ),
         ):
             resp = await client.delete(
-                f"/api/v1/admin/users/{user['id']}", headers=headers
+                f"/api/v1/users/{user['id']}", headers=headers
             )
         assert resp.status_code == 200
         assert ws_id not in registry._workspace_locks
@@ -8544,7 +8516,7 @@ class TestAdminEndpoints:
         user = ws_admin  # ws_admin returns the user dict
         # The `user` fixture owns no workspaces yet.
         resp = await client.get(
-            f"/api/v1/admin/users/{user['id']}/workspaces", headers=headers
+            f"/api/v1/users/{user['id']}/workspaces", headers=headers
         )
         assert resp.status_code == 200
         assert resp.json()["items"] == []
@@ -8568,7 +8540,7 @@ class TestAdminEndpoints:
         )
         assert ws_resp.status_code == 200
         resp = await client.get(
-            f"/api/v1/admin/users/{user['id']}/workspaces", headers=headers
+            f"/api/v1/users/{user['id']}/workspaces", headers=headers
         )
         assert resp.status_code == 200
         names = [ws["name"] for ws in resp.json()["items"]]
@@ -8578,14 +8550,14 @@ class TestAdminEndpoints:
         """Listing workspaces for a nonexistent user 404s."""
         headers = await self._admin_headers(client)
         resp = await client.get(
-            "/api/v1/admin/users/nonexistent-id/workspaces", headers=headers
+            "/api/v1/users/nonexistent-id/workspaces", headers=headers
         )
         assert resp.status_code == 404
 
     async def test_update_email(self, client, admin_user, user, app_state):
         headers = await self._admin_headers(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             json={"email": "renamed"},
             headers=headers,
         )
@@ -8596,7 +8568,7 @@ class TestAdminEndpoints:
     async def test_update_password(self, client, admin_user, user):
         headers = await self._admin_headers(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             json={"password": "newpass123"},
             headers=headers,
         )
@@ -8614,7 +8586,7 @@ class TestAdminEndpoints:
     async def test_update_nonexistent_user(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.patch(
-            "/api/v1/admin/users/nonexistent-id",
+            "/api/v1/users/nonexistent-id",
             json={"email": "x"},
             headers=headers,
         )
@@ -8635,7 +8607,7 @@ class TestAdminEndpoints:
         await Lifecycle(_seed_state).seed_agent_user()
         headers = await self._admin_headers(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{model.AGENT_USER_ID}",
+            f"/api/v1/users/{model.AGENT_USER_ID}",
             json={"password": "sneaky123"},
             headers=headers,
         )
@@ -8660,7 +8632,7 @@ class TestAdminEndpoints:
         assert info["locked_until"] is not None
         # Unlock via admin endpoint
         resp = await client.post(
-            f"/api/v1/admin/users/{user['id']}/unlockout", headers=headers
+            f"/api/v1/users/{user['id']}/unlockout", headers=headers
         )
         assert resp.status_code == 200
         assert resp.json()["status"] == "unlocked"
@@ -8675,7 +8647,7 @@ class TestAdminEndpoints:
     async def test_unlock_nonexistent_user(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/users/nonexistent-id/unlockout", headers=headers
+            "/api/v1/users/nonexistent-id/unlockout", headers=headers
         )
         assert resp.status_code == 404
 
@@ -8689,7 +8661,7 @@ class TestAdminEndpoints:
         )
         headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
         resp = await client.post(
-            f"/api/v1/admin/users/{user['id']}/unlockout", headers=headers
+            f"/api/v1/users/{user['id']}/unlockout", headers=headers
         )
         assert resp.status_code == 403
 
@@ -8744,7 +8716,7 @@ class TestUserSessionsAudit:
             )
             assert resp.status_code == 200
         resp = await client.get(
-            f"/api/v1/admin/users/{user['id']}/sessions", headers=headers
+            f"/api/v1/users/{user['id']}/sessions", headers=headers
         )
         assert resp.status_code == 200
         items = resp.json()["items"]
@@ -8776,7 +8748,7 @@ class TestUserSessionsAudit:
         assert resp.status_code == 200
         headers = await self._admin_headers(client)
         resp = await client.get(
-            f"/api/v1/admin/users/{user['id']}/sessions", headers=headers
+            f"/api/v1/users/{user['id']}/sessions", headers=headers
         )
         assert resp.status_code == 200
         items = resp.json()["items"]
@@ -8787,7 +8759,7 @@ class TestUserSessionsAudit:
     async def test_admin_sessions_404_unknown_user(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.get(
-            "/api/v1/admin/users/no-such-user/sessions", headers=headers
+            "/api/v1/users/no-such-user/sessions", headers=headers
         )
         assert resp.status_code == 404
 
@@ -8801,7 +8773,7 @@ class TestUserSessionsAudit:
         )
         headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
         resp = await client.get(
-            f"/api/v1/admin/users/{user['id']}/sessions", headers=headers
+            f"/api/v1/users/{user['id']}/sessions", headers=headers
         )
         assert resp.status_code == 403
 
@@ -8823,7 +8795,7 @@ class TestGroupEndpoints:
 
     async def test_list_groups(self, client, admin_user):
         headers = await self._admin_headers(client)
-        resp = await client.get("/api/v1/admin/groups", headers=headers)
+        resp = await client.get("/api/v1/groups", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         groups = body["groups"]
@@ -8839,7 +8811,7 @@ class TestGroupEndpoints:
         headers = await self._admin_headers(client)
         for i in range(12):
             await app_state.state.model.users.create_group(f"size-{i}")
-        resp = await client.get("/api/v1/admin/groups", headers=headers)
+        resp = await client.get("/api/v1/groups", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         assert body["page"] == 1
@@ -8854,10 +8826,10 @@ class TestGroupEndpoints:
         for i in range(5):
             await app_state.state.model.users.create_group(f"pg-{i}")
         page1 = await client.get(
-            "/api/v1/admin/groups?page=1&page_size=3", headers=headers
+            "/api/v1/groups?page=1&page_size=3", headers=headers
         )
         page2 = await client.get(
-            "/api/v1/admin/groups?page=2&page_size=3", headers=headers
+            "/api/v1/groups?page=2&page_size=3", headers=headers
         )
         assert page1.status_code == 200
         assert page2.status_code == 200
@@ -8881,7 +8853,7 @@ class TestGroupEndpoints:
         for n in ["charlie", "alpha", "bravo"]:
             await app_state.state.model.users.create_group(n)
         resp = await client.get(
-            "/api/v1/admin/groups?sort=name&order=asc&page_size=200",
+            "/api/v1/groups?sort=name&order=asc&page_size=200",
             headers=headers,
         )
         names = [g["name"] for g in resp.json()["groups"]]
@@ -8895,11 +8867,11 @@ class TestGroupEndpoints:
         for n in ["charlie", "alpha", "bravo"]:
             await app_state.state.model.users.create_group(n)
         asc = await client.get(
-            "/api/v1/admin/groups?sort=name&order=asc&page_size=200",
+            "/api/v1/groups?sort=name&order=asc&page_size=200",
             headers=headers,
         )
         desc = await client.get(
-            "/api/v1/admin/groups?sort=name&order=desc&page_size=200",
+            "/api/v1/groups?sort=name&order=desc&page_size=200",
             headers=headers,
         )
         asc_names = [g["name"] for g in asc.json()["groups"]]
@@ -8913,7 +8885,7 @@ class TestGroupEndpoints:
         await app_state.state.model.users.create_group("needle-group")
         await app_state.state.model.users.create_group("haystack-group")
         resp = await client.get(
-            "/api/v1/admin/groups?q=needle&page_size=200",
+            "/api/v1/groups?q=needle&page_size=200",
             headers=headers,
         )
         body = resp.json()
@@ -8927,7 +8899,7 @@ class TestGroupEndpoints:
         headers = await self._admin_headers(client)
         # An unknown sort column must not 500 (falls back to name).
         resp = await client.get(
-            "/api/v1/admin/groups?sort=evil%3B%20DROP%20TABLE&order=asc",
+            "/api/v1/groups?sort=evil%3B%20DROP%20TABLE&order=asc",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -8936,7 +8908,7 @@ class TestGroupEndpoints:
     async def test_create_group(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "editors", "description": "Editor group"},
         )
@@ -8946,12 +8918,12 @@ class TestGroupEndpoints:
     async def test_create_group_duplicate(self, client, admin_user):
         headers = await self._admin_headers(client)
         await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "dup-group"},
         )
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "dup-group"},
         )
@@ -8960,13 +8932,13 @@ class TestGroupEndpoints:
     async def test_update_group(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "to-rename"},
         )
         group_id = resp.json()["id"]
         resp = await client.patch(
-            f"/api/v1/admin/groups/{group_id}",
+            f"/api/v1/groups/{group_id}",
             headers=headers,
             json={"name": "renamed", "description": "new desc"},
         )
@@ -8975,13 +8947,13 @@ class TestGroupEndpoints:
     async def test_update_group_no_fields(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "no-update"},
         )
         group_id = resp.json()["id"]
         resp = await client.patch(
-            f"/api/v1/admin/groups/{group_id}",
+            f"/api/v1/groups/{group_id}",
             headers=headers,
             json={},
         )
@@ -8990,7 +8962,7 @@ class TestGroupEndpoints:
     async def test_update_group_not_found(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.patch(
-            "/api/v1/admin/groups/nonexistent",
+            "/api/v1/groups/nonexistent",
             headers=headers,
             json={"name": "x"},
         )
@@ -8999,41 +8971,41 @@ class TestGroupEndpoints:
     async def test_delete_group(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "to-delete"},
         )
         group_id = resp.json()["id"]
         resp = await client.delete(
-            f"/api/v1/admin/groups/{group_id}", headers=headers
+            f"/api/v1/groups/{group_id}", headers=headers
         )
         assert resp.status_code == 200
 
     async def test_delete_group_not_found(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.delete(
-            "/api/v1/admin/groups/nonexistent", headers=headers
+            "/api/v1/groups/nonexistent", headers=headers
         )
         assert resp.status_code == 404
 
     async def test_list_group_members(self, client, admin_user, user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "members-test"},
         )
         group_id = resp.json()["id"]
         # Add user to group
         resp = await client.post(
-            f"/api/v1/admin/groups/{group_id}/members",
+            f"/api/v1/groups/{group_id}/members",
             headers=headers,
             json={"user_id": user["id"]},
         )
         assert resp.status_code == 200
         # List members
         resp = await client.get(
-            f"/api/v1/admin/groups/{group_id}/members", headers=headers
+            f"/api/v1/groups/{group_id}/members", headers=headers
         )
         assert resp.status_code == 200
         assert len(resp.json()) == 1
@@ -9042,20 +9014,20 @@ class TestGroupEndpoints:
     async def test_list_group_members_not_found(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.get(
-            "/api/v1/admin/groups/nonexistent/members", headers=headers
+            "/api/v1/groups/nonexistent/members", headers=headers
         )
         assert resp.status_code == 404
 
     async def test_add_group_member_user_not_found(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "member-test2"},
         )
         group_id = resp.json()["id"]
         resp = await client.post(
-            f"/api/v1/admin/groups/{group_id}/members",
+            f"/api/v1/groups/{group_id}/members",
             headers=headers,
             json={"user_id": "nonexistent"},
         )
@@ -9064,7 +9036,7 @@ class TestGroupEndpoints:
     async def test_add_group_member_group_not_found(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups/nonexistent/members",
+            "/api/v1/groups/nonexistent/members",
             headers=headers,
             json={"user_id": "x"},
         )
@@ -9073,18 +9045,18 @@ class TestGroupEndpoints:
     async def test_remove_group_member(self, client, admin_user, user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "remove-test"},
         )
         group_id = resp.json()["id"]
         await client.post(
-            f"/api/v1/admin/groups/{group_id}/members",
+            f"/api/v1/groups/{group_id}/members",
             headers=headers,
             json={"user_id": user["id"]},
         )
         resp = await client.delete(
-            f"/api/v1/admin/groups/{group_id}/members/{user['id']}",
+            f"/api/v1/groups/{group_id}/members/{user['id']}",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -9092,13 +9064,13 @@ class TestGroupEndpoints:
     async def test_remove_group_member_not_member(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/groups",
+            "/api/v1/groups",
             headers=headers,
             json={"name": "rm-test"},
         )
         group_id = resp.json()["id"]
         resp = await client.delete(
-            f"/api/v1/admin/groups/{group_id}/members/nonexistent",
+            f"/api/v1/groups/{group_id}/members/nonexistent",
             headers=headers,
         )
         assert resp.status_code == 404
@@ -9117,7 +9089,7 @@ class TestACLEndpoints:
 
     async def test_get_acl_tree(self, client, admin_user):
         headers = await self._admin_headers(client)
-        resp = await client.get("/api/v1/admin/acl/tree", headers=headers)
+        resp = await client.get("/api/v1/acl/tree", headers=headers)
         assert resp.status_code == 200
         tree = resp.json()
         assert len(tree) > 0
@@ -9125,7 +9097,7 @@ class TestACLEndpoints:
     async def test_get_acl_by_user(self, client, admin_user, user):
         headers = await self._admin_headers(client)
         resp = await client.get(
-            f"/api/v1/admin/acl/by-principal/user/{user['id']}",
+            f"/api/v1/acl/by-principal/user/{user['id']}",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -9136,7 +9108,7 @@ class TestACLEndpoints:
         groups = (await app_state.state.model.users.list_groups())["groups"]
         admin_group = next(g for g in groups if g["name"] == "admins")
         resp = await client.get(
-            f"/api/v1/admin/acl/by-principal/group/{admin_group['id']}",
+            f"/api/v1/acl/by-principal/group/{admin_group['id']}",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -9237,7 +9209,7 @@ class TestAdminResourceACL:
     async def test_get_resource_acl(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.get(
-            "/api/v1/admin/acl/resource?resource=/workspaces", headers=headers
+            "/api/v1/acl/resource?resource=/workspaces", headers=headers
         )
         assert resp.status_code == 200
         entries = resp.json()
@@ -9248,7 +9220,7 @@ class TestAdminResourceACL:
         headers = await self._admin_headers(client)
         # Get current ACL
         resp = await client.get(
-            "/api/v1/admin/acl/resource?resource=/workspaces", headers=headers
+            "/api/v1/acl/resource?resource=/workspaces", headers=headers
         )
         original = resp.json()
 
@@ -9272,7 +9244,7 @@ class TestAdminResourceACL:
             },
         ]
         resp = await client.put(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=headers,
             json=new_entries,
         )
@@ -9292,7 +9264,7 @@ class TestAdminResourceACL:
             for e in original
         ]
         resp = await client.put(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=headers,
             json=restore,
         )
@@ -9301,7 +9273,7 @@ class TestAdminResourceACL:
     async def test_get_resource_acl_requires_admin(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.get(
-            "/api/v1/admin/acl/resource?resource=/workspaces", headers=headers
+            "/api/v1/acl/resource?resource=/workspaces", headers=headers
         )
         assert resp.status_code == 403
 
@@ -9321,7 +9293,7 @@ class TestAdminResourceACL:
 
         headers = await self._admin_headers(client)
         resp = await client.get(
-            f"/api/v1/admin/acl/resource?resource={resource}",
+            f"/api/v1/acl/resource?resource={resource}",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -9338,7 +9310,7 @@ class TestAdminResourceACL:
         ]
         # Site admin alone cannot rewrite an individual workspace's ACL.
         resp = await client.put(
-            f"/api/v1/admin/acl/resource?resource={resource}",
+            f"/api/v1/acl/resource?resource={resource}",
             headers=headers,
             json=payload,
         )
@@ -9356,7 +9328,7 @@ class TestAdminResourceACL:
             user_id=admin_user["id"],
         )
         resp = await client.put(
-            f"/api/v1/admin/acl/resource?resource={resource}",
+            f"/api/v1/acl/resource?resource={resource}",
             headers=headers,
             json=payload,
         )
@@ -9368,7 +9340,7 @@ class TestAdminResourceACL:
         headers = await self._admin_headers(client)
         # Try to save root ACL without Authenticated view
         resp = await client.put(
-            "/api/v1/admin/acl/resource?resource=/",
+            "/api/v1/acl/resource?resource=/",
             headers=headers,
             json=[
                 {
@@ -9388,7 +9360,7 @@ class TestAdminResourceACL:
         headers = await self._admin_headers(client)
         # Authenticated with * should be accepted
         resp = await client.put(
-            "/api/v1/admin/acl/resource?resource=/",
+            "/api/v1/acl/resource?resource=/",
             headers=headers,
             json=[
                 {
@@ -9413,7 +9385,7 @@ class TestAdminResourceACL:
         headers = await self._admin_headers(client)
         # Try to save /admin ACL with no group Allow
         resp = await client.put(
-            "/api/v1/admin/acl/resource?resource=/admin",
+            "/api/v1/acl/resource?resource=/admin",
             headers=headers,
             json=[
                 {
@@ -11532,7 +11504,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ) as mock_send:
             resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "invited@example.com"},
             )
@@ -11551,7 +11523,7 @@ class TestInvitations:
             app.state.auth, "invitations_enabled", lambda: False
         )
         resp = await client.post(
-            "/api/v1/admin/invitations",
+            "/api/v1/invitations",
             headers=headers,
             json={"email": "invited@example.com"},
         )
@@ -11563,7 +11535,7 @@ class TestInvitations:
     ):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/invitations",
+            "/api/v1/invitations",
             headers=headers,
             json={"email": "testuser@example.com"},
         )
@@ -11578,12 +11550,12 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "dup@example.com"},
             )
             resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "dup@example.com"},
             )
@@ -11593,7 +11565,7 @@ class TestInvitations:
     async def test_send_invitation_invalid_email(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/invitations",
+            "/api/v1/invitations",
             headers=headers,
             json={"email": "not-an-email"},
         )
@@ -11611,7 +11583,7 @@ class TestInvitations:
             "Authorization": f"Bearer {login_resp.json()['access_token']}"
         }
         resp = await client.post(
-            "/api/v1/admin/invitations",
+            "/api/v1/invitations",
             headers=headers,
             json={"email": "invited@example.com"},
         )
@@ -11625,16 +11597,16 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "list1@example.com"},
             )
             await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "list2@example.com"},
             )
-        resp = await client.get("/api/v1/admin/invitations", headers=headers)
+        resp = await client.get("/api/v1/invitations", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         invitations = body["invitations"]
@@ -11661,11 +11633,11 @@ class TestInvitations:
         ):
             for i in range(12):
                 await client.post(
-                    "/api/v1/admin/invitations",
+                    "/api/v1/invitations",
                     headers=headers,
                     json={"email": f"page{i}@example.com"},
                 )
-        resp = await client.get("/api/v1/admin/invitations", headers=headers)
+        resp = await client.get("/api/v1/invitations", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         assert body["page"] == 1
@@ -11684,15 +11656,15 @@ class TestInvitations:
         ):
             for i in range(6):
                 await client.post(
-                    "/api/v1/admin/invitations",
+                    "/api/v1/invitations",
                     headers=headers,
                     json={"email": f"pg{i}@example.com"},
                 )
         page1 = await client.get(
-            "/api/v1/admin/invitations?page=1&page_size=3", headers=headers
+            "/api/v1/invitations?page=1&page_size=3", headers=headers
         )
         page2 = await client.get(
-            "/api/v1/admin/invitations?page=2&page_size=3", headers=headers
+            "/api/v1/invitations?page=2&page_size=3", headers=headers
         )
         assert page1.status_code == 200
         assert page2.status_code == 200
@@ -11722,12 +11694,12 @@ class TestInvitations:
                 "bravo@example.com",
             ]:
                 await client.post(
-                    "/api/v1/admin/invitations",
+                    "/api/v1/invitations",
                     headers=headers,
                     json={"email": e},
                 )
         resp = await client.get(
-            "/api/v1/admin/invitations?sort=email&order=asc&page_size=50",
+            "/api/v1/invitations?sort=email&order=asc&page_size=50",
             headers=headers,
         )
         emails = [inv["email"] for inv in resp.json()["invitations"]]
@@ -11754,7 +11726,7 @@ class TestInvitations:
         )
         headers = await self._admin_headers(client)
         resp = await client.get(
-            "/api/v1/admin/invitations?sort=invited_by&order=asc&page_size=50",
+            "/api/v1/invitations?sort=invited_by&order=asc&page_size=50",
             headers=headers,
         )
         rows = resp.json()["invitations"]
@@ -11785,16 +11757,16 @@ class TestInvitations:
                 "bravo@example.com",
             ]:
                 await client.post(
-                    "/api/v1/admin/invitations",
+                    "/api/v1/invitations",
                     headers=headers,
                     json={"email": e},
                 )
         asc = await client.get(
-            "/api/v1/admin/invitations?sort=email&order=asc&page_size=50",
+            "/api/v1/invitations?sort=email&order=asc&page_size=50",
             headers=headers,
         )
         desc = await client.get(
-            "/api/v1/admin/invitations?sort=email&order=desc&page_size=50",
+            "/api/v1/invitations?sort=email&order=desc&page_size=50",
             headers=headers,
         )
         asc_emails = [inv["email"] for inv in asc.json()["invitations"]]
@@ -11809,17 +11781,17 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "needle@example.com"},
             )
             await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "haystack@example.com"},
             )
         resp = await client.get(
-            "/api/v1/admin/invitations?q=needle&page_size=50",
+            "/api/v1/invitations?q=needle&page_size=50",
             headers=headers,
         )
         body = resp.json()
@@ -11835,7 +11807,7 @@ class TestInvitations:
         headers = await self._admin_headers(client)
         # An unknown sort column must not 500 (falls back to created_at).
         resp = await client.get(
-            "/api/v1/admin/invitations?sort=evil%3B%20DROP%20TABLE&order=asc",
+            "/api/v1/invitations?sort=evil%3B%20DROP%20TABLE&order=asc",
             headers=headers,
         )
         assert resp.status_code == 200
@@ -11849,27 +11821,27 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "revoke@example.com"},
             )
         inv_id = create_resp.json()["id"]
         resp = await client.delete(
-            f"/api/v1/admin/invitations/{inv_id}", headers=headers
+            f"/api/v1/invitations/{inv_id}", headers=headers
         )
         assert resp.status_code == 200
         assert resp.json()["status"] == "revoked"
 
         # Can't revoke again
         resp = await client.delete(
-            f"/api/v1/admin/invitations/{inv_id}", headers=headers
+            f"/api/v1/invitations/{inv_id}", headers=headers
         )
         assert resp.status_code == 404
 
     async def test_revoke_nonexistent(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.delete(
-            "/api/v1/admin/invitations/nonexistent-id", headers=headers
+            "/api/v1/invitations/nonexistent-id", headers=headers
         )
         assert resp.status_code == 404
 
@@ -11881,7 +11853,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "resend@example.com"},
             )
@@ -11892,7 +11864,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ) as mock_resend:
             resp = await client.post(
-                f"/api/v1/admin/invitations/{inv_id}/resend", headers=headers
+                f"/api/v1/invitations/{inv_id}/resend", headers=headers
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "resent"
@@ -11901,7 +11873,7 @@ class TestInvitations:
     async def test_resend_nonexistent(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/invitations/nonexistent/resend", headers=headers
+            "/api/v1/invitations/nonexistent/resend", headers=headers
         )
         assert resp.status_code == 404
 
@@ -11913,16 +11885,14 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "revoked-resend@example.com"},
             )
         inv_id = create_resp.json()["id"]
-        await client.delete(
-            f"/api/v1/admin/invitations/{inv_id}", headers=headers
-        )
+        await client.delete(f"/api/v1/invitations/{inv_id}", headers=headers)
         resp = await client.post(
-            f"/api/v1/admin/invitations/{inv_id}/resend", headers=headers
+            f"/api/v1/invitations/{inv_id}/resend", headers=headers
         )
         assert resp.status_code == 404
 
@@ -11934,7 +11904,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "accept@example.com"},
             )
@@ -11976,7 +11946,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "double@example.com"},
             )
@@ -12004,7 +11974,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "short@example.com"},
             )
@@ -12028,7 +11998,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "noreg@example.com"},
             )
@@ -12058,7 +12028,7 @@ class TestInvitations:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "race@example.com"},
             )
@@ -13408,7 +13378,7 @@ class TestHandleEndpoints:
             "Authorization": f"Bearer {admin_resp.json()['access_token']}"
         }
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             json={"handle": "admin-set-handle"},
             headers=admin_headers,
         )
@@ -13435,7 +13405,7 @@ class TestHandleEndpoints:
             new_callable=AsyncMock,
         ) as mock_refresh:
             resp = await client.patch(
-                f"/api/v1/admin/users/{user['id']}",
+                f"/api/v1/users/{user['id']}",
                 json={"handle": "admin-refreshed"},
                 headers=admin_headers,
             )
@@ -13458,7 +13428,7 @@ class TestHandleEndpoints:
             "Authorization": f"Bearer {admin_resp.json()['access_token']}"
         }
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             json={"handle": "", "password": "testpass"},
             headers=admin_headers,
         )
@@ -13555,7 +13525,7 @@ class TestPasswordPolicyRouteEnforcement:
             new_callable=AsyncMock,
         ):
             create_resp = await client.post(
-                "/api/v1/admin/invitations",
+                "/api/v1/invitations",
                 headers=headers,
                 json={"email": "policyinvite@example.com"},
             )
@@ -13575,7 +13545,7 @@ class TestPasswordPolicyRouteEnforcement:
     ):
         headers = await _admin_login(client)
         resp = await client.post(
-            "/api/v1/admin/users",
+            "/api/v1/users",
             headers=headers,
             json={
                 "email": "policyadmin@example.com",
@@ -13590,7 +13560,7 @@ class TestPasswordPolicyRouteEnforcement:
     ):
         headers = await _admin_login(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"password": "alllowercase1!"},
         )
@@ -13630,7 +13600,7 @@ class TestInactivityDisable:
     ):
         headers = await _admin_login(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"disabled": True},
         )
@@ -13649,7 +13619,7 @@ class TestInactivityDisable:
         assert resp.status_code == 403
         # ...and accepted again after re-enable.
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"disabled": False},
         )
@@ -13666,7 +13636,7 @@ class TestInactivityDisable:
     async def test_admin_cannot_disable_self(self, client, admin_user):
         headers = await _admin_login(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{admin_user['id']}",
+            f"/api/v1/users/{admin_user['id']}",
             headers=headers,
             json={"disabled": True},
         )
@@ -13687,7 +13657,7 @@ class TestInactivityDisable:
         await Lifecycle(_seed_state).seed_agent_user()
         headers = await _admin_login(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{model.AGENT_USER_ID}",
+            f"/api/v1/users/{model.AGENT_USER_ID}",
             headers=headers,
             json={"disabled": True},
         )
@@ -13699,9 +13669,7 @@ class TestInactivityDisable:
     ):
         await app.state.model.users.set_user_disabled(user["id"], True)
         headers = await _admin_login(client)
-        resp = await client.get(
-            "/api/v1/admin/users?page_size=200", headers=headers
-        )
+        resp = await client.get("/api/v1/users?page_size=200", headers=headers)
         by_id = {u["id"]: u for u in resp.json()["users"]}
         assert by_id[user["id"]]["disabled"] is True
         assert by_id[admin_user["id"]]["disabled"] is False
@@ -13745,7 +13713,7 @@ class TestInactivityDisable:
 
         headers = await _admin_login(client)
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"disabled": True},
         )
@@ -13754,7 +13722,7 @@ class TestInactivityDisable:
         assert closed == [(4001, "Account disabled")]
         # Re-enable does not touch sockets.
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"disabled": False},
         )
@@ -13799,7 +13767,7 @@ class TestAdminServerSchedule:
     ):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/server/schedule",
+            "/api/v1/server/schedule",
             headers=headers,
             json={"action": "stop", "in_seconds": 3600},
         )
@@ -13808,26 +13776,22 @@ class TestAdminServerSchedule:
         assert schedule["action"] == "stop"
         assert schedule["id"]
 
-        resp = await client.get(
-            "/api/v1/admin/server/schedule", headers=headers
-        )
+        resp = await client.get("/api/v1/server/schedule", headers=headers)
         assert resp.status_code == 200
         assert [s["id"] for s in resp.json()["schedules"]] == [schedule["id"]]
 
         resp = await client.delete(
-            f"/api/v1/admin/server/schedule/{schedule['id']}",
+            f"/api/v1/server/schedule/{schedule['id']}",
             headers=headers,
         )
         assert resp.status_code == 200
-        resp = await client.get(
-            "/api/v1/admin/server/schedule", headers=headers
-        )
+        resp = await client.get("/api/v1/server/schedule", headers=headers)
         assert resp.json()["schedules"] == []
 
     async def test_schedule_absolute_at(self, client, app, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
-            "/api/v1/admin/server/schedule",
+            "/api/v1/server/schedule",
             headers=headers,
             json={"action": "recycle", "at": "2030-01-01T00:00:00+00:00"},
         )
@@ -13844,7 +13808,7 @@ class TestAdminServerSchedule:
             {"action": "stop", "at": "not-a-date"},
         ):
             resp = await client.post(
-                "/api/v1/admin/server/schedule",
+                "/api/v1/server/schedule",
                 headers=headers,
                 json=body,
             )
@@ -13853,7 +13817,7 @@ class TestAdminServerSchedule:
     async def test_schedule_requires_admin(self, client, app, user):
         headers = await _auth_headers(client)
         resp = await client.post(
-            "/api/v1/admin/server/schedule",
+            "/api/v1/server/schedule",
             headers=headers,
             json={"action": "stop", "in_seconds": 60},
         )
@@ -13862,7 +13826,7 @@ class TestAdminServerSchedule:
     async def test_cancel_missing_404(self, client, app, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.delete(
-            "/api/v1/admin/server/schedule/nope", headers=headers
+            "/api/v1/server/schedule/nope", headers=headers
         )
         assert resp.status_code == 404
 
@@ -13872,7 +13836,7 @@ class TestAdminServerSchedule:
             app.state.server_scheduler, "notify_pending", new=AsyncMock()
         ) as mock_notify:
             resp = await client.post(
-                "/api/v1/admin/server/schedule",
+                "/api/v1/server/schedule",
                 headers=headers,
                 json={"action": "stop", "in_seconds": 60},
             )
@@ -13926,9 +13890,7 @@ class TestContainerEventsAPI:
         )
         await events.record(ws_id, EVENT_START, CAUSE_AUTO_START)
 
-        resp = await client.get(
-            "/api/v1/admin/container-events", headers=headers
-        )
+        resp = await client.get("/api/v1/events", headers=headers)
         assert resp.status_code == 200, resp.text
         data = resp.json()
         assert data["total"] == 3
@@ -13965,7 +13927,7 @@ class TestContainerEventsAPI:
         await events.record(ws_b, EVENT_START, CAUSE_API, container_id="b-0")
 
         resp = await client.get(
-            "/api/v1/admin/container-events",
+            "/api/v1/events",
             headers=headers,
             params={"workspace_id": ws_a, "limit": 2, "offset": 1},
         )
@@ -13989,9 +13951,7 @@ class TestContainerEventsAPI:
             CAUSE_DELETE,
             actor_id="no-such-user",
         )
-        resp = await client.get(
-            "/api/v1/admin/container-events", headers=headers
-        )
+        resp = await client.get("/api/v1/events", headers=headers)
         assert resp.status_code == 200
         item = resp.json()["items"][0]
         assert item["workspace_name"] is None
@@ -14002,7 +13962,7 @@ class TestContainerEventsAPI:
         headers = await self._admin_headers(client)
         for params in ({"limit": 0}, {"limit": 501}, {"offset": -1}):
             resp = await client.get(
-                "/api/v1/admin/container-events",
+                "/api/v1/events",
                 headers=headers,
                 params=params,
             )
@@ -14010,9 +13970,7 @@ class TestContainerEventsAPI:
 
     async def test_plain_user_forbidden(self, client, app, user):
         headers = await _auth_headers(client)
-        resp = await client.get(
-            "/api/v1/admin/container-events", headers=headers
-        )
+        resp = await client.get("/api/v1/events", headers=headers)
         assert resp.status_code == 403
 
     async def test_delegated_grant_reads_without_admin(
@@ -14023,7 +13981,7 @@ class TestContainerEventsAPI:
         # the more-specific path wins the ACL walk over /admin's
         # Deny-everyone.
         await app_state.state.model.acl.add_acl_entry(
-            "/admin/container-events",
+            "/events",
             0,
             model.ACTION_ALLOW,
             "manage-events",
@@ -14036,9 +13994,7 @@ class TestContainerEventsAPI:
         )
 
         headers = await _auth_headers(client)
-        resp = await client.get(
-            "/api/v1/admin/container-events", headers=headers
-        )
+        resp = await client.get("/api/v1/events", headers=headers)
         assert resp.status_code == 200, resp.text
         data = resp.json()
         assert data["total"] == 1
@@ -14048,7 +14004,7 @@ class TestContainerEventsAPI:
         # frontend can show the tab to the delegated auditor.
         resp = await client.get("/api/v1/my-permissions", headers=headers)
         perms = resp.json()["permissions"]
-        assert "manage-events" in perms.get("/admin/container-events", [])
+        assert "manage-events" in perms.get("/events", [])
 
     async def test_admin_my_permissions_lists_resource(
         self, client, app, admin_user
@@ -14056,7 +14012,7 @@ class TestContainerEventsAPI:
         headers = await self._admin_headers(client)
         resp = await client.get("/api/v1/my-permissions", headers=headers)
         perms = resp.json()["permissions"]
-        assert "manage-events" in perms.get("/admin/container-events", [])
+        assert "manage-events" in perms.get("/events", [])
 
 
 class TestBranchGaps2834:
@@ -14086,7 +14042,7 @@ class TestBranchGaps2834:
         group = await app.state.model.users.get_group_by_name("admins")
         headers = await _admin_login(client)
         resp = await client.put(
-            "/api/v1/admin/acl/resource?resource=/admin",
+            "/api/v1/acl/resource?resource=/admin",
             headers=headers,
             json=[
                 {
@@ -14726,11 +14682,11 @@ class TestAdminTabPermissions:
         """The seeded /admin Allow * satisfies every tab permission."""
         headers = await self._admin_headers(client)
         for path in (
-            "/api/v1/admin/users",
-            "/api/v1/admin/invitations",
-            "/api/v1/admin/acl/tree",
-            "/api/v1/admin/server/schedule",
-            "/api/v1/admin/container-events",
+            "/api/v1/users",
+            "/api/v1/invitations",
+            "/api/v1/acl/tree",
+            "/api/v1/server/schedule",
+            "/api/v1/events",
         ):
             resp = await client.get(path, headers=headers)
             assert resp.status_code == 200, (path, resp.text)
@@ -14738,12 +14694,12 @@ class TestAdminTabPermissions:
     async def test_plain_user_locked_out_everywhere(self, client, app, user):
         headers = await _auth_headers(client)
         for path in (
-            "/api/v1/admin/users",
-            "/api/v1/admin/groups",
-            "/api/v1/admin/invitations",
-            "/api/v1/admin/acl/tree",
-            "/api/v1/admin/server/schedule",
-            "/api/v1/admin/container-events",
+            "/api/v1/users",
+            "/api/v1/groups/some-id/members",
+            "/api/v1/invitations",
+            "/api/v1/acl/tree",
+            "/api/v1/server/schedule",
+            "/api/v1/events",
         ):
             resp = await client.get(path, headers=headers)
             assert resp.status_code == 403, path
@@ -14751,23 +14707,21 @@ class TestAdminTabPermissions:
     async def test_delegated_manage_users_covers_the_whole_tab(
         self, client, app, user, app_state
     ):
-        await self._grant(
-            app_state, "/admin/users", "manage-users", user["id"]
-        )
+        await self._grant(app_state, "/users", "manage-users", user["id"])
         headers = await _auth_headers(client)
 
-        resp = await client.get("/api/v1/admin/users", headers=headers)
+        resp = await client.get("/api/v1/users", headers=headers)
         assert resp.status_code == 200, resp.text
 
         # Sessions (IP/UA rows) are part of the tab, not a separate gate.
         resp = await client.get(
-            f"/api/v1/admin/users/{user['id']}/sessions", headers=headers
+            f"/api/v1/users/{user['id']}/sessions", headers=headers
         )
         assert resp.status_code == 200, resp.text
 
         # Writes pass the gate too — one permission, whole tab.
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=headers,
             json={"handle": "helpdesk"},
         )
@@ -14775,9 +14729,9 @@ class TestAdminTabPermissions:
 
         # ...and nothing outside the tab.
         for path in (
-            "/api/v1/admin/invitations",
-            "/api/v1/admin/acl/tree",
-            "/api/v1/admin/server/schedule",
+            "/api/v1/invitations",
+            "/api/v1/acl/tree",
+            "/api/v1/server/schedule",
         ):
             resp = await client.get(path, headers=headers)
             assert resp.status_code == 403, path
@@ -14786,41 +14740,39 @@ class TestAdminTabPermissions:
         self, client, app, user, app_state
     ):
         await self._grant(
-            app_state, "/admin/invitations", "manage-invitations", user["id"]
+            app_state, "/invitations", "manage-invitations", user["id"]
         )
         headers = await _auth_headers(client)
 
-        resp = await client.get("/api/v1/admin/invitations", headers=headers)
+        resp = await client.get("/api/v1/invitations", headers=headers)
         assert resp.status_code == 200, resp.text
 
         # Past the gate: 400 because the email belongs to an existing
         # user (no email side effect on this branch).
         resp = await client.post(
-            "/api/v1/admin/invitations",
+            "/api/v1/invitations",
             headers=headers,
             json={"email": "testuser@example.com"},
         )
         assert resp.status_code == 400
         assert "already exists" in resp.json()["detail"]
 
-        resp = await client.get("/api/v1/admin/users", headers=headers)
+        resp = await client.get("/api/v1/users", headers=headers)
         assert resp.status_code == 403
 
     async def test_delegated_manage_server_schedule_covers_create_and_list(
         self, client, app, user, app_state
     ):
         await self._grant(
-            app_state, "/admin/server", "manage-server-schedule", user["id"]
+            app_state, "/server", "manage-server-schedule", user["id"]
         )
         headers = await _auth_headers(client)
 
-        resp = await client.get(
-            "/api/v1/admin/server/schedule", headers=headers
-        )
+        resp = await client.get("/api/v1/server/schedule", headers=headers)
         assert resp.status_code == 200, resp.text
 
         resp = await client.post(
-            "/api/v1/admin/server/schedule",
+            "/api/v1/server/schedule",
             headers=headers,
             json={"action": "stop", "in_seconds": 3600},
         )
@@ -14828,7 +14780,7 @@ class TestAdminTabPermissions:
         schedule_id = resp.json()["id"]
 
         resp = await client.delete(
-            f"/api/v1/admin/server/schedule/{schedule_id}", headers=headers
+            f"/api/v1/server/schedule/{schedule_id}", headers=headers
         )
         assert resp.status_code == 200, resp.text
 
@@ -14839,15 +14791,15 @@ class TestAdminTabPermissions:
         rewrite ACLs on ANY resource — including collections like
         /workspaces — so the permission is root-equivalent and granted
         only to administrators. This pins that deliberately."""
-        await self._grant(app_state, "/admin/acl", "manage-acls", user["id"])
+        await self._grant(app_state, "/acl", "manage-acls", user["id"])
         headers = await _auth_headers(client)
 
-        resp = await client.get("/api/v1/admin/acl/tree", headers=headers)
+        resp = await client.get("/api/v1/acl/tree", headers=headers)
         assert resp.status_code == 200, resp.text
 
         # Read the current entries, append a self-grant, replace.
         resp = await client.get(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=headers,
         )
         assert resp.status_code == 200, resp.text
@@ -14873,7 +14825,7 @@ class TestAdminTabPermissions:
             }
         )
         resp = await client.put(
-            "/api/v1/admin/acl/resource?resource=/workspaces",
+            "/api/v1/acl/resource?resource=/workspaces",
             headers=headers,
             json=entries,
         )
@@ -14888,19 +14840,17 @@ class TestAdminTabPermissions:
         assert resp.status_code == 200, resp.text
 
         # manage-acls alone opens no other tab.
-        resp = await client.get("/api/v1/admin/users", headers=headers)
+        resp = await client.get("/api/v1/users", headers=headers)
         assert resp.status_code == 403
 
     async def test_my_permissions_surfaces_tab_names(
         self, client, app, user, app_state
     ):
-        await self._grant(
-            app_state, "/admin/users", "manage-users", user["id"]
-        )
+        await self._grant(app_state, "/users", "manage-users", user["id"])
         headers = await _auth_headers(client)
         resp = await client.get("/api/v1/my-permissions", headers=headers)
         perms = resp.json()["permissions"]
-        assert "manage-users" in perms.get("/admin/users", [])
+        assert "manage-users" in perms.get("/users", [])
 
     async def test_admin_my_permissions_lists_all_tab_names(
         self, client, app, admin_user
@@ -14915,5 +14865,5 @@ class TestAdminTabPermissions:
             "manage-events",
         ):
             assert name in perms.get("/admin", [])
-        assert "manage-acls" in perms.get("/admin/acl", [])
-        assert "manage-events" in perms.get("/admin/container-events", [])
+        assert "manage-acls" in perms.get("/acl", [])
+        assert "manage-events" in perms.get("/events", [])

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -35,7 +35,7 @@ api_auth = sys.modules["klangk.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 91
+EXPECTED_ROUTE_COUNT = 90
 
 # Per-domain submodules and the number of routes each owns.  86 sub-routes
 # + 3 routes defined directly on the main router (version, config,
@@ -45,7 +45,7 @@ SUBMODULE_ROUTES = {
     "workspaces": 27,
     "resources": 10,  # 6 files + 4 images/volumes (merged submodules)
     "browser_delegate": 2,
-    "admin": 28,
+    "admin": 27,
     "llm_proxy": 2,
 }
 
@@ -82,16 +82,17 @@ REPRESENTATIVE_PATHS = [
     # browser bridge
     f"{API_PREFIX}/browser-delegate",
     f"{API_PREFIX}/browser-delegate/stream",
-    # admin (users / groups / invitations / acl)
-    f"{API_PREFIX}/admin/users",
-    f"{API_PREFIX}/admin/invitations",
-    f"{API_PREFIX}/admin/groups",
-    f"{API_PREFIX}/admin/acl/tree",
+    # first-class resources (#2944): users / groups / invitations /
+    # server / events / acl
+    f"{API_PREFIX}/users",
+    f"{API_PREFIX}/invitations",
+    f"{API_PREFIX}/groups",
+    f"{API_PREFIX}/server/schedule",
+    f"{API_PREFIX}/events",
+    f"{API_PREFIX}/acl/tree",
     # llm proxy (#2072)
     "/llm-proxy/models",
     "/llm-proxy/chat/completions",
-    # user-accessible groups
-    f"{API_PREFIX}/groups",
 ]
 
 
@@ -247,8 +248,8 @@ class TestSubmoduleStructure:
         total = 0
         for submod in SUBMODULE_ROUTES:
             total += len(import_module(f"klangk.api.{submod}").router.routes)
-        # 86 sub-routes + 3 direct (version/config/my-permissions) + 2
-        # root (health/empty) == 91.
+        # 85 sub-routes + 3 direct (version/config/my-permissions) + 2
+        # root (health/empty) == 90.
         assert total == EXPECTED_ROUTE_COUNT - 3 - 2
 
     def test_common_module_has_no_router(self):
@@ -333,4 +334,4 @@ def test_static_resources_single_source():
     assert not hasattr(api_admin, "STATIC_RESOURCES")
     # #2923's events resource must be reported so the frontend can gate
     # the Events tab on the dedicated permission.
-    assert "/admin/container-events" in api.STATIC_RESOURCES
+    assert "/events" in api.STATIC_RESOURCES

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -521,6 +521,30 @@ class TestConsentDeciderWS:
         assert ws.closed == (4003, "Forbidden")
         assert ws.accepted is False
 
+    async def test_deploy_wide_gate_checks_server_schedule(self):
+        """#2944: the deploy-wide handshake checks manage-server-schedule
+        on /server (previously the legacy admin-on-/admin gate) — pin
+        the exact resource and permission so a regression back to the
+        old names fails here, not in production."""
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "admin@x"})
+        checked = []
+
+        async def check(resource, principals, perm):
+            checked.append((resource, perm))
+            return perm == "manage-server-schedule"
+
+        app.state.acl.check_permission = AsyncMock(side_effect=check)
+        ws = _FakeWS({"token": "tok"}, [WebSocketDisconnect()])
+        await handle_consent_decider(ws, app)
+        assert ws.accepted is True
+        assert ("/server", "manage-server-schedule") in checked
+        # The old gate must not appear at all.
+        assert ("/admin", "admin") not in checked
+
     async def test_ping_touches_and_pongs(self):
         from fastapi import WebSocketDisconnect
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -5838,6 +5838,33 @@ def _health_state(
     return st
 
 
+class _CountingBool:
+    """A bool stand-in that counts evaluations — used to observe that
+    the health loop actually iterated before the test cancels it (a
+    fixed sleep window can expire under -n auto load before the first
+    tick, silently losing the skip-branch coverage, #2944)."""
+
+    def __init__(self, value: bool) -> None:
+        self.value = value
+        self.reads = 0
+
+    def __bool__(self) -> bool:
+        self.reads += 1
+        return self.value
+
+
+async def _wait_for_called(check, ticks: int = 500) -> None:
+    """Deterministically wait for a mocked call instead of a fixed
+    sleep: under -n auto load a 50ms window can elapse before the
+    health loop's first tick, de-flaking both the assertion and the
+    line coverage (#2944)."""
+    for _ in range(ticks):
+        if check.called:
+            return
+        await asyncio.sleep(0.001)
+    raise AssertionError("health loop never called _check_workspace")
+
+
 class TestHealthMonitorRunOne:
     def setup_method(self):
         app_state = _make_app_state()
@@ -6354,11 +6381,20 @@ class TestHealthMonitorLoopSkips:
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
                 patch.object(
+                    monitor,
+                    "_setup_complete",
+                    MagicMock(return_value=False),
+                ) as setup,
+                patch.object(
                     reg.app.state.settings, "health_check_interval", 0.01
                 ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
-                await asyncio.sleep(0.05)
+                for _ in range(500):
+                    if setup.call_count:
+                        break
+                    await asyncio.sleep(0.001)
+                assert setup.call_count, "loop never iterated"
                 task.cancel()
                 try:
                     await task
@@ -6372,6 +6408,8 @@ class TestHealthMonitorLoopSkips:
         reg = _health_registry()
         monitor = reg.health
         st = _health_state(health_check=None)
+        gate = _CountingBool(False)
+        st.health_check = gate
         reg.states[st.workspace_id] = st
         try:
             with (
@@ -6383,7 +6421,11 @@ class TestHealthMonitorLoopSkips:
                 ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
-                await asyncio.sleep(0.05)
+                for _ in range(500):
+                    if gate.reads:
+                        break
+                    await asyncio.sleep(0.001)
+                assert gate.reads, "loop never iterated"
                 task.cancel()
                 try:
                     await task
@@ -6408,7 +6450,7 @@ class TestHealthMonitorLoopSkips:
                 ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
-                await asyncio.sleep(0.05)
+                await _wait_for_called(check)
                 task.cancel()
                 try:
                     await task

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -231,9 +231,9 @@ class TestSeedDefaultUser:
 
 
 class TestSeedDefaultAcls:
-    """Seeded-ACL shape. The /groups `create` seed (tightened in #2770)
-    was removed entirely in #2940 — group management rides the /admin
-    `*` wildcard; fresh installs seed nothing on /groups."""
+    """Seeded-ACL shape (#2944): the first-class trees each seed an
+    Allow manage-* (admins) + Deny everyone pair; /admin remains as
+    the wildcard-admin marker."""
 
     async def test_first_class_resources_seeded(self, db, app_state):
         """#2944: each first-class tree seeds Allow manage-* (admins) +

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -235,16 +235,29 @@ class TestSeedDefaultAcls:
     was removed entirely in #2940 — group management rides the /admin
     `*` wildcard; fresh installs seed nothing on /groups."""
 
-    async def test_groups_create_not_seeded(self, db, app_state):
-        """#2941-fold: the /groups `create` seed is gone — the write
-        surface is /admin/groups behind manage-groups, covered for
-        admins by the /admin * wildcard (no per-resource seed needed)."""
+    async def test_first_class_resources_seeded(self, db, app_state):
+        """#2944: each first-class tree seeds Allow manage-* (admins) +
+        Deny everyone; /admin remains as the wildcard-admin marker."""
         lifecycle = _lifecycle(make_settings({}))
         admin_group_id = await lifecycle.ensure_admin_group()
         await lifecycle.seed_default_acls(admin_group_id)
 
-        entries = await app_state.state.model.acl.get_acl_entries("/groups")
-        assert entries == []
+        for resource, permission in (
+            ("/users", "manage-users"),
+            ("/groups", "manage-groups"),
+            ("/invitations", "manage-invitations"),
+            ("/server", "manage-server-schedule"),
+            ("/events", "manage-events"),
+            ("/acl", "manage-acls"),
+        ):
+            entries = await app_state.state.model.acl.get_acl_entries(resource)
+            assert len(entries) == 2, resource
+            allow, deny = entries
+            assert allow["permission"] == permission
+            assert allow["group_id"] == admin_group_id
+            assert deny["permission"] == "*"
+            assert deny["system_principal"] == model.SYSTEM_EVERYONE
+
         admin_entries = await app_state.state.model.acl.get_acl_entries(
             "/admin"
         )

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -1935,3 +1935,30 @@ class TestM0021FirstClassResourceAcls:
                 ], resource
         finally:
             await db.__aexit__(None, None, None)
+
+    async def test_legacy_groups_seed_is_replaced(self, tmp_path):
+        """The blocker the #2945 review proved: every pre-#2943
+        deployment carries the m0014-rewritten Allow create row on
+        /groups. The migration must replace it with the manage-groups
+        pair — leaving it locks admins out of group management."""
+        from klangk.model.migrations import m0021_first_class_resource_acls
+
+        db = await self._db(tmp_path)
+        try:
+            gid = await self._admins(db)
+            # The m0014 output shape: single Allow create for the group.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission) VALUES ('/groups', 0, 1, 2, ?, 'create')",
+                (gid,),
+            )
+            await db.commit()
+            await m0021_first_class_resource_acls.migration.apply(db)
+
+            assert await self._entries(db, "/groups") == [
+                (0, 1, "manage-groups", gid, None),
+                (1, 0, "*", None, 0),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -73,6 +73,7 @@ class TestRunner:
             (18, "0018_egress_consent_permission"),
             (19, "0019_container_events"),
             (20, "0020_rename_admin_group"),
+            (21, "0021_first_class_resource_acls"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -159,6 +160,7 @@ class TestRunner:
                 (18, "0018_egress_consent_permission"),
                 (19, "0019_container_events"),
                 (20, "0020_rename_admin_group"),
+                (21, "0021_first_class_resource_acls"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -1777,5 +1779,159 @@ class TestM0020RenameAdminGroup:
             )
             await m0020_rename_admin_group.migration.apply(db)
             assert await self._names(db) == {"g1": "admins"}
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0021FirstClassResourceAcls:
+    """m0021 seeds Allow manage-* (admins) + Deny everyone on each
+    first-class resource (#2944) — without the rows, admins lock out of
+    users/groups/invitations/server/events/acl the moment the checks
+    move off the /admin wildcard."""
+
+    RESOURCE_PERMS = {
+        "/users": "manage-users",
+        "/groups": "manage-groups",
+        "/invitations": "manage-invitations",
+        "/server": "manage-server-schedule",
+        "/events": "manage-events",
+        "/acl": "manage-acls",
+    }
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0021.db"))
+        db = await db.__aenter__()
+        # Minimal shape the migration touches (mirrors the m0013 test's
+        # harness): groups + acl_entries only.
+        await db.execute(
+            "CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT)"
+        )
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT,"
+            " UNIQUE(resource, position))"
+        )
+        return db
+
+    async def _admins(self, db) -> str:
+        await db.execute(
+            "INSERT INTO groups (id, name) VALUES ('g-admins', 'admins')"
+        )
+        await db.commit()
+        return "g-admins"
+
+    async def _entries(self, db, resource) -> list:
+        cursor = await db.execute(
+            "SELECT position, action, permission, group_id,"
+            " system_principal FROM acl_entries WHERE resource = ?"
+            " ORDER BY position",
+            (resource,),
+        )
+        return list(await cursor.fetchall())
+
+    async def test_upgraded_db_gets_all_six_pairs(self, tmp_path):
+        from klangk.model.migrations import m0021_first_class_resource_acls
+
+        db = await self._db(tmp_path)
+        try:
+            gid = await self._admins(db)
+            # An "upgraded" DB has some ACL rows already (the old seeds).
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission) VALUES ('/', 0, 1, 2, ?, 'view')",
+                (gid,),
+            )
+            await db.commit()
+            await m0021_first_class_resource_acls.migration.apply(db)
+
+            for resource, permission in self.RESOURCE_PERMS.items():
+                assert await self._entries(db, resource) == [
+                    (0, 1, permission, gid, None),
+                    (1, 0, "*", None, 0),
+                ], resource
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_empty_table_is_a_noop(self, tmp_path):
+        """Fresh DBs are the boot seed's job — inserting here would trip
+        the seed's empty-table gate and lose the / and /workspaces rows."""
+        from klangk.model.migrations import m0021_first_class_resource_acls
+
+        db = await self._db(tmp_path)
+        try:
+            await self._admins(db)
+            await m0021_first_class_resource_acls.migration.apply(db)
+            for resource in self.RESOURCE_PERMS:
+                assert await self._entries(db, resource) == []
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_pre_staged_resource_is_untouched(self, tmp_path):
+        """An operator who pre-staged grants on one resource keeps them
+        verbatim — the migration never half-merges onto unknown rows."""
+        from klangk.model.migrations import m0021_first_class_resource_acls
+
+        db = await self._db(tmp_path)
+        try:
+            gid = await self._admins(db)
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission) VALUES ('/users', 5, 1, 2, ?,"
+                " 'manage-users')",
+                (gid,),
+            )
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/groups', 0, 1, 0, 1, 'custom')"
+            )
+            await db.commit()
+            await m0021_first_class_resource_acls.migration.apply(db)
+
+            # /users: exactly the operator's row.
+            assert await self._entries(db, "/users") == [
+                (5, 1, "manage-users", gid, None)
+            ]
+            # /groups: skipped too (any rows present -> skip).
+            assert await self._entries(db, "/groups") == [
+                (0, 1, "custom", None, 1)
+            ]
+            # Untouched resources still get the pair.
+            assert await self._entries(db, "/acl") == [
+                (0, 1, "manage-acls", gid, None),
+                (1, 0, "*", None, 0),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_no_admins_group_still_denies_everyone(self, tmp_path):
+        """A deployment with no 'admins' group (custom topology) gets the
+        Deny rows only — the Allow rows have no principal to name, and
+        default-deny applies either way."""
+        from klangk.model.migrations import m0021_first_class_resource_acls
+
+        db = await self._db(tmp_path)
+        try:
+            # No groups row at all; some existing ACL rows so the
+            # migration is not in fresh-skip territory.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/', 0, 1, 0, 1, 'view')"
+            )
+            await db.commit()
+            await m0021_first_class_resource_acls.migration.apply(db)
+
+            for resource in self.RESOURCE_PERMS:
+                assert await self._entries(db, resource) == [
+                    (1, 0, "*", None, 0)
+                ], resource
         finally:
             await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_mode_switching.py
+++ b/src/klangk/klangkd-tests/tests/test_mode_switching.py
@@ -169,7 +169,7 @@ class TestNoneToPasswordUpgrade:
 
         # admin set-password equivalent.
         resp = await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers=h,
             json={"password": NEW_PASSWORD},
         )
@@ -186,7 +186,7 @@ class TestNoneToPasswordUpgrade:
             "access_token"
         ]
         await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers={"Authorization": f"Bearer {token}"},
             json={"password": NEW_PASSWORD},
         )
@@ -210,7 +210,7 @@ class TestNoneToPasswordUpgrade:
             "access_token"
         ]
         await client.patch(
-            f"/api/v1/admin/users/{user['id']}",
+            f"/api/v1/users/{user['id']}",
             headers={"Authorization": f"Bearer {token}"},
             json={"password": NEW_PASSWORD},
         )

--- a/src/klangk/klangkd-tests/tests/test_mode_switching.py
+++ b/src/klangk/klangkd-tests/tests/test_mode_switching.py
@@ -150,7 +150,7 @@ class TestNoneToPasswordUpgrade:
     async def test_free_token_is_admin_and_can_set_password(
         self, mode_server, monkeypatch
     ):
-        """Steps 1-2: get the free token, then ``PATCH /admin/users/{id}``
+        """Steps 1-2: get the free token, then ``PATCH /users/{id}``
         with a new password — succeeds because the seeded default user is an
         admin."""
         client, user = mode_server


### PR DESCRIPTION
## Summary

Location tranche of #2890, closing #2944 (design locked in the issue). **`/admin` retires as a permission-checking resource**: every governed surface moves to a first-class top-level tree with one flat `manage-*` permission. The resource tree becomes pure nouns; `/admin` keeps only its seeded `*` row as the instance-administrator marker (nothing checks a permission there anymore — including the WS decider, re-pointed to `manage-server-schedule` on `/server`).

| Resource | Permission | Notes |
|----------|------------|-------|
| `/users*` | `manage-users` | all user reads/writes; `/users/search` stays authenticated (pickers) |
| `/groups*` | `manage-groups` | writes gated; `GET /groups` merged into one authenticated listing; creator-`*` ACE dropped (unreachable under flat permissions) |
| `/invitations*` | `manage-invitations` | list/send/resend/revoke |
| `/server/schedule*` | `manage-server-schedule` | + drain/consent decider WS re-point |
| `/events` | `manage-events` | read-only audit (was `/admin/container-events`) |
| `/acl/*` | `manage-acls` | root-equivalent, unchanged semantics |

## Migration (lockout-critical)

`request_to_resource` drops the `/admin` special case (one-segment fallback collapses `/users/{id}` etc. — flat by design). `seed_default_acls` emits Allow (admins) + Deny (everyone) on each new resource; **m0021** inserts the same pairs on existing deployments — no-op on fresh DBs (the boot seed owns those; inserting would trip the seed's empty-table gate) and on operator-pre-staged resources. Without m0021 in the same release, admins lock out of every moved surface. Behavioral migration tests cover all three cases.

## Consumers migrated

Frontend (tab gates, `canAdminSection`, ACL browser sidebar → Root/Workspaces/Users/Groups/Invitations/Server/Events/ACL, members-picker type-ahead), CLI `klangk admin` commands, e2e + demo seeds, `fmtk-seed.py`, `fuzz-api.py`, `api-endpoints.md`, `acl.md` (rewritten seeded-defaults table + resource-tree diagram + per-resource delegation recipe), changelog (Added + Breaking path-move entry).

## Tests

Backend 6502 passed / 100% branch coverage (incl. `scripts/tests`; new `TestM0021FirstClassResourceAcls`, re-pointed route-parity + seed tests). Frontend 1177 passed. Also de-flaked the health-loop skip tests (wait for a tick signal instead of a fixed 50ms window — under `-n auto` load the window could expire before the first tick, silently losing the skip-branch coverage).
