### PR TITLE
settings: accept native YAML integers for port, egress_port, bridge_timeout_seconds, idle_timeout_seconds

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -381,6 +381,14 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Native YAML integers for `port`, `egress_port`,
+  `bridge_timeout_seconds`, and `idle_timeout_seconds` (#2967).** A
+  bare YAML integer (`port: 8997`) now parses the same as the quoted
+  string form — previously it was rejected at construction unless
+  quoted. The deprecated `proxy_port` alias accepts a bare integer
+  too. Env vars, quoted strings, and `file:`/`cmd:` indirection are
+  unaffected.
+
 - **Granular `/admin` tab permissions (#2940).** The admin endpoints
   split off the monolithic `admin` gate onto one permission per tab:
   `manage-users` (Users), `manage-invitations` (Invitations),

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -38,6 +38,10 @@ Config-file keys map directly to `KLANGK_*` environment variable names with the 
 
 Every config-file key accepts **either** `snake_case` or `kebab-case` — `jwt_secret` and `jwt-secret` resolve to the same setting, as do `egress_port` / `egress-port`, `auth_modes` / `auth-modes`, and so on ([#1538](https://github.com/mcdonc/klangk/issues/1538)). This matches the dual-form lookup the OIDC provider dicts already had and is forgiving of either style, but **`snake_case` is the preferred/documented form** — all examples in this chapter (and the field names they map to) use `snake_case`.
 
+### Native scalar types
+
+Numeric, boolean, and list fields accept their natural YAML scalar types — a bare number for numeric fields (`access_token_hours: 48`, `port: 8997`), a bare `true`/`false` for boolean fields (`allow_sudo: true`), and a bare list for list fields. Quoted strings (`port: "8997"`) keep working everywhere; both forms parse identically ([#2603](https://github.com/mcdonc/klangk/issues/2603), [#2796](https://github.com/mcdonc/klangk/issues/2796), [#2967](https://github.com/mcdonc/klangk/issues/2967)). Env vars are always strings and behave exactly as before.
+
 ## `file:` and `cmd:` resolution
 
 Any value — whether from the config file or an env var — can use `file:` or `cmd:` prefixes to resolve secrets at **construction time** (not per-call at use time):
@@ -92,7 +96,7 @@ Each key may be written as the **stripped, lowercased short form** — e.g. `sol
 
 This block is read at boot and on `SIGHUP` (reloadable, like the rest of the file). It supplies values only; it does **not** change which features are compiled in (build-time, [#1655](https://github.com/mcdonc/klangk/issues/1655)) or which are turned on (`KLANGKD_FEATURES_ENABLE`, deploy-time).
 
-> **Quote non-string values.** The block's values are strings, so quote numerics and booleans the way you would for any other config-file field — `port: "8080"`, not `8080` (the unquoted form is parsed as an int and rejected at construction). This matches the rest of `klangkd.yaml` (the complete example quotes every numeric).
+> **Quote non-string values.** The block is typed as a plain string map and is resolved outside the typed settings model (`resolve_dynamic_config`), so quote numerics and booleans here — `soliplex_port: "8080"`, not `8080`. (Top-level settings fields, unlike this block, accept their native YAML scalar types — see above.)
 
 ## Complete example
 
@@ -117,8 +121,8 @@ password_history_count: 5
 
 # --- Server / network ---
 listen: "127.0.0.1"
-port: "8997"
-egress_port: "8995"
+port: 8997
+egress_port: 8995
 hosting_hostname: klangk.example.com
 hosting_proto: https
 trusted_proxy_cidrs: "127.0.0.1,::1,10.0.0.0/8"
@@ -216,7 +220,7 @@ since #1642):
 # --- Deployment shape ---
 # port is the browser/proxy port. Unset ⇒ headless (no browser listener).
 # Set ⇒ full/browser mode (UI + API + hosted apps).
-port: "8997"
+port: 8997
 # listen is the browser interface address (rendered only when port is set).
 # listen: "127.0.0.1"  # browser interface address (default loopback; set 0.0.0.0 for all interfaces)
 # egress_listen is the egress interface address. Defaults to 0.0.0.0 (all

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -595,6 +595,24 @@ BOOL_STRING_FIELDS = (
     "test_mode",
 )
 
+# The str-typed settings consumed as port numbers / second counts (their
+# consumers int()/float() the string). They stay str-typed — env vars are
+# always strings, ``file:``/``cmd:`` indirection keeps working — but a
+# native YAML int is translated to its string form at construction so a
+# bare ``port: 8997`` parses the same as ``port: "8997"`` (#2967). The
+# deprecated ``proxy_port`` alias is included: it is still folded into
+# ``egress_port`` by ``_resolve_socket_and_ports``, so its natural form
+# must parse too. One tuple feeds the field validator below and the
+# tests, so the family can't drift (same shape as BOOL_STRING_FIELDS,
+# #2796).
+INT_STRING_FIELDS = (
+    "port",
+    "egress_port",
+    "proxy_port",
+    "bridge_timeout_seconds",
+    "idle_timeout_seconds",
+)
+
 
 class KlangkSettings(BaseSettings):
     """Typed configuration for all ``KLANGKD_*`` environment variables.
@@ -1646,6 +1664,38 @@ class KlangkSettings(BaseSettings):
             return "true"
         if v is False:
             return "false"
+        return v
+
+    @field_validator(*INT_STRING_FIELDS, mode="before")
+    @classmethod
+    def _coerce_int_string_fields(cls, v, info):
+        """Accept a native YAML int for the str-typed port/timeout
+        settings, including the deprecated ``proxy_port`` alias (#2967
+        — the int sibling of ``_coerce_bool_string_fields``, #2796).
+
+        The family is :data:`INT_STRING_FIELDS`. A bare
+        ``port: 8997`` in YAML parses as an int and used to fail
+        validation with ``Input should be a valid string``. Translate a
+        native int to its string form. A bool (``port: true``) or a
+        float (``port: 8997.5`` — silently truncating would hide a
+        typo) raises naming the field, matching the strict-on-malformed
+        posture of the #2603 numeric coercers instead of pydantic's
+        generic str error (which steers the operator to *quote* the
+        value). Everything else (strings, ``None``) passes through
+        unchanged — env vars, quoted YAML, and ``file:``/``cmd:``
+        references are unaffected.
+        """
+        if isinstance(v, bool):
+            raise ValueError(
+                f"{info.field_name}={v!r} must be an integer, not a boolean."
+            )
+        if isinstance(v, float):
+            raise ValueError(
+                f"{info.field_name}={v!r} must be an integer, not a float "
+                "(use 8997, not 8997.5)."
+            )
+        if isinstance(v, int):
+            return str(v)
         return v
 
     @field_validator("log_level")

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -13,6 +13,7 @@ import pytest
 from _helpers import make_settings
 from klangk.settings import (
     BOOL_STRING_FIELDS,
+    INT_STRING_FIELDS,
     KlangkSettings,
     resolve_indirection,
     parse_bool_setting,
@@ -1897,6 +1898,105 @@ class TestBoolStringSettingCoercion:
         assert s.reject_proxy_headers is None
         assert s.smtp_use_tls == "true"
         assert s.test_mode is None
+
+
+class TestIntStringSettingCoercion:
+    """Str-typed port/timeout settings accept native YAML ints (#2967).
+
+    The int sibling of the #2796 bool-string coercion: fields stay
+    str-typed (env vars are always strings; consumers int()/float()
+    the value), but a bare ``port: 8997`` in YAML parses as an int and
+    used to fail validation with ``Input should be a valid string``.
+    """
+
+    # Imported from settings so the validator's family and this test
+    # class can't drift apart (same guard as BOOL_STRING_FIELDS).
+    FIELDS = list(INT_STRING_FIELDS)
+
+    @pytest.mark.parametrize("field", FIELDS)
+    @pytest.mark.parametrize("value", [8997, 0])
+    def test_yaml_native_int(self, field, value, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"{field}: {value}\n")
+        s = make_settings({}, config_file=str(cfg))
+        assert getattr(s, field) == str(value)
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [(f, v) for f in FIELDS for v in ("8997", "0", " 30", "")],
+    )
+    def test_env_strings_unchanged(self, field, value):
+        s = make_settings({f"KLANGKD_{field.upper()}": value})
+        assert getattr(s, field) == value
+
+    def test_yaml_quoted_strings_unchanged(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            'port: "8997"\n'
+            "egress_port: '8995'\n"
+            'bridge_timeout_seconds: "30"\n'
+            "idle_timeout_seconds: '1800'\n"
+        )
+        s = make_settings({}, config_file=str(cfg))
+        assert s.port == "8997"
+        assert s.egress_port == "8995"
+        assert s.bridge_timeout_seconds == "30"
+        assert s.idle_timeout_seconds == "1800"
+
+    def test_file_indirection_still_works(self, tmp_path):
+        secret = tmp_path / "port"
+        secret.write_text("9464\n")
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"port: file:{secret}\n")
+        s = make_settings({}, config_file=str(cfg))
+        assert s.port == "9464"
+
+    @pytest.mark.parametrize("field", FIELDS)
+    def test_native_bool_rejected(self, field, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"{field}: true\n")
+        with pytest.raises(Exception, match="must be an integer"):
+            make_settings({}, config_file=str(cfg))
+
+    @pytest.mark.parametrize("field", FIELDS)
+    def test_native_float_rejected(self, field, tmp_path):
+        # A float must fail with the field named (the #2603 posture),
+        # not pydantic's generic str error — which steers the operator
+        # to *quote* the value instead of fixing the typo.
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"{field}: 8997.5\n")
+        with pytest.raises(Exception, match="not a float"):
+            make_settings({}, config_file=str(cfg))
+
+    def test_unset_keeps_defaults(self):
+        s = make_settings({})
+        assert s.port is None
+        assert s.egress_port == "8995"
+        assert s.bridge_timeout_seconds is None
+        assert s.idle_timeout_seconds is None
+
+    def test_coerced_values_flow_into_port_invariants(self, tmp_path):
+        """Native ints must land as strings *before* the downstream
+        model validators run: the egress≠browser guard compares the
+        str fields, and the port-collision probe int()s them (#2967)."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("port: 8995\n")  # same as the default egress port
+        with pytest.raises(Exception, match="must differ"):
+            make_settings({}, config_file=str(cfg))
+        cfg.write_text("port: 8997\negress_port: 8996\n")
+        s = make_settings({}, config_file=str(cfg))
+        assert s.port == "8997"
+        assert s.egress_port == "8996"
+
+    def test_deprecated_proxy_port_native_int_folds(self, tmp_path):
+        """The deprecated alias takes the natural bare int too: its
+        coerced string must flow through the proxy_port→egress_port
+        fold in ``_resolve_socket_and_ports`` (#2967)."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("proxy_port: 8996\n")
+        s = make_settings({}, config_file=str(cfg))
+        assert s.proxy_port == "8996"
+        assert s.egress_port == "8996"
 
 
 class TestParseBoolSetting:


### PR DESCRIPTION
## Summary

`port`, `egress_port`, `bridge_timeout_seconds`, and `idle_timeout_seconds` were the last str-typed settings where a bare YAML scalar failed construction — a native YAML int (`port: 8997`) was rejected with `Input should be a valid string` while the quoted form worked (the bool-string family got native-bool support in #2796, the numeric fields got bare-number support in #2603).

Adds `INT_STRING_FIELDS` + a `mode="before"` field validator (`_coerce_int_string_fields`) that translates a native `int` to its string form — the same pattern as `_coerce_bool_string_fields`. Fields stay str-typed, so env vars, `file:`/`cmd:` indirection, and existing consumers are unaffected. A bool (`port: true`) raises naming the field; a float (`port: 8997.5`) still fails the str check loudly. With this, **every settings field accepts its natural YAML scalar type**.

## Docs

- `klangkd-config.md`: new "Native scalar types" section; the stale "Quote non-string values" note no longer claims `port: 8080` is rejected (still true for the `features_config:` block, which is outside the settings model); example configs show the bare form.
- Changelog entry under `[Unreleased]` → Added.

## Testing

- `TestIntStringSettingCoercion` mirrors `TestBoolStringSettingCoercion`: native int per field, env/quoted strings unchanged, `file:` indirection, bool/float rejection, defaults, and coercion landing before the egress≠browser port invariant.
- Full suite: 6461 passed, 100% branch coverage.

Fixes #2967.
