### PR TITLE
refactor(api,auth): bring every block under rank A (T4-T6)

### DIFF
--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -42,17 +42,21 @@ class SendInviteRequest(BaseModel):
     email: str
 
 
-def _validate_root_acl(entries, resource: str) -> None:
-    """Root ACL must keep Authenticated view access."""
-    if resource != "/":
-        return
-    has_auth_view = any(
+def _auth_view_entry(e) -> bool:
+    """True when an entry grants view (or wildcard) to Authenticated."""
+    return (
         e.action == ACTION_ALLOW
         and e.principal_type == PRINCIPAL_SYSTEM
         and e.system_principal == SYSTEM_AUTHENTICATED
         and e.permission in ("view", "*")
-        for e in entries
     )
+
+
+def _validate_root_acl(entries, resource: str) -> None:
+    """Root ACL must keep Authenticated view access."""
+    if resource != "/":
+        return
+    has_auth_view = any(_auth_view_entry(e) for e in entries)
     if not has_auth_view:
         raise HTTPException(
             status_code=400,
@@ -350,6 +354,32 @@ class UpdateUserRequest(auth.BaseModel):
     disabled: bool | None = None
 
 
+async def _require_user(app, user_id: str) -> dict:
+    """The user row; 404 when it does not exist."""
+    user = await app.state.model.users.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+async def _update_user_password(app, user_id: str, password: str) -> None:
+    """Validate + persist a password change from the admin console."""
+    app.state.auth.validate_password(password)
+    await app.state.auth.validate_password_not_reused(user_id, password)
+    password_hash = await asyncio.to_thread(auth.hash_password, password)
+    await app.state.model.users.update_password(user_id, password_hash)
+
+
+async def _update_user_handle(app, user_id: str, handle: str) -> None:
+    """Set + propagate a handle change to live WS sessions; 400 on an
+    invalid handle."""
+    try:
+        await app.state.model.users.set_user_handle(user_id, handle)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    await wshandler.refresh_user_handle(app.state.sockets, user_id, handle)
+
+
 @router.patch("/users/{user_id}")
 async def update_user(
     user_id: str,
@@ -357,31 +387,28 @@ async def update_user(
     admin: dict = Depends(acl.has_permission("manage-users")),
     app=Depends(get_app_dep),
 ):
-    user = await app.state.model.users.get_user_by_id(user_id)
-    if user is None:
-        raise HTTPException(status_code=404, detail="User not found")
+    await _require_user(app, user_id)
     if req.email is not None:
         await app.state.model.users.update_email(user_id, req.email)
     if req.password is not None:
-        app.state.auth.validate_password(req.password)
-        await app.state.auth.validate_password_not_reused(
-            user_id, req.password
-        )
-        password_hash = await asyncio.to_thread(
-            auth.hash_password, req.password
-        )
-        await app.state.model.users.update_password(user_id, password_hash)
+        await _update_user_password(app, user_id, req.password)
     if req.handle is not None:
-        try:
-            await app.state.model.users.set_user_handle(user_id, req.handle)
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
-        await wshandler.refresh_user_handle(
-            app.state.sockets, user_id, req.handle
-        )
+        await _update_user_handle(app, user_id, req.handle)
     if req.disabled is not None:
         await _update_user_disabled(app, req, user_id, admin)
     return {"status": "updated"}
+
+
+def _reject_self_disable(
+    req: UpdateUserRequest, user_id: str, admin: dict
+) -> None:
+    """An admin must not disable their own account (#2588) — the
+    only accounts that can re-enable are the admin group's."""
+    if req.disabled and user_id == admin["id"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot disable your own account",
+        )
 
 
 async def _update_user_disabled(
@@ -389,13 +416,7 @@ async def _update_user_disabled(
 ) -> None:
     """Apply a disabled flag: guard self-disable, persist, and cut the
     user's live connections when disabling (#2588)."""
-    # An admin must not disable their own account (#2588) — the
-    # only accounts that can re-enable are the admin group's.
-    if req.disabled and user_id == admin["id"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Cannot disable your own account",
-        )
+    _reject_self_disable(req, user_id, admin)
     try:
         updated = await app.state.model.users.set_user_disabled(
             user_id, req.disabled
@@ -787,24 +808,37 @@ async def cancel_server_schedule(
 # --- Container lifecycle events (#2923) ---
 
 
-async def _annotate_events(app, rows: list[dict]) -> list[dict]:
-    """Resolve workspace names and actor emails for one page of events.
-
-    Cosmetic joins bounded by the page size: a deleted workspace or a
-    purged user yields ``None`` and the client falls back to the raw id.
-    System/agent actors carry no email by construction.
-    """
+async def _workspace_names(app, rows: list[dict]) -> dict:
+    """One workspace-name lookup per distinct workspace id in the page;
+    a deleted workspace yields ``None`` and the client falls back to
+    the raw id."""
     names: dict[str, str | None] = {}
-    emails: dict[str, str | None] = {}
     for row in rows:
         wid = row["workspace_id"]
         if wid not in names:
             ws = await app.state.model.workspaces.get_workspace(wid)
             names[wid] = ws["name"] if ws else None
+    return names
+
+
+async def _actor_emails(app, rows: list[dict]) -> dict:
+    """One email lookup per distinct human actor id in the page. A
+    purged user yields ``None``; system/agent actors carry no email by
+    construction."""
+    emails: dict[str, str | None] = {}
+    for row in rows:
         actor_id = row["actor_id"]
         if row["actor_type"] == "user" and actor_id not in emails:
             user = await app.state.model.users.get_user_by_id(actor_id)
             emails[actor_id] = user["email"] if user else None
+    return emails
+
+
+async def _annotate_events(app, rows: list[dict]) -> list[dict]:
+    """Resolve workspace names and actor emails for one page of events
+    (cosmetic joins bounded by the page size)."""
+    names = await _workspace_names(app, rows)
+    emails = await _actor_emails(app, rows)
     return [
         {
             **row,

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -209,6 +209,33 @@ resend_timestamps: dict[str, float] = {}
 RESEND_COOLDOWN_SECONDS = 60
 
 
+def _rate_limited(timestamps: dict, cooldown: float, email: str) -> bool:
+    """True when *email* hit its per-address cooldown window; otherwise
+    records this attempt. Bounds both size and retention of the window
+    (stale entries are pruned on each call)."""
+    now = time.time()
+    prune_timestamps(timestamps, cooldown, now)
+    last = timestamps.get(email, 0)
+    if now - last < cooldown:
+        return True
+    timestamps[email] = now
+    return False
+
+
+async def _authorize_resend(app, user, req, lockout_key, attempt_info) -> None:
+    """401 unless the email+password pair authorizes a resend.
+
+    Same lockout accounting as login (#2618): failures are recorded on
+    the lockout key. Without this the endpoint accepted unlimited
+    password guesses — the 60s cooldown only bounds email sending and
+    only applies after the check succeeds.
+    """
+    password_ok = await auth.verify_login_password(user, req.password)
+    if user is None or not user.get("password_hash") or not password_ok:
+        await app.state.auth.record_login_failure(lockout_key, attempt_info)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+
 @router.post("/auth/resend-verification")
 async def resend_verification(
     req: auth.EmailRequest,
@@ -217,44 +244,21 @@ async def resend_verification(
 ):
     """Resend verification email. Requires email+password to prevent abuse."""
     user = await app.state.model.users.get_user_by_email(req.email)
-    # Same lockout accounting as login (#2618): key on the resolved
-    # user's canonical email (raw input for unknown addresses), check
-    # before the expensive verify, and record failures on a bad
-    # password. Without this the endpoint accepted unlimited password
-    # guesses — the 60s cooldown below only bounds email sending and
-    # only applies after the check succeeds.
+    # Lockout key: the resolved user's canonical email when known, the
+    # raw input for unknown addresses (#2618).
     lockout_key = user["email"] if user else req.email
     attempt_info = await app.state.auth.check_login_lockout(lockout_key)
-    # OIDC-only users have no password hash; unknown users have no
-    # account. Both verify against the dummy hash so the failure path
-    # costs one full password verify either way — response timing
-    # cannot enumerate accounts (#2618). Authorization still requires
-    # a real hash to have matched. The dummy hash is minted off the
-    # event loop too — the one-time PBKDF2 cost must never block
-    # request handling (functools.cache makes later calls free).
-    password_hash = (user.get("password_hash") if user else None) or (
-        await asyncio.to_thread(auth.dummy_verify_hash)
-    )
-    password_ok = await asyncio.to_thread(
-        auth.verify_password, req.password, password_hash
-    )
-    if user is None or not user.get("password_hash") or not password_ok:
-        await app.state.auth.record_login_failure(lockout_key, attempt_info)
-        raise HTTPException(status_code=401, detail="Invalid credentials")
+    await _authorize_resend(app, user, req, lockout_key, attempt_info)
     if user.get("verified"):
         raise HTTPException(status_code=400, detail="Account already verified")
     await app.state.auth.clear_login_failures(lockout_key)
 
     # Rate limit: one resend per email per minute
-    now = time.time()
-    prune_timestamps(resend_timestamps, RESEND_COOLDOWN_SECONDS, now)
-    last = resend_timestamps.get(req.email, 0)
-    if now - last < RESEND_COOLDOWN_SECONDS:
+    if _rate_limited(resend_timestamps, RESEND_COOLDOWN_SECONDS, req.email):
         raise HTTPException(
             status_code=429,
             detail="Please wait before requesting another email",
         )
-    resend_timestamps[req.email] = now
 
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
@@ -302,15 +306,11 @@ async def forgot_password(
         return {"status": "sent"}
 
     # Rate limit: one reset email per address per minute
-    now = time.time()
-    prune_timestamps(reset_timestamps, RESET_COOLDOWN_SECONDS, now)
-    last = reset_timestamps.get(req.email, 0)
-    if now - last < RESET_COOLDOWN_SECONDS:
+    if _rate_limited(reset_timestamps, RESET_COOLDOWN_SECONDS, req.email):
         raise HTTPException(
             status_code=429,
             detail="Please wait before requesting another email",
         )
-    reset_timestamps[req.email] = now
 
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
@@ -597,6 +597,28 @@ async def get_me(
     }
 
 
+async def _oidc_logout_url(request: Request, user: dict) -> str | None:
+    """The IdP logout URL when *user* is an OIDC user whose provider has
+    logout_redirect enabled; ``None`` for local users (or a missing
+    provider/URL)."""
+    db_user = await request.app.state.model.users.get_user_by_email(
+        user["email"]
+    )
+    if not db_user or db_user.get("provider", "local") == "local":
+        return None
+    provider = request.app.state.oidc.get_provider(db_user["provider"])
+    if not provider:
+        return None
+    hostname, proto, base_path = request.app.state.util.derive_hosting_info(
+        request.headers,
+        request.client.host if request.client else None,
+    )
+    post_logout_uri = f"{proto}://{hostname}{base_path}/#/login"
+    return await request.app.state.oidc.build_logout_url(
+        provider, post_logout_uri
+    )
+
+
 @router.post("/auth/logout")
 async def logout(
     request: Request,
@@ -627,24 +649,9 @@ async def logout(
         return result
     # If the user logged in via OIDC and the provider has logout_redirect
     # enabled, return the IdP logout URL so the frontend can redirect.
-    db_user = await request.app.state.model.users.get_user_by_email(
-        user["email"]
-    )
-    if db_user and db_user.get("provider", "local") != "local":
-        provider = request.app.state.oidc.get_provider(db_user["provider"])
-        if provider:
-            hostname, proto, base_path = (
-                request.app.state.util.derive_hosting_info(
-                    request.headers,
-                    request.client.host if request.client else None,
-                )
-            )
-            post_logout_uri = f"{proto}://{hostname}{base_path}/#/login"
-            logout_url = await request.app.state.oidc.build_logout_url(
-                provider, post_logout_uri
-            )
-            if logout_url:
-                result["oidc_logout_url"] = logout_url
+    logout_url = await _oidc_logout_url(request, user)
+    if logout_url:
+        result["oidc_logout_url"] = logout_url
     return result
 
 
@@ -707,6 +714,18 @@ async def accept_invite(req: AcceptInviteRequest, request: Request):
 # ---------------------------------------------------------------------------
 
 
+def _is_local_url(parsed) -> bool:
+    """The parsed URL must be plain http to loopback with an explicit
+    port and no userinfo."""
+    return (
+        parsed.scheme == "http"
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.hostname in ("localhost", "127.0.0.1")
+        and parsed.port is not None
+    )
+
+
 def _valid_cli_redirect(url: str | None) -> bool:
     """True if *url* is a permitted CLI redirect target (localhost only).
 
@@ -722,14 +741,7 @@ def _valid_cli_redirect(url: str | None) -> bool:
     if not url:
         return False
     try:
-        parsed = urlparse(url)
-        return (
-            parsed.scheme == "http"
-            and parsed.username is None
-            and parsed.password is None
-            and parsed.hostname in ("localhost", "127.0.0.1")
-            and parsed.port is not None
-        )
+        return _is_local_url(urlparse(url))
     except ValueError:
         # Malformed URL (e.g. non-integer port) — reject, don't 500.
         return False
@@ -813,6 +825,18 @@ def _derive_redirect_uri(request: Request, provider_id: str) -> str:
     return f"{proto}://{hostname}{base_path}{API_PREFIX}/auth/oidc/{provider_id}/callback"
 
 
+def _cookie_state_matches(cookie_data, state: str) -> bool:
+    """The cookie must decode to a dict whose state echoes the
+    callback's."""
+    return isinstance(cookie_data, dict) and cookie_data.get("state") == state
+
+
+def _valid_verifier(verifier) -> bool:
+    """The PKCE verifier is required downstream; a cookie missing it
+    must 400, not KeyError-500."""
+    return isinstance(verifier, str) and bool(verifier)
+
+
 def _validate_state_cookie(
     request: Request, provider_id: str, state: str
 ) -> dict:
@@ -831,18 +855,24 @@ def _validate_state_cookie(
             status_code=400, detail="Invalid OIDC state cookie"
         )
 
-    if not isinstance(cookie_data, dict) or cookie_data.get("state") != state:
+    if not _cookie_state_matches(cookie_data, state):
         raise HTTPException(status_code=400, detail="State mismatch")
 
-    # The PKCE verifier is required downstream; a cookie missing it
-    # must 400, not KeyError-500.
-    verifier = cookie_data.get("verifier")
-    if not isinstance(verifier, str) or not verifier:
+    if not _valid_verifier(cookie_data.get("verifier")):
         raise HTTPException(
             status_code=400, detail="Invalid OIDC state cookie"
         )
 
     return cookie_data
+
+
+def _require_oidc_claims(claims: dict) -> None:
+    """502 when the ID token lacks a usable sub/email pair."""
+    if not claims.get("sub") or not claims.get("email"):
+        raise HTTPException(
+            status_code=502,
+            detail="ID token missing sub or email claim",
+        )
 
 
 async def _exchange_and_validate_token(
@@ -881,13 +911,7 @@ async def _exchange_and_validate_token(
             status_code=502, detail="ID token validation failed"
         ) from None
 
-    sub = claims.get("sub")
-    email = claims.get("email")
-    if not sub or not email:
-        raise HTTPException(
-            status_code=502,
-            detail="ID token missing sub or email claim",
-        )
+    _require_oidc_claims(claims)
 
     return claims, tokens
 
@@ -956,6 +980,32 @@ def _build_redirect_response(
     return response
 
 
+def _require_verified_email(provider, claims: dict) -> None:
+    """403 unless the IdP verified the email claim — or the operator
+    trusts this IdP's email claims (``trust-email: true`` in the
+    provider config)."""
+    if not provider.trust_email and claims.get("email_verified") is not True:
+        raise HTTPException(
+            status_code=403,
+            detail="Email not verified by identity provider",
+        )
+
+
+async def _call_login_hook(request: Request, provider, claims, email, tokens):
+    """Run the OIDC login hook (if configured); any failure denies the
+    login (403)."""
+    try:
+        return await request.app.state.oidc.call_login_hook(
+            provider, claims, email, tokens
+        )
+    except Exception:
+        logger.exception("OIDC login hook failed for provider %s", provider)
+        raise HTTPException(
+            status_code=403,
+            detail="Login denied by server policy",
+        ) from None
+
+
 @router.get("/auth/oidc/{provider_id}/callback")
 async def oidc_callback(
     provider_id: str,
@@ -989,23 +1039,12 @@ async def oidc_callback(
 
     # Require email_verified unless the operator trusts this IdP's
     # email claims (trust-email: true in the provider config).
-    if not provider.trust_email and claims.get("email_verified") is not True:
-        raise HTTPException(
-            status_code=403,
-            detail="Email not verified by identity provider",
-        )
+    _require_verified_email(provider, claims)
 
     # Call the OIDC login hook (if configured).
-    try:
-        hook_groups = await request.app.state.oidc.call_login_hook(
-            provider, claims, email, tokens
-        )
-    except Exception:
-        logger.exception("OIDC login hook failed for provider %s", provider)
-        raise HTTPException(
-            status_code=403,
-            detail="Login denied by server policy",
-        ) from None
+    hook_groups = await _call_login_hook(
+        request, provider, claims, email, tokens
+    )
 
     user = await _find_or_create_user(
         request.app, provider_id, claims["sub"], email

--- a/src/klangk/klangk/api/llm_proxy.py
+++ b/src/klangk/klangk/api/llm_proxy.py
@@ -48,6 +48,79 @@ async def list_models(request: Request):
     }
 
 
+def _passthrough_stream_response(resp) -> StreamingResponse:
+    """A StreamingResponse forwarding the upstream's SSE lines."""
+
+    async def stream_passthrough():
+        try:
+            async for line in resp.aiter_lines():
+                yield f"{line}\n"
+        finally:
+            await resp.aclose()
+
+    return StreamingResponse(
+        stream_passthrough(),
+        media_type="text/event-stream",
+    )
+
+
+async def _chunk_data(chunk):
+    """Convert one streamed chunk to its payload (model_dump, dict, or
+    str fallback); awaits an async ``model_dump``."""
+    if hasattr(chunk, "model_dump"):
+        data = chunk.model_dump()
+        if inspect.isawaitable(data):
+            data = await data
+        return data
+    if isinstance(chunk, dict):
+        return chunk
+    return str(chunk)
+
+
+async def _stream_litellm_response(response) -> StreamingResponse:
+    """A StreamingResponse rendering the litellm async-generator chunks
+    in the OpenAI SSE shape, terminated with [DONE]."""
+
+    async def stream_litellm():
+        async for chunk in response:
+            data = await _chunk_data(chunk)
+            yield f"data: {json.dumps(data)}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        stream_litellm(),
+        media_type="text/event-stream",
+    )
+
+
+async def _json_response(response) -> JSONResponse:
+    """Convert a non-streaming litellm response to a plain dict for
+    JSONResponse; awaits an async ``model_dump``."""
+    if hasattr(response, "model_dump"):
+        data = response.model_dump()
+        if inspect.isawaitable(data):
+            data = await data
+    elif isinstance(response, dict):
+        data = response
+    else:
+        data = dict(response)
+    return JSONResponse(content=data)
+
+
+async def _dispatch_completion(llm_router, body):
+    """Route one completion body to its response flavor: passthrough
+    SSE, litellm async-generator SSE, or plain JSON."""
+    if body.get("stream", False) and llm_router.passthrough:
+        resp = await llm_router.passthrough_completion_stream(body)
+        return _passthrough_stream_response(resp)
+    response = await llm_router.acompletion(**body)
+    # litellm returns an async generator when stream=True.
+    if hasattr(response, "__aiter__"):
+        return await _stream_litellm_response(response)
+    # Non-streaming: convert to a plain dict for JSONResponse.
+    return await _json_response(response)
+
+
 @router.post("/chat/completions")
 async def chat_completions(request: Request):
     """Proxy a chat completion request to the litellm Router.
@@ -65,57 +138,7 @@ async def chat_completions(request: Request):
         )
     body = await request.json()
     try:
-        is_stream = body.get("stream", False)
-
-        # Passthrough streaming: forward the SSE stream from the upstream.
-        if is_stream and llm_router.passthrough:
-            resp = await llm_router.passthrough_completion_stream(body)
-
-            async def stream_passthrough():
-                try:
-                    async for line in resp.aiter_lines():
-                        yield f"{line}\n"
-                finally:
-                    await resp.aclose()
-
-            return StreamingResponse(
-                stream_passthrough(),
-                media_type="text/event-stream",
-            )
-
-        response = await llm_router.acompletion(**body)
-
-        # litellm returns an async generator when stream=True.
-        if hasattr(response, "__aiter__"):
-
-            async def stream_litellm():
-                async for chunk in response:
-                    if hasattr(chunk, "model_dump"):
-                        data = chunk.model_dump()
-                        if inspect.isawaitable(data):
-                            data = await data
-                    elif isinstance(chunk, dict):
-                        data = chunk
-                    else:
-                        data = str(chunk)
-                    yield f"data: {json.dumps(data)}\n\n"
-                yield "data: [DONE]\n\n"
-
-            return StreamingResponse(
-                stream_litellm(),
-                media_type="text/event-stream",
-            )
-
-        # Non-streaming: convert to a plain dict for JSONResponse.
-        if hasattr(response, "model_dump"):
-            data = response.model_dump()
-            if inspect.isawaitable(data):
-                data = await data
-        elif isinstance(response, dict):
-            data = response
-        else:
-            data = dict(response)
-        return JSONResponse(content=data)
+        return await _dispatch_completion(llm_router, body)
     except Exception:
         logger.exception("LLM completion failed")
         return JSONResponse(

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -192,6 +192,31 @@ async def download_file(
     )
 
 
+def _upload_filename(path: str, file: UploadFile) -> str:
+    """The target filename: an explicit path wins, else the upload's
+    basename; 400 when neither yields one."""
+    filename = path if path else posixpath.basename(file.filename or "")
+    if not filename:
+        raise HTTPException(status_code=400, detail="No filename provided")
+    return filename
+
+
+async def _read_upload(file: UploadFile, max_upload: int) -> bytes:
+    """Stream the whole upload into memory, enforcing the size cap
+    (413 past the limit)."""
+    buf = io.BytesIO()
+    total = 0
+    while chunk := await file.read(1024 * 1024):
+        total += len(chunk)
+        if total > max_upload:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File exceeds {max_upload // (1024 * 1024)} MB limit",
+            )
+        buf.write(chunk)
+    return buf.getvalue()
+
+
 @router.post("/workspaces/{workspace_id}/files/upload")
 async def upload_file(
     workspace_id: str,
@@ -205,25 +230,14 @@ async def upload_file(
 ):
     cid = _require_container(workspace_id, app.state.container_registry)
 
-    filename = path if path else posixpath.basename(file.filename or "")
-    if not filename:
-        raise HTTPException(status_code=400, detail="No filename provided")
-
-    max_upload = app.state.settings.file_upload_size_max
-    buf = io.BytesIO()
-    total = 0
-    while chunk := await file.read(1024 * 1024):
-        total += len(chunk)
-        if total > max_upload:
-            raise HTTPException(
-                status_code=413,
-                detail=f"File exceeds {max_upload // (1024 * 1024)} MB limit",
-            )
-        buf.write(chunk)
+    filename = _upload_filename(path, file)
+    data = await _read_upload(file, app.state.settings.file_upload_size_max)
 
     try:
         saved_path = await app.state.files.write_file(
-            cid, filename, buf.getvalue()
+            cid,
+            filename,
+            data,
         )
     except (ValueError, OSError) as e:
         raise _files_http_error(e) from None
@@ -286,19 +300,26 @@ def _volume_usage_map(rows) -> dict[str, list[str]]:
     return usage
 
 
-async def _creator_handles(app, volumes) -> dict[str, str | None]:
-    """Creator ``klangk.user-id`` label → the user's handle (#2993).
+def _volume_creator_label(v: dict) -> str | None:
+    """The ``klangk.user-id`` creator label of a podman volume row."""
+    return (v.get("Labels") or {}).get("klangk.user-id")
 
-    A label whose user no longer exists (deleted creator) maps to
-    ``None`` — the id stays in ``user_id`` as provenance.
-    """
+
+async def _creator_handle(app, uid: str) -> str | None:
+    """The creator's handle; ``None`` when the creator no longer exists
+    (the id stays in ``user_id`` as provenance)."""
+    creator = await app.state.model.users.get_user_by_id(uid)
+    return (creator or {}).get("handle") or None
+
+
+async def _creator_handles(app, volumes) -> dict[str, str | None]:
+    """Creator ``klangk.user-id`` label → the user's handle (#2993)."""
     handles: dict[str, str | None] = {}
     for v in volumes:
-        uid = (v.get("Labels") or {}).get("klangk.user-id")
+        uid = _volume_creator_label(v)
         if not uid or uid in handles:
             continue
-        creator = await app.state.model.users.get_user_by_id(uid)
-        handles[uid] = (creator or {}).get("handle") or None
+        handles[uid] = await _creator_handle(app, uid)
     return handles
 
 
@@ -364,10 +385,8 @@ async def list_volumes(
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
-            "user_id": (v.get("Labels") or {}).get("klangk.user-id"),
-            "created_by": handles.get(
-                (v.get("Labels") or {}).get("klangk.user-id")
-            ),
+            "user_id": _volume_creator_label(v),
+            "created_by": handles.get(_volume_creator_label(v)),
             "workspaces": usage.get(v["Name"], []),
         }
         for v in volumes
@@ -402,37 +421,57 @@ class CreateVolumeRequest(BaseModel):
     name: str = Field(pattern=VOLUME_NAME_PATTERN)
 
 
-@router.post("/volumes")
-async def create_volume(
-    body: CreateVolumeRequest,
-    user: dict = Depends(acl.has_permission("manage-volumes")),
-    app=Depends(get_app_dep),
-):
-    existing = await app.state.podman.inspect_volume(body.name)
-    if existing is not None:
-        labels = existing.get("Labels") or {}
-        if labels.get("klangk.instance") == app.state.util.instance_id():
-            raise HTTPException(
-                status_code=409, detail=f"Volume {body.name!r} already exists"
-            )
-    # Per-user volume quota (#2972): a create past the cap is refused
-    # with 429 (not 403 — the refusal is capacity, not authorization;
-    # not 503 either — the workspace-admission 503s are auto-retried by
-    # the CLI's request_with_retry, and a quota refusal must not be).
-    # Checked after the conflict probe so an in-instance duplicate
-    # still reports 409 (the route's caller can list the instance
-    # inventory either way). Only runs when a quota is configured —
-    # the default 0 keeps the create path exactly as before, with no
-    # extra podman call. The per-user lock spans count+create: without
-    # it, N concurrent creates each count the same pre-create total
-    # and all pass a cap they jointly exceed. The workspace-start
-    # auto-create door (container/spec.py ensure_volumes) shares the
-    # same lock and quota gate.
-    labels = {
-        "klangk.managed": "true",
-        "klangk.instance": app.state.util.instance_id(),
-        "klangk.user-id": user["id"],
-    }
+async def _reject_in_instance_duplicate(app, name: str) -> None:
+    """409 when *name* is already an instance-managed volume.
+
+    Checked before the quota so an in-instance duplicate still reports
+    409. A non-managed name (another instance's or the operator's
+    volume) falls through: podman's own create failure raises
+    PodmanError, which reaches the client as a bare 500 with no probed
+    name in the body. 500-vs-200 still hints at existence, but no
+    longer with a 409 + echoed detail (#2973). In-instance cross-user
+    names still 409 (issue scope: instance-managed volumes only; the
+    admin-surface rework, #2993, narrows who can call this at all).
+    """
+    existing = await app.state.podman.inspect_volume(name)
+    if existing is None:
+        return
+    labels = existing.get("Labels") or {}
+    if labels.get("klangk.instance") == app.state.util.instance_id():
+        raise HTTPException(
+            status_code=409, detail=f"Volume {name!r} already exists"
+        )
+
+
+def _volume_quota_error(count: int, quota: int) -> HTTPException:
+    """The 429 raised when a create would pass the per-user volume cap
+    (#2972) — capacity, not authorization (not 403), and not
+    auto-retried (not 503, which the CLI's request_with_retry
+    re-drives)."""
+    return HTTPException(
+        status_code=429,
+        detail=(
+            f"volume quota reached: {count} of this user's "
+            f"volumes already exist and the server caps it at "
+            f"{quota} (KLANGKD_VOLUME_QUOTA_PER_USER). Delete "
+            "a volume first, or ask the operator to raise the cap."
+        ),
+    )
+
+
+async def _create_volume_checked(
+    app, user: dict, name: str, labels: dict
+) -> dict:
+    """Create the volume under the per-user quota (#2972).
+
+    The per-user lock spans count+create: without it, N concurrent
+    creates each count the same pre-create total and all pass a cap
+    they jointly exceed. The workspace-start auto-create door
+    (container/spec.py ensure_volumes) shares the same lock and quota
+    gate. Only runs the count when a quota is configured — the default
+    0 keeps the create path exactly as before, with no extra podman
+    call.
+    """
     quota = app.state.settings.volume_quota_per_user
     if quota > 0:
         async with app.state.podman.volume_create_lock(user["id"]):
@@ -440,28 +479,56 @@ async def create_volume(
                 app.state.util.instance_id(), user["id"]
             )
             if count >= quota:
-                raise HTTPException(
-                    status_code=429,
-                    detail=(
-                        f"volume quota reached: {count} of this user's "
-                        f"volumes already exist and the server caps it at "
-                        f"{quota} (KLANGKD_VOLUME_QUOTA_PER_USER). Delete "
-                        "a volume first, or ask the operator to raise the "
-                        "cap."
-                    ),
-                )
-            info = await app.state.podman.create_volume(body.name, labels)
-    else:
-        # A non-managed name (another instance's or the operator's volume)
-        # falls through to create_volume: podman's own create failure
-        # raises PodmanError, which reaches the client as a bare 500 with
-        # no probed name in the body. 500-vs-200 still hints at
-        # existence, but no longer with a 409 + echoed detail (#2973).
-        # In-instance cross-user names still 409 (issue scope:
-        # instance-managed volumes only; the admin-surface rework,
-        # #2993, narrows who can call this at all).
-        info = await app.state.podman.create_volume(body.name, labels)
+                raise _volume_quota_error(count, quota)
+            return await app.state.podman.create_volume(name, labels)
+    return await app.state.podman.create_volume(name, labels)
+
+
+@router.post("/volumes")
+async def create_volume(
+    body: CreateVolumeRequest,
+    user: dict = Depends(acl.has_permission("manage-volumes")),
+    app=Depends(get_app_dep),
+):
+    await _reject_in_instance_duplicate(app, body.name)
+    labels = {
+        "klangk.managed": "true",
+        "klangk.instance": app.state.util.instance_id(),
+        "klangk.user-id": user["id"],
+    }
+    info = await _create_volume_checked(app, user, body.name, labels)
     return {"name": info["Name"], "created": info.get("CreatedAt", "")}
+
+
+async def _require_managed_volume(app, name: str) -> dict:
+    """The volume's info; 404 when missing or not managed by this
+    Klangk instance."""
+    info = await app.state.podman.inspect_volume(name)
+    if info is None:
+        raise HTTPException(status_code=404, detail="Volume not found")
+    labels = info.get("Labels") or {}
+    if labels.get("klangk.instance") != app.state.util.instance_id():
+        raise HTTPException(
+            status_code=404,
+            detail="Volume not managed by this Klangk instance",
+        )
+    return info
+
+
+async def _remove_volume(app, name: str) -> None:
+    """Remove the volume; a podman 404 → 404, 409 (in use) → 409."""
+    try:
+        await app.state.podman.remove_volume(name)
+    except PodmanError as e:
+        if e.status == 404:
+            raise HTTPException(
+                status_code=404, detail="Volume not found"
+            ) from None
+        if e.status == 409:
+            raise HTTPException(
+                status_code=409, detail="Volume is in use"
+            ) from None
+        raise
 
 
 @router.delete("/volumes/{name}")
@@ -480,25 +547,6 @@ async def delete_volume(
     verbatim, and podman parses a leading-dash name as a flag —
     `--all` would remove every unused volume on the host.
     """
-    info = await app.state.podman.inspect_volume(name)
-    if info is None:
-        raise HTTPException(status_code=404, detail="Volume not found")
-    labels = info.get("Labels") or {}
-    if labels.get("klangk.instance") != app.state.util.instance_id():
-        raise HTTPException(
-            status_code=404,
-            detail="Volume not managed by this Klangk instance",
-        )
-    try:
-        await app.state.podman.remove_volume(name)
-    except PodmanError as e:
-        if e.status == 404:
-            raise HTTPException(
-                status_code=404, detail="Volume not found"
-            ) from None
-        if e.status == 409:
-            raise HTTPException(
-                status_code=409, detail="Volume is in use"
-            ) from None
-        raise
+    await _require_managed_volume(app, name)
+    await _remove_volume(app, name)
     return {"status": "deleted"}

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -32,6 +32,7 @@ from .. import (
 )
 from ..exceptions import NodeDrainingError, WorkspaceCapacityError
 from ..model.container_events import (
+    CAUSE_API,
     CAUSE_CREATE,
     CAUSE_DELETE,
     CAUSE_RESTART,
@@ -110,23 +111,14 @@ def _validate_allowed_domains(
     return domains
 
 
-def _validate_rejected_domains(
-    values: list[str] | None, app
-) -> list[str] | None:
-    """Validate + normalize a workspace's ``rejected_domains`` list (#2367).
+def _reject_cidr_specs(values: list[str]) -> None:
+    """Raise HTTP 400 on any CIDR spec in a ``rejected_domains`` list.
 
-    The deny counterpart to :func:`_validate_allowed_domains`. Reuses
-    :func:`klangk.netfilter.parse_allowed_domains` so the host grammar matches
-    (bare = exact apex, ``.host`` = apex + subdomains, ``*.host`` = subdomains
-    only, #2377). Host-only: a CIDR spec is rejected up front -- the network
-    sidecar NXDOMAINs a rejected name *before* resolution, which has no
-    IP/CIDR dimension, and a deny-list must not silently ignore an entry an
-    operator believed was blocking something. Raises HTTP 400 on a malformed
-    entry or a CIDR. Only warns -- never rejects -- when the network sidecar
-    is not configured (the value is persisted for when filtering is re-enabled).
+    The deny list is host-only (#2367): the network sidecar NXDOMAINs a
+    rejected name *before* resolution, which has no IP/CIDR dimension,
+    and a deny-list must not silently ignore an entry an operator
+    believed was blocking something.
     """
-    if not values:
-        return None
     for raw in values:
         spec = raw.strip()
         if spec and "/" in spec:
@@ -138,6 +130,24 @@ def _validate_rejected_domains(
                     " Use a host/domain spec instead."
                 ),
             )
+
+
+def _validate_rejected_domains(
+    values: list[str] | None, app
+) -> list[str] | None:
+    """Validate + normalize a workspace's ``rejected_domains`` list (#2367).
+
+    The deny counterpart to :func:`_validate_allowed_domains`. Reuses
+    :func:`klangk.netfilter.parse_allowed_domains` so the host grammar matches
+    (bare = exact apex, ``.host`` = apex + subdomains, ``*.host`` = subdomains
+    only, #2377). Host-only: a CIDR spec is rejected up front (see
+    :func:`_reject_cidr_specs`). Raises HTTP 400 on a malformed entry or a
+    CIDR. Only warns -- never rejects -- when the network sidecar is not
+    configured (the value is persisted for when filtering is re-enabled).
+    """
+    if not values:
+        return None
+    _reject_cidr_specs(values)
     try:
         domains = netfilter_mod.parse_allowed_domains(
             values, label="rejected_domains"
@@ -277,11 +287,18 @@ async def list_shared_workspaces(
     )
 
 
-class CreateWorkspaceRequest(BaseModel):
-    name: str
+class WorkspaceBodyFields(BaseModel):
+    """The optional workspace fields shared verbatim by the create
+    (POST) and update (PUT) bodies.
+
+    Fields whose type or default *differs* between the two bodies
+    (``name``, ``auto_start``, ``egress_mode``, ``per_handle_home``)
+    stay declared on the concrete classes; everything else lives here
+    so the two request schemas cannot drift apart.
+    """
+
     image: str | None = None
     service_command: str | None = None
-    auto_start: bool = False
     mounts: list[str] | None = None
     env: dict[str, str] | None = None
     setup_state: Literal["pending", "complete", "failed"] | None = None
@@ -289,6 +306,11 @@ class CreateWorkspaceRequest(BaseModel):
     allowed_domains: list[str] | None = None
     rejected_domains: list[str] | None = None
     settings: dict | None = None
+
+
+class CreateWorkspaceRequest(WorkspaceBodyFields):
+    name: str
+    auto_start: bool = False
     egress_mode: Literal["static", "interactive", "allow"] = (
         EGRESS_MODE_DEFAULT
     )
@@ -349,41 +371,87 @@ async def create_workspace(
     return ws
 
 
-def _validate_create_fields(body, app) -> dict:
-    """Validate the POST body (400s raise); returns the derived
-    allowed/rejected domains, settings, per_handle_home, and banner."""
-    if body.auto_start and not autostart_allowed(app):
+def _check_autostart(auto_start, app) -> None:
+    """400 when a body asks for auto-start on a server without it."""
+    if auto_start and not autostart_allowed(app):
         raise HTTPException(
             status_code=400,
             detail="Auto-start is not enabled on this server"
             " (set KLANGKD_ALLOW_AUTOSTART=1)",
         )
-    if (
-        body.image
-        and body.image not in app.state.container_registry.allowed_images
+
+
+def _check_image(image: str | None, app) -> None:
+    """400 when *image* is present but not on this instance's allow-list.
+
+    ``None`` (absent) skips; any other value must be allowed. The create
+    path calls this only for truthy images (an empty image on create
+    means "the deploy default").
+    """
+    if image is not None and image not in (
+        app.state.container_registry.allowed_images
     ):
         raise HTTPException(
             status_code=400,
-            detail=f"Image {body.image!r} is not allowed. "
+            detail=f"Image {image!r} is not allowed. "
             f"Allowed: {sorted(app.state.container_registry.allowed_images)}",
         )
-    if body.mounts:
-        mount_err = app.state.container_registry.validate_mounts(body.mounts)
-        if mount_err:
-            raise HTTPException(status_code=400, detail=mount_err)
+
+
+def _check_mounts(mounts, app) -> None:
+    """400 when *mounts* is a present, non-empty list that fails this
+    instance's mount validation."""
+    if not mounts:
+        return
+    mount_err = app.state.container_registry.validate_mounts(mounts)
+    if mount_err:
+        raise HTTPException(status_code=400, detail=mount_err)
+
+
+def _validated_settings(raw) -> dict:
+    """Run :func:`validate_settings`, re-raising ``ValueError`` as 400."""
     try:
-        settings = validate_settings(body.settings)
-        # #2560: while the feature is off, a create may not opt in to nix
-        # (there is no existing bag on create, so any nix=true rejects).
-        validate_nix_optin(settings, nix_available=app.state.nix.available)
+        return validate_settings(raw)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _check_nix_optin(settings: dict, app, previous=None) -> None:
+    """400 on a nix opt-in while the feature is off (#2560).
+
+    *previous* is the already-stored bag a PUT may echo (update path);
+    ``None`` on create/import where any nix=true rejects.
+    """
     try:
-        classification_banner = normalize_classification_banner(
-            body.classification_banner
+        validate_nix_optin(
+            settings,
+            nix_available=app.state.nix.available,
+            previous=previous,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _normalized_banner(classification_banner) -> str | None:
+    """Normalize a classification marking, re-raising ``ValueError`` as
+    400."""
+    try:
+        return normalize_classification_banner(classification_banner)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _validate_create_fields(body, app) -> dict:
+    """Validate the POST body (400s raise); returns the derived
+    allowed/rejected domains, settings, per_handle_home, and banner."""
+    _check_autostart(body.auto_start, app)
+    if body.image:
+        _check_image(body.image, app)
+    _check_mounts(body.mounts, app)
+    settings = _validated_settings(body.settings)
+    # #2560: while the feature is off, a create may not opt in to nix
+    # (there is no existing bag on create, so any nix=true rejects).
+    _check_nix_optin(settings, app)
     return {
         "allowed_domains": _validate_allowed_domains(
             body.allowed_domains, app
@@ -397,7 +465,9 @@ def _validate_create_fields(body, app) -> dict:
             if body.per_handle_home is not None
             else app.state.settings.per_handle_home
         ),
-        "classification_banner": classification_banner,
+        "classification_banner": _normalized_banner(
+            body.classification_banner
+        ),
     }
 
 
@@ -438,18 +508,9 @@ async def _eager_start(app, body, ws, actor_id: str | None) -> None:
         )
 
 
-class UpdateWorkspaceRequest(BaseModel):
+class UpdateWorkspaceRequest(WorkspaceBodyFields):
     name: str | None = None
-    image: str | None = None
-    service_command: str | None = None
     auto_start: bool | None = None
-    mounts: list[str] | None = None
-    env: dict[str, str] | None = None
-    setup_state: Literal["pending", "complete", "failed"] | None = None
-    health_check: str | None = None
-    allowed_domains: list[str] | None = None
-    rejected_domains: list[str] | None = None
-    settings: dict | None = None
     # egress_mode (like allowed_domains) is enforced by the network
     # sidecar at container start, so a change here takes effect on the
     # next start/restart, not on the live container (PR #2248 review N3).
@@ -475,25 +536,10 @@ def _validate_update_fields(app, fields: dict) -> None:
 def _validate_update_core(app, fields: dict) -> None:
     """The 400-raising checks: autostart enablement, image allow-list,
     mount validity."""
-    if fields.get("auto_start") and not autostart_allowed(app):
-        raise HTTPException(
-            status_code=400,
-            detail="Auto-start is not enabled on this server"
-            " (set KLANGKD_ALLOW_AUTOSTART=1)",
-        )
-    if "image" in fields and fields["image"] is not None:
-        if fields["image"] not in app.state.container_registry.allowed_images:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Image {fields['image']!r} is not allowed. "
-                f"Allowed: {sorted(app.state.container_registry.allowed_images)}",
-            )
-    if "mounts" in fields and fields["mounts"]:
-        mount_err = app.state.container_registry.validate_mounts(
-            fields["mounts"]
-        )
-        if mount_err:
-            raise HTTPException(status_code=400, detail=mount_err)
+    _check_autostart(fields.get("auto_start"), app)
+    if "image" in fields:
+        _check_image(fields["image"], app)
+    _check_mounts(fields.get("mounts"), app)
 
 
 def _normalize_update_fields(app, fields: dict) -> None:
@@ -510,17 +556,23 @@ def _normalize_update_fields(app, fields: dict) -> None:
     # ``exclude_unset=True`` means the key is present only when the client
     # sent it; a missing ``settings`` key leaves the bag untouched.
     if "settings" in fields:
-        try:
-            fields["settings"] = validate_settings(fields["settings"])
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        fields["settings"] = _validated_settings(fields["settings"])
     if "classification_banner" in fields:
-        try:
-            fields["classification_banner"] = normalize_classification_banner(
-                fields["classification_banner"]
-            )
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        fields["classification_banner"] = _normalized_banner(
+            fields["classification_banner"]
+        )
+
+
+def _notify_workspace_audience(
+    app, user: dict, workspace: dict, members: list[dict]
+) -> None:
+    """Push workspaces-changed to the caller, the owner, and every
+    shared member -- the exact audience a workspace-scoped change
+    re-renders for."""
+    member_ids = {m["id"] for m in members}
+    member_ids.update({user["id"], workspace["user_id"]})
+    for uid in member_ids:
+        app.state.sockets.notify_user_workspaces_changed(uid)
 
 
 async def _notify_marking_change(
@@ -538,10 +590,26 @@ async def _notify_marking_change(
     members = await app.state.model.workspaces.get_workspace_members(
         workspace["id"]
     )
-    member_ids = {m["id"] for m in members}
-    member_ids.update({user["id"], workspace["user_id"]})
-    for uid in member_ids:
-        app.state.sockets.notify_user_workspaces_changed(uid)
+    _notify_workspace_audience(app, user, workspace, members)
+
+
+def _reset_health_probe(live_state, health_check) -> None:
+    """Apply an edited health_check to live state and reset the cached
+    status so the next poll re-broadcasts (#1015)."""
+    live_state.health_check = health_check or None
+    live_state.health_status = None
+    live_state.health_checked_at = None
+    live_state.health_message = None
+
+
+async def _sync_tmux_workspace_name(app, live_state, fields: dict) -> None:
+    """Keep the tmux status bar in sync when the workspace is renamed
+    (#1880): open terminals would otherwise keep showing the old
+    name until a new terminal_start fires. Idempotent + non-fatal."""
+    if "name" in fields and app.state.terminal.tmux_enabled():
+        await app.state.terminal.set_workspace_name(
+            live_state.container_id, fields["name"]
+        )
 
 
 async def _apply_live_state_updates(
@@ -557,18 +625,8 @@ async def _apply_live_state_updates(
     if "setup_state" in fields:
         live_state.setup_state = fields["setup_state"]
     if "health_check" in fields:
-        live_state.health_check = fields["health_check"] or None
-        # Reset the cached status so the next poll re-broadcasts.
-        live_state.health_status = None
-        live_state.health_checked_at = None
-        live_state.health_message = None
-    # Keep the tmux status bar in sync when the workspace is renamed
-    # (#1880): open terminals would otherwise keep showing the old
-    # name until a new terminal_start fires. Idempotent + non-fatal.
-    if "name" in fields and app.state.terminal.tmux_enabled():
-        await app.state.terminal.set_workspace_name(
-            live_state.container_id, fields["name"]
-        )
+        _reset_health_probe(live_state, fields["health_check"])
+    await _sync_tmux_workspace_name(app, live_state, fields)
 
 
 @router.put("/workspaces/{workspace_id}")
@@ -591,14 +649,9 @@ async def update_workspace(
         # #2560: PUT settings is a full-replace bag; a new nix=true opt-in
         # rejects while the feature is off, but an echo of the workspace's
         # already-stored true is tolerated (clients merge over the bag).
-        try:
-            validate_nix_optin(
-                fields["settings"],
-                nix_available=app.state.nix.available,
-                previous=workspace["settings"],
-            )
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        _check_nix_optin(
+            fields["settings"], app, previous=workspace["settings"]
+        )
     updated = await app.state.model.workspaces.update_workspace(
         workspace_id, workspace["user_id"], **fields
     )
@@ -724,6 +777,30 @@ async def duplicate_workspace(
     return ws
 
 
+async def _stop_workspace_container(
+    app, workspace: dict, cause: str, actor_id: str | None
+) -> None:
+    """Stop and remove the workspace's container.
+
+    Prefers the live container_id from the registry (tracks the currently
+    running container) over the DB value (may be stale if the container
+    was already stopped by idle timeout). No-op when neither is set.
+    """
+    live_state = app.state.container_registry.get_state(workspace["id"])
+    cid = (
+        live_state.container_id
+        if live_state
+        else workspace.get("container_id")
+    )
+    if cid:
+        await app.state.container_registry.stop_and_remove_container(
+            cid,
+            workspace_id=workspace["id"],
+            cause=cause,
+            actor_id=actor_id,
+        )
+
+
 @router.delete("/workspaces/{workspace_id}")
 async def delete_workspace(
     workspace_id: str,
@@ -742,25 +819,10 @@ async def delete_workspace(
         workspace_id
     )
 
-    # Prefer the live container_id from the registry (tracks the currently
-    # running container) over the DB value (may be stale if the container
-    # was already stopped by idle timeout).
-    live_state = app.state.container_registry.get_state(workspace_id)
-    cid = (
-        live_state.container_id
-        if live_state
-        else workspace.get("container_id")
-    )
-    # reset_workspace_state (below) stops the agent session and clears
-    # shared state; the agent subprocess runs inside the container, so
-    # stopping the container kills it either way.
-    if cid:
-        await app.state.container_registry.stop_and_remove_container(
-            cid,
-            workspace_id=workspace_id,
-            cause=CAUSE_DELETE,
-            actor_id=user["id"],
-        )
+    # _stop_workspace_container + reset_workspace_state (below) also stop
+    # the agent session and clear shared state; the agent subprocess runs
+    # inside the container, so stopping the container kills it either way.
+    await _stop_workspace_container(app, workspace, CAUSE_DELETE, user["id"])
     await wshandler.reset_workspace_state(app.state.sockets, workspace_id)
 
     deleted = await app.state.workspaces.delete_workspace(
@@ -775,10 +837,7 @@ async def delete_workspace(
     # Notify the deleter, the owner, and any shared members so their
     # workspace list refreshes (members were fetched above, before the
     # resource's ACL entries were removed).
-    member_ids = {m["id"] for m in members}
-    member_ids.update({user["id"], workspace["user_id"]})
-    for uid in member_ids:
-        app.state.sockets.notify_user_workspaces_changed(uid)
+    _notify_workspace_audience(app, user, workspace, members)
     return {"status": "deleted"}
 
 
@@ -808,42 +867,11 @@ async def restart_workspace(
     workspace = await app.state.model.workspaces.get_workspace(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    live_state = app.state.container_registry.get_state(workspace_id)
-    cid = (
-        live_state.container_id
-        if live_state
-        else workspace.get("container_id")
-    )
-    if cid:
-        await app.state.container_registry.stop_and_remove_container(
-            cid,
-            workspace_id=workspace_id,
-            cause=CAUSE_RESTART,
-            actor_id=user["id"],
-        )
+    await _stop_workspace_container(app, workspace, CAUSE_RESTART, user["id"])
     await wshandler.reset_workspace_state(app.state.sockets, workspace_id)
     # Start a fresh container; the service command fires via the
     # create choke point in start_container.
-    try:
-        await app.state.workspaces.start_workspace(
-            workspace, actor_id=user["id"], cause=CAUSE_RESTART
-        )
-    except NodeDrainingError as exc:
-        # A draining node refuses fresh starts (#2527); the stop above
-        # already happened, so the workspace is simply left stopped.
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-    except WorkspaceCapacityError as exc:
-        # Admission control refused the restart (#2525) — host memory
-        # or the per-user quota. 503 (not 400/500) so clients can tell
-        # a deterministic, operator-actionable capacity refusal apart
-        # from config errors and runtime failures. The stop above
-        # already happened, so the workspace is left stopped; capacity
-        # is re-checked on every start.
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-    except ValueError as exc:
-        # User-config error (e.g. a bind-mount source path that doesn't
-        # exist) — surface as a 400, not an unhandled 500 (#2157).
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    await _start_or_http_error(app, workspace, user["id"], cause=CAUSE_RESTART)
     return {"status": "restarted"}
 
 
@@ -904,6 +932,35 @@ async def stop_workspace(
     return {"status": "stopped"}
 
 
+async def _start_or_http_error(
+    app, workspace: dict, actor_id, cause: str = CAUSE_API
+) -> None:
+    """Start a workspace container, mapping the service-layer errors to
+    client-distinguishable HTTP statuses.
+
+    On a drain/capacity refusal the stop (restart path) already
+    happened, so the workspace is simply left stopped; capacity and
+    drain state are re-checked on every start (#2525 / #2527).
+    """
+    try:
+        await app.state.workspaces.start_workspace(
+            workspace, actor_id=actor_id, cause=cause
+        )
+    except NodeDrainingError as exc:
+        # Draining node (#2527): clear 503 so clients/CLI can distinguish
+        # "temporarily disabled by a restart" from a config error.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except WorkspaceCapacityError as exc:
+        # Capacity refusal (#2525): distinguishable 503 with an
+        # actionable "stop a workspace / free memory" detail.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except ValueError as exc:
+        # User-config error (e.g. a bind-mount source path that doesn't
+        # exist) — surface as a 400, not an unhandled 500 (#2157). The WS
+        # start path sends an error frame for the same condition.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 @router.post("/workspaces/{workspace_id}/start")
 async def start_workspace(
     workspace_id: str,
@@ -922,23 +979,7 @@ async def start_workspace(
         raise HTTPException(status_code=404, detail="Workspace not found")
     if app.state.container_registry.get_state(workspace_id) is not None:
         return {"status": "already_running"}
-    try:
-        await app.state.workspaces.start_workspace(
-            workspace, actor_id=user["id"]
-        )
-    except NodeDrainingError as exc:
-        # Draining node (#2527): clear 503 so clients/CLI can distinguish
-        # "temporarily disabled by a restart" from a config error.
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-    except WorkspaceCapacityError as exc:
-        # Capacity refusal (#2525): distinguishable 503 with an
-        # actionable "stop a workspace / free memory" detail.
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-    except ValueError as exc:
-        # User-config error (e.g. a bind-mount source path that doesn't
-        # exist) — surface as a 400, not an unhandled 500 (#2157). The WS
-        # start path sends an error frame for the same condition.
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    await _start_or_http_error(app, workspace, user["id"])
     return {"status": "started"}
 
 
@@ -1017,6 +1058,45 @@ async def workspace_status(
 # --- Workspace export/import endpoints ---
 
 
+async def _exportable_workspace(app, workspace_id: str, user_id) -> dict:
+    """Resolve the workspace to export; 404 when it cannot be found.
+
+    Owner-scoped first; the caller may hold export via a group ACE (e.g.
+    the owners role group) rather than a direct access row, in which case
+    the bare-id lookup finds it — the permission layer already gated.
+    """
+    workspace = await app.state.model.workspaces.get_workspace(
+        workspace_id, user_id
+    )
+    if workspace is None:
+        workspace = await app.state.model.workspaces.get_workspace_by_id(
+            workspace_id
+        )
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return workspace
+
+
+async def _estimate_home_size(home_dir) -> int:
+    """Estimate the uncompressed home size (bytes) for the client's
+    progress display; 0 when ``du`` is unavailable or fails."""
+    if not home_dir.exists():
+        return 0
+    try:
+        result = await asyncio.to_thread(
+            subprocess.run,
+            ["du", "-sb", str(home_dir)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.split()[0])
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        pass  # fall back to 0
+    return 0
+
+
 @router.get("/workspaces/{workspace_id}/export")
 async def export_workspace(
     workspace_id: str,
@@ -1037,18 +1117,7 @@ async def export_workspace(
     The archive contains workspace.json (metadata) and the home
     directory tree under home/.
     """
-    workspace = await app.state.model.workspaces.get_workspace(
-        workspace_id, user["id"]
-    )
-    if workspace is None:
-        # The caller may hold export via a group ACE (e.g. the owners
-        # role group) rather than a direct access row — look it up
-        # without the access check; the permission layer already gated.
-        workspace = await app.state.model.workspaces.get_workspace_by_id(
-            workspace_id
-        )
-    if workspace is None:
-        raise HTTPException(status_code=404, detail="Workspace not found")
+    workspace = await _exportable_workspace(app, workspace_id, user["id"])
 
     home_dir = app.state.workspaces.home_path(workspace_id)
     ws_name = workspace["name"]
@@ -1056,20 +1125,7 @@ async def export_workspace(
     metadata = app.state.workspaces.workspace_metadata(workspace)
 
     # Estimate uncompressed size for client progress display.
-    estimated_size = 0
-    if home_dir.exists():
-        try:
-            result = await asyncio.to_thread(
-                subprocess.run,
-                ["du", "-sb", str(home_dir)],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            if result.returncode == 0:
-                estimated_size = int(result.stdout.split()[0])
-        except (OSError, ValueError, subprocess.TimeoutExpired):
-            pass  # fall back to 0
+    estimated_size = await _estimate_home_size(home_dir)
 
     # Stream the tarball using GNU tar piped to stdout. Uses the shared
     # build_export_tar_args (workspaces.py), same as build_workspace_archive.
@@ -1324,6 +1380,66 @@ async def _extract_home_directory(
         )
 
 
+def _imported_settings(meta: dict, app) -> dict:
+    """Re-validate imported settings; 400 on any invalid value.
+
+    An archive from this instance is trusted, but the bag may predate a
+    schema change or carry a value the current deploy rejects. Validate
+    rather than persist blindly. #2560: import is a create path (no
+    previous bag) — the archive is user-supplied, editable input, so a
+    nix=true opt-in rejects while the feature is off, exactly like POST
+    /workspaces.
+    """
+    try:
+        settings = validate_settings(meta.get("settings"))
+        validate_nix_optin(settings, nix_available=app.state.nix.available)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Archive settings are invalid: {exc}",
+        ) from exc
+    return settings
+
+
+async def _create_from_archive(
+    app,
+    user: dict,
+    meta: dict,
+    settings: dict,
+    allowed_domains,
+    rejected_domains,
+) -> dict:
+    """Create the workspace row from the sanitized archive metadata;
+    a name collision is a 409."""
+    try:
+        return await app.state.workspaces.create_workspace(
+            user["id"],
+            meta["name"],
+            image=meta["image"],
+            service_command=meta["service_command"],
+            auto_start=meta["auto_start"],
+            mounts=meta["mounts"],
+            env=meta["env"],
+            health_check=meta["health_check"],
+            allowed_domains=allowed_domains,
+            rejected_domains=rejected_domains,
+            settings=settings,
+            egress_mode=meta["egress_mode"],
+            # The archive's explicit layout wins over the deploy
+            # default (KLANGKD_PER_HANDLE_HOME): import is a creation,
+            # but the exported workspace's home tree is laid out for
+            # that layout (#2722). Legacy archives without the field
+            # already carried True from _extract_archive_metadata.
+            per_handle_home=meta["per_handle_home"],
+            classification_banner=meta["classification_banner"],
+        )
+    except SAIntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A workspace named {meta['name']!r} already exists",
+        )
+
+
 @router.post("/workspaces/import")
 async def import_workspace(
     file: UploadFile,
@@ -1350,48 +1466,11 @@ async def import_workspace(
         rejected_domains = _validate_rejected_domains(
             meta.get("rejected_domains"), app
         )
-        # Re-validate imported settings — an archive from this instance is
-        # trusted, but the bag may predate a schema change or carry a value
-        # the current deploy rejects. Validate rather than persist blindly.
-        try:
-            settings = validate_settings(meta.get("settings"))
-            # #2560: import is a create path (no previous bag) — the archive
-            # is user-supplied, editable input, so a nix=true opt-in rejects
-            # while the feature is off, exactly like POST /workspaces.
-            validate_nix_optin(settings, nix_available=app.state.nix.available)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Archive settings are invalid: {exc}",
-            ) from exc
+        settings = _imported_settings(meta, app)
 
-        try:
-            ws = await app.state.workspaces.create_workspace(
-                user["id"],
-                meta["name"],
-                image=meta["image"],
-                service_command=meta["service_command"],
-                auto_start=meta["auto_start"],
-                mounts=meta["mounts"],
-                env=meta["env"],
-                health_check=meta["health_check"],
-                allowed_domains=allowed_domains,
-                rejected_domains=rejected_domains,
-                settings=settings,
-                egress_mode=meta["egress_mode"],
-                # The archive's explicit layout wins over the deploy
-                # default (KLANGKD_PER_HANDLE_HOME): import is a creation,
-                # but the exported workspace's home tree is laid out for
-                # that layout (#2722). Legacy archives without the field
-                # already carried True from _extract_archive_metadata.
-                per_handle_home=meta["per_handle_home"],
-                classification_banner=meta["classification_banner"],
-            )
-        except SAIntegrityError:
-            raise HTTPException(
-                status_code=409,
-                detail=f"A workspace named {meta['name']!r} already exists",
-            )
+        ws = await _create_from_archive(
+            app, user, meta, settings, allowed_domains, rejected_domains
+        )
 
         try:
             await _extract_home_directory(
@@ -1659,6 +1738,29 @@ class ChangeRoleRequest(BaseModel):
     role: str | None = None  # None = remove from all roles
 
 
+async def _remove_from_all_roles(app, workspace_id: str, user_id) -> None:
+    """Drop the user from every workspace role group."""
+    for suffix in ROLE_GROUP_SUFFIXES:
+        group_name = f"{suffix}-{workspace_id}"
+        group = await app.state.model.users.get_group_by_name(group_name)
+        if group is None:
+            continue
+        await app.state.model.users.remove_user_from_group(
+            user_id, group["id"]
+        )
+
+
+async def _add_to_role(app, workspace_id: str, user_id, role: str) -> None:
+    """Add the user to a workspace role group; 404 when the group is
+    missing."""
+    group = await app.state.model.users.get_group_by_name(
+        f"{role}-{workspace_id}"
+    )
+    if group is None:
+        raise HTTPException(status_code=404, detail="Role group not found")
+    await app.state.model.users.add_user_to_group(user_id, group["id"])
+
+
 @router.patch("/workspaces/{workspace_id}/roles")
 async def change_workspace_role(
     workspace_id: str,
@@ -1682,24 +1784,11 @@ async def change_workspace_role(
         )
 
     # Remove from all current roles
-    for suffix in ROLE_GROUP_SUFFIXES:
-        group_name = f"{suffix}-{workspace_id}"
-        group = await app.state.model.users.get_group_by_name(group_name)
-        if group is None:
-            continue
-        await app.state.model.users.remove_user_from_group(
-            target["id"], group["id"]
-        )
+    await _remove_from_all_roles(app, workspace_id, target["id"])
 
     # Add to target role if specified
     if body.role is not None:
-        group_name = f"{body.role}-{workspace_id}"
-        group = await app.state.model.users.get_group_by_name(group_name)
-        if group is None:
-            raise HTTPException(status_code=404, detail="Role group not found")
-        await app.state.model.users.add_user_to_group(
-            target["id"], group["id"]
-        )
+        await _add_to_role(app, workspace_id, target["id"], body.role)
 
     app.state.sockets.notify_user_workspaces_changed(user["id"])
     app.state.sockets.notify_user_workspaces_changed(target["id"])

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -74,6 +74,11 @@ PASSWORD_CLASSES = (
 )
 
 
+def _count_class(password: str, lo: str, hi: str) -> int:
+    """Count the ASCII characters in the inclusive range ``lo``..``hi``."""
+    return sum(1 for c in password if lo <= c <= hi)
+
+
 def password_class_counts(password: str) -> dict[str, int]:
     """ASCII character-class counts for the complexity policy (#2581).
 
@@ -86,9 +91,9 @@ def password_class_counts(password: str) -> dict[str, int]:
     means by "a digit" (``٣``) or "uppercase" (``Ⅰ``) while disagreeing
     with the clients. Server, web UI, and CLI must stay in sync.
     """
-    upper = sum(1 for c in password if "A" <= c <= "Z")
-    lower = sum(1 for c in password if "a" <= c <= "z")
-    digit = sum(1 for c in password if "0" <= c <= "9")
+    upper = _count_class(password, "A", "Z")
+    lower = _count_class(password, "a", "z")
+    digit = _count_class(password, "0", "9")
     return {
         "upper": upper,
         "lower": lower,
@@ -127,6 +132,18 @@ def is_locked_out(
             f"Too many failed attempts. Try again in {remaining // 60} minutes.",
         )
     return False, None
+
+
+def _unmet_requirement(
+    key: str, name: str, configured: dict, counts: dict
+) -> str | None:
+    """The human phrase for an unmet class requirement, or ``None``
+    when the class requirement is met (or its minimum is 0 —
+    disabled)."""
+    need = configured[key]
+    if need > 0 and counts[key] < need:
+        return f"at least {need} {name}{'s' if need != 1 else ''}"
+    return None
 
 
 def ensure_not_disabled(user: dict) -> None:
@@ -214,6 +231,23 @@ def dummy_verify_hash() -> str:
     return hash_password(secrets.token_urlsafe(32))
 
 
+async def verify_login_password(user: dict | None, password: str) -> bool:
+    """Time-equalized password verify for login-style endpoints (#2618).
+
+    OIDC-only users have no password hash; unknown users have no
+    account. Both verify against the dummy hash so the failure path
+    costs one full password verify either way — response timing cannot
+    enumerate accounts. The dummy hash is minted off the event loop
+    too — the one-time PBKDF2 cost must never block request handling
+    (functools.cache makes later calls free). Authorization still
+    requires a real hash to have matched.
+    """
+    password_hash = (user.get("password_hash") if user else None) or (
+        await asyncio.to_thread(dummy_verify_hash)
+    )
+    return await asyncio.to_thread(verify_password, password, password_hash)
+
+
 class RegisterRequest(BaseModel):
     email: str
     password: str
@@ -249,6 +283,21 @@ def validate_email(email: str) -> None:
         raise HTTPException(
             status_code=400, detail="Must be a valid email address"
         )
+
+
+def _other_workstation_ips(rows: list[dict], source_ip: str) -> list[str]:
+    """The distinct known IPs (other than *source_ip*) the user has
+    active sessions from, sorted.
+
+    Sessions with an unknown IP (pre-#2586 rows, unresolvable clients)
+    are never reported as different."""
+    return sorted(
+        {
+            row["source_ip"]
+            for row in rows
+            if row["source_ip"] is not None and row["source_ip"] != source_ip
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -426,9 +475,10 @@ class Auth:
             "special": self.password_require_special,
         }
         unmet = [
-            f"at least {need} {name}{'s' if need != 1 else ''}"
+            phrase
             for key, name in PASSWORD_CLASSES
-            if (need := configured[key]) > 0 and counts[key] < need
+            if (phrase := _unmet_requirement(key, name, configured, counts))
+            is not None
         ]
         if unmet:
             raise HTTPException(
@@ -654,14 +704,7 @@ class Auth:
         sessions = self.app.state.model.sessions
         await sessions.purge_expired()
         rows = await sessions.list_sessions(user_id)
-        others = sorted(
-            {
-                row["source_ip"]
-                for row in rows
-                if row["source_ip"] is not None
-                and row["source_ip"] != source_ip
-            }
-        )
+        others = _other_workstation_ips(rows, source_ip)
         if not others:
             return
         logger.info(
@@ -674,8 +717,10 @@ class Auth:
             ", ".join(others),
         )
 
-    async def _enforce_session_limit(self, user_id: str) -> None:
-        """Revoke the user's oldest sessions past the configured cap.
+    async def _revoke_sessions(
+        self, user_id: str, rows: list[dict], limit: int
+    ) -> None:
+        """Blocklist then delete the given (oldest-first) session rows.
 
         Victims are removed oldest-first by blocklisting their JTIs (the
         same revocation path as logout: the next HTTP request 401s with
@@ -685,17 +730,7 @@ class Auth:
         can only leave a dead token's row behind (purged on the next
         issuance), never a live token without a row.
         """
-        sessions = self.app.state.model.sessions
-        # Dead sessions (their JWT already failed exp verification) never
-        # count toward the cap; purge also bounds the table when the
-        # limit is off.
-        await sessions.purge_expired()
-        limit = self.max_sessions_per_user
-        if limit <= 0:
-            return
-        rows = await sessions.list_sessions(user_id)
-        excess = rows[:-limit] if len(rows) > limit else []
-        for row in excess:
+        for row in rows:
             logger.info(
                 "session limit: revoking oldest session jti=%s "
                 "(user %s over cap %d)",
@@ -706,8 +741,25 @@ class Auth:
             await self.app.state.model.tokens.blocklist_token(
                 row["jti"], row["expires_at"]
             )
-        if excess:
-            await sessions.remove_sessions([row["jti"] for row in excess])
+        await self.app.state.model.sessions.remove_sessions(
+            [row["jti"] for row in rows]
+        )
+
+    async def _enforce_session_limit(self, user_id: str) -> None:
+        """Revoke the user's oldest sessions past the configured cap.
+
+        Dead sessions (their JWT already failed exp verification) never
+        count toward the cap; the purge also bounds the table when the
+        limit is off.
+        """
+        sessions = self.app.state.model.sessions
+        await sessions.purge_expired()
+        limit = self.max_sessions_per_user
+        if limit <= 0:
+            return
+        rows = await sessions.list_sessions(user_id)
+        if len(rows) > limit:
+            await self._revoke_sessions(user_id, rows[:-limit], limit)
 
     async def record_activity(self, user_id: str) -> None:
         """Stamp ``users.last_activity_at`` (throttled) on API access (#2588).
@@ -900,6 +952,16 @@ class Auth:
             user_id=user["id"], email=user["email"], access_token=token
         )
 
+    async def _reject_bad_credentials(
+        self, user: dict | None, password: str, lockout_key: str, attempt_info
+    ) -> None:
+        """401 unless a real password hash matched; records the failure
+        on the lockout key."""
+        password_ok = await verify_login_password(user, password)
+        if user is None or not user.get("password_hash") or not password_ok:
+            await self.record_login_failure(lockout_key, attempt_info)
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+
     async def login(
         self,
         req: LoginRequest,
@@ -922,24 +984,9 @@ class Auth:
         # expensive step below is verify_password's PBKDF2, run in a
         # worker thread so the event loop is not blocked).
         attempt_info = await self.check_login_lockout(lockout_key)
-
-        # OIDC-only users have no password hash; unknown users have no
-        # account. Both verify against the dummy hash so the failure
-        # path costs one full password verify either way — response
-        # timing cannot enumerate accounts (#2618). Authorization
-        # still requires a real hash to have matched. The dummy hash is
-        # minted off the event loop too — the one-time PBKDF2 cost must
-        # never block request handling (functools.cache makes later
-        # calls free).
-        password_hash = (user.get("password_hash") if user else None) or (
-            await asyncio.to_thread(dummy_verify_hash)
+        await self._reject_bad_credentials(
+            user, req.password, lockout_key, attempt_info
         )
-        password_ok = await asyncio.to_thread(
-            verify_password, req.password, password_hash
-        )
-        if user is None or not user.get("password_hash") or not password_ok:
-            await self.record_login_failure(lockout_key, attempt_info)
-            raise HTTPException(status_code=401, detail="Invalid credentials")
         if not user.get("verified"):
             raise HTTPException(
                 status_code=403,
@@ -961,6 +1008,63 @@ class Auth:
         await self.app.state.model.users.record_login(user["id"])
         return TokenResponse(access_token=token)
 
+    async def _refreshed_or_revoked(self, jti: str) -> TokenResponse | None:
+        """The cached replacement when *jti* was already refreshed.
+
+        ``None`` when the jti is not blocklisted at all; a blocklisted
+        jti with no cached replacement was revoked by logout → 401.
+        """
+        if not await self.app.state.model.tokens.is_token_blocklisted(jti):
+            return None
+        cached = await self.app.state.model.tokens.get_refreshed_token(jti)
+        if cached is not None:
+            return TokenResponse(access_token=cached)
+        raise HTTPException(status_code=401, detail="Token has been revoked")
+
+    async def _require_active_user(self, user_id: str) -> dict:
+        """The user row for a token rotation; 401 when the user is gone
+        and 403 when disabled (a disabled account cannot rotate its way
+        back in, #2588)."""
+        user = await self.app.state.model.users.get_user_by_id(user_id)
+        if user is None:
+            raise HTTPException(status_code=401, detail="User not found")
+        ensure_not_disabled(user)
+        return user
+
+    async def _swap_token(
+        self, jti: str, exp, user_id: str, new_token: str
+    ) -> None:
+        """Blocklist the old jti with the new token cached alongside it
+        (making refresh idempotent), then move the session row onto the
+        refreshed jti — a refresh is the same session under a new token
+        (#2585), so the user's session count does not grow on refresh."""
+        expires_at = datetime.fromtimestamp(exp, tz=timezone.utc).isoformat()
+        logger.info(
+            "REFRESH: blocklisting old access token; any WS still using "
+            "it will be rejected as 4001 on its next connect"
+        )
+        await self.app.state.model.tokens.blocklist_token(
+            jti, expires_at, new_token=new_token
+        )
+        new_payload = self.decode_token(new_token)
+        new_expires_at = datetime.fromtimestamp(
+            new_payload["exp"], tz=timezone.utc
+        ).isoformat()
+        await self.app.state.model.sessions.replace_session(
+            jti, user_id, new_payload["jti"], new_expires_at
+        )
+
+    async def _expired_token_response(self, token: str) -> TokenResponse:
+        """A previously-refreshed expired token still returns its cached
+        replacement; anything else is a plain 401."""
+        payload = self.decode_token(token, allow_expired=True)
+        jti = payload.get("jti")
+        if jti:
+            cached = await self.app.state.model.tokens.get_refreshed_token(jti)
+            if cached is not None:
+                return TokenResponse(access_token=cached)
+        raise HTTPException(status_code=401, detail="Token expired")
+
     async def refresh_token(self, token: str) -> TokenResponse:
         """Exchange a valid access token for a new one.
 
@@ -968,7 +1072,6 @@ class Auth:
         alongside it, making the endpoint idempotent: repeated calls
         with the same old token return the same new token.
         """
-        jti = None
         try:
             payload = self.decode_token(token)
             user_id = payload.get("sub")
@@ -978,48 +1081,18 @@ class Auth:
             if not all([user_id, email, jti, exp]):
                 raise HTTPException(status_code=401, detail="Invalid token")
 
-            if await self.app.state.model.tokens.is_token_blocklisted(jti):
-                # Already refreshed — return the cached replacement
-                cached = await self.app.state.model.tokens.get_refreshed_token(
-                    jti
-                )
-                if cached is not None:
-                    return TokenResponse(access_token=cached)
-                raise HTTPException(
-                    status_code=401, detail="Token has been revoked"
-                )
+            cached = await self._refreshed_or_revoked(jti)
+            if cached is not None:
+                return cached
 
-            user = await self.app.state.model.users.get_user_by_id(user_id)
-            if user is None:
-                raise HTTPException(status_code=401, detail="User not found")
-            # A disabled account cannot rotate its way back in (#2588).
-            ensure_not_disabled(user)
+            await self._require_active_user(user_id)
             # A refresh is authenticated API use (#2588 review): stamp so
             # a headless client that only refreshes (no other API calls)
             # still counts as active.
             await self.record_activity(user_id)
 
             new_token = self.create_token(user_id, email)
-            expires_at = datetime.fromtimestamp(
-                exp, tz=timezone.utc
-            ).isoformat()
-            logger.info(
-                "REFRESH: blocklisting old access token; any WS still using "
-                "it will be rejected as 4001 on its next connect"
-            )
-            await self.app.state.model.tokens.blocklist_token(
-                jti, expires_at, new_token=new_token
-            )
-            # The refreshed JTI occupies the old session's slot (a refresh
-            # is the same session under a new token, #2585): the user's
-            # session count does not grow on refresh.
-            new_payload = self.decode_token(new_token)
-            new_expires_at = datetime.fromtimestamp(
-                new_payload["exp"], tz=timezone.utc
-            ).isoformat()
-            await self.app.state.model.sessions.replace_session(
-                jti, user_id, new_payload["jti"], new_expires_at
-            )
+            await self._swap_token(jti, exp, user_id, new_token)
             # Refreshing a pre-#2585 token (no row) INSERTS one; enforce
             # so the cap holds on every path that adds a session row,
             # not just logins (#2585 review).
@@ -1028,17 +1101,42 @@ class Auth:
 
         except ExpiredSignatureError:
             # Token expired — check if it was previously refreshed
-            payload = self.decode_token(token, allow_expired=True)
-            jti = payload.get("jti")
-            if jti:
-                cached = await self.app.state.model.tokens.get_refreshed_token(
-                    jti
-                )
-                if cached is not None:
-                    return TokenResponse(access_token=cached)
-            raise HTTPException(status_code=401, detail="Token expired")
+            return await self._expired_token_response(token)
         except JWTError:
             raise HTTPException(status_code=401, detail="Invalid token")
+
+    async def _token_revoked(self, jti: str) -> bool:
+        """True when *jti* was revoked (by a refresh or a logout)."""
+        revoked = await self.app.state.model.tokens.is_token_blocklisted(jti)
+        if revoked:
+            logger.info(
+                "token reject: BLOCKLISTED (revoked by a refresh or "
+                "logout -> WS will close 4001 -> client logout)"
+            )
+        return revoked
+
+    async def _user_from_valid_payload(self, payload: dict) -> dict | None:
+        """The user for a decoded, unexpired token payload; ``None`` for
+        malformed claims, a revoked token, or a missing user."""
+        user_id = payload.get("sub")
+        jti = payload.get("jti")
+        if None in (user_id, jti):
+            return None
+        if await self._token_revoked(jti):
+            return None
+        user = await self.app.state.model.users.get_user_by_id(user_id)
+        if user is None:
+            return None
+        # Disabled accounts keep their WS connections shut (#2588):
+        # returning None rejects the connect like any dead token.
+        if user.get("disabled"):
+            logger.info(
+                "token reject: ACCOUNT DISABLED -> WS will close 4001"
+                " -> client logout"
+            )
+            return None
+        await self.record_activity(user_id)
+        return user
 
     async def get_user_from_token(self, token: str) -> dict | str | None:
         """Validate a token string (used for WebSocket auth).
@@ -1049,30 +1147,9 @@ class Auth:
             None: for all other failures (malformed, revoked, missing user).
         """
         try:
-            payload = self.decode_token(token)
-            user_id = payload.get("sub")
-            jti = payload.get("jti")
-            if user_id is None or jti is None:
-                return None
-            if await self.app.state.model.tokens.is_token_blocklisted(jti):
-                logger.info(
-                    "token reject: BLOCKLISTED (revoked by a refresh or "
-                    "logout -> WS will close 4001 -> client logout)"
-                )
-                return None
-            user = await self.app.state.model.users.get_user_by_id(user_id)
-            if user is None:
-                return None
-            # Disabled accounts keep their WS connections shut (#2588):
-            # returning None rejects the connect like any dead token.
-            if user.get("disabled"):
-                logger.info(
-                    "token reject: ACCOUNT DISABLED -> WS will close 4001"
-                    " -> client logout"
-                )
-                return None
-            await self.record_activity(user_id)
-            return user
+            return await self._user_from_valid_payload(
+                self.decode_token(token)
+            )
         except ExpiredSignatureError:
             logger.info(
                 "token reject: EXPIRED -> WS will close 4002 -> client logout"
@@ -1104,6 +1181,35 @@ class Auth:
 # ---------------------------------------------------------------------------
 
 
+async def _authenticated_user(request: Request, credentials) -> dict:
+    """The user for valid, unrevoked credentials; raises 401 for every
+    failure mode (missing claims, a revoked token, an unknown user)."""
+    payload = request.app.state.auth.decode_token(credentials.credentials)
+    user_id = payload.get("sub")
+    jti = payload.get("jti")
+    if None in (user_id, jti):
+        raise HTTPException(status_code=401, detail="Invalid token")
+    if await request.app.state.model.tokens.is_token_blocklisted(jti):
+        raise HTTPException(status_code=401, detail="Token has been revoked")
+    user = await request.app.state.model.users.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user
+
+
+async def _optional_user(request: Request, credentials) -> dict | None:
+    """The user for valid, unrevoked credentials; ``None`` for missing
+    claims, a revoked token, or an unknown user."""
+    payload = request.app.state.auth.decode_token(credentials.credentials)
+    user_id = payload.get("sub")
+    jti = payload.get("jti")
+    if None in (user_id, jti):
+        return None
+    if await request.app.state.model.tokens.is_token_blocklisted(jti):
+        return None
+    return await request.app.state.model.users.get_user_by_id(user_id)
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
@@ -1113,24 +1219,11 @@ async def get_current_user(
         raise HTTPException(status_code=401, detail="Not authenticated")
 
     try:
-        payload = auth.decode_token(credentials.credentials)
-        user_id = payload.get("sub")
-        jti = payload.get("jti")
-        if user_id is None or jti is None:
-            raise HTTPException(status_code=401, detail="Invalid token")
-
-        if await request.app.state.model.tokens.is_token_blocklisted(jti):
-            raise HTTPException(
-                status_code=401, detail="Token has been revoked"
-            )
-
-        user = await request.app.state.model.users.get_user_by_id(user_id)
-        if user is None:
-            raise HTTPException(status_code=401, detail="User not found")
+        user = await _authenticated_user(request, credentials)
         # A disabled account fails every authenticated request (#2588);
         # 403 (not 401) so clients don't loop on refresh/relogin.
         ensure_not_disabled(user)
-        await auth.record_activity(user_id)
+        await auth.record_activity(user["id"])
         return user
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid token")
@@ -1150,21 +1243,14 @@ async def get_current_user_optional(
         return None
     auth = request.app.state.auth
     try:
-        payload = auth.decode_token(credentials.credentials)
-        user_id = payload.get("sub")
-        jti = payload.get("jti")
-        if user_id is None or jti is None:
-            return None
-        if await request.app.state.model.tokens.is_token_blocklisted(jti):
-            return None
-        user = await request.app.state.model.users.get_user_by_id(user_id)
+        user = await _optional_user(request, credentials)
         if user is None:
             return None
         # Valid credentials on a disabled account still 403 (#2588) —
         # returning None here would silently degrade /config to the
         # anonymous view and hide the reason from the client.
         ensure_not_disabled(user)
-        await auth.record_activity(user_id)
+        await auth.record_activity(user["id"])
         return user
     except JWTError:
         return None

--- a/src/klangk/klangk/fips.py
+++ b/src/klangk/klangk/fips.py
@@ -63,6 +63,26 @@ logger = logging.getLogger(__name__)
 _PROBE_BYTES = b"klangk-fips-probe"
 
 
+def _lists_sha2(low: str) -> bool:
+    """True when any SHA-2 digest name appears in lowered openssl
+    output."""
+    return "sha256" in low or "sha2-256" in low or "sha512" in low
+
+
+def _digest_verdict(low: str) -> tuple[bool, str] | None:
+    """The ``(ok, detail)`` verdict for non-empty lowered algorithm
+    output, or ``None`` when it cannot be interpreted."""
+    has_sha2 = _lists_sha2(low)
+    has_md5 = "md5" in low
+    if has_sha2 and not has_md5:
+        return True, "approved set has SHA-2 and no MD5"
+    if has_md5:
+        return False, "MD5 appears in the fips=yes approved set"
+    if not has_sha2:
+        return False, "no SHA-2 digest in the fips=yes approved set"
+    return None  # pragma: no cover — unreachable by construction
+
+
 def parse_openssl_list(stdout: str) -> tuple[bool, str] | None:
     """Parse ``openssl list -digest-algorithms -propquery fips=yes`` output.
 
@@ -71,17 +91,9 @@ def parse_openssl_list(stdout: str) -> tuple[bool, str] | None:
     the output cannot be interpreted (caller treats as inconclusive).
     """
     low = stdout.lower()
-    has_sha2 = "sha256" in low or "sha2-256" in low or "sha512" in low
-    has_md5 = "md5" in low
     if not low.strip():
         return None
-    if has_sha2 and not has_md5:
-        return True, "approved set has SHA-2 and no MD5"
-    if has_md5:
-        return False, "MD5 appears in the fips=yes approved set"
-    if not has_sha2:
-        return False, "no SHA-2 digest in the fips=yes approved set"
-    return None  # pragma: no cover — unreachable by construction
+    return _digest_verdict(low)
 
 
 def run_openssl_list() -> tuple[bool, str]:
@@ -124,6 +136,31 @@ def run_openssl_list() -> tuple[bool, str]:
     return parsed
 
 
+def _sha2_still_available(sha256) -> tuple[bool, str]:
+    """The outcome when md5 was rejected on the fetch path — the FIPS
+    enforcement signal. An approved digest must still work, else the
+    whole fetch path is broken (fail closed)."""
+    try:
+        sha256(_PROBE_BYTES)
+    except ValueError:
+        return False, "md5 rejected but SHA-256 unavailable too"
+    return True, "md5 rejected, SHA-256 available (OpenSSL fetch path)"
+
+
+def _md5_probe_result(md5, sha256) -> tuple[bool, str] | None:
+    """The probe outcome for a working ``_hashlib``: ``(True, ...)`` when
+    md5 is rejected on the fetch path, ``(False, ...)`` when md5 works
+    (FIPS not enforcing), ``None`` when an unexpected error made the
+    probe inconclusive (the caller falls through to the CLI layer)."""
+    try:
+        md5(_PROBE_BYTES)
+    except ValueError:
+        return _sha2_still_available(sha256)
+    except Exception:
+        return None
+    return False, "md5 not rejected — FIPS provider not enforcing"
+
+
 def probe_hashlib() -> tuple[bool, str] | None:
     """Layer-1 probe via CPython's ``_hashlib`` (provider-aware).
 
@@ -150,22 +187,7 @@ def probe_hashlib() -> tuple[bool, str] | None:
     sha256 = getattr(_hashlib, "openssl_sha256", None)
     if md5 is None or sha256 is None:
         return None
-    try:
-        md5(_PROBE_BYTES)
-    except ValueError:
-        # Non-approved digest rejected on the OpenSSL fetch path — the
-        # FIPS enforcement signal. An approved digest must still work,
-        # else the whole fetch path is broken (fail closed).
-        try:
-            sha256(_PROBE_BYTES)
-        except ValueError:
-            return False, "md5 rejected but SHA-256 unavailable too"
-        return True, "md5 rejected, SHA-256 available (OpenSSL fetch path)"
-    except Exception:
-        # An unexpected error is not a FIPS signal — inconclusive here,
-        # fall through to the CLI layer.
-        return None
-    return False, "md5 not rejected — FIPS provider not enforcing"
+    return _md5_probe_result(md5, sha256)
 
 
 def probe_process() -> tuple[bool, str]:

--- a/src/klangk/klangk/oidc.py
+++ b/src/klangk/klangk/oidc.py
@@ -71,22 +71,28 @@ def get(entry: dict, key: str, default: object = _SENTINEL) -> object:
     raise KeyError(key)
 
 
+def _resolve_ca_cert(entry: dict, config_dir: str | None) -> str | None:
+    """The provider's CA cert path, resolved against *config_dir* when
+    relative (external-config loading; inline loading passes ``None`` —
+    relative paths are not meaningful without a file to be relative
+    to)."""
+    ca_cert = get(entry, "ca-cert", None)
+    if ca_cert and config_dir and not os.path.isabs(ca_cert):
+        return os.path.join(config_dir, ca_cert)
+    return ca_cert
+
+
 def _parse_providers(
     entries: list[dict], config_dir: str | None = None
 ) -> list[OIDCProvider]:
     """Parse a list of raw provider dicts into OIDCProvider objects.
 
     Shared by both inline (config-file ``oidc_providers:``) and external
-    (``KLANGKD_OIDC_CONFIG``) loading paths.  *config_dir* is used to resolve
-    relative ``ca-cert`` paths — ``None`` when loaded inline (relative paths
-    are not meaningful without a file to be relative to).
+    (``KLANGKD_OIDC_CONFIG``) loading paths.
     """
     providers = []
     for entry in entries:
         secret = resolve_file_value(get(entry, "client-secret", ""))
-        ca_cert = get(entry, "ca-cert", None)
-        if ca_cert and config_dir and not os.path.isabs(ca_cert):
-            ca_cert = os.path.join(config_dir, ca_cert)
         providers.append(
             OIDCProvider(
                 id=entry["id"],
@@ -95,7 +101,7 @@ def _parse_providers(
                 client_id=get(entry, "client-id"),
                 client_secret=secret or "",
                 scopes=entry.get("scopes", "openid email profile"),
-                ca_cert=ca_cert,
+                ca_cert=_resolve_ca_cert(entry, config_dir),
                 token_validation_pem=get(entry, "token-validation-pem", None),
                 logout_redirect=get(entry, "logout-redirect", False),
                 trust_email=get(entry, "trust-email", False),
@@ -436,13 +442,37 @@ class OIDC:
 
     # --- login hook ---
 
+    def _load_hook_module(self, path: str):
+        """Import the hook script directly via ``importlib.util`` — it
+        does **not** need to be on ``PYTHONPATH``."""
+        spec = importlib.util.spec_from_file_location(
+            "_klangk_login_hook", path
+        )
+        if spec is None or spec.loader is None:
+            raise ConfigurationError(
+                f"KLANGKD_OIDC_LOGIN_HOOK: could not load: {path!r}"
+            )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _load_hook_callable(self, mod, path: str, func_name: str):
+        """The hook function from *mod*; ``ConfigurationError`` when
+        missing or not callable."""
+        hook = getattr(mod, func_name, None)
+        if hook is None or not callable(hook):
+            raise ConfigurationError(
+                f"KLANGKD_OIDC_LOGIN_HOOK: {func_name!r} not found or not "
+                f"callable in {path!r}"
+            )
+        return hook
+
     def load_login_hook(self) -> None:
         """Load the OIDC login hook from KLANGKD_OIDC_LOGIN_HOOK.
 
         The value is a file path to a Python script, optionally followed
         by ``:func_name``.  If the function name is omitted it defaults
-        to ``on_login``.  The file is loaded directly via
-        ``importlib.util`` — it does **not** need to be on ``PYTHONPATH``.
+        to ``on_login``.
 
         The hook is called after ID token validation and before user
         provisioning.  It combines login validation and group mapping:
@@ -465,21 +495,8 @@ class OIDC:
             raise ConfigurationError(
                 f"KLANGKD_OIDC_LOGIN_HOOK: file not found: {path!r}"
             )
-        spec = importlib.util.spec_from_file_location(
-            "_klangk_login_hook", path
-        )
-        if spec is None or spec.loader is None:
-            raise ConfigurationError(
-                f"KLANGKD_OIDC_LOGIN_HOOK: could not load: {path!r}"
-            )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        hook = getattr(mod, func_name, None)
-        if hook is None or not callable(hook):
-            raise ConfigurationError(
-                f"KLANGKD_OIDC_LOGIN_HOOK: {func_name!r} not found or not "
-                f"callable in {path!r}"
-            )
+        mod = self._load_hook_module(path)
+        hook = self._load_hook_callable(mod, path, func_name)
         self.login_hook = hook
         self.login_hook_is_async = inspect.iscoroutinefunction(hook)
         logger.info("OIDC login hook loaded: %s", raw)

--- a/src/klangk/klangk/ssl_trust.py
+++ b/src/klangk/klangk/ssl_trust.py
@@ -119,6 +119,29 @@ def _first_existing_ca(candidates: list[str], self_real) -> str | None:
     return None
 
 
+def _append_bundle_file(out, path: str, warn: str) -> bool:
+    """Append one bundle/cert file's contents to *out*; ``False`` (with
+    a warning) when unreadable."""
+    try:
+        with open(path) as f:
+            out.write(f.read())
+        return True
+    except OSError as exc:
+        logger.warning(warn, path, exc)
+        return False
+
+
+def _append_custom_certs(out, ssl_dir: str) -> int:
+    """Append every readable cert in *ssl_dir*; returns how many were
+    written (unreadable files are skipped with a warning)."""
+    written = 0
+    for cert in iter_cert_files(ssl_dir):
+        written += _append_bundle_file(
+            out, cert, "Skipping unreadable cert %s: %s"
+        )
+    return written
+
+
 def write_merged_bundle(bundle_path: str, ssl_dir: str) -> bool:
     """Write system CAs + custom certs to ``bundle_path``.
 
@@ -129,22 +152,17 @@ def write_merged_bundle(bundle_path: str, ssl_dir: str) -> bool:
     with open(bundle_path, "w") as out:
         sys_bundle = system_ca_bundle(self_bundle=bundle_path)
         if sys_bundle:
-            try:
-                with open(sys_bundle) as f:
-                    out.write(f.read())
-                written += 1
-            except OSError as exc:
-                logger.warning(
-                    "Could not read system CA bundle %s: %s", sys_bundle, exc
-                )
-        for cert in iter_cert_files(ssl_dir):
-            try:
-                with open(cert) as f:
-                    out.write(f.read())
-                written += 1
-            except OSError as exc:
-                logger.warning("Skipping unreadable cert %s: %s", cert, exc)
+            written += _append_bundle_file(
+                out, sys_bundle, "Could not read system CA bundle %s: %s"
+            )
+        written += _append_custom_certs(out, ssl_dir)
     return written > 0 and os.path.getsize(bundle_path) > 0
+
+
+def _apply_trust_vars(bundle_path: str) -> None:
+    """Point every backend trust env var at the bundle."""
+    for name in SSL_TRUST_VARS:
+        os.environ[name] = bundle_path
 
 
 class SSLTrust:
@@ -182,23 +200,11 @@ class SSLTrust:
         path = os.path.realpath(candidate)
         return path if any(True for _ in iter_cert_files(path)) else None
 
-    def apply_backend_ssl_trust(self) -> str | None:
-        """Make the backend process trust the deployer's custom CAs.
-
-        Builds a merged bundle (system + custom) under ``<data_dir>/ssl`` and sets
-        :data:`SSL_TRUST_VARS` in :data:`os.environ`, so the backend's outbound TLS
-        (OIDC discovery, SMTP relay, LLM-proxy upstream) honors the private CAs.
-        Idempotent and safe to call at startup; a no-op when no cert dir is
-        configured.  Refuses to apply trust when the system bundle can't be found
-        *and* no cert was written (would risk losing public-internet trust).
-
-        Returns the bundle path, or ``None`` if trust was not applied.
-        """
-        ssl_dir = self.ssl_cert_dir()
-        if not ssl_dir:
-            return None
-        state_dir = self.app.state.settings.state_dir
-        bundle_dir = os.path.join(state_dir, "ssl")
+    def _build_bundle(self, ssl_dir: str) -> str | None:
+        """Write the merged bundle under ``<state_dir>/ssl``; ``None``
+        (with a log) when the dir cannot be created or the bundle comes
+        out empty."""
+        bundle_dir = os.path.join(self.app.state.settings.state_dir, "ssl")
         try:
             os.makedirs(bundle_dir, exist_ok=True)
         except OSError as exc:
@@ -214,6 +220,26 @@ class SSLTrust:
                 bundle_path,
             )
             return None
+        return bundle_path
+
+    def apply_backend_ssl_trust(self) -> str | None:
+        """Make the backend process trust the deployer's custom CAs.
+
+        Builds a merged bundle (system + custom) under ``<data_dir>/ssl`` and sets
+        :data:`SSL_TRUST_VARS` in :data:`os.environ`, so the backend's outbound TLS
+        (OIDC discovery, SMTP relay, LLM-proxy upstream) honors the private CAs.
+        Idempotent and safe to call at startup; a no-op when no cert dir is
+        configured.  Refuses to apply trust when the system bundle can't be found
+        *and* no cert was written (would risk losing public-internet trust).
+
+        Returns the bundle path, or ``None`` if trust was not applied.
+        """
+        ssl_dir = self.ssl_cert_dir()
+        if not ssl_dir:
+            return None
+        bundle_path = self._build_bundle(ssl_dir)
+        if bundle_path is None:
+            return None
         if not system_ca_bundle(self_bundle=bundle_path):
             logger.warning(
                 "Applying backend SSL trust without a system bundle: the trust "
@@ -221,8 +247,7 @@ class SSLTrust:
                 "may fail. Provide a system CA bundle, or remove the custom certs "
                 "from <KLANGKD_CUSTOMIZE_DIR>/certs/ to skip backend trust."
             )
-        for name in SSL_TRUST_VARS:
-            os.environ[name] = bundle_path
+        _apply_trust_vars(bundle_path)
         logger.info(
             "Backend SSL trust applied: %s -> %d env var(s) (custom certs from %s)",
             bundle_path,


### PR DESCRIPTION
## Summary

Tranches 4–6 of the #2845 A-ratchet (issue #3032): every rank-B block in the api layer and the auth backend refactored down to rank A (cyclomatic complexity ≤ 5) via pure extract-function refactors — no behavior change.

43 blocks measured on `main` @ `dbd707c5`:

- **T4 — api/workspaces.py (12)**: shared `_check_autostart` / `_check_image` / `_check_mounts` / `_validated_settings` / `_check_nix_optin` / `_normalized_banner` now serve both the create and update validation paths; `_stop_workspace_container` dedupes the delete/restart stop sequence; `_start_or_http_error` maps the start-service errors to 503/503/400 for both the start and restart routes; `_notify_workspace_audience` dedupes the member-fanout loops; `_exportable_workspace` / `_estimate_home_size`, `_imported_settings` / `_create_from_archive`, and `_remove_from_all_roles` / `_add_to_role` extract the export/import and role-change stages.
- **T5 — api rest (16)**: `api/auth.py` gets `_rate_limited` (shared resend/reset cooldown), `_authorize_resend`, `_oidc_logout_url`, `_is_local_url`, and claim/verifier/hook validation helpers; `api/admin.py` gets `_auth_view_entry`, `_require_user`, per-field update helpers, and `_workspace_names`/`_actor_emails`; `api/resources.py` gets upload filename/read-loop, volume-label, quota-checked-create, and managed-volume helpers; `api/llm_proxy.py` splits the completion dispatch into the passthrough/litellm/JSON response builders.
- **T6 — auth backend (15)**: `auth.py` extracts the class-count helper, the unmet-requirement phrase, the concurrent-logon IP set, session revocation, the time-equalized `verify_login_password` (now shared with the resend-verification endpoint), the refresh blocklist/swap/expired paths, and `_authenticated_user`/`_optional_user` for the FastAPI dependencies; `oidc.py` extracts CA-cert resolution and hook module/callable loading; `fips.py` splits the digest verdict and md5 probe; `ssl_trust.py` extracts the bundle-append and trust-var application.

## Verification

- `xenon --max-absolute A --max-modules F --max-average F` passes on all 9 touched files.
- Repo-wide xenon B gate (`pre-commit run xenon --all-files`) passes.
- Full suite CI-style (`-n auto` + coverage): **6575 passed, 100% branch coverage**.

Closes #3032. Part of #2845 (ticks the T4, T5, and T6 boxes).
