### PR TITLE
volumes: move /volumes to the admin surface (#2974)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,19 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **`/volumes` is now an admin surface (#2974).** The volume listing
+  checks the new `view-volumes` permission on `/volumes`, and
+  create/delete check `manage-volumes` — both seeded Allow for the
+  `admins` group (migration m0024 rewrites the #2946 Allow
+  Authenticated rows on existing deployments; operator-customized
+  rows are preserved). Non-admin users lose volume API access by
+  default — re-grant via the ACL editor if a deploy wants them back.
+  The listing now returns the whole deployment inventory (each entry
+  carries the creating user as `owner`) and `manage-volumes` holders
+  can delete any managed volume — the per-user ownership scoping is
+  gone. The web frontend gains a Volumes tab under Admin (view +
+  delete), and the CLI volume commands are now admin-gated.
+
 - **Deploy-wide consent decider removed (#2976).** The
   `/ws/consent-decider` handshake without a `?workspace=` param is now
   refused (HTTP 403): consent authority is strictly per-workspace

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -35,7 +35,7 @@ operators or integrators to act when upgrading.
 - **`/volumes` is now an admin surface (#2974).** The volume listing
   checks the new `view-volumes` permission on `/volumes`, and
   create/delete check `manage-volumes` — both seeded Allow for the
-  `admins` group (migration m0024 rewrites the #2946 Allow
+  `admins` group (migration m0025 rewrites the #2946 Allow
   Authenticated rows on existing deployments; operator-customized
   rows are preserved). Non-admin users lose volume API access by
   default — re-grant via the ACL editor if a deploy wants them back.

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -72,7 +72,7 @@ same recipe as
 
 The Volumes tab in the Admin panel shows the deployment's klangk-managed
 podman volumes — every volume on the instance, with its creating user as
-provenance and a delete action. There is no create surface in the tab:
+provenance (when the volume carries the label) and a delete action. There is no create surface in the tab:
 workspace extra-mount volumes are provisioned automatically at container
 assembly.
 

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -68,6 +68,21 @@ resource targeting the group of your choice via the ACL editor — the
 same recipe as
 [workspace creation](#granting-workspace-creation-to-non-admin-users).
 
+## Volumes
+
+The Volumes tab in the Admin panel shows the deployment's klangk-managed
+podman volumes — every volume on the instance, with its creating user as
+provenance and a delete action. There is no create surface in the tab:
+workspace extra-mount volumes are provisioned automatically at container
+assembly.
+
+The tab is gated by `view-volumes` on `/volumes`; the delete action
+additionally requires `manage-volumes` (both seeded to the `admins`
+group, #2974). This makes read-only delegation possible: grant only
+`view-volumes` to a group and its members see the inventory but cannot
+delete — the same recipe as
+group-management delegation above.
+
 ## Default access rules
 
 On first startup, Klangk seeds these defaults:

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -24,6 +24,7 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 ├── /server                    (flat — lifecycle schedules)
 ├── /events                    (flat — read-only audit)
 ├── /acl                       (flat — the ACL editor itself)
+├── /volumes                   (flat — the volume inventory, admin surface #2974)
 └── /admin                     (marker only — nothing checks here, #2944)
 ```
 
@@ -47,10 +48,9 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/events`      | Deny   | Everyone      | `*`                      |
 | `/acl`         | Allow  | group:admins  | `manage-acls`            |
 | `/acl`         | Deny   | Everyone      | `*`                      |
-| `/volumes`     | Allow  | Authenticated | `manage-volumes`         |
-| `/volumes`     | Deny   | Everyone      | `*`                      |
+| `/volumes`     | Allow  | group:admins  | `view-volumes`           |
+| `/volumes`     | Allow  | group:admins  | `manage-volumes`         |
 | `/images`      | Allow  | Authenticated | `view-images`            |
-| `/images`      | Deny   | Everyone      | `*`                      |
 | `/admin`       | Allow  | group:admins  | `*` (admin marker only)  |
 | `/admin`       | Deny   | Everyone      | `*`                      |
 
@@ -179,8 +179,9 @@ all, #2886).
 ### First-class resource permissions
 
 Every governed surface is a first-class top-level resource (#2944);
-each carries **one** flat `manage-*` permission covering all of its
-actions — no per-action splits:
+each carries a flat permission covering its actions — `manage-*` for
+the whole admin surface, plus view-only splits where read-only
+delegation matters:
 
 | Permission               | Where it is checked | Controls                                                                                                                                                              |
 | ------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -191,7 +192,8 @@ actions — no per-action splits:
 | `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel                                                                                                                   |
 | `manage-events`          | `/events`           | Read the container start/stop history (`GET /events`) — read-only audit                                                                                               |
 | `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                        |
-| `manage-volumes`         | `/volumes`          | Self-service volumes (still label-scoped to the caller at runtime) — Allow Authenticated by default (#2946)                                                           |
+| `view-volumes`           | `/volumes`          | The Volumes admin tab's read: list the deployment's volume inventory (`GET /volumes`) with per-volume provenance — admins by default, delegable read-only (#2974)     |
+| `manage-volumes`         | `/volumes`          | The volume mutating endpoints (`POST /volumes`, `DELETE /volumes/{name}`) — admins by default (#2974; was Allow Authenticated in #2946)                               |
 | `view-images`            | `/images`           | The image/nix/sudo capability listing the create/edit UIs read (#2946)                                                                                                |
 | `search-users`           | `/users`            | The member-picker type-ahead (`GET /users/search`) — Allow Authenticated by default (#2946)                                                                           |
 | `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing checks it anywhere anymore (#2944, #2946 — the transfer gate now checks `transfer-workspace`)           |

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -51,6 +51,7 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/volumes`     | Allow  | group:admins  | `view-volumes`           |
 | `/volumes`     | Allow  | group:admins  | `manage-volumes`         |
 | `/images`      | Allow  | Authenticated | `view-images`            |
+| `/images`      | Deny   | Everyone      | `*`                      |
 | `/admin`       | Allow  | group:admins  | `*` (admin marker only)  |
 | `/admin`       | Deny   | Everyone      | `*`                      |
 
@@ -59,6 +60,15 @@ the `admins` group can create workspaces or hold a `manage-*`
 permission; unauthenticated users are denied everything. `/admin`
 checks nothing anymore (#2944) — its `*` row only marks "instance
 administrator" for permission-map consumers.
+
+`/volumes` carries no trailing Deny Everyone row (#2974): a no-match
+walk is already default-deny, and unauthenticated requests are
+rejected by the JWT middleware before any ACL check. One consequence
+of the ancestor walk (`/volumes` falls through to `/`): a row on `/`
+whose permission is `*` (e.g. an operator-added `Allow * Authenticated`)
+can grant volume access. Every other first-class resource blocks that
+with its own terminal Deny — keep such `/` wildcard rows in mind when
+editing the root resource.
 
 ### Granting workspace creation to non-admin users
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -589,6 +589,10 @@ No request body.
 ]
 ```
 
+`owner` is the creating user's id taken from the `klangk.user-id`
+label — `null` when the volume carries no label (e.g. volumes
+provisioned without a user in the loop).
+
 ---
 
 ### GET `/api/v1/workspaces`

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -569,16 +569,24 @@ No request body.
 
 ### GET `/api/v1/volumes`
 
-List podman volumes owned by the current user.
+List the deployment's klangk-managed podman volumes — the admin
+inventory view, every volume on the instance with its creating user as
+provenance.
 
-**Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946; seeded Allow for Authenticated; volumes stay
-label-scoped to the caller at runtime).
+**Auth:** JWT required. User must have the `view-volumes` permission
+on `/volumes` (#2974; seeded Allow for the admins group, delegable
+read-only).
 
 No request body.
 
 ```json
-[{ "name": "my-volume", "created": "2025-01-01T12:00:00Z" }]
+[
+  {
+    "name": "my-volume",
+    "created": "2025-01-01T12:00:00Z",
+    "owner": "<user-id>"
+  }
+]
 ```
 
 ---
@@ -1314,10 +1322,12 @@ Returns `StreamingResponse` (`application/x-ndjson`).
 
 ### POST `/api/v1/volumes`
 
-Create a new podman volume labeled with the current user's ID.
+Create a new podman volume labeled with the current user's ID (the
+label is provenance for the inventory view — workspace extra-mount
+volumes are also auto-provisioned at container assembly).
 
 **Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946).
+on `/volumes` (#2974; seeded Allow for the admins group).
 
 ```json
 { "name": "my-volume" }
@@ -1760,10 +1770,11 @@ Replace all ACL entries for a workspace.
 
 ### DELETE `/api/v1/volumes/{name}`
 
-Delete a podman volume. Only the owning user can delete their volumes.
+Delete a klangk-managed podman volume.
 
 **Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946). Checks user ownership.
+on `/volumes` (#2974; admins by default). No per-user ownership check:
+holders administer every managed volume on the instance.
 
 No request body.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -297,9 +297,9 @@ klangk admin users set-password user@example.com   # set/reset a password (admin
 klangk admin invitations send user@example.com     # send an invitation email (admin only)
 klangk admin invitations ls                       # list all invitations (admin only)
 klangk images                       # list available container images
-klangk volumes ls                   # list your podman volumes
-klangk volumes create nix-store     # create a named volume (owned by you)
-klangk volumes rm nix-store         # delete a volume (must be yours)
+klangk volumes ls                   # list the deployment's podman volumes (admin)
+klangk volumes create nix-store     # create a named volume (admin)
+klangk volumes rm nix-store         # delete a volume (admin)
 ```
 
 `klangk status` shows the active server, your user id/email, and whether

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -45,6 +45,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   bool _canUsers = false;
   bool _canGroups = false;
+  bool _canVolumes = false;
   bool _canInvitations = false;
   bool _canServer = false;
   bool _canEvents = false;
@@ -100,6 +101,10 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     _canInvitations = auth.hasPermission('/invitations', 'manage-invitations');
     _canServer = auth.hasPermission('/server', 'manage-server-schedule');
     _canEvents = auth.hasPermission('/events', 'manage-events');
+    // #2974: the Volumes tab is the /volumes admin surface — visible to
+    // view-volumes holders (read-only auditors), deleting needs
+    // manage-volumes (checked inside the tab).
+    _canVolumes = auth.hasPermission('/volumes', 'view-volumes');
     // The Access Control browser reads /acl/*, gated on `manage-acls`
     // (#2940) — root-equivalent (it can rewrite ACLs on any
     // resource), so it is granted only to administrators.
@@ -540,6 +545,13 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         label: 'Events',
         icon: Icons.history,
         view: const ContainerEventsPanel(),
+      );
+    }
+    if (_canVolumes) {
+      addTab(
+        label: 'Volumes',
+        icon: Icons.storage,
+        view: const _VolumesTab(key: ValueKey('volumes-tab')),
       );
     }
     // The Access Control browser reads /acl/*, gated on
@@ -1890,6 +1902,158 @@ class _SystemAgentBadge extends StatelessWidget {
   }
 }
 
+/// Volumes tab (#2974): the /volumes admin surface — the deployment's
+/// klangk-managed volume inventory with per-volume provenance and a
+/// delete action. Visible to view-volumes holders (read-only
+/// auditors); the delete action additionally requires manage-volumes.
+/// No create surface: workspace extra-mount volumes are provisioned
+/// at container assembly (ensure_volumes), and the CLI admin commands
+/// remain the scripting path.
+class _VolumesTab extends StatefulWidget {
+  const _VolumesTab({super.key});
+
+  @override
+  State<_VolumesTab> createState() => _VolumesTabState();
+}
+
+class _VolumesTabState extends State<_VolumesTab> {
+  List<Map<String, dynamic>> _volumes = [];
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVolumes();
+  }
+
+  Future<void> _loadVolumes() async {
+    try {
+      final auth = context.read<AuthService>();
+      final resp = await auth.authGet('/api/v1/volumes');
+      if (resp.statusCode == 200) {
+        if (!mounted) return;
+        setState(() {
+          _volumes =
+              (jsonDecode(resp.body) as List).cast<Map<String, dynamic>>();
+          _loading = false;
+          _error = null;
+        });
+      } else {
+        if (!mounted) return;
+        setState(() {
+          _error = 'Failed to load volumes: ${resp.statusCode}';
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[AdminUsersPage] load volumes failed: $e');
+      if (!mounted) return;
+      setState(() {
+        _error = 'Could not load volumes. Please try again.';
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _deleteVolume(String name) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Volume'),
+        content: Text(
+          'Delete the volume "$name"? Its data is destroyed; workspaces '
+          'mounting it will fail to start.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: KColors.accentRed,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+
+    final auth = context.read<AuthService>();
+    final resp = await auth.authDelete('/api/v1/volumes/$name');
+    if (resp.statusCode == 200) {
+      await _loadVolumes();
+    } else {
+      if (!mounted) return;
+      final detail =
+          (jsonDecode(resp.body) as Map<String, dynamic>)['detail'] as String?;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(detail ?? 'Failed to delete volume')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!),
+            const SizedBox(height: 8),
+            FilledButton(onPressed: _loadVolumes, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_volumes.isEmpty) {
+      return const Center(child: Text('No volumes'));
+    }
+    final canManage =
+        context.read<AuthService>().hasPermission('/volumes', 'manage-volumes');
+    return RefreshIndicator(
+      onRefresh: _loadVolumes,
+      child: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _volumes.length,
+        itemBuilder: (ctx, i) {
+          final volume = _volumes[i];
+          final name = volume['name'] as String? ?? '';
+          final created = (volume['created'] as String?) ?? '';
+          final owner = (volume['owner'] as String?) ?? '';
+          final ownerTag = owner.length >= 8 ? owner.substring(0, 8) : owner;
+          return Card(
+            margin: const EdgeInsets.only(bottom: 8),
+            child: ListTile(
+              leading: const Icon(Icons.storage),
+              title: Text(name, key: const ValueKey('volume-name')),
+              subtitle: Text(
+                created.isNotEmpty
+                    ? 'Created $created · owner $ownerTag'
+                    : 'owner $ownerTag',
+              ),
+              trailing: canManage
+                  ? IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Delete volume',
+                      onPressed: () => _deleteVolume(name),
+                    )
+                  : null,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
 /// ACL browser tab: shows the static resource tree and lets you edit ACLs.
 class _AclBrowserTab extends StatefulWidget {
   const _AclBrowserTab();
@@ -1932,7 +2096,8 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
     '/invitations': 'manage-invitations',
     '/server': 'manage-server-schedule',
     '/events': 'manage-events (read-only audit)',
-    '/volumes': 'manage-volumes — self-service volumes (Allow Authenticated)',
+    '/volumes':
+        'view-volumes — see the volume inventory; manage-volumes — delete',
     '/images': 'view-images — the image/capability listing',
     '/acl': 'manage-acls — root-equivalent, administrators only',
   };

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -1957,6 +1957,9 @@ class _VolumesTabState extends State<_VolumesTab> {
   }
 
   Future<void> _deleteVolume(String name) async {
+    // Capture before the first await — the dialog/request can outlive
+    // the widget (same pattern as _deleteUser).
+    final auth = context.read<AuthService>();
     final confirm = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -1984,16 +1987,22 @@ class _VolumesTabState extends State<_VolumesTab> {
     );
     if (confirm != true) return;
 
-    final auth = context.read<AuthService>();
     final resp = await auth.authDelete('/api/v1/volumes/$name');
     if (resp.statusCode == 200) {
+      if (!mounted) return;
       await _loadVolumes();
     } else {
       if (!mounted) return;
-      final detail =
-          (jsonDecode(resp.body) as Map<String, dynamic>)['detail'] as String?;
+      String detail = 'Failed to delete volume';
+      try {
+        detail = (jsonDecode(resp.body) as Map<String, dynamic>)['detail']
+                as String? ??
+            detail;
+      } catch (e) {
+        debugPrint('[AdminUsersPage] parse delete-volume error: $e');
+      }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(detail ?? 'Failed to delete volume')),
+        SnackBar(content: Text(detail)),
       );
     }
   }

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -157,7 +157,8 @@ class AuthService extends ChangeNotifier {
       hasPermission('/groups', 'manage-groups') ||
       hasPermission('/server', 'manage-server-schedule') ||
       hasPermission('/events', 'manage-events') ||
-      hasPermission('/acl', 'manage-acls');
+      hasPermission('/acl', 'manage-acls') ||
+      hasPermission('/volumes', 'view-volumes');
 
   /// Check if the user has a specific permission on a resource.
   bool hasPermission(String resource, String permission) {

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -79,6 +79,7 @@ class AclEditorState extends State<AclEditor> {
     'manage-events',
     'search-users',
     'manage-volumes',
+    'view-volumes',
     'view-images',
   ];
 

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -465,6 +465,138 @@ void main() {
     });
   });
 
+  group('AdminUsersPage volumes tab', () {
+    /// Mock client serving [permissions] plus a /volumes listing.
+    /// DELETE mutates [volumes] so the reload reflects the deletion.
+    void serveVolumes(
+      Map<String, List<String>> permissions,
+      List<Map<String, dynamic>> volumes,
+    ) {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/config')) {
+          return http.Response(
+            jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/my-permissions')) {
+          return http.Response(
+            jsonEncode({
+              'user_id': 'admin-user',
+              'email': 'admin@example.com',
+              'permissions': permissions,
+              'groups': [],
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/volumes' && request.method == 'GET') {
+          return http.Response(jsonEncode(volumes), 200);
+        }
+        if (request.url.path.startsWith('/api/v1/volumes/') &&
+            request.method == 'DELETE') {
+          final name = request.url.path.split('/').last;
+          volumes.removeWhere((v) => v['name'] == name);
+          return http.Response(jsonEncode({'status': 'deleted'}), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+    }
+
+    testWidgets('lists the deployment volume inventory for an admin',
+        (tester) async {
+      serveVolumes({
+        '/users': ['manage-users'],
+        '/volumes': ['view-volumes', 'manage-volumes'],
+      }, [
+        {
+          'name': 'vol-a',
+          'created': '2026-01-01T00:00:00Z',
+          'owner': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        },
+        {
+          'name': 'vol-b',
+          'created': '2026-02-02T00:00:00Z',
+          'owner': '12345678-1234-1234-1234-123456789012',
+        },
+      ]);
+
+      await pumpPage(tester);
+
+      expect(find.text('Volumes'), findsOneWidget);
+      await tester.tap(find.text('Volumes'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('vol-a'), findsOneWidget);
+      expect(find.text('vol-b'), findsOneWidget);
+      // Provenance: the creating user's id prefix rides each row.
+      expect(find.textContaining('owner aaaaaaaa'), findsOneWidget);
+      expect(find.textContaining('owner 12345678'), findsOneWidget);
+      // manage-volumes holder: delete offered.
+      expect(find.byTooltip('Delete volume'), findsNWidgets(2));
+    });
+
+    testWidgets('view-only delegate sees the tab without delete actions',
+        (tester) async {
+      serveVolumes({
+        '/volumes': ['view-volumes'],
+      }, [
+        {
+          'name': 'vol-a',
+          'created': '2026-01-01T00:00:00Z',
+          'owner': 'aaaaaaaa-bbbb',
+        },
+      ]);
+
+      await pumpPage(tester);
+
+      // view-volumes alone admits into the admin section (#2974).
+      expect(find.text('Volumes'), findsOneWidget);
+      await tester.tap(find.text('Volumes'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('vol-a'), findsOneWidget);
+      expect(find.byTooltip('Delete volume'), findsNothing);
+    });
+
+    testWidgets('deletes a volume after confirmation', (tester) async {
+      final volumes = <Map<String, dynamic>>[
+        {
+          'name': 'vol-a',
+          'created': '2026-01-01T00:00:00Z',
+          'owner': 'aaaaaaaa-bbbb',
+        },
+      ];
+      serveVolumes({
+        '/volumes': ['view-volumes', 'manage-volumes'],
+      }, volumes);
+
+      await pumpPage(tester);
+      await tester.tap(find.text('Volumes'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Delete volume'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete Volume'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      // The deletion hit the backend and the listing reloaded empty.
+      expect(volumes, isEmpty);
+      expect(find.text('No volumes'), findsOneWidget);
+    });
+
+    testWidgets('hides the Volumes tab without the permission', (tester) async {
+      serveVolumes({
+        '/users': ['manage-users'],
+      }, []);
+
+      await pumpPage(tester);
+
+      expect(find.text('Volumes'), findsNothing);
+    });
+  });
+
   group('AdminUsersPage groups tab', () {
     /// Pump the page on the users tab, then switch to the Groups tab.
     Future<void> pumpGroupsTab(WidgetTester tester) async {

--- a/src/klangk/klangk/api/common.py
+++ b/src/klangk/klangk/api/common.py
@@ -55,6 +55,7 @@ ALL_PERMISSIONS = [
     "manage-acls",
     "manage-events",
     "manage-volumes",
+    "view-volumes",
     "view-images",
     "search-users",
     "*",

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -263,20 +263,26 @@ async def list_images(
 
 @router.get("/volumes")
 async def list_volumes(
-    user: dict = Depends(acl.has_permission("manage-volumes")),
+    _user: dict = Depends(acl.has_permission("view-volumes")),
     app=Depends(get_app_dep),
 ):
+    """List the deployment's klangk-managed volumes (#2974).
+
+    Admin-surface view: every volume on the instance, with the
+    creating user's id as ``owner`` (provenance — the ``klangk.user-id``
+    label the create path stamps). Viewers need ``view-volumes``;
+    the seeded grant is the admins group, delegable read-only.
+    """
     volumes = await app.state.podman.list_volumes(
         f"klangk.instance={app.state.util.instance_id()}"
     )
-    uid = user["id"]
     return [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
+            "owner": (v.get("Labels") or {}).get("klangk.user-id"),
         }
         for v in volumes
-        if (v.get("Labels") or {}).get("klangk.user-id") == uid
     ]
 
 
@@ -318,7 +324,7 @@ async def create_volume(
 @router.delete("/volumes/{name}")
 async def delete_volume(
     name: str,
-    user: dict = Depends(acl.has_permission("manage-volumes")),
+    _user: dict = Depends(acl.has_permission("manage-volumes")),
     app=Depends(get_app_dep),
 ):
     info = await app.state.podman.inspect_volume(name)
@@ -330,11 +336,9 @@ async def delete_volume(
             status_code=404,
             detail="Volume not managed by this Klangk instance",
         )
-    if labels.get("klangk.user-id") != user["id"]:
-        raise HTTPException(
-            status_code=403,
-            detail="Volume belongs to another user",
-        )
+    # No per-user ownership check (#2974): manage-volumes is the
+    # admin-surface grant — holders administer every managed volume,
+    # not just their own. The user-id label survives for provenance.
     try:
         await app.state.podman.remove_volume(name)
     except PodmanError as e:

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -240,8 +240,10 @@ def volumes_list(
     table = Table(box=None, pad_edge=False)
     table.add_column("Name", style="bold")
     table.add_column("Created")
+    table.add_column("Owner", style="dim")
     for v in volumes:
-        table.add_row(v["name"], v.get("created", "")[:19])
+        owner = v.get("owner") or "—"
+        table.add_row(v["name"], v.get("created", "")[:19], owner[:8])
     console.print(table)
 
 

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -239,19 +239,32 @@ class Lifecycle:
                 PRINCIPAL_SYSTEM,
                 system_principal=SYSTEM_EVERYONE,
             )
-        # #2946 self-service surfaces, granted to every authenticated
-        # user by default (a deploy that wants them restricted denies
-        # or scopes these rows in the ACL editor):
-        #   /volumes    manage-volumes — user-owned volumes (label-
-        #                               scoped per user at runtime)
+        # /volumes admin surface (#2974): the inventory tab in /admin —
+        # view-volumes gates the listing (GET), manage-volumes the
+        # mutating endpoints (POST/DELETE). Both to admins, delegable
+        # separately (a read-only volumes auditor holds view alone).
+        # No trailing Deny Everyone row: unauthenticated requests die
+        # at the JWT middleware before any ACL check, and no-match is
+        # already default-deny.
+        for permission in ("view-volumes", "manage-volumes"):
+            await self.app.state.model.acl.add_acl_entry(
+                "/volumes",
+                0 if permission == "view-volumes" else 1,
+                ACTION_ALLOW,
+                permission,
+                PRINCIPAL_GROUP,
+                group_id=admin_group_id,
+            )
+        # #2946 self-service surface, granted to every authenticated
+        # user by default (a deploy that wants it restricted denies
+        # or scopes the rows in the ACL editor):
         #   /images     view-images    — the image/nix/sudo capability
         #                               listing (create/edit UIs)
         # NB: /llm-proxy is NOT here — #2959 gives it its own
         # workspace-token-only gate, independent of the ACL system.
-        for resource, permission in (
-            ("/volumes", "manage-volumes"),
-            ("/images", "view-images"),
-        ):
+        # (#2974: the /volumes rows above moved to the admins group;
+        # the /images rework lands in its own PR.)
+        for resource, permission in (("/images", "view-images"),):
             await self.app.state.model.acl.add_acl_entry(
                 resource,
                 0,

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -245,7 +245,9 @@ class Lifecycle:
         # separately (a read-only volumes auditor holds view alone).
         # No trailing Deny Everyone row: unauthenticated requests die
         # at the JWT middleware before any ACL check, and no-match is
-        # already default-deny.
+        # already default-deny. The ancestor-walk consequence (a `*`
+        # row on / can grant volume access) is documented in
+        # docs/reference/acl.md (#2974 decision).
         for permission in ("view-volumes", "manage-volumes"):
             await self.app.state.model.acl.add_acl_entry(
                 "/volumes",

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -72,6 +72,7 @@ from klangk.model.migrations import m0021_first_class_resource_acls
 from klangk.model.migrations import m0022_workspace_permission_renames
 from klangk.model.migrations import m0023_self_service_resources
 from klangk.model.migrations import m0024_join_workspace_permission
+from klangk.model.migrations import m0025_volumes_admin_surface
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -104,6 +105,7 @@ MIGRATIONS: list[Migration] = [
     m0022_workspace_permission_renames.migration,
     m0023_self_service_resources.migration,
     m0024_join_workspace_permission.migration,
+    m0025_volumes_admin_surface.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0025_volumes_admin_surface.py
+++ b/src/klangk/klangk/model/migrations/m0025_volumes_admin_surface.py
@@ -1,0 +1,138 @@
+"""Migration 0025: /volumes becomes an admin surface (#2974).
+
+The #2946 seed granted ``manage-volumes`` to every authenticated user —
+a ``manage-*`` name on the whole deployment's volume inventory, which
+contradicts the #2944 convention (``manage-*`` = admin surface, admins
+by default, delegable). #2974 splits the endpoint gates:
+
+- ``GET /api/v1/volumes``      → ``view-volumes``  (the admin tab's read)
+- ``POST /api/v1/volumes``     → ``manage-volumes``
+- ``DELETE /api/v1/volumes/…`` → ``manage-volumes``
+
+and re-seeds ``/volumes`` to the admins group, view + manage. The
+per-user ``klangk.user-id`` runtime scoping is dropped for the same
+reason: a ``manage-volumes`` holder administers every managed volume
+(the label survives for provenance).
+
+This migration rewrites existing deployments to the new shape:
+
+- Deletes rows on ``/volumes`` that match the retired seed exactly
+  (Allow ``manage-volumes`` Authenticated, Deny ``*`` Everyone) — they
+  are the defaults this change replaces, not operator intent.
+- Inserts Allow ``view-volumes`` + Allow ``manage-volumes`` for the
+  admins group at positions 0/1, unless a row already grants that
+  permission on ``/volumes`` (idempotent; operator-staged rows win).
+- Custom rows the operator added (anything that is not the retired
+  seed pair) are left untouched.
+
+A fresh database (entirely empty ``acl_entries``) is a no-op — the boot
+seeds own it (the m0021 precedent; inserting here would trip the seed's
+empty-table gate and lose the ``/``, ``/workspaces``, ``/admin`` rows).
+
+The admins group is located by name (``admins``; migration 0020
+renamed legacy ``admin`` rows), matching the seeds' shape.
+"""
+
+from klangk.model.acl import (
+    ACTION_ALLOW,
+    ACTION_DENY,
+    PRINCIPAL_GROUP,
+    PRINCIPAL_SYSTEM,
+    SYSTEM_AUTHENTICATED,
+    SYSTEM_EVERYONE,
+)
+from klangk.model.migrations.base import Migration
+
+# (position, action, principal_type, system_principal, permission) of the
+# retired #2946 seed pair on /volumes.
+_RETIRED_SEED = {
+    (
+        0,
+        ACTION_ALLOW,
+        PRINCIPAL_SYSTEM,
+        SYSTEM_AUTHENTICATED,
+        "manage-volumes",
+    ),
+    (1, ACTION_DENY, PRINCIPAL_SYSTEM, SYSTEM_EVERYONE, "*"),
+}
+
+_ADMIN_PERMISSIONS = ("view-volumes", "manage-volumes")
+
+
+async def _admins_group_id(db) -> str | None:
+    cursor = await db.execute(
+        "SELECT id FROM groups WHERE name = 'admins' LIMIT 1"
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else None
+
+
+async def _rows(db):
+    cursor = await db.execute(
+        "SELECT position, action, principal_type, system_principal,"
+        " permission, rowid FROM acl_entries WHERE resource = '/volumes'"
+        " ORDER BY position"
+    )
+    return list(await cursor.fetchall())
+
+
+async def _delete_retired_seed_rows(db, rows) -> None:
+    for row in rows:
+        key = (row[0], row[1], row[2], row[3], row[4])
+        if key in _RETIRED_SEED:
+            await db.execute(
+                "DELETE FROM acl_entries WHERE rowid = ?", (row[5],)
+            )
+
+
+async def _permission_exists(db, permission: str) -> bool:
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM acl_entries"
+        " WHERE resource = '/volumes' AND permission = ?",
+        (permission,),
+    )
+    return (await cursor.fetchone())[0] > 0
+
+
+async def _next_position(db) -> int:
+    cursor = await db.execute(
+        "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
+        " WHERE resource = '/volumes'"
+    )
+    return (await cursor.fetchone())[0] + 1
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        return  # fresh database — the boot seeds own it
+
+    group_id = await _admins_group_id(db)
+    if group_id is None:
+        return  # no admins group: nothing to grant; rows left untouched
+
+    rows = await _rows(db)
+    await _delete_retired_seed_rows(db, rows)
+
+    for permission in _ADMIN_PERMISSIONS:
+        if await _permission_exists(db, permission):
+            continue  # operator-staged or already migrated
+        # Append rather than assume 0/1: a deployment whose retired
+        # pair was only half-customized keeps rows at those positions,
+        # and a fixed insert would violate UNIQUE(resource, position)
+        # (failed migration = boot loop).
+        position = await _next_position(db)
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type, user_id,"
+            " group_id, system_principal, permission)"
+            " VALUES ('/volumes', ?, ?, ?, NULL, ?, NULL, ?)",
+            (position, ACTION_ALLOW, PRINCIPAL_GROUP, group_id, permission),
+        )
+
+
+migration = Migration(
+    id=25,
+    name="0025_volumes_admin_surface",
+    apply=apply,
+)

--- a/src/klangk/klangk/model/migrations/m0025_volumes_admin_surface.py
+++ b/src/klangk/klangk/model/migrations/m0025_volumes_admin_surface.py
@@ -10,18 +10,24 @@ by default, delegable). #2974 splits the endpoint gates:
 - ``DELETE /api/v1/volumes/…`` → ``manage-volumes``
 
 and re-seeds ``/volumes`` to the admins group, view + manage. The
-per-user ``klangk.user-id`` runtime scoping is dropped for the same
-reason: a ``manage-volumes`` holder administers every managed volume
-(the label survives for provenance).
+endpoint-level per-user ownership check on DELETE is dropped for
+the same reason: a ``manage-volumes`` holder administers every
+managed volume (the label survives for provenance; the
+``ensure_volumes`` mount-time validation at container assembly is
+unaffected, #2974).
 
 This migration rewrites existing deployments to the new shape:
 
 - Deletes rows on ``/volumes`` that match the retired seed exactly
   (Allow ``manage-volumes`` Authenticated, Deny ``*`` Everyone) — they
-  are the defaults this change replaces, not operator intent.
+  are the defaults this change replaces, not operator intent. This
+  runs even when the deployment has no ``admins`` group: the
+  over-broad Allow Authenticated grant must not survive an upgrade
+  just because the grantee group is missing.
 - Inserts Allow ``view-volumes`` + Allow ``manage-volumes`` for the
-  admins group at positions 0/1, unless a row already grants that
-  permission on ``/volumes`` (idempotent; operator-staged rows win).
+  admins group unless a row already *allows* that permission on
+  ``/volumes`` (idempotent; operator-staged Allow rows win — a staged
+  Deny does not suppress the insert, so admins keep the surface).
 - Custom rows the operator added (anything that is not the retired
   seed pair) are left untouched.
 
@@ -85,11 +91,15 @@ async def _delete_retired_seed_rows(db, rows) -> None:
             )
 
 
-async def _permission_exists(db, permission: str) -> bool:
+async def _permission_allowed(db, permission: str) -> bool:
+    # Allow rows only: a staged Deny must not suppress the admins'
+    # Allow insert (first-match-wins still lets the operator's Deny
+    # take effect for the principals it covers).
     cursor = await db.execute(
         "SELECT COUNT(*) FROM acl_entries"
-        " WHERE resource = '/volumes' AND permission = ?",
-        (permission,),
+        " WHERE resource = '/volumes' AND permission = ?"
+        " AND action = ?",
+        (permission, ACTION_ALLOW),
     )
     return (await cursor.fetchone())[0] > 0
 
@@ -107,15 +117,17 @@ async def apply(db) -> None:
     if (await cursor.fetchone())[0] == 0:
         return  # fresh database — the boot seeds own it
 
-    group_id = await _admins_group_id(db)
-    if group_id is None:
-        return  # no admins group: nothing to grant; rows left untouched
-
     rows = await _rows(db)
     await _delete_retired_seed_rows(db, rows)
 
+    group_id = await _admins_group_id(db)
+    if group_id is None:
+        # Nothing to grant — but the retired rows are already gone, so
+        # /volumes is locked rather than left world-manageable.
+        return
+
     for permission in _ADMIN_PERMISSIONS:
-        if await _permission_exists(db, permission):
+        if await _permission_allowed(db, permission):
             continue  # operator-staged or already migrated
         # Append rather than assume 0/1: a deployment whose retired
         # pair was only half-customized keeps rows at those positions,

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4653,7 +4653,11 @@ class TestVolumes:
             status_code=200,
             json=MagicMock(
                 return_value=[
-                    {"name": "vol-1", "created": "2026-01-01T00:00:00Z"},
+                    {
+                        "name": "vol-1",
+                        "created": "2026-01-01T00:00:00Z",
+                        "owner": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    }
                 ]
             ),
         )
@@ -4665,6 +4669,8 @@ class TestVolumes:
         result = runner.invoke(main.app, ["volumes", "ls"])
         assert result.exit_code == 0
         assert "vol-1" in result.stdout
+        # #2974: the owner column shows the creating user's id prefix.
+        assert "aaaaaaaa" in result.stdout
 
     def test_volumes_ls_empty(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -281,7 +281,7 @@ async def admin_group(app_state):
             system_principal=SYSTEM_EVERYONE,
         )
     # /volumes admin surface (#2974): view + manage to admins —
-    # mirrors the updated seed_default_acls / m0024.
+    # mirrors the updated seed_default_acls / m0025.
     for position, permission in enumerate(("view-volumes", "manage-volumes")):
         await acl.add_acl_entry(
             "/volumes",

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -92,11 +92,14 @@ async def _seed_2946_self_service(app_state):
     """Seed the #2946 self-service ACL rows (idempotent).
 
     Mirrors m0023 / seed_default_acls: Allow <perm> for Authenticated
-    plus Deny Everyone on /volumes, /images, /llm-proxy, and the
+    plus Deny Everyone on /images, /llm-proxy, and the
     Allow search-users Authenticated row on /users (inserted at
-    position 1, shifting later rows down — m0023's logic). Called by
-    the seed fixtures (user / agent_user / admin_group) so any test
-    reaching the DB gets the production-shaped world.
+    position 1, shifting later rows down — m0023's logic).
+    /volumes is no longer here — #2974 moved it to the admins group
+    (view-volumes + manage-volumes, seeded by the admin_group
+    fixture like the other admin surfaces). Called by the seed
+    fixtures (user / agent_user / admin_group) so any test reaching
+    the DB gets the production-shaped world.
     """
     from klangk.model.acl import (
         ACTION_ALLOW,
@@ -107,10 +110,7 @@ async def _seed_2946_self_service(app_state):
     )
 
     acl = app_state.state.model.acl
-    for resource, permission in (
-        ("/volumes", "manage-volumes"),
-        ("/images", "view-images"),
-    ):
+    for resource, permission in (("/images", "view-images"),):
         existing = await acl.get_acl_entries(resource)
         if existing:
             continue
@@ -279,6 +279,17 @@ async def admin_group(app_state):
             "*",
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_EVERYONE,
+        )
+    # /volumes admin surface (#2974): view + manage to admins —
+    # mirrors the updated seed_default_acls / m0024.
+    for position, permission in enumerate(("view-volumes", "manage-volumes")):
+        await acl.add_acl_entry(
+            "/volumes",
+            position,
+            ACTION_ALLOW,
+            permission,
+            PRINCIPAL_GROUP,
+            group_id=group["id"],
         )
     await _seed_2946_self_service(app_state)
     # /admin stays as the instance-admin wildcard marker (#2944).

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6799,6 +6799,20 @@ class TestVolumeRoutes:
         resp = await client.get("/api/v1/volumes", headers=headers)
         assert resp.status_code == 403
 
+    async def test_mutate_volumes_requires_manage_permission(
+        self, client, user
+    ):
+        """#2974: a user with no /volumes grants at all cannot create or
+        delete — the manage gate must hold for the mutating endpoints
+        too, not just alongside a view grant."""
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/volumes", json={"name": "nope"}, headers=headers
+        )
+        assert resp.status_code == 403
+        resp = await client.delete("/api/v1/volumes/nope", headers=headers)
+        assert resp.status_code == 403
+
     async def test_delegated_viewer_lists_but_cannot_mutate(
         self, client, user, app_state
     ):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6748,8 +6748,20 @@ def _managed_volume(user_id="test-user"):
 
 
 class TestVolumeRoutes:
-    async def test_list_volumes(self, client, user):
-        headers = await _auth_headers(client)
+    async def _admin_headers(self, client):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
+        )
+        return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+    async def test_list_volumes(self, client, admin_user, user):
+        """#2974: the listing is the admin-surface view — every managed
+        volume on the instance, with the creating user as owner."""
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod,
             "list_volumes",
@@ -6777,11 +6789,54 @@ class TestVolumeRoutes:
             resp = await client.get("/api/v1/volumes", headers=headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "my-vol"
+        assert [v["name"] for v in data] == ["my-vol", "other-vol"]
+        assert data[0]["owner"] == user["id"]
+        assert data[1]["owner"] == "someone-else"
 
-    async def test_create_volume(self, client, user):
+    async def test_list_volumes_requires_view_permission(self, client, user):
+        """#2974: a non-admin (no view-volumes grant) cannot list."""
         headers = await _auth_headers(client)
+        resp = await client.get("/api/v1/volumes", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_delegated_viewer_lists_but_cannot_mutate(
+        self, client, user, app_state
+    ):
+        """#2974: view-volumes alone is a read-only delegation — the
+        listing works, create/delete stay denied."""
+        from klangk.model import ACTION_ALLOW, PRINCIPAL_USER
+
+        await app_state.state.model.acl.add_acl_entry(
+            "/volumes",
+            0,
+            ACTION_ALLOW,
+            "view-volumes",
+            PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        headers = await _auth_headers(client)
+        with patch.object(
+            _mock_pod,
+            "list_volumes",
+            AsyncMock(return_value=[]),
+        ):
+            resp = await client.get("/api/v1/volumes", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+        resp = await client.post(
+            "/api/v1/volumes",
+            json={"name": "nope"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        resp = await client.delete("/api/v1/volumes/nope", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_create_volume(self, client, admin_user):
+        """#2974: create is manage-gated; the volume is stamped with the
+        creating admin's user-id (provenance)."""
+        headers = await self._admin_headers(client)
         mock_create = AsyncMock(
             return_value={"Name": "new-vol", "CreatedAt": "2026-01-01"}
         )
@@ -6799,10 +6854,10 @@ class TestVolumeRoutes:
         assert resp.status_code == 200
         assert resp.json()["name"] == "new-vol"
         _, labels = mock_create.call_args.args
-        assert labels["klangk.user-id"] == user["id"]
+        assert labels["klangk.user-id"] == admin_user["id"]
 
-    async def test_create_duplicate_volume(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_create_duplicate_volume(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod,
             "inspect_volume",
@@ -6816,12 +6871,13 @@ class TestVolumeRoutes:
         assert resp.status_code == 409
 
     async def test_create_volume_foreign_instance_not_enumerable(
-        self, app, user
+        self, app, admin_user
     ):
         """#2973: a volume owned by another instance must not confirm its
         existence via 409 — the create falls through to podman, and the
         client sees a bare 500 whose body carries no probed name
-        (podman's own conflict text stays in the server log)."""
+        (podman's own conflict text stays in the server log).
+        #2974: create is manage-gated, so drive it as an admin."""
         mock_create = AsyncMock(
             side_effect=podman.PodmanError(
                 500, "volume with name 'foreign-vol' already exists"
@@ -6844,7 +6900,7 @@ class TestVolumeRoutes:
             async with AsyncClient(
                 transport=transport, base_url="http://test"
             ) as c:
-                headers = await _auth_headers(c)
+                headers = await self._admin_headers(c)
                 resp = await c.post(
                     "/api/v1/volumes",
                     json={"name": "foreign-vol"},
@@ -6854,8 +6910,10 @@ class TestVolumeRoutes:
         assert resp.status_code == 500
         assert "foreign-vol" not in resp.text
 
-    async def test_create_volume_error_propagates(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_create_volume_error_propagates(
+        self, client, admin_user, user
+    ):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod, "inspect_volume", AsyncMock(return_value=None)
@@ -6873,8 +6931,8 @@ class TestVolumeRoutes:
                 headers=headers,
             )
 
-    async def test_delete_volume(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,
@@ -6888,16 +6946,18 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 200
 
-    async def test_delete_volume_not_found(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_not_found(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod, "inspect_volume", AsyncMock(return_value=None)
         ):
             resp = await client.delete("/api/v1/volumes/nope", headers=headers)
         assert resp.status_code == 404
 
-    async def test_delete_volume_wrong_instance(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_wrong_instance(
+        self, client, admin_user, user
+    ):
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod,
             "inspect_volume",
@@ -6908,21 +6968,28 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 404
 
-    async def test_delete_volume_wrong_user(self, client, user):
-        headers = await _auth_headers(client)
-        with patch.object(
-            _mock_pod,
-            "inspect_volume",
-            AsyncMock(return_value=_managed_volume("someone-else")),
+    async def test_delete_volume_other_owner(self, client, admin_user, user):
+        """#2974: manage-volumes holders administer every managed volume —
+        the old per-user ownership 403 is gone (label is provenance)."""
+        headers = await self._admin_headers(client)
+        with (
+            patch.object(
+                _mock_pod,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume("someone-else")),
+            ),
+            patch.object(_mock_pod, "remove_volume", AsyncMock()),
         ):
             resp = await client.delete(
                 "/api/v1/volumes/other", headers=headers
             )
-        assert resp.status_code == 403
+        assert resp.status_code == 200
 
-    async def test_delete_volume_remove_not_found(self, client, user):
+    async def test_delete_volume_remove_not_found(
+        self, client, admin_user, user
+    ):
         """Volume vanishes between inspect and remove -> 404."""
-        headers = await _auth_headers(client)
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,
@@ -6938,8 +7005,8 @@ class TestVolumeRoutes:
             resp = await client.delete("/api/v1/volumes/gone", headers=headers)
         assert resp.status_code == 404
 
-    async def test_delete_volume_other_error(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_other_error(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,
@@ -6955,8 +7022,8 @@ class TestVolumeRoutes:
         ):
             await client.delete("/api/v1/volumes/err-vol", headers=headers)
 
-    async def test_delete_volume_in_use(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_in_use(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -277,12 +277,19 @@ class TestSeedDefaultAcls:
         ]
         assert users[1]["system_principal"] == model.SYSTEM_AUTHENTICATED
         assert users[2]["action"] == model.ACTION_DENY
-        # ...and the self-service trio seeds Allow Authenticated +
-        # Deny Everyone.
-        for resource, permission in (
-            ("/volumes", "manage-volumes"),
-            ("/images", "view-images"),
-        ):
+        # #2974: /volumes seeds the admin surface — Allow view-volumes +
+        # Allow manage-volumes for admins, no Deny row (no-match is
+        # default-deny; unauthenticated dies at the JWT middleware).
+        volumes = await app_state.state.model.acl.get_acl_entries("/volumes")
+        assert [
+            (e["position"], e["permission"], e["group_id"]) for e in volumes
+        ] == [
+            (0, "view-volumes", admin_group_id),
+            (1, "manage-volumes", admin_group_id),
+        ]
+        # ...and /images still seeds the #2946 self-service pair:
+        # Allow Authenticated + Deny Everyone.
+        for resource, permission in (("/images", "view-images"),):
             entries = await app_state.state.model.acl.get_acl_entries(resource)
             assert len(entries) == 2, resource
             allow, deny = entries

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -85,6 +85,7 @@ class TestRunner:
             (22, "0022_workspace_permission_renames"),
             (23, "0023_self_service_resources"),
             (24, "0024_join_workspace_permission"),
+            (25, "0025_volumes_admin_surface"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -175,6 +176,7 @@ class TestRunner:
                 (22, "0022_workspace_permission_renames"),
                 (23, "0023_self_service_resources"),
                 (24, "0024_join_workspace_permission"),
+                (25, "0025_volumes_admin_surface"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -2642,5 +2644,165 @@ class TestM0024JoinWorkspacePermission:
             await m0024_join_workspace_permission.migration.apply(db)
             cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
             assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0025VolumesAdminSurface:
+    """m0025 re-seeds /volumes to the admins group (view + manage) and
+    deletes the retired #2946 Allow-Authenticated / Deny-Everyone pair
+    (#2974)."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0025.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT,"
+            " UNIQUE(resource, position))"
+        )
+        await db.execute(
+            "CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT)"
+        )
+        await db.execute(
+            "INSERT INTO groups (id, name) VALUES ('g-admin', 'admins')"
+        )
+        return db
+
+    async def _rows(self, db, resource) -> list:
+        cursor = await db.execute(
+            "SELECT position, action, group_id, system_principal,"
+            " permission FROM acl_entries"
+            " WHERE resource = ? ORDER BY position",
+            (resource,),
+        )
+        return list(await cursor.fetchall())
+
+    async def test_upgraded_db_reseeds_to_admins(self, tmp_path):
+        """The retired seed pair is replaced by the admins' view+manage
+        rows; re-running changes nothing."""
+        from klangk.model import ACTION_ALLOW
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            # Existing deployment: rows elsewhere (skips the fresh-DB
+            # gate) + the retired #2946 pair on /volumes.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/', 0, 1, 0, 1, 'view')"
+            )
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/volumes', 0, 1, 0, 1, 'manage-volumes')"
+            )
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/volumes', 1, 0, 0, 0, '*')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (0, ACTION_ALLOW, "g-admin", None, "view-volumes"),
+                (1, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+            # Idempotent: re-run changes nothing.
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (0, ACTION_ALLOW, "g-admin", None, "view-volumes"),
+                (1, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_fresh_db_is_noop(self, tmp_path):
+        """An empty acl_entries table belongs to the boot seeds."""
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await m0025_volumes_admin_surface.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_operator_custom_rows_preserved(self, tmp_path):
+        """Rows that are not the retired seed pair are operator intent:
+        left untouched, with only the missing admin rows added."""
+        from klangk.model import ACTION_ALLOW
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/volumes', 2, 1, 2, 'g-a', 'custom'),"
+                "        ('/', 0, 1, 3, NULL, 'view')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (2, ACTION_ALLOW, "g-a", None, "custom"),
+                (3, ACTION_ALLOW, "g-admin", None, "view-volumes"),
+                (4, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_staged_permission_wins(self, tmp_path):
+        """A row already granting one of the two permissions (operator
+        staged or partial re-run) is not duplicated."""
+        from klangk.model import ACTION_ALLOW
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, user_id,"
+                "  permission)"
+                " VALUES ('/volumes', 0, 1, 1, 'u-9', 'view-volumes'),"
+                "        ('/', 0, 1, 3, NULL, 'view')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (0, ACTION_ALLOW, None, None, "view-volumes"),
+                (1, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_no_admins_group_leaves_rows(self, tmp_path):
+        """Without an admins group there is nothing to grant; the
+        retired rows are left as-is (early return)."""
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute("DELETE FROM groups")
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/volumes', 0, 1, 0, 1, 'manage-volumes'),"
+                "        ('/volumes', 1, 0, 0, 0, '*'),"
+                "        ('/', 0, 1, 0, 1, 'view')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert len(await self._rows(db, "/volumes")) == 2
         finally:
             await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -2785,9 +2785,36 @@ class TestM0025VolumesAdminSurface:
         finally:
             await db.__aexit__(None, None, None)
 
-    async def test_no_admins_group_leaves_rows(self, tmp_path):
-        """Without an admins group there is nothing to grant; the
-        retired rows are left as-is (early return)."""
+    async def test_staged_deny_does_not_suppress_allow(self, tmp_path):
+        """A staged Deny row is not a grant: the admins' Allow is still
+        inserted (first-match-wins lets the operator's Deny keep its
+        effect for the principals it covers)."""
+        from klangk.model import ACTION_ALLOW, ACTION_DENY
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/volumes', 0, ?, 2, 'g-auditors', 'view-volumes'),"
+                "        ('/', 0, 1, 3, NULL, 'view')",
+                (ACTION_DENY,),
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            rows = await self._rows(db, "/volumes")
+            assert (0, ACTION_DENY, "g-auditors", None, "view-volumes") in rows
+            assert (1, ACTION_ALLOW, "g-admin", None, "view-volumes") in rows
+            assert (2, ACTION_ALLOW, "g-admin", None, "manage-volumes") in rows
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_no_admins_group_still_retires_seed_rows(self, tmp_path):
+        """Without an admins group there is nothing to grant, but the
+        retired over-broad Allow Authenticated row must not survive the
+        upgrade — /volumes ends up locked rather than world-manageable."""
         from klangk.model.migrations import m0025_volumes_admin_surface
 
         db = await self._db(tmp_path)
@@ -2803,6 +2830,6 @@ class TestM0025VolumesAdminSurface:
             )
             await db.commit()
             await m0025_volumes_admin_surface.migration.apply(db)
-            assert len(await self._rows(db, "/volumes")) == 2
+            assert await self._rows(db, "/volumes") == []
         finally:
             await db.__aexit__(None, None, None)


### PR DESCRIPTION
Part 1 of 3 for #2974 (umbrella). The `/volumes` and `/images` reworks land as separate PRs; `/admin` follows.

## What changes

`/volumes` moves from a self-service surface to an admin surface:

- **`GET /api/v1/volumes` now checks `view-volumes`** — a new read-only permission, seeded Allow for the `admins` group and delegable separately (a read-only volumes auditor holds it alone).
- **`POST /api/v1/volumes` / `DELETE /api/v1/volumes/{name}` keep `manage-volumes`** (admins by default).
- **The listing is the deployment inventory**: every klangk-managed volume on the instance, each carrying the creating user's id as `owner` (provenance) — replacing the caller-scoped filter. `manage-volumes` holders can delete any managed volume; the per-user ownership 403 is gone.
- **Admin UI**: a new Volumes tab under Admin (view + delete only — no create surface; workspace extra-mount volumes are auto-provisioned at container assembly). The tab is visible to `view-volumes` holders; delete additionally requires `manage-volumes`.
- **CLI**: `klangk volumes ls` shows the owner column; the volume commands are admin-gated now.
- **Migration m0025** rewrites the retired #2946 Allow-Authenticated / Deny-Everyone pair to the admins' view+manage rows on existing deployments (appends at free positions; operator-customized rows preserved; fresh databases untouched — the boot seed owns them).

## Why

The #2946 seed granted `manage-volumes` to every authenticated user — a `manage-*` name (admin-surface vocabulary) on the whole volume inventory, contradicting the #2944 convention. The runtime ownership scoping made the row a misleading global on/off. #2974 decided the admin-surface shape with a view/manage split for read-only delegation.

## Tests

- Seed shape: `/volumes` seeds view+manage for admins (`test_main.py`).
- Routes: admin listing/owner provenance, non-admin 403, delegated viewer read-only, delete-any-volume (`test_api.py`).
- Migration m0025: reseed, idempotency, fresh-db no-op, custom rows preserved, staged permission wins, no-admins-group early return (`test_migrations.py`).
- Flutter: tab listing + provenance, view-only delegate without delete, delete-after-confirm, hidden without permission (`admin_users_page_test.dart`).

Docs: `docs/reference/acl.md`, `docs/reference/api-endpoints.md`, `docs/reference/cli.md`, `docs/features/authorization.md`, changelog (Breaking).

Closes the `/volumes` section of #2974.
