### PR TITLE
E2E: files-only member (no terminal) sees no Terminal tab

### DIFF
--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -91,12 +91,17 @@ async function makeUserAdmin(
  *  By default the user is added to the admin group so they can create
  *  workspaces (#2569).  Pass `admin: false` for tests that need a genuine
  *  non-admin user (#2643).
- *  Returns { token, headers }. */
+ *  Returns { token, headers, userId } — userId feeds principal-scoped
+ *  ACL grants (the Advanced ACL editor's user ACEs, #3026). */
 export async function registerUser(
   request: APIRequestContext,
   email: string,
   { admin = true }: { admin?: boolean } = {},
-): Promise<{ token: string; headers: Record<string, string> }> {
+): Promise<{
+  token: string;
+  headers: Record<string, string>;
+  userId: string | undefined;
+}> {
   const data = await postJsonWithRetry(
     request,
     `${API_BASE}/api/v1/auth/register`,
@@ -109,7 +114,7 @@ export async function registerUser(
   if (admin && data.user_id) {
     await makeUserAdmin(request, data.user_id);
   }
-  return { token, headers };
+  return { token, headers, userId: data.user_id };
 }
 
 /** Type email + password into the Flutter login form and click Login.

--- a/src/frontend/e2e-tests/e2e/terminal-tab-gate.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tab-gate.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect, Page, APIRequestContext } from "@playwright/test";
+import {
+  registerUser,
+  createWorkspace,
+  openWorkspace,
+  API_BASE,
+} from "./helpers";
+
+// #3023/#3026: the Terminal-tab `terminal`-permission gate at the UI
+// level. The predicate (terminal_tab_gate.dart) and the null-pane
+// behavior (ide_layout.dart) are unit-tested; this spec exercises the
+// path a regression would actually take — workspace_page.dart passing
+// the /api/v1/my-permissions list into the gate. A wrong list or
+// reverted conditional there leaves every unit test green while the tab
+// mounts (or not) for the wrong members.
+
+/** Grant `permissions` to a user on a workspace by appending user ACEs to
+ *  the workspace ACL via the Advanced ACL editor's PUT endpoint — the
+ *  same surface a human owner would use (#3023's custom-ACL criterion).
+ *  The owner's existing entries (the `*` row) are kept untouched. */
+async function grantViaAcl(
+  request: APIRequestContext,
+  ownerHeaders: Record<string, string>,
+  workspaceId: string,
+  userId: string,
+  permissions: string[],
+) {
+  const aclResp = await request.get(
+    `${API_BASE}/api/v1/workspaces/${workspaceId}/acl`,
+    { headers: ownerHeaders },
+  );
+  expect(aclResp.ok()).toBeTruthy();
+  const existing = await aclResp.json();
+  const entries = [
+    ...existing.map((ace: any) => ({
+      action: ace.action,
+      principal_type: ace.principal_type,
+      permission: ace.permission,
+      user_id: ace.user_id || null,
+      group_id: ace.group_id || null,
+      system_principal: ace.system_principal ?? null,
+    })),
+    // action 1 = Allow, principal_type 1 = User.
+    ...permissions.map((permission) => ({
+      action: 1,
+      principal_type: 1,
+      permission,
+      user_id: userId,
+      group_id: null,
+      system_principal: null,
+    })),
+  ];
+  const putResp = await request.put(
+    `${API_BASE}/api/v1/workspaces/${workspaceId}/acl`,
+    { headers: ownerHeaders, data: entries },
+  );
+  expect(putResp.ok()).toBeTruthy();
+}
+
+/** Turn on Flutter's semantics tree so the canvas-rendered tab labels
+ *  become visible to text locators. openWorkspace clicks the a11y
+ *  invoker when it is already up — the early return covers that case;
+ *  the invoker click covers the race where it attached too late for
+ *  that (the prompt re-appears a few seconds after each route load). */
+async function ensureSemantics(page: Page) {
+  if (
+    await page
+      .getByText("Files", { exact: true })
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ) {
+    return;
+  }
+  const btn = page.getByRole("button", { name: /^Enable accessibility$/i });
+  await btn.waitFor({ state: "attached", timeout: 30_000 });
+  await btn.evaluate((el) => (el as HTMLElement).click());
+  await page.waitForTimeout(500);
+}
+
+/** Owner + workspace + a genuine non-admin member whose ONLY grants are
+ *  `permissions`, as direct user ACEs — no role group, so none of the
+ *  default buckets' incidental `terminal` leaks in. The only delta
+ *  between the two tests below is one ACE. */
+async function setupMemberWithGrants(
+  request: APIRequestContext,
+  permissions: string[],
+): Promise<{
+  memberEmail: string;
+  workspaceId: string;
+  cleanup: () => Promise<void>;
+}> {
+  const ownerEmail = `term-gate-owner-${Date.now()}@test.example.com`;
+  const owner = await registerUser(request, ownerEmail);
+  const { workspaceId, cleanup } = await createWorkspace(
+    request,
+    owner.headers,
+    "term-gate",
+  );
+  const memberEmail = `term-gate-member-${Date.now()}@test.example.com`;
+  const member = await registerUser(request, memberEmail, { admin: false });
+  expect(member.userId).toBeTruthy();
+  await grantViaAcl(
+    request,
+    owner.headers,
+    workspaceId,
+    member.userId!,
+    permissions,
+  );
+  return { memberEmail, workspaceId, cleanup };
+}
+
+test.describe("Terminal tab permission gate (#3023)", () => {
+  test("files-only member (join-workspace + files-view) sees no Terminal tab", async ({
+    page,
+    request,
+  }) => {
+    const { memberEmail, workspaceId, cleanup } = await setupMemberWithGrants(
+      request,
+      ["join-workspace", "files-view"],
+    );
+    try {
+      // join-workspace alone is the connect gate (#2975): the page
+      // renders and the container starts with no terminal grant.
+      await openWorkspace(page, memberEmail, workspaceId);
+      await ensureSemantics(page);
+
+      // The Files tab renders — and proves the permission list arrived,
+      // so the absence assertion below is not just "too early to tell".
+      await expect(
+        page.getByText("Files", { exact: true }).first(),
+      ).toBeVisible({ timeout: 15_000 });
+
+      // No `terminal` grant → no Terminal tab in the strip. "Terminal"
+      // appears nowhere else in the app (only the tab label).
+      await expect(page.getByText("Terminal", { exact: true })).toHaveCount(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("terminal-holding member still sees the Terminal tab", async ({
+    page,
+    request,
+  }) => {
+    const { memberEmail, workspaceId, cleanup } = await setupMemberWithGrants(
+      request,
+      ["join-workspace", "files-view", "terminal"],
+    );
+    try {
+      await openWorkspace(page, memberEmail, workspaceId);
+      await ensureSemantics(page);
+
+      // The identical setup plus one `terminal` ACE mounts the tab —
+      // the permission is the only variable.
+      await expect(
+        page.getByText("Terminal", { exact: true }).first(),
+      ).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.getByText("Files", { exact: true }).first(),
+      ).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/e2e-tests/e2e/terminal-tab-gate.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tab-gate.spec.ts
@@ -58,46 +58,54 @@ async function grantViaAcl(
 }
 
 /** Turn on Flutter's semantics tree so the canvas-rendered tab labels
- *  become visible to text locators. openWorkspace clicks the a11y
- *  invoker when it is already up — the early return covers that case;
- *  the invoker click covers the race where it attached too late for
- *  that (the prompt re-appears a few seconds after each route load). */
+ *  become visible to text locators. The invoker is a zero-sized
+ *  <flt-semantics-placeholder role=button> — not a <button> tag, and with
+ *  no text content — so nothing in the login path can enable semantics
+ *  for us: resolve it by role and click it (the password-history /
+ *  workspace-export pattern). Deciding on the flt-semantics node count,
+ *  not on a tab label, keeps this race-free: a populated tree means
+ *  semantics are on regardless of mount timing (the tab-strip wait is
+ *  the test's own assertion), an empty one means the invoker is still
+ *  there to click. */
 async function ensureSemantics(page: Page) {
-  if (
-    await page
-      .getByText("Files", { exact: true })
-      .first()
-      .isVisible()
-      .catch(() => false)
-  ) {
-    return;
-  }
+  const populated = () =>
+    page.evaluate(() => document.querySelectorAll("flt-semantics *").length);
+  if ((await populated()) > 0) return;
   const btn = page.getByRole("button", { name: /^Enable accessibility$/i });
   await btn.waitFor({ state: "attached", timeout: 30_000 });
   await btn.evaluate((el) => (el as HTMLElement).click());
-  await page.waitForTimeout(500);
+  await expect
+    .poll(populated, {
+      timeout: 15_000,
+      message: "flt-semantics tree populated",
+    })
+    .toBeGreaterThan(0);
 }
 
 /** Owner + workspace + a genuine non-admin member whose ONLY grants are
  *  `permissions`, as direct user ACEs — no role group, so none of the
  *  default buckets' incidental `terminal` leaks in. The only delta
- *  between the two tests below is one ACE. */
+ *  between the two tests below is one ACE. `tag` keeps the per-test
+ *  email prefixes distinct: the tests run in parallel and a shared
+ *  prefix plus a same-millisecond Date.now() would collide on
+ *  registration (duplicate email → hard setup failure). */
 async function setupMemberWithGrants(
   request: APIRequestContext,
+  tag: string,
   permissions: string[],
 ): Promise<{
   memberEmail: string;
   workspaceId: string;
   cleanup: () => Promise<void>;
 }> {
-  const ownerEmail = `term-gate-owner-${Date.now()}@test.example.com`;
+  const ownerEmail = `term-gate-${tag}-owner-${Date.now()}@test.example.com`;
   const owner = await registerUser(request, ownerEmail);
   const { workspaceId, cleanup } = await createWorkspace(
     request,
     owner.headers,
     "term-gate",
   );
-  const memberEmail = `term-gate-member-${Date.now()}@test.example.com`;
+  const memberEmail = `term-gate-${tag}-member-${Date.now()}@test.example.com`;
   const member = await registerUser(request, memberEmail, { admin: false });
   expect(member.userId).toBeTruthy();
   await grantViaAcl(
@@ -117,6 +125,7 @@ test.describe("Terminal tab permission gate (#3023)", () => {
   }) => {
     const { memberEmail, workspaceId, cleanup } = await setupMemberWithGrants(
       request,
+      "files-only",
       ["join-workspace", "files-view"],
     );
     try {
@@ -145,6 +154,7 @@ test.describe("Terminal tab permission gate (#3023)", () => {
   }) => {
     const { memberEmail, workspaceId, cleanup } = await setupMemberWithGrants(
       request,
+      "term-holder",
       ["join-workspace", "files-view", "terminal"],
     );
     try {

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
         "klangk.spec.ts",
         "pending-redirect.spec.ts",
         "terminal-keymap.spec.ts",
+        "terminal-tab-gate.spec.ts",
         "per-user-home.spec.ts",
         "terminal-tabs.spec.ts",
         "shared-terminals.spec.ts",


### PR DESCRIPTION
## Summary

Adds the missing UI-level e2e coverage for the Terminal-tab `terminal`-permission gate (#3023), closing #3026. The predicate (`terminalTabAllowed`) and the null-pane behavior are unit-tested (#3025), but nothing exercised the path a regression would actually take: `workspace_page.dart` passing the `/api/v1/my-permissions` list into the gate. A wrong list or reverted conditional would have left every existing test green.

## What changed

- **`e2e/terminal-tab-gate.spec.ts`** (new, chromium project) — two tests sharing one setup: an owner workspace plus a genuine non-admin member whose *only* grants are direct user ACEs written through the Advanced ACL editor's `PUT /workspaces/{id}/acl` (no role group, so none of the default buckets' incidental `terminal` leaks in). The only delta between the two tests is one ACE:
  - `join-workspace` + `files-view` → the workspace page opens (connect gate is `join-workspace`, #2975), the **Files tab renders**, and the **Terminal tab is absent** (asserted after Files is visible, so the absence check can't pass merely by being "too early").
  - `join-workspace` + `files-view` + `terminal` → the **Terminal tab is back**.
  - Assertions run against Flutter's semantics tree (tab labels are canvas-rendered; the spec enables a11y like `password-history`/`workspace-export` do).
- **`e2e/helpers.ts`** — `registerUser` now also returns `userId` (needed for principal-scoped ACEs). Backward compatible; all 31 spec files still compile.
- **`playwright.config.ts`** — `terminal-tab-gate.spec.ts` added to the `chromium` project (the merge-gating one).

## Verification

- Targeted run: `2 passed`.
- Counterfactual: temporarily mounting the terminal pane unconditionally makes the absent-tab assertion fail against the sabotaged build, then green again after revert — the test bites.
- No user-visible behavior change; no changelog entry (test-only).
