### PR TITLE
fix(git-credential): reuse cached token before device-flow login

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1714,6 +1714,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **GitHub device-flow login runs once per tab session (#2953).**
+  With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, every
+  authenticated git operation (push, pull, clone) started a fresh
+  OAuth device-flow login — the browser tab's credential cache,
+  populated by git's `store` after a successful push, was never
+  consulted on the device-flow path. The credential helper now checks
+  the cache first (new `peek` bridge operation); one login covers
+  subsequent github.com operations in that tab, and a rejected token
+  still triggers `erase` → a fresh login. Rebuild the workspace image
+  and the frontend bundle to pick up the fixed helper and feature.
+
 - **OpenClaw sandbox: every workspace sharing a mount now runs its own
   gateway (#2947).** openclaw 2026.8.1 added a single-instance gateway
   lock under its state dir, which defaulted onto the shared `/openclaw`

--- a/docs/features/github-authentication.md
+++ b/docs/features/github-authentication.md
@@ -56,8 +56,12 @@ the device flow automatically.
 The entire device flow runs inside the workspace container. The
 container-side credential helper (`git-credential-klangk`) talks to
 GitHub directly, and only sends the display code to the browser for the
-user to see. The access token never leaves the container — it goes
-straight from GitHub to git via the helper's stdout.
+user to see. The access token goes straight from GitHub to git via the
+helper's stdout — it is never displayed. After a successful
+authenticated operation, git calls the helper's `store` operation,
+which places the credential in the browser tab's in-memory cache so
+subsequent operations in that tab reuse it without a new login (see
+[Credential cache](#credential-cache) for lifetime and scope).
 
 If the device flow fails (network error, expired code, denied), the
 helper falls back to the PAT dialog automatically.
@@ -179,8 +183,9 @@ create a GitHub OAuth App and set one environment variable.
    KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID=Ov23li...
    ```
 
-8. Rebuild the workspace image so the variable is injected into
-   containers. The device flow will activate automatically for
+8. The variable is injected into workspace containers at **start** —
+   no image rebuild is needed. Restart existing workspaces (or open a
+   new one) and the device flow will activate automatically for
    `github.com` hosts.
 
 **Important**: this must be an **OAuth App**, not a GitHub App. The
@@ -199,11 +204,12 @@ The PAT cache is **per-tab** and **in-memory only**:
 - Closing the tab clears the cache.
 - The cache is keyed by `protocol://host` (e.g. `https://github.com`).
 
-Device flow tokens are not cached in the browser — the token goes
-directly from the container helper to git. However, after a successful
-`git push`, git calls the helper's `store` operation, which caches the
-credentials in the browser for subsequent operations within the same
-session.
+Device flow tokens reach git directly (the helper writes the token to
+its stdout for git, never to the screen). After a successful
+authenticated operation (`git push`, an authenticated pull, …), git
+calls the helper's `store` operation, which caches the credential in
+the browser for subsequent operations within the same session — the
+same store/erase lifecycle as PATs above.
 
 ## Multiple browser tabs
 
@@ -243,7 +249,8 @@ HTTPS with PATs or OAuth is the recommended authentication method.
   check is an ad-hoc `export` in the shell.
 - Check that the OAuth App has **Enable Device Flow** turned on.
 - The device flow only activates for `github.com` hosts.
-- Rebuild the workspace image after setting the variable.
+- Restart the workspace after setting the variable — it is injected at
+  container start, not baked into the image.
 
 ### Device flow code expired
 

--- a/docs/features/github-authentication.md
+++ b/docs/features/github-authentication.md
@@ -28,9 +28,11 @@ the workspace image (`build-workspace-image`).
 
 ## Sign in with GitHub (recommended)
 
-When the admin has configured GitHub OAuth (see
-[Admin setup](#admin-setup-creating-a-github-oauth-app) below), running
-a git command that requires authentication for `github.com` triggers
+When the GitHub OAuth client ID is configured — deploy-wide by the
+admin (see [Admin setup](#admin-setup-creating-a-github-oauth-app)
+below), per workspace, or ad hoc in a shell (see
+[Ways to set the client ID](#ways-to-set-the-client-id)) — running a
+git command that requires authentication for `github.com` triggers
 the device flow automatically.
 
 ### How it works
@@ -77,6 +79,41 @@ The device flow only activates when all of these are true:
 
 For non-GitHub hosts, or when the client ID is not configured, the
 helper falls through to the PAT dialog.
+
+### Ways to set the client ID
+
+`KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` can come from three levels.
+Where several apply, the narrower one wins (the per-workspace value is
+injected after — and so overrides — the deploy-wide value; a shell
+export shadows both for commands run from that shell):
+
+1. **Deploy-wide (admin).** The `features_config:` block of
+   `klangkd.yaml` (`github_oauth_client_id: "Ov23li..."`) or the
+   `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` environment variable on
+   the server. Injected into every workspace container at start. See
+   [Admin setup](#admin-setup-creating-a-github-oauth-app).
+2. **Per workspace.** The workspace's environment settings (the `env`
+   map on workspace create/edit, e.g.
+   `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID=Ov23li...`).
+   Useful for testing or when only one workspace should use GitHub
+   OAuth. Takes effect the next time the workspace container starts
+   (restart the workspace after changing it) and survives restarts of
+   that workspace. Stripped on export/import — an imported copy falls
+   back to the deploy-wide value.
+3. **Ad hoc, in a shell.** Inside the workspace terminal:
+
+   ```sh
+   export KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID=Ov23li...
+   git push
+   ```
+
+   Takes effect immediately for git commands run from that shell — no
+   container restart needed — but is gone when the shell or the
+   workspace restarts.
+
+In all three cases the value only needs to be the OAuth App's **client
+ID** — no client secret is ever needed (the device flow is designed for
+public clients).
 
 ## Using a personal access token
 
@@ -200,8 +237,10 @@ HTTPS with PATs or OAuth is the recommended authentication method.
 ### Device flow not activating
 
 - Verify `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` is set in the container
-  environment (check with `echo $KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` in the
-  workspace terminal).
+  environment (check with `echo $KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` in
+  the workspace terminal; empty means the device flow is off). See
+  [Ways to set the client ID](#ways-to-set-the-client-id) — the quickest
+  check is an ad-hoc `export` in the shell.
 - Check that the OAuth App has **Enable Device Flow** turned on.
 - The device flow only activates for `github.com` hosts.
 - Rebuild the workspace image after setting the variable.

--- a/features/git-credential/klangk/lib/feature.dart
+++ b/features/git-credential/klangk/lib/feature.dart
@@ -35,6 +35,18 @@ class GitCredentialFeature extends ToolPlugin with ChangeNotifier {
     switch (operation) {
       case 'get':
         return _handleGet(key, host);
+      case 'peek':
+        // Cache-only lookup: answer immediately with a miss when empty —
+        // never show a dialog. The container helper peeks before starting
+        // a GitHub device flow so a cached token is reused.
+        final cached = _cache[key];
+        if (cached != null) {
+          return jsonEncode({
+            'username': cached.username,
+            'password': cached.password,
+          });
+        }
+        return jsonEncode({'error': 'miss'});
       case 'store':
         final username = request['username'] as String? ?? '';
         final password = request['password'] as String? ?? '';

--- a/features/git-credential/klangk/test/feature_test.dart
+++ b/features/git-credential/klangk/test/feature_test.dart
@@ -192,6 +192,69 @@ void main() {
     });
   });
 
+  group('peek operation', () {
+    test('returns cached credentials without dialog', () async {
+      await feature.handlers['git_credential']!({
+        'operation': 'store',
+        'protocol': 'https',
+        'host': 'github.com',
+        'username': 'x-access-token',
+        'password': 'gho_abc123',
+      });
+
+      final result = jsonDecode(await feature.handlers['git_credential']!({
+        'operation': 'peek',
+        'protocol': 'https',
+        'host': 'github.com',
+      }));
+      expect(result['username'], 'x-access-token');
+      expect(result['password'], 'gho_abc123');
+    });
+
+    test('returns miss immediately on empty cache', () async {
+      final result = jsonDecode(await feature.handlers['git_credential']!({
+        'operation': 'peek',
+        'protocol': 'https',
+        'host': 'github.com',
+      }));
+      expect(result['error'], 'miss');
+    });
+
+    test('returns miss after erase', () async {
+      await feature.handlers['git_credential']!({
+        'operation': 'store',
+        'protocol': 'https',
+        'host': 'github.com',
+        'username': 'octocat',
+        'password': 'ghp_abc123',
+      });
+      await feature.handlers['git_credential']!({
+        'operation': 'erase',
+        'protocol': 'https',
+        'host': 'github.com',
+      });
+
+      final result = jsonDecode(await feature.handlers['git_credential']!({
+        'operation': 'peek',
+        'protocol': 'https',
+        'host': 'github.com',
+      }));
+      expect(result['error'], 'miss');
+    });
+
+    test('does not block on cache miss', () async {
+      bool completed = false;
+      await feature.handlers['git_credential']!({
+        'operation': 'peek',
+        'protocol': 'https',
+        'host': 'github.com',
+      })
+          .then((_) => completed = true);
+      expect(completed, isTrue,
+          reason: 'peek must resolve without waiting for a dialog');
+    });
+  });
+
   group('device flow operations', () {
     test('device_flow_show returns ok and notifies', () async {
       bool notified = false;

--- a/features/git-credential/tools/git-credential-klangk
+++ b/features/git-credential/tools/git-credential-klangk
@@ -30,6 +30,11 @@ TIMEOUT = 30
 # longer timeout than the default bridge timeout.
 GET_TIMEOUT = 900
 GITHUB_CLIENT_ID = os.environ.get("KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID", "").strip()
+# Device-flow endpoints. Overridable so the test suite can fake GitHub
+# locally (same prefix family as GIT_CREDENTIAL_KLANGK_DEBUG).
+GITHUB_URL = os.environ.get(
+    "GIT_CREDENTIAL_KLANGK_GITHUB_URL", "https://github.com"
+).rstrip("/")
 DEBUG = os.environ.get("GIT_CREDENTIAL_KLANGK_DEBUG", "")
 
 
@@ -146,13 +151,48 @@ def post_bridge(operation, cred, browser_id, timeout=None, extra=None):
         return None
 
 
+def _unwrap_bridge_response(resp):
+    """Unwrap the bridge's {"status": "ok", "result": ...} envelope.
+
+    The bridge wraps feature responses as {"status": "ok", "result":
+    "<json-string>"}; return the inner dict when wrapped, the original
+    response otherwise (also on an unwrappable result).
+    """
+    result = resp.get("result")
+    if isinstance(result, str):
+        try:
+            return json.loads(result)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return resp
+
+
+def _peek_bridge_cache(cred, browser_id):
+    """Return cached (username, password) from the browser, or None.
+
+    Consults the tab's credential cache without triggering any UI: a
+    device-flow login should only start when the cache is empty. The cache
+    is populated by git's "store" call after a successful authenticated
+    operation, so this turns one login into one per tab session.
+    """
+    resp = post_bridge("peek", cred, browser_id)
+    if not resp:
+        return None
+    resp = _unwrap_bridge_response(resp)
+    username = resp.get("username", "")
+    password = resp.get("password", "")
+    if username and password:
+        return (username, password)
+    return None
+
+
 def _github_request_device_code():
     """Request a device code from GitHub. Returns parsed JSON or None."""
     data = urllib.parse.urlencode(
         {"client_id": GITHUB_CLIENT_ID, "scope": "repo"}
     ).encode()
     req = urllib.request.Request(
-        "https://github.com/login/device/code",
+        f"{GITHUB_URL}/login/device/code",
         data=data,
         headers={"Accept": "application/json"},
         method="POST",
@@ -175,7 +215,7 @@ def _github_poll_token(device_code):
         }
     ).encode()
     req = urllib.request.Request(
-        "https://github.com/login/oauth/access_token",
+        f"{GITHUB_URL}/login/oauth/access_token",
         data=data,
         headers={"Accept": "application/json"},
         method="POST",
@@ -298,9 +338,18 @@ def main():
     _debug(f"cred input: {_redact(cred)}")
 
     if operation == "get":
-        # Try GitHub device flow first if configured and host is GitHub.
+        # Try GitHub device flow first if configured and host is GitHub —
+        # but only after checking the tab's cache: git calls "store" after
+        # a successful push, so a cached token must be reused instead of
+        # forcing a fresh device-flow login on every operation.
         host = cred.get("host", "")
         if GITHUB_CLIENT_ID and host in ("github.com", "www.github.com"):
+            cached = _peek_bridge_cache(cred, browser_id)
+            if cached:
+                _debug("using cached credential from browser")
+                print(f"username={cached[0]}")
+                print(f"password={cached[1]}")
+                return
             result = _handle_device_flow(cred, browser_id)
             if result:
                 print(f"username={result[0]}")
@@ -312,14 +361,7 @@ def main():
         if not resp:
             sys.exit(1)
 
-        # The bridge wraps the feature response in {"status": "ok",
-        # "result": "<json-string>"}. Unwrap if needed.
-        result = resp.get("result")
-        if isinstance(result, str):
-            try:
-                resp = json.loads(result)
-            except (json.JSONDecodeError, ValueError):
-                pass
+        resp = _unwrap_bridge_response(resp)
 
         username = resp.get("username", "")
         password = resp.get("password", "")

--- a/src/klangk/klangkd-tests/tests/test_git_credential.py
+++ b/src/klangk/klangkd-tests/tests/test_git_credential.py
@@ -96,20 +96,43 @@ class TestNoBridge:
 
 
 class _BridgeHandler(BaseHTTPRequestHandler):
-    """Minimal HTTP handler that records requests and returns canned responses."""
+    """Minimal HTTP handler that records requests and returns canned responses.
+
+    Response selection, in order: a path-routed body (``routes`` — used to
+    fake GitHub's device-flow endpoints when the helper's GITHUB_URL points
+    here), an operation-routed body (``op_bodies`` — keyed on the payload's
+    ``operation``), then the catch-all ``response_body``.
+    """
 
     requests = []
     response_body = b"{}"
     response_status = 200
+    routes = {}
+    op_bodies = {}
+
+    def _response_for(self, path, body_json):
+        if path in self.__class__.routes:
+            return self.__class__.routes[path]
+        op = body_json.get("operation", "")
+        if op in self.__class__.op_bodies:
+            return self.__class__.op_bodies[op]
+        return self.__class__.response_body
 
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(length)
-        self.__class__.requests.append(json.loads(body))
+        try:
+            parsed = json.loads(body)
+            self.__class__.requests.append(parsed)
+        except (json.JSONDecodeError, ValueError):
+            # The faked GitHub endpoints receive form-encoded bodies
+            # (the helper posts urlencoded data there); they aren't
+            # bridge operations, so don't record them.
+            parsed = {}
         self.send_response(self.__class__.response_status)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(self.__class__.response_body)
+        self.wfile.write(self._response_for(self.path, parsed))
 
     def log_message(self, *args):
         pass  # suppress output
@@ -121,6 +144,8 @@ def bridge_server():
     _BridgeHandler.requests = []
     _BridgeHandler.response_body = b"{}"
     _BridgeHandler.response_status = 200
+    _BridgeHandler.routes = {}
+    _BridgeHandler.op_bodies = {}
 
     server = HTTPServer(("127.0.0.1", 0), _BridgeHandler)
     port = server.server_address[1]
@@ -281,6 +306,119 @@ class TestGetOperation:
             _BridgeHandler.do_POST = orig_do_post
 
         assert headers_seen[-1] == "Bearer ws-jwt-123"
+
+
+class TestDeviceFlowCache:
+    """The device flow must not re-run when the tab cache has a token.
+
+    Regression: with the client ID set, ``get`` used to start a fresh
+    device flow on every git operation — git's post-success ``store``
+    populated the browser cache, but the helper never consulted it.
+    """
+
+    CLIENT_ENV = {"KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID": "Ov23test"}
+
+    def test_cached_credential_short_circuits_device_flow(
+        self, bridge_server, fake_browser_id
+    ):
+        server, port = bridge_server
+        _BridgeHandler.op_bodies = {
+            "peek": json.dumps(
+                {"username": "x-access-token", "password": "gho_cached"}
+            ).encode()
+        }
+
+        result = run_helper(
+            "get",
+            "protocol=https\nhost=github.com\n\n",
+            env_override={
+                "KLANGKWS_BRIDGE_URL": f"http://127.0.0.1:{port}",
+                **self.CLIENT_ENV,
+            },
+            extra_path=str(fake_browser_id),
+        )
+
+        assert result.returncode == 0
+        assert "username=x-access-token" in result.stdout
+        assert "password=gho_cached" in result.stdout
+        # Only the cache peek reached the bridge — no device_flow_show, no
+        # PAT-dialog "get", so no login was attempted.
+        assert [r["operation"] for r in _BridgeHandler.requests] == ["peek"]
+
+    def test_device_flow_runs_on_cache_miss(
+        self, bridge_server, fake_browser_id
+    ):
+        """Cache miss → full device flow against the faked GitHub endpoints."""
+        server, port = bridge_server
+        base = f"http://127.0.0.1:{port}"
+        _BridgeHandler.op_bodies = {
+            "peek": json.dumps({"error": "miss"}).encode()
+        }
+        _BridgeHandler.routes = {
+            "/login/device/code": json.dumps(
+                {
+                    "device_code": "dc-123",
+                    "user_code": "ABCD-1234",
+                    "verification_uri": f"{base}/login/device",
+                    "interval": 0,
+                    "expires_in": 60,
+                }
+            ).encode(),
+            "/login/oauth/access_token": json.dumps(
+                {"access_token": "gho_fresh", "token_type": "bearer"}
+            ).encode(),
+        }
+
+        result = run_helper(
+            "get",
+            "protocol=https\nhost=github.com\n\n",
+            env_override={
+                "KLANGKWS_BRIDGE_URL": base,
+                "GIT_CREDENTIAL_KLANGK_GITHUB_URL": base,
+                **self.CLIENT_ENV,
+            },
+            extra_path=str(fake_browser_id),
+        )
+
+        assert result.returncode == 0
+        assert "username=x-access-token" in result.stdout
+        assert "password=gho_fresh" in result.stdout
+        ops = [r["operation"] for r in _BridgeHandler.requests]
+        assert ops[0] == "peek"
+        assert "device_flow_show" in ops
+        assert "device_flow_done" in ops
+
+    def test_peek_error_falls_through_to_pat_dialog(
+        self, bridge_server, fake_browser_id
+    ):
+        """A peek the bridge can't answer (error body) must not strand git —
+        the helper falls through to the ordinary get (PAT dialog) path."""
+        server, port = bridge_server
+        _BridgeHandler.op_bodies = {
+            "peek": json.dumps({"status": "error"}).encode(),
+            "get": json.dumps(
+                {"username": "octocat", "password": "ghp_pat"}
+            ).encode(),
+        }
+
+        result = run_helper(
+            "get",
+            "protocol=https\nhost=github.com\n\n",
+            env_override={
+                "KLANGKWS_BRIDGE_URL": f"http://127.0.0.1:{port}",
+                "GIT_CREDENTIAL_KLANGK_GITHUB_URL": "http://127.0.0.1:1",
+                **self.CLIENT_ENV,
+            },
+            extra_path=str(fake_browser_id),
+        )
+
+        # Device flow unreachable (dead GITHUB_URL) → peek error → PAT path.
+        assert result.returncode == 0
+        assert "username=octocat" in result.stdout
+        assert "password=ghp_pat" in result.stdout
+        ops = [r["operation"] for r in _BridgeHandler.requests]
+        assert ops[0] == "peek"
+        assert "get" in ops
 
 
 class TestStoreAndErase:

--- a/src/klangk/klangkd-tests/tests/test_git_credential.py
+++ b/src/klangk/klangkd-tests/tests/test_git_credential.py
@@ -322,10 +322,14 @@ class TestDeviceFlowCache:
         self, bridge_server, fake_browser_id
     ):
         server, port = bridge_server
+        # Wrapped in the bridge's {"status": "ok", "result": ...} envelope,
+        # exactly as the frontend produces it — the peek path must unwrap
+        # (a bare body is a shape production never sends).
+        inner = json.dumps(
+            {"username": "x-access-token", "password": "gho_cached"}
+        )
         _BridgeHandler.op_bodies = {
-            "peek": json.dumps(
-                {"username": "x-access-token", "password": "gho_cached"}
-            ).encode()
+            "peek": json.dumps({"status": "ok", "result": inner}).encode()
         }
 
         result = run_helper(
@@ -333,6 +337,10 @@ class TestDeviceFlowCache:
             "protocol=https\nhost=github.com\n\n",
             env_override={
                 "KLANGKWS_BRIDGE_URL": f"http://127.0.0.1:{port}",
+                # Dead local endpoint: if the short-circuit ever regresses,
+                # the device flow fails fast here instead of reaching the
+                # real github.com with the fake client id.
+                "GIT_CREDENTIAL_KLANGK_GITHUB_URL": "http://127.0.0.1:1",
                 **self.CLIENT_ENV,
             },
             extra_path=str(fake_browser_id),


### PR DESCRIPTION
## Summary

Fixes #2953.

With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, every authenticated
git operation to github.com started a fresh OAuth device-flow login — the code
dialog, the copy-paste, the authorize click, every single push. The browser
tab's credential cache (which git populates via the helper's `store` after a
successful push) was only consulted on the PAT fallback path; the device-flow
path short-circuited straight to a new login.

## Changes

- `features/git-credential/klangk/lib/feature.dart` — new cache-only `peek`
  bridge operation: returns cached credentials or `{"error": "miss"}`,
  never shows UI. The existing `get`/`store`/`erase` behavior is unchanged.
- `features/git-credential/tools/git-credential-klangk` — on `get`, the
  helper now peeks the tab cache before starting a device flow for
  `github.com`/`www.github.com`; a hit is returned to git directly. A
  peek that errors (bridge unreachable/bad body) falls through to the
  device flow as before, and a rejected token still triggers git's `erase`,
  so the next `get` performs a fresh login. Also: bridge-response unwrapping
  extracted into `_unwrap_bridge_response` (shared by the PAT path), and the
  device-flow endpoint base is overridable via `GIT_CREDENTIAL_KLANGK_GITHUB_URL`
  (same prefix family as the existing debug var) so tests can fake GitHub
  locally.
- `test_git_credential.py` — fake bridge gains per-path / per-operation
  response routing (and tolerates the form-encoded GitHub-side posts), plus a
  `TestDeviceFlowCache` class covering: cache hit short-circuits the device
  flow (only a `peek` reaches the bridge), cache miss runs the full device
  flow against faked GitHub endpoints, and a peek error falls through to the
  PAT dialog.
- `feature_test.dart` — `peek` group: hit returns creds, miss returns
  immediately (no dialog blocking), erase invalidates, no blocking on miss.

## Operator notes

One device-flow login now covers subsequent github.com operations within a
browser-tab session. Deployments must rebuild the workspace image (helper) and
the frontend bundle (feature) to pick up both halves; the halves are
independently backward compatible — an old helper simply never peeks.

## Testing

- `python -m pytest src/klangk/klangkd-tests/tests/test_git_credential.py` — 20 passed
- `cd features/git-credential/klangk && flutter test` — 18 passed
- pre-commit (ruff, dart format, xenon, trufflehog) — clean
