### PR TITLE
admin: derive instance-admin status from group membership (#2974)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,19 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **`/volumes` is now an admin surface (#2974).** The volume listing
+  checks the new `view-volumes` permission on `/volumes`, and
+  create/delete check `manage-volumes` — both seeded Allow for the
+  `admins` group (migration m0024 rewrites the #2946 Allow
+  Authenticated rows on existing deployments; operator-customized
+  rows are preserved). Non-admin users lose volume API access by
+  default — re-grant via the ACL editor if a deploy wants them back.
+  The listing now returns the whole deployment inventory (each entry
+  carries the creating user as `owner`) and `manage-volumes` holders
+  can delete any managed volume — the per-user ownership scoping is
+  gone. The web frontend gains a Volumes tab under Admin (view +
+  delete), and the CLI volume commands are now admin-gated.
+
 - **Workspace-sphere permission names (#2946).** Every stored ACE and
   every client that checks a workspace permission must use the new
   specific names: `create-workspace` (on `/workspaces`),

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,17 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **`/admin` is retired as an ACL resource (#2974).** Nothing checked a
+  permission on `/admin` since #2944; its rows survived only as the
+  instance-administrator wildcard marker. `/my-permissions` now returns
+  an explicit `is_admin` flag derived from `admins`-group membership
+  (the source of truth), `/admin` is gone from the permission map and
+  the seed, and migration `0027` deletes the stored rows. Scripts and
+  clients that probed the `/admin` `*` ACE for admin status must read
+  the flag instead; delegations that lived on the dead tree match
+  nothing (no endpoint resolved to `/admin` since #2944, so only the
+  marker semantics are affected).
+
 - **Deploy capability toggles moved off the images listing (#2974).**
   `GET /api/v1/images` no longer returns `nix_available` /
   `sudo_available` — clients read them from the new

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,19 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **Deploy capability toggles moved off the images listing (#2974).**
+  `GET /api/v1/images` no longer returns `nix_available` /
+  `sudo_available` — clients read them from the new
+  authenticated-only `GET /api/v1/config` fields of the same names
+  (same posture as the netfilter fields). The web frontend, the TUI
+  create/edit forms, and the `klangk images` CLI surface are migrated;
+  hand-built clients reading the toggles off the images response must
+  switch to `/config`. The dead Deny Everyone row on `/images` is also
+  dropped from the seed (migration `0026` removes it on existing
+  deployments — it could never fire, and no-match is already
+  default-deny); the Allow Authenticated `view-images` default is
+  unchanged and remains operator-modifiable via the ACL editor.
+
 - **`/volumes` is now an admin surface (#2974).** The volume listing
   checks the new `view-volumes` permission on `/volumes`, and
   create/delete check `manage-volumes` — both seeded Allow for the

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -68,6 +68,21 @@ resource targeting the group of your choice via the ACL editor — the
 same recipe as
 [workspace creation](#granting-workspace-creation-to-non-admin-users).
 
+## Volumes
+
+The Volumes tab in the Admin panel shows the deployment's klangk-managed
+podman volumes — every volume on the instance, with its creating user as
+provenance and a delete action. There is no create surface in the tab:
+workspace extra-mount volumes are provisioned automatically at container
+assembly.
+
+The tab is gated by `view-volumes` on `/volumes`; the delete action
+additionally requires `manage-volumes` (both seeded to the `admins`
+group, #2974). This makes read-only delegation possible: grant only
+`view-volumes` to a group and its members see the inventory but cannot
+delete — the same recipe as
+group-management delegation above.
+
 ## Default access rules
 
 On first startup, Klangk seeds these defaults:

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -24,6 +24,7 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 ├── /server                    (flat — lifecycle schedules)
 ├── /events                    (flat — read-only audit)
 ├── /acl                       (flat — the ACL editor itself)
+├── /volumes                   (flat — the volume inventory, admin surface #2974)
 └── /admin                     (marker only — nothing checks here, #2944)
 ```
 
@@ -47,10 +48,9 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/events`      | Deny   | Everyone      | `*`                      |
 | `/acl`         | Allow  | group:admins  | `manage-acls`            |
 | `/acl`         | Deny   | Everyone      | `*`                      |
-| `/volumes`     | Allow  | Authenticated | `manage-volumes`         |
-| `/volumes`     | Deny   | Everyone      | `*`                      |
+| `/volumes`     | Allow  | group:admins  | `view-volumes`           |
+| `/volumes`     | Allow  | group:admins  | `manage-volumes`         |
 | `/images`      | Allow  | Authenticated | `view-images`            |
-| `/images`      | Deny   | Everyone      | `*`                      |
 | `/admin`       | Allow  | group:admins  | `*` (admin marker only)  |
 | `/admin`       | Deny   | Everyone      | `*`                      |
 
@@ -179,8 +179,9 @@ all, #2886).
 ### First-class resource permissions
 
 Every governed surface is a first-class top-level resource (#2944);
-each carries **one** flat `manage-*` permission covering all of its
-actions — no per-action splits:
+each carries a flat permission covering its actions — `manage-*` for
+the whole admin surface, plus view-only splits where read-only
+delegation matters:
 
 | Permission               | Where it is checked | Controls                                                                                                                                                              |
 | ------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -191,7 +192,8 @@ actions — no per-action splits:
 | `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel — plus the drain/consent decider WS handshake                                                                     |
 | `manage-events`          | `/events`           | Read the container start/stop history (`GET /events`) — read-only audit                                                                                               |
 | `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                        |
-| `manage-volumes`         | `/volumes`          | Self-service volumes (still label-scoped to the caller at runtime) — Allow Authenticated by default (#2946)                                                           |
+| `view-volumes`           | `/volumes`          | The Volumes admin tab's read: list the deployment's volume inventory (`GET /volumes`) with per-volume provenance — admins by default, delegable read-only (#2974)     |
+| `manage-volumes`         | `/volumes`          | The volume mutating endpoints (`POST /volumes`, `DELETE /volumes/{name}`) — admins by default (#2974; was Allow Authenticated in #2946)                               |
 | `view-images`            | `/images`           | The image/nix/sudo capability listing the create/edit UIs read (#2946)                                                                                                |
 | `search-users`           | `/users`            | The member-picker type-ahead (`GET /users/search`) — Allow Authenticated by default (#2946)                                                                           |
 | `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing checks it anywhere anymore (#2944, #2946 — the transfer gate now checks `transfer-workspace`)           |

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -60,6 +60,15 @@ permission; unauthenticated users are denied everything. `/admin`
 checks nothing anymore (#2944) — its `*` row only marks "instance
 administrator" for permission-map consumers.
 
+The `/images` Allow Authenticated row is the deliberate exception to
+the admin-default convention (#2974): the listing's consumers are the
+workspace create/edit UIs, which non-admins reach with
+`create-workspace`/`edit-workspace`. It is still an operator choice —
+delete the row (default-deny then takes over) or scope it to a group in
+the ACL editor; no trailing Deny Everyone row is seeded because it could
+never fire (the JWT middleware rejects unauthenticated requests before
+any ACL check) and no-match is already default-deny.
+
 ### Granting workspace creation to non-admin users
 
 By default only administrators can create workspaces (#2569). To allow
@@ -194,7 +203,7 @@ delegation matters:
 | `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                        |
 | `view-volumes`           | `/volumes`          | The Volumes admin tab's read: list the deployment's volume inventory (`GET /volumes`) with per-volume provenance — admins by default, delegable read-only (#2974)     |
 | `manage-volumes`         | `/volumes`          | The volume mutating endpoints (`POST /volumes`, `DELETE /volumes/{name}`) — admins by default (#2974; was Allow Authenticated in #2946)                               |
-| `view-images`            | `/images`           | The image/nix/sudo capability listing the create/edit UIs read (#2946)                                                                                                |
+| `view-images`            | `/images`           | The image listing the create/edit UIs read (#2946; Allow Authenticated by default — the deliberate, ACL-editor-modifiable exception, #2974)                           |
 | `search-users`           | `/users`            | The member-picker type-ahead (`GET /users/search`) — Allow Authenticated by default (#2946)                                                                           |
 | `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing checks it anywhere anymore (#2944, #2946 — the transfer gate now checks `transfer-workspace`)           |
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -24,8 +24,7 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 ├── /server                    (flat — lifecycle schedules)
 ├── /events                    (flat — read-only audit)
 ├── /acl                       (flat — the ACL editor itself)
-├── /volumes                   (flat — the volume inventory, admin surface #2974)
-└── /admin                     (marker only — nothing checks here, #2944)
+└── /volumes                   (flat — the volume inventory, admin surface #2974)
 ```
 
 ## Default ACEs (seeded on first startup)
@@ -51,14 +50,17 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/volumes`     | Allow  | group:admins  | `view-volumes`           |
 | `/volumes`     | Allow  | group:admins  | `manage-volumes`         |
 | `/images`      | Allow  | Authenticated | `view-images`            |
-| `/admin`       | Allow  | group:admins  | `*` (admin marker only)  |
-| `/admin`       | Deny   | Everyone      | `*`                      |
 
 These defaults mean: any logged-in user can view pages; only members of
 the `admins` group can create workspaces or hold a `manage-*`
-permission; unauthenticated users are denied everything. `/admin`
-checks nothing anymore (#2944) — its `*` row only marks "instance
-administrator" for permission-map consumers.
+permission; unauthenticated users are denied everything.
+
+Instance-administrator status is **not** an ACL anymore (#2974): the
+`/admin` marker resource is retired (nothing checked a permission there
+since #2944), and `/my-permissions` derives an explicit `is_admin` flag
+from `admins`-group membership — the source of truth. Clients that
+probed the `/admin` `*` wildcard ACE must read the flag instead
+(migration `0027` removes the stored marker rows).
 
 The `/images` Allow Authenticated row is the deliberate exception to
 the admin-default convention (#2974): the listing's consumers are the
@@ -205,7 +207,6 @@ delegation matters:
 | `manage-volumes`         | `/volumes`          | The volume mutating endpoints (`POST /volumes`, `DELETE /volumes/{name}`) — admins by default (#2974; was Allow Authenticated in #2946)                               |
 | `view-images`            | `/images`           | The image listing the create/edit UIs read (#2946; Allow Authenticated by default — the deliberate, ACL-editor-modifiable exception, #2974)                           |
 | `search-users`           | `/users`            | The member-picker type-ahead (`GET /users/search`) — Allow Authenticated by default (#2946)                                                                           |
-| `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing checks it anywhere anymore (#2944, #2946 — the transfer gate now checks `transfer-workspace`)           |
 
 `PUT /acl/resource` additionally requires `share-advanced` on the target
 when that target is an individual workspace (`/workspaces/{id}`) — the

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -569,16 +569,24 @@ No request body.
 
 ### GET `/api/v1/volumes`
 
-List podman volumes owned by the current user.
+List the deployment's klangk-managed podman volumes — the admin
+inventory view, every volume on the instance with its creating user as
+provenance.
 
-**Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946; seeded Allow for Authenticated; volumes stay
-label-scoped to the caller at runtime).
+**Auth:** JWT required. User must have the `view-volumes` permission
+on `/volumes` (#2974; seeded Allow for the admins group, delegable
+read-only).
 
 No request body.
 
 ```json
-[{ "name": "my-volume", "created": "2025-01-01T12:00:00Z" }]
+[
+  {
+    "name": "my-volume",
+    "created": "2025-01-01T12:00:00Z",
+    "owner": "<user-id>"
+  }
+]
 ```
 
 ---
@@ -1314,10 +1322,12 @@ Returns `StreamingResponse` (`application/x-ndjson`).
 
 ### POST `/api/v1/volumes`
 
-Create a new podman volume labeled with the current user's ID.
+Create a new podman volume labeled with the current user's ID (the
+label is provenance for the inventory view — workspace extra-mount
+volumes are also auto-provisioned at container assembly).
 
 **Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946).
+on `/volumes` (#2974; seeded Allow for the admins group).
 
 ```json
 { "name": "my-volume" }
@@ -1760,10 +1770,11 @@ Replace all ACL entries for a workspace.
 
 ### DELETE `/api/v1/volumes/{name}`
 
-Delete a podman volume. Only the owning user can delete their volumes.
+Delete a klangk-managed podman volume.
 
 **Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946). Checks user ownership.
+on `/volumes` (#2974; admins by default). No per-user ownership check:
+holders administer every managed volume on the instance.
 
 No request body.
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -448,9 +448,12 @@ Get public instance configuration: whether registration and invitations
 are enabled, available OIDC providers, login banner text, auth mode,
 and the branding / feature flags the pre-auth UI needs. An
 **authenticated** caller additionally receives the deploy-wide netfilter
-default + enabled flag (the egress perimeter is not exposed pre-auth),
-plus any feature-declared frontend config keys and `features_enable`
-when set.
+default + enabled flag (the egress perimeter is not exposed pre-auth)
+and the deploy-level capability toggles `nix_available` /
+`sudo_available` (#2974 — moved off the images listing; whether the
+per-workspace nix mount can arm, and whether the deploy allows sudo at
+all), plus any feature-declared frontend config keys and
+`features_enable` when set.
 
 **Auth:** None (public payload; authenticated callers get a few extra
 fields).
@@ -480,9 +483,14 @@ No request body.
   "privacy_url": "",
   "aup_url": "",
   "support_url": "",
-  "support_email": ""
+  "support_email": "",
+  "nix_available": false,
+  "sudo_available": true
 }
 ```
+
+The last two keys (like `netfilter_enabled`) appear only on the
+authenticated payload.
 
 `auth_modes` is a string — one of `password`, `oidc`, `both`, or `none`
 (no-login single-user mode). The frontend and CLI branch on this value;
@@ -493,10 +501,12 @@ see [Auth Modes](../features/auth-modes.md).
 ### GET `/api/v1/images`
 
 List available container images that can be used when creating or
-editing workspaces.
+editing workspaces. Deployment-level capability toggles (nix/sudo
+availability) moved to the authenticated-only `/config` fields (#2974).
 
 **Auth:** JWT required. User must have the `view-images` permission on
-`/images` (#2946; seeded Allow for Authenticated).
+`/images` (#2946; seeded Allow for Authenticated — the deliberate,
+ACL-editor-modifiable default, #2974).
 
 No request body.
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -520,7 +520,9 @@ No request body.
 
 Get the current user's effective permissions. If a `resource` query param
 is provided, returns permissions for that specific resource; otherwise
-returns permissions across all static resources.
+returns permissions across all static resources. The `is_admin` flag is
+derived from `admins`-group membership (#2974) — the instance-admin
+marker, replacing the retired `/admin` wildcard ACE.
 
 **Auth:** JWT required. Optional query param: `resource`.
 
@@ -530,6 +532,7 @@ No request body.
 {
   "user_id": "uuid",
   "email": "user@example.com",
+  "is_admin": false,
   "groups": [],
   "permissions": {
     "/workspaces/uuid": ["view", "terminal", "files-view"]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -297,9 +297,9 @@ klangk admin users set-password user@example.com   # set/reset a password (admin
 klangk admin invitations send user@example.com     # send an invitation email (admin only)
 klangk admin invitations ls                       # list all invitations (admin only)
 klangk images                       # list available container images
-klangk volumes ls                   # list your podman volumes
-klangk volumes create nix-store     # create a named volume (owned by you)
-klangk volumes rm nix-store         # delete a volume (must be yours)
+klangk volumes ls                   # list the deployment's podman volumes (admin)
+klangk volumes create nix-store     # create a named volume (admin)
+klangk volumes rm nix-store         # delete a volume (admin)
 ```
 
 `klangk status` shows the active server, your user id/email, and whether

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -45,6 +45,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   bool _canUsers = false;
   bool _canGroups = false;
+  bool _canVolumes = false;
   bool _canInvitations = false;
   bool _canServer = false;
   bool _canEvents = false;
@@ -100,6 +101,10 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     _canInvitations = auth.hasPermission('/invitations', 'manage-invitations');
     _canServer = auth.hasPermission('/server', 'manage-server-schedule');
     _canEvents = auth.hasPermission('/events', 'manage-events');
+    // #2974: the Volumes tab is the /volumes admin surface — visible to
+    // view-volumes holders (read-only auditors), deleting needs
+    // manage-volumes (checked inside the tab).
+    _canVolumes = auth.hasPermission('/volumes', 'view-volumes');
     // The Access Control browser reads /acl/*, gated on `manage-acls`
     // (#2940) — root-equivalent (it can rewrite ACLs on any
     // resource), so it is granted only to administrators.
@@ -540,6 +545,13 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         label: 'Events',
         icon: Icons.history,
         view: const ContainerEventsPanel(),
+      );
+    }
+    if (_canVolumes) {
+      addTab(
+        label: 'Volumes',
+        icon: Icons.storage,
+        view: const _VolumesTab(key: ValueKey('volumes-tab')),
       );
     }
     // The Access Control browser reads /acl/*, gated on
@@ -1890,6 +1902,158 @@ class _SystemAgentBadge extends StatelessWidget {
   }
 }
 
+/// Volumes tab (#2974): the /volumes admin surface — the deployment's
+/// klangk-managed volume inventory with per-volume provenance and a
+/// delete action. Visible to view-volumes holders (read-only
+/// auditors); the delete action additionally requires manage-volumes.
+/// No create surface: workspace extra-mount volumes are provisioned
+/// at container assembly (ensure_volumes), and the CLI admin commands
+/// remain the scripting path.
+class _VolumesTab extends StatefulWidget {
+  const _VolumesTab({super.key});
+
+  @override
+  State<_VolumesTab> createState() => _VolumesTabState();
+}
+
+class _VolumesTabState extends State<_VolumesTab> {
+  List<Map<String, dynamic>> _volumes = [];
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVolumes();
+  }
+
+  Future<void> _loadVolumes() async {
+    try {
+      final auth = context.read<AuthService>();
+      final resp = await auth.authGet('/api/v1/volumes');
+      if (resp.statusCode == 200) {
+        if (!mounted) return;
+        setState(() {
+          _volumes =
+              (jsonDecode(resp.body) as List).cast<Map<String, dynamic>>();
+          _loading = false;
+          _error = null;
+        });
+      } else {
+        if (!mounted) return;
+        setState(() {
+          _error = 'Failed to load volumes: ${resp.statusCode}';
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[AdminUsersPage] load volumes failed: $e');
+      if (!mounted) return;
+      setState(() {
+        _error = 'Could not load volumes. Please try again.';
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _deleteVolume(String name) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Volume'),
+        content: Text(
+          'Delete the volume "$name"? Its data is destroyed; workspaces '
+          'mounting it will fail to start.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: KColors.accentRed,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+
+    final auth = context.read<AuthService>();
+    final resp = await auth.authDelete('/api/v1/volumes/$name');
+    if (resp.statusCode == 200) {
+      await _loadVolumes();
+    } else {
+      if (!mounted) return;
+      final detail =
+          (jsonDecode(resp.body) as Map<String, dynamic>)['detail'] as String?;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(detail ?? 'Failed to delete volume')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!),
+            const SizedBox(height: 8),
+            FilledButton(onPressed: _loadVolumes, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_volumes.isEmpty) {
+      return const Center(child: Text('No volumes'));
+    }
+    final canManage =
+        context.read<AuthService>().hasPermission('/volumes', 'manage-volumes');
+    return RefreshIndicator(
+      onRefresh: _loadVolumes,
+      child: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _volumes.length,
+        itemBuilder: (ctx, i) {
+          final volume = _volumes[i];
+          final name = volume['name'] as String? ?? '';
+          final created = (volume['created'] as String?) ?? '';
+          final owner = (volume['owner'] as String?) ?? '';
+          final ownerTag = owner.length >= 8 ? owner.substring(0, 8) : owner;
+          return Card(
+            margin: const EdgeInsets.only(bottom: 8),
+            child: ListTile(
+              leading: const Icon(Icons.storage),
+              title: Text(name, key: const ValueKey('volume-name')),
+              subtitle: Text(
+                created.isNotEmpty
+                    ? 'Created $created · owner $ownerTag'
+                    : 'owner $ownerTag',
+              ),
+              trailing: canManage
+                  ? IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Delete volume',
+                      onPressed: () => _deleteVolume(name),
+                    )
+                  : null,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
 /// ACL browser tab: shows the static resource tree and lets you edit ACLs.
 class _AclBrowserTab extends StatefulWidget {
   const _AclBrowserTab();
@@ -1932,7 +2096,8 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
     '/invitations': 'manage-invitations',
     '/server': 'manage-server-schedule',
     '/events': 'manage-events (read-only audit)',
-    '/volumes': 'manage-volumes — self-service volumes (Allow Authenticated)',
+    '/volumes':
+        'view-volumes — see the volume inventory; manage-volumes — delete',
     '/images': 'view-images — the image/capability listing',
     '/acl': 'manage-acls — root-equivalent, administrators only',
   };

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -2086,7 +2086,8 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
   /// checks key on these names, so the browser shows the mapping next
   /// to the ACE list instead of leaving the operator to guess which
   /// name the server actually asks for on this resource. /admin no
-  /// longer appears — it is only the instance-admin wildcard marker.
+  /// longer appears — it is retired entirely (#2974); instance-admin
+  /// status is the is_admin flag on /my-permissions.
   static const _resourceHints = {
     '/': 'view — held by every authenticated user via the seed',
     '/workspaces':

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -155,14 +155,18 @@ class AuthService extends ChangeNotifier {
   /// Permissions fetched from /api/v1/my-permissions.
   Map<String, List<String>> _permissions = {};
   List<Map<String, dynamic>> _groups = [];
+  bool _isAdmin = false;
 
   Map<String, List<String>> get permissions => _permissions;
   List<Map<String, dynamic>> get groups => _groups;
 
-  bool get isAdmin => hasPermission('/admin', '*');
+  /// #2974: instance-admin status — the explicit is_admin flag from
+  /// /my-permissions, derived server-side from admins-group membership
+  /// (replaces the /admin wildcard-ACE marker lookup).
+  bool get isAdmin => _isAdmin;
 
-  /// True for wildcard admins and for holders of any delegated /admin
-  /// tab permission (#2923, #2940): the principals allowed into the admin
+  /// True for instance admins and for holders of any delegated admin-tab
+  /// permission (#2923, #2940): the principals allowed into the admin
   /// section at all. The route guard and the app-bar admin icon key off
   /// this — a delegated user sees only the tabs their ACEs grant, admins
   /// see everything.
@@ -287,6 +291,7 @@ class AuthService extends ChangeNotifier {
         _groups = List<Map<String, dynamic>>.from(
           data['groups'] as List? ?? [],
         );
+        _isAdmin = data['is_admin'] == true;
       } else if (resp.statusCode == 401) {
         await _clearToken();
       }
@@ -345,6 +350,7 @@ class AuthService extends ChangeNotifier {
     _token = null;
     _permissions = {};
     _groups = [];
+    _isAdmin = false;
     // The pending redirect belongs to the session being cleared; drop it
     // so the next login can never inherit the old session's destination
     // (#2670). If the user was on a protected page, guardAuth re-stashes

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -157,7 +157,8 @@ class AuthService extends ChangeNotifier {
       hasPermission('/groups', 'manage-groups') ||
       hasPermission('/server', 'manage-server-schedule') ||
       hasPermission('/events', 'manage-events') ||
-      hasPermission('/acl', 'manage-acls');
+      hasPermission('/acl', 'manage-acls') ||
+      hasPermission('/volumes', 'view-volumes');
 
   /// Check if the user has a specific permission on a resource.
   bool hasPermission(String resource, String permission) {

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -53,6 +53,13 @@ class AuthService extends ChangeNotifier {
   // overrides, not unions) and gate the editor on netfilter_enabled.
   List<String> _netfilterDefaultDomains = const [];
   bool _netfilterEnabled = false;
+
+  /// #2974: deploy-level capability toggles (from the authenticated-only
+  /// /config fields — moved off the /images listing). The workspace
+  /// create/edit UIs read these to decide whether the nix and sudo
+  /// toggles render.
+  bool _nixAvailable = false;
+  bool _sudoAvailable = false;
   Timer? _permissionTimer;
   Timer? _refreshTimer;
 
@@ -112,6 +119,15 @@ class AuthService extends ChangeNotifier {
   /// The UI shows the allowed-domains editor only when the deploy can
   /// actually enforce it.
   bool get netfilterEnabled => _netfilterEnabled;
+
+  /// #2202: whether the per-workspace nix flag can trigger the
+  /// per-workspace /nix mount — only when the backend is configured AND
+  /// nix_enabled on; inert otherwise.
+  bool get nixAvailable => _nixAvailable;
+
+  /// #2017: whether the deploy allows sudo at all — the ceiling the
+  /// per-workspace lock-down toggle opts out below.
+  bool get sudoAvailable => _sudoAvailable;
 
   /// Decode the JWT payload.
   Map<String, dynamic>? get _payload {
@@ -212,6 +228,8 @@ class AuthService extends ChangeNotifier {
             (data['netfilter_default_domains'] as List?)?.cast<String>() ??
                 const [];
         _netfilterEnabled = (data['netfilter_enabled'] as bool?) ?? false;
+        _nixAvailable = (data['nix_available'] as bool?) ?? false;
+        _sudoAvailable = (data['sudo_available'] as bool?) ?? false;
         _passwordPolicy = PasswordPolicy.fromConfig(data);
         // White-label values — mirrored into the Branding helper so widgets
         // that don't have an AuthService context (e.g. the app-bar logo,

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -79,6 +79,7 @@ class AclEditorState extends State<AclEditor> {
     'manage-events',
     'search-users',
     'manage-volumes',
+    'view-volumes',
     'view-images',
   ];
 

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -440,14 +440,11 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     final defaultImage = imageData?['default'] as String? ?? 'klangk-pi';
     final allowedImages =
         (imageData?['allowed'] as List?)?.cast<String>() ?? [defaultImage];
-    // #2202: the per-workspace nix toggle is only meaningful when the server
-    // has a zfs seed dataset configured (nix_available); otherwise nix is
-    // image-only and the toggle would do nothing.
-    final nixAvailable = imageData?['nix_available'] == true;
-    // #2017: the sudo lock-down toggle is only meaningful when the deploy
-    // allows sudo at all — the per-workspace knob may only opt a workspace
-    // out below that ceiling.
-    final sudoAvailable = imageData?['sudo_available'] == true;
+    // #2974: the deploy-level toggles now live on the auth service's
+    // config cache (authenticated-only /config fields), not the images
+    // listing.
+    final nixAvailable = _auth.nixAvailable;
+    final sudoAvailable = _auth.sudoAvailable;
 
     if (!mounted) return;
 

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -55,7 +55,7 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
   bool _nixAvailable = false;
 
   // #2017: whether the deploy allows sudo at all (sudo_available on
-  // /api/v1/images) — gates the settings form's lock-down toggle.
+  // /api/v1/config, #2974) — gates the settings form's lock-down toggle.
   bool _sudoAvailable = false;
   bool _loading = true;
   String? _error;
@@ -124,16 +124,20 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
 
     _workspace = ws;
 
-    // Load allowed images
+    // Load allowed images. #2974: the deploy-level nix/sudo toggles
+    // come from the auth service's config cache — call
+    // refreshDeployConfig so a SIGHUP-reloaded deploy is reflected
+    // without a re-login.
     try {
+      await auth.refreshDeployConfig();
       final imgResp = await auth.authGet('/api/v1/images');
       if (mounted && imgResp.statusCode == 200) {
         final imgData = jsonDecode(imgResp.body) as Map<String, dynamic>;
         _defaultImage = imgData['default'] as String? ?? 'klangk-pi';
         _allowedImages =
             (imgData['allowed'] as List?)?.cast<String>() ?? [_defaultImage];
-        _nixAvailable = imgData['nix_available'] == true;
-        _sudoAvailable = imgData['sudo_available'] == true;
+        _nixAvailable = auth.nixAvailable;
+        _sudoAvailable = auth.sudoAvailable;
       }
     } catch (e) {
       // coverage:ignore-start

--- a/src/frontend/test/admin_invitations_page_test.dart
+++ b/src/frontend/test/admin_invitations_page_test.dart
@@ -75,6 +75,7 @@ http.Client _mockClient(
         jsonEncode({
           'user_id': 'admin-user',
           'email': 'admin@example.com',
+          'is_admin': true,
           'permissions': {
             '/admin': ['*'],
             '/users': ['manage-users'],

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -99,6 +99,7 @@ http.Client _mockClient(
         jsonEncode({
           'user_id': 'admin-user',
           'email': 'admin@example.com',
+          'is_admin': true,
           'permissions': {
             '/admin': ['*'],
             '/users': ['manage-users'],

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -465,6 +465,138 @@ void main() {
     });
   });
 
+  group('AdminUsersPage volumes tab', () {
+    /// Mock client serving [permissions] plus a /volumes listing.
+    /// DELETE mutates [volumes] so the reload reflects the deletion.
+    void serveVolumes(
+      Map<String, List<String>> permissions,
+      List<Map<String, dynamic>> volumes,
+    ) {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/config')) {
+          return http.Response(
+            jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/my-permissions')) {
+          return http.Response(
+            jsonEncode({
+              'user_id': 'admin-user',
+              'email': 'admin@example.com',
+              'permissions': permissions,
+              'groups': [],
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/volumes' && request.method == 'GET') {
+          return http.Response(jsonEncode(volumes), 200);
+        }
+        if (request.url.path.startsWith('/api/v1/volumes/') &&
+            request.method == 'DELETE') {
+          final name = request.url.path.split('/').last;
+          volumes.removeWhere((v) => v['name'] == name);
+          return http.Response(jsonEncode({'status': 'deleted'}), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+    }
+
+    testWidgets('lists the deployment volume inventory for an admin',
+        (tester) async {
+      serveVolumes({
+        '/users': ['manage-users'],
+        '/volumes': ['view-volumes', 'manage-volumes'],
+      }, [
+        {
+          'name': 'vol-a',
+          'created': '2026-01-01T00:00:00Z',
+          'owner': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        },
+        {
+          'name': 'vol-b',
+          'created': '2026-02-02T00:00:00Z',
+          'owner': '12345678-1234-1234-1234-123456789012',
+        },
+      ]);
+
+      await pumpPage(tester);
+
+      expect(find.text('Volumes'), findsOneWidget);
+      await tester.tap(find.text('Volumes'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('vol-a'), findsOneWidget);
+      expect(find.text('vol-b'), findsOneWidget);
+      // Provenance: the creating user's id prefix rides each row.
+      expect(find.textContaining('owner aaaaaaaa'), findsOneWidget);
+      expect(find.textContaining('owner 12345678'), findsOneWidget);
+      // manage-volumes holder: delete offered.
+      expect(find.byTooltip('Delete volume'), findsNWidgets(2));
+    });
+
+    testWidgets('view-only delegate sees the tab without delete actions',
+        (tester) async {
+      serveVolumes({
+        '/volumes': ['view-volumes'],
+      }, [
+        {
+          'name': 'vol-a',
+          'created': '2026-01-01T00:00:00Z',
+          'owner': 'aaaaaaaa-bbbb',
+        },
+      ]);
+
+      await pumpPage(tester);
+
+      // view-volumes alone admits into the admin section (#2974).
+      expect(find.text('Volumes'), findsOneWidget);
+      await tester.tap(find.text('Volumes'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('vol-a'), findsOneWidget);
+      expect(find.byTooltip('Delete volume'), findsNothing);
+    });
+
+    testWidgets('deletes a volume after confirmation', (tester) async {
+      final volumes = <Map<String, dynamic>>[
+        {
+          'name': 'vol-a',
+          'created': '2026-01-01T00:00:00Z',
+          'owner': 'aaaaaaaa-bbbb',
+        },
+      ];
+      serveVolumes({
+        '/volumes': ['view-volumes', 'manage-volumes'],
+      }, volumes);
+
+      await pumpPage(tester);
+      await tester.tap(find.text('Volumes'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Delete volume'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete Volume'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      // The deletion hit the backend and the listing reloaded empty.
+      expect(volumes, isEmpty);
+      expect(find.text('No volumes'), findsOneWidget);
+    });
+
+    testWidgets('hides the Volumes tab without the permission', (tester) async {
+      serveVolumes({
+        '/users': ['manage-users'],
+      }, []);
+
+      await pumpPage(tester);
+
+      expect(find.text('Volumes'), findsNothing);
+    });
+  });
+
   group('AdminUsersPage groups tab', () {
     /// Pump the page on the users tab, then switch to the Groups tab.
     Future<void> pumpGroupsTab(WidgetTester tester) async {

--- a/src/frontend/test/app_bar_actions_test.dart
+++ b/src/frontend/test/app_bar_actions_test.dart
@@ -17,6 +17,7 @@ String _adminToken() {
   final header = base64Url.encode(utf8.encode(jsonEncode({'alg': 'none'})));
   final body = base64Url.encode(utf8.encode(jsonEncode({
     'email': 'admin@example.com',
+    'is_admin': true,
     'permissions': {
       '/admin': ['*'],
     },
@@ -58,6 +59,7 @@ void main() {
             jsonEncode({
               'user_id': 'u1',
               'email': 'admin@example.com',
+              'is_admin': true,
               'permissions': {
                 '/admin': ['*']
               },
@@ -93,6 +95,7 @@ void main() {
             jsonEncode({
               'user_id': 'u1',
               'email': 'admin@example.com',
+              'is_admin': true,
               'permissions': {
                 '/admin': ['*']
               },

--- a/src/frontend/test/app_redirect_test.dart
+++ b/src/frontend/test/app_redirect_test.dart
@@ -59,7 +59,10 @@ void main() {
   // All HTTP the app issues during this flow: config (login page +
   // AuthService), login, and my-permissions. No token exp claim -> no
   // refresh timer for the test to fight with.
-  String installMocks({Map<String, List<String>> permissions = const {}}) {
+  String installMocks({
+    Map<String, List<String>> permissions = const {},
+    bool isAdmin = false,
+  }) {
     final token = makeJwt({'sub': 'user-1', 'email': 'user@example.com'});
     testConfigHttpClientOverride = MockClient((request) async {
       return http.Response(
@@ -83,6 +86,7 @@ void main() {
           jsonEncode({
             'user_id': 'u1',
             'email': 'user@example.com',
+            'is_admin': isAdmin,
             'permissions': permissions,
             'groups': <Map<String, dynamic>>[],
           }),
@@ -210,11 +214,14 @@ void main() {
   // Mirror that here: let the persisted token restore (permissions fetch
   // included) settle before mounting the router at /admin/users.
   Future<AuthService> restoreSession(
-      WidgetTester tester, Map<String, List<String>> permissions) async {
+    WidgetTester tester,
+    Map<String, List<String>> permissions, {
+    bool isAdmin = false,
+  }) async {
     final token = makeJwt({'sub': 'user-1', 'email': 'user@example.com'});
     // ignore: invalid_use_of_visible_for_testing
     SharedPreferences.setMockInitialValues({'klangk_jwt': token});
-    installMocks(permissions: permissions);
+    installMocks(permissions: permissions, isAdmin: isAdmin);
     final auth = AuthService();
     // A quiet host widget: pump until _loadToken (config + permissions)
     // completes and initialized flips true.
@@ -250,9 +257,13 @@ void main() {
 
   testWidgets('restored admin session at /admin/users stays put (#2669)',
       (tester) async {
-    final auth = await restoreSession(tester, const {
-      '/admin': ['*'],
-    });
+    final auth = await restoreSession(
+      tester,
+      const {
+        '/users': ['manage-users'],
+      },
+      isAdmin: true,
+    );
     expect(auth.isAdmin, isTrue);
 
     final router = buildRouter(auth, '/admin/users');

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -27,6 +27,7 @@ void main() {
   http.Client _emptyConfigClient({
     Map<String, List<String>>? permissions,
     List<Map<String, dynamic>>? groups,
+    bool isAdmin = false,
   }) {
     return MockClient((request) async {
       if (request.url.path.contains('/api/v1/config')) {
@@ -43,6 +44,7 @@ void main() {
           jsonEncode({
             'user_id': 'test',
             'email': 'test@example.com',
+            'is_admin': isAdmin,
             'permissions': permissions ?? {},
             'groups': groups ?? [],
           }),
@@ -870,11 +872,9 @@ void main() {
       expect(service.userId, 'user-42');
     });
 
-    test('isAdmin returns true when admin permission present', () async {
+    test('isAdmin returns true when the flag is set', () async {
       testAuthHttpClientOverride = _emptyConfigClient(
-        permissions: {
-          '/admin': ['*'],
-        },
+        isAdmin: true,
         groups: [
           {'id': 'g1', 'name': 'admins'},
         ],
@@ -884,7 +884,6 @@ void main() {
       final service = AuthService();
       await Future.delayed(Duration.zero);
       expect(service.isAdmin, isTrue);
-      expect(service.hasPermission('/admin', 'manage_users'), isTrue);
     });
 
     test('isAdmin returns false when no admin permission', () async {
@@ -918,8 +917,9 @@ void main() {
 
     test('permissions cleared on logout', () async {
       testAuthHttpClientOverride = _emptyConfigClient(
+        isAdmin: true,
         permissions: {
-          '/admin': ['*'],
+          '/users': ['manage-users'],
         },
       );
       final token = makeJwt({'sub': 'user-1'});
@@ -966,9 +966,10 @@ void main() {
             jsonEncode({
               'user_id': 'u',
               'email': 'u',
+              'is_admin': isAdmin,
               'permissions': isAdmin
                   ? {
-                      '/admin': ['*']
+                      '/users': ['manage-users']
                     }
                   : {
                       '/': ['view']

--- a/src/frontend/test/container_events_panel_test.dart
+++ b/src/frontend/test/container_events_panel_test.dart
@@ -70,8 +70,9 @@ String get _adminToken {
 /// plus a custom handler for everything else.
 http.Client _mockClient(
   Map<String, List<String>> permissions,
-  Future<http.Response> Function(http.Request) handler,
-) {
+  Future<http.Response> Function(http.Request) handler, {
+  bool isAdmin = true,
+}) {
   return MockClient((request) async {
     if (request.url.path.contains('/api/v1/config')) {
       return http.Response(
@@ -84,6 +85,7 @@ http.Client _mockClient(
         jsonEncode({
           'user_id': 'admin-user',
           'email': 'admin@example.com',
+          'is_admin': isAdmin,
           'permissions': permissions,
           'groups': [
             {'id': 'g1', 'name': 'admin'}
@@ -299,9 +301,9 @@ void main() {
           '/users': ['manage-users'],
           '/groups': ['manage-groups'],
           '/invitations': ['manage-invitations'],
-          '/admin': ['admin'],
         },
         (request) async => http.Response('Not found', 404),
+        isAdmin: false,
       );
 
       await pumpPage(tester, toEvents: false);

--- a/src/frontend/test/server_schedule_panel_test.dart
+++ b/src/frontend/test/server_schedule_panel_test.dart
@@ -73,6 +73,7 @@ http.Client _mockClient(
         jsonEncode({
           'user_id': 'admin-user',
           'email': 'admin@example.com',
+          'is_admin': true,
           'permissions': {
             '/admin': ['*'],
           },

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -107,6 +107,7 @@ void main() {
     Map<String, List<String>>? permissions,
     List<Map<String, dynamic>>? groups,
     bool netfilterEnabled = false,
+    bool isAdmin = false,
   }) {
     return MockClient((request) async {
       if (request.url.path.contains('/api/v1/config')) {
@@ -124,6 +125,7 @@ void main() {
           jsonEncode({
             'user_id': 'test',
             'email': 'test@example.com',
+            'is_admin': isAdmin,
             'permissions': permissions ??
                 {
                   '/': ['view'],
@@ -1502,12 +1504,12 @@ void main() {
           return http.Response('Not found', 404);
         },
         permissions: {
-          '/admin': ['*'],
           '/workspaces': ['create-workspace'],
         },
         groups: [
           {'id': 'g1', 'name': 'admins'},
         ],
+        isAdmin: true,
       );
 
       await tester.pumpWidget(buildPage());
@@ -1966,12 +1968,12 @@ void main() {
           return http.Response('Not found', 404);
         },
         permissions: {
-          '/admin': ['*'],
           '/workspaces': ['create-workspace'],
         },
         groups: [
           {'id': 'g1', 'name': 'admins'},
         ],
+        isAdmin: true,
       );
 
       String? navigatedTo;

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -78,7 +78,11 @@ http.Client _client({
     final p = request.url.path;
     if (p == '/api/v1/config') {
       return http.Response(
-        jsonEncode({'netfilter_enabled': netfilterEnabled}),
+        jsonEncode({
+          'netfilter_enabled': netfilterEnabled,
+          'nix_available': nixAvailable,
+          'sudo_available': sudoAvailable,
+        }),
         200,
       );
     }
@@ -94,8 +98,6 @@ http.Client _client({
         jsonEncode({
           'default': 'klangk-pi',
           'allowed': ['klangk-pi', 'other:latest'],
-          'nix_available': nixAvailable,
-          'sudo_available': sudoAvailable,
         }),
         200,
       );
@@ -198,7 +200,9 @@ void main() {
       Map<String, dynamic>? savedBody;
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
-        if (p == '/api/v1/config') return http.Response(jsonEncode({}), 200);
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({}), 200);
+        }
         if (p == '/api/v1/workspaces') {
           return http.Response(
             jsonEncode([
@@ -355,7 +359,10 @@ void main() {
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
         if (p == '/api/v1/config') {
-          return http.Response(jsonEncode({}), 200);
+          return http.Response(
+            jsonEncode({'nix_available': true}),
+            200,
+          );
         }
         if (p == '/api/v1/workspaces') {
           return http.Response(jsonEncode([_workspace]), 200);
@@ -368,7 +375,6 @@ void main() {
             jsonEncode({
               'default': 'klangk-pi',
               'allowed': ['klangk-pi'],
-              'nix_available': true,
             }),
             200,
           );
@@ -433,7 +439,9 @@ void main() {
       Map<String, dynamic>? savedBody;
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
-        if (p == '/api/v1/config') return http.Response(jsonEncode({}), 200);
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({'nix_available': true}), 200);
+        }
         if (p == '/api/v1/workspaces') {
           return http.Response(
             jsonEncode([
@@ -453,7 +461,6 @@ void main() {
             jsonEncode({
               'default': 'klangk-pi',
               'allowed': ['klangk-pi'],
-              'nix_available': true,
             }),
             200,
           );
@@ -561,7 +568,9 @@ void main() {
       Map<String, dynamic>? savedBody;
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
-        if (p == '/api/v1/config') return http.Response(jsonEncode({}), 200);
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({'sudo_available': true}), 200);
+        }
         if (p == '/api/v1/workspaces') {
           return http.Response(
             jsonEncode([
@@ -578,7 +587,6 @@ void main() {
             jsonEncode({
               'default': 'klangk-pi',
               'allowed': ['klangk-pi'],
-              'sudo_available': true,
             }),
             200,
           );
@@ -615,7 +623,9 @@ void main() {
       Map<String, dynamic>? savedBody;
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
-        if (p == '/api/v1/config') return http.Response(jsonEncode({}), 200);
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({'sudo_available': true}), 200);
+        }
         if (p == '/api/v1/workspaces') {
           return http.Response(
             jsonEncode([
@@ -635,7 +645,6 @@ void main() {
             jsonEncode({
               'default': 'klangk-pi',
               'allowed': ['klangk-pi'],
-              'sudo_available': true,
             }),
             200,
           );
@@ -734,7 +743,9 @@ void main() {
       Map<String, dynamic>? savedBody;
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
-        if (p == '/api/v1/config') return http.Response(jsonEncode({}), 200);
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({}), 200);
+        }
         if (p == '/api/v1/workspaces') {
           return http.Response(
             jsonEncode([
@@ -754,7 +765,6 @@ void main() {
             jsonEncode({
               'default': 'klangk-pi',
               'allowed': ['klangk-pi'],
-              'nix_available': true,
             }),
             200,
           );
@@ -1566,7 +1576,9 @@ void main() {
       Map<String, dynamic>? savedBody;
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
-        if (p == '/api/v1/config') return http.Response(jsonEncode({}), 200);
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({}), 200);
+        }
         if (p == '/api/v1/workspaces') {
           return http.Response(
             jsonEncode([
@@ -1739,7 +1751,10 @@ void main() {
       testAuthHttpClientOverride = MockClient((request) async {
         final p = request.url.path;
         if (p == '/api/v1/config') {
-          return http.Response(jsonEncode({}), 200);
+          return http.Response(
+            jsonEncode({}),
+            200,
+          );
         }
         if (p == '/api/v1/workspaces') {
           return http.Response(

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -43,6 +43,7 @@ from .. import (
     wshandler,
 )
 from .common import ALL_PERMISSIONS, autostart_allowed, get_app_dep
+from ..settings import parse_bool_setting
 
 # Imported under an alias: the ``from . import auth as _auth_routes`` line
 # below pulls in the api/auth.py *submodule*, and the import machinery writes
@@ -274,6 +275,16 @@ async def get_config(
             app.state.netfilter.default_domains()
         )
         config["netfilter_enabled"] = app.state.netfilter.enabled()
+        # #2974: the deploy-level nix/sudo toggles the workspace
+        # create/edit UIs render moved here from GET /images — they are
+        # deployment config, not image data. Same authenticated-only
+        # posture as the netfilter fields (nix_available: #2202/#2560 —
+        # whether the per-workspace nix flag can trigger the per-
+        # workspace /nix mount; sudo_available: #2017 — whether the
+        # deploy allows sudo at all, the ceiling the per-workspace
+        # lock-down toggle opts out below).
+        config["nix_available"] = app.state.nix.available
+        config["sudo_available"] = parse_bool_setting(s.allow_sudo)
     config.update(app.state.features.frontend_config())
     # KLANGKD_FEATURES_ENABLE: the deploy's chosen active-feature list,
     # forwarded verbatim so the frontend can resolve the active set against

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -310,8 +310,12 @@ STATIC_RESOURCES = [
     "/acl",
     "/volumes",
     "/images",
-    "/admin",
 ]
+
+# The instance-admin group name — /my-permissions derives the explicit
+# is_admin flag from membership in it (#2974; replaces the /admin
+# wildcard-ACE marker the #2944 overhaul retired as a checking tree).
+ADMIN_GROUP_NAME = "admins"
 
 
 @router.get("/my-permissions")
@@ -324,7 +328,9 @@ async def my_permissions(
 
     If ``resource`` query param is provided, checks permissions for that
     specific resource path (e.g., ``/workspaces/{id}``). Otherwise
-    returns permissions for all static resources.
+    returns permissions for all static resources. The ``is_admin`` flag
+    is derived from admins-group membership (#2974) — /admin is no
+    longer a permission-checking resource.
     """
     principals = await request.app.state.acl.get_principals(user["id"])
     groups = await request.app.state.model.users.get_user_groups(user["id"])
@@ -337,6 +343,7 @@ async def my_permissions(
             "user_id": user["id"],
             "email": user["email"],
             "groups": groups,
+            "is_admin": any(g["name"] == ADMIN_GROUP_NAME for g in groups),
             "permissions": {resource: perms} if perms else {},
         }
     # Batch all static resources into a single ACL query instead of
@@ -348,6 +355,7 @@ async def my_permissions(
         "user_id": user["id"],
         "email": user["email"],
         "groups": groups,
+        "is_admin": any(g["name"] == ADMIN_GROUP_NAME for g in groups),
         "permissions": permissions,
     }
 

--- a/src/klangk/klangk/api/common.py
+++ b/src/klangk/klangk/api/common.py
@@ -55,6 +55,7 @@ ALL_PERMISSIONS = [
     "manage-acls",
     "manage-events",
     "manage-volumes",
+    "view-volumes",
     "view-images",
     "search-users",
     "*",

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -263,20 +263,26 @@ async def list_images(
 
 @router.get("/volumes")
 async def list_volumes(
-    user: dict = Depends(acl.has_permission("manage-volumes")),
+    _user: dict = Depends(acl.has_permission("view-volumes")),
     app=Depends(get_app_dep),
 ):
+    """List the deployment's klangk-managed volumes (#2974).
+
+    Admin-surface view: every volume on the instance, with the
+    creating user's id as ``owner`` (provenance — the ``klangk.user-id``
+    label the create path stamps). Viewers need ``view-volumes``;
+    the seeded grant is the admins group, delegable read-only.
+    """
     volumes = await app.state.podman.list_volumes(
         f"klangk.instance={app.state.util.instance_id()}"
     )
-    uid = user["id"]
     return [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
+            "owner": (v.get("Labels") or {}).get("klangk.user-id"),
         }
         for v in volumes
-        if (v.get("Labels") or {}).get("klangk.user-id") == uid
     ]
 
 
@@ -308,7 +314,7 @@ async def create_volume(
 @router.delete("/volumes/{name}")
 async def delete_volume(
     name: str,
-    user: dict = Depends(acl.has_permission("manage-volumes")),
+    _user: dict = Depends(acl.has_permission("manage-volumes")),
     app=Depends(get_app_dep),
 ):
     info = await app.state.podman.inspect_volume(name)
@@ -320,11 +326,9 @@ async def delete_volume(
             status_code=404,
             detail="Volume not managed by this Klangk instance",
         )
-    if labels.get("klangk.user-id") != user["id"]:
-        raise HTTPException(
-            status_code=403,
-            detail="Volume belongs to another user",
-        )
+    # No per-user ownership check (#2974): manage-volumes is the
+    # admin-surface grant — holders administer every managed volume,
+    # not just their own. The user-id label survives for provenance.
     try:
         await app.state.podman.remove_volume(name)
     except PodmanError as e:

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -22,7 +22,6 @@ from .. import (
     acl,
 )
 from ..podman import PodmanError as PodmanError
-from ..settings import parse_bool_setting
 from ..util import (
     sanitize_disposition_name,
 )
@@ -239,22 +238,15 @@ async def list_images(
     _user: dict = Depends(acl.has_permission("view-images")),
     app=Depends(get_app_dep),
 ):
+    """The image listing for the workspace create/edit UIs (#2974).
+
+    Deployment-level toggles (nix/sudo availability) moved to the
+    authenticated-only fields on ``/api/v1/config`` — they are
+    deployment config, not image data.
+    """
     return {
         "default": app.state.container_registry.image_name,
         "allowed": sorted(app.state.container_registry.allowed_images),
-        # #2202/#2560: whether the per-workspace nix flag can trigger the
-        # per-workspace /nix mount. The create UI shows the "nix" toggle
-        # only when the feature is armed — a backend configured (btrfs
-        # snapshot or fuse-overlayfs, #2219) AND nix_enabled on (#2560,
-        # off by default); the flag is inert otherwise (workspaces use the
-        # nix image's baked /nix).
-        "nix_available": app.state.nix.available,
-        # #2017: whether the deploy allows sudo at all (the per-workspace
-        # knob may only lock a workspace down below this). The create/edit
-        # UIs show the sudo toggle only when this is true — on a
-        # sudo-forbidding deploy the toggle is a no-op (sudo is off for
-        # every workspace regardless).
-        "sudo_available": parse_bool_setting(app.state.settings.allow_sudo),
     }
 
 

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -240,8 +240,10 @@ def volumes_list(
     table = Table(box=None, pad_edge=False)
     table.add_column("Name", style="bold")
     table.add_column("Created")
+    table.add_column("Owner", style="dim")
     for v in volumes:
-        table.add_row(v["name"], v.get("created", "")[:19])
+        owner = v.get("owner") or "—"
+        table.add_row(v["name"], v.get("created", "")[:19], owner[:8])
     console.print(table)
 
 

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -70,8 +70,8 @@ def logout(
 def admin_status(token: str | None) -> bool | None:
     """Admin status from /my-permissions (the canonical source the
     frontend uses for isAdmin). Best-effort: if the probe fails (offline,
-    token expired, old server without /admin in the static set) status
-    still reports everything else rather than erroring out."""
+    token expired, old server without the explicit flag) status still
+    reports everything else rather than erroring out."""
     is_admin: bool | None = None
     if token:
         try:
@@ -79,8 +79,12 @@ def admin_status(token: str | None) -> bool | None:
             resp = client.get("/api/v1/my-permissions")
             client.check_auth(resp)
             if resp.status_code == 200:
-                perms = resp.json().get("permissions", {})
-                is_admin = "*" in perms.get("/admin", [])
+                # #2974: explicit flag derived server-side from
+                # admins-group membership (the /admin wildcard-ACE
+                # marker is retired). Absent on an old server -> None
+                # (unknown), never silently False.
+                flag = resp.json().get("is_admin")
+                is_admin = flag if isinstance(flag, bool) else None
         except Exception:
             is_admin = None
     return is_admin

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -826,16 +826,24 @@ class MainScreen(StatusScreen):
             data = await asyncio.to_thread(state.list_images)
             default = data.get("default", "") or ""
             allowed = list(data.get("allowed") or [])
-            nix_available = data.get("nix_available") is True
-            sudo_available = data.get("sudo_available") is True
         except AuthError:
             self.app.session_expired()
             return
         except (httpx.HTTPError, OSError, ValueError) as exc:
             logger.debug("Could not fetch image list: %s", exc)
             default, allowed = "", []
-            nix_available = False
-            sudo_available = False
+        # #2974: deploy-level nix/sudo toggles moved from the images
+        # payload to the authenticated-only /config fields.
+        try:
+            nix_available, sudo_available = await asyncio.to_thread(
+                state.deploy_toggles
+            )
+        except AuthError:
+            self.app.session_expired()
+            return
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            logger.debug("Could not fetch deploy toggles: %s", exc)
+            nix_available = sudo_available = False
         try:
             allow_autostart = await asyncio.to_thread(state.allow_autostart)
         except (httpx.HTTPError, OSError, ValueError) as exc:

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -352,22 +352,30 @@ async def open_edit_screen(screen, state, workspace, on_edited) -> None:
 
     Shared by the workspace-list (main) and workspace-detail screens.
     An image-listing failure degrades to empty defaults (the form's
-    image field then accepts free text); an autostart failure leaves it
-    disabled; ``AuthError`` ends the session via ``session_expired``.
+    image field then accepts free text); an autostart or toggle
+    failure leaves them disabled; ``AuthError`` ends the session via
+    ``session_expired``.
     """
     try:
         data = await asyncio.to_thread(state.list_images)
         default = data.get("default", "") or ""
         allowed = list(data.get("allowed") or [])
-        nix_available = data.get("nix_available") is True
-        sudo_available = data.get("sudo_available") is True
     except AuthError:
         screen.app.session_expired()
         return
     except Exception:
         default, allowed = "", []
-        nix_available = False
-        sudo_available = False
+    # #2974: deploy-level nix/sudo toggles moved from the images
+    # payload to the authenticated-only /config fields.
+    try:
+        nix_available, sudo_available = await asyncio.to_thread(
+            state.deploy_toggles
+        )
+    except AuthError:
+        screen.app.session_expired()
+        return
+    except Exception:
+        nix_available = sudo_available = False
     try:
         allow_autostart = await asyncio.to_thread(state.allow_autostart)
     except AuthError:

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -355,6 +355,20 @@ class TuiState:
     def list_images(self) -> dict:
         return self.client().list_images()
 
+    def deploy_toggles(self) -> tuple[bool, bool]:
+        """Deploy-level nix/sudo availability (#2974).
+
+        Moved off the ``/images`` payload to the authenticated-only
+        ``/config`` fields — deployment config, not image data. Strict
+        bool checks (``allow_autostart`` precedent). Raises on failure;
+        callers fall back to ``(False, False)`` so the form still opens.
+        """
+        cfg = self.client().config()
+        return (
+            cfg.get("nix_available") is True,
+            cfg.get("sudo_available") is True,
+        )
+
     def default_allowed_domains(self) -> list[str]:
         """Deploy-wide netfilter allow-list (``KLANGKD_NETFILTER_DEFAULT_DOMAINS``)
         used to seed the create form's Netfilter tab (#1931).

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -239,19 +239,32 @@ class Lifecycle:
                 PRINCIPAL_SYSTEM,
                 system_principal=SYSTEM_EVERYONE,
             )
-        # #2946 self-service surfaces, granted to every authenticated
-        # user by default (a deploy that wants them restricted denies
-        # or scopes these rows in the ACL editor):
-        #   /volumes    manage-volumes — user-owned volumes (label-
-        #                               scoped per user at runtime)
+        # /volumes admin surface (#2974): the inventory tab in /admin —
+        # view-volumes gates the listing (GET), manage-volumes the
+        # mutating endpoints (POST/DELETE). Both to admins, delegable
+        # separately (a read-only volumes auditor holds view alone).
+        # No trailing Deny Everyone row: unauthenticated requests die
+        # at the JWT middleware before any ACL check, and no-match is
+        # already default-deny.
+        for permission in ("view-volumes", "manage-volumes"):
+            await self.app.state.model.acl.add_acl_entry(
+                "/volumes",
+                0 if permission == "view-volumes" else 1,
+                ACTION_ALLOW,
+                permission,
+                PRINCIPAL_GROUP,
+                group_id=admin_group_id,
+            )
+        # #2946 self-service surface, granted to every authenticated
+        # user by default (a deploy that wants it restricted denies
+        # or scopes the rows in the ACL editor):
         #   /images     view-images    — the image/nix/sudo capability
         #                               listing (create/edit UIs)
         # NB: /llm-proxy is NOT here — #2959 gives it its own
         # workspace-token-only gate, independent of the ACL system.
-        for resource, permission in (
-            ("/volumes", "manage-volumes"),
-            ("/images", "view-images"),
-        ):
+        # (#2974: the /volumes rows above moved to the admins group;
+        # the /images rework lands in its own PR.)
+        for resource, permission in (("/images", "view-images"),):
             await self.app.state.model.acl.add_acl_entry(
                 resource,
                 0,

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -255,32 +255,25 @@ class Lifecycle:
                 PRINCIPAL_GROUP,
                 group_id=admin_group_id,
             )
-        # #2946 self-service surface, granted to every authenticated
-        # user by default (a deploy that wants it restricted denies
-        # or scopes the rows in the ACL editor):
-        #   /images     view-images    — the image/nix/sudo capability
-        #                               listing (create/edit UIs)
+        # /images self-service surface (#2946, #2974): Allow
+        # view-images for every authenticated user — the deliberate
+        # default (the create/edit UIs read the listing), modifiable by
+        # an operator via the ACL editor (delete the row and default-deny
+        # takes over, or scope it to a group). No trailing Deny Everyone
+        # row: it can never fire (the JWT middleware rejects
+        # unauthenticated requests before any ACL check) and no-match is
+        # already default-deny. Migration 0026 drops it on existing
+        # deployments.
         # NB: /llm-proxy is NOT here — #2959 gives it its own
         # workspace-token-only gate, independent of the ACL system.
-        # (#2974: the /volumes rows above moved to the admins group;
-        # the /images rework lands in its own PR.)
-        for resource, permission in (("/images", "view-images"),):
-            await self.app.state.model.acl.add_acl_entry(
-                resource,
-                0,
-                ACTION_ALLOW,
-                permission,
-                PRINCIPAL_SYSTEM,
-                system_principal=SYSTEM_AUTHENTICATED,
-            )
-            await self.app.state.model.acl.add_acl_entry(
-                resource,
-                1,
-                ACTION_DENY,
-                "*",
-                PRINCIPAL_SYSTEM,
-                system_principal=SYSTEM_EVERYONE,
-            )
+        await self.app.state.model.acl.add_acl_entry(
+            "/images",
+            0,
+            ACTION_ALLOW,
+            "view-images",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
         # /admin: kept as the instance-administrator marker — Allow *
         # for admins, deny everyone. No route checks a permission here
         # anymore (#2944); the wildcard marks "is an instance admin"

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -274,26 +274,11 @@ class Lifecycle:
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_AUTHENTICATED,
         )
-        # /admin: kept as the instance-administrator marker — Allow *
-        # for admins, deny everyone. No route checks a permission here
-        # anymore (#2944); the wildcard marks "is an instance admin"
-        # for /my-permissions consumers (the frontend's isAdmin).
-        await self.app.state.model.acl.add_acl_entry(
-            "/admin",
-            0,
-            ACTION_ALLOW,
-            "*",
-            PRINCIPAL_GROUP,
-            group_id=admin_group_id,
-        )
-        await self.app.state.model.acl.add_acl_entry(
-            "/admin",
-            1,
-            ACTION_DENY,
-            "*",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_EVERYONE,
-        )
+        # No /admin rows (#2974): nothing checks a permission there since
+        # #2944 — the instance-admin marker is now the explicit is_admin
+        # flag on /my-permissions, derived from admins-group membership.
+        # Migration 0027 removes the stored marker rows on existing
+        # deployments.
         logger.info("Seeded default ACL entries")
 
     async def ensure_admin_group(self) -> str:

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -72,6 +72,7 @@ from klangk.model.migrations import m0021_first_class_resource_acls
 from klangk.model.migrations import m0022_workspace_permission_renames
 from klangk.model.migrations import m0023_self_service_resources
 from klangk.model.migrations import m0024_join_workspace_permission
+from klangk.model.migrations import m0025_volumes_admin_surface
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -104,6 +105,7 @@ MIGRATIONS: list[Migration] = [
     m0022_workspace_permission_renames.migration,
     m0023_self_service_resources.migration,
     m0024_join_workspace_permission.migration,
+    m0025_volumes_admin_surface.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -74,6 +74,7 @@ from klangk.model.migrations import m0023_self_service_resources
 from klangk.model.migrations import m0024_join_workspace_permission
 from klangk.model.migrations import m0025_volumes_admin_surface
 from klangk.model.migrations import m0026_drop_dead_images_deny_row
+from klangk.model.migrations import m0027_retire_admin_marker
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -108,6 +109,7 @@ MIGRATIONS: list[Migration] = [
     m0024_join_workspace_permission.migration,
     m0025_volumes_admin_surface.migration,
     m0026_drop_dead_images_deny_row.migration,
+    m0027_retire_admin_marker.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -73,6 +73,7 @@ from klangk.model.migrations import m0022_workspace_permission_renames
 from klangk.model.migrations import m0023_self_service_resources
 from klangk.model.migrations import m0024_join_workspace_permission
 from klangk.model.migrations import m0025_volumes_admin_surface
+from klangk.model.migrations import m0026_drop_dead_images_deny_row
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -106,6 +107,7 @@ MIGRATIONS: list[Migration] = [
     m0023_self_service_resources.migration,
     m0024_join_workspace_permission.migration,
     m0025_volumes_admin_surface.migration,
+    m0026_drop_dead_images_deny_row.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0025_volumes_admin_surface.py
+++ b/src/klangk/klangk/model/migrations/m0025_volumes_admin_surface.py
@@ -1,0 +1,138 @@
+"""Migration 0025: /volumes becomes an admin surface (#2974).
+
+The #2946 seed granted ``manage-volumes`` to every authenticated user —
+a ``manage-*`` name on the whole deployment's volume inventory, which
+contradicts the #2944 convention (``manage-*`` = admin surface, admins
+by default, delegable). #2974 splits the endpoint gates:
+
+- ``GET /api/v1/volumes``      → ``view-volumes``  (the admin tab's read)
+- ``POST /api/v1/volumes``     → ``manage-volumes``
+- ``DELETE /api/v1/volumes/…`` → ``manage-volumes``
+
+and re-seeds ``/volumes`` to the admins group, view + manage. The
+per-user ``klangk.user-id`` runtime scoping is dropped for the same
+reason: a ``manage-volumes`` holder administers every managed volume
+(the label survives for provenance).
+
+This migration rewrites existing deployments to the new shape:
+
+- Deletes rows on ``/volumes`` that match the retired seed exactly
+  (Allow ``manage-volumes`` Authenticated, Deny ``*`` Everyone) — they
+  are the defaults this change replaces, not operator intent.
+- Inserts Allow ``view-volumes`` + Allow ``manage-volumes`` for the
+  admins group at positions 0/1, unless a row already grants that
+  permission on ``/volumes`` (idempotent; operator-staged rows win).
+- Custom rows the operator added (anything that is not the retired
+  seed pair) are left untouched.
+
+A fresh database (entirely empty ``acl_entries``) is a no-op — the boot
+seeds own it (the m0021 precedent; inserting here would trip the seed's
+empty-table gate and lose the ``/``, ``/workspaces``, ``/admin`` rows).
+
+The admins group is located by name (``admins``; migration 0020
+renamed legacy ``admin`` rows), matching the seeds' shape.
+"""
+
+from klangk.model.acl import (
+    ACTION_ALLOW,
+    ACTION_DENY,
+    PRINCIPAL_GROUP,
+    PRINCIPAL_SYSTEM,
+    SYSTEM_AUTHENTICATED,
+    SYSTEM_EVERYONE,
+)
+from klangk.model.migrations.base import Migration
+
+# (position, action, principal_type, system_principal, permission) of the
+# retired #2946 seed pair on /volumes.
+_RETIRED_SEED = {
+    (
+        0,
+        ACTION_ALLOW,
+        PRINCIPAL_SYSTEM,
+        SYSTEM_AUTHENTICATED,
+        "manage-volumes",
+    ),
+    (1, ACTION_DENY, PRINCIPAL_SYSTEM, SYSTEM_EVERYONE, "*"),
+}
+
+_ADMIN_PERMISSIONS = ("view-volumes", "manage-volumes")
+
+
+async def _admins_group_id(db) -> str | None:
+    cursor = await db.execute(
+        "SELECT id FROM groups WHERE name = 'admins' LIMIT 1"
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else None
+
+
+async def _rows(db):
+    cursor = await db.execute(
+        "SELECT position, action, principal_type, system_principal,"
+        " permission, rowid FROM acl_entries WHERE resource = '/volumes'"
+        " ORDER BY position"
+    )
+    return list(await cursor.fetchall())
+
+
+async def _delete_retired_seed_rows(db, rows) -> None:
+    for row in rows:
+        key = (row[0], row[1], row[2], row[3], row[4])
+        if key in _RETIRED_SEED:
+            await db.execute(
+                "DELETE FROM acl_entries WHERE rowid = ?", (row[5],)
+            )
+
+
+async def _permission_exists(db, permission: str) -> bool:
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM acl_entries"
+        " WHERE resource = '/volumes' AND permission = ?",
+        (permission,),
+    )
+    return (await cursor.fetchone())[0] > 0
+
+
+async def _next_position(db) -> int:
+    cursor = await db.execute(
+        "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
+        " WHERE resource = '/volumes'"
+    )
+    return (await cursor.fetchone())[0] + 1
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        return  # fresh database — the boot seeds own it
+
+    group_id = await _admins_group_id(db)
+    if group_id is None:
+        return  # no admins group: nothing to grant; rows left untouched
+
+    rows = await _rows(db)
+    await _delete_retired_seed_rows(db, rows)
+
+    for permission in _ADMIN_PERMISSIONS:
+        if await _permission_exists(db, permission):
+            continue  # operator-staged or already migrated
+        # Append rather than assume 0/1: a deployment whose retired
+        # pair was only half-customized keeps rows at those positions,
+        # and a fixed insert would violate UNIQUE(resource, position)
+        # (failed migration = boot loop).
+        position = await _next_position(db)
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type, user_id,"
+            " group_id, system_principal, permission)"
+            " VALUES ('/volumes', ?, ?, ?, NULL, ?, NULL, ?)",
+            (position, ACTION_ALLOW, PRINCIPAL_GROUP, group_id, permission),
+        )
+
+
+migration = Migration(
+    id=25,
+    name="0025_volumes_admin_surface",
+    apply=apply,
+)

--- a/src/klangk/klangk/model/migrations/m0026_drop_dead_images_deny_row.py
+++ b/src/klangk/klangk/model/migrations/m0026_drop_dead_images_deny_row.py
@@ -1,0 +1,44 @@
+"""Migration 0026: drop the dead Deny Everyone row on /images (#2974).
+
+The #2946 seed for ``/images`` was Allow ``view-images`` Authenticated
+(position 0) + Deny ``*`` Everyone (position 1). The Deny row can never
+fire: unauthenticated requests are rejected by the JWT middleware
+before any ACL check, and no-match is already default-deny. #2974 keeps
+the Allow Authenticated row as the deliberate, operator-modifiable
+default and removes the dead row from the seed — this migration applies
+the same cleanup to existing deployments.
+
+Only rows matching the retired seed's Deny exactly (Deny, system
+principal Everyone, ``*``) on ``/images`` are deleted; any other row an
+operator added is left untouched.
+
+A fresh database (entirely empty ``acl_entries``) is a no-op — the boot
+seeds own it.
+"""
+
+from klangk.model.acl import (
+    ACTION_DENY,
+    PRINCIPAL_SYSTEM,
+    SYSTEM_EVERYONE,
+)
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        return  # fresh database — the boot seeds own it
+    await db.execute(
+        "DELETE FROM acl_entries"
+        " WHERE resource = '/images' AND action = ?"
+        " AND principal_type = ? AND system_principal = ?"
+        " AND permission = '*'",
+        (ACTION_DENY, PRINCIPAL_SYSTEM, SYSTEM_EVERYONE),
+    )
+
+
+migration = Migration(
+    id=26,
+    name="0026_drop_dead_images_deny_row",
+    apply=apply,
+)

--- a/src/klangk/klangk/model/migrations/m0027_retire_admin_marker.py
+++ b/src/klangk/klangk/model/migrations/m0027_retire_admin_marker.py
@@ -1,0 +1,34 @@
+"""Migration 0027: remove the retired /admin marker rows (#2974).
+
+Since #2944 no route checks a permission on ``/admin``; the resource's
+rows survived only as the instance-administrator wildcard marker that
+``/my-permissions`` consumers read via ``*`` on ``/admin``. #2974
+replaces the hack with an explicit ``is_admin`` flag on
+``/my-permissions`` derived from admins-group membership — the source
+of truth — so the marker rows (and the resource) are retired.
+
+This migration deletes every stored row on ``/admin``: the seeded pair
+(Allow ``*`` admins + Deny ``*`` Everyone) and anything an operator
+added on the dead tree (it can only ever have served the marker — no
+endpoint resolves to ``/admin`` since #2944, so nothing else can be
+reading those rows).
+
+A fresh database (entirely empty ``acl_entries``) is a no-op — the boot
+seeds own it.
+"""
+
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        return  # fresh database — the boot seeds own it
+    await db.execute("DELETE FROM acl_entries WHERE resource = '/admin'")
+
+
+migration = Migration(
+    id=27,
+    name="0027_retire_admin_marker",
+    apply=apply,
+)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -6018,7 +6018,10 @@ class TestStatusAdminFlag:
         client = MagicMock()
         resp = MagicMock(
             status_code=200,
-            json=lambda: {"permissions": perms},
+            json=lambda: {
+                "permissions": perms,
+                "is_admin": perms.get("_admin", False),
+            },
         )
         resp.headers = {"content-type": "application/json"}
         client.get.return_value = resp
@@ -6028,7 +6031,7 @@ class TestStatusAdminFlag:
     def test_plain_shows_admin_yes(self, logged_in_cfg, capsys, monkeypatch):
         from klangk.cli import main
 
-        self._perms_client({"/admin": ["*"]}, monkeypatch)
+        self._perms_client({"_admin": True}, monkeypatch)
         main.status(plain=True)
         out = capsys.readouterr().out
         assert "admin=yes" in out
@@ -6036,7 +6039,7 @@ class TestStatusAdminFlag:
     def test_plain_shows_admin_no(self, logged_in_cfg, capsys, monkeypatch):
         from klangk.cli import main
 
-        self._perms_client({"/admin": []}, monkeypatch)
+        self._perms_client({}, monkeypatch)
         main.status(plain=True)
         out = capsys.readouterr().out
         assert "admin=no" in out
@@ -6048,7 +6051,7 @@ class TestStatusAdminFlag:
 
         from klangk.cli import main
 
-        self._perms_client({"/admin": ["*"]}, monkeypatch)
+        self._perms_client({"_admin": True}, monkeypatch)
         buf = StringIO()
         with patch.object(
             klangk.cli.authcmds,
@@ -6065,7 +6068,7 @@ class TestStatusAdminFlag:
 
         from klangk.cli import main
 
-        self._perms_client({"/admin": []}, monkeypatch)
+        self._perms_client({}, monkeypatch)
         buf = StringIO()
         with patch.object(
             klangk.cli.authcmds,

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -74,6 +74,7 @@ from klangk.cli.tui.screens import (
 )
 from klangk.cli.tui.state import LoginError, TuiState
 from klangk.cli.tui.screens.main import listen_for_status
+from klangk.cli.tui.screens import workspace_form as scr_form
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +150,9 @@ def _st(**methods):
         "list_shared_workspaces": lambda: [],
         # #2768: the detail screen's deploy-default marking fetch.
         "default_classification_banner": lambda: "",
+        # #2974: deploy-level nix/sudo toggles (moved off list_images to
+        # the /config fields) — off by default; tests override to arm.
+        "deploy_toggles": lambda: (False, False),
     }
     for k, v in {**defaults, **methods}.items():
         setattr(st, k, v)
@@ -3416,7 +3420,7 @@ async def test_main_screen_action_edit_load_fallbacks(monkeypatch):
 
 async def test_main_and_detail_edit_pass_sudo_available(monkeypatch):
     """#2017 review: both real edit entry points (list 'e' and the detail
-    screen) must forward sudo_available from /api/v1/images — the screen
+    screen) must forward sudo_available from the deploy toggles (/config, #2974) — the screen
     constructor default (False) otherwise hides the toggle as dead wiring."""
 
     async def noop(*a, **k):
@@ -3426,17 +3430,14 @@ async def test_main_and_detail_edit_pass_sudo_available(monkeypatch):
     a = _wsobj("alpha", image="base")
 
     def images():
-        return {
-            "default": "base",
-            "allowed": ["base", "py:3"],
-            "sudo_available": True,
-        }
+        return {"default": "base", "allowed": ["base", "py:3"]}
 
     # List-screen entry.
     st = _ws(
         owned=[a],
         list_images=images,
         allow_autostart=lambda: True,
+        deploy_toggles=lambda: (False, True),
     )
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
@@ -3454,6 +3455,7 @@ async def test_main_and_detail_edit_pass_sudo_available(monkeypatch):
         owned=[a],
         list_images=images,
         allow_autostart=lambda: True,
+        deploy_toggles=lambda: (False, True),
     )
     st2.find_workspace = lambda n: a
     app2 = KlangkApp(st2)
@@ -9103,6 +9105,7 @@ async def test_create_screen_images_unavailable(monkeypatch):
             create=create,
             list_images=boom,
             allow_autostart=boom,
+            deploy_toggles=boom,
             default_allowed_domains=boom,
             default_per_handle_home=boom,
         )
@@ -9420,7 +9423,7 @@ async def test_create_screen_nix_hidden_when_not_available(monkeypatch):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    app = KlangkApp(_create_state())  # list_images omits nix_available
+    app = KlangkApp(_create_state())  # deploy_toggles default (False, False)
     async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
@@ -9447,11 +9450,7 @@ async def test_create_screen_nix_shown_and_sent_when_checked(monkeypatch):
     app = KlangkApp(
         _create_state(
             create=create,
-            list_images=lambda: {
-                "default": "base",
-                "allowed": ["base", "py:3"],
-                "nix_available": True,
-            },
+            deploy_toggles=lambda: (True, False),
         )
     )
     async with app.run_test(size=(140, 40)) as pilot:
@@ -9470,13 +9469,13 @@ async def test_create_screen_nix_shown_and_sent_when_checked(monkeypatch):
 
 async def test_create_screen_sudo_hidden_when_not_available(monkeypatch):
     """#2017: the Allow sudo toggle is hidden unless the deploy allows
-    sudo (sudo_available on /api/v1/images)."""
+    sudo (deploy_toggles reports sudo on, #2974)."""
 
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
-    app = KlangkApp(_create_state())  # list_images omits sudo_available
+    app = KlangkApp(_create_state())  # deploy_toggles default (False, False)
     async with app.run_test(size=(140, 40)) as pilot:
         app.screen.action_create()
         await app.workers.wait_for_complete()
@@ -9503,11 +9502,7 @@ async def test_create_screen_sudo_unchecked_sends_lockdown(monkeypatch):
     app = KlangkApp(
         _create_state(
             create=create,
-            list_images=lambda: {
-                "default": "base",
-                "allowed": ["base", "py:3"],
-                "sudo_available": True,
-            },
+            deploy_toggles=lambda: (False, True),
         )
     )
     async with app.run_test(size=(140, 40)) as pilot:
@@ -15062,3 +15057,99 @@ async def test_token_refresh_body_actually_runs_2834(monkeypatch):
         await _real_token_refresh_loop(app.screen)
         assert expired == [1]  # the expired result surfaces the overlay
     assert ran
+
+
+def test_deploy_toggles(monkeypatch, redirect_xdg):
+    # #2974: the toggles are auth-gated /config fields, read via the
+    # authed client (not fetch_config). Strict bools — a string
+    # "false" must not coerce.
+    from unittest.mock import MagicMock
+
+    t = TuiState("https://x.example")
+    fake = MagicMock()
+    monkeypatch.setattr(t, "client", lambda: fake)
+    fake.config.return_value = {"nix_available": True, "sudo_available": True}
+    assert t.deploy_toggles() == (True, True)
+    fake.config.return_value = {}
+    assert t.deploy_toggles() == (False, False)
+    fake.config.return_value = {"nix_available": "false", "sudo_available": 1}
+    assert t.deploy_toggles() == (False, False)
+
+
+async def test_create_screen_deploy_toggles_failure(monkeypatch):
+    """#2974: a deploy-toggles fetch failure must not block the create
+    form — the toggles degrade to off."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    def boom():
+        raise OSError("config endpoint down")
+
+    app = KlangkApp(
+        _create_state(
+            list_images=boom,
+            deploy_toggles=boom,
+        )
+    )
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, CreateWorkspaceScreen)
+        assert app.screen._nix_available is False
+        assert app.screen._sudo_available is False
+
+
+async def test_create_screen_deploy_toggles_auth_error(monkeypatch):
+    """#2974: an auth failure on the toggles fetch ends the session."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    def expired():
+        raise AuthError("expired")
+
+    app = KlangkApp(_create_state(deploy_toggles=expired))
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.screen.action_create()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionExpiredScreen)
+
+
+async def test_edit_screen_deploy_toggles_failure(monkeypatch):
+    """#2974: the edit form also degrades to toggles-off when the fetch
+    fails, and an auth failure ends the session."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    def boom():
+        raise OSError("config endpoint down")
+
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws, deploy_toggles=boom))
+    async with app.run_test() as pilot:
+        await scr_form.open_edit_screen(app.screen, app.tui_state, ws, None)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, EditWorkspaceScreen)
+        assert app.screen._nix_available is False
+        assert app.screen._sudo_available is False
+
+    def expired():
+        raise AuthError("expired")
+
+    app2 = KlangkApp(_edit_state(ws, deploy_toggles=expired))
+    async with app2.run_test() as pilot:
+        await scr_form.open_edit_screen(app2.screen, app2.tui_state, ws, None)
+        await app2.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app2.screen, SessionExpiredScreen)

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -92,11 +92,14 @@ async def _seed_2946_self_service(app_state):
     """Seed the #2946 self-service ACL rows (idempotent).
 
     Mirrors m0023 / seed_default_acls: Allow <perm> for Authenticated
-    plus Deny Everyone on /volumes, /images, /llm-proxy, and the
+    plus Deny Everyone on /images, /llm-proxy, and the
     Allow search-users Authenticated row on /users (inserted at
-    position 1, shifting later rows down — m0023's logic). Called by
-    the seed fixtures (user / agent_user / admin_group) so any test
-    reaching the DB gets the production-shaped world.
+    position 1, shifting later rows down — m0023's logic).
+    /volumes is no longer here — #2974 moved it to the admins group
+    (view-volumes + manage-volumes, seeded by the admin_group
+    fixture like the other admin surfaces). Called by the seed
+    fixtures (user / agent_user / admin_group) so any test reaching
+    the DB gets the production-shaped world.
     """
     from klangk.model.acl import (
         ACTION_ALLOW,
@@ -107,10 +110,7 @@ async def _seed_2946_self_service(app_state):
     )
 
     acl = app_state.state.model.acl
-    for resource, permission in (
-        ("/volumes", "manage-volumes"),
-        ("/images", "view-images"),
-    ):
+    for resource, permission in (("/images", "view-images"),):
         existing = await acl.get_acl_entries(resource)
         if existing:
             continue
@@ -279,6 +279,17 @@ async def admin_group(app_state):
             "*",
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_EVERYONE,
+        )
+    # /volumes admin surface (#2974): view + manage to admins —
+    # mirrors the updated seed_default_acls / m0024.
+    for position, permission in enumerate(("view-volumes", "manage-volumes")):
+        await acl.add_acl_entry(
+            "/volumes",
+            position,
+            ACTION_ALLOW,
+            permission,
+            PRINCIPAL_GROUP,
+            group_id=group["id"],
         )
     await _seed_2946_self_service(app_state)
     # /admin stays as the instance-admin wildcard marker (#2944).

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -283,23 +283,9 @@ async def admin_group(app_state):
             group_id=group["id"],
         )
     await _seed_2946_self_service(app_state)
-    # /admin stays as the instance-admin wildcard marker (#2944).
-    await acl.add_acl_entry(
-        "/admin",
-        0,
-        ACTION_ALLOW,
-        "*",
-        PRINCIPAL_GROUP,
-        group_id=group["id"],
-    )
-    await acl.add_acl_entry(
-        "/admin",
-        1,
-        ACTION_DENY,
-        "*",
-        PRINCIPAL_SYSTEM,
-        system_principal=SYSTEM_EVERYONE,
-    )
+    # No /admin rows (#2974): the instance-admin marker is the explicit
+    # is_admin flag on /my-permissions, derived from admins-group
+    # membership — not a wildcard ACE.
     # #2569: seed the members group (mirrors main.py ensure_members_group).
     members = await app_state.state.model.users.create_group(
         "members", description="All regular users"

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -103,32 +103,23 @@ async def _seed_2946_self_service(app_state):
     """
     from klangk.model.acl import (
         ACTION_ALLOW,
-        ACTION_DENY,
         PRINCIPAL_SYSTEM,
         SYSTEM_AUTHENTICATED,
-        SYSTEM_EVERYONE,
     )
 
     acl = app_state.state.model.acl
-    for resource, permission in (("/images", "view-images"),):
-        existing = await acl.get_acl_entries(resource)
-        if existing:
-            continue
+    # /images: Allow Authenticated only (#2974 — the dead Deny Everyone
+    # row is gone from the seed; migration 0026 drops it on existing
+    # deployments).
+    existing = await acl.get_acl_entries("/images")
+    if not existing:
         await acl.add_acl_entry(
-            resource,
+            "/images",
             0,
             ACTION_ALLOW,
-            permission,
+            "view-images",
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_AUTHENTICATED,
-        )
-        await acl.add_acl_entry(
-            resource,
-            1,
-            ACTION_DENY,
-            "*",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_EVERYONE,
         )
     rows = await acl.get_acl_entries("/users")
     if not any(r["permission"] == "search-users" for r in rows):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6748,8 +6748,20 @@ def _managed_volume(user_id="test-user"):
 
 
 class TestVolumeRoutes:
-    async def test_list_volumes(self, client, user):
-        headers = await _auth_headers(client)
+    async def _admin_headers(self, client):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
+        )
+        return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+    async def test_list_volumes(self, client, admin_user, user):
+        """#2974: the listing is the admin-surface view — every managed
+        volume on the instance, with the creating user as owner."""
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod,
             "list_volumes",
@@ -6777,11 +6789,54 @@ class TestVolumeRoutes:
             resp = await client.get("/api/v1/volumes", headers=headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "my-vol"
+        assert [v["name"] for v in data] == ["my-vol", "other-vol"]
+        assert data[0]["owner"] == user["id"]
+        assert data[1]["owner"] == "someone-else"
 
-    async def test_create_volume(self, client, user):
+    async def test_list_volumes_requires_view_permission(self, client, user):
+        """#2974: a non-admin (no view-volumes grant) cannot list."""
         headers = await _auth_headers(client)
+        resp = await client.get("/api/v1/volumes", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_delegated_viewer_lists_but_cannot_mutate(
+        self, client, user, app_state
+    ):
+        """#2974: view-volumes alone is a read-only delegation — the
+        listing works, create/delete stay denied."""
+        from klangk.model import ACTION_ALLOW, PRINCIPAL_USER
+
+        await app_state.state.model.acl.add_acl_entry(
+            "/volumes",
+            0,
+            ACTION_ALLOW,
+            "view-volumes",
+            PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        headers = await _auth_headers(client)
+        with patch.object(
+            _mock_pod,
+            "list_volumes",
+            AsyncMock(return_value=[]),
+        ):
+            resp = await client.get("/api/v1/volumes", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+        resp = await client.post(
+            "/api/v1/volumes",
+            json={"name": "nope"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        resp = await client.delete("/api/v1/volumes/nope", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_create_volume(self, client, admin_user):
+        """#2974: create is manage-gated; the volume is stamped with the
+        creating admin's user-id (provenance)."""
+        headers = await self._admin_headers(client)
         mock_create = AsyncMock(
             return_value={"Name": "new-vol", "CreatedAt": "2026-01-01"}
         )
@@ -6799,10 +6854,10 @@ class TestVolumeRoutes:
         assert resp.status_code == 200
         assert resp.json()["name"] == "new-vol"
         _, labels = mock_create.call_args.args
-        assert labels["klangk.user-id"] == user["id"]
+        assert labels["klangk.user-id"] == admin_user["id"]
 
-    async def test_create_duplicate_volume(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_create_duplicate_volume(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod,
             "inspect_volume",
@@ -6815,8 +6870,10 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 409
 
-    async def test_create_volume_error_propagates(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_create_volume_error_propagates(
+        self, client, admin_user, user
+    ):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod, "inspect_volume", AsyncMock(return_value=None)
@@ -6834,8 +6891,8 @@ class TestVolumeRoutes:
                 headers=headers,
             )
 
-    async def test_delete_volume(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,
@@ -6849,16 +6906,18 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 200
 
-    async def test_delete_volume_not_found(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_not_found(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod, "inspect_volume", AsyncMock(return_value=None)
         ):
             resp = await client.delete("/api/v1/volumes/nope", headers=headers)
         assert resp.status_code == 404
 
-    async def test_delete_volume_wrong_instance(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_wrong_instance(
+        self, client, admin_user, user
+    ):
+        headers = await self._admin_headers(client)
         with patch.object(
             _mock_pod,
             "inspect_volume",
@@ -6869,21 +6928,28 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 404
 
-    async def test_delete_volume_wrong_user(self, client, user):
-        headers = await _auth_headers(client)
-        with patch.object(
-            _mock_pod,
-            "inspect_volume",
-            AsyncMock(return_value=_managed_volume("someone-else")),
+    async def test_delete_volume_other_owner(self, client, admin_user, user):
+        """#2974: manage-volumes holders administer every managed volume —
+        the old per-user ownership 403 is gone (label is provenance)."""
+        headers = await self._admin_headers(client)
+        with (
+            patch.object(
+                _mock_pod,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume("someone-else")),
+            ),
+            patch.object(_mock_pod, "remove_volume", AsyncMock()),
         ):
             resp = await client.delete(
                 "/api/v1/volumes/other", headers=headers
             )
-        assert resp.status_code == 403
+        assert resp.status_code == 200
 
-    async def test_delete_volume_remove_not_found(self, client, user):
+    async def test_delete_volume_remove_not_found(
+        self, client, admin_user, user
+    ):
         """Volume vanishes between inspect and remove -> 404."""
-        headers = await _auth_headers(client)
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,
@@ -6899,8 +6965,8 @@ class TestVolumeRoutes:
             resp = await client.delete("/api/v1/volumes/gone", headers=headers)
         assert resp.status_code == 404
 
-    async def test_delete_volume_other_error(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_other_error(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,
@@ -6916,8 +6982,8 @@ class TestVolumeRoutes:
         ):
             await client.delete("/api/v1/volumes/err-vol", headers=headers)
 
-    async def test_delete_volume_in_use(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_in_use(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
         with (
             patch.object(
                 _mock_pod,

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -9295,8 +9295,10 @@ class TestACLEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["email"] == "testadmin@example.com"
-        assert "/admin" in data["permissions"]
-        assert "*" in data["permissions"]["/admin"]
+        # #2974: instance-admin status is the explicit flag derived from
+        # admins-group membership — /admin is gone from the permission map.
+        assert data["is_admin"] is True
+        assert "/admin" not in data["permissions"]
 
     async def test_my_permissions_non_admin(self, client, admin_user, user):
         """Non-admin user has no admin permissions."""
@@ -9305,6 +9307,7 @@ class TestACLEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert "/admin" not in data["permissions"]
+        assert data["is_admin"] is False
 
     async def test_my_permissions_for_resource(self, client, ws_admin):
         """Check permissions for a specific resource."""
@@ -15046,13 +15049,15 @@ class TestAdminTabPermissions:
     ):
         headers = await self._admin_headers(client)
         resp = await client.get("/api/v1/my-permissions", headers=headers)
-        perms = resp.json()["permissions"]
-        for name in (
-            "manage-users",
-            "manage-invitations",
-            "manage-server-schedule",
-            "manage-events",
-        ):
-            assert name in perms.get("/admin", [])
-        assert "manage-acls" in perms.get("/acl", [])
+        data = resp.json()
+        perms = data["permissions"]
+        # #2974: the instance-admin marker is the explicit flag; /admin
+        # itself is gone from the permission map.
+        assert data["is_admin"] is True
+        assert "/admin" not in perms
+        # Every tab surface is listed under its own first-class resource.
+        assert "manage-users" in perms.get("/users", [])
+        assert "manage-invitations" in perms.get("/invitations", [])
+        assert "manage-server-schedule" in perms.get("/server", [])
         assert "manage-events" in perms.get("/events", [])
+        assert "manage-acls" in perms.get("/acl", [])

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2617,19 +2617,26 @@ class TestWorkspaceRoutes:
         assert "default" in data
         assert "allowed" in data
         assert data["default"] in data["allowed"]
+        # #2974: the deploy-level toggles moved to the authenticated-only
+        # /config fields — the images listing is image data only.
+        assert "nix_available" not in data
+        assert "sudo_available" not in data
 
-    async def test_list_images_sudo_available(
-        self, client, app, user, monkeypatch
-    ):
-        """#2017: sudo_available reports the deploy-wide allow_sudo posture
-        so create/edit UIs can gate the per-workspace lock-down toggle."""
+    async def test_config_sudo_available(self, client, app, user, monkeypatch):
+        """#2017/#2974: sudo_available reports the deploy-wide allow_sudo
+        posture (authenticated-only /config field) so create/edit UIs can
+        gate the per-workspace lock-down toggle."""
         headers = await _auth_headers(client)
         monkeypatch.setattr(app.state.settings, "allow_sudo", "true")
-        resp = await client.get("/api/v1/images", headers=headers)
+        resp = await client.get("/api/v1/config", headers=headers)
         assert resp.json()["sudo_available"] is True
         monkeypatch.setattr(app.state.settings, "allow_sudo", "")
-        resp = await client.get("/api/v1/images", headers=headers)
+        resp = await client.get("/api/v1/config", headers=headers)
         assert resp.json()["sudo_available"] is False
+        # #1365 posture: like the netfilter fields, absent pre-auth.
+        resp = await client.get("/api/v1/config")
+        assert "sudo_available" not in resp.json()
+        assert "nix_available" not in resp.json()
 
     async def test_delete_workspace(self, client, user, registry):
         headers = await _auth_headers(client)
@@ -3854,20 +3861,20 @@ class TestWorkspaceRoutes:
         app.state.settings.nix_enabled = on
         app.state.settings.nix_seed.path = "/tmp/nix-seed" if on else None
 
-    async def test_images_reports_nix_unavailable_by_default(
+    async def test_config_reports_nix_unavailable_by_default(
         self, client, user
     ):
         headers = await _auth_headers(client)
-        resp = await client.get("/api/v1/images", headers=headers)
+        resp = await client.get("/api/v1/config", headers=headers)
         assert resp.status_code == 200
         assert resp.json()["nix_available"] is False
 
-    async def test_images_reports_available_when_armed(
+    async def test_config_reports_nix_available_when_armed(
         self, client, user, app
     ):
         self._arm_nix(app, True)
         headers = await _auth_headers(client)
-        resp = await client.get("/api/v1/images", headers=headers)
+        resp = await client.get("/api/v1/config", headers=headers)
         assert resp.json()["nix_available"] is True
 
     async def test_create_rejects_nix_optin_while_off(self, client, user, app):

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -277,12 +277,19 @@ class TestSeedDefaultAcls:
         ]
         assert users[1]["system_principal"] == model.SYSTEM_AUTHENTICATED
         assert users[2]["action"] == model.ACTION_DENY
-        # ...and the self-service trio seeds Allow Authenticated +
-        # Deny Everyone.
-        for resource, permission in (
-            ("/volumes", "manage-volumes"),
-            ("/images", "view-images"),
-        ):
+        # #2974: /volumes seeds the admin surface — Allow view-volumes +
+        # Allow manage-volumes for admins, no Deny row (no-match is
+        # default-deny; unauthenticated dies at the JWT middleware).
+        volumes = await app_state.state.model.acl.get_acl_entries("/volumes")
+        assert [
+            (e["position"], e["permission"], e["group_id"]) for e in volumes
+        ] == [
+            (0, "view-volumes", admin_group_id),
+            (1, "manage-volumes", admin_group_id),
+        ]
+        # ...and /images still seeds the #2946 self-service pair:
+        # Allow Authenticated + Deny Everyone.
+        for resource, permission in (("/images", "view-images"),):
             entries = await app_state.state.model.acl.get_acl_entries(resource)
             assert len(entries) == 2, resource
             allow, deny = entries

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -232,12 +232,13 @@ class TestSeedDefaultUser:
 
 class TestSeedDefaultAcls:
     """Seeded-ACL shape (#2944): the first-class trees each seed an
-    Allow manage-* (admins) + Deny everyone pair; /admin remains as
-    the wildcard-admin marker."""
+    Allow manage-* (admins) + Deny everyone pair; /admin is retired
+    (#2974 — the admin marker lives in /my-permissions' is_admin flag)."""
 
     async def test_first_class_resources_seeded(self, db, app_state):
         """#2944: each first-class tree seeds Allow manage-* (admins) +
-        Deny everyone; /admin remains as the wildcard-admin marker."""
+        Deny everyone; /admin is retired (#2974 — the marker is the
+        is_admin flag on /my-permissions)."""
         lifecycle = _lifecycle(make_settings({}))
         admin_group_id = await lifecycle.ensure_admin_group()
         await lifecycle.seed_default_acls(admin_group_id)
@@ -259,13 +260,13 @@ class TestSeedDefaultAcls:
             assert deny["permission"] == "*"
             assert deny["system_principal"] == model.SYSTEM_EVERYONE
 
+        # #2974: /admin is gone from the seed — the instance-admin
+        # marker is the is_admin flag on /my-permissions (admins-group
+        # membership), not a wildcard ACE.
         admin_entries = await app_state.state.model.acl.get_acl_entries(
             "/admin"
         )
-        assert any(
-            e["permission"] == "*" and e["group_id"] == admin_group_id
-            for e in admin_entries
-        )
+        assert admin_entries == []
 
         # #2946: /users carries the search-users row for Authenticated
         # between the admins' Allow and the blanket Deny.

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -287,16 +287,15 @@ class TestSeedDefaultAcls:
             (0, "view-volumes", admin_group_id),
             (1, "manage-volumes", admin_group_id),
         ]
-        # ...and /images still seeds the #2946 self-service pair:
-        # Allow Authenticated + Deny Everyone.
-        for resource, permission in (("/images", "view-images"),):
-            entries = await app_state.state.model.acl.get_acl_entries(resource)
-            assert len(entries) == 2, resource
-            allow, deny = entries
-            assert allow["permission"] == permission
-            assert allow["system_principal"] == model.SYSTEM_AUTHENTICATED
-            assert deny["permission"] == "*"
-            assert deny["system_principal"] == model.SYSTEM_EVERYONE
+        # ...and /images seeds the #2946 self-service row — Allow
+        # Authenticated only (#2974 dropped the dead Deny Everyone row:
+        # it can never fire, and no-match is default-deny).
+        images = await app_state.state.model.acl.get_acl_entries("/images")
+        assert [(e["position"], e["permission"]) for e in images] == [
+            (0, "view-images")
+        ]
+        assert images[0]["system_principal"] == model.SYSTEM_AUTHENTICATED
+        assert images[0]["action"] == model.ACTION_ALLOW
 
 
 class TestSeedDefaultUserAuthModeGating:

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -85,6 +85,7 @@ class TestRunner:
             (22, "0022_workspace_permission_renames"),
             (23, "0023_self_service_resources"),
             (24, "0024_join_workspace_permission"),
+            (25, "0025_volumes_admin_surface"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -175,6 +176,7 @@ class TestRunner:
                 (22, "0022_workspace_permission_renames"),
                 (23, "0023_self_service_resources"),
                 (24, "0024_join_workspace_permission"),
+                (25, "0025_volumes_admin_surface"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -2642,5 +2644,165 @@ class TestM0024JoinWorkspacePermission:
             await m0024_join_workspace_permission.migration.apply(db)
             cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
             assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0025VolumesAdminSurface:
+    """m0025 re-seeds /volumes to the admins group (view + manage) and
+    deletes the retired #2946 Allow-Authenticated / Deny-Everyone pair
+    (#2974)."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0025.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT,"
+            " UNIQUE(resource, position))"
+        )
+        await db.execute(
+            "CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT)"
+        )
+        await db.execute(
+            "INSERT INTO groups (id, name) VALUES ('g-admin', 'admins')"
+        )
+        return db
+
+    async def _rows(self, db, resource) -> list:
+        cursor = await db.execute(
+            "SELECT position, action, group_id, system_principal,"
+            " permission FROM acl_entries"
+            " WHERE resource = ? ORDER BY position",
+            (resource,),
+        )
+        return list(await cursor.fetchall())
+
+    async def test_upgraded_db_reseeds_to_admins(self, tmp_path):
+        """The retired seed pair is replaced by the admins' view+manage
+        rows; re-running changes nothing."""
+        from klangk.model import ACTION_ALLOW
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            # Existing deployment: rows elsewhere (skips the fresh-DB
+            # gate) + the retired #2946 pair on /volumes.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/', 0, 1, 0, 1, 'view')"
+            )
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/volumes', 0, 1, 0, 1, 'manage-volumes')"
+            )
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/volumes', 1, 0, 0, 0, '*')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (0, ACTION_ALLOW, "g-admin", None, "view-volumes"),
+                (1, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+            # Idempotent: re-run changes nothing.
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (0, ACTION_ALLOW, "g-admin", None, "view-volumes"),
+                (1, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_fresh_db_is_noop(self, tmp_path):
+        """An empty acl_entries table belongs to the boot seeds."""
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await m0025_volumes_admin_surface.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_operator_custom_rows_preserved(self, tmp_path):
+        """Rows that are not the retired seed pair are operator intent:
+        left untouched, with only the missing admin rows added."""
+        from klangk.model import ACTION_ALLOW
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/volumes', 2, 1, 2, 'g-a', 'custom'),"
+                "        ('/', 0, 1, 3, NULL, 'view')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (2, ACTION_ALLOW, "g-a", None, "custom"),
+                (3, ACTION_ALLOW, "g-admin", None, "view-volumes"),
+                (4, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_staged_permission_wins(self, tmp_path):
+        """A row already granting one of the two permissions (operator
+        staged or partial re-run) is not duplicated."""
+        from klangk.model import ACTION_ALLOW
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, user_id,"
+                "  permission)"
+                " VALUES ('/volumes', 0, 1, 1, 'u-9', 'view-volumes'),"
+                "        ('/', 0, 1, 3, NULL, 'view')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == [
+                (0, ACTION_ALLOW, None, None, "view-volumes"),
+                (1, ACTION_ALLOW, "g-admin", None, "manage-volumes"),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_no_admins_group_leaves_rows(self, tmp_path):
+        """Without an admins group there is nothing to grant; the
+        retired rows are left as-is (early return)."""
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute("DELETE FROM groups")
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/volumes', 0, 1, 0, 1, 'manage-volumes'),"
+                "        ('/volumes', 1, 0, 0, 0, '*'),"
+                "        ('/', 0, 1, 0, 1, 'view')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+            assert len(await self._rows(db, "/volumes")) == 2
         finally:
             await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -87,6 +87,7 @@ class TestRunner:
             (24, "0024_join_workspace_permission"),
             (25, "0025_volumes_admin_surface"),
             (26, "0026_drop_dead_images_deny_row"),
+            (27, "0027_retire_admin_marker"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -179,6 +180,7 @@ class TestRunner:
                 (24, "0024_join_workspace_permission"),
                 (25, "0025_volumes_admin_surface"),
                 (26, "0026_drop_dead_images_deny_row"),
+                (27, "0027_retire_admin_marker"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -2898,6 +2900,69 @@ class TestM0026DropDeadImagesDenyRow:
         db = await self._db(tmp_path)
         try:
             await m0026_drop_dead_images_deny_row.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0027RetireAdminMarker:
+    """m0027 deletes every stored row on /admin (#2974) — nothing checks
+    a permission there since #2944; the marker is the is_admin flag on
+    /my-permissions now."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0027.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT,"
+            " UNIQUE(resource, position))"
+        )
+        return db
+
+    async def _count(self, db, resource) -> int:
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM acl_entries WHERE resource = ?",
+            (resource,),
+        )
+        return (await cursor.fetchone())[0]
+
+    async def test_deletes_seeded_pair_and_custom_rows(self, tmp_path):
+        from klangk.model.migrations import m0027_retire_admin_marker
+
+        db = await self._db(tmp_path)
+        try:
+            # The #2944 seeded pair + an operator row on the dead tree,
+            # plus rows elsewhere (skips the fresh-DB gate; must survive).
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/admin', 0, 1, 2, 'g-admin', '*'),"
+                "        ('/admin', 1, 0, 3, NULL, '*'),"
+                "        ('/admin', 2, 1, 2, 'g-a', 'custom'),"
+                "        ('/', 0, 1, 0, NULL, 'view')"
+            )
+            await db.commit()
+            await m0027_retire_admin_marker.migration.apply(db)
+            assert await self._count(db, "/admin") == 0
+            assert await self._count(db, "/") == 1
+            # Idempotent: re-run changes nothing.
+            await m0027_retire_admin_marker.migration.apply(db)
+            assert await self._count(db, "/admin") == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_fresh_db_is_noop(self, tmp_path):
+        from klangk.model.migrations import m0027_retire_admin_marker
+
+        db = await self._db(tmp_path)
+        try:
+            await m0027_retire_admin_marker.migration.apply(db)
             cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
             assert (await cursor.fetchone())[0] == 0
         finally:

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -86,6 +86,7 @@ class TestRunner:
             (23, "0023_self_service_resources"),
             (24, "0024_join_workspace_permission"),
             (25, "0025_volumes_admin_surface"),
+            (26, "0026_drop_dead_images_deny_row"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -177,6 +178,7 @@ class TestRunner:
                 (23, "0023_self_service_resources"),
                 (24, "0024_join_workspace_permission"),
                 (25, "0025_volumes_admin_surface"),
+                (26, "0026_drop_dead_images_deny_row"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -2804,5 +2806,99 @@ class TestM0025VolumesAdminSurface:
             await db.commit()
             await m0025_volumes_admin_surface.migration.apply(db)
             assert len(await self._rows(db, "/volumes")) == 2
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0026DropDeadImagesDenyRow:
+    """m0026 deletes the unreachable Deny Everyone ``*`` row on /images
+    (#2974) — the JWT middleware rejects unauthenticated requests before
+    any ACL check, and no-match is default-deny."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0026.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT,"
+            " UNIQUE(resource, position))"
+        )
+        return db
+
+    async def _rows(self, db, resource) -> list:
+        cursor = await db.execute(
+            "SELECT position, action, permission, system_principal"
+            " FROM acl_entries WHERE resource = ? ORDER BY position",
+            (resource,),
+        )
+        return list(await cursor.fetchall())
+
+    async def test_drops_only_the_dead_deny(self, tmp_path):
+        from klangk.model import ACTION_ALLOW
+        from klangk.model.migrations import m0026_drop_dead_images_deny_row
+
+        db = await self._db(tmp_path)
+        try:
+            # The #2946 seed shape + an operator row at position 2.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  system_principal, permission)"
+                " VALUES ('/images', 0, 1, 0, 1, 'view-images'),"
+                "        ('/images', 1, 0, 0, 0, '*'),"
+                "        ('/images', 2, 1, 2, NULL, 'custom')"
+            )
+            await db.commit()
+            await m0026_drop_dead_images_deny_row.migration.apply(db)
+            assert await self._rows(db, "/images") == [
+                (0, ACTION_ALLOW, "view-images", 1),
+                (2, ACTION_ALLOW, "custom", None),
+            ]
+            # Idempotent: re-run changes nothing.
+            await m0026_drop_dead_images_deny_row.migration.apply(db)
+            assert await self._rows(db, "/images") == [
+                (0, ACTION_ALLOW, "view-images", 1),
+                (2, ACTION_ALLOW, "custom", None),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_custom_deny_shapes_untouched(self, tmp_path):
+        """A Deny row that is not the seed's Everyone ``*`` (e.g. a
+        group-scoped deny, or a ``view-images`` deny) is operator intent
+        and stays."""
+        from klangk.model import ACTION_DENY
+        from klangk.model.migrations import m0026_drop_dead_images_deny_row
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/images', 0, 0, 2, 'g-a', '*'),"
+                "        ('/images', 1, 0, 0, NULL, 'view-images')"
+            )
+            await db.commit()
+            await m0026_drop_dead_images_deny_row.migration.apply(db)
+            assert await self._rows(db, "/images") == [
+                (0, ACTION_DENY, "*", None),
+                (1, ACTION_DENY, "view-images", None),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_fresh_db_is_noop(self, tmp_path):
+        """An empty acl_entries table belongs to the boot seeds."""
+        from klangk.model.migrations import m0026_drop_dead_images_deny_row
+
+        db = await self._db(tmp_path)
+        try:
+            await m0026_drop_dead_images_deny_row.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
         finally:
             await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_mode_switching.py
+++ b/src/klangk/klangkd-tests/tests/test_mode_switching.py
@@ -165,7 +165,7 @@ class TestNoneToPasswordUpgrade:
         me_perms = (
             await client.get("/api/v1/my-permissions", headers=h)
         ).json()
-        assert "*" in me_perms["permissions"].get("/admin", [])
+        assert me_perms["is_admin"] is True
 
         # admin set-password equivalent.
         resp = await client.patch(
@@ -455,4 +455,4 @@ class TestRestartIdempotency:
                 headers={"Authorization": f"Bearer {token}"},
             )
         ).json()
-        assert perms and "*" in perms["permissions"].get("/admin", [])
+        assert perms and perms["is_admin"] is True

--- a/src/klangk/klangkd-tests/tests/test_nix.py
+++ b/src/klangk/klangkd-tests/tests/test_nix.py
@@ -90,7 +90,7 @@ async def test_no_op_when_not_configured(monkeypatch):
 
 def test_available_is_switch_and_backend():
     """available = nix_enabled AND nix_seed.path — the resolved armed status
-    reported by /api/v1/images nix_available."""
+    reported by the /config nix_available field (#2974)."""
     assert Nix(_app(SEED)).available is True
     assert Nix(_app(SEED, enabled=False)).available is False
     assert Nix(_app(None, enabled=False)).available is False


### PR DESCRIPTION
Part 3 of 3 for #2974 (umbrella). **Stacked on #2989 + #2990** — merge those first; this branch contains all three commits until then.

## What changes

The `/admin` marker is retired; instance-admin status comes from its source of truth:

- **`/my-permissions` returns an explicit `is_admin` flag**, derived from `admins`-group membership (also present on the `?resource=` form). This replaces the wildcard-ACE hack: since #2944 nothing checked a permission on `/admin`, and the rows survived only so clients could probe `*` on `/admin` for admin status.
- **`/admin` is dropped** from `STATIC_RESOURCES` (gone from the permission map) and from the seed.
- **Migration `0027`** deletes every stored row on `/admin` on existing deployments — nothing can be reading them except the marker, and the marker is now the flag.
- **Frontend**: `AuthService.isAdmin` reads the flag (cleared on logout); route guards and the app-bar admin icon are unchanged consumers.
- **CLI**: `klangk status`'s admin probe reads the flag; an absent flag (old server) reports unknown, never silently non-admin.

## Why

A resource the #2944 overhaul retired as a permission-checking tree still shaped UI state through a wildcard ACE hack. #2974 decided admin status derives from group membership, where it actually lives.

## Tests

- `/my-permissions`: `is_admin` true for admins / false for non-admins, absent `/admin` key, both the batch and `?resource=` forms; mode-switching re-seed keeps the flag.
- Seed shape: no `/admin` rows (`test_main.py`).
- Migration 0027: deletes the seeded pair and custom rows, fresh-db no-op, idempotent (`test_migrations.py`).
- Flutter: `isAdmin` flag parsing, logout clearing, admin icon/route-guard stubs serve `is_admin`; parameterized test helpers.
- CLI: status admin yes/no via the flag, unknown on absent/non-bool.

Docs: `docs/reference/acl.md` (tree, seed table, marker narrative), `docs/reference/api-endpoints.md` (`/my-permissions`), changelog (Breaking).

Closes the `/admin` section of #2974 — with #2989 and #2990, all three decisions from the umbrella issue are implemented.
