### PR TITLE
Split view-volumes from manage-volumes, admin-only seed + admin Volumes tab

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -33,18 +33,20 @@ operators or integrators to act when upgrading.
 ### Breaking
 
 - **Volumes are an admin surface (#2993).** `GET /volumes` now checks
-  the new `view-volumes` permission (the admin Volumes tab's gate;
-  view + delete only, no create), while `POST /volumes` and
-  `DELETE /volumes/{name}` keep `manage-volumes` — both seeded Allow
-  for the `admins` group only, so non-admin users lose volume
-  list/create/delete access on upgrade (migration m0025 replaces the
-  old rows; custom operator rows that don't match the seeded shapes
-  survive below the new admin rows — re-grant via the ACL editor if a
-  deploy wants self-service volumes back). The listing returns the
-  deployment's whole instance-managed inventory — the creator label
-  is provenance (`user_id` plus the creator's handle `created_by`),
-  and each row lists the workspace names mounting it (`workspaces`);
-  `manage-volumes` holders may delete any instance volume.
+  the new `view-volumes` permission (the admin Volumes tab's listing
+  gate), while `POST /volumes` and `DELETE /volumes/{name}` keep
+  `manage-volumes` — both seeded Allow for the `admins` group only,
+  so non-admin users lose volume list/create/delete access on
+  upgrade (migration m0025 replaces the old rows; custom operator
+  rows that don't match the seeded shapes survive below the new admin
+  rows — re-grant via the ACL editor if a deploy wants self-service
+  volumes back). The tab lists and deletes volumes (delete needs
+  `manage-volumes`); there is no create surface. The listing returns
+  the deployment's whole instance-managed inventory — the creator
+  label is provenance (`user_id` plus the creator's handle
+  `created_by`), and each row lists the workspace names mounting it
+  (`workspaces`); `manage-volumes` holders may delete any instance
+  volume.
 
 - **Deploy-wide consent decider removed (#2976).** The
   `/ws/consent-decider` handshake without a `?workspace=` param is now

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,21 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **Volumes are an admin surface (#2993).** `GET /volumes` now checks
+  the new `view-volumes` permission (the admin Volumes tab's gate;
+  view + delete only, no create), while `POST /volumes` and
+  `DELETE /volumes/{name}` keep `manage-volumes` — both seeded Allow
+  for the `admins` group only. Non-admin users lose volume
+  list/create/delete access on upgrade (migration m0025 replaces the
+  old Allow-Authenticated row; operator-staged grants survive below
+  the new admin rows). A deploy that wants self-service volumes back
+  adds an Allow `manage-volumes` (and/or `view-volumes`) row for
+  `Authenticated` or a group via the ACL editor. The listing now
+  returns the deployment's whole instance-managed inventory — the
+  per-user creator label is provenance in the new `user_id` field,
+  no longer a filter — and `manage-volumes` holders may delete any
+  instance volume, not only their own.
+
 - **Deploy-wide consent decider removed (#2976).** The
   `/ws/consent-decider` handshake without a `?workspace=` param is now
   refused (HTTP 403): consent authority is strictly per-workspace

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -46,7 +46,10 @@ operators or integrators to act when upgrading.
   label is provenance (`user_id` plus the creator's handle
   `created_by`), and each row lists the workspace names mounting it
   (`workspaces`); `manage-volumes` holders may delete any instance
-  volume.
+  volume. The listing is server-side searchable (volume name, creator
+  handle, or using-workspace name) and paginated, returning the
+  `{volumes, page, page_size, total}` envelope — `klangk volumes ls`
+  ships with it; external API consumers must read the envelope.
 
 - **Deploy-wide consent decider removed (#2976).** The
   `/ws/consent-decider` handshake without a `?workspace=` param is now

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -37,7 +37,7 @@ operators or integrators to act when upgrading.
   gate), while `POST /volumes` and `DELETE /volumes/{name}` keep
   `manage-volumes` — both seeded Allow for the `admins` group only,
   so non-admin users lose volume list/create/delete access on
-  upgrade (migration m0025 replaces the old rows; custom operator
+  upgrade (migration m0026 replaces the old rows; custom operator
   rows that don't match the seeded shapes survive below the new admin
   rows — re-grant via the ACL editor if a deploy wants self-service
   volumes back). The tab lists and deletes volumes (delete needs

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -41,15 +41,13 @@ operators or integrators to act when upgrading.
   rows that don't match the seeded shapes survive below the new admin
   rows — re-grant via the ACL editor if a deploy wants self-service
   volumes back). The tab lists and deletes volumes (delete needs
-  `manage-volumes`); there is no create surface. The listing returns
-  the deployment's whole instance-managed inventory — the creator
-  label is provenance (`user_id` plus the creator's handle
-  `created_by`), and each row lists the workspace names mounting it
-  (`workspaces`); `manage-volumes` holders may delete any instance
-  volume. The listing is server-side searchable (volume name, creator
-  handle, or using-workspace name) and paginated, returning the
-  `{volumes, page, page_size, total}` envelope — `klangk volumes ls`
-  ships with it; external API consumers must read the envelope.
+  `manage-volumes`); there is no create surface, and
+  `manage-volumes` holders may delete any instance volume. The
+  listing now returns the whole inventory — creator provenance,
+  using-workspace names, search, and paging — in a
+  `{volumes, page, page_size, total}` envelope documented in
+  `docs/reference/api-endpoints.md`; `klangk volumes ls` ships with
+  it, but external API consumers must read the envelope.
 
 - **Deploy-wide consent decider removed (#2976).** The
   `/ws/consent-decider` handshake without a `?workspace=` param is now

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -42,7 +42,8 @@ operators or integrators to act when upgrading.
   survive below the new admin rows — re-grant via the ACL editor if a
   deploy wants self-service volumes back). The listing returns the
   deployment's whole instance-managed inventory — the creator label
-  is provenance in the new `user_id` field, no longer a filter — and
+  is provenance (`user_id` plus the creator's handle `created_by`),
+  and each row lists the workspace names mounting it (`workspaces`);
   `manage-volumes` holders may delete any instance volume.
 
 - **Deploy-wide consent decider removed (#2976).** The

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -36,16 +36,14 @@ operators or integrators to act when upgrading.
   the new `view-volumes` permission (the admin Volumes tab's gate;
   view + delete only, no create), while `POST /volumes` and
   `DELETE /volumes/{name}` keep `manage-volumes` — both seeded Allow
-  for the `admins` group only. Non-admin users lose volume
+  for the `admins` group only, so non-admin users lose volume
   list/create/delete access on upgrade (migration m0025 replaces the
-  old Allow-Authenticated row; operator-staged grants survive below
-  the new admin rows). A deploy that wants self-service volumes back
-  adds an Allow `manage-volumes` (and/or `view-volumes`) row for
-  `Authenticated` or a group via the ACL editor. The listing now
-  returns the deployment's whole instance-managed inventory — the
-  per-user creator label is provenance in the new `user_id` field,
-  no longer a filter — and `manage-volumes` holders may delete any
-  instance volume, not only their own.
+  old rows; custom operator rows that don't match the seeded shapes
+  survive below the new admin rows — re-grant via the ACL editor if a
+  deploy wants self-service volumes back). The listing returns the
+  deployment's whole instance-managed inventory — the creator label
+  is provenance in the new `user_id` field, no longer a filter — and
+  `manage-volumes` holders may delete any instance volume.
 
 - **Deploy-wide consent decider removed (#2976).** The
   `/ws/consent-decider` handshake without a `?workspace=` param is now

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -24,6 +24,7 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 ├── /server                    (flat — lifecycle schedules)
 ├── /events                    (flat — read-only audit)
 ├── /acl                       (flat — the ACL editor itself)
+├── /volumes                   (flat — the admin volume inventory)
 └── /admin                     (marker only — nothing checks here, #2944)
 ```
 
@@ -47,8 +48,8 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/events`      | Deny   | Everyone      | `*`                      |
 | `/acl`         | Allow  | group:admins  | `manage-acls`            |
 | `/acl`         | Deny   | Everyone      | `*`                      |
-| `/volumes`     | Allow  | Authenticated | `manage-volumes`         |
-| `/volumes`     | Deny   | Everyone      | `*`                      |
+| `/volumes`     | Allow  | group:admins  | `view-volumes`           |
+| `/volumes`     | Allow  | group:admins  | `manage-volumes`         |
 | `/images`      | Allow  | Authenticated | `view-images`            |
 | `/images`      | Deny   | Everyone      | `*`                      |
 | `/admin`       | Allow  | group:admins  | `*` (admin marker only)  |
@@ -72,6 +73,18 @@ requests are rejected by the JWT middleware before any ACL check.
 permissions on `/images` include the `view` inherited from `/` —
 visible in `/my-permissions`; nothing checks it.)
 
+`/volumes` is the one `manage-*` resource whose read side is split
+out (#2993): the admin Volumes tab lists and deletes volumes, and a
+read-only "volumes auditor" delegation makes sense, so
+`GET /volumes` checks `view-volumes` while `POST`/`DELETE` check
+`manage-volumes` — the action-specific naming pattern of
+`/acl`+`manage-acls`, `/server`+`manage-server-schedule`, and
+`/images`+`view-images`. The volume listing shows the deployment's
+whole instance-managed inventory (the per-user creator label is
+provenance, not an access filter). Deploys that want self-service
+volumes back grant `manage-volumes` to `Authenticated` or a group via
+the ACL editor. No trailing Deny Everyone row is seeded on `/volumes` either,
+for the same reason.
 ### Granting workspace creation to non-admin users
 
 By default only administrators can create workspaces (#2569). To allow
@@ -203,9 +216,9 @@ actions — no per-action splits:
 | `manage-server-schedule` | `/server`           | Server stop/recycle schedules: list, create, cancel                                                                                                                   |
 | `manage-events`          | `/events`           | Read the container start/stop history (`GET /events`) — read-only audit                                                                                               |
 | `manage-acls`            | `/acl`              | The Access Control browser: read and rewrite ACL entries on **any** resource via `GET/PUT /acl/*` — root-equivalent, see below                                        |
-| `manage-volumes`         | `/volumes`          | Self-service volumes (still label-scoped to the caller at runtime) — Allow Authenticated by default (#2946)                                                           |
-| `view-images`            | `/images`           | The image listing the create/edit UIs read (#2946; Allow Authenticated by default — the deliberate, ACL-editor-modifiable exception, #2974)                           |
-| `search-users`           | `/users`            | The member-picker type-ahead (`GET /users/search`) — Allow Authenticated by default (#2946)                                                                           |
+| `view-volumes`           | `/volumes`          | The volume inventory listing (`GET /volumes`) — the admin Volumes tab's gate; Allow group:admins by default (#2993)                                                   |
+| `manage-volumes`         | `/volumes`          | Create/delete instance-managed volumes (`POST /volumes`, `DELETE /volumes/{name}`) — Allow group:admins by default (#2993); the CLI's volume commands use it too      |
+| `view-images`            | `/images`           | The image listing the create/edit UIs read (#2946; Allow Authenticated by default — the deliberate, ACL-editor-modifiable exception, #2974)                           || `search-users`           | `/users`            | The member-picker type-ahead (`GET /users/search`) — Allow Authenticated by default (#2946)                                                                           |
 | `admin`                  | `/admin`            | The instance-administrator **marker** only (`*` row); nothing checks it anywhere anymore (#2944, #2946 — the transfer gate now checks `transfer-workspace`)           |
 
 `PUT /acl/resource` additionally requires `share-advanced` on the target

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -204,8 +204,10 @@ all, #2886).
 ### First-class resource permissions
 
 Every governed surface is a first-class top-level resource (#2944);
-each carries **one** flat `manage-*` permission covering all of its
-actions — no per-action splits:
+each carries a flat `manage-*` permission covering its actions. The
+one split: `/volumes` also has a read-side `view-volumes` (#2993) —
+the listing gate of its admin tab, separate from `manage-volumes` so
+a read-only volumes auditor can be delegated:
 
 | Permission               | Where it is checked | Controls                                                                                                                                                              |
 | ------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -591,16 +591,34 @@ names whose extra mounts reference the volume.
 
 No request body.
 
+**Query params (optional, server-side paging/sort/filter):**
+
+| Param       | Type   | Default   | Constraints                          |
+| ----------- | ------ | --------- | ------------------------------------ |
+| `page`      | int    | `1`       | `>= 1` (clamped)                     |
+| `page_size` | int    | `10`      | `1`–`200` (clamped)                  |
+| `sort`      | string | `created` | `name` \| `created` (else `created`) |
+| `order`     | string | `desc`    | `asc` \| `desc`                      |
+| `q`         | string | (none)    | substring match, case-insensitive    |
+
+`q` matches the volume name, the creator's handle, or any workspace
+name using the volume.
+
 ```json
-[
-  {
-    "name": "my-volume",
-    "created": "2025-01-01T12:00:00Z",
-    "user_id": "<creator user id>",
-    "created_by": "alice",
-    "workspaces": ["my-workspace"]
-  }
-]
+{
+  "volumes": [
+    {
+      "name": "my-volume",
+      "created": "2025-01-01T12:00:00Z",
+      "user_id": "<creator user id>",
+      "created_by": "alice",
+      "workspaces": ["my-workspace"]
+    }
+  ],
+  "page": 1,
+  "page_size": 10,
+  "total": 1
+}
 ```
 
 ---

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -584,7 +584,10 @@ List every podman volume this klangk instance manages.
 **Auth:** JWT required. User must have the `view-volumes` permission
 on `/volumes` (#2993; seeded Allow for the `admins` group — the admin
 Volumes tab's listing gate). The creator label is surfaced as
-provenance, not used as an access filter.
+provenance, not used as an access filter. `created_by` is the
+creator's handle (null when the creator no longer exists or the
+volume was created without a label); `workspaces` lists the workspace
+names whose extra mounts reference the volume.
 
 No request body.
 
@@ -593,7 +596,9 @@ No request body.
   {
     "name": "my-volume",
     "created": "2025-01-01T12:00:00Z",
-    "user_id": "<creator user id>"
+    "user_id": "<creator user id>",
+    "created_by": "alice",
+    "workspaces": ["my-workspace"]
   }
 ]
 ```

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -579,16 +579,23 @@ No request body.
 
 ### GET `/api/v1/volumes`
 
-List podman volumes owned by the current user.
+List every podman volume this klangk instance manages.
 
-**Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946; seeded Allow for Authenticated; volumes stay
-label-scoped to the caller at runtime).
+**Auth:** JWT required. User must have the `view-volumes` permission
+on `/volumes` (#2993; seeded Allow for the `admins` group — the admin
+Volumes tab's listing gate). The creator label is surfaced as
+provenance, not used as an access filter.
 
 No request body.
 
 ```json
-[{ "name": "my-volume", "created": "2025-01-01T12:00:00Z" }]
+[
+  {
+    "name": "my-volume",
+    "created": "2025-01-01T12:00:00Z",
+    "user_id": "<creator user id>"
+  }
+]
 ```
 
 ---
@@ -1324,10 +1331,12 @@ Returns `StreamingResponse` (`application/x-ndjson`).
 
 ### POST `/api/v1/volumes`
 
-Create a new podman volume labeled with the current user's ID.
+Create a new podman volume labeled with the current user's ID (the
+label is provenance; the admin Volumes tab offers no create surface —
+this endpoint serves the CLI's volume commands).
 
 **Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946).
+on `/volumes` (#2993; seeded Allow for the `admins` group).
 
 ```json
 { "name": "my-volume" }
@@ -1770,10 +1779,13 @@ Replace all ACL entries for a workspace.
 
 ### DELETE `/api/v1/volumes/{name}`
 
-Delete a podman volume. Only the owning user can delete their volumes.
+Delete an instance-managed podman volume. Any holder of the
+permission may delete any instance volume (#2993 — the surface is
+admin-only by seed; the creator label is provenance, not an access
+filter).
 
 **Auth:** JWT required. User must have the `manage-volumes` permission
-on `/volumes` (#2946). Checks user ownership.
+on `/volumes` (#2993; seeded Allow for the `admins` group).
 
 No request body.
 

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -49,6 +49,10 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   bool _canServer = false;
   bool _canEvents = false;
   bool _canAcl = false;
+  // The Volumes tab (#2993) splits view from manage: view-volumes
+  // keys the tab (the listing), manage-volumes the delete action.
+  bool _canVolumes = false;
+  bool _canManageVolumes = false;
 
   // Pending invitation count for the tab badge — updated by the
   // _InvitationsTab widget via callback.
@@ -104,6 +108,11 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     // (#2940) — root-equivalent (it can rewrite ACLs on any
     // resource), so it is granted only to administrators.
     _canAcl = auth.hasPermission('/acl', 'manage-acls');
+    // #2993: the Volumes admin tab offers view + delete only — no
+    // create surface. Visibility keys on view-volumes (GET /volumes);
+    // the per-row delete additionally needs manage-volumes.
+    _canVolumes = auth.hasPermission('/volumes', 'view-volumes');
+    _canManageVolumes = auth.hasPermission('/volumes', 'manage-volumes');
   }
 
   Future<void> _loadUsers({int page = 1}) async {
@@ -470,6 +479,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (_canInvitations) types.add('invitations');
     if (_canServer) types.add('server');
     if (_canEvents) types.add('events');
+    if (_canVolumes) types.add('volumes');
     // The Access Control browser reads /acl/*, gated on
     // `manage-acls` (#2940) — a delegated container-events auditor
     // (#2923) gets only the Events tab, not a dead ACL tab.
@@ -542,6 +552,16 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         view: const ContainerEventsPanel(),
       );
     }
+    // The Volumes tab (#2993): the deployment's instance-managed
+    // volume inventory — listing plus delete, no create.
+    if (_canVolumes) {
+      addTab(
+        label: 'Volumes',
+        icon: Icons.storage,
+        view: _VolumesTab(
+            key: const ValueKey('volumes-tab'), canManage: _canManageVolumes),
+      );
+    }
     // The Access Control browser reads /acl/*, gated on
     // `manage-acls` (#2940) — shown exactly to its holders.
     if (_canAcl) {
@@ -574,7 +594,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       'invitations' ||
       'groups' ||
       'server' ||
-      'events' =>
+      'events' ||
+      'volumes' =>
         null, // FABs inside tabs
       _ => null,
     };
@@ -1418,6 +1439,165 @@ class _InvitationsTabState extends State<_InvitationsTab> {
 }
 
 // ---------------------------------------------------------------------------
+// Volumes tab
+// ---------------------------------------------------------------------------
+
+/// The Volumes admin tab (#2993): the deployment's instance-managed
+/// volume inventory — view and delete only, no create (volume creation
+/// is runtime-auto per workspace, or the CLI's volume commands). The
+/// tab keys on `view-volumes`; the delete action additionally needs
+/// `manage-volumes`.
+class _VolumesTab extends StatefulWidget {
+  final bool canManage;
+
+  const _VolumesTab({super.key, required this.canManage});
+
+  @override
+  State<_VolumesTab> createState() => _VolumesTabState();
+}
+
+class _VolumesTabState extends State<_VolumesTab> {
+  List<Map<String, dynamic>> _volumes = [];
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVolumes();
+  }
+
+  Future<void> _loadVolumes() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final auth = context.read<AuthService>();
+      final resp = await auth.authGet('/api/v1/volumes');
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        setState(() {
+          _volumes =
+              (jsonDecode(resp.body) as List).cast<Map<String, dynamic>>();
+          _loading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load volumes: ${resp.statusCode}';
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[AdminUsersPage] load volumes failed: $e');
+      if (mounted) {
+        setState(() {
+          _error = 'Could not load volumes. Please try again.';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _deleteVolume(Map<String, dynamic> volume) async {
+    final name = volume['name'] as String;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Volume'),
+        content: Text(
+          'Delete volume "$name"? Workspaces using it lose its data.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: KColors.accentRed,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+    final auth = context.read<AuthService>();
+    final resp = await auth.authDelete('/api/v1/volumes/$name');
+    if (!mounted) return;
+    if (resp.statusCode == 200) {
+      await _loadVolumes();
+    } else {
+      String detail;
+      try {
+        detail = jsonDecode(resp.body)['detail'] ?? 'Error ${resp.statusCode}';
+      } catch (_) {
+        detail = 'Error ${resp.statusCode}';
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(detail)));
+    }
+  }
+
+  Widget _buildVolumesList() {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) return Center(child: Text(_error!));
+    if (_volumes.isEmpty) return const Center(child: Text('No volumes'));
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: _volumes.length,
+      itemBuilder: (ctx, i) {
+        final volume = _volumes[i];
+        final name = volume['name'] as String? ?? '';
+        final createdRaw = volume['created'] as String? ?? '';
+        final created =
+            createdRaw.length >= 10 ? createdRaw.substring(0, 10) : createdRaw;
+        // Provenance only (#2993): who created the volume. The raw
+        // user id is opaque, so only its leading characters show.
+        final userId = volume['user_id'] as String? ?? '';
+        final owner = userId.length >= 8 ? userId.substring(0, 8) : userId;
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            leading: const CircleAvatar(
+              backgroundColor: KColors.accentBlue,
+              child: Icon(Icons.storage, color: Colors.white),
+            ),
+            title: Text(name),
+            subtitle: Text(
+              owner.isEmpty
+                  ? 'Created $created'
+                  : 'Created $created · by $owner…',
+              style: const TextStyle(color: KColors.textSecondary),
+            ),
+            trailing: widget.canManage
+                ? IconButton(
+                    icon: const Icon(
+                      Icons.delete_outline,
+                      color: KColors.accentRed,
+                    ),
+                    tooltip: 'Delete volume',
+                    onPressed: () => _deleteVolume(volume),
+                  )
+                : null,
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: _buildVolumesList());
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Dialogs
 // ---------------------------------------------------------------------------
 
@@ -1932,7 +2112,8 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
     '/invitations': 'manage-invitations',
     '/server': 'manage-server-schedule',
     '/events': 'manage-events (read-only audit)',
-    '/volumes': 'manage-volumes — self-service volumes (Allow Authenticated)',
+    '/volumes':
+        'view-volumes — the Volumes tab listing; manage-volumes — create/delete',
     '/images': 'view-images — the image/capability listing',
     '/acl': 'manage-acls — root-equivalent, administrators only',
   };

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -1557,10 +1557,17 @@ class _VolumesTabState extends State<_VolumesTab> {
         final createdRaw = volume['created'] as String? ?? '';
         final created =
             createdRaw.length >= 10 ? createdRaw.substring(0, 10) : createdRaw;
-        // Provenance only (#2993): who created the volume. The raw
-        // user id is opaque, so only its leading characters show.
+        // Who created it (#2993): the creator's handle when the user
+        // still exists, else the raw label's leading characters as a
+        // fallback (deleted creator / runtime-created without a
+        // label → provenance only).
+        final handle = volume['created_by'] as String? ?? '';
         final userId = volume['user_id'] as String? ?? '';
-        final owner = userId.length >= 8 ? userId.substring(0, 8) : userId;
+        final owner = handle.isNotEmpty
+            ? '@$handle'
+            : (userId.length >= 8 ? userId.substring(0, 8) : userId);
+        // Which workspaces mount this volume (#2993).
+        final workspaces = (volume['workspaces'] as List? ?? []).cast<String>();
         return Card(
           margin: const EdgeInsets.only(bottom: 8),
           child: ListTile(
@@ -1569,12 +1576,24 @@ class _VolumesTabState extends State<_VolumesTab> {
               child: Icon(Icons.storage, color: Colors.white),
             ),
             title: Text(name),
-            subtitle: Text(
-              owner.isEmpty
-                  ? 'Created $created'
-                  : 'Created $created · by $owner…',
-              style: const TextStyle(color: KColors.textSecondary),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  owner.isEmpty
+                      ? 'Created $created'
+                      : 'Created $created · by $owner',
+                  style: const TextStyle(color: KColors.textSecondary),
+                ),
+                Text(
+                  workspaces.isEmpty
+                      ? 'Unused'
+                      : 'Used by ${workspaces.join(', ')}',
+                  style: const TextStyle(color: KColors.textSecondary),
+                ),
+              ],
             ),
+            isThreeLine: true,
             trailing: widget.canManage
                 ? IconButton(
                     icon: const Icon(

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -1651,12 +1651,16 @@ class _VolumesTabState extends State<_VolumesTab> {
                   owner.isEmpty
                       ? 'Created $created'
                       : 'Created $created · by $owner',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                   style: const TextStyle(color: KColors.textSecondary),
                 ),
                 Text(
                   workspaces.isEmpty
                       ? 'Unused'
                       : 'Used by ${workspaces.join(', ')}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                   style: const TextStyle(color: KColors.textSecondary),
                 ),
               ],

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -1461,25 +1461,93 @@ class _VolumesTabState extends State<_VolumesTab> {
   bool _loading = true;
   String? _error;
 
+  // Server-side pagination / sort / filter state (#2993), mirroring
+  // the sibling admin tabs (q matches volume name, creator handle,
+  // or a using workspace's name).
+  int _page = 1;
+  final int _pageSize = 10;
+  int _total = 0;
+  String _sort = 'created';
+  String _order = 'desc';
+  String _query = '';
+  final TextEditingController _searchController = TextEditingController();
+  Timer? _queryDebounce;
+
+  /// URL-encode a query param map (sorted for stable, cacheable URLs).
+  static String _encodeQuery(Map<String, String> params) {
+    final pairs = <String>[];
+    for (final key in params.keys.toList()..sort()) {
+      pairs.add(
+        '${Uri.encodeQueryComponent(key)}='
+        '${Uri.encodeQueryComponent(params[key]!)}',
+      );
+    }
+    return pairs.join('&');
+  }
+
   @override
   void initState() {
     super.initState();
+    _searchController.addListener(() {
+      final value = _searchController.text;
+      if (value == _query) return;
+      _query = value;
+      _queryDebounce?.cancel();
+      _queryDebounce = Timer(
+        const Duration(milliseconds: 300),
+        () => _loadVolumes(page: 1),
+      );
+    });
     _loadVolumes();
   }
 
-  Future<void> _loadVolumes() async {
+  @override
+  void dispose() {
+    _queryDebounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  /// Select a sort column, or toggle direction if already selected —
+  /// mirrors the sibling tabs (name reads naturally ascending; created
+  /// descending).
+  Future<void> _changeSort(String sortKey) async {
+    if (_sort == sortKey) {
+      setState(() => _order = _order == 'asc' ? 'desc' : 'asc');
+    } else {
+      setState(() {
+        _sort = sortKey;
+        _order = sortKey == 'created' ? 'desc' : 'asc';
+      });
+    }
+    await _loadVolumes(page: 1);
+  }
+
+  Future<void> _loadVolumes({int page = 1}) async {
     setState(() {
+      _page = page;
       _loading = true;
       _error = null;
     });
     try {
       final auth = context.read<AuthService>();
-      final resp = await auth.authGet('/api/v1/volumes');
+      final query = <String, String>{
+        'page': '$_page',
+        'page_size': '$_pageSize',
+        'sort': _sort,
+        'order': _order,
+      };
+      final q = _query.trim();
+      if (q.isNotEmpty) query['q'] = q;
+      final resp = await auth.authGet(
+        '/api/v1/volumes?${_encodeQuery(query)}',
+      );
       if (!mounted) return;
       if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
         setState(() {
-          _volumes =
-              (jsonDecode(resp.body) as List).cast<Map<String, dynamic>>();
+          _volumes = (data['volumes'] as List).cast<Map<String, dynamic>>();
+          _total = (data['total'] as num).toInt();
           _loading = false;
         });
       } else {
@@ -1612,7 +1680,26 @@ class _VolumesTabState extends State<_VolumesTab> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(body: _buildVolumesList());
+    return Scaffold(
+      body: Column(
+        children: [
+          _AdminListToolbar(
+            key: const ValueKey('admin-volumes-toolbar'),
+            columns: const [('Name', 'name'), ('Created', 'created')],
+            sort: _sort,
+            order: _order,
+            onChangeSort: _changeSort,
+            searchController: _searchController,
+            searchHint: 'Filter by name, creator, or workspace…',
+            page: _page,
+            pageSize: _pageSize,
+            total: _total,
+            onPage: (p) => _loadVolumes(page: p),
+          ),
+          Expanded(child: _buildVolumesList()),
+        ],
+      ),
+    );
   }
 }
 

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -79,6 +79,7 @@ class AclEditorState extends State<AclEditor> {
     'manage-events',
     'search-users',
     'manage-volumes',
+    'view-volumes',
     'view-images',
   ];
 

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -1580,7 +1580,32 @@ void main() {
           );
         }
         if (request.url.path == '/api/v1/volumes' && request.method == 'GET') {
-          return http.Response(jsonEncode(volumes), 200);
+          // The paged envelope (#2993), honoring q/page/page_size the
+          // way the backend does (q matches name, handle, workspace).
+          final q = (request.url.queryParameters['q'] ?? '').toLowerCase();
+          final page = int.parse(request.url.queryParameters['page'] ?? '1');
+          final pageSize =
+              int.parse(request.url.queryParameters['page_size'] ?? '10');
+          bool matches(Map<String, dynamic> v) {
+            final handle = (v['created_by'] as String?) ?? '';
+            final workspaces = (v['workspaces'] as List).cast<String>();
+            return (v['name'] as String).toLowerCase().contains(q) ||
+                handle.toLowerCase().contains(q) ||
+                workspaces.any((w) => w.toLowerCase().contains(q));
+          }
+
+          final filtered =
+              q.isEmpty ? volumes : volumes.where(matches).toList();
+          final start = (page - 1) * pageSize;
+          return http.Response(
+            jsonEncode({
+              'volumes': filtered.skip(start).take(pageSize).toList(),
+              'page': page,
+              'page_size': pageSize,
+              'total': filtered.length,
+            }),
+            200,
+          );
         }
         if (request.url.path.startsWith('/api/v1/volumes/') &&
             request.method == 'DELETE') {
@@ -1604,6 +1629,13 @@ void main() {
           matching: find.byType(SkeuoTab),
         );
 
+    /// The Volumes tab's toolbar (the sibling tabs' toolbars are also
+    /// built inside the IndexedStack — scope to this one's key).
+    Finder inVolumesToolbar(Finder inner) => find.descendant(
+          of: find.byKey(const ValueKey('admin-volumes-toolbar')),
+          matching: inner,
+        );
+
     testWidgets('lists the inventory with creator and usage', (tester) async {
       final deletes = <String>[];
       serveVolumes([
@@ -1622,6 +1654,12 @@ void main() {
       await tester.tap(volumesTab());
       await tester.pumpAndSettle();
 
+      // The toolbar is there with its search field.
+      expect(
+        find.byKey(const ValueKey('admin-volumes-toolbar')),
+        findsOneWidget,
+      );
+      expect(inVolumesToolbar(find.byType(TextField)), findsOneWidget);
       expect(find.text('ws-cache'), findsOneWidget);
       expect(find.text('extra-mount'), findsOneWidget);
       // The creator's handle shows (@alice); a volume with no resolvable
@@ -1632,6 +1670,34 @@ void main() {
       expect(find.text('Used by ws-one, ws-two'), findsOneWidget);
       expect(find.text('Unused'), findsOneWidget);
       expect(find.byTooltip('Delete volume'), findsNWidgets(2));
+      expect(deletes, isEmpty);
+    });
+
+    testWidgets('search filters the listing server-side', (tester) async {
+      final deletes = <String>[];
+      serveVolumes([
+        _volume('ws-cache', 'aaaaaaaa', createdBy: 'alice'),
+        _volume('extra-mount', '11111111', createdBy: 'bob'),
+      ], deletes);
+
+      await pumpPage(tester);
+      await tester.tap(volumesTab());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        inVolumesToolbar(find.byType(TextField)),
+        'ws-cache',
+      );
+      // The 300ms debounce fires, the fetch runs, the list narrows.
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      // Scoped to the list: the search field itself holds the text.
+      expect(
+        find.descendant(of: find.byType(Card), matching: find.text('ws-cache')),
+        findsOneWidget,
+      );
+      expect(find.text('extra-mount'), findsNothing);
       expect(deletes, isEmpty);
     });
 

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -9,6 +9,7 @@ import 'package:klangk_frontend/admin/admin_users_page.dart';
 import 'package:klangk_frontend/admin/server_schedule_panel.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_frontend/utils/system_agent.dart';
+import 'package:klangk_frontend/widgets/skeuo_tab.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
@@ -1524,6 +1525,162 @@ void main() {
         find.textContaining('manage-acls — root-equivalent'),
         findsOneWidget,
       );
+    });
+  });
+
+  group('AdminUsersPage volumes tab', () {
+    /// A volume row as `GET /api/v1/volumes` serves it (#2993): name,
+    /// created, and the creator label as provenance.
+    Map<String, dynamic> _volume(
+      String name,
+      String userId, [
+      String created = '2026-01-02T03:04:05Z',
+    ]) =>
+        {'name': name, 'created': created, 'user_id': userId};
+
+    /// Serve the volume inventory via [volumes] and capture DELETE
+    /// calls into [deletes]; a successful DELETE removes the volume
+    /// from the served list so the reload sees it gone. view-volumes
+    /// keys the tab; manage-volumes the delete action.
+    void serveVolumes(
+      List<Map<String, dynamic>> volumes,
+      List<String> deletes, {
+      bool canManage = true,
+    }) {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/config')) {
+          return http.Response(
+            jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/my-permissions')) {
+          return http.Response(
+            jsonEncode({
+              'user_id': 'admin-user',
+              'email': 'admin@example.com',
+              'permissions': {
+                '/users': ['manage-users'],
+                '/volumes': [
+                  'view-volumes',
+                  if (canManage) 'manage-volumes',
+                ],
+              },
+              'groups': [],
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/volumes' && request.method == 'GET') {
+          return http.Response(jsonEncode(volumes), 200);
+        }
+        if (request.url.path.startsWith('/api/v1/volumes/') &&
+            request.method == 'DELETE') {
+          deletes.add(request.url.path);
+          volumes.removeWhere(
+            (v) => '/api/v1/volumes/${v['name']}' == request.url.path,
+          );
+          return http.Response('{}', 200);
+        }
+        if (request.url.path == '/api/v1/users') {
+          return http.Response(_usersEnvelope([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+    }
+
+    /// The Volumes tab in the tab strip (the ACL browser sidebar also
+    /// labels a 'Volumes' node, so scope to the SkeuoTab row).
+    Finder volumesTab() => find.ancestor(
+          of: find.text('Volumes'),
+          matching: find.byType(SkeuoTab),
+        );
+
+    testWidgets('lists the inventory with creator provenance', (tester) async {
+      final deletes = <String>[];
+      serveVolumes([
+        _volume('ws-cache', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+        _volume('extra-mount', '11111111-2222-3333-4444-555555555555'),
+      ], deletes);
+
+      await pumpPage(tester);
+
+      expect(volumesTab(), findsOneWidget);
+      await tester.tap(volumesTab());
+      await tester.pumpAndSettle();
+
+      expect(find.text('ws-cache'), findsOneWidget);
+      expect(find.text('extra-mount'), findsOneWidget);
+      // The creator label shows as provenance (leading id chars).
+      expect(find.textContaining('by aaaaaaaa…'), findsOneWidget);
+      expect(find.byTooltip('Delete volume'), findsNWidgets(2));
+      expect(deletes, isEmpty);
+    });
+
+    testWidgets('deletes after a confirmation', (tester) async {
+      final deletes = <String>[];
+      serveVolumes([_volume('ws-cache', 'aaaaaaaa')], deletes);
+
+      await pumpPage(tester);
+      await tester.tap(volumesTab());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Delete volume'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete Volume'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      expect(deletes, ['/api/v1/volumes/ws-cache']);
+      expect(find.text('No volumes'), findsOneWidget);
+    });
+
+    testWidgets('view-only holder lists but gets no delete action',
+        (tester) async {
+      final deletes = <String>[];
+      serveVolumes([_volume('ws-cache', 'aaaaaaaa')], deletes,
+          canManage: false);
+
+      await pumpPage(tester);
+      await tester.tap(volumesTab());
+      await tester.pumpAndSettle();
+
+      expect(find.text('ws-cache'), findsOneWidget);
+      expect(find.byTooltip('Delete volume'), findsNothing);
+      expect(deletes, isEmpty);
+    });
+
+    testWidgets('hides the Volumes tab without view-volumes', (tester) async {
+      // manage-users only — no /volumes grant, so no Volumes tab.
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/config')) {
+          return http.Response(
+            jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/my-permissions')) {
+          return http.Response(
+            jsonEncode({
+              'user_id': 'admin-user',
+              'email': 'admin@example.com',
+              'permissions': {
+                '/users': ['manage-users'],
+              },
+              'groups': [],
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/users') {
+          return http.Response(_usersEnvelope([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pumpPage(tester);
+
+      expect(volumesTab(), findsNothing);
     });
   });
 }

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -1530,13 +1530,21 @@ void main() {
 
   group('AdminUsersPage volumes tab', () {
     /// A volume row as `GET /api/v1/volumes` serves it (#2993): name,
-    /// created, and the creator label as provenance.
+    /// created, the creator label as provenance, the creator's handle,
+    /// and the workspaces mounting it.
     Map<String, dynamic> _volume(
       String name,
-      String userId, [
-      String created = '2026-01-02T03:04:05Z',
-    ]) =>
-        {'name': name, 'created': created, 'user_id': userId};
+      String userId, {
+      String? createdBy,
+      List<String> workspaces = const [],
+    }) =>
+        {
+          'name': name,
+          'created': '2026-01-02T03:04:05Z',
+          'user_id': userId,
+          'created_by': createdBy,
+          'workspaces': workspaces,
+        };
 
     /// Serve the volume inventory via [volumes] and capture DELETE
     /// calls into [deletes]; a successful DELETE removes the volume
@@ -1596,10 +1604,15 @@ void main() {
           matching: find.byType(SkeuoTab),
         );
 
-    testWidgets('lists the inventory with creator provenance', (tester) async {
+    testWidgets('lists the inventory with creator and usage', (tester) async {
       final deletes = <String>[];
       serveVolumes([
-        _volume('ws-cache', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+        _volume(
+          'ws-cache',
+          'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          createdBy: 'alice',
+          workspaces: ['ws-one', 'ws-two'],
+        ),
         _volume('extra-mount', '11111111-2222-3333-4444-555555555555'),
       ], deletes);
 
@@ -1611,8 +1624,13 @@ void main() {
 
       expect(find.text('ws-cache'), findsOneWidget);
       expect(find.text('extra-mount'), findsOneWidget);
-      // The creator label shows as provenance (leading id chars).
-      expect(find.textContaining('by aaaaaaaa…'), findsOneWidget);
+      // The creator's handle shows (@alice); a volume with no resolvable
+      // creator falls back to the raw label's leading characters.
+      expect(find.textContaining('by @alice'), findsOneWidget);
+      expect(find.textContaining('by 11111111'), findsOneWidget);
+      // Workspace usage: named per volume, 'Unused' when none mount it.
+      expect(find.text('Used by ws-one, ws-two'), findsOneWidget);
+      expect(find.text('Unused'), findsOneWidget);
       expect(find.byTooltip('Delete volume'), findsNWidgets(2));
       expect(deletes, isEmpty);
     });

--- a/src/klangk/klangk/api/common.py
+++ b/src/klangk/klangk/api/common.py
@@ -55,6 +55,7 @@ ALL_PERMISSIONS = [
     "manage-acls",
     "manage-events",
     "manage-volumes",
+    "view-volumes",
     "view-images",
     "search-users",
     "*",

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -310,11 +310,17 @@ def _volume_matches(item: dict, needle: str) -> bool:
 
 def _sort_volume_items(items: list[dict], sort: str, order: str) -> None:
     """Sort listing rows in place by the whitelisted key (``name`` or
-    ``created``; unknown → created), name as the deterministic
-    tiebreaker — the list_users/list_workspaces posture."""
+    ``created``; unknown → created) with the name tiebreaker always
+    ascending — the list_users/list_workspaces posture (``ORDER BY col
+    DESC, id``). Two stable sorts: name first, then the primary key.
+    ``created`` is podman's RFC3339Nano string; lexicographic order is
+    exact within one UTC offset (the stored-format reality of this
+    field) and approximate across a DST boundary.
+    """
     primary = "name" if sort == "name" else "created"
+    items.sort(key=lambda it: it["name"])
     items.sort(
-        key=lambda it: ((it[primary] or ""), it["name"]),
+        key=lambda it: it[primary] or "",
         reverse=order.lower() == "desc",
     )
 

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -4,6 +4,7 @@ former files and images submodules (images.py was misnamed: it lists
 volumes too)."""
 
 import io
+import json
 import logging
 import posixpath
 
@@ -253,6 +254,50 @@ async def list_images(
 # --- Volume management ---
 
 
+def _named_volume_sources(mounts) -> list[str]:
+    """The named-volume sources in a workspace's mounts list.
+
+    A mount spec is ``<source>:<dest>``; a source with no ``/`` that
+    doesn't start with ``.`` is a named volume — the same rule as
+    ``container.spec.is_named_volume``, inlined so the api layer
+    doesn't reach into the container package.
+    """
+    sources = []
+    for spec in mounts or []:
+        source = spec.split(":")[0]
+        if "/" not in source and not source.startswith("."):
+            sources.append(source)
+    return sources
+
+
+def _volume_usage_map(rows) -> dict[str, list[str]]:
+    """Volume name → the workspace names whose mounts use it (#2993)."""
+    usage: dict[str, list[str]] = {}
+    for row in rows:
+        mounts = json.loads(row["mounts"]) if row["mounts"] else None
+        for source in _named_volume_sources(mounts):
+            usage.setdefault(source, []).append(row["name"])
+    for names in usage.values():
+        names.sort()
+    return usage
+
+
+async def _creator_handles(app, volumes) -> dict[str, str | None]:
+    """Creator ``klangk.user-id`` label → the user's handle (#2993).
+
+    A label whose user no longer exists (deleted creator) maps to
+    ``None`` — the id stays in ``user_id`` as provenance.
+    """
+    handles: dict[str, str | None] = {}
+    for v in volumes:
+        uid = (v.get("Labels") or {}).get("klangk.user-id")
+        if not uid or uid in handles:
+            continue
+        creator = await app.state.model.users.get_user_by_id(uid)
+        handles[uid] = (creator or {}).get("handle") or None
+    return handles
+
+
 @router.get("/volumes")
 async def list_volumes(
     _user: dict = Depends(acl.has_permission("view-volumes")),
@@ -264,16 +309,25 @@ async def list_volumes(
     visibility keys on it); ``manage-volumes`` covers create/delete.
     The ``klangk.user-id`` label is surfaced as provenance, not used
     as an access filter — an admin operating the tab sees every
-    volume this instance manages.
+    volume this instance manages, who created it (``created_by``, the
+    creator's handle), and which workspaces mount it (``workspaces``).
     """
     volumes = await app.state.podman.list_volumes(
         f"klangk.instance={app.state.util.instance_id()}"
     )
+    usage = _volume_usage_map(
+        await app.state.model.workspaces.workspace_mount_rows()
+    )
+    handles = await _creator_handles(app, volumes)
     return [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
             "user_id": (v.get("Labels") or {}).get("klangk.user-id"),
+            "created_by": handles.get(
+                (v.get("Labels") or {}).get("klangk.user-id")
+            ),
+            "workspaces": usage.get(v["Name"], []),
         }
         for v in volumes
     ]

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -298,8 +298,34 @@ async def _creator_handles(app, volumes) -> dict[str, str | None]:
     return handles
 
 
+def _volume_matches(item: dict, needle: str) -> bool:
+    """Whether a listing row matches the search needle — volume name,
+    creator handle, or a using workspace's name (case-insensitive)."""
+    return (
+        needle in item["name"].lower()
+        or needle in (item["created_by"] or "").lower()
+        or any(needle in w.lower() for w in item["workspaces"])
+    )
+
+
+def _sort_volume_items(items: list[dict], sort: str, order: str) -> None:
+    """Sort listing rows in place by the whitelisted key (``name`` or
+    ``created``; unknown → created), name as the deterministic
+    tiebreaker — the list_users/list_workspaces posture."""
+    primary = "name" if sort == "name" else "created"
+    items.sort(
+        key=lambda it: ((it[primary] or ""), it["name"]),
+        reverse=order.lower() == "desc",
+    )
+
+
 @router.get("/volumes")
 async def list_volumes(
+    page: int = 1,
+    page_size: int = 10,
+    sort: str = "created",
+    order: str = "desc",
+    q: str | None = None,
     _user: dict = Depends(acl.has_permission("view-volumes")),
     app=Depends(get_app_dep),
 ):
@@ -311,6 +337,11 @@ async def list_volumes(
     as an access filter — an admin operating the tab sees every
     volume this instance manages, who created it (``created_by``, the
     creator's handle), and which workspaces mount it (``workspaces``).
+
+    Server-side paginated/sorted/filtered like the other admin tabs:
+    ``q`` matches volume name, creator handle, or a using workspace
+    name (case-insensitive substring); ``sort`` is ``name`` | ``created``;
+    returns the paged envelope ``{volumes, page, page_size, total}``.
     """
     volumes = await app.state.podman.list_volumes(
         f"klangk.instance={app.state.util.instance_id()}"
@@ -319,7 +350,7 @@ async def list_volumes(
         await app.state.model.workspaces.workspace_mount_rows()
     )
     handles = await _creator_handles(app, volumes)
-    return [
+    items = [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
@@ -331,6 +362,19 @@ async def list_volumes(
         }
         for v in volumes
     ]
+    if q:
+        needle = q.lower()
+        items = [it for it in items if _volume_matches(it, needle)]
+    _sort_volume_items(items, sort, order)
+    page = max(1, page)
+    page_size = max(1, min(page_size, 200))
+    start = (page - 1) * page_size
+    return {
+        "volumes": items[start : start + page_size],
+        "page": page,
+        "page_size": page_size,
+        "total": len(items),
+    }
 
 
 class CreateVolumeRequest(BaseModel):

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -255,20 +255,27 @@ async def list_images(
 
 @router.get("/volumes")
 async def list_volumes(
-    user: dict = Depends(acl.has_permission("manage-volumes")),
+    _user: dict = Depends(acl.has_permission("view-volumes")),
     app=Depends(get_app_dep),
 ):
+    """The whole instance-managed volume inventory (#2993).
+
+    The admin tab's listing gate is ``view-volumes`` (the tab's
+    visibility keys on it); ``manage-volumes`` covers create/delete.
+    The ``klangk.user-id`` label is surfaced as provenance, not used
+    as an access filter — an admin operating the tab sees every
+    volume this instance manages.
+    """
     volumes = await app.state.podman.list_volumes(
         f"klangk.instance={app.state.util.instance_id()}"
     )
-    uid = user["id"]
     return [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
+            "user_id": (v.get("Labels") or {}).get("klangk.user-id"),
         }
         for v in volumes
-        if (v.get("Labels") or {}).get("klangk.user-id") == uid
     ]
 
 
@@ -295,7 +302,7 @@ async def create_volume(
     # name in the body. 500-vs-200 still hints at existence, but no
     # longer with a 409 + echoed detail (#2973). In-instance cross-user
     # names still 409 (issue scope: instance-managed volumes only; the
-    # admin-surface rework, #2989, narrows who can call this at all).
+    # admin-surface rework, #2993, narrows who can call this at all).
     info = await app.state.podman.create_volume(
         body.name,
         {
@@ -310,9 +317,16 @@ async def create_volume(
 @router.delete("/volumes/{name}")
 async def delete_volume(
     name: str,
-    user: dict = Depends(acl.has_permission("manage-volumes")),
+    _user: dict = Depends(acl.has_permission("manage-volumes")),
     app=Depends(get_app_dep),
 ):
+    """Delete an instance-managed volume (#2993).
+
+    ``manage-volumes`` is the whole gate — the surface is admin-only
+    by seed, so the former per-user label check is gone (the admin
+    tab lists and deletes any volume this instance manages). The
+    creator label stays on the row as provenance.
+    """
     info = await app.state.podman.inspect_volume(name)
     if info is None:
         raise HTTPException(status_code=404, detail="Volume not found")
@@ -321,11 +335,6 @@ async def delete_volume(
         raise HTTPException(
             status_code=404,
             detail="Volume not managed by this Klangk instance",
-        )
-    if labels.get("klangk.user-id") != user["id"]:
-        raise HTTPException(
-            status_code=403,
-            detail="Volume belongs to another user",
         )
     try:
         await app.state.podman.remove_volume(name)

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -228,7 +228,8 @@ def volumes_list(
     resp = client.get("/api/v1/volumes")
     client.check_auth(resp)
     resp.raise_for_status()
-    volumes = resp.json()
+    # Paged envelope (#2993): {volumes, page, page_size, total}.
+    volumes = resp.json()["volumes"]
     if not volumes:
         typer.echo("No volumes.")
         return

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -225,11 +225,15 @@ def volumes_list(
     """List klangk-managed container volumes."""
     context.require_auth()
     client = context.client()
-    resp = client.get("/api/v1/volumes")
+    resp = client.get("/api/v1/volumes?page_size=200")
     client.check_auth(resp)
     resp.raise_for_status()
-    # Paged envelope (#2993): {volumes, page, page_size, total}.
-    volumes = resp.json()["volumes"]
+    # Paged envelope (#2993): {volumes, page, page_size, total}. The
+    # explicit page_size keeps the whole inventory on one page (the
+    # server default is 10 — the invitations-listing precedent);
+    # .get() degrades to an empty listing against a pre-envelope
+    # server shape, like the sibling envelope readers.
+    volumes = resp.json().get("volumes", [])
     if not volumes:
         typer.echo("No volumes.")
         return

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -239,11 +239,26 @@ class Lifecycle:
                 PRINCIPAL_SYSTEM,
                 system_principal=SYSTEM_EVERYONE,
             )
+        # /volumes: the admin volume surface (#2993) — the listing
+        # gate splits from the write gate per endpoint (GET needs
+        # view-volumes; POST/DELETE keep manage-volumes), both granted
+        # to the admins group like every other admin tab's first-class
+        # resource. The caller-scoped user-id label stays provenance
+        # only. No trailing Deny Everyone row: the JWT middleware
+        # rejects unauthenticated callers before any ACL check, and
+        # default-deny covers the no-match case.
+        for permission in ("view-volumes", "manage-volumes"):
+            await self.app.state.model.acl.add_acl_entry(
+                "/volumes",
+                0 if permission == "view-volumes" else 1,
+                ACTION_ALLOW,
+                permission,
+                PRINCIPAL_GROUP,
+                group_id=admin_group_id,
+            )
         # #2946 self-service surfaces, granted to every authenticated
         # user by default (a deploy that wants them restricted denies
         # or scopes these rows in the ACL editor):
-        #   /volumes    manage-volumes — user-owned volumes (label-
-        #                               scoped per user at runtime)
         #   /images     view-images    — the image listing the
         #                               create/edit UIs read
         # /images gets no trailing Deny Everyone row (#2994): no
@@ -255,22 +270,6 @@ class Lifecycle:
         # deployments.
         # NB: /llm-proxy is NOT here — #2959 gives it its own
         # workspace-token-only gate, independent of the ACL system.
-        await self.app.state.model.acl.add_acl_entry(
-            "/volumes",
-            0,
-            ACTION_ALLOW,
-            "manage-volumes",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_AUTHENTICATED,
-        )
-        await self.app.state.model.acl.add_acl_entry(
-            "/volumes",
-            1,
-            ACTION_DENY,
-            "*",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_EVERYONE,
-        )
         await self.app.state.model.acl.add_acl_entry(
             "/images",
             0,

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -73,6 +73,7 @@ from klangk.model.migrations import m0022_workspace_permission_renames
 from klangk.model.migrations import m0023_self_service_resources
 from klangk.model.migrations import m0024_join_workspace_permission
 from klangk.model.migrations import m0025_drop_dead_images_deny_row
+from klangk.model.migrations import m0026_volumes_admin_surface
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -106,6 +107,7 @@ MIGRATIONS: list[Migration] = [
     m0023_self_service_resources.migration,
     m0024_join_workspace_permission.migration,
     m0025_drop_dead_images_deny_row.migration,
+    m0026_volumes_admin_surface.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
+++ b/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
@@ -1,0 +1,122 @@
+"""Migration 0026: /volumes becomes an admin-surface resource (#2993).
+
+(Renumbered from 0025 during rebase: the sibling /images PR, #2996,
+took id 25 on main — migration ids are contiguous and frozen once
+shipped.)
+
+The #2946 seed granted ``manage-volumes`` to every authenticated user
+with a trailing Deny ``*`` Everyone row. #2993 splits the surface per
+endpoint — ``GET /volumes`` checks ``view-volumes``, ``POST``/``DELETE``
+keep ``manage-volumes`` — both granted to the admins group only, like
+every other admin tab's first-class resource.
+
+This migration rewrites a deployed database to the new seed shape:
+
+- The two #2946 rows are removed: the Allow-Authenticated row (a
+  ``manage-*`` name on a grant every authenticated user holds
+  contradicts the #2944 convention) and the Deny ``*`` Everyone row
+  (dead weight — the JWT middleware rejects unauthenticated requests
+  before any ACL check, and default-deny covers the no-match case).
+- Allow ``view-volumes`` + Allow ``manage-volumes`` rows for the admins
+  group are inserted at positions 0/1 (the fresh-seed layout), with any
+  surviving rows shifted down so first-match-wins order keeps the
+  admins' grants ahead of operator rows (an operator-staged Deny must
+  not shadow what the old Allow-Authenticated row gave admins).
+
+Operator-customized rows (a scoped self-service grant, an explicit
+Deny) survive untouched, below the inserted admin rows. A deploy that
+wants self-service volumes back adds an Allow row via the ACL editor.
+
+A fresh database (entirely empty ``acl_entries``) is a no-op — the
+boot seeds own it (the m0021 precedent).
+
+Idempotent by construction: the deletes match only the exact #2946
+shapes, and the admin-row insert is guarded by an existence check.
+"""
+
+from klangk.model.acl import (
+    ACTION_ALLOW,
+    ACTION_DENY,
+    PRINCIPAL_GROUP,
+    PRINCIPAL_SYSTEM,
+    SYSTEM_AUTHENTICATED,
+    SYSTEM_EVERYONE,
+)
+from klangk.model.migrations.base import Migration
+
+# The exact #2946 seed rows on /volumes: (action, principal_type,
+# system_principal, permission).
+OLD_SEED_ROWS = (
+    (ACTION_ALLOW, PRINCIPAL_SYSTEM, SYSTEM_AUTHENTICATED, "manage-volumes"),
+    (ACTION_DENY, PRINCIPAL_SYSTEM, SYSTEM_EVERYONE, "*"),
+)
+
+# The #2993 admin rows, in seed-position order.
+ADMIN_PERMISSIONS = ("view-volumes", "manage-volumes")
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        return  # fresh database — the boot seeds own it
+
+    for action, principal_type, system_principal, permission in OLD_SEED_ROWS:
+        await db.execute(
+            "DELETE FROM acl_entries WHERE resource = '/volumes'"
+            " AND action = ? AND principal_type = ?"
+            " AND system_principal = ? AND permission = ?",
+            (action, principal_type, system_principal, permission),
+        )
+
+    cursor = await db.execute("SELECT id FROM groups WHERE name = 'admins'")
+    row = await cursor.fetchone()
+    if row is None:
+        return  # no admins group: nothing to grant (the m0021 posture)
+    admins_id = row[0]
+
+    cursor = await db.execute(
+        "SELECT permission FROM acl_entries WHERE resource = '/volumes'"
+        " AND action = ? AND principal_type = ? AND group_id = ?",
+        (ACTION_ALLOW, PRINCIPAL_GROUP, admins_id),
+    )
+    held = {r[0] for r in await cursor.fetchall()}
+    missing = [p for p in ADMIN_PERMISSIONS if p not in held]
+    if not missing:
+        return
+
+    # Park the surviving rows two slots down so positions 0/1 are free.
+    # UNIQUE(resource, position) forbids an in-place +2 shift past a
+    # neighbor, so rows first jump far above the occupied range and
+    # then settle back (m0023's two-step offset).
+    offset = 1_000_000
+    await db.execute(
+        "UPDATE acl_entries SET position = position + ?"
+        " WHERE resource = '/volumes'",
+        (offset,),
+    )
+    await db.execute(
+        "UPDATE acl_entries SET position = position - ? + 2"
+        " WHERE resource = '/volumes' AND position > ?",
+        (offset, offset),
+    )
+    for permission in missing:
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type, user_id,"
+            "  group_id, system_principal, permission)"
+            " VALUES ('/volumes', ?, ?, ?, NULL, ?, NULL, ?)",
+            (
+                ADMIN_PERMISSIONS.index(permission),
+                ACTION_ALLOW,
+                PRINCIPAL_GROUP,
+                admins_id,
+                permission,
+            ),
+        )
+
+
+migration = Migration(
+    id=26,
+    name="0026_volumes_admin_surface",
+    apply=apply,
+)

--- a/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
+++ b/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
@@ -23,9 +23,13 @@ This migration rewrites a deployed database to the new seed shape:
   admins' grants ahead of operator rows (an operator-staged Deny must
   not shadow what the old Allow-Authenticated row gave admins).
 
-Operator-customized rows (a scoped self-service grant, an explicit
-Deny) survive untouched, below the inserted admin rows. A deploy that
-wants self-service volumes back adds an Allow row via the ACL editor.
+Operator-customized rows that do not match the #2946 shapes (a
+scoped self-service grant, an explicit Deny) survive untouched, below
+the inserted admin rows. An operator row that happens to repeat a
+#2946 shape exactly (e.g. a deliberately re-staged Allow
+manage-volumes for Authenticated) is indistinguishable from the seed
+and goes with it. A deploy that wants self-service volumes back adds
+an Allow row via the ACL editor.
 
 A fresh database (entirely empty ``acl_entries``) is a no-op — the
 boot seeds own it (the m0021 precedent).
@@ -87,7 +91,10 @@ async def apply(db) -> None:
     # Park the surviving rows two slots down so positions 0/1 are free.
     # UNIQUE(resource, position) forbids an in-place +2 shift past a
     # neighbor, so rows first jump far above the occupied range and
-    # then settle back (m0023's two-step offset).
+    # then settle back (m0023's two-step offset). Every parked row is
+    # >= offset, so the settle matches >= offset — a strict > would
+    # strand the row parked at exactly offset (the original position
+    # 0) up there forever.
     offset = 1_000_000
     await db.execute(
         "UPDATE acl_entries SET position = position + ?"
@@ -96,7 +103,7 @@ async def apply(db) -> None:
     )
     await db.execute(
         "UPDATE acl_entries SET position = position - ? + 2"
-        " WHERE resource = '/volumes' AND position > ?",
+        " WHERE resource = '/volumes' AND position >= ?",
         (offset, offset),
     )
     for permission in missing:

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -715,6 +715,19 @@ class WorkspacesModel(Submodel):
                 db, user_id, name, **insert
             )
 
+    async def workspace_mount_rows(self) -> list[dict]:
+        """Every workspace's ``(name, mounts)`` row.
+
+        The admin volume listing builds its usage map on this (#2993):
+        which workspace mounts reference each named volume. ``mounts``
+        is the raw JSON blob column (NULL when the workspace has no
+        extra mounts); the decoding stays with the caller.
+        """
+        rows = await self.app.state.db.fetchall(
+            "SELECT name, mounts FROM workspaces"
+        )
+        return [{"name": r["name"], "mounts": r["mounts"]} for r in rows]
+
     async def list_workspaces(
         self,
         user_id: str,

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1518,7 +1518,14 @@ class TestAllowedMountRoots:
 
 
 class TestVolumeUserIsolation:
-    """Verify that a user cannot mount another user's volume."""
+    """Volume ownership is isolated at runtime; management is admin-only.
+
+    Mounting another user's named volume is rejected at container
+    assembly (``ensure_volumes``, no HTTP ACL involved), while the
+    ``volumes`` CLI surface — list, create, delete — is the #2993
+    admin surface: seeded Allow for the admins group only, so a plain
+    registered user is denied on every command.
+    """
 
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
@@ -1615,47 +1622,50 @@ class TestVolumeUserIsolation:
                 capture_output=True,
             )
 
-    def test_volumes_ls_only_own(self):
-        """Each user only sees their own volumes via 'volumes ls'."""
+    def test_volumes_non_admin_denied(self):
+        """A plain registered user is denied the whole volumes surface
+        (#2993): list, create, and delete all fail with a nonzero
+        exit."""
+        env_b = self._env_b
+
+        result = run(["klangk", "volumes", "create", "vol-b"], env=env_b)
+        assert result.returncode != 0
+        assert "403" in result.stderr or "denied" in result.stderr.lower()
+
+        result = run(["klangk", "volumes", "ls", "--plain"], env=env_b)
+        assert result.returncode != 0
+        assert "403" in result.stderr or "denied" in result.stderr.lower()
+
+        # rm has an explicit 403 path: a clean 'Permission denied' error.
+        result = run(["klangk", "volumes", "rm", "vol-b"], env=env_b)
+        assert result.returncode != 0
+        assert "Permission denied" in result.stderr
+
+    def test_volumes_admin_manages_all_volumes(self):
+        """The admin holds the whole surface: create, list (the whole
+        instance inventory), and delete — including deleting a volume
+        while a non-admin is refused on the same name (#2993)."""
         env_a = self._env_a
         env_b = self._env_b
 
-        # User A creates a volume
         result = run(["klangk", "volumes", "create", "vol-a"], env=env_a)
         assert result.returncode == 0
         try:
-            # User B creates a volume
-            result = run(["klangk", "volumes", "create", "vol-b"], env=env_b)
-            assert result.returncode == 0
-            try:
-                # User A should see vol-a but not vol-b
-                result = run(["klangk", "volumes", "ls", "--plain"], env=env_a)
-                assert "vol-a" in result.stdout
-                assert "vol-b" not in result.stdout
-
-                # User B should see vol-b but not vol-a
-                result = run(["klangk", "volumes", "ls", "--plain"], env=env_b)
-                assert "vol-b" in result.stdout
-                assert "vol-a" not in result.stdout
-            finally:
-                run(["klangk", "volumes", "rm", "vol-b"], env=env_b)
-        finally:
-            run(["klangk", "volumes", "rm", "vol-a"], env=env_a)
-
-    def test_volumes_rm_other_user_rejected(self):
-        """A user cannot delete another user's volume."""
-        env_a = self._env_a
-        env_b = self._env_b
-
-        # User A creates a volume
-        result = run(["klangk", "volumes", "create", "vol-private"], env=env_a)
-        assert result.returncode == 0
-        try:
-            # User B tries to delete it — should fail
-            result = run(["klangk", "volumes", "rm", "vol-private"], env=env_b)
+            # The non-admin cannot delete what the admin created.
+            result = run(["klangk", "volumes", "rm", "vol-a"], env=env_b)
             assert result.returncode != 0
+            assert "Permission denied" in result.stderr
+
+            # The admin lists the instance inventory and deletes from it.
+            result = run(["klangk", "volumes", "ls", "--plain"], env=env_a)
+            assert result.returncode == 0
+            assert "vol-a" in result.stdout
         finally:
-            run(["klangk", "volumes", "rm", "vol-private"], env=env_a)
+            result = run(["klangk", "volumes", "rm", "vol-a"], env=env_a)
+            assert result.returncode == 0
+            result = run(["klangk", "volumes", "ls", "--plain"], env=env_a)
+            assert result.returncode == 0
+            assert "vol-a" not in result.stdout
 
 
 class TestTerminalSharing:

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1661,11 +1661,11 @@ class TestVolumeUserIsolation:
             assert result.returncode == 0
             assert "vol-a" in result.stdout
         finally:
-            result = run(["klangk", "volumes", "rm", "vol-a"], env=env_a)
-            assert result.returncode == 0
-            result = run(["klangk", "volumes", "ls", "--plain"], env=env_a)
-            assert result.returncode == 0
-            assert "vol-a" not in result.stdout
+            run(["klangk", "volumes", "rm", "vol-a"], env=env_a)
+
+        result = run(["klangk", "volumes", "ls", "--plain"], env=env_a)
+        assert result.returncode == 0
+        assert "vol-a" not in result.stdout
 
 
 class TestTerminalSharing:

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4652,9 +4652,14 @@ class TestVolumes:
         client.get.return_value = MagicMock(
             status_code=200,
             json=MagicMock(
-                return_value=[
-                    {"name": "vol-1", "created": "2026-01-01T00:00:00Z"},
-                ]
+                return_value={
+                    "volumes": [
+                        {"name": "vol-1", "created": "2026-01-01T00:00:00Z"},
+                    ],
+                    "page": 1,
+                    "page_size": 10,
+                    "total": 1,
+                }
             ),
         )
         monkeypatch.setattr(context_mod, "client", lambda: client)
@@ -4672,7 +4677,7 @@ class TestVolumes:
         client = MagicMock()
         client.get.return_value = MagicMock(
             status_code=200,
-            json=MagicMock(return_value=[]),
+            json=MagicMock(return_value={"volumes": [], "total": 0}),
         )
         monkeypatch.setattr(context_mod, "client", lambda: client)
 
@@ -4690,7 +4695,10 @@ class TestVolumes:
         client.get.return_value = MagicMock(
             status_code=200,
             json=MagicMock(
-                return_value=[{"name": "vol-1", "created": "2026-01-01"}]
+                return_value={
+                    "volumes": [{"name": "vol-1", "created": "2026-01-01"}],
+                    "total": 1,
+                }
             ),
         )
         monkeypatch.setattr(context_mod, "client", lambda: client)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4671,6 +4671,26 @@ class TestVolumes:
         assert result.exit_code == 0
         assert "vol-1" in result.stdout
 
+    def test_volumes_ls_requests_full_page(self, logged_in_cfg, monkeypatch):
+        """#2993 review: the listing request must pin page_size=200 —
+        the server default is 10, and a bare GET silently hid every
+        volume past the newest ten from the admin."""
+        from klangk.cli import main
+
+        client = MagicMock()
+        client.get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"volumes": [], "total": 0}),
+        )
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["volumes", "ls"])
+        assert result.exit_code == 0
+        assert "page_size=200" in client.get.call_args.args[0]
+
     def test_volumes_ls_empty(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main
 

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -88,7 +88,7 @@ def temp_data_dir(tmp_path, monkeypatch):
     reset_test_db()
 
 
-async def _seed_2946_self_service(app_state):
+async def _seed_resource_acls(app_state):
     """Seed the #2946/#2993/#2994 resource ACL rows (idempotent).
 
     Mirrors m0023/m0026 + seed_default_acls: Allow view-volumes +
@@ -185,7 +185,7 @@ async def agent_user(app_state):
             (AGENT_USER_ID, "klangk@example.com", "klangk"),
         )
     app_state.state.model.users.clear_agent_cache()
-    await _seed_2946_self_service(app_state)
+    await _seed_resource_acls(app_state)
 
 
 @pytest.fixture
@@ -195,7 +195,7 @@ async def user(app_state):
     result = await app_state.state.model.users.create_user(
         "testuser@example.com", _TEST_PASSWORD_HASH, verified=True
     )
-    await _seed_2946_self_service(app_state)
+    await _seed_resource_acls(app_state)
     return result
 
 
@@ -258,7 +258,7 @@ async def admin_group(app_state):
     )
     # First-class resource seeds (#2944), mirroring seed_default_acls.
     # /users manage-users for admins; the Deny lands at a high position
-    # so _seed_2946_self_service's search-users insert (position 1,
+    # so _seed_resource_acls's search-users insert (position 1,
     # shifting >= 1) keeps Allow-Authenticated before it.
     await acl.add_acl_entry(
         "/users",
@@ -299,7 +299,7 @@ async def admin_group(app_state):
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_EVERYONE,
         )
-    await _seed_2946_self_service(app_state)
+    await _seed_resource_acls(app_state)
     # /admin stays as the instance-admin wildcard marker (#2944).
     await acl.add_acl_entry(
         "/admin",

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -89,40 +89,50 @@ def temp_data_dir(tmp_path, monkeypatch):
 
 
 async def _seed_2946_self_service(app_state):
-    """Seed the #2946 self-service ACL rows (idempotent).
+    """Seed the #2946/#2993/#2994 resource ACL rows (idempotent).
 
-    Mirrors m0023 / seed_default_acls: Allow <perm> for Authenticated
-    plus Deny Everyone on /volumes, /images, /llm-proxy, and the
-    Allow search-users Authenticated row on /users (inserted at
-    position 1, shifting later rows down — m0023's logic). Called by
-    the seed fixtures (user / agent_user / admin_group) so any test
-    reaching the DB gets the production-shaped world.
+    Mirrors m0023/m0026 + seed_default_acls: Allow view-volumes +
+    Allow manage-volumes for the admins group on /volumes (#2993),
+    Allow view-images for Authenticated alone on /images (#2994 — no
+    Deny Everyone row), and the Allow search-users Authenticated row
+    on /users (inserted at position 1, shifting later rows down —
+    m0023's logic). Called by the seed fixtures (user / agent_user /
+    admin_group) so any test reaching the DB gets the
+    production-shaped world.
     """
     from klangk.model.acl import (
         ACTION_ALLOW,
         ACTION_DENY,
+        PRINCIPAL_GROUP,
         PRINCIPAL_SYSTEM,
         SYSTEM_AUTHENTICATED,
         SYSTEM_EVERYONE,
     )
 
     acl = app_state.state.model.acl
-    if not await acl.get_acl_entries("/volumes"):
-        await acl.add_acl_entry(
-            "/volumes",
-            0,
-            ACTION_ALLOW,
-            "manage-volumes",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_AUTHENTICATED,
+    users = app_state.state.model.users
+    # The admins group may or may not exist yet (the admin_group
+    # fixture can run before or after this helper) — get-or-create,
+    # mirroring lifecycle.ensure_admin_group.
+    admins = await users.get_group_by_name("admins")
+    if admins is None:
+        admins = await users.create_group(
+            "admins", description="Administrators"
         )
+    for position, permission in enumerate(("view-volumes", "manage-volumes")):
+        rows = await acl.get_acl_entries("/volumes")
+        if any(
+            r["permission"] == permission and r["group_id"] == admins["id"]
+            for r in rows
+        ):
+            continue
         await acl.add_acl_entry(
             "/volumes",
-            1,
-            ACTION_DENY,
-            "*",
-            PRINCIPAL_SYSTEM,
-            system_principal=SYSTEM_EVERYONE,
+            position,
+            ACTION_ALLOW,
+            permission,
+            PRINCIPAL_GROUP,
+            group_id=admins["id"],
         )
     # /images: Allow Authenticated only (#2994 — the dead Deny Everyone
     # row is gone from the seed; migration 0025 drops it on existing
@@ -215,9 +225,11 @@ async def admin_group(app_state):
     )
 
     await app_state.state.model.init_db()
-    group = await app_state.state.model.users.create_group(
-        "admins", description="Administrators"
-    )
+    group = await app_state.state.model.users.get_group_by_name("admins")
+    if group is None:
+        group = await app_state.state.model.users.create_group(
+            "admins", description="Administrators"
+        )
     acl = app_state.state.model.acl
     # Seed default ACLs
     await acl.add_acl_entry(

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6766,11 +6766,33 @@ class TestVolumeRoutes:
         """An admin sees every instance volume with creator provenance
         (no longer an access filter), the creator's handle, and the
         workspaces mounting each volume (#2993)."""
+        await self._seed_volume_world(app_state, user, admin_user)
+        headers = await _admin_login(client)
+        with patch.object(
+            _mock_pod,
+            "list_volumes",
+            AsyncMock(return_value=self._world_volumes(user)),
+        ):
+            resp = await client.get("/api/v1/volumes", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 4
+        assert [
+            (v["name"], v["user_id"], v["created_by"], v["workspaces"])
+            for v in data["volumes"]
+        ] == [
+            ("system-vol", None, None, []),
+            ("orphan-vol", "ghost-user", None, []),
+            ("my-vol", user["id"], user["handle"], ["aaa-ws", "ws-uses-vol"]),
+            ("my-vol-2", user["id"], user["handle"], []),
+        ]
+
+    async def _seed_volume_world(self, app_state, user, admin_user):
+        """The shared listing world: two workspaces mounting my-vol,
+        one workspace without mounts."""
         await app_state.state.model.workspaces.create_workspace(
             user["id"],
             "ws-uses-vol",
-            # A path mount must not count as volume usage; the named
-            # one must.
             mounts=["my-vol:/data", "/host/path:/ro"],
         )
         await app_state.state.model.workspaces.create_workspace(
@@ -6781,60 +6803,123 @@ class TestVolumeRoutes:
         await app_state.state.model.workspaces.create_workspace(
             user["id"], "no-mounts-ws"
         )
+
+    def _world_volumes(self, user):
+        """The podman listing behind the shared world (four volumes)."""
+        return [
+            {
+                "Name": "my-vol",
+                "CreatedAt": "2026-01-01T00:00:00Z",
+                "Labels": {
+                    "klangk.instance": _instance_id(),
+                    "klangk.user-id": user["id"],
+                },
+            },
+            # No CreatedAt: the sort key's empty-date branch.
+            {
+                "Name": "my-vol-2",
+                "Labels": {
+                    "klangk.instance": _instance_id(),
+                    "klangk.user-id": user["id"],
+                },
+            },
+            {
+                "Name": "orphan-vol",
+                "CreatedAt": "2026-01-02T00:00:00Z",
+                "Labels": {
+                    "klangk.instance": _instance_id(),
+                    "klangk.user-id": "ghost-user",
+                },
+            },
+            {
+                "Name": "system-vol",
+                "CreatedAt": "2026-01-03T00:00:00Z",
+                "Labels": {"klangk.instance": _instance_id()},
+            },
+        ]
+
+    async def test_list_volumes_search_and_paging(
+        self, client, admin_user, user, app_state
+    ):
+        """q matches volume name, creator handle, and workspace name
+        (case-insensitive); the envelope paginates and sorts (#2993)."""
+        await self._seed_volume_world(app_state, user, admin_user)
         headers = await _admin_login(client)
         with patch.object(
             _mock_pod,
             "list_volumes",
-            AsyncMock(
-                return_value=[
-                    {
-                        "Name": "my-vol",
-                        "CreatedAt": "2026-01-01T00:00:00Z",
-                        "Labels": {
-                            "klangk.instance": _instance_id(),
-                            "klangk.user-id": user["id"],
-                        },
-                    },
-                    # Same creator again: the handle lookup dedups.
-                    {
-                        "Name": "my-vol-2",
-                        "CreatedAt": "2026-01-01T00:00:00Z",
-                        "Labels": {
-                            "klangk.instance": _instance_id(),
-                            "klangk.user-id": user["id"],
-                        },
-                    },
-                    # Deleted creator: the label stays provenance, the
-                    # handle resolves to None.
-                    {
-                        "Name": "orphan-vol",
-                        "CreatedAt": "2026-01-02T00:00:00Z",
-                        "Labels": {
-                            "klangk.instance": _instance_id(),
-                            "klangk.user-id": "ghost-user",
-                        },
-                    },
-                    # Runtime-created volume with no creator label.
-                    {
-                        "Name": "system-vol",
-                        "CreatedAt": "2026-01-03T00:00:00Z",
-                        "Labels": {"klangk.instance": _instance_id()},
-                    },
-                ]
-            ),
+            AsyncMock(return_value=self._world_volumes(user)),
         ):
-            resp = await client.get("/api/v1/volumes", headers=headers)
-        assert resp.status_code == 200
-        data = resp.json()
-        assert [
-            (v["name"], v["user_id"], v["created_by"], v["workspaces"])
-            for v in data
-        ] == [
-            ("my-vol", user["id"], user["handle"], ["aaa-ws", "ws-uses-vol"]),
-            ("my-vol-2", user["id"], user["handle"], []),
-            ("orphan-vol", "ghost-user", None, []),
-            ("system-vol", None, None, []),
-        ]
+
+            async def listing(**params):
+                resp = await client.get(
+                    "/api/v1/volumes",
+                    headers=headers,
+                    params=params,
+                )
+                assert resp.status_code == 200
+                return resp.json()
+
+            # By name (case-insensitive; matches both my-vol*).
+            data = await listing(q="MY-VOL")
+            assert [v["name"] for v in data["volumes"]] == [
+                "my-vol",
+                "my-vol-2",
+            ]
+            assert data["total"] == 2
+            # By creator handle.
+            data = await listing(q=user["handle"])
+            assert [v["name"] for v in data["volumes"]] == [
+                "my-vol",
+                "my-vol-2",
+            ]
+            # By workspace name using the volume.
+            data = await listing(q="uses")
+            assert [v["name"] for v in data["volumes"]] == ["my-vol"]
+            # No match anywhere.
+            data = await listing(q="nope")
+            assert data["volumes"] == []
+            assert data["total"] == 0
+
+            # Sort: created desc (default) vs name asc.
+            data = await listing()
+            assert [v["name"] for v in data["volumes"]] == [
+                "system-vol",
+                "orphan-vol",
+                "my-vol",
+                "my-vol-2",
+            ]
+            data = await listing(sort="name", order="asc")
+            assert [v["name"] for v in data["volumes"]] == [
+                "my-vol",
+                "my-vol-2",
+                "orphan-vol",
+                "system-vol",
+            ]
+            # Unknown sort falls back to created.
+            data = await listing(sort="bogus")
+            assert data["volumes"][0]["name"] == "system-vol"
+
+            # Paging: page/page_size over the unfiltered four.
+            data = await listing(page=2, page_size=2, sort="name", order="asc")
+            assert [v["name"] for v in data["volumes"]] == [
+                "orphan-vol",
+                "system-vol",
+            ]
+            assert (data["page"], data["page_size"], data["total"]) == (
+                2,
+                2,
+                4,
+            )
+            # Past the end: empty page, total intact; page 0 clamps to 1.
+            data = await listing(page=9, page_size=2)
+            assert data["volumes"] == []
+            assert data["total"] == 4
+            data = await listing(page=0, page_size=2, sort="name", order="asc")
+            assert [v["name"] for v in data["volumes"]] == [
+                "my-vol",
+                "my-vol-2",
+            ]
 
     async def test_list_volumes_requires_view_volumes(self, client, user):
         """A plain authenticated user holds nothing on /volumes by seed

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6761,10 +6761,26 @@ class TestVolumeRoutes:
     plain (non-admin) user."""
 
     async def test_list_volumes_shows_whole_inventory(
-        self, client, admin_user
+        self, client, admin_user, user, app_state
     ):
-        """An admin sees every instance volume, with the creator label
-        surfaced as provenance (no longer an access filter)."""
+        """An admin sees every instance volume with creator provenance
+        (no longer an access filter), the creator's handle, and the
+        workspaces mounting each volume (#2993)."""
+        await app_state.state.model.workspaces.create_workspace(
+            user["id"],
+            "ws-uses-vol",
+            # A path mount must not count as volume usage; the named
+            # one must.
+            mounts=["my-vol:/data", "/host/path:/ro"],
+        )
+        await app_state.state.model.workspaces.create_workspace(
+            admin_user["id"],
+            "aaa-ws",
+            mounts=["my-vol:/x"],
+        )
+        await app_state.state.model.workspaces.create_workspace(
+            user["id"], "no-mounts-ws"
+        )
         headers = await _admin_login(client)
         with patch.object(
             _mock_pod,
@@ -6776,16 +6792,33 @@ class TestVolumeRoutes:
                         "CreatedAt": "2026-01-01T00:00:00Z",
                         "Labels": {
                             "klangk.instance": _instance_id(),
-                            "klangk.user-id": "owner-a",
+                            "klangk.user-id": user["id"],
                         },
                     },
+                    # Same creator again: the handle lookup dedups.
                     {
-                        "Name": "other-vol",
+                        "Name": "my-vol-2",
+                        "CreatedAt": "2026-01-01T00:00:00Z",
+                        "Labels": {
+                            "klangk.instance": _instance_id(),
+                            "klangk.user-id": user["id"],
+                        },
+                    },
+                    # Deleted creator: the label stays provenance, the
+                    # handle resolves to None.
+                    {
+                        "Name": "orphan-vol",
                         "CreatedAt": "2026-01-02T00:00:00Z",
                         "Labels": {
                             "klangk.instance": _instance_id(),
-                            "klangk.user-id": "owner-b",
+                            "klangk.user-id": "ghost-user",
                         },
+                    },
+                    # Runtime-created volume with no creator label.
+                    {
+                        "Name": "system-vol",
+                        "CreatedAt": "2026-01-03T00:00:00Z",
+                        "Labels": {"klangk.instance": _instance_id()},
                     },
                 ]
             ),
@@ -6793,9 +6826,14 @@ class TestVolumeRoutes:
             resp = await client.get("/api/v1/volumes", headers=headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert [(v["name"], v["user_id"]) for v in data] == [
-            ("my-vol", "owner-a"),
-            ("other-vol", "owner-b"),
+        assert [
+            (v["name"], v["user_id"], v["created_by"], v["workspaces"])
+            for v in data
+        ] == [
+            ("my-vol", user["id"], user["handle"], ["aaa-ws", "ws-uses-vol"]),
+            ("my-vol-2", user["id"], user["handle"], []),
+            ("orphan-vol", "ghost-user", None, []),
+            ("system-vol", None, None, []),
         ]
 
     async def test_list_volumes_requires_view_volumes(self, client, user):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6755,8 +6755,17 @@ def _managed_volume(user_id="test-user"):
 
 
 class TestVolumeRoutes:
-    async def test_list_volumes(self, client, user):
-        headers = await _auth_headers(client)
+    """Volume endpoints (#2993): GET needs view-volumes, POST/DELETE
+    need manage-volumes — admins hold both by seed. Functional tests
+    authenticate as the admin; the permission-split tests use the
+    plain (non-admin) user."""
+
+    async def test_list_volumes_shows_whole_inventory(
+        self, client, admin_user
+    ):
+        """An admin sees every instance volume, with the creator label
+        surfaced as provenance (no longer an access filter)."""
+        headers = await _admin_login(client)
         with patch.object(
             _mock_pod,
             "list_volumes",
@@ -6767,15 +6776,15 @@ class TestVolumeRoutes:
                         "CreatedAt": "2026-01-01T00:00:00Z",
                         "Labels": {
                             "klangk.instance": _instance_id(),
-                            "klangk.user-id": user["id"],
+                            "klangk.user-id": "owner-a",
                         },
                     },
                     {
                         "Name": "other-vol",
-                        "CreatedAt": "2026-01-01T00:00:00Z",
+                        "CreatedAt": "2026-01-02T00:00:00Z",
                         "Labels": {
                             "klangk.instance": _instance_id(),
-                            "klangk.user-id": "someone-else",
+                            "klangk.user-id": "owner-b",
                         },
                     },
                 ]
@@ -6784,11 +6793,51 @@ class TestVolumeRoutes:
             resp = await client.get("/api/v1/volumes", headers=headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "my-vol"
+        assert [(v["name"], v["user_id"]) for v in data] == [
+            ("my-vol", "owner-a"),
+            ("other-vol", "owner-b"),
+        ]
 
-    async def test_create_volume(self, client, user):
+    async def test_list_volumes_requires_view_volumes(self, client, user):
+        """A plain authenticated user holds nothing on /volumes by seed
+        (#2993) — the listing is admin-surface now."""
         headers = await _auth_headers(client)
+        with patch.object(
+            _mock_pod, "list_volumes", AsyncMock(return_value=[])
+        ):
+            resp = await client.get("/api/v1/volumes", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_view_only_holder_lists_but_cannot_delete(
+        self, client, user, app_state
+    ):
+        """A delegated read-only volumes auditor (view-volumes alone)
+        lists the inventory but cannot delete — manage-volumes gates
+        the write endpoints."""
+        await app_state.state.model.acl.add_acl_entry(
+            "/volumes",
+            2,
+            model.ACTION_ALLOW,
+            "view-volumes",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        headers = await _auth_headers(client)
+        with patch.object(
+            _mock_pod, "list_volumes", AsyncMock(return_value=[])
+        ):
+            resp = await client.get("/api/v1/volumes", headers=headers)
+        assert resp.status_code == 200
+        with patch.object(
+            _mock_pod,
+            "inspect_volume",
+            AsyncMock(return_value=_managed_volume(user["id"])),
+        ):
+            resp = await client.delete("/api/v1/volumes/mine", headers=headers)
+        assert resp.status_code == 403
+
+    async def test_create_volume(self, client, admin_user):
+        headers = await _admin_login(client)
         mock_create = AsyncMock(
             return_value={"Name": "new-vol", "CreatedAt": "2026-01-01"}
         )
@@ -6806,14 +6855,24 @@ class TestVolumeRoutes:
         assert resp.status_code == 200
         assert resp.json()["name"] == "new-vol"
         _, labels = mock_create.call_args.args
-        assert labels["klangk.user-id"] == user["id"]
+        # The creator label stays on created volumes (provenance).
+        assert labels["klangk.user-id"] == admin_user["id"]
 
-    async def test_create_duplicate_volume(self, client, user):
+    async def test_create_volume_requires_manage_volumes(self, client, user):
         headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/volumes",
+            json={"name": "nope-vol"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+
+    async def test_create_duplicate_volume(self, client, admin_user):
+        headers = await _admin_login(client)
         with patch.object(
             _mock_pod,
             "inspect_volume",
-            AsyncMock(return_value=_managed_volume(user["id"])),
+            AsyncMock(return_value=_managed_volume(admin_user["id"])),
         ):
             resp = await client.post(
                 "/api/v1/volumes",
@@ -6823,7 +6882,7 @@ class TestVolumeRoutes:
         assert resp.status_code == 409
 
     async def test_create_volume_foreign_instance_not_enumerable(
-        self, app, user
+        self, app, admin_user
     ):
         """#2973: a volume owned by another instance must not confirm its
         existence via 409 — the create falls through to podman, and the
@@ -6851,7 +6910,7 @@ class TestVolumeRoutes:
             async with AsyncClient(
                 transport=transport, base_url="http://test"
             ) as c:
-                headers = await _auth_headers(c)
+                headers = await _admin_login(c)
                 resp = await c.post(
                     "/api/v1/volumes",
                     json={"name": "foreign-vol"},
@@ -6861,8 +6920,8 @@ class TestVolumeRoutes:
         assert resp.status_code == 500
         assert "foreign-vol" not in resp.text
 
-    async def test_create_volume_error_propagates(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_create_volume_error_propagates(self, client, admin_user):
+        headers = await _admin_login(client)
         with (
             patch.object(
                 _mock_pod, "inspect_volume", AsyncMock(return_value=None)
@@ -6880,13 +6939,13 @@ class TestVolumeRoutes:
                 headers=headers,
             )
 
-    async def test_delete_volume(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume(self, client, admin_user):
+        headers = await _admin_login(client)
         with (
             patch.object(
                 _mock_pod,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume(user["id"])),
+                AsyncMock(return_value=_managed_volume(admin_user["id"])),
             ),
             patch.object(_mock_pod, "remove_volume", AsyncMock()),
         ):
@@ -6895,16 +6954,34 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 200
 
-    async def test_delete_volume_not_found(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_other_users_volume(self, client, admin_user):
+        """#2993: manage-volumes is the whole gate — an admin deletes any
+        instance-managed volume, not only their own (the creator label
+        is provenance, not an access filter)."""
+        headers = await _admin_login(client)
+        with (
+            patch.object(
+                _mock_pod,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume("someone-else")),
+            ),
+            patch.object(_mock_pod, "remove_volume", AsyncMock()),
+        ):
+            resp = await client.delete(
+                "/api/v1/volumes/other", headers=headers
+            )
+        assert resp.status_code == 200
+
+    async def test_delete_volume_not_found(self, client, admin_user):
+        headers = await _admin_login(client)
         with patch.object(
             _mock_pod, "inspect_volume", AsyncMock(return_value=None)
         ):
             resp = await client.delete("/api/v1/volumes/nope", headers=headers)
         assert resp.status_code == 404
 
-    async def test_delete_volume_wrong_instance(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_wrong_instance(self, client, admin_user):
+        headers = await _admin_login(client)
         with patch.object(
             _mock_pod,
             "inspect_volume",
@@ -6915,26 +6992,14 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 404
 
-    async def test_delete_volume_wrong_user(self, client, user):
-        headers = await _auth_headers(client)
-        with patch.object(
-            _mock_pod,
-            "inspect_volume",
-            AsyncMock(return_value=_managed_volume("someone-else")),
-        ):
-            resp = await client.delete(
-                "/api/v1/volumes/other", headers=headers
-            )
-        assert resp.status_code == 403
-
-    async def test_delete_volume_remove_not_found(self, client, user):
+    async def test_delete_volume_remove_not_found(self, client, admin_user):
         """Volume vanishes between inspect and remove -> 404."""
-        headers = await _auth_headers(client)
+        headers = await _admin_login(client)
         with (
             patch.object(
                 _mock_pod,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume(user["id"])),
+                AsyncMock(return_value=_managed_volume(admin_user["id"])),
             ),
             patch.object(
                 _mock_pod,
@@ -6945,13 +7010,13 @@ class TestVolumeRoutes:
             resp = await client.delete("/api/v1/volumes/gone", headers=headers)
         assert resp.status_code == 404
 
-    async def test_delete_volume_other_error(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_other_error(self, client, admin_user):
+        headers = await _admin_login(client)
         with (
             patch.object(
                 _mock_pod,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume(user["id"])),
+                AsyncMock(return_value=_managed_volume(admin_user["id"])),
             ),
             patch.object(
                 _mock_pod,
@@ -6962,13 +7027,13 @@ class TestVolumeRoutes:
         ):
             await client.delete("/api/v1/volumes/err-vol", headers=headers)
 
-    async def test_delete_volume_in_use(self, client, user):
-        headers = await _auth_headers(client)
+    async def test_delete_volume_in_use(self, client, admin_user):
+        headers = await _admin_login(client)
         with (
             patch.object(
                 _mock_pod,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume(user["id"])),
+                AsyncMock(return_value=_managed_volume(admin_user["id"])),
             ),
             patch.object(
                 _mock_pod,

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -277,15 +277,17 @@ class TestSeedDefaultAcls:
         ]
         assert users[1]["system_principal"] == model.SYSTEM_AUTHENTICATED
         assert users[2]["action"] == model.ACTION_DENY
-        # ...and /volumes keeps its #2946 self-service pair (Allow
-        # Authenticated + Deny Everyone).
-        entries = await app_state.state.model.acl.get_acl_entries("/volumes")
-        assert len(entries) == 2
-        allow, deny = entries
-        assert allow["permission"] == "manage-volumes"
-        assert allow["system_principal"] == model.SYSTEM_AUTHENTICATED
-        assert deny["permission"] == "*"
-        assert deny["system_principal"] == model.SYSTEM_EVERYONE
+        # #2993: /volumes seeds the admin pair — Allow view-volumes +
+        # Allow manage-volumes for the admins group, no Authenticated
+        # row and no dead Deny Everyone row.
+        volumes = await app_state.state.model.acl.get_acl_entries("/volumes")
+        assert [
+            (e["position"], e["permission"], e["group_id"]) for e in volumes
+        ] == [
+            (0, "view-volumes", admin_group_id),
+            (1, "manage-volumes", admin_group_id),
+        ]
+        assert all(e["system_principal"] is None for e in volumes)
         # ...and /images seeds the #2946 self-service row — Allow
         # Authenticated only (#2994 dropped the dead Deny Everyone row:
         # it can never fire, and no-match is default-deny).

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -2888,7 +2888,58 @@ class TestM0026VolumesAdminSurface:
         a strict > in the settle step stranded the row parked at
         exactly the offset, permanently."""
         from klangk.model import ACTION_ALLOW, PRINCIPAL_GROUP
+<<<<<<< HEAD
         from klangk.model.migrations import m0026_volumes_admin_surface
+=======
+        from klangk.model.migrations import m0025_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/volumes', 0, 1, 2, 'g-op', 'manage-volumes'),"
+                "        ('/', 0, 1, 0, NULL, 'view')"
+            )
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-a', 'admins')"
+            )
+            await db.commit()
+            await m0025_volumes_admin_surface.migration.apply(db)
+
+            assert await self._rows(db, "/volumes") == [
+                (
+                    0,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "view-volumes",
+                ),
+                (
+                    1,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "manage-volumes",
+                ),
+                (
+                    2,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-op",
+                    None,
+                    "manage-volumes",
+                ),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_fresh_db_is_noop(self, tmp_path):
+        from klangk.model.migrations import m0025_volumes_admin_surface
+>>>>>>> 1ed93a9d (Fix m0025 settle-back stranding the position-0 row (#2997 review))
 
         db = await self._db(tmp_path)
         try:

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -86,6 +86,7 @@ class TestRunner:
             (23, "0023_self_service_resources"),
             (24, "0024_join_workspace_permission"),
             (25, "0025_drop_dead_images_deny_row"),
+            (26, "0026_volumes_admin_surface"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -177,6 +178,7 @@ class TestRunner:
                 (23, "0023_self_service_resources"),
                 (24, "0024_join_workspace_permission"),
                 (25, "0025_drop_dead_images_deny_row"),
+                (26, "0026_volumes_admin_surface"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -2743,5 +2745,216 @@ class TestM0025DropDeadImagesDenyRow:
             await m0025_drop_dead_images_deny_row.migration.apply(db)
             cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
             assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0026VolumesAdminSurface:
+    """m0026 rewrites /volumes from the #2946 self-service pair (Allow
+    manage-volumes Authenticated + Deny * Everyone) to the #2993 admin
+    pair (Allow view-volumes + Allow manage-volumes for the admins
+    group at positions 0/1)."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0026.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT,"
+            " UNIQUE(resource, position))"
+        )
+        await db.execute(
+            "CREATE TABLE groups ("
+            " id TEXT PRIMARY KEY, name TEXT UNIQUE,"
+            " description TEXT, source TEXT, created_at TEXT)"
+        )
+        return db
+
+    async def _seed_old_pair(self, db) -> None:
+        """The #2946 rows a deployed database holds on /volumes."""
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type,"
+            "  system_principal, permission)"
+            " VALUES ('/volumes', 0, 1, 0, 1, 'manage-volumes'),"
+            "        ('/volumes', 1, 0, 0, 0, '*'),"
+            "        ('/', 0, 1, 0, 1, 'view')"
+        )
+
+    async def _rows(self, db, resource) -> list:
+        cursor = await db.execute(
+            "SELECT position, action, principal_type, group_id,"
+            " system_principal, permission"
+            " FROM acl_entries WHERE resource = ? ORDER BY position",
+            (resource,),
+        )
+        return list(await cursor.fetchall())
+
+    async def test_upgraded_db_gets_the_admin_pair(self, tmp_path):
+        from klangk.model import ACTION_ALLOW, PRINCIPAL_GROUP
+        from klangk.model.migrations import m0026_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await self._seed_old_pair(db)
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-a', 'admins')"
+            )
+            await db.commit()
+            await m0026_volumes_admin_surface.migration.apply(db)
+
+            assert await self._rows(db, "/volumes") == [
+                (
+                    0,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "view-volumes",
+                ),
+                (
+                    1,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "manage-volumes",
+                ),
+            ]
+            # Idempotent: re-run changes nothing.
+            await m0026_volumes_admin_surface.migration.apply(db)
+            assert len(await self._rows(db, "/volumes")) == 2
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_operator_rows_survive_below_the_admin_rows(self, tmp_path):
+        """A scoped self-service grant an operator staged on top of the
+        #2946 pair survives, shifted below the inserted admin rows (the
+        old Allow-Authenticated row gave admins access; the rewrite
+        must not let a later Deny shadow their replacement rows)."""
+        from klangk.model import ACTION_ALLOW, PRINCIPAL_GROUP
+        from klangk.model.migrations import m0026_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await self._seed_old_pair(db)
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/volumes', 2, 1, 2, 'g-team', 'manage-volumes')"
+            )
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-a', 'admins')"
+            )
+            await db.commit()
+            await m0026_volumes_admin_surface.migration.apply(db)
+
+            assert await self._rows(db, "/volumes") == [
+                (
+                    0,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "view-volumes",
+                ),
+                (
+                    1,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "manage-volumes",
+                ),
+                (
+                    4,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-team",
+                    None,
+                    "manage-volumes",
+                ),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_operator_row_at_position_zero_settles_below(self, tmp_path):
+        """Regression (review B1): an operator who replaced the seed with
+        their own row at position 0 must see it settle to position 2 —
+        a strict > in the settle step stranded the row parked at
+        exactly the offset, permanently."""
+        from klangk.model import ACTION_ALLOW, PRINCIPAL_GROUP
+        from klangk.model.migrations import m0026_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/volumes', 0, 1, 2, 'g-op', 'manage-volumes'),"
+                "        ('/', 0, 1, 0, NULL, 'view')"
+            )
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-a', 'admins')"
+            )
+            await db.commit()
+            await m0026_volumes_admin_surface.migration.apply(db)
+
+            assert await self._rows(db, "/volumes") == [
+                (
+                    0,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "view-volumes",
+                ),
+                (
+                    1,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "manage-volumes",
+                ),
+                (
+                    2,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-op",
+                    None,
+                    "manage-volumes",
+                ),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_fresh_db_is_noop(self, tmp_path):
+        from klangk.model.migrations import m0026_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await m0026_volumes_admin_surface.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_no_admins_group_still_drops_the_old_rows(self, tmp_path):
+        """Without an admins group there is no grantee — the #2946 rows
+        still go (the m0021 posture), and nothing is inserted."""
+        from klangk.model.migrations import m0026_volumes_admin_surface
+
+        db = await self._db(tmp_path)
+        try:
+            await self._seed_old_pair(db)
+            await db.commit()
+            await m0026_volumes_admin_surface.migration.apply(db)
+            assert await self._rows(db, "/volumes") == []
         finally:
             await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -2888,58 +2888,7 @@ class TestM0026VolumesAdminSurface:
         a strict > in the settle step stranded the row parked at
         exactly the offset, permanently."""
         from klangk.model import ACTION_ALLOW, PRINCIPAL_GROUP
-<<<<<<< HEAD
         from klangk.model.migrations import m0026_volumes_admin_surface
-=======
-        from klangk.model.migrations import m0025_volumes_admin_surface
-
-        db = await self._db(tmp_path)
-        try:
-            await db.execute(
-                "INSERT INTO acl_entries"
-                " (resource, position, action, principal_type, group_id,"
-                "  permission)"
-                " VALUES ('/volumes', 0, 1, 2, 'g-op', 'manage-volumes'),"
-                "        ('/', 0, 1, 0, NULL, 'view')"
-            )
-            await db.execute(
-                "INSERT INTO groups (id, name) VALUES ('g-a', 'admins')"
-            )
-            await db.commit()
-            await m0025_volumes_admin_surface.migration.apply(db)
-
-            assert await self._rows(db, "/volumes") == [
-                (
-                    0,
-                    ACTION_ALLOW,
-                    PRINCIPAL_GROUP,
-                    "g-a",
-                    None,
-                    "view-volumes",
-                ),
-                (
-                    1,
-                    ACTION_ALLOW,
-                    PRINCIPAL_GROUP,
-                    "g-a",
-                    None,
-                    "manage-volumes",
-                ),
-                (
-                    2,
-                    ACTION_ALLOW,
-                    PRINCIPAL_GROUP,
-                    "g-op",
-                    None,
-                    "manage-volumes",
-                ),
-            ]
-        finally:
-            await db.__aexit__(None, None, None)
-
-    async def test_fresh_db_is_noop(self, tmp_path):
-        from klangk.model.migrations import m0025_volumes_admin_surface
->>>>>>> 1ed93a9d (Fix m0025 settle-back stranding the position-0 row (#2997 review))
 
         db = await self._db(tmp_path)
         try:


### PR DESCRIPTION
## Summary

Implements the `/volumes` decision from the #2974 umbrella (sub-issue #2993): volumes become an admin-surface tab with the read gate split from the write gate, per the action-specific naming pattern of `/acl`+`manage-acls`, `/server`+`manage-server-schedule`, `/images`+`view-images`.

Closes #2993. Part of #2974.

## Changes

**Permissions (split per endpoint, checked against `/volumes`, its own first-class tree — not `/admin`):**
- `GET /volumes` → new **`view-volumes`** — the read/list gate; the admin tab's visibility keys on it.
- `POST /volumes`, `DELETE /volumes/{name}` → **`manage-volumes`** (unchanged names).
- `view-volumes` added to `ALL_PERMISSIONS` and the ACL editor's admin vocabulary.

**Listing & delete semantics:**
- The listing returns the deployment's **whole instance-managed inventory**; the caller-scoped `klangk.user-id` filter is gone. The creator label is surfaced as provenance in a new `user_id` response field (kept on create too).
- Delete drops the wrong-user 403: `manage-volumes` is the whole gate, so a holder may delete any instance volume (the admin tab lists and deletes the whole inventory).

**Seeds + migration:**
- Fresh seed: Allow `view-volumes` + Allow `manage-volumes` for `group:admins` at positions 0/1; the Allow-Authenticated row and the dead Deny Everyone row are gone.
- **m0025** rewrites existing deployments the same way: deletes the exact #2946 shapes, inserts the admin pair at 0/1, shifts operator-staged rows below (their grants survive — a deploy wanting self-service back adds an Allow row via the ACL editor). Fresh DB is a no-op (boot seeds own it). Idempotent.

**Frontend:**
- New **Volumes** tab in the admin section (view + delete only, **no create**): lists name/created/creator-provenance, per-row delete with confirmation, gated on `manage-volumes`; visibility keys on `view-volumes`. `POST /volumes` stays for the CLI's volume commands; workspace extra-mount creation is runtime-auto (`ensure_volumes`, no HTTP ACL) and unaffected.
- ACL browser resource hint updated for the split.

**Docs:** `acl.md` (seed table, permission table, rationale — including the no-Deny-row reasoning), `api-endpoints.md`, changelog entry (Breaking: non-admins lose volume access on upgrade; migration handles the rows).

## Testing

- Migration tests (TestM0025): upgraded-db rewrite, operator rows preserved below, fresh-DB no-op, no-admins-group posture, idempotence.
- Route tests: admin sees whole inventory + provenance; non-admin 403 on GET/POST; view-only holder lists but cannot delete; admin deletes another user's volume; existing 404/409/500/instance checks under admin auth.
- Seed test: `/volumes` asserts the admin pair shape.
- Frontend: tab listed with provenance, delete-after-confirm flow, view-only holder gets no delete action, tab hidden without `view-volumes`.
- Full Python suite (`-n auto`, 100% branch coverage gate) and full `flutter test --coverage` pass; xenon B-clean.
