### PR TITLE
docs(readme): add latest-release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Built with devenv](https://devenv.sh/assets/devenv-badge.svg)](https://devenv.sh)
 [![Built with Nix](https://img.shields.io/static/v1?logo=nixos&logoColor=white&label=&message=Built%20with%20Nix&color=41439a)](https://builtwithnix.org)
+[![Release](https://img.shields.io/github/v/release/mcdonc/klangk)](https://github.com/mcdonc/klangk/releases)
 
 ![Klangk Web Coding Agent](docs/screenshot.png)
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -381,6 +381,10 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **README release badge (#2981).** The README now carries a release
+  badge showing the latest `v*` tag, driven by GitHub Releases —
+  no manual updates needed.
+
 - **Native YAML integers for `port`, `egress_port`,
   `bridge_timeout_seconds`, and `idle_timeout_seconds` (#2967).** A
   bare YAML integer (`port: 8997`) now parses the same as the quoted


### PR DESCRIPTION
## Summary

Generalizes the git-credential plugin's OAuth device flow beyond GitHub to any RFC 8628 provider (#432).

- **`KLANGKWS_FEATURE_OAUTH_PROVIDERS`** (new container-scope config var): a JSON list of provider entries — `{host, client_id, device_code_url, token_url, scope, username}` — that activates the device flow for any git host (GitLab 13.x+, Gitea 1.17+, Bitbucket, self-hosted). Required fields: `host`, `client_id`, `device_code_url`, `token_url`; optional: `scope` (omitted from the code request when empty) and `username` (default `oauth2`).
- **Host-based provider lookup** in `tools/git-credential-klangk` replaces the hardcoded GitHub endpoints. Matching normalizes case, explicit port, trailing dot, and a `www.` prefix. The poll loop is unchanged RFC 8628 and works across providers.
- **Backward compatible:** `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` still works and expands to the stock GitHub entry (`repo` scope, `x-access-token` username). When both define a provider for the same host, the explicit map entry wins.
- **Browser dialog** now names the provider host ("Sign in to gitlab.com") via a `host` field on `device_flow_show` (falls back to `github.com` for older helpers), and the fixed-width rows ellipsis instead of overflowing — the new widget tests exposed a latent overflow with wide text.
- Malformed JSON in the map disables it (debug-logged) and falls through to the PAT dialog; individual bad entries are skipped.

The config var rides the existing container-env bridge, so it works at all three levels like the shorthand: deploy-wide (server env or `features_config:` as `oauth_providers`), per workspace (`env` map), ad hoc (`export` in a shell). No backend changes.

## Tests

- `TestProviderMap` in `test_git_credential.py`: flow against provider endpoints, client_id/scope in the code request, custom username, empty-scope omission, www/host-normalized matching, map-over-shorthand precedence, shorthand alongside a map, invalid/non-list JSON and broken entries falling back to the PAT dialog, unmapped hosts.
- Dart: device-flow dialog names the provider host, falls back when host absent, error display.
- Build-pipeline expectations updated for the new key; feature `pubspec.lock` refreshed to the pubspec's pinned plugin-api `v0.5.1` (lock was stale at `v0.2.0`; CI re-resolved it every run anyway).
- Full suites pass the CI way: backend `-n auto` (6436, 100% coverage), `scripts/tests` (97), frontend (1177), feature Dart (28), xenon.
