### PR TITLE
Require workspace JWT on /llm-proxy — container-internal callers only (#2959)

### DIFF
--- a/docs/architecture/llm-proxy.md
+++ b/docs/architecture/llm-proxy.md
@@ -19,7 +19,7 @@ Pi container
           → upstream LLM provider(s)
 ```
 
-The reverse proxy's `/llm-proxy/` block validates the workspace JWT via `forward_auth` (Caddy) and enforces the container-source IP ACL. It then forwards the request to the klangkd backend.
+The reverse proxy's `/llm-proxy/` block validates the workspace JWT via `forward_auth` (Caddy) and enforces the container-source IP ACL. It then forwards the request to the klangkd backend, which re-validates the workspace JWT itself (#2959, defense-in-depth): a request arriving without a valid workspace token — including a user login token or no token at all — is rejected with `401`. The proxy is therefore unreachable from outside workspace containers even when the backend port is directly reachable.
 
 ## Operating modes
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -204,6 +204,13 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **`/llm-proxy` endpoints now require a workspace JWT (#2959).** The
+  backend validates the workspace token itself, mirroring the egress
+  proxy's `forward_auth` check. Previously the backend routes were
+  unauthenticated, so a client that could reach the backend port could
+  use the proxy (and its upstream API keys) from outside a workspace
+  container; user login tokens are rejected — the proxy is usable only
+  from inside workspace containers.
 - **Image builds verify third-party inputs (#2063).** Base images (workspace base, python host, Alpine sidecar, Debian FIPS builders + nix-seed sandbox) are now pulled by immutable `@sha256:` digest, with the base-image workflow's auto-PR pinning the digest. The uv and process-compose release tarballs are SHA-256-verified per architecture before extraction (no more `curl | sh` / `curl | tar` pipes), the Pi agent npm tarball is fetched directly and SHA-512-verified, and the NodeSource / GitHub CLI / Caddy apt repo keys are hash-verified before entering a keyring (Caddy's sources list is written inline). Pins live in the Dockerfiles; rotation procedures and known residuals are documented in [Building Images](development/building-images.md).
 
 - **Browser-delegate requests are bound to the caller's workspace

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -207,10 +207,11 @@ operators or integrators to act when upgrading.
 - **`/llm-proxy` endpoints now require a workspace JWT (#2959).** The
   backend validates the workspace token itself, mirroring the egress
   proxy's `forward_auth` check. Previously the backend routes were
-  unauthenticated, so a client that could reach the backend port could
-  use the proxy (and its upstream API keys) from outside a workspace
-  container; user login tokens are rejected — the proxy is usable only
-  from inside workspace containers.
+  unauthenticated, so the proxy (and its upstream API keys) was usable
+  from outside a workspace container by any client that could reach the
+  backend directly — including anonymously through the browser
+  listener's `/llm-proxy/` pass-through. User login tokens are rejected;
+  the proxy is usable only from inside workspace containers.
 - **Image builds verify third-party inputs (#2063).** Base images (workspace base, python host, Alpine sidecar, Debian FIPS builders + nix-seed sandbox) are now pulled by immutable `@sha256:` digest, with the base-image workflow's auto-PR pinning the digest. The uv and process-compose release tarballs are SHA-256-verified per architecture before extraction (no more `curl | sh` / `curl | tar` pipes), the Pi agent npm tarball is fetched directly and SHA-512-verified, and the NodeSource / GitHub CLI / Caddy apt repo keys are hash-verified before entering a keyring (Caddy's sources list is written inline). Pins live in the Dockerfiles; rotation procedures and known residuals are documented in [Building Images](development/building-images.md).
 
 - **Browser-delegate requests are bound to the caller's workspace

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1909,8 +1909,12 @@ authenticated with the workspace JWT validated by the egress listener's
 
 Served under `/llm-proxy/` (no `/api/v1` prefix) — on the egress
 listener, gated by the proxy's workspace-JWT `forward_auth` + container
-IP ACL, so only workspace containers can reach them. See
-[LLM Proxy](../architecture/llm-proxy.md).
+IP ACL, so only workspace containers can reach them. The backend
+re-validates the workspace JWT itself (#2959): user login tokens and
+anonymous requests are rejected with `401` even on the backend port.
+See [LLM Proxy](../architecture/llm-proxy.md).
+
+**Auth:** Workspace JWT.
 
 ### GET `/llm-proxy/models`
 

--- a/src/klangk/klangk/api/llm_proxy.py
+++ b/src/klangk/klangk/api/llm_proxy.py
@@ -3,18 +3,33 @@
 Handles ``/llm-proxy/`` requests that were previously forwarded by the
 reverse proxy to an external LLM base URL or a LiteLLM sidecar container.
 Now served in-process by :class:`~klangk.llm_router.LLMRouter`.
+
+#2959: container-internal callers only. Every route requires a
+**workspace JWT** — the in-container path through the egress caddy's
+``forward_auth``, which forwards the original ``Authorization`` header
+on to the backend. User JWTs and anonymous requests are rejected with
+401: the proxy must not be usable from outside workspace containers,
+even by authenticated users. Mirrors the defense-in-depth pattern of
+:func:`klangk.api.common.require_workspace_token` (the egress proxy
+already validated the token; the routes re-validate it).
 """
 
 import inspect
 import json
 import logging
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+
+from .common import require_workspace_token
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/llm-proxy", tags=["llm-proxy"])
+router = APIRouter(
+    prefix="/llm-proxy",
+    tags=["llm-proxy"],
+    dependencies=[Depends(require_workspace_token)],
+)
 
 
 @router.get("/models")

--- a/src/klangk/klangkd-tests/e2e-tests/_fake_llm.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_fake_llm.py
@@ -1,0 +1,96 @@
+"""A fake OpenAI-compatible upstream for LLM-proxy E2E tests.
+
+Shared by ``test_llm_proxy_e2e.py`` (backend-level) and
+``test_llm_proxy_in_workspace_e2e.py`` (full container path). Serves
+``/v1/models`` and ``/v1/chat/completions`` with canned responses;
+every completion echoes the model name in its content so callers can
+assert the proxy forwarded the request verbatim.
+"""
+
+import json
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+from klangk.model import free_port
+
+
+class FakeLLMHandler(BaseHTTPRequestHandler):
+    """Minimal OpenAI-compatible handler."""
+
+    def do_GET(self):
+        if self.path == "/v1/models":
+            body = json.dumps(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "fake-model",
+                            "object": "model",
+                            "owned_by": "test",
+                        }
+                    ],
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        if self.path == "/v1/chat/completions":
+            length = int(self.headers.get("Content-Length", 0))
+            request_body = (
+                json.loads(self.rfile.read(length)) if length else {}
+            )
+            model = request_body.get("model", "unknown")
+            body = json.dumps(
+                {
+                    "id": "chatcmpl-fake",
+                    "object": "chat.completion",
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": f"Hello from {model}!",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 5,
+                        "total_tokens": 10,
+                    },
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format, *args):
+        pass  # suppress request logs
+
+
+def start_fake_llm() -> dict:
+    """Start the fake upstream on a free loopback port.
+
+    Returns ``{"port", "url", "httpd"}``; stop with :func:`stop_fake_llm`.
+    """
+    port = free_port()
+    httpd = HTTPServer(("127.0.0.1", port), FakeLLMHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return {"port": port, "url": f"http://127.0.0.1:{port}", "httpd": httpd}
+
+
+def stop_fake_llm(fake: dict) -> None:
+    fake["httpd"].shutdown()

--- a/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_e2e.py
@@ -12,11 +12,29 @@ Run with: devenv shell -- test-backend-e2e -k test_llm_proxy_e2e
 import json
 import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from types import SimpleNamespace
 
 import pytest
 
+from klangk.auth import Auth
 from klangk.model import free_port
 from _e2e_server import start_server, stop_server
+
+
+def _ws_headers(secret, workspace_id="e2e-llm"):
+    """Auth headers with a workspace JWT signed by the server's secret
+    (the token class the egress caddy's forward_auth forwards, #2959)."""
+    auth = Auth(
+        SimpleNamespace(
+            state=SimpleNamespace(
+                settings=SimpleNamespace(
+                    jwt_secret=secret, workspace_token_hours=24.0
+                )
+            )
+        )
+    )
+    token = auth.create_workspace_token(workspace_id)
+    return {"Authorization": f"Bearer {token}"}
 
 
 class _FakeLLMHandler(BaseHTTPRequestHandler):
@@ -115,8 +133,33 @@ def server(fake_llm):
 
 
 class TestLLMProxyE2E:
-    def test_models_endpoint_returns_configured_model(self, server):
+    def test_unauthenticated_rejected(self, server):
+        """#2959: no token → 401 (backend-side, not just the egress gate)."""
         resp = server["client"].get("/llm-proxy/models", timeout=10)
+        assert resp.status_code == 401
+
+    def test_user_jwt_rejected(self, server):
+        """#2959: a logged-in user's JWT is not a workspace token → 401."""
+        login = server["client"].post(
+            "/api/v1/auth/login",
+            json={"identifier": "test@example.com", "password": "testpass"},
+            timeout=10,
+        )
+        assert login.status_code == 200
+        user_jwt = login.json()["access_token"]
+        resp = server["client"].get(
+            "/llm-proxy/models",
+            headers={"Authorization": f"Bearer {user_jwt}"},
+            timeout=10,
+        )
+        assert resp.status_code == 401
+
+    def test_models_endpoint_returns_configured_model(self, server):
+        resp = server["client"].get(
+            "/llm-proxy/models",
+            headers=_ws_headers("llm-e2e-secret"),
+            timeout=10,
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert data["object"] == "list"
@@ -126,6 +169,7 @@ class TestLLMProxyE2E:
     def test_chat_completions_proxies_to_upstream(self, server):
         resp = server["client"].post(
             "/llm-proxy/chat/completions",
+            headers=_ws_headers("llm-e2e-secret"),
             json={
                 "model": "fake-model",
                 "messages": [{"role": "user", "content": "hello"}],
@@ -140,6 +184,7 @@ class TestLLMProxyE2E:
     def test_chat_completions_returns_usage(self, server):
         resp = server["client"].post(
             "/llm-proxy/chat/completions",
+            headers=_ws_headers("llm-e2e-secret"),
             json={
                 "model": "fake-model",
                 "messages": [{"role": "user", "content": "hi"}],
@@ -163,7 +208,11 @@ class TestLLMProxyE2E:
             LOGFIRE_TOKEN="",
         )
         try:
-            resp = srv["client"].get("/llm-proxy/models", timeout=10)
+            resp = srv["client"].get(
+                "/llm-proxy/models",
+                headers=_ws_headers("llm-e2e-none"),
+                timeout=10,
+            )
             assert resp.status_code == 200
             assert resp.json()["data"] == []
         finally:
@@ -201,7 +250,11 @@ class TestLLMProxyPassthroughE2E:
 
     def test_models_discovers_upstream(self, passthrough_stack):
         """GET /llm-proxy/models queries the upstream and returns its models."""
-        resp = passthrough_stack["client"].get("/llm-proxy/models", timeout=10)
+        resp = passthrough_stack["client"].get(
+            "/llm-proxy/models",
+            headers=_ws_headers("llm-pt-e2e"),
+            timeout=10,
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert data["object"] == "list"
@@ -212,6 +265,7 @@ class TestLLMProxyPassthroughE2E:
         """POST /llm-proxy/chat/completions forwards the model name as-is."""
         resp = passthrough_stack["client"].post(
             "/llm-proxy/chat/completions",
+            headers=_ws_headers("llm-pt-e2e"),
             json={
                 "model": "fake-model",
                 "messages": [{"role": "user", "content": "hello"}],

--- a/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_e2e.py
@@ -9,15 +9,12 @@ end-to-end through the in-process litellm Router.
 Run with: devenv shell -- test-backend-e2e -k test_llm_proxy_e2e
 """
 
-import json
-import threading
-from http.server import HTTPServer, BaseHTTPRequestHandler
-
 import httpx
 import pytest
 
 from klangk.model import free_port
 from _e2e_server import start_server, stop_server
+from _fake_llm import start_fake_llm, stop_fake_llm
 
 
 def _ws_headers(client, workspace_id="e2e-llm"):
@@ -31,81 +28,12 @@ def _ws_headers(client, workspace_id="e2e-llm"):
     return {"Authorization": f"Bearer {resp.json()['token']}"}
 
 
-class _FakeLLMHandler(BaseHTTPRequestHandler):
-    """Minimal OpenAI-compatible handler."""
-
-    def do_GET(self):
-        if self.path == "/v1/models":
-            body = json.dumps(
-                {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "fake-model",
-                            "object": "model",
-                            "owned_by": "test",
-                        }
-                    ],
-                }
-            ).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-        else:
-            self.send_error(404)
-
-    def do_POST(self):
-        if self.path == "/v1/chat/completions":
-            length = int(self.headers.get("Content-Length", 0))
-            request_body = (
-                json.loads(self.rfile.read(length)) if length else {}
-            )
-            model = request_body.get("model", "unknown")
-            body = json.dumps(
-                {
-                    "id": "chatcmpl-fake",
-                    "object": "chat.completion",
-                    "model": model,
-                    "choices": [
-                        {
-                            "index": 0,
-                            "message": {
-                                "role": "assistant",
-                                "content": f"Hello from {model}!",
-                            },
-                            "finish_reason": "stop",
-                        }
-                    ],
-                    "usage": {
-                        "prompt_tokens": 5,
-                        "completion_tokens": 5,
-                        "total_tokens": 10,
-                    },
-                }
-            ).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-        else:
-            self.send_error(404)
-
-    def log_message(self, format, *args):
-        pass  # suppress request logs
-
-
 @pytest.fixture(scope="module")
 def fake_llm():
     """Start a fake OpenAI-compatible LLM server on a free port."""
-    port = free_port()
-    httpd = HTTPServer(("127.0.0.1", port), _FakeLLMHandler)
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    yield {"port": port, "url": f"http://127.0.0.1:{port}"}
-    httpd.shutdown()
+    fake = start_fake_llm()
+    yield fake
+    stop_fake_llm(fake)
 
 
 @pytest.fixture(scope="module")

--- a/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_e2e.py
@@ -12,29 +12,23 @@ Run with: devenv shell -- test-backend-e2e -k test_llm_proxy_e2e
 import json
 import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from types import SimpleNamespace
 
+import httpx
 import pytest
 
-from klangk.auth import Auth
 from klangk.model import free_port
 from _e2e_server import start_server, stop_server
 
 
-def _ws_headers(secret, workspace_id="e2e-llm"):
-    """Auth headers with a workspace JWT signed by the server's secret
-    (the token class the egress caddy's forward_auth forwards, #2959)."""
-    auth = Auth(
-        SimpleNamespace(
-            state=SimpleNamespace(
-                settings=SimpleNamespace(
-                    jwt_secret=secret, workspace_token_hours=24.0
-                )
-            )
-        )
+def _ws_headers(client, workspace_id="e2e-llm"):
+    """Auth headers with a workspace JWT minted by the server's own
+    test-mode endpoint — the token class the egress caddy's forward_auth
+    forwards and the backend gate now requires (#2959)."""
+    resp = client.get(
+        f"/api/v1/test/workspace-token/{workspace_id}", timeout=10
     )
-    token = auth.create_workspace_token(workspace_id)
-    return {"Authorization": f"Bearer {token}"}
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
 
 
 class _FakeLLMHandler(BaseHTTPRequestHandler):
@@ -157,7 +151,7 @@ class TestLLMProxyE2E:
     def test_models_endpoint_returns_configured_model(self, server):
         resp = server["client"].get(
             "/llm-proxy/models",
-            headers=_ws_headers("llm-e2e-secret"),
+            headers=_ws_headers(server["client"]),
             timeout=10,
         )
         assert resp.status_code == 200
@@ -169,7 +163,7 @@ class TestLLMProxyE2E:
     def test_chat_completions_proxies_to_upstream(self, server):
         resp = server["client"].post(
             "/llm-proxy/chat/completions",
-            headers=_ws_headers("llm-e2e-secret"),
+            headers=_ws_headers(server["client"]),
             json={
                 "model": "fake-model",
                 "messages": [{"role": "user", "content": "hello"}],
@@ -184,7 +178,7 @@ class TestLLMProxyE2E:
     def test_chat_completions_returns_usage(self, server):
         resp = server["client"].post(
             "/llm-proxy/chat/completions",
-            headers=_ws_headers("llm-e2e-secret"),
+            headers=_ws_headers(server["client"]),
             json={
                 "model": "fake-model",
                 "messages": [{"role": "user", "content": "hi"}],
@@ -210,7 +204,7 @@ class TestLLMProxyE2E:
         try:
             resp = srv["client"].get(
                 "/llm-proxy/models",
-                headers=_ws_headers("llm-e2e-none"),
+                headers=_ws_headers(srv["client"]),
                 timeout=10,
             )
             assert resp.status_code == 200
@@ -252,7 +246,7 @@ class TestLLMProxyPassthroughE2E:
         """GET /llm-proxy/models queries the upstream and returns its models."""
         resp = passthrough_stack["client"].get(
             "/llm-proxy/models",
-            headers=_ws_headers("llm-pt-e2e"),
+            headers=_ws_headers(passthrough_stack["client"]),
             timeout=10,
         )
         assert resp.status_code == 200
@@ -265,7 +259,7 @@ class TestLLMProxyPassthroughE2E:
         """POST /llm-proxy/chat/completions forwards the model name as-is."""
         resp = passthrough_stack["client"].post(
             "/llm-proxy/chat/completions",
-            headers=_ws_headers("llm-pt-e2e"),
+            headers=_ws_headers(passthrough_stack["client"]),
             json={
                 "model": "fake-model",
                 "messages": [{"role": "user", "content": "hello"}],
@@ -275,3 +269,63 @@ class TestLLMProxyPassthroughE2E:
         assert resp.status_code == 200
         content = resp.json()["choices"][0]["message"]["content"]
         assert "Hello from" in content
+
+
+class TestLLMProxyEgressHopE2E:
+    """The full production hop: caddy egress listener → backend gate.
+
+    The other classes hit the backend directly, and the caddy ACL suite
+    uses an echo upstream — neither proves that a request through the
+    egress listener carries the workspace JWT all the way into the
+    backend's ``require_workspace_token`` gate (#2959). A caddy-side
+    regression that stopped forwarding ``Authorization`` would 401 every
+    in-container LLM call while both suites stayed green; this closes
+    that gap.
+
+    Real klangkd in TCP mode renders its own caddy (browser + egress
+    listeners). ``KLANGKD_CONTAINER_SUBNETS=127.0.0.1`` makes the test's
+    loopback source a container source so the egress ACL allows it (the
+    same trick the caddy ACL suite uses with the host IP).
+    """
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def stack(fake_llm):
+        egress_port = free_port()
+        model_entry = f"openai/fake-model:{fake_llm['url']}/v1:dummy-key"
+        srv = start_server(
+            uds=False,
+            KLANGKD_JWT_SECRET="llm-hop-e2e",
+            KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
+            KLANGKD_DEFAULT_USER="test@example.com",
+            KLANGKD_DEFAULT_PASSWORD="testpass",
+            KLANGKD_TEST_MODE="1",
+            KLANGKD_IDLE_TIMEOUT_SECONDS="300",
+            LOGFIRE_TOKEN="",
+            KLANGKD_LLM_MODELS=model_entry,
+            KLANGKD_EGRESS_PORT=str(egress_port),
+            KLANGKD_CONTAINER_SUBNETS="127.0.0.1",
+        )
+        yield {"client": srv["client"], "egress_port": egress_port}
+        stop_server(srv)
+
+    def test_tokenless_rejected_by_forward_auth(self, stack):
+        """No token → the egress forward_auth verifier 401s it."""
+        resp = httpx.get(
+            f"http://127.0.0.1:{stack['egress_port']}/llm-proxy/models",
+            timeout=10,
+        )
+        assert resp.status_code == 401
+
+    def test_workspace_token_survives_the_hop(self, stack):
+        """Workspace token → passes the ACL, forward_auth, AND the
+        backend gate; the model list comes back (200)."""
+        headers = _ws_headers(stack["client"], "ws-hop")
+        resp = httpx.get(
+            f"http://127.0.0.1:{stack['egress_port']}/llm-proxy/models",
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        ids = [m["id"] for m in resp.json()["data"]]
+        assert "fake-model" in ids

--- a/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_in_workspace_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_llm_proxy_in_workspace_e2e.py
@@ -1,0 +1,213 @@
+"""In-workspace LLM-proxy E2E tests (#2959).
+
+The deepest integration of the LLM proxy: a real klangkd (TCP mode, so
+its own caddy runs the browser + egress listeners) with
+``KLANGKD_LLM_MODELS`` pointing at a fake OpenAI-compatible upstream,
+a real workspace container, and ``curl`` driven from *inside* it — the
+exact production path:
+
+    curl in container
+      → egress caddy (container-source ACL + workspace-JWT forward_auth)
+        → klangkd backend (workspace-token gate, #2959)
+          → litellm router → fake upstream
+
+Also proves the gate's negative from the inside: a tokenless request
+from within the container is rejected (401 at forward_auth), and a
+chat completion echoes the fake upstream's canned content.
+
+Requires: podman available, klangk image built.
+
+Run with: devenv shell -- test-backend-e2e -k test_llm_proxy_in_workspace
+"""
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from _e2e_server import start_server, stop_server, ws_connect as _ws_dial
+from _fake_llm import start_fake_llm, stop_fake_llm
+
+
+@pytest.fixture(scope="module")
+def fake_llm():
+    """Start a fake OpenAI-compatible LLM server on a free port."""
+    fake = start_fake_llm()
+    yield fake
+    stop_fake_llm(fake)
+
+
+@pytest.fixture(scope="module")
+def server(fake_llm):
+    """Real klangkd with LLM models pointing at the fake upstream.
+
+    TCP mode (uds=False) so klangkd's own caddy runs — the egress
+    listener the container's ``KLANGKWS_LLM_PROXY_URL`` points at only
+    exists when the proxy is up. ``KLANGKD_CONTAINER_SUBNETS`` is left
+    unset so caddy auto-derives the container sources from the host's
+    IPv4s (the production behavior: pasta NAT makes container traffic
+    appear as the host's own addresses, never loopback).
+    """
+    model_entry = f"openai/fake-model:{fake_llm['url']}/v1:dummy-key"
+    srv = start_server(
+        uds=False,
+        KLANGKD_JWT_SECRET="llm-ws-e2e-secret",
+        KLANGKD_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGKD_DEFAULT_USER="test@example.com",
+        KLANGKD_DEFAULT_PASSWORD="testpass",
+        KLANGKD_TEST_MODE="1",
+        KLANGKD_IDLE_TIMEOUT_SECONDS="300",
+        LOGFIRE_TOKEN="",
+        KLANGKD_LLM_MODELS=model_entry,
+    )
+    yield srv
+    stop_server(srv)
+
+
+@pytest.fixture(scope="module")
+def auth(server):
+    resp = server["client"].post(
+        "/api/v1/auth/login",
+        json={"identifier": "test@example.com", "password": "testpass"},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    return {"token": token, "headers": {"Authorization": f"Bearer {token}"}}
+
+
+async def recv_until(ws, predicate, timeout=30):
+    deadline = asyncio.get_event_loop().time() + timeout
+    messages = []
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            msg = await asyncio.wait_for(ws.recv(), timeout=1)
+            data = json.loads(msg)
+            messages.append(data)
+            if predicate(data):
+                return messages
+        except asyncio.TimeoutError:
+            continue
+    return messages
+
+
+def is_container_ready(msg):
+    if msg.get("type") != "event":
+        return False
+    event = msg.get("event", {})
+    return (
+        event.get("type") == "CUSTOM"
+        and event.get("name") == "container_ready"
+    )
+
+
+async def ws_connect(server, auth, workspace_id):
+    """Open a WebSocket, connect to the workspace, wait for the container.
+
+    Mirrors test_per_user_home.py: the first wait is on the direct
+    ``container_ready`` WS message (connect ack); after ``ui_ready`` a
+    CUSTOM ``container_ready`` event follows (handle auto-create).
+    """
+    ws = await _ws_dial(server, f"/ws?token={auth['token']}", max_size=2**20)
+    await ws.send(
+        json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})
+    )
+    deadline = asyncio.get_event_loop().time() + 90
+    while asyncio.get_event_loop().time() < deadline:
+        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=90))
+        if msg.get("type") == "container_ready":
+            break
+    await ws.send(json.dumps({"cmd": "ui_ready"}))
+    while asyncio.get_event_loop().time() < deadline:
+        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=90))
+        if is_container_ready(msg):
+            break
+    return ws
+
+
+async def exec_command(ws, command):
+    """Run a command via exec and return combined output (base64-decoded)."""
+    await ws.send(json.dumps({"cmd": "exec_start", "command": command}))
+    msgs = await recv_until(
+        ws, lambda m: m.get("type") == "exec_exit", timeout=60
+    )
+    outputs = [m for m in msgs if m.get("type") == "exec_output"]
+    return b"".join(base64.b64decode(m["data"]) for m in outputs).decode()
+
+
+class TestLLMProxyFromWorkspace:
+    @pytest.mark.asyncio
+    async def test_llm_proxy_round_trip_from_inside_workspace(
+        self, server, auth
+    ):
+        """One container, three legs through the production path:
+
+        1. models with the workspace token → the fake model is listed;
+        2. chat completion with the token → the canned content comes
+           back (echoed model name proves verbatim forwarding);
+        3. no token → 401 (egress forward_auth rejects it before the
+           backend ever sees it).
+        """
+        client = server["client"]
+        resp = client.post(
+            "/api/v1/workspaces",
+            headers=auth["headers"],
+            json={"name": "llm-proxy-in-ws"},
+            timeout=10,
+        )
+        assert resp.status_code == 200, resp.text
+        workspace_id = resp.json()["id"]
+        try:
+            ws = await ws_connect(server, auth, workspace_id)
+            try:
+                models = await exec_command(
+                    ws,
+                    [
+                        "bash",
+                        "-c",
+                        'curl -s -H "Authorization: Bearer '
+                        '$(klangk-workspace-token)" '
+                        '"$KLANGKWS_LLM_PROXY_URL/models"',
+                    ],
+                )
+                assert "fake-model" in models, models
+
+                completion = await exec_command(
+                    ws,
+                    [
+                        "bash",
+                        "-c",
+                        "curl -s "
+                        '-H "Authorization: Bearer '
+                        '$(klangk-workspace-token)" '
+                        '-H "Content-Type: application/json" '
+                        '-d \'{"model": "fake-model", '
+                        '"messages": [{"role": "user", '
+                        '"content": "hi"}]}\' '
+                        '"$KLANGKWS_LLM_PROXY_URL/chat/completions"',
+                    ],
+                )
+                assert "Hello from fake-model!" in completion, completion
+
+                status = await exec_command(
+                    ws,
+                    [
+                        "bash",
+                        "-c",
+                        'curl -s -o /dev/null -w "%{http_code}" '
+                        '"$KLANGKWS_LLM_PROXY_URL/models"',
+                    ],
+                )
+                assert status.strip() == "401", status
+            finally:
+                await ws.close()
+        finally:
+            try:
+                client.delete(
+                    f"/api/v1/workspaces/{workspace_id}",
+                    headers=auth["headers"],
+                    timeout=30,
+                )
+            except Exception:
+                pass

--- a/src/klangk/klangkd-tests/tests/test_llm_proxy_api.py
+++ b/src/klangk/klangkd-tests/tests/test_llm_proxy_api.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from klangk.api.llm_proxy import router
+from klangk.auth import Auth
 from klangk.llm_router import LLMRouter
 from _helpers import make_settings
 
@@ -20,14 +21,62 @@ def _app(extra_env=None):
     )
     app = FastAPI()
     app.state.llm_router = LLMRouter(mock_app_state)
+    app.state.auth = Auth(mock_app_state)
     app.include_router(router)
     return app
 
 
-def _client(app):
+def _client(app, authed=True):
+    """A client for the minimal app; `authed` pre-loads the workspace
+    token as the default Authorization header (per-request headers still
+    override it, #2959 gate tests rely on that)."""
+    headers = _ws_headers(app) if authed else None
     return AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers=headers,
     )
+
+
+def _ws_headers(app, workspace_id="ws-llm"):
+    """Auth headers with a workspace JWT (the only accepted caller class,
+    #2959 — the egress caddy forwards this same header to the backend)."""
+    token = app.state.auth.create_workspace_token(workspace_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestWorkspaceTokenGate:
+    """#2959: /llm-proxy is container-internal — workspace JWTs only."""
+
+    async def test_missing_token_returns_401(self):
+        app = _app()
+        async with _client(app, authed=False) as client:
+            resp = await client.get("/llm-proxy/models")
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Missing workspace token"
+
+    async def test_user_jwt_rejected(self):
+        """A valid user login token is NOT a workspace token → 401."""
+        app = _app()
+        user_jwt = app.state.auth.create_token("user-1", "u@example.com")
+        async with _client(app, authed=False) as client:
+            resp = await client.get(
+                "/llm-proxy/models",
+                headers={"Authorization": f"Bearer {user_jwt}"},
+            )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid workspace token"
+
+    async def test_expired_workspace_token_returns_401(self):
+        app = _app()
+        headers = _ws_headers(app)
+        app.state.auth.decode_workspace_token = lambda token: (
+            Auth.WORKSPACE_TOKEN_EXPIRED
+        )
+        async with _client(app, authed=False) as client:
+            resp = await client.get("/llm-proxy/models", headers=headers)
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Workspace token expired"
 
 
 class TestListModels:

--- a/src/klangk/klangkd-tests/tests/test_llm_proxy_api.py
+++ b/src/klangk/klangkd-tests/tests/test_llm_proxy_api.py
@@ -27,9 +27,10 @@ def _app(extra_env=None):
 
 
 def _client(app, authed=True):
-    """A client for the minimal app; `authed` pre-loads the workspace
-    token as the default Authorization header (per-request headers still
-    override it, #2959 gate tests rely on that)."""
+    """A client for the minimal app. `authed` pre-loads the workspace
+    token as the default Authorization header so existing cases exercise
+    the accepted caller class; the #2959 gate tests pass `authed=False`
+    (or per-request headers) to control exactly what is sent."""
     headers = _ws_headers(app) if authed else None
     return AsyncClient(
         transport=ASGITransport(app=app),


### PR DESCRIPTION
Closes #2959.

## What changed

`/llm-proxy/*` had **no backend-side auth** on main — the egress caddy's `forward_auth` + container-source ACL were the only gates, so anything that could reach the backend port directly could use the proxy (and its upstream API keys) from outside a workspace container, with no token at all.

Both routes now take `Depends(require_workspace_token)` — the same defense-in-depth pattern as `/api/v1/browser-delegate`:

- **Workspace JWTs** (the in-container path: egress caddy `forward_auth` validates and forwards the same `Authorization` header) → accepted.
- **User JWTs and anonymous requests** → `401`. The proxy is not usable from outside workspace containers, even by authenticated users — so #2956's `use-llm-proxy` user-JWT branch must be dropped when it rebases; its workspace-owner-principals check remains compatible.

The egress path is unchanged (caddy config untouched); in-container clients (`klangk-setup-pi`, the `llm-proxy-models` extension) already send the workspace token.

## Also

- Unit tests: `TestWorkspaceTokenGate` (missing token / user JWT / expired token → 401); all existing cases now send the workspace token.
- E2E: unauthenticated → 401, real login JWT → 401, and token-authenticated model/completion flows.
- Docs: `docs/architecture/llm-proxy.md` and `docs/reference/api-endpoints.md` state the backend re-validation; changelog entry under Security.

## Verification

- Backend + CLI: **6414 passed / 100% branch coverage** (CI-style `-n auto`).
- `test-backend-e2e -k test_llm_proxy_e2e`: 8 passed (real klangkd, fake upstream).
- scripts/tests: 97 passed; xenon + full pre-commit clean.
