### PR TITLE
Unit-test the Terminal-tab terminal gate (#3023)

### DIFF
--- a/src/frontend/lib/workspace/consent_surface.dart
+++ b/src/frontend/lib/workspace/consent_surface.dart
@@ -4,15 +4,19 @@
 /// unit-tested directly (importing the page from a test would pull its
 /// whole widget tree into the coverage denominator).
 
+import 'permission_gate.dart';
+
 /// Whether the consent-decider surface (the consent banner and the
 /// Network tab) may mount for this member: the workspace must be in
 /// interactive egress mode (#2246) AND the member must hold
 /// `egress-consent` (or the `*` wildcard) — spectators are watch-only
-/// and never decide egress (#2883).
+/// and never decide egress (#2883). The permission check delegates to
+/// permGranted (permission_gate.dart), the single source of the
+/// wildcard semantics.
 bool consentSurfaceAllowed({
   required String egressMode,
   required List<String> permissions,
 }) {
   if (egressMode != 'interactive') return false;
-  return permissions.contains('egress-consent') || permissions.contains('*');
+  return permGranted(permissions: permissions, permission: 'egress-consent');
 }

--- a/src/frontend/lib/workspace/permission_gate.dart
+++ b/src/frontend/lib/workspace/permission_gate.dart
@@ -1,0 +1,19 @@
+/// Single source of the workspace-permission check (#3023 review).
+///
+/// Pure predicate, kept outside [WorkspacePage] so every gate built on it
+/// is unit-testable directly (importing the page from a test would pull
+/// its whole widget tree into the coverage denominator). Both extracted
+/// gates (consent_surface.dart, terminal_tab_gate.dart) and the page's
+/// own `_hasPerm` delegate here, so the wildcard semantics have exactly
+/// one definition.
+
+/// Whether [permissions] — the my-permissions answer for one workspace
+/// resource — grants [permission]. The `*` wildcard (owners) satisfies
+/// any permission; anything else requires the literal name. Fail-closed:
+/// an empty list grants nothing.
+bool permGranted({
+  required List<String> permissions,
+  required String permission,
+}) {
+  return permissions.contains(permission) || permissions.contains('*');
+}

--- a/src/frontend/lib/workspace/terminal_tab_gate.dart
+++ b/src/frontend/lib/workspace/terminal_tab_gate.dart
@@ -3,15 +3,23 @@
 /// Pure predicate, kept outside [WorkspacePage] so the gate is
 /// unit-tested directly (importing the page from a test would pull its
 /// whole widget tree into the coverage denominator) — the same pattern
-/// as consent_surface.dart (#2883).
+/// as consent_surface.dart (#2883). Both delegate the permission check
+/// to permGranted (permission_gate.dart), the single source of the
+/// wildcard semantics.
+
+import 'permission_gate.dart';
 
 /// Whether the Terminal tab may mount for this member: they must hold
 /// `terminal` (or the `*` wildcard). Since the workspace_connect gate
 /// moved to `join-workspace` (#2975), `terminal` is the Terminal-tab
 /// visibility signal — a files-only member (`join-workspace` +
-/// `files-view`) gets the workspace page with no Terminal tab. The
-/// inner gates (`code-in-isolation`, `spectate-on-shared-terminals`)
-/// apply inside the mounted tab and are unaffected.
+/// `files-view`) gets the workspace page with no Terminal tab. The same
+/// predicate also gates the spectator auto-join
+/// (`_onClientUpdate` in workspace_page.dart): without `terminal` there
+/// is no Terminal surface at all, so nothing subscribes to shared PTY
+/// frames. The inner gates (`code-in-isolation`,
+/// `spectate-on-shared-terminals`) apply inside the mounted tab and are
+/// unaffected — do not "simplify" one call site away from the other.
 bool terminalTabAllowed({required List<String> permissions}) {
-  return permissions.contains('terminal') || permissions.contains('*');
+  return permGranted(permissions: permissions, permission: 'terminal');
 }

--- a/src/frontend/lib/workspace/terminal_tab_gate.dart
+++ b/src/frontend/lib/workspace/terminal_tab_gate.dart
@@ -1,0 +1,17 @@
+/// Mount policy for the Terminal tab (#3023).
+///
+/// Pure predicate, kept outside [WorkspacePage] so the gate is
+/// unit-tested directly (importing the page from a test would pull its
+/// whole widget tree into the coverage denominator) — the same pattern
+/// as consent_surface.dart (#2883).
+
+/// Whether the Terminal tab may mount for this member: they must hold
+/// `terminal` (or the `*` wildcard). Since the workspace_connect gate
+/// moved to `join-workspace` (#2975), `terminal` is the Terminal-tab
+/// visibility signal — a files-only member (`join-workspace` +
+/// `files-view`) gets the workspace page with no Terminal tab. The
+/// inner gates (`code-in-isolation`, `spectate-on-shared-terminals`)
+/// apply inside the mounted tab and are unaffected.
+bool terminalTabAllowed({required List<String> permissions}) {
+  return permissions.contains('terminal') || permissions.contains('*');
+}

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -33,6 +33,7 @@ import 'workspace_sharing_panel.dart';
 import 'terminal_tabs_view.dart';
 import 'workspace_connector.dart';
 import 'consent_surface.dart';
+import 'terminal_tab_gate.dart';
 
 class WorkspacePage extends StatefulWidget {
   final String workspaceId;
@@ -467,9 +468,11 @@ class _WorkspacePageState extends State<WorkspacePage> {
       // shares a terminal — swapping the page for an error view with no
       // user action at all. Also gated on `terminal` (#2975 review):
       // without it there is no Terminal tab to render the stream in —
-      // joining would subscribe to PTY frames nothing displays.
+      // joining would subscribe to PTY frames nothing displays. Uses the
+      // same predicate as the tab mount (#3023): no `terminal` → no
+      // Terminal surface at all.
       if (_activeSharedTerminal == null &&
-          _hasPerm('terminal') &&
+          terminalTabAllowed(permissions: _workspacePermissions) &&
           !_hasPerm('code-in-isolation') &&
           _hasPerm('spectate-on-shared-terminals') &&
           wsClient.sharedTerminals.isNotEmpty) {
@@ -721,10 +724,12 @@ class _WorkspacePageState extends State<WorkspacePage> {
             )
           : null,
       featureTabs: _featureTabs,
-      // #2975: no `terminal` permission → no Terminal tab at all (the
+      // #2975/#3023: no `terminal` permission → no Terminal tab at all (the
       // #2886 files-view mount pattern) — `join-workspace` alone renders
       // the workspace, so a files-only member sees exactly the Files tab.
-      terminal: _hasPerm('terminal')
+      // The gate is a pure predicate (terminal_tab_gate.dart) so the
+      // my-permissions wiring is unit-testable directly.
+      terminal: terminalTabAllowed(permissions: _workspacePermissions)
           ? TerminalTabsView(
               wsClient: wsClient,
               terminalKey: _terminalKey,

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -33,6 +33,7 @@ import 'workspace_sharing_panel.dart';
 import 'terminal_tabs_view.dart';
 import 'workspace_connector.dart';
 import 'consent_surface.dart';
+import 'permission_gate.dart';
 import 'terminal_tab_gate.dart';
 
 class WorkspacePage extends StatefulWidget {
@@ -259,8 +260,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
   }
 
   bool _hasPerm(String perm) =>
-      _workspacePermissions.contains(perm) ||
-      _workspacePermissions.contains('*');
+      permGranted(permissions: _workspacePermissions, permission: perm);
 
   Future<void> _connectToWorkspace() async {
     final wsClient = context.read<WsClient>();

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/workspace/workspace_overlays.dart';
 import 'package:klangk_frontend/workspace/consent_surface.dart';
+import 'package:klangk_frontend/workspace/terminal_tab_gate.dart';
 
 void main() {
   Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
@@ -380,6 +381,76 @@ void main() {
         consentSurfaceAllowed(
           egressMode: 'static',
           permissions: ['egress-consent', '*'],
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  /// #3023: the Terminal-tab mount gate. Pure predicate, unit-tested
+  /// directly (the full WorkspacePage cannot be mounted — see the header
+  /// note). Both outcomes pair with the IdeLayout tests
+  /// (ide_layout_test.dart, 'terminal-permission gating (#2975)'):
+  /// false → terminal pane is null → no tab; true → tab mounts with its
+  /// inner gates (`code-in-isolation`, `spectate-on-shared-terminals`)
+  /// unchanged.
+  group('terminalTabAllowed (#3023)', () {
+    test('member whose grants omit terminal sees no Terminal tab', () {
+      // A custom ACL granting files-only access: join-workspace renders
+      // the page, files-view renders the Files tab, no terminal.
+      expect(
+        terminalTabAllowed(
+          permissions: ['join-workspace', 'files-view'],
+        ),
+        isFalse,
+      );
+    });
+
+    test('member holding terminal sees the tab exactly as today', () {
+      expect(
+        terminalTabAllowed(
+          permissions: [
+            'join-workspace',
+            'files-view',
+            'terminal',
+            'code-in-isolation',
+          ],
+        ),
+        isTrue,
+      );
+    });
+
+    test('spectator-style grant (terminal + spectate) mounts the tab', () {
+      expect(
+        terminalTabAllowed(
+          permissions: [
+            'join-workspace',
+            'view',
+            'terminal',
+            'spectate-on-shared-terminals',
+          ],
+        ),
+        isTrue,
+      );
+    });
+
+    test('owner wildcard mounts the tab', () {
+      expect(terminalTabAllowed(permissions: ['*']), isTrue);
+    });
+
+    test('no permissions at all never mounts (fail-closed)', () {
+      expect(terminalTabAllowed(permissions: []), isFalse);
+    });
+
+    test('terminal-like names do not satisfy the gate', () {
+      // Not `terminal`: fail closed on near-miss names.
+      expect(
+        terminalTabAllowed(
+          permissions: [
+            'join-workspace',
+            'share-terminals',
+            'spectate-on-shared-terminals',
+          ],
         ),
         isFalse,
       );

--- a/src/frontend/test/workspace_page_test.dart
+++ b/src/frontend/test/workspace_page_test.dart
@@ -1,13 +1,17 @@
-/// Tests for the container-stopped and disconnected overlays and the
+/// Tests for the container-stopped and disconnected overlays, the
 /// container lifecycle event transition (`containerEventTransition`) that
-/// drives them. These exercise the REAL extracted builders / pure function
-/// from `workspace_overlays.dart` rather than duplicated standalone copies
-/// (the full `WorkspacePage` cannot be mounted in tests — see the note in
-/// `workspace_overlays.dart`), so the actual page logic is covered.
+/// drives them, and the extracted pure permission-gate predicates
+/// (`consentSurfaceAllowed`, `terminalTabAllowed`, `permGranted`). These
+/// exercise the REAL extracted builders / pure functions from
+/// `workspace_overlays.dart` / `*_gate.dart` rather than duplicated
+/// standalone copies (the full `WorkspacePage` cannot be mounted in tests —
+/// see the note in `workspace_overlays.dart`), so the actual page logic is
+/// covered.
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/workspace/workspace_overlays.dart';
 import 'package:klangk_frontend/workspace/consent_surface.dart';
+import 'package:klangk_frontend/workspace/permission_gate.dart';
 import 'package:klangk_frontend/workspace/terminal_tab_gate.dart';
 
 void main() {
@@ -389,13 +393,13 @@ void main() {
 
   /// #3023: the Terminal-tab mount gate. Pure predicate, unit-tested
   /// directly (the full WorkspacePage cannot be mounted — see the header
-  /// note). Both outcomes pair with the IdeLayout tests
-  /// (ide_layout_test.dart, 'terminal-permission gating (#2975)'):
-  /// false → terminal pane is null → no tab; true → tab mounts with its
-  /// inner gates (`code-in-isolation`, `spectate-on-shared-terminals`)
-  /// unchanged.
+  /// note). Test names state the *predicate* outcome; the UI outcomes pair
+  /// with the IdeLayout tests (ide_layout_test.dart, 'terminal-permission
+  /// gating (#2975)'): gate closed → terminal pane is null → no tab; gate
+  /// open → tab mounts with its inner gates (`code-in-isolation`,
+  /// `spectate-on-shared-terminals`) unchanged.
   group('terminalTabAllowed (#3023)', () {
-    test('member whose grants omit terminal sees no Terminal tab', () {
+    test('files-only grants (no terminal) leave the gate closed', () {
       // A custom ACL granting files-only access: join-workspace renders
       // the page, files-view renders the Files tab, no terminal.
       expect(
@@ -406,7 +410,7 @@ void main() {
       );
     });
 
-    test('member holding terminal sees the tab exactly as today', () {
+    test('terminal grant opens the gate (tab mounts as today)', () {
       expect(
         terminalTabAllowed(
           permissions: [
@@ -420,7 +424,7 @@ void main() {
       );
     });
 
-    test('spectator-style grant (terminal + spectate) mounts the tab', () {
+    test('spectator-style grant (terminal + spectate) opens the gate', () {
       expect(
         terminalTabAllowed(
           permissions: [
@@ -434,11 +438,11 @@ void main() {
       );
     });
 
-    test('owner wildcard mounts the tab', () {
+    test('owner wildcard opens the gate', () {
       expect(terminalTabAllowed(permissions: ['*']), isTrue);
     });
 
-    test('no permissions at all never mounts (fail-closed)', () {
+    test('no permissions at all leaves the gate closed (fail-closed)', () {
       expect(terminalTabAllowed(permissions: []), isFalse);
     });
 
@@ -452,6 +456,48 @@ void main() {
             'spectate-on-shared-terminals',
           ],
         ),
+        isFalse,
+      );
+    });
+  });
+
+  /// The primitive both extracted gates (and the page's `_hasPerm`)
+  /// delegate to — the single definition of the wildcard semantics
+  /// (#3023 review: was a three-way copy that could drift).
+  group('permGranted (#3023)', () {
+    test('literal permission grants', () {
+      expect(
+        permGranted(
+          permissions: ['join-workspace', 'terminal'],
+          permission: 'terminal',
+        ),
+        isTrue,
+      );
+    });
+
+    test('wildcard grants any permission', () {
+      expect(
+        permGranted(
+          permissions: ['*'],
+          permission: 'share-advanced',
+        ),
+        isTrue,
+      );
+    });
+
+    test('other permissions do not grant', () {
+      expect(
+        permGranted(
+          permissions: ['join-workspace', 'share-terminals'],
+          permission: 'terminal',
+        ),
+        isFalse,
+      );
+    });
+
+    test('empty list grants nothing (fail-closed)', () {
+      expect(
+        permGranted(permissions: [], permission: 'terminal'),
         isFalse,
       );
     });


### PR DESCRIPTION
## Summary

Closes #3023.

The Terminal-tab render gate itself (`terminal: _hasPerm('terminal') ?
TerminalTabsView(...) : null`) shipped with #2988/#2975. What the issue's
acceptance criteria still lacked was the frontend test of that wiring:
`WorkspacePage` cannot be mounted in tests, so the my-permissions
decision had no testable seam.

This PR follows the #2883 pattern (`consentSurfaceAllowed`): the gate is
extracted as a pure predicate, `terminalTabAllowed`
(`lib/workspace/terminal_tab_gate.dart`), used both by the `_buildIdeLayout`
tab mount and the spectator auto-join (single-sourcing the
terminal-surface visibility decision — behavior identical).

## Tests

- New `terminalTabAllowed (#3023)` group in `workspace_page_test.dart`
  covering both outcomes plus edge cases: files-only custom ACL
  (`join-workspace` + `files-view`) → no tab; `terminal` holders (coder-
  and spectator-style grants) and `*` wildcard → tab; empty permissions
  fail closed; near-miss names (`share-terminals`,
  `spectate-on-shared-terminals`) do not satisfy the gate.
- Inner gates (`code-in-isolation`, `spectate-on-shared-terminals`)
  untouched; covered by the existing `terminal_tabs_view_test.dart` and
  the `ide_layout_test.dart` `terminal-permission gating (#2975)` group.
- Full frontend suite passes (`flutter test --coverage`, 1198 tests);
  the new file is at 100% coverage.
