### PR TITLE
refactor(model): bring core model modules under rank A (T1)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -191,6 +191,7 @@ in
       rsync
       twine
       xenon # cyclomatic-complexity gate tool (#2828): same pinned build as the hook
+      (python314Packages.radon) # complexity introspection (radon cc) for xenon ratchet work (#2845)
       zensical
     ]
     ++ (

--- a/src/klangk/klangk/model/acl.py
+++ b/src/klangk/klangk/model/acl.py
@@ -6,6 +6,7 @@ and the pure ``row_to_acl_entry`` helper stay module-level — they are
 imported as literal values by ``workspaces.py`` and ``schema.py``.
 """
 
+from .base import Submodel
 from .users import (
     AGENT_USER_ID,
     AgentPrincipalError,
@@ -94,7 +95,7 @@ def _reject_agent_principal(entry: dict) -> None:
         )
 
 
-class ACLModel:
+class ACLModel(Submodel):
     """ACL data access, through ``app_state.db``.
 
     Reached via ``app_state.model.acl``. Reaches the DB through
@@ -103,12 +104,6 @@ class ACLModel:
     (backstop); the constants and the pure ``row_to_acl_entry`` helper
     stay module-level.
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def _check_role_group_scope(
         self, db, resource: str, group_id: str

--- a/src/klangk/klangk/model/acl.py
+++ b/src/klangk/klangk/model/acl.py
@@ -40,6 +40,60 @@ def row_to_acl_entry(row) -> dict:
     }
 
 
+def _system_principal_fields(row) -> dict:
+    """Display fields for a system-principal row."""
+    sp = row["system_principal"]
+    return {
+        "principal": "Everyone" if sp == SYSTEM_EVERYONE else "Authenticated",
+        "system_principal": sp,
+    }
+
+
+def _user_principal_fields(row) -> dict:
+    """Display fields for a user-principal row."""
+    return {
+        "principal": row["user_email"] or row["user_id"],
+        "user_id": row["user_id"],
+    }
+
+
+def _group_principal_fields(row) -> dict:
+    """Display fields for a group-principal row."""
+    return {
+        "principal": row["group_name"] or row["group_id"],
+        "group_id": row["group_id"],
+    }
+
+
+def _resolved_principal_fields(row) -> dict:
+    """Principal display fields for one resolved ACL row.
+
+    An unknown principal type yields no fields (the entry carries only
+    the base columns).
+    """
+    pt = row["principal_type"]
+    if pt == PRINCIPAL_SYSTEM:
+        return _system_principal_fields(row)
+    if pt == PRINCIPAL_USER:
+        return _user_principal_fields(row)
+    if pt == PRINCIPAL_GROUP:
+        return _group_principal_fields(row)
+    return {}
+
+
+def _reject_agent_principal(entry: dict) -> None:
+    """Guard: no entry may make the system agent a user principal."""
+    if (
+        entry.get("principal_type") == PRINCIPAL_USER
+        and entry.get("user_id") == AGENT_USER_ID
+    ):
+        raise AgentPrincipalError(
+            "The system agent cannot hold ACL entries"
+            " (global fixed UUID — granting it cross-workspace"
+            " blast radius)."
+        )
+
+
 class ACLModel:
     """ACL data access, through ``app_state.db``.
 
@@ -188,19 +242,7 @@ class ACLModel:
                 "principal_type": row["principal_type"],
                 "permission": row["permission"],
             }
-            pt = row["principal_type"]
-            if pt == PRINCIPAL_SYSTEM:
-                sp = row["system_principal"]
-                entry["principal"] = (
-                    "Everyone" if sp == SYSTEM_EVERYONE else "Authenticated"
-                )
-                entry["system_principal"] = sp
-            elif pt == PRINCIPAL_USER:
-                entry["principal"] = row["user_email"] or row["user_id"]
-                entry["user_id"] = row["user_id"]
-            elif pt == PRINCIPAL_GROUP:
-                entry["principal"] = row["group_name"] or row["group_id"]
-                entry["group_id"] = row["group_id"]
+            entry.update(_resolved_principal_fields(row))
             results.append(entry)
         return results
 
@@ -217,44 +259,45 @@ class ACLModel:
         principal.
         """
         for entry in entries:
-            if (
-                entry.get("principal_type") == PRINCIPAL_USER
-                and entry.get("user_id") == AGENT_USER_ID
-            ):
-                raise AgentPrincipalError(
-                    "The system agent cannot hold ACL entries"
-                    " (global fixed UUID — granting it cross-workspace"
-                    " blast radius)."
-                )
+            _reject_agent_principal(entry)
         async with self.app.state.db.transaction() as db:
-            for entry in entries:
-                if (
-                    entry.get("principal_type") == PRINCIPAL_GROUP
-                    and entry.get("group_id") is not None
-                ):
-                    await self._check_role_group_scope(
-                        db, resource, entry["group_id"]
-                    )
+            await self._check_entry_role_group_scopes(db, resource, entries)
             await db.execute(
                 "DELETE FROM acl_entries WHERE resource = ?", (resource,)
             )
             for entry in entries:
-                await db.execute(
-                    "INSERT INTO acl_entries"
-                    " (resource, position, action, principal_type,"
-                    "  user_id, group_id, system_principal, permission)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        resource,
-                        entry["position"],
-                        entry["action"],
-                        entry["principal_type"],
-                        entry.get("user_id"),
-                        entry.get("group_id"),
-                        entry.get("system_principal"),
-                        entry["permission"],
-                    ),
+                await self._insert_acl_entry(db, resource, entry)
+
+    async def _check_entry_role_group_scopes(
+        self, db, resource: str, entries: list[dict]
+    ) -> None:
+        """Guard: group entries must respect the role-group scope."""
+        for entry in entries:
+            if (
+                entry.get("principal_type") == PRINCIPAL_GROUP
+                and entry.get("group_id") is not None
+            ):
+                await self._check_role_group_scope(
+                    db, resource, entry["group_id"]
                 )
+
+    async def _insert_acl_entry(self, db, resource: str, entry: dict) -> None:
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type,"
+            "  user_id, group_id, system_principal, permission)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                resource,
+                entry["position"],
+                entry["action"],
+                entry["principal_type"],
+                entry.get("user_id"),
+                entry.get("group_id"),
+                entry.get("system_principal"),
+                entry["permission"],
+            ),
+        )
 
     async def delete_acl_entries_for_resource(self, resource: str) -> int:
         """Delete all ACL entries for a resource. Returns count deleted."""

--- a/src/klangk/klangk/model/base.py
+++ b/src/klangk/klangk/model/base.py
@@ -1,0 +1,17 @@
+"""Shared base for the model package's app-bound submodels."""
+
+
+class Submodel:
+    """Base for :class:`~klangk.model.model.Model`'s subdomains.
+
+    Every submodel holds only the ``app`` reference (the app-ownership
+    rule: constructed as ``X(app)``, caching only ``self.app``, reading
+    ``self.app.state.*`` live at call time). ``reconfigure`` rebinds the
+    reference on a settings swap (the SIGHUP config reload, #1587).
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    def reconfigure(self, app) -> None:
+        self.app = app

--- a/src/klangk/klangk/model/base.py
+++ b/src/klangk/klangk/model/base.py
@@ -1,4 +1,7 @@
-"""Shared base for the model package's app-bound submodels."""
+"""Shared plumbing for the model package: the app-bound submodel base
+and small helpers used across the domain modules."""
+
+import time
 
 
 class Submodel:
@@ -15,3 +18,8 @@ class Submodel:
 
     def reconfigure(self, app) -> None:
         self.app = app
+
+
+def resolve_prune_now(now: float | None) -> float:
+    """A prune sweep's reference clock (caller-supplied or wall clock)."""
+    return time.time() if now is None else now

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -20,7 +20,7 @@ keeping the newest. An admin-facing paged view is tracked separately.
 import logging
 import time
 
-from .base import Submodel
+from .base import Submodel, resolve_prune_now
 from .users import AGENT_USER_ID
 
 logger = logging.getLogger(__name__)
@@ -86,11 +86,6 @@ def row_to_dict(row) -> dict:
     """Row-tuple -> dict with the column names of ``_EVENT_COLUMNS``."""
     keys = [c.strip() for c in _EVENT_COLUMNS.split(",")]
     return dict(zip(keys, row, strict=True))
-
-
-def _resolve_prune_now(now: float | None) -> float:
-    """The sweep's reference clock (caller-supplied or wall clock)."""
-    return time.time() if now is None else now
 
 
 class ContainerEventsModel(Submodel):
@@ -181,7 +176,7 @@ class ContainerEventsModel(Submodel):
         row_cap = settings.container_events_row_cap
         if retention_days <= 0 and row_cap <= 0:
             return 0
-        when = _resolve_prune_now(now)
+        when = resolve_prune_now(now)
         deleted = 0
         if retention_days > 0:
             deleted += await self._prune_retention(when, retention_days)

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -20,6 +20,7 @@ keeping the newest. An admin-facing paged view is tracked separately.
 import logging
 import time
 
+from .base import Submodel
 from .users import AGENT_USER_ID
 
 logger = logging.getLogger(__name__)
@@ -87,14 +88,13 @@ def row_to_dict(row) -> dict:
     return dict(zip(keys, row, strict=True))
 
 
-class ContainerEventsModel:
+def _resolve_prune_now(now: float | None) -> float:
+    """The sweep's reference clock (caller-supplied or wall clock)."""
+    return time.time() if now is None else now
+
+
+class ContainerEventsModel(Submodel):
     """CRUD for the ``container_events`` table."""
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def record(
         self,
@@ -179,7 +179,9 @@ class ContainerEventsModel:
         settings = self.app.state.settings
         retention_days = settings.container_events_retention_days
         row_cap = settings.container_events_row_cap
-        when = time.time() if now is None else now
+        if retention_days <= 0 and row_cap <= 0:
+            return 0
+        when = _resolve_prune_now(now)
         deleted = 0
         if retention_days > 0:
             deleted += await self._prune_retention(when, retention_days)

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -179,21 +179,22 @@ class ContainerEventsModel:
         settings = self.app.state.settings
         retention_days = settings.container_events_retention_days
         row_cap = settings.container_events_row_cap
-        if retention_days <= 0 and row_cap <= 0:
-            return 0
-        if now is None:
-            now = time.time()
+        when = time.time() if now is None else now
         deleted = 0
         if retention_days > 0:
-            async with self.app.state.db.transaction() as db:
-                cursor = await db.execute(
-                    "DELETE FROM container_events WHERE created_at < ?",
-                    (now - retention_days * 86400.0,),
-                )
-                deleted += cursor.rowcount
+            deleted += await self._prune_retention(when, retention_days)
         if row_cap > 0:
             deleted += await self._prune_row_cap(row_cap)
         return deleted
+
+    async def _prune_retention(self, now: float, retention_days: int) -> int:
+        """Retention pass: delete rows older than the window."""
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "DELETE FROM container_events WHERE created_at < ?",
+                (now - retention_days * 86400.0,),
+            )
+            return cursor.rowcount
 
     async def _prune_row_cap(self, row_cap: int) -> int:
         """Deploy-wide cap: delete the oldest rows over the cap, keeping

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -639,18 +639,14 @@ class EgressConsentModel:
         settings = self.app.state.settings
         retention_days = settings.egress_consent_retention_days
         row_cap = settings.egress_consent_row_cap
-        if retention_days <= 0 and row_cap <= 0:
-            return 0
-        if now is None:
-            now = time.time()
+        when = _resolve_prune_now(now)
         deleted = 0
-
         if retention_days > 0:
             deleted += await self._prune_retention(
-                now - retention_days * 86400.0, now
+                when - retention_days * 86400.0, when
             )
         if row_cap > 0:
-            deleted += await self._prune_row_cap(row_cap, now)
+            deleted += await self._prune_row_cap(row_cap, when)
         return deleted
 
     async def _prune_retention(self, cutoff: float, now: float) -> int:
@@ -671,23 +667,25 @@ class EgressConsentModel:
             " WHERE COALESCE(revoked_at, decided_at, requested_at) < ?",
             (cutoff,),
         )
-        pending_ids = [
-            r["id"]
-            for r in rows
-            if r["decision"] == DECISION_PENDING
-            and self._prune_eligible(r, now)
-        ]
-        other_ids = [
-            r["id"]
-            for r in rows
-            if r["decision"] != DECISION_PENDING
-            and self._prune_eligible(r, now)
-        ]
+        pending_ids, decided_ids = self._retention_split_ids(rows, now)
         deleted = await self._delete_ids(
             pending_ids, require_decision=DECISION_PENDING
         )
-        deleted += await self._delete_ids(other_ids)
+        deleted += await self._delete_ids(decided_ids)
         return deleted
+
+    def _retention_split_ids(
+        self, rows: list, now: float
+    ) -> tuple[list[str], list[str]]:
+        """Split prunable rows into ``(pending, decided)`` id lists."""
+        pending: list[str] = []
+        decided: list[str] = []
+        for r in rows:
+            if not self._prune_eligible(r, now):
+                continue
+            bucket = pending if r["decision"] == DECISION_PENDING else decided
+            bucket.append(r["id"])
+        return pending, decided
 
     async def _prune_row_cap(self, row_cap: int, now: float) -> int:
         """Per workspace over the cap, delete the oldest eligible rows down
@@ -743,6 +741,11 @@ class EgressConsentModel:
                 cursor = await db.execute(sql, params)
                 removed += cursor.rowcount
         return removed
+
+
+def _resolve_prune_now(now: float | None) -> float:
+    """The sweep's reference clock (caller-supplied or wall clock)."""
+    return time.time() if now is None else now
 
 
 def _row_to_dict(row) -> dict:

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -9,7 +9,7 @@ reach while in ``egress_mode='interactive'``.
 import time
 import uuid
 
-from .base import Submodel
+from .base import Submodel, resolve_prune_now
 
 
 # Decision lifecycle values.
@@ -620,7 +620,7 @@ class EgressConsentModel(Submodel):
         row_cap = settings.egress_consent_row_cap
         if retention_days <= 0 and row_cap <= 0:
             return 0
-        when = _resolve_prune_now(now)
+        when = resolve_prune_now(now)
         deleted = 0
         if retention_days > 0:
             deleted += await self._prune_retention(
@@ -722,11 +722,6 @@ class EgressConsentModel(Submodel):
                 cursor = await db.execute(sql, params)
                 removed += cursor.rowcount
         return removed
-
-
-def _resolve_prune_now(now: float | None) -> float:
-    """The sweep's reference clock (caller-supplied or wall clock)."""
-    return time.time() if now is None else now
 
 
 def _row_to_dict(row) -> dict:

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -9,6 +9,8 @@ reach while in ``egress_mode='interactive'``.
 import time
 import uuid
 
+from .base import Submodel
+
 
 # Decision lifecycle values.
 DECISION_PENDING = "pending"
@@ -74,14 +76,8 @@ _EC_COLUMNS = (
 )
 
 
-class EgressConsentModel:
+class EgressConsentModel(Submodel):
     """CRUD for the ``egress_consent`` table."""
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def create_request(
         self,
@@ -148,39 +144,9 @@ class EgressConsentModel:
         a flooding workspace can't spam denial rows. Returns the row, or
         None if one already exists.
         """
-        request_id = str(uuid.uuid4())
-        now = time.time()
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "INSERT OR IGNORE INTO egress_consent"
-                " (id, workspace_id, dest_host, dest_port,"
-                "  decision, requested_at, decided_at, decided_by)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    request_id,
-                    workspace_id,
-                    dest_host,
-                    dest_port,
-                    DECISION_DENIED,
-                    now,
-                    now,
-                    None,
-                ),
-            )
-            if cursor.rowcount == 0:
-                return None
-        return {
-            "id": request_id,
-            "workspace_id": workspace_id,
-            "dest_host": dest_host,
-            "dest_port": dest_port,
-            "pid": None,
-            "process_name": None,
-            "decision": DECISION_DENIED,
-            "requested_at": now,
-            "decided_at": now,
-            "decided_by": None,
-        }
+        return await self._record_static_row(
+            DECISION_DENIED, workspace_id, dest_host, dest_port
+        )
 
     async def record_static_allow(
         self,
@@ -199,6 +165,19 @@ class EgressConsentModel:
         flooding workspace can't spam allow rows. Returns the row, or None if
         one already exists.
         """
+        return await self._record_static_row(
+            DECISION_ALLOWED, workspace_id, dest_host, dest_port
+        )
+
+    async def _record_static_row(
+        self,
+        decision: str,
+        workspace_id: str,
+        dest_host: str,
+        dest_port: int | None,
+    ) -> dict | None:
+        """INSERT OR IGNORE one static-mode consent row; the new row, or
+        None when the mode's dedup index already had it."""
         request_id = str(uuid.uuid4())
         now = time.time()
         async with self.app.state.db.transaction() as db:
@@ -212,7 +191,7 @@ class EgressConsentModel:
                     workspace_id,
                     dest_host,
                     dest_port,
-                    DECISION_ALLOWED,
+                    decision,
                     now,
                     now,
                     None,
@@ -227,7 +206,7 @@ class EgressConsentModel:
             "dest_port": dest_port,
             "pid": None,
             "process_name": None,
-            "decision": DECISION_ALLOWED,
+            "decision": decision,
             "requested_at": now,
             "decided_at": now,
             "decided_by": None,
@@ -639,6 +618,8 @@ class EgressConsentModel:
         settings = self.app.state.settings
         retention_days = settings.egress_consent_retention_days
         row_cap = settings.egress_consent_row_cap
+        if retention_days <= 0 and row_cap <= 0:
+            return 0
         when = _resolve_prune_now(now)
         deleted = 0
         if retention_days > 0:

--- a/src/klangk/klangk/model/invitations.py
+++ b/src/klangk/klangk/model/invitations.py
@@ -10,6 +10,8 @@ as the backstop until #1578 dissolves the ContextVar.
 import uuid
 from datetime import datetime, timezone
 
+from .base import Submodel
+
 
 # Whitelisted sort columns for the admin invitations list. Values are the
 # SQL expressions to ORDER BY; the ``invited_by`` key sorts by the inviter's
@@ -38,7 +40,7 @@ def _invitation_row_to_dict(row) -> dict:
     }
 
 
-class InvitationsModel:
+class InvitationsModel(Submodel):
     """Invitation lifecycle, resolved through ``app_state.db``.
 
     Reached via ``app_state.model.invitations``. Reaches the DB through
@@ -47,12 +49,6 @@ class InvitationsModel:
     the duplication is temporary and removed in #1578 when the free
     functions are deleted.
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def create_invitation(self, email: str, invited_by: str) -> dict:
         """Create a new invitation. Returns the invitation dict."""

--- a/src/klangk/klangk/model/model.py
+++ b/src/klangk/klangk/model/model.py
@@ -19,6 +19,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 from .acl import ACLModel
+from .base import Submodel
 from .container_events import ContainerEventsModel
 from .egress_consent import EgressConsentModel
 from .server_schedules import ServerSchedulesModel
@@ -37,19 +38,13 @@ from .schema import init_db
 # ---------------------------------------------------------------------------
 
 
-class TokensModel:
+class TokensModel(Submodel):
     """Token-blocklist operations, resolved through ``app_state.db``.
 
     Constructed by :class:`~klangk.model.model.Model` and reached
     via ``app_state.model.tokens``. Reaches the DB through
     ``self.app.state.db`` (the single DB instance for the whole app).
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def blocklist_token(
         self, jti: str, expires_at: str, new_token: str | None = None
@@ -82,18 +77,12 @@ class TokensModel:
         return row[0] if row else None
 
 
-class LoginAttemptsModel:
+class LoginAttemptsModel(Submodel):
     """Login-attempt storage, resolved through ``app_state.db``.
 
     Reached via ``app_state.model.login_attempts``. Reaches the DB through
     ``self.app.state.db`` (the single DB instance for the whole app).
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def record_failed_login(
         self, email: str, *, reset: bool = False

--- a/src/klangk/klangk/model/ports.py
+++ b/src/klangk/klangk/model/ports.py
@@ -18,6 +18,7 @@ from ..util import (  # moved to util (#1547); re-exported via __all__
     port_in_use,
     scan_free_ports,
 )
+from .base import Submodel
 
 
 __all__ = [
@@ -35,7 +36,7 @@ __all__ = [
 ]
 
 
-class PortsModel:
+class PortsModel(Submodel):
     """DB-backed port-allocation tracking, through ``app_state.db``.
 
     Reached via ``app_state.model.ports``. Reaches the DB through
@@ -43,12 +44,6 @@ class PortsModel:
     OS-level socket probes (``port_in_use`` etc.) stay in ``util`` — only
     the DB-backed allocation tracking lives here.
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def add_port_allocations(
         self, workspace_id: str, ports: list[int]

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -35,6 +35,57 @@ _EGRESS_CONSENT_COLUMNS = f"""(
         )"""
 
 
+def _users_table_needs_recreate(columns: dict) -> bool:
+    """True when the pre-migrations users shape must be rebuilt.
+
+    SQLite can't ALTER COLUMN, so the table is recreated when
+    password_hash is NOT NULL (OIDC users need it nullable) or the
+    provider/handle columns are missing.
+    """
+    if "password_hash" in columns and columns["password_hash"][3]:
+        # password_hash has NOT NULL — need to drop it for OIDC users
+        return True
+    return "provider" not in columns or "handle" not in columns
+
+
+async def _rebuild_users_table(db, columns: dict) -> None:
+    """Recreate users with the modern shape, copying shared data across."""
+    await db.execute(f"""
+        CREATE TABLE users_new (
+            id TEXT PRIMARY KEY,
+            email TEXT UNIQUE NOT NULL,
+            password_hash TEXT,
+            verified INTEGER NOT NULL DEFAULT 0,
+            provider TEXT NOT NULL DEFAULT 'local',
+            external_id TEXT,
+            handle TEXT UNIQUE,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            CHECK (id != '{AGENT_USER_ID}' OR password_hash IS NULL)
+        )
+    """)  # noqa: S608
+    # Copy existing data — old tables may lack some columns
+    shared = [
+        c
+        for c in columns
+        if c
+        in (
+            "id",
+            "email",
+            "password_hash",
+            "verified",
+            "created_at",
+            "handle",
+        )
+    ]
+    cols_str = ", ".join(shared)
+    await db.execute(
+        f"INSERT INTO users_new ({cols_str})"  # noqa: S608
+        f" SELECT {cols_str} FROM users"
+    )
+    await db.execute("DROP TABLE users")
+    await db.execute("ALTER TABLE users_new RENAME TO users")
+
+
 async def init_users_table(db) -> None:
     """users table: baseline CREATE, the pre-migrations-era table
     rebuild (nullable password_hash / provider / handle columns),
@@ -58,50 +109,8 @@ async def init_users_table(db) -> None:
     # SQLite can't ALTER COLUMN, so we recreate the table if needed.
     cursor = await db.execute("PRAGMA table_info(users)")
     columns = {row[1]: row for row in await cursor.fetchall()}
-    needs_recreate = False
-    if "password_hash" in columns and columns["password_hash"][3]:
-        # password_hash has NOT NULL — need to drop it for OIDC users
-        needs_recreate = True
-    if "provider" not in columns:
-        needs_recreate = True
-    if "handle" not in columns:
-        needs_recreate = True
-    if needs_recreate:
-        await db.execute(f"""
-            CREATE TABLE users_new (
-                id TEXT PRIMARY KEY,
-                email TEXT UNIQUE NOT NULL,
-                password_hash TEXT,
-                verified INTEGER NOT NULL DEFAULT 0,
-                provider TEXT NOT NULL DEFAULT 'local',
-                external_id TEXT,
-                handle TEXT UNIQUE,
-                created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                CHECK (id != '{AGENT_USER_ID}' OR password_hash IS NULL)
-            )
-        """)  # noqa: S608
-        # Copy existing data — old tables may lack some columns
-        old_cols = list(columns.keys())
-        shared = [
-            c
-            for c in old_cols
-            if c
-            in (
-                "id",
-                "email",
-                "password_hash",
-                "verified",
-                "created_at",
-                "handle",
-            )
-        ]
-        cols_str = ", ".join(shared)
-        await db.execute(
-            f"INSERT INTO users_new ({cols_str})"  # noqa: S608
-            f" SELECT {cols_str} FROM users"
-        )
-        await db.execute("DROP TABLE users")
-        await db.execute("ALTER TABLE users_new RENAME TO users")
+    if _users_table_needs_recreate(columns):
+        await _rebuild_users_table(db, columns)
     # Backfill handles for existing users that don't have one.
     await backfill_handles(db)
     # --- Data-model belt-and-suspenders for the system agent (#1135) ---
@@ -377,6 +386,62 @@ async def init_core_tables(db) -> None:
     """)
 
 
+def _shared_ec_columns(ec_old_cols: set[str]) -> list[str]:
+    """Columns present in both egress_consent shapes, new-table order."""
+    return [
+        c
+        for c in (
+            "id",
+            "workspace_id",
+            "dest_host",
+            "dest_port",
+            "pid",
+            "process_name",
+            "decision",
+            "duration",
+            "requested_at",
+            "decided_at",
+            "decided_by",
+            "revoked_at",
+            "revoked_by",
+        )
+        if c in ec_old_cols
+    ]
+
+
+async def _rebuild_egress_consent_table(db) -> None:
+    """Rebuild egress_consent to attach the revoked decision + audit
+    columns (#2339) when the pre-#2339 shape is detected.
+
+    Detection is via sqlite_master (PRAGMA table_info doesn't expose
+    CHECK/columns). Data is copied across (mirrors the users rebuild
+    above); the partial unique indexes are recreated by the CREATE INDEX
+    statements in :func:`init_egress_consent_table`.
+    """
+    ec_sql_cur = await db.execute(
+        "SELECT sql FROM sqlite_master"
+        " WHERE type='table' AND name='egress_consent'"
+    )
+    ec_sql_row = await ec_sql_cur.fetchone()
+    if ec_sql_row is None or "revoked_at" in ec_sql_row[0]:
+        return
+    await db.execute(
+        f"""
+        CREATE TABLE egress_consent_new
+        {_EGRESS_CONSENT_COLUMNS}
+        """
+    )
+    ec_info = await db.execute("PRAGMA table_info(egress_consent)")
+    ec_old_cols = {r[1] for r in await ec_info.fetchall()}
+    ec_cols_str = ", ".join(_shared_ec_columns(ec_old_cols))
+    await db.execute(
+        f"INSERT INTO egress_consent_new ({ec_cols_str})"  # noqa: S608
+        f" SELECT {ec_cols_str} FROM egress_consent"
+    )
+    await db.execute("DROP TABLE egress_consent")
+    await db.execute("ALTER TABLE egress_consent_new RENAME TO egress_consent")
+
+
 async def init_egress_consent_table(db) -> None:
     """egress_consent table (#2239): baseline CREATE, the rebuild
     that attaches the revoked decision + audit columns (#2339),
@@ -395,52 +460,8 @@ async def init_egress_consent_table(db) -> None:
     # egress_consent: add the `revoked` decision (#2339) + the
     # `revoked_at`/`revoked_by` audit columns (and attach the CHECKs). The
     # table may already exist from #2338 (has the duration CHECK but not
-    # `revoked`); rebuild it either way so the shape is universal. Detected
-    # via sqlite_master (PRAGMA table_info doesn't expose CHECK/columns).
-    # Data is copied across (mirrors the users rebuild above); the partial
-    # unique indexes are recreated by the CREATE INDEX statements below.
-    ec_sql_cur = await db.execute(
-        "SELECT sql FROM sqlite_master"
-        " WHERE type='table' AND name='egress_consent'"
-    )
-    ec_sql_row = await ec_sql_cur.fetchone()
-    if ec_sql_row and "revoked_at" not in ec_sql_row[0]:
-        await db.execute(
-            f"""
-            CREATE TABLE egress_consent_new
-            {_EGRESS_CONSENT_COLUMNS}
-            """
-        )
-        ec_info = await db.execute("PRAGMA table_info(egress_consent)")
-        ec_old_cols = {r[1] for r in await ec_info.fetchall()}
-        ec_shared = [
-            c
-            for c in (
-                "id",
-                "workspace_id",
-                "dest_host",
-                "dest_port",
-                "pid",
-                "process_name",
-                "decision",
-                "duration",
-                "requested_at",
-                "decided_at",
-                "decided_by",
-                "revoked_at",
-                "revoked_by",
-            )
-            if c in ec_old_cols
-        ]
-        ec_cols_str = ", ".join(ec_shared)
-        await db.execute(
-            f"INSERT INTO egress_consent_new ({ec_cols_str})"  # noqa: S608
-            f" SELECT {ec_cols_str} FROM egress_consent"
-        )
-        await db.execute("DROP TABLE egress_consent")
-        await db.execute(
-            "ALTER TABLE egress_consent_new RENAME TO egress_consent"
-        )
+    # `revoked`); rebuild it either way so the shape is universal.
+    await _rebuild_egress_consent_table(db)
     await db.execute("""
         CREATE INDEX IF NOT EXISTS idx_egress_consent_workspace
         ON egress_consent(workspace_id, decision)

--- a/src/klangk/klangk/model/server_schedules.py
+++ b/src/klangk/klangk/model/server_schedules.py
@@ -12,6 +12,8 @@ ownership rule as the sibling models (#1563).
 import uuid
 from datetime import datetime, timezone
 
+from .base import Submodel
+
 _VALID_ACTIONS = ("stop", "recycle")
 
 
@@ -39,14 +41,8 @@ def _row_to_dict(row) -> dict:
     }
 
 
-class ServerSchedulesModel:
+class ServerSchedulesModel(Submodel):
     """CRUD for pending server schedules, resolved through ``app_state.db``."""
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def create_schedule(
         self, action: str, fire_at: datetime, created_by: str

--- a/src/klangk/klangk/model/sessions.py
+++ b/src/klangk/klangk/model/sessions.py
@@ -14,20 +14,16 @@ login and audited later.
 
 from datetime import datetime, timezone
 
+from .base import Submodel
 
-class SessionsModel:
+
+class SessionsModel(Submodel):
     """Active-session storage, resolved through ``app_state.db``.
 
     Constructed by :class:`~klangk.model.model.Model` and reached via
     ``app_state.model.sessions``. Reaches the DB through
     ``self.app.state.db`` (the single DB instance for the whole app).
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def record_session(
         self,

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -89,16 +89,8 @@ def derive_handle(email: str) -> str:
     return handle[:MAX_HANDLE_LEN]
 
 
-def validate_handle(handle: str) -> str | None:
-    """Return an error message if the handle is invalid, else None.
-
-    Note: this only checks *static* rules (length, charset, the fixed
-    reserved set — which includes the agent's handle `klangk`, #2718).
-    """
-    if not handle:
-        return "Handle cannot be empty"
-    if len(handle) > MAX_HANDLE_LEN:
-        return f"Handle must be {MAX_HANDLE_LEN} characters or fewer"
+def _handle_rule_error(handle: str) -> str | None:
+    """The dot-prefix, reserved-set, and charset static rules."""
     if handle.startswith("."):
         return "Handle cannot start with a dot"
     if handle in RESERVED_HANDLES:
@@ -111,37 +103,67 @@ def validate_handle(handle: str) -> str | None:
     return None
 
 
+def validate_handle(handle: str) -> str | None:
+    """Return an error message if the handle is invalid, else None.
+
+    Note: this only checks *static* rules (length, charset, the fixed
+    reserved set — which includes the agent's handle `klangk`, #2718).
+    """
+    if not handle:
+        return "Handle cannot be empty"
+    if len(handle) > MAX_HANDLE_LEN:
+        return f"Handle must be {MAX_HANDLE_LEN} characters or fewer"
+    return _handle_rule_error(handle)
+
+
+async def _live_agent_handle(db) -> str:
+    """The agent's current handle, or the default pre-seed.
+
+    Resolves on the *passed* connection (not via the cached
+    :func:`agent_handle`, which opens a fresh connection): callers run
+    during DB migration where the ``handle`` column's schema change is
+    uncommitted on *db* but invisible to a new connection.
+    """
+    cursor = await db.execute(
+        "SELECT handle FROM users WHERE id = ?", (AGENT_USER_ID,)
+    )
+    row = await cursor.fetchone()
+    if row and row[0]:
+        return row[0]
+    return _DEFAULT_AGENT_HANDLE
+
+
+async def _handle_taken(db, candidate: str) -> bool:
+    cursor = await db.execute(
+        "SELECT 1 FROM users WHERE handle = ?", (candidate,)
+    )
+    return await cursor.fetchone() is not None
+
+
+def _suffixed_handle(base: str, i: int) -> str:
+    """``base-i``, truncated to fit the handle length cap."""
+    candidate = f"{base}-{i}"
+    if len(candidate) <= MAX_HANDLE_LEN:
+        return candidate
+    return f"{base[: MAX_HANDLE_LEN - len(str(i)) - 1]}-{i}"
+
+
 async def unique_handle(db, base: str) -> str:
     """Return *base* if available, else append -2, -3, … until unique.
 
     The live agent handle is always treated as taken (#1160) — even if
     the agent row hasn't been seeded yet — so a derived handle never
     collides with ``/home/<agent_handle>``.
-
-    Resolves the agent handle on the *passed* connection (not via the
-    cached :func:`agent_handle`, which opens a fresh connection): this
-    runs during DB migration where the ``handle`` column's schema change
-    is uncommitted on *db* but invisible to a new connection.
     """
-    cursor = await db.execute(
-        "SELECT handle FROM users WHERE id = ?", (AGENT_USER_ID,)
-    )
-    row = await cursor.fetchone()
-    agent = row[0] if row and row[0] else _DEFAULT_AGENT_HANDLE
+    agent = await _live_agent_handle(db)
     # Try base, then base-2, base-3, …; skip the agent handle each time.
     candidate = base
     i = 1
     while i < 10000:
-        if candidate != agent:
-            cursor = await db.execute(
-                "SELECT 1 FROM users WHERE handle = ?", (candidate,)
-            )
-            if await cursor.fetchone() is None:
-                return candidate
+        if candidate != agent and not await _handle_taken(db, candidate):
+            return candidate
         i += 1
-        candidate = f"{base}-{i}"
-        if len(candidate) > MAX_HANDLE_LEN:
-            candidate = f"{base[: MAX_HANDLE_LEN - len(str(i)) - 1]}-{i}"
+        candidate = _suffixed_handle(base, i)
     return hash_fallback_handle(base)
 
 
@@ -247,6 +269,41 @@ def _user_is_inactive(row, cutoff) -> bool:
         if ts is not None
     ]
     return bool(stamps) and max(stamps) < cutoff
+
+
+def _group_filter_clause(q: str | None, source: str | None) -> tuple:
+    """WHERE clause + params for the group-list filters.
+
+    *source* filters by the origin marker (#2750): ``None`` shows all,
+    ``'manual'`` hides the seeded workspace-role groups,
+    ``'workspace-role'`` shows only them.
+    """
+    where_parts: list[str] = []
+    params: list = []
+    if q:
+        where_parts.append("name LIKE ?")
+        params.append(f"%{q}%")
+    if source is not None:
+        where_parts.append("source = ?")
+        params.append(source)
+    if not where_parts:
+        return "", []
+    return f" WHERE {' AND '.join(where_parts)}", params
+
+
+def _group_update_fields(name: str | None, description: str | None) -> dict:
+    """The provided (non-None) update fields for update_group."""
+    updates = {}
+    if name is not None:
+        updates["name"] = name
+    if description is not None:
+        updates["description"] = description
+    return updates
+
+
+def _exempt_from_inactivity_sweep(user_id: str, admin_ids: set[str]) -> bool:
+    """The system agent and admins are never auto-disabled (#2588)."""
+    return user_id == AGENT_USER_ID or user_id in admin_ids
 
 
 class UsersModel:
@@ -538,20 +595,9 @@ class UsersModel:
         page = max(1, page)
         page_size = max(1, min(page_size, 200))
         offset = (page - 1) * page_size
+        where_clause, params = _group_filter_clause(q, source)
 
         async with self.app.state.db.transaction() as db:
-            where_parts: list[str] = []
-            params: list = []
-            if q:
-                where_parts.append("name LIKE ?")
-                params.append(f"%{q}%")
-            if source is not None:
-                where_parts.append("source = ?")
-                params.append(source)
-            where_clause = (
-                f" WHERE {' AND '.join(where_parts)}" if where_parts else ""
-            )
-
             count_cursor = await db.execute(
                 f"SELECT COUNT(*) AS c FROM groups{where_clause}",  # noqa: S608
                 params,
@@ -605,23 +651,8 @@ class UsersModel:
         it), so a rename would orphan them on delete or point the guard
         at the wrong workspace. Descriptions stay editable.
         """
-        if name is not None:
-            row = await self.app.state.db.fetchone(
-                "SELECT source FROM groups WHERE id = ?", (group_id,)
-            )
-            if (
-                row is not None
-                and row["source"] == GROUP_SOURCE_WORKSPACE_ROLE
-            ):
-                raise WorkspaceRoleScopeError(
-                    "Workspace role group names are managed by the system"
-                    " and cannot be changed"
-                )
-        updates = {}
-        if name is not None:
-            updates["name"] = name
-        if description is not None:
-            updates["description"] = description
+        await self._reject_role_group_rename(group_id, name)
+        updates = _group_update_fields(name, description)
         if not updates:
             return False
         set_clause = ", ".join(f"{k} = ?" for k in updates)
@@ -632,6 +663,22 @@ class UsersModel:
                 values,
             )
             return cursor.rowcount > 0
+
+    async def _reject_role_group_rename(
+        self, group_id: str, name: str | None
+    ) -> None:
+        """Guard: a workspace-role group's name is system-managed (#2750)."""
+        if name is None:
+            return
+        row = await self.app.state.db.fetchone(
+            "SELECT source FROM groups WHERE id = ?", (group_id,)
+        )
+        if row is None or row["source"] != GROUP_SOURCE_WORKSPACE_ROLE:
+            return
+        raise WorkspaceRoleScopeError(
+            "Workspace role group names are managed by the system"
+            " and cannot be changed"
+        )
 
     async def add_user_to_group(
         self, user_id: str, group_id: str, source: str = "manual"
@@ -972,22 +1019,15 @@ class UsersModel:
         if days <= 0:
             return []
         cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-        admin_ids: set[str] = set()
-        admin_group = await self.get_group_by_name("admins")
         async with self.app.state.db.transaction() as db:
-            if admin_group is not None:
-                cursor = await db.execute(
-                    "SELECT user_id FROM user_groups WHERE group_id = ?",
-                    (admin_group["id"],),
-                )
-                admin_ids = {row[0] for row in await cursor.fetchall()}
+            admin_ids = await self._admin_member_ids(db)
             cursor = await db.execute(
                 "SELECT id, email, created_at, last_login_at,"
                 " last_activity_at FROM users WHERE disabled = 0"
             )
             disabled: list[dict] = []
             for row in await cursor.fetchall():
-                if row["id"] == AGENT_USER_ID or row["id"] in admin_ids:
+                if _exempt_from_inactivity_sweep(row["id"], admin_ids):
                     continue
                 if not _user_is_inactive(row, cutoff):
                     continue
@@ -997,6 +1037,21 @@ class UsersModel:
                 )
                 disabled.append({"id": row["id"], "email": row["email"]})
             return disabled
+
+    async def _admin_member_ids(self, db) -> set[str]:
+        """IDs of ``admins`` group members (empty when unseeded).
+
+        Reads on the caller's connection so the sweep's exemption set
+        and its row scan share one snapshot.
+        """
+        admin_group = await self.get_group_by_name("admins")
+        if admin_group is None:
+            return set()
+        cursor = await db.execute(
+            "SELECT user_id FROM user_groups WHERE group_id = ?",
+            (admin_group["id"],),
+        )
+        return {row[0] for row in await cursor.fetchall()}
 
     async def get_user_by_id(self, user_id: str) -> dict | None:
         row = await self.app.state.db.fetchone(

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -5,6 +5,8 @@ import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
+from .base import Submodel
+
 
 # Agent identity
 AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
@@ -306,19 +308,13 @@ def _exempt_from_inactivity_sweep(user_id: str, admin_ids: set[str]) -> bool:
     return user_id == AGENT_USER_ID or user_id in admin_ids
 
 
-class UsersModel:
+class UsersModel(Submodel):
     """User/group/handle operations, resolved through ``app_state.db``.
 
     Constructed by :class:`~klangk.model.model.Model` and reached
     via ``app_state.model.users``. Reaches the DB through
     ``self.app.state.db`` (the single DB instance for the whole app).
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def get_agent_user(self) -> dict:
         """Return the agent user dict from DB, cached after first call."""
@@ -1041,8 +1037,8 @@ class UsersModel:
     async def _admin_member_ids(self, db) -> set[str]:
         """IDs of ``admins`` group members (empty when unseeded).
 
-        Reads on the caller's connection so the sweep's exemption set
-        and its row scan share one snapshot.
+        Only the membership query runs on *db* (so it shares the
+        sweep's snapshot); the group lookup uses the pool connection.
         """
         admin_group = await self.get_group_by_name("admins")
         if admin_group is None:

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -1015,8 +1015,11 @@ class UsersModel(Submodel):
         if days <= 0:
             return []
         cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        # Resolve the admins group on the pool connection *before* the
+        # transaction opens — no pool acquisition inside it (#2978).
+        admin_group = await self.get_group_by_name("admins")
         async with self.app.state.db.transaction() as db:
-            admin_ids = await self._admin_member_ids(db)
+            admin_ids = await self._admin_member_ids(db, admin_group)
             cursor = await db.execute(
                 "SELECT id, email, created_at, last_login_at,"
                 " last_activity_at FROM users WHERE disabled = 0"
@@ -1034,13 +1037,15 @@ class UsersModel(Submodel):
                 disabled.append({"id": row["id"], "email": row["email"]})
             return disabled
 
-    async def _admin_member_ids(self, db) -> set[str]:
+    async def _admin_member_ids(
+        self, db, admin_group: dict | None
+    ) -> set[str]:
         """IDs of ``admins`` group members (empty when unseeded).
 
-        Only the membership query runs on *db* (so it shares the
-        sweep's snapshot); the group lookup uses the pool connection.
+        The group row is resolved by the caller (outside the sweep's
+        transaction); only the membership query runs here, on *db*,
+        sharing the sweep's snapshot.
         """
-        admin_group = await self.get_group_by_name("admins")
         if admin_group is None:
             return set()
         cursor = await db.execute(

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -139,6 +139,39 @@ SORT_COLUMNS = {"created": "created_at", "name": "name"}
 CLASSIFICATION_BANNER_MAX_LEN = 120
 
 
+def _banner_character_error(v: str) -> str | None:
+    """Error message for control/invisible characters in a marking.
+
+    Cc (control: newline/tab/DEL/NEL), Cf (format: bidi overrides,
+    zero-width chars, soft hyphen, BOM), Zl/Zp (line/paragraph
+    separators) — all either break the one-line layout or can spoof the
+    displayed marking.
+    """
+    bad = {
+        ch for ch in v if unicodedata.category(ch) in {"Cc", "Cf", "Zl", "Zp"}
+    }
+    if not bad:
+        return None
+    return (
+        "classification_banner must be a single line of printable"
+        " text without control or invisible format characters"
+        f" (found: {', '.join(f'U+{ord(ch):04X}' for ch in sorted(bad))})"
+    )
+
+
+def _validated_banner_text(v: str) -> str:
+    """Length + character validation for an already-stripped marking."""
+    if len(v) > CLASSIFICATION_BANNER_MAX_LEN:
+        raise ValueError(
+            "classification_banner must be at most"
+            f" {CLASSIFICATION_BANNER_MAX_LEN} characters, got {len(v)}"
+        )
+    msg = _banner_character_error(v)
+    if msg:
+        raise ValueError(msg)
+    return v
+
+
 def normalize_classification_banner(value) -> str | None:
     """Validate + normalize a classification marking (#2768).
 
@@ -164,25 +197,7 @@ def normalize_classification_banner(value) -> str | None:
     v = value.strip()
     if not v:
         return None
-    if len(v) > CLASSIFICATION_BANNER_MAX_LEN:
-        raise ValueError(
-            "classification_banner must be at most"
-            f" {CLASSIFICATION_BANNER_MAX_LEN} characters, got {len(v)}"
-        )
-    # Cc (control: newline/tab/DEL/NEL), Cf (format: bidi overrides,
-    # zero-width chars, soft hyphen, BOM), Zl/Zp (line/paragraph
-    # separators) — all either break the one-line layout or can spoof the
-    # displayed marking.
-    bad = {
-        ch for ch in v if unicodedata.category(ch) in {"Cc", "Cf", "Zl", "Zp"}
-    }
-    if bad:
-        raise ValueError(
-            "classification_banner must be a single line of printable"
-            " text without control or invisible format characters"
-            f" (found: {', '.join(f'U+{ord(ch):04X}' for ch in sorted(bad))})"
-        )
-    return v
+    return _validated_banner_text(v)
 
 
 def sort_order_clause(sort: str, order: str, prefix: str = "") -> str:
@@ -261,50 +276,81 @@ def _workspace_list_item(row, *, owner_email: bool = False) -> dict:
     return item
 
 
+def _coerce_enum_field(name: str, valid: frozenset, value) -> object:
+    """Validate one enum workspace field; raises ``ValueError``."""
+    if value not in valid:
+        raise ValueError(f"Invalid {name}: {value!r}")
+    return value
+
+
+def _coerce_json_blob(value) -> str | None:
+    """Encode an optional JSON-blob column (None passes through)."""
+    return json.dumps(value) if value is not None else None
+
+
+def _bool_int(value) -> int:
+    """The SQLite integer for a boolean column."""
+    return 1 if value else 0
+
+
+# Per-key coercers for coerce_workspace_field (dispatch table): each
+# declarative field's stored representation, applied before any write.
+_FIELD_COERCERS: dict[str, object] = {
+    "setup_state": lambda v: _coerce_enum_field(
+        "setup_state", SETUP_STATES, v
+    ),
+    "egress_mode": lambda v: _coerce_enum_field(
+        "egress_mode", EGRESS_MODES, v
+    ),
+    # Empty/whitespace text clears the override (back to inheriting the
+    # deploy default); the validator raises on control characters /
+    # oversize values.
+    "classification_banner": normalize_classification_banner,
+    "auto_start": _bool_int,
+    "per_handle_home": _bool_int,
+    **{col: _coerce_json_blob for col in _JSON_BLOB_COLUMNS},
+}
+
+
 def coerce_workspace_field(key: str, value) -> object:
     """Coerce one workspace-update field to its stored representation.
 
     Raises ``ValueError`` on invalid enum values (checked before any
     write)."""
-    if key == "setup_state":
-        if value not in SETUP_STATES:
-            raise ValueError(f"Invalid setup_state: {value!r}")
+    coercer = _FIELD_COERCERS.get(key)
+    if coercer is None:
         return value
-    if key == "egress_mode":
-        if value not in EGRESS_MODES:
-            raise ValueError(f"Invalid egress_mode: {value!r}")
-        return value
-    if key == "classification_banner":
-        # Empty/whitespace text clears the override (back to
-        # inheriting the deploy default); the validator raises
-        # on control characters / oversize values.
-        return normalize_classification_banner(value)
-    if key in (
-        "mounts",
-        "env",
-        "allowed_domains",
-        "rejected_domains",
-        "settings",
-    ):
-        return json.dumps(value) if value is not None else None
-    if key in ("auto_start", "per_handle_home"):
-        return 1 if value else 0
-    return value
+    return coercer(value)
+
+
+def _domain_entry_index(current: list, spec: str) -> int | None:
+    """Index of the case-insensitive match for *spec*, or None."""
+    return next((i for i, s in enumerate(current) if s.lower() == spec), None)
+
+
+def _add_domain_entry(current: list, spec: str) -> bool:
+    """Append *spec*; True when it was already present (no-op)."""
+    if _domain_entry_index(current, spec) is not None:
+        return True
+    current.append(spec)
+    return False
+
+
+def _remove_domain_entry(current: list, spec: str) -> bool:
+    """Pop the match for *spec*; True when it was absent (no-op)."""
+    idx = _domain_entry_index(current, spec)
+    if idx is None:
+        return True
+    current.pop(idx)
+    return False
 
 
 def mutate_domain_entries(current: list, spec: str, add: bool) -> bool:
     """Apply the add/remove to *current* in place; True when it was a
     no-op (entry already present for an add / absent for a remove)."""
     if add:
-        if spec in (s.lower() for s in current):
-            return True
-        current.append(spec)
-        return False
-    idx = next((i for i, s in enumerate(current) if s.lower() == spec), None)
-    if idx is None:
-        return True
-    current.pop(idx)
-    return False
+        return _add_domain_entry(current, spec)
+    return _remove_domain_entry(current, spec)
 
 
 def _validated_create_kwargs(
@@ -351,6 +397,49 @@ def _validated_create_kwargs(
             classification_banner
         ),
     )
+
+
+def _optional_json(value) -> str | None:
+    """JSON-encode an optional blob column (falsy → NULL)."""
+    return json.dumps(value) if value else None
+
+
+def _decode_settings_blob(blob: str | None) -> dict:
+    """Decode the settings JSON column (NULL/empty → empty dict)."""
+    return json.loads(blob) if blob else {}
+
+
+def _encode_settings_blob(current: dict) -> str | None:
+    """Encode the settings JSON column (empty bag → NULL)."""
+    return json.dumps(current) if current else None
+
+
+def _merge_settings_patch(current: dict, patch: dict) -> None:
+    """Apply one PATCH: each key sets/replaces; a None value deletes."""
+    for key, value in patch.items():
+        if value is None:
+            current.pop(key, None)
+        else:
+            current[key] = value
+
+
+def _normalize_domain_entry(entry: str) -> str | None:
+    """Normalize one domain-list entry; None when malformed or empty."""
+    try:
+        normalized = parse_allowed_domains([entry])
+    except ValueError:
+        return None
+    return normalized[0].lower() if normalized else None
+
+
+def _decode_list_blob(blob: str | None) -> list:
+    """Decode a domain-list JSON column (NULL/empty → empty list)."""
+    return json.loads(blob) if blob else []
+
+
+# Sentinel distinguishing "workspace row gone" (stop, return False) from
+# "CAS lost" (retry) in _mutate_domain_list's loop.
+_DOMAIN_MISSING = object()
 
 
 class WorkspacesModel:
@@ -400,15 +489,11 @@ class WorkspacesModel:
         """
         workspace_id = str(uuid.uuid4())
         created_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-        mounts_json = json.dumps(mounts) if mounts else None
-        env_json = json.dumps(env) if env else None
-        allowed_domains_json = (
-            json.dumps(allowed_domains) if allowed_domains else None
-        )
-        rejected_domains_json = (
-            json.dumps(rejected_domains) if rejected_domains else None
-        )
-        settings_json = json.dumps(settings) if settings else None
+        mounts_json = _optional_json(mounts)
+        env_json = _optional_json(env)
+        allowed_domains_json = _optional_json(allowed_domains)
+        rejected_domains_json = _optional_json(rejected_domains)
+        settings_json = _optional_json(settings)
         await db.execute(
             "INSERT INTO workspaces"
             " (id, user_id, name, image, service_command, auto_start,"
@@ -422,7 +507,7 @@ class WorkspacesModel:
                 name,
                 image,
                 service_command,
-                1 if auto_start else 0,
+                _bool_int(auto_start),
                 setup_state,
                 health_check,
                 mounts_json,
@@ -431,7 +516,7 @@ class WorkspacesModel:
                 rejected_domains_json,
                 settings_json,
                 egress_mode,
-                1 if per_handle_home else 0,
+                _bool_int(per_handle_home),
                 classification_banner,
                 created_at,
             ),
@@ -900,34 +985,60 @@ class WorkspacesModel:
         """
         for _ in range(_SETTINGS_CAS_RETRIES):
             async with self.app.state.db.transaction() as db:
-                cursor = await db.execute(
-                    "SELECT settings FROM workspaces"
-                    " WHERE id = ? AND user_id = ?",
-                    (workspace_id, user_id),
+                current, old_blob = await self._read_merged_settings(
+                    db, workspace_id, user_id, patch
                 )
-                row = await cursor.fetchone()
-                if row is None:
+                if current is None:
                     return None
-                old_blob = row["settings"]
-                current = json.loads(old_blob) if old_blob else {}
-                for key, value in patch.items():
-                    if value is None:
-                        current.pop(key, None)
-                    else:
-                        current[key] = value
-                new_blob = json.dumps(current) if current else None
-                cursor = await db.execute(
-                    "UPDATE workspaces SET settings = ?"
-                    " WHERE id = ? AND user_id = ? AND settings IS ?",
-                    (new_blob, workspace_id, user_id, old_blob),
-                )
-                if cursor.rowcount == 1:
-                    return current if current else None
-                # rowcount 0 — settings changed under us (or the row went
+                if await self._cas_store_settings(
+                    db, workspace_id, user_id, old_blob, current
+                ):
+                    return current or None
+                # CAS lost — settings changed under us (or the row went
                 # away); loop re-reads the latest blob and re-applies.
         raise RuntimeError(  # pragma: no cover - only under extreme contention
             f"settings CAS retry exhausted for workspace {workspace_id}"
         )
+
+    async def _read_merged_settings(
+        self, db, workspace_id: str, user_id: str, patch: dict
+    ) -> tuple[dict | None, str | None]:
+        """Read the settings blob and apply *patch* to it.
+
+        Returns ``(None, None)`` when the workspace row is missing.
+        """
+        cursor = await db.execute(
+            "SELECT settings FROM workspaces WHERE id = ? AND user_id = ?",
+            (workspace_id, user_id),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None, None
+        old_blob = row["settings"]
+        current = _decode_settings_blob(old_blob)
+        _merge_settings_patch(current, patch)
+        return current, old_blob
+
+    async def _cas_store_settings(
+        self,
+        db,
+        workspace_id: str,
+        user_id: str,
+        old_blob: str | None,
+        current: dict,
+    ) -> bool:
+        """Compare-and-swap the settings blob; True when it committed."""
+        cursor = await db.execute(
+            "UPDATE workspaces SET settings = ?"
+            " WHERE id = ? AND user_id = ? AND settings IS ?",
+            (
+                _encode_settings_blob(current),
+                workspace_id,
+                user_id,
+                old_blob,
+            ),
+        )
+        return cursor.rowcount == 1
 
     async def update_workspace(
         self,
@@ -1002,35 +1113,46 @@ class WorkspacesModel:
         state afterwards (idempotent); False if the workspace is missing
         or *entry* is malformed.
         """
-        try:
-            normalized = parse_allowed_domains([entry])
-        except ValueError:
+        spec = _normalize_domain_entry(entry)
+        if spec is None:
             return False
-        if not normalized:
-            return False
-        spec = normalized[0].lower()
         for _ in range(_SETTINGS_CAS_RETRIES):
             async with self.app.state.db.transaction() as db:
-                cursor = await db.execute(
-                    f"SELECT {column} FROM workspaces WHERE id = ?",
-                    (workspace_id,),
+                outcome = await self._domain_cas_attempt(
+                    db, workspace_id, column, spec, add
                 )
-                row = await cursor.fetchone()
-                if row is None:
+                if outcome is _DOMAIN_MISSING:
                     return False
-                old_blob = row[column]
-                current = json.loads(old_blob) if old_blob else []
-                if mutate_domain_entries(current, spec, add):
-                    return True  # already present/absent (idempotent)
-                new_blob = json.dumps(current)
-                cursor = await db.execute(
-                    f"UPDATE workspaces SET {column} = ?"
-                    f" WHERE id = ? AND {column} IS ?",
-                    (new_blob, workspace_id, old_blob),
-                )
-                if cursor.rowcount == 1:
+                if outcome:
                     return True
         return False  # pragma: no cover - CAS exhausted under contention
+
+    async def _domain_cas_attempt(
+        self, db, workspace_id: str, column: str, spec: str, add: bool
+    ):
+        """One read-modify-write CAS step on a domain-list column.
+
+        Returns ``_DOMAIN_MISSING`` when the workspace row is gone,
+        ``True`` when the wanted state is reached (idempotent no-op or
+        committed write), ``False`` on contention (caller retries).
+        """
+        cursor = await db.execute(
+            f"SELECT {column} FROM workspaces WHERE id = ?",
+            (workspace_id,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return _DOMAIN_MISSING
+        old_blob = row[column]
+        current = _decode_list_blob(old_blob)
+        if mutate_domain_entries(current, spec, add):
+            return True  # already present/absent (idempotent)
+        cursor = await db.execute(
+            f"UPDATE workspaces SET {column} = ?"
+            f" WHERE id = ? AND {column} IS ?",
+            (json.dumps(current), workspace_id, old_blob),
+        )
+        return cursor.rowcount == 1
 
     async def add_allowed_domain(self, workspace_id: str, entry: str) -> bool:
         """Append ``entry`` (``host[:port]``) to a workspace's
@@ -1154,15 +1276,9 @@ class WorkspacesModel:
                 raise ValueError("Target user is already the owner")
 
             # Check UNIQUE(user_id, name) won't be violated.
-            dup = await db.execute(
-                "SELECT 1 FROM workspaces"
-                " WHERE user_id = ? AND name = ? AND id != ?",
-                (new_owner_id, ws_name, workspace_id),
+            await self._transfer_reject_duplicate(
+                db, new_owner_id, ws_name, workspace_id
             )
-            if await dup.fetchone():
-                raise ValueError(
-                    f"Target user already owns a workspace named {ws_name!r}"
-                )
 
             # 1. Update workspace owner.
             await db.execute(
@@ -1182,29 +1298,54 @@ class WorkspacesModel:
             # 3. Swap owners-group membership: remove old owner, add new.
             # The owners group is found by the source marker + workspace
             # id (#2750), not by reconstructed name.
-            owners_group = next(
-                (
-                    g
-                    for g in await self.get_workspace_role_groups(
-                        db, workspace_id
-                    )
-                    if g["name"].startswith(f"{OWNER_ROLE}-")
-                ),
-                None,
+            await self._swap_owners_group(
+                db, workspace_id, old_owner_id, new_owner_id
             )
-            if owners_group:
-                group_id = owners_group["id"]
-                await db.execute(
-                    "DELETE FROM user_groups WHERE user_id = ? AND group_id = ?",
-                    (old_owner_id, group_id),
-                )
-                await db.execute(
-                    "INSERT OR IGNORE INTO user_groups"
-                    " (user_id, group_id, source) VALUES (?, ?, ?)",
-                    (new_owner_id, group_id, "manual"),
-                )
 
         return await self.get_workspace_by_id(workspace_id)
+
+    async def _transfer_reject_duplicate(
+        self, db, new_owner_id: str, ws_name: str, workspace_id: str
+    ) -> None:
+        """Raise when the target already owns a same-named workspace."""
+        dup = await db.execute(
+            "SELECT 1 FROM workspaces"
+            " WHERE user_id = ? AND name = ? AND id != ?",
+            (new_owner_id, ws_name, workspace_id),
+        )
+        if await dup.fetchone():
+            raise ValueError(
+                f"Target user already owns a workspace named {ws_name!r}"
+            )
+
+    async def _swap_owners_group(
+        self, db, workspace_id: str, old_owner_id: str, new_owner_id: str
+    ) -> None:
+        """Move owners-group membership from the old to the new owner.
+
+        The owners group is found by the source marker + workspace-id
+        suffix of the name (#2750); a no-op when it is missing.
+        """
+        owners_group = next(
+            (
+                g
+                for g in await self.get_workspace_role_groups(db, workspace_id)
+                if g["name"].startswith(f"{OWNER_ROLE}-")
+            ),
+            None,
+        )
+        if owners_group is None:
+            return
+        group_id = owners_group["id"]
+        await db.execute(
+            "DELETE FROM user_groups WHERE user_id = ? AND group_id = ?",
+            (old_owner_id, group_id),
+        )
+        await db.execute(
+            "INSERT OR IGNORE INTO user_groups"
+            " (user_id, group_id, source) VALUES (?, ?, ?)",
+            (new_owner_id, group_id, "manual"),
+        )
 
     async def get_user_workspaces_with_containers(
         self, user_id: str

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 from ..netfilter import parse_allowed_domains
 from .acl import ACTION_ALLOW, PRINCIPAL_GROUP, PRINCIPAL_USER
+from .base import Submodel
 from .users import (
     AGENT_USER_ID,
     AgentPrincipalError,
@@ -437,12 +438,18 @@ def _decode_list_blob(blob: str | None) -> list:
     return json.loads(blob) if blob else []
 
 
-# Sentinel distinguishing "workspace row gone" (stop, return False) from
-# "CAS lost" (retry) in _mutate_domain_list's loop.
-_DOMAIN_MISSING = object()
+class _DomainMissing:
+    """Sentinel: the workspace row is gone (stop, return False).
+
+    Distinguishes "row gone" from "CAS lost" (retry) in
+    ``_mutate_domain_list``'s loop.
+    """
 
 
-class WorkspacesModel:
+_DOMAIN_MISSING = _DomainMissing()
+
+
+class WorkspacesModel(Submodel):
     """Workspace CRUD/members/listings, resolved through ``app_state.db``.
 
     Constructed by :class:`~klangk.model.model.Model` and reached
@@ -456,12 +463,6 @@ class WorkspacesModel:
     constraint (the owner ACE + role groups must commit/roll back with the
     row insert) is load-bearing (#128).
     """
-
-    def __init__(self, app):
-        self.app = app
-
-    def reconfigure(self, app) -> None:
-        self.app = app
 
     async def _insert_workspace_row(
         self,
@@ -988,6 +989,8 @@ class WorkspacesModel:
                 current, old_blob = await self._read_merged_settings(
                     db, workspace_id, user_id, patch
                 )
+                # current is None only when the row is missing (empty
+                # patches are rejected upstream).
                 if current is None:
                     return None
                 if await self._cas_store_settings(
@@ -1129,7 +1132,7 @@ class WorkspacesModel:
 
     async def _domain_cas_attempt(
         self, db, workspace_id: str, column: str, spec: str, add: bool
-    ):
+    ) -> _DomainMissing | bool:
         """One read-modify-write CAS step on a domain-list column.
 
         Returns ``_DOMAIN_MISSING`` when the workspace row is gone,
@@ -1225,16 +1228,14 @@ class WorkspacesModel:
         self, workspace_id: str, entry: str
     ) -> bool:
         """Remove ``entry`` from a workspace's ``rejected_domains`` (#2370) --
-        the inverse of :meth:`add_rejected_domain`.
+        the inverse of :meth:`add_rejected_domain`, sharing its mechanics
+        with :meth:`remove_allowed_domain` (compare-and-swap on the JSON
+        blob, case-insensitive match, idempotent; False when the workspace
+        is missing or ``entry`` is malformed).
 
         Revoking a ``forever`` egress-consent deny retracts the durable entry
         it added (so the deny does not re-apply on the next sidecar restart);
         the in-memory REJECT rules are dropped separately by the sidecar.
-        Compare-and-swap on the JSON blob, case-insensitive match, mirroring
-        :meth:`add_rejected_domain`. Returns True if the workspace exists and
-        ``entry`` is absent from the list afterwards (removed or already
-        absent -- idempotent); False if the workspace is missing or ``entry``
-        is malformed.
         """
         return await self._mutate_domain_list(
             workspace_id, "rejected_domains", add=False, entry=entry


### PR DESCRIPTION
## Summary

First PR of the #2845 A-ratchet (closes #2977): every block in the core `model/` modules — `workspaces.py`, `users.py`, `acl.py`, `egress_consent.py`, `schema.py`, plus the one straggler `container_events.py` — drops from rank B to rank A (cyclomatic complexity ≤ 5). `model/migrations/` is deliberately untouched; it gets its own tranche. Pure extract-function / dispatch-table refactors; no behavior change. A follow-up commit (fresh-eyes review fixes) also dedupes the package's copy-paste clones: jscpd (`min-tokens 50`) on `model/` goes **13 → 8 clones, 2.54% → 1.85% duplicated lines**; the 8 that remain are the migrations tranche (5) plus three deliberate `workspaces.py` create-path signature clones.

## Details

- **`workspaces.py`** (7 blocks): banner validation split into `_validated_banner_text`/`_banner_character_error`; `coerce_workspace_field` (10) → `_FIELD_COERCERS` dispatch table; `update_workspace_settings`/`_mutate_domain_list` split into read-merge/CAS-store helpers (`_DomainMissing` sentinel class distinguishes gone-row from lost-CAS); `mutate_domain_entries` add/remove split; `transfer_workspace` duplicate-check + owners-group swap extracted; `_insert_workspace_row` blob ternaries → `_optional_json`.
- **`users.py`** (5): `validate_handle` static-rule split; `unique_handle` agent/taken/suffix helpers; `list_groups` WHERE builder; `update_group` rename-guard + fields split; `disable_inactive_users` admin-ids + exemption split.
- **`acl.py`** (2): per-principal display-field builders (unknown principal types still yield no `principal` key); agent-principal + role-group-scope guards extracted from `replace_acl_entries`.
- **`egress_consent.py` / `container_events.py`** (3): prune passes split (`_resolve_prune_now`, retention id bucketing, `_prune_retention`).
- **`schema.py`** (2): users/egress_consent table-rebuild helpers extracted from the init functions.
- **`devenv.nix`**: add `radon` (`python314Packages.radon`, not top-level in the pinned channel) for per-block complexity introspection during ratchet work.
- **Follow-up (review + dedup)**: `_DomainMissing` gets a `-> _DomainMissing | bool` return annotation on `_domain_cas_attempt` and a comment pins the `current is None` ⇔ row-missing contract in `update_workspace_settings`; the both-zero early return is restored in both `prune()`s (exact pre-refactor behavior; `container_events` gains its twin's `_resolve_prune_now` helper to stay rank A); `_admin_member_ids`' docstring now states correctly that only the membership query shares the sweep's snapshot. New **`model/base.py`**: a `Submodel` base owns the `__init__(app)`/`reconfigure(app)` pair for all 11 submodel classes; `record_static_denial`/`record_static_allow` share `_record_static_row`; `remove_rejected_domain`'s docstring cross-references `remove_allowed_domain`. The three `workspaces.py` create-path clones are left by design — the 14-field parameter surface is spelled at each seam (public signature, validator defaults, insert params, forwarding call), and collapsing it via `**kwargs` would trade typed explicitness for token count.

## Verification

- Full Python suite (`-n auto`, coverage) on the first commit: 6496 passed, **100% coverage**.
- Follow-up commit: 1253 scoped tests pass (`model`/`migration`/`inactivity`/`invitation`/`port`/`schedule`/`session`/`token`/`login` selection); `xenon --max-absolute A --max-modules A --max-average A` clean on all touched modules + `base.py`; repo-wide B gate (`pre-commit run xenon --all-files`) passes; ruff clean; jscpd 13 → 8 clones.
- No changelog entry (internal refactor).
