### PR TITLE
Validate volume names: podman-safe charset + length cap

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -243,6 +243,15 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Volume name validation (#2971).** `POST /api/v1/volumes` and
+  `DELETE /api/v1/volumes/{name}` now reject names that are not
+  podman-safe — they must start with an alphanumeric character,
+  continue with `a-zA-Z0-9_.-` only, and be at most 64 characters —
+  with HTTP 422. Previously any string was appended verbatim to the
+  podman command line, so a leading-dash name was parsed as a podman
+  flag (on delete, `--all` could remove every unused volume on the
+  host).
+
 - **Volume-create conflict check no longer leaks foreign volume names
   (#2973).** `POST /api/v1/volumes` answered 409 for any podman volume
   name that existed on the host, letting a user probe for volumes the
@@ -429,12 +438,6 @@ sync` report a clear permission-denied error.
 
 ### Added
 
-- **Volume name validation (#2971).** `POST /api/v1/volumes` now
-  rejects names that are not podman-safe — they must start with an
-  alphanumeric character, continue with `a-zA-Z0-9_.-` only, and be at
-  most 64 characters — with HTTP 422. Previously any string was
-  appended verbatim to the podman command line, so a leading-dash
-  name could be parsed as a podman flag.
 - **Backup and restore docs (#2999).** New "Backup and Restore" reference
   chapter covering the full-site backup set (data dir, labeled podman
   volumes with their labels, env + config file + `file:` secrets,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -429,6 +429,12 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Volume name validation (#2971).** `POST /api/v1/volumes` now
+  rejects names that are not podman-safe — they must start with an
+  alphanumeric character, continue with `a-zA-Z0-9_.-` only, and be at
+  most 64 characters — with HTTP 422. Previously any string was
+  appended verbatim to the podman command line, so a leading-dash
+  name could be parsed as a podman flag.
 - **Backup and restore docs (#2999).** New "Backup and Restore" reference
   chapter covering the full-site backup set (data dir, labeled podman
   volumes with their labels, env + config file + `file:` secrets,

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1822,6 +1822,9 @@ filter).
 **Auth:** JWT required. User must have the `manage-volumes` permission
 on `/volumes` (#2993; seeded Allow for the `admins` group).
 
+`{name}` in the path must satisfy the same podman-safe rule as on
+create (#2971); violations return HTTP 422.
+
 No request body.
 
 ```json

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1369,6 +1369,10 @@ the count is the caller's instance-managed volumes (`GET
 concurrent creates. The same cap also gates the workspace-start
 auto-create of mounted named volumes. `0` (the default) = unlimited.
 
+`name` must be podman-safe (#2971): start with an alphanumeric
+character, continue with `a-zA-Z0-9_.-` only, and be at most 64
+characters; violations return HTTP 422.
+
 ```json
 { "name": "my-volume" }
 ```

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -8,10 +8,13 @@ import json
 import logging
 import posixpath
 
+from typing import Annotated
+
 from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
+    Path,
     UploadFile,
 )
 from fastapi.responses import (
@@ -389,6 +392,10 @@ async def list_volumes(
 # alphanumerics/underscore/dot/hyphen only, and stays within 64 chars
 # ({0,63} after the first character) — a cap picked for UX, well under
 # podman's own generous limit. Pydantic violations surface as 422.
+# Anchored ^...$ under pydantic-core's Rust regex (strict end-of-
+# haystack). Do NOT reuse this constant with Python's `re`: its `$`
+# also matches before a trailing newline, so "abc\n" would slip
+# through a `re.search`-based check.
 VOLUME_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
 
 
@@ -460,7 +467,7 @@ async def create_volume(
 
 @router.delete("/volumes/{name}")
 async def delete_volume(
-    name: str,
+    name: Annotated[str, Path(pattern=VOLUME_NAME_PATTERN)],
     _user: dict = Depends(acl.has_permission("manage-volumes")),
     app=Depends(get_app_dep),
 ):
@@ -469,7 +476,10 @@ async def delete_volume(
     ``manage-volumes`` is the whole gate — the surface is admin-only
     by seed, so the former per-user label check is gone (the admin
     tab lists and deletes any volume this instance manages). The
-    creator label stays on the row as provenance.
+    creator label stays on the row as provenance. The name is
+    pattern-validated (#2971): a raw path param reaches podman argv
+    verbatim, and podman parses a leading-dash name as a flag —
+    `--all` would remove every unused volume on the host.
     """
     info = await app.state.podman.inspect_volume(name)
     if info is None:

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -17,7 +17,7 @@ from fastapi import (
 from fastapi.responses import (
     StreamingResponse,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .. import (
     acl,
@@ -383,8 +383,17 @@ async def list_volumes(
     }
 
 
+# Podman-safe volume name (#2971): starts with an alphanumeric (so a
+# leading "-" can never be parsed as a flag by the podman CLI, whose
+# argv we build by appending the name verbatim), continues with
+# alphanumerics/underscore/dot/hyphen only, and stays within 64 chars
+# ({0,63} after the first character) — a cap picked for UX, well under
+# podman's own generous limit. Pydantic violations surface as 422.
+VOLUME_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+
+
 class CreateVolumeRequest(BaseModel):
-    name: str
+    name: str = Field(pattern=VOLUME_NAME_PATTERN)
 
 
 @router.post("/volumes")

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6982,6 +6982,72 @@ class TestVolumeRoutes:
         # The creator label stays on created volumes (provenance).
         assert labels["klangk.user-id"] == admin_user["id"]
 
+    async def test_create_volume_rejects_leading_dash(
+        self, client, admin_user
+    ):
+        """#2971: a name starting with "-" would be parsed as a flag by
+        the podman CLI — rejected with 422 before podman is called."""
+        headers = await _admin_login(client)
+        mock_create = AsyncMock()
+        with patch.object(_mock_pod, "create_volume", mock_create):
+            resp = await client.post(
+                "/api/v1/volumes",
+                json={"name": "-flag"},
+                headers=headers,
+            )
+        assert resp.status_code == 422
+        assert mock_create.await_count == 0
+
+    async def test_create_volume_rejects_overlong_name(
+        self, client, admin_user
+    ):
+        """#2971: names past the 64-char cap are rejected with 422 (the
+        64-char boundary itself is still accepted)."""
+        headers = await _admin_login(client)
+        mock_create = AsyncMock(
+            return_value={"Name": "x", "CreatedAt": "2026-01-01"}
+        )
+        with (
+            patch.object(
+                _mock_pod, "inspect_volume", AsyncMock(return_value=None)
+            ),
+            patch.object(_mock_pod, "create_volume", mock_create),
+        ):
+            boundary = await client.post(
+                "/api/v1/volumes",
+                json={"name": "a" * 64},
+                headers=headers,
+            )
+            overlong = await client.post(
+                "/api/v1/volumes",
+                json={"name": "a" * 65},
+                headers=headers,
+            )
+        assert boundary.status_code == 200
+        assert overlong.status_code == 422
+        assert mock_create.await_count == 1
+
+    async def test_create_volume_rejects_bad_charset(self, client, admin_user):
+        """#2971: names outside [a-zA-Z0-9_.-] (after an alphanumeric
+        first char) are rejected with 422."""
+        headers = await _admin_login(client)
+        mock_create = AsyncMock()
+        with patch.object(_mock_pod, "create_volume", mock_create):
+            for name in (
+                "has space",
+                "sla/sh",
+                "ex!am",
+                ".dotstart",
+                "_under",
+            ):
+                resp = await client.post(
+                    "/api/v1/volumes",
+                    json={"name": name},
+                    headers=headers,
+                )
+                assert resp.status_code == 422, name
+        assert mock_create.await_count == 0
+
     async def test_create_volume_requires_manage_volumes(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -6982,20 +6982,48 @@ class TestVolumeRoutes:
         # The creator label stays on created volumes (provenance).
         assert labels["klangk.user-id"] == admin_user["id"]
 
+    async def test_create_volume_accepts_full_charset(
+        self, client, admin_user
+    ):
+        """#2971: every character the pattern allows is accepted
+        together in one name."""
+        headers = await _admin_login(client)
+        with (
+            patch.object(
+                _mock_pod, "inspect_volume", AsyncMock(return_value=None)
+            ),
+            patch.object(
+                _mock_pod,
+                "create_volume",
+                AsyncMock(return_value={"Name": "a-b_c.d", "CreatedAt": ""}),
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/volumes",
+                json={"name": "a-b_c.d"},
+                headers=headers,
+            )
+        assert resp.status_code == 200
+
     async def test_create_volume_rejects_leading_dash(
         self, client, admin_user
     ):
         """#2971: a name starting with "-" would be parsed as a flag by
         the podman CLI — rejected with 422 before podman is called."""
         headers = await _admin_login(client)
+        mock_inspect = AsyncMock()
         mock_create = AsyncMock()
-        with patch.object(_mock_pod, "create_volume", mock_create):
+        with (
+            patch.object(_mock_pod, "inspect_volume", mock_inspect),
+            patch.object(_mock_pod, "create_volume", mock_create),
+        ):
             resp = await client.post(
                 "/api/v1/volumes",
                 json={"name": "-flag"},
                 headers=headers,
             )
         assert resp.status_code == 422
+        assert mock_inspect.await_count == 0
         assert mock_create.await_count == 0
 
     async def test_create_volume_rejects_overlong_name(
@@ -7031,14 +7059,20 @@ class TestVolumeRoutes:
         """#2971: names outside [a-zA-Z0-9_.-] (after an alphanumeric
         first char) are rejected with 422."""
         headers = await _admin_login(client)
+        mock_inspect = AsyncMock()
         mock_create = AsyncMock()
-        with patch.object(_mock_pod, "create_volume", mock_create):
+        with (
+            patch.object(_mock_pod, "inspect_volume", mock_inspect),
+            patch.object(_mock_pod, "create_volume", mock_create),
+        ):
             for name in (
                 "has space",
                 "sla/sh",
                 "ex!am",
                 ".dotstart",
                 "_under",
+                "abc\n",
+                "a\nb",
             ):
                 resp = await client.post(
                     "/api/v1/volumes",
@@ -7046,6 +7080,7 @@ class TestVolumeRoutes:
                     headers=headers,
                 )
                 assert resp.status_code == 422, name
+        assert mock_inspect.await_count == 0
         assert mock_create.await_count == 0
 
     async def test_create_volume_requires_manage_volumes(self, client, user):
@@ -7304,6 +7339,27 @@ class TestVolumeRoutes:
         assert resp.status_code == 200
         mock_count.assert_not_awaited()
         assert mock_create.await_count == 1
+
+    async def test_delete_volume_rejects_invalid_name(
+        self, client, admin_user
+    ):
+        """#2971: a leading-dash path param would reach podman argv
+        verbatim — `DELETE /volumes/--all` would run `podman volume
+        rm --all` (every unused volume on the host). 422 before any
+        podman call."""
+        headers = await _admin_login(client)
+        mock_inspect = AsyncMock()
+        mock_remove = AsyncMock()
+        with (
+            patch.object(_mock_pod, "inspect_volume", mock_inspect),
+            patch.object(_mock_pod, "remove_volume", mock_remove),
+        ):
+            resp = await client.delete(
+                "/api/v1/volumes/--all", headers=headers
+            )
+        assert resp.status_code == 422
+        assert mock_inspect.await_count == 0
+        assert mock_remove.await_count == 0
 
     async def test_delete_volume(self, client, admin_user):
         headers = await _admin_login(client)


### PR DESCRIPTION
## Summary

`POST /api/v1/volumes` accepted any string as the volume name and appended it
verbatim to the podman argv list, so a name beginning with `-` was parsed by
podman as a flag (#2971).

`CreateVolumeRequest.name` is now validated with a Pydantic pattern:
`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$` — alphanumeric first character (rejects
leading `-`/`--`), `a-zA-Z0-9_.-` thereafter, capped at 64 chars (documented in
`docs/reference/api-endpoints.md`). Violations return HTTP 422 before any
podman call.

## Tests

- leading-dash name → 422, podman never called
- 64-char name → 200, 65-char name → 422
- bad-charset names (space, slash, punctuation, leading `.`/`_`) → 422

Full backend suite green (6536 passed, 100% branch coverage).

Closes #2971.
