### PR TITLE
Remove explanatory text above server admin schedule list

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1472,6 +1472,11 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **Server admin schedule list (#3002).** The explanatory paragraph
+  ("A stop exits the server process…") no longer renders above the
+  schedule list on the Server admin tab; the list now fills the tab
+  directly.
+
 - **Password-field visibility toggle (#2893).** The "eye" toggle on
   password fields (login, settings, invitations, password reset, admin
   user forms) is no longer a Tab stop — Tab moves only between input

--- a/src/frontend/lib/admin/server_schedule_panel.dart
+++ b/src/frontend/lib/admin/server_schedule_panel.dart
@@ -216,22 +216,7 @@ class _ServerSchedulePanelState extends State<ServerSchedulePanel> {
         tooltip: 'Schedule server action',
         child: const Icon(Icons.add_alarm),
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-            child: Text(
-              'A stop exits the server process (the service manager decides '
-              'what happens next); a recycle rebuilds it in place. Every '
-              'connected client sees a countdown while a schedule is pending.',
-              style:
-                  const TextStyle(color: KColors.textSecondary, fontSize: 12),
-            ),
-          ),
-          Expanded(child: _buildList(sorted, hasLive: live != null)),
-        ],
-      ),
+      body: _buildList(sorted, hasLive: live != null),
     );
   }
 


### PR DESCRIPTION
## Summary

Removes the explanatory paragraph ("A stop exits the server process… a recycle rebuilds it in place. Every connected client sees a countdown while a schedule is pending.") that rendered above the schedule list on the Server admin tab.

- `ServerSchedulePanel.build` now passes `_buildList(...)` directly as the `Scaffold` body — the `Column`/`Padding`/`Text` wrapper is gone, and the list's own `EdgeInsets.all(16)` provides the top spacing.
- Changelog entry under `[Unreleased]` → `Changed`.

Closes #3002.

## Testing

- `flutter test test/server_schedule_panel_test.dart test/admin_users_page_test.dart` — green (no test referenced the removed text).
- `test-push` — frontend unit suite green.
