### PR TITLE
Replace the session window watcher when its container is recycled

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1888,6 +1888,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Tab-strip sync survives a container restart (#3015).** The
+  server's tmux window watcher was built once per workspace session
+  and never replaced when the container was recycled while members
+  stayed connected, so idle clients' terminal tab strips and the
+  shared-terminal list went stale until each user took a terminal
+  action or reloaded. A stale or dead watcher is now detected on every
+  (re)connect and rebuilt against the current container.
 - **Workspace restart now notifies every connected member (#3008).**
   When one member restarted a workspace container, only that member's
   client was told — other members' terminals went dead with no recovery

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -412,11 +412,28 @@ class WorkspaceSession:
 
     def start_window_sync(self) -> None:
         """Start (once) the tmux control-mode window-change watcher so every
-        client's tab strip stays in sync with tmux (#2161 / #2171)."""
-        if self._window_watcher is not None or self.app is None:
+        client's tab strip stays in sync with tmux (#2161 / #2171).
+
+        Container-aware (#3015): the watcher's exec dies with its
+        container and ``_container_id`` is baked in at construction, so
+        a watcher left from a recycled container — one bound to a stale
+        container id, or whose reader task already exited — is torn down
+        and replaced by a fresh one bound to the session's current
+        container. Without the replacement every later
+        ``add_subscriber`` (reconnect or restart) no-opped on the dead
+        watcher and push-based sync stayed dead for the session's
+        remaining life. The old watcher's ``stop()`` is spawned, not
+        awaited — it is safe against a start still in flight (#2929)
+        and its teardown execs must not pin the session lock.
+        """
+        if self.app is None or self.container_id is None:
             return
-        if self.container_id is None:
-            return
+        watcher = self._window_watcher
+        if watcher is not None:
+            if watcher.container_id == self.container_id and watcher.alive:
+                return
+            self._window_watcher = None
+            spawn_session_task(watcher.stop())
         self._window_watcher = WindowEventWatcher(
             self.app.state.podman,
             self.container_id,

--- a/src/klangk/klangk/wshandler/window_watcher.py
+++ b/src/klangk/klangk/wshandler/window_watcher.py
@@ -90,6 +90,30 @@ class WindowEventWatcher:
         # instance (e.g. across a container restart) never collides.
         self._ctrl_session = f"__klangk_ctrl-{uuid.uuid4().hex[:8]}"
 
+    @property
+    def container_id(self) -> str:
+        """The container this watcher's control client is bound to.
+
+        Baked in at construction, so a watcher can never be re-aimed at
+        a recycled container — the session replaces it instead (#3015).
+        """
+        return self._container_id
+
+    @property
+    def alive(self) -> bool:
+        """True while the watcher can still deliver events.
+
+        False when stopped (single-use, #2929), when the reader task
+        has exited — the exec died with its container — or when a start
+        never got far enough to spawn one. The session treats a watcher
+        that is not alive as dead and builds a fresh one (#3015).
+        """
+        if self._stopped:
+            return False
+        if self._task is None:
+            return self._starting
+        return not self._task.done()
+
     async def start(
         self,
     ) -> None:

--- a/src/klangk/klangk/wshandler/window_watcher.py
+++ b/src/klangk/klangk/wshandler/window_watcher.py
@@ -84,6 +84,15 @@ class WindowEventWatcher:
         # ``start()`` observes it right after its exec await and tears the
         # fresh client down itself instead of orphaning it. A stopped
         # watcher is single-use: a later ``start()`` never spawns.
+        # ``_start_pending`` is True from construction (#3015 review): the
+        # session spawns ``start()`` fire-and-forget, and until that task
+        # first runs the watcher must already read alive — a second
+        # ``add_subscriber`` in that window would otherwise discard the
+        # fresh watcher and waste a control-client exec. ``start()``
+        # clears it synchronously before its guards, so a direct first
+        # call still spawns; only a start whose exec failed (or never
+        # ran) leaves a no-task watcher reading not-alive.
+        self._start_pending = True
         self._starting = False
         self._stopped = False
         # Unique per-watcher session name so a stale client from a prior
@@ -103,20 +112,27 @@ class WindowEventWatcher:
     def alive(self) -> bool:
         """True while the watcher can still deliver events.
 
-        False when stopped (single-use, #2929), when the reader task
-        has exited — the exec died with its container — or when a start
-        never got far enough to spawn one. The session treats a watcher
-        that is not alive as dead and builds a fresh one (#3015).
+        True from construction (a start is pending — the session spawns
+        it fire-and-forget, #3015 review), while the start exec is in
+        flight, and while the reader task runs. False when stopped
+        (single-use, #2929), when the reader task has exited — the exec
+        died with its container — or when a start failed before
+        spawning a reader. The session treats a watcher that is not
+        alive as dead and builds a fresh one (#3015).
         """
         if self._stopped:
             return False
         if self._task is None:
-            return self._starting
+            return self._starting or self._start_pending
         return not self._task.done()
 
     async def start(
         self,
     ) -> None:
+        # Clear the pending marker synchronously before any guard: the
+        # task is running now, so "constructed but never started" no
+        # longer describes it (#3015 review).
+        self._start_pending = False
         if self._task is not None and not self._task.done():
             return
         if self._starting or self._stopped:

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -104,6 +104,8 @@ async def test_start_window_sync_creates_watcher_once():
     sess, _sock, _terminal = _session_with_user()
     with patch("klangk.wshandler.session.WindowEventWatcher") as wc:
         wc.return_value.start = AsyncMock()
+        wc.return_value.container_id = "cid"
+        wc.return_value.alive = True
         sess.start_window_sync()
         assert wc.call_count == 1
         sess.start_window_sync()  # idempotent — no second watcher
@@ -116,6 +118,87 @@ def test_start_window_sync_noop_without_container():
     sess.container_id = None
     sess.start_window_sync()
     assert sess._window_watcher is None
+
+
+# --- #3015: a watcher that died with its container is replaced ---
+
+
+async def test_start_window_sync_replaces_watcher_bound_to_old_container():
+    """After a container recycle the watcher is bound to a dead id.
+
+    The recycling connection's ``add_subscriber`` updates the session's
+    container id, so ``start_window_sync`` must tear the stale watcher
+    down and start a fresh one against the new container — not no-op on
+    the non-None field and leave push-based sync dead (#3015).
+    """
+    sess, _, _ = _session_with_user()
+    sess.container_id = "new-cid"
+    stale = MagicMock()
+    stale.container_id = "old-cid"
+    stale.alive = True  # even a still-live watcher aims at the wrong pod
+    stale.stop = AsyncMock()
+    sess._window_watcher = stale
+    with (
+        patch("klangk.wshandler.session.WindowEventWatcher") as wc,
+        patch(
+            "klangk.wshandler.session.spawn_session_task",
+            side_effect=lambda coro: coro.close(),
+        ) as spawn,
+    ):
+        sess.start_window_sync()
+    # Old watcher torn down (scheduled, not awaited inline) and a fresh
+    # one built against the new container id.
+    assert spawn.call_count == 2  # stale stop + fresh start
+    stale.stop.assert_not_awaited()
+    assert wc.call_args.args[1] == "new-cid"
+    assert sess._window_watcher is wc.return_value
+
+
+async def test_start_window_sync_replaces_dead_watcher_same_container():
+    """A same-id restart (podman restart keeps the id) kills the exec.
+
+    The container id matches, so only the reader-task liveness check
+    catches the dead watcher — the exact "died with the container,
+    never stopped" case #3015 describes.
+    """
+    sess, _, _ = _session_with_user()  # container_id "cid"
+    dead = MagicMock()
+    dead.container_id = "cid"
+    dead.alive = False
+    dead.stop = AsyncMock()
+    sess._window_watcher = dead
+    with (
+        patch("klangk.wshandler.session.WindowEventWatcher") as wc,
+        patch(
+            "klangk.wshandler.session.spawn_session_task",
+            side_effect=lambda coro: coro.close(),
+        ) as spawn,
+    ):
+        sess.start_window_sync()
+    assert spawn.call_count == 2  # dead watcher stop + fresh start
+    assert wc.call_args.args[1] == "cid"
+    assert sess._window_watcher is wc.return_value
+
+
+async def test_start_window_sync_keeps_watcher_mid_start():
+    """A watcher whose start exec is still in flight is alive (#2929): a
+    concurrent add_subscriber must not tear it down and double-spawn."""
+    sess, _, _ = _session_with_user()
+    starting = MagicMock()
+    starting.container_id = "cid"
+    starting.alive = True
+    starting.stop = AsyncMock()
+    sess._window_watcher = starting
+    with (
+        patch("klangk.wshandler.session.WindowEventWatcher") as wc,
+        patch(
+            "klangk.wshandler.session.spawn_session_task",
+            side_effect=lambda coro: coro.close(),
+        ),
+    ):
+        sess.start_window_sync()
+    wc.assert_not_called()
+    assert sess._window_watcher is starting
 
 
 async def test_reset_cancels_pending_sync_and_stops_watcher():

--- a/src/klangk/klangkd-tests/tests/test_session_sync.py
+++ b/src/klangk/klangkd-tests/tests/test_session_sync.py
@@ -201,6 +201,29 @@ async def test_start_window_sync_keeps_watcher_mid_start():
     assert sess._window_watcher is starting
 
 
+async def test_rapid_reconnect_keeps_freshly_built_watcher():
+    """#3015 review follow-up: between constructing the replacement
+    watcher and its spawned ``start()`` first running (no await between
+    the two sync calls, so the task is still queued), the watcher must
+    already read alive — a second connect in that window must not
+    discard the fresh watcher and waste another control-client exec.
+
+    Uses the REAL watcher class: the mocked tests above fake ``alive``;
+    this one pins the real construction-time flag the fix added.
+    """
+    sess, _, _ = _session_with_user()
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock()) as spawn:
+        sess.start_window_sync()
+        first = sess._window_watcher
+        sess.start_window_sync()  # start task still queued, not yet run
+        assert sess._window_watcher is first
+
+        await first.stop()  # single-use: the queued start() then no-ops
+        for _ in range(3):
+            await asyncio.sleep(0)  # drain the queued start task
+        spawn.assert_not_called()
+
+
 async def test_reset_cancels_pending_sync_and_stops_watcher():
     sess, _sock, _terminal = _session_with_user()
     with patch("klangk.wshandler.session.WindowEventWatcher") as wc:

--- a/src/klangk/klangkd-tests/tests/test_window_watcher.py
+++ b/src/klangk/klangkd-tests/tests/test_window_watcher.py
@@ -70,6 +70,49 @@ async def test_read_loop_propagates_cancellation():
         await task
 
 
+# --- #3015: container binding + liveness, seen by the session ---------
+
+
+async def test_container_id_reports_bound_container():
+    watcher = WindowEventWatcher(MagicMock(), "cid", lambda: None)
+    assert watcher.container_id == "cid"
+
+
+async def test_alive_tracks_lifecycle():
+    """alive is the session's replacement signal (#3015): False before a
+    start, True while the start exec is in flight, True while the reader
+    task runs, False once the reader exits (the exec died with the
+    container), and always False once stopped."""
+    watcher = WindowEventWatcher(MagicMock(), "cid", lambda: None)
+    assert watcher.alive is False  # never started
+
+    watcher._starting = True
+    assert watcher.alive is True  # start exec in flight
+
+    watcher._starting = False
+    watcher._task = asyncio.ensure_future(asyncio.sleep(3600))
+    assert watcher.alive is True  # reader task running
+
+    task = watcher._task
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert watcher.alive is False  # reader exited: died with container
+
+    # Stopped mid-teardown (task fields not yet cleared by stop()):
+    # a watcher that will never deliver again must not read alive.
+    watcher._task = asyncio.ensure_future(asyncio.sleep(3600))
+    watcher._stopped = True
+    assert watcher.alive is False
+    watcher._task.cancel()
+    try:
+        await watcher._task
+    except asyncio.CancelledError:
+        pass
+
+
 # --- No-cover audit tests (#2910, part 3) --------------------------------
 
 

--- a/src/klangk/klangkd-tests/tests/test_window_watcher.py
+++ b/src/klangk/klangkd-tests/tests/test_window_watcher.py
@@ -79,17 +79,24 @@ async def test_container_id_reports_bound_container():
 
 
 async def test_alive_tracks_lifecycle():
-    """alive is the session's replacement signal (#3015): False before a
-    start, True while the start exec is in flight, True while the reader
-    task runs, False once the reader exits (the exec died with the
-    container), and always False once stopped."""
+    """alive is the session's replacement signal (#3015): True from
+    construction (a start is pending — the session spawns it
+    fire-and-forget, so a second subscriber in the spawn window must
+    not treat the fresh watcher as dead), True while the start exec is
+    in flight, True while the reader task runs, False once the reader
+    exits (the exec died with the container), False after a failed
+    start (the finally reset), and always False once stopped."""
     watcher = WindowEventWatcher(MagicMock(), "cid", lambda: None)
-    assert watcher.alive is False  # never started
+    assert watcher.alive is True  # constructed: start pending
 
     watcher._starting = True
     assert watcher.alive is True  # start exec in flight
 
+    # start() ran and failed before spawning a reader: not alive.
     watcher._starting = False
+    watcher._start_pending = False
+    assert watcher.alive is False
+
     watcher._task = asyncio.ensure_future(asyncio.sleep(3600))
     assert watcher.alive is True  # reader task running
 

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -6587,6 +6587,82 @@ class TestHandleRestartContainer:
         sockets.connections.pop(sock2, None)
         sockets.sessions.pop(workspace["id"], None)
 
+    async def test_restart_replaces_dead_window_watcher(self, user, app_state):
+        """#3015: the session's tmux window watcher is bound to one
+        container; a restart that recycles the container (with a sibling
+        still subscribed, so the session survives) must replace the
+        watcher instead of no-oping on the stale field forever."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        registry = app_state.state.container_registry
+        sock1 = _mock_sock(headers={"host": "localhost:8997"})
+        sock2 = _mock_sock()
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "restart-watcher"
+        )
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
+        conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
+        conn1.workspace_id = workspace["id"]
+        conn1.container_id = "old-cid"
+        conn1.workspace = workspace
+        conn2.workspace_id = workspace["id"]
+        conn2.container_id = "old-cid"
+        session = sockets.get_or_create_session(workspace["id"], app_state)
+        # Seed the watcher the pre-restart session would hold: bound to
+        # the old container (its exec died with it, but the session
+        # cannot know that — it only sees the binding).
+        stale = MagicMock()
+        stale.container_id = "old-cid"
+        stale.alive = True
+        stale.stop = AsyncMock()
+        session._window_watcher = stale
+        await session.add_subscriber(sock1, "old-cid")
+        await session.add_subscriber(sock2, "old-cid")
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
+
+        async def fake_start(self_arg, wid, ws_obj):
+            self_arg.container_id = "new-cid"
+            self_arg.workspace_id = wid
+            # start_workspace_container re-subscribes the restarting
+            # socket (the real path calls add_subscriber).
+            await session.add_subscriber(sock1, "new-cid")
+
+        with (
+            patch.object(
+                Connection,
+                "start_workspace_container",
+                autospec=True,
+                side_effect=fake_start,
+            ),
+            patch("klangk.wshandler.session.WindowEventWatcher") as wc,
+            patch.object(registry, "record_activity"),
+            patch.object(
+                registry,
+                "get_workspace_ports",
+                return_value=[],
+            ),
+        ):
+            wc.return_value.start = AsyncMock()
+            await conn1.handle_restart_container()
+
+        for _ in range(3):
+            await asyncio.sleep(0)  # drain the spawned stop/start tasks
+
+        # The stale watcher was torn down and a fresh one was built
+        # against the recycled container — while sock2 stayed subscribed
+        # the whole time (the session was never reset).
+        stale.stop.assert_awaited_once()
+        wc.assert_called_once()
+        assert wc.call_args.args[1] == "new-cid"
+        assert session._window_watcher is wc.return_value
+
+        await session.remove_subscriber(sock1)
+        await session.remove_subscriber(sock2)
+        sockets.connections.pop(sock1, None)
+        sockets.connections.pop(sock2, None)
+        sockets.sessions.pop(workspace["id"], None)
+
 
 class TestTerminalWindowHandlers:
     async def test_new_window_no_container(self):


### PR DESCRIPTION
## Summary

Fixes #3015.

`WorkspaceSession`'s tmux control-mode window watcher is built once against one container id and its exec dies with that container. While any subscriber stayed connected, `session._window_watcher` stayed non-`None`, so `start_window_sync` no-opped on every later `add_subscriber` (reconnect or restart) and push-based tab-strip sync stayed dead for the session's remaining life — idle clients' tab strips and the `shared_terminals` map went stale until each user took a terminal action or reloaded.

- `WindowEventWatcher` now exposes `container_id` (its baked-in binding) and `alive` (false once stopped per #2929, once the reader task exited — the exec died with the container — or when a start never got far enough to spawn one).
- `start_window_sync` is container-aware: a watcher bound to a stale container id, or not alive (same-id restart case), is torn down and replaced by a fresh one bound to the session's current container. The old watcher's `stop()` is spawned, not awaited — it is safe against a start still in flight (#2929 race guard) and must not pin the session lock through its teardown execs.

## Testing

- Unit: watcher property lifecycle tests (`test_window_watcher.py`), replacement tests for stale-container / dead-same-container / keep-mid-start (`test_session_sync.py`).
- End-to-end: `test_restart_replaces_dead_window_watcher` — a restart with a sibling still subscribed replaces the session's watcher with one bound to the new container.
- Full suite: 6559 passed, 100% branch coverage, xenon clean.

Changelog entry added under `[Unreleased]` → Fixed.
