### PR TITLE
fix(git-credential): host-aware hint text in PAT dialog

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1715,10 +1715,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 ### Fixed
 
 - **Git credential dialog hint text (#2954).** The browser-side
-  "Git credentials" dialog now derives its field hints from the host:
-  `github.com` keeps "GitHub username" and the `ghp_...`/`github_pat_...`
-  PAT placeholder, while any other host (gitlab.com, bitbucket.org, gitea,
-  self-hosted) shows neutral "Username" and "Token or password" hints.
+  "Git credentials" dialog now derives its field wording from the host
+  (case-, port-, and trailing-dot-insensitive): `github.com` keeps
+  "GitHub username" and the PAT-flavored token label and placeholder,
+  while any other host (gitlab.com, bitbucket.org, gitea, self-hosted)
+  shows neutral "Username" / "Token or password" text.
 
 - **GitHub device-flow login runs once per tab session (#2953).**
   With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, every

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1714,6 +1714,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Git credential dialog hint text (#2954).** The browser-side
+  "Git credentials" dialog now derives its field hints from the host:
+  `github.com` keeps "GitHub username" and the `ghp_...`/`github_pat_...`
+  PAT placeholder, while any other host (gitlab.com, bitbucket.org, gitea,
+  self-hosted) shows neutral "Username" and "Token or password" hints.
+
 - **GitHub device-flow login runs once per tab session (#2953).**
   With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, every
   authenticated git operation (push, pull, clone) started a fresh

--- a/features/git-credential/klangk/lib/feature.dart
+++ b/features/git-credential/klangk/lib/feature.dart
@@ -361,6 +361,18 @@ class _CredentialDialog extends StatefulWidget {
     required this.onCancel,
   });
 
+  /// GitHub hosts keep the PAT-flavored hints; every other host gets
+  /// neutral wording (gitlab.com, bitbucket.org, gitea, self-hosted, ...).
+  bool get isGitHubHost {
+    final normalized = host.toLowerCase();
+    return normalized == 'github.com' || normalized == 'www.github.com';
+  }
+
+  String get usernameHint => isGitHubHost ? 'GitHub username' : 'Username';
+
+  String get tokenHint =>
+      isGitHubHost ? 'ghp_... or github_pat_...' : 'Token or password';
+
   @override
   State<_CredentialDialog> createState() => _CredentialDialogState();
 }
@@ -444,7 +456,7 @@ class _CredentialDialogState extends State<_CredentialDialog> {
                     focusNode: _usernameFocusNode,
                     style: const TextStyle(color: Colors.white, fontSize: 14),
                     decoration: InputDecoration(
-                      hintText: 'GitHub username',
+                      hintText: widget.usernameHint,
                       hintStyle: const TextStyle(color: Colors.white30),
                       filled: true,
                       fillColor: Colors.black26,
@@ -479,7 +491,7 @@ class _CredentialDialogState extends State<_CredentialDialog> {
                     obscureText: true,
                     style: const TextStyle(color: Colors.white, fontSize: 14),
                     decoration: InputDecoration(
-                      hintText: 'ghp_... or github_pat_...',
+                      hintText: widget.tokenHint,
                       hintStyle: const TextStyle(color: Colors.white30),
                       filled: true,
                       fillColor: Colors.black26,

--- a/features/git-credential/klangk/lib/feature.dart
+++ b/features/git-credential/klangk/lib/feature.dart
@@ -361,14 +361,25 @@ class _CredentialDialog extends StatefulWidget {
     required this.onCancel,
   });
 
-  /// GitHub hosts keep the PAT-flavored hints; every other host gets
-  /// neutral wording (gitlab.com, bitbucket.org, gitea, self-hosted, ...).
+  /// GitHub hosts keep the PAT-flavored wording; every other host gets
+  /// neutral text (gitlab.com, bitbucket.org, gitea, self-hosted, ...).
+  /// Normalizes what git can put in the credential `host` field: case
+  /// (`GitHub.com`), an explicit port (`github.com:443`), and a trailing
+  /// dot (`github.com.`) are all GitHub.
   bool get isGitHubHost {
-    final normalized = host.toLowerCase();
+    var normalized = host.toLowerCase();
+    final port = normalized.indexOf(':');
+    if (port >= 0) normalized = normalized.substring(0, port);
+    while (normalized.endsWith('.')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
     return normalized == 'github.com' || normalized == 'www.github.com';
   }
 
   String get usernameHint => isGitHubHost ? 'GitHub username' : 'Username';
+
+  String get tokenLabel =>
+      isGitHubHost ? 'Personal access token (PAT):' : 'Token or password:';
 
   String get tokenHint =>
       isGitHubHost ? 'ghp_... or github_pat_...' : 'Token or password';
@@ -480,9 +491,9 @@ class _CredentialDialogState extends State<_CredentialDialog> {
                     onSubmitted: (_) => _tokenFocusNode.requestFocus(),
                   ),
                   const SizedBox(height: 12),
-                  const Text(
-                    'Personal access token (PAT):',
-                    style: TextStyle(color: Colors.white70, fontSize: 13),
+                  Text(
+                    widget.tokenLabel,
+                    style: const TextStyle(color: Colors.white70, fontSize: 13),
                   ),
                   const SizedBox(height: 4),
                   TextField(

--- a/features/git-credential/klangk/test/feature_test.dart
+++ b/features/git-credential/klangk/test/feature_test.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_feature_git_credential/feature.dart';
 
@@ -316,6 +318,63 @@ void main() {
         'host': 'github.com',
       });
       expect(jsonDecode(result)['error'], contains('unknown operation'));
+    });
+  });
+
+  group('credential dialog hints', () {
+    Widget overlayHost(GitCredentialFeature feature) => MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Stack(
+                children: [feature.buildOverlay(context)!],
+              ),
+            ),
+          ),
+        );
+
+    Future<void> pumpWithPendingGet(
+      WidgetTester tester,
+      GitCredentialFeature feature,
+      String host,
+    ) async {
+      // Cache-miss get blocks on the dialog completer; do not await it.
+      unawaited(feature.handlers['git_credential']!({
+        'operation': 'get',
+        'protocol': 'https',
+        'host': host,
+      }));
+      await tester.pumpWidget(overlayHost(feature));
+      await tester.pump();
+    }
+
+    String? hintOf(WidgetTester tester, int textFieldIndex) {
+      final field =
+          tester.widget<TextField>(find.byType(TextField).at(textFieldIndex));
+      return field.decoration?.hintText;
+    }
+
+    testWidgets('github.com keeps the GitHub hints', (tester) async {
+      await pumpWithPendingGet(tester, feature, 'github.com');
+      expect(hintOf(tester, 0), 'GitHub username');
+      expect(hintOf(tester, 1), 'ghp_... or github_pat_...');
+    });
+
+    testWidgets('www.github.com keeps the GitHub hints', (tester) async {
+      await pumpWithPendingGet(tester, feature, 'www.github.com');
+      expect(hintOf(tester, 0), 'GitHub username');
+      expect(hintOf(tester, 1), 'ghp_... or github_pat_...');
+    });
+
+    testWidgets('gitlab.com gets neutral hints', (tester) async {
+      await pumpWithPendingGet(tester, feature, 'gitlab.com');
+      expect(hintOf(tester, 0), 'Username');
+      expect(hintOf(tester, 1), 'Token or password');
+    });
+
+    testWidgets('self-hosted host gets neutral hints', (tester) async {
+      await pumpWithPendingGet(tester, feature, 'git.example.com');
+      expect(hintOf(tester, 0), 'Username');
+      expect(hintOf(tester, 1), 'Token or password');
     });
   });
 

--- a/features/git-credential/klangk/test/feature_test.dart
+++ b/features/git-credential/klangk/test/feature_test.dart
@@ -357,6 +357,8 @@ void main() {
       await pumpWithPendingGet(tester, feature, 'github.com');
       expect(hintOf(tester, 0), 'GitHub username');
       expect(hintOf(tester, 1), 'ghp_... or github_pat_...');
+      expect(find.text('Personal access token (PAT):'), findsOneWidget);
+      expect(find.text('Token or password:'), findsNothing);
     });
 
     testWidgets('www.github.com keeps the GitHub hints', (tester) async {
@@ -365,10 +367,33 @@ void main() {
       expect(hintOf(tester, 1), 'ghp_... or github_pat_...');
     });
 
+    testWidgets('uppercase GitHub.com host keeps the GitHub hints',
+        (tester) async {
+      await pumpWithPendingGet(tester, feature, 'GitHub.com');
+      expect(hintOf(tester, 0), 'GitHub username');
+      expect(hintOf(tester, 1), 'ghp_... or github_pat_...');
+    });
+
+    testWidgets('github.com with explicit port keeps the GitHub hints',
+        (tester) async {
+      await pumpWithPendingGet(tester, feature, 'github.com:443');
+      expect(hintOf(tester, 0), 'GitHub username');
+      expect(hintOf(tester, 1), 'ghp_... or github_pat_...');
+    });
+
+    testWidgets('github.com with trailing dot keeps the GitHub hints',
+        (tester) async {
+      await pumpWithPendingGet(tester, feature, 'github.com.');
+      expect(hintOf(tester, 0), 'GitHub username');
+      expect(hintOf(tester, 1), 'ghp_... or github_pat_...');
+    });
+
     testWidgets('gitlab.com gets neutral hints', (tester) async {
       await pumpWithPendingGet(tester, feature, 'gitlab.com');
       expect(hintOf(tester, 0), 'Username');
       expect(hintOf(tester, 1), 'Token or password');
+      expect(find.text('Token or password:'), findsOneWidget);
+      expect(find.text('Personal access token (PAT):'), findsNothing);
     });
 
     testWidgets('self-hosted host gets neutral hints', (tester) async {


### PR DESCRIPTION
## Summary

- The browser-side "Git credentials" dialog hardcoded GitHub-flavored hints
  for every host: the username field hinted "GitHub username" and the token
  field's placeholder was `ghp_... or github_pat_...`, even for gitlab.com,
  bitbucket.org, gitea, or self-hosted remotes.
- Hints are now derived from the host (`_CredentialDialog`): `github.com` /
  `www.github.com` keep the current hints including the PAT format hint;
  every other host gets neutral "Username" / "Token or password" wording.
- Purely cosmetic; no protocol change. Adds widget tests covering both
  hint variants plus a changelog entry.

Closes #2954.

## Testing

- `flutter test` in `features/git-credential/klangk` (22 tests, incl. 4 new
  dialog-hint widget tests) passes.
- `dart analyze` / `dart format` clean.
