### PR TITLE
docs: native YAML bools for bool-string settings in config examples

### DIFF
--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -104,7 +104,7 @@ A production-ready config file covering all common settings:
 # --- Auth / identity ---
 auth_modes: both
 jwt_secret: "file:/run/secrets/jwt"
-prevent_insecure_jwt_secret: "1"
+prevent_insecure_jwt_secret: true
 default_user: admin@example.com
 default_password: "file:/run/secrets/admin-pw"
 access_token_hours: 24


### PR DESCRIPTION
## Summary

Model the canonical native-bool form for bool-string settings everywhere they appear in tracked config surfaces (#2966).

## What changed

- `docs/reference/klangkd-config.md` complete example: `prevent_insecure_jwt_secret: "1"` → `prevent_insecure_jwt_secret: true`, matching its siblings (`allow_sudo: true`, `smtp_use_tls: true`). Since #2796 (`_coerce_bool_string_fields`) every `BOOL_STRING_FIELDS` member accepts a native YAML `true`/`false`.

## Swept, no change needed

- `klangkd.yaml.devenv` — emits no bool-string values.
- First-run generated config (`first_run._render_config`) — the commented `admission_memory_enabled: false` is already native.
- `customize/docker-compose.yml` `KLANGKD_*: "1"` entries — env-var values (strings by necessity), not config-file fields.
- Settings docstrings/tests quoting the string form — historical/explanatory or deliberately exercising the string path.

Fixes #2966.
