### PR TITLE
consent: remove deploy-wide decider; consent stays workspace-scoped (#2976)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,18 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **Deploy-wide consent decider removed (#2976).** The
+  `/ws/consent-decider` handshake without a `?workspace=` param is now
+  refused (HTTP 403): consent authority is strictly per-workspace
+  (`egress-consent` on `/workspaces/{id}`), and `manage-server-schedule`
+  no longer authorizes any consent path. Operators who relied on a
+  standing admin decider covering every interactive workspace lose that
+  override: a workspace with no connected member decider now reverts to
+  its static allow-list. The `klangk shell` popup decider and the web
+  workspace page both register a decider whenever the member holds
+  `egress-consent`, so interactive workspaces keep working for their own
+  members.
+
 - **Workspace-sphere permission names (#2946).** Every stored ACE and
   every client that checks a workspace permission must use the new
   specific names: `create-workspace` (on `/workspaces`),

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -126,8 +126,8 @@ there is no per-process attribution.
 
 `egress_mode = "interactive"` is the opt-in, but interactivity is
 **runtime state** (#2308): a workspace's off-list egress is actually held
-only while **at least one live consent decider** is connected for it (or
-deploy-wide). A decider is a connected client — the `klangk
+only while **at least one live consent decider** is connected for it. A
+decider is a connected client — the `klangk
 consent-decide` TUI, the consent popup inside `klangk shell`, or the web
 UI — and its WebSocket connection _is_ the registration; liveness is
 driven by client pings, and a decider silent for
@@ -187,20 +187,17 @@ left pending forever.
   (until restart), and the attached ▾ menu sends the verdict with any
   other duration (#2246, #2499), plus a **Network** tab
   listing the in-effect rules with revoke actions.
-- **Deploy-wide** — an admin may connect a decider without a workspace
-  scope (via the `/ws/consent-decider` WebSocket) to decide for every
-  interactive workspace on the deploy. It receives newly-created holds
-  live, but no replay of holds that predate its connection (those simply
-  time out).
 
 Several deciders may be connected at once (two CLI sessions and the web
 UI, say): each pending request is fanned out to all of them and the first
-decision wins (#2244).
+decision wins (#2244). Deciders are strictly workspace-scoped (#2976):
+there is no deploy-wide flavor — a decider handshake without a workspace
+param is refused.
 
-**Authorization.** A workspace-scoped decider needs the `egress-consent`
-permission on the workspace (owner, coder, or collaborator — #2883;
+**Authorization.** A decider needs the `egress-consent` permission on
+the workspace (owner, coder, or collaborator — #2883;
 spectators are watch-only and never see the Network tab or the consent
-banner); a deploy-wide decider needs admin. A verdict can only decide a
+banner). A verdict can only decide a
 request inside the decider's own workspace. Pausing prompting (below)
 shares the same single gate — anyone who may register a decider may
 also pause.

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -188,7 +188,7 @@ actions — no per-action splits:
 | `manage-users`           | `/users`            | The whole Users surface: list users and their workspaces, create, edit, unlock, delete, read active login sessions. `GET /users/search` stays authenticated (pickers) |
 | `manage-groups`          | `/groups`           | The whole Groups surface: create, edit, delete, manage members. `GET /groups` stays authenticated (pickers)                                                           |
 | `manage-invitations`     | `/invitations`      | List, send, resend, revoke invitations                                                                                                                                |
-| `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel — plus the drain/consent decider WS handshake                                                                     |
+| `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel                                                                                                                   |
 | `manage-events`          | `/events`           | Read the container start/stop history (`GET /events`) — read-only audit                                                                                               |
 | `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                        |
 | `manage-volumes`         | `/volumes`          | Self-service volumes (still label-scoped to the caller at runtime) — Allow Authenticated by default (#2946)                                                           |
@@ -245,7 +245,19 @@ re-checked:
 | service-health fan-out (per transition)                       | `monitor-workspace`                                 | `/workspaces/{id}` | coders, collaborators, spectators | per fan-out (revocation stops delivery on the next frame)                                           |
 | service-health snapshot at registration                       | `monitor-workspace`                                 | `/workspaces/{id}` | coders, collaborators, spectators | per snapshot                                                                                        |
 | consent-decider WS, workspace-scoped                          | `egress-consent`                                    | `/workspaces/{id}` | coders, collaborators             | once at registration (handshake)                                                                    |
-| consent-decider WS, deploy-wide (drain)                       | `manage-server-schedule`                            | `/server`          | admins group                      | once at registration (handshake)                                                                    |
+
+There is no deploy-wide consent-decider handshake (#2976, decision A):
+consent authority is strictly per-workspace (`egress-consent` on
+`/workspaces/{id}`), and a handshake without a `workspace` param is
+refused. The deploy-wide flavor was an instance-administrator override
+standing in for absent workspace members — an operator escape hatch, not
+a consent concept — and it was gated by `manage-server-schedule`, which
+has nothing to do with consent. Removed rather than renamed: with no
+admin backstop, a workspace is interactive exactly while one of its own
+members (a client of the `klangk shell` popup decider or the web
+workspace page, both of which register whenever the member holds
+`egress-consent`) is connected; with none, it reverts to the static
+allow-list (the documented fallback, #2311).
 
 Audit conclusions (#2939): all 33 permission names in the vocabulary
 are enforced somewhere (no dead names); every WS gate's permission

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1886,10 +1886,11 @@ decider is connected (and pinging inside
 `KLANGKD_CONSENT_DECIDER_TIMEOUT`), held egress requests are offered to
 it for accept/deny; the `klangk consent-decide` command drives this
 socket. Requires the `egress-consent` permission on the workspace
-(see [Egress Filtering](../features/egress-filtering.md)).
+(see [Egress Filtering](../features/egress-filtering.md)). Deciders are
+strictly workspace-scoped (#2976): the `workspace` query param is
+required — a handshake without it is refused.
 
-**Auth:** JWT required. Optional query param: `workspace` (omit for
-deploy-wide deciding).
+**Auth:** JWT required. Query param: `workspace` (the workspace id).
 
 ---
 

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -616,14 +616,13 @@ class ConsentDeciderService extends ChangeNotifier {
   }
 
   /// Apply a `pause_ack` (#2494 review): a nack reverts the highlight (the
-  /// server refused -- missing `share-terminals`, deploy-wide decider, bad
-  /// duration -- so no window was set) and flashes which op failed; a
-  /// success applies the ack's own pause state as an authoritative fallback
-  /// -- the refreshed `egress_rules` broadcast normally lands first (the
-  /// server awaits it before acking), but the broadcast is best-effort
-  /// server-side, so without this the display could sit stale after a
-  /// successful pause. Null `until` on an ok ack means the pause was cleared
-  /// (unpause).
+  /// server refused -- unknown duration, for instance -- so no window was
+  /// set) and flashes which op failed; a success applies the ack's own
+  /// pause state as an authoritative fallback -- the refreshed
+  /// `egress_rules` broadcast normally lands first (the server awaits it
+  /// before acking), but the broadcast is best-effort server-side, so
+  /// without this the display could sit stale after a successful pause.
+  /// Null `until` on an ok ack means the pause was cleared (unpause).
   void _applyPauseAck(bool ok, double? until) {
     final op = _pendingPauseOp;
     _pendingPauseOp = null;

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -126,6 +126,7 @@ from .edit import (  # noqa: F401
 from .shellcmd import (  # noqa: F401
     consent_popup_enabled,
     klangk_argv,
+    member_may_decide,
     popup_decider_argv,
     popup_inner_shell_argv,
     run_consent_popup,

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -12,6 +12,7 @@ import asyncio
 import os
 import sys
 
+import httpx
 import typer
 import websockets
 
@@ -112,6 +113,33 @@ def consent_popup_enabled(ws, no_consent_popup: bool) -> bool:
         isatty=True,
         tmux_version=host_tmux_version(),
     )
+
+
+def member_may_decide(client, workspace_id: str) -> bool:
+    """True when the logged-in member may decide egress for the workspace.
+
+    #2976: the consent-popup decider must register exactly when the member
+    holds ``egress-consent`` (or ``*``) on the workspace -- the same gate the
+    decider handshake enforces server-side. A spectator-profile member
+    (terminal only) skips the popup wrapper instead of spawning a decider
+    that is 403-refused at the handshake (the #2490 slow-retry loop).
+    Fails OPEN on API errors: the server handshake stays the authority, and
+    a flaky preflight must never silently drop the decider for an entitled
+    member.
+    """
+    resource = f"/workspaces/{workspace_id}"
+    try:
+        resp = client.get(
+            "/api/v1/my-permissions", params={"resource": resource}
+        )
+        perms = resp.json().get("permissions", {}).get(resource)
+    except (httpx.HTTPError, ValueError):
+        # ValueError: a non-JSON error body (e.g. an HTML 500 page from a
+        # proxy in front of klangkd) must not skip the decider.
+        return True
+    if not isinstance(perms, list):
+        return True
+    return "egress-consent" in perms or "*" in perms
 
 
 def run_consent_popup(ws, terminal: str | None, forward_agent: bool) -> int:
@@ -224,11 +252,14 @@ def shell(
         config_default=context.cfg().get_forward_agent(context.server_url())
         or False,
     )
-    if consent_popup_enabled(ws, no_consent_popup):
+    if consent_popup_enabled(ws, no_consent_popup) and member_may_decide(
+        client, ws.id
+    ):
         # Wrap the normal shell in the consent-popup russian-doll (#2383).
         # Falls back to the plain attach below when tmux is prevented, opted
-        # out (--no-consent-popup / the inner re-invocation), or the workspace
-        # is not interactive-egress.
+        # out (--no-consent-popup / the inner re-invocation), the workspace
+        # is not interactive-egress, or the member may not decide egress
+        # (#2976: spectator-profile members never spawn a decider).
         raise typer.Exit(code=run_consent_popup(ws, terminal, forward_agent))
     try:
         asyncio.run(

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -670,7 +670,7 @@ class ConsentCoordinator:
         """Broadcast the pending request to the workspace's deciders (#2244).
 
         Pushes an ``egress_request`` frame to every live decider for the
-        workspace (and deploy-wide). Until a decider responds with a verdict,
+        workspace. Until a decider responds with a verdict,
         the hold simply waits for its timeout (or a ``resolve`` call) -- the
         hold is correct end-to-end regardless: it fail-closes on timeout.
         """
@@ -686,19 +686,13 @@ class ConsentCoordinator:
             str(request.get("id"))[:8],
         )
 
-    async def snapshot(self, workspace_id: str | None) -> list[dict]:
+    async def snapshot(self, workspace_id: str) -> list[dict]:
         """Pending-request frames for a newly-connected decider (replay).
 
         A decider that connects mid-flight sees the workspace's current holds
         so it can act on in-flight requests, not just ones created after it
-        joined. Deploy-wide deciders (``workspace_id`` None) get no snapshot
-        for now -- a cross-workspace pending list is a follow-up. Caveat: a
-        deploy-only decider connecting after holds exist will not see them, so
-        those holds time out fail-closed; they still receive NEW holds live via
-        :meth:`_fanout`.
+        joined.
         """
-        if workspace_id is None:
-            return []
         rows = await self.app.state.model.egress_consent.list_requests(
             workspace_id, decision=DECISION_PENDING
         )
@@ -716,17 +710,13 @@ class ConsentCoordinator:
             if row["id"] in self._holds
         ]
 
-    async def rules_frame(self, workspace_id: str | None) -> dict | None:
+    async def rules_frame(self, workspace_id: str) -> dict | None:
         """Build an ``egress_rules`` snapshot for a workspace (#2335 slice A).
 
         The in-effect consent verdicts (grouped allow/deny) + the static
         allow-list, for the decider's rule-management view. Returns None for a
-        missing/deleted workspace (the caller skips the frame); deploy-wide
-        deciders (workspace None) get no frame for now (a cross-workspace view
-        is a follow-up, matching :meth:`snapshot`).
+        missing/deleted workspace (the caller skips the frame).
         """
-        if workspace_id is None:
-            return None
         ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
         if ws is None:
             return None

--- a/src/klangk/klangk/consent/deciders.py
+++ b/src/klangk/klangk/consent/deciders.py
@@ -2,12 +2,13 @@
 
 A workspace is treated as "interactive" (its blocked egress is held for a
 human decision, #2311) exactly while **at least one consent decider** is
-registered for it -- or deploy-wide. Interactivity is therefore *runtime
+registered for it. Interactivity is therefore *runtime
 state*, not the stored ``egress_mode`` flag: a decider connects (#2310, over
 the decider WebSocket) -> the workspace becomes interactive; the decider
 disconnects -> it reverts to static allow-list behavior. With no decider,
 blocked egress just fails (clean denial, no hanging connection -- the #2308
-model).
+model). Deciders are strictly workspace-scoped (#2976): consent has no
+deploy-wide flavor.
 
 The registry supports **N concurrent deciders** per workspace (several CLI
 sessions + Flutter clients at once): it is a collection keyed by decider id,
@@ -45,9 +46,8 @@ class ConsentDeciderRegistry:
 
     def __init__(self, app) -> None:
         self.app = app
-        # decider_id -> {"ws": workspace_id | None, "seen": monotonic,
+        # decider_id -> {"ws": workspace_id, "seen": monotonic,
         #                 "email": str, "sock": SafeWebSocket}
-        # workspace_id None = deploy-wide (decides for every workspace).
         self._deciders: dict[str, dict] = {}
         self._reaper: asyncio.Task | None = None
 
@@ -61,7 +61,7 @@ class ConsentDeciderRegistry:
     def register(
         self,
         decider_id: str,
-        workspace_id: str | None,
+        workspace_id: str,
         email: str | None,
         sock,
     ) -> None:
@@ -79,7 +79,7 @@ class ConsentDeciderRegistry:
         }
         logger.info(
             "consent decider registered: scope=%s decider=%s",
-            workspace_id[:8] if workspace_id else "deploy",
+            workspace_id[:8],
             decider_id[:8],
         )
 
@@ -97,30 +97,26 @@ class ConsentDeciderRegistry:
             entry["seen"] = time.monotonic()
 
     def has_decider(self, workspace_id: str) -> bool:
-        """True iff >= 1 live decider is registered for this workspace or deploy-wide."""
+        """True iff >= 1 live decider is registered for this workspace."""
         now = time.monotonic()
         cutoff = self.timeout
         for entry in self._deciders.values():
-            scope = entry["ws"]
-            if (scope is None or scope == workspace_id) and (
-                now - entry["seen"] <= cutoff
-            ):
+            if entry["ws"] == workspace_id and (now - entry["seen"] <= cutoff):
                 return True
         return False
 
     def deciders_for(self, workspace_id: str) -> list[str]:
-        """Ids of live deciders for this workspace or deploy-wide (#2244 fanout)."""
+        """Ids of live deciders for this workspace (#2244 fanout)."""
         now = time.monotonic()
         cutoff = self.timeout
         return [
             did
             for did, entry in self._deciders.items()
-            if (entry["ws"] is None or entry["ws"] == workspace_id)
-            and (now - entry["seen"] <= cutoff)
+            if entry["ws"] == workspace_id and (now - entry["seen"] <= cutoff)
         ]
 
     def broadcast(self, workspace_id: str, message: dict) -> int:
-        """Send *message* to every live decider for this workspace or deploy-wide.
+        """Send *message* to every live decider for this workspace.
 
         Used by the coordinator to fan out ``egress_request`` (new hold) and
         ``egress_resolved`` (verdict/timeout) frames. A decider whose socket is
@@ -133,11 +129,7 @@ class ConsentDeciderRegistry:
         dead: list[str] = []
         delivered = 0
         for did, entry in self._deciders.items():
-            scope = entry["ws"]
-            if (
-                not (scope is None or scope == workspace_id)
-                or now - entry["seen"] > cutoff
-            ):
+            if entry["ws"] != workspace_id or now - entry["seen"] > cutoff:
                 continue
             try:
                 entry["sock"].send_json(message)

--- a/src/klangk/klangk/consent/egress.py
+++ b/src/klangk/klangk/consent/egress.py
@@ -40,9 +40,9 @@ PRUNE_INTERVAL = 3600.0
 
 async def workspace_is_interactive(app, workspace_id: str) -> bool:
     # #2308: interactivity is runtime state -- a workspace is interactive
-    # only while a live consent decider is registered for it (or
-    # deploy-wide), AND the workspace has opted in (egress_mode). No
-    # decider -> static behavior (clean denial, no held connection).
+    # only while a live consent decider is registered for it, AND the
+    # workspace has opted in (egress_mode). No decider -> static behavior
+    # (clean denial, no held connection).
     ws = await app.state.model.workspaces.get_workspace(workspace_id)
     if not ws or ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
         return False

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -2,12 +2,16 @@
 
 A decider (a live client that can approve/deny held egress -- the ``klangk``
 CLI in #2310, or a Flutter client) connects here to register its live presence
-for a workspace (or deploy-wide) AND to act on held requests. The connection
+for a workspace AND to act on held requests. The connection
 lifecycle drives the :class:`~klangk.consent.deciders.ConsentDeciderRegistry`:
 connect -> register, client ``ping`` -> touch (liveness), disconnect ->
 deregister. While at least one decider is registered the workspace is
 "interactive" (its blocked egress is held for a decision, #2311); with none,
 it reverts to static allow-list.
+
+Consent is strictly a workspace concern (#2976): the ``workspace`` query
+param is required, and there is no deploy-wide flavor. A workspace with
+no connected decider simply reverts to the static allow-list fallback.
 
 #2244 adds the decision half on top of #2308's registration/liveness:
 
@@ -20,15 +24,14 @@ it reverts to static allow-list.
   held sidecar connection, and broadcasts ``egress_resolved`` so co-deciders
   drop it (first-decision-wins).
 
-Authorization (#2244 closes the #2308 authz gap): a workspace-scoped decider
-(``?workspace=<id>``) must have the ``egress-consent`` permission on that
-workspace (owner, coder, or collaborator -- #2883; spectators are
-watch-only and never register); a deploy-wide decider (no ``workspace``)
-must hold `manage-server-schedule`. A verdict is honored only if it targets the decider's
-own workspace (defense-in-depth), enforced in ``resolve`` via
-``decider_workspace``. Pause/unpause share the same single gate as the
-connection itself (#2883): anyone who may register may also pause.
-Auth mirrors the main ``/ws`` handler: a user JWT in the ``token``
+Authorization (#2244 closes the #2308 authz gap): a decider must be
+workspace-scoped (``?workspace=<id>``) and hold the ``egress-consent``
+permission on that workspace (owner, coder, or collaborator -- #2883;
+spectators are watch-only and never register). A verdict is honored only if
+it targets the decider's own workspace (defense-in-depth), enforced in
+``resolve`` via ``decider_workspace``. Pause/unpause share the same single
+gate as the connection itself (#2883): anyone who may register may also
+pause. Auth mirrors the main ``/ws`` handler: a user JWT in the ``token``
 query param.
 
 Outbound writes go through :class:`SafeWebSocket` (bounded queue +
@@ -78,22 +81,21 @@ async def _refuse(
         reason,
         code,
         _log_safe(email or "unknown"),
-        _log_safe(websocket.query_params.get("workspace") or "deploy-wide"),
+        _log_safe(websocket.query_params.get("workspace") or "missing"),
         websocket.headers.get("user-agent", "?"),
     )
     await websocket.close(code=code, reason=reason)
 
 
 async def _refuse_invalid_handshake(
-    websocket: WebSocket, app, workspace: str | None, user: dict
+    websocket: WebSocket, app, workspace: str, user: dict
 ) -> bool:
     """Authorization + static-mode gate for a consent decider.
 
-    Workspace-scoped deciders need the ``egress-consent`` permission on
+    The decider must have the ``egress-consent`` permission on
     the workspace (owner, coder, or collaborator -- #2883; a spectator
     has only watch access and is refused here, so it can never reach the
-    verdict/revoke/pause handlers); deploy-wide deciders need
-    ``manage-server-schedule`` on ``/server`` (#2944).
+    verdict/revoke/pause handlers).
     Mirrors the main /ws handler's workspace gate
     (wshandler/connection.py).
 
@@ -103,8 +105,6 @@ async def _refuse_invalid_handshake(
     static/interactive boundary is structural (enforced here), not just
     behavioral (the coordinator's hold-time ``is_interactive`` gate stays
     as defense-in-depth). Reads the same egress_mode the coordinator does.
-    Deploy-wide deciders (workspace None) are unaffected -- they cover
-    interactive workspaces without flipping a static one.
 
     NB: these closes run before websocket.accept(), so the ASGI server
     (uvicorn) answers the handshake with a bare HTTP 403 -- the close code
@@ -114,35 +114,26 @@ async def _refuse_invalid_handshake(
 
     Returns True when the handshake was refused."""
     principals = await app.state.acl.get_principals(user["id"])
-    if workspace is not None:
-        allowed = await app.state.acl.check_permission(
-            f"/workspaces/{workspace}", principals, "egress-consent"
-        )
-    else:
-        # Server-lifecycle decisions (drain/recycle consent) are
-        # instance-sphere: manage-server-schedule on /server (#2944;
-        # previously the legacy `admin`-on-`/admin` gate).
-        allowed = await app.state.acl.check_permission(
-            "/server", principals, "manage-server-schedule"
-        )
+    allowed = await app.state.acl.check_permission(
+        f"/workspaces/{workspace}", principals, "egress-consent"
+    )
     if not allowed:
         await _refuse(websocket, 4003, "Forbidden", user.get("email"))
         return True
-    if workspace is not None:
-        ws = await app.state.model.workspaces.get_workspace(workspace)
-        if ws is None:
-            # Vanished between the authz check and now (a delete race) -- the
-            # workspace authz just passed against can no longer be registered.
-            await _refuse(websocket, 4003, "Forbidden", user.get("email"))
-            return True
-        if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
-            await _refuse(
-                websocket,
-                4003,
-                "workspace egress mode is not interactive",
-                user.get("email"),
-            )
-            return True
+    ws = await app.state.model.workspaces.get_workspace(workspace)
+    if ws is None:
+        # Vanished between the authz check and now (a delete race) -- the
+        # workspace authz just passed against can no longer be registered.
+        await _refuse(websocket, 4003, "Forbidden", user.get("email"))
+        return True
+    if ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
+        await _refuse(
+            websocket,
+            4003,
+            "workspace egress mode is not interactive",
+            user.get("email"),
+        )
+        return True
     return False
 
 
@@ -165,7 +156,7 @@ async def _dispatch_decider_message(
     registry,
     safe_ws,
     msg: dict,
-    workspace: str | None,
+    workspace: str,
     user_id: str,
     decider_id: str,
 ) -> None:
@@ -197,8 +188,7 @@ async def _dispatch_decider_message(
         )
     elif mtype == "pause":
         # #2332: pause interactive consent prompting for this
-        # decider's workspace for a window. A deploy-wide decider
-        # (workspace None) has no single workspace to pause -> nack.
+        # decider's workspace for a window.
         await _handle_pause(app, safe_ws, msg, workspace)
     elif mtype == "unpause":
         # #2332: clear an active pause for this decider's workspace.
@@ -286,7 +276,17 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     user = await _decider_authenticate(websocket, app, _hs_mark)
     if user is None:
         return
-    workspace = websocket.query_params.get("workspace")  # None = deploy-wide
+    workspace = websocket.query_params.get("workspace")
+    if workspace is None:
+        # #2976: consent is strictly a workspace concern -- there is no
+        # deploy-wide decider flavor, so the workspace param is required.
+        await _refuse(
+            websocket,
+            4003,
+            "workspace query parameter is required",
+            user.get("email"),
+        )
+        return
 
     if await _refuse_invalid_handshake(websocket, app, workspace, user):
         return
@@ -311,8 +311,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         for frame in await app.state.consent_coordinator.snapshot(workspace):
             safe_ws.send_json(frame)
         # The in-effect rules snapshot (#2335 slice A): lets a decider joining
-        # mid-flight see what's currently allowed/denied, not just holds. None
-        # for a deploy-wide decider (no single workspace) — matches snapshot().
+        # mid-flight see what's currently allowed/denied, not just holds.
         rules = await app.state.consent_coordinator.rules_frame(workspace)
         if rules is not None:
             safe_ws.send_json(rules)
@@ -326,23 +325,8 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         await safe_ws.stop_sender()
 
 
-def _can_pause(workspace: str | None) -> bool:
-    """Pause/unpause eligibility (#2332, #2883).
-
-    The old higher ``share-terminals`` bar is gone: pause/unpause ride
-    the connection's own ``egress-consent`` gate, so every decider that
-    registered may also pause. Only a deploy-wide decider (workspace
-    None) has no single workspace to pause.
-    """
-    return workspace is not None
-
-
 async def _handle_pause(app, safe_ws, msg, workspace) -> None:
     """Pause consent prompting for the decider's workspace (#2332)."""
-    if not _can_pause(workspace):
-        # A deploy-wide decider has no single workspace to pause.
-        safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
-        return
     result = await app.state.consent_coordinator.pause(
         workspace, msg.get("duration")
     )
@@ -357,9 +341,6 @@ async def _handle_pause(app, safe_ws, msg, workspace) -> None:
 
 async def _handle_unpause(app, safe_ws, workspace) -> None:
     """Clear an active consent pause for the decider's workspace (#2332)."""
-    if not _can_pause(workspace):
-        safe_ws.send_json({"type": "pause_ack", "ok": False, "until": None})
-        return
     result = await app.state.consent_coordinator.unpause(workspace)
     safe_ws.send_json({"type": "pause_ack", "ok": result["ok"], "until": None})
 

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1364,16 +1364,71 @@ class TestMainCLI:
                 return_value=True,
             ):
                 with patch.object(
-                    klangk.cli.shellcmd, "run_consent_popup", return_value=0
-                ) as fake_popup:
+                    klangk.cli.shellcmd,
+                    "member_may_decide",
+                    return_value=True,
+                ):
                     with patch.object(
-                        klangk.cli.shellcmd, "ws_shell"
-                    ) as fake_shell:
-                        with pytest.raises(typer.Exit) as exc:
-                            main.shell("ws", "@1")
+                        klangk.cli.shellcmd,
+                        "run_consent_popup",
+                        return_value=0,
+                    ) as fake_popup:
+                        with patch.object(
+                            klangk.cli.shellcmd, "ws_shell"
+                        ) as fake_shell:
+                            with pytest.raises(typer.Exit) as exc:
+                                main.shell("ws", "@1")
         assert exc.value.exit_code == 0
         fake_popup.assert_called_once()  # the wrapper ran
         fake_shell.assert_not_called()  # the plain attach did not
+
+    def test_shell_skips_consent_popup_for_spectator(
+        self, logged_in_cfg, monkeypatch, reset_env
+    ):
+        """#2976: a member without egress-consent (the spectator profile)
+        never spawns the popup decider -- the plain attach runs instead, so
+        no decider sits in the 403-retry loop."""
+
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="wid" + "0" * 51,
+            name="ws",
+            created_at="2025-01-01T00:00:00Z",
+            egress_mode="interactive",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+
+        async def fake_shell(*args, **kwargs):
+            pass
+
+        shell_fn = MagicMock(side_effect=fake_shell)
+
+        with patch.object(context_mod, "client", return_value=client):
+            with patch.object(
+                klangk.cli.shellcmd,
+                "consent_popup_enabled",
+                return_value=True,
+            ):
+                with patch.object(
+                    klangk.cli.shellcmd,
+                    "member_may_decide",
+                    return_value=False,
+                ):
+                    with patch.object(
+                        klangk.cli.shellcmd,
+                        "run_consent_popup",
+                        return_value=0,
+                    ) as fake_popup:
+                        with patch.object(
+                            klangk.cli.shellcmd, "ws_shell", shell_fn
+                        ):
+                            os.environ["TERM"] = "xterm-256color"
+                            with patch("termios.tcgetattr", return_value=None):
+                                main.shell("ws")
+        fake_popup.assert_not_called()  # no decider spawned
+        shell_fn.assert_called_once()  # plain attach ran
 
     def test_shell_with_terminal_arg(
         self, logged_in_cfg, monkeypatch, reset_env

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -887,3 +887,74 @@ class TestShellWiring:
         assert rc == 0
         out = capsys.readouterr()
         assert "Disconnected from mork" in out.err
+
+
+class TestMemberMayDecide:
+    """#2976: the shell spawns its consent-popup decider exactly when the
+    member holds ``egress-consent`` (or ``*``) on the workspace -- the same
+    gate the decider handshake enforces. Spectator-profile members skip the
+    wrapper instead of 403-looping; API failures fail OPEN (the handshake is
+    the authority)."""
+
+    WS_ID = "wid" + "0" * 51
+
+    @staticmethod
+    def _client(perms):
+        client = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {
+            "permissions": {f"/workspaces/{TestMemberMayDecide.WS_ID}": perms}
+        }
+        client.get.return_value = resp
+        return client
+
+    def test_true_when_egress_consent_held(self):
+        assert (
+            cli_main.member_may_decide(
+                self._client(["terminal", "egress-consent"]), self.WS_ID
+            )
+            is True
+        )
+
+    def test_true_when_wildcard_held(self):
+        assert (
+            cli_main.member_may_decide(self._client(["*"]), self.WS_ID) is True
+        )
+
+    def test_false_for_spectator_profile(self):
+        # terminal-only (the spectator profile): no consent authority.
+        assert (
+            cli_main.member_may_decide(self._client(["terminal"]), self.WS_ID)
+            is False
+        )
+
+    def test_false_for_no_grants(self):
+        assert (
+            cli_main.member_may_decide(self._client([]), self.WS_ID) is False
+        )
+
+    def test_true_on_api_error(self):
+        # Fail-open: a flaky preflight must never drop the decider for an
+        # entitled member -- the server handshake stays the authority.
+        import httpx
+
+        client = MagicMock()
+        client.get.side_effect = httpx.ConnectError("down")
+        assert cli_main.member_may_decide(client, self.WS_ID) is True
+
+    def test_true_on_non_json_body(self):
+        # A non-JSON error body (an HTML 500 page from a proxy) fails open.
+        client = MagicMock()
+        resp = MagicMock()
+        resp.json.side_effect = ValueError("not json")
+        client.get.return_value = resp
+        assert cli_main.member_may_decide(client, self.WS_ID) is True
+
+    def test_true_when_resource_missing_from_response(self):
+        # my-permissions returned no entry for the workspace: unknown, not
+        # a refusal -- fail open and let the handshake decide.
+        client = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"permissions": {}}
+        client.get.return_value = resp
+        assert cli_main.member_may_decide(client, self.WS_ID) is True

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -929,6 +929,11 @@ class TestMemberMayDecide:
         )
 
     def test_false_for_no_grants(self):
+        # Defensive shape: an explicit empty list for the resource. The real
+        # endpoint omits the resource entirely for a zero-grants member (that
+        # case is covered by test_true_when_resource_missing_from_response and
+        # fails open); this pins that an empty list is read as no consent
+        # authority, not as an error.
         assert (
             cli_main.member_may_decide(self._client([]), self.WS_ID) is False
         )

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -810,6 +810,7 @@ OUTCOME_NAMES: dict[str, str] = {
     "CONN-NOT-CLEAN": "connection not cleanly refused / a resolve frame wasn't seen.",
     "AB-HELD-HUNG": "concurrent A/B hold hung (NFQUEUE/DNS; possibly a concurrent-hold issue).",
     "ISOLATION-BROKEN": "a workspace-scoped decider saw another workspace's request. #2392",
+    "DEPLOYWIDE-ACCEPTED": "a no-workspace decider handshake was accepted -- the cross-workspace consent path is back. #2976",
     "UNEXPECTED-ERROR": "a phase bring-up or per-step exception (an unexpected error).",
     "AUDIT-MISLABELED": "expired/denied audit distinction broken (timeout audited as deny, or vice-versa). #2392",
     "ALLOWLIST-PROMPTED": "an allow-list-covered host prompted for consent (a real static-allow invariant break). #2419",
@@ -3626,7 +3627,11 @@ class SmokeTest:
         """#2976: a decider handshake with no ``workspace`` param must be
         refused pre-accept (uvicorn answers a bare HTTP 403). An accepted
         one would be a cross-workspace consent path -- anyone with an
-        admin-ish grant deciding for every workspace."""
+        admin-ish grant deciding for every workspace.
+
+        NB: a 403 here is also what an invalid/expired token yields -- the
+        token is proven live by the app's own decider connect earlier in
+        the run, so a 403 at this point is the workspace-param refusal."""
         step = _Step(
             self.summary.total, "(no-workspace)", "n/a", False, "scope-nw", "-"
         )

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -46,6 +46,7 @@ if _HERE not in sys.path:
     sys.path.insert(0, _HERE)
 
 import httpx  # noqa: E402
+import websockets  # noqa: E402
 
 from _e2e_server import start_server, stop_server, tracked_mkdtemp, ws_connect  # noqa: E402
 
@@ -719,10 +720,8 @@ _DETAIL_PREFIX_NAMES: list[tuple[str, str]] = [
     ("B sidecar not ready", "NO-EXPECTED-REQUEST"),
     ("A-scoped decider saw B's request", "ISOLATION-BROKEN"),
     ("B deny let the connection through", "DENY-RELEASED"),
-    ("deploy-wide's B deny let it through", "DENY-RELEASED"),
-    ("deploy-wide didn't see A", "NO-EXPECTED-REQUEST"),
-    ("deploy-wide saw A but the app didn't", "NO-EXPECTED-REQUEST"),
-    ("deploy-wide didn't see B", "NO-EXPECTED-REQUEST"),
+    ("deploy-wide connect was accepted", "DEPLOYWIDE-ACCEPTED"),
+    ("no-workspace handshake failed unexpectedly", "UNEXPECTED-ERROR"),
     ("could not set up the scope phase", "UNEXPECTED-ERROR"),
     ("no hold surfaced", "NO-EXPECTED-REQUEST"),
     ("expired but the connection succeeded", "NORESPONSE-OK"),
@@ -827,7 +826,7 @@ OUTCOME_NAMES: dict[str, str] = {
     "PAUSE-REFUSED": "an off-list host was refused or hung while paused instead of auto-allowing -- the pause did not take effect at the gate. #2332",
     "PAUSE-POLICY-BYPASS": "a static policy (allow-list / rejected_domains) was bypassed or changed while paused -- pause must affect only the interactive hold, not the DNS-layer lists. #2332",
     "PAUSE-RESUME-BROKEN": "after resume, an off-list host was not re-held for consent (the pause lingered, or the re-hold failed). #2332",
-    "PAUSE-ACK-FAILED": "the pause/unpause pause_ack came back not-ok (protocol: unknown duration, or a deploy-wide decider). #2332/#2389/#2883",
+    "PAUSE-ACK-FAILED": "the pause/unpause pause_ack came back not-ok (protocol: unknown duration). #2332/#2389/#2883",
     "FANOUT-SERIALIZED": "N concurrent off-list connects did not all surface a held request simultaneously (the NFQUEUE consumer serialized them -- a #2331/#2337 regression).",
     "CONCURRENT-NOT-DEDUPED": "concurrent connections to the same destination each produced a prompt (the coordinator's per-destination dedup is broken -- each should collapse to one).",
     "ONCE-CROSS-CONN": "a `once` verdict on one connection released a separate concurrent connection to the same host (the verdict leaked across connections -- #2361).",
@@ -923,8 +922,8 @@ class SmokeTest:
         # Extra deciders / workspaces / terminal-WS opened by the decider-scope
         # + audit phases. Closed + deleted in teardown so nothing leaks into
         # the no-decider phase (the #2413 leak class) or past the run. A phase
-        # also closes its own deciders eagerly: the deploy-wide one covers
-        # workspace A and would otherwise keep it interactive.
+        # also closes its own deciders eagerly: a live one keeps its workspace
+        # interactive and would break the no-decider phase premise.
         self._extra_deciders: list[RawDecider] = []
         self._extra_ws_ids: list[str] = []
         self._extra_ws_conns: list[tuple] = []
@@ -1899,7 +1898,7 @@ class SmokeTest:
 
     async def _connect_raw_decider(
         self,
-        workspace_id: str | None = None,
+        workspace_id: str,
         attempts: int = 4,
         *,
         ping: bool = False,
@@ -1923,13 +1922,12 @@ class SmokeTest:
         # (The prior framing as a TCP-proxy flakiness workaround was
         # disproven -- the proxy is Caddy and reliable, #2398.)
         #
-        # workspace_id scopes the decider: a real id -> workspace-scoped
-        # (needs terminal access); None -> deploy-wide (needs admin, decides
-        # for every workspace). Used by the decider-scope phase's
-        # isolation / coverage probes (#2392).
-        url = f"/ws/consent-decider?token={self.auth['token']}"
-        if workspace_id is not None:
-            url += f"&workspace={workspace_id}"
+        # workspace_id scopes the decider: a workspace id -> that
+        # workspace's consent (needs egress-consent on it). Consent is
+        # strictly workspace-scoped (#2976); there is no deploy-wide
+        # flavor. Used by the decider-scope phase's isolation probe
+        # (#2392) and the multi-decider/audit phases.
+        url = f"/ws/consent-decider?token={self.auth['token']}&workspace={workspace_id}"
         last: Exception | None = None
         for i in range(attempts):
             began = time.time()
@@ -3503,28 +3501,36 @@ class SmokeTest:
             self._abort = True
 
     async def run_decider_scope_phase(self, pilot) -> None:
-        """Workspace-scoped vs deploy-wide decider authz (#2392).
+        """Workspace-scoped decider isolation + no-deploy-wide refusal
+        (#2392, #2976).
 
         Cross-workspace isolation: a decider scoped to workspace A must NOT
         receive workspace B's ``egress_request`` (the registry's
-        ``deciders_for`` filters by scope). Deploy-wide coverage: an admin
-        decider (no ``workspace`` param) receives ``egress_request`` from
-        EVERY workspace. Both are driven on the real stack with a second
-        interactive workspace B.
+        ``deciders_for`` filters by scope). Driven on the real stack with a
+        second interactive workspace B.
 
-        ``pilot`` drives the textual app (decider #1, scoped to A = the
-        isolation subject); we read its ``controller.pending`` directly.
+        No deploy-wide flavor: a decider handshake with no ``workspace``
+        param must be refused (#2976) -- an accepted one would be a
+        cross-workspace consent path again.
+
+        ``pilot`` is unused (signature symmetry); the textual app (decider
+        #1, scoped to A = the isolation subject) is read directly via its
+        ``controller.pending``.
         """
         if not self.args.decider_scope:
             return
         print(
-            "\n--- decider scope: workspace-scoped isolation + deploy-wide ---"
+            "\n--- decider scope: workspace-scoped isolation + no deploy-wide ---"
         )
         d_b: RawDecider | None = None
-        d_dep: RawDecider | None = None
         cont_b: str | None = None
         step_tag = "create B"
         try:
+            # 0) no deploy-wide flavor (#2976): the no-workspace handshake
+            #    is refused pre-accept (uvicorn answers a bare HTTP 403).
+            step_tag = "no-workspace handshake"
+            await self._probe_no_workspace_decider_refused()
+
             ws_b = await asyncio.to_thread(
                 self._create_workspace, self.server, self.auth
             )
@@ -3544,10 +3550,6 @@ class SmokeTest:
             d_b = await self._connect_raw_decider(ws_b, ping=True)
             self._extra_deciders.append(d_b)
             await d_b.settle()
-            step_tag = "deploy-wide decider"
-            d_dep = await self._connect_raw_decider(None, ping=True)
-            self._extra_deciders.append(d_dep)
-            await d_dep.settle()
 
             # 1) isolation + B readiness: B's off-list SYN is held; d_b sees
             #    it, the A-scoped app does NOT. If d_b never sees it, B's
@@ -3600,100 +3602,6 @@ class SmokeTest:
                 if sx == MISMATCH and not self.args.continue_run:
                     self._abort = True
                     return
-
-            # 2) deploy-wide positive control: an A off-list SYN reaches the
-            #    deploy-wide decider AND the A-scoped app (proves d_dep really
-            #    receives frames, so #3's "didn't see B" can't be a false neg).
-            host_a = "rust-lang.org"  # fresh
-            ca = _canonical(host_a)
-            step_a = _Step(
-                self.summary.total, host_a, "domain", False, "scope-A", "-"
-            )
-            of_a = f"/tmp/smoke_scope_a_{self.summary.total}.out"
-            _trigger(self.container, host_a, of_a)
-            rid_a = await d_dep.wait_for(ca, 20.0)
-            app_a = (
-                await _wait_for_request(self.app, ca, 8.0) if rid_a else None
-            )
-            if rid_a is None:
-                self._record_probe(
-                    step_a,
-                    "A off-list -> deploy-wide",
-                    "no-request(!)",
-                    None,
-                    FINDING,
-                    "deploy-wide didn't see A (A sidecar readiness, #2417)",
-                )
-            else:
-                if app_a is not None:
-                    self.app._decide_id(app_a, DECISION_ALLOWED, DURATION_ONCE)
-                    await pilot.pause()
-                    await _wait_resolved(self.app, app_a, 15.0)
-                text_a = await _wait_result(self.container, of_a)
-                ec_a = _parse_exit(text_a)
-                if app_a is not None:
-                    sx, dx = PASS, ""
-                else:
-                    sx, dx = (
-                        FINDING,
-                        "deploy-wide saw A but the app didn't (timing)",
-                    )
-                self._record_probe(
-                    step_a,
-                    "A off-list -> deploy-wide + app",
-                    "covered" if app_a else "partial",
-                    ec_a,
-                    sx,
-                    dx,
-                )
-                if sx == MISMATCH and not self.args.continue_run:
-                    self._abort = True
-                    return
-
-            # 3) deploy-wide sees B: the SAME deploy-wide decider receives a B
-            #    off-list SYN -- coverage is deploy-wide, not A-scoped.
-            host_b2 = "elixir-lang.org"  # fresh
-            cb2 = _canonical(host_b2)
-            step_b2 = _Step(
-                self.summary.total, host_b2, "domain", False, "scope-B2", "-"
-            )
-            of_b2 = f"/tmp/smoke_scope_b2_{self.summary.total}.out"
-            _trigger(cont_b, host_b2, of_b2)
-            rid_b2 = await d_dep.wait_for(cb2, 20.0)
-            if rid_b2 is None:
-                self._record_probe(
-                    step_b2,
-                    "B off-list -> deploy-wide",
-                    "no-request(!)",
-                    None,
-                    FINDING,
-                    "deploy-wide didn't see B (B sidecar readiness, #2417)",
-                )
-            else:
-                await d_b.verdict(rid_b2, DECISION_DENIED, DURATION_ONCE)
-                await d_b.wait_resolution(rid_b2, 15.0)
-                text_b2 = await _wait_result(cont_b, of_b2)
-                ec_b2 = _parse_exit(text_b2)
-                if ec_b2 == EXIT_REFUSED:
-                    sx, dx = PASS, ""
-                elif ec_b2 == 0:
-                    sx, dx = MISMATCH, "deploy-wide's B deny let it through"
-                else:
-                    sx, dx = (
-                        FINDING,
-                        f"B2 conn not cleanly refused (exit {ec_b2})",
-                    )
-                self._record_probe(
-                    step_b2,
-                    "B off-list -> deploy-wide too",
-                    "covered",
-                    ec_b2,
-                    sx,
-                    dx,
-                )
-                if sx == MISMATCH and not self.args.continue_run:
-                    self._abort = True
-                    return
         except Exception as e:  # noqa: BLE001
             self._record_probe(
                 _Step(
@@ -3708,13 +3616,65 @@ class SmokeTest:
             if not self.args.continue_run:
                 self._abort = True
         finally:
-            # CRITICAL: the deploy-wide decider covers workspace A, so a live one
-            # keeps A interactive and breaks the no-decider phase premise (the
-            # #2413 leak class). Close both eagerly; teardown is a backstop
-            # (double-close is a safe no-op).
-            for d in (d_dep, d_b):
-                if d is not None:
-                    await d.close()
+            # CRITICAL: a live d_b keeps workspace B interactive (and would
+            # break later phases' premises), so close it eagerly; teardown is
+            # a backstop (double-close is a safe no-op).
+            if d_b is not None:
+                await d_b.close()
+
+    async def _probe_no_workspace_decider_refused(self) -> None:
+        """#2976: a decider handshake with no ``workspace`` param must be
+        refused pre-accept (uvicorn answers a bare HTTP 403). An accepted
+        one would be a cross-workspace consent path -- anyone with an
+        admin-ish grant deciding for every workspace."""
+        step = _Step(
+            self.summary.total, "(no-workspace)", "n/a", False, "scope-nw", "-"
+        )
+        try:
+            ws_nw = await ws_connect(
+                self.server,
+                f"/ws/consent-decider?token={self.auth['token']}",
+                open_timeout=15,
+            )
+        except websockets.InvalidStatus as e:
+            if e.response.status_code == 403:
+                self._record_probe(
+                    step, "no-workspace handshake", "refused", None, PASS, ""
+                )
+                return
+            self._record_probe(
+                step,
+                "no-workspace handshake",
+                f"http {e.response.status_code}",
+                None,
+                FINDING,
+                "no-workspace handshake failed unexpectedly",
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            self._record_probe(
+                step,
+                "no-workspace handshake",
+                "error",
+                None,
+                FINDING,
+                f"no-workspace handshake failed unexpectedly: {e!r}",
+            )
+            return
+        # Accepted -- the cross-workspace path is back. Close it so it
+        # cannot hold workspaces interactive for later phases.
+        await ws_nw.close()
+        self._record_probe(
+            step,
+            "no-workspace handshake",
+            "accepted(!)",
+            None,
+            MISMATCH,
+            "deploy-wide connect was accepted (cross-workspace consent "
+            "path is back, #2976)",
+        )
+        if not self.args.continue_run:
+            self._abort = True
 
     async def run_audit_distinction_phase(self, pilot) -> None:
         """Audit distinction: ``expired`` (timeout) vs ``denied`` (human) (#2392).
@@ -5189,7 +5149,7 @@ def main() -> int:
         "--no-decider-scope",
         dest="decider_scope",
         action="store_false",
-        help="skip the workspace-scoped vs deploy-wide decider phase (#2392)",
+        help="skip the workspace-scoped decider isolation phase (#2392/#2976)",
     )
     p.add_argument(
         "--no-audit-distinction",

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -6,6 +6,10 @@ Standalone, human-run, not in CI (no ``test_`` prefix). Invoke under devenv:
     devenv --quiet shell -- \\
         python src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py [--count N]
 
+Add ``--as-member`` (#2976) to run the consent flow as a plain workspace
+member (coders role, no instance-admin grants) instead of the seeded
+admin; the admin only bootstraps (member user, workspaces, role shares).
+
 Brings up a real klangkd, creates a workspace with an allow-list + interactive
 egress, attaches the real ConsentDeciderApp decider, then for N fuzzed
 destinations: ``podman exec`` a curl, wait for the consent request if one is
@@ -88,6 +92,12 @@ EXPECT_NOT0 = "not0"  # no-response (timeout) -> exit != 0
 # deterministically and a denied one reaches exit 7 (forged RST). example.com is
 # seeded onto the allow-list; the rest are off-list. Raw IPs are exploratory.
 _ALLOW_LIST = ["example.com"]
+
+# The --as-member acting identity (#2976): a plain user with no instance
+# grants. The seeded admin creates + shares workspaces to this user's
+# coders role; every consent operation then runs on this token.
+MEMBER_EMAIL = "smoke-member@example.com"
+MEMBER_PASSWORD = "smokepass"
 # A workspace-level deny-list baked into the main workspace (#2367). A rejected
 # host is pre-emptively denied at the sidecar -- no consent request is ever
 # surfaced, even in interactive mode. kernel.org is fresh (not in the fuzz pool
@@ -902,6 +912,10 @@ class SmokeTest:
         self._owned_server: dict | None = None
         self.server: dict | None = None
         self.auth: dict | None = None
+        # The bootstrap identity (seeded admin): workspace create/delete,
+        # member provisioning, and the no-workspace decider probe. Equals
+        # self.auth unless --as-member splits them.
+        self.admin_auth: dict | None = None
         self.ws_id: str | None = None
         self.ws_conn = None
         self._drain_task: asyncio.Task | None = None
@@ -1200,15 +1214,16 @@ class SmokeTest:
             raise SystemExit(2)
 
     @staticmethod
-    def _login(url: str) -> dict:
+    def _login(
+        url: str,
+        identifier: str = "smoke@example.com",
+        password: str = "smokepass",
+    ) -> dict:
         client = httpx.Client(base_url=url, timeout=30)
         try:
             r = client.post(
                 "/api/v1/auth/login",
-                json={
-                    "identifier": "smoke@example.com",
-                    "password": "smokepass",
-                },
+                json={"identifier": identifier, "password": password},
             )
             if r.status_code != 200:
                 raise RuntimeError(f"login failed: {r.status_code} {r.text}")
@@ -1219,6 +1234,78 @@ class SmokeTest:
             "token": token,
             "headers": {"Authorization": f"Bearer {token}"},
         }
+
+    @staticmethod
+    def _ensure_member(server: dict, admin: dict) -> None:
+        """Create the plain member user for --as-member (idempotent).
+
+        The member is deliberately NOT added to any instance group: no
+        admins membership, no manage-* grants -- consent authority must
+        come from the workspace ACL alone (#2976). A 400 "already
+        registered" (a rerun against the same server) is tolerated.
+        """
+        client = httpx.Client(
+            base_url=server["url"], headers=admin["headers"], timeout=30
+        )
+        try:
+            r = client.post(
+                "/api/v1/users",
+                json={"email": MEMBER_EMAIL, "password": MEMBER_PASSWORD},
+            )
+            if r.status_code not in (
+                200,
+                201,
+            ) and "already registered" not in (r.text or ""):
+                raise RuntimeError(
+                    f"member create failed: {r.status_code} {r.text}"
+                )
+        finally:
+            client.close()
+
+    @staticmethod
+    def _share_coder(server: dict, admin: dict, ws_id: str) -> None:
+        """Add the member to the workspace's coders role group.
+
+        Coders hold exactly the member consent profile (#2883): terminal,
+        egress-consent, restart, files -- and NOT the owner `*`. Every
+        workspace the member acts on must be shared this way (workspace
+        creation is admin-only, #2569).
+        """
+        client = httpx.Client(
+            base_url=server["url"], headers=admin["headers"], timeout=30
+        )
+        try:
+            r = client.post(
+                f"/api/v1/workspaces/{ws_id}/roles/coders",
+                json={"email": MEMBER_EMAIL},
+            )
+            if r.status_code != 200:
+                raise RuntimeError(
+                    f"member share failed: {r.status_code} {r.text}"
+                )
+        finally:
+            client.close()
+
+    async def _new_workspace(self, *args, **kwargs) -> str:
+        """Create a workspace the acting identity can use.
+
+        Creation always runs as the bootstrap (admin) identity --
+        `create-workspace` is admin-gated (#2569) -- and under --as-member
+        the workspace is then shared to the member's coders role so the
+        member's decider/terminal connections on it are authorized.
+        """
+        ws_id = await asyncio.to_thread(
+            self._create_workspace,
+            self.server,
+            self.admin_auth,
+            *args,
+            **kwargs,
+        )
+        if self.args.as_member:
+            await asyncio.to_thread(
+                self._share_coder, self.server, self.admin_auth, ws_id
+            )
+        return ws_id
 
     @staticmethod
     def _create_workspace(
@@ -1401,10 +1488,28 @@ class SmokeTest:
             self._owned_server = self._start_server()
             self.server = self._owned_server
             print(f"started klangkd: {self.server['url']}")
-        self.auth = await asyncio.to_thread(self._login, self.server["url"])
-        self.ws_id = await asyncio.to_thread(
-            self._create_workspace, self.server, self.auth
+        self.admin_auth = await asyncio.to_thread(
+            self._login, self.server["url"]
         )
+        self.auth = self.admin_auth
+        if self.args.as_member:
+            # #2976 posture: run the whole consent flow as a plain member.
+            # The admin only bootstraps (member user + workspace + coders
+            # share); the member's authority is the workspace ACL alone.
+            await asyncio.to_thread(
+                self._ensure_member, self.server, self.admin_auth
+            )
+            self.auth = await asyncio.to_thread(
+                self._login,
+                self.server["url"],
+                MEMBER_EMAIL,
+                MEMBER_PASSWORD,
+            )
+            print(
+                f"acting as member {MEMBER_EMAIL} "
+                f"(coders role; no instance-admin grants)"
+            )
+        self.ws_id = await self._new_workspace()
         print(f"workspace {self.ws_id}  allow-list={_ALLOW_LIST}  interactive")
         await self._wait_container_ready()
         self.container = _container_for_workspace(self.ws_id)
@@ -2665,10 +2770,7 @@ class SmokeTest:
         cont: str | None = None
         conn = None
         try:
-            ws_id = await asyncio.to_thread(
-                self._create_workspace,
-                self.server,
-                self.auth,
+            ws_id = await self._new_workspace(
                 allow,
                 [],
                 f"smoke-hostscope-{int(time.time() * 1000) % 100000}",
@@ -2814,10 +2916,7 @@ class SmokeTest:
         cont: str | None = None
         conn = None
         try:
-            ws_id = await asyncio.to_thread(
-                self._create_workspace,
-                self.server,
-                self.auth,
+            ws_id = await self._new_workspace(
                 allow,
                 [],
                 f"smoke-portscope-{int(time.time() * 1000) % 100000}",
@@ -2991,10 +3090,7 @@ class SmokeTest:
         cont: str | None = None
         conn = None
         try:
-            ws_id = await asyncio.to_thread(
-                self._create_workspace,
-                self.server,
-                self.auth,
+            ws_id = await self._new_workspace(
                 allow,
                 [],
                 f"smoke-coresident-{int(time.time() * 1000) % 100000}",
@@ -3188,7 +3284,7 @@ class SmokeTest:
             "-",
         )
         static_ws = await asyncio.to_thread(
-            self._create_static_workspace, self.server, self.auth
+            self._create_static_workspace, self.server, self.admin_auth
         )
         try:
             url = (
@@ -3247,7 +3343,7 @@ class SmokeTest:
                     pass
         finally:
             await asyncio.to_thread(
-                self._delete_workspace, self.server, self.auth, static_ws
+                self._delete_workspace, self.server, self.admin_auth, static_ws
             )
 
     async def run_rejected_phase(self, pilot) -> None:
@@ -3532,9 +3628,7 @@ class SmokeTest:
             step_tag = "no-workspace handshake"
             await self._probe_no_workspace_decider_refused()
 
-            ws_b = await asyncio.to_thread(
-                self._create_workspace, self.server, self.auth
-            )
+            ws_b = await self._new_workspace()
             self._extra_ws_ids.append(ws_b)
             print(f"workspace B {ws_b}  (interactive, for scope isolation)")
             # Keep B's container up + confirm readiness. A second workspace's
@@ -3631,14 +3725,17 @@ class SmokeTest:
 
         NB: a 403 here is also what an invalid/expired token yields -- the
         token is proven live by the app's own decider connect earlier in
-        the run, so a 403 at this point is the workspace-param refusal."""
+        the run, so a 403 at this point is the workspace-param refusal.
+        Deliberately probed with the ADMIN token (#2976): the admin is the
+        strongest principal -- if even it cannot register without a
+        workspace, no lesser identity can either."""
         step = _Step(
             self.summary.total, "(no-workspace)", "n/a", False, "scope-nw", "-"
         )
         try:
             ws_nw = await ws_connect(
                 self.server,
-                f"/ws/consent-decider?token={self.auth['token']}",
+                f"/ws/consent-decider?token={self.admin_auth['token']}",
                 open_timeout=15,
             )
         except websockets.InvalidStatus as e:
@@ -3887,10 +3984,7 @@ class SmokeTest:
         conn = None
         drain = None
         try:
-            ws_id = await asyncio.to_thread(
-                self._create_workspace,
-                self.server,
-                self.auth,
+            ws_id = await self._new_workspace(
                 [],  # no allow-list: allow mode permits all non-rejected hosts
                 ["evil.example.com"],  # rejected -> sidecar NXDOMAIN
                 f"smoke-allow-{int(time.time() * 1000) % 100000}",
@@ -4097,10 +4191,7 @@ class SmokeTest:
         conn = None
         d: RawDecider | None = None
         try:
-            rws = await asyncio.to_thread(
-                self._create_workspace,
-                self.server,
-                self.auth,
+            rws = await self._new_workspace(
                 [],  # no allow-list: every probe host prompts
                 [],  # no rejected-list
                 f"smoke-restart-{int(time.time() * 1000) % 100000}",
@@ -4399,10 +4490,7 @@ class SmokeTest:
         conn = None
         d: RawDecider | None = None
         try:
-            pws = await asyncio.to_thread(
-                self._create_workspace,
-                self.server,
-                self.auth,
+            pws = await self._new_workspace(
                 [host_allow],  # allow-list: DNS-layer allow, pause-independent
                 [host_rej],  # rejected: DNS-layer NXDOMAIN, pause-independent
                 f"smoke-pause-{int(time.time() * 1000) % 100000}",
@@ -4950,7 +5038,10 @@ class SmokeTest:
             for wid in self._extra_ws_ids:
                 try:
                     await asyncio.to_thread(
-                        self._delete_workspace, self.server, self.auth, wid
+                        self._delete_workspace,
+                        self.server,
+                        self.admin_auth,
+                        wid,
                     )
                 except Exception:
                     pass
@@ -4976,7 +5067,10 @@ class SmokeTest:
         ):
             try:
                 await asyncio.to_thread(
-                    self._delete_workspace, self.server, self.auth, self.ws_id
+                    self._delete_workspace,
+                    self.server,
+                    self.admin_auth,
+                    self.ws_id,
                 )
             except Exception:
                 pass
@@ -5231,6 +5325,20 @@ def main() -> int:
         action="store_false",
         help="skip the co-resident-hosts phase (canary for per-IP allow/revoke "
         "sharing, #2352/#2440)",
+    )
+    p.add_argument(
+        "--as-member",
+        dest="as_member",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="run the consent flow as a plain workspace member instead of "
+        "the seeded admin (#2976): the admin only bootstraps (create the "
+        "member, the workspaces, and share them to its coders role), then "
+        "every decider connection, verdict, and terminal WS runs on the "
+        "member's token -- consent authority flows from the workspace ACL "
+        "alone, with no instance-admin grants anywhere in the run. The "
+        "no-workspace decider probe still uses the admin token (the "
+        "strongest principal).",
     )
     p.add_argument(
         "--cleanup",

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -596,12 +596,6 @@ class TestConsentCoordinatorFanout:
         frames = await coord.snapshot(FULL_WS)
         assert [f["request"]["id"] for f in frames] == ["a"]
 
-    async def test_snapshot_deploy_wide_is_empty(self):
-        app = _app()
-        coord = ConsentCoordinator(app)
-        assert await coord.snapshot(None) == []
-        app.state.model.egress_consent.list_requests.assert_not_awaited()
-
 
 class TestConsentCoordinatorRules:
     async def test_rules_frame_groups_active_and_allow_list(self):
@@ -645,15 +639,6 @@ class TestConsentCoordinatorRules:
         app = _app(workspace_exists=False)
         coord = ConsentCoordinator(app)
         assert await coord.rules_frame(FULL_WS) is None
-        app.state.model.egress_consent.list_active.assert_not_awaited()
-
-    async def test_rules_frame_none_for_deploy_wide(self):
-        app = _app()
-        coord = ConsentCoordinator(app)
-        assert await coord.rules_frame(None) is None
-        # deploy-wide deciders get no rules frame (no single workspace),
-        # matching snapshot().
-        app.state.model.workspaces.get_workspace.assert_not_awaited()
         app.state.model.egress_consent.list_active.assert_not_awaited()
 
     async def test_rules_frame_includes_active_pause_window(self):

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -70,13 +70,6 @@ class TestConsentDeciderRegistry:
         assert reg.has_decider(WS2) is False
         assert reg.deciders_for(WS2) == []
 
-    async def test_deploy_wide_decider_covers_every_workspace(self):
-        reg = ConsentDeciderRegistry(_app())
-        reg.register("admin", None, "admin@example.com", _FakeSock())
-        assert reg.has_decider(WS) is True
-        assert reg.has_decider(WS2) is True
-        assert set(reg.deciders_for(WS)) == {"admin"}
-
     async def test_register_is_idempotent_on_decider_id(self):
         reg = ConsentDeciderRegistry(_app())
         reg.register("d1", WS, "a@x", _FakeSock())
@@ -124,7 +117,7 @@ class TestConsentDeciderRegistry:
     async def test_stop_clears_all_and_is_idempotent(self):
         reg = ConsentDeciderRegistry(_app())
         reg.register("d1", WS, "a@x", _FakeSock())
-        reg.register("d2", None, "b@x", _FakeSock())
+        reg.register("d2", WS2, "b@x", _FakeSock())
         await reg.stop()
         assert reg._deciders == {}
         assert reg._reaper is None
@@ -143,16 +136,6 @@ class TestConsentDeciderRegistryBroadcast:
         assert len(s1.sent) == 1
         assert len(s2.sent) == 1
         assert s3.sent == []  # different workspace, not delivered
-
-    async def test_broadcast_includes_deploy_wide_deciders(self):
-        reg = ConsentDeciderRegistry(_app())
-        deploy, scoped = _FakeSock(), _FakeSock()
-        reg.register("admin", None, "admin@x", deploy)  # deploy-wide
-        reg.register("d2", WS, "a@x", scoped)  # scoped to WS
-        delivered = reg.broadcast(WS, {"type": "egress_request"})
-        assert delivered == 2
-        assert len(deploy.sent) == 1
-        assert len(scoped.sent) == 1
 
     async def test_broadcast_prunes_dead_deciders(self):
         reg = ConsentDeciderRegistry(_app())
@@ -493,41 +476,43 @@ class TestConsentDeciderWS:
         assert "refused: Forbidden" in caplog.text
         assert "user=a@x" in caplog.text
 
-    async def test_deploy_wide_decider_unaffected_by_static_mode(self):
-        # #2394: deploy-wide deciders (no ?workspace=) cover all interactive
-        # workspaces without flipping a static one's behavior, so the
-        # egress_mode check is skipped for them -- they register normally and
-        # the workspace model is never consulted.
-        from fastapi import WebSocketDisconnect
-
+    async def test_missing_workspace_param_is_refused(self):
+        # #2976: consent is strictly a workspace concern -- there is no
+        # deploy-wide decider flavor, so a handshake with no ``workspace``
+        # param is refused before any authz check.
         from klangk.wshandler.decider import handle_consent_decider
 
-        app = _ws_app({"id": "u1", "email": "admin@x"}, egress_mode="static")
-        ws = _FakeWS(
-            {"token": "tok"},  # no workspace -> deploy-wide
-            [WebSocketDisconnect()],
-        )
+        app = _ws_app({"id": "u1", "email": "admin@x"})
+        ws = _FakeWS({"token": "tok"}, [])  # no workspace param
         await handle_consent_decider(ws, app)
-        assert ws.accepted is True
-        assert ws.closed is None
-        app.state.model.workspaces.get_workspace.assert_not_awaited()
-
-    async def test_non_admin_deploy_wide_is_forbidden(self):
-        from klangk.wshandler.decider import handle_consent_decider
-
-        app = _ws_app({"id": "u1", "email": "a@x"}, allowed=False)
-        ws = _FakeWS({"token": "tok"}, [])  # no workspace -> deploy-wide
-        await handle_consent_decider(ws, app)
-        assert ws.closed == (4003, "Forbidden")
+        assert ws.closed == (4003, "workspace query parameter is required")
         assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+        assert app.state.consent_deciders.has_decider(WS2) is False
 
-    async def test_deploy_wide_gate_checks_server_schedule(self):
-        """#2944: the deploy-wide handshake checks manage-server-schedule
-        on /server (previously the legacy admin-on-/admin gate) — pin
-        the exact resource and permission so a regression back to the
-        old names fails here, not in production."""
-        from fastapi import WebSocketDisconnect
+    async def test_missing_workspace_refusal_is_logged(self, caplog):
+        # #2490: the missing-workspace refusal is logged like every other
+        # pre-accept refusal (the close code/reason never reach the client).
+        import logging
 
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "admin@x"})
+        ws = _FakeWS({"token": "tok"}, [])  # no workspace param
+        with caplog.at_level(
+            logging.WARNING, logger="klangk.wshandler.decider"
+        ):
+            await handle_consent_decider(ws, app)
+        assert "refused: workspace query parameter is required" in caplog.text
+        assert "workspace=missing" in caplog.text
+
+    async def test_manage_server_schedule_grants_no_consent_path(self):
+        """#2976: the deploy-wide flavor is gone, so ``manage-server-schedule``
+        must not authorize any consent path. A member holding only it (an
+        instance admin with no egress-consent grant on the workspace) is
+        refused at the workspace-scoped handshake, and the gate checks
+        exactly ``egress-consent`` on ``/workspaces/{id}`` -- never
+        ``/server``."""
         from klangk.wshandler.decider import handle_consent_decider
 
         app = _ws_app({"id": "u1", "email": "admin@x"})
@@ -538,12 +523,13 @@ class TestConsentDeciderWS:
             return perm == "manage-server-schedule"
 
         app.state.acl.check_permission = AsyncMock(side_effect=check)
-        ws = _FakeWS({"token": "tok"}, [WebSocketDisconnect()])
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
         await handle_consent_decider(ws, app)
-        assert ws.accepted is True
-        assert ("/server", "manage-server-schedule") in checked
-        # The old gate must not appear at all.
-        assert ("/admin", "admin") not in checked
+        assert ws.closed == (4003, "Forbidden")
+        assert ws.accepted is False
+        # The only consent gate is egress-consent on the workspace resource.
+        assert checked == [(f"/workspaces/{WS}", "egress-consent")]
+        assert ("/server", "manage-server-schedule") not in checked
 
     async def test_ping_touches_and_pongs(self):
         from fastapi import WebSocketDisconnect
@@ -695,47 +681,6 @@ class TestConsentDeciderWS:
         ]
         assert acks and acks[0]["ok"] is True
 
-    async def test_pause_deploy_wide_decider_nacks(self):
-        # A deploy-wide decider (no workspace) has no single workspace to
-        # pause -> nack without calling the coordinator.
-        from fastapi import WebSocketDisconnect
-
-        from klangk.wshandler.decider import handle_consent_decider
-
-        app = _ws_app({"id": "u1", "email": "admin@x"})
-        ws = _FakeWS(
-            {"token": "tok"},  # no workspace -> deploy-wide
-            ['{"type":"pause","duration":"1h"}', WebSocketDisconnect()],
-        )
-        await handle_consent_decider(ws, app)
-        app.state.consent_coordinator.pause.assert_not_awaited()
-        acks = [
-            json.loads(m)
-            for m in ws.sent
-            if json.loads(m).get("type") == "pause_ack"
-        ]
-        assert acks and acks[0]["ok"] is False
-
-    async def test_unpause_deploy_wide_decider_nacks(self):
-        # A deploy-wide decider has no single workspace to unpause either.
-        from fastapi import WebSocketDisconnect
-
-        from klangk.wshandler.decider import handle_consent_decider
-
-        app = _ws_app({"id": "u1", "email": "admin@x"})
-        ws = _FakeWS(
-            {"token": "tok"},  # no workspace -> deploy-wide
-            ['{"type":"unpause"}', WebSocketDisconnect()],
-        )
-        await handle_consent_decider(ws, app)
-        app.state.consent_coordinator.unpause.assert_not_awaited()
-        acks = [
-            json.loads(m)
-            for m in ws.sent
-            if json.loads(m).get("type") == "pause_ack"
-        ]
-        assert acks and acks[0]["ok"] is False
-
     async def test_pause_requires_no_permission_beyond_registration(self):
         # #2883: the old ``share-terminals`` bar is gone -- pause/unpause
         # ride the connection's own ``egress-consent`` gate. A coder
@@ -853,19 +798,6 @@ class TestConsentDeciderWS:
         await handle_consent_decider(ws, app)
         app.state.consent_coordinator.resolve.assert_not_awaited()
         assert any(json.loads(m).get("type") == "error" for m in ws.sent)
-
-    async def test_deploy_wide_when_no_workspace_param(self):
-        from fastapi import WebSocketDisconnect
-
-        from klangk.wshandler.decider import handle_consent_decider
-
-        app = _ws_app({"id": "u1", "email": "admin@example.com"})
-        ws = _FakeWS({"token": "tok"}, [WebSocketDisconnect()])
-        # While connected it would cover every workspace; after disconnect,
-        # nothing remains.
-        await handle_consent_decider(ws, app)
-        assert app.state.consent_deciders.has_decider(WS) is False
-        assert app.state.consent_deciders.has_decider(WS2) is False
 
     async def test_verdict_resolve_error_does_not_tear_down_connection(self):
         # a verdict whose resolve() raises is logged + swallowed -- the


### PR DESCRIPTION
## Summary

Implements #2976 (decision A): removes the deploy-wide consent-decider flavor entirely — consent authority is strictly per-workspace.

- **Server**: `/ws/consent-decider` requires `?workspace=<id>` (missing param refused 4003, logged per #2490); the `manage-server-schedule` gate branch, the registry's `None`-scope arms (`register`/`has_decider`/`deciders_for`/`broadcast`), the coordinator's `snapshot(None)`/`rules_frame(None)` paths, and the deploy-wide pause/unpause nack path are all gone.
- **`klangk shell`**: new `member_may_decide` preflight (`GET /api/v1/my-permissions`) so the consent-popup wrapper spawns its decider iff the member holds `egress-consent`/`*` on the workspace — spectator-profile members skip the wrapper instead of 403-looping. Fails open on API error; the handshake stays the authority.
- **Web workspace view**: no change needed — `consentSurfaceAllowed` already connects the decider exactly when interactive + `egress-consent` (spectators never mount the surface).
- **E2E**: the decider-scope phase keeps cross-workspace isolation and now asserts the no-workspace handshake is refused (403), probed with the **admin** token (the strongest principal). New `--as-member` mode runs the whole consent flow as a plain member (`coders` role: `terminal` + `egress-consent`, no owner wildcard, no instance-admin grants) — the admin only bootstraps (member user, workspaces, role shares); every decider connection, verdict, and terminal WS runs on the member's token. Both modes verified against a live stack.
- **Docs**: decision recorded in `docs/reference/acl.md` (deploy-wide WS-gate row removed, `manage-server-schedule` row cleaned up), `egress-filtering.md` + `api-endpoints.md` updated, Breaking changelog entry.

## Security invariant

Only a principal holding `egress-consent` on the workspace can register or decide. Non-members, spectator-profile members, and instance admins are all refused at the handshake; the removal only narrows the decider population.

Closes #2976
