### PR TITLE
ci: skip test workflows for .md-only and root-meta-only changes

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths-ignore:
+      # Root-only docs/meta files can never affect what this workflow
+      # tests — a PR changing only these starts no run at all (#2957).
+      - "*.md"
+      - "zensical.toml"
+      - "bootstrap"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -19,6 +25,10 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # some-with-excludes: a changed file counts toward the filter only
+          # if it matches an inclusion and no exclusion — without this the
+          # default 'some' quantifier ignores negated patterns entirely.
+          predicate-quantifier: some-with-excludes
           filters: |
             python:
               - 'src/klangk/**'
@@ -26,6 +36,9 @@ jobs:
               - 'features/**'
               - 'features.yaml'
               - '.github/workflows/backend-tests.yml'
+              # Docs-only .md changes (READMEs, feature docs) can't affect
+              # the suite — a PR whose diff is otherwise docs-only skips it (#2957).
+              - '!**/*.md'
 
       - uses: actions/setup-python@v6
         if: steps.filter.outputs.python == 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths-ignore:
+      # Root-only docs/meta files can never affect what this workflow
+      # tests — a PR changing only these starts no run at all (#2957).
+      - "*.md"
+      - "zensical.toml"
+      - "bootstrap"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths-ignore:
+      # Root-only docs/meta files can never affect what this workflow
+      # tests — a PR changing only these starts no run at all (#2957).
+      - "*.md"
+      - "zensical.toml"
+      - "bootstrap"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -19,6 +25,9 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # some-with-excludes: see backend-tests.yml (#2957) — the default
+          # 'some' quantifier ignores negated patterns.
+          predicate-quantifier: some-with-excludes
           filters: |
             frontend:
               - 'src/frontend/lib/**'
@@ -27,6 +36,7 @@ jobs:
               - 'features/**/klangk/**'
               - 'scripts/lcov-report.py'
               - '.github/workflows/frontend-tests.yml'
+              - '!**/*.md'
 
       # Pin Flutter to the nixpkgs-unstable version (devenv ships 3.47.0,
       # #2869) so CI and local runs stay in lockstep — the local coverage

--- a/.github/workflows/fuzz-check.yml
+++ b/.github/workflows/fuzz-check.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths-ignore:
+      # Root-only docs/meta files can never affect what this workflow
+      # tests — a PR changing only these starts no run at all (#2957).
+      - "*.md"
+      - "zensical.toml"
+      - "bootstrap"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -20,6 +20,12 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths-ignore:
+      # Root-only docs/meta files can never affect what this workflow
+      # tests — a PR changing only these starts no run at all (#2957).
+      - "*.md"
+      - "zensical.toml"
+      - "bootstrap"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -35,6 +41,9 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # some-with-excludes: see backend-tests.yml (#2957) — the default
+          # 'some' quantifier ignores negated patterns.
+          predicate-quantifier: some-with-excludes
           filters: |
             backend:
               - 'src/klangk/**'
@@ -42,6 +51,7 @@ jobs:
               - 'features/**'
               - 'features.yaml'
               - '.github/workflows/macos-smoke.yml'
+              - '!**/*.md'
 
       - uses: actions/setup-python@v6
         if: steps.filter.outputs.backend == 'true'

--- a/.github/workflows/python-deps-audit.yml
+++ b/.github/workflows/python-deps-audit.yml
@@ -19,6 +19,12 @@ on:
     # Weekly, Tuesdays 06:00 UTC (trivy scans Mondays 06:00; fuzz is daily).
     - cron: "0 6 * * 2"
   pull_request:
+    paths-ignore:
+      # Root-only docs/meta files can never affect what this workflow
+      # tests — a PR changing only these starts no run at all (#2957).
+      - "*.md"
+      - "zensical.toml"
+      - "bootstrap"
 
 permissions:
   contents: read

--- a/.github/workflows/sidecar-tests.yml
+++ b/.github/workflows/sidecar-tests.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    paths-ignore:
+      # Root-only docs/meta files can never affect what this workflow
+      # tests — a PR changing only these starts no run at all (#2957).
+      - "*.md"
+      - "zensical.toml"
+      - "bootstrap"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -19,10 +25,14 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # some-with-excludes: see backend-tests.yml (#2957) — the default
+          # 'some' quantifier ignores negated patterns.
+          predicate-quantifier: some-with-excludes
           filters: |
             sidecar:
               - 'src/klangksidecar/**'
               - '.github/workflows/sidecar-tests.yml'
+              - '!**/*.md'
 
       - uses: actions/setup-python@v6
         if: steps.filter.outputs.sidecar == 'true'


### PR DESCRIPTION
Fixes #2957.

## What changed

Two levels of skipping for docs-only changes:

**Trigger level** — every workflow with a bare `pull_request:` trigger
(backend-tests, frontend-tests, macos-smoke, sidecar-tests, codeql,
fuzz-check, python-deps-audit) now carries `paths-ignore` for root-only
meta files: `*.md` (README, AGENTS, LICENSE, CONTRIBUTING, SECURITY),
`zensical.toml`, `bootstrap`. A PR changing only those starts no run at
all.

**Job level** — the four unit suites' `dorny/paths-filter` filters gain
`- '!**/*.md'` plus `predicate-quantifier: some-with-excludes`. This
covers `.md` files *inside* the matched trees (`features/*/README.md`,
`src/klangk/klangk/cli/CHANGES.md`, …): a PR changing only those checks
out, matches nothing, and completes via the existing Skip-notice step.

## Why the quantifier matters

dorny's default `some` quantifier evaluates each changed file against
each pattern independently — a file matching `features/**` matches the
filter even when `!**/*.md` is present, so the exclusion is silently
dead (dorny/paths-filter#135, #260). `some-with-excludes` gives the
intended semantics: a file counts only if it matches an inclusion and
no exclusion; exclusion is final. Verified against the v4 `filter.ts`
source and replicated its matching locally over the real pattern list.

## Safety checks

- No test reads any `.md` file inside the matched trees (grep for
  `CHANGES.md`, `cli/README`, feature READMEs across `src/klangk`,
  `scripts`, `features`): all `.md` there is pure docs.
- Mixed PRs (code + docs) still run everything — matching is per-file,
  and the merge gate needs the head SHA reported.
- `workflow_dispatch` stays un-gated (forced runs always possible), and
  CodeQL still scans `bootstrap` post-merge via its `push: main`
  trigger.
- Semantics matrix verified locally: nested `.md` → skip; code paths →
  run; `features.yaml` → run; root `.md` → no run.
