### PR TITLE
Scope volume-create conflict check to instance-managed volumes (#2973)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1816,6 +1816,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Volume-create conflict check no longer leaks foreign volume names
+  (#2973).** `POST /api/v1/volumes` answered 409 for any podman volume
+  name that existed on the host, letting a user probe for volumes the
+  Klangk instance doesn't manage (other instances', operator-created).
+  The 409 is now returned only for volumes labeled with this instance's
+  id; other names fall through to the create, which fails with podman's
+  own name-conflict error.
+
 - **GitHub device-flow gate now normalizes the git host (#2963).**
   With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, a remote
   written as `https://github.com:443/...`, `https://GitHub.com/...`, or

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -216,6 +216,15 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Volume-create conflict check no longer leaks foreign volume names
+  (#2973).** `POST /api/v1/volumes` answered 409 for any podman volume
+  name that existed on the host, letting a user probe for volumes the
+  Klangk instance doesn't manage (other instances', operator-created).
+  The 409 is now returned only for volumes labeled with this instance's
+  id; other names fall through to the create, which fails podman-side —
+  the client sees a bare internal error with no probed name, and
+  podman's conflict text reaches only the server log.
+
 - **`/llm-proxy` endpoints now require a workspace JWT (#2959).** The
   backend validates the workspace token itself, mirroring the egress
   proxy's `forward_auth` check. Previously the backend routes were
@@ -1815,14 +1824,6 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   custom `features.yaml` if present.
 
 ### Fixed
-
-- **Volume-create conflict check no longer leaks foreign volume names
-  (#2973).** `POST /api/v1/volumes` answered 409 for any podman volume
-  name that existed on the host, letting a user probe for volumes the
-  Klangk instance doesn't manage (other instances', operator-created).
-  The 409 is now returned only for volumes labeled with this instance's
-  id; other names fall through to the create, which fails with podman's
-  own name-conflict error.
 
 - **GitHub device-flow gate now normalizes the git host (#2963).**
   With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, a remote

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -298,9 +298,12 @@ async def create_volume(
                 status_code=409, detail=f"Volume {body.name!r} already exists"
             )
     # A non-managed name (another instance's or the operator's volume)
-    # falls through to create_volume, which surfaces podman's own
-    # "volume already exists" failure instead of confirming the
-    # volume's existence with a 409 (#2973).
+    # falls through to create_volume: podman's own create failure raises
+    # PodmanError, which reaches the client as a bare 500 with no probed
+    # name in the body. 500-vs-200 still hints at existence, but no
+    # longer with a 409 + echoed detail (#2973). In-instance cross-user
+    # names still 409 (issue scope: instance-managed volumes only; the
+    # admin-surface rework, #2989, narrows who can call this at all).
     info = await app.state.podman.create_volume(
         body.name,
         {

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -290,10 +290,17 @@ async def create_volume(
     user: dict = Depends(acl.has_permission("manage-volumes")),
     app=Depends(get_app_dep),
 ):
-    if await app.state.podman.inspect_volume(body.name) is not None:
-        raise HTTPException(
-            status_code=409, detail=f"Volume {body.name!r} already exists"
-        )
+    existing = await app.state.podman.inspect_volume(body.name)
+    if existing is not None:
+        labels = existing.get("Labels") or {}
+        if labels.get("klangk.instance") == app.state.util.instance_id():
+            raise HTTPException(
+                status_code=409, detail=f"Volume {body.name!r} already exists"
+            )
+    # A non-managed name (another instance's or the operator's volume)
+    # falls through to create_volume, which surfaces podman's own
+    # "volume already exists" failure instead of confirming the
+    # volume's existence with a 409 (#2973).
     info = await app.state.podman.create_volume(
         body.name,
         {

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6816,14 +6816,16 @@ class TestVolumeRoutes:
         assert resp.status_code == 409
 
     async def test_create_volume_foreign_instance_not_enumerable(
-        self, client, user
+        self, app, user
     ):
         """#2973: a volume owned by another instance must not confirm its
-        existence via 409 — the create falls through to podman and
-        surfaces its own failure instead."""
-        headers = await _auth_headers(client)
+        existence via 409 — the create falls through to podman, and the
+        client sees a bare 500 whose body carries no probed name
+        (podman's own conflict text stays in the server log)."""
         mock_create = AsyncMock(
-            side_effect=podman.PodmanError(500, "volume already exists")
+            side_effect=podman.PodmanError(
+                500, "volume with name 'foreign-vol' already exists"
+            )
         )
         with (
             patch.object(
@@ -6837,14 +6839,20 @@ class TestVolumeRoutes:
                 ),
             ),
             patch.object(_mock_pod, "create_volume", mock_create),
-            pytest.raises(podman.PodmanError),
         ):
-            await client.post(
-                "/api/v1/volumes",
-                json={"name": "foreign-vol"},
-                headers=headers,
-            )
+            transport = ASGITransport(app=app, raise_app_exceptions=False)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as c:
+                headers = await _auth_headers(c)
+                resp = await c.post(
+                    "/api/v1/volumes",
+                    json={"name": "foreign-vol"},
+                    headers=headers,
+                )
         assert mock_create.await_count == 1
+        assert resp.status_code == 500
+        assert "foreign-vol" not in resp.text
 
     async def test_create_volume_error_propagates(self, client, user):
         headers = await _auth_headers(client)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6806,7 +6806,7 @@ class TestVolumeRoutes:
         with patch.object(
             _mock_pod,
             "inspect_volume",
-            AsyncMock(return_value={"Name": "dup-vol"}),
+            AsyncMock(return_value=_managed_volume(user["id"])),
         ):
             resp = await client.post(
                 "/api/v1/volumes",
@@ -6814,6 +6814,37 @@ class TestVolumeRoutes:
                 headers=headers,
             )
         assert resp.status_code == 409
+
+    async def test_create_volume_foreign_instance_not_enumerable(
+        self, client, user
+    ):
+        """#2973: a volume owned by another instance must not confirm its
+        existence via 409 — the create falls through to podman and
+        surfaces its own failure instead."""
+        headers = await _auth_headers(client)
+        mock_create = AsyncMock(
+            side_effect=podman.PodmanError(500, "volume already exists")
+        )
+        with (
+            patch.object(
+                _mock_pod,
+                "inspect_volume",
+                AsyncMock(
+                    return_value={
+                        "Name": "foreign-vol",
+                        "Labels": {"klangk.instance": "other"},
+                    }
+                ),
+            ),
+            patch.object(_mock_pod, "create_volume", mock_create),
+            pytest.raises(podman.PodmanError),
+        ):
+            await client.post(
+                "/api/v1/volumes",
+                json={"name": "foreign-vol"},
+                headers=headers,
+            )
+        assert mock_create.await_count == 1
 
     async def test_create_volume_error_propagates(self, client, user):
         headers = await _auth_headers(client)


### PR DESCRIPTION
## What

`POST /api/v1/volumes` pre-checked `podman volume inspect <name>` and returned
409 whenever *any* volume with that name existed — without checking the
`klangk.instance` label. Any authenticated user (the endpoint is Allow
Authenticated for `manage-volumes`, #2946) could probe whether an arbitrary
host podman volume exists: 409 = exists, 200 = didn't. Non-managed volumes
(other instances, operator-created host volumes) were enumerable this way.

## Change

The conflict pre-check now follows the `DELETE /volumes/{name}` pattern
(resources.py): it 409s only when the existing volume carries this instance's
`klangk.instance` label. A non-managed name falls through to `create_volume`,
which fails podman-side — the client sees a bare 500 whose body carries no
probed name; podman's conflict text reaches only the server log.

## Scope note (deliberate)

Per the issue's preferred proposal, the pre-check is scoped to *instance*
label only, not `klangk.user-id`: within this instance, a 409-vs-200 still
tells a caller whether another user's managed volume name exists. #2989 moves
`/volumes` to the admin surface and gates `manage-volumes` away from
Allow-Authenticated, narrowing the probe population to admins; tightening the
409 to `user-id` (or namespacing names per user) can ride that rework if
wanted.

## Tests

- existing managed volume → 409 (duplicate test uses a managed-labeled volume)
- existing non-managed (foreign instance) volume → falls through to
  `create_volume`; asserted client-side via a `raise_app_exceptions=False`
  transport: status 500, probed name absent from the body (a future global
  `PodmanError` handler that renders `e.message` would fail this test)
- absent volume → 200 (unchanged)

Full suite green: 6508 passed, 100% coverage; xenon pass.

Closes #2973.
