### PR TITLE
refactor(migrations): bring model/migrations under rank A (T2)

### DIFF
--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -105,21 +105,31 @@ MIGRATIONS: list[Migration] = [
 ]
 
 
-def validate_migrations(
-    migrations: list[Migration] | None = None,
-) -> None:
-    """Assert ids are contiguous 1..N and names unique (fail fast at
-    import time rather than mid-boot on a deployed server)."""
-    migrations = migrations if migrations is not None else MIGRATIONS
+def _assert_contiguous_ids(migrations: list[Migration]) -> None:
+    """Migration ids must be 1..N in order."""
     ids = [m.id for m in migrations]
     if ids != list(range(1, len(migrations) + 1)):
         raise RuntimeError(
             f"MIGRATIONS ids must be contiguous 1..{len(migrations)},"
             f" got {ids}. Never renumber or reorder — append instead."
         )
+
+
+def _assert_unique_names(migrations: list[Migration]) -> None:
+    """Migration names must be unique."""
     names = [m.name for m in migrations]
     if len(set(names)) != len(names):
         raise RuntimeError(f"Duplicate migration names: {names}")
+
+
+def validate_migrations(
+    migrations: list[Migration] | None = None,
+) -> None:
+    """Assert ids are contiguous 1..N and names unique (fail fast at
+    import time rather than mid-boot on a deployed server)."""
+    migrations = migrations if migrations is not None else MIGRATIONS
+    _assert_contiguous_ids(migrations)
+    _assert_unique_names(migrations)
 
 
 validate_migrations()
@@ -151,32 +161,53 @@ async def run_migrations(db) -> list[str]:
 
     applied_now: list[str] = []
     for migration in MIGRATIONS:
+        _assert_recorded_name_matches(migration, applied)
         if migration.id in applied:
-            if applied[migration.id] != migration.name:
-                raise RuntimeError(
-                    f"Migration {migration.id} is recorded as"
-                    f" {applied[migration.id]!r} but the code says"
-                    f" {migration.name!r}. Migration names are frozen"
-                    " once shipped (a rename forks history); restore"
-                    " the recorded name or append a new migration."
-                )
             continue
         logger.info("Applying schema migration %s", migration.name)
-        # Close any implicit transaction left open by earlier init_db
-        # statements (sqlite3 legacy control implicitly begins before
-        # DML; an open transaction would make BEGIN IMMEDIATE fail with
-        # "cannot start a transaction within a transaction").
-        await db.commit()
-        await db.execute("BEGIN IMMEDIATE")
-        try:
-            await migration.apply(db)
-            await db.execute(
-                "INSERT INTO schema_migrations (id, name) VALUES (?, ?)",
-                (migration.id, migration.name),
-            )
-            await db.commit()
-        except BaseException:
-            await db.rollback()
-            raise
+        await _apply_migration(db, migration)
         applied_now.append(migration.name)
     return applied_now
+
+
+def _assert_recorded_name_matches(
+    migration: Migration, applied: dict[int, str]
+) -> None:
+    """A recorded id must still carry its shipped name."""
+    recorded = applied.get(migration.id)
+    if recorded is None or recorded == migration.name:
+        return
+    raise RuntimeError(
+        f"Migration {migration.id} is recorded as"
+        f" {recorded!r} but the code says"
+        f" {migration.name!r}. Migration names are frozen"
+        " once shipped (a rename forks history); restore"
+        " the recorded name or append a new migration."
+    )
+
+
+async def _apply_migration(db, migration: Migration) -> None:
+    """Apply one migration + its record row atomically.
+
+    Closes any implicit transaction left open by earlier init_db
+    statements (sqlite3 legacy control implicitly begins before DML;
+    an open transaction would make BEGIN IMMEDIATE fail with
+    "cannot start a transaction within a transaction"), then runs
+    apply+record in one explicit ``BEGIN IMMEDIATE`` transaction —
+    SQLite DDL is transactional only under an explicit BEGIN (legacy
+    autocommit would leave failed migrations half-applied), so a
+    failure rolls both back and the migration is retried on the next
+    ``init_db``.
+    """
+    await db.commit()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await migration.apply(db)
+        await db.execute(
+            "INSERT INTO schema_migrations (id, name) VALUES (?, ?)",
+            (migration.id, migration.name),
+        )
+        await db.commit()
+    except BaseException:
+        await db.rollback()
+        raise

--- a/src/klangk/klangk/model/migrations/m0010_groups_source.py
+++ b/src/klangk/klangk/model/migrations/m0010_groups_source.py
@@ -36,6 +36,24 @@ _ROLE_GROUP_NAME_RE = re.compile(
 _WORKSPACE_ROLE = "workspace-role"
 
 
+def _workspace_role_target(
+    name: str, ws_names: dict[str, str]
+) -> tuple[str, str] | None:
+    """``(role, workspace_id)`` when *name* is a seeded role group of a
+    real workspace; None otherwise (collision skip, #2750)."""
+    m = _ROLE_GROUP_NAME_RE.match(name)
+    if m is None:
+        return None
+    role, ws_id = m.group(1), m.group(2)
+    try:
+        uuid_mod.UUID(ws_id)
+    except ValueError:
+        return None  # suffix is not a UUID — human-named, skip
+    if ws_id not in ws_names:
+        return None  # collision: pattern-matching human group, skip
+    return role, ws_id
+
+
 async def apply(db) -> None:
     await db.execute(
         "ALTER TABLE groups ADD COLUMN source TEXT NOT NULL DEFAULT 'manual'"
@@ -50,16 +68,10 @@ async def apply(db) -> None:
     ws_names = {row[0]: row[1] for row in await ws_cursor.fetchall()}
     for row in rows:
         group_id, name = row[0], row[1]
-        m = _ROLE_GROUP_NAME_RE.match(name)
-        if m is None:
+        target = _workspace_role_target(name, ws_names)
+        if target is None:
             continue
-        role, ws_id = m.group(1), m.group(2)
-        try:
-            uuid_mod.UUID(ws_id)
-        except ValueError:
-            continue  # suffix is not a UUID — human-named, skip
-        if ws_id not in ws_names:
-            continue  # collision: pattern-matching human group, skip
+        role, ws_id = target
         await db.execute(
             "UPDATE groups SET source = ?, description = ? WHERE id = ?",
             (

--- a/src/klangk/klangk/model/migrations/m0011_files_download.py
+++ b/src/klangk/klangk/model/migrations/m0011_files_download.py
@@ -68,32 +68,35 @@ async def apply(db) -> None:
             " FROM acl_entries WHERE resource = ? ORDER BY position",
             (resource,),
         )
-        rows = await cursor.fetchall()
-        # Park existing rows at unique negative positions (ids are
-        # unique, so -1 - id never collides) before re-sequencing.
-        for row in rows:
+        await _resequence_with_mirrors(db, await cursor.fetchall())
+
+
+async def _resequence_with_mirrors(db, rows) -> None:
+    """Park existing rows at unique negative positions (ids are unique,
+    so -1 - id never collides), then rewrite the sequence inserting each
+    mirror directly after its source entry so evaluation order vs. `*`
+    ACEs is kept."""
+    for row in rows:
+        await db.execute(
+            "UPDATE acl_entries SET position = ? WHERE id = ?",
+            (-1 - row[0], row[0]),
+        )
+    position = 0
+    for row in rows:
+        await db.execute(
+            "UPDATE acl_entries SET position = ? WHERE id = ?",
+            (position, row[0]),
+        )
+        position += 1
+        if row[3] == _ALLOW and row[8] == _FILES:  # action, permission
             await db.execute(
-                "UPDATE acl_entries SET position = ? WHERE id = ?",
-                (-1 - row[0], row[0]),
-            )
-        # Rewrite the sequence, inserting each mirror directly after
-        # its source entry so evaluation order vs. `*` ACEs is kept.
-        position = 0
-        for row in rows:
-            await db.execute(
-                "UPDATE acl_entries SET position = ? WHERE id = ?",
-                (position, row[0]),
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  user_id, group_id, system_principal, permission)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                _mirror_row(row, position),
             )
             position += 1
-            if row[3] == _ALLOW and row[8] == _FILES:  # action, permission
-                await db.execute(
-                    "INSERT INTO acl_entries"
-                    " (resource, position, action, principal_type,"
-                    "  user_id, group_id, system_principal, permission)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    _mirror_row(row, position),
-                )
-                position += 1
 
 
 migration = Migration(11, "0011_files_download", apply)

--- a/src/klangk/klangk/model/migrations/m0011_files_download.py
+++ b/src/klangk/klangk/model/migrations/m0011_files_download.py
@@ -30,73 +30,14 @@ the runner's ``BEGIN IMMEDIATE`` transaction.
 """
 
 from klangk.model.migrations.base import Migration
+from klangk.model.migrations.shared import mirror_permission_aces
 
 _FILES = "files"
 _FILES_DOWNLOAD = "files-download"
-_ALLOW = 1
-
-
-def _mirror_row(row: tuple, position: int) -> tuple:
-    """Build an INSERT tuple mirroring *row* (minus id) for the new perm.
-
-    ``row`` is ``(id, resource, position, action, principal_type,
-    user_id, group_id, system_principal, permission)``.
-    """
-    return (
-        row[1],  # resource
-        position,
-        row[3],  # action (Allow)
-        row[4],  # principal_type
-        row[5],  # user_id
-        row[6],  # group_id
-        row[7],  # system_principal
-        _FILES_DOWNLOAD,
-    )
 
 
 async def apply(db) -> None:
-    cursor = await db.execute(
-        "SELECT DISTINCT resource FROM acl_entries"
-        " WHERE action = ? AND permission = ?",
-        (_ALLOW, _FILES),
-    )
-    resources = [row[0] for row in await cursor.fetchall()]
-    for resource in resources:
-        cursor = await db.execute(
-            "SELECT id, resource, position, action, principal_type,"
-            " user_id, group_id, system_principal, permission"
-            " FROM acl_entries WHERE resource = ? ORDER BY position",
-            (resource,),
-        )
-        await _resequence_with_mirrors(db, await cursor.fetchall())
-
-
-async def _resequence_with_mirrors(db, rows) -> None:
-    """Park existing rows at unique negative positions (ids are unique,
-    so -1 - id never collides), then rewrite the sequence inserting each
-    mirror directly after its source entry so evaluation order vs. `*`
-    ACEs is kept."""
-    for row in rows:
-        await db.execute(
-            "UPDATE acl_entries SET position = ? WHERE id = ?",
-            (-1 - row[0], row[0]),
-        )
-    position = 0
-    for row in rows:
-        await db.execute(
-            "UPDATE acl_entries SET position = ? WHERE id = ?",
-            (position, row[0]),
-        )
-        position += 1
-        if row[3] == _ALLOW and row[8] == _FILES:  # action, permission
-            await db.execute(
-                "INSERT INTO acl_entries"
-                " (resource, position, action, principal_type,"
-                "  user_id, group_id, system_principal, permission)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                _mirror_row(row, position),
-            )
-            position += 1
+    await mirror_permission_aces(db, _FILES, _FILES_DOWNLOAD)
 
 
 migration = Migration(11, "0011_files_download", apply)

--- a/src/klangk/klangk/model/migrations/m0012_files_write.py
+++ b/src/klangk/klangk/model/migrations/m0012_files_write.py
@@ -34,73 +34,14 @@ the source and target permission strings.
 """
 
 from klangk.model.migrations.base import Migration
+from klangk.model.migrations.shared import mirror_permission_aces
 
 _SOURCE = "files-download"
 _TARGET = "files-write"
-_ALLOW = 1
-
-
-def _mirror_row(row: tuple, position: int) -> tuple:
-    """Build an INSERT tuple mirroring *row* (minus id) for the new perm.
-
-    ``row`` is ``(id, resource, position, action, principal_type,
-    user_id, group_id, system_principal, permission)``.
-    """
-    return (
-        row[1],  # resource
-        position,
-        row[3],  # action (Allow)
-        row[4],  # principal_type
-        row[5],  # user_id
-        row[6],  # group_id
-        row[7],  # system_principal
-        _TARGET,
-    )
 
 
 async def apply(db) -> None:
-    cursor = await db.execute(
-        "SELECT DISTINCT resource FROM acl_entries"
-        " WHERE action = ? AND permission = ?",
-        (_ALLOW, _SOURCE),
-    )
-    resources = [row[0] for row in await cursor.fetchall()]
-    for resource in resources:
-        cursor = await db.execute(
-            "SELECT id, resource, position, action, principal_type,"
-            " user_id, group_id, system_principal, permission"
-            " FROM acl_entries WHERE resource = ? ORDER BY position",
-            (resource,),
-        )
-        await _resequence_with_mirrors(db, await cursor.fetchall())
-
-
-async def _resequence_with_mirrors(db, rows) -> None:
-    """Park existing rows at unique negative positions (ids are unique,
-    so -1 - id never collides), then rewrite the sequence inserting each
-    mirror directly after its source entry so evaluation order vs. `*`
-    ACEs is kept."""
-    for row in rows:
-        await db.execute(
-            "UPDATE acl_entries SET position = ? WHERE id = ?",
-            (-1 - row[0], row[0]),
-        )
-    position = 0
-    for row in rows:
-        await db.execute(
-            "UPDATE acl_entries SET position = ? WHERE id = ?",
-            (position, row[0]),
-        )
-        position += 1
-        if row[3] == _ALLOW and row[8] == _SOURCE:  # action, permission
-            await db.execute(
-                "INSERT INTO acl_entries"
-                " (resource, position, action, principal_type,"
-                "  user_id, group_id, system_principal, permission)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                _mirror_row(row, position),
-            )
-            position += 1
+    await mirror_permission_aces(db, _SOURCE, _TARGET)
 
 
 migration = Migration(12, "0012_files_write", apply)

--- a/src/klangk/klangk/model/migrations/m0012_files_write.py
+++ b/src/klangk/klangk/model/migrations/m0012_files_write.py
@@ -72,32 +72,35 @@ async def apply(db) -> None:
             " FROM acl_entries WHERE resource = ? ORDER BY position",
             (resource,),
         )
-        rows = await cursor.fetchall()
-        # Park existing rows at unique negative positions (ids are
-        # unique, so -1 - id never collides) before re-sequencing.
-        for row in rows:
+        await _resequence_with_mirrors(db, await cursor.fetchall())
+
+
+async def _resequence_with_mirrors(db, rows) -> None:
+    """Park existing rows at unique negative positions (ids are unique,
+    so -1 - id never collides), then rewrite the sequence inserting each
+    mirror directly after its source entry so evaluation order vs. `*`
+    ACEs is kept."""
+    for row in rows:
+        await db.execute(
+            "UPDATE acl_entries SET position = ? WHERE id = ?",
+            (-1 - row[0], row[0]),
+        )
+    position = 0
+    for row in rows:
+        await db.execute(
+            "UPDATE acl_entries SET position = ? WHERE id = ?",
+            (position, row[0]),
+        )
+        position += 1
+        if row[3] == _ALLOW and row[8] == _SOURCE:  # action, permission
             await db.execute(
-                "UPDATE acl_entries SET position = ? WHERE id = ?",
-                (-1 - row[0], row[0]),
-            )
-        # Rewrite the sequence, inserting each mirror directly after
-        # its source entry so evaluation order vs. `*` ACEs is kept.
-        position = 0
-        for row in rows:
-            await db.execute(
-                "UPDATE acl_entries SET position = ? WHERE id = ?",
-                (position, row[0]),
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  user_id, group_id, system_principal, permission)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                _mirror_row(row, position),
             )
             position += 1
-            if row[3] == _ALLOW and row[8] == _SOURCE:  # action, permission
-                await db.execute(
-                    "INSERT INTO acl_entries"
-                    " (resource, position, action, principal_type,"
-                    "  user_id, group_id, system_principal, permission)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    _mirror_row(row, position),
-                )
-                position += 1
 
 
 migration = Migration(12, "0012_files_write", apply)

--- a/src/klangk/klangk/model/migrations/m0013_exec_and_sync_permission.py
+++ b/src/klangk/klangk/model/migrations/m0013_exec_and_sync_permission.py
@@ -23,50 +23,14 @@ for them —
 terminals are unaffected.
 """
 
-import re
-
-from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_GROUP
 from klangk.model.migrations.base import Migration
+from klangk.model.migrations.shared import grant_role_group_permission
 
-_SYNC_ROLES = ("coders", "collaborators")
-_ROLE_GROUP_RE = re.compile(r"^(%s)-(.+)$" % "|".join(_SYNC_ROLES))
+_EXEC_AND_SYNC = "exec-and-sync"
 
 
 async def apply(db) -> None:
-    cursor = await db.execute(
-        "SELECT name FROM groups WHERE source = 'workspace-role'"
-    )
-    role_groups = [row[0] for row in await cursor.fetchall()]
-    for name in role_groups:
-        m = _ROLE_GROUP_RE.match(name)
-        if m is None:
-            continue  # owners/spectators (and unknown suffixes) untouched
-        ws_id = m.group(2)
-        resource = f"/workspaces/{ws_id}"
-        existing = await db.execute(
-            "SELECT 1 FROM acl_entries"
-            " WHERE resource = ? AND group_id = ("
-            "   SELECT id FROM groups WHERE name = ?)"
-            " AND permission = 'exec-and-sync' LIMIT 1",
-            (resource, name),
-        )
-        if await existing.fetchone() is not None:
-            continue
-        max_pos = await db.execute(
-            "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
-            " WHERE resource = ?",
-            (resource,),
-        )
-        pos = (await max_pos.fetchone())[0] + 1
-        await db.execute(
-            "INSERT INTO acl_entries"
-            " (resource, position, action, principal_type,"
-            "  user_id, group_id, system_principal, permission)"
-            " VALUES (?, ?, ?, ?, NULL,"
-            "  (SELECT id FROM groups WHERE name = ?), NULL,"
-            "  'exec-and-sync')",
-            (resource, pos, ACTION_ALLOW, PRINCIPAL_GROUP, name),
-        )
+    await grant_role_group_permission(db, _EXEC_AND_SYNC)
 
 
 migration = Migration(13, "0013_exec_and_sync_permission", apply)

--- a/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
+++ b/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
@@ -46,7 +46,18 @@ def _is_seeded_shape(rows) -> bool:
     system-authenticated create entry the seed wrote."""
     if len(rows) != 1:
         return False
-    return rows[0][:7] == (
+    row = rows[0]
+    # Integer-indexed compare: rows may be the db.Row wrapper (no slice
+    # support) on the production connection path.
+    return (
+        row[0],
+        row[1],
+        row[2],
+        row[3],
+        row[4],
+        row[5],
+        row[6],
+    ) == (
         0,  # position
         ACTION_ALLOW,
         PRINCIPAL_SYSTEM,

--- a/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
+++ b/src/klangk/klangk/model/migrations/m0014_groups_create_admin.py
@@ -44,15 +44,16 @@ _RESOURCE = "/groups"
 def _is_seeded_shape(rows) -> bool:
     """Whether the /groups ACL still holds exactly the single
     system-authenticated create entry the seed wrote."""
-    return bool(
-        len(rows) == 1
-        and rows[0][0] == 0  # position
-        and rows[0][1] == ACTION_ALLOW
-        and rows[0][2] == PRINCIPAL_SYSTEM
-        and rows[0][3] is None  # user_id
-        and rows[0][4] is None  # group_id
-        and rows[0][5] == SYSTEM_AUTHENTICATED
-        and rows[0][6] == "create"
+    if len(rows) != 1:
+        return False
+    return rows[0][:7] == (
+        0,  # position
+        ACTION_ALLOW,
+        PRINCIPAL_SYSTEM,
+        None,  # user_id
+        None,  # group_id
+        SYSTEM_AUTHENTICATED,
+        "create",
     )
 
 

--- a/src/klangk/klangk/model/migrations/m0018_egress_consent_permission.py
+++ b/src/klangk/klangk/model/migrations/m0018_egress_consent_permission.py
@@ -25,50 +25,14 @@ Admins who granted ``terminal`` to other principals via custom ACEs
 preserve deciding for them.
 """
 
-import re
-
-from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_GROUP
 from klangk.model.migrations.base import Migration
+from klangk.model.migrations.shared import grant_role_group_permission
 
-_CONSENT_ROLES = ("coders", "collaborators")
-_ROLE_GROUP_RE = re.compile(r"^(%s)-(.+)$" % "|".join(_CONSENT_ROLES))
+_EGRESS_CONSENT = "egress-consent"
 
 
 async def apply(db) -> None:
-    cursor = await db.execute(
-        "SELECT name FROM groups WHERE source = 'workspace-role'"
-    )
-    role_groups = [row[0] for row in await cursor.fetchall()]
-    for name in role_groups:
-        m = _ROLE_GROUP_RE.match(name)
-        if m is None:
-            continue  # owners/spectators (and unknown suffixes) untouched
-        ws_id = m.group(2)
-        resource = f"/workspaces/{ws_id}"
-        existing = await db.execute(
-            "SELECT 1 FROM acl_entries"
-            " WHERE resource = ? AND group_id = ("
-            "   SELECT id FROM groups WHERE name = ?)"
-            " AND permission = 'egress-consent' LIMIT 1",
-            (resource, name),
-        )
-        if await existing.fetchone() is not None:
-            continue
-        max_pos = await db.execute(
-            "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
-            " WHERE resource = ?",
-            (resource,),
-        )
-        pos = (await max_pos.fetchone())[0] + 1
-        await db.execute(
-            "INSERT INTO acl_entries"
-            " (resource, position, action, principal_type,"
-            "  user_id, group_id, system_principal, permission)"
-            " VALUES (?, ?, ?, ?, NULL,"
-            "  (SELECT id FROM groups WHERE name = ?), NULL,"
-            "  'egress-consent')",
-            (resource, pos, ACTION_ALLOW, PRINCIPAL_GROUP, name),
-        )
+    await grant_role_group_permission(db, _EGRESS_CONSENT)
 
 
 migration = Migration(18, "0018_egress_consent_permission", apply)

--- a/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
+++ b/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
@@ -69,11 +69,16 @@ def _is_legacy_groups_shape(rows) -> bool:
 
 def _is_legacy_row_shape(row) -> bool:
     """The single-row seed shape: ``Allow create`` for a group principal
-    at position 0."""
+    at position 0.
+
+    Integer-indexed compare: rows may be the db.Row wrapper (no slice
+    support) on the production connection path.
+    """
     return (
-        row[:4] == (0, ACTION_ALLOW, PRINCIPAL_GROUP, None)
+        (row[0], row[1], row[2], row[3])
+        == (0, ACTION_ALLOW, PRINCIPAL_GROUP, None)
         and row[4] is not None  # group_id
-        and row[5:] == (None, "create")
+        and (row[5], row[6]) == (None, "create")
     )
 
 

--- a/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
+++ b/src/klangk/klangk/model/migrations/m0021_first_class_resource_acls.py
@@ -64,15 +64,75 @@ RESOURCES = {
 def _is_legacy_groups_shape(rows) -> bool:
     """Whether /groups holds exactly the m0014-rewritten seed: a single
     ``Allow create`` row for a group principal at position 0."""
-    return bool(
-        len(rows) == 1
-        and rows[0][0] == 0  # position
-        and rows[0][1] == ACTION_ALLOW
-        and rows[0][2] == PRINCIPAL_GROUP
-        and rows[0][3] is None  # user_id
-        and rows[0][4] is not None  # group_id
-        and rows[0][5] is None  # system_principal
-        and rows[0][6] == "create"
+    return len(rows) == 1 and _is_legacy_row_shape(rows[0])
+
+
+def _is_legacy_row_shape(row) -> bool:
+    """The single-row seed shape: ``Allow create`` for a group principal
+    at position 0."""
+    return (
+        row[:4] == (0, ACTION_ALLOW, PRINCIPAL_GROUP, None)
+        and row[4] is not None  # group_id
+        and row[5:] == (None, "create")
+    )
+
+
+def _resource_acl_action(resource: str, rows) -> str:
+    """What to do with a resource's existing ACL rows: ``fresh`` (none),
+    ``replace`` (the well-known m0014 /groups seed), or ``skip``
+    (operator pre-staged/customized rows)."""
+    if not rows:
+        return "fresh"
+    if resource == "/groups" and _is_legacy_groups_shape(rows):
+        return "replace"
+    return "skip"
+
+
+async def _migrate_resource_acl(
+    db, resource: str, permission: str, admins_id: str | None
+) -> None:
+    """Clear the replaceable rows and write the admins Allow + everyone
+    Deny pair for *resource*."""
+    cursor = await db.execute(
+        "SELECT position, action, principal_type, user_id, group_id,"
+        " system_principal, permission FROM acl_entries"
+        " WHERE resource = ?",
+        (resource,),
+    )
+    rows = list(await cursor.fetchall())
+    action = _resource_acl_action(resource, rows)
+    if action == "skip":
+        # Operator pre-staged/customized rows; don't disturb
+        # them (manual step documented in the changelog).
+        return
+    if action == "replace":
+        # The well-known m0014 seed: replace it — nothing checks
+        # `create` on /groups anymore, so leaving it would lock
+        # admins out of group management (#2945 review).
+        await db.execute(
+            "DELETE FROM acl_entries WHERE resource = ?",
+            (resource,),
+        )
+    if admins_id is not None:
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type, user_id,"
+            "  group_id, system_principal, permission)"
+            " VALUES (?, 0, ?, ?, NULL, ?, NULL, ?)",
+            (
+                resource,
+                ACTION_ALLOW,
+                PRINCIPAL_GROUP,
+                admins_id,
+                permission,
+            ),
+        )
+    await db.execute(
+        "INSERT INTO acl_entries"
+        " (resource, position, action, principal_type, user_id,"
+        "  group_id, system_principal, permission)"
+        " VALUES (?, 1, ?, ?, NULL, NULL, ?, '*')",
+        (resource, ACTION_DENY, PRINCIPAL_SYSTEM, SYSTEM_EVERYONE),
     )
 
 
@@ -89,47 +149,7 @@ async def apply(db) -> None:
     admins_id = row[0] if row is not None else None
 
     for resource, permission in RESOURCES.items():
-        cursor = await db.execute(
-            "SELECT position, action, principal_type, user_id, group_id,"
-            " system_principal, permission FROM acl_entries"
-            " WHERE resource = ?",
-            (resource,),
-        )
-        rows = list(await cursor.fetchall())
-        if rows:
-            if resource == "/groups" and _is_legacy_groups_shape(rows):
-                # The well-known m0014 seed: replace it — nothing checks
-                # `create` on /groups anymore, so leaving it would lock
-                # admins out of group management (#2945 review).
-                await db.execute(
-                    "DELETE FROM acl_entries WHERE resource = ?",
-                    (resource,),
-                )
-            else:
-                # Operator pre-staged/customized rows; don't disturb
-                # them (manual step documented in the changelog).
-                continue
-        if admins_id is not None:
-            await db.execute(
-                "INSERT INTO acl_entries"
-                " (resource, position, action, principal_type, user_id,"
-                "  group_id, system_principal, permission)"
-                " VALUES (?, 0, ?, ?, NULL, ?, NULL, ?)",
-                (
-                    resource,
-                    ACTION_ALLOW,
-                    PRINCIPAL_GROUP,
-                    admins_id,
-                    permission,
-                ),
-            )
-        await db.execute(
-            "INSERT INTO acl_entries"
-            " (resource, position, action, principal_type, user_id,"
-            "  group_id, system_principal, permission)"
-            " VALUES (?, 1, ?, ?, NULL, NULL, ?, '*')",
-            (resource, ACTION_DENY, PRINCIPAL_SYSTEM, SYSTEM_EVERYONE),
-        )
+        await _migrate_resource_acl(db, resource, permission, admins_id)
 
 
 migration = Migration(21, "0021_first_class_resource_acls", apply)

--- a/src/klangk/klangk/model/migrations/m0022_workspace_permission_renames.py
+++ b/src/klangk/klangk/model/migrations/m0022_workspace_permission_renames.py
@@ -93,6 +93,22 @@ async def apply(db) -> None:
     await _grant_lifecycle_trio(db)
 
 
+_LIFECYCLE_TRIO = (
+    "start-workspace",
+    "stop-workspace",
+    "restart-workspace",
+)
+
+
+def _missing_lifecycle_perms(held: set) -> list[str]:
+    """The trio permissions the group doesn't already hold."""
+    return [
+        perm
+        for perm in _LIFECYCLE_TRIO
+        if "*" not in held and perm not in held
+    ]
+
+
 async def _grant_lifecycle_trio(db) -> None:
     """Insert start/stop/restart-workspace for every existing coders-*
     / collaborators-* role group's workspace resource (seeded only for
@@ -120,13 +136,7 @@ async def _grant_lifecycle_trio(db) -> None:
             (resource,),
         )
         pos = (await cursor2.fetchone())[0]
-        for perm in (
-            "start-workspace",
-            "stop-workspace",
-            "restart-workspace",
-        ):
-            if perm in held or "*" in held:
-                continue
+        for perm in _missing_lifecycle_perms(held):
             pos += 1
             await db.execute(
                 "INSERT INTO acl_entries"

--- a/src/klangk/klangk/model/migrations/shared.py
+++ b/src/klangk/klangk/model/migrations/shared.py
@@ -1,0 +1,141 @@
+"""Helpers shared by the frozen schema migrations.
+
+Each helper consolidates a pattern two or more migrations repeat
+verbatim (the migration-clone residuals of the #2904 jscpd scan,
+consolidated during the #2845 ratchet). The SQL statements and their
+ordering are exactly what the migrations shipped with — parameterized
+only by the strings the migrations differ in — so the upgrade outcome
+for a deployed database is unchanged.
+"""
+
+import re
+
+from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_GROUP
+
+# The operating role groups whose per-workspace grants get backfilled
+# (owners hold the ``*`` wildcard; spectators never had these channels).
+_ROLE_GROUP_RE = re.compile(r"^(coders|collaborators)-(.+)$")
+
+
+def _mirror_row(row: tuple, position: int, target: str) -> tuple:
+    """Build an INSERT tuple mirroring *row* (minus id) for *target*.
+
+    ``row`` is ``(id, resource, position, action, principal_type,
+    user_id, group_id, system_principal, permission)``.
+    """
+    return (
+        row[1],  # resource
+        position,
+        row[3],  # action (Allow)
+        row[4],  # principal_type
+        row[5],  # user_id
+        row[6],  # group_id
+        row[7],  # system_principal
+        target,
+    )
+
+
+async def _resequence_with_mirrors(db, rows, source: str, target: str) -> None:
+    """Park existing rows at unique negative positions (ids are unique,
+    so -1 - id never collides), then rewrite the sequence inserting each
+    mirror directly after its source entry so evaluation order vs. `*`
+    ACEs is kept."""
+    for row in rows:
+        await db.execute(
+            "UPDATE acl_entries SET position = ? WHERE id = ?",
+            (-1 - row[0], row[0]),
+        )
+    position = 0
+    for row in rows:
+        await db.execute(
+            "UPDATE acl_entries SET position = ? WHERE id = ?",
+            (position, row[0]),
+        )
+        position += 1
+        if row[3] == ACTION_ALLOW and row[8] == source:  # action, permission
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  user_id, group_id, system_principal, permission)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                _mirror_row(row, position, target),
+            )
+            position += 1
+
+
+async def mirror_permission_aces(db, source: str, target: str) -> None:
+    """Mirror every Allow ``source`` ACE as an Allow ``target`` ACE for
+    the same principal at the same resource, at the adjacent position.
+
+    ``acl_entries`` has ``UNIQUE(resource, position)`` and SQLite
+    enforces it per-statement (no deferring), so re-sequencing a
+    resource's positions can transiently collide: each resource's rows
+    are first parked at unique negative positions, then the final
+    sequence (with the mirrors interleaved) is written back (m0011's
+    rationale). Adjacency, not appending, is load-bearing: a ``*`` ACE
+    matches every check, so a mirror appended after a later ``Deny *``
+    would be shadowed.
+    """
+    cursor = await db.execute(
+        "SELECT DISTINCT resource FROM acl_entries"
+        " WHERE action = ? AND permission = ?",
+        (ACTION_ALLOW, source),
+    )
+    resources = [row[0] for row in await cursor.fetchall()]
+    for resource in resources:
+        cursor = await db.execute(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            " FROM acl_entries WHERE resource = ? ORDER BY position",
+            (resource,),
+        )
+        await _resequence_with_mirrors(
+            db, await cursor.fetchall(), source, target
+        )
+
+
+async def grant_role_group_permission(db, permission: str) -> None:
+    """Append an Allow *permission* ACE for every ``coders-``/
+    ``collaborators-<workspace_id>`` role group's workspace resource
+    (max position + 1) unless one already exists.
+
+    The match is by role-group name + ``workspace-role`` source marker,
+    not by ACEs: a coders/collaborators group an admin deliberately
+    stripped still gains the permission (the backfill covers the role
+    groups of every existing workspace; stripping the grant afterwards
+    is then an owner edit).
+    """
+    cursor = await db.execute(
+        "SELECT name FROM groups WHERE source = 'workspace-role'"
+    )
+    role_groups = [row[0] for row in await cursor.fetchall()]
+    for name in role_groups:
+        m = _ROLE_GROUP_RE.match(name)
+        if m is None:
+            continue  # owners/spectators (and unknown suffixes) untouched
+        ws_id = m.group(2)
+        resource = f"/workspaces/{ws_id}"
+        existing = await db.execute(
+            "SELECT 1 FROM acl_entries"
+            " WHERE resource = ? AND group_id = ("
+            "   SELECT id FROM groups WHERE name = ?)"
+            " AND permission = ? LIMIT 1",
+            (resource, name, permission),
+        )
+        if await existing.fetchone() is not None:
+            continue
+        max_pos = await db.execute(
+            "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
+            " WHERE resource = ?",
+            (resource,),
+        )
+        pos = (await max_pos.fetchone())[0] + 1
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type,"
+            "  user_id, group_id, system_principal, permission)"
+            " VALUES (?, ?, ?, ?, NULL,"
+            "  (SELECT id FROM groups WHERE name = ?), NULL,"
+            "  ?)",
+            (resource, pos, ACTION_ALLOW, PRINCIPAL_GROUP, name, permission),
+        )

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -19,6 +19,14 @@ import aiosqlite
 import pytest
 
 from klangk.model import migrations as migrations_mod
+from klangk.model.acl import (
+    ACTION_ALLOW,
+    ACTION_DENY,
+    PRINCIPAL_GROUP,
+    PRINCIPAL_SYSTEM,
+    SYSTEM_AUTHENTICATED,
+    SYSTEM_EVERYONE,
+)
 from klangk.model.migrations import Migration, run_migrations
 from klangk.model.users import AGENT_USER_ID
 
@@ -1966,6 +1974,109 @@ class TestM0021FirstClassResourceAcls:
             ]
         finally:
             await db.__aexit__(None, None, None)
+
+
+class TestLegacyShapesThroughProductionConnection:
+    """The m0014/m0021 shape compares must tolerate the ``db.Row``
+    wrapper (integer keys only — no slices) used on the production
+    connection path, not just the raw-aiosqlite rows the per-migration
+    harnesses use (#2980 review)."""
+
+    async def _forget(self, app_state, migration_id: int) -> None:
+        async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
+            await db.execute(
+                "DELETE FROM schema_migrations WHERE id = ?", (migration_id,)
+            )
+            await db.commit()
+
+    async def test_m0014_seeded_shape_reapplied_via_wrapper(
+        self, temp_data_dir, app_state
+    ):
+        """m0014's seeded-shape check sees wrapper rows and consumes the
+        pre-#2770 /groups seed (regression: row slicing crashed on the
+        wrapper, boot-looping upgrades)."""
+        await app_state.state.model.init_db()
+        async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
+            await db.execute(
+                "DELETE FROM acl_entries WHERE resource = '/groups'"
+            )
+            # The pre-m0014 seed: single system-authenticated Allow
+            # create at position 0.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, user_id,"
+                "  group_id, system_principal, permission)"
+                " VALUES ('/groups', 0, ?, ?, NULL, NULL, ?, 'create')",
+                (ACTION_ALLOW, PRINCIPAL_SYSTEM, SYSTEM_AUTHENTICATED),
+            )
+            await db.commit()
+        await self._forget(app_state, 14)
+
+        # Through the production wrapper: the shape check must match,
+        # and m0014 consumes the seeded row (no 'admin' group exists
+        # post-m0020, so no replacement is inserted).
+        await app_state.state.model.init_db()
+        async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM acl_entries WHERE resource = '/groups'"
+            )
+            assert (await cursor.fetchone())[0] == 0
+
+    async def test_m0021_legacy_groups_shape_replaced_via_wrapper(
+        self, temp_data_dir, app_state
+    ):
+        """m0021's legacy-shape check sees wrapper rows and replaces the
+        m0014 seed with the manage-groups pair (regression: row slicing
+        crashed on the wrapper, boot-looping upgrades)."""
+        await app_state.state.model.init_db()
+        async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
+            cursor = await db.execute(
+                "SELECT id FROM groups WHERE name = 'admins'"
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                await db.execute(
+                    "INSERT INTO groups (id, name) VALUES ('g-admins',"
+                    " 'admins')"
+                )
+                admins_id = "g-admins"
+            else:
+                admins_id = row[0]
+            await db.execute(
+                "DELETE FROM acl_entries WHERE resource = '/groups'"
+            )
+            # The m0014 output shape: single group-principal Allow
+            # create at position 0.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, user_id,"
+                "  group_id, system_principal, permission)"
+                " VALUES ('/groups', 0, ?, ?, NULL, ?, NULL, 'create')",
+                (ACTION_ALLOW, PRINCIPAL_GROUP, admins_id),
+            )
+            await db.commit()
+        await self._forget(app_state, 21)
+
+        # Through the production wrapper: the legacy shape must be
+        # recognized and replaced with the admins Allow + everyone Deny.
+        await app_state.state.model.init_db()
+        async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
+            cursor = await db.execute(
+                "SELECT position, action, principal_type, group_id,"
+                " system_principal, permission FROM acl_entries"
+                " WHERE resource = '/groups' ORDER BY position"
+            )
+            assert list(await cursor.fetchall()) == [
+                (
+                    0,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    admins_id,
+                    None,
+                    "manage-groups",
+                ),
+                (1, ACTION_DENY, PRINCIPAL_SYSTEM, None, SYSTEM_EVERYONE, "*"),
+            ]
 
 
 class TestM0022WorkspacePermissionRenames:


### PR DESCRIPTION
## Summary

Second PR of the #2845 A-ratchet (closes #2979), scope expanded per review direction to also consolidate the jscpd migration clones (#2904 residuals):

1. Every block in `model/migrations/` drops from rank B to rank A; the four module-average-B modules come down to A.
2. The m0011↔m0012 and m0013↔m0018 verbatim clones are consolidated into a shared `migrations/shared.py` (parameterized by the permission strings they differ in). jscpd on `model/migrations/`: **3 → 0 clones**; tree-wide 7 → 4 (the rest live in `api/`, `cli/`, `model/workspaces.py` and belong to their own tranches).
3. Includes a blocking review fix: the shape compares were rewritten to integer-indexed tuples after the fresh-eyes review caught that row **slices** crash on the production `db.Row` wrapper (raw-aiosqlite tests masked it).

Migration SQL and ordering are unchanged (one exception noted below); rationale docstrings stay in the migration modules.

## Details

- **`__init__.py`**: `validate_migrations` split into `_assert_contiguous_ids` / `_assert_unique_names`; `run_migrations` sheds the recorded-name check (`_assert_recorded_name_matches`) and the per-migration BEGIN IMMEDIATE block (`_apply_migration`, comments preserved).
- **`m0010`**: the match/UUID/workspace-existence predicate → `_workspace_role_target`.
- **`shared.py`** (new): `mirror_permission_aces(db, source, target)` — the m0011/m0012 mirror-and-resequence logic; `grant_role_group_permission(db, permission)` — the m0013/m0018 role-group backfill. m0013/m0018's permission literal moves from in-SQL text to a bound parameter (semantics identical); all other SQL is byte-for-byte as shipped.
- **`m0014` / `m0021`**: shape checks rebuilt as integer-indexed tuple compares — `db.Row` (the production connection wrapper) supports only int/str keys, so slices raise `NoSuchColumnError`; integer indexing works on both wrapper and raw-aiosqlite rows.
- **`m0021`**: per-resource handling → `_resource_acl_action` fresh/replace/skip dispatch + `_migrate_resource_acl`.
- **`m0022`**: the held-set skip → `_missing_lifecycle_perms` comprehension.
- **Regression tests**: `TestLegacyShapesThroughProductionConnection` replays the m0014 seeded-shape and m0021 legacy-shape paths through `app_state.state.model.init_db()` — the production wrapper path — planting the legacy `/groups` shapes and forgetting the migration records. These crash on the slice version and pass on the fix.

## Verification

- Full Python suite (`-n auto`, coverage): 6498 passed, **100% coverage**.
- `xenon --max-absolute A --max-modules A --max-average A` clean on `model/migrations/`; repo-wide B gate passes.
- `jscpd src/klangk/klangk --min-tokens 70`: 4 clones (0.08%), all outside this PR's scope.
- No changelog entry (internal refactor).
