### PR TITLE
refactor(core): bring core services, terminal, consent, podman under rank A (T7-T12)

### DIFF
--- a/src/klangk/klangk/acl.py
+++ b/src/klangk/klangk/acl.py
@@ -16,18 +16,25 @@ from .model import (
 )
 
 
+def _matches_system_principal(ace: dict, principals: dict) -> bool:
+    """A system ACE matches Everyone always, Authenticated when the
+    caller is signed in."""
+    sp = ace["system_principal"]
+    if sp == SYSTEM_EVERYONE:
+        return True
+    if sp == SYSTEM_AUTHENTICATED:
+        return principals["authenticated"]
+    return False
+
+
 def ace_matches_principals(ace: dict, principals: dict) -> bool:
     """Check whether a single ACE matches the given principals."""
     pt = ace["principal_type"]
     if pt == PRINCIPAL_SYSTEM:
-        sp = ace["system_principal"]
-        if sp == SYSTEM_EVERYONE:
-            return True
-        if sp == SYSTEM_AUTHENTICATED:
-            return principals["authenticated"]
-    elif pt == PRINCIPAL_USER:
+        return _matches_system_principal(ace, principals)
+    if pt == PRINCIPAL_USER:
         return ace["user_id"] == principals["user_id"]
-    elif pt == PRINCIPAL_GROUP:
+    if pt == PRINCIPAL_GROUP:
         return ace["group_id"] in principals["group_ids"]
     return False
 
@@ -47,6 +54,15 @@ def resource_ancestors(resource_path: str) -> list[str]:
         parent = path.rsplit("/", 1)[0]
         path = parent if parent else "/"
     return paths
+
+
+def _ace_decision(ace: dict, permission: str) -> bool | None:
+    """The ACE's decision for *permission*: True/False when it applies
+    (wildcard or exact permission match), ``None`` when it doesn't
+    apply and the walk continues."""
+    if ace["permission"] != "*" and ace["permission"] != permission:
+        return None
+    return ace["action"] == ACTION_ALLOW
 
 
 def check_permission_inmemory(
@@ -69,9 +85,29 @@ def check_permission_inmemory(
     for path in resource_ancestors(resource_path):
         for ace in entries_by_resource.get(path, ()):
             if ace_matches_principals(ace, principals):
-                if ace["permission"] == "*" or ace["permission"] == permission:
-                    return ace["action"] == ACTION_ALLOW
+                decision = _ace_decision(ace, permission)
+                if decision is not None:
+                    return decision
     return False
+
+
+def _logical_path(request: Request) -> str:
+    """The request URL path with the versioned API prefix stripped."""
+    path = request.url.path
+    if path.startswith(API_PREFIX + "/"):
+        return path[len(API_PREFIX) :]
+    return path
+
+
+def _granted_permissions(
+    res: str, principals: dict, permissions: list[str], entries: dict
+) -> list[str]:
+    """The subset of *permissions* effectively granted on *res*."""
+    return [
+        p
+        for p in permissions
+        if check_permission_inmemory(res, principals, p, entries)
+    ]
 
 
 def request_to_resource(request: Request) -> str:
@@ -92,10 +128,7 @@ def request_to_resource(request: Request) -> str:
       /acl/...             -> /acl
     """
     # Strip the versioned API prefix to get the logical resource path.
-    path = request.url.path
-    if path.startswith(API_PREFIX + "/"):
-        path = path[len(API_PREFIX) :]
-    parts = path.strip("/").split("/")
+    parts = _logical_path(request).strip("/").split("/")
     if not parts or parts[0] == "":
         return "/"
 
@@ -253,11 +286,7 @@ class ACL:
         )
         result: dict[str, list[str]] = {}
         for res in resources:
-            perms = [
-                p
-                for p in permissions
-                if check_permission_inmemory(res, principals, p, entries)
-            ]
+            perms = _granted_permissions(res, principals, permissions, entries)
             if perms:
                 result[res] = perms
         return result

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -74,6 +74,34 @@ def _is_loopback(addr: str) -> bool:
     return any(ip in net for net in _LOOPBACK_NETS)
 
 
+def _split_sources(raw: str) -> list[str]:
+    """The stripped, non-empty entries of a comma-separated setting."""
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def _non_loopback(entries: list[str]) -> list[str]:
+    """The non-loopback subset (loopback keeps full browser UI/API access)."""
+    return [s for s in entries if not _is_loopback(s)]
+
+
+def _warned_non_loopback(entries: list[str]) -> list[str]:
+    """The non-loopback subset, warning when it is empty (the catch-all
+    location then denies nothing — deny-by-default inactive)."""
+    deny_entries = _non_loopback(entries)
+    if not deny_entries:
+        logger.warning(
+            "container source set has no non-loopback entries — "
+            "catch-all location / denies nothing (deny-by-default inactive)"
+        )
+    return deny_entries
+
+
+def _explicit_source_entries(raw: str) -> tuple[list[str], list[str]]:
+    """(acl, deny) from the explicit KLANGKD_CONTAINER_SUBNETS setting."""
+    entries = _split_sources(raw)
+    return entries, _warned_non_loopback(entries)
+
+
 def detect_host_ipv4s() -> list[str]:
     """Auto-detect this host's IPv4 addresses (the pasta-NAT container source set).
 
@@ -147,11 +175,7 @@ def classify_caddy_line(line: str) -> tuple[int, str]:
     if caddy_logger:
         msg = f"[{caddy_logger}] {msg}"
 
-    if (
-        caddy_level == "error"
-        or caddy_level == "fatal"
-        or caddy_level == "panic"
-    ):
+    if caddy_level in ("error", "fatal", "panic"):
         return logging.ERROR, msg
 
     return logging.DEBUG, msg
@@ -278,19 +302,10 @@ class CaddyRenderer:
         """
         explicit = self.app.state.settings.container_subnets
         if explicit:
-            entries = [
-                s.strip() for s in str(explicit).split(",") if s.strip()
-            ]
-            deny_entries = [s for s in entries if not _is_loopback(s)]
-            if not deny_entries:
-                logger.warning(
-                    "container source set has no non-loopback entries — "
-                    "catch-all location / denies nothing (deny-by-default inactive)"
-                )
-            return entries, deny_entries
+            return _explicit_source_entries(str(explicit))
         addrs = detect_host_ipv4s()
         if addrs:
-            return addrs, [a for a in addrs if not _is_loopback(a)]
+            return addrs, _non_loopback(addrs)
         logger.warning(
             "container subnet detection failed, using fallback RFC1918 ranges"
         )
@@ -915,6 +930,14 @@ class CaddyWatchdog:
                 await asyncio.sleep(0.2)
         return False
 
+    def _relay_line(self, line: str) -> None:  # pragma: no cover  – e2e
+        """Log one Caddy stderr line; a bind failure marks the supervision
+        loop fatal."""
+        level, msg = classify_caddy_line(line)
+        logger.log(level, "caddy: %s", msg)
+        if level >= logging.ERROR and is_bind_error(line):
+            self._bind_fatal = True
+
     async def _relay_stderr(
         self,
         stream: asyncio.StreamReader,
@@ -934,12 +957,8 @@ class CaddyWatchdog:
             if not raw:
                 break
             line = raw.decode("utf-8", errors="replace").rstrip()
-            if not line:
-                continue
-            level, msg = classify_caddy_line(line)
-            logger.log(level, "caddy: %s", msg)
-            if level >= logging.ERROR and is_bind_error(line):
-                self._bind_fatal = True
+            if line:
+                self._relay_line(line)
 
     def _log_listeners(self) -> None:
         """Log which addresses Caddy is serving after a successful config load."""
@@ -1038,6 +1057,16 @@ class CaddyWatchdog:
         self._proc = None
         return rc
 
+    def _terminate_live(self) -> None:  # pragma: no cover – e2e
+        """SIGTERM Caddy when it is still up (no-op otherwise), so the
+        backoff loop retries."""
+        proc = self._proc
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+
     async def _load_or_kill(self) -> None:  # pragma: no cover – e2e
         """Push the real config over the admin API once the admin UDS is up;
         when that fails (or the UDS never came up), kill Caddy so the backoff
@@ -1060,11 +1089,8 @@ class CaddyWatchdog:
             logger.error(
                 "caddy admin UDS never came up at %s", self.admin_socket
             )
-        if not load_ok and self._proc and self._proc.returncode is None:
-            try:
-                self._proc.terminate()
-            except ProcessLookupError:
-                pass
+        if not load_ok:
+            self._terminate_live()
 
     async def start(self) -> None:
         """Bootstrap Caddy (admin on a UDS, no config) and start the watchdog.
@@ -1085,27 +1111,31 @@ class CaddyWatchdog:
         self._stopping = False
         self._task = asyncio.create_task(self._watch(bin_path))
 
-    async def stop(self) -> None:
-        """Stop Caddy and cancel the watchdog (cooperative: waits for exit).
-
-        Kills the entire process group so no orphaned Caddy lingers after
-        shutdown (#1533).
-        """
-        self._stopping = True
-        proc = self._proc
-        if proc is not None and proc.returncode is None:
-            try:
-                os.killpg(proc.pid, signal.SIGTERM)
-            except (ProcessLookupError, PermissionError):
+    def _signal_group(self, proc, sig: int) -> None:
+        """Signal Caddy's whole process group, falling back to the process
+        alone when the group is gone or not ours."""
+        try:
+            os.killpg(proc.pid, sig)
+        except (ProcessLookupError, PermissionError):
+            if sig == signal.SIGTERM:
                 proc.terminate()
-            try:
-                await asyncio.wait_for(proc.wait(), timeout=5)
-            except asyncio.TimeoutError:
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except (ProcessLookupError, PermissionError):
-                    proc.kill()
-        self._proc = None
+            else:
+                proc.kill()
+
+    async def _stop_proxy_proc(self) -> None:
+        """Terminate Caddy's whole process group — TERM, 5s wait, KILL — so
+        no orphaned Caddy lingers after shutdown (#1533)."""
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            return
+        self._signal_group(proc, signal.SIGTERM)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except asyncio.TimeoutError:
+            self._signal_group(proc, signal.SIGKILL)
+
+    async def _cancel_watch_task(self) -> None:
+        """Cancel (and await) the watchdog task."""
         task = self._task
         if task is not None:
             task.cancel()
@@ -1114,3 +1144,14 @@ class CaddyWatchdog:
             except asyncio.CancelledError:
                 pass
         self._task = None
+
+    async def stop(self) -> None:
+        """Stop Caddy and cancel the watchdog (cooperative: waits for exit).
+
+        Kills the entire process group so no orphaned Caddy lingers after
+        shutdown (#1533).
+        """
+        self._stopping = True
+        await self._stop_proxy_proc()
+        self._proc = None
+        await self._cancel_watch_task()

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -98,6 +98,76 @@ def _build_verdict(
     return verdict, "denied", None, forever_deny
 
 
+def _completed_verdict(verdict: dict) -> asyncio.Future:
+    """A Future already resolved to *verdict* (a no-hold immediate
+    answer)."""
+    fut = asyncio.get_running_loop().create_future()
+    fut.set_result(verdict)
+    return fut
+
+
+def _hold_in_scope(hold: dict, decider_workspace: str | None) -> bool:
+    """True when a held request is decidable by this caller: a
+    workspace-scoped decider may only decide its own workspace's holds."""
+    if decider_workspace is None:
+        return True
+    return hold["workspace_id"] == decider_workspace
+
+
+def _forever_allow_entry(row: dict) -> str | None:
+    """The ``host:port`` allowed_domains entry for a forever allow, or
+    ``None`` when it must not be persisted: a missing host/workspace, or a
+    port-less dest (e.g. an ICMP ping, dest_port 0) -- a port-less bare host
+    would durably broaden one connection's consent to every port on that
+    host (the sidecar treats a port-less spec as all-ports on the apex,
+    since bare is now exact). The deciding connection still got its
+    in-memory ACCEPT for this session; durability is simply withheld
+    (#2368)."""
+    host = row.get("dest_host")
+    port = row.get("dest_port")
+    workspace_id = row.get("workspace_id")
+    if not host or not workspace_id:
+        return None
+    if not port:
+        logger.info(
+            "consent: forever allow of port-less dest %s ws=%s not "
+            "persisted (a bare host would broaden to all-ports); "
+            "session still works",
+            host,
+            str(workspace_id)[:8],
+        )
+        return None
+    return f"{host}:{port}"
+
+
+def _forever_deny_entry(row: dict) -> str | None:
+    """The rejected_domains entry for a forever deny, or ``None`` when it
+    must not be persisted. Unlike the allow side, a port-less deny IS
+    persisted (as a bare host): the sidecar's reject enforcement is
+    name-level (:func:`rejected_for` ignores port -- a rejected name is
+    NXDOMAIN'd before resolution), so the whole host is the natural unit,
+    and "block more" is the safe direction."""
+    host = row.get("dest_host")
+    port = row.get("dest_port")
+    workspace_id = row.get("workspace_id")
+    if not host or not workspace_id:
+        return None
+    return f"{host}:{port}" if port else host
+
+
+def _by_decision(rows: list[dict], decision: str) -> list[dict]:
+    """The in-effect rows carrying one decision."""
+    return [r for r in rows if r["decision"] == decision]
+
+
+def _pause_frame(until: float | None) -> dict | None:
+    """The live pause window (#2332), read fresh so a self-expired pause
+    shows as cleared."""
+    if until is not None and until > time.time():
+        return {"paused": True, "until": until}
+    return None
+
+
 class ConsentCoordinator:
     """In-process holds for egress requests awaiting a verdict (#2311).
 
@@ -141,6 +211,75 @@ class ConsentCoordinator:
                 hold["task"].cancel()
             await self._fail_close(request_id, reason="shutdown")
 
+    async def _allow_mode_verdict(
+        self, workspace_id: str, dst: str, dport: int | None
+    ) -> asyncio.Future:
+        """The default-permit shortcut verdict (#2406).
+
+        egress_mode == allow is default-permit: record the off-list
+        destination (logging -- mirrors how static records a denial via
+        record_static_denial) and allow at once -- no hold, no prompt.
+        Behaves as if an internal always-allow decider were registered, but
+        is a short-circuit branch. rejected_domains is enforced earlier at
+        the sidecar DNS layer (rejected_for -> NXDOMAIN), so a host reaching
+        this gate is already not rejected. duration=tilrestart
+        (DURATION_DEFAULT) so the sidecar learns the IP all-ports for its
+        lifetime (no per-connection re-prompt); nothing persists to
+        allowed_domains (this branch bypasses resolve())."""
+        await self.app.state.model.egress_consent.record_static_allow(
+            workspace_id, dst, dport
+        )
+        return _completed_verdict(
+            {
+                "decision": VERDICT_ALLOW,
+                "reason": "allow_mode",
+                "duration": DURATION_DEFAULT,
+            }
+        )
+
+    async def _static_denial_verdict(
+        self, workspace_id: str, dst: str, dport: int | None
+    ) -> asyncio.Future:
+        """The non-interactive verdict: record the static denial and deny
+        at once (no pending row, no hold, no timeout) -- the sidecar denies
+        immediately."""
+        await self.app.state.model.egress_consent.record_static_denial(
+            workspace_id, dst, dport
+        )
+        return _completed_verdict(
+            {"decision": VERDICT_DENY, "reason": "static"}
+        )
+
+    async def _paused_gate_verdict(
+        self, workspace_id: str, dst: str, dport: int | None
+    ) -> asyncio.Future:
+        """The #2332 paused-prompting verdict: a destination with an
+        in-effect recorded DENY is still blocked (the pause does not
+        override existing verdicts); everything else is auto-allowed (no
+        hold, no prompt, no row -- the sidecar learns/accepts the SYN like
+        a static allow). Allow-list rules are enforced earlier at the
+        sidecar DNS layer, so a host reaching this gate is already not
+        allow-listed."""
+        verdict = await self._paused_verdict(workspace_id, dst, dport)
+        return _completed_verdict(verdict)
+
+    async def _interactive_hold(
+        self, workspace_id: str, dst: str, dport: int | None
+    ) -> asyncio.Future:
+        """The interactive path: a deny Future for a rate-limited or
+        duplicate request, else the registered hold's verdict Future."""
+        consent = self.app.state.model.egress_consent
+        if await consent.count_pending(workspace_id) >= self.rate_limit:
+            return _completed_verdict(
+                {"decision": VERDICT_DENY, "reason": "rate_limited"}
+            )
+        request = await consent.create_request(workspace_id, dst, dport)
+        if request is None:
+            return _completed_verdict(
+                {"decision": VERDICT_DENY, "reason": "duplicate"}
+            )
+        return self._register_hold(request)
+
     async def hold(
         self, workspace_id: str, dst: str, dport: int | None
     ) -> asyncio.Future:
@@ -156,76 +295,27 @@ class ConsentCoordinator:
         - otherwise -> create the pending request, register the hold, arm its
           timeout, and fan out to the workspace's deciders (#2244 stub).
         """
-        loop = asyncio.get_running_loop()
         try:
             if await self._is_allow(workspace_id):
-                # #2406: egress_mode == allow is default-permit. Record the
-                # off-list destination (logging -- mirrors how static records
-                # a denial via record_static_denial) and allow at once -- no
-                # hold, no prompt. Behaves as if an internal always-allow
-                # decider were registered, but is a short-circuit branch (no
-                # decider object, no consent round-trip beyond the verdict).
-                # rejected_domains is enforced earlier at the sidecar DNS layer
-                # (rejected_for -> NXDOMAIN), so a host reaching this gate is
-                # already not rejected. duration=tilrestart (DURATION_DEFAULT)
-                # so the sidecar learns the IP all-ports for its lifetime (no
-                # per-connection re-prompt); nothing persists to
-                # allowed_domains (this branch bypasses resolve()).
-                await self.app.state.model.egress_consent.record_static_allow(
-                    workspace_id, dst, dport
-                )
-                fut = loop.create_future()
-                fut.set_result(
-                    {
-                        "decision": VERDICT_ALLOW,
-                        "reason": "allow_mode",
-                        "duration": DURATION_DEFAULT,
-                    }
-                )
-                return fut
+                return await self._allow_mode_verdict(workspace_id, dst, dport)
             if await self._is_paused(workspace_id):
-                # #2332: prompting is paused workspace-wide. A destination
-                # with an in-effect recorded DENY is still blocked (the pause
-                # does not override existing verdicts); everything else is
-                # auto-allowed (no hold, no prompt, no row -- the sidecar
-                # learns/accepts the SYN like a static allow). Allow-list
-                # rules are enforced earlier at the sidecar DNS layer, so a
-                # host reaching this gate is already not allow-listed.
-                verdict = await self._paused_verdict(workspace_id, dst, dport)
-                fut = loop.create_future()
-                fut.set_result(verdict)
-                return fut
-            if not await self.is_interactive(workspace_id):
-                await self.app.state.model.egress_consent.record_static_denial(
+                return await self._paused_gate_verdict(
                     workspace_id, dst, dport
                 )
-                fut: asyncio.Future = loop.create_future()
-                fut.set_result({"decision": VERDICT_DENY, "reason": "static"})
-                return fut
-            consent = self.app.state.model.egress_consent
-            if await consent.count_pending(workspace_id) >= self.rate_limit:
-                fut = loop.create_future()
-                fut.set_result(
-                    {"decision": VERDICT_DENY, "reason": "rate_limited"}
+            if not await self.is_interactive(workspace_id):
+                return await self._static_denial_verdict(
+                    workspace_id, dst, dport
                 )
-                return fut
-            request = await consent.create_request(workspace_id, dst, dport)
-            if request is None:
-                fut = loop.create_future()
-                fut.set_result(
-                    {"decision": VERDICT_DENY, "reason": "duplicate"}
-                )
-                return fut
-            return self._register_hold(request)
+            return await self._interactive_hold(workspace_id, dst, dport)
         except Exception:
             # A model/DB failure must not crash the relay or strand the hold:
             # fail-close to a deny verdict so the sidecar NXDOMAIN/DROPs. The
             # kernel keeps the connection blocked either way (fail-closed), but
             # this gives the sidecar a definitive deny instead of silence.
             logger.exception("consent: hold failed; fail-closing to deny")
-            fut = loop.create_future()
-            fut.set_result({"decision": VERDICT_DENY, "reason": "error"})
-            return fut
+            return _completed_verdict(
+                {"decision": VERDICT_DENY, "reason": "error"}
+            )
 
     async def pause(self, workspace_id: str, duration: str) -> dict:
         """Pause interactive consent prompting workspace-wide for ``duration`` (#2332).
@@ -317,6 +407,30 @@ class ConsentCoordinator:
         self._fanout(request)
         return fut
 
+    async def _finish_resolve(
+        self,
+        request_id: str,
+        hold: dict,
+        verdict: dict,
+        resolved: str,
+        allow_row: dict | None,
+        deny_row: dict | None,
+    ) -> None:
+        """Resolve the hold's Future, broadcast to co-deciders, persist
+        any ``forever`` rules, and refresh the rules view when a verdict
+        landed."""
+        if not hold["future"].done():
+            hold["future"].set_result(verdict)
+        self._broadcast_resolved(request_id, hold["workspace_id"], resolved)
+        if allow_row is not None:
+            await self._persist_forever_allow(allow_row)
+        if deny_row is not None:
+            await self._persist_forever_deny(deny_row)
+        if resolved in ("allowed", "denied"):
+            # A new verdict entered the in-effect set: refresh the deciders'
+            # rule-management view (#2335 slice A) without a reconnect.
+            await self._broadcast_rules(hold["workspace_id"])
+
     async def resolve(
         self,
         request_id: str,
@@ -339,10 +453,7 @@ class ConsentCoordinator:
         hold = self._holds.get(request_id)
         if hold is None:
             return None
-        if (
-            decider_workspace is not None
-            and hold["workspace_id"] != decider_workspace
-        ):
+        if not _hold_in_scope(hold, decider_workspace):
             # Restore nothing (we only peeked); the hold stays for a decider
             # actually scoped to it.
             return None
@@ -370,17 +481,14 @@ class ConsentCoordinator:
                 forever_allow_row,
                 forever_deny_row,
             ) = _build_verdict(row, decision, duration)
-        if not hold["future"].done():
-            hold["future"].set_result(verdict)
-        self._broadcast_resolved(request_id, hold["workspace_id"], resolved)
-        if forever_allow_row is not None:
-            await self._persist_forever_allow(forever_allow_row)
-        if forever_deny_row is not None:
-            await self._persist_forever_deny(forever_deny_row)
-        if resolved in ("allowed", "denied"):
-            # A new verdict entered the in-effect set: refresh the deciders'
-            # rule-management view (#2335 slice A) without a reconnect.
-            await self._broadcast_rules(hold["workspace_id"])
+        await self._finish_resolve(
+            request_id,
+            hold,
+            verdict,
+            resolved,
+            forever_allow_row,
+            forever_deny_row,
+        )
         return verdict
 
     async def _persist_forever_allow(self, row: dict) -> None:
@@ -407,27 +515,10 @@ class ConsentCoordinator:
         A ``forever`` allow now lives in BOTH ``allowed_domains`` and an
         ``egress_consent`` audit row; revoking it must remove both (#2370).
         """
-        host = row.get("dest_host")
-        port = row.get("dest_port")
+        entry = _forever_allow_entry(row)
+        if entry is None:
+            return
         workspace_id = row.get("workspace_id")
-        if not host or not workspace_id:
-            return
-        if not port:
-            # Port-scoped only (#2368): a port-less verdict (e.g. an ICMP
-            # ping, dest_port 0) must not be persisted as a bare host -- the
-            # sidecar treats a port-less spec as all-ports on the apex (bare is
-            # exact), durably broadening one connection's consent to every port
-            # on that host. The deciding connection still gets its in-memory
-            # ACCEPT for this session; durability is simply withheld.
-            logger.info(
-                "consent: forever allow of port-less dest %s ws=%s not "
-                "persisted (a bare host would broaden to all-ports); "
-                "session still works",
-                host,
-                str(workspace_id)[:8],
-            )
-            return
-        entry = f"{host}:{port}"
         try:
             added = await self.app.state.model.workspaces.add_allowed_domain(
                 workspace_id, entry
@@ -475,12 +566,10 @@ class ConsentCoordinator:
         deny also lives in an ``egress_consent`` audit row; revoking it must
         remove both (#2370).
         """
-        host = row.get("dest_host")
-        port = row.get("dest_port")
-        workspace_id = row.get("workspace_id")
-        if not host or not workspace_id:
+        entry = _forever_deny_entry(row)
+        if entry is None:
             return
-        entry = f"{host}:{port}" if port else host
+        workspace_id = row.get("workspace_id")
         try:
             added = await self.app.state.model.workspaces.add_rejected_domain(
                 workspace_id, entry
@@ -506,35 +595,23 @@ class ConsentCoordinator:
                 str(workspace_id)[:8],
             )
 
-    async def _retract_forever_entry(self, row: dict, decision: str) -> None:
-        """Retract the durable list entry a ``forever`` verdict added (#2370).
-
-        The inverse of :meth:`_persist_forever_allow` /
-        :meth:`_persist_forever_deny`: removes the consented host from
-        ``allowed_domains`` (allow) or ``rejected_domains`` (deny) so the
-        verdict does not re-apply on the next sidecar restart. The deciding
-        connection's in-memory ACCEPT/REJECT + ``_SESSION_HOST_ALLOWS``/
-        ``_VERDICT_CACHE`` were already cleared by the drop the caller sent.
-
-        Best-effort (failures logged + swallowed): the row is already revoked,
-        so a persistence failure only risks the entry re-applying on restart,
-        not a broken revoke. A port-less allow was never persisted
-        (:meth:`_persist_forever_allow` skips it), so there is nothing to
-        retract; a port-less deny was persisted as a bare host, so retract that.
-        """
+    def _retract_spec(self, row: dict, decision: str):
+        """``(remove callable, entry)`` for the durable-list retract, or
+        ``None`` when there is nothing to retract."""
         host = row.get("dest_host")
         port = row.get("dest_port")
-        workspace_id = row.get("workspace_id")
-        if not host or not workspace_id:
-            return
         if decision == DECISION_ALLOWED:
             if not port:
-                return  # port-less allow was never persisted
-            entry = f"{host}:{port}"
+                return None  # port-less allow was never persisted
             remove = self.app.state.model.workspaces.remove_allowed_domain
-        else:
-            entry = f"{host}:{port}" if port else host
-            remove = self.app.state.model.workspaces.remove_rejected_domain
+            return remove, f"{host}:{port}"
+        remove = self.app.state.model.workspaces.remove_rejected_domain
+        return remove, (f"{host}:{port}" if port else host)
+
+    async def _remove_list_entry(
+        self, remove, workspace_id: str, entry: str, decision: str
+    ) -> None:
+        """Best-effort removal of a durable list entry with its logs."""
         try:
             retracted = await remove(workspace_id, entry)
         except Exception:
@@ -552,6 +629,68 @@ class ConsentCoordinator:
                 entry,
                 str(workspace_id)[:8],
             )
+
+    async def _retract_forever_entry(self, row: dict, decision: str) -> None:
+        """Retract the durable list entry a ``forever`` verdict added (#2370).
+
+        The inverse of :meth:`_persist_forever_allow` /
+        :meth:`_persist_forever_deny`: removes the consented host from
+        ``allowed_domains`` (allow) or ``rejected_domains`` (deny) so the
+        verdict does not re-apply on the next sidecar restart. The deciding
+        connection's in-memory ACCEPT/REJECT + ``_SESSION_HOST_ALLOWS``/
+        ``_VERDICT_CACHE`` were already cleared by the drop the caller sent.
+
+        Best-effort (failures logged + swallowed): the row is already revoked,
+        so a persistence failure only risks the entry re-applying on restart,
+        not a broken revoke. A port-less allow was never persisted
+        (:meth:`_persist_forever_allow` skips it), so there is nothing to
+        retract; a port-less deny was persisted as a bare host, so retract that.
+        """
+        host = row.get("dest_host")
+        workspace_id = row.get("workspace_id")
+        if not host or not workspace_id:
+            return
+        spec = self._retract_spec(row, decision)
+        if spec is None:
+            return
+        remove, entry = spec
+        await self._remove_list_entry(remove, workspace_id, entry, decision)
+
+    def _revocable(
+        self, row: dict | None, decider_workspace: str | None
+    ) -> bool:
+        """True when the row is an active verdict inside the decider's
+        scope."""
+        if row is None or row["decision"] not in (
+            DECISION_ALLOWED,
+            DECISION_DENIED,
+        ):
+            return False
+        if (
+            decider_workspace is not None
+            and row["workspace_id"] != decider_workspace
+        ):
+            return False
+        return True
+
+    async def _sidecar_acked_drop(
+        self, workspace_id: str, host: str, decision: str
+    ) -> bool:
+        """True when the sidecar dropped its rule (or none is live).
+
+        No live sidecar -> nothing is enforced (its in-memory rules die with
+        it), so proceed. A live sidecar must ack first: else a
+        connected-but-unresponsive sidecar could keep enforcing after the
+        view says "revoked"."""
+        fut = self.app.state.sidecar_connections.send_drop(
+            workspace_id, host, decision
+        )
+        if fut is None:
+            return True
+        try:
+            return await asyncio.wait_for(fut, REVOKE_ACK_TIMEOUT)
+        except asyncio.TimeoutError:
+            return False
 
     async def revoke(
         self,
@@ -572,14 +711,9 @@ class ConsentCoordinator:
         rule still fires).
         """
         row = await self.app.state.model.egress_consent.get_request(request_id)
-        if row is None or row["decision"] not in (
-            DECISION_ALLOWED,
-            DECISION_DENIED,
-        ):
+        if not self._revocable(row, decider_workspace):
             return False
         workspace_id = row["workspace_id"]
-        if decider_workspace is not None and workspace_id != decider_workspace:
-            return False
         host = row["dest_host"]
         decision = row["decision"]
         # NOTE (#2370): a `forever` verdict also lives in the workspace's
@@ -588,21 +722,9 @@ class ConsentCoordinator:
         # in-memory rules + _SESSION_HOST_ALLOWS/_VERDICT_CACHE; retract the durable
         # entry too (after the row is marked revoked) so the verdict does not
         # re-apply on the next sidecar restart.
-        # Ask the sidecar to drop its rule for this host+decision. No live
-        # sidecar -> nothing is enforced (its in-memory rules die with it), so
-        # proceed to mark revoked. A live sidecar must ack first: else a
-        # connected-but-unresponsive sidecar could keep enforcing after the
-        # view says "revoked".
-        fut = self.app.state.sidecar_connections.send_drop(
-            workspace_id, host, decision
-        )
-        if fut is not None:
-            try:
-                ok = await asyncio.wait_for(fut, REVOKE_ACK_TIMEOUT)
-            except asyncio.TimeoutError:
-                ok = False
-            if not ok:
-                return False
+        # Ask the sidecar to drop its rule for this host+decision.
+        if not await self._sidecar_acked_drop(workspace_id, host, decision):
+            return False
         if (
             await self.app.state.model.egress_consent.revoke(
                 request_id, revoked_by
@@ -732,21 +854,15 @@ class ConsentCoordinator:
         until = await self.app.state.model.workspaces.get_consent_pause(
             workspace_id
         )
-        now = time.time()
-        paused = (
-            {"paused": True, "until": until}
-            if until is not None and until > now
-            else None
-        )
         return {
             "type": "egress_rules",
             "workspace_id": workspace_id,
             "allow_list": ws.get("allowed_domains") or [],
             # #2370: surface the reject list alongside the allow list (#2340).
             "reject_list": ws.get("rejected_domains") or [],
-            "allowed": [r for r in rows if r["decision"] == DECISION_ALLOWED],
-            "denied": [r for r in rows if r["decision"] == DECISION_DENIED],
-            "paused": paused,
+            "allowed": _by_decision(rows, DECISION_ALLOWED),
+            "denied": _by_decision(rows, DECISION_DENIED),
+            "paused": _pause_frame(until),
         }
 
     @staticmethod

--- a/src/klangk/klangk/consent/deciders.py
+++ b/src/klangk/klangk/consent/deciders.py
@@ -37,6 +37,13 @@ from ..wshandler.safe_websocket import WS_ERRORS
 logger = logging.getLogger(__name__)
 
 
+def _entry_matches(
+    entry: dict, workspace_id: str, now: float, cutoff: float
+) -> bool:
+    """True when a decider entry serves *workspace_id* and is live."""
+    return entry["ws"] == workspace_id and now - entry["seen"] <= cutoff
+
+
 class ConsentDeciderRegistry:
     """Tracks live consent deciders; the gate for interactive egress (#2308).
 
@@ -129,7 +136,7 @@ class ConsentDeciderRegistry:
         dead: list[str] = []
         delivered = 0
         for did, entry in self._deciders.items():
-            if entry["ws"] != workspace_id or now - entry["seen"] > cutoff:
+            if not _entry_matches(entry, workspace_id, now, cutoff):
                 continue
             try:
                 entry["sock"].send_json(message)

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -255,6 +255,23 @@ def parse_tmux_version(out: str) -> tuple[int, int] | None:
     return (int(m.group(1)), int(m.group(2)))
 
 
+def _tmux_warning(message: str, manager: str | None) -> CheckResult:
+    """A consent-popup warning result carrying the tmux install hint."""
+    return CheckResult(
+        name="tmux (consent popup)",
+        ok=False,
+        is_warning=True,
+        message=message,
+        hint=install_hint("tmux", manager),
+    )
+
+
+def _tmux_probe_text(out: str) -> str:
+    """The raw ``tmux -V`` text for a warning message (or a note that
+    the probe itself failed)."""
+    return out.strip()[:40] or "tmux -V failed"
+
+
 def check_tmux_version(manager: str | None) -> CheckResult:
     """Check host tmux is new enough for the consent-popup shell layer (#2383).
 
@@ -271,28 +288,18 @@ def check_tmux_version(manager: str | None) -> CheckResult:
         )
     rc, out, _err = run(["tmux", "-V"])
     ver = parse_tmux_version(out) if rc == 0 else None
-    label = ".".join(map(str, ver)) if ver is not None else "unknown"
     if ver is None:
-        return CheckResult(
-            name="tmux (consent popup)",
-            ok=False,
-            is_warning=True,
-            message=(
-                f"tmux version unparseable ({out.strip()[:40] or 'tmux -V failed'});"
-                " consent popup needs >= 3.2"
-            ),
-            hint=install_hint("tmux", manager),
+        return _tmux_warning(
+            f"tmux version unparseable ({_tmux_probe_text(out)});"
+            " consent popup needs >= 3.2",
+            manager,
         )
+    label = ".".join(map(str, ver))
     if ver < TMUX_MIN_VERSION:
-        return CheckResult(
-            name="tmux (consent popup)",
-            ok=False,
-            is_warning=True,
-            message=(
-                f"tmux {label} < 3.2 — consent popup unavailable"
-                " (plain shell attach used)"
-            ),
-            hint=install_hint("tmux", manager),
+        return _tmux_warning(
+            f"tmux {label} < 3.2 — consent popup unavailable"
+            " (plain shell attach used)",
+            manager,
         )
     return CheckResult(
         name="tmux (consent popup)",
@@ -386,6 +393,35 @@ def check_gnu_stat(manager: str | None) -> CheckResult:
     )
 
 
+def _user_range_present(content: str, user: str) -> bool:
+    """True when a subuid/subgid file carries a range line for *user*."""
+    return any(line.startswith(f"{user}:") for line in content.splitlines())
+
+
+def _missing_subuid_result(
+    user: str, path_name: str, label: str | None
+) -> CheckResult:
+    """A failed subuid/subgid result with the usermod fix hint.
+
+    A ``None`` label means the file itself is missing, not just the
+    user's range.
+    """
+    message = (
+        f"{path_name} does not exist"
+        if label is None
+        else f"no {label} range for user '{user}' in {path_name}"
+    )
+    return CheckResult(
+        name="subuid/subgid",
+        ok=False,
+        message=message,
+        hint=(
+            f"sudo usermod --add-subuids 100000-165535 "
+            f"--add-subgids 100000-165535 {user}"
+        ),
+    )
+
+
 def check_subuid(user: str) -> CheckResult:
     """Check /etc/subuid has a range for the given user."""
     if platform.system() == "Darwin":
@@ -400,28 +436,9 @@ def check_subuid(user: str) -> CheckResult:
     ]:
         p = Path(path_name)
         if not p.exists():
-            return CheckResult(
-                name="subuid/subgid",
-                ok=False,
-                message=f"{path_name} does not exist",
-                hint=(
-                    f"sudo usermod --add-subuids 100000-165535 "
-                    f"--add-subgids 100000-165535 {user}"
-                ),
-            )
-        content = p.read_text()
-        if not any(
-            line.startswith(f"{user}:") for line in content.splitlines()
-        ):
-            return CheckResult(
-                name="subuid/subgid",
-                ok=False,
-                message=f"no {label} range for user '{user}' in {path_name}",
-                hint=(
-                    f"sudo usermod --add-subuids 100000-165535 "
-                    f"--add-subgids 100000-165535 {user}"
-                ),
-            )
+            return _missing_subuid_result(user, path_name, None)
+        if not _user_range_present(p.read_text(), user):
+            return _missing_subuid_result(user, path_name, label)
     return CheckResult(
         name="subuid/subgid",
         ok=True,
@@ -541,6 +558,39 @@ _REQUIRED_BINARIES: list[tuple[str, list[str]]] = [
 ]
 
 
+def _check_ip_command(report: DoctorReport, manager: str | None) -> None:
+    """Optional ``ip`` check for container subnet auto-detection (#2089);
+    a missing binary downgrades to a warning with the fallback note."""
+    ip_result = check_binary("ip", ["ip", "-V"], manager)
+    if not ip_result.ok:
+        ip_result.is_warning = True
+        ip_result.message = (
+            "ip not found — container subnet auto-detection will fall "
+            "back to broad RFC1918 ranges (172.16/12 + 10/8). Install "
+            "the iproute/iproute2 package for your distro for precise "
+            "detection, or set KLANGKD_CONTAINER_SUBNETS explicitly."
+        )
+    report.add(ip_result)
+
+
+def _check_linux_prereqs(
+    report: DoctorReport, user: str, manager: str | None
+) -> None:
+    """Linux-only rootless prereqs: newuidmap (warning-grade when
+    missing) and the subuid/subgid ranges.
+
+    fuse-overlayfs and slirp4netns are no longer checked — modern podman
+    (4.x+) uses native kernel overlayfs and pasta respectively; the
+    end-to-end rootless check below validates that storage and
+    networking actually work (#1950).
+    """
+    result = check_binary("newuidmap", [], manager)
+    if not result.ok:
+        result.is_warning = True
+    report.add(result)
+    report.add(check_subuid(user))
+
+
 def run_doctor(*, verbose: bool = False) -> DoctorReport:
     """Run all doctor checks and return the report."""
     report = DoctorReport()
@@ -558,37 +608,16 @@ def run_doctor(*, verbose: bool = False) -> DoctorReport:
     # GNU tar and GNU du (special: must verify GNU, not just present)
     report.add(check_gnu_tar(manager))
     report.add(check_gnu_du(manager))
-    # GNU stat: only the nix btrfs-snapshot backend needs `stat -f -c %T`
-    # (Linux-only); not required on macOS.
     if platform.system() != "Darwin":
+        # GNU stat: only the nix btrfs-snapshot backend needs
+        # `stat -f -c %T` (Linux-only); not required on macOS.
         report.add(check_gnu_stat(manager))
-
-    # 1b. Optional: ip command for container subnet auto-detection (#2089)
-    if platform.system() != "Darwin":
-        ip_result = check_binary("ip", ["ip", "-V"], manager)
-        if not ip_result.ok:
-            ip_result.is_warning = True
-            ip_result.message = (
-                "ip not found — container subnet auto-detection will fall "
-                "back to broad RFC1918 ranges (172.16/12 + 10/8). Install "
-                "the iproute/iproute2 package for your distro for precise "
-                "detection, or set KLANGKD_CONTAINER_SUBNETS explicitly."
-            )
-        report.add(ip_result)
+        # Optional: ip command for container subnet auto-detection (#2089)
+        _check_ip_command(report, manager)
 
     # 2. Rootless podman prereqs
     if platform.system() != "Darwin":
-        # Linux: check newuidmap (suid helper for rootless user
-        # namespaces). fuse-overlayfs and slirp4netns are no longer
-        # checked — modern podman (4.x+) uses native kernel overlayfs
-        # and pasta respectively; the end-to-end rootless check below
-        # validates that storage and networking actually work (#1950).
-        result = check_binary("newuidmap", [], manager)
-        if not result.ok:
-            result.is_warning = True
-        report.add(result)
-
-        report.add(check_subuid(user))
+        _check_linux_prereqs(report, user, manager)
     else:
         report.add(check_podman_machine())
 
@@ -630,39 +659,35 @@ def append_failure_block(
         lines.append("")
 
 
-def format_report(report: DoctorReport) -> str:
-    """Format a doctor report for terminal output."""
-    lines: list[str] = []
-    manager = detect_package_manager()
-
+def _report_header(lines: list[str]) -> None:
+    """The doctor banner with the detected package manager."""
     lines.append("klangkd doctor")
     lines.append("=" * 40)
+    manager = detect_package_manager()
     if manager:
         lines.append(f"Package manager: {manager}")
     else:
         lines.append("Package manager: (none detected)")
     lines.append("")
 
-    for r in report.results:
-        _append_result_line(lines, r)
 
-    lines.append("")
+def _finish_report(lines: list[str], report: DoctorReport) -> str:
+    """Append the summary tally and, when anything failed, repeat each
+    failure with its fix so the user doesn't have to scroll back up
+    through a long check list (#1968)."""
     errors = report.errors
     warnings = report.warnings
-    ok_count = sum(1 for r in report.results if r.ok)
+    ok_count = len(report.results) - len(errors) - len(warnings)
+    if not errors and not warnings:
+        lines.append(f"All {ok_count} checks passed.")
+        return "\n".join(lines)
     if errors:
         lines.append(
             f"{ok_count} passed, {len(errors)} errors,"
             f" {len(warnings)} warnings"
         )
-    elif warnings:
-        lines.append(f"{ok_count} passed, {len(warnings)} warnings")
     else:
-        lines.append(f"All {ok_count} checks passed.")
-        return "\n".join(lines)
-
-    # Repeat each failure with its fix so the user doesn't have to
-    # scroll back up through a long check list (#1968).
+        lines.append(f"{ok_count} passed, {len(warnings)} warnings")
     lines.append("")
     append_failure_block(
         lines, errors, "✗", "Errors (must fix before starting klangkd):"
@@ -670,8 +695,17 @@ def format_report(report: DoctorReport) -> str:
     append_failure_block(
         lines, warnings, "⚠", "Warnings (recommended but not required):"
     )
-
     return "\n".join(lines)
+
+
+def format_report(report: DoctorReport) -> str:
+    """Format a doctor report for terminal output."""
+    lines: list[str] = []
+    _report_header(lines)
+    for r in report.results:
+        _append_result_line(lines, r)
+    lines.append("")
+    return _finish_report(lines, report)
 
 
 def doctor_main(verbose: bool = False) -> int:

--- a/src/klangk/klangk/emailsvc.py
+++ b/src/klangk/klangk/emailsvc.py
@@ -178,6 +178,16 @@ class EmailService:
         """Root customization directory (defaults to ``<state_dir>/custom``)."""
         return self.app.state.settings.customize_dir
 
+    def _user_templates_dir(self) -> str | None:
+        """The deployer templates dir: ``KLANGKD_EMAIL_TEMPLATES_DIR``
+        when set, else ``<customize_dir>/email-templates`` when it
+        exists, else ``None``."""
+        user_dir = self.app.state.settings.email_templates_dir
+        if not user_dir:
+            candidate = Path(self._customize_dir()) / "email-templates"
+            user_dir = str(candidate) if candidate.is_dir() else ""
+        return user_dir or None
+
     def _template_env(self) -> Environment:
         """Build (and cache) the Jinja environment.
 
@@ -189,16 +199,10 @@ class EmailService:
         """
         if self._env is None:
             loaders = []
-            user_dir = self.app.state.settings.email_templates_dir
-            if not user_dir:
-                candidate = Path(self._customize_dir()) / "email-templates"
-                if candidate.is_dir():
-                    user_dir = str(candidate)
-            if user_dir:
-                path = Path(user_dir)
-                if path.is_dir():
-                    logger.info("Email templates loaded from %s", path)
-                    loaders.append(FileSystemLoader(str(path)))
+            user_dir = self._user_templates_dir()
+            if user_dir and Path(user_dir).is_dir():
+                logger.info("Email templates loaded from %s", user_dir)
+                loaders.append(FileSystemLoader(user_dir))
             loaders.append(PackageLoader("klangk", "email_templates"))
             self._env = Environment(
                 loader=ChoiceLoader(loaders),

--- a/src/klangk/klangk/features.py
+++ b/src/klangk/klangk/features.py
@@ -70,6 +70,11 @@ MAX_MANIFEST_BYTES = 1024 * 1024
 _REMOVED_FEATURES = {"chat"}
 
 
+def _feature_names(raw: str) -> set[str]:
+    """The stripped, non-empty names in a comma-separated feature list."""
+    return {part for part in (e.strip() for e in raw.split(",")) if part}
+
+
 def warn_removed_features(raw: str | None) -> None:
     """Log a tailored warning for removed feature names in *raw*.
 
@@ -79,8 +84,7 @@ def warn_removed_features(raw: str | None) -> None:
     """
     if not raw:
         return
-    names = {part for part in (e.strip() for e in raw.split(",")) if part}
-    for name in names & _REMOVED_FEATURES:
+    for name in _feature_names(raw) & _REMOVED_FEATURES:
         logger.warning(
             "feature %r was removed from Klangk; ignoring it in "
             "KLANGKD_FEATURES_ENABLE (remove the entry to silence this "
@@ -309,6 +313,49 @@ class Features:
             )
         return result
 
+    def _frontend_key_ok(self, key) -> bool:
+        """A usable config key: a string carrying the feature-config
+        prefix. Anything else is logged and skipped — the prefix is the
+        feature-config namespace (#1662)."""
+        if isinstance(key, str) and key.startswith(CONTAINER_ENV_KEY_PREFIX):
+            return True
+        logger.warning(
+            "features.json frontend-scope config key %r — "
+            "missing KLANGKWS_FEATURE_ prefix; skipping. Rebuild "
+            "with a corrected feature.",
+            key,
+        )
+        return False
+
+    def _frontend_entry(self, key, spec, features_config):
+        """One ``(json_key, value)`` pair for a frontend-scope config
+        spec, or ``None`` when the spec is skipped."""
+        if not isinstance(spec, dict):
+            return None
+        if spec.get("scope", "container") not in _FRONTEND_SCOPES:
+            return None
+        if not self._frontend_key_ok(key):
+            return None
+        default = spec.get("default", "")
+        # Strip the KLANGKWS_FEATURE_ prefix and lowercase the suffix
+        # for the JSON key (e.g. KLANGKWS_FEATURE_BOING_SPEED →
+        # boing_speed). The prefix is enforced above; the suffix is
+        # the feature-owned name, surfaced un-prefixed to the frontend.
+        json_key = key[len(CONTAINER_ENV_KEY_PREFIX) :].lower()
+        value = resolve_dynamic_config(
+            key, default, features_config=features_config
+        )
+        return json_key, value or ""
+
+    def _add_frontend_entries(
+        self, result: dict[str, str], config: dict, features_config
+    ) -> None:
+        """Add every frontend-scope config entry of one feature block."""
+        for key, spec in config.items():
+            entry = self._frontend_entry(key, spec, features_config)
+            if entry is not None:
+                result[entry[0]] = entry[1]
+
     def frontend_config(self) -> dict[str, str]:
         """Return config entries for the ``GET /api/config`` response.
 
@@ -334,34 +381,7 @@ class Features:
             config = feature.get("config", {})
             if not isinstance(config, dict):
                 continue
-            for key, spec in config.items():
-                if not isinstance(spec, dict):
-                    continue
-                scope = spec.get("scope", "container")
-                if scope not in _FRONTEND_SCOPES:
-                    continue
-                if not isinstance(key, str) or not key.startswith(
-                    CONTAINER_ENV_KEY_PREFIX
-                ):
-                    logger.warning(
-                        "features.json frontend-scope config key %r — "
-                        "missing KLANGKWS_FEATURE_ prefix; skipping. Rebuild "
-                        "with a corrected feature.",
-                        key,
-                    )
-                    continue
-                default = spec.get("default", "")
-                # Strip the KLANGKWS_FEATURE_ prefix and lowercase the suffix
-                # for the JSON key (e.g. KLANGKWS_FEATURE_BOING_SPEED →
-                # boing_speed). The prefix is enforced above; the suffix is
-                # the feature-owned name, surfaced un-prefixed to the frontend.
-                json_key = key[len(CONTAINER_ENV_KEY_PREFIX) :].lower()
-                result[json_key] = (
-                    resolve_dynamic_config(
-                        key, default, features_config=features_config
-                    )
-                    or ""
-                )
+            self._add_frontend_entries(result, config, features_config)
         return result
 
     def features_enable(self) -> str | None:

--- a/src/klangk/klangk/files.py
+++ b/src/klangk/klangk/files.py
@@ -33,6 +33,21 @@ _FIND_ERROR_PATH_RE = re.compile(r"^find: '(.*)': ")
 NAME_MAX = 255
 
 
+def _single_leading_slash(normalized: str) -> str:
+    """Force one leading slash: ``normpath("//foo")`` keeps the double
+    slash on POSIX (implementation-defined)."""
+    if normalized.startswith("//") and not normalized.startswith("///"):
+        return normalized[1:]
+    return normalized
+
+
+def _reject_oversized_parts(normalized: str) -> None:
+    """Reject any path component over the NAME_MAX byte limit."""
+    for part in normalized.split("/"):
+        if len(part.encode("utf-8")) > NAME_MAX:
+            raise ValueError(f"Filename exceeds {NAME_MAX}-byte limit")
+
+
 def validate_path(path: str) -> str:
     """Validate and normalize an absolute container path.
 
@@ -48,24 +63,14 @@ def validate_path(path: str) -> str:
         raise ValueError("Null byte in path")
     if not path.startswith("/"):
         raise ValueError("Path must be absolute")
-    normalized = posixpath.normpath(path)
-    # normpath("//foo") → "//foo" on POSIX (implementation-defined);
-    # force a single leading slash.
-    if normalized.startswith("//") and not normalized.startswith("///"):
-        normalized = normalized[1:]
-    for part in normalized.split("/"):
-        if len(part.encode("utf-8")) > NAME_MAX:
-            raise ValueError(f"Filename exceeds {NAME_MAX}-byte limit")
+    normalized = _single_leading_slash(posixpath.normpath(path))
+    _reject_oversized_parts(normalized)
     return normalized
 
 
-def classify_find_errors(
-    container_id: str, path: str, err: str, rc: int
-) -> None:
-    """Act on find's stderr diagnostics: start-point failures raise (or
-    list empty for ENOENT), child-entry failures only warn (the readable
-    entries survive), and a total lack of diagnostics surfaces as a
-    generic OSError."""
+def _split_find_errors(err: str, path: str) -> tuple[list[str], list[str]]:
+    """Partition find's stderr lines into (start-point, child-entry)
+    diagnostics for *path*."""
     start_errors = []
     child_errors = []
     for line in err.splitlines():
@@ -76,6 +81,13 @@ def classify_find_errors(
             start_errors.append(line)
         else:
             child_errors.append(line)
+    return start_errors, child_errors
+
+
+def _warn_child_errors(
+    container_id: str, path: str, child_errors: list[str]
+) -> None:
+    """Child-entry failures only warn (the readable entries survive)."""
     if child_errors:
         logger.warning(
             "list_files: skipped unreadable entries under %s in "
@@ -84,6 +96,27 @@ def classify_find_errors(
             container_id,
             " | ".join(child_errors),
         )
+
+
+def _raise_for_start_error(message: str) -> None:
+    """A surfaced start-point failure: permission-denied raises
+    PermissionError (a denied volume root must not render as a
+    mysterious "Empty directory", #2766); anything else a generic
+    OSError."""
+    if "Permission denied" in message:
+        raise PermissionError(message)
+    raise OSError(message)
+
+
+def classify_find_errors(
+    container_id: str, path: str, err: str, rc: int
+) -> None:
+    """Act on find's stderr diagnostics: start-point failures raise (or
+    list empty for ENOENT), child-entry failures only warn (the readable
+    entries survive), and a total lack of diagnostics surfaces as a
+    generic OSError."""
+    start_errors, child_errors = _split_find_errors(err, path)
+    _warn_child_errors(container_id, path, child_errors)
     if start_errors:
         message = " ".join(" ".join(start_errors).split())
         if "No such file or directory" in message:
@@ -96,16 +129,19 @@ def classify_find_errors(
             container_id,
             message,
         )
-        if "Permission denied" in message:
-            # A permission-denied volume root rendered as a
-            # mysterious "Empty directory" (#2766) — surfaced,
-            # not swallowed.
-            raise PermissionError(message)
-        raise OSError(message)
+        _raise_for_start_error(message)
     if not child_errors:
         # rc != 0 with no diagnostics at all: cannot classify —
         # surface it rather than guess.
         raise OSError(f"find exited with status {rc}")
+
+
+def _float_or(text: str, fallback: float) -> float:
+    """A ``find -printf`` timestamp, or *fallback* when malformed."""
+    try:
+        return float(text)
+    except ValueError:
+        return fallback
 
 
 def _parse_find_line(line: str, path: str) -> dict | None:
@@ -121,21 +157,13 @@ def _parse_find_line(line: str, path: str) -> dict | None:
         size = int(size_str) if not is_dir else None
     except ValueError:
         size = None
-    try:
-        mtime = float(mtime_str)
-    except ValueError:
-        mtime = 0.0
-    try:
-        ctime = float(ctime_str)
-    except ValueError:
-        ctime = 0.0
     return {
         "name": name,
         "path": entry_path,
         "is_dir": is_dir,
         "size": size,
-        "mtime": mtime,
-        "ctime": ctime,
+        "mtime": _float_or(mtime_str, 0.0),
+        "ctime": _float_or(ctime_str, 0.0),
     }
 
 

--- a/src/klangk/klangk/hooks.py
+++ b/src/klangk/klangk/hooks.py
@@ -97,12 +97,23 @@ def _coerce_acl_int(value: Any, field: str) -> int:
         ) from exc
 
 
+def _enum_error(changed: dict, field: str, allowed) -> str | None:
+    """A changed enum field must carry one of *allowed* (else the
+    client-safe rejection message)."""
+    if field not in changed:
+        return None
+    if changed[field] not in allowed:
+        return f"invalid {field}: {changed[field]!r}"
+    return None
+
+
 def _validate_hook_enums(changed: dict) -> str | None:
     """Enum / bool fields: a bad value is rejected, not coerced."""
-    if "setup_state" in changed and changed["setup_state"] not in SETUP_STATES:
-        return f"invalid setup_state: {changed['setup_state']!r}"
-    if "egress_mode" in changed and changed["egress_mode"] not in EGRESS_MODES:
-        return f"invalid egress_mode: {changed['egress_mode']!r}"
+    enum_error = _enum_error(
+        changed, "setup_state", SETUP_STATES
+    ) or _enum_error(changed, "egress_mode", EGRESS_MODES)
+    if enum_error:
+        return enum_error
     if "per_handle_home" in changed and not isinstance(
         changed["per_handle_home"], bool
     ):
@@ -110,30 +121,55 @@ def _validate_hook_enums(changed: dict) -> str | None:
     return None
 
 
+def _validate_hook_banner(changed: dict) -> str | None:
+    """classification_banner: normalized in place, rejected when the
+    normalizer refuses it."""
+    if (
+        "classification_banner" not in changed
+        or changed["classification_banner"] is None
+    ):
+        return None
+    try:
+        changed["classification_banner"] = normalize_classification_banner(
+            changed["classification_banner"]
+        )
+    except ValueError as exc:
+        return f"invalid classification_banner: {exc}"
+    return None
+
+
+def _validate_hook_image(app, changed: dict) -> str | None:
+    """image: must be in the container registry's allowlist."""
+    image = changed.get("image")
+    if image is None:
+        return None
+    registry: ContainerRegistry = app.state.container_registry
+    if image not in registry.allowed_images:
+        return (
+            f"image {image!r} is not in the allowed image"
+            f" list: {sorted(registry.allowed_images)}"
+        )
+    return None
+
+
+def _validate_hook_mounts(app, changed: dict) -> str | None:
+    """mounts: the container registry's mount-spec policy."""
+    mounts = changed.get("mounts")
+    if mounts is None:
+        return None
+    error = app.state.container_registry.validate_mounts(mounts)
+    if error:
+        return f"invalid mounts: {error}"
+    return None
+
+
 def _validate_hook_strings(app, changed: dict) -> str | None:
     """Banner / image / mounts: normalization and registry policy."""
-    if (
-        "classification_banner" in changed
-        and changed["classification_banner"] is not None
-    ):
-        try:
-            changed["classification_banner"] = normalize_classification_banner(
-                changed["classification_banner"]
-            )
-        except ValueError as exc:
-            return f"invalid classification_banner: {exc}"
-    if "image" in changed and changed["image"] is not None:
-        registry: ContainerRegistry = app.state.container_registry
-        if changed["image"] not in registry.allowed_images:
-            return (
-                f"image {changed['image']!r} is not in the allowed image"
-                f" list: {sorted(registry.allowed_images)}"
-            )
-    if "mounts" in changed and changed["mounts"] is not None:
-        error = app.state.container_registry.validate_mounts(changed["mounts"])
-        if error:
-            return f"invalid mounts: {error}"
-    return None
+    return (
+        _validate_hook_banner(changed)
+        or _validate_hook_image(app, changed)
+        or _validate_hook_mounts(app, changed)
+    )
 
 
 def hook_field_changes(handle, workspace: dict) -> dict:
@@ -150,33 +186,55 @@ def hook_field_changes(handle, workspace: dict) -> dict:
     return changed
 
 
+def _validate_hook_settings(app, changed: dict) -> str | None:
+    """The settings bag: parsed/normalized in place, the nix opt-in
+    gated (#2560)."""
+    if "settings" not in changed or changed["settings"] is None:
+        return None
+    try:
+        changed["settings"] = validate_settings(changed["settings"])
+        # #2560: the hook fires at create (a fresh bag, no previous) —
+        # mirror POST /workspaces and reject a nix=true opt-in while
+        # the feature is off.
+        validate_nix_optin(
+            changed["settings"],
+            nix_available=app.state.nix.available,
+        )
+    except ValueError as exc:
+        return f"invalid settings: {exc}"
+    return None
+
+
+def _validate_hook_allowed_domains(changed: dict) -> str | None:
+    """allowed_domains: parsed/normalized in place."""
+    if "allowed_domains" not in changed or changed["allowed_domains"] is None:
+        return None
+    try:
+        changed["allowed_domains"] = parse_allowed_domains(
+            changed["allowed_domains"]
+        )
+    except ValueError as exc:
+        return f"invalid allowed_domains: {exc}"
+    return None
+
+
+def _validate_hook_rejected_if_changed(changed: dict) -> str | None:
+    """rejected_domains: validated only when the hook changed them."""
+    if (
+        "rejected_domains" not in changed
+        or changed["rejected_domains"] is None
+    ):
+        return None
+    return _validate_hook_rejected_domains(changed)
+
+
 def _validate_hook_lists(app, changed: dict) -> str | None:
     """Settings bag and domain lists: parsed/normalized in place."""
-    if "settings" in changed and changed["settings"] is not None:
-        try:
-            changed["settings"] = validate_settings(changed["settings"])
-            # #2560: the hook fires at create (a fresh bag, no previous) —
-            # mirror POST /workspaces and reject a nix=true opt-in while
-            # the feature is off.
-            validate_nix_optin(
-                changed["settings"],
-                nix_available=app.state.nix.available,
-            )
-        except ValueError as exc:
-            return f"invalid settings: {exc}"
-    if "allowed_domains" in changed and changed["allowed_domains"] is not None:
-        try:
-            changed["allowed_domains"] = parse_allowed_domains(
-                changed["allowed_domains"]
-            )
-        except ValueError as exc:
-            return f"invalid allowed_domains: {exc}"
-    if (
-        "rejected_domains" in changed
-        and changed["rejected_domains"] is not None
-    ):
-        return _validate_hook_rejected_domains(changed)
-    return None
+    return (
+        _validate_hook_settings(app, changed)
+        or _validate_hook_allowed_domains(changed)
+        or _validate_hook_rejected_if_changed(changed)
+    )
 
 
 def _validate_hook_rejected_domains(changed: dict) -> str | None:
@@ -220,6 +278,36 @@ def _validate_hook_changes(app, changed: dict) -> str | None:
         or _validate_hook_strings(app, changed)
         or _validate_hook_lists(app, changed)
     )
+
+
+def _load_hook_module(path: str):
+    """Execute the hook file as a module (importlib, no PYTHONPATH
+    needed)."""
+    spec = importlib.util.spec_from_file_location(
+        "_klangk_workspace_created_hook", path
+    )
+    if spec is None or spec.loader is None:
+        raise ConfigurationError(
+            f"KLANGKD_WORKSPACE_CREATED_HOOK: could not load: {path!r}"
+        )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _resolve_hook_callable(path: str, func_name: str) -> Callable:
+    """The hook function from its file."""
+    if not os.path.isfile(path):
+        raise ConfigurationError(
+            f"KLANGKD_WORKSPACE_CREATED_HOOK: file not found: {path!r}"
+        )
+    hook = getattr(_load_hook_module(path), func_name, None)
+    if hook is None or not callable(hook):
+        raise ConfigurationError(
+            f"KLANGKD_WORKSPACE_CREATED_HOOK: {func_name!r} not found"
+            f" or not callable in {path!r}"
+        )
+    return hook
 
 
 class WorkspaceHookHandle(dict):
@@ -368,32 +456,51 @@ class Hooks:
             self.workspace_created_hook_is_async = False
             self.workspace_created_hook_source = None
             return
-        path, func_name = parse_hook_value(raw)
-        if not os.path.isfile(path):
-            raise ConfigurationError(
-                f"KLANGKD_WORKSPACE_CREATED_HOOK: file not found: {path!r}"
-            )
-        spec = importlib.util.spec_from_file_location(
-            "_klangk_workspace_created_hook", path
-        )
-        if spec is None or spec.loader is None:
-            raise ConfigurationError(
-                f"KLANGKD_WORKSPACE_CREATED_HOOK: could not load: {path!r}"
-            )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        hook = getattr(mod, func_name, None)
-        if hook is None or not callable(hook):
-            raise ConfigurationError(
-                f"KLANGKD_WORKSPACE_CREATED_HOOK: {func_name!r} not found"
-                f" or not callable in {path!r}"
-            )
+        hook = _resolve_hook_callable(*parse_hook_value(raw))
         self.workspace_created_hook = hook
         self.workspace_created_hook_is_async = inspect.iscoroutinefunction(
             hook
         )
         self.workspace_created_hook_source = raw
         logger.info("Workspace-created hook loaded: %s", raw)
+
+    async def _invoke_hook(self, hook, handle, actor) -> None:
+        """Dispatch the hook — sync or async —; a raising hook
+        propagates to the caller's log-and-continue."""
+        if self.workspace_created_hook_is_async:
+            await hook(handle, actor)
+        else:
+            hook(handle, actor)
+
+    async def _persist_hook_changes(
+        self, workspace: dict, changed: dict
+    ) -> dict:
+        """Persist the validated changes and return the row to hand
+        back: the re-read row on success, else the input row
+        (log-and-continue)."""
+        try:
+            await self.app.state.model.workspaces.update_workspace(
+                workspace["id"], workspace["user_id"], **changed
+            )
+            refreshed = await self.app.state.model.workspaces.get_workspace(
+                workspace["id"]
+            )
+        except Exception:
+            logger.warning(
+                "workspace-created hook %s: persisting attribute changes "
+                "for workspace %s failed; the row is unchanged",
+                self.workspace_created_hook_source,
+                workspace.get("id"),
+                exc_info=True,
+            )
+            return workspace
+        if refreshed is None:
+            return workspace  # pragma: no cover — row vanished mid-fire
+        # get_workspace omits created_at; carry it from the input so
+        # the create response's shape is hook-invariant.
+        if "created_at" not in refreshed and "created_at" in workspace:
+            refreshed["created_at"] = workspace["created_at"]
+        return refreshed
 
     async def fire_workspace_created(
         self, workspace: dict, actor: dict
@@ -428,10 +535,7 @@ class Hooks:
             allow_await=self.workspace_created_hook_is_async,
         )
         try:
-            if self.workspace_created_hook_is_async:
-                await hook(handle, actor)
-            else:
-                hook(handle, actor)
+            await self._invoke_hook(hook, handle, actor)
         except Exception:
             logger.warning(
                 "workspace-created hook %s failed for workspace %s; "
@@ -454,26 +558,4 @@ class Hooks:
                 invalid,
             )
             return workspace
-        try:
-            await self.app.state.model.workspaces.update_workspace(
-                workspace["id"], workspace["user_id"], **changed
-            )
-            refreshed = await self.app.state.model.workspaces.get_workspace(
-                workspace["id"]
-            )
-        except Exception:
-            logger.warning(
-                "workspace-created hook %s: persisting attribute changes "
-                "for workspace %s failed; the row is unchanged",
-                source,
-                ws_id,
-                exc_info=True,
-            )
-            return workspace
-        if refreshed is not None:
-            # get_workspace omits created_at; carry it from the input so
-            # the create response's shape is hook-invariant.
-            if "created_at" not in refreshed and "created_at" in workspace:
-                refreshed["created_at"] = workspace["created_at"]
-            return refreshed
-        return workspace  # pragma: no cover — row vanished mid-fire
+        return await self._persist_hook_changes(workspace, changed)

--- a/src/klangk/klangk/interval.py
+++ b/src/klangk/klangk/interval.py
@@ -56,20 +56,23 @@ class IntervalWorker:
                 pass
             self._task = None
 
+    async def _guarded_sweep(self) -> None:
+        """One sweep; non-cancellation failures are logged and swallowed
+        (the loop continues). Cancellation propagates."""
+        try:
+            await self.sweep()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("%s failed", self.log_label, exc_info=True)
+
     async def run(self) -> None:
         # 0.0 sweeps once immediately on startup, then every interval.
         next_sweep = 0.0
         try:
             while True:
                 if time.monotonic() >= next_sweep:
-                    try:
-                        await self.sweep()
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        logger.warning(
-                            "%s failed", self.log_label, exc_info=True
-                        )
+                    await self._guarded_sweep()
                     next_sweep = time.monotonic() + self.interval
                 await asyncio.sleep(max(0.0, next_sweep - time.monotonic()))
         except asyncio.CancelledError:

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -98,6 +98,45 @@ _NON_RELOADABLE_SETTINGS: tuple[tuple[str, str], ...] = (
 )
 
 
+def _password_policy_errors(settings, password: str) -> list[str]:
+    """The password-policy violations of *password* (empty when it is
+    compliant)."""
+    errors = []
+    min_len = int(settings.min_password_length or "8")
+    if len(password) < min_len:
+        errors.append(f"is shorter than KLANGKD_MIN_PASSWORD_LENGTH={min_len}")
+    counts = password_class_counts(password)
+    for key, name in PASSWORD_CLASSES:
+        _password_class_error(errors, settings, counts, key, name)
+    return errors
+
+
+def _password_class_error(
+    errors: list[str], settings, counts: dict, key: str, name: str
+) -> None:
+    """Append the violation when *password* misses a required class."""
+    need = getattr(settings, f"password_require_{key}")
+    if need > 0 and counts[key] < need:
+        errors.append(
+            f"lacks the {need} required {name}"
+            f"{'s' if need != 1 else ''} "
+            f"(KLANGKD_PASSWORD_REQUIRE_{key.upper()}={need})"
+        )
+
+
+def _policy_error_message(errors: list[str]) -> str:
+    """The refusal message naming the first violation (and a count of
+    the rest)."""
+    more = f" (and {len(errors) - 1} more issue(s))" if len(errors) > 1 else ""
+    return (
+        "KLANGKD_DEFAULT_PASSWORD violates the configured "
+        f"password policy: it {errors[0]}"
+        + more
+        + ". Fix the password or loosen the policy; refusing to "
+        "boot with a seeded admin that already violates it."
+    )
+
+
 class Lifecycle:
     """App-level bringup/shutdown and DB seeding (#1571).
 
@@ -409,33 +448,24 @@ class Lifecycle:
         seeding a non-compliant password and letting it fail at first
         change would strand deployments whose policy was tightened
         after the seed ran."""
-        _policy_errors = []
-        min_len = int(settings.min_password_length or "8")
-        if len(password) < min_len:
-            _policy_errors.append(
-                f"is shorter than KLANGKD_MIN_PASSWORD_LENGTH={min_len}"
+        errors = _password_policy_errors(settings, password)
+        if errors:
+            raise ConfigurationError(_policy_error_message(errors))
+
+    async def _any_admin_with_password(self, admin_members) -> bool:
+        """True when at least one admin member carries a password hash.
+
+        get_group_members doesn't carry password_hash; fetch per member.
+        The admin group is small (typically 1-3 members) so the N queries
+        are cheap; a single JOIN would require a new model method for this
+        one call site, which isn't worth it."""
+        for member in admin_members:
+            user = await self.app.state.model.users.get_user_by_email(
+                member["email"]
             )
-        _counts = password_class_counts(password)
-        for _key, _name in PASSWORD_CLASSES:
-            _need = getattr(settings, f"password_require_{_key}")
-            if _need > 0 and _counts[_key] < _need:
-                _policy_errors.append(
-                    f"lacks the {_need} required {_name}"
-                    f"{'s' if _need != 1 else ''} "
-                    f"(KLANGKD_PASSWORD_REQUIRE_{_key.upper()}={_need})"
-                )
-        if _policy_errors:
-            raise ConfigurationError(
-                "KLANGKD_DEFAULT_PASSWORD violates the configured "
-                f"password policy: it {_policy_errors[0]}"
-                + (
-                    f" (and {len(_policy_errors) - 1} more issue(s))"
-                    if len(_policy_errors) > 1
-                    else ""
-                )
-                + ". Fix the password or loosen the policy; refusing to "
-                "boot with a seeded admin that already violates it."
-            )
+            if user and user.get("password_hash"):
+                return True
+        return False
 
     async def _enforce_password_mode_has_hashed_admin(
         self, admin_members: list[dict]
@@ -463,16 +493,8 @@ class Lifecycle:
         auth_modes = self.app.state.settings.auth_modes or "none"
         if auth_modes not in ("password", "both"):
             return
-        # get_group_members doesn't carry password_hash; fetch per member.
-        # The admin group is small (typically 1-3 members) so the N queries
-        # are cheap; a single JOIN would require a new model method for this
-        # one call site, which isn't worth it.
-        for member in admin_members:
-            user = await self.app.state.model.users.get_user_by_email(
-                member["email"]
-            )
-            if user and user.get("password_hash"):
-                return  # At least one admin can log in — fine.
+        if await self._any_admin_with_password(admin_members):
+            return  # At least one admin can log in — fine.
         # #2738 audit: ConfigurationError (not bare RuntimeError) so the
         # launcher maps this permanent misconfiguration to EX_CONFIG (#2666)
         # instead of a generic crash a supervisor would restart-loop.
@@ -596,6 +618,90 @@ class Lifecycle:
         state.util.remove_pid_file()
         await state.db.dispose_engine()
 
+    def _recycle_settings(self) -> KlangkSettings | None:
+        """Phase 1 (validate) of the recycle: re-resolve settings. A
+        shutdown already in progress or an invalid config denies the
+        restart — ``None`` — leaving the runtime on its last-known-good
+        config."""
+        logger.info("SIGHUP: restart beginning (phase: validate)")
+        # #2527 review: a shutdown arriving before the restart begins
+        # wins outright (on_sighup also drops later signals, but this
+        # closes the checked-to-started race window).
+        if self.shutting_down:
+            logger.info("SIGHUP: restart aborted; shutdown in progress")
+            return None
+        new_settings, error = self.reload_settings()
+        if error is not None:
+            logger.error(
+                "SIGHUP: denying restart — invalid configuration: %s",
+                error,
+            )
+            logger.info(
+                "SIGHUP: restart denied; runtime left running on "
+                "existing configuration"
+            )
+            return None
+        return new_settings
+
+    async def _quiesce_and_drain(
+        self, state, registry, new_settings: KlangkSettings
+    ) -> None:
+        """Phases 3–4 of the recycle: quiesce in-flight HTTP requests,
+        then drain every workspace through the graceful path."""
+        # #2527 review: read the timeout from the NEW settings so
+        # a reload takes effect on THIS restart, not the next.
+        timeout = new_settings.quiesce_timeout
+        logger.info(
+            "SIGHUP: phase: quiesce (waiting up to %.1fs for "
+            "in-flight requests)",
+            timeout,
+        )
+        inflight = state.inflight_requests
+        idle = await inflight.wait_for_idle(timeout)
+        if not idle:
+            logger.warning(
+                "SIGHUP: %d request(s) still in flight after "
+                "%.1fs; proceeding with the restart",
+                inflight.count,
+                timeout,
+            )
+        logger.info("SIGHUP: phase: drain (stopping workspaces)")
+        stopped = await registry.drain_all_containers(reason="server recycle")
+        logger.info("SIGHUP: drained %d workspace(s)", stopped)
+
+    def _shutdown_won_mid_recycle(self) -> bool:
+        """True when a shutdown raced the recycle mid-drain.
+
+        #2527 review: a TERM/INT landing mid-restart starts the shutdown
+        drain concurrently; from here on the restart must not resurrect
+        what the shutdown is tearing down (no settings apply, no runtime
+        recycle, no auto-start), and its error recovery must not run
+        either — the process is exiting. The done-callback sees the task
+        complete normally (CancelledError would also be fine)."""
+        if self.shutting_down:
+            logger.info(
+                "SIGHUP: restart aborted mid-drain; shutdown in progress"
+            )
+            return True
+        return False
+
+    async def _apply_and_recycle(self, state, new_settings) -> None:
+        """Phases 5–7 of the recycle: apply the reloaded config, recycle
+        the runtime, and resume. The drain flag deliberately stays set
+        through ``startup()``'s podman pre-warm and container reaps (so a
+        client that reconnects and starts a workspace in that window is
+        refused — 503, with the reason — instead of having its fresh
+        container destroyed by the reap); ``startup()`` clears it."""
+        logger.info("SIGHUP: phase: apply (applying reloaded config)")
+        await self.apply_reloaded_settings(new_settings)
+        state.sockets.notify_server_recycle("recycling")
+        logger.info(
+            "SIGHUP: phase: restart (recycling runtime; "
+            "HTTP listener stays up)"
+        )
+        await self.runtime_shutdown()
+        await self.startup()
+
     async def recycle_runtime(self) -> None:
         """Graceful runtime recycle: quiesce, drain, re-read config, recycle.
 
@@ -647,74 +753,17 @@ class Lifecycle:
         async with self._recycle_lock:
             state = self.app.state
             registry = state.container_registry
-            logger.info("SIGHUP: restart beginning (phase: validate)")
-            # #2527 review: a shutdown arriving before the restart begins
-            # wins outright (on_sighup also drops later signals, but this
-            # closes the checked-to-started race window).
-            if self.shutting_down:
-                logger.info("SIGHUP: restart aborted; shutdown in progress")
-                return
-            new_settings, error = self.reload_settings()
-            if error is not None:
-                logger.error(
-                    "SIGHUP: denying restart — invalid configuration: %s",
-                    error,
-                )
-                logger.info(
-                    "SIGHUP: restart denied; runtime left running on "
-                    "existing configuration"
-                )
+            new_settings = self._recycle_settings()
+            if new_settings is None:
                 return
             logger.info("SIGHUP: phase: draining (refusing new starts)")
             state.sockets.notify_server_recycle("draining")
             registry.draining = True
             try:
-                # #2527 review: read the timeout from the NEW settings so
-                # a reload takes effect on THIS restart, not the next.
-                timeout = new_settings.quiesce_timeout
-                logger.info(
-                    "SIGHUP: phase: quiesce (waiting up to %.1fs for "
-                    "in-flight requests)",
-                    timeout,
-                )
-                inflight = state.inflight_requests
-                idle = await inflight.wait_for_idle(timeout)
-                if not idle:
-                    logger.warning(
-                        "SIGHUP: %d request(s) still in flight after "
-                        "%.1fs; proceeding with the restart",
-                        inflight.count,
-                        timeout,
-                    )
-                logger.info("SIGHUP: phase: drain (stopping workspaces)")
-                stopped = await registry.drain_all_containers(
-                    reason="server recycle"
-                )
-                logger.info("SIGHUP: drained %d workspace(s)", stopped)
-                # #2527 review: a TERM/INT landing mid-restart starts the
-                # shutdown drain concurrently; from here on the restart
-                # must not resurrect what the shutdown is tearing down
-                # (no settings apply, no runtime recycle, no auto-start),
-                # and its error recovery must not run either — the
-                # process is exiting. The done-callback sees the task
-                # complete normally (CancelledError would also be fine).
-                if self.shutting_down:
-                    logger.info(
-                        "SIGHUP: restart aborted mid-drain; shutdown in "
-                        "progress"
-                    )
+                await self._quiesce_and_drain(state, registry, new_settings)
+                if self._shutdown_won_mid_recycle():
                     return
-                logger.info("SIGHUP: phase: apply (applying reloaded config)")
-                await self.apply_reloaded_settings(new_settings)
-                state.sockets.notify_server_recycle("recycling")
-                logger.info(
-                    "SIGHUP: phase: restart (recycling runtime; "
-                    "HTTP listener stays up)"
-                )
-                await self.runtime_shutdown()
-                # draining deliberately stays True here: startup() clears
-                # it after its container reaps (see startup()).
-                await self.startup()
+                await self._apply_and_recycle(state, new_settings)
             finally:
                 # A failed restart must never leave the node refusing
                 # starts: the in-memory flag has no DB persistence an
@@ -742,6 +791,72 @@ class Lifecycle:
             return None, str(exc)
         return new, None
 
+    _RECONFIGURE_SUBSYSTEMS = [
+        "ssl_trust",
+        "netfilter",
+        "auth",
+        "podman",
+        "sockets",
+        "container_registry",
+        "consent_sweeper",
+        "inactivity_sweeper",
+        "memory_evictor",
+        "consent_coordinator",
+        "consent_deciders",
+        "sidecar_connections",
+        "proxy_watchdog",
+        "llm_router",
+        "terminal",
+        "oidc",
+        "hooks",
+        "features",
+        "workspaces",
+        "files",
+        "db",
+        "model",
+        "agents",
+        "acl",
+        "email",
+        "util",
+        "lifecycle",
+        "server_scheduler",
+    ]
+
+    async def _reconfigure_subsystems(self, app) -> None:
+        """Call ``reconfigure(app_state)`` on every subsystem. Each call
+        is best-effort: a failure is logged at warning level and skipped
+        so one bad step can't leave the runtime half-reconfigured."""
+        for name in self._RECONFIGURE_SUBSYSTEMS:
+            try:
+                getattr(app.state, name).reconfigure(app)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "SIGHUP: %s reconfigure failed (skipped): %s", name, exc
+                )
+
+    async def _reapply_async_reconfigures(self, app) -> None:
+        """The async follow-ups a sync ``reconfigure()`` can only flag."""
+        # Lifecycle.reconfigure flags an agent re-seed; apply it now
+        # (async, so it can't run inside the sync reconfigure loop).
+        try:
+            await app.state.lifecycle.apply_pending_reseed()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "SIGHUP: agent user re-seed failed (skipped): %s", exc
+            )
+        # CaddyWatchdog.reconfigure flags an admin-API POST /load of the
+        # re-rendered Caddyfile; apply it now (async). No-op for the nginx
+        # engine (its watchdog has no apply_pending_reload) and when the
+        # proxy is disabled. #1559: a settings change is a fresh /load.
+        caddy_wd = getattr(app.state, "proxy_watchdog", None)
+        if caddy_wd is not None and hasattr(caddy_wd, "apply_pending_reload"):
+            try:
+                await caddy_wd.apply_pending_reload()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "SIGHUP: caddy config reload failed (skipped): %s", exc
+                )
+
     async def apply_reloaded_settings(self, new: KlangkSettings) -> None:
         """Swap settings and call ``reconfigure(app_state)`` on every subsystem.
 
@@ -763,65 +878,8 @@ class Lifecycle:
         # module state, reconfigured at this explicit seam (not an
         # app.state.* subsystem).
         configure_logging(new)
-
-        # Every app.state subsystem that implements reconfigure().
-        subsystems = [
-            "ssl_trust",
-            "netfilter",
-            "auth",
-            "podman",
-            "sockets",
-            "container_registry",
-            "consent_sweeper",
-            "inactivity_sweeper",
-            "memory_evictor",
-            "consent_coordinator",
-            "consent_deciders",
-            "sidecar_connections",
-            "proxy_watchdog",
-            "llm_router",
-            "terminal",
-            "oidc",
-            "hooks",
-            "features",
-            "workspaces",
-            "files",
-            "db",
-            "model",
-            "agents",
-            "acl",
-            "email",
-            "util",
-            "lifecycle",
-            "server_scheduler",
-        ]
-        for name in subsystems:
-            try:
-                getattr(app.state, name).reconfigure(app)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "SIGHUP: %s reconfigure failed (skipped): %s", name, exc
-                )
-        # Lifecycle.reconfigure flags an agent re-seed; apply it now
-        # (async, so it can't run inside the sync reconfigure loop).
-        try:
-            await app.state.lifecycle.apply_pending_reseed()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "SIGHUP: agent user re-seed failed (skipped): %s", exc
-            )
-        # CaddyWatchdog.reconfigure flags an admin-API POST /load of the
-        # re-rendered Caddyfile; apply it now (async). No-op for the nginx
-        # engine (its watchdog has no apply_pending_reload) and when the
-        # proxy is disabled. #1559: a settings change is a fresh /load.
-        caddy_wd = getattr(app.state, "proxy_watchdog", None)
-        if caddy_wd is not None and hasattr(caddy_wd, "apply_pending_reload"):
-            try:
-                await caddy_wd.apply_pending_reload()
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "SIGHUP: caddy config reload failed (skipped): %s", exc
-                )
+        await self._reconfigure_subsystems(app)
+        await self._reapply_async_reconfigures(app)
         # #1610: remount frontend_dir if it changed.
         if old.frontend_dir != new.frontend_dir:
             self.remount_frontend(app, new)
@@ -1074,6 +1132,90 @@ def setup_logfire(app: FastAPI) -> bool:
 # devenv / supervisord remain only the outer restart layer for uvicorn (klangkd).
 
 
+async def validate_and_seed(app: FastAPI) -> None:
+    """Deterministic config validation + seeding at startup.
+
+    A :class:`ConfigurationError` from this stretch is a config problem
+    a restart cannot fix; the lifespan flags it on ``app.state`` so the
+    launcher can exit EX_CONFIG (78) instead of uvicorn's generic
+    startup-failure status — without that, a supervisor restart-loops a
+    bad password/secret/bind forever (#2666).
+    """
+    app.state.auth.require_secure_jwt_secret()
+    # #2570: with KLANGKD_FIPS_MODE on, audit klangkd's own OpenSSL (its
+    # password hashing + JWT signing) once at startup — verified, or a
+    # prominent warning (klangkd may legitimately run on a non-FIPS
+    # control host; workspace containers are the fail-closed gate).
+    fips_mod.verify_process_fips(app.state.settings)
+    # Features reads the build-emitted features.json at construction
+    # (Features(app) in build_app); no separate load() step (#1655).
+    app.state.oidc.init_providers()
+    enforce_no_auth_bind_safety(app)
+    app.state.oidc.load_login_hook()
+    # #2762: customize-dir lifecycle hooks, loaded beside the login
+    # hook with the same failure semantics (ConfigurationError →
+    # startup_config_error → EX_CONFIG). Guarded: some minimal test
+    # apps wire the lifespan without build_app's full state.
+    hooks_state = getattr(app.state, "hooks", None)
+    if hooks_state is not None:
+        hooks_state.load_workspace_created_hook()
+    await app.state.lifecycle.seed_default_user()
+    await app.state.lifecycle.seed_agent_user()
+
+
+def wire_registry_callbacks(app: FastAPI) -> None:
+    """Wire the container-registry callbacks: a killed workspace resets
+    the WS state; a status change broadcasts to subscribers."""
+
+    async def _on_workspace_killed(ws_id, container_id=None):
+        await wshandler.reset_workspace_state(
+            app.state.sockets, ws_id, expected_container_id=container_id
+        )
+
+    registry = app.state.container_registry
+    registry.set_on_workspace_killed(_on_workspace_killed)
+    registry.set_on_container_status_changed(
+        lambda ws_id, running, started_at=None: broadcast_container_status(
+            app, ws_id, running, started_at
+        )
+    )
+
+
+def start_background_workers(app: FastAPI) -> None:
+    """Start every interval worker (sweepers, evictor, scheduler)."""
+    app.state.consent_sweeper.start()
+    app.state.inactivity_sweeper.start()
+    app.state.consent_coordinator.start()
+    app.state.consent_deciders.start()
+    app.state.sidecar_connections.start()
+    # #2526: host memory-pressure eviction loop (k8s node-pressure-eviction
+    # analogue) — stops idle workspaces before the kernel OOM killer picks a
+    # random victim (possibly klangkd itself).
+    app.state.memory_evictor.start()
+    # #2661: scheduled server stop/recycle loop — fires persisted
+    # schedules (surviving this daemon's restarts) and keeps every
+    # client informed with the pending-schedule snapshot. Guarded: some
+    # minimal test apps wire the lifespan without build_app's full state.
+    server_scheduler = getattr(app.state, "server_scheduler", None)
+    if server_scheduler is not None:
+        server_scheduler.start()
+
+
+async def stop_background_workers(app: FastAPI) -> None:
+    """Stop every interval worker (reverse of
+    :func:`start_background_workers`)."""
+    await app.state.consent_sweeper.stop()
+    server_scheduler = getattr(app.state, "server_scheduler", None)
+    if server_scheduler is not None:
+        await server_scheduler.stop()
+    await app.state.inactivity_sweeper.stop()
+    await app.state.memory_evictor.stop()
+    await app.state.consent_coordinator.stop()
+    await app.state.consent_deciders.stop()
+    await app.state.sidecar_connections.stop()
+    await app.state.proxy_watchdog.stop()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Schema bootstrap: reach the DB through the single owned
@@ -1108,48 +1250,12 @@ async def lifespan(app: FastAPI):
     # and therefore before trust is applied.
     setup_logfire(app)
 
-    # Deterministic config validation + seeding. A ConfigurationError from
-    # this stretch is a config problem a restart cannot fix; flag it on
-    # app.state so the launcher can exit EX_CONFIG (78) instead of uvicorn's
-    # generic startup-failure status — without that, a supervisor
-    # restart-loops a bad password/secret/bind forever (#2666).
     try:
-        app.state.auth.require_secure_jwt_secret()
-        # #2570: with KLANGKD_FIPS_MODE on, audit klangkd's own OpenSSL (its
-        # password hashing + JWT signing) once at startup — verified, or a
-        # prominent warning (klangkd may legitimately run on a non-FIPS
-        # control host; workspace containers are the fail-closed gate).
-        fips_mod.verify_process_fips(app.state.settings)
-        # Features reads the build-emitted features.json at construction
-        # (Features(app) in build_app); no separate load() step (#1655).
-        app.state.oidc.init_providers()
-        enforce_no_auth_bind_safety(app)
-        app.state.oidc.load_login_hook()
-        # #2762: customize-dir lifecycle hooks, loaded beside the login
-        # hook with the same failure semantics (ConfigurationError →
-        # startup_config_error → EX_CONFIG). Guarded: some minimal test
-        # apps wire the lifespan without build_app's full state.
-        hooks_state = getattr(app.state, "hooks", None)
-        if hooks_state is not None:
-            hooks_state.load_workspace_created_hook()
-        await app.state.lifecycle.seed_default_user()
-        await app.state.lifecycle.seed_agent_user()
+        await validate_and_seed(app)
     except ConfigurationError as exc:
         app.state.startup_config_error = str(exc)
         raise
-    registry = app.state.container_registry
-
-    async def _on_workspace_killed(ws_id, container_id=None):
-        await wshandler.reset_workspace_state(
-            app.state.sockets, ws_id, expected_container_id=container_id
-        )
-
-    registry.set_on_workspace_killed(_on_workspace_killed)
-    registry.set_on_container_status_changed(
-        lambda ws_id, running, started_at=None: broadcast_container_status(
-            app, ws_id, running, started_at
-        )
-    )
+    wire_registry_callbacks(app)
     await app.state.lifecycle.startup()
     # Reap orphaned pending consent rows from a prior run: the in-memory
     # holds are gone on restart, so without this the decider snapshot would
@@ -1159,22 +1265,7 @@ async def lifespan(app: FastAPI):
         "expired %d orphaned pending egress-consent request(s) on startup",
         reaped,
     )
-    app.state.consent_sweeper.start()
-    app.state.inactivity_sweeper.start()
-    app.state.consent_coordinator.start()
-    app.state.consent_deciders.start()
-    app.state.sidecar_connections.start()
-    # #2526: host memory-pressure eviction loop (k8s node-pressure-eviction
-    # analogue) — stops idle workspaces before the kernel OOM killer picks a
-    # random victim (possibly klangkd itself).
-    app.state.memory_evictor.start()
-    # #2661: scheduled server stop/recycle loop — fires persisted
-    # schedules (surviving this daemon's restarts) and keeps every
-    # client informed with the pending-schedule snapshot. Guarded: some
-    # minimal test apps wire the lifespan without build_app's full state.
-    server_scheduler = getattr(app.state, "server_scheduler", None)
-    if server_scheduler is not None:
-        server_scheduler.start()
+    start_background_workers(app)
     # Start the proxy (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.proxy_watchdog.start()
@@ -1193,16 +1284,7 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
-        await app.state.consent_sweeper.stop()
-        server_scheduler = getattr(app.state, "server_scheduler", None)
-        if server_scheduler is not None:
-            await server_scheduler.stop()
-        await app.state.inactivity_sweeper.stop()
-        await app.state.memory_evictor.stop()
-        await app.state.consent_coordinator.stop()
-        await app.state.consent_deciders.stop()
-        await app.state.sidecar_connections.stop()
-        await app.state.proxy_watchdog.stop()
+        await stop_background_workers(app)
         await app.state.lifecycle.runtime_shutdown()
         await app.state.lifecycle.process_shutdown()
         logger.info("Klangk backend stopped")

--- a/src/klangk/klangk/llm_router.py
+++ b/src/klangk/klangk/llm_router.py
@@ -113,6 +113,42 @@ _PROVIDER_DEFAULTS: dict[str, str] = {
 _INDIRECT_KEYS = frozenset({"api_key", "api_base"})
 
 
+def _split_entry(entry: str) -> tuple[str, str, str]:
+    """(litellm_model, api_base, api_key): the **first** colon bounds
+    the model, the **last** colon of the remainder bounds the key."""
+    first_colon = entry.find(":")
+    if first_colon == -1:
+        return entry, "", ""
+    litellm_model = entry[:first_colon]
+    rest = entry[first_colon + 1 :]
+    last_colon = rest.rfind(":")
+    if last_colon == -1:
+        return litellm_model, rest, ""
+    return litellm_model, rest[:last_colon], rest[last_colon + 1 :]
+
+
+def _resolve_api_base(api_base: str, litellm_model: str) -> str:
+    """A known provider's default base URL when none was given (only a
+    ``provider/model`` string names a provider)."""
+    if "/" not in litellm_model:
+        return api_base
+    provider = litellm_model.split("/", 1)[0]
+    if api_base or provider not in _PROVIDER_DEFAULTS:
+        return api_base
+    return _PROVIDER_DEFAULTS[provider]
+
+
+def _model_params(litellm_model: str, api_base: str, api_key: str) -> dict:
+    """The ``litellm_params`` dict — api_base/api_key present only when
+    set."""
+    params: dict = {"model": litellm_model}
+    if api_base:
+        params["api_base"] = api_base
+    if api_key:
+        params["api_key"] = api_key
+    return params
+
+
 def parse_model_entry(entry: str) -> dict:
     """Parse a ``provider/model:api_base:api_key`` string into a LiteLLM
     ``model_list`` entry dict.
@@ -124,46 +160,34 @@ def parse_model_entry(entry: str) -> dict:
 
     Returns a dict suitable for inclusion in LiteLLM's ``model_list``.
     """
-    first_colon = entry.find(":")
-    if first_colon == -1:
-        litellm_model = entry
-        api_base = ""
-        api_key = ""
-    else:
-        litellm_model = entry[:first_colon]
-        rest = entry[first_colon + 1 :]
-        last_colon = rest.rfind(":")
-        if last_colon == -1:
-            api_base = rest
-            api_key = ""
-        else:
-            api_base = rest[:last_colon]
-            api_key = rest[last_colon + 1 :]
-
-    if "/" in litellm_model:
-        provider, model_name = litellm_model.split("/", 1)
-    else:
-        provider = ""
-        model_name = litellm_model
-
-    if not api_base and provider in _PROVIDER_DEFAULTS:
-        api_base = _PROVIDER_DEFAULTS[provider]
-
-    params: dict = {"model": litellm_model}
-    if api_base:
-        params["api_base"] = api_base
-    if api_key:
-        params["api_key"] = api_key
-
+    litellm_model, api_base, api_key = _split_entry(entry)
+    model_name = (
+        litellm_model.split("/", 1)[1]
+        if "/" in litellm_model
+        else litellm_model
+    )
+    api_base = _resolve_api_base(api_base, litellm_model)
     return {
         "model_name": model_name,
-        "litellm_params": params,
+        "litellm_params": _model_params(litellm_model, api_base, api_key),
     }
 
 
 def _normalize_key(key: str) -> str:
     """Convert kebab-case to snake_case."""
     return key.replace("-", "_")
+
+
+def _normalize_params(v: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one ``litellm_params`` block: kebab→snake keys,
+    ``file:``/``cmd:`` indirection resolved on secret-bearing values."""
+    params: dict[str, Any] = {}
+    for pk, pv in v.items():
+        npk = _normalize_key(pk)
+        if npk in _INDIRECT_KEYS and isinstance(pv, str):
+            pv = resolve_indirection(pv, npk) or ""
+        params[npk] = pv
+    return params
 
 
 def normalize_dict_entry(entry: dict[str, Any]) -> dict[str, Any]:
@@ -181,13 +205,7 @@ def normalize_dict_entry(entry: dict[str, Any]) -> dict[str, Any]:
         if nk == "params":
             nk = "litellm_params"
         if nk == "litellm_params" and isinstance(v, dict):
-            params: dict[str, Any] = {}
-            for pk, pv in v.items():
-                npk = _normalize_key(pk)
-                if npk in _INDIRECT_KEYS and isinstance(pv, str):
-                    pv = resolve_indirection(pv, npk) or ""
-                params[npk] = pv
-            norm[nk] = params
+            norm[nk] = _normalize_params(v)
         else:
             norm[nk] = v
     return norm
@@ -295,6 +313,17 @@ class LLMRouter:
         if self.active:
             logger.info("llm router reconfigured")
 
+    def _resolve_router_model(self, kwargs: dict) -> None:
+        """Default ``model`` to the first configured model when the
+        request's model is empty, missing, or matches no configured
+        ``model_name``."""
+        model = kwargs.get("model", "")
+        names = self.get_model_names()
+        if not names:
+            raise RuntimeError("LLM router has no models configured")
+        if not model or model not in names:
+            kwargs["model"] = names[0]
+
     async def acompletion(self, **kwargs: Any) -> Any:
         """Proxy to ``litellm.Router.acompletion`` or passthrough.
 
@@ -307,12 +336,7 @@ class LLMRouter:
             return await self._passthrough_completion(**kwargs)
         if self._router is None:
             raise RuntimeError("LLM router not configured")
-        model = kwargs.get("model", "")
-        names = self.get_model_names()
-        if not names:
-            raise RuntimeError("LLM router has no models configured")
-        if not model or model not in names:
-            kwargs["model"] = names[0]
+        self._resolve_router_model(kwargs)
         return await self._router.acompletion(**kwargs)
 
     def _passthrough_headers(self) -> dict[str, str]:

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -394,6 +394,21 @@ app = typer.Typer(
 )
 
 
+def _default_config_path() -> str:
+    """The default config path, generating a template on first run."""
+    path = first_run.default_config_path()
+    if os.path.isfile(path):
+        return path
+    try:
+        first_run.generate_default_config(path)
+    except FileExistsError:
+        # Race: another klangkd (e.g. a systemd restart overlap)
+        # generated the file between our isfile check and the open.
+        # Treat it as "the file is there now" and proceed.
+        pass
+    return path
+
+
 def resolve_config_path(config: str | None) -> str:
     """Resolve the ``--config`` value into a path or the 'none' sentinel.
 
@@ -417,16 +432,7 @@ def resolve_config_path(config: str | None) -> str:
     missing explicitly-required file.
     """
     if config is None:
-        path = first_run.default_config_path()
-        if not os.path.isfile(path):
-            try:
-                first_run.generate_default_config(path)
-            except FileExistsError:
-                # Race: another klangkd (e.g. a systemd restart overlap)
-                # generated the file between our isfile check and the open.
-                # Treat it as "the file is there now" and proceed.
-                pass
-        return path
+        return _default_config_path()
     if config == "none":
         return "none"
     path = Path(config)
@@ -438,41 +444,54 @@ def resolve_config_path(config: str | None) -> str:
     return str(path)
 
 
+def _read_instance_id(settings: KlangkSettings) -> str | None:
+    """The instance id on disk, read-only; ``None`` when absent or blank.
+
+    Read the same way :meth:`Util.resolve_instance_id` does, but never
+    generates one — the pre-app callers here treat a missing id as
+    "no running instance to collide with".
+    """
+    instance_id_path = Path(settings.data_dir) / "instance-id"
+    try:
+        return instance_id_path.read_text().strip() or None
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _live_foreign_pid(pid_path: Path, pid: int) -> bool:
+    """True when *pid* is a live process other than ours.
+
+    A dead (or invalid) PID is a stale PID file — unlinked on the way.
+    A PID we cannot signal exists but belongs to another user.
+    """
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, OverflowError):
+        # Stale PID file — clean it up.
+        pid_path.unlink(missing_ok=True)
+        return False
+    except PermissionError:
+        return True
+    # Don't treat our own PID as a conflict (e.g., after a crash that
+    # left the PID file behind and the OS recycled the PID).
+    return pid != os.getpid()
+
+
 def check_pid_preflight(settings: KlangkSettings) -> int | None:
     """Return the PID of a live klangkd for this instance, or ``None``.
 
     Mirrors :meth:`Util.check_pid_file` but runs *before* the app is
     built so the launcher can abort before touching the UDS (#1837).
     """
-    # Read the instance ID the same way Util.resolve_instance_id does,
-    # but read-only — don't generate one; if the file is missing there
-    # is no running instance to collide with.
-    instance_id_path = Path(settings.data_dir) / "instance-id"
-    try:
-        instance_id = instance_id_path.read_text().strip()
-    except (FileNotFoundError, ValueError):
+    instance_id = _read_instance_id(settings)
+    if instance_id is None:
         return None
-    if not instance_id:
-        return None
-
     pid_path = Path(settings.state_dir) / f"klangk-{instance_id}.pid"
     try:
         pid = int(pid_path.read_text().strip())
     except (FileNotFoundError, ValueError):
         return None
-
-    try:
-        os.kill(pid, 0)
-    except (ProcessLookupError, OverflowError):
-        # Stale PID file — clean it up.
-        pid_path.unlink(missing_ok=True)
-        return None
-    except PermissionError:
-        return pid
-
-    if pid == os.getpid():
-        return None
-    return pid
+    return pid if _live_foreign_pid(pid_path, pid) else None
 
 
 # Per-instance marker recording the live winner PID whose duplicate-launch
@@ -494,12 +513,8 @@ def refusal_marker_path(settings: KlangkSettings) -> Path | None:
     Sibling of the pidfile (``klangk-<instance>.refusal`` in the state dir).
     ``None`` (no dedup — always emit) when there is no instance id on disk.
     """
-    instance_id_path = Path(settings.data_dir) / "instance-id"
-    try:
-        instance_id = instance_id_path.read_text().strip()
-    except (FileNotFoundError, ValueError):
-        return None
-    if not instance_id:
+    instance_id = _read_instance_id(settings)
+    if instance_id is None:
         return None
     return (
         Path(settings.state_dir)
@@ -565,6 +580,33 @@ def config_error_exit_status(app_state) -> int | None:
     return EX_CONFIG
 
 
+def _brew_prefix() -> str:
+    """The Homebrew prefix (via ``brew --prefix``), or "" when brew is
+    absent or fails to answer within 5s."""
+    brew = shutil.which("brew")
+    if not brew:
+        return ""
+    try:
+        result = subprocess.run(
+            [brew, "--prefix"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+
+
+def _existing_gnubin_dirs(prefix: str) -> list[str]:
+    """The Homebrew gnubin dirs that exist on this machine."""
+    gnubin_dirs = [
+        os.path.join(prefix, "opt", "coreutils", "libexec", "gnubin"),
+        os.path.join(prefix, "opt", "gnu-tar", "libexec", "gnubin"),
+    ]
+    return [d for d in gnubin_dirs if os.path.isdir(d)]
+
+
 def prepend_gnubin_paths() -> None:
     """On macOS, prepend Homebrew gnubin dirs to ``PATH`` (#1947).
 
@@ -581,30 +623,52 @@ def prepend_gnubin_paths() -> None:
     """
     if platform.system() != "Darwin":
         return
-    brew = shutil.which("brew")
-    if not brew:
-        return
-    try:
-        result = subprocess.run(
-            [brew, "--prefix"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        prefix = result.stdout.strip()
-    except (subprocess.TimeoutExpired, OSError):
-        return
+    prefix = _brew_prefix()
     if not prefix:
         return
-    gnubin_dirs = [
-        os.path.join(prefix, "opt", "coreutils", "libexec", "gnubin"),
-        os.path.join(prefix, "opt", "gnu-tar", "libexec", "gnubin"),
-    ]
-    existing = [d for d in gnubin_dirs if os.path.isdir(d)]
+    existing = _existing_gnubin_dirs(prefix)
     if existing:
         os.environ["PATH"] = (
             os.pathsep.join(existing) + os.pathsep + os.environ.get("PATH", "")
         )
+
+
+def _prepare_uds_bind(uds_path: str) -> None:
+    """Unlink a stale UDS socket and ensure its parent dir is private
+    (0700) so only the klangk user can open the socket — the same-uid
+    trust boundary Util.set_uds_mode relies on."""
+    try:
+        os.unlink(uds_path)
+    except FileNotFoundError:
+        pass
+    Path(uds_path).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+
+def _run_server(server, uds_path: str, app_state) -> None:
+    """Run uvicorn, mapping a UDS bind failure to ``exit(1)`` and a
+    deterministic config refusal to ``EX_CONFIG`` (#2666)."""
+    try:
+        server.run()
+    except OSError as exc:
+        logger.error(
+            "uvicorn failed to bind UDS at %s: %s — exiting", uds_path, exc
+        )
+        sys.exit(1)
+    except SystemExit:
+        # uvicorn exits STARTUP_FAILURE (3) for every startup failure. If the
+        # failure was a deterministic config error (flagged by the lifespan
+        # on app.state), translate to EX_CONFIG (78) so supervisors can stop
+        # restart-looping a config that cannot fix itself (#2666).
+        config_status = config_error_exit_status(app_state)
+        if config_status is None:
+            raise
+        logger.error(
+            "klangkd refused to start over a configuration error — exiting "
+            "with status %d (EX_CONFIG); restarting cannot fix this, fix "
+            "the config instead",
+            config_status,
+        )
+        raise SystemExit(config_status) from None
 
 
 @app.callback()
@@ -677,14 +741,8 @@ def main(
 
     # Bind the UDS. A stale socket from a kill -9'd process makes the
     # bind fail with EADDRINUSE — unlink first (the pidfile guard in the
-    # lifespan refuses a concurrent klangkd). Ensure the parent dir is
-    # private (0700) so only the klangk user can open the socket — the
-    # same-uid trust boundary Util.set_uds_mode relies on.
-    try:
-        os.unlink(uds_path)
-    except FileNotFoundError:
-        pass
-    Path(uds_path).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # lifespan refuses a concurrent klangkd).
+    _prepare_uds_bind(uds_path)
     # Construct the app explicitly and pass the object to uvicorn (not a
     # ``module:app`` string import). This avoids the module-level
     # ``app = build_app()`` global — there's one ``build_app(settings)`` call,
@@ -715,28 +773,7 @@ def main(
             ws_ping_timeout=20,
         )
     )
-    try:
-        server.run()
-    except OSError as exc:
-        logger.error(
-            "uvicorn failed to bind UDS at %s: %s — exiting", uds_path, exc
-        )
-        sys.exit(1)
-    except SystemExit:
-        # uvicorn exits STARTUP_FAILURE (3) for every startup failure. If the
-        # failure was a deterministic config error (flagged by the lifespan
-        # on app.state), translate to EX_CONFIG (78) so supervisors can stop
-        # restart-looping a config that cannot fix itself (#2666).
-        config_status = config_error_exit_status(asgi_app.state)
-        if config_status is None:
-            raise
-        logger.error(
-            "klangkd refused to start over a configuration error — exiting "
-            "with status %d (EX_CONFIG); restarting cannot fix this, fix "
-            "the config instead",
-            config_status,
-        )
-        raise SystemExit(config_status) from None
+    _run_server(server, uds_path, asgi_app.state)
 
 
 def make_graceful_exit_server(asgi_app):

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -50,8 +50,18 @@ _DOMAIN_RE = re.compile(
 )
 
 
+def _has_no_whitespace(spec: str) -> bool:
+    """True when the spec carries no whitespace."""
+    return not any(ch.isspace() for ch in spec)
+
+
+def _valid_host_port(host: str) -> bool:
+    """A ``host[:port]`` spec against the host grammar + port range."""
+    return bool(_DOMAIN_RE.match(host)) and _valid_spec_port(host)
+
+
 def _valid_domain_spec(spec: str) -> bool:
-    if not spec or any(ch.isspace() for ch in spec):
+    if not spec or not _has_no_whitespace(spec):
         return False
     # A "/" denotes an IPv4 CIDR range (e.g. ``10.0.0.0/8``, optionally
     # scoped to a port as ``10.0.0.0/8:443``). The slash cleanly
@@ -63,12 +73,10 @@ def _valid_domain_spec(spec: str) -> bool:
     # leading ``.`` is INCLUSIVE (apex + subdomains); ``*.`` is SUBDOMAINS only.
     # Strip the sigil and validate the remaining ``host[:port]`` grammar; a bare
     # ``*``, ``*.``, or ``.`` has no matchable base (#2256).
-    spec = _strip_host_sigil(spec)
-    if not spec:
+    host = _strip_host_sigil(spec)
+    if not host:
         return False
-    if not _DOMAIN_RE.match(spec):
-        return False
-    return _valid_spec_port(spec)
+    return _valid_host_port(host)
 
 
 def _strip_host_sigil(spec: str) -> str:
@@ -94,6 +102,18 @@ def _valid_spec_port(spec: str) -> bool:
     return True
 
 
+def _valid_cidr_port_suffix(spec: str) -> tuple[str, str | None] | None:
+    """(cidr, port) with the port split off; ``None`` when the port suffix
+    is malformed (the grammar matches the host spec: 1–65535, digits
+    only)."""
+    if ":" not in spec:
+        return spec, None
+    cidr, port = spec.rsplit(":", 1)
+    if not port or not port.isdigit() or int(port) > 65535:
+        return None
+    return cidr, port
+
+
 def valid_cidr_spec(spec: str) -> bool:
     """Validate an IPv4 CIDR spec, optionally scoped to a TCP port.
 
@@ -108,19 +128,31 @@ def valid_cidr_spec(spec: str) -> bool:
     missing prefixes (``10.0.0.0/``), and non-numeric prefixes are rejected
     via the ``IPv4Network`` ``ValueError`` (#1935).
     """
-    # Split off an optional :port suffix first; the port grammar matches
-    # the host spec (1–65535, digits only).
-    cidr = spec
-    port: str | None = None
-    if ":" in spec:
-        cidr, port = spec.rsplit(":", 1)
-        if not port or not port.isdigit() or int(port) > 65535:
-            return False
+    split = _valid_cidr_port_suffix(spec)
+    if split is None:
+        return False
+    cidr, _port = split
     try:
         ipaddress.IPv4Network(cidr, strict=False)
     except ValueError:
         return False
     return True
+
+
+def _add_valid_spec(
+    out: list[str], seen: set[str], invalid: list[str], raw: str
+) -> None:
+    """Validate one raw entry: strip it, validate it, de-duplicate it, or
+    record it as invalid."""
+    spec = raw.strip()
+    if not spec:
+        return
+    if not _valid_domain_spec(spec):
+        invalid.append(raw)
+        return
+    if spec not in seen:
+        seen.add(spec)
+        out.append(spec)
 
 
 def parse_allowed_domains(
@@ -141,15 +173,7 @@ def parse_allowed_domains(
     seen: set[str] = set()
     invalid: list[str] = []
     for raw in values:
-        spec = raw.strip()
-        if not spec:
-            continue
-        if not _valid_domain_spec(spec):
-            invalid.append(raw)
-            continue
-        if spec not in seen:
-            seen.add(spec)
-            out.append(spec)
+        _add_valid_spec(out, seen, invalid, raw)
     if invalid:
         raise ValueError(
             f"Invalid {label} entry/entries: "
@@ -199,22 +223,41 @@ def is_ipv4(s: str) -> bool:
         return False
 
 
+def _nameserver_line_ip(line: str) -> str | None:
+    """The IPv4 nameserver of a resolv.conf line, or ``None``."""
+    parts = line.split()
+    if len(parts) >= 2 and parts[0] == "nameserver" and is_ipv4(parts[1]):
+        return parts[1]
+    return None
+
+
 def nameservers(path: str) -> list[str]:
     """IPv4 ``nameserver`` IPs from a resolv.conf file (best-effort)."""
     out: list[str] = []
     try:
         with open(path) as f:
             for line in f:
-                parts = line.split()
-                if (
-                    len(parts) >= 2
-                    and parts[0] == "nameserver"
-                    and is_ipv4(parts[1])
-                ):
-                    out.append(parts[1])
+                ip = _nameserver_line_ip(line)
+                if ip is not None:
+                    out.append(ip)
     except OSError:
         pass
     return out
+
+
+def _resolved_stub_upstream(primary: list[str]) -> list[str]:
+    """The real upstream resolvers behind the ``127.0.0.53`` systemd
+    stub, or ``[]`` when the stub isn't in use."""
+    if not any(ns == "127.0.0.53" for ns in primary):
+        return []
+    return nameservers("/run/systemd/resolve/resolv.conf")
+
+
+def _non_loopback_resolvers(primary: list[str]) -> list[str]:
+    """The primary resolvers minus loopback stubs, de-duplicated in order."""
+    return list(
+        dict.fromkeys(ns for ns in primary if not ns.startswith("127."))
+    )
 
 
 def detect_host_resolvers() -> list[str]:
@@ -228,13 +271,10 @@ def detect_host_resolvers() -> list[str]:
     to one of these (picking one that differs from the REDIRECT target for
     loop-avoidance)."""
     primary = nameservers("/etc/resolv.conf")
-    if any(ns == "127.0.0.53" for ns in primary):
-        upstream = nameservers("/run/systemd/resolve/resolv.conf")
-        if upstream:
-            return list(dict.fromkeys(upstream))
-    return list(
-        dict.fromkeys(ns for ns in primary if not ns.startswith("127."))
-    )
+    upstream = _resolved_stub_upstream(primary)
+    if upstream:
+        return list(dict.fromkeys(upstream))
+    return _non_loopback_resolvers(primary)
 
 
 class NetFilter:

--- a/src/klangk/klangk/nix.py
+++ b/src/klangk/klangk/nix.py
@@ -158,28 +158,40 @@ class Nix:
 
     # --- subprocess helper ---------------------------------------------------
 
-    async def run(
-        self, args: list[str], *, check: bool = True, timeout: float = 30.0
-    ) -> tuple[int, str, str]:
+    async def _spawn(self, args: list[str]):
+        """Spawn a backend tool with captured output. A missing binary
+        (fuse-overlayfs / fusermount3 / btrfs / stat) surfaces as a
+        clear NixError, not a raw FileNotFoundError out of container
+        start."""
         try:
-            proc = await asyncio.create_subprocess_exec(
+            return await asyncio.create_subprocess_exec(
                 *args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
         except FileNotFoundError as exc:
-            # Missing fuse-overlayfs / fusermount3 / btrfs / stat — surface a
-            # clear NixError, not a raw FileNotFoundError out of container start.
             raise NixError(
                 f"{args[0]} not found on PATH — install the nix backend "
                 f"tooling and re-run `klangkd doctor`"
             ) from exc
+
+    async def _communicate(
+        self, proc, args: list[str], timeout: float
+    ) -> tuple[bytes, bytes]:
+        """``communicate()`` bounded by *timeout*; a hang is killed and
+        raises a clear NixError."""
         try:
-            out, err = await asyncio.wait_for(proc.communicate(), timeout)
+            return await asyncio.wait_for(proc.communicate(), timeout)
         except asyncio.TimeoutError:
             proc.kill()
             await proc.wait()
             raise NixError(f"{' '.join(args)} timed out after {timeout}s")
+
+    async def run(
+        self, args: list[str], *, check: bool = True, timeout: float = 30.0
+    ) -> tuple[int, str, str]:
+        proc = await self._spawn(args)
+        out, err = await self._communicate(proc, args, timeout)
         rc = proc.returncode if proc.returncode is not None else 1
         out_s, err_s = out.decode(), err.decode()
         if check and rc != 0:

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -63,12 +63,21 @@ class PodmanError(Exception):
         super().__init__(f"[{status}] {message}")
 
 
+_NOT_FOUND_HINTS = ("no such", "not found", "no container")
+_IN_USE_HINTS = ("in use", "being used", "already in use")
+
+
+def _matches_any(low: str, hints: tuple[str, ...]) -> bool:
+    """True when any hint appears in the lowercased stderr."""
+    return any(h in low for h in hints)
+
+
 def classify(stderr: str) -> int:
     """Map podman stderr text to an HTTP-like status code."""
     low = stderr.lower()
-    if "no such" in low or "not found" in low or "no container" in low:
+    if _matches_any(low, _NOT_FOUND_HINTS):
         return 404
-    if "in use" in low or "being used" in low or "already in use" in low:
+    if _matches_any(low, _IN_USE_HINTS):
         return 409
     return 500
 
@@ -136,21 +145,21 @@ class Podman:
             return True
 
     @staticmethod
-    def _finish_podman_run(
-        proc,
-        timed_out: bool,
+    def _timeout_rc(
         err: str,
         cmd_label: str,
         timeout: float | None,
-        args: list[str],
-        check: bool,
-        timings: tuple[float, float, float, float],
+        timed_out: bool,
+        rc: int,
     ) -> tuple[int, str]:
-        """Apply the timeout override, log timings, and enforce *check*."""
-        rc = proc.returncode or 0
-        if timed_out:
-            rc = -1
-            err = err or f"{cmd_label} timed out after {timeout}s"
+        """(rc, err) with the timeout override applied."""
+        if not timed_out:
+            return rc, err
+        return -1, err or f"{cmd_label} timed out after {timeout}s"
+
+    @staticmethod
+    def _log_podman_timing(cmd_label: str, timings, err: str) -> None:
+        """Debug-log the phase timings; a slow run's stderr rides along."""
         t0, t1, t2, t3 = timings
         elapsed = t3 - t0
         logger.debug(
@@ -166,6 +175,22 @@ class Podman:
             logger.debug(
                 "podman-timing: %s stderr: %s", cmd_label, err.strip()
             )
+
+    @staticmethod
+    def _finish_podman_run(
+        proc,
+        timed_out: bool,
+        err: str,
+        cmd_label: str,
+        timeout: float | None,
+        args: list[str],
+        check: bool,
+        timings: tuple[float, float, float, float],
+    ) -> tuple[int, str]:
+        """Apply the timeout override, log timings, and enforce *check*."""
+        rc = proc.returncode or 0
+        rc, err = Podman._timeout_rc(err, cmd_label, timeout, timed_out, rc)
+        Podman._log_podman_timing(cmd_label, timings, err)
         if check and rc != 0:
             raise PodmanError(
                 classify(err), err.strip() or f"podman {args[0]}"
@@ -344,6 +369,30 @@ class Podman:
         return args
 
     @staticmethod
+    def _hooks_dir_args(hooks_dir: list[str] | None) -> list[str]:
+        """``--hooks-dir`` global flags — podman global flags precede the
+        subcommand, and podman does not persist them from create to
+        start."""
+        args: list[str] = []
+        for d in hooks_dir or []:
+            args += ["--hooks-dir", d]
+        return args
+
+    @staticmethod
+    def _publish_args(publish: list | None) -> list[str]:
+        """``-p`` flags for ``(host_port, container_port)`` or
+        ``(bind_addr, host_port, container_port)`` entries."""
+        args: list[str] = []
+        for entry in publish or []:
+            if len(entry) == 3:
+                bind, host_port, container_port = entry
+                args += ["-p", f"{bind}:{host_port}:{container_port}"]
+            else:
+                host_port, container_port = entry
+                args += ["-p", f"{host_port}:{container_port}"]
+        return args
+
+    @staticmethod
     def _create_storage_args(
         binds: list[str] | None,
         tmpfs: dict[str, str] | None,
@@ -357,14 +406,7 @@ class Podman:
             args += ["-v", bind]
         for path, opts in (tmpfs or {}).items():
             args += ["--tmpfs", f"{path}:{opts}"]
-        for entry in publish or []:
-            if len(entry) == 3:
-                bind, host_port, container_port = entry
-                args += ["-p", f"{bind}:{host_port}:{container_port}"]
-            else:
-                host_port, container_port = entry
-                args += ["-p", f"{host_port}:{container_port}"]
-        return args
+        return args + Podman._publish_args(publish)
 
     @staticmethod
     def _create_dns_args(
@@ -374,12 +416,13 @@ class Podman:
     ) -> list[str]:
         """Hosts-file / DNS server / DNS search flags."""
         args: list[str] = []
-        for host in add_hosts or []:
-            args += ["--add-host", host]
-        for server in dns or []:
-            args += ["--dns", server]
-        for domain in dns_search or []:
-            args += ["--dns-search", domain]
+        for flag, values in (
+            ("--add-host", add_hosts),
+            ("--dns", dns),
+            ("--dns-search", dns_search),
+        ):
+            for value in values or []:
+                args += [flag, value]
         return args
 
     async def create_container(
@@ -440,9 +483,7 @@ class Podman:
         # --hooks-dir is a podman global flag (before the subcommand), not a
         # create flag. Placing it after "create" causes podman to silently
         # ignore it. Global flags must precede the subcommand.
-        args: list[str] = []
-        for d in hooks_dir or []:
-            args += ["--hooks-dir", d]
+        args: list[str] = self._hooks_dir_args(hooks_dir)
         args += self._create_base_args(
             name, pull, replace, init, interactive, userns
         )
@@ -473,9 +514,7 @@ class Podman:
         ``create``.  OCI hooks are discovered and executed at ``start``
         time, so omitting the flag here silently skips all hooks.
         """
-        args: list[str] = []
-        for d in hooks_dir or []:
-            args += ["--hooks-dir", d]
+        args: list[str] = self._hooks_dir_args(hooks_dir)
         args += ["start", container_id]
         await self.run(args, timeout=120.0)
 
@@ -581,6 +620,27 @@ class Podman:
         )
         return await self.run_raw(args, check=False, timeout=timeout)
 
+    def _stream_failure(
+        self, proc, container_id: str, cmd: list[str], yielded: bool
+    ) -> None:
+        """Warn on a failed stream; abort (raise) only when no data was
+        produced — if data was yielded the response is already in-flight
+        and may be valid (e.g. tar exits 1 when files change during
+        archiving)."""
+        if proc.returncode == 0:
+            return
+        logger.warning(
+            "exec_container_stream command failed (rc=%d): %s %s",
+            proc.returncode,
+            container_id,
+            cmd,
+        )
+        if not yielded:
+            raise PodmanError(
+                proc.returncode,
+                f"stream command exited with code {proc.returncode}",
+            )
+
     async def exec_container_stream(
         self,
         container_id: str,
@@ -618,21 +678,21 @@ class Podman:
             if proc.returncode is None:
                 proc.kill()
             await proc.wait()
-        if proc.returncode != 0:
-            logger.warning(
-                "exec_container_stream command failed (rc=%d): %s %s",
-                proc.returncode,
-                container_id,
-                cmd,
-            )
-            # Only abort the stream if no data was produced; if data was
-            # yielded the response is already in-flight and may be valid
-            # (e.g. tar exits 1 when files change during archiving).
-            if not yielded:
-                raise PodmanError(
-                    proc.returncode,
-                    f"stream command exited with code {proc.returncode}",
-                )
+        self._stream_failure(proc, container_id, cmd, yielded)
+
+    async def _stop_before_remove(self, container_id: str) -> bool:
+        """Graceful stop first (conmon cleanup kills pasta). False when
+        the container is already gone — remove is then a no-op."""
+        rc, _out, err = await self.run(
+            ["stop", "-t", "5", container_id], check=False
+        )
+        return not (rc != 0 and classify(err) == 404)
+
+    def _raise_rm_error(self, rc: int, err: str) -> None:
+        """Raise for a failed ``podman rm``, except when the container is
+        already gone."""
+        if rc != 0 and classify(err) != 404:
+            raise PodmanError(classify(err), err.strip() or "podman rm")
 
     async def remove_container(
         self, container_id: str, *, force: bool = True
@@ -644,20 +704,14 @@ class Podman:
         ``podman rm -f`` skips cleanup and can leave orphaned pasta
         processes holding ports indefinitely (podman#14276).
         """
-        if force:
-            # Graceful stop triggers conmon cleanup (kills pasta).
-            rc, _out, err = await self.run(
-                ["stop", "-t", "5", container_id], check=False
-            )
-            if rc != 0 and classify(err) == 404:
-                return  # already gone
+        if force and not await self._stop_before_remove(container_id):
+            return  # already gone
         args = ["rm"]
         if force:
             args.append("-f")  # catch stragglers
         args.append(container_id)
         rc, _out, err = await self.run(args, check=False)
-        if rc != 0 and classify(err) != 404:
-            raise PodmanError(classify(err), err.strip() or "podman rm")
+        self._raise_rm_error(rc, err)
 
     async def list_containers(self, label: str) -> list[dict]:
         """List containers matching ``label`` (``key=value``)."""
@@ -702,12 +756,7 @@ class Podman:
         subset of what GET returns, never more.
         """
         volumes = await self.list_volumes(f"klangk.instance={instance}")
-        return sum(
-            1
-            for v in volumes
-            if (v.get("Labels") or {}).get("klangk.instance") == instance
-            and (v.get("Labels") or {}).get("klangk.user-id") == user_id
-        )
+        return sum(1 for v in volumes if _is_user_volume(v, instance, user_id))
 
     async def remove_volume(self, name: str) -> None:
         """Remove a volume.
@@ -721,6 +770,17 @@ class Podman:
 
 
 # --- Exec sessions ---
+
+
+def _is_user_volume(v: dict, instance: str, user_id: str) -> bool:
+    """The quota-matching label rule: the instance label is re-checked
+    defensively — a stray out-of-band volume must not consume quota —
+    plus the user-id label (#2972)."""
+    labels = v.get("Labels") or {}
+    return (
+        labels.get("klangk.instance") == instance
+        and labels.get("klangk.user-id") == user_id
+    )
 
 
 class ExecSession:
@@ -805,33 +865,40 @@ class ExecSession:
             command,
         )
 
+    async def _pump_stdout(self, stdout) -> None:
+        """Read chunks to the bounded queue (a full queue blocks,
+        back-pressuring the process via its kernel pipe buffer)."""
+        while True:
+            data = await stdout.read(65536)
+            if not data:
+                break
+            await self._output_queue.put(data)
+
+    async def _await_proc_exit(self) -> None:
+        """Wait (bounded) for the process to exit so returncode is set
+        before the caller reads it."""
+        if self._proc is None or self._proc.returncode is not None:
+            return
+        try:
+            await asyncio.wait_for(self._proc.wait(), timeout=5)
+        except (
+            asyncio.TimeoutError,
+            ProcessLookupError,
+            OSError,
+        ):
+            pass
+
     async def _read_stdout(self) -> None:
         """Read stdout in a background task and queue chunks."""
         assert self._proc is not None
         assert self._proc.stdout is not None
         try:
-            while True:
-                data = await self._proc.stdout.read(65536)
-                if not data:
-                    break
-                # Bounded queue: blocks when full, back-pressuring the
-                # process via its kernel pipe buffer.
-                await self._output_queue.put(data)
+            await self._pump_stdout(self._proc.stdout)
         except asyncio.CancelledError:
             raise
         except OSError:
             pass
-        # Wait for the process to exit so returncode is set before
-        # the caller reads it.
-        if self._proc and self._proc.returncode is None:
-            try:
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except (
-                asyncio.TimeoutError,
-                ProcessLookupError,
-                OSError,
-            ):
-                pass
+        await self._await_proc_exit()
         self._output_queue.send_sentinel()
 
     @property
@@ -860,6 +927,11 @@ class ExecSession:
         if self._proc is not None and self._proc.stdin is not None:
             self._proc.stdin.close()
 
+    def _read_task_done(self) -> bool:
+        """True when the stdout producer finished (its sentinel may have
+        been dropped when the queue was full)."""
+        return self._read_task is not None and self._read_task.done()
+
     async def output(self) -> AsyncGenerator[bytes, None]:
         """Yield stdout data as it arrives."""
         while self._running:
@@ -868,44 +940,53 @@ class ExecSession:
                     self._output_queue.get(), timeout=1.0
                 )
             except asyncio.TimeoutError:
-                # Producer finished but sentinel was dropped (queue was full).
-                if self._read_task is not None and self._read_task.done():
+                if self._read_task_done():
                     break
                 continue
             if data is None:
                 break
             yield data
 
+    async def _cancel_read_task(self) -> None:
+        """Cancel (and await) the stdout read task."""
+        if self._read_task is None:
+            return
+        self._read_task.cancel()
+        try:
+            await self._read_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Error awaiting exec read task")
+        self._read_task = None
+
+    def _save_returncode(self) -> None:
+        """Record the current exit code (when set) for post-stop reads."""
+        if self._proc is not None and self._proc.returncode is not None:
+            self._returncode = self._proc.returncode
+
+    async def _terminate_proc(self) -> None:
+        """Terminate the exec process — TERM, 5s wait, KILL — saving its
+        exit code so ``returncode`` stays accessible after stop()."""
+        if not self._proc:
+            return
+        self._save_returncode()
+        try:
+            self._proc.terminate()
+            await asyncio.wait_for(self._proc.wait(), timeout=5)
+        except (ProcessLookupError, asyncio.TimeoutError, OSError):
+            try:
+                self._proc.kill()
+            except (ProcessLookupError, OSError):
+                pass
+        self._save_returncode()
+        self._proc = None
+
     async def stop(self) -> None:
         """Stop the exec session and clean up."""
         self._running = False
-
-        if self._read_task is not None:
-            self._read_task.cancel()
-            try:
-                await self._read_task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.exception("Error awaiting exec read task")
-            self._read_task = None
-
-        if self._proc:
-            # Save exit code before nulling _proc so returncode stays
-            # accessible after stop().
-            if self._proc.returncode is not None:
-                self._returncode = self._proc.returncode
-            try:
-                self._proc.terminate()
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except (ProcessLookupError, asyncio.TimeoutError, OSError):
-                try:
-                    self._proc.kill()
-                except (ProcessLookupError, OSError):
-                    pass
-            if self._proc.returncode is not None:
-                self._returncode = self._proc.returncode
-            self._proc = None
+        await self._cancel_read_task()
+        await self._terminate_proc()
         logger.info("Exec session stopped for container %s", self.container_id)
 
     @property

--- a/src/klangk/klangk/seed.py
+++ b/src/klangk/klangk/seed.py
@@ -81,6 +81,31 @@ def sig_policy_args() -> list[str]:
 # --- subprocess helper -----------------------------------------------------
 
 
+async def _spawn_seed_proc(binary: str, args: list[str]):
+    """Spawn a seed tool with captured output; a missing binary surfaces
+    as :class:`SeedError`, not a raw ``FileNotFoundError``."""
+    try:
+        return await asyncio.create_subprocess_exec(
+            binary,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=subprocess_env(),
+        )
+    except FileNotFoundError as exc:
+        raise SeedError(f"{binary} not found on PATH") from exc
+
+
+def _check_seed_run(
+    binary: str, args: list[str], check: bool, rc: int, err_s: str
+) -> None:
+    """Raise :class:`SeedError` on a checked nonzero exit."""
+    if check and rc != 0:
+        raise SeedError(
+            f"{binary} {' '.join(args[:2])} failed (rc={rc}): {err_s.strip()}"
+        )
+
+
 async def run(
     binary: str,
     args: list[str],
@@ -96,16 +121,7 @@ async def run(
     devenv. A missing binary surfaces as ``SeedError`` (not a raw
     ``FileNotFoundError``), and a wedged call times out + is killed.
     """
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            binary,
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=subprocess_env(),
-        )
-    except FileNotFoundError as exc:
-        raise SeedError(f"{binary} not found on PATH") from exc
+    proc = await _spawn_seed_proc(binary, args)
     try:
         out, err = await asyncio.wait_for(proc.communicate(), timeout)
     except asyncio.TimeoutError:
@@ -116,10 +132,7 @@ async def run(
     rc = proc.returncode or 0
     out_s = out.decode("utf-8", "replace")
     err_s = err.decode("utf-8", "replace")
-    if check and rc != 0:
-        raise SeedError(
-            f"{binary} {' '.join(args[:2])} failed (rc={rc}): {err_s.strip()}"
-        )
+    _check_seed_run(binary, args, check, rc, err_s)
     return rc, out_s, err_s
 
 
@@ -151,18 +164,35 @@ async def build_image(
         await run(podman_bin, args, timeout=2400.0)
 
 
+def _seed_member_name(member) -> str:
+    """The member path with a leading ``./`` stripped."""
+    name = member.name
+    return name[2:] if name.startswith("./") else name
+
+
+def _is_seed_member(name: str) -> bool:
+    """True for the whitelisted seed members: ``nix`` + ``etc/nix/nix.conf``."""
+    return (
+        name == "nix" or name.startswith("nix/") or name == "etc/nix/nix.conf"
+    )
+
+
 def _extract_seed_members(tar, out: str) -> None:
     """Extract only ``nix`` + ``etc/nix/nix.conf`` members (every member is
     a whitelisted relative path; ``filter="fully_trusted"`` preserves the
     seed's uid-1000 ownership — the workspace klangk user)."""
     for member in tar:
-        name = member.name[2:] if member.name.startswith("./") else member.name
-        if (
-            name == "nix"
-            or name.startswith("nix/")
-            or name == "etc/nix/nix.conf"
-        ):
+        if _is_seed_member(_seed_member_name(member)):
             tar.extract(member, out, filter="fully_trusted")
+
+
+def _export_error(proc) -> str:
+    """``podman export``'s stderr (empty when it closed the stream)."""
+    return (
+        proc.stderr.read().decode("utf-8", "replace").strip()
+        if proc.stderr
+        else ""
+    )
 
 
 def export_to_dir_sync(podman_bin: str, cid: str, out: str) -> None:
@@ -194,17 +224,30 @@ def export_to_dir_sync(podman_bin: str, cid: str, out: str) -> None:
         assert proc.stdout is not None
         proc.stdout.close()
         proc.wait()
-    err = (
-        proc.stderr.read().decode("utf-8", "replace").strip()
-        if proc.stderr
-        else ""
-    )
+    err = _export_error(proc)
     if proc.returncode != 0:
         raise SeedError(f"podman export failed (rc={proc.returncode}): {err}")
     if not extracted:
         raise SeedError(
             f"podman export produced no readable tar stream: {err}"
         )
+
+
+def _flatten_nix_conf(out: Path) -> None:
+    """tar wrote ``etc/nix/nix.conf``; flatten it to ``<out>/nix.conf``
+    and drop the emptied ``etc/`` tree."""
+    conf = out / "etc" / "nix" / "nix.conf"
+    if not conf.is_file():
+        raise SeedError("/etc/nix/nix.conf missing from the seed image")
+    target = out / "nix.conf"
+    if target.exists():
+        target.unlink()
+    conf.rename(target)
+    for d in (conf.parent, conf.parent.parent):
+        try:
+            d.rmdir()
+        except OSError:
+            pass
 
 
 async def export_and_extract(podman_bin: str, image: str, out: Path) -> None:
@@ -221,20 +264,7 @@ async def export_and_extract(podman_bin: str, image: str, out: Path) -> None:
         await asyncio.to_thread(export_to_dir_sync, podman_bin, cid, str(out))
     finally:
         await run(podman_bin, ["rm", cid], check=False)
-
-    # tar wrote etc/nix/nix.conf; flatten it to <out>/nix.conf + drop etc/.
-    conf = out / "etc" / "nix" / "nix.conf"
-    if not conf.is_file():
-        raise SeedError("/etc/nix/nix.conf missing from the seed image")
-    target = out / "nix.conf"
-    if target.exists():
-        target.unlink()
-    conf.rename(target)
-    for d in (conf.parent, conf.parent.parent):
-        try:
-            d.rmdir()
-        except OSError:
-            pass
+    _flatten_nix_conf(out)
 
 
 async def verify(podman_bin: str, image: str, out: Path) -> None:
@@ -293,21 +323,26 @@ def cp_a(src: Path, dst: Path) -> None:
         shutil.copy2(src, dst)
 
 
+def _clear_seed_entry(p: Path) -> None:
+    """Remove one seed entry; a dir is chmod'd writable first so the
+    read-only store files can be removed."""
+    if p.is_dir():
+        chmod_w(p)
+        shutil.rmtree(p, ignore_errors=True)
+        return
+    try:
+        p.unlink()
+    except OSError:
+        pass
+
+
 def clear_seed_dir(out: Path) -> None:
     """Remove an existing ``nix/`` + ``nix.conf`` + ``etc/`` (chmod read-only
     store files first so rmdir/unlink can proceed)."""
     for name in ("nix", "nix.conf", "etc"):
         p = out / name
-        if not p.exists() and not p.is_symlink():
-            continue
-        if p.is_dir():
-            chmod_w(p)
-            shutil.rmtree(p, ignore_errors=True)
-        else:
-            try:
-                p.unlink()
-            except OSError:
-                pass
+        if p.exists() or p.is_symlink():
+            _clear_seed_entry(p)
 
 
 # --- orchestration ---------------------------------------------------------

--- a/src/klangk/klangk/server_schedule.py
+++ b/src/klangk/klangk/server_schedule.py
@@ -108,27 +108,34 @@ class ServerScheduler(IntervalWorker):
             # owns cleanup on disconnect.
             pass
 
-    async def sweep(self) -> None:
-        schedules = await self.snapshot()
-        now = datetime.now(timezone.utc)
-        # 7: a malformed fire_at row (manual DB edit) must not kill the
-        # whole tick — skip and log it, keep the healthy rows working.
+    def _split_due(
+        self, schedules: list[dict], now: datetime
+    ) -> tuple[list[dict], list[dict]]:
+        """Partition the pending rows into (due, pending)."""
         due = []
         pending = []
         for s in schedules:
             try:
                 is_due = parse_fire_at(s["fire_at"]) <= now
             except (TypeError, ValueError):
+                # 7: a malformed fire_at row (manual DB edit) must not
+                # kill the whole tick — skip and log it, keep the healthy
+                # rows working (still broadcast it; never fire it).
                 logger.exception(
                     "Server scheduler: skipping schedule %s — malformed "
                     "fire_at %r",
                     s.get("id"),
                     s.get("fire_at"),
                 )
-                pending.append(s)  # keep broadcasting it; never fire it
+                pending.append(s)
                 continue
             (due if is_due else pending).append(s)
-        # Refresh clients when the set changed or on the periodic cadence.
+        return due, pending
+
+    def _broadcast_stale(self, pending: list[dict], now: datetime) -> None:
+        """Refresh clients when the pending set changed or on the
+        periodic cadence (a client that missed a change-driven
+        broadcast is caught by the timer)."""
         changed = pending != (self._last_snapshot or [])
         periodic = (
             self._last_broadcast is None
@@ -137,6 +144,12 @@ class ServerScheduler(IntervalWorker):
         )
         if changed or periodic:
             self.notify_pending_sync(pending)
+
+    async def sweep(self) -> None:
+        schedules = await self.snapshot()
+        now = datetime.now(timezone.utc)
+        due, pending = self._split_due(schedules, now)
+        self._broadcast_stale(pending, now)
         for schedule in due:
             await self._fire(schedule)
 
@@ -206,12 +219,50 @@ class ServerScheduler(IntervalWorker):
             lifecycle.request_recycle(source="scheduled recycle")
 
 
-def parse_fire_at(value: str) -> datetime:
-    """Parse a stored fire_at ISO string as timezone-aware UTC."""
-    parsed = datetime.fromisoformat(value)
+def _as_utc(parsed: datetime) -> datetime:
+    """A naive datetime reads as UTC; convert to timezone-aware UTC."""
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def parse_fire_at(value: str) -> datetime:
+    """Parse a stored fire_at ISO string as timezone-aware UTC."""
+    return _as_utc(datetime.fromisoformat(value))
+
+
+def _resolve_at(at) -> datetime:
+    """The absolute ``{"at": ISO-8601}`` form; naive values read as UTC."""
+    try:
+        return _as_utc(datetime.fromisoformat(str(at)))
+    except ValueError as e:
+        raise ValueError(f"invalid 'at' timestamp: {at!r}") from e
+
+
+def _finite_seconds(value) -> float:
+    """``in_seconds`` as a float; NaN and infinities rejected."""
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError("'in_seconds' must be a number") from e
+    if seconds != seconds or seconds in (float("inf"), float("-inf")):
+        raise ValueError("'in_seconds' must be a finite number")
+    return seconds
+
+
+def _require_positive(seconds: float) -> None:
+    """Reject non-positive and absurdly large relative delays."""
+    if seconds <= 0:
+        raise ValueError("'in_seconds' must be positive")
+    if seconds > _MAX_IN_SECONDS:
+        raise ValueError(f"'in_seconds' must be at most {_MAX_IN_SECONDS:g}")
+
+
+def _finite_positive_seconds(value) -> float:
+    """Validate ``in_seconds``: a finite, positive, bounded number."""
+    seconds = _finite_seconds(value)
+    _require_positive(seconds)
+    return seconds
 
 
 def resolve_fire_at(payload: dict) -> datetime:
@@ -223,26 +274,9 @@ def resolve_fire_at(payload: dict) -> datetime:
     """
     at = payload.get("at")
     if at:
-        try:
-            parsed = datetime.fromisoformat(str(at))
-        except ValueError as e:
-            raise ValueError(f"invalid 'at' timestamp: {at!r}") from e
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return parsed.astimezone(timezone.utc)
+        return _resolve_at(at)
     in_seconds = payload.get("in_seconds")
     if in_seconds is not None:
-        try:
-            seconds = float(in_seconds)
-        except (TypeError, ValueError) as e:
-            raise ValueError("'in_seconds' must be a number") from e
-        if seconds != seconds or seconds in (float("inf"), float("-inf")):
-            raise ValueError("'in_seconds' must be a finite number")
-        if seconds <= 0:
-            raise ValueError("'in_seconds' must be positive")
-        if seconds > _MAX_IN_SECONDS:
-            raise ValueError(
-                f"'in_seconds' must be at most {_MAX_IN_SECONDS:g}"
-            )
+        seconds = _finite_positive_seconds(in_seconds)
         return datetime.now(timezone.utc) + timedelta(seconds=seconds)
     raise ValueError("provide either 'at' or 'in_seconds'")

--- a/src/klangk/klangk/sidecar_connections.py
+++ b/src/klangk/klangk/sidecar_connections.py
@@ -50,22 +50,35 @@ class SidecarConnections:
             "sidecar connection registered: ws=%s", str(workspace_id)[:8]
         )
 
-    def deregister(self, workspace_id: str) -> None:
-        """Drop a sidecar socket (disconnect) + fail its pending drop-acks.
-
-        Failing the acks (rather than leaving them to time out) lets an
-        in-flight ``revoke`` learn at once that the sidecar is gone.
-        """
-        self._conns.pop(workspace_id, None)
-        stale = [
+    def _stale_ack_ids(self, workspace_id: str) -> list[str]:
+        """Ids of the pending drop-acks waiting on this sidecar."""
+        return [
             aid
             for aid, entry in self._pending.items()
             if entry["ws"] == workspace_id
         ]
+
+    @staticmethod
+    def _fail_ack(entry) -> None:
+        """Resolve one pending drop-ack to False (sidecar gone)."""
+        if entry is not None and not entry["future"].done():
+            entry["future"].set_result(False)
+
+    def _fail_pending_acks(self, workspace_id: str) -> list[str]:
+        """Fail the sidecar's pending drop-acks and return their ids.
+
+        Failing the acks (rather than leaving them to time out) lets an
+        in-flight ``revoke`` learn at once that the sidecar is gone.
+        """
+        stale = self._stale_ack_ids(workspace_id)
         for aid in stale:
-            entry = self._pending.pop(aid, None)
-            if entry is not None and not entry["future"].done():
-                entry["future"].set_result(False)
+            self._fail_ack(self._pending.pop(aid, None))
+        return stale
+
+    def deregister(self, workspace_id: str) -> None:
+        """Drop a sidecar socket (disconnect) + fail its pending drop-acks."""
+        self._conns.pop(workspace_id, None)
+        stale = self._fail_pending_acks(workspace_id)
         if stale or workspace_id in self._conns:
             logger.info(
                 "sidecar connection deregistered: ws=%s", str(workspace_id)[:8]

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -299,6 +299,41 @@ def _window_target(
     return f"{session_name}:{target}"
 
 
+def _session_env_args(
+    user_home: str | None,
+    ssh_agent_socket: str | None,
+    user_id: str | None,
+    user_handle: str | None,
+) -> list[str]:
+    """tmux ``-e`` flags carrying HOME, SSH_AUTH_SOCK, and the user
+    identity vars into the session's window-0 shell (#2259)."""
+    env = {
+        "HOME": user_home,
+        "SSH_AUTH_SOCK": ssh_agent_socket,
+        "KLANGKWS_USER_ID": user_id,
+        "KLANGKWS_USER_HANDLE": user_handle,
+    }
+    args: list[str] = []
+    for key, value in env.items():
+        if value is not None:
+            args += ["-e", f"{key}={value}"]
+    return args
+
+
+def _container_gone(stderr: str) -> bool:
+    """True when an exec failed because the container is gone.
+
+    Podman's 404 (the container recycled between terminal start and this
+    call, #2178) and its *stopped*-container wording (an idle-reap racing
+    this exec — "state improper" / "can only create exec sessions on
+    running containers", #2514) are the same recoverable recycle race,
+    not a tmux/server failure."""
+    if classify(stderr) == 404:
+        return True
+    low = stderr.lower()
+    return "state improper" in low or "running containers" in low
+
+
 class Terminal:
     """Groups the ~25 tmux-session management functions that share a
     :class:`~klangk.podman.Podman` dependency.
@@ -414,15 +449,9 @@ class Terminal:
         """
         if await self.has_tmux_session(container_id, session_name):
             return False
-        env_args: list[str] = []
-        if user_home is not None:
-            env_args += ["-e", f"HOME={user_home}"]
-        if ssh_agent_socket is not None:
-            env_args += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
-        if user_id is not None:
-            env_args += ["-e", f"KLANGKWS_USER_ID={user_id}"]
-        if user_handle is not None:
-            env_args += ["-e", f"KLANGKWS_USER_HANDLE={user_handle}"]
+        env_args = _session_env_args(
+            user_home, ssh_agent_socket, user_id, user_handle
+        )
         try:
             await self.podman.exec_container(
                 container_id,
@@ -660,6 +689,53 @@ class Terminal:
                 container_id,
             )
 
+    async def _create_service_cmd_window(self, container_id: str) -> bool:
+        """The ``tmux new-window`` step of a service fire. ``False`` on
+        any failure — an exec killed client-side is indistinguishable
+        from a real failure."""
+        try:
+            rc, _, _ = await self.podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "new-window",
+                    "-d",
+                    "-t",
+                    SERVICE_SESSION,
+                    "-n",
+                    SERVICE_CMD_WINDOW,
+                ],
+                user=CONTAINER_USER,
+                timeout=SERVICE_EXEC_TIMEOUT,
+            )
+        except Exception:
+            rc = -1
+        if rc != 0:
+            logger.warning(
+                "Failed to create %s window in %s",
+                SERVICE_CMD_WINDOW,
+                SERVICE_SESSION,
+            )
+            return False
+        return True
+
+    async def _abort_service_fire(
+        self, container_id: str, *, note: str
+    ) -> None:
+        """Mark the fire pending, then clean up the half-fired window; a
+        failed cleanup leaves the pending flag so the next fire retries
+        the whole sequence (#2740, #1186)."""
+        self.registry.mark_service_fire_pending(container_id)
+        if await self.kill_service_cmd_window(container_id):
+            self.registry.clear_service_fire_pending(container_id)
+            return
+        logger.warning(
+            "Failed to clean up %s window in %s%s",
+            SERVICE_CMD_WINDOW,
+            SERVICE_SESSION,
+            note,
+        )
+
     async def fire_service_command(
         self, container_id: str, service_command: str
     ) -> None:
@@ -670,42 +746,12 @@ class Terminal:
         # other way) is moot once this sequence runs.
         self.registry.clear_service_fire_pending(container_id)
         try:
-            try:
-                rc, _, _ = await self.podman.exec_container(
-                    container_id,
-                    [
-                        "tmux",
-                        "new-window",
-                        "-d",
-                        "-t",
-                        SERVICE_SESSION,
-                        "-n",
-                        SERVICE_CMD_WINDOW,
-                    ],
-                    user=CONTAINER_USER,
-                    timeout=SERVICE_EXEC_TIMEOUT,
-                )
-            except Exception:
-                rc = -1
-            if rc != 0:
-                logger.warning(
-                    "Failed to create %s window in %s",
-                    SERVICE_CMD_WINDOW,
-                    SERVICE_SESSION,
-                )
+            if not await self._create_service_cmd_window(container_id):
                 # The exec may have been killed client-side while the
                 # container side created the window -- clean it up so
                 # the next fire re-runs the whole sequence instead of
                 # suppressing on a command-less window (#2740).
-                self.registry.mark_service_fire_pending(container_id)
-                if await self.kill_service_cmd_window(container_id):
-                    self.registry.clear_service_fire_pending(container_id)
-                else:
-                    logger.warning(
-                        "Failed to clean up %s window in %s",
-                        SERVICE_CMD_WINDOW,
-                        SERVICE_SESSION,
-                    )
+                await self._abort_service_fire(container_id, note="")
                 return
             # The new window's shell needs a moment to source
             # .profile / .bashrc before it can resolve PATH-dependent
@@ -730,15 +776,9 @@ class Terminal:
             # half-created window (#1186). If the cleanup itself
             # fails, leave the fire pending so the next call retries
             # the send into the surviving window (#2740).
-            self.registry.mark_service_fire_pending(container_id)
-            if await self.kill_service_cmd_window(container_id):
-                self.registry.clear_service_fire_pending(container_id)
-            else:
-                logger.warning(
-                    "Failed to clean up %s window in %s; fire marked pending",
-                    SERVICE_CMD_WINDOW,
-                    SERVICE_SESSION,
-                )
+            await self._abort_service_fire(
+                container_id, note="; fire marked pending"
+            )
         except asyncio.CancelledError:
             # The caller (e.g. the _start_terminal task on a client WS
             # drop) went away mid-sequence. The synchronous pending
@@ -810,6 +850,19 @@ class Terminal:
         "no such session",
     )
 
+    def _cold_start_retry(
+        self, stderr: str, attempt: int, attempts: int
+    ) -> bool:
+        """A cold-start failure with retry budget left (#2623): the tmux
+        socket missing while the server boots in a fresh container, or
+        the target session missing while a just-spawned attach is still
+        creating it."""
+        low = stderr.lower()
+        return (
+            any(s in low for s in self._COLD_START_STDERR)
+            and attempt < attempts - 1
+        )
+
     async def tmux_command(
         self, container_id: str, session_name: str, args: list[str]
     ) -> str:
@@ -833,25 +886,10 @@ class Terminal:
             )
             if rc == 0:
                 return stdout
-            low = stderr.lower()
-            if (
-                any(s in low for s in self._COLD_START_STDERR)
-                and attempt < attempts - 1
-            ):
+            if self._cold_start_retry(stderr, attempt, attempts):
                 await asyncio.sleep(0.5)
                 continue
-            # "container gone" is a recoverable condition (the container
-            # was recycled between terminal start and this call), not a
-            # tmux/server failure — surface it distinctly so callers can
-            # avoid tracebacking an expected race (#2178). Podman reports
-            # a *stopped* container (an idle-reap racing this exec) as
-            # "state improper" / "can only create exec sessions on running
-            # containers" — same recycle race, found by the idle fuzz
-            # harness (#2514), so it maps to the same exception.
-            if classify(stderr) == 404 or (
-                "state improper" in stderr.lower()
-                or "running containers" in stderr.lower()
-            ):
+            if _container_gone(stderr):
                 raise ContainerGoneError(
                     f"container {container_id!r} is gone: {stderr.strip()}"
                 )
@@ -1086,6 +1124,21 @@ class ShellProcess:
         if self._proc is not None:
             os.kill(self._proc.pid, signal.SIGWINCH)
 
+    def _close_master_fd(self) -> None:
+        """Tear down the PTY master fd: drop the loop reader, unblock any
+        pending read, close the fd."""
+        try:
+            asyncio.get_running_loop().remove_reader(self._master_fd)
+        except (ValueError, RuntimeError):
+            pass  # loop already closed or fd not registered
+        if self._read_event is not None:
+            self._read_event.set()  # unblock any pending read
+        try:
+            os.close(self._master_fd)
+        except OSError:
+            pass
+        self._master_fd = None
+
     def close(self) -> None:
         if self._proc is not None and self._proc.returncode is None:
             try:
@@ -1093,17 +1146,7 @@ class ShellProcess:
             except ProcessLookupError:
                 pass
         if self._master_fd is not None:
-            try:
-                asyncio.get_running_loop().remove_reader(self._master_fd)
-            except (ValueError, RuntimeError):
-                pass  # loop already closed or fd not registered
-            if self._read_event is not None:
-                self._read_event.set()  # unblock any pending read
-            try:
-                os.close(self._master_fd)
-            except OSError:
-                pass
-            self._master_fd = None
+            self._close_master_fd()
 
 
 def _set_winsize(fd: int, rows: int, cols: int) -> None:
@@ -1268,6 +1311,36 @@ class TerminalSession:
         except Exception:
             pass
 
+    async def _pump_chunk(self, decoder, data: bytes) -> None:
+        """Decode one PTY chunk and queue it; output is dropped on
+        back-pressure (never block the PTY read)."""
+        text = decoder.decode(data)
+        if not text:
+            return
+        try:
+            self._output_queue.put_nowait(text)
+        except asyncio.QueueFull:
+            pass  # drop output; don't block the PTY read
+
+    async def _flush_decoder_tail(self, decoder) -> None:
+        """Flush any trailing partial sequence (a stream that ends
+        mid-character yields a single replacement char rather than
+        dropping bytes)."""
+        tail = decoder.decode(b"", final=True)
+        if tail:
+            await self._output_queue.put(tail)
+
+    async def _read_chunks(self, decoder) -> None:
+        """The read loop proper: PTY chunks until EOF/stop."""
+        while self._running and self._shell is not None:
+            data = await self._shell.read()
+            if not data:
+                logger.info("Terminal read loop: EOF from PTY")
+                await self._log_exec_exit_code()
+                break
+            await self._pump_chunk(decoder, data)
+        await self._flush_decoder_tail(decoder)
+
     async def read_loop(self) -> None:
         """Read PTY output and queue it as text.
 
@@ -1279,24 +1352,7 @@ class TerminalSession:
         """
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         try:
-            while self._running and self._shell is not None:
-                data = await self._shell.read()
-                if not data:
-                    logger.info("Terminal read loop: EOF from PTY")
-                    await self._log_exec_exit_code()
-                    break
-                text = decoder.decode(data)
-                if text:
-                    try:
-                        self._output_queue.put_nowait(text)
-                    except asyncio.QueueFull:
-                        pass  # drop output; don't block the PTY read
-            # Flush any trailing partial sequence (a stream that ends
-            # mid-character yields a single replacement char rather than
-            # dropping bytes).
-            tail = decoder.decode(b"", final=True)
-            if tail:
-                await self._output_queue.put(tail)
+            await self._read_chunks(decoder)
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -1336,6 +1392,11 @@ class TerminalSession:
             except OSError:
                 logger.debug("Terminal resize failed", exc_info=True)
 
+    def _read_task_done(self) -> bool:
+        """True when the PTY read task has finished (nothing more can
+        arrive)."""
+        return self._read_task is not None and self._read_task.done()
+
     async def output(self) -> AsyncGenerator[str, None]:
         """Yield terminal output as it arrives."""
         while self._running:
@@ -1344,63 +1405,71 @@ class TerminalSession:
                     self._output_queue.get(), timeout=1.0
                 )
             except asyncio.TimeoutError:
-                if self._read_task is not None and self._read_task.done():
+                if self._read_task_done():
                     break
                 continue
             if data is None:
                 break
             yield data
 
+    async def _cancel_read_task(self) -> None:
+        """Cancel (and await) the PTY read task."""
+        if self._read_task is None:
+            return
+        self._read_task.cancel()
+        try:
+            await self._read_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Error awaiting terminal read task")
+        self._read_task = None
+
+    async def _close_shell(self) -> None:
+        """Close the host-side PTY shell."""
+        if self._shell is None:
+            return
+        try:
+            self._shell.close()
+        except OSError:
+            logger.debug("Error closing terminal shell", exc_info=True)
+        self._shell = None
+
+    async def _kill_grouped_tmux_session(self) -> None:
+        """Kill the tmux session inside the container so the client
+        doesn't stay attached after the host-side process is gone.
+        All grouped sessions (own, join, shared) are killed — the
+        base session persists independently. tmux_session_name is a
+        unique grouped name for all connection types."""
+        if not self.tmux_session_name:
+            return
+        try:
+            socket_args = ["-S", self.socket_path] if self.socket_path else []
+            await self.podman.exec_container(
+                self.container_id,
+                [
+                    "tmux",
+                    *socket_args,
+                    "kill-session",
+                    "-t",
+                    self.tmux_session_name,
+                ],
+                user=CONTAINER_USER,
+                timeout=5,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to kill tmux session %s",
+                self.tmux_session_name,
+                exc_info=True,
+            )
+
     async def stop(self) -> None:
         """Stop the terminal session and clean up."""
         self._running = False
-
-        if self._read_task is not None:
-            self._read_task.cancel()
-            try:
-                await self._read_task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.exception("Error awaiting terminal read task")
-            self._read_task = None
-
-        if self._shell is not None:
-            try:
-                self._shell.close()
-            except OSError:
-                logger.debug("Error closing terminal shell", exc_info=True)
-            self._shell = None
-
-        # Kill the tmux session inside the container so the client
-        # doesn't stay attached after the host-side process is gone.
-        # All grouped sessions (own, join, shared) are killed — the
-        # base session persists independently.  tmux_session_name is
-        # a unique grouped name for all connection types.
-        if self.tmux_session_name:
-            try:
-                socket_args = (
-                    ["-S", self.socket_path] if self.socket_path else []
-                )
-                await self.podman.exec_container(
-                    self.container_id,
-                    [
-                        "tmux",
-                        *socket_args,
-                        "kill-session",
-                        "-t",
-                        self.tmux_session_name,
-                    ],
-                    user=CONTAINER_USER,
-                    timeout=5,
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to kill tmux session %s",
-                    self.tmux_session_name,
-                    exc_info=True,
-                )
-
+        await self._cancel_read_task()
+        await self._close_shell()
+        await self._kill_grouped_tmux_session()
         logger.info(
             "Terminal session stopped for container %s", self.container_id
         )

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -86,27 +86,35 @@ def run_cmd_value(value: str) -> tuple[str | None, str | None]:
     return proc.stdout.strip(), None
 
 
+def _resolved_or_empty(
+    contents: str | None, err: OSError | str | None, log_msg: str
+) -> str:
+    """Empty string on a failed file:/cmd: resolution (the error is
+    logged by the caller's message); otherwise the resolved contents."""
+    if err is not None:
+        logger.error(log_msg, err)
+        return ""
+    assert contents is not None
+    return contents
+
+
 def resolve_file_value(value: str) -> str:
     """Resolve a value that may have a 'file:' or 'cmd:' prefix.
 
     If the value starts with 'file:', reads the file and returns its
     stripped contents. If it starts with 'cmd:', runs the command and
     returns its stripped stdout. Otherwise returns the value as-is.
+    A failed resolution logs and yields "" rather than surfacing
+    the raw prefixed value.
     """
     if value.startswith("file:"):
         contents, err = read_file_value(value)
-        if err is not None:
-            logger.error("Cannot read secret file: %s", err)
-            return ""
-        assert contents is not None
-        return contents
+        return _resolved_or_empty(contents, err, "Cannot read secret file: %s")
     if value.startswith("cmd:"):
         contents, err = run_cmd_value(value)
-        if err is not None:
-            logger.error("Cannot resolve secret via cmd: %s", err)
-            return ""
-        assert contents is not None
-        return contents
+        return _resolved_or_empty(
+            contents, err, "Cannot resolve secret via cmd: %s"
+        )
     return value
 
 
@@ -216,6 +224,32 @@ def authority_has_port(authority: str) -> bool:
     return bool(sep) and port.isdigit()
 
 
+def _unbracketed_host(candidate: str) -> str | None:
+    """Strip IPv6 brackets from a colon-bearing candidate.
+
+    ``None`` for a bare (unbracketed) colon-bearing form — every bare
+    IPv6 literal, including v4-mapped loopback like ``::ffff:127.0.0.1``
+    — which cannot take a bare :port append and is left alone by the
+    caller.
+    """
+    if ":" not in candidate:
+        return candidate
+    if candidate.startswith("[") and candidate.endswith("]"):
+        return candidate[1:-1]
+    return None
+
+
+def _is_loopback_literal(candidate: str) -> bool:
+    """``localhost`` or any parseable loopback IP literal (covers
+    127.0.0.0/8 dotted-quads and ``::1``)."""
+    if candidate == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
+
+
 def is_portless_loopback_host(authority: str) -> bool:
     """True if *authority* is a port-less loopback hostname (#2732).
 
@@ -235,19 +269,33 @@ def is_portless_loopback_host(authority: str) -> bool:
     """
     if not authority or authority_has_port(authority):
         return False
-    candidate = authority.lower()
-    if ":" in candidate:
-        # Bracketed form only; a bare IPv6 literal (``::1``, ``::ffff:..``)
-        # cannot take a bare :port append.
-        if not (candidate.startswith("[") and candidate.endswith("]")):
-            return False
-        candidate = candidate[1:-1]
-    if candidate == "localhost":
-        return True
+    candidate = _unbracketed_host(authority.lower())
+    return candidate is not None and _is_loopback_literal(candidate)
+
+
+def _parse_trusted_entry(token: str) -> ipaddress._BaseAddress | None:
+    """One trusted-proxy token: a bare IP address, else a CIDR network
+    (non-strict, so a bare host address widens to its network), else
+    ``None`` for an invalid entry."""
     try:
-        return ipaddress.ip_address(candidate).is_loopback
+        return ipaddress.ip_address(token)
     except ValueError:
-        return False
+        pass
+    try:
+        return ipaddress.ip_network(token, strict=False)
+    except ValueError:
+        return None
+
+
+def _canonical_ip_or_raw(candidate: str | None) -> str | None:
+    """The canonical (``str()``-normalized) form of a parseable IP
+    address; the raw string (or ``None``) when it does not parse."""
+    if candidate is None:
+        return None
+    try:
+        return str(ipaddress.ip_address(candidate))
+    except ValueError:
+        return candidate
 
 
 # Loopback addresses used by ``Util.client_is_loopback`` (the none-mode
@@ -261,6 +309,13 @@ _LOOPBACK_ADDRS = {
 }
 
 
+def _first_forwarded_hop(headers) -> str:
+    """The first hop of X-Forwarded-For (the client as the trusted
+    proxy saw it), or "" when the header is absent."""
+    xff = headers.get("x-forwarded-for") or ""
+    return xff.split(",")[0].strip() if xff else ""
+
+
 def trusted_forwarded_ip(headers) -> str | None:
     """The parsed IP from trusted proxy headers (X-Real-IP, then the first
     hop of X-Forwarded-For), or None when absent or unparseable (garbage or
@@ -268,8 +323,7 @@ def trusted_forwarded_ip(headers) -> str | None:
     instead of trusting an unvalidated string)."""
     real_ip = headers.get("x-real-ip") or ""
     if not real_ip:
-        xff = headers.get("x-forwarded-for") or ""
-        real_ip = xff.split(",")[0].strip() if xff else ""
+        real_ip = _first_forwarded_hop(headers)
     if not real_ip:
         return None
     try:
@@ -482,25 +536,27 @@ class Util:
         """
         raw = self.app.state.settings.trusted_proxy_cidrs
         trusted: set[ipaddress._BaseAddress] = set()
-        for token in (raw or "").split(","):
-            token = token.strip()
-            if not token:
-                continue
-            try:
-                trusted.add(ipaddress.ip_address(token))
-            except ValueError:
-                try:
-                    net = ipaddress.ip_network(token, strict=False)
-                    trusted.add(net)
-                except ValueError:
-                    # Log without interpolating the value (CodeQL treats
-                    # env-var-derived data as potentially sensitive).
-                    logger.warning(
-                        "Ignoring an invalid KLANGKD_TRUSTED_PROXY_CIDRS entry"
-                    )
+        for token in filter(None, map(str.strip, (raw or "").split(","))):
+            self._add_trusted_entry(trusted, token)
         if not trusted:
             trusted.add(ipaddress.ip_address("127.0.0.1"))
         return trusted
+
+    @staticmethod
+    def _add_trusted_entry(
+        trusted: set[ipaddress._BaseAddress], token: str
+    ) -> None:
+        """Add one KLANGKD_TRUSTED_PROXY_CIDRS token: a bare IP, a CIDR
+        network, or (logged and skipped) an invalid entry."""
+        entry = _parse_trusted_entry(token)
+        if entry is None:
+            # Log without interpolating the value (CodeQL treats
+            # env-var-derived data as potentially sensitive).
+            logger.warning(
+                "Ignoring an invalid KLANGKD_TRUSTED_PROXY_CIDRS entry"
+            )
+            return
+        trusted.add(entry)
 
     def peer_trusted(self, client_host: str | None) -> bool:
         """True if the immediate peer is in the trusted proxy set."""
@@ -510,13 +566,20 @@ class Util:
             ip = ipaddress.ip_address(client_host)
         except ValueError:
             return False
-        for entry in self.trusted_proxy_cidrs():
-            if isinstance(entry, ipaddress._BaseNetwork):
-                if ip in entry:
-                    return True
-            elif entry == ip:
-                return True
-        return False
+        return any(
+            self._entry_matches(entry, ip)
+            for entry in self.trusted_proxy_cidrs()
+        )
+
+    @staticmethod
+    def _entry_matches(
+        entry: ipaddress._BaseAddress, ip: ipaddress._BaseAddress
+    ) -> bool:
+        """True when *ip* is covered by a trusted entry — containment
+        for a network entry, equality for a bare address."""
+        if isinstance(entry, ipaddress._BaseNetwork):
+            return ip in entry
+        return entry == ip
 
     def connection_peer_is_trusted(self, client_host: str | None) -> bool:
         """True if the immediate connection peer is the trusted reverse proxy.
@@ -547,22 +610,24 @@ class Util:
         (``str()``-normalized) address, or ``None`` when there is no
         client at all.
         """
-        candidate = client_host
-        trust = (
+        if self._forwarded_headers_trusted(headers, client_host):
+            forwarded = trusted_forwarded_ip(headers)
+            if forwarded is not None:
+                return forwarded
+        return _canonical_ip_or_raw(client_host)
+
+    def _forwarded_headers_trusted(
+        self, headers, client_host: str | None
+    ) -> bool:
+        """The shared forwarded-header trust gate: honored only when the
+        immediate peer is the trusted proxy and the hard-off override is
+        unset. ``headers is not None`` keeps request-less callers on the
+        env-var path (:meth:`derive_hosting_info})."""
+        return (
             (not self.reject_proxy_headers())
             and self.connection_peer_is_trusted(client_host)
             and headers is not None
         )
-        if trust:
-            forwarded = trusted_forwarded_ip(headers)
-            if forwarded is not None:
-                return forwarded
-        if candidate is None:
-            return None
-        try:
-            return str(ipaddress.ip_address(candidate))
-        except ValueError:
-            return candidate
 
     def client_is_loopback(
         self, headers=None, client_host: str | None = None
@@ -618,11 +683,7 @@ class Util:
         hostname = self.app.state.settings.hosting_hostname
         proto = self.app.state.settings.hosting_proto
         base_path = self.app.state.settings.hosting_base_path
-        trust = (
-            (not self.reject_proxy_headers())
-            and self.connection_peer_is_trusted(client_host)
-            and headers is not None
-        )
+        trust = self._forwarded_headers_trusted(headers, client_host)
         hostname = self._hosting_hostname(headers, hostname, trust)
         if not proto:
             proto = self._hosting_proto(headers, trust)
@@ -637,22 +698,32 @@ class Util:
         X-Forwarded-Host, else the Host header, else ``localhost``. A
         synthetic (non-pinned, non-forwarded) loopback hostname is pointed
         at the browser listener (#2732)."""
-        hostname = env_hostname
-        pinned = bool(hostname)
-        forwarded = False
-        if not hostname and headers is not None:
-            if trust:
-                forwarded_host = headers.get("x-forwarded-host")
-                if forwarded_host:
-                    hostname = forwarded_host
-                    forwarded = True
-            if not hostname:
-                hostname = headers.get("host") or "localhost"
-        if not hostname:
-            hostname = "localhost"
+        pinned = bool(env_hostname)
+        hostname, forwarded = self._hostname_source(
+            headers, env_hostname, trust
+        )
         if not pinned and not forwarded:
             hostname = self.browser_listener_hostname(hostname)
         return hostname
+
+    def _hostname_source(
+        self, headers, env_hostname: str, trust: bool
+    ) -> tuple[str, bool]:
+        """(hostname, came-from-a-trusted-forwarded-header)."""
+        if env_hostname:
+            return env_hostname, False
+        if headers is None:
+            return "localhost", False
+        return self._hostname_from_headers(headers, trust)
+
+    def _hostname_from_headers(self, headers, trust: bool) -> tuple[str, bool]:
+        """Trusted X-Forwarded-Host when present (flagged True), else the
+        raw Host header, else ``localhost``."""
+        if trust:
+            forwarded_host = headers.get("x-forwarded-host")
+            if forwarded_host:
+                return forwarded_host, True
+        return headers.get("host") or "localhost", False
 
     @staticmethod
     def _hosting_proto(headers, trust: bool) -> str:

--- a/src/klangk/klangk/workspace_settings.py
+++ b/src/klangk/klangk/workspace_settings.py
@@ -54,6 +54,30 @@ from typing import Any, Callable
 _MEMORY_LIMIT_RE = re.compile(r"^(?P<num>\d+(\.\d+)?)[kKmMgGtTpP]?[bB]?$")
 
 
+def _int_from_string(key: str, value: str) -> int:
+    """A settings int from its string form (``"512"``)."""
+    s = value.strip()
+    if not s:
+        raise ValueError(f"settings.{key} must not be empty")
+    try:
+        # int("1.5") raises — that's what we want (reject non-integer
+        # strings); int("0x10", base=10) is the documented base-10 parse.
+        return int(s, base=10)
+    except ValueError as exc:
+        raise ValueError(
+            f"settings.{key} must be an integer, got {value!r}"
+        ) from exc
+
+
+def _int_from_float(key: str, value: float) -> int:
+    """A settings int from a float (whole floats only)."""
+    if value.is_integer():
+        return int(value)
+    raise ValueError(
+        f"settings.{key} must be an integer, got non-integer float {value!r}"
+    )
+
+
 def _coerce_int(key: str, value: Any) -> int:
     """Coerce a settings value to an ``int`` (no sign gating).
 
@@ -71,24 +95,9 @@ def _coerce_int(key: str, value: Any) -> int:
     if isinstance(value, int):
         return value
     if isinstance(value, float):
-        if value.is_integer():
-            return int(value)
-        raise ValueError(
-            f"settings.{key} must be an integer, got non-integer float"
-            f" {value!r}"
-        )
+        return _int_from_float(key, value)
     if isinstance(value, str):
-        s = value.strip()
-        if not s:
-            raise ValueError(f"settings.{key} must not be empty")
-        try:
-            # int("1.5") raises — that's what we want (reject non-integer
-            # strings); int("0x10", base=10) is the documented base-10 parse.
-            return int(s, base=10)
-        except ValueError as exc:
-            raise ValueError(
-                f"settings.{key} must be an integer, got {value!r}"
-            ) from exc
+        return _int_from_string(key, value)
     raise ValueError(
         f"settings.{key} must be an integer, got {type(value).__name__}"
     )
@@ -118,26 +127,21 @@ def _coerce_nonnegative_int(key: str, value: Any) -> int:
     return n
 
 
-def _coerce_float(key: str, value: Any) -> float:
-    """Coerce a settings value to a positive ``float`` (CPU limit)."""
-    if isinstance(value, bool):
-        raise ValueError(f"settings.{key} must be a number, not a boolean")
-    if isinstance(value, (int, float)):
-        f = float(value)
-    elif isinstance(value, str):
-        s = value.strip()
-        if not s:
-            raise ValueError(f"settings.{key} must not be empty")
-        try:
-            f = float(s)
-        except ValueError as exc:
-            raise ValueError(
-                f"settings.{key} must be a number, got {value!r}"
-            ) from exc
-    else:
+def _float_from_string(key: str, value: str) -> float:
+    """A settings float from its string form."""
+    s = value.strip()
+    if not s:
+        raise ValueError(f"settings.{key} must not be empty")
+    try:
+        return float(s)
+    except ValueError as exc:
         raise ValueError(
-            f"settings.{key} must be a number, got {type(value).__name__}"
-        )
+            f"settings.{key} must be a number, got {value!r}"
+        ) from exc
+
+
+def _require_positive_float(key: str, f: float) -> float:
+    """Reject non-positive numbers (a 0 limit is not a limit)."""
     if f <= 0:
         raise ValueError(
             f"settings.{key} must be a positive number, got {f!r}"
@@ -145,17 +149,38 @@ def _coerce_float(key: str, value: Any) -> float:
     return f
 
 
+def _coerce_float(key: str, value: Any) -> float:
+    """Coerce a settings value to a positive ``float`` (CPU limit)."""
+    if isinstance(value, bool):
+        raise ValueError(f"settings.{key} must be a number, not a boolean")
+    if isinstance(value, (int, float)):
+        f = float(value)
+    elif isinstance(value, str):
+        f = _float_from_string(key, value)
+    else:
+        raise ValueError(
+            f"settings.{key} must be a number, got {type(value).__name__}"
+        )
+    return _require_positive_float(key, f)
+
+
+def _memory_from_number(key: str, value: Any) -> str:
+    """A bare-byte integer/float re-stringified into the podman form
+    (the stored bag always carries the size-string form)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(
+            f"settings.{key} must be a size string (e.g. '2g', '512m'),"
+            f" got {type(value).__name__}"
+        )
+    return str(int(value))
+
+
 def _coerce_memory(key: str, value: Any) -> str:
     """Coerce a settings value to a podman memory-limit string (``2g``)."""
     if not isinstance(value, str):
         # Allow an integer/float of bare bytes for ergonomics, then
         # re-stringify so the stored bag always carries the podman form.
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise ValueError(
-                f"settings.{key} must be a size string (e.g. '2g', '512m'),"
-                f" got {type(value).__name__}"
-            )
-        value = str(int(value))
+        value = _memory_from_number(key, value)
     value = value.strip()
     m = _MEMORY_LIMIT_RE.match(value)
     if not m:
@@ -175,6 +200,22 @@ def _coerce_memory(key: str, value: Any) -> str:
     return value
 
 
+# Boolean spellings accepted in the per-workspace settings bag.
+_TRUE_STRINGS = frozenset({"true", "1", "yes", "on"})
+_FALSE_STRINGS = frozenset({"false", "0", "no", "off", ""})
+
+
+def _bool_from_string(value: str) -> bool | None:
+    """The bool named by a settings string, or ``None`` when it names
+    none."""
+    v = value.strip().lower()
+    if v in _TRUE_STRINGS:
+        return True
+    if v in _FALSE_STRINGS:
+        return False
+    return None
+
+
 def coerce_bool(key: str, value: Any) -> bool:
     """Coerce a settings value to a bool.
 
@@ -183,15 +224,19 @@ def coerce_bool(key: str, value: Any) -> bool:
     """
     if isinstance(value, bool):
         return value
+    if _coerce_bool_like(key, value) is None:
+        raise ValueError(f"settings.{key}={value!r} is not a boolean")
+    return _coerce_bool_like(key, value)
+
+
+def _coerce_bool_like(key: str, value: Any) -> bool | None:
+    """The bool named by *value* (number or spelling), or None when the
+    value names no bool."""
     if isinstance(value, (int, float)) and value in (0, 1):
         return bool(value)
     if isinstance(value, str):
-        v = value.strip().lower()
-        if v in ("true", "1", "yes", "on"):
-            return True
-        if v in ("false", "0", "no", "off", ""):
-            return False
-    raise ValueError(f"settings.{key}={value!r} is not a boolean")
+        return _bool_from_string(value)
+    return None
 
 
 # Schema: each known settings key maps to a normalizer that validates +
@@ -252,6 +297,45 @@ def validate_settings(
     return normalized
 
 
+def _normalizer_for(key: Any) -> Callable[[str, Any], Any]:
+    """The schema normalizer for *key*, rejecting non-string and unknown
+    keys with the shared client-safe messages."""
+    if not isinstance(key, str):
+        raise ValueError(
+            f"settings keys must be strings, got {type(key).__name__}"
+        )
+    normalizer = SCHEMA.get(key)
+    if normalizer is None:
+        raise ValueError(
+            f"Unknown setting {key!r}; known settings: "
+            f"{sorted(KNOWN_SETTINGS)}"
+        )
+    return normalizer
+
+
+def _require_patch_shape(patch: Any) -> None:
+    """A settings PATCH body must be a non-empty JSON object."""
+    if patch is None:
+        raise ValueError("settings patch must not be empty")
+    if not isinstance(patch, dict):
+        raise ValueError(
+            "settings patch must be a JSON object (dict), got"
+            f" {type(patch).__name__}"
+        )
+    if not patch:
+        raise ValueError("settings patch must not be empty")
+
+
+def _patch_entry(key: Any, value: Any) -> Any:
+    """One patch entry: the ``None`` deletion marker is preserved; every
+    other value is coerced. Key/unknown-key errors surface even for a
+    marker entry."""
+    normalizer = _normalizer_for(key)
+    if value is None:
+        return None
+    return normalizer(key, value)
+
+
 def validate_settings_patch(
     patch: dict[str, Any] | None,
 ) -> dict[str, Any]:
@@ -268,34 +352,23 @@ def validate_settings_patch(
     or ``{}``) raises ``ValueError`` — a PATCH that changes nothing is a
     client error, not a silent no-op.
     """
-    if patch is None:
-        raise ValueError("settings patch must not be empty")
-    if not isinstance(patch, dict):
-        raise ValueError(
-            "settings patch must be a JSON object (dict), got"
-            f" {type(patch).__name__}"
-        )
-    if not patch:
-        raise ValueError("settings patch must not be empty")
+    _require_patch_shape(patch)
     result: dict[str, Any] = {}
     for key, value in patch.items():
-        if not isinstance(key, str):
-            raise ValueError(
-                f"settings keys must be strings, got {type(key).__name__}"
-            )
-        normalizer = SCHEMA.get(key)
-        if normalizer is None:
-            raise ValueError(
-                f"Unknown setting {key!r}; known settings: "
-                f"{sorted(KNOWN_SETTINGS)}"
-            )
         # None is the deletion marker — preserved through validation so
         # the model merge can act on it. Everything else is coerced.
-        if value is None:
-            result[key] = None
-        else:
-            result[key] = normalizer(key, value)
+        result[key] = _patch_entry(key, value)
     return result
+
+
+def _normalized_pair(key: Any, value: Any) -> tuple[str, Any] | None:
+    """The normalized (key, value) pair, or ``None`` when the value is an
+    explicit null (dropped in a full-replace bag). Key/unknown-key errors
+    surface before the null drop."""
+    normalizer = _normalizer_for(key)
+    if value is None:
+        return None
+    return key, normalizer(key, value)
 
 
 def _validate_settings_dict(
@@ -317,19 +390,9 @@ def _validate_settings_dict(
         )
     normalized: dict[str, Any] = {}
     for key, value in settings.items():
-        if not isinstance(key, str):
-            raise ValueError(
-                f"settings keys must be strings, got {type(key).__name__}"
-            )
-        normalizer = SCHEMA.get(key)
-        if normalizer is None:
-            raise ValueError(
-                f"Unknown setting {key!r}; known settings: "
-                f"{sorted(KNOWN_SETTINGS)}"
-            )
-        if value is None:
-            continue
-        normalized[key] = normalizer(key, value)
+        pair = _normalized_pair(key, value)
+        if pair is not None:
+            normalized[pair[0]] = pair[1]
     return normalized
 
 
@@ -412,6 +475,14 @@ def resolve_allow_sudo(workspace: dict | None, deploy_default: bool) -> bool:
     )
 
 
+def _nix_echo(previous: dict[str, Any] | None) -> bool:
+    """True when the stored bag already has ``nix=true`` — an echo of an
+    existing opt-in, not a new one (the TUI and web panel PUT a
+    full-replace bag merged over the existing one, so a legacy nix
+    workspace stays editable while the flag is off)."""
+    return previous is not None and bool(previous.get("nix"))
+
+
 def validate_nix_optin(
     bag: dict[str, Any] | None,
     *,
@@ -433,7 +504,7 @@ def validate_nix_optin(
     """
     if nix_available or not (bag or {}).get("nix"):
         return
-    if previous is not None and previous.get("nix"):
+    if _nix_echo(previous):
         return
     raise ValueError(
         "settings.nix=true requires the nix feature to be enabled on the "

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -128,6 +128,31 @@ def _unlink_stale_handle_symlink(workspace_home, target: str) -> None:
             break
 
 
+def _adopt_children(old_target: Path, user_dir: Path) -> None:
+    """Move files from the old user dir into the new one."""
+    for child in old_target.iterdir():
+        dest = user_dir / child.name
+        if not dest.exists():
+            child.rename(dest)
+
+
+def _replace_stale_symlink(symlink: Path, user_dir: Path) -> bool:
+    """Handle a pre-existing handle path: when it is a symlink to a
+    different user's directory (e.g. from a workspace import), adopt the
+    old user's files into the new user directory so the importer gets
+    the exported content, then drop it. Returns True when content was
+    adopted (no skel needed)."""
+    if not symlink.is_symlink():
+        return False
+    old_target = symlink.resolve()
+    adopted = False
+    if old_target.is_dir() and old_target != user_dir:
+        _adopt_children(old_target, user_dir)
+        adopted = True
+    symlink.unlink()
+    return adopted
+
+
 def _ensure_home_symlink_sync(
     workspace_home: Path,
     handle: str,
@@ -166,17 +191,8 @@ def _ensure_home_symlink_sync(
     # different user's directory from a workspace import.  Adopt the old
     # user's files into the new user directory so the importer gets the
     # exported content, then replace the symlink.
-    if symlink.is_symlink():
-        old_target = symlink.resolve()
-        if old_target.is_dir() and old_target != user_dir:
-            # Move files from the old user dir into the new one.
-            for child in old_target.iterdir():
-                dest = user_dir / child.name
-                if not dest.exists():
-                    child.rename(dest)
-            created = False  # content adopted, no skel needed
-        symlink.unlink()
-
+    if _replace_stale_symlink(symlink, user_dir):
+        created = False  # content adopted, no skel needed
     symlink.symlink_to(target)
     return f"/home/{handle}", created
 
@@ -335,6 +351,17 @@ class Workspaces:
 
     # --- archive ---
 
+    def _path_within_root(self, label: str, p: Path) -> bool:
+        """True when *p* (or its nearest existing ancestor) stays under
+        the workspace root."""
+        if not (p.exists() or p.parent.exists()):
+            return True
+        resolved = (p if p.exists() else p.parent).resolve()
+        if not resolved.is_relative_to(self.root.resolve()):
+            logger.error("Path validation failed for %s: %s", label, p)
+            return False
+        return True
+
     async def build_workspace_archive(
         self, metadata: dict, home_dir: Path, archive_path: Path
     ) -> bool:
@@ -350,11 +377,8 @@ class Workspaces:
             ("home_dir", home_dir),
             ("archive_path", archive_path),
         ]:
-            if p.exists() or p.parent.exists():
-                resolved = (p if p.exists() else p.parent).resolve()
-                if not resolved.is_relative_to(self.root.resolve()):
-                    logger.error("Path validation failed for %s: %s", label, p)
-                    return False
+            if not self._path_within_root(label, p):
+                return False
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -388,6 +412,56 @@ class Workspaces:
         finally:
             await async_rmtree(tmpdir, "build_workspace_archive tmpdir")
 
+    def _user_archive_path(
+        self, ws: dict, user_id: str, safe_email: str
+    ) -> Path | None:
+        """The safe archive path for one workspace (``None`` when path
+        traversal is blocked)."""
+        ws_name = sanitize_filename(ws["name"])
+        archive_name = f"{user_id}-{safe_email}-{ws_name}.tar.gz"
+        try:
+            return self.safe_path(archive_name)  # lgtm[py/path-injection]
+        except ValueError:
+            logger.error(
+                "Archive path traversal blocked for workspace %s",
+                ws["name"],
+            )
+            return None
+
+    async def _archive_page(
+        self, user_id: str, safe_email: str, user_workspaces: list[dict]
+    ) -> tuple[list[Path], list[str]]:
+        """Archive one page of workspaces: (archive paths, archived ids)."""
+        archives: list[Path] = []
+        archived_ids: list[str] = []
+        for ws in user_workspaces:
+            archive_path = self._user_archive_path(ws, user_id, safe_email)
+            if archive_path is None:
+                continue
+            home_dir = self.home_path(ws["id"])
+            metadata = self.workspace_metadata(ws)
+            if await self.build_workspace_archive(
+                metadata, home_dir, archive_path
+            ):
+                # lgtm[py/clear-text-logging-sensitive-data]
+                logger.info(
+                    "Archived workspace %s to %s", ws["name"], archive_path
+                )
+                archives.append(archive_path)
+                archived_ids.append(ws["id"])
+        return archives, archived_ids
+
+    async def _remove_archived_dirs(self, archived_ws_ids: list[str]) -> None:
+        """Remove each archived workspace's data directory + per-workspace
+        nix snapshot (#2201 — no-op when nix isn't configured or the snapshot
+        is absent; matches delete_workspace, so account deletion doesn't
+        orphan snapshots outside the workspace data dir)."""
+        for ws_id in archived_ws_ids:
+            await self.app.state.nix.destroy_workspace_nix(ws_id)
+            ws_dir = self.safe_path(ws_id)
+            if ws_dir.exists():
+                await async_rmtree(ws_dir, f"workspace data {ws_id}")
+
     async def archive_user_data(self, user_id: str, email: str) -> list[Path]:
         """Archive each workspace to a .tar.gz in the export/import format.
 
@@ -408,49 +482,37 @@ class Workspaces:
             page = await self.app.state.model.workspaces.list_workspaces(
                 user_id, offset=offset
             )
-            user_workspaces = page["items"]
-            if not user_workspaces:
+            if not page["items"]:
                 break
-            for ws in user_workspaces:
-                ws_name = sanitize_filename(ws["name"])
-                archive_name = f"{user_id}-{safe_email}-{ws_name}.tar.gz"
-                try:
-                    archive_path = self.safe_path(
-                        archive_name
-                    )  # lgtm[py/path-injection]
-                except ValueError:
-                    logger.error(
-                        "Archive path traversal blocked for workspace %s",
-                        ws["name"],
-                    )
-                    continue
-                home_dir = self.home_path(ws["id"])
-                metadata = self.workspace_metadata(ws)
-                if await self.build_workspace_archive(
-                    metadata, home_dir, archive_path
-                ):
-                    # lgtm[py/clear-text-logging-sensitive-data]
-                    logger.info(
-                        "Archived workspace %s to %s", ws["name"], archive_path
-                    )
-                    archives.append(archive_path)
-                    archived_ws_ids.append(ws["id"])
+            page_archives, page_ids = await self._archive_page(
+                user_id, safe_email, page["items"]
+            )
+            archives.extend(page_archives)
+            archived_ws_ids.extend(page_ids)
             if not page["has_more"]:
                 break
             offset = page["next_offset"]
 
-        # Remove each archived workspace's data directory + per-workspace
-        # nix snapshot (#2201 — no-op when nix isn't configured or the snapshot
-        # is absent; matches delete_workspace, so account deletion doesn't
-        # orphan snapshots outside the workspace data dir).
-        for ws_id in archived_ws_ids:
-            await self.app.state.nix.destroy_workspace_nix(ws_id)
-            ws_dir = self.safe_path(ws_id)
-            if ws_dir.exists():
-                await async_rmtree(ws_dir, f"workspace data {ws_id}")
+        await self._remove_archived_dirs(archived_ws_ids)
         return archives
 
     # --- CRUD ---
+
+    async def _fire_created_hook(self, workspace: dict, user_id: str) -> dict:
+        """#2762: fire the deployment's workspace-created hook
+        (KLANGKD_WORKSPACE_CREATED_HOOK) on every creation path — create,
+        import, and duplicate all land here. Runs after the row + owner
+        ACE + role groups are committed and the workspace is fully
+        provisioned; failures are logged and never fail the create
+        (Hooks.fire_workspace_created). Guarded: minimal test apps wire
+        Workspaces without the full build_app state."""
+        hooks_state = getattr(self.app.state, "hooks", None)
+        if hooks_state is None or hooks_state.workspace_created_hook is None:
+            return workspace
+        actor = await self.app.state.model.users.get_user_by_id(user_id)
+        return await hooks_state.fire_workspace_created(
+            workspace, actor or {"id": user_id}
+        )
 
     async def create_workspace(
         self,
@@ -507,23 +569,7 @@ class Workspaces:
             )
             await async_rmtree(home, f"workspace {workspace['id']} rollback")
             raise
-        # #2762: fire the deployment's workspace-created hook
-        # (KLANGKD_WORKSPACE_CREATED_HOOK) on every creation path —
-        # create, import, and duplicate all land here. Runs after the
-        # row + owner ACE + role groups are committed and the workspace
-        # is fully provisioned; failures are logged and never fail the
-        # create (Hooks.fire_workspace_created). Guarded: minimal test
-        # apps wire Workspaces without the full build_app state.
-        hooks_state = getattr(self.app.state, "hooks", None)
-        if (
-            hooks_state is not None
-            and hooks_state.workspace_created_hook is not None
-        ):
-            actor = await self.app.state.model.users.get_user_by_id(user_id)
-            workspace = await hooks_state.fire_workspace_created(
-                workspace, actor or {"id": user_id}
-            )
-        return workspace
+        return await self._fire_created_hook(workspace, user_id)
 
     async def list_workspaces(
         self,
@@ -736,6 +782,39 @@ class Workspaces:
         )
         return cid, status
 
+    async def _auto_start_one(self, ws: dict, first: bool) -> bool:
+        """Start one auto-start workspace (True when it started). The
+        stagger sleep runs between workspaces so a fleet doesn't
+        stampede podman."""
+        if not first:
+            await asyncio.sleep(random.uniform(0.5, 2.0))
+        try:
+            cid, status = await self.start_workspace(
+                ws, cause=CAUSE_AUTO_START
+            )
+            # Auto-started containers are boot services: pin them alive
+            # so they do not idle out between user connections. Only the
+            # boot path does this -- create/restart use the default idle
+            # timeout (#1244).
+            state = self.app.state.container_registry.states.get(ws["id"])
+            if state:
+                state.idle_timeout = 0
+            logger.info(
+                "Auto-started workspace %s (%s): %s",
+                ws["name"],
+                cid[:12],
+                status,
+            )
+            return True
+        except Exception:
+            logger.warning(
+                "Failed to auto-start workspace %s (%s)",
+                ws["name"],
+                ws["id"],
+                exc_info=True,
+            )
+            return False
+
     async def auto_start_workspaces(self) -> int:
         """Start containers for all workspaces with auto_start enabled.
 
@@ -768,31 +847,6 @@ class Workspaces:
         )
         started = 0
         for i, ws in enumerate(ws_list):
-            if i > 0:
-                await asyncio.sleep(random.uniform(0.5, 2.0))
-            try:
-                cid, status = await self.start_workspace(
-                    ws, cause=CAUSE_AUTO_START
-                )
-                # Auto-started containers are boot services: pin them alive
-                # so they do not idle out between user connections. Only the
-                # boot path does this -- create/restart use the default idle
-                # timeout (#1244).
-                state = self.app.state.container_registry.states.get(ws["id"])
-                if state:
-                    state.idle_timeout = 0
-                logger.info(
-                    "Auto-started workspace %s (%s): %s",
-                    ws["name"],
-                    cid[:12],
-                    status,
-                )
+            if await self._auto_start_one(ws, first=(i == 0)):
                 started += 1
-            except Exception:
-                logger.warning(
-                    "Failed to auto-start workspace %s (%s)",
-                    ws["name"],
-                    ws["id"],
-                    exc_info=True,
-                )
         return started


### PR DESCRIPTION
Tranches 7–12 of the #2845 A-ratchet: bring every rank-B block in the core backend services down to rank A (cyclomatic complexity ≤ 5) — 97 blocks across 23 files, per the measured list in #3035.

Same discipline as T1–T6 (#2977, #2979, #3028, #3033): pure extract-function / dispatch-table refactors, one commit per tranche, no behavior change, full suite + 100% branch coverage green.

- **T7 — util & misc core (21)**: `util.py`, `main.py`, `doctor.py`, `interval.py`, `nix.py`, `server_schedule.py`, `sidecar_connections.py`, `emailsvc.py`
- **T8 — core services I (25)**: `hooks.py`, `features.py`, `files.py`, `acl.py`, `llm_router.py`, `workspace_settings.py`
- **T9 — core services II (25)**: `lifecycle.py`, `workspaces.py`, `seed.py`, `caddy.py`, `netfilter.py`
- **T10 — terminal (7)**: `terminal.py`
- **T11 — consent (8)**: `consent/{coordinator,deciders}.py`
- **T12 — podman (11)**: `podman.py`

Verified: `radon cc --min B` is empty on every touched file; the repo-wide xenon B gate stays green (`pre-commit run xenon --all-files`); the full backend+CLI suite passes with 100% branch coverage.

Closes #3035 (ticks the T7–T12 boxes of #2845).
