### PR TITLE
fix(frontend): late-mounting terminal catches up on container readiness (#3000)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1825,6 +1825,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Blank terminal for members joining a running workspace (#3000).**
+  Opening a workspace whose container is already running (a member
+  opening a shared workspace after the owner) could leave the Terminal
+  tab permanently blank: the one-shot `container_ready` event fired
+  before the permission-gated terminal view mounted, so the terminal
+  was never started. The WebSocket client now tracks container
+  readiness, and a late-mounting terminal view catches up from that
+  state instead of waiting for an event that never re-fires. This also
+  un-breaks the deterministically red `browser-delegate` frontend-E2E
+  test.
 - **GitHub device-flow gate now normalizes the git host (#2963).**
   With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, a remote
   written as `https://github.com:443/...`, `https://GitHub.com/...`, or

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1826,15 +1826,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 ### Fixed
 
 - **Blank terminal for members joining a running workspace (#3000).**
-  Opening a workspace whose container is already running (a member
+  Opening a workspace whose container is already running (e.g. a member
   opening a shared workspace after the owner) could leave the Terminal
   tab permanently blank: the one-shot `container_ready` event fired
   before the permission-gated terminal view mounted, so the terminal
   was never started. The WebSocket client now tracks container
   readiness, and a late-mounting terminal view catches up from that
-  state instead of waiting for an event that never re-fires. This also
-  un-breaks the deterministically red `browser-delegate` frontend-E2E
-  test.
+  state.
 - **GitHub device-flow gate now normalizes the git host (#2963).**
   With `KLANGKWS_FEATURE_GITHUB_OAUTH_CLIENT_ID` configured, a remote
   written as `https://github.com:443/...`, `https://GitHub.com/...`, or

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -300,6 +300,13 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
         // size, so the pty isn't created at the 80x24 seed.
         _startPending = true;
       }
+    } else if (event['type'] == 'CUSTOM' &&
+        event['name'] == 'container_stopped') {
+      // Disarm a pending start (#3000 review): if the container stops
+      // between mount and the first measured resize, the armed start
+      // would otherwise fire into a dead container once layout happens.
+      // A later container_ready re-arms it.
+      _startPending = false;
     }
   }
 

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -120,6 +120,17 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
       _terminal.write(utf8.encode(data));
     });
     _eventSub = widget.wsClient.customEvents.listen(_handleEvent);
+    // #3000: the CUSTOM container_ready event is one-shot, and this widget
+    // can mount after it fired — the Terminal tab is permission-gated
+    // (#2988) and the permissions fetch can lose the race to an already-
+    // running container (a member joining an owner-started workspace gets
+    // container_ready in ~0.2s). Catch up from the client's tracked state:
+    // arm the pending start so the first measured resize creates the PTY,
+    // exactly as if the event had arrived just before mounting. A widget
+    // that mounts before the event still takes the normal event path.
+    if (widget.wsClient.containerReady) {
+      _startPending = true;
+    }
     // When the terminal gains focus (e.g. user clicks the terminal or
     // switches tabs), re-register this tab's browser ID so bridge
     // requests route to the active browser tab.

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -191,6 +191,20 @@ class WsClient extends ChangeNotifier {
   Stream<Map<String, dynamic>> get customEvents =>
       _customEventController.stream;
 
+  /// Whether the workspace container is currently ready, tracked from the
+  /// typed `container_ready` frame and the CUSTOM `container_ready` /
+  /// `container_stopped` events. The CUSTOM event is one-shot (no replay:
+  /// the server holds it until `ui_ready`, then emits it once), so a
+  /// terminal widget that mounts after it fired — the #2988 permission-
+  /// gated Terminal tab can build after `ui_ready` when the permissions
+  /// fetch loses the race to an already-running container (#3000) —
+  /// catches up by reading this instead of waiting for an event that will
+  /// never re-fire.
+  bool _containerReady = false;
+
+  /// See [_containerReady].
+  bool get containerReady => _containerReady;
+
   /// Fires when a shared terminal is deleted.
   Stream<Map<String, dynamic>> get sharedTerminalDeleted =>
       _sharedTerminalDeletedController.stream;
@@ -381,7 +395,7 @@ class WsClient extends ChangeNotifier {
     'workspaces_changed': (json) => _workspacesChangedController.add(null),
     'container_status': _containerStatusController.add,
     'service_health': _serviceHealthController.add,
-    'event': _customEventController.add,
+    'event': _onCustomEvent,
     'host_shutdown': (json) => _onHostNotice('Server shutting down'),
     'host_started': (json) => _onHostNotice(null),
     'server_schedule': (json) {
@@ -409,6 +423,19 @@ class WsClient extends ChangeNotifier {
       }
     },
   };
+
+  /// Forward a CUSTOM event to [customEvents], tracking the container's
+  /// readiness so late-mounting widgets can query it (#3000).
+  void _onCustomEvent(Map<String, dynamic> json) {
+    final event = json['event'] as Map<String, dynamic>?;
+    final name = event?['name'] as String?;
+    if (name == 'container_ready') {
+      _containerReady = true;
+    } else if (name == 'container_stopped') {
+      _containerReady = false;
+    }
+    _customEventController.add(json);
+  }
 
   /// Set/clear the host lifecycle notice and notify listeners (#2527).
   /// Notification only — the reconnect loop is untouched, so a restart/
@@ -446,6 +473,10 @@ class WsClient extends ChangeNotifier {
       onDone: () {
         _stopHeartbeat();
         _connected = false;
+        // #3000: readiness tracked with the socket that reported it — a
+        // remounting terminal must not start a PTY into a container this
+        // connection can no longer reach.
+        _containerReady = false;
         _pendingWorkspaceId ??= _currentWorkspaceId;
         _currentWorkspaceId = null;
         _serviceCommand = null;
@@ -504,6 +535,7 @@ class WsClient extends ChangeNotifier {
   }
 
   void _onContainerReady(Map<String, dynamic> json) {
+    _containerReady = true;
     _currentWorkspaceId = json['workspaceId'] as String?;
     _currentUserId = json['userId'] as String?;
     _serviceCommand = json['serviceCommand'] as String?;
@@ -551,6 +583,7 @@ class WsClient extends ChangeNotifier {
     _connected = false;
     _connecting = false;
     _currentWorkspaceId = null;
+    _containerReady = false; // see [containerReady] (#3000)
     _serverSchedules = null;
     notifyListeners();
   }
@@ -584,6 +617,7 @@ class WsClient extends ChangeNotifier {
     _reconnectAttempt = 0;
     _pendingWorkspaceId = null;
     _stopHeartbeat();
+    _containerReady = false; // see [#containerReady] (#3000)
     _send({'cmd': 'workspace_disconnect'});
     _currentWorkspaceId = null;
     notifyListeners();

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -425,14 +425,18 @@ class WsClient extends ChangeNotifier {
   };
 
   /// Forward a CUSTOM event to [customEvents], tracking the container's
-  /// readiness so late-mounting widgets can query it (#3000).
+  /// readiness so late-mounting widgets can query it (#3000). Matches the
+  /// widget-side `_handleEvent` strictness: only CUSTOM container events
+  /// move the flag.
   void _onCustomEvent(Map<String, dynamic> json) {
     final event = json['event'] as Map<String, dynamic>?;
-    final name = event?['name'] as String?;
-    if (name == 'container_ready') {
-      _containerReady = true;
-    } else if (name == 'container_stopped') {
-      _containerReady = false;
+    if (event?['type'] == 'CUSTOM') {
+      final name = event!['name'] as String?;
+      if (name == 'container_ready') {
+        _containerReady = true;
+      } else if (name == 'container_stopped') {
+        _containerReady = false;
+      }
     }
     _customEventController.add(json);
   }
@@ -512,6 +516,9 @@ class WsClient extends ChangeNotifier {
         _errorController.add(WsError(message: 'WebSocket error: $e'));
         _stopHeartbeat();
         _connected = false;
+        // #3000: same invariant as onDone — readiness does not survive the
+        // socket that reported it.
+        _containerReady = false;
         _pendingWorkspaceId ??= _currentWorkspaceId;
         _currentWorkspaceId = null;
         terminalWindows = [];

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -134,6 +134,36 @@ void main() {
       client.close();
     });
 
+    testWidgets('container_stopped disarms a pending catch-up start (#3000)',
+        (tester) async {
+      // Mount with the container already ready (pending start armed at
+      // initState), then the container stops before the first measured
+      // resize — the armed start must not fire into the dead container.
+      final fontGate = Completer<ByteData>();
+      final realFont =
+          await rootBundle.load('assets/fonts/JetBrainsMono-Regular.ttf');
+      GhosttyTerminalState.loadFontAsset = (_) => fontGate.future;
+      addTearDown(() => GhosttyTerminalState.loadFontAsset = rootBundle.load);
+
+      final client = _MockWsClient(containerReadyOverride: true);
+      await tester.pumpWidget(_build(client));
+      expect(find.byType(TerminalView), findsNothing);
+
+      client.emit({
+        'type': 'event',
+        'event': {'type': 'CUSTOM', 'name': 'container_stopped'},
+      });
+      await tester.pump();
+
+      // Font loads, the view lays out and measures — no start may fire.
+      fontGate.complete(realFont);
+      await tester.pumpAndSettle();
+
+      expect(client.sentCommands.where((c) => c.startsWith('terminal_start')),
+          isEmpty);
+      client.close();
+    });
+
     testWidgets('sends terminal_start on container_ready', (tester) async {
       final client = _MockWsClient();
       await tester.pumpWidget(_build(client));

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -17,7 +17,16 @@ class _MockWsClient extends WsClient {
   final List<String> sentCommands = [];
   final bool hasWorkspace;
 
-  _MockWsClient({this.hasWorkspace = true});
+  /// #3000: simulates the client having already seen container_ready
+  /// before the widget mounts (typed frame arrived, one-shot CUSTOM event
+  /// lost to a late-mounting terminal).
+  final bool containerReadyOverride;
+
+  _MockWsClient(
+      {this.hasWorkspace = true, this.containerReadyOverride = false});
+
+  @override
+  bool get containerReady => containerReadyOverride;
 
   @override
   Stream<Map<String, dynamic>> get customEvents => _events.stream;
@@ -84,6 +93,44 @@ void main() {
       expect(find.byType(TerminalView), findsNothing);
       await tester.pumpAndSettle();
       expect(find.byType(TerminalView), findsOneWidget);
+      client.close();
+    });
+
+    testWidgets(
+        'starts the terminal without a container_ready event when the '
+        'container was already ready before mount (#3000)', (tester) async {
+      // The #2988 permission-gated Terminal tab can mount after the
+      // one-shot CUSTOM container_ready event fired (the permissions fetch
+      // lost the race to an already-running container). The widget must
+      // catch up from the client's tracked state instead of waiting for
+      // an event that never re-fires.
+      final client = _MockWsClient(containerReadyOverride: true);
+      await tester.pumpWidget(_build(client));
+      await tester.pumpAndSettle();
+
+      // No container_ready was emitted on customEvents — the start must
+      // come from the tracked-state catch-up, at the measured grid.
+      final starts = client.sentCommands
+          .where((c) => c.startsWith('terminal_start:'))
+          .toList();
+      expect(starts.length, 1);
+      final resizes = client.sentCommands
+          .where((c) => c.startsWith('terminal_resize:'))
+          .toList();
+      expect(resizes, isNotEmpty);
+      expect(starts.single.split(':')[1], resizes.last.split(':')[1]);
+      client.close();
+    });
+
+    testWidgets(
+        'does not start the terminal on mount when the container '
+        'was never ready (#3000)', (tester) async {
+      final client = _MockWsClient(containerReadyOverride: false);
+      await tester.pumpWidget(_build(client));
+      await tester.pumpAndSettle();
+
+      expect(client.sentCommands.where((c) => c.startsWith('terminal_start')),
+          isEmpty);
       client.close();
     });
 

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -303,6 +303,24 @@ void main() {
       client.dispose();
     });
 
+    test('socket error clears the flag', () async {
+      final client = WsClient();
+      final channel = _FakeWebSocketChannel();
+      client.connectForTest(channel);
+      channel.serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.containerReady, isTrue);
+
+      channel.serverError('boom');
+      await Future.delayed(Duration.zero);
+
+      expect(client.containerReady, isFalse);
+      client.dispose();
+    });
+
     test('unrelated CUSTOM events leave the flag untouched', () async {
       final client = WsClient();
       final channel = _FakeWebSocketChannel();

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -208,6 +208,122 @@ void main() {
     });
   });
 
+  group('WsClient.containerReady (#3000)', () {
+    test('typed container_ready frame marks the container ready', () async {
+      final client = WsClient();
+      final channel = _FakeWebSocketChannel();
+      client.connectForTest(channel);
+      expect(client.containerReady, isFalse);
+
+      channel.serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.containerReady, isTrue);
+      client.dispose();
+    });
+
+    test('CUSTOM container_ready event marks the container ready', () async {
+      final client = WsClient();
+      final channel = _FakeWebSocketChannel();
+      client.connectForTest(channel);
+
+      channel.serverSend({
+        'type': 'event',
+        'event': {
+          'type': 'CUSTOM',
+          'name': 'container_ready',
+          'value': {},
+        },
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.containerReady, isTrue);
+      client.dispose();
+    });
+
+    test('CUSTOM container_stopped event clears the flag', () async {
+      final client = WsClient();
+      final channel = _FakeWebSocketChannel();
+      client.connectForTest(channel);
+      channel.serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.containerReady, isTrue);
+
+      channel.serverSend({
+        'type': 'event',
+        'event': {
+          'type': 'CUSTOM',
+          'name': 'container_stopped',
+        },
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.containerReady, isFalse);
+      client.dispose();
+    });
+
+    test('socket close clears the flag', () async {
+      final client = WsClient();
+      final channel = _FakeWebSocketChannel();
+      client.connectForTest(channel);
+      channel.serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.containerReady, isTrue);
+
+      channel.serverClose();
+      await Future.delayed(Duration.zero);
+
+      expect(client.containerReady, isFalse);
+      client.dispose();
+    });
+
+    test('disconnectWorkspace clears the flag', () async {
+      final client = WsClient();
+      final channel = _FakeWebSocketChannel();
+      client.connectForTest(channel);
+      channel.serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.containerReady, isTrue);
+
+      client.disconnectWorkspace();
+
+      expect(client.containerReady, isFalse);
+      client.dispose();
+    });
+
+    test('unrelated CUSTOM events leave the flag untouched', () async {
+      final client = WsClient();
+      final channel = _FakeWebSocketChannel();
+      client.connectForTest(channel);
+      channel.serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+
+      channel.serverSend({
+        'type': 'event',
+        'event': {'type': 'CUSTOM', 'name': 'something_else'},
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.containerReady, isTrue);
+      client.dispose();
+    });
+  });
+
   group('WsClient.disconnect', () {
     test('disconnect resets state', () {
       final client = WsClient();


### PR DESCRIPTION
## Summary

Fixes #3000.

The `browser-delegate routes to the correct connection` frontend-E2E test
was red on every run from 2026-09-02 ~04:28Z. The issue's prime suspect —
a rolled build input — is exonerated: the "Build images" step logs of the
last green run (33587211771) and the red runs are byte-identical (same
pinned base digest, same 127-package npm set, same sidecar pins). The
decisive evidence is in the artifacts:

- The **last green run was already flaky on this test** — attempt 1 hung
  with the identical error, the retry passed ("1 flaky").
- In every failing execution the backend log shows the **owner's**
  terminal starting normally, then the **member** connecting,
  `container_ready` sent — and `terminal_start` never arriving from the
  member's page. The page snapshot is a near-blank page with one textbox
  (a terminal that never started).

## Root cause

`terminal_start` is only ever sent by `GhosttyTerminal` in response to the
one-shot CUSTOM `container_ready` event, which the server parks until
`ui_ready` and then emits exactly once into a broadcast stream (no replay).

PR #2988 (merged 02:23Z, ~2h before the first failures) made the Terminal
tab mount conditional on the async `my-permissions` fetch. The frame that
fires `ui_ready` can render **without** the terminal widget when the
permissions fetch loses the race — and for a member joining an
owner-started workspace the container is already running, so
`container_ready` fires ~0.2s after the WS connect. The event lands with
no terminal subscribed; the tab mounts milliseconds later and waits
forever. The red-run backend log shows exactly this ordering:
`User bridge-member connected` → *then* the member's
`GET /my-permissions?resource=/workspaces/{id}` completing.

This is also a real product bug: any member opening a shared workspace
whose container is already running can get a permanently blank Terminal
tab until refresh.

## Fix

- `WsClient` tracks container readiness: set by the typed
  `container_ready` frame and the CUSTOM `container_ready` event, cleared
  by `container_stopped`, socket loss, `disconnect()`, and
  `disconnectWorkspace()`.
- `GhosttyTerminal.initState` arms its existing deferred-start machinery
  (`_startPending`) from that tracked state when the container was
  already ready at mount — the late-mounting widget then creates the PTY
  at the first measured resize, exactly as if the event had arrived.

## Testing

- New widget tests: late mount with `containerReady == true` sends
  `terminal_start` at the measured grid (no event needed); late mount
  without readiness sends nothing.
- New `WsClient` tests: flag set by the typed frame and the CUSTOM event,
  cleared by `container_stopped`, socket close, and
  `disconnectWorkspace()`; unrelated events leave it untouched.
- Full `flutter test` suite: 1193 passing.
