### PR TITLE
Sharing tab: list each role group's live permissions in its bucket

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -381,6 +381,13 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Live permission lists in the Sharing tab (#2986).** Each role
+  bucket (owners, collaborators, coders, spectators) now lists the
+  permissions its group actually holds on the workspace, read live
+  from the ACL — post-seed edits made in the Advanced ACL editor are
+  reflected on reload. A `*` grant shows as "All permissions". The
+  buckets span about three quarters of the screen width.
+
 - **README release badge (#2981).** The README now carries a release
   badge showing the latest `v*` tag, driven by GitHub Releases —
   no manual updates needed.

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -15,7 +15,9 @@ friendlier interfaces:
 - **Workspace sharing** — the Sharing tab on each workspace lets you
   add users or groups and assign them a role (Owner, Coder,
   Collaborator, Spectator). Behind the scenes, each role maps to a
-  set of ACL entries.
+  set of ACL entries, and each bucket lists the permissions its group
+  currently holds — read live from the ACL, so edits made in the
+  Advanced ACL editor show up on reload.
 - **Admin panel** — the Admin page lets you manage users, groups,
   and global access rules.
 - **UI visibility** — tabs and buttons appear or disappear based on

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -805,8 +805,12 @@ No request body.
 
 ### GET `/api/v1/workspaces/{id}/roles`
 
-List role groups for a workspace and their members. Each workspace has
-four roles: `owners`, `coders`, `collaborators`, `spectators`.
+List role groups for a workspace, their members, and each group's
+effective permissions. Each workspace has four roles: `owners`,
+`coders`, `collaborators`, `spectators`. `permissions` is read live
+from the ACEs on `/workspaces/{id}` (not inherited from ancestors),
+so post-seed ACL edits are reflected; a `*` grant expands to the
+whole vocabulary, including the literal `*`.
 
 **Auth:** JWT required. User must have `share-workspace` permission on `/workspaces/{id}`.
 
@@ -818,7 +822,8 @@ No request body.
     "role": "owners",
     "group_id": "uuid",
     "group_name": "owners-uuid",
-    "members": [{ "id": "uuid", "email": "user@example.com" }]
+    "members": [{ "id": "uuid", "email": "user@example.com" }],
+    "permissions": ["*", "view", "terminal"]
   }
 ]
 ```

--- a/src/frontend/lib/workspace/workspace_sharing_panel.dart
+++ b/src/frontend/lib/workspace/workspace_sharing_panel.dart
@@ -281,6 +281,21 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
     );
   }
 
+  /// A quiet outlined pill for one granted permission (or the collapsed
+  /// "All permissions" label): no fill, muted border and text — it must
+  /// not compete with the member chips beside it.
+  Widget _permissionTag(String label) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: KColors.borderMuted),
+        ),
+        child: Text(
+          label,
+          style: const TextStyle(color: KColors.textSecondary, fontSize: 10),
+        ),
+      );
+
   Widget _buildRoleBucket(Map<String, dynamic> role) {
     final roleName = role['role'] as String;
     final members = role['members'] as List? ?? [];
@@ -329,37 +344,13 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
             if (permissions.isNotEmpty) ...[
               const SizedBox(height: 4),
               if (permissions.contains('*'))
-                const Text(
-                  'All permissions',
-                  style: TextStyle(
-                    color: KColors.textSecondary,
-                    fontSize: 11,
-                  ),
-                )
+                _permissionTag('All permissions')
               else
                 Wrap(
                   spacing: 6,
                   runSpacing: 4,
                   children: [
-                    for (final p in permissions)
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 6,
-                          vertical: 2,
-                        ),
-                        decoration: BoxDecoration(
-                          color: KColors.bgInset,
-                          borderRadius: BorderRadius.circular(4),
-                          border: Border.all(color: KColors.borderMuted),
-                        ),
-                        child: Text(
-                          p,
-                          style: const TextStyle(
-                            color: KColors.textSecondary,
-                            fontSize: 10,
-                          ),
-                        ),
-                      ),
+                    for (final p in permissions) _permissionTag(p),
                   ],
                 ),
             ],

--- a/src/frontend/lib/workspace/workspace_sharing_panel.dart
+++ b/src/frontend/lib/workspace/workspace_sharing_panel.dart
@@ -41,15 +41,6 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
 
   static const _roleOrder = ['owners', 'collaborators', 'coders', 'spectators'];
 
-  static const _roleDescriptions = {
-    'owners': 'Full admin access',
-    'coders':
-        'Use isolated terminals, spectate on shared terminals, files + upload/download',
-    'collaborators':
-        'Use isolated and shared terminals, share terminals, files + upload/download',
-    'spectators': 'Watch shared terminals',
-  };
-
   static const _roleIcons = {
     'owners': Icons.shield,
     'coders': Icons.code,
@@ -235,11 +226,14 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
 
   @override
   Widget build(BuildContext context) {
+    // Buckets span ~3/4 of the screen so the permission lists have room
+    // to lay out on one or two rows (#2986).
+    final maxPanelWidth = MediaQuery.of(context).size.width * 0.75;
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
       child: Center(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 500),
+          constraints: BoxConstraints(maxWidth: maxPanelWidth),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -290,9 +284,10 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
   Widget _buildRoleBucket(Map<String, dynamic> role) {
     final roleName = role['role'] as String;
     final members = role['members'] as List? ?? [];
+    final permissions =
+        (role['permissions'] as List? ?? []).whereType<String>().toList();
     final icon = _roleIcons[roleName] ?? Icons.group;
     final color = _roleColors[roleName] ?? KColors.accentBlue;
-    final desc = _roleDescriptions[roleName] ?? '';
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
@@ -317,16 +312,7 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
                     fontSize: 14,
                   ),
                 ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    desc,
-                    style: const TextStyle(
-                      color: KColors.textSecondary,
-                      fontSize: 11,
-                    ),
-                  ),
-                ),
+                const Spacer(),
                 if (widget.canEditAcl)
                   IconButton(
                     icon: const Icon(Icons.person_add, size: 16),
@@ -340,6 +326,43 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
                   ),
               ],
             ),
+            if (permissions.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              if (permissions.contains('*'))
+                const Text(
+                  'All permissions',
+                  style: TextStyle(
+                    color: KColors.textSecondary,
+                    fontSize: 11,
+                  ),
+                )
+              else
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  children: [
+                    for (final p in permissions)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: KColors.bgInset,
+                          borderRadius: BorderRadius.circular(4),
+                          border: Border.all(color: KColors.borderMuted),
+                        ),
+                        child: Text(
+                          p,
+                          style: const TextStyle(
+                            color: KColors.textSecondary,
+                            fontSize: 10,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+            ],
             if (members.isEmpty)
               const Padding(
                 padding: EdgeInsets.only(top: 4),

--- a/src/frontend/test/workspace_sharing_panel_test.dart
+++ b/src/frontend/test/workspace_sharing_panel_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -28,13 +27,20 @@ String get _token {
 /// Role payload as served by `GET /api/v1/workspaces/{id}/roles`:
 /// deliberately scrambled server-side so the sort order is asserted, with
 /// an empty role (spectators), and an unknown suffix (auditors) that
-/// exercises the icon/color/description fallbacks.
+/// exercises the icon/color fallbacks and the missing-`permissions`
+/// graceful path. Owners carry the wildcard expansion the backend emits
+/// for a `*` grant (collapsed to 'All permissions' in the UI).
 List<Map<String, dynamic>> _roles() => [
       {
         'role': 'spectators',
         'group_id': 'g4',
         'group_name': 'spectators-ws1',
         'members': [],
+        'permissions': [
+          'monitor-workspace',
+          'terminal',
+          'spectate-on-shared-terminals',
+        ],
       },
       {
         'role': 'coders',
@@ -42,6 +48,13 @@ List<Map<String, dynamic>> _roles() => [
         'group_name': 'coders-ws1',
         'members': [
           {'id': 'u-bob', 'email': 'bob@example.com'},
+        ],
+        'permissions': [
+          'monitor-workspace',
+          'terminal',
+          'egress-consent',
+          'code-in-isolation',
+          'files-view',
         ],
       },
       {
@@ -59,6 +72,7 @@ List<Map<String, dynamic>> _roles() => [
         'members': [
           {'id': 'u-alice', 'email': 'alice@example.com'},
         ],
+        'permissions': ['*', 'view', 'terminal'],
       },
       {
         'role': 'collaborators',
@@ -66,6 +80,12 @@ List<Map<String, dynamic>> _roles() => [
         'group_name': 'collaborators-ws1',
         'members': [
           {'id': 'u-carol', 'email': 'carol@example.com'},
+        ],
+        'permissions': [
+          'monitor-workspace',
+          'terminal',
+          'egress-consent',
+          'share-terminals',
         ],
       },
     ];
@@ -166,6 +186,17 @@ void main() {
     // Members render as chips; the empty role shows its empty state.
     expect(find.text('alice@example.com'), findsOneWidget);
     expect(find.text('No members'), findsOneWidget);
+
+    // Permission lists render per bucket (#2986): the owners' wildcard
+    // collapses to a label (the expanded names never render), granted
+    // permissions render once per bucket that holds them, and a role
+    // without a `permissions` key (auditors) renders no chips.
+    expect(find.text('All permissions'), findsOneWidget);
+    expect(find.text('terminal'), findsNWidgets(3));
+    expect(find.text('egress-consent'), findsNWidgets(2));
+    expect(find.text('share-terminals'), findsOneWidget);
+    expect(find.text('view'), findsNothing);
+
     // Without change-acls (#2764) the role-write affordances are hidden:
     // no add-user buttons, chips carry no delete icons.
     expect(find.byTooltip('Add user'), findsNothing);
@@ -174,6 +205,26 @@ void main() {
           of: find.byType(Chip), matching: find.byIcon(Icons.close)),
       findsNothing,
     );
+  });
+
+  testWidgets('panel spans three quarters of the screen width (#2986)',
+      (tester) async {
+    tester.view.physicalSize = const Size(1600, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    stubHttp();
+    await tester.pumpWidget(buildPanel(canEditAcl: false));
+    await tester.pumpAndSettle();
+
+    final constraint = tester.widget<ConstrainedBox>(
+      find
+          .ancestor(
+            of: find.text('Owners'),
+            matching: find.byType(ConstrainedBox),
+          )
+          .first,
+    );
+    expect(constraint.constraints.maxWidth, 1200);
   });
 
   testWidgets('role-write affordances appear with change-acls (#2764)',

--- a/src/frontend/test/workspace_sharing_panel_test.dart
+++ b/src/frontend/test/workspace_sharing_panel_test.dart
@@ -197,6 +197,30 @@ void main() {
     expect(find.text('share-terminals'), findsOneWidget);
     expect(find.text('view'), findsNothing);
 
+    // Permission names and the collapsed 'All permissions' label share
+    // one quiet tag style: outlined pill, no background fill (#2987).
+    BoxDecoration tagDecoration(String label) => tester
+        .widget<Container>(
+          find
+              .ancestor(
+                of: find.text(label),
+                matching: find.byType(Container),
+              )
+              .first,
+        )
+        .decoration! as BoxDecoration;
+    final permDeco = tagDecoration('egress-consent');
+    final allDeco = tagDecoration('All permissions');
+    for (final deco in [permDeco, allDeco]) {
+      expect(deco.color, isNull);
+      expect(deco.border, isNotNull);
+      expect(deco.borderRadius, isNotNull);
+    }
+    expect(
+      (allDeco.borderRadius as BorderRadius).bottomLeft,
+      (permDeco.borderRadius as BorderRadius).bottomLeft,
+    );
+
     // Without change-acls (#2764) the role-write affordances are hidden:
     // no add-user buttons, chips carry no delete icons.
     expect(find.byTooltip('Add user'), findsNothing);

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -42,7 +42,7 @@ from .. import (
     oidc,
     wshandler,
 )
-from .common import autostart_allowed, get_app_dep
+from .common import ALL_PERMISSIONS, autostart_allowed, get_app_dep
 
 # Imported under an alias: the ``from . import auth as _auth_routes`` line
 # below pulls in the api/auth.py *submodule*, and the import machinery writes
@@ -300,42 +300,6 @@ STATIC_RESOURCES = [
     "/volumes",
     "/images",
     "/admin",
-]
-
-ALL_PERMISSIONS = [
-    "view",
-    "monitor-workspace",
-    "create-workspace",
-    "duplicate-workspace",
-    "edit-workspace",
-    "delete-workspace",
-    "start-workspace",
-    "stop-workspace",
-    "restart-workspace",
-    "transfer-workspace",
-    "terminal",
-    "egress-consent",
-    "code-in-isolation",
-    "exec-and-sync",
-    "spectate-on-shared-terminals",
-    "code-in-shared-terminals",
-    "share-terminals",
-    "files-view",
-    "files-download",
-    "files-write",
-    "export-workspace",
-    "share-workspace",
-    "share-advanced",
-    "manage-users",
-    "manage-invitations",
-    "manage-groups",
-    "manage-server-schedule",
-    "manage-acls",
-    "manage-events",
-    "manage-volumes",
-    "view-images",
-    "search-users",
-    "*",
 ]
 
 

--- a/src/klangk/klangk/api/common.py
+++ b/src/klangk/klangk/api/common.py
@@ -17,6 +17,48 @@ from ..settings import parse_bool_setting
 
 logger = logging.getLogger(__name__)
 
+# The full permission vocabulary: every string an ACE may carry and every
+# permission the permission layer can be asked about. ``api/__init__.py``
+# re-exports it (``klangk.api.ALL_PERMISSIONS``), and the roles endpoint
+# uses it to expand each role group's effective grants (#2986). Kept here
+# — a module no route submodule imports from — so workspaces.py can use it
+# without a circular import through ``api/__init__``.
+ALL_PERMISSIONS = [
+    "view",
+    "monitor-workspace",
+    "create-workspace",
+    "duplicate-workspace",
+    "edit-workspace",
+    "delete-workspace",
+    "start-workspace",
+    "stop-workspace",
+    "restart-workspace",
+    "transfer-workspace",
+    "terminal",
+    "egress-consent",
+    "code-in-isolation",
+    "exec-and-sync",
+    "spectate-on-shared-terminals",
+    "code-in-shared-terminals",
+    "share-terminals",
+    "files-view",
+    "files-download",
+    "files-write",
+    "export-workspace",
+    "share-workspace",
+    "share-advanced",
+    "manage-users",
+    "manage-invitations",
+    "manage-groups",
+    "manage-server-schedule",
+    "manage-acls",
+    "manage-events",
+    "manage-volumes",
+    "view-images",
+    "search-users",
+    "*",
+]
+
 
 async def send_email(coro, recipient: str, kind: str = "email") -> None:
     """Await an email-sending coroutine, converting failures to 503."""

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -1529,14 +1529,16 @@ def _group_effective_permissions(
     """Effective permission list for a role group on ``resource``.
 
     Evaluates the preloaded ACE map in memory with the group as the sole
-    principal (``user_id=None`` matches no user ACE; everyone/authenticated
-    grants apply to any member). A ``*`` grant therefore expands to the
+    principal. ``user_id`` is the empty-string sentinel, never ``None``:
+    a malformed user-principal ACE with a NULL ``user_id`` must not
+    ``None == None``-match the synthetic principal the way it would match
+    no real user (#2987 review). A ``*`` grant therefore expands to the
     whole vocabulary — including the literal ``*`` — which callers can
     collapse for display. Mirrors how ``permissions_for_resources``
     computes a user's effective permissions (#2986).
     """
     principals = {
-        "user_id": None,
+        "user_id": "",
         "group_ids": [group_id],
         "authenticated": True,
     }
@@ -1557,14 +1559,17 @@ async def get_workspace_roles(
 ):
     """Return the workspace's role groups with members and grants.
 
-    Each role carries ``permissions``: the group's effective permissions on
-    ``/workspaces/{id}``, read from the live ACEs (one preload for all
-    groups) so post-seed ACL edits are reflected (#2986).
+    Each role carries ``permissions``: the group's effective permissions
+    on ``/workspaces/{id}``, read from the live ACEs on that node so
+    post-seed ACL edits are reflected (#2986). Only the workspace's own
+    node is preloaded — deliberately not the ancestor walk
+    ``check_permission`` uses: role groups are scope-locked to their own
+    workspace node (#2750), so walking up could only misattribute
+    inherited everyone/authenticated grants (e.g. the seeded ``Allow view
+    Authenticated`` on ``/``) to every bucket.
     """
     resource = f"/workspaces/{workspace_id}"
-    entries = await app.state.model.acl.get_acl_entries_map(
-        acl.resource_ancestors(resource)
-    )
+    entries = await app.state.model.acl.get_acl_entries_map([resource])
     roles = []
     for suffix in ROLE_GROUP_SUFFIXES:
         group_name = f"{suffix}-{workspace_id}"

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -55,6 +55,7 @@ from ..util import (
     sanitize_disposition_name,
 )
 from .common import (
+    ALL_PERMISSIONS,
     WorkspaceAclEntry,
     autostart_allowed,
     serialize_acl_entries,
@@ -1522,6 +1523,30 @@ async def remove_workspace_member(
 ROLE_GROUP_SUFFIXES = ["owners", "coders", "collaborators", "spectators"]
 
 
+def _group_effective_permissions(
+    resource: str, group_id: str, entries: dict[str, list[dict]]
+) -> list[str]:
+    """Effective permission list for a role group on ``resource``.
+
+    Evaluates the preloaded ACE map in memory with the group as the sole
+    principal (``user_id=None`` matches no user ACE; everyone/authenticated
+    grants apply to any member). A ``*`` grant therefore expands to the
+    whole vocabulary — including the literal ``*`` — which callers can
+    collapse for display. Mirrors how ``permissions_for_resources``
+    computes a user's effective permissions (#2986).
+    """
+    principals = {
+        "user_id": None,
+        "group_ids": [group_id],
+        "authenticated": True,
+    }
+    return [
+        p
+        for p in ALL_PERMISSIONS
+        if acl.check_permission_inmemory(resource, principals, p, entries)
+    ]
+
+
 @router.get("/workspaces/{workspace_id}/roles")
 async def get_workspace_roles(
     workspace_id: str,
@@ -1530,7 +1555,16 @@ async def get_workspace_roles(
     ),
     app=Depends(get_app_dep),
 ):
-    """Return the workspace's role groups with their members."""
+    """Return the workspace's role groups with members and grants.
+
+    Each role carries ``permissions``: the group's effective permissions on
+    ``/workspaces/{id}``, read from the live ACEs (one preload for all
+    groups) so post-seed ACL edits are reflected (#2986).
+    """
+    resource = f"/workspaces/{workspace_id}"
+    entries = await app.state.model.acl.get_acl_entries_map(
+        acl.resource_ancestors(resource)
+    )
     roles = []
     for suffix in ROLE_GROUP_SUFFIXES:
         group_name = f"{suffix}-{workspace_id}"
@@ -1546,6 +1580,9 @@ async def get_workspace_roles(
                 "members": [
                     {"id": m["id"], "email": m["email"]} for m in members
                 ],
+                "permissions": _group_effective_permissions(
+                    resource, group["id"], entries
+                ),
             }
         )
     return roles

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -5429,6 +5429,48 @@ class TestWorkspaceRoles:
         assert "collaborators" in role_names
         assert "spectators" in role_names
 
+    async def test_roles_include_effective_permissions(
+        self, client, user, app_state
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "role-perms-ws"},
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/roles", headers=headers
+        )
+        roles = {r["role"]: r for r in resp.json()}
+
+        # Seeded grants show per group (#2986): the owners' wildcard
+        # expands to the whole vocabulary (including the literal '*'),
+        # the operating roles hold egress-consent, spectators never do.
+        assert "*" in roles["owners"]["permissions"]
+        assert "terminal" in roles["owners"]["permissions"]
+        assert "egress-consent" in roles["coders"]["permissions"]
+        assert "egress-consent" in roles["collaborators"]["permissions"]
+        assert "share-terminals" in roles["collaborators"]["permissions"]
+        assert "egress-consent" not in roles["spectators"]["permissions"]
+        assert "share-terminals" not in roles["spectators"]["permissions"]
+
+        # Effective, not seeded-static: a post-seed ACE grant on the
+        # group is reflected on the next roles read.
+        await app_state.state.model.acl.add_acl_entry(
+            f"/workspaces/{ws_id}",
+            position=100,
+            action=model.ACTION_ALLOW,
+            permission="share-advanced",
+            principal_type=model.PRINCIPAL_GROUP,
+            group_id=roles["spectators"]["group_id"],
+        )
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/roles", headers=headers
+        )
+        roles = {r["role"]: r for r in resp.json()}
+        assert "share-advanced" in roles["spectators"]["permissions"]
+
     async def test_creator_in_owners_group(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -5471,6 +5471,64 @@ class TestWorkspaceRoles:
         roles = {r["role"]: r for r in resp.json()}
         assert "share-advanced" in roles["spectators"]["permissions"]
 
+        # No inherited root grants: the seeded `Allow view Authenticated`
+        # on `/` must not surface in every bucket (#2987 review) — the
+        # roles read evaluates only the workspace's own node.
+        assert "view" not in roles["spectators"]["permissions"]
+
+        # A malformed user-principal ACE with a NULL user_id (inert for
+        # every real principal) must not None==None-match its way into
+        # any group's list (#2987 review).
+        await app_state.state.model.acl.add_acl_entry(
+            f"/workspaces/{ws_id}",
+            position=101,
+            action=model.ACTION_ALLOW,
+            permission="egress-consent",
+            principal_type=model.PRINCIPAL_USER,
+        )
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/roles", headers=headers
+        )
+        roles = {r["role"]: r for r in resp.json()}
+        assert "egress-consent" not in roles["spectators"]["permissions"]
+
+        # First-match-wins: a deny positioned before the group's allow
+        # removes the permission from the bucket exactly as it would
+        # deny a real member.
+        await app_state.state.model.acl.replace_acl_entries(
+            f"/workspaces/{ws_id}",
+            [
+                {
+                    "position": 0,
+                    "action": model.ACTION_DENY,
+                    "permission": "terminal",
+                    "principal_type": model.PRINCIPAL_GROUP,
+                    "group_id": roles["spectators"]["group_id"],
+                },
+                {
+                    "position": 1,
+                    "action": model.ACTION_ALLOW,
+                    "permission": "terminal",
+                    "principal_type": model.PRINCIPAL_GROUP,
+                    "group_id": roles["spectators"]["group_id"],
+                },
+                # Keep the creator's own wildcard so the share-gated
+                # roles read below stays authorized.
+                {
+                    "position": 2,
+                    "action": model.ACTION_ALLOW,
+                    "permission": "*",
+                    "principal_type": model.PRINCIPAL_USER,
+                    "user_id": user["id"],
+                },
+            ],
+        )
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/roles", headers=headers
+        )
+        roles = {r["role"]: r for r in resp.json()}
+        assert "terminal" not in roles["spectators"]["permissions"]
+
     async def test_creator_in_owners_group(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(


### PR DESCRIPTION
## Summary

Closes #2986.

- `GET /api/v1/workspaces/{id}/roles` now returns each role group's **effective permissions** on `/workspaces/{id}`, computed in memory from a single ACE preload (one query for all four groups) — so post-seed edits made through the Advanced ACL editor are reflected, not just the seeded defaults. `ALL_PERMISSIONS` moved from `api/__init__.py` to `api/common.py` (re-exported from `api`) so the endpoint can use it without a circular import.
- The Sharing tab renders one chip per granted permission in each bucket (owners/collaborators/coders/spectators), replacing the hardcoded prose descriptions. A `*` grant collapses to an "All permissions" label; a role without a `permissions` key renders no chips.
- The panel widened from a 500 px cap to ~3/4 of the screen width so the permission lists lay out compactly.

## Test plan

- Backend: new `test_roles_include_effective_permissions` asserts the seeded grants per group (wildcard expansion, egress-consent present on coders/collaborators and absent on spectators) and that a post-seed `add_acl_entry` grant shows up on the next roles read. Full suite green: 6499 passed, 100% branch coverage.
- Frontend: sharing-panel widget tests updated — permission chips per bucket, `*` collapse, missing-key fallback, and a new test pinning the ¾-width `ConstrainedBox` (1200 px at a 1600 px surface). Full `flutter test --coverage` green at 100%.
