### PR TITLE
Versioned documentation with mike + zensical

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,44 +5,60 @@ on:
     tags:
       - "v[0-9]*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Docs version to deploy (defaults to the ref name minus any v prefix)"
+        required: false
+        type: string
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
+  group: gh-pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history: mike reads prior versions off the gh-pages
+          # branch, which must be present as a remote ref.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
-      - name: Install Zensical
-        run: pip install zensical
+      - name: Install docs toolchain
+        run: |
+          pip install zensical
+          # squidfunk's mike fork adapts mike to zensical; it is not on
+          # PyPI, so install it from GitHub (see zensical's versioning
+          # docs). No mkdocs needed — the fork builds via zensical.
+          pip install git+https://github.com/squidfunk/mike.git
 
-      - name: Build docs
-        run: zensical build
+      - name: Configure git for gh-pages commits
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: site
+      - name: Extract docs version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Deploy docs to gh-pages
+        env:
+          MIKE_DOCS_VERSION: ${{ steps.version.outputs.version }}
+        run: python scripts/deploy-docs.py
+
+      - name: Push gh-pages
+        run: git push origin gh-pages

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -384,6 +384,12 @@ sync` report a clear permission-denied error.
 - **README release badge (#2981).** The README now carries a release
   badge showing the latest `v*` tag, driven by GitHub Releases —
   no manual updates needed.
+- **Versioned documentation (#687).** Each release tag now deploys its
+  docs as a versioned subdirectory of the `gh-pages` branch (managed by
+  mike, with the zensical version selector), instead of overwriting the
+  whole site. The docs root redirects to the `latest` version. One-time
+  operator action: after the first tagged deploy creates the branch,
+  switch the GitHub Pages source to "Deploy from a branch: `gh-pages`".
 
 - **Native YAML integers for `port`, `egress_port`,
   `bridge_timeout_seconds`, and `idle_timeout_seconds` (#2967).** A

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -6,7 +6,6 @@ triggering.
 
 ## Tests
 
-
 | Workflow                | File                             | Trigger                                        |
 | ----------------------- | -------------------------------- | ---------------------------------------------- |
 | **Python Tests**        | `backend-tests.yml`              | PRs; pushes to `release/**`                    |
@@ -17,7 +16,7 @@ triggering.
 | **E2E: Frontend Tests** | `frontend-e2e-tests.yml`         | Changes to `src/klangk/`, `src/frontend/`      |
 | **E2E: Sandbox Tests**  | `sandbox-e2e-tests.yml`          | PRs (stock runners; `nix` opt-in via dispatch) |
 | **E2E: Cross-Browser**  | `frontend-e2e-cross-browser.yml` | Scheduled (every 6 hours), release branches    |
-| **E2E: Super (host)**    | `super-e2e.yml`                  | Manual, release branches (#2561)                |
+| **E2E: Super (host)**   | `super-e2e.yml`                  | Manual, release branches (#2561)               |
 | **API Fuzz**            | `fuzz-check.yml`                 | PRs; pushes to `release/**`                    |
 | **macOS Smoke**         | `macos-smoke.yml`                | PRs; pushes to `release/**`                    |
 
@@ -55,7 +54,7 @@ runners; the self-hosted NixOS runner is an opt-in via `workflow_dispatch`
 | --------------- | ---------------- | ----------------------- | ---------------------------------------------------------------------------------------- |
 | **Release**     | `release.yml`    | Push a `v*` tag         | Build and publish host container **and** the `klangk` wheel to PyPI (trusted publishing) |
 | **Dist Smoke**  | `dist-smoke.yml` | Manual                  | Verify the to-be-published wheel serves a working login page before tagging (#1611)      |
-| **Deploy Docs** | `docs.yml`       | Push a `v*` tag, manual | Deploy docs to GitHub Pages                                                              |
+| **Deploy Docs** | `docs.yml`       | Push a `v*` tag, manual | Deploy versioned docs to GitHub Pages via the gh-pages branch (#687)                     |
 
 Releases are cut by pushing a `v*` tag; see
 [Releasing](releasing.md) for the full procedure.

--- a/scripts/deploy-docs.py
+++ b/scripts/deploy-docs.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Deploy versioned documentation to the gh-pages branch with mike (#687).
+
+Zensical has no native versioning support yet; the official bridge is
+squidfunk's fork of mike (installed from GitHub in CI — it is not
+published on PyPI). This script drives that fork's Python API:
+
+1. sync the local gh-pages branch from origin (creating it on the first
+   deploy — without this, deploying would clobber every earlier version),
+2. build the docs with ``zensical build``, with ``MIKE_DOCS_VERSION``
+   exported so zensical prefixes ``site_url`` with the version,
+3. commit ``site/`` into a versioned subdirectory of gh-pages, refresh
+   the ``latest`` alias as HTML redirect pages (GitHub Pages does not
+   serve symlinks), and rewrite ``versions.json``,
+4. write a root ``index.html`` redirecting to the ``latest`` alias.
+
+The version comes from the ``MIKE_DOCS_VERSION`` environment variable
+(set by the docs workflow from the pushed tag). Run from the repository
+root; the caller pushes gh-pages afterwards.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from mike import commands, git_utils, utils
+
+GH_PAGES_BRANCH = "gh-pages"
+LATEST_ALIAS = "latest"
+
+
+def sync_gh_pages() -> None:
+    """Create or fast-forward the local gh-pages branch from origin."""
+    git_utils.update_from_upstream("origin", GH_PAGES_BRANCH)
+
+
+def deploy_version(version: str) -> None:
+    """Build the site and commit it as a versioned gh-pages deployment."""
+    cfg = utils.load_config()
+    with commands.deploy(
+        cfg,
+        version,
+        aliases=[LATEST_ALIAS],
+        update_aliases=True,
+        alias_type=commands.AliasType.redirect,
+    ):
+        utils.build(None, version)
+
+
+def set_default_redirect() -> None:
+    """Point the gh-pages root index.html at the latest alias."""
+    commands.set_default(LATEST_ALIAS)
+
+
+def main() -> int:
+    version = os.environ.get("MIKE_DOCS_VERSION", "")
+    if not version:
+        print(
+            "MIKE_DOCS_VERSION is not set — pass the docs version to "
+            "deploy (e.g. 1.2.3)",
+            file=sys.stderr,
+        )
+        return 1
+
+    sync_gh_pages()
+    try:
+        deploy_version(version)
+        set_default_redirect()
+    except git_utils.GitEmptyCommit:
+        # Re-deploying unchanged docs makes mike roll back the empty
+        # commit; that is a successful no-op, not an error.
+        print("docs unchanged since the last deploy — nothing to commit")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_deploy_docs.py
+++ b/scripts/tests/test_deploy_docs.py
@@ -1,0 +1,116 @@
+"""Contract tests for the versioned-docs deployment (#687).
+
+``scripts/deploy-docs.py`` drives squidfunk's mike fork (Zensical's
+official versioning bridge — native versioning does not exist yet, see
+https://zensical.org/docs/setup/versioning/) to publish each release's
+docs as a versioned subdirectory of the gh-pages branch. These grep-style
+tests pin the wiring — in the spirit of ``test_fmtk_harness.py`` — so a
+future edit that silently drops a piece (the redirect alias type, the
+gh-pages sync that keeps older versions alive, the workflow's full
+checkout) is loud.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "deploy-docs.py"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "docs.yml"
+_ZENSICAL_TOML = _REPO_ROOT / "zensical.toml"
+
+
+def test_zensical_config_declares_version_selector():
+    """The theme must render the mike-driven version selector."""
+    toml = _ZENSICAL_TOML.read_text()
+    assert "[project.extra.version]" in toml, (
+        "zensical.toml no longer configures project.extra.version — the "
+        "version selector will not render (see #687)"
+    )
+    assert 'provider = "mike"' in toml, (
+        'project.extra.version must set provider = "mike"'
+    )
+    assert 'default = "latest"' in toml, (
+        "project.extra.version must declare which alias is the default "
+        "version (the root redirect and version-warning target it)"
+    )
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT.is_file(), f"{_SCRIPT} is missing"
+    mode = _SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR, "scripts/deploy-docs.py must be executable"
+    first = _SCRIPT.read_text().splitlines()[0]
+    assert first.startswith("#!"), "scripts/deploy-docs.py needs a shebang"
+
+
+def test_script_uses_mike_python_api_with_redirect_aliases():
+    """The deploy must keep every prior version and alias safely."""
+    script = _SCRIPT.read_text()
+    assert "AliasType.redirect" in script, (
+        "deploy must use redirect alias pages — GitHub Pages does not serve symlinks"
+    )
+    assert "AliasType.symlink" not in script, "symlink aliases break on GitHub Pages"
+    assert "aliases=[LATEST_ALIAS]" in script, (
+        "deploy must refresh the latest alias alongside the version"
+    )
+    assert "update_aliases=True" in script, (
+        "deploy without update_aliases leaves the latest alias stale"
+    )
+    assert "update_from_upstream" in script, (
+        "deploy must sync the local gh-pages branch from origin first — "
+        "otherwise every deploy clobbers all earlier versions"
+    )
+    assert "GitEmptyCommit" in script, (
+        "re-deploying unchanged docs raises GitEmptyCommit; it must be "
+        "treated as a no-op, not a failure"
+    )
+
+
+def test_script_versions_the_build_and_root_redirect():
+    script = _SCRIPT.read_text()
+    assert "MIKE_DOCS_VERSION" in script, (
+        "deploy must read the version from MIKE_DOCS_VERSION (set by the "
+        "docs workflow from the tag)"
+    )
+    assert "utils.build" in script, (
+        "the zensical build must run inside mike's deploy context so "
+        "site_url gets the version prefix"
+    )
+    assert "set_default" in script, (
+        "deploy must write a root index.html redirect — without it the "
+        "site root 404s under gh-pages serving"
+    )
+
+
+def test_workflow_deploys_via_gh_pages_branch():
+    """The workflow pushes a versioned gh-pages branch, not artifacts."""
+    workflow = _WORKFLOW.read_text()
+    assert "fetch-depth: 0" in workflow, (
+        "checkout must fetch all refs so mike sees origin/gh-pages"
+    )
+    assert "contents: write" in workflow, "pushing gh-pages needs contents: write"
+    assert "pages: write" not in workflow, (
+        "the pages: write permission belongs to the removed actions/deploy-pages flow"
+    )
+    assert "id-token: write" not in workflow, (
+        "the id-token: write permission belongs to the removed "
+        "actions/deploy-pages flow"
+    )
+    assert "squidfunk/mike.git" in workflow, (
+        "CI must install squidfunk's mike fork — the PyPI mike builds via "
+        "mkdocs and cannot parse zensical.toml"
+    )
+    assert "deploy-pages" not in workflow, (
+        "docs now deploy from the gh-pages branch, not a workflow artifact"
+    )
+    assert "upload-pages-artifact" not in workflow, (
+        "docs now deploy from the gh-pages branch, not a workflow artifact"
+    )
+    assert "git push origin gh-pages" in workflow, (
+        "the workflow must push the gh-pages branch mike committed to"
+    )
+    assert "MIKE_DOCS_VERSION:" in workflow, (
+        "the workflow must pass the extracted version to deploy-docs.py"
+    )

--- a/zensical.toml
+++ b/zensical.toml
@@ -134,3 +134,7 @@ custom_fences = [
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
 [project.markdown_extensions.pymdownx.details]
+
+[project.extra.version]
+provider = "mike"
+default = "latest"


### PR DESCRIPTION
## Summary

Versioned documentation via mike + zensical, closing #687. Each release tag now deploys its docs as a versioned subdirectory of the `gh-pages` branch instead of overwriting the whole site; the theme renders a version selector and the docs root redirects to `latest`.

Research note: zensical has **no native versioning yet** — its official docs prescribe squidfunk's mike fork (`pip install git+https://github.com/squidfunk/mike.git`, not on PyPI) as the bridge until native support lands on the roadmap. The fork drops the mkdocs dependency and shells out to `zensical build` itself, so CI installs `zensical` + the fork (no `mkdocs` — unlike the upstream PyPI mike, which would need it).

## Changes

- **`zensical.toml`** — `[project.extra.version]` with `provider = "mike"`, `default = "latest"`: renders the version selector and the outdated-version banner; `latest` is the alias the root redirect targets.
- **`scripts/deploy-docs.py`** — drives the mike fork's Python API: syncs the local `gh-pages` from `origin` (without this every deploy would clobber older versions), builds via `utils.build` (sets `MIKE_DOCS_VERSION` so zensical prefixes `site_url`), commits `site/` into `<version>/`, refreshes the `latest` alias as redirect pages (`AliasType.redirect` — GitHub Pages does not serve symlinks), writes `versions.json` + `.nojekyll`, and a root `index.html` → `latest/` redirect. Re-deploying unchanged docs is a no-op (`GitEmptyCommit` caught).
- **`.github/workflows/docs.yml`** — rewritten for gh-pages: single job, `contents: write` (no `pages:`/`id-token:`), `fetch-depth: 0` so mike sees `origin/gh-pages`, bot git identity, version extracted from the tag (`v1.2.3` → `1.2.3`) with a `workflow_dispatch` input override, then `git push origin gh-pages`.
- **`scripts/tests/test_deploy_docs.py`** — contract tests pinning the wiring (redirect alias type, gh-pages sync, fork install, full checkout, root redirect).
- Changelog + CI-table doc updates.

## Verification

- `MIKE_DOCS_VERSION=1.2.3 zensical build` → canonical URL `https://mcdonc.github.io/klangk/1.2.3/` and `"version":{"default":"latest","provider":"mike"}` in the built `__config`.
- Full smoke in a scratch clone: first deploy creates `gh-pages` with `0.0.1/`, `latest/` (redirect → `../0.0.1/`), `versions.json`, `.nojekyll`, root `index.html` → `latest/`; a second deploy keeps `0.0.1/` and moves `latest` to `0.0.2/`; re-deploying the same version exits 0 with "nothing to commit"; missing env var errors cleanly.
- `python -m pytest scripts/tests` green (102 passed); pre-commit incl. xenon/actionlint/markdownlint green.

## Post-merge (one-time, manual)

After the first tagged deploy creates `gh-pages`, switch Pages from "deploy from workflow artifact" to branch serving:

    gh api repos/mcdonc/klangk/pages -X PUT -f build_type=legacy -f source[branch]=gh-pages -f source[path]=/
