### PR TITLE
test(e2e): deflake test_cli_reconnect_to_named_window expect handshake

### DIFF
--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -16,7 +16,9 @@ import asyncio
 import json
 import logging
 import os
+import re
 import subprocess
+import time
 
 import httpx
 import pytest
@@ -97,23 +99,38 @@ def _get_token(base_url):
     return r.json()["access_token"]
 
 
-def _cli_check_window(ws_name, env, timeout=25):
-    """Use expect to connect CLI to workspace, check tmux window, disconnect."""
+def _expect_window_capture(ws_name, env, timeout=25):
+    """One expect-driven CLI connect; returns the raw capture.
+
+    Every expect block handles eof explicitly: a PTY that dies before the
+    prompt used to fall through with no output, leaving an empty capture
+    with no diagnostic (#3012). The pre-command fixed ``sleep 2`` is
+    replaced by an executed-marker round-trip — the shell must actually
+    run a command before the tmux query is sent — so a slow attach is
+    polled instead of guessed at.
+    """
     script = f"""
 set timeout {timeout}
 log_user 0
 spawn klangk shell {ws_name} --no-consent-popup
 expect {{
     -re {{\\$ }} {{}}
-    timeout {{ puts "TIMEOUT"; exit 1 }}
+    timeout {{ puts "TIMEOUT:prompt"; exit 1 }}
+    eof {{ puts "EOF:prompt"; exit 1 }}
 }}
-sleep 2
+send "echo KLANGK_READY_\\$?\\r"
+expect {{
+    -re {{KLANGK_READY_0}} {{}}
+    timeout {{ puts "TIMEOUT:ready"; exit 1 }}
+    eof {{ puts "EOF:ready"; exit 1 }}
+}}
 send "echo W_S; tmux display-message -p '#I:#W'; echo W_E\\r"
 expect {{
     -re {{W_S\\r?\\n(\\d+:\\S+)\\r?\\nW_E}} {{
         puts $expect_out(1,string)
     }}
-    timeout {{ puts "TIMEOUT"; exit 1 }}
+    timeout {{ puts "TIMEOUT:capture"; exit 1 }}
+    eof {{ puts "EOF:capture"; exit 1 }}
 }}
 send "\\r"
 sleep 0.5
@@ -121,14 +138,36 @@ send "~."
 expect {{ eof {{}} timeout {{ close }} }}
 wait
 """
-    result = subprocess.run(
-        ["expect", "-c", script],
-        capture_output=True,
-        text=True,
-        timeout=timeout + 10,
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            ["expect", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout + 10,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return "EXPECT-TIMEOUT"
     return result.stdout.strip()
+
+
+def _cli_check_window(ws_name, env, timeout=25):
+    """Connect CLI to workspace, return its tmux window as ``N:name``.
+
+    Retried once (#3012): under CI load a cold attach can race the expect
+    handshake once (empty capture / prompt never matched); a single retry
+    absorbs the transient while persistent breakage still fails — both
+    attempts are joined into the returned diagnostic.
+    """
+    attempts = []
+    for attempt in range(2):
+        out = _expect_window_capture(ws_name, env, timeout)
+        attempts.append(out)
+        if re.fullmatch(r"\d+:\S+", out):
+            return out
+        if attempt == 0:
+            time.sleep(3)
+    return " | ".join(attempts)
 
 
 def _cli_hold_and_check(ws_name, window_name, hold_seconds, env):
@@ -144,14 +183,21 @@ spawn {cmd}
 expect {{
     -re {{\\$ }} {{}}
     timeout {{ puts "TIMEOUT:prompt"; exit 1 }}
+    eof {{ puts "EOF:prompt"; exit 1 }}
 }}
-sleep 2
+send "echo KLANGK_READY_\\$?\\r"
+expect {{
+    -re {{KLANGK_READY_0}} {{}}
+    timeout {{ puts "TIMEOUT:ready"; exit 1 }}
+    eof {{ puts "EOF:ready"; exit 1 }}
+}}
 send "echo BS; tmux display-message -p '#I:#W'; echo BE\\r"
 expect {{
     -re {{BS\\r?\\n(\\d+:\\S+)\\r?\\nBE}} {{
         set before $expect_out(1,string)
     }}
     timeout {{ puts "TIMEOUT:before"; exit 1 }}
+    eof {{ puts "EOF:before"; exit 1 }}
 }}
 puts "BEFORE=$before"
 sleep {hold_seconds}
@@ -161,6 +207,7 @@ expect {{
         set after $expect_out(1,string)
     }}
     timeout {{ puts "TIMEOUT:after"; exit 1 }}
+    eof {{ puts "EOF:after"; exit 1 }}
 }}
 puts "AFTER=$after"
 send "\\r"


### PR DESCRIPTION
## Summary

Deflake `TestTerminalWindows::test_cli_reconnect_to_named_window` (#3012): the failed run's empty first-connect capture came from the expect script's `expect` blocks having no `eof` handler — a PTY that died before the prompt fell through, the follow-up `send`/`puts` aborted on the dead spawn, and stdout came back `''` with no diagnostic.

Harness-only changes in `test_terminal_windows_e2e.py`:

- **Explicit `eof` handlers everywhere** (`_expect_window_capture`, `_cli_hold_and_check`) with stage-tagged diagnostics (`EOF:prompt`, `EOF:capture`, …) — a future failure is identifiable instead of silently empty.
- **Poll instead of fixed sleeps**: the pre-command `sleep 2` is replaced by an executed-marker round-trip (`echo KLANGK_READY_$?` must come back as `KLANGK_READY_0`), so the tmux query is sent only after the shell provably executes a command — a slow attach is waited out, not guessed at.
- **Retry the connect once** in `_cli_check_window`: a transient cold-attach race is absorbed; persistent breakage still fails, with both attempts joined into the assertion message. `subprocess.TimeoutExpired` is folded into the retry path too.

## Testing

- Targeted run: `test-terminal-windows-e2e -k test_cli_reconnect_to_named_window` — pass.
- Full file: `test-terminal-windows-e2e` — 10/10 pass.
- Standalone expect rehearsals confirmed the readiness ping matches executed output only (not the typed echo) and the eof path prints a diagnostic.

Closes #3012.
