### PR TITLE
fix(git-credential): normalize host in device-flow gate

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1714,6 +1714,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **GitHub device-flow gate now normalizes the git host (#2963).**
+  With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, a remote
+  written as `https://github.com:443/...`, `https://GitHub.com/...`, or
+  `https://github.com./...` skipped the device flow and fell back to the
+  manual PAT dialog; the credential helper now matches those spellings
+  the same way the browser dialog does.
+
 - **Git credential dialog hint text (#2954).** The browser-side
   "Git credentials" dialog now derives its field wording from the host
   (case-, port-, and trailing-dot-insensitive): `github.com` keeps

--- a/docs/features/github-authentication.md
+++ b/docs/features/github-authentication.md
@@ -78,7 +78,9 @@ organization has approved the app.
 The device flow only activates when all of these are true:
 
 - `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` is set in the container environment
-- The git host is `github.com` (or `www.github.com`)
+- The git host is GitHub — any spelling of `github.com` (or `www.github.com`)
+  counts: case (`GitHub.com`), explicit port (`github.com:443`), and a
+  trailing dot (`github.com.`) all match
 - A browser tab is connected (the helper needs to show the code)
 
 For non-GitHub hosts, or when the client ID is not configured, the
@@ -248,7 +250,9 @@ HTTPS with PATs or OAuth is the recommended authentication method.
   [Ways to set the client ID](#ways-to-set-the-client-id) — the quickest
   check is an ad-hoc `export` in the shell.
 - Check that the OAuth App has **Enable Device Flow** turned on.
-- The device flow only activates for `github.com` hosts.
+- The device flow only activates for GitHub hosts — any spelling of
+  `github.com` (case, explicit port, and trailing dot all match; see
+  [When does the device flow activate?](#when-does-the-device-flow-activate)).
 - Restart the workspace after setting the variable — it is injected at
   container start, not baked into the image.
 

--- a/features/git-credential/tools/git-credential-klangk
+++ b/features/git-credential/tools/git-credential-klangk
@@ -4,7 +4,8 @@
 Called by git as: git-credential-klangk get|store|erase
 
 On "get": reads protocol/host/path from stdin. If KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID
-is set and the host is github.com, runs the GitHub device flow (requesting
+is set and the host is any spelling of github.com (case, port, and trailing
+dot are normalized away), runs the GitHub device flow (requesting
 the code from GitHub directly, showing it in the browser, and polling for the
 token). Otherwise, or on fallback, delegates to the browser for a PAT dialog.
 On "store"/"erase": forwards to the bridge so the frontend can update or

--- a/features/git-credential/tools/git-credential-klangk
+++ b/features/git-credential/tools/git-credential-klangk
@@ -321,6 +321,23 @@ def _handle_device_flow(cred, browser_id):
     return None
 
 
+def _is_github_host(host):
+    """Return True when a git credential ``host`` names GitHub.
+
+    Git preserves case in the credential ``host`` field and can include an
+    explicit port or a trailing dot (``GitHub.com``, ``github.com:443``,
+    ``github.com.``). Normalize all of that away before comparing, so every
+    spelling of a GitHub remote gets the device flow. Mirrors
+    ``_CredentialDialog.isGitHubHost`` in the browser-side feature.
+    """
+    normalized = host.lower()
+    port = normalized.find(":")
+    if port >= 0:
+        normalized = normalized[:port]
+    normalized = normalized.rstrip(".")
+    return normalized in ("github.com", "www.github.com")
+
+
 def main():
     operation = sys.argv[1] if len(sys.argv) > 1 else ""
 
@@ -343,7 +360,7 @@ def main():
         # a successful push, so a cached token must be reused instead of
         # forcing a fresh device-flow login on every operation.
         host = cred.get("host", "")
-        if GITHUB_CLIENT_ID and host in ("github.com", "www.github.com"):
+        if GITHUB_CLIENT_ID and _is_github_host(host):
             cached = _peek_bridge_cache(cred, browser_id)
             if cached:
                 _debug("using cached credential from browser")

--- a/src/klangk/klangkd-tests/tests/test_git_credential.py
+++ b/src/klangk/klangkd-tests/tests/test_git_credential.py
@@ -429,6 +429,82 @@ class TestDeviceFlowCache:
         assert "get" in ops
 
 
+class TestDeviceFlowHostGate:
+    """The device-flow gate must normalize the git credential host (#2963).
+
+    Git preserves case and can include an explicit port or trailing dot in
+    ``host``; every spelling of a GitHub remote must reach the device flow,
+    and non-GitHub hosts must skip it entirely.
+    """
+
+    CLIENT_ENV = {"KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID": "Ov23test"}
+
+    def _run_get(self, bridge_server, fake_browser_id, host):
+        server, port = bridge_server
+        base = f"http://127.0.0.1:{port}"
+        _BridgeHandler.op_bodies = {
+            "peek": json.dumps({"error": "miss"}).encode(),
+            "get": json.dumps({"username": "u", "password": "p"}).encode(),
+        }
+        _BridgeHandler.routes = {
+            "/login/device/code": json.dumps(
+                {
+                    "device_code": "dc-123",
+                    "user_code": "ABCD-1234",
+                    "verification_uri": f"{base}/login/device",
+                    "interval": 0,
+                    "expires_in": 60,
+                }
+            ).encode(),
+            "/login/oauth/access_token": json.dumps(
+                {"access_token": "gho_fresh", "token_type": "bearer"}
+            ).encode(),
+        }
+        return run_helper(
+            "get",
+            f"protocol=https\nhost={host}\n\n",
+            env_override={
+                "KLANGKWS_BRIDGE_URL": base,
+                "GIT_CREDENTIAL_KLANGK_GITHUB_URL": base,
+                **self.CLIENT_ENV,
+            },
+            extra_path=str(fake_browser_id),
+        )
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "github.com",
+            "www.github.com",
+            "github.com:443",
+            "GitHub.com",
+            "github.com.",
+        ],
+    )
+    def test_gate_takes_device_flow_for_every_github_spelling(
+        self, bridge_server, fake_browser_id, host
+    ):
+        result = self._run_get(bridge_server, fake_browser_id, host)
+
+        assert result.returncode == 0
+        assert "password=gho_fresh" in result.stdout
+        ops = [r["operation"] for r in _BridgeHandler.requests]
+        assert ops[0] == "peek"
+        assert "device_flow_show" in ops
+        assert "device_flow_done" in ops
+        assert "get" not in ops  # never fell through to the PAT dialog
+
+    def test_gate_skips_device_flow_for_non_github_host(
+        self, bridge_server, fake_browser_id
+    ):
+        result = self._run_get(bridge_server, fake_browser_id, "gitlab.com")
+
+        assert result.returncode == 0
+        assert "password=p" in result.stdout
+        ops = [r["operation"] for r in _BridgeHandler.requests]
+        assert ops == ["get"]  # no peek, no device flow, straight to PAT
+
+
 class TestStoreAndErase:
     def test_store_forwards_credentials(self, bridge_server, fake_browser_id):
         server, port = bridge_server

--- a/src/klangk/klangkd-tests/tests/test_git_credential.py
+++ b/src/klangk/klangkd-tests/tests/test_git_credential.py
@@ -494,10 +494,13 @@ class TestDeviceFlowHostGate:
         assert "device_flow_done" in ops
         assert "get" not in ops  # never fell through to the PAT dialog
 
+    @pytest.mark.parametrize(
+        "host", ["gitlab.com", "github.com.evil.com", "notgithub.com"]
+    )
     def test_gate_skips_device_flow_for_non_github_host(
-        self, bridge_server, fake_browser_id
+        self, bridge_server, fake_browser_id, host
     ):
-        result = self._run_get(bridge_server, fake_browser_id, "gitlab.com")
+        result = self._run_get(bridge_server, fake_browser_id, host)
 
         assert result.returncode == 0
         assert "password=p" in result.stdout


### PR DESCRIPTION
## Summary

- The container-side git-credential helper gated the GitHub OAuth device
  flow on an exact, unnormalized host match, so `github.com:443`,
  `GitHub.com`, and `github.com.` remotes skipped the device flow and fell
  back to the manual PAT dialog even with
  `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured.
- Adds `_is_github_host()` — lowercase, strip port, strip trailing dot —
  mirroring `_CredentialDialog.isGitHubHost` from #2961, so both sides of
  the bridge classify hosts identically.
- Tests: a parametrized gate test over every GitHub spelling (device flow
  attempted, never the PAT `get`), plus a gitlab.com test proving
  non-GitHub hosts skip peek/device flow entirely.

Closes #2963.

## Testing

- `pytest src/klangk/klangkd-tests/tests/test_git_credential.py` — 26
  passed (6 new).
- `test-push` gate green (6417 passed); xenon clean.
