### PR TITLE
Events tab: fit-viewport table + workspace id-or-name filter

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -420,6 +420,11 @@ sync` report a clear permission-denied error.
   deployments, including the instance-id and volume-label constraints
   that make a restore succeed.
 
+- **`workspace` filter on `GET /api/v1/events` (#3006).** The Admin →
+  Events filter now accepts a workspace name as well as a workspace id:
+  the new `workspace` query param matches an exact id or a workspace-name
+  substring. The legacy `workspace_id` param keeps its exact-id behavior.
+
 - **Live permission lists in the Sharing tab (#2986).** Each role
   bucket (owners, collaborators, coders, spectators) now lists the
   permissions its group actually holds on the workspace, read live
@@ -1847,6 +1852,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   custom `features.yaml` if present.
 
 ### Fixed
+
+- **Admin → Events table no longer runs off the screen (#3006).** The
+  table columns now share the panel width — long container ids and
+  network-namespace names ellipsize with a tooltip carrying the full
+  value — instead of laying out wider than the viewport and pushing
+  content past the right-hand screen edge.
 
 - **Blank terminal for members joining a running workspace (#3000).**
   Opening a workspace whose container is already running (e.g. a member

--- a/src/frontend/lib/admin/container_events_panel.dart
+++ b/src/frontend/lib/admin/container_events_panel.dart
@@ -2,10 +2,10 @@
 /// Admin → Events tab: paged container start/stop history (#2923).
 ///
 /// Reads the `container_events` audit table (#2915) through
-/// `GET /api/v1/events` — newest first, optional
-/// workspace-id filter, offset-based paging. The tab itself is gated on
+/// `GET /api/v1/events` — newest first, optional id-or-name workspace
+/// filter (#3006), offset-based paging. The tab itself is gated on
 /// the dedicated `manage-events` permission over
-/// `/admin/container-events` (see [AdminUsersPage]); admins hold it via
+/// `/events` (see [AdminUsersPage]); admins hold it via
 /// the `/admin` wildcard, other principals only via an explicit grant.
 library;
 
@@ -86,7 +86,7 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
       final query = <String, String>{
         'limit': '$_pageSize',
         'offset': '$offset',
-        if (_workspaceQuery.isNotEmpty) 'workspace_id': _workspaceQuery,
+        if (_workspaceQuery.isNotEmpty) 'workspace': _workspaceQuery,
       };
       final auth = context.read<AuthService>();
       final resp = await auth.authGet(
@@ -173,7 +173,7 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
                   controller: _workspaceController,
                   decoration: const InputDecoration(
                     isDense: true,
-                    labelText: 'Filter by workspace id',
+                    labelText: 'Filter by workspace id or name',
                     border: OutlineInputBorder(),
                     prefixIcon: Icon(Icons.filter_list),
                   ),
@@ -223,6 +223,20 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
     );
   }
 
+  /// Column labels with the flex weights shared by the header row and
+  /// every data row: aligned columns that always share the panel width,
+  /// so nothing scrolls off the screen edge (#3006). Long cell values
+  /// ellipsize; a tooltip carries the full text.
+  static const _columns = <(String, int)>[
+    ('When', 3),
+    ('Workspace', 3),
+    ('Event', 2),
+    ('Actor', 3),
+    ('Cause', 2),
+    ('Container', 3),
+    ('Network ns', 3),
+  ];
+
   Widget _buildBody() {
     if (_loading && _events.isEmpty) {
       return const Center(child: CircularProgressIndicator());
@@ -245,42 +259,73 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
     if (_events.isEmpty) {
       return const Center(child: Text('No container events recorded'));
     }
-    return ScrollConfiguration(
-      behavior: ScrollConfiguration.of(context).copyWith(scrollbars: true),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: SingleChildScrollView(
-          child: DataTable(
-            headingTextStyle: const TextStyle(
-              color: KColors.textSecondary,
-              fontWeight: FontWeight.bold,
-            ),
-            columns: const [
-              DataColumn(label: Text('When')),
-              DataColumn(label: Text('Workspace')),
-              DataColumn(label: Text('Event')),
-              DataColumn(label: Text('Actor')),
-              DataColumn(label: Text('Cause')),
-              DataColumn(label: Text('Container')),
-              DataColumn(label: Text('Network ns')),
-            ],
-            rows: [
-              for (final row in _events)
-                DataRow(
-                  cells: [
-                    DataCell(Text(_timeLabel(row['created_at']))),
-                    DataCell(Text(_workspaceLabel(row))),
-                    DataCell(_eventChip(row['event'] as String? ?? '')),
-                    DataCell(Text(_actorLabel(row))),
-                    DataCell(Text(row['cause'] as String? ?? '')),
-                    DataCell(Text(_containerLabel(row))),
-                    DataCell(Text(row['network_namespace'] as String? ?? '')),
-                  ],
+    return Column(
+      children: [
+        Container(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+          decoration: const BoxDecoration(
+            border: Border(bottom: BorderSide(color: KColors.borderDefault)),
+          ),
+          child: Row(
+            children: [
+              for (final (label, flex) in _columns)
+                Expanded(
+                  flex: flex,
+                  child: Text(
+                    label,
+                    style: const TextStyle(
+                      color: KColors.textSecondary,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 12,
+                    ),
+                  ),
                 ),
             ],
           ),
         ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: _events.length,
+            itemBuilder: (ctx, i) => _eventRow(_events[i]),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _eventRow(Map<String, dynamic> row) {
+    // Cells built in _columns order; the flex weights below always come
+    // from the same _columns iteration, so a column reorder cannot
+    // relabel the header while leaving the old weight on a cell.
+    final cells = <Widget>[
+      _textCell(_timeLabel(row['created_at'])),
+      _textCell(_workspaceLabel(row)),
+      _eventChip(row['event'] as String? ?? ''),
+      _textCell(_actorLabel(row)),
+      _textCell(row['cause'] as String? ?? ''),
+      _textCell(_containerLabel(row)),
+      _textCell(row['network_namespace'] as String? ?? ''),
+    ];
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: KColors.borderMuted)),
       ),
+      child: Row(
+        children: [
+          for (final (i, (_, flex)) in _columns.indexed)
+            Expanded(flex: flex, child: cells[i]),
+        ],
+      ),
+    );
+  }
+
+  /// One ellipsized table cell; the tooltip keeps the full value
+  /// reachable when the flex share is too narrow to show it.
+  Widget _textCell(String text) {
+    return Tooltip(
+      message: text,
+      child: Text(text, maxLines: 1, overflow: TextOverflow.ellipsis),
     );
   }
 
@@ -302,6 +347,8 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
       ),
       child: Text(
         event,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style: const TextStyle(color: Colors.white, fontSize: 12),
       ),
     );

--- a/src/frontend/test/container_events_panel_test.dart
+++ b/src/frontend/test/container_events_panel_test.dart
@@ -6,6 +6,7 @@ import 'package:http/testing.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/admin/admin_users_page.dart';
+import 'package:klangk_frontend/admin/container_events_panel.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
@@ -126,6 +127,20 @@ void main() {
     );
   }
 
+  /// The panel alone (no admin-page chrome), for surface-size tests
+  /// that exercise the table under width constraint (#3006).
+  Widget buildPanel() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+        ChangeNotifierProvider(create: (_) => WsClient()),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: ContainerEventsPanel()),
+      ),
+    );
+  }
+
   /// Pump the page on a wide surface (the admin tab row overflows on the
   /// default 800px test surface) and settle. Optionally navigates to the
   /// Events tab before settling.
@@ -140,13 +155,13 @@ void main() {
   }
 
   /// Serve the container-events endpoint via [eventsFor] (called with the
-  /// parsed limit/offset/workspace_id of each request) plus the empty
+  /// parsed limit/offset/workspace query of each request) plus the empty
   /// users/groups/schedule loads so the page itself renders.
   List<http.Request> serveEvents(
     http.Response Function(
       int limit,
       int offset,
-      String? workspaceId,
+      String? workspace,
     ) eventsFor,
   ) {
     final requests = <http.Request>[];
@@ -156,8 +171,8 @@ void main() {
         requests.add(request);
         final limit = int.parse(request.url.queryParameters['limit'] ?? '50');
         final offset = int.parse(request.url.queryParameters['offset'] ?? '0');
-        final workspaceId = request.url.queryParameters['workspace_id'];
-        return eventsFor(limit, offset, workspaceId);
+        final workspace = request.url.queryParameters['workspace'];
+        return eventsFor(limit, offset, workspace);
       }
       if (request.url.path == '/api/v1/users') {
         return http.Response(
@@ -184,7 +199,7 @@ void main() {
 
   group('AdminUsersPage events tab', () {
     testWidgets('renders history rows from the paged envelope', (tester) async {
-      serveEvents((limit, offset, workspaceId) => http.Response(
+      serveEvents((limit, offset, workspace) => http.Response(
             _eventsEnvelope([
               _event(
                 'ws-1',
@@ -224,7 +239,7 @@ void main() {
     });
 
     testWidgets('next/prev page through the history', (tester) async {
-      serveEvents((limit, offset, workspaceId) => http.Response(
+      serveEvents((limit, offset, workspace) => http.Response(
             _eventsEnvelope(
               [
                 _event('ws-${offset + 1}', workspaceName: 'page-ws'),
@@ -263,17 +278,16 @@ void main() {
 
     testWidgets('workspace filter debounces into a fresh query',
         (tester) async {
-      final requests =
-          serveEvents((limit, offset, workspaceId) => http.Response(
-                _eventsEnvelope(
-                  [
-                    if (workspaceId != null)
-                      _event(workspaceId, workspaceName: 'Filtered WS'),
-                  ],
-                  total: workspaceId == null ? 0 : 1,
-                ),
-                200,
-              ));
+      final requests = serveEvents((limit, offset, workspace) => http.Response(
+            _eventsEnvelope(
+              [
+                if (workspace != null)
+                  _event(workspace, workspaceName: 'Filtered WS'),
+              ],
+              total: workspace == null ? 0 : 1,
+            ),
+            200,
+          ));
 
       await pumpPage(tester);
 
@@ -286,8 +300,36 @@ void main() {
 
       expect(find.text('Filtered WS'), findsOneWidget);
       final query = requests.last.url.queryParameters;
-      expect(query['workspace_id'], 'ws-filtered');
+      // #3006: the id-or-name `workspace` query param.
+      expect(query['workspace'], 'ws-filtered');
+      expect(query['workspace_id'], isNull);
       expect(query['offset'], '0');
+    });
+
+    testWidgets('table rows fit a narrow viewport (#3006)', (tester) async {
+      // The whole point of the flex-weight rewrite: at 400px the seven
+      // columns ellipsize instead of laying out past the right edge.
+      // Long values stay present for finders (ellipsis is paint-only)
+      // and no RenderFlex overflow exception is thrown.
+      serveEvents((limit, offset, workspace) => http.Response(
+            _eventsEnvelope([
+              _event(
+                'ws-narrow',
+                workspaceName: 'narrow-ws',
+                containerId: 'cid-0123456789abcdef',
+                networkNamespace: 'sidecar-ns-0123456789',
+              ),
+            ], total: 1),
+            200,
+          ));
+
+      await tester.binding.setSurfaceSize(const Size(400, 900));
+      await tester.pumpWidget(buildPanel());
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('cid-0123456789abcdef'), findsOneWidget);
+      expect(find.text('sidecar-ns-0123456789'), findsOneWidget);
     });
 
     testWidgets('tab hidden without the permission', (tester) async {

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -840,6 +840,7 @@ async def list_container_events(
     request: Request,
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
+    workspace: str | None = None,
     workspace_id: str | None = None,
     viewer: dict = Depends(acl.has_permission("manage-events")),
 ):
@@ -847,17 +848,24 @@ async def list_container_events(
 
     Newest-first rows from the ``container_events`` audit table
     (#2915) plus the filter-matching total, optionally narrowed to one
-    workspace. Gated on the dedicated ``manage-events`` permission
-    over the URL-derived resource ``/events``: the admin group holds it
-    through the seeded Allow row, and a non-admin gets it only via an
-    explicit ACE on that resource — read-only audit access without
-    full admin.
+    workspace: ``workspace`` (#3006) matches an exact workspace id or a
+    workspace-name substring, while the legacy ``workspace_id`` stays
+    an exact-id match. Gated on the dedicated ``manage-events``
+    permission over the URL-derived resource ``/events``: the admin
+    group holds it through the seeded Allow row, and a non-admin gets
+    it only via an explicit ACE on that resource — read-only audit
+    access without full admin.
     """
     app = request.app
     rows = await app.state.model.container_events.list_events(
-        workspace_id, limit=limit, offset=offset
+        workspace_id=workspace_id,
+        workspace=workspace,
+        limit=limit,
+        offset=offset,
     )
-    total = await app.state.model.container_events.count_events(workspace_id)
+    total = await app.state.model.container_events.count_events(
+        workspace_id=workspace_id, workspace=workspace
+    )
     return {
         "items": await _annotate_events(app, rows),
         "total": total,

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -73,6 +73,31 @@ _EVENT_COLUMNS = (
 )
 
 
+def workspace_filter_clause(
+    workspace: str | None, workspace_id: str | None
+) -> tuple[str, list]:
+    """WHERE clause + params narrowing event reads to one workspace.
+
+    ``workspace`` (#3006) is the id-or-name query the admin UI sends:
+    an exact workspace-id match or a workspace whose *name* contains the
+    text, so typing either narrows the history. It wins over the legacy
+    exact ``workspace_id`` param when both are sent. Name matching is
+    SQLite ``LIKE`` — ASCII case-insensitive, ``%``/``_`` wildcards not
+    escaped (the same convention as the other admin filters). An empty
+    string for either param means no filter, so a degenerate
+    ``?workspace=`` cannot silently narrow the audit history.
+    """
+    if workspace:
+        return (
+            " WHERE (workspace_id = ? OR workspace_id IN"
+            " (SELECT id FROM workspaces WHERE name LIKE '%' || ? || '%'))",
+            [workspace, workspace],
+        )
+    if workspace_id:
+        return " WHERE workspace_id = ?", [workspace_id]
+    return "", []
+
+
 def actor_type_for(actor_id: str | None) -> str:
     """Classify an acting principal id into an ``actor_type``."""
     if actor_id is None:
@@ -134,27 +159,29 @@ class ContainerEventsModel(Submodel):
         self,
         workspace_id: str | None = None,
         *,
+        workspace: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[dict]:
-        """Newest-first event history, optionally filtered to a workspace."""
-        sql = f"SELECT {_EVENT_COLUMNS} FROM container_events"
-        params: list = []
-        if workspace_id is not None:
-            sql += " WHERE workspace_id = ?"
-            params.append(workspace_id)
+        """Newest-first event history, optionally filtered to a workspace
+        (exact ``workspace_id``, or id-or-name via ``workspace``)."""
+        where, params = workspace_filter_clause(workspace, workspace_id)
+        sql = f"SELECT {_EVENT_COLUMNS} FROM container_events{where}"
         sql += " ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?"
         rows = await self.app.state.db.fetchall(sql, (*params, limit, offset))
         return [row_to_dict(row) for row in rows]
 
-    async def count_events(self, workspace_id: str | None = None) -> int:
+    async def count_events(
+        self,
+        workspace_id: str | None = None,
+        *,
+        workspace: str | None = None,
+    ) -> int:
         """Row count for paging, with the same optional workspace filter."""
-        sql = "SELECT COUNT(*) FROM container_events"
-        params: tuple = ()
-        if workspace_id is not None:
-            sql += " WHERE workspace_id = ?"
-            params = (workspace_id,)
-        row = await self.app.state.db.fetchone(sql, params)
+        where, params = workspace_filter_clause(workspace, workspace_id)
+        row = await self.app.state.db.fetchone(
+            f"SELECT COUNT(*) FROM container_events{where}", tuple(params)
+        )
         return row[0] if row else 0
 
     async def prune(self, now: float | None = None) -> int:

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -14100,6 +14100,78 @@ class TestContainerEventsAPI:
         assert data["limit"] == 2
         assert data["offset"] == 1
 
+    async def test_workspace_query_matches_id_or_name(
+        self, client, app, admin_user
+    ):
+        """#3006: the unified ``workspace`` param accepts an exact id or a
+        name substring."""
+        headers = await self._admin_headers(client)
+        ws_a = await self._make_workspace(client, headers, "alpha-lab")
+        ws_b = await self._make_workspace(client, headers, "beta-lab")
+        events = app.state.model.container_events
+        await events.record(ws_a, EVENT_START, CAUSE_API, container_id="a-0")
+        await events.record(ws_b, EVENT_START, CAUSE_API, container_id="b-0")
+
+        # An exact id through the unified param narrows like workspace_id.
+        resp = await client.get(
+            "/api/v1/events", headers=headers, params={"workspace": ws_a}
+        )
+        assert resp.status_code == 200, resp.text
+        assert [i["container_id"] for i in resp.json()["items"]] == ["a-0"]
+
+        # A name substring narrows to every workspace whose name matches.
+        resp = await client.get(
+            "/api/v1/events", headers=headers, params={"workspace": "alpha"}
+        )
+        data = resp.json()
+        assert data["total"] == 1
+        assert [i["container_id"] for i in data["items"]] == ["a-0"]
+
+        resp = await client.get(
+            "/api/v1/events", headers=headers, params={"workspace": "lab"}
+        )
+        assert resp.json()["total"] == 2
+
+        # A query matching no id and no name yields an empty page.
+        resp = await client.get(
+            "/api/v1/events", headers=headers, params={"workspace": "nope"}
+        )
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+
+        # The unified param wins over the legacy exact workspace_id.
+        resp = await client.get(
+            "/api/v1/events",
+            headers=headers,
+            params={"workspace": "alpha", "workspace_id": ws_b},
+        )
+        assert [i["container_id"] for i in resp.json()["items"]] == ["a-0"]
+
+    async def test_empty_workspace_params_are_no_filter(
+        self, client, app, admin_user
+    ):
+        """#3009 review: ``?workspace=`` (empty string) must not degrade
+        into a name-substring filter — ``LIKE '%%'`` matches every *live*
+        workspace and would silently hide deleted-workspace history."""
+        headers = await self._admin_headers(client)
+        events = app.state.model.container_events
+        await events.record(
+            "gone-ws", EVENT_STOP, CAUSE_DELETE, container_id="g-0"
+        )
+        await events.record(
+            "live-ws", EVENT_START, CAUSE_API, container_id="l-0"
+        )
+
+        for key in ("workspace", "workspace_id"):
+            resp = await client.get(
+                "/api/v1/events", headers=headers, params={key: ""}
+            )
+            assert resp.status_code == 200, (key, resp.text)
+            data = resp.json()
+            assert data["total"] == 2, (key, data)
+            assert len(data["items"]) == 2, (key, data)
+
     async def test_deleted_workspace_and_purged_actor_fall_back_to_ids(
         self, client, app, admin_user
     ):


### PR DESCRIPTION
## Summary

Closes #3006.

**Layout.** The Admin → Events table laid out intrinsically wide (raw container ids, network-namespace names) inside nested `SingleChildScrollView`s, so content ran past the right-hand screen edge. The `DataTable` is replaced with flex-weighted rows sharing the panel width — aligned columns at any viewport, long values ellipsize under a tooltip carrying the full text, vertical paging via `ListView.builder` (the same list idiom the other admin tabs use).

**Filter.** The workspace filter now accepts a name as well as an id: `GET /api/v1/events` gains a `workspace` query param matching an exact workspace id **or** a workspace-name substring (`workspace_filter_clause` in the model, shared by `list_events`/`count_events`). The legacy exact `workspace_id` param keeps its behavior; `workspace` wins when both are sent. The filter field label reads "Filter by workspace id or name".

## Testing

- `test_api.py`: new `test_workspace_query_matches_id_or_name` — exact id via `workspace`, name substring (one and multiple matches), no-match → empty page, `workspace` precedence over `workspace_id`; every branch of `workspace_filter_clause` covered.
- `container_events_panel_test.dart`: mock server reads the `workspace` param; debounce test asserts `workspace` is sent and `workspace_id` is not.
- `test-push` green (Python testmon + flutter unit); xenon passed.
