### PR TITLE
ci: authenticate nix GitHub API calls with the job token

### DIFF
--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -14,10 +14,16 @@ runs:
     # install.determinate.systems substituter to strip out (the workaround
     # for #1420 is no longer needed). Flakes/nix-command are turned on both
     # by the action's built-in --enable-flakes flag and explicitly below.
+    # access-tokens authenticates nix's api.github.com calls (flake tag -> rev
+    # resolution in the bootstrap step) with the job's GITHUB_TOKEN. Without
+    # it those calls are unauthenticated and share the runner IP's 60 req/hr
+    # limit with every other tenant, so a busy neighbor IP can 403 the
+    # bootstrap (#2948). The token is job-scoped and the runner is ephemeral.
     - uses: NixOS/nix-installer-action@v1
       with:
         extra-conf: |
           experimental-features = nix-command flakes
+          access-tokens = github.com=${{ github.token }}
 
     - name: Free disk space
       if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

Adds `access-tokens = github.com=${{ github.token }}` to the `nix-installer-action` `extra-conf` in the shared `devenv-setup` composite action, closing #2948.

## Why

The `Bootstrap` step runs `nix profile install github:cachix/devenv/v2.2.2`, which resolves the tag → rev via an **unauthenticated** GET to `api.github.com`. GitHub-hosted runners share egress IPs across tenants, and the unauthenticated API limit is 60 req/hr per IP — a busy neighbor IP can 403 the bootstrap and cascade-fail every downstream step. Observed on the scheduled CDK host pentest ([run 33505286835](https://github.com/mcdonc/klangk/actions/runs/33505286835), job 99847782467):

```
error: unable to download 'https://api.github.com/repos/cachix/devenv/commits/v2.2.2': HTTP error 403
Probe failed with '/bin/sh: 1: devenv: not found'
```

With the job's `GITHUB_TOKEN` baked into `/etc/nix/nix.conf`, nix authenticates those calls (per-repo limits instead of shared per-IP). The token is job-scoped and runners are ephemeral, so nothing sensitive outlives the job. All nix-booting workflows go through this single composite action, so one line covers the five E2E suites, image builds, both CDK pentests, and the rest.

## Testing

- `actionlint` on workflows that reference the action: clean.
- pre-commit hooks (yamllint, prettier, trufflehog) passed on the commit. Trufflehog confirms no secret leakage — `github.token` is the runner-provided ephemeral token, not a stored credential.
- No product code touched; no changelog entry (CI-only change).
