### PR TITLE
Validate named-volume sources in workspace mounts (podman argv injection)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -243,6 +243,17 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Workspace-mount volume-source validation (#3018).** A mount
+  source with no `/` that doesn't start with `.` is a named volume,
+  and must now be podman-safe to pass workspace create/update mount
+  validation (alphanumeric first character, `a-zA-Z0-9_.-` only, at
+  most 64 characters — the same rule as the volumes API, #2971),
+  returning HTTP 400 on violation. Previously such a source reached
+  `podman volume create/inspect` argv verbatim at container start, so
+  a leading-dash source was parsed as a podman flag; the check also
+  runs at start as defense in depth for workspaces created before the
+  gate.
+
 - **Volume name validation (#2971).** `POST /api/v1/volumes` and
   `DELETE /api/v1/volumes/{name}` now reject names that are not
   podman-safe — they must start with an alphanumeric character,

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1410,6 +1410,13 @@ gives each member a private `/home/<handle>`, `false` (the server
 default, `KLANGKD_PER_HANDLE_HOME`) shares one `/home/klangk`. Omit it
 to inherit the server default.
 
+A `mounts` source with no `/` that doesn't start with `.` is a named
+volume and must be podman-safe (#3018): start with an alphanumeric
+character, continue with `a-zA-Z0-9_.-` only, and be at most 64
+characters — the same rule as the volumes API (#2971). Violations
+return HTTP 400; bind-mount sources (absolute paths, `.`-prefixed)
+keep the protected-path / allowed-root checks.
+
 `settings` is a bag of per-workspace behavioral overrides (#864). Known
 keys (unknown keys are rejected with `400`):
 
@@ -1758,6 +1765,9 @@ command, volume mounts, environment variables). All fields optional.
 `per_handle_home` may be flipped here too; the new layout applies from
 the workspace's next connect/start (open terminals keep their layout
 until they end).
+
+`mounts` named-volume sources are subject to the same podman-safe
+rule as on create (#3018); violations return HTTP 400.
 
 `settings` is a **full replace** of the
 [settings bag](#post-apiv1workspaces) — keys absent from the request are

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field
 from .. import (
     acl,
 )
+from ..container.spec import VOLUME_NAME_PATTERN
 from ..podman import PodmanError as PodmanError
 from ..util import (
     sanitize_disposition_name,
@@ -386,17 +387,15 @@ async def list_volumes(
     }
 
 
-# Podman-safe volume name (#2971): starts with an alphanumeric (so a
-# leading "-" can never be parsed as a flag by the podman CLI, whose
-# argv we build by appending the name verbatim), continues with
-# alphanumerics/underscore/dot/hyphen only, and stays within 64 chars
-# ({0,63} after the first character) — a cap picked for UX, well under
-# podman's own generous limit. Pydantic violations surface as 422.
-# Anchored ^...$ under pydantic-core's Rust regex (strict end-of-
-# haystack). Do NOT reuse this constant with Python's `re`: its `$`
-# also matches before a trailing newline, so "abc\n" would slip
-# through a `re.search`-based check.
-VOLUME_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+# The podman-safe volume-name rule lives next to its sibling
+# ``is_named_volume`` in ``container.spec`` (moved there in #3018 so the
+# workspace mount validator shares the single home): starts with an
+# alphanumeric (so a leading "-" can never be parsed as a flag by the
+# podman CLI, whose argv we build by appending the name verbatim),
+# continues with alphanumerics/underscore/dot/hyphen only, and stays
+# within 64 chars. Pydantic violations surface as 422 here; the same
+# pattern gates workspace mount sources via
+# ``container.spec.valid_volume_name`` (#3018).
 
 
 class CreateVolumeRequest(BaseModel):

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -56,6 +56,7 @@ from .spec import (
     SHARED_HOME,
     is_named_volume,
     split_csv,
+    valid_volume_name,
     build_create_kwargs,
     build_env,
     build_mounts,
@@ -350,8 +351,23 @@ class ContainerRegistry(NetworkSidecarMixin):
                 if opt and opt not in _VALID_MOUNT_OPTIONS:
                     return f"Invalid mount {spec!r}: unknown option {opt!r}"
         if is_named_volume(source):
-            return None
+            return self._validate_named_volume_source(spec, source)
         return self._validate_bind_source(spec, source)
+
+    def _validate_named_volume_source(
+        self, spec: str, source: str
+    ) -> str | None:
+        """A named-volume source must be podman-safe (#3018): it is
+        appended verbatim to the podman argv at container start, so a
+        leading dash would be parsed as a flag — the same rule as the
+        volumes API (``VOLUME_NAME_PATTERN``, #2971)."""
+        if valid_volume_name(source):
+            return None
+        return (
+            f"Invalid mount {spec!r}: named-volume source {source!r} "
+            "is not podman-safe (must start alphanumeric, contain only "
+            "[a-zA-Z0-9_.-], and be at most 64 chars)"
+        )
 
     def _validate_bind_source(self, spec: str, source: str) -> str | None:
         """A non-named-volume source must not be a protected host path and

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -19,6 +19,9 @@ live off ``app.state`` (the app-ownership rule, #1608).
 import logging
 import os
 from dataclasses import dataclass
+from typing import Annotated
+
+from pydantic import StringConstraints, TypeAdapter, ValidationError
 
 from .. import workspace_settings as ws_settings
 from ..podman import (
@@ -75,6 +78,42 @@ def split_csv(raw: str | None) -> list[str]:
 def is_named_volume(source: str) -> bool:
     """A mount source with no '/' that doesn't start with '.' is a volume."""
     return "/" not in source and not source.startswith(".")
+
+
+# Podman-safe volume name (#2971, single home since #3018): starts with
+# an alphanumeric (so a leading "-" can never be parsed as a flag by
+# the podman CLI, whose argv we build by appending the name verbatim),
+# continues with alphanumerics/underscore/dot/hyphen only, and stays
+# within 64 chars ({0,63} after the first character) — a cap picked for
+# UX, well under podman's own generous limit. Consumers: the api
+# layer's pydantic validation (``POST/DELETE /volumes`` → 422, and —
+# via ``valid_volume_name`` — the workspace mount validator → 400,
+# #3018). Anchored ^...$ under pydantic-core's Rust regex (strict
+# end-of-haystack). Do NOT reuse this constant with Python's `re`:
+# its `$` also matches before a trailing newline, so "abc\n" would
+# slip through a `re.search`-based check — use ``valid_volume_name``.
+VOLUME_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+
+# Same pattern, validated by pydantic-core itself (the exact engine
+# behind ``Field(pattern=...)``) so the mount validator and the api
+# endpoints can never drift in semantics.
+_volume_name_validator = TypeAdapter(
+    Annotated[str, StringConstraints(pattern=VOLUME_NAME_PATTERN)]
+)
+
+
+def valid_volume_name(name: str) -> bool:
+    """Whether ``name`` is a podman-safe volume name (#2971, #3018).
+
+    Checked with the pydantic-core adapter for ``VOLUME_NAME_PATTERN``
+    (not Python ``re``) so the Rust-regex anchors — strict `$`, no
+    before-trailing-newline allowance — are the ones enforced.
+    """
+    try:
+        _volume_name_validator.validate_python(name)
+    except ValidationError:
+        return False
+    return True
 
 
 @dataclass(slots=True)
@@ -409,6 +448,17 @@ async def ensure_volumes(
     for mount_spec in extra_mounts:
         source = mount_spec.split(":")[0]
         if is_named_volume(source):
+            # Defense in depth (#3018): validate_mount_spec already
+            # rejects unsafe names at the API boundary, but a row
+            # created before that gate (or written by another path)
+            # must never reach podman argv either — _ensure_named_volume
+            # appends the name verbatim to the command line.
+            if not valid_volume_name(source):
+                raise ValueError(
+                    f"Volume name {source!r} is not podman-safe "
+                    "(must start alphanumeric, contain only "
+                    "[a-zA-Z0-9_.-], and be at most 64 chars)"
+                )
             await _ensure_named_volume(app, user_id, podman, source)
         elif not os.path.exists(source):
             raise ValueError(f"Bind mount source does not exist: {source}")

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -14872,6 +14872,31 @@ class TestBranchGaps2834:
         assert resp.status_code == 400
         assert "mount source" in resp.json()["detail"]
 
+    async def test_create_workspace_rejects_flaglike_volume_source(
+        self, client, admin_user
+    ):
+        """#3018 (real, unmocked gate): a leading-dash mount source would
+        reach ``podman volume create`` argv verbatim — 400 at create,
+        while a podman-safe named volume still passes."""
+        headers = await _admin_login(client)
+        bad = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={
+                "name": "flaglike-mount-ws",
+                "mounts": ["--opt=x:/data"],
+            },
+        )
+        assert bad.status_code == 400
+        assert "podman-safe" in bad.json()["detail"]
+        good = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "safe-vol-ws", "mounts": ["my-vol:/data"]},
+        )
+        assert good.status_code == 200
+        assert good.json()["mounts"] == ["my-vol:/data"]
+
     async def test_stop_workspace_running_container_no_session(
         self, client, admin_user, app
     ):

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -3990,6 +3990,38 @@ class TestValidateMountSpec:
         assert err is not None
         assert "unknown option" in err.lower()
 
+    def test_named_volume_leading_dash_rejected(self):
+        """#3018: a leading-dash source is parsed as a flag by the podman
+        CLI (``podman volume create --opt=...``) — rejected at the mount
+        gate, same rule as the volumes API (#2971)."""
+        err = self.registry.validate_mount_spec("--opt=x:/data")
+        assert err is not None
+        assert "podman-safe" in err.lower()
+
+    def test_named_volume_bad_charset_rejected(self):
+        """#3018: sources outside [a-zA-Z0-9_.-] (after an alphanumeric
+        first char) are rejected — including the trailing-newline case
+        that a Python ``re`` ``$`` anchor would wrongly accept.
+        (A "."-prefixed source is a bind source, not a volume — that
+        case is covered by test_bind_sources_unaffected_by_volume_rule.)"""
+        for source in ("has space", "ex!am", "_under", "a\nb"):
+            err = self.registry.validate_mount_spec(f"{source}:/data")
+            assert err is not None, source
+            assert "podman-safe" in err.lower()
+
+    def test_named_volume_length_cap(self):
+        """#3018: the 64-char boundary passes, 65 chars rejects."""
+        assert self.registry.validate_mount_spec(f"{'a' * 64}:/data") is None
+        err = self.registry.validate_mount_spec(f"{'a' * 65}:/data")
+        assert err is not None
+        assert "podman-safe" in err.lower()
+
+    def test_bind_sources_unaffected_by_volume_rule(self):
+        """#3018: absolute paths and '.'-prefixed (bind) sources never hit
+        the volume-name rule — they keep the protected/allowed-root path."""
+        assert self.registry.validate_mount_spec("/host:/container") is None
+        assert self.registry.validate_mount_spec("./cache:/data") is None
+
     def test_validate_mounts_list(self):
         assert self.registry.validate_mounts(["/a:/b", "vol:/c"]) is None
 
@@ -4188,6 +4220,28 @@ class TestExtraMountsVolumeCreation:
             == self.registry.app.state.util.instance_id()
         )
         assert labels["klangk.user-id"] == "user-123"
+
+    async def test_unsafe_volume_name_rejected_at_start(self, workspace):
+        """#3018 defense in depth: a row that slipped past the API gate
+        (created before #3018, or via another writer) must not reach
+        podman argv either — ValueError before any podman call."""
+        mock_inspect = AsyncMock()
+        mock_create = AsyncMock()
+        with patch_podman(
+            self.registry,
+            inspect_volume=mock_inspect,
+            create_volume=mock_create,
+        ):
+            with pytest.raises(ValueError, match="not podman-safe"):
+                await self.registry.start_container(
+                    container.ContainerStartSpec(
+                        workspace["id"],
+                        "/tmp/home",
+                        extra_mounts=["--opt=x:/data"],
+                    )
+                )
+        assert mock_inspect.await_count == 0
+        assert mock_create.await_count == 0
 
     async def test_existing_volume_not_recreated(self, workspace, app_state):
         """Existing volumes owned by this instance and user are used as-is."""


### PR DESCRIPTION
Replacement for #3020 (closed automatically when its base branch `i2971-validate-v` was deleted by the #3017 merge — not reopenable). Same branch `i3018-validate-n`, rebased directly onto `main` (CI on the identical SHA was green there).

---

Closes #3018. Stacked on #3017 (`VOLUME_NAME_PATTERN` is introduced there and moved to its single home here — rebase onto main and re-target once #3017 merges).

## What

A mount source with no `/` and no leading `.` is classified as a named volume and is appended **verbatim to the podman argv** at container start (`_ensure_named_volume` → `inspect_volume`/`create_volume`). `validate_mount_spec` accepted any such source, so `POST /api/v1/workspaces` with `"mounts": ["--opt=…:/data"]` reached `podman volume create --label … --opt=…`, where podman parses the name as a flag. The gate is `create-workspace` — every workspace creator, not just `manage-volumes` holders.

## Changes

- **`validate_mount_spec`** (`container/registry.py`): a named-volume source must now be podman-safe — same rule as the volumes API (#2971): start alphanumeric, continue `[a-zA-Z0-9_.-]` only, ≤ 64 chars. Violations return the established mount-validation error → **400** at workspace create/update (and drops the mounts on archive import, the existing behavior of that call site).
- **`VOLUME_NAME_PATTERN` moved** from `api/resources.py` to `container/spec.py` — single home next to `is_named_volume`, imported back by the api layer (which keeps its pydantic `Field`/`Path` validation → 422).
- **`valid_volume_name()`** (`container/spec.py`): checks the pattern through a pydantic-core `TypeAdapter` — the exact engine behind `Field(pattern=...)` — so the Rust-regex anchors apply; Python `re`'s `$` would accept `"abc\n"`.
- **Defense in depth**: `ensure_volumes` re-checks at container start, so a workspace row created before the gate (the injection otherwise still fires on every restart of a pre-existing row) fails its start with a clean `ValueError` instead of reaching podman argv.

## Tests

- Unit (`TestValidateMountSpec`): leading-dash source rejected; bad charset (space, `!`, `_`-lead, embedded newline) rejected; 64-char boundary accepted / 65 rejected; absolute and `.`-prefixed bind sources unaffected; valid named volume still accepted.
- Start-time (`TestExtraMountsVolumeCreation`): unsafe name raises before any podman call; valid named volume still auto-created at start (existing test).
- API (`test_api.py`): real (unmocked) create gate — `--opt=x:/data` → 400, `my-vol:/data` → 200.

Full Python suite: 6549 passed, 100% branch coverage maintained; xenon B. Docs: `changes.md` Security entry + `api-endpoints.md` mount-source rule on create/update.

