### PR TITLE
fix(sandbox): per-workspace openclaw gateway state for shared mounts (#2947)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1714,6 +1714,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **OpenClaw sandbox: every workspace sharing a mount now runs its own
+  gateway (#2947).** openclaw 2026.8.1 added a single-instance gateway
+  lock under its state dir, which defaulted onto the shared `/openclaw`
+  mount — so with several workspaces at one mount only the first
+  workspace's gateway could start and every other workspace's health
+  check reported `unhealthy` forever. Setup now points
+  `OPENCLAW_STATE_DIR` at the per-workspace agent home (own lock and
+  state per workspace) while `OPENCLAW_CONFIG_PATH` keeps the shared
+  config on the mount.
+
 - **Window watcher start/stop race (#2929).** A quick connect→disconnect
   on a live workspace could land `stop()` inside the tmux control-mode
   watcher's still-in-flight start, leaving the host-side podman exec

--- a/docs/sandboxes/openclaw.md
+++ b/docs/sandboxes/openclaw.md
@@ -54,3 +54,9 @@ the user's home directory:
 - **`/openclaw/.openclaw/openclaw.json`** — pre-seeded config using
   the Klangk LLM proxy with dynamic token auth, gateway bound to
   container port 8000 for hosted app access
+
+Runtime state (the gateway's single-instance lock and sqlite store)
+lives per workspace under the agent home
+(`~/.openclaw-state`, `OPENCLAW_STATE_DIR`), not on the shared mount:
+openclaw ≥ 2026.8.1 would otherwise let only the first workspace at a
+shared mount run a gateway (#2947).

--- a/sandboxes/openclaw/healthcheck.sh
+++ b/sandboxes/openclaw/healthcheck.sh
@@ -17,6 +17,16 @@
 # See docs/features/health-check.md.
 set -euo pipefail
 export OPENCLAW_HOME=/openclaw
+# Per-workspace gateway state (#2947): the gateway's single-instance
+# lock and sqlite state live under OPENCLAW_STATE_DIR (the agent's
+# per-workspace home), while the config stays shared on the mount via
+# OPENCLAW_CONFIG_PATH. This mirror of setup.sh's ~/.profile exports is
+# required because this wrapper runs as a NON-login shell and sources
+# nothing; $HOME here is the image default (/home), NOT the agent home,
+# so KLANGKWS_AGENT_HOME (injected into every podman exec) supplies the
+# per-workspace path with a matching fallback.
+export OPENCLAW_STATE_DIR="${KLANGKWS_AGENT_HOME:-/home/klangk}/.openclaw-state"
+export OPENCLAW_CONFIG_PATH=/openclaw/.openclaw/openclaw.json
 
 # `openclaw health` connects to the running gateway over WebSocket and
 # exits non-zero if it is unreachable -- a liveness check for the

--- a/sandboxes/openclaw/setup.sh
+++ b/sandboxes/openclaw/setup.sh
@@ -39,6 +39,9 @@ export HOME="${KLANGKWS_AGENT_HOME:-/home/klangk}"
 # pointer set from its very first spawn:
 #   - NVM_DIR + nvm.sh source (so nvm/node load in new shells)
 #   - /openclaw/bin on PATH (so the `openclaw` binary is found)
+#   - OPENCLAW_STATE_DIR + OPENCLAW_CONFIG_PATH (so each workspace's
+#     gateway holds its own lock and state in the agent home while
+#     every workspace reads the one shared config on the mount, #2947)
 #   - OPENCLAW_HOME (so openclaw locates its config; the agent's
 #     $HOME is /home/klangk, not /openclaw, so without this openclaw
 #     looks in the wrong place and reports "Missing config" -- #1039)
@@ -55,6 +58,27 @@ fi
 # shellcheck disable=SC2016
 if ! grep -q "$INSTALL_DIR/bin" ~/.profile 2>/dev/null; then
   echo "export PATH=\"$INSTALL_DIR/bin:\$PATH\"" >>~/.profile
+fi
+# Per-workspace gateway state (#2947): openclaw >= 2026.8.1 enforces a
+# single-instance gateway lock (and keeps its sqlite state) under the
+# STATE dir, resolving config as state-dir-derived before anything
+# else. The state dir defaults to $OPENCLAW_HOME/.openclaw -- ON THE
+# SHARED MOUNT -- so the first workspace's gateway holds the lock for
+# the life of its container and every other workspace at the same
+# mount dies with "gateway already running" while its health check
+# polls a loopback nobody binds. Pointing OPENCLAW_STATE_DIR into the
+# agent's (per-workspace) home gives each workspace its own lock and
+# state; OPENCLAW_CONFIG_PATH pins config resolution to the shared
+# config on the mount so nothing about the shared-install design
+# changes. Same split in healthcheck.sh (the NON-login check cannot
+# source this profile) and in the onboard env below.
+# shellcheck disable=SC2016
+if ! grep -q OPENCLAW_STATE_DIR ~/.profile 2>/dev/null; then
+  echo 'export OPENCLAW_STATE_DIR="${KLANGKWS_AGENT_HOME:-/home/klangk}/.openclaw-state"' >>~/.profile
+fi
+# shellcheck disable=SC2016
+if ! grep -q OPENCLAW_CONFIG_PATH ~/.profile 2>/dev/null; then
+  echo "export OPENCLAW_CONFIG_PATH=\"$INSTALL_DIR/.openclaw/openclaw.json\"" >>~/.profile
 fi
 # shellcheck disable=SC2016
 if ! grep -q OPENCLAW_HOME ~/.profile 2>/dev/null; then
@@ -126,6 +150,11 @@ export PATH="$INSTALL_DIR/bin:$PATH"
 # and sets up auth tokens. We overwrite the config afterward so
 # onboard doesn't clobber our settings (bind, http endpoints, etc.).
 export OPENCLAW_HOME="$INSTALL_DIR"
+# Same per-workspace state/config split as the ~/.profile exports
+# above (#2947): onboard must create its state in the agent home, not
+# on the shared mount, and keep writing the shared config.
+export OPENCLAW_STATE_DIR="${KLANGKWS_AGENT_HOME:-/home/klangk}/.openclaw-state"
+export OPENCLAW_CONFIG_PATH="$INSTALL_DIR/.openclaw/openclaw.json"
 openclaw onboard --non-interactive \
   --accept-risk \
   --mode local \

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -18,11 +18,22 @@ Under the agent-owns-the-service model (#1133/#1158) the service command
 runs in the agent's standalone ``service`` tmux session, whose login shell
 sources the AGENT's ``~/.profile``. So ``setup.sh`` repoints ``HOME`` at
 ``$KLANGKWS_AGENT_HOME`` and writes its exports there (``NVM_DIR`` + nvm
-source, ``/openclaw/bin`` on ``PATH``, ``OPENCLAW_HOME``); the owner
+source, ``/openclaw/bin`` on ``PATH``, ``OPENCLAW_HOME``, and the #2947
+split -- per-workspace ``OPENCLAW_STATE_DIR`` in the agent home plus
+shared ``OPENCLAW_CONFIG_PATH`` on the mount); the owner
 manages openclaw through the Service terminal tab, not their own shell, so
 nothing openclaw-related lives in the owner's home (#1171). The health
 check is unaffected: it runs as a non-login ``bash -c`` and uses an
-absolute-path wrapper that bakes in ``OPENCLAW_HOME``.
+absolute-path wrapper that bakes in ``OPENCLAW_HOME`` (and the #2947
+split).
+
+Why the #2947 split exists: openclaw >= 2026.8.1 enforces a
+single-instance gateway lock under its STATE dir, which defaults to a
+path on the SHARED ``/openclaw`` mount -- so with several workspaces at
+one mount only the first workspace's gateway could run (the others die
+with "gateway already running") and their health checks polled a
+loopback that never listens. The state dir therefore lives per
+workspace (agent home) while the config stays shared.
 
 Why ``~/.profile`` and not ``~/.bashrc`` (#1087): ``~/.profile`` is the
 POSIX file sourced by login shells. ``~/.bashrc`` has an interactivity
@@ -357,6 +368,21 @@ class TestOpenclawSetupProfileExports:
             )
             assert 'export PATH="/openclaw/bin:$PATH"' in profile
 
+            # The #2947 split: per-workspace gateway state in the agent
+            # home, shared config pinned on the mount. Both must also be
+            # written up front — the service session's gateway needs them
+            # from its first spawn, exactly like OPENCLAW_HOME.
+            assert "OPENCLAW_STATE_DIR=" in profile, (
+                "OPENCLAW_STATE_DIR missing from ~/.profile before the "
+                "slow install -- a second workspace at the same mount "
+                "cannot run its own gateway (shared lock, #2947).\n"
+                "~/.profile:\n" + profile
+            )
+            assert (
+                'export OPENCLAW_CONFIG_PATH="/openclaw/.openclaw/openclaw.json"'
+                in profile
+            )
+
             # Release setup.sh and let the real openclaw install finish.
             os.remove(SENTINEL)
             assert sandbox_proc.wait(timeout=SETUP_TIMEOUT) == 0, (
@@ -453,6 +479,20 @@ class TestOpenclawSetupProfileExports:
                 "shared-mount failure mode.\n~/.profile:\n" + profile
             )
             assert 'export PATH="/openclaw/bin:$PATH"' in profile
+            # The #2947 state/config split exports ride the same
+            # up-front block; on the skip path they must still land.
+            assert "OPENCLAW_STATE_DIR=" in profile, (
+                "OPENCLAW_STATE_DIR missing from the second workspace's "
+                "~/.profile even though setup completed -- a regression "
+                "that moved the export inside the install-skip guard "
+                "leaves it out permanently here (the install is skipped, "
+                "so the guard body never runs). This is the #1039 "
+                "shared-mount failure mode.\n~/.profile:\n" + profile
+            )
+            assert (
+                'export OPENCLAW_CONFIG_PATH="/openclaw/.openclaw/openclaw.json"'
+                in profile
+            )
         finally:
             if sandbox_proc.poll() is None:
                 sandbox_proc.kill()


### PR DESCRIPTION
## Summary

Fixes #2947 — `test_health_check_reports_healthy_when_gateway_up` fails on main: the workspace health check stays `unhealthy` for the full 180s because the `openclaw gateway` service-command never binds.

## Root cause

`setup.sh` installs `openclaw@latest`; **openclaw 2026.8.1** (published Aug 31, inside the Aug 27 → Sep 1 breakage window) enforces a **single-instance gateway lock** under its state dir, which defaults to `$OPENCLAW_HOME/.openclaw` — **on the shared `/openclaw` mount**. The e2e suite (and any real deployment) creates three workspaces at one mount: the first workspace's gateway holds the lock for its container's lifetime; every later workspace's gateway dies with

```
Gateway failed to start: gateway already running (pid 1993); lock timeout after 5000ms
```

and its health check polls its own loopback, where nothing ever listens (the one live gateway binds :8000 in the *first* workspace's netns). Verified by exec'ing into the containers mid-test: WS1 runs a live `openclaw-gateway` with `0.0.0.0:8000` LISTEN plus the lock file recording its pid; WS3's pane shows the lock-timeout failure. 2026.7.1 had no such lock, which is why the suite was green before Aug 31.

## Fix

Split gateway *state* from *config* using openclaw's own env overrides:

- `OPENCLAW_STATE_DIR` → the per-workspace agent home (`~/.openclaw-state`): each workspace gets its own gateway lock and sqlite store.
- `OPENCLAW_CONFIG_PATH` → pinned to the shared `/openclaw/.openclaw/openclaw.json`: the shared-install/shared-config design is unchanged.

The exports ride the #1039 up-front `~/.profile` block (the service session's login shell needs them from its first spawn), mirror into `healthcheck.sh` (the NON-login `bash -c` check — its `$HOME` is `/home`, so `KLANGKWS_AGENT_HOME` supplies the agent home), and are exported by `setup.sh` around onboard. e2e assertions extended to cover both new exports on the full-install and install-skip paths.

## Testing

`sandboxes/tests/openclaw` — reproduced the failure locally (1 failed, 2 passed, identical to CI), then green with the fix (3 passed, ~2 min, no lock churn). Changelog + sandbox README/docs updated.
