### PR TITLE
Add "Built with devenv" and "Built with Nix" badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Klangk
 
+[![Built with devenv](https://devenv.sh/assets/devenv-badge.svg)](https://devenv.sh)
+[![Built with Nix](https://img.shields.io/static/v1?logo=nixos&logoColor=white&label=&message=Built%20with%20Nix&color=41439a)](https://builtwithnix.org)
+
 ![Klangk Web Coding Agent](docs/screenshot.png)
 
 Klangk is a multi-user AI sandboxing, collaboration and coding platform.


### PR DESCRIPTION
## Summary

Adds the "Built with devenv" and "Built with Nix" badges (the same pair used at the top of the [cachix/devenv README](https://github.com/cachix/devenv)) directly under the `# Klangk` heading, above the screenshot. Badges sit below the heading to satisfy `markdownlint` MD041 (first line must be a top-level heading).

Closes #2950.
